### PR TITLE
Fix Jupiter and Sov-CLI bugs

### DIFF
--- a/adapters/celestia/src/verifier/mod.rs
+++ b/adapters/celestia/src/verifier/mod.rs
@@ -236,8 +236,7 @@ impl da::DaVerifier for CelestiaVerifier {
                 let blob_ref = blob.clone();
 
                 let mut blob_iter = blob_ref.data();
-                let mut blob_data = Vec::with_capacity(blob_iter.remaining());
-                blob_data.resize(blob_iter.remaining(), 0);
+                let mut blob_data = vec![0; blob_iter.remaining()];
                 blob_iter.copy_to_slice(blob_data.as_mut_slice());
                 let tx_data = tx.data().acc();
 

--- a/adapters/celestia/src/verifier/mod.rs
+++ b/adapters/celestia/src/verifier/mod.rs
@@ -69,7 +69,9 @@ impl TmHash {
     pub fn inner(&self) -> &[u8; 32] {
         match self.0 {
             tendermint::Hash::Sha256(ref h) => h,
-            tendermint::Hash::None => unreachable!("tendermint::Hash::None should not be possible"),
+            // Hack: when the hash is None, we return a hash of all 255s as a placeholder.
+            // TODO: add special casing for the genesis block at a higher level
+            tendermint::Hash::None => &[255u8; 32],
         }
     }
 }
@@ -235,6 +237,7 @@ impl da::DaVerifier for CelestiaVerifier {
 
                 let mut blob_iter = blob_ref.data();
                 let mut blob_data = Vec::with_capacity(blob_iter.remaining());
+                blob_data.resize(blob_iter.remaining(), 0);
                 blob_iter.copy_to_slice(blob_data.as_mut_slice());
                 let tx_data = tx.data().acc();
 

--- a/examples/demo-rollup/Makefile
+++ b/examples/demo-rollup/Makefile
@@ -98,8 +98,11 @@ build-sov-cli:
 test-serialize-create-token: check-container-running build-sov-cli
 	$(SOV_CLI_REL_PATH) serialize-call ../demo-stf/src/sov-cli/test_data/minter_private_key.json Bank ../demo-stf/src/sov-cli/test_data/create_token.json 0
 
-test-create-token: test-serialize-create-token
-	$(MAKE) submit-txn SERIALIZED_BLOB_PATH=../demo-stf/src/sov-cli/test_data/create_token.dat
+test-build-blob-from-create-token: test-serialize-create-token
+	$(SOV_CLI_REL_PATH) make-blob ../demo-stf/src/sov-cli/test_data/create_token.dat > ../demo-stf/src/sov-cli/test_data/test_blob.dat
+
+test-create-token: test-build-blob-from-create-token
+	$(MAKE) submit-txn SERIALIZED_BLOB_PATH=../demo-stf/src/sov-cli/test_data/test_blob.dat
 
 clean-rollup-db:
 	$(eval path := ./$(shell awk -F'=' '/^path/ {print $$2}' rollup_config.toml | tr -d '[:space:]"\n'))
@@ -109,4 +112,3 @@ clean-rollup-db:
         fi
 	@echo removing rollup database "${path}"
 	rm -rf "${path}"
-

--- a/examples/demo-stf/src/sov-cli/main.rs
+++ b/examples/demo-stf/src/sov-cli/main.rs
@@ -195,8 +195,13 @@ pub fn main() {
             let mut file = File::create(bin_path)
                 .unwrap_or_else(|e| panic!("Unable to crate .dat file: {}", e));
 
-            let raw_contents = hex::encode(serialized.raw.data).as_bytes().to_vec();
-            file.write_all(&raw_contents)
+            let raw_contents = hex::encode(
+                serialized
+                    .raw
+                    .try_to_vec()
+                    .expect("serialization to vec is infallible"),
+            );
+            file.write_all(raw_contents.as_bytes())
                 .unwrap_or_else(|e| panic!("Unable to save .dat file: {}", e));
         }
         Commands::MakeBlob { path_list } => {

--- a/examples/demo-stf/src/sov-cli/main.rs
+++ b/examples/demo-stf/src/sov-cli/main.rs
@@ -184,13 +184,10 @@ fn serialize_call(command: &crate::Commands) -> String {
     } = command
     {
         let serialized =
-            SerializedTx::new(&sender_priv_key_path, &module_name, &call_data_path, *nonce)
+            SerializedTx::new(&sender_priv_key_path, module_name, &call_data_path, *nonce)
                 .unwrap_or_else(|e| panic!("Call message serialization error: {}", e));
 
-        let raw_contents = hex::encode(
-            serialized.raw.data, // .expect("serialization to vec is infallible"),
-        );
-        raw_contents
+        hex::encode(serialized.raw.data)
     } else {
         Default::default()
     }
@@ -443,10 +440,10 @@ mod test {
             None,
         )
         .inner;
-        assert!(
-            matches!(apply_blob_outcome, SequencerOutcome::Rewarded(0)),
-            "Sequencer execution should have succeeded but failed {:?}",
-            apply_blob_outcome
+        assert_eq!(
+            SequencerOutcome::Rewarded(0),
+            apply_blob_outcome,
+            "Sequencer execution should have succeeded but failed",
         );
         StateTransitionFunction::<MockZkvm>::end_slot(demo);
     }


### PR DESCRIPTION
# Description
This PR fixes several bugs related to sequencing and transaction inclusion:
1. The genesis block on Celestia does not have a `prev_hash`, which caused a panic when running on local testnets
2. Jupiter had an erroneous `copy_from_slice` which copied into an empty vec with enough capacity but 0 length. This triggered an assertion when processing blobs
3. The makefile command to submit the `create-token` transaction to Celestia submitted an individual transaction instead of a batch, causing the transaction to be ignored
4. The `sov-cli` had a serialization bug, causing all of its batches to be rejected

