### PR TITLE
Pin foundry version in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.3
       - uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: 1.0.0
+          version: v1.0.0
       - name: Run cargo test
         run: cargo test
   coverage:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,6 +86,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: mozilla-actions/sccache-action@v0.0.3
       - uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: 1.0.0
       - name: Run cargo test
         run: cargo test
   coverage:


### PR DESCRIPTION
# Description
This PR pins foundry to version `v1.0.0` in CI

## Testing
Ci works

## Docs
No doc changes.
