### PR TITLE
fix readme instructions and test data to run correctly when tutorial is followed exactly

### DIFF
--- a/examples/const-rollup-config/src/lib.rs
+++ b/examples/const-rollup-config/src/lib.rs
@@ -1,3 +1,3 @@
 // The rollup stores its data in the namespace b"sov-test" on Celestia.
 pub const ROLLUP_NAMESPACE_RAW: [u8; 8] = [115, 111, 118, 45, 116, 101, 115, 116];
-pub const SEQUENCER_DA_ADDRESS: [u8; 47] = *b"celestia1qp09ysygcx6npted5yc0au6k9lner05yvs9208";
+pub const SEQUENCER_DA_ADDRESS: [u8; 47] = *b"celestia1u5duzsla6ugarucp2n8s227dvspkavz8mt6xz4";

--- a/examples/demo-rollup/Makefile
+++ b/examples/demo-rollup/Makefile
@@ -96,7 +96,7 @@ build-sov-cli:
 	cd ../demo-stf && cargo build --bin sov-cli
 
 test-serialize-create-token: check-container-running build-sov-cli
-	$(SOV_CLI_REL_PATH) serialize-call ../demo-stf/src/sov-cli/test_data/minter_private_key.json Bank ../demo-stf/src/sov-cli/test_data/create_token.json 0
+	$(SOV_CLI_REL_PATH) serialize-call ../demo-stf/src/sov-cli/test_data/token_deployer_private_key.json Bank ../demo-stf/src/sov-cli/test_data/create_token.json 0
 
 test-build-blob-from-create-token: test-serialize-create-token
 	$(SOV_CLI_REL_PATH) make-blob ../demo-stf/src/sov-cli/test_data/create_token.dat > ../demo-stf/src/sov-cli/test_data/test_blob.dat

--- a/examples/demo-rollup/rollup_config.toml
+++ b/examples/demo-rollup/rollup_config.toml
@@ -1,12 +1,12 @@
 # We define the rollup's genesis to occur at Celestia block number `start_height`. The rollup will ignore
 # any Celestia blocks before this height
-start_height = 671431
+start_height = 1
 
 [da]
 # The JWT used to authenticate with the celestia light client. Instructions for generating this token can be found in the README
-celestia_rpc_auth_token = "MY.SECRET.TOKEN"
+celestia_rpc_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.YNNrJz6mCD6ypuH9Ay6NuCy1B6oQVTa2wi5-etSeY-8"
 # The address of the *trusted* Celestia light client to interact with
-celestia_rpc_address = "http://localhost:11111/"
+celestia_rpc_address = "http://127.0.0.1:26658"
 # The largest response the rollup will accept from the Celestia node. Defaults to 100 MB
 max_celestia_response_body_size = 104_857_600
 

--- a/examples/demo-stf/src/sov-cli/test_data/burn.json
+++ b/examples/demo-stf/src/sov-cli/test_data/burn.json
@@ -2,7 +2,7 @@
     "Burn":{
         "coins":{
             "amount":300,
-            "token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27seu4hmg"
+            "token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"
         }
     }
 }

--- a/examples/demo-stf/src/sov-cli/test_data/create_token.json
+++ b/examples/demo-stf/src/sov-cli/test_data/create_token.json
@@ -3,7 +3,7 @@
       "salt": 11,
       "token_name": "sov-test-token",
       "initial_balance": 1000,
-      "minter_address": "sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqmlyjd6",
-      "authorized_minters": ["sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqmlyjd6"]
+      "minter_address": "sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqwr57gc",
+      "authorized_minters": ["sov1l6n2cku82yfqld30lanm2nfw43n2auc8clw7r5u5m6s7p8jrm4zqrr8r94"]
     }
 }

--- a/examples/demo-stf/src/sov-cli/test_data/transfer.json
+++ b/examples/demo-stf/src/sov-cli/test_data/transfer.json
@@ -3,7 +3,7 @@
         "to":"sov1zgfpyysjzgfpyysjzgfpyysjzgfpyysjzgfpyysjzgfpyysjzgfqve8h6h",
         "coins":{
             "amount":200,
-            "token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27seu4hmg"
+            "token_address":"sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"
         }
     }
 }


### PR DESCRIPTION
The current README instructions when followed exactly will lead to a transaction getting reverted. This is because in our README, we have an automated/abstracted transaction that is used for sanity checking the setup and this creates a token with the address configured in `test_data`. Because this is just a sanity check, the subsequent instructions show how a transaction can be serialized manually using sov-cli and then submitted. Unfortunately, we also used `CreateToken` as the example there and this causes a nonce clash as well as an error (even if the nonce is fixed) that the token already exists. To solve this issue, we're modifying the README to use `Transfer` as the call for serializing and submitting manually using `sov-cli` and `make`

Additional fixes: The current test data is not compatible with itself, so modified the addresses to ensure CreateToken, Transfer, Burn are all coherent with each other


## Linked Issues
- Fixes # (476)

