### PR TITLE
Simplify STF interface

### DIFF
--- a/src/state_machine/da.rs
+++ b/src/state_machine/da.rs
@@ -51,7 +51,7 @@ pub trait DaLayerTrait {
 }
 
 pub trait BlobTransactionTrait<Addr> {
-    type Data: Buf;
+    type Data: AsRef<[u8]>;
 
     fn sender(&self) -> Addr;
     fn data(&self) -> Self::Data;

--- a/src/state_machine/serial.rs
+++ b/src/state_machine/serial.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub enum DeserializationError {
     #[error("Data was too short to deserialize. Expected {expected:}, got {got:}")]
     DataTooShort { expected: usize, got: usize },
+    #[error("Invalid enum tag. Only tags 0-{max_allowed:} are valid, got {got:}")]
+    InvalidTag { max_allowed: u8, got: u8 },
 }
 
 // TODO: do this in a sensible/generic way

--- a/src/state_machine/stf.rs
+++ b/src/state_machine/stf.rs
@@ -1,111 +1,67 @@
+use std::collections::HashMap;
+
 use bytes::{Buf, Bytes};
 
-use crate::core::traits::{AddressTrait, BatchTrait, BlockheaderTrait, TransactionTrait};
+use crate::{
+    core::traits::{AddressTrait, BatchTrait, BlockheaderTrait, TransactionTrait},
+    serial::{Deser, DeserializationError},
+};
 
+/// An address on the DA layer. Opaque to the StateTransitionFunction
+type OpaqueAddress = Bytes;
+
+// TODO(@preston-evans98): update spec with simplified API
 pub trait StateTransitionFunction {
-    type Address: AddressTrait;
     type StateRoot;
     type ChainParams;
     type Transaction: TransactionTrait;
     /// A batch of transactions. Also known as a "block" in most systems: we use
     /// the term batch in this context to avoid ambiguity with DA layer blocks
-    type Batch: BatchTrait<Header = Self::Header, Transaction = Self::Transaction>;
-    type Proof;
-    type Error;
-    /// The header of a rollup block
-    type Header: BlockheaderTrait;
+    type Batch: BatchTrait<Transaction = Self::Transaction>;
+    type Proof: Deser;
+
     /// A proof that the sequencer has misbehaved. For example, this could be a merkle proof of a transaction
     /// with an invalid signature
     type MisbehaviorProof;
 
+    fn init_chain(&mut self, params: Self::ChainParams);
+
     /// Called at the beginning of each DA-layer block - whether or not that block contains any
-    /// data relevant to the rollup
-    fn begin_slot(&mut self);
+    /// data relevant to the rollup.
+    fn begin_slot(&self) -> StateUpdate;
 
-    /// Parses a sequence of bytes into a rollup block if it meets some basic validity conditions
-    /// (for example - if the sender is bonded on the rollup). If the sender was bonded but the block is illegal
-    /// the rollup may slash the sender
-    fn parse_batch(
-        &mut self,
-        msg: impl Buf,
-        sender: &[u8],
-    ) -> Result<Self::Batch, Option<ConsensusSetUpdate<Bytes>>>;
+    /// Apply a batch of transactions to the rollup, slashing the sequencer who proposed the batch on failure
+    fn apply_batch(
+        &self,
+        cache: &mut StateUpdate,
+        batch: Self::Batch,
+        sequencer: &[u8],
+        misbehavior_hint: Option<Self::MisbehaviorProof>,
+    ) -> Result<Vec<Vec<Event>>, ConsensusSetUpdate<OpaqueAddress>>;
 
-    /// Parses a sequence of bytes into a zero-knowledge proof if the message meets some basic validity conditions
-    /// (for example - if the sender is bonded on the rollup). If the sender was bonded but the message is illegal
-    /// the rollup may slash the sender
-    fn parse_proof(
-        &mut self,
-        msg: impl Buf,
-        sender: &[u8],
-    ) -> Result<Self::Proof, Option<ConsensusSetUpdate<Bytes>>>;
-
-    /// Called once at the beginning of each batch (aka rollup block) - so, potentially many times per DA block.
-    /// This method has two purposes: to allow the rollup to perform and needed initialiation before
-    /// processing the block, and to process an optional "misbehavior proof" to allow short-circuiting
-    /// in case the block is invalid. (An example misbehavior proof would be a merkle-proof to a transaction)
-    /// with an invalid signature. In case of misbehavior, this method should slash the block's sender.
-    ///
-    /// TODO: decide whether to add events
-    fn begin_batch(
-        &mut self,
-        block: &Self::Batch,
-        sender: &[u8],
-        misbehavior: Option<Self::MisbehaviorProof>,
-    ) -> Result<(), ConsensusSetUpdate<Bytes>>;
-
-    /// The core of the state transition function - called once for each rollup transaction.
-    ///
-    /// TODO: consider simplifying the response to a `MinDeliverTxResponse` for greater efficiency in zkVM
-    /// TODO: decide if events/logs need to be included in the zk-proof
-    fn deliver_tx(
-        &mut self,
-        tx: Self::Transaction,
-    ) -> Result<AugmentedDeliverTxResponse, ConsensusSetUpdate<Bytes>>;
-
-    /// Called once at the end of each slot.
-    fn end_batch(&mut self) -> EndBlockResponse<Bytes, Self::MisbehaviorProof>;
-
-    /// Called once at the "end" of each DA layer block (i.e. after all rollup batches have been processed)
-    fn end_slot(&mut self) -> Self::StateRoot;
-
-    /// Called once to update the state of the rollup with an on-chain proof. This method is useful for
-    /// updating gas costs - for example, by keeping an estimate of the lag time between when a transaction
-    /// is submitted and when it is proved,
-    fn deliver_proof(
-        &mut self,
+    fn apply_proof(
+        &self,
+        cache: &mut StateUpdate,
         proof: Self::Proof,
-        sender: &[u8],
-    ) -> Result<DeliverProofResponse, Option<ConsensusSetUpdate<Bytes>>>;
+        prover: &[u8],
+    ) -> Result<(), ConsensusSetUpdate<OpaqueAddress>>;
+
+    /// Called once at the *end* of each DA layer block (i.e. after all rollup batches and proofs have been processed)
+    /// Commits state changes to the database
+    fn end_slot(
+        &mut self,
+        cache: StateUpdate,
+    ) -> (Self::StateRoot, Vec<ConsensusSetUpdate<OpaqueAddress>>);
 }
 
-/// A minimal response to a deliver_tx invocation. Contains
-/// the information required to validate the chain, but does
-/// not include indexing information
-///
-/// TODO: decide whether to add events
-pub struct MinDeliverTxResponse {
-    /// the response code. 0 indicates success.
-    pub code: u32,
-    pub data: Bytes,
-    /// The amount of computational gas reserved by the transaction
-    pub gas_wanted: i64,
-    /// The amount of computational gas consumed by the transaction
-    pub gas_used: i64,
-    /// The amount of storage diesel reserved by the transaction
-    pub diesel_wanted: i64,
-    /// The amount of storage diesel used by the transaction
-    pub diesel_used: i64,
-}
+// TODO(@bkolad): replace with first-read-last-write cache
+pub struct StateUpdate {}
 
-/// A full response to a deliver_tx invocation, including supplemental data
-/// useful for indexing.
-pub struct AugmentedDeliverTxResponse {
-    pub core: MinDeliverTxResponse,
-    /// Key-value pairs representing changes to rollup state
-    pub events: Vec<Event>,
-    /// Free-form strings to allow additional output from the rollup
-    pub logs: Vec<String>,
+#[derive(Debug, Clone, Copy)]
+pub enum ConsensusRole {
+    Prover,
+    Sequencer,
+    ProverAndSequencer,
 }
 
 /// A key-value pair representing a change to the rollup state
@@ -114,25 +70,34 @@ pub struct Event {
     pub value: Bytes,
 }
 
-pub struct EndBlockResponse<Addr, MisbehaviorProof> {
-    pub sequencer_updates: Vec<ConsensusSetUpdate<Addr>>,
-    pub prover_updates: Vec<ConsensusSetUpdate<Addr>>,
-    pub misbehavior_proof: Option<MisbehaviorProof>,
+#[derive(Debug, Clone)]
+pub struct ConsensusSetUpdate<Address> {
+    pub address: Address,
+    pub new_role: Option<ConsensusRole>,
 }
 
-pub struct DeliverProofResponse {
-    /// The amount of computational gas used
-    pub gas_proved: i64,
-    /// The amount of storage diesel used
-    pub diesel_proved: i64,
-}
-
-pub struct ConsensusSetUpdate<Addr> {
-    pub owner: Addr,
-    pub power: u64,
-}
-
-pub enum ConsensusMsg<P, B> {
-    Proof(P),
+pub enum ConsensusMessage<B, P> {
     Batch(B),
+    Proof(P),
+}
+
+impl<P: Deser, B: Deser> Deser for ConsensusMessage<B, P> {
+    fn deser(target: &mut &[u8]) -> Result<Self, crate::serial::DeserializationError> {
+        Ok(
+            match *target
+                .iter()
+                .next()
+                .ok_or(DeserializationError::DataTooShort {
+                    expected: 1,
+                    got: 0,
+                })? {
+                0 => Self::Batch(B::deser(&mut &target[1..])?),
+                1 => Self::Proof(P::deser(&mut &target[1..])?),
+                _ => Err(DeserializationError::InvalidTag {
+                    max_allowed: 1,
+                    got: target[0],
+                })?,
+            },
+        )
+    }
 }


### PR DESCRIPTION
- Remove Address, Error and Header types
- Combine begin_batch, deliver_tx, and end_batch methods
- Simplify return type of apply_batch
- Simplify Consensus set management