### PR TITLE
Bump `rust-rocksdb` to 0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ proptest = "1.0.0"
 proptest-derive = "0.3.0"
 rand = "0.8"
 rayon = "1.5.2"
-rocksdb = { version = "0.19.0", features = ["lz4"] }
+rocksdb = { version = "0.21.0", features = ["lz4"] }
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_json = { version = "1.0" }
 sha2 = "0.10.6"


### PR DESCRIPTION
# Description
`rust-rocksdb` 0.21.0 ships several build fixes compared to 0.19.0 and uses RocksDB 8.0.0, with more bug fixes and performance improvements.

## Linked Issues
None

## Testing
No testing, we shouldn't see any behavior difference.


