### PR TITLE
ApplyBlobHooks, always call `end_blob_hook`: iteration 2

### DIFF
--- a/examples/demo-stf/src/tests/tx_revert_tests.rs
+++ b/examples/demo-stf/src/tests/tx_revert_tests.rs
@@ -3,9 +3,13 @@ use crate::{
     runtime::Runtime,
     tests::{data_generation::simulate_da_with_bad_serialization, has_tx_events},
 };
+use borsh::BorshSerialize;
+use sov_accounts::query::Response;
+use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{
-    default_context::DefaultContext, default_signature::private_key::DefaultPrivateKey,
+    default_context::DefaultContext, default_signature::private_key::DefaultPrivateKey, PublicKey,
 };
+use sov_modules_stf_template::RawTx;
 use sov_modules_stf_template::{Batch, SequencerOutcome, SlashingReason};
 use sov_rollup_interface::{mocks::MockZkvm, stf::StateTransitionFunction};
 use sov_state::{ProverStorage, WorkingSet};
@@ -46,13 +50,14 @@ fn test_tx_revert() {
             None,
         );
 
-        assert!(
-            matches!(apply_blob_outcome.inner, SequencerOutcome::Rewarded(0),),
-            "Unexpected outcome: Batch exeuction should have succeeded"
+        assert_eq!(
+            SequencerOutcome::Rewarded(0),
+            apply_blob_outcome.inner,
+            "Unexpected outcome: Batch execution should have succeeded",
         );
 
         // Some events were observed
-        assert!(has_tx_events(&apply_blob_outcome));
+        assert!(has_tx_events(&apply_blob_outcome), "No events were taken");
 
         StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
     }
@@ -87,6 +92,96 @@ fn test_tx_revert() {
 }
 
 #[test]
