### PR TITLE
Remove jmt (fixed); Add EventKey and EventValue types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 bytes = "1.2.1"
 sha2 = "0.10.6"
-jmt = { git  = "https://github.com/penumbra-zone/jmt.git", rev = "18eb03cf053d15799ee3aa0c09b56c9f44485175" }
 
 anyhow = "1.0.68"
 thiserror = "1.0.38"

--- a/src/state_machine/serial.rs
+++ b/src/state_machine/serial.rs
@@ -35,11 +35,10 @@ pub trait Decode: Sized {
     fn decode(target: &mut &[u8]) -> Result<Self, Self::Error>;
 }
 
-// Automatically implement encode for smart pointers
-impl<T, U> Encode for T
+#[cfg(feature = "sync")]
+impl<T> Encode for Arc<T>
 where
-    T: Deref<Target = U>,
-    U: Encode,
+    T: Encode,
 {
     fn encode(&self, target: &mut impl std::io::Write) {
         self.deref().encode(target)
@@ -58,6 +57,15 @@ where
     }
 }
 
+impl<T> Encode for Rc<T>
+where
+    T: Encode,
+{
+    fn encode(&self, target: &mut impl std::io::Write) {
+        self.deref().encode(target)
+    }
+}
+
 impl<T, E> Decode for Rc<T>
 where
     T: Decode<Error = E>,
@@ -66,5 +74,67 @@ where
 
     fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
         Ok(Rc::new(T::decode(target)?))
+    }
+}
+
+impl<T: Encode> Encode for Vec<T> {
+    fn encode(&self, target: &mut impl std::io::Write) {
+        target
+            .write_all(&(self.len() as u64).to_le_bytes())
+            .expect("Serialization should not fail");
+        for item in self.iter() {
+            item.encode(target)
+        }
+    }
+}
+
+impl<T: Decode<Error = E>, E> Decode for Vec<T>
+where
+    DeserializationError: From<E>,
+{
+    type Error = DeserializationError;
+
+    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
+        if target.len() < 8 {
+            return Err(DeserializationError::DataTooShort {
+                expected: 8,
+                got: target.len(),
+            });
+        }
+        let mut serialized_len = [0u8; 8];
+        serialized_len.copy_from_slice(&target[..8]);
+        let len: u64 = u64::from_le_bytes(serialized_len);
+        *target = &mut &target[8..];
+
+        let mut out = Vec::new();
+        for _ in 0..len {
+            out.push(T::decode(target)?)
+        }
+        Ok(out)
+    }
+}
+
+impl<T, U> Encode for (T, U)
+where
+    T: Encode,
+    U: Encode,
+{
+    fn encode(&self, target: &mut impl std::io::Write) {
+        self.0.encode(target);
+        self.1.encode(target)
+    }
+}
+
+impl<T, U, E1, E2> Decode for (T, U)
+where
+    T: Decode<Error = E1>,
+    U: Decode<Error = E2>,
+    DeserializationError: From<E1>,
+    DeserializationError: From<E2>,
+{
+    type Error = DeserializationError;
+
+    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
+        Ok((T::decode(target)?, U::decode(target)?))
     }
 }

--- a/src/state_machine/serial.rs
+++ b/src/state_machine/serial.rs
@@ -35,10 +35,11 @@ pub trait Decode: Sized {
     fn decode(target: &mut &[u8]) -> Result<Self, Self::Error>;
 }
 
-#[cfg(feature = "sync")]
-impl<T> Encode for Arc<T>
+// Automatically implement encode for smart pointers
+impl<T, U> Encode for T
 where
-    T: Encode,
+    T: Deref<Target = U>,
+    U: Encode,
 {
     fn encode(&self, target: &mut impl std::io::Write) {
         self.deref().encode(target)
@@ -57,15 +58,6 @@ where
     }
 }
 
-impl<T> Encode for Rc<T>
-where
-    T: Encode,
-{
-    fn encode(&self, target: &mut impl std::io::Write) {
-        self.deref().encode(target)
-    }
-}
-
 impl<T, E> Decode for Rc<T>
 where
     T: Decode<Error = E>,
@@ -74,67 +66,5 @@ where
 
     fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
         Ok(Rc::new(T::decode(target)?))
