### PR TITLE
Loosen trait bound on BobTransactionTrait::Data from AsRef<[u8]> to Buf

### DIFF
--- a/src/state_machine/da.rs
+++ b/src/state_machine/da.rs
@@ -1,3 +1,5 @@
+use bytes::Buf;
+
 use crate::core::traits::{AddressTrait, BlockheaderTrait};
 use crate::serial::{Decode, DeserializationError, Encode};
 use core::fmt::Debug;
@@ -47,7 +49,7 @@ pub trait DaLayerTrait {
 }
 
 pub trait BlobTransactionTrait<Addr> {
-    type Data: AsRef<[u8]>;
+    type Data: Buf;
 
     fn sender(&self) -> Addr;
     fn data(&self) -> Self::Data;


### PR DESCRIPTION
This relaxation makes it easier to implement efficient share decoding inside Jupiter, without changing the intent of the trait.