+fn test_nonce_incremented_on_revert() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let path = tempdir.path();
+    let value_setter_admin_private_key = DefaultPrivateKey::generate();
+    let election_admin_private_key = DefaultPrivateKey::generate();
+    let voter = DefaultPrivateKey::generate();
+
+    let config = create_demo_config(
+        SEQUENCER_BALANCE,
+        &value_setter_admin_private_key,
+        &election_admin_private_key,
+    );
+
+    {
+        let mut demo = create_new_demo(path);
+        StateTransitionFunction::<MockZkvm>::init_chain(&mut demo, config);
+        StateTransitionFunction::<MockZkvm>::begin_slot(&mut demo, Default::default());
+
+        let set_candidates_message = Runtime::<DefaultContext>::encode_election_call(
+            sov_election::call::CallMessage::SetCandidates {
+                names: vec!["candidate_1".to_owned(), "candidate_2".to_owned()],
+            },
+        );
+
+        let set_candidates_message = Transaction::<DefaultContext>::new_signed_tx(
+            &election_admin_private_key,
+            set_candidates_message,
+            0,
+        );
+
+        let add_voter_message = Runtime::<DefaultContext>::encode_election_call(
+            sov_election::call::CallMessage::AddVoter(voter.pub_key().to_address()),
+        );
+        let add_voter_message = Transaction::<DefaultContext>::new_signed_tx(
+            &election_admin_private_key,
+            add_voter_message,
+            1,
+        );
+
+        let vote_message = Runtime::<DefaultContext>::encode_election_call(
+            sov_election::call::CallMessage::Vote(100),
+        );
+        let vote_message = Transaction::<DefaultContext>::new_signed_tx(&voter, vote_message, 0);
+
+        let txs = vec![set_candidates_message, add_voter_message, vote_message];
+        let txs = txs
+            .into_iter()
+            .map(|t| RawTx {
+                data: t.try_to_vec().unwrap(),
+            })
+            .collect();
+
+        let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
+            &mut demo,
+            new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
+            None,
+        );
+
+        assert_eq!(
+            SequencerOutcome::Rewarded(0),
+            apply_blob_outcome.inner,
+            "Unexpected outcome: Batch execution should have succeeded",
+        );
+        StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
+    }
+
+    {
+        let runtime = &mut Runtime::<DefaultContext>::default();
+        let storage = ProverStorage::with_path(path).unwrap();
+        let mut working_set = WorkingSet::new(storage);
+
+        // We sent 4 vote messages but one of them is invalid and should be reverted.
+        let resp = runtime.election.number_of_votes(&mut working_set);
+
+        assert_eq!(resp, sov_election::query::GetNbOfVotesResponse::Result(0));
+
+        let nonce = match runtime
+            .accounts
+            .get_account(voter.pub_key(), &mut working_set)
+        {
+            Response::AccountExists { nonce, .. } => nonce,
+            Response::AccountEmpty => 0,
+        };
+
+        // Voter should have its nonce implemented
+        assert_eq!(1, nonce);
+    }
+}
+
+#[test]
 fn test_tx_bad_sig() {
     let tempdir = tempfile::tempdir().unwrap();
     let path = tempdir.path();
@@ -113,8 +208,9 @@ fn test_tx_bad_sig() {
             None,
         );
 
-        assert!(
-            matches!(apply_blob_outcome.inner, SequencerOutcome::Slashed(SlashingReason::StatelessVerificationFailed),),
+        assert_eq!(
+            SequencerOutcome::Slashed(SlashingReason::StatelessVerificationFailed),
+            apply_blob_outcome.inner,
             "Unexpected outcome: Stateless verification should have failed due to invalid signature"
         );
 
@@ -173,8 +269,9 @@ fn test_tx_bad_serialization() {
             None,
         );
 
-        assert!(
-            matches!(apply_blob_outcome.inner, sov_modules_stf_template::SequencerOutcome::Slashed(SlashingReason::InvalidTransactionEncoding)),
+        assert_eq!(
+            SequencerOutcome::Slashed(SlashingReason::InvalidTransactionEncoding),
+            apply_blob_outcome.inner,
             "Unexpected outcome: Stateless verification should have failed due to invalid signature"
         );
 

--- a/examples/demo-stf/src/tests/tx_revert_tests.rs
+++ b/examples/demo-stf/src/tests/tx_revert_tests.rs
@@ -146,7 +146,7 @@ fn test_nonce_incremented_on_revert() {
 
         let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
             &mut demo,
-            new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
+            &mut new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
             None,
         );
 

--- a/module-system/module-implementations/sov-accounts/src/hooks.rs
+++ b/module-system/module-implementations/sov-accounts/src/hooks.rs
@@ -11,24 +11,23 @@ impl<C: Context> TxHooks for Accounts<C> {
 
     fn pre_dispatch_tx_hook(
         &self,
-        tx: Transaction<C>,
+        tx: &Transaction<C>,
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     ) -> anyhow::Result<<Self::Context as Spec>::Address> {
         let pub_key = tx.pub_key().clone();
 
-        let acc = match self.accounts.get(&pub_key, working_set) {
+        let account = match self.accounts.get(&pub_key, working_set) {
             Some(acc) => Ok(acc),
             None => self.create_default_account(pub_key, working_set),
         }?;
 
         let tx_nonce = tx.nonce();
-        let acc_nonce = acc.nonce;
+        let account_nonce = account.nonce;
         anyhow::ensure!(
-            acc_nonce == tx_nonce,
-            "Tx bad nonce, expected: {acc_nonce}, but found: {tx_nonce}",
+            account_nonce == tx_nonce,
+            "Tx bad nonce, expected: {account_nonce}, but found: {tx_nonce}",
         );
-
-        Ok(acc.addr)
+        Ok(account.addr)
     }
 
     fn post_dispatch_tx_hook(

--- a/module-system/sov-modules-stf-template/src/app_template.rs
+++ b/module-system/sov-modules-stf-template/src/app_template.rs
@@ -91,11 +91,10 @@ where
                 "Error: The batch was rejected by the 'begin_blob_hook' hook. Skipping batch without slashing the sequencer: {}",
                 e
             );
-            // TODO: Should it commit?
+            // TODO: will be covered in https://github.com/Sovereign-Labs/sovereign-sdk/issues/421
             self.checkpoint = Some(batch_workspace.revert());
             return Err(ApplyBatchError::Ignored(blob.hash()));
         }
-        let blob_hash = blob.hash();
         batch_workspace = batch_workspace.checkpoint().to_revertable();
 
         // TODO: don't ignore these events: https://github.com/Sovereign-Labs/sovereign/issues/350
@@ -112,7 +111,7 @@ where
                     .end_blob_hook(sequencer_outcome, &mut batch_workspace)
                 {
                     Ok(()) => {
-                        // TODO:Should we save changes after end_blob_hook
+                        // TODO: will be covered in https://github.com/Sovereign-Labs/sovereign-sdk/issues/421
                         self.checkpoint = Some(batch_workspace.checkpoint());
                     }
                     Err(e) => {
@@ -122,7 +121,7 @@ where
                 };
 
                 return Err(ApplyBatchError::Slashed {
-                    hash: blob_hash,
+                    hash: blob.hash(),
                     reason: slashing_reason,
                 });
             }
@@ -193,6 +192,7 @@ where
             // We commit after events have been extracted into receipt.
             batch_workspace = batch_workspace.checkpoint().to_revertable();
 
+            // TODO: `panic` will be covered in https://github.com/Sovereign-Labs/sovereign-sdk/issues/421
             self.runtime
                 .post_dispatch_tx_hook(&tx, &mut batch_workspace)
                 .expect("Impossible happened: error in post_dispatch_tx_hook");
@@ -205,12 +205,13 @@ where
             .runtime
             .end_blob_hook(sequencer_outcome, &mut batch_workspace)
         {
+            // TODO: will be covered in https://github.com/Sovereign-Labs/sovereign-sdk/issues/421
             error!("Failed on `end_blob_hook`: {}", e);
         };
 
         self.checkpoint = Some(batch_workspace.checkpoint());
         Ok(BatchReceipt {
-            batch_hash: blob_hash,
+            batch_hash: blob.hash(),
             tx_receipts,
             inner: sequencer_outcome,
         })

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -24,8 +24,11 @@ pub enum TxEffect {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SequencerOutcome {
+    /// Sequencer receives reward amount in defined token and can withdraw its deposit
     Rewarded(u64),
+    /// Sequencer loses its deposit and receives no reward
     Slashed(SlashingReason),
+    /// Batch was ignored, sequencer deposit left untouched.
     Ignored,
 }
 


### PR DESCRIPTION
# Description

Now `end_blob_hook` is always called 

* Clearer separation of conserns. Now `apply_batch` method solely controls when and where working set is commited or revereted. Stateless checks are kept in separate stateless methos
* Decoding and dispatching are split into 2 different iteration. That should make it less cost efficient to DoS with bad batches. If last transaction of batch cannot be decoded, but previous txs are expensive to dispatch, for example.
* Transaction pre_dispatch_hook now takes reference instead of consuming transaction. This removes extra cloning.


## Linked Issues
- Related to #391 , because it is required for changes in sequencer registry

## Testing
Existing tests hopefully cover the change.

## Docs
Doc strings were updated
