### PR TITLE
Adjust cache for cargo

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     name: check
+    timeout-minutes: 60
     env:
       RUSTFLAGS: -D warnings
       SCCACHE_GHA_ENABLED: "true"
@@ -37,6 +38,7 @@ jobs:
   check-demo-prover:
     runs-on: ubuntu-latest
     name: check demo prover
+    timeout-minutes: 90
     env:
       RUSTFLAGS: -D warnings
       SCCACHE_GHA_ENABLED: "true"
@@ -59,6 +61,7 @@ jobs:
   hack:
     runs-on: ubuntu-latest
     name: features
+    timeout-minutes: 60
     env:
       RUSTFLAGS: -D warnings
       SCCACHE_GHA_ENABLED: "true"
@@ -74,6 +77,7 @@ jobs:
         run: make check-features
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
@@ -85,6 +89,7 @@ jobs:
         run: cargo test
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,9 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-        with:
-          # False, so sccache handles target caching/compilation
-          cache-targets: "false"
       - uses: mozilla-actions/sccache-action@v0.0.3
       - name: Run lint
         run: |
@@ -47,9 +44,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-        with:
-          # False, so sccache handles target caching/compilation
-          cache-targets: "false"
       - uses: mozilla-actions/sccache-action@v0.0.3
       - name: Run cargo check
         run: cd examples/demo-prover && cargo check
@@ -72,9 +66,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-        with:
-          # False, so sccache handles target caching/compilation
-          cache-targets: "false"
       - uses: mozilla-actions/sccache-action@v0.0.3
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
@@ -89,9 +80,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-        with:
-          # False, so sccache handles target caching/compilation
-          cache-targets: "false"
       - uses: mozilla-actions/sccache-action@v0.0.3
       - name: Run cargo test
         run: cargo test
@@ -107,9 +95,6 @@ jobs:
       - name: add llvm component
         run: rustup component add llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
-        with:
-          # False, so sccache handles target caching/compilation
-          cache-targets: "false"
       - uses: mozilla-actions/sccache-action@v0.0.3
       - name: cargo install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,10 +23,11 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v3
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: Swatinem/rust-cache@v2
         with:
-          version: "v0.4.0"
+          # False, so sccache handles target caching/compilation
+          cache-targets: "false"
+      - uses: mozilla-actions/sccache-action@v0.0.3
       - name: Run lint
         run: |
           if ! make lint ; then
@@ -45,10 +46,11 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v3
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: Swatinem/rust-cache@v2
         with:
-          version: "v0.4.0"
+          # False, so sccache handles target caching/compilation
+          cache-targets: "false"
+      - uses: mozilla-actions/sccache-action@v0.0.3
       - name: Run cargo check
         run: cd examples/demo-prover && cargo check
       - name: Run cargo fmt check
@@ -69,8 +71,11 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v3
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # False, so sccache handles target caching/compilation
+          cache-targets: "false"
+      - uses: mozilla-actions/sccache-action@v0.0.3
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
@@ -83,10 +88,11 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v3
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: Swatinem/rust-cache@v2
         with:
-          version: "v0.4.0"
+          # False, so sccache handles target caching/compilation
+          cache-targets: "false"
+      - uses: mozilla-actions/sccache-action@v0.0.3
       - name: Run cargo test
         run: cargo test
   coverage:
@@ -100,8 +106,11 @@ jobs:
           submodules: true
       - name: add llvm component
         run: rustup component add llvm-tools-preview
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # False, so sccache handles target caching/compilation
+          cache-targets: "false"
+      - uses: mozilla-actions/sccache-action@v0.0.3
       - name: cargo install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: cargo generate-lockfile

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean: ## Cleans compiled
 	@cargo clean
 
 test: ## Runs test suite with output from tests printed
-	@cargo test -- --nocapture
+	@cargo test -- --nocapture -Zunstable-options --report-time
 
 install-dev-tools:  ## Installs all necessary cargo helpers
 	cargo install cargo-llvm-cov

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -200,15 +200,16 @@ pub mod test {
 
         let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
-        let some_sequencer: [u8; 32] = [101; 32];
+        let some_sequencer: [u8; 32] = [102; 32];
         let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
             &mut demo,
             &mut new_test_blob(Batch { txs }, &some_sequencer),
             None,
         );
 
