### PR TITLE
Publish `cargo doc` assets to GH pages

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -152,4 +152,29 @@ jobs:
             echo "Curl failed, retrying in 5 seconds..."
             sleep 5
           done
-
+  cargo-doc-artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      # The artifact tends to become quite large with all the dependencies, so
+      # we don't include them in the docs.
+      - run: cargo doc --no-deps
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: target/doc
+  deploy:
+    needs: cargo-doc-artifact
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
# Description
As we add more doc comments to our crates, it'd be nice to have up-to-date Cargo docs hosted somewhere. I'm adding 2 steps to our CI, one to build the docs and one to upload them to GH Pages.
