### PR TITLE
De-anonymizing BlobTransactionTrait in STF

### DIFF
--- a/examples/demo-prover/host/src/main.rs
+++ b/examples/demo-prover/host/src/main.rs
@@ -8,6 +8,7 @@ use demo_stf::runner_config::{from_toml_path, Config as RunnerConfig};
 use jupiter::da_service::{CelestiaService, DaServiceConfig};
 use jupiter::types::NamespaceId;
 use jupiter::verifier::RollupParams;
+use jupiter::BlobWithSender;
 use methods::{ROLLUP_ELF, ROLLUP_ID};
 use risc0_adapter::host::Risc0Host;
 use serde::Deserialize;
@@ -54,7 +55,8 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let sequencer_private_key = DefaultPrivateKey::generate();
 
-    let mut demo_runner = NativeAppRunner::<Risc0Host>::new(rollup_config.runner.clone());
+    let mut demo_runner =
+        NativeAppRunner::<Risc0Host, BlobWithSender>::new(rollup_config.runner.clone());
     let is_storage_empty = demo_runner.get_storage().is_empty();
     let demo = demo_runner.inner_mut();
 

--- a/examples/demo-prover/methods/guest/src/bin/rollup.rs
+++ b/examples/demo-prover/methods/guest/src/bin/rollup.rs
@@ -45,9 +45,10 @@ pub fn main() {
     env::write(&"txs read\n");
 
     // Step 2: Apply blobs
-    let mut demo_runner = <ZkAppRunner<Risc0Guest> as StateTransitionRunner<
+    let mut demo_runner = <ZkAppRunner<Risc0Guest, BlobWithSender> as StateTransitionRunner<
         ZkConfig,
         Risc0Guest,
+        BlobWithSender,
     >>::new(prev_state_root_hash);
     let demo = demo_runner.inner_mut();
 

--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -53,7 +53,6 @@ prettytable-rs = "^0.10"
 criterion = "0.5.1"
 
 [features]
-default = []
 experimental = ["sov-ethereum/experimental"]
 
 [[bench]]

--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -53,6 +53,7 @@ prettytable-rs = "^0.10"
 criterion = "0.5.1"
 
 [features]
+default = []
 experimental = ["sov-ethereum/experimental"]
 
 [[bench]]

--- a/examples/demo-rollup/benches/rollup_bench.rs
+++ b/examples/demo-rollup/benches/rollup_bench.rs
@@ -9,12 +9,13 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use demo_stf::app::NativeAppRunner;
 use demo_stf::genesis_config::create_demo_genesis_config;
 use demo_stf::runner_config::from_toml_path;
+use jupiter::verifier::address::CelestiaAddress;
 use risc0_adapter::host::Risc0Verifier;
 use sov_db::ledger_db::{LedgerDB, SlotCommit};
 use sov_demo_rollup::config::RollupConfig;
 use sov_demo_rollup::rng_xfers::RngDaService;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
-use sov_rollup_interface::mocks::{TestBlock, TestBlockHeader, TestHash};
+use sov_rollup_interface::mocks::{TestBlob, TestBlock, TestBlockHeader, TestHash};
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::services::stf_runner::StateTransitionRunner;
 use sov_rollup_interface::stf::StateTransitionFunction;
@@ -42,7 +43,8 @@ fn rollup_bench(_bench: &mut Criterion) {
 
     let da_service = Arc::new(RngDaService::new());
 
-    let mut demo_runner = NativeAppRunner::<Risc0Verifier>::new(rollup_config.runner);
+    let mut demo_runner =
+        NativeAppRunner::<Risc0Verifier, TestBlob<CelestiaAddress>>::new(rollup_config.runner);
 
     let demo = demo_runner.inner_mut();
     let sequencer_private_key = DefaultPrivateKey::generate();

--- a/examples/demo-rollup/benches/rollup_coarse_measure.rs
+++ b/examples/demo-rollup/benches/rollup_coarse_measure.rs
@@ -8,13 +8,14 @@ use const_rollup_config::SEQUENCER_DA_ADDRESS;
 use demo_stf::app::NativeAppRunner;
 use demo_stf::genesis_config::create_demo_genesis_config;
 use demo_stf::runner_config::from_toml_path;
+use jupiter::verifier::address::CelestiaAddress;
 use prometheus::{Histogram, HistogramOpts, Registry};
 use risc0_adapter::host::Risc0Verifier;
 use sov_db::ledger_db::{LedgerDB, SlotCommit};
 use sov_demo_rollup::config::RollupConfig;
 use sov_demo_rollup::rng_xfers::RngDaService;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
-use sov_rollup_interface::mocks::{TestBlock, TestBlockHeader, TestHash};
+use sov_rollup_interface::mocks::{TestBlob, TestBlock, TestBlockHeader, TestHash};
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::services::stf_runner::StateTransitionRunner;
 use sov_rollup_interface::stf::StateTransitionFunction;
@@ -22,6 +23,7 @@ use tempfile::TempDir;
 
 #[macro_use]
 extern crate prettytable;
+
 use prettytable::Table;
 
 fn print_times(
@@ -113,7 +115,8 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let da_service = Arc::new(RngDaService::new());
 
-    let mut demo_runner = NativeAppRunner::<Risc0Verifier>::new(rollup_config.runner);
+    let mut demo_runner =
+        NativeAppRunner::<Risc0Verifier, TestBlob<CelestiaAddress>>::new(rollup_config.runner);
 
     let demo = demo_runner.inner_mut();
     let sequencer_private_key = DefaultPrivateKey::generate();

--- a/examples/demo-rollup/src/main.rs
+++ b/examples/demo-rollup/src/main.rs
@@ -14,6 +14,7 @@ use jsonrpsee::core::server::rpc_module::Methods;
 use jupiter::da_service::CelestiaService;
 use jupiter::types::NamespaceId;
 use jupiter::verifier::{CelestiaVerifier, ChainValidityCondition, RollupParams};
+use jupiter::BlobWithSender;
 use risc0_adapter::host::Risc0Verifier;
 use sov_db::ledger_db::{LedgerDB, SlotCommit};
 #[cfg(feature = "experimental")]
@@ -142,7 +143,8 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Our state transition function implements the StateTransitionRunner interface,
     // so we use that to initialize the STF
-    let mut demo_runner = NativeAppRunner::<Risc0Verifier>::new(rollup_config.runner.clone());
+    let mut demo_runner =
+        NativeAppRunner::<Risc0Verifier, BlobWithSender>::new(rollup_config.runner.clone());
 
     // Our state transition also implements the RpcRunner interface,
     // so we use that to initialize the RPC server.

--- a/examples/demo-simple-stf/src/lib.rs
+++ b/examples/demo-simple-stf/src/lib.rs
@@ -15,7 +15,7 @@ pub enum ApplyBlobResult {
     Success,
 }
 
-impl<VM: Zkvm> StateTransitionFunction<VM> for CheckHashPreimageStf {
+impl<Vm: Zkvm, B: BlobTransactionTrait> StateTransitionFunction<Vm, B> for CheckHashPreimageStf {
     // Since our rollup is stateless, we don't need to consider the StateRoot.
     type StateRoot = ();
 
@@ -49,7 +49,7 @@ impl<VM: Zkvm> StateTransitionFunction<VM> for CheckHashPreimageStf {
     // The core logic of our rollup.
     fn apply_blob(
         &mut self,
-        blob: &mut impl BlobTransactionTrait,
+        blob: &mut B,
         _misbehavior_hint: Option<Self::MisbehaviorProof>,
     ) -> BatchReceipt<Self::BatchReceiptContents, Self::TxReceiptContents> {
         let blob_data = blob.data_mut();

--- a/examples/demo-simple-stf/tests/stf_test.rs
+++ b/examples/demo-simple-stf/tests/stf_test.rs
@@ -51,11 +51,15 @@ fn test_stf() {
     let mut test_blob = TestBlob::<DaAddress>::new(preimage, address, [0; 32]);
     let stf = &mut CheckHashPreimageStf {};
 
-    StateTransitionFunction::<MockZkvm>::init_chain(stf, ());
-    StateTransitionFunction::<MockZkvm>::begin_slot(stf, ());
+    StateTransitionFunction::<MockZkvm, TestBlob<DaAddress>>::init_chain(stf, ());
+    StateTransitionFunction::<MockZkvm, TestBlob<DaAddress>>::begin_slot(stf, ());
 
-    let receipt = StateTransitionFunction::<MockZkvm>::apply_blob(stf, &mut test_blob, None);
+    let receipt = StateTransitionFunction::<MockZkvm, TestBlob<DaAddress>>::apply_blob(
+        stf,
+        &mut test_blob,
+        None,
+    );
     assert_eq!(receipt.inner, ApplyBlobResult::Success);
 
-    StateTransitionFunction::<MockZkvm>::end_slot(stf);
+    StateTransitionFunction::<MockZkvm, TestBlob<DaAddress>>::end_slot(stf);
 }

--- a/examples/demo-stf/src/sov-cli/main.rs
+++ b/examples/demo-stf/src/sov-cli/main.rs
@@ -401,7 +401,7 @@ mod test {
     // Test helpers
     struct TestDemo {
         config: GenesisConfig<C>,
-        demo: DemoApp<C, MockZkvm>,
+        demo: DemoApp<C, MockZkvm, TestBlob>,
     }
 
     impl TestDemo {
@@ -421,7 +421,7 @@ mod test {
 
             Self {
                 config: genesis_config,
-                demo: DemoAppRunner::<DefaultContext, MockZkvm>::new(runner_config).stf,
+                demo: DemoAppRunner::<DefaultContext, MockZkvm, TestBlob>::new(runner_config).stf,
             }
         }
     }
@@ -476,11 +476,15 @@ mod test {
         }
     }
 
-    fn execute_txs(demo: &mut DemoApp<C, MockZkvm>, config: GenesisConfig<C>, txs: Vec<RawTx>) {
-        StateTransitionFunction::<MockZkvm>::init_chain(demo, config);
-        StateTransitionFunction::<MockZkvm>::begin_slot(demo, Default::default());
+    fn execute_txs(
+        demo: &mut DemoApp<C, MockZkvm, TestBlob>,
+        config: GenesisConfig<C>,
+        txs: Vec<RawTx>,
+    ) {
+        StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(demo, config);
+        StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(demo, Default::default());
 
-        let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
+        let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
             demo,
             &mut new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
             None,
@@ -491,11 +495,11 @@ mod test {
             apply_blob_outcome,
             "Sequencer execution should have succeeded but failed",
         );
-        StateTransitionFunction::<MockZkvm>::end_slot(demo);
+        StateTransitionFunction::<MockZkvm, TestBlob>::end_slot(demo);
     }
 
     fn get_balance(
-        demo: &mut DemoApp<DefaultContext, MockZkvm>,
+        demo: &mut DemoApp<DefaultContext, MockZkvm, TestBlob>,
         token_deployer_address: &Address,
         user_address: Address,
     ) -> Option<u64> {

--- a/examples/demo-stf/src/tests/mod.rs
+++ b/examples/demo-stf/src/tests/mod.rs
@@ -19,7 +19,7 @@ pub type TestBlob = sov_rollup_interface::mocks::TestBlob<Address>;
 
 pub fn create_new_demo(
     path: impl AsRef<Path>,
-) -> DemoApp<DefaultContext, sov_rollup_interface::mocks::MockZkvm> {
+) -> DemoApp<DefaultContext, sov_rollup_interface::mocks::MockZkvm, TestBlob> {
     let runtime = Runtime::default();
     let storage = ProverStorage::with_path(path).unwrap();
     AppTemplate::new(storage, runtime)

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -10,7 +10,7 @@ pub mod test {
     use crate::genesis_config::{create_demo_config, DEMO_SEQUENCER_DA_ADDRESS, LOCKED_AMOUNT};
     use crate::runtime::Runtime;
     use crate::tests::data_generation::simulate_da;
-    use crate::tests::{create_new_demo, has_tx_events, new_test_blob, C};
+    use crate::tests::{create_new_demo, has_tx_events, new_test_blob, TestBlob, C};
 
     #[test]
     fn test_demo_values_in_db() {
@@ -27,12 +27,15 @@ pub mod test {
         {
             let mut demo = create_new_demo(path);
 
-            StateTransitionFunction::<MockZkvm>::init_chain(&mut demo, config);
-            StateTransitionFunction::<MockZkvm>::begin_slot(&mut demo, Default::default());
+            StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(&mut demo, config);
+            StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(
+                &mut demo,
+                Default::default(),
+            );
 
             let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
-            let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
+            let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
                 &mut demo,
                 &mut new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
                 None,
@@ -46,7 +49,7 @@ pub mod test {
 
             assert!(has_tx_events(&apply_blob_outcome),);
 
-            StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
+            StateTransitionFunction::<MockZkvm, TestBlob>::end_slot(&mut demo);
         }
 
         // Generate a new storage instance after dumping data to the db.
@@ -85,12 +88,12 @@ pub mod test {
             &election_admin_private_key,
         );
 
-        StateTransitionFunction::<MockZkvm>::init_chain(&mut demo, config);
-        StateTransitionFunction::<MockZkvm>::begin_slot(&mut demo, Default::default());
+        StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(&mut demo, config);
+        StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(&mut demo, Default::default());
 
         let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
-        let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
+        let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
             &mut demo,
             &mut new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
             None,
@@ -104,7 +107,7 @@ pub mod test {
 
         assert!(has_tx_events(&apply_blob_outcome),);
 
-        StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
+        StateTransitionFunction::<MockZkvm, TestBlob>::end_slot(&mut demo);
 
         let runtime = &mut Runtime::<DefaultContext>::default();
         let mut working_set = WorkingSet::new(demo.current_storage.clone());
@@ -140,12 +143,15 @@ pub mod test {
         {
             let mut demo = create_new_demo(path);
 
-            StateTransitionFunction::<MockZkvm>::init_chain(&mut demo, config);
-            StateTransitionFunction::<MockZkvm>::begin_slot(&mut demo, Default::default());
+            StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(&mut demo, config);
+            StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(
+                &mut demo,
+                Default::default(),
+            );
 
             let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
-            let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
+            let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
                 &mut demo,
                 &mut new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
                 None,
@@ -193,13 +199,13 @@ pub mod test {
 
         let mut demo = create_new_demo(path);
 
-        StateTransitionFunction::<MockZkvm>::init_chain(&mut demo, config);
-        StateTransitionFunction::<MockZkvm>::begin_slot(&mut demo, Default::default());
+        StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(&mut demo, config);
+        StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(&mut demo, Default::default());
 
         let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
         let some_sequencer: [u8; 32] = [121; 32];
-        let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
+        let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
             &mut demo,
             &mut new_test_blob(Batch { txs }, &some_sequencer),
             None,

--- a/examples/demo-stf/src/tests/tx_revert_tests.rs
+++ b/examples/demo-stf/src/tests/tx_revert_tests.rs
@@ -15,7 +15,7 @@ use super::data_generation::{simulate_da_with_bad_sig, simulate_da_with_revert_m
 use crate::genesis_config::{create_demo_config, DEMO_SEQUENCER_DA_ADDRESS, LOCKED_AMOUNT};
 use crate::runtime::Runtime;
 use crate::tests::data_generation::simulate_da_with_bad_serialization;
-use crate::tests::{has_tx_events, new_test_blob};
+use crate::tests::{has_tx_events, new_test_blob, TestBlob};
 
 const SEQUENCER_BALANCE_DELTA: u64 = 1;
 const SEQUENCER_BALANCE: u64 = LOCKED_AMOUNT + SEQUENCER_BALANCE_DELTA;
@@ -37,12 +37,12 @@ fn test_tx_revert() {
     {
         let mut demo = create_new_demo(path);
 
-        StateTransitionFunction::<MockZkvm>::init_chain(&mut demo, config);
-        StateTransitionFunction::<MockZkvm>::begin_slot(&mut demo, Default::default());
+        StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(&mut demo, config);
+        StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(&mut demo, Default::default());
 
         let txs = simulate_da_with_revert_msg(election_admin_private_key);
 
-        let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
+        let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
             &mut demo,
             &mut new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
             None,
@@ -57,7 +57,7 @@ fn test_tx_revert() {
         // Some events were observed
         assert!(has_tx_events(&apply_blob_outcome), "No events were taken");
 
-        StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
+        StateTransitionFunction::<MockZkvm, TestBlob>::end_slot(&mut demo);
     }
 
     // Checks
@@ -108,8 +108,8 @@ fn test_nonce_incremented_on_revert() {
 
     {
         let mut demo = create_new_demo(path);
-        StateTransitionFunction::<MockZkvm>::init_chain(&mut demo, config);
-        StateTransitionFunction::<MockZkvm>::begin_slot(&mut demo, Default::default());
+        StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(&mut demo, config);
+        StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(&mut demo, Default::default());
 
         let set_candidates_message = Runtime::<DefaultContext>::encode_election_call(
             sov_election::call::CallMessage::SetCandidates {
@@ -147,7 +147,7 @@ fn test_nonce_incremented_on_revert() {
             })
             .collect();
 
-        let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
+        let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
             &mut demo,
             &mut new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
             None,
@@ -158,7 +158,7 @@ fn test_nonce_incremented_on_revert() {
             apply_blob_outcome.inner,
             "Unexpected outcome: Batch execution should have succeeded",
         );
-        StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
+        StateTransitionFunction::<MockZkvm, TestBlob>::end_slot(&mut demo);
     }
 
     {
@@ -200,12 +200,12 @@ fn test_tx_bad_sig() {
     {
         let mut demo = create_new_demo(path);
 
-        StateTransitionFunction::<MockZkvm>::init_chain(&mut demo, config);
-        StateTransitionFunction::<MockZkvm>::begin_slot(&mut demo, Default::default());
+        StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(&mut demo, config);
+        StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(&mut demo, Default::default());
 
         let txs = simulate_da_with_bad_sig(election_admin_private_key);
 
-        let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
+        let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
             &mut demo,
             &mut new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
             None,
@@ -223,7 +223,7 @@ fn test_tx_bad_sig() {
         // The batch receipt contains no events.
         assert!(!has_tx_events(&apply_blob_outcome));
 
-        StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
+        StateTransitionFunction::<MockZkvm, TestBlob>::end_slot(&mut demo);
     }
 
     {
@@ -256,10 +256,9 @@ fn test_tx_bad_serialization() {
         &election_admin_private_key,
     );
     let sequencer_rollup_address = config.sequencer_registry.seq_rollup_address.clone();
-
     let sequencer_balance_before = {
         let mut demo = create_new_demo(path);
-        StateTransitionFunction::<MockZkvm>::init_chain(&mut demo, config);
+        StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(&mut demo, config);
         let mut working_set = WorkingSet::new(demo.current_storage);
         let coins = demo
             .runtime
@@ -279,11 +278,11 @@ fn test_tx_bad_serialization() {
 
     {
         let mut demo = create_new_demo(path);
-        StateTransitionFunction::<MockZkvm>::begin_slot(&mut demo, Default::default());
+        StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(&mut demo, Default::default());
 
         let txs = simulate_da_with_bad_serialization(election_admin_private_key);
 
-        let apply_blob_outcome = StateTransitionFunction::<MockZkvm>::apply_blob(
+        let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
             &mut demo,
             &mut new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
             None,
@@ -300,7 +299,7 @@ fn test_tx_bad_serialization() {
 
         // The batch receipt contains no events.
         assert!(!has_tx_events(&apply_blob_outcome));
-        StateTransitionFunction::<MockZkvm>::end_slot(&mut demo);
+        StateTransitionFunction::<MockZkvm, TestBlob>::end_slot(&mut demo);
     }
 
     {

--- a/module-system/sov-modules-api/src/encode.rs
+++ b/module-system/sov-modules-api/src/encode.rs
@@ -1,11 +1,9 @@
-use std::io::Read;
-
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::NonInstantiable;
 
 impl BorshDeserialize for NonInstantiable {
-    fn deserialize_reader<R: Read>(_reader: &mut R) -> std::io::Result<Self> {
+    fn deserialize_reader<R: std::io::Read>(_reader: &mut R) -> std::io::Result<Self> {
         unreachable!()
     }
 }

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -6,6 +6,7 @@ pub use app_template::AppTemplate;
 pub use batch::Batch;
 use sov_modules_api::hooks::{ApplyBlobHooks, TxHooks};
 use sov_modules_api::{Context, DispatchCall, Genesis, Spec};
+use sov_rollup_interface::da::BlobTransactionTrait;
 use sov_rollup_interface::stf::{BatchReceipt, StateTransitionFunction};
 use sov_rollup_interface::zk::Zkvm;
 use sov_state::{StateCheckpoint, Storage};
@@ -41,7 +42,8 @@ pub enum SlashingReason {
     InvalidTransactionEncoding,
 }
 
-impl<C: Context, RT, Vm: Zkvm> StateTransitionFunction<Vm> for AppTemplate<C, RT, Vm>
+impl<C: Context, RT, Vm: Zkvm, B: BlobTransactionTrait> StateTransitionFunction<Vm, B>
+    for AppTemplate<C, RT, Vm, B>
 where
     RT: DispatchCall<Context = C>
         + Genesis<Context = C>
@@ -82,7 +84,7 @@ where
 
     fn apply_blob(
         &mut self,
-        blob: &mut impl sov_rollup_interface::da::BlobTransactionTrait,
+        blob: &mut B,
         _misbehavior_hint: Option<Self::MisbehaviorProof>,
     ) -> BatchReceipt<Self::BatchReceiptContents, Self::TxReceiptContents> {
         match self.apply_blob(blob) {

--- a/rollup-interface/Cargo.toml
+++ b/rollup-interface/Cargo.toml
@@ -38,6 +38,5 @@ proptest = { workspace = true }
 proptest-derive =  { workspace = true }
 
 [features]
-default = []
 fuzzing = ["proptest", "proptest-derive", "sha2"]
 mocks = ["sha2", "bytes/serde"]

--- a/rollup-interface/Cargo.toml
+++ b/rollup-interface/Cargo.toml
@@ -30,13 +30,14 @@ anyhow = { workspace = true }
 
 # Proptest should be a dev-dependency, but those can't be optional
 proptest = { workspace = true, optional = true }
-proptest-derive =  { workspace = true, optional = true }
+proptest-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = "1"
 proptest = { workspace = true }
-proptest-derive =  { workspace = true }
+proptest-derive = { workspace = true }
 
 [features]
+default = []
 fuzzing = ["proptest", "proptest-derive", "sha2"]
 mocks = ["sha2", "bytes/serde"]

--- a/rollup-interface/src/node/services/stf_runner.rs
+++ b/rollup-interface/src/node/services/stf_runner.rs
@@ -1,5 +1,6 @@
 //! This module defines the traits that are used by the full node to
 //! instantiate and run the state transition function.
+use crate::da::BlobTransactionTrait;
 use crate::services::batch_builder::BatchBuilder;
 use crate::stf::{StateTransitionConfig, StateTransitionFunction};
 use crate::zk::Zkvm;
@@ -23,13 +24,13 @@ use crate::zk::Zkvm;
 /// and a `impl StateTransitionRunner<ZkConfig, Vm> for MyRunner` which instead uses a state root as its runtime config.
 ///
 /// TODO: Why is it called runner? It only creates. Creator, Factory: https://github.com/Sovereign-Labs/sovereign-sdk/issues/447
-pub trait StateTransitionRunner<T: StateTransitionConfig, Vm: Zkvm> {
+pub trait StateTransitionRunner<T: StateTransitionConfig, Vm: Zkvm, B: BlobTransactionTrait> {
     /// The parameters of the state transition function which are set at runtime. For example,
     /// the runtime config might contain path to a data directory.
     type RuntimeConfig;
 
     /// The inner [`StateTransitionFunction`] which is being run.
-    type Inner: StateTransitionFunction<Vm>;
+    type Inner: StateTransitionFunction<Vm, B>;
 
     /// The [`BatchBuilder`] accepts transactions from the mempool and returns bundles of transactions
     /// on request from the full node.

--- a/rollup-interface/src/state_machine/stf.rs
+++ b/rollup-interface/src/state_machine/stf.rs
@@ -76,7 +76,7 @@ pub struct BatchReceipt<BatchReceiptContents, TxReceiptContents> {
 ///  - block: DA layer block
 ///  - batch: Set of transactions grouped together, or block on L2
 ///  - blob: Non serialised batch
-pub trait StateTransitionFunction<Vm: Zkvm> {
+pub trait StateTransitionFunction<Vm: Zkvm, B: BlobTransactionTrait> {
     /// Root hash of state merkle tree
     type StateRoot;
     /// The initial state of the rollup.
@@ -116,7 +116,7 @@ pub trait StateTransitionFunction<Vm: Zkvm> {
     /// just panic - which means that no proof will be created).
     fn apply_blob(
         &mut self,
-        blob: &mut impl BlobTransactionTrait,
+        blob: &mut B,
         misbehavior_hint: Option<Self::MisbehaviorProof>,
     ) -> BatchReceipt<Self::BatchReceiptContents, Self::TxReceiptContents>;
 


### PR DESCRIPTION
# Description

Currently STF has anonymous `BlobTransactionTrait`:

```rust

pub trait StateTransitionFunction<Vm: Zkvm> {
  // ...
  
      fn apply_blob(
        &mut self,
        blob: &mut impl BlobTransactionTrait,
        misbehavior_hint: Option<Self::MisbehaviorProof>,
    ) -> BatchReceipt<Self::BatchReceiptContents, Self::TxReceiptContents>;
}
```

 In order to solve #465 , this trait needs to be de-anonymized, so then `Address` associated type can be linked to `BatchReceiptContent` or other enums that need it.

This PR is first step towards this change, by bringing this trait to trait definition of STF


## Linked Issues
- Related to #465 

## Testing
All automated tests have passed

## Docs
No change in the documentation, since change is only cosmetical.
