### PR TITLE
Fix demo-rollup restart issue

### DIFF
--- a/full-node/db/sov-schema-db/src/lib.rs
+++ b/full-node/db/sov-schema-db/src/lib.rs
@@ -20,7 +20,7 @@ use metrics::{
     SCHEMADB_BATCH_PUT_LATENCY_SECONDS, SCHEMADB_DELETES, SCHEMADB_GET_BYTES,
     SCHEMADB_GET_LATENCY_SECONDS, SCHEMADB_PUT_BYTES,
 };
-use rocksdb::{ColumnFamilyDescriptor, ReadOptions};
+use rocksdb::{ColumnFamilyDescriptor, IteratorMode, ReadOptions};
 use std::{collections::HashMap, path::Path, sync::Mutex};
 use tracing::info;
 
@@ -305,6 +305,10 @@ impl DB {
         rocksdb::checkpoint::Checkpoint::new(&self.inner)?.create_checkpoint(path)?;
         Ok(())
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.iterator(IteratorMode::Start).next().is_none()
+    }
 }
 
 /// For now we always use synchronous writes. This makes sure that once the operation returns
@@ -388,7 +392,7 @@ pub mod temppath {
         }
     }
 
-    impl std::convert::AsRef<Path> for TempPath {
+    impl AsRef<Path> for TempPath {
         fn as_ref(&self) -> &Path {
             self.path()
         }

--- a/module-system/sov-state/src/storage.rs
+++ b/module-system/sov-state/src/storage.rs
@@ -111,6 +111,10 @@ pub trait Storage: Clone {
         state_accesses: OrderedReadsAndWrites,
         witness: &Self::Witness,
     ) -> Result<[u8; 32], anyhow::Error>;
+
+    /// Indicates if storage is empty or not.
+    /// Useful during initialization
+    fn is_empty(&self) -> bool;
 }
 
 // Used only in tests.

--- a/module-system/sov-state/src/zk_storage.rs
+++ b/module-system/sov-state/src/zk_storage.rs
@@ -91,4 +91,9 @@ impl<S: MerkleProofSpec> Storage for ZkStorage<S> {
 
         Ok(new_root.0)
     }
+
+    // ZK Storage is never empty
+    fn is_empty(&self) -> bool {
+        false
+    }
 }


### PR DESCRIPTION
# Description
Adds `is_empty` method to `Storage` trait so it can be checked during initialization.

## Linked Issues
- Fixes #340 

## Testing
Added unit tests with restart lifecycle

## Docs
Trait documentation has been updated
