### PR TITLE
Write slot as atomic batch

### DIFF
--- a/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -205,7 +205,6 @@ impl LedgerDB {
         &self,
         data_to_commit: SlotCommit<S, B, T>,
     ) -> Result<(), anyhow::Error> {
-        // TODO: expose a batch API on the db to commit everything atomically
         // Create a scope to ensure that the lock is released before we commit to the db
         let mut current_item_numbers = {
             let mut next_item_numbers = self.next_item_numbers.lock().unwrap();


### PR DESCRIPTION
# Description
This commit updates the ledger DB so that all components of a slot are written as batch. This should both improve efficiency and eliminate some potential concurrency bugs. 

## Linked Issues
- Related to #417 

## Testing
Existing unit tests pass. cc @theochap @citizen-stig - let's see if we can reproduce the issue from #417 after this change or not

