### PR TITLE
Switch to bech32m address encoding

### DIFF
--- a/module-system/module-implementations/sov-accounts/src/tests.rs
+++ b/module-system/module-implementations/sov-accounts/src/tests.rs
@@ -176,13 +176,13 @@ fn test_response_serialization() {
     let json = serde_json::to_string(&response).unwrap();
     assert_eq!(
         json,
-        r#"{"AccountExists":{"addr":"sov1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5z5tpwxqergd3c8g7rusq4vrkje","nonce":123456789}}"#
+        r#"{"AccountExists":{"addr":"sov1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5z5tpwxqergd3c8g7rusqqsn6hm","nonce":123456789}}"#
     );
 }
 
 #[test]
 fn test_response_deserialization() {
-    let json = r#"{"AccountExists":{"addr":"sov1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5z5tpwxqergd3c8g7rusq4vrkje","nonce":123456789}}"#;
+    let json = r#"{"AccountExists":{"addr":"sov1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5z5tpwxqergd3c8g7rusqqsn6hm","nonce":123456789}}"#;
     let response: Response = serde_json::from_str(json).unwrap();
 
     let expected_addr: Vec<u8> = (1..=32).collect();

--- a/module-system/module-implementations/sov-bank/tests/burn_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/burn_test.rs
@@ -119,7 +119,7 @@ fn burn_deployed_tokens() {
     let failed_to_burn = bank.call(burn_message, &minter_context, &mut working_set);
     assert!(failed_to_burn.is_err());
     assert_eq!(
-        "Insufficient funds for sov1h6t805h2vjfzpa3m9n8kyadyng9xf604nhvev8tf5qdg65jh3ruqfckjuq",
+        "Insufficient funds for sov1h6t805h2vjfzpa3m9n8kyadyng9xf604nhvev8tf5qdg65jh3ruquyx7ez",
         failed_to_burn.err().unwrap().to_string()
     );
 

--- a/module-system/module-implementations/sov-bank/tests/transfer_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/transfer_test.rs
@@ -89,7 +89,7 @@ fn transfer_initial_token() {
         assert!(result.is_err());
         let error = result.err().unwrap();
         assert_eq!(
-            "Insufficient funds for sov1h5567we4l0ne5vyrkvqd6jq5qp2cs7sa780vut0vrwr8pytwrzess8mu2s",
+            "Insufficient funds for sov1h5567we4l0ne5vyrkvqd6jq5qp2cs7sa780vut0vrwr8pytwrzes9mts0j",
             error.to_string()
         );
     }

--- a/module-system/sov-modules-api/src/bech32.rs
+++ b/module-system/sov-modules-api/src/bech32.rs
@@ -3,13 +3,13 @@ use bech32::{Error, FromBase32, ToBase32};
 use derive_more::{Display, Into};
 use std::str::FromStr;
 
-pub fn vec_to_bech32(vec: &[u8], hrp: &str) -> Result<String, Error> {
+pub fn vec_to_bech32m(vec: &[u8], hrp: &str) -> Result<String, Error> {
     let data = vec.to_base32();
-    let bech32_addr = bech32::encode(hrp, data, bech32::Variant::Bech32)?;
+    let bech32_addr = bech32::encode(hrp, data, bech32::Variant::Bech32m)?;
     Ok(bech32_addr)
 }
 
-pub fn bech32_to_decoded_vec(bech32_addr: &str) -> Result<(String, Vec<u8>), Error> {
+pub fn bech32m_to_decoded_vec(bech32_addr: &str) -> Result<(String, Vec<u8>), Error> {
     let (hrp, data, _) = bech32::decode(bech32_addr)?;
     let vec = Vec::<u8>::from_base32(&data)?;
     Ok((hrp, vec))
@@ -37,7 +37,7 @@ pub struct AddressBech32 {
 
 impl AddressBech32 {
     pub(crate) fn to_byte_array(&self) -> [u8; 32] {
-        let (_, data) = bech32_to_decoded_vec(&self.value).unwrap();
+        let (_, data) = bech32m_to_decoded_vec(&self.value).unwrap();
 
         if data.len() != 32 {
             panic!("Invalid length {}, should be 32", data.len())
@@ -57,21 +57,21 @@ impl TryFrom<&[u8]> for AddressBech32 {
         if addr.len() != 32 {
             return Err(bech32::Error::InvalidLength);
         }
-        let string = vec_to_bech32(addr, HRP)?;
+        let string = vec_to_bech32m(addr, HRP)?;
         Ok(AddressBech32 { value: string })
     }
 }
 
 impl From<&Address> for AddressBech32 {
     fn from(addr: &Address) -> Self {
-        let string = vec_to_bech32(&addr.addr, HRP).unwrap();
+        let string = vec_to_bech32m(&addr.addr, HRP).unwrap();
         AddressBech32 { value: string }
     }
 }
 
 impl From<Address> for AddressBech32 {
     fn from(addr: Address) -> Self {
-        let string = vec_to_bech32(&addr.addr, HRP).unwrap();
+        let string = vec_to_bech32m(&addr.addr, HRP).unwrap();
         AddressBech32 { value: string }
     }
 }
@@ -96,7 +96,7 @@ impl FromStr for AddressBech32 {
     type Err = Bech32ParseError;
 
     fn from_str(s: &str) -> Result<Self, Bech32ParseError> {
-        let (hrp, _) = bech32_to_decoded_vec(s)?;
+        let (hrp, _) = bech32m_to_decoded_vec(s)?;
 
         if HRP != hrp {
             return Err(Bech32ParseError::WrongHPR(hrp));

--- a/module-system/sov-modules-api/src/serde_address.rs
+++ b/module-system/sov-modules-api/src/serde_address.rs
@@ -41,7 +41,7 @@ mod test {
         assert_eq!(address, deserialized_address);
         assert_eq!(
             deserialized_address.to_string(),
-            "sov1pv9skzctpv9skzctpv9skzctpv9skzctpv9skzctpv9skzctpv9s7q3twy"
+            "sov1pv9skzctpv9skzctpv9skzctpv9skzctpv9skzctpv9skzctpv9stup8tx"
         );
     }
 }

--- a/module-system/sov-modules-api/src/tests.rs
+++ b/module-system/sov-modules-api/src/tests.rs
@@ -5,12 +5,12 @@ use crate::{
 use borsh::{BorshDeserialize, BorshSerialize};
 
 #[test]
-fn test_account_bech32_display() {
+fn test_account_bech32m_display() {
     let expected_addr: Vec<u8> = (1..=32).collect();
     let account = crate::AddressBech32::try_from(expected_addr.as_slice()).unwrap();
     assert_eq!(
         account.to_string(),
-        "sov1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5z5tpwxqergd3c8g7rusq4vrkje"
+        "sov1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5z5tpwxqergd3c8g7rusqqsn6hm"
     );
 }
 


### PR DESCRIPTION
# Description
This PR updates our address encoding from bech32 to bech32m, which has a more robust checksum. See [BIP 350](https://en.bitcoin.it/wiki/BIP_0350#Motivation) for more detail. 

## Testing
Tests are updated