-        assert!(
-            matches!(apply_blob_outcome.inner, SequencerOutcome::Ignored),
+        assert_eq!(
+            SequencerOutcome::Ignored,
+            apply_blob_outcome.inner,
             "Batch should have been skipped due to unknown sequencer"
         );
 

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -200,7 +200,7 @@ pub mod test {
 
         let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
-        let some_sequencer: [u8; 32] = [102; 32];
+        let some_sequencer: [u8; 32] = [110; 32];
         let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
             &mut demo,
             &mut new_test_blob(Batch { txs }, &some_sequencer),

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -200,7 +200,7 @@ pub mod test {
 
         let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
-        let some_sequencer: [u8; 32] = [110; 32];
+        let some_sequencer: [u8; 32] = [112; 32];
         let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
             &mut demo,
             &mut new_test_blob(Batch { txs }, &some_sequencer),

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -200,7 +200,7 @@ pub mod test {
 
         let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
-        let some_sequencer: [u8; 32] = [121; 32];
+        let some_sequencer: [u8; 32] = [111; 32];
         let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
             &mut demo,
             &mut new_test_blob(Batch { txs }, &some_sequencer),

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -153,9 +153,10 @@ pub mod test {
                 None,
             )
             .inner;
-            assert!(
-                matches!(apply_blob_outcome, SequencerOutcome::Rewarded(0),),
-                "Sequencer execution should have succeeded but failed "
+            assert_eq!(
+                SequencerOutcome::Rewarded(0),
+                apply_blob_outcome,
+                "Sequencer execution should have succeeded but failed",
             );
         }
 

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -98,9 +98,10 @@ pub mod test {
             None,
         );
 
-        assert!(
-            matches!(apply_blob_outcome.inner, SequencerOutcome::Rewarded(0),),
-            "Sequencer execution should have succeeded but failed "
+        assert_eq!(
+            SequencerOutcome::Rewarded(0),
+            apply_blob_outcome.inner,
+            "Sequencer execution should have succeeded but failed"
         );
 
         assert!(has_tx_events(&apply_blob_outcome),);

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -200,7 +200,7 @@ pub mod test {
 
         let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
-        let some_sequencer: [u8; 32] = [111; 32];
+        let some_sequencer: [u8; 32] = [121; 32];
         let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
             &mut demo,
             &mut new_test_blob(Batch { txs }, &some_sequencer),

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -200,7 +200,7 @@ pub mod test {
 
         let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
-        let some_sequencer: [u8; 32] = [112; 32];
+        let some_sequencer: [u8; 32] = [121; 32];
         let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
             &mut demo,
             &mut new_test_blob(Batch { txs }, &some_sequencer),

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -40,8 +40,9 @@ pub mod test {
                 None,
             );
 
-            assert!(
-                matches!(apply_blob_outcome.inner, SequencerOutcome::Rewarded(0),),
+            assert_eq!(
+                SequencerOutcome::Rewarded(0),
+                apply_blob_outcome.inner,
                 "Sequencer execution should have succeeded but failed "
             );
 

--- a/module-system/sov-modules-macros/Cargo.toml
+++ b/module-system/sov-modules-macros/Cargo.toml
@@ -21,9 +21,9 @@ path = "tests/all_tests.rs"
 
 [dev-dependencies]
 trybuild = "1.0"
-sov-modules-api = { path = "../sov-modules-api", version = "0.1" }
+sov-modules-api = { path = "../sov-modules-api", version = "0.1", default-features = false }
 jsonrpsee = { workspace = true, features = ["macros", "http-client", "server"] }
-sov-state = { path = "../sov-state", version = "0.1" }
+sov-state = { path = "../sov-state", version = "0.1", default-features = false }
 tempfile = { workspace = true }
 
 [dependencies]

--- a/module-system/sov-modules-macros/tests/derive_rpc.rs
+++ b/module-system/sov-modules-macros/tests/derive_rpc.rs
@@ -1,8 +1,8 @@
-use sov_modules_api::default_context::DefaultContext;
+use sov_modules_api::default_context::ZkDefaultContext;
 use sov_modules_api::Context;
 use sov_modules_macros::rpc_gen;
 use sov_modules_macros::ModuleInfo;
-use sov_state::{ProverStorage, WorkingSet};
+use sov_state::{WorkingSet, ZkStorage};
 
 #[derive(ModuleInfo)]
 pub struct TestStruct<C: ::sov_modules_api::Context> {
@@ -33,7 +33,7 @@ impl<C: sov_modules_api::Context> TestStruct<C> {
     }
 }
 
-pub struct TestRuntime<C: sov_modules_api::Context> {
+pub struct TestRuntime<C: Context> {
     test_struct: TestStruct<C>,
 }
 
@@ -43,29 +43,30 @@ struct RpcStorage<C: Context> {
     pub storage: C::Storage,
 }
 
-impl TestStructRpcImpl<DefaultContext> for RpcStorage<DefaultContext> {
+impl TestStructRpcImpl<ZkDefaultContext> for RpcStorage<ZkDefaultContext> {
     fn get_working_set(
         &self,
-    ) -> ::sov_state::WorkingSet<<DefaultContext as ::sov_modules_api::Spec>::Storage> {
+    ) -> ::sov_state::WorkingSet<<ZkDefaultContext as ::sov_modules_api::Spec>::Storage> {
         ::sov_state::WorkingSet::new(self.storage.clone())
     }
 }
 
 fn main() {
-    let tmpdir = tempfile::tempdir().unwrap();
-    let native_storage = ProverStorage::with_path(tmpdir.path()).unwrap();
-    let r: RpcStorage<DefaultContext> = RpcStorage {
-        storage: native_storage.clone(),
+    let storage = ZkStorage::new([1u8; 32]);
+    let r: RpcStorage<ZkDefaultContext> = RpcStorage {
+        storage: storage.clone(),
     };
     {
         let result =
-            <RpcStorage<DefaultContext> as TestStructRpcServer<DefaultContext>>::first_method(&r);
+            <RpcStorage<ZkDefaultContext> as TestStructRpcServer<ZkDefaultContext>>::first_method(
+                &r,
+            );
         assert_eq!(result.unwrap(), 11);
     }
 
     {
         let result =
-            <RpcStorage<DefaultContext> as TestStructRpcServer<DefaultContext>>::second_method(
+            <RpcStorage<ZkDefaultContext> as TestStructRpcServer<ZkDefaultContext>>::second_method(
                 &r, 22,
             );
         assert_eq!(result.unwrap(), 22);
@@ -73,7 +74,7 @@ fn main() {
 
     {
         let result =
-            <RpcStorage<DefaultContext> as TestStructRpcServer<DefaultContext>>::third_method(
+            <RpcStorage<ZkDefaultContext> as TestStructRpcServer<ZkDefaultContext>>::third_method(
                 &r, 33,
             );
         assert_eq!(result.unwrap(), 33);
@@ -81,7 +82,7 @@ fn main() {
 
     {
         let result =
-            <RpcStorage<DefaultContext> as TestStructRpcServer<DefaultContext>>::fourth_method(
+            <RpcStorage<ZkDefaultContext> as TestStructRpcServer<ZkDefaultContext>>::fourth_method(
                 &r, 44,
             );
         assert_eq!(result.unwrap(), 44);
@@ -89,7 +90,7 @@ fn main() {
 
     {
         let result =
-            <RpcStorage<DefaultContext> as TestStructRpcServer<DefaultContext>>::health(&r);
+            <RpcStorage<ZkDefaultContext> as TestStructRpcServer<ZkDefaultContext>>::health(&r);
         assert_eq!(result.unwrap(), ());
     }
 

--- a/module-system/sov-modules-macros/tests/dispatch/derive_dispatch.rs
+++ b/module-system/sov-modules-macros/tests/dispatch/derive_dispatch.rs
@@ -2,9 +2,9 @@ mod modules;
 use modules::{first_test_module, second_test_module};
 use sov_modules_api::Address;
 use sov_modules_api::ModuleInfo;
-use sov_modules_api::{default_context::DefaultContext, Context, Genesis};
+use sov_modules_api::{default_context::ZkDefaultContext, Context, Genesis};
 use sov_modules_macros::{DefaultRuntime, DispatchCall, Genesis, MessageCodec};
-use sov_state::ProverStorage;
+use sov_state::ZkStorage;
 
 #[derive(Genesis, DispatchCall, MessageCodec, DefaultRuntime)]
 #[serialization(borsh::BorshDeserialize, borsh::BorshSerialize)]
@@ -15,15 +15,14 @@ struct Runtime<C: Context> {
 
 fn main() {
     use sov_modules_api::DispatchCall;
-    type RT = Runtime<DefaultContext>;
+    type RT = Runtime<ZkDefaultContext>;
     let runtime = &mut RT::default();
 
-    let tmpdir = tempfile::tempdir().unwrap();
-    let storage = ProverStorage::with_path(tmpdir.path()).unwrap();
+    let storage = ZkStorage::new([1u8; 32]);
     let mut working_set = &mut sov_state::WorkingSet::new(storage);
     let config = GenesisConfig::new((), ());
     runtime.genesis(&config, working_set).unwrap();
-    let context = DefaultContext::new(Address::try_from([0; 32].as_ref()).unwrap());
+    let context = ZkDefaultContext::new(Address::try_from([0; 32].as_ref()).unwrap());
 
     let value = 11;
     {

--- a/module-system/sov-modules-macros/tests/dispatch/derive_genesis.rs
+++ b/module-system/sov-modules-macros/tests/dispatch/derive_genesis.rs
@@ -1,10 +1,10 @@
 mod modules;
 
 use modules::{first_test_module, second_test_module};
-use sov_modules_api::default_context::DefaultContext;
+use sov_modules_api::default_context::ZkDefaultContext;
 use sov_modules_api::Context;
 use sov_modules_macros::{DefaultRuntime, DispatchCall, Genesis, MessageCodec};
-use sov_state::ProverStorage;
+use sov_state::ZkStorage;
 
 // Debugging hint: To expand the macro in tests run: `cargo expand --test tests`
 #[derive(Genesis, DispatchCall, MessageCodec, DefaultRuntime)]
@@ -20,9 +20,8 @@ where
 fn main() {
     use sov_modules_api::Genesis;
 
-    type C = DefaultContext;
-    let tmpdir = tempfile::tempdir().unwrap();
-    let storage = ProverStorage::with_path(tmpdir.path()).unwrap();
+    type C = ZkDefaultContext;
+    let storage = ZkStorage::new([1u8; 32]);
     let mut working_set = &mut sov_state::WorkingSet::new(storage);
     let runtime = &mut Runtime::<C>::default();
     let config = GenesisConfig::new((), ());

--- a/module-system/sov-modules-macros/tests/module_info/mod_and_state.rs
+++ b/module-system/sov-modules-macros/tests/module_info/mod_and_state.rs
@@ -1,4 +1,4 @@
-use sov_modules_api::default_context::DefaultContext;
+use sov_modules_api::default_context::ZkDefaultContext;
 use sov_modules_api::Context;
 use sov_modules_macros::ModuleInfo;
 use sov_state::StateMap;
@@ -39,7 +39,7 @@ mod second_test_module {
 }
 
 fn main() {
-    type C = DefaultContext;
+    type C = ZkDefaultContext;
     let second_test_struct =
         <second_test_module::SecondTestStruct<C> as std::default::Default>::default();
 

--- a/module-system/sov-modules-macros/tests/module_info/parse.rs
+++ b/module-system/sov-modules-macros/tests/module_info/parse.rs
@@ -1,4 +1,4 @@
-use sov_modules_api::default_context::DefaultContext;
+use sov_modules_api::default_context::ZkDefaultContext;
 use sov_modules_api::{Context, ModuleInfo};
 use sov_modules_macros::ModuleInfo;
 use sov_state::{StateMap, StateValue};
@@ -25,7 +25,7 @@ mod test_module {
 }
 
 fn main() {
-    type C = DefaultContext;
+    type C = ZkDefaultContext;
     let test_struct = <test_module::TestStruct<C> as std::default::Default>::default();
 
     let prefix1 = test_struct.test_state1.prefix();

--- a/module-system/sov-state/Cargo.toml
+++ b/module-system/sov-state/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 resolver = "2"
 
 [dependencies]
-
 anyhow = { workspace = true }
 borsh = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
# Short summary

* Add Swatinem/rust-cache@v2 before sccache, so we can combine crates/target cache with recompilation.
* Adjust macro tests to not require native flag
* change `assert!(matches!())` to `assert_eq!()`
* Switch to use latest `sccache` instead of hard coded.

# Description

Currently we use [sccache](https://github.com/mozilla/sccache) for caching compilation. and it helps, especially with rocksdb, as it can cache not only rust compilation artifacts, but also C/C++.

But it looks like cargo download dependencies everytime and scacche does not handle it that well.

So idea is to put sccache on top of standard rust caching mechanism.



| Iteration                              | Check | Test | Coverage | Features | Check Prover |
| -------------------------- | ------ | ----- | --------- | --------- | ------------ |
| 1 (empty cache)                  | 13m   | 23m  | 23m        | 30m         | 45m             |
| 2                                           | 9 m   | 19m  | 20m       | 23m         | 22m             |
| 3 (add cache for `target`) | 12m   | 26m  | 20m       | 25m         | 24m             |
| 4                                           |  2m   |  7m  |   20m       | 3m         | 10m             |
| 5                                           |  1m   | 9m  | 10m       | 4m         | 14m             |
| 6 (adjust macro test)            |  12m   | 15m  | 17m       | 28m         | 16m             |
| 7                                           | 1m   | 9m  | 7m       | 3m         | 10m             |


## Macro tests

Current macro tests use native flag for testing compilation, which brings compilation of rocksdb second time inside macro test. 
I've changed the tests to operate on ZK conteext and ZK storage, as it require less dependencies.


# Future improvements

Things that can be done to make CI even smoother:

1. Set `check` step to be the first and rest depend on it, so it doesn't waste runner's time if it fails
2. Figure out why llvm-cov spends 10 minutes recompiling.
3. tune `SCCACHE_CACHE_SIZE` to get best results
4. Try [cargo-nextest](https://nexte.st/)
