### PR TITLE
Split Decode trait to allow zero-copy deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 bytes = "1.2.1"
 sha2 = "0.10.6"
-borsh = "0.10.0"
+borsh = { version = "0.10.0", features = ["rc"]}
 
 anyhow = "1.0.68"
 thiserror = "1.0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 bytes = "1.2.1"
 sha2 = "0.10.6"
+borsh = "0.10.0"
 
 anyhow = "1.0.68"
 thiserror = "1.0.38"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,5 @@ pub use state_machine::*;
 
 mod node;
 pub use node::*;
+
+pub use borsh::maybestd;

--- a/src/state_machine/core/crypto/hash.rs
+++ b/src/state_machine/core/crypto/hash.rs
@@ -1,10 +1,11 @@
+use borsh::{BorshDeserialize, BorshSerialize};
 use sha2::{Digest, Sha256};
 
 pub type DefaultHash = Sha2Hash;
 
 /// The output of a sha2-256 hash
 ///
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize)]
 pub struct Sha2Hash(pub [u8; 32]);
 
 impl AsRef<[u8]> for Sha2Hash {

--- a/src/state_machine/core/run.rs
+++ b/src/state_machine/core/run.rs
@@ -3,7 +3,7 @@ use bytes::Buf;
 use crate::{
     core::traits::{BlockheaderTrait, CanonicalHash},
     da::{BlobTransactionTrait, DaLayerTrait},
-    serial::{Decode, DecodeBorrowed},
+    serial::DecodeBorrowed,
     state_machine::env,
     stf::{ConsensusMessage, StateTransitionFunction},
     zk::traits::{ProofTrait, RecursiveProofInput, ZkVM},

--- a/src/state_machine/core/run.rs
+++ b/src/state_machine/core/run.rs
@@ -3,7 +3,7 @@ use bytes::Buf;
 use crate::{
     core::traits::{BlockheaderTrait, CanonicalHash},
     da::{BlobTransactionTrait, DaLayerTrait},
-    serial::Decode,
+    serial::{Decode, DecodeBorrowed},
     state_machine::env,
     stf::{ConsensusMessage, StateTransitionFunction},
     zk::traits::{ProofTrait, RecursiveProofInput, ZkVM},
@@ -108,7 +108,7 @@ impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Rollup<DaLayer, App> {
             let mut data = tx.data();
             let len = data.remaining();
             let data = data.copy_to_bytes(len);
-            match ConsensusMessage::decode(&mut &data[..]).unwrap() {
+            match ConsensusMessage::decode_from_slice(&mut &data[..]).unwrap() {
                 ConsensusMessage::Batch(batch) => {
                     if current_sequencers.allows(tx.sender()) {
                         match self.app.apply_batch(

--- a/src/state_machine/core/types.rs
+++ b/src/state_machine/core/types.rs
@@ -1,10 +1,7 @@
-use borsh::{BorshDeserialize, BorshSerialize};
-use bytes::{Buf, Bytes};
-
 use crate::{
     da::DaLayerTrait,
     maybestd::rc::Rc,
-    serial::{Decode, DecodeBorrowed, DeserializationError, Encode},
+    serial::{Decode, DecodeBorrowed, Encode},
     stf::{ConsensusSetUpdate, StateTransitionFunction},
 };
 
@@ -33,7 +30,7 @@ pub struct RollupHeader<DaLayer: DaLayerTrait, App: StateTransitionFunction> {
 }
 
 impl<D: DaLayerTrait, A: StateTransitionFunction> Encode for RollupHeader<D, A> {
-    fn encode(&self, target: &mut impl std::io::Write) {
+    fn encode(&self, _target: &mut impl std::io::Write) {
         todo!()
     }
 }
@@ -41,7 +38,7 @@ impl<D: DaLayerTrait, A: StateTransitionFunction> Encode for RollupHeader<D, A> 
 impl<D: DaLayerTrait, A: StateTransitionFunction> Decode for RollupHeader<D, A> {
     type Error = ();
 
-    fn decode<R: std::io::Read>(target: &mut R) -> Result<Self, <Self as Decode>::Error> {
+    fn decode<R: std::io::Read>(_target: &mut R) -> Result<Self, <Self as Decode>::Error> {
         todo!()
     }
 }
@@ -49,7 +46,7 @@ impl<D: DaLayerTrait, A: StateTransitionFunction> Decode for RollupHeader<D, A> 
 impl<'de, D: DaLayerTrait, A: StateTransitionFunction> DecodeBorrowed<'de> for RollupHeader<D, A> {
     type Error = ();
 
-    fn decode_from_slice(target: &'de [u8]) -> Result<Self, Self::Error> {
+    fn decode_from_slice(_target: &'de [u8]) -> Result<Self, Self::Error> {
         todo!()
     }
 }

--- a/src/state_machine/core/types.rs
+++ b/src/state_machine/core/types.rs
@@ -1,8 +1,10 @@
-use bytes::Bytes;
+use borsh::{BorshDeserialize, BorshSerialize};
+use bytes::{Buf, Bytes};
 
 use crate::{
     da::DaLayerTrait,
-    serial::{Decode, DeserializationError, Encode},
+    maybestd::rc::Rc,
+    serial::{Decode, DecodeBorrowed, DeserializationError, Encode},
     stf::{ConsensusSetUpdate, StateTransitionFunction},
 };
 
@@ -30,20 +32,30 @@ pub struct RollupHeader<DaLayer: DaLayerTrait, App: StateTransitionFunction> {
     pub prev_hash: DefaultHash,
 }
 
-impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> RollupHeader<DaLayer, App> {
-    pub fn hash(&self) -> DefaultHash {
+impl<D: DaLayerTrait, A: StateTransitionFunction> Encode for RollupHeader<D, A> {
+    fn encode(&self, target: &mut impl std::io::Write) {
         todo!()
     }
 }
 
-impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Encode for RollupHeader<DaLayer, App> {
-    fn encode(&self, _target: &mut impl std::io::Write) {
+impl<D: DaLayerTrait, A: StateTransitionFunction> Decode for RollupHeader<D, A> {
+    type Error = ();
+
+    fn decode<R: std::io::Read>(target: &mut R) -> Result<Self, <Self as Decode>::Error> {
         todo!()
     }
 }
-impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> Decode for RollupHeader<DaLayer, App> {
-    type Error = DeserializationError;
-    fn decode(_target: &mut &[u8]) -> Result<Self, Self::Error> {
+
+impl<'de, D: DaLayerTrait, A: StateTransitionFunction> DecodeBorrowed<'de> for RollupHeader<D, A> {
+    type Error = ();
+
+    fn decode_from_slice(target: &'de [u8]) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl<DaLayer: DaLayerTrait, App: StateTransitionFunction> RollupHeader<DaLayer, App> {
+    pub fn hash(&self) -> DefaultHash {
         todo!()
     }
 }
@@ -100,14 +112,14 @@ impl<Addr: PartialEq> ConsensusParticipantRoot<Addr> {
         }
     }
 
-    pub fn process_update(&mut self, _updates: ConsensusSetUpdate<Bytes>) {
+    pub fn process_update(&mut self, _updates: ConsensusSetUpdate<Rc<Vec<u8>>>) {
         match self {
             ConsensusParticipantRoot::Anyone => todo!(),
             ConsensusParticipantRoot::Centralized(_) => todo!(),
             ConsensusParticipantRoot::Registered(_) => todo!(),
         }
     }
-    pub fn process_updates(&mut self, _updates: Vec<ConsensusSetUpdate<Bytes>>) {
+    pub fn process_updates(&mut self, _updates: Vec<ConsensusSetUpdate<Rc<Vec<u8>>>>) {
         // for item in vec.map(|| to_address).then(...)
         match self {
             ConsensusParticipantRoot::Anyone => todo!(),

--- a/src/state_machine/serial.rs
+++ b/src/state_machine/serial.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 // use borsh::maybestd::io::Error as StdError;
 use borsh::{
     maybestd::{self, io::Read},
-    BorshDeserialize,
+    BorshDeserialize, BorshSerialize,
 };
 
 use thiserror::Error;
@@ -35,7 +35,7 @@ pub trait Encode {
 ///
 ///
 /// For example, one could implement Decode using serde_json:
-///```no_run
+///```ignore
 /// impl<T> Decode for T where T: DeserializeOwned + for<'de> DecodeBorrowed<'de>  {
 ///     type Error = serde_json::Error;
 ///
@@ -54,7 +54,7 @@ pub trait Decode: Sized + for<'de> DecodeBorrowed<'de> {
 /// Supports zero-copy deserialization.
 ///
 /// For example, one could implement DecodeBorrowed using serde_json:
-/// ```no_run
+/// ```ignore
 /// impl<'de, T> DecodeBorrowed<'de> for T where T: Deserialize<'de> {
 ///     type Error = serde_json::Error;
 ///
@@ -66,6 +66,12 @@ pub trait Decode: Sized + for<'de> DecodeBorrowed<'de> {
 pub trait DecodeBorrowed<'de>: Sized {
     type Error: core::fmt::Debug;
     fn decode_from_slice(target: &'de [u8]) -> Result<Self, Self::Error>;
+}
+
+impl<T: BorshSerialize> Encode for T {
+    fn encode(&self, target: &mut impl std::io::Write) {
+        self.serialize(target).expect("Serialization is infallible");
+    }
 }
 
 impl<T: BorshDeserialize> Decode for T {

--- a/src/state_machine/serial.rs
+++ b/src/state_machine/serial.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "sync")]
 use std::sync::Arc;
-use std::{ops::Deref, rc::Rc};
 
 // use borsh::maybestd::io::Error as StdError;
 use borsh::{

--- a/src/state_machine/serial.rs
+++ b/src/state_machine/serial.rs
@@ -2,6 +2,16 @@
 use std::sync::Arc;
 use std::{ops::Deref, rc::Rc};
 
+// use borsh::maybestd::io::Error as StdError;
+use borsh::{
+    maybestd::{self, io::Read},
+    BorshDeserialize,
+};
+
+use serde::{
+    de::{DeserializeOwned, Visitor},
+    Deserialize,
+};
 use thiserror::Error;
 
 #[derive(Debug, PartialEq, Error)]
@@ -11,11 +21,6 @@ pub enum DeserializationError {
     #[error("Invalid enum tag. Only tags 0-{max_allowed:} are valid, got {got:}")]
     InvalidTag { max_allowed: u8, got: u8 },
 }
-
-// TODO: do this in a sensible/generic way
-// The objective is to not introduce a forcible serde dependency and potentially
-// allow implementers to use rykv or another zero-copy framework. But we
-// need to design that. This will work for now
 
 /// Trait used to express encoding relationships.
 pub trait Encode {
@@ -28,43 +33,58 @@ pub trait Encode {
     }
 }
 
-/// Trait used to express decoding relationships.
-pub trait Decode: Sized {
+/// Decode a type from an arbitrary reader.
+///
+/// Decoding cannot be zero-copy, since zero-copy deserialization depends on the liftime of the input.
+/// Types that support zero-copy deserialization implement `DecodeBorrowed` only.
+///
+///
+/// For example, one could implement Decode using serde_json:
+///```no_run
+/// impl<T> Decode for T where T: DeserializeOwned + for<'de> DecodeBorrowed<'de>  {
+///     type Error = serde_json::Error;
+///
+///     fn decode<R: Read>(target: R) -> Result<Self, Self::Error> {
+///         serde_json::from_reader(target)
+///     }
+/// }
+/// ```
+pub trait Decode: Sized + for<'de> DecodeBorrowed<'de> {
     type Error;
-
-    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error>;
+    fn decode<R: Read>(target: &mut R) -> Result<Self, <Self as Decode>::Error>;
 }
 
-// Automatically implement encode for smart pointers
-impl<T, U> Encode for T
-where
-    T: Deref<Target = U>,
-    U: Encode,
-{
-    fn encode(&self, target: &mut impl std::io::Write) {
-        self.deref().encode(target)
+/// Decode a type from a slice of bytes with a known lifetime, tying
+/// the lifetime of the deserialized value to the lifetime of the input.
+/// Supports zero-copy deserialization.
+///
+/// For example, one could implement DecodeBorrowed using serde_json:
+/// ```no_run
+/// impl<'de, T> DecodeBorrowed<'de> for T where T: Deserialize<'de> {
+///     type Error = serde_json::Error;
+///
+///     fn decode_from_slice(target: &'de [u8]) -> Result<Self, Self::Error> {
+///         serde_json::from_slice(target)
+///     }
+/// }
+/// ```
+pub trait DecodeBorrowed<'de>: Sized {
+    type Error;
+    fn decode_from_slice(target: &'de [u8]) -> Result<Self, Self::Error>;
+}
+
+impl<T: BorshDeserialize> Decode for T {
+    type Error = maybestd::io::Error;
+
+    fn decode<R: Read>(target: &mut R) -> Result<Self, <Self as Decode>::Error> {
+        T::deserialize_reader(&mut target)
     }
 }
 
-#[cfg(feature = "sync")]
-impl<T, E> Decode for Arc<T>
-where
-    T: Decode<Error = E>,
-{
-    type Error = E;
+impl<'de, T: BorshDeserialize> DecodeBorrowed<'de> for T {
+    type Error = maybestd::io::Error;
 
-    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
-        Ok(Arc::new(T::decode(target)?))
-    }
-}
-
-impl<T, E> Decode for Rc<T>
-where
-    T: Decode<Error = E>,
-{
-    type Error = E;
-
-    fn decode(target: &mut &[u8]) -> Result<Self, Self::Error> {
-        Ok(Rc::new(T::decode(target)?))
+    fn decode_from_slice(target: &'de [u8]) -> Result<Self, Self::Error> {
+        T::deserialize(&mut &target)
     }
 }

--- a/src/state_machine/serial.rs
+++ b/src/state_machine/serial.rs
@@ -8,10 +8,6 @@ use borsh::{
     BorshDeserialize,
 };
 
-use serde::{
-    de::{DeserializeOwned, Visitor},
-    Deserialize,
-};
 use thiserror::Error;
 
 #[derive(Debug, PartialEq, Error)]
@@ -50,7 +46,7 @@ pub trait Encode {
 /// }
 /// ```
 pub trait Decode: Sized + for<'de> DecodeBorrowed<'de> {
-    type Error;
+    type Error: core::fmt::Debug;
     fn decode<R: Read>(target: &mut R) -> Result<Self, <Self as Decode>::Error>;
 }
 
@@ -69,7 +65,7 @@ pub trait Decode: Sized + for<'de> DecodeBorrowed<'de> {
 /// }
 /// ```
 pub trait DecodeBorrowed<'de>: Sized {
-    type Error;
+    type Error: core::fmt::Debug;
     fn decode_from_slice(target: &'de [u8]) -> Result<Self, Self::Error>;
 }
 
@@ -77,7 +73,7 @@ impl<T: BorshDeserialize> Decode for T {
     type Error = maybestd::io::Error;
 
     fn decode<R: Read>(target: &mut R) -> Result<Self, <Self as Decode>::Error> {
-        T::deserialize_reader(&mut target)
+        T::deserialize_reader(target)
     }
 }
 
@@ -85,6 +81,6 @@ impl<'de, T: BorshDeserialize> DecodeBorrowed<'de> for T {
     type Error = maybestd::io::Error;
 
     fn decode_from_slice(target: &'de [u8]) -> Result<Self, Self::Error> {
-        T::deserialize(&mut &target)
+        T::deserialize(&mut &target[..])
     }
 }

--- a/src/state_machine/stf.rs
+++ b/src/state_machine/stf.rs
@@ -3,7 +3,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::{
     core::traits::{BatchTrait, TransactionTrait},
-    serial::{Decode, DecodeBorrowed, DeserializationError, Encode},
+    serial::{Decode, DecodeBorrowed, DeserializationError},
 };
 
 /// An address on the DA layer. Opaque to the StateTransitionFunction

--- a/src/state_machine/zk/traits.rs
+++ b/src/state_machine/zk/traits.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
-use crate::serial::{Decode, DeserializationError, Encode};
+use crate::serial::{Decode, Encode};
 
 /// A proof that a program was executed in a zkVM.
 pub trait ZkVM {
@@ -40,5 +40,6 @@ pub struct RecursiveProofOutput<Vm: ZkVM, T> {
 
 // TODO!
 mod risc0 {
+    #[allow(unused)]
     struct MethodId([u8; 32]);
 }


### PR DESCRIPTION
- Create DecodeBorrowed trait, which ties the liftime of its output to the lifetime of its input. This allows for borrow-based deserialization (aka zero-copy).
- Create Decode trait, whose output is not tied to its input lifetime.
- Implement DecodeBorrowed + Decode in terms of Borsch