### PR TITLE
Impl Encode/Decode for smart pointers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ proptest =  { version = "1.0.0", optional = true }
 
 [features]
 fuzzing = ["proptest"]
+sync = []

--- a/src/node/db/errors.rs
+++ b/src/node/db/errors.rs
@@ -10,6 +10,8 @@ pub enum CodecError {
     DeserializationError(#[from] DeserializationError),
     #[error(transparent)]
     Wrapped(#[from] anyhow::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }
 
 pub fn convert_to_codec_error(e: impl Into<anyhow::Error>) -> CodecError {


### PR DESCRIPTION
- Implement Encode for all type that impl `Deref<T> where T: Encode`
- Implement Decode for `Rc<T> where T: Decode`
- Implement Decode for `Arc<T> where T: Decode` if feature `sync` is enabled
- Add `IoError` variant to `CodecError`