-    }
-}
-
-impl<T: Encode> Encode for Vec<T> {
-    fn encode(&self, target: &mut impl std::io::Write) {
-        target
-            .write_all(&(self.len() as u64).to_le_bytes())
-            .expect("Serialization should not fail");
-        for item in self.iter() {
-            item.encode(target)
-        }
-    }
-}
-
-impl<T: Decode<Error = E>, E> Decode for Vec<T>
-where
-    DeserializationError: From<E>,
-{
-    type Error = DeserializationError;
-
-    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
-        if target.len() < 8 {
-            return Err(DeserializationError::DataTooShort {
-                expected: 8,
-                got: target.len(),
-            });
-        }
-        let mut serialized_len = [0u8; 8];
-        serialized_len.copy_from_slice(&target[..8]);
-        let len: u64 = u64::from_le_bytes(serialized_len);
-        *target = &mut &target[8..];
-
-        let mut out = Vec::new();
-        for _ in 0..len {
-            out.push(T::decode(target)?)
-        }
-        Ok(out)
-    }
-}
-
-impl<T, U> Encode for (T, U)
-where
-    T: Encode,
-    U: Encode,
-{
-    fn encode(&self, target: &mut impl std::io::Write) {
-        self.0.encode(target);
-        self.1.encode(target)
-    }
-}
-
-impl<T, U, E1, E2> Decode for (T, U)
-where
-    T: Decode<Error = E1>,
-    U: Decode<Error = E2>,
-    DeserializationError: From<E1>,
-    DeserializationError: From<E2>,
-{
-    type Error = DeserializationError;
-
-    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
-        Ok((T::decode(target)?, U::decode(target)?))
     }
 }

--- a/src/state_machine/stf.rs
+++ b/src/state_machine/stf.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 
 use crate::{
     core::traits::{BatchTrait, TransactionTrait},
-    serial::{Decode, DeserializationError},
+    serial::{Decode, DeserializationError, Encode},
 };
 
 /// An address on the DA layer. Opaque to the StateTransitionFunction
@@ -64,8 +64,41 @@ pub enum ConsensusRole {
 
 /// A key-value pair representing a change to the rollup state
 pub struct Event {
-    pub key: Bytes,
-    pub value: Bytes,
+    pub key: EventKey,
+    pub value: EventValue,
+}
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EventKey(Bytes);
+
+impl Encode for EventKey {
+    fn encode(&self, target: &mut impl std::io::Write) {
+        todo!()
+    }
+}
+
+impl Decode for EventKey {
+    type Error = DeserializationError;
+
+    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct EventValue(Bytes);
+
+impl Encode for EventValue {
+    fn encode(&self, target: &mut impl std::io::Write) {
+        todo!()
+    }
+}
+
+impl Decode for EventValue {
+    type Error = DeserializationError;
+
+    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
+        todo!()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/state_machine/stf.rs
+++ b/src/state_machine/stf.rs
@@ -67,11 +67,29 @@ pub struct Event {
     pub key: EventKey,
     pub value: EventValue,
 }
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+
+impl Encode for Event {
+    fn encode(&self, target: &mut impl std::io::Write) {
+        self.key.encode(target);
+        self.value.encode(target);
+    }
+}
+
+impl Decode for Event {
+    type Error = DeserializationError;
+
+    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
+        Ok(Self {
+            key: EventKey::decode(target)?,
+            value: EventValue::decode(target)?,
+        })
+    }
+}
+
 pub struct EventKey(Bytes);
 
 impl Encode for EventKey {
-    fn encode(&self, target: &mut impl std::io::Write) {
+    fn encode(&self, _target: &mut impl std::io::Write) {
         todo!()
     }
 }
@@ -79,7 +97,7 @@ impl Encode for EventKey {
 impl Decode for EventKey {
     type Error = DeserializationError;
 
-    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
+    fn decode(_target: &mut &[u8]) -> Result<Self, Self::Error> {
         todo!()
     }
 }
@@ -88,7 +106,7 @@ impl Decode for EventKey {
 pub struct EventValue(Bytes);
 
 impl Encode for EventValue {
-    fn encode(&self, target: &mut impl std::io::Write) {
+    fn encode(&self, _target: &mut impl std::io::Write) {
         todo!()
     }
 }
@@ -96,7 +114,7 @@ impl Encode for EventValue {
 impl Decode for EventValue {
     type Error = DeserializationError;
 
-    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
+    fn decode(_target: &mut &[u8]) -> Result<Self, Self::Error> {
         todo!()
     }
 }

--- a/src/state_machine/stf.rs
+++ b/src/state_machine/stf.rs
@@ -63,6 +63,7 @@ pub enum ConsensusRole {
 }
 
 /// A key-value pair representing a change to the rollup state
+#[derive(Debug, PartialEq)]
 pub struct Event {
     pub key: EventKey,
     pub value: EventValue,
@@ -86,6 +87,7 @@ impl Decode for Event {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EventKey(Bytes);
 
 impl Encode for EventKey {


### PR DESCRIPTION
The previous commit failed to remove penumbra's `jmt` from the `Cargo.toml` file. This PR fixes that issue, and adds new types for EventKey and EventValue.