### PR TITLE
Add `new_signed_tx` to `sov-module-api::transaction::Transaction`

### DIFF
--- a/examples/demo-stf/src/bank_cmd/main.rs
+++ b/examples/demo-stf/src/bank_cmd/main.rs
@@ -104,8 +104,7 @@ impl SerializedTx {
         let sender_address = sender_priv_key.pub_key().to_address();
         let message = Self::serialize_call_message(call_data_path, &sender_address)?;
 
-        let sig = Transaction::<C>::sign(&sender_priv_key, &message, nonce);
-        let tx = Transaction::<C>::new(message, sender_priv_key.pub_key(), sig, nonce);
+        let tx = Transaction::<C>::new_signed_tx(&sender_priv_key, message, nonce);
 
         Ok(SerializedTx {
             raw: RawTx {

--- a/examples/demo-stf/src/tests/data_generation/value_setter_data.rs
+++ b/examples/demo-stf/src/tests/data_generation/value_setter_data.rs
@@ -47,7 +47,6 @@ impl MessageGenerator for ValueSetterMessages {
         _is_last: bool,
     ) -> Transaction<DefaultContext> {
         let message = Runtime::<DefaultContext>::encode_value_setter_call(message);
-        let sig = Transaction::<DefaultContext>::sign(sender, &message, nonce);
-        Transaction::<DefaultContext>::new(message, sender.pub_key(), sig, nonce)
+        Transaction::<DefaultContext>::new_signed_tx(sender, message, nonce)
     }
 }


### PR DESCRIPTION
# Description
Add `fn new_signed_tx(..)` to `sov-module-api::transaction::Transaction`.
This change simplifies testing and ensures that created transaction is correctly signed. 

## Testing
All relevant tests updated.

## Docs
No changes in docs.