### PR TITLE
Fix tests in `sov-modules-macros`

### DIFF
--- a/module-system/sov-modules-macros/tests/dispatch/derive_dispatch.rs
+++ b/module-system/sov-modules-macros/tests/dispatch/derive_dispatch.rs
@@ -2,7 +2,7 @@ mod modules;
 use modules::{first_test_module, second_test_module};
 use sov_modules_api::Address;
 use sov_modules_api::ModuleInfo;
-use sov_modules_api::{default_context::DefaultContext, Context, Genesis, Module};
+use sov_modules_api::{default_context::DefaultContext, Context, Genesis};
 use sov_modules_macros::{DefaultRuntime, DispatchCall, Genesis, MessageCodec};
 use sov_state::ProverStorage;
 

--- a/module-system/sov-modules-macros/tests/dispatch/derive_genesis.rs
+++ b/module-system/sov-modules-macros/tests/dispatch/derive_genesis.rs
@@ -2,7 +2,7 @@ mod modules;
 
 use modules::{first_test_module, second_test_module};
 use sov_modules_api::default_context::DefaultContext;
-use sov_modules_api::{Context, Module, ModuleInfo};
+use sov_modules_api::Context;
 use sov_modules_macros::{DefaultRuntime, DispatchCall, Genesis, MessageCodec};
 use sov_state::ProverStorage;
 

--- a/module-system/sov-modules-macros/tests/module_info/mod_and_state.rs
+++ b/module-system/sov-modules-macros/tests/module_info/mod_and_state.rs
@@ -1,5 +1,5 @@
 use sov_modules_api::default_context::DefaultContext;
-use sov_modules_api::{Context, ModuleInfo};
+use sov_modules_api::Context;
 use sov_modules_macros::ModuleInfo;
 use sov_state::StateMap;
 


### PR DESCRIPTION
# Description
Recently #364 change removed `new` from `ModuleInfo` and in order to instantiate a module there is no more need to import the `ModuleInfo` trait. Another recent change from @citizen-stig made the `cargo check` more strict and the CI started failing. This PR removes unused import. 

## Linked Issues
- Fixes  #364
