### PR TITLE
docs: readme edits to demo-rollup

### DIFF
--- a/examples/demo-rollup/README.md
+++ b/examples/demo-rollup/README.md
@@ -145,7 +145,7 @@ $ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method"
 {"jsonrpc":"2.0","result":{"amount":5000},"id":1}
 ```
 
-- params: should be the token address created in step 6
+- params: should be the token address created in step 5
 
 ## Interacting with your Node via RPC
 


### PR DESCRIPTION
# Description
- [x] I think that "params: should be the token address created in step 6" should link to step 5, not 6

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?