### PR TITLE
Remove experimental from default features in `EVM` module

### DIFF
--- a/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/module-system/module-implementations/sov-evm/Cargo.toml
@@ -47,7 +47,7 @@ tempfile = { workspace = true }
 bytes = { workspace = true }
 
 [features]
-default = ["native", "experimental"]
+default = ["native"]
 serde = ["dep:serde", "dep:serde_json"]
 native = ["serde", "sov-state/native", "dep:jsonrpsee", "sov-modules-api/native"]
 experimental = []


### PR DESCRIPTION
# Description
This PR removes `experimental` feature from default features in `EVM` module.

