### PR TITLE
Change `State` API: `StorageValue::new(..)` takes a reference

### DIFF
--- a/examples/demo-nft-module/README.md
+++ b/examples/demo-nft-module/README.md
@@ -238,12 +238,12 @@ impl<C: Context> NonFungibleToken<C> {
         config: &<Self as sov_modules_api::Module>::Config,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<()> {
-        self.admin.set(config.admin.clone(), working_set);
+        self.admin.set(&config.admin, working_set);
         for (id, owner) in config.owners.iter() {
             if self.owners.get(id, working_set).is_some() {
                 bail!("Token id {} already exists", id);
             }
-            self.owners.set(id, owner.clone(), working_set);
+            self.owners.set(id, owner, working_set);
         }
         Ok(())
     }
@@ -268,7 +268,7 @@ impl<C: Context> NonFungibleToken<C> {
             bail!("Token with id {} already exists", id);
         }
 
-        self.owners.set(&id, context.sender().clone(), working_set);
+        self.owners.set(&id, context.sender(), working_set);
 
         working_set.add_event("NFT mint", &format!("A token with id {id} was minted"));
         Ok(CallResponse::default())
@@ -290,7 +290,7 @@ impl<C: Context> NonFungibleToken<C> {
         if &token_owner != context.sender() {
             bail!("Only token owner can transfer token");
         }
-        self.owners.set(&id, to, working_set);
+        self.owners.set(&id, &to, working_set);
         working_set.add_event(
             "NFT transfer",
             &format!("A token with id {id} was transferred"),

--- a/examples/demo-nft-module/src/call.rs
+++ b/examples/demo-nft-module/src/call.rs
@@ -36,7 +36,7 @@ impl<C: Context> NonFungibleToken<C> {
             bail!("Token with id {} already exists", id);
         }
 
-        self.owners.set(&id, context.sender().clone(), working_set);
+        self.owners.set(&id, context.sender(), working_set);
 
         working_set.add_event("NFT mint", &format!("A token with id {id} was minted"));
         Ok(CallResponse::default())
@@ -58,7 +58,7 @@ impl<C: Context> NonFungibleToken<C> {
         if &token_owner != context.sender() {
             bail!("Only token owner can transfer token");
         }
-        self.owners.set(&id, to, working_set);
+        self.owners.set(&id, &to, working_set);
         working_set.add_event(
             "NFT transfer",
             &format!("A token with id {id} was transferred"),

--- a/examples/demo-nft-module/src/genesis.rs
+++ b/examples/demo-nft-module/src/genesis.rs
@@ -9,12 +9,12 @@ impl<C: Context> NonFungibleToken<C> {
         config: &<Self as sov_modules_api::Module>::Config,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<()> {
-        self.admin.set(config.admin.clone(), working_set);
+        self.admin.set(&config.admin, working_set);
         for (id, owner) in config.owners.iter() {
             if self.owners.get(id, working_set).is_some() {
                 bail!("Token id {} already exists", id);
             }
-            self.owners.set(id, owner.clone(), working_set);
+            self.owners.set(id, owner, working_set);
         }
         Ok(())
     }

--- a/module-system/module-implementations/examples/sov-election/src/call.rs
+++ b/module-system/module-implementations/examples/sov-election/src/call.rs
@@ -30,7 +30,7 @@ impl<C: sov_modules_api::Context> Election<C> {
         self.exit_if_candidates_already_set(working_set)?;
 
         let candidates = candidate_names.into_iter().map(Candidate::new).collect();
-        self.candidates.set(candidates, working_set);
+        self.candidates.set(&candidates, working_set);
         working_set.add_event("Election: set_candidates", "Candidate was set");
 
         Ok(CallResponse::default())
@@ -48,7 +48,7 @@ impl<C: sov_modules_api::Context> Election<C> {
         self.exit_if_voter_already_set(&voter_address, working_set)?;
 
         self.allowed_voters
-            .set(&voter_address, Voter::fresh(), working_set);
+            .set(&voter_address, &Voter::fresh(), working_set);
 
         working_set.add_event(
             "Election: add_voter",
@@ -80,7 +80,7 @@ impl<C: sov_modules_api::Context> Election<C> {
             .checked_add(1)
             .ok_or(anyhow!("Vote count overflow"))?;
 
-        self.number_of_votes.set(new_number_of_votes, working_set);
+        self.number_of_votes.set(&new_number_of_votes, working_set);
         self.exit_if_frozen(working_set)?;
 
         let voter = self
@@ -91,7 +91,7 @@ impl<C: sov_modules_api::Context> Election<C> {
             Voter::Voted => bail!("Voter tried voting a second time!"),
             Voter::Fresh => {
                 self.allowed_voters
-                    .set(context.sender(), Voter::voted(), working_set);
+                    .set(context.sender(), &Voter::voted(), working_set);
 
                 let mut candidates = self.candidates.get_or_err(working_set)?;
 
@@ -105,7 +105,7 @@ impl<C: sov_modules_api::Context> Election<C> {
                     .checked_add(1)
                     .ok_or(anyhow!("Vote count overflow"))?;
 
-                self.candidates.set(candidates, working_set);
+                self.candidates.set(&candidates, working_set);
 
                 working_set.add_event(
                     "Election: make_vote",
@@ -123,7 +123,7 @@ impl<C: sov_modules_api::Context> Election<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
         self.exit_if_not_admin(context, working_set)?;
-        self.is_frozen.set(true, working_set);
+        self.is_frozen.set(&true, working_set);
         working_set.add_event("Election: freeze_election", "Election was frozen");
         Ok(CallResponse::default())
     }

--- a/module-system/module-implementations/examples/sov-election/src/genesis.rs
+++ b/module-system/module-implementations/examples/sov-election/src/genesis.rs
@@ -8,8 +8,8 @@ impl<C: sov_modules_api::Context> Election<C> {
         config: &<Self as sov_modules_api::Module>::Config,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<()> {
-        self.admin.set(config.admin.clone(), working_set);
-        self.is_frozen.set(false, working_set);
+        self.admin.set(&config.admin, working_set);
+        self.is_frozen.set(&false, working_set);
 
         Ok(())
     }

--- a/module-system/module-implementations/examples/sov-value-setter/src/call.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/call.rs
@@ -36,7 +36,7 @@ impl<C: sov_modules_api::Context> ValueSetter<C> {
         }
 
         // This is how we set a new value:
-        self.value.set(new_value, working_set);
+        self.value.set(&new_value, working_set);
         working_set.add_event("set", &format!("value_set: {new_value:?}"));
 
         Ok(CallResponse::default())

--- a/module-system/module-implementations/examples/sov-value-setter/src/genesis.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/genesis.rs
@@ -9,7 +9,7 @@ impl<C: sov_modules_api::Context> ValueSetter<C> {
         admin_config: &<Self as sov_modules_api::Module>::Config,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<()> {
-        self.admin.set(admin_config.admin.clone(), working_set);
+        self.admin.set(&admin_config.admin, working_set);
         Ok(())
     }
 }

--- a/module-system/module-implementations/integration-tests/tests/nested_modules_tests.rs
+++ b/module-system/module-implementations/integration-tests/tests/nested_modules_tests.rs
@@ -23,8 +23,8 @@ pub mod module_a {
         pub fn update(&mut self, key: &str, value: &str, working_set: &mut WorkingSet<C::Storage>) {
             working_set.add_event("module A", "update");
             self.state_1_a
-                .set(&key.to_owned(), value.to_owned(), working_set);
-            self.state_2_a.set(value.to_owned(), working_set)
+                .set(&key.to_owned(), &value.to_owned(), working_set);
+            self.state_2_a.set(&value.to_owned(), working_set)
         }
     }
 }
@@ -48,7 +48,7 @@ pub mod module_b {
         pub fn update(&mut self, key: &str, value: &str, working_set: &mut WorkingSet<C::Storage>) {
             working_set.add_event("module B", "update");
             self.state_1_b
-                .set(&key.to_owned(), value.to_owned(), working_set);
+                .set(&key.to_owned(), &value.to_owned(), working_set);
             self.mod_1_a.update("key_from_b", value, working_set);
         }
     }

--- a/module-system/module-implementations/module-template/src/call.rs
+++ b/module-system/module-implementations/module-template/src/call.rs
@@ -24,7 +24,7 @@ impl<C: sov_modules_api::Context> ExampleModule<C> {
         _context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<sov_modules_api::CallResponse> {
-        self.value.set(new_value, working_set);
+        self.value.set(&new_value, working_set);
         working_set.add_event("set", &format!("value_set: {new_value:?}"));
 
         Ok(CallResponse::default())

--- a/module-system/module-implementations/sov-accounts/src/call.rs
+++ b/module-system/module-implementations/sov-accounts/src/call.rs
@@ -36,9 +36,9 @@ impl<C: sov_modules_api::Context> Accounts<C> {
         signature.verify(&new_pub_key, UPDATE_ACCOUNT_MSG)?;
 
         // Update the public key (account data remains the same).
-        self.accounts.set(&new_pub_key, account, working_set);
+        self.accounts.set(&new_pub_key, &account, working_set);
         self.public_keys
-            .set(context.sender(), new_pub_key, working_set);
+            .set(context.sender(), &new_pub_key, working_set);
         Ok(CallResponse::default())
     }
 

--- a/module-system/module-implementations/sov-accounts/src/genesis.rs
+++ b/module-system/module-implementations/sov-accounts/src/genesis.rs
@@ -33,10 +33,10 @@ impl<C: sov_modules_api::Context> Accounts<C> {
             nonce: 0,
         };
 
-        self.accounts
-            .set(&pub_key, new_account.clone(), working_set);
+        self.accounts.set(&pub_key, &new_account, working_set);
 
-        self.public_keys.set(&default_address, pub_key, working_set);
+        self.public_keys
+            .set(&default_address, &pub_key, working_set);
         Ok(new_account)
     }
 

--- a/module-system/module-implementations/sov-accounts/src/hooks.rs
+++ b/module-system/module-implementations/sov-accounts/src/hooks.rs
@@ -38,7 +38,7 @@ impl<C: Context> TxHooks for Accounts<C> {
     ) -> anyhow::Result<()> {
         let mut account = self.accounts.get_or_err(tx.pub_key(), working_set)?;
         account.nonce += 1;
-        self.accounts.set(tx.pub_key(), account, working_set);
+        self.accounts.set(tx.pub_key(), &account, working_set);
         Ok(())
     }
 }

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -84,7 +84,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
             );
         }
 
-        self.tokens.set(&token_address, token, working_set);
+        self.tokens.set(&token_address, &token, working_set);
         Ok(CallResponse::default())
     }
 
@@ -107,7 +107,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
         let mut token = self.tokens.get_or_err(&coins.token_address, working_set)?;
         token.burn(context.sender(), coins.amount, working_set)?;
         token.total_supply -= coins.amount;
-        self.tokens.set(&coins.token_address, token, working_set);
+        self.tokens.set(&coins.token_address, &token, working_set);
 
         Ok(CallResponse::default())
     }
@@ -121,7 +121,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
     ) -> Result<CallResponse> {
         let mut token = self.tokens.get_or_err(&coins.token_address, working_set)?;
         token.mint(context.sender(), &minter_address, coins.amount, working_set)?;
-        self.tokens.set(&coins.token_address, token, working_set);
+        self.tokens.set(&coins.token_address, &token, working_set);
 
         Ok(CallResponse::default())
     }
@@ -134,7 +134,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
     ) -> Result<CallResponse> {
         let mut token = self.tokens.get_or_err(&token_address, working_set)?;
         token.freeze(context.sender())?;
-        self.tokens.set(&token_address, token, working_set);
+        self.tokens.set(&token_address, &token, working_set);
 
         Ok(CallResponse::default())
     }

--- a/module-system/module-implementations/sov-bank/src/genesis.rs
+++ b/module-system/module-implementations/sov-bank/src/genesis.rs
@@ -27,7 +27,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
                 bail!("Token address already exists");
             }
 
-            self.tokens.set(&token_address, token, working_set);
+            self.tokens.set(&token_address, &token, working_set);
         }
         Ok(())
     }

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -51,8 +51,8 @@ impl<C: sov_modules_api::Context> Token<C> {
         // We can't overflow here because the sum must be smaller or eq to `total_supply` which is u64.
         let to_balance = self.balances.get(to, working_set).unwrap_or_default() + amount;
 
-        self.balances.set(from, from_balance, working_set);
-        self.balances.set(to, to_balance, working_set);
+        self.balances.set(from, &from_balance, working_set);
+        self.balances.set(to, &to_balance, working_set);
 
         Ok(())
     }
@@ -64,7 +64,7 @@ impl<C: sov_modules_api::Context> Token<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<()> {
         let new_balance = self.check_balance(from, amount, working_set)?;
-        self.balances.set(from, new_balance, working_set);
+        self.balances.set(from, &new_balance, working_set);
 
         Ok(())
     }
@@ -101,7 +101,7 @@ impl<C: sov_modules_api::Context> Token<C> {
                 "Account Balance overflow in the mint method of bank module",
             ))?;
 
-        self.balances.set(minter_address, to_balance, working_set);
+        self.balances.set(minter_address, &to_balance, working_set);
         self.total_supply = self
             .total_supply
             .checked_add(amount)
@@ -149,7 +149,7 @@ impl<C: sov_modules_api::Context> Token<C> {
 
         let mut total_supply: Option<u64> = Some(0);
         for (address, balance) in address_and_balances.iter() {
-            balances.set(address, *balance, working_set);
+            balances.set(address, balance, working_set);
             total_supply = total_supply.and_then(|ts| ts.checked_add(*balance));
         }
 

--- a/module-system/module-implementations/sov-prover-incentives/src/call.rs
+++ b/module-system/module-implementations/sov-prover-incentives/src/call.rs
@@ -46,7 +46,7 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
             .get(prover, working_set)
             .unwrap_or_default();
         let total_balance = old_balance + bond_amount;
-        self.bonded_provers.set(prover, total_balance, working_set);
+        self.bonded_provers.set(prover, &total_balance, working_set);
 
         // Emit the bonding event
         working_set.add_event(
@@ -90,7 +90,7 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
                 .transfer_from(&self.address, context.sender(), coins, working_set)?;
 
             // Update our internal tracking of the total bonded amount for the sender.
-            self.bonded_provers.set(context.sender(), 0, working_set);
+            self.bonded_provers.set(context.sender(), &0, working_set);
 
             // Emit the unbonding event
             working_set.add_event(
@@ -126,7 +126,7 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
 
         // Lock the prover's bond amount.
         self.bonded_provers
-            .set(context.sender(), old_balance - minimum_bond, working_set);
+            .set(context.sender(), &(old_balance - minimum_bond), working_set);
 
         // Don't return an error for invalid proofs - those are expected and shouldn't cause reverts.
         if let Ok(_public_outputs) =
@@ -139,7 +139,7 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
             // TODO: reward the prover with newly minted tokens as appropriate based on gas fees.
             // https://github.com/Sovereign-Labs/sovereign/issues/271
             self.bonded_provers
-                .set(context.sender(), old_balance, working_set);
+                .set(context.sender(), &old_balance, working_set);
 
             working_set.add_event(
                 "processed_valid_proof",

--- a/module-system/module-implementations/sov-prover-incentives/src/genesis.rs
+++ b/module-system/module-implementations/sov-prover-incentives/src/genesis.rs
@@ -15,15 +15,15 @@ impl<C: sov_modules_api::Context, Vm: Zkvm> ProverIncentives<C, Vm> {
             "At least one prover must be set at genesis!"
         );
 
-        self.minimum_bond.set(config.minimum_bond, working_set);
+        self.minimum_bond.set(&config.minimum_bond, working_set);
         self.commitment_of_allowed_verifier_method.set(
-            crate::StoredCodeCommitment {
+            &crate::StoredCodeCommitment {
                 commitment: config.commitment_of_allowed_verifier_method.clone(),
             },
             working_set,
         );
         self.bonding_token_address
-            .set(config.bonding_token_address.clone(), working_set);
+            .set(&config.bonding_token_address, working_set);
 
         for (prover, bond) in config.initial_provers.iter() {
             self.bond_prover_helper(*bond, prover, working_set)?;

--- a/module-system/module-implementations/sov-sequencer-registry/src/genesis.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/src/genesis.rs
@@ -9,13 +9,11 @@ impl<C: sov_modules_api::Context> Sequencer<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<()> {
         self.seq_rollup_address
-            .set(config.seq_rollup_address.clone(), working_set);
+            .set(&config.seq_rollup_address, working_set);
 
-        self.seq_da_address
-            .set(config.seq_da_address.clone(), working_set);
+        self.seq_da_address.set(&config.seq_da_address, working_set);
 
-        self.coins_to_lock
-            .set(config.coins_to_lock.clone(), working_set);
+        self.coins_to_lock.set(&config.coins_to_lock, working_set);
 
         Ok(())
     }

--- a/module-system/sov-modules-macros/tests/dispatch/derive_dispatch.rs
+++ b/module-system/sov-modules-macros/tests/dispatch/derive_dispatch.rs
@@ -2,7 +2,7 @@ mod modules;
 use modules::{first_test_module, second_test_module};
 use sov_modules_api::Address;
 use sov_modules_api::ModuleInfo;
-use sov_modules_api::{default_context::DefaultContext, Context, Genesis, Module};
+use sov_modules_api::{default_context::DefaultContext, Context, Genesis};
 use sov_modules_macros::{DispatchCall, Genesis, MessageCodec};
 use sov_state::ProverStorage;
 

--- a/module-system/sov-modules-macros/tests/dispatch/modules.rs
+++ b/module-system/sov-modules-macros/tests/dispatch/modules.rs
@@ -30,7 +30,7 @@ pub mod first_test_module {
             _config: &Self::Config,
             working_set: &mut WorkingSet<C::Storage>,
         ) -> Result<(), Error> {
-            self.state_in_first_struct.set(1, working_set);
+            self.state_in_first_struct.set(&1, working_set);
             Ok(())
         }
 
@@ -40,7 +40,7 @@ pub mod first_test_module {
             _context: &Self::Context,
             working_set: &mut WorkingSet<C::Storage>,
         ) -> Result<CallResponse, Error> {
-            self.state_in_first_struct.set(msg, working_set);
+            self.state_in_first_struct.set(&msg, working_set);
             Ok(CallResponse::default())
         }
     }
@@ -74,7 +74,7 @@ pub mod second_test_module {
             _config: &Self::Config,
             working_set: &mut WorkingSet<Ctx::Storage>,
         ) -> Result<(), Error> {
-            self.state_in_second_struct.set(2, working_set);
+            self.state_in_second_struct.set(&2, working_set);
             Ok(())
         }
 
@@ -84,7 +84,7 @@ pub mod second_test_module {
             _context: &Self::Context,
             working_set: &mut WorkingSet<Ctx::Storage>,
         ) -> Result<CallResponse, Error> {
-            self.state_in_second_struct.set(msg, working_set);
+            self.state_in_second_struct.set(&msg, working_set);
             Ok(CallResponse::default())
         }
     }

--- a/module-system/sov-state/README.md
+++ b/module-system/sov-state/README.md
@@ -38,7 +38,7 @@ Module developers can interact with the `WorkingSet`, `StateValue`, and `StateMa
 The above API is used in the following way:
 
 ```Rust
-state.value.set(some_value, working_set);
+state.value.set(&some_value, working_set);
 let maybe_value = state.value.get(working_set);
 
 ```

--- a/module-system/sov-state/src/map.rs
+++ b/module-system/sov-state/src/map.rs
@@ -28,7 +28,7 @@ impl<K: BorshSerialize, V: BorshSerialize + BorshDeserialize> StateMap<K, V> {
     }
 
     /// Inserts a key-value pair into the map.
-    pub fn set<S: Storage>(&self, key: &K, value: V, working_set: &mut WorkingSet<S>) {
+    pub fn set<S: Storage>(&self, key: &K, value: &V, working_set: &mut WorkingSet<S>) {
         working_set.set_value(self.prefix(), key, value)
     }
 

--- a/module-system/sov-state/src/scratchpad.rs
+++ b/module-system/sov-state/src/scratchpad.rs
@@ -251,7 +251,7 @@ impl<S: Storage> WorkingSet<S> {
         &mut self,
         prefix: &Prefix,
         storage_key: &K,
-        value: V,
+        value: &V,
     ) {
         let storage_key = StorageKey::new(prefix, storage_key);
         let storage_value = StorageValue::new(value);

--- a/module-system/sov-state/src/state_tests.rs
+++ b/module-system/sov-state/src/state_tests.rs
@@ -86,7 +86,7 @@ fn create_state_map_and_storage(
     let mut working_set = WorkingSet::new(ProverStorage::with_path(&path).unwrap());
 
     let state_map = StateMap::new(Prefix::new(vec![0]));
-    state_map.set(&key, value, &mut working_set);
+    state_map.set(&key, &value, &mut working_set);
     (state_map, working_set)
 }
 
@@ -132,7 +132,7 @@ fn create_state_value_and_storage(
     let mut working_set = WorkingSet::new(ProverStorage::with_path(&path).unwrap());
 
     let state_value = StateValue::new(Prefix::new(vec![0]));
-    state_value.set(value, &mut working_set);
+    state_value.set(&value, &mut working_set);
     (state_value, working_set)
 }
 
@@ -175,9 +175,9 @@ fn test_witness_roundtrip() {
     let witness: ArrayWitness = {
         let storage = ProverStorage::<DefaultStorageSpec>::with_path(&path).unwrap();
         let mut working_set = WorkingSet::new(storage.clone());
-        state_value.set(11, &mut working_set);
+        state_value.set(&11, &mut working_set);
         let _ = state_value.get(&mut working_set);
-        state_value.set(22, &mut working_set);
+        state_value.set(&22, &mut working_set);
         let (cache_log, witness) = working_set.freeze();
 
         let _ = storage
@@ -189,9 +189,9 @@ fn test_witness_roundtrip() {
     {
         let storage = ZkStorage::<DefaultStorageSpec>::new(EMPTY_ROOT);
         let mut working_set = WorkingSet::with_witness(storage.clone(), witness);
-        state_value.set(11, &mut working_set);
+        state_value.set(&11, &mut working_set);
         let _ = state_value.get(&mut working_set);
-        state_value.set(22, &mut working_set);
+        state_value.set(&22, &mut working_set);
         let (cache_log, witness) = working_set.freeze();
 
         let _ = storage

--- a/module-system/sov-state/src/storage.rs
+++ b/module-system/sov-state/src/storage.rs
@@ -65,7 +65,7 @@ pub struct StorageValue {
 }
 
 impl StorageValue {
-    pub fn new<V: BorshSerialize>(value: V) -> Self {
+    pub fn new<V: BorshSerialize>(value: &V) -> Self {
         let encoded_value = value.try_to_vec().unwrap();
         Self {
             value: Arc::new(encoded_value),

--- a/module-system/sov-state/src/value.rs
+++ b/module-system/sov-state/src/value.rs
@@ -42,7 +42,7 @@ impl<V: BorshSerialize + BorshDeserialize> StateValue<V> {
     }
 
     /// Sets a value in the StateValue.
-    pub fn set<S: Storage>(&self, value: V, working_set: &mut WorkingSet<S>) {
+    pub fn set<S: Storage>(&self, value: &V, working_set: &mut WorkingSet<S>) {
         working_set.set_value(self.prefix(), &SingletonKey, value)
     }
 


### PR DESCRIPTION
# Description
This PR modifies the signature of `StorageValue::new(..)`  
from: 
```Rust
impl StorageValue {
    pub fn new<V: BorshSerialize>(value: V) -> Self {
     ...
    }
}
```

to 

```Rust
impl StorageValue {
    pub fn new<V: BorshSerialize>(value: &V) -> Self {
      ...
    }
}
```

This change has eliminated some unnecessary cloning operations from the modules' code.

## Testing
Updated all relevant unit tests
## Docs
Updated relevant docs. 