### PR TITLE
Update links for branch renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ![](./assets/banner.jpg)
 
 <div align="center">
-  <a href="https://github.com/Sovereign-Labs/sovereign-sdk/blob/main/LICENSE">
+  <a href="https://github.com/Sovereign-Labs/sovereign-sdk/blob/stable/LICENSE">
     <img alt="License: Apache-2.0" src="https://img.shields.io/github/license/Sovereign-Labs/sovereign-sdk.svg" />
   </a>
   <a href="https://codecov.io/gh/Sovereign-Labs/sovereign-sdk" > 
-      <img alt="Coverage" src="https://codecov.io/gh/Sovereign-Labs/sovereign-sdk/branch/main/graph/badge.svg"/> 
+      <img alt="Coverage" src="https://codecov.io/gh/Sovereign-Labs/sovereign-sdk/branch/stable/graph/badge.svg"/> 
   </a>
    <a href="https://discord.gg/kbykCcPrcA" > 
       <img alt="Discord" src="https://img.shields.io/discord/1050059327626555462?label=discord"/> 

--- a/examples/demo-nft-module/README.md
+++ b/examples/demo-nft-module/README.md
@@ -41,8 +41,8 @@ Here are defining basic dependencies in `Cargo.toml` that module needs to get st
 ```toml
 [dependencies]
 anyhow = { anyhow = "1.0.62" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", branch = "main", default-features = false }
-sov-modules-macros = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", branch = "main" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", branch = "stable", default-features = false }
+sov-modules-macros = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", branch = "stable" }
 ```
 
 ### Establishing the Root Module Structure
@@ -121,9 +121,9 @@ Before we start implementing the `Module` trait, there are several preparatory s
     serde = { version = "1", features = ["derive"] }
     serde_json = "1"
 
-     sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", branch = "main", default-features = false }
-     sov-modules-macros = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", branch = "main" }
-     sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", branch = "main", default-features = false }
+     sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", branch = "stable", default-features = false }
+     sov-modules-macros = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", branch = "stable" }
+     sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", branch = "stable", default-features = false }
 
      [features]
      default = ["native"]
@@ -371,7 +371,7 @@ Temporary storage is needed for testing, so we enable the `temp` feature of `sov
 
 ```toml
 [dev-dependencies]
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", branch = "main", features = ["temp"] }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", branch = "stable", features = ["temp"] }
 ```
 
 Here is some boilerplate for NFT module integration tests:

--- a/rollup-interface/README.md
+++ b/rollup-interface/README.md
@@ -3,7 +3,7 @@
 </div>
 
 <div align="center">
-  <a href="https://github.com/Sovereign-Labs/sovereign-sdk/blob/main/LICENSE">
+  <a href="https://github.com/Sovereign-Labs/sovereign-sdk/blob/stable/LICENSE">
     <img alt="License: Apache-2.0" src="https://img.shields.io/github/license/Sovereign-Labs/sovereign-sdk.svg" />
 </div>
 


### PR DESCRIPTION
# Description
Update all references to the old `main` branch to point at `stable` instead
