### PR TITLE
Allow rpc tests to choose random port

### DIFF
--- a/examples/demo-rollup/src/test_rpc.rs
+++ b/examples/demo-rollup/src/test_rpc.rs
@@ -1,6 +1,8 @@
 use reqwest::header::CONTENT_TYPE;
 use sov_db::ledger_db::{LedgerDB, SlotCommit};
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::Arc;
 
 #[cfg(test)]
 use sov_rollup_interface::mocks::{TestBlock, TestBlockHeader};
@@ -73,7 +75,7 @@ fn populate_ledger(ledger_db: &mut LedgerDB) -> () {
     ledger_db.commit_slot(slot).unwrap()
 }
 
-fn test_helper(data: String, expected: &str, port: u16) {
+fn test_helper(data: String, expected: &str) {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_io()
         .enable_time()
@@ -83,12 +85,8 @@ fn test_helper(data: String, expected: &str, port: u16) {
     rt.block_on(async {
         let (tx_start, rx_start) = oneshot::channel();
         let (tx_end, rx_end) = oneshot::channel();
-        let rpc_config = RpcConfig {
-            bind_host: "127.0.0.1".to_string(),
-            bind_port: port,
-        };
 
-        let address = SocketAddr::new(rpc_config.bind_host.parse().unwrap(), rpc_config.bind_port);
+        let address = SocketAddr::new("127.0.0.1".parse().unwrap(), 0);
 
         // Initialize the ledger database, which stores blocks, transactions, events, etc.
         let tmpdir = tempfile::tempdir().unwrap();
@@ -98,17 +96,33 @@ fn test_helper(data: String, expected: &str, port: u16) {
 
         let ledger_rpc_module = ledger_rpc::get_ledger_rpc::<i32, i32>(ledger_db.clone());
 
+        let actual_port_placeholder: Arc<AtomicU16> = Arc::new(AtomicU16::new(0));
+        let actual_port_placeholder_clone = actual_port_placeholder.clone();
         rt.spawn(async move {
             let server = jsonrpsee::server::ServerBuilder::default()
                 .build([address].as_ref())
                 .await
                 .unwrap();
+            let actual_address = server.local_addr().unwrap();
+            actual_port_placeholder_clone.store(actual_address.port(), Ordering::Relaxed);
             let _server_handle = server.start(ledger_rpc_module).unwrap();
             tx_start.send("server started").unwrap();
             rx_end.await.unwrap();
         });
 
         rx_start.await.unwrap();
+
+        for _ in 0..1000 {
+            if actual_port_placeholder.load(Ordering::Relaxed) != 0 {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        let rpc_config = RpcConfig {
+            bind_host: "127.0.0.1".to_string(),
+            bind_port: actual_port_placeholder.load(Ordering::Relaxed),
+        };
 
         query_test_helper(data, expected, rpc_config).await;
 
@@ -126,19 +140,19 @@ fn test_get_head() {
     let data = r#"{"jsonrpc":"2.0","method":"ledger_getHead","params":[],"id":1}"#.to_string();
     let expected = r#"{"jsonrpc":"2.0","result":{"number":1,"hash":"0xd1231a38586e68d0405dc55ae6775e219f29fff1f7e0c6410d0ac069201e550b","batch_range":{"start":1,"end":3}},"id":1}"#;
 
-    test_helper(data, expected, 12345);
+    test_helper(data, expected);
 }
 
 #[test]
 fn test_get_transactions() {
     let data = r#"{"jsonrpc":"2.0","method":"ledger_getTransactions","params":[[{ "batch_id": 1, "offset": 0}]],"id":1}"#.to_string();
     let expected = r#"{"jsonrpc":"2.0","result":[{"hash":"0x709b55bd3da0f5a838125bd0ee20c5bfdd7caba173912d4281cae816b79a201b","event_range":{"start":1,"end":1},"body":[116,120,49,32,98,111,100,121],"custom_receipt":0}],"id":1}"#;
-    test_helper(data, expected, 12346);
+    test_helper(data, expected);
 
     let data = r#"{"jsonrpc":"2.0","method":"ledger_getTransactions","params":[[{ "batch_id": 1, "offset": 1}]],"id":1}"#
             .to_string();
     let expected = r#"{"jsonrpc":"2.0","result":[{"hash":"0x27ca64c092a959c7edc525ed45e845b1de6a7590d173fd2fad9133c8a779a1e3","event_range":{"start":1,"end":3},"body":[116,120,50,32,98,111,100,121],"custom_receipt":1}],"id":1}"#;
-    test_helper(data, expected, 12346);
+    test_helper(data, expected);
 }
 
 #[test]
@@ -147,30 +161,30 @@ fn test_get_batches() {
         r#"{"jsonrpc":"2.0","method":"ledger_getBatches","params":[[2], "Standard"],"id":1}"#
             .to_string();
     let expected = r#"{"jsonrpc":"2.0","result":[{"hash":"0xf85fe0cb36fdaeca571c896ed476b49bb3c8eff00d935293a8967e1e9a62071e","tx_range":{"start":3,"end":4},"txs":["0x709b55bd3da0f5a838125bd0ee20c5bfdd7caba173912d4281cae816b79a201b"],"custom_receipt":1}],"id":1}"#;
-    test_helper(data, expected, 12347);
+    test_helper(data, expected);
 
     let data = r#"{"jsonrpc":"2.0","method":"ledger_getBatches","params":[[1], "Compact"],"id":1}"#
         .to_string();
     let expected = r#"{"jsonrpc":"2.0","result":[{"hash":"0xb5515a80204963f7db40e98af11aedb49a394b1c7e3d8b5b7a33346b8627444f","tx_range":{"start":1,"end":3},"custom_receipt":0}],"id":1}"#;
-    test_helper(data, expected, 12347);
+    test_helper(data, expected);
 
     let data = r#"{"jsonrpc":"2.0","method":"ledger_getBatches","params":[[0], "Compact"],"id":1}"#
         .to_string();
     let expected = r#"{"jsonrpc":"2.0","result":[null],"id":1}"#;
-    test_helper(data, expected, 12347);
+    test_helper(data, expected);
 }
 
 #[test]
 fn test_get_events() {
     let data = r#"{"jsonrpc":"2.0","method":"ledger_getEvents","params":[1],"id":1}"#.to_string();
     let expected = r#"{"jsonrpc":"2.0","result":[{"key":[101,118,101,110,116,49,95,107,101,121],"value":[101,118,101,110,116,49,95,118,97,108,117,101]}],"id":1}"#;
-    test_helper(data, expected, 12348);
+    test_helper(data, expected);
 
     let data = r#"{"jsonrpc":"2.0","method":"ledger_getEvents","params":[2],"id":1}"#.to_string();
     let expected = r#"{"jsonrpc":"2.0","result":[{"key":[101,118,101,110,116,50,95,107,101,121],"value":[101,118,101,110,116,50,95,118,97,108,117,101]}],"id":1}"#;
-    test_helper(data, expected, 12348);
+    test_helper(data, expected);
 
     let data = r#"{"jsonrpc":"2.0","method":"ledger_getEvents","params":[3],"id":1}"#.to_string();
     let expected = r#"{"jsonrpc":"2.0","result":[null],"id":1}"#;
-    test_helper(data, expected, 12348);
+    test_helper(data, expected);
 }


### PR DESCRIPTION
# Description

In order to faster find flaky tests `flaky-finder` allows to run tests in parallel. But RPC tests have hard coded port, so they fail and clash.

This PR fixes it.