### PR TITLE
#369 switch mint functionality in bank module to use checked_add instead of simple add which can cause overflow.

### DIFF
--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -100,7 +100,8 @@ impl<C: sov_modules_api::Context> Token<C> {
             .ok_or(anyhow::Error::msg("Overflow"))?;
 
         self.balances.set(minter_address, to_balance, working_set);
-        self.total_supply = self.total_supply
+        self.total_supply = self
+            .total_supply
             .checked_add(amount)
             .ok_or(anyhow::Error::msg("Overflow"))?;
         Ok(())

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -92,13 +92,17 @@ impl<C: sov_modules_api::Context> Token<C> {
             bail!("Attempt to mint frozen token")
         }
         self.is_authorized_minter(sender)?;
-        let to_balance = self
+        let to_balance: Amount = self
             .balances
             .get(minter_address, working_set)
             .unwrap_or_default()
-            + amount;
+            .checked_add(amount)
+            .ok_or(anyhow::Error::msg("Overflow"))?;
+
         self.balances.set(minter_address, to_balance, working_set);
-        self.total_supply += amount;
+        self.total_supply = self.total_supply
+            .checked_add(amount)
+            .ok_or(anyhow::Error::msg("Overflow"))?;
         Ok(())
     }
 

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -97,13 +97,17 @@ impl<C: sov_modules_api::Context> Token<C> {
             .get(minter_address, working_set)
             .unwrap_or_default()
             .checked_add(amount)
-            .ok_or(anyhow::Error::msg("Overflow"))?;
+            .ok_or(anyhow::Error::msg(
+                "Account Balance overflow in the mint method of bank module",
+            ))?;
 
         self.balances.set(minter_address, to_balance, working_set);
         self.total_supply = self
             .total_supply
             .checked_add(amount)
-            .ok_or(anyhow::Error::msg("Overflow"))?;
+            .ok_or(anyhow::Error::msg(
+                "Total Supply overflow in the mint method of bank module",
+            ))?;
         Ok(())
     }
 

--- a/module-system/module-implementations/sov-bank/tests/mint_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/mint_test.rs
@@ -184,4 +184,21 @@ fn mint_token() {
     let supply = query_total_supply(token_address.clone(), &mut working_set);
     assert!(working_set.events().is_empty());
     assert_eq!(Some(120), supply);
+
+    // Overflow test
+    let overflow_mint_message = CallMessage::Mint {
+        coins: Coins {
+            amount: u64::MAX,
+            token_address: token_address.clone(),
+        },
+        minter_address: new_holder.clone(),
+    };
+
+    let minted = bank.call(
+        overflow_mint_message.clone(),
+        &authorized_minter_1_context,
+        &mut working_set,
+    );
+    assert!(minted.is_err());
+    assert_eq!("Overflow", minted.err().unwrap().to_string());
 }


### PR DESCRIPTION
couple of places for mint using "+" has been replaced with checked_add to avoid overflow issues