### PR TITLE
Update serialisation traits

### DIFF
--- a/specs/interfaces/zkvm.md
+++ b/specs/interfaces/zkvm.md
@@ -63,7 +63,7 @@ Expressed in Rust, zkVM would be a `trait` that looked something like the follow
 ```rust
 pub trait ZkVM {
     type CodeCommitment: PartialEq + Clone;
-    type Proof: Encode + Decode;
+    type Proof: Encode + Decode<Error = DeserializationError>;
     type Error;
 
     fn log<T: Encode>(item: T);

--- a/specs/interfaces/zkvm.md
+++ b/specs/interfaces/zkvm.md
@@ -59,14 +59,15 @@ when proof verification fails.
 
 Expressed in Rust, zkVM would be a `trait` that looked something like the following:
 
+
 ```rust
 pub trait ZkVM {
     type CodeCommitment: PartialEq + Clone;
-    type Proof: Serialize + Deserialize;
+    type Proof: Encode + Decode;
     type Error;
 
-    fn log<T: Serialize>(item: T);
-    fn verify<T: Deserialize>(
+    fn log<T: Encode>(item: T);
+    fn verify<T: Decode>(
         proof: Self::Proof,
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error>;

--- a/src/node/db/slot.rs
+++ b/src/node/db/slot.rs
@@ -2,7 +2,7 @@ use super::Result;
 use super::{errors::CodecError, ColumnFamilyName, KeyCodec, Schema, ValueCodec};
 use std::fmt::Debug;
 
-use crate::{serial::Deser, services::da::SlotData};
+use crate::{serial::Decode, services::da::SlotData};
 
 pub const SLOT_CF_NAME: ColumnFamilyName = "slot";
 pub type SlotNumber = u64;
@@ -42,10 +42,10 @@ where
     T: SlotData,
 {
     fn encode_value(&self) -> Result<Vec<u8>> {
-        Ok(self.serialize_to_vec())
+        Ok(self.encode_to_vec())
     }
 
     fn decode_value(mut data: &[u8]) -> Result<Self> {
-        Ok(<T as Deser>::deser(&mut data)?)
+        Ok(<T as Decode>::decode(&mut data)?)
     }
 }

--- a/src/node/db/slot_by_hash.rs
+++ b/src/node/db/slot_by_hash.rs
@@ -3,7 +3,10 @@ use super::{ColumnFamilyName, KeyCodec, Schema, ValueCodec};
 use std::fmt::Debug;
 
 use crate::da::BlockHashTrait;
-use crate::{serial::Deser, services::da::SlotData};
+use crate::{
+    serial::{Decode, Encode},
+    services::da::SlotData,
+};
 
 pub const SLOT_BY_HASH_CF_NAME: ColumnFamilyName = "slot_by_hash";
 
@@ -27,11 +30,11 @@ where
     V: Debug + Send + Sync + 'static + SlotData,
 {
     fn encode_key(&self) -> Result<Vec<u8>> {
-        Ok(self.serialize_to_vec())
+        Ok(self.encode_to_vec())
     }
 
     fn decode_key(mut data: &[u8]) -> Result<Self> {
-        Ok(K::deser(&mut data)?)
+        Ok(K::decode(&mut data)?)
     }
 }
 
@@ -41,10 +44,10 @@ where
     V: Debug + Send + Sync + 'static + SlotData,
 {
     fn encode_value(&self) -> Result<Vec<u8>> {
-        Ok(self.serialize_to_vec())
+        Ok(self.encode_to_vec())
     }
 
     fn decode_value(mut data: &[u8]) -> Result<Self> {
-        Ok(<V as Deser>::deser(&mut data)?)
+        Ok(<V as Decode>::decode(&mut data)?)
     }
 }

--- a/src/node/db/slot_by_hash.rs
+++ b/src/node/db/slot_by_hash.rs
@@ -3,10 +3,7 @@ use super::{ColumnFamilyName, KeyCodec, Schema, ValueCodec};
 use std::fmt::Debug;
 
 use crate::da::BlockHashTrait;
-use crate::{
-    serial::{Decode, Encode},
-    services::da::SlotData,
-};
+use crate::{serial::Decode, services::da::SlotData};
 
 pub const SLOT_BY_HASH_CF_NAME: ColumnFamilyName = "slot_by_hash";
 

--- a/src/node/services/da.rs
+++ b/src/node/services/da.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-use crate::serial::{Deser, Serialize};
+use crate::serial::{Decode, Encode};
 
 // TODO: Rename to clarify distinction with DaApp
 /// A DaService is the local side of an RPC connection talking to node of the DA layer
@@ -27,4 +27,4 @@ pub trait DaService {
     // TODO: Consider adding the send_transaction method
     // fn send_transaction(tx: Self::Transaction, sender: Self::Address)
 }
-pub trait SlotData: Serialize + Deser + PartialEq {}
+pub trait SlotData: Encode + Decode + PartialEq {}

--- a/src/node/services/da.rs
+++ b/src/node/services/da.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-use crate::serial::{Decode, Encode};
+use crate::serial::{Decode, DeserializationError, Encode};
 
 // TODO: Rename to clarify distinction with DaApp
 /// A DaService is the local side of an RPC connection talking to node of the DA layer
@@ -27,4 +27,4 @@ pub trait DaService {
     // TODO: Consider adding the send_transaction method
     // fn send_transaction(tx: Self::Transaction, sender: Self::Address)
 }
-pub trait SlotData: Encode + Decode + PartialEq {}
+pub trait SlotData: Encode + Decode<Error = DeserializationError> + PartialEq {}

--- a/src/state_machine/core/run.rs
+++ b/src/state_machine/core/run.rs
@@ -1,7 +1,7 @@
 use crate::{
-    core::traits::{BatchTrait, BlockheaderTrait, CanonicalHash},
+    core::traits::{BlockheaderTrait, CanonicalHash},
     da::{BlobTransactionTrait, DaLayerTrait},
-    serial::Deser,
+    serial::Decode,
     state_machine::env,
     stf::{ConsensusMessage, StateTransitionFunction},
     zk::traits::{ProofTrait, RecursiveProofInput, ZkVM},
@@ -103,7 +103,7 @@ impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Rollup<DaLayer, App> {
 
         let mut state_tracker = self.app.begin_slot();
         for tx in relevant_txs {
-            match ConsensusMessage::deser(&mut tx.data().as_ref()).unwrap() {
+            match ConsensusMessage::decode(&mut tx.data().as_ref()).unwrap() {
                 ConsensusMessage::Batch(batch) => {
                     if current_sequencers.allows(tx.sender()) {
                         match self.app.apply_batch(

--- a/src/state_machine/core/traits.rs
+++ b/src/state_machine/core/traits.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use crate::serial::{Decode, Encode};
+use crate::serial::{Decode, DeserializationError, Encode};
 
 // NOTE: When naming traits, we use the naming convention below:
 // *Trait IFF there's an associated type that would otherwise have the same name
@@ -15,7 +15,7 @@ pub trait CanonicalHash {
     fn hash(&self) -> Self::Output;
 }
 
-pub trait BatchTrait: PartialEq + Debug + Encode + Decode {
+pub trait BatchTrait: PartialEq + Debug + Encode + Decode<Error = DeserializationError> {
     type Header: BlockheaderTrait;
     type Transaction: TransactionTrait;
     fn header(&self) -> &Self::Header;

--- a/src/state_machine/core/traits.rs
+++ b/src/state_machine/core/traits.rs
@@ -24,7 +24,11 @@ pub trait BatchTrait: PartialEq + Debug + Encode + Decode<Error = Deserializatio
 }
 
 pub trait TransactionTrait:
-    PartialEq + Debug + CanonicalHash<Output = Self::Hash> + Encode + Decode
+    PartialEq
+    + Debug
+    + CanonicalHash<Output = Self::Hash>
+    + Encode
+    + Decode<Error = DeserializationError>
 {
     type Hash: AsRef<[u8]>;
 }

--- a/src/state_machine/core/traits.rs
+++ b/src/state_machine/core/traits.rs
@@ -1,6 +1,6 @@
 use core::fmt::Debug;
 
-use crate::serial::{Deser, Serialize};
+use crate::serial::{Decode, Encode};
 
 // NOTE: When naming traits, we use the naming convention below:
 // *Trait IFF there's an associated type that would otherwise have the same name
@@ -15,7 +15,7 @@ pub trait CanonicalHash {
     fn hash(&self) -> Self::Output;
 }
 
-pub trait BatchTrait: PartialEq + Debug + Serialize + Deser {
+pub trait BatchTrait: PartialEq + Debug + Encode + Decode {
     type Header: BlockheaderTrait;
     type Transaction: TransactionTrait;
     fn header(&self) -> &Self::Header;
@@ -24,7 +24,7 @@ pub trait BatchTrait: PartialEq + Debug + Serialize + Deser {
 }
 
 pub trait TransactionTrait:
-    PartialEq + Debug + CanonicalHash<Output = Self::Hash> + Serialize + Deser
+    PartialEq + Debug + CanonicalHash<Output = Self::Hash> + Encode + Decode
 {
     type Hash: AsRef<[u8]>;
 }

--- a/src/state_machine/core/types.rs
+++ b/src/state_machine/core/types.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 
 use crate::{
     da::DaLayerTrait,
-    serial::{Decode, Encode},
+    serial::{Decode, DeserializationError, Encode},
     stf::{ConsensusSetUpdate, StateTransitionFunction},
 };
 
@@ -42,7 +42,7 @@ impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Encode for RollupHeade
     }
 }
 impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Decode for RollupHeader<DaLayer, App> {
-    type Error = crate::serial::DeserializationError;
+    type Error = DeserializationError;
     fn decode(_target: &mut &[u8]) -> Result<Self, Self::Error> {
         todo!()
     }

--- a/src/state_machine/core/types.rs
+++ b/src/state_machine/core/types.rs
@@ -37,12 +37,13 @@ impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> RollupHeader<DaLayer, 
 }
 
 impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Encode for RollupHeader<DaLayer, App> {
-    fn encode(&self, target: &mut impl std::io::Write) {
+    fn encode(&self, _target: &mut impl std::io::Write) {
         todo!()
     }
 }
 impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Decode for RollupHeader<DaLayer, App> {
-    fn decode(target: &mut &[u8]) -> Result<Self, crate::serial::DeserializationError> {
+    type Error = crate::serial::DeserializationError;
+    fn decode(_target: &mut &[u8]) -> Result<Self, Self::Error> {
         todo!()
     }
 }

--- a/src/state_machine/core/types.rs
+++ b/src/state_machine/core/types.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 
 use crate::{
     da::DaLayerTrait,
-    serial::{Deser, Serialize},
+    serial::{Decode, Encode},
     stf::{ConsensusSetUpdate, StateTransitionFunction},
 };
 
@@ -36,13 +36,13 @@ impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> RollupHeader<DaLayer, 
     }
 }
 
-impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Serialize for RollupHeader<DaLayer, App> {
-    fn serialize(&self, target: &mut impl std::io::Write) {
+impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Encode for RollupHeader<DaLayer, App> {
+    fn encode(&self, target: &mut impl std::io::Write) {
         todo!()
     }
 }
-impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Deser for RollupHeader<DaLayer, App> {
-    fn deser(target: &mut &[u8]) -> Result<Self, crate::serial::DeserializationError> {
+impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Decode for RollupHeader<DaLayer, App> {
+    fn decode(target: &mut &[u8]) -> Result<Self, crate::serial::DeserializationError> {
         todo!()
     }
 }

--- a/src/state_machine/da.rs
+++ b/src/state_machine/da.rs
@@ -1,5 +1,5 @@
 use crate::core::traits::{AddressTrait, BlockheaderTrait};
-use crate::serial::{Decode, Encode};
+use crate::serial::{Decode, DeserializationError, Encode};
 use core::fmt::Debug;
 
 /// A DaLayer implements the logic required to create a zk proof that some data
@@ -53,4 +53,7 @@ pub trait BlobTransactionTrait<Addr> {
     fn data(&self) -> Self::Data;
 }
 
-pub trait BlockHashTrait: Encode + Decode + PartialEq + Debug {}
+pub trait BlockHashTrait:
+    Encode + Decode<Error = DeserializationError> + PartialEq + Debug
+{
+}

--- a/src/state_machine/da.rs
+++ b/src/state_machine/da.rs
@@ -1,9 +1,5 @@
-use bytes::Buf;
-
-use crate::{
-    core::traits::{self, AddressTrait, BlockheaderTrait},
-    serial::{Deser, Serialize},
-};
+use crate::core::traits::{AddressTrait, BlockheaderTrait};
+use crate::serial::{Decode, Encode};
 use core::fmt::Debug;
 
 /// A DaLayer implements the logic required to create a zk proof that some data
@@ -57,4 +53,4 @@ pub trait BlobTransactionTrait<Addr> {
     fn data(&self) -> Self::Data;
 }
 
-pub trait BlockHashTrait: Serialize + Deser + PartialEq + Debug {}
+pub trait BlockHashTrait: Encode + Decode + PartialEq + Debug {}

--- a/src/state_machine/serial.rs
+++ b/src/state_machine/serial.rs
@@ -23,5 +23,6 @@ pub trait Encode {
 }
 
 pub trait Decode: Sized {
-    fn decode(target: &mut &[u8]) -> Result<Self, DeserializationError>;
+    type Error;
+    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error>;
 }

--- a/src/state_machine/serial.rs
+++ b/src/state_machine/serial.rs
@@ -12,20 +12,16 @@ pub enum DeserializationError {
 // The objective is to not introduce a forcible serde dependency and potentially
 // allow implementers to use rykv or another zero-copy framework. But we
 // need to design that. This will work for now
-pub trait Serialize {
-    fn serialize(&self, target: &mut impl std::io::Write);
-    fn serialize_to_vec(&self) -> Vec<u8> {
+pub trait Encode {
+    fn encode(&self, target: &mut impl std::io::Write);
+
+    fn encode_to_vec(&self) -> Vec<u8> {
         let mut target = Vec::new();
-        self.serialize(&mut target);
+        self.encode(&mut target);
         target
     }
 }
 
-// impl<T: Serialize> Serialize for &T {
-//     fn serialize(&self, target: &mut Vec<u8>) {
-//         (*self).serialize(target);
-//     }
-// }
-pub trait Deser: Sized {
-    fn deser(target: &mut &[u8]) -> Result<Self, DeserializationError>;
+pub trait Decode: Sized {
+    fn decode(target: &mut &[u8]) -> Result<Self, DeserializationError>;
 }

--- a/src/state_machine/serial.rs
+++ b/src/state_machine/serial.rs
@@ -12,6 +12,8 @@ pub enum DeserializationError {
 // The objective is to not introduce a forcible serde dependency and potentially
 // allow implementers to use rykv or another zero-copy framework. But we
 // need to design that. This will work for now
+
+/// Trait used to express encoding relationships.
 pub trait Encode {
     fn encode(&self, target: &mut impl std::io::Write);
 
@@ -22,7 +24,9 @@ pub trait Encode {
     }
 }
 
+/// Trait used to express decoding relationships.
 pub trait Decode: Sized {
     type Error;
+
     fn decode(target: &mut &[u8]) -> Result<Self, Self::Error>;
 }

--- a/src/state_machine/stf.rs
+++ b/src/state_machine/stf.rs
@@ -79,12 +79,10 @@ pub enum ConsensusMessage<B, P> {
     Proof(P),
 }
 
-impl<
-        P: Decode<Error = crate::serial::DeserializationError>,
-        B: Decode<Error = crate::serial::DeserializationError>,
-    > Decode for ConsensusMessage<B, P>
+impl<P: Decode<Error = DeserializationError>, B: Decode<Error = DeserializationError>> Decode
+    for ConsensusMessage<B, P>
 {
-    type Error = crate::serial::DeserializationError;
+    type Error = DeserializationError;
     fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
         Ok(
             match *target

--- a/src/state_machine/stf.rs
+++ b/src/state_machine/stf.rs
@@ -16,7 +16,7 @@ pub trait StateTransitionFunction {
     /// A batch of transactions. Also known as a "block" in most systems: we use
     /// the term batch in this context to avoid ambiguity with DA layer blocks
     type Batch: BatchTrait<Transaction = Self::Transaction>;
-    type Proof: Decode;
+    type Proof: Decode<Error = DeserializationError>;
 
     /// A proof that the sequencer has misbehaved. For example, this could be a merkle proof of a transaction
     /// with an invalid signature
@@ -79,8 +79,13 @@ pub enum ConsensusMessage<B, P> {
     Proof(P),
 }
 
-impl<P: Decode, B: Decode> Decode for ConsensusMessage<B, P> {
-    fn decode(target: &mut &[u8]) -> Result<Self, crate::serial::DeserializationError> {
+impl<
+        P: Decode<Error = crate::serial::DeserializationError>,
+        B: Decode<Error = crate::serial::DeserializationError>,
+    > Decode for ConsensusMessage<B, P>
+{
+    type Error = crate::serial::DeserializationError;
+    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
         Ok(
             match *target
                 .iter()

--- a/src/state_machine/zk/traits.rs
+++ b/src/state_machine/zk/traits.rs
@@ -16,7 +16,7 @@ pub trait ZkVM {
 }
 
 pub trait ProofTrait<VM: ZkVM + ?Sized> {
-    type Output: Encode + Decode;
+    type Output: Encode + Decode<Error = DeserializationError>;
     /// Verify the proof, deserializing the result if successful.
     fn verify(self, code_commitment: &VM::CodeCommitment) -> Result<Self::Output, VM::Error>;
 }

--- a/src/state_machine/zk/traits.rs
+++ b/src/state_machine/zk/traits.rs
@@ -41,7 +41,8 @@ impl<Vm: ZkVM<CodeCommitment = C>, C: Encode, T: Encode> Encode for RecursivePro
     }
 }
 impl<Vm: ZkVM, T> Decode for RecursiveProofOutput<Vm, T> {
-    fn decode(target: &mut &[u8]) -> Result<Self, DeserializationError> {
+    type Error = DeserializationError;
+    fn decode(_target: &mut &[u8]) -> Result<Self, DeserializationError> {
         todo!()
     }
 }


### PR DESCRIPTION
Changes in this PR:
1. The `Serialize & Deser` traits are renamed to `Encode & Decode`.
2. A new associated type Error is defined in the `Decode` trait. This way every de-serializable type can have a custom error type.