### PR TITLE
`sov-ethereum`: remove `experimental` form `default` features

### DIFF
--- a/full-node/sov-ethereum/Cargo.toml
+++ b/full-node/sov-ethereum/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { workspace = true }
 
 
 [features]
-default = ["native", "experimental"]
+default = ["native"]
 experimental =["demo-stf/experimental", "sov-evm/experimental"]
 
 native = ["demo-stf/native", "sov-evm/native"]


### PR DESCRIPTION
# Description
This PR removes `experimental`  form `default` features in `sov-ethereum`.  