### PR TITLE
EVM: `get_transaction_receipt & eth_call` endpoints implementation. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ ethers-providers = "2.0.8"
 ethers-signers = { version = "2.0.8", default-features = false }
 ethers-middleware = "2.0.8"
 
-# todo https://github.com/Sovereign-Labs/sovereign-sdk/issues/498
+# TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/498
 anvil = { git = "https://github.com/foundry-rs/foundry", rev = "684d394db587bef427475a660c72013e97ef71d2" }
 anvil-core = { git = "https://github.com/foundry-rs/foundry", features = ["fastrlp", "serde"], rev = "684d394db587bef427475a660c72013e97ef71d2" }
 

--- a/examples/demo-rollup/rollup_config.toml
+++ b/examples/demo-rollup/rollup_config.toml
@@ -4,7 +4,7 @@ start_height = 1
 
 [da]
 # The JWT used to authenticate with the celestia light client. Instructions for generating this token can be found in the README
-celestia_rpc_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.jp_hghhRkcur3g0o-QhQnkLt89YPu4oykLtZW52_ZA0"
+celestia_rpc_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.0lh1NrdtePmLPvpf2xR_i5wLWWYyxY_e_jHzHXV7aKE"
 # The address of the *trusted* Celestia light client to interact with
 celestia_rpc_address = "http://127.0.0.1:26658"
 # The largest response the rollup will accept from the Celestia node. Defaults to 100 MB

--- a/examples/demo-rollup/rollup_config.toml
+++ b/examples/demo-rollup/rollup_config.toml
@@ -4,7 +4,7 @@ start_height = 1
 
 [da]
 # The JWT used to authenticate with the celestia light client. Instructions for generating this token can be found in the README
-celestia_rpc_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.0lh1NrdtePmLPvpf2xR_i5wLWWYyxY_e_jHzHXV7aKE"
+celestia_rpc_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.i6Cx-WziFU3Jcz2INKii2uMCareIZHDDMR0v8zW5zZc"
 # The address of the *trusted* Celestia light client to interact with
 celestia_rpc_address = "http://127.0.0.1:26658"
 # The largest response the rollup will accept from the Celestia node. Defaults to 100 MB

--- a/full-node/sov-ethereum/src/lib.rs
+++ b/full-node/sov-ethereum/src/lib.rs
@@ -127,8 +127,8 @@ pub mod experimental {
 
                 let raw_tx = {
                     let mut nonces = ethereum.nonces.lock().unwrap();
-                    let n = nonces.entry(sender).and_modify(|n| *n += 1).or_insert(0);
-                    make_raw_tx(evm_transaction, *n)?
+                    let nonce = nonces.entry(sender).and_modify(|n| *n += 1).or_insert(0);
+                    make_raw_tx(evm_transaction, *nonce)?
                 };
 
                 ethereum.send_tx_to_da(raw_tx).await?;
@@ -142,8 +142,8 @@ pub mod experimental {
     fn make_raw_tx(evm_tx: EvmTransaction, nonce: u64) -> Result<Vec<u8>, std::io::Error> {
         let tx = CallMessage { tx: evm_tx };
         let message = Runtime::<DefaultContext>::encode_evm_call(tx);
-        // todo don't generate sender here.
-        let sender = DefaultPrivateKey::generate();
+        // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/514
+        let sender = DefaultPrivateKey::from_hex("236e80cb222c4ed0431b093b3ac53e6aa7a2273fe1f4351cd354989a823432a27b758bf2e7670fafaf6bf0015ce0ff5aa802306fc7e3f45762853ffc37180fe6").unwrap();
         let tx = Transaction::<DefaultContext>::new_signed_tx(&sender, message, nonce);
         tx.try_to_vec()
     }

--- a/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/module-system/module-implementations/sov-evm/Cargo.toml
@@ -37,6 +37,7 @@ ethers-middleware = { workspace = true }
 ethers-providers = { workspace = true }
 ethers-signers = { workspace = true }
 
+
 anvil-core  = { workspace = true }
 ethers = { workspace = true }
 
@@ -50,7 +51,7 @@ bytes = { workspace = true }
 sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
 
 [features]
-default = ["native"]
+default = ["native", "experimental"]
 serde = ["dep:serde", "dep:serde_json"]
 native = ["serde", "sov-state/native", "dep:jsonrpsee", "sov-modules-api/native"]
 experimental = ["native"]

--- a/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/module-system/module-implementations/sov-evm/Cargo.toml
@@ -38,6 +38,7 @@ ethers-providers = { workspace = true }
 ethers-signers = { workspace = true }
 
 
+anvil  = { workspace = true }
 anvil-core  = { workspace = true }
 ethers = { workspace = true }
 
@@ -51,7 +52,7 @@ bytes = { workspace = true }
 sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
 
 [features]
-default = ["native", "experimental"]
+default = ["native"]
 serde = ["dep:serde", "dep:serde_json"]
 native = ["serde", "sov-state/native", "dep:jsonrpsee", "sov-modules-api/native"]
 experimental = ["native"]

--- a/module-system/module-implementations/sov-evm/src/call.rs
+++ b/module-system/module-implementations/sov-evm/src/call.rs
@@ -6,7 +6,7 @@ use sov_state::WorkingSet;
 use crate::evm::db::EvmDb;
 use crate::evm::executor::{self};
 use crate::evm::transaction::EvmTransaction;
-use crate::Evm;
+use crate::{Evm, TransactionReceipt};
 
 #[cfg_attr(
     feature = "native",
@@ -33,7 +33,32 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let evm_db: EvmDb<'_, C> = self.get_db(working_set);
 
         // It is ok to use the unwrap here because the error type is `Infallible`.
-        let result = executor::execute_tx(evm_db, block_env, tx, cfg_env).unwrap();
+        let result = executor::execute_tx(evm_db, block_env, tx.clone(), cfg_env).unwrap();
+
+        let receipt = TransactionReceipt {
+            transaction_hash: tx.hash,
+            // todo
+            transaction_index: 0,
+            // todo
+            block_hash: Default::default(),
+            // todo
+            block_number: Some(0),
+            from: tx.sender,
+            to: tx.to,
+            // todo
+            cumulative_gas_used: Default::default(),
+            // todo
+            gas_used: Default::default(),
+            contract_address: Default::default(), //todo!(),
+            status: Some(1),
+            root: Default::default(),
+            // todo
+            transaction_type: Some(1),
+            effective_gas_price: Default::default(),
+        };
+
+        self.receipts
+            .set(&receipt.transaction_hash, &receipt, working_set);
 
         println!("Result {:?}", result);
         Ok(CallResponse::default())

--- a/module-system/module-implementations/sov-evm/src/call.rs
+++ b/module-system/module-implementations/sov-evm/src/call.rs
@@ -3,6 +3,7 @@ use revm::primitives::CfgEnv;
 use sov_modules_api::CallResponse;
 use sov_state::WorkingSet;
 
+use crate::evm::contract_address;
 use crate::evm::db::EvmDb;
 use crate::evm::executor::{self};
 use crate::evm::transaction::EvmTransaction;
@@ -25,34 +26,36 @@ impl<C: sov_modules_api::Context> Evm<C> {
         _context: &C,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse> {
+        // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/515
+        // https://github.com/Sovereign-Labs/sovereign-sdk/issues/516
         let cfg_env = CfgEnv::default();
         let block_env = self.block_env.get(working_set).unwrap_or_default();
-
         self.transactions.set(&tx.hash, &tx, working_set);
 
         let evm_db: EvmDb<'_, C> = self.get_db(working_set);
 
-        // It is ok to use the unwrap here because the error type is `Infallible`.
+        // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/505
         let result = executor::execute_tx(evm_db, block_env, tx.clone(), cfg_env).unwrap();
 
         let receipt = TransactionReceipt {
             transaction_hash: tx.hash,
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/504
             transaction_index: 0,
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/504
             block_hash: Default::default(),
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/504
             block_number: Some(0),
             from: tx.sender,
             to: tx.to,
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/504
             cumulative_gas_used: Default::default(),
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/504
             gas_used: Default::default(),
-            contract_address: Default::default(), //todo!(),
+            contract_address: contract_address(result).map(|addr| addr.into()),
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/504
             status: Some(1),
             root: Default::default(),
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/504
             transaction_type: Some(1),
             effective_gas_price: Default::default(),
         };
@@ -60,7 +63,6 @@ impl<C: sov_modules_api::Context> Evm<C> {
         self.receipts
             .set(&receipt.transaction_hash, &receipt, working_set);
 
-        println!("Result {:?}", result);
         Ok(CallResponse::default())
     }
 }

--- a/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -1,4 +1,4 @@
-use anvil_core::eth::transaction::EIP1559Transaction;
+use anvil_core::eth::transaction::{EIP1559Transaction, EthTransactionRequest};
 use bytes::Bytes;
 use ethers_core::types::{OtherFields, Transaction};
 use revm::primitives::{
@@ -105,15 +105,15 @@ impl From<EvmTransaction> for Transaction {
             max_priority_fee_per_gas: Some(evm_tx.max_priority_fee_per_gas.into()),
             max_fee_per_gas: Some(evm_tx.max_fee_per_gas.into()),
             chain_id: Some(evm_tx.chain_id.into()),
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/503
             block_hash: Some([0; 32].into()),
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/503
             block_number: Some(1.into()),
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/503
             transaction_index: Some(1.into()),
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/503
             gas: Default::default(),
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/503
             other: OtherFields::default(),
         }
     }
@@ -123,7 +123,7 @@ impl From<EIP1559Transaction> for EvmTransaction {
     fn from(transaction: EIP1559Transaction) -> Self {
         let to = transaction.kind.as_call().map(|addr| (*addr).into());
         let tx_hash = transaction.hash();
-        // todo error handling
+        // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/515
         let sender = transaction.recover().unwrap();
 
         Self {
@@ -137,14 +137,41 @@ impl From<EIP1559Transaction> for EvmTransaction {
             to,
             value: transaction.value.into(),
             nonce: transaction.nonce.as_u64(),
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/503
             access_lists: vec![],
             chain_id: transaction.chain_id,
-            // todo remove it
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/503
             hash: tx_hash.into(),
             odd_y_parity: transaction.odd_y_parity,
             r: transaction.r.into(),
             s: transaction.s.into(),
+        }
+    }
+}
+
+impl From<EthTransactionRequest> for EvmTransaction {
+    fn from(req: EthTransactionRequest) -> Self {
+        Self {
+            sender: req.from.map(|addr| addr.into()).unwrap(),
+            data: req.data.map(|d| d.to_vec()).unwrap_or_default(),
+            gas_limit: req.gas.unwrap_or_default().as_u64(),
+            gas_price: req.gas_price.unwrap_or_default().into(),
+            max_priority_fee_per_gas: req.max_priority_fee_per_gas.unwrap_or_default().into(),
+            max_fee_per_gas: req.max_fee_per_gas.unwrap_or_default().into(),
+            to: req.to.map(|to| to.into()),
+            value: req.value.unwrap_or_default().into(),
+            nonce: req.nonce.unwrap_or_default().as_u64(),
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/503
+            access_lists: Default::default(),
+            chain_id: req.chain_id.unwrap_or_default().as_u64(),
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/515
+            odd_y_parity: Default::default(),
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/515
+            r: Default::default(),
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/515
+            s: Default::default(),
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/503
+            hash: Default::default(),
         }
     }
 }

--- a/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -1,6 +1,7 @@
 use std::convert::Infallible;
 
-use revm::primitives::{CfgEnv, EVMError, Env, ExecutionResult};
+use anvil::eth::backend::mem::inspector::Inspector;
+use revm::primitives::{CfgEnv, EVMError, Env, ExecutionResult, ResultAndState};
 use revm::{self, Database, DatabaseCommit};
 
 use super::transaction::{BlockEnv, EvmTransaction};
@@ -22,4 +23,25 @@ pub(crate) fn execute_tx<DB: Database<Error = Infallible> + DatabaseCommit>(
     evm.env = env;
     evm.database(db);
     evm.transact_commit()
+}
+
+pub(crate) fn inspect<DB: Database<Error = Infallible> + DatabaseCommit>(
+    db: DB,
+    block_env: BlockEnv,
+    tx: EvmTransaction,
+    config_env: CfgEnv,
+) -> Result<ResultAndState, EVMError<Infallible>> {
+    let mut evm = revm::new();
+
+    let env = Env {
+        cfg: config_env,
+        block: block_env.into(),
+        tx: tx.into(),
+    };
+
+    evm.env = env;
+    evm.database(db);
+
+    let mut inspector = Inspector::default();
+    evm.inspect(&mut inspector)
 }

--- a/module-system/module-implementations/sov-evm/src/evm/mod.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/mod.rs
@@ -1,3 +1,4 @@
+use revm::primitives::{ExecutionResult, Output, B160};
 use sov_state::Prefix;
 
 mod conversions;
@@ -54,5 +55,15 @@ impl DbAccount {
         let mut prefix = parent_prefix.as_aligned_vec().clone().into_inner();
         prefix.extend_from_slice(&address);
         Prefix::new(prefix)
+    }
+}
+
+pub(crate) fn contract_address(result: ExecutionResult) -> Option<B160> {
+    match result {
+        ExecutionResult::Success {
+            output: Output::Create(_, Some(addr)),
+            ..
+        } => Some(addr),
+        _ => None,
     }
 }

--- a/module-system/module-implementations/sov-evm/src/evm/test_helpers.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/test_helpers.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use ethers_contract::BaseContract;
 use ethers_core::abi::Abi;
 use ethers_core::types::Bytes;
-use revm::primitives::{ExecutionResult, Output, B160};
+use revm::primitives::{ExecutionResult, Output};
 
 pub(crate) fn output(result: ExecutionResult) -> bytes::Bytes {
     match result {
@@ -12,16 +12,6 @@ pub(crate) fn output(result: ExecutionResult) -> bytes::Bytes {
             Output::Create(out, _) => out,
         },
         _ => panic!("Expected successful ExecutionResult"),
-    }
-}
-
-pub(crate) fn contract_address(result: ExecutionResult) -> B160 {
-    match result {
-        ExecutionResult::Success {
-            output: Output::Create(_, Some(addr)),
-            ..
-        } => addr,
-        _ => panic!("Expected successful contract creation"),
     }
 }
 

--- a/module-system/module-implementations/sov-evm/src/evm/tests.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/tests.rs
@@ -8,9 +8,9 @@ use sov_state::{ProverStorage, WorkingSet};
 use super::db::EvmDb;
 use super::db_init::InitEvmDb;
 use super::executor;
-use crate::evm::test_helpers::{contract_address, output, SimpleStorageContract};
+use crate::evm::test_helpers::{output, SimpleStorageContract};
 use crate::evm::transaction::{BlockEnv, EvmTransaction};
-use crate::evm::AccountInfo;
+use crate::evm::{contract_address, AccountInfo};
 use crate::Evm;
 
 type C = sov_modules_api::default_context::DefaultContext;
@@ -58,7 +58,7 @@ fn simple_contract_execution<DB: Database<Error = Infallible> + DatabaseCommit +
 
         let result =
             executor::execute_tx(&mut evm_db, BlockEnv::default(), tx, CfgEnv::default()).unwrap();
-        contract_address(result)
+        contract_address(result).expect("Expected successful contract creation")
     };
 
     let set_arg = 21989;

--- a/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/module-system/module-implementations/sov-evm/src/lib.rs
@@ -8,10 +8,14 @@ pub mod genesis;
 #[cfg(feature = "experimental")]
 pub mod query;
 #[cfg(feature = "experimental")]
+mod receipt;
+#[cfg(feature = "experimental")]
 #[cfg(test)]
 mod tests;
 #[cfg(feature = "experimental")]
 pub use experimental::{AccountData, Evm, EvmConfig};
+#[cfg(feature = "experimental")]
+pub use receipt::TransactionReceipt;
 
 #[cfg(feature = "experimental")]
 mod experimental {
@@ -24,6 +28,7 @@ mod experimental {
     use super::evm::transaction::BlockEnv;
     use super::evm::{DbAccount, EthAddress};
     use crate::evm::{Bytes32, EvmTransaction};
+    use crate::TransactionReceipt;
 
     #[derive(Clone)]
     pub struct AccountData {
@@ -63,6 +68,9 @@ mod experimental {
 
         #[state]
         pub(crate) transactions: sov_state::StateMap<Bytes32, EvmTransaction>,
+
+        #[state]
+        pub(crate) receipts: sov_state::StateMap<Bytes32, TransactionReceipt>,
     }
 
     impl<C: sov_modules_api::Context> sov_modules_api::Module for Evm<C> {

--- a/module-system/module-implementations/sov-evm/src/query.rs
+++ b/module-system/module-implementations/sov-evm/src/query.rs
@@ -1,20 +1,27 @@
+use anvil_core::eth::state::StateOverride;
 use anvil_core::eth::transaction::EthTransactionRequest;
 use ethereum_types::{Address, H256, U256, U64};
+use ethers::types::Bytes;
 use ethers_core::types::{Block, BlockId, FeeHistory, Transaction, TransactionReceipt, TxHash};
+use revm::primitives::{CfgEnv, ExecutionResult, U256 as EVM_U256};
 use sov_modules_macros::rpc_gen;
 use sov_state::WorkingSet;
 use tracing::info;
 
+use crate::evm::db::EvmDb;
+use crate::evm::{executor, EvmTransaction};
 use crate::Evm;
 
 #[rpc_gen(client, server, namespace = "eth")]
 impl<C: sov_modules_api::Context> Evm<C> {
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
     #[rpc_method(name = "chainId")]
     pub fn chain_id(&self, _working_set: &mut WorkingSet<C::Storage>) -> Option<U64> {
         info!("evm module: eth_chainId");
         Some(U64::from(1u64))
     }
 
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
     #[rpc_method(name = "getBlockByNumber")]
     pub fn get_block_by_number(
         &self,
@@ -32,6 +39,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         Some(block)
     }
 
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
     #[rpc_method(name = "feeHistory")]
     pub fn fee_history(&self, _working_set: &mut WorkingSet<C::Storage>) -> FeeHistory {
         info!("evm module: eth_feeHistory");
@@ -43,20 +51,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         }
     }
 
-    #[rpc_method(name = "sendTransaction")]
-    pub fn send_transaction(
-        &self,
-        _request: EthTransactionRequest,
-        _working_set: &mut WorkingSet<C::Storage>,
-    ) -> U256 {
-        unimplemented!("eth_sendTransaction not implemented")
-    }
-
-    #[rpc_method(name = "blockNumber")]
-    pub fn block_number(&self, _working_set: &mut WorkingSet<C::Storage>) -> U256 {
-        unimplemented!("eth_blockNumber not implemented")
-    }
-
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
     #[rpc_method(name = "getTransactionByHash")]
     pub fn get_transaction_by_hash(
         &self,
@@ -68,6 +63,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         evm_transaction.map(|tx| tx.into())
     }
 
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
     #[rpc_method(name = "getTransactionReceipt")]
     pub fn get_transaction_receipt(
         &self,
@@ -80,6 +76,56 @@ impl<C: sov_modules_api::Context> Evm<C> {
         receipt.map(|r| r.into())
     }
 
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
+    #[rpc_method(name = "call")]
+    pub fn get_call(
+        &self,
+        // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/501
+        request: EthTransactionRequest,
+        _block_number: Option<BlockId>,
+        // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/501
+        _overrides: Option<StateOverride>,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Bytes {
+        info!("evm module: eth_call");
+        let tx: EvmTransaction = request.into();
+
+        // https://github.com/Sovereign-Labs/sovereign-sdk/issues/516
+        let cfg_env = CfgEnv {
+            chain_id: EVM_U256::ZERO,
+            ..Default::default()
+        };
+
+        let block_env = self.block_env.get(working_set).unwrap_or_default();
+        let evm_db: EvmDb<'_, C> = self.get_db(working_set);
+
+        // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/505
+        let result = executor::inspect(evm_db, block_env, tx, cfg_env).unwrap();
+        let output = match result.result {
+            ExecutionResult::Success { output, .. } => output,
+            _ => todo!(),
+        };
+        output.into_data().into()
+    }
+
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
+    #[rpc_method(name = "sendTransaction")]
+    pub fn send_transaction(
+        &self,
+        // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/501
+        _request: EthTransactionRequest,
+        _working_set: &mut WorkingSet<C::Storage>,
+    ) -> U256 {
+        unimplemented!("eth_sendTransaction not implemented")
+    }
+
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
+    #[rpc_method(name = "blockNumber")]
+    pub fn block_number(&self, _working_set: &mut WorkingSet<C::Storage>) -> U256 {
+        unimplemented!("eth_blockNumber not implemented")
+    }
+
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
     #[rpc_method(name = "getTransactionCount")]
     pub fn get_transaction_count(
         &self,

--- a/module-system/module-implementations/sov-evm/src/query.rs
+++ b/module-system/module-implementations/sov-evm/src/query.rs
@@ -71,10 +71,13 @@ impl<C: sov_modules_api::Context> Evm<C> {
     #[rpc_method(name = "getTransactionReceipt")]
     pub fn get_transaction_receipt(
         &self,
-        _hash: H256,
-        _working_set: &mut WorkingSet<C::Storage>,
+        hash: H256,
+        working_set: &mut WorkingSet<C::Storage>,
     ) -> Option<TransactionReceipt> {
-        unimplemented!("eth_getTransactionReceipt not implemented")
+        info!("evm module: eth_getTransactionReceipt");
+
+        let receipt = self.receipts.get(&hash.into(), working_set);
+        receipt.map(|r| r.into())
     }
 
     #[rpc_method(name = "getTransactionCount")]

--- a/module-system/module-implementations/sov-evm/src/receipt.rs
+++ b/module-system/module-implementations/sov-evm/src/receipt.rs
@@ -1,0 +1,64 @@
+use ethers_core::types::transaction::response;
+use ethers_core::types::OtherFields;
+
+use crate::evm::{Bytes32, EthAddress};
+
+#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
+pub struct TransactionReceipt {
+    /// Transaction hash.
+    pub transaction_hash: Bytes32,
+    /// Index within the block.
+    pub transaction_index: u64,
+    /// Hash of the block this transaction was included within.
+    pub block_hash: Option<Bytes32>,
+    /// Number of the block this transaction was included within.
+    pub block_number: Option<u64>,
+    /// address of the sender.
+    pub from: EthAddress,
+    // address of the receiver. null when its a contract creation transaction.
+    pub to: Option<EthAddress>,
+    /// Cumulative gas used within the block after this was executed.
+    pub cumulative_gas_used: Bytes32,
+    pub gas_used: Bytes32,
+    pub contract_address: Option<EthAddress>,
+    // todo
+    // pub logs: Vec<Log>,
+    /// Status: either 1 (success) or 0 (failure). Only present after activation of [EIP-658](https://eips.ethereum.org/EIPS/eip-658)
+    pub status: Option<u64>,
+    /// State root. Only present before activation of [EIP-658](https://eips.ethereum.org/EIPS/eip-658)
+    pub root: Option<Bytes32>,
+    /// Logs bloom
+    /// todo
+    //pub logs_bloom: Bloom,
+    /// Transaction type, Some(1) for AccessList transaction, None for Legacy
+    pub transaction_type: Option<u64>,
+    /// The price paid post-execution by the transaction (i.e. base fee + priority fee).
+    /// Both fields in 1559-style transactions are *maximums* (max fee + max priority fee), the
+    /// amount that's actually paid by users can only be determined post-execution
+    pub effective_gas_price: Option<Bytes32>,
+}
+
+impl From<TransactionReceipt> for response::TransactionReceipt {
+    fn from(receipt: TransactionReceipt) -> Self {
+        Self {
+            transaction_hash: receipt.transaction_hash.into(),
+            transaction_index: receipt.transaction_index.into(),
+            block_hash: receipt.block_hash.map(|hash| hash.into()),
+            block_number: receipt.block_number.map(|bn| bn.into()),
+            from: receipt.from.into(),
+            to: receipt.to.map(|to| to.into()),
+            cumulative_gas_used: receipt.cumulative_gas_used.into(),
+            gas_used: Some(receipt.gas_used.into()),
+            contract_address: receipt.contract_address.map(|addr| addr.into()),
+            // todo
+            logs: Default::default(),
+            status: receipt.status.map(|s| s.into()),
+            root: receipt.root.map(|r| r.into()),
+            // todo
+            logs_bloom: Default::default(),
+            transaction_type: receipt.transaction_type.map(|t| t.into()),
+            effective_gas_price: receipt.effective_gas_price.map(|p| p.into()),
+            other: OtherFields::default(),
+        }
+    }
+}

--- a/module-system/module-implementations/sov-evm/src/receipt.rs
+++ b/module-system/module-implementations/sov-evm/src/receipt.rs
@@ -21,15 +21,15 @@ pub struct TransactionReceipt {
     pub cumulative_gas_used: Bytes32,
     pub gas_used: Bytes32,
     pub contract_address: Option<EthAddress>,
-    // todo
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/504
     // pub logs: Vec<Log>,
-    /// Status: either 1 (success) or 0 (failure). Only present after activation of [EIP-658](https://eips.ethereum.org/EIPS/eip-658)
+    // Status: either 1 (success) or 0 (failure). Only present after activation of [EIP-658](https://eips.ethereum.org/EIPS/eip-658)
     pub status: Option<u64>,
     /// State root. Only present before activation of [EIP-658](https://eips.ethereum.org/EIPS/eip-658)
     pub root: Option<Bytes32>,
-    /// Logs bloom
-    /// todo
-    //pub logs_bloom: Bloom,
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/504
+    // Logs bloom
+    //  pub logs_bloom: Bloom,
     /// Transaction type, Some(1) for AccessList transaction, None for Legacy
     pub transaction_type: Option<u64>,
     /// The price paid post-execution by the transaction (i.e. base fee + priority fee).
@@ -50,11 +50,11 @@ impl From<TransactionReceipt> for response::TransactionReceipt {
             cumulative_gas_used: receipt.cumulative_gas_used.into(),
             gas_used: Some(receipt.gas_used.into()),
             contract_address: receipt.contract_address.map(|addr| addr.into()),
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/504
             logs: Default::default(),
             status: receipt.status.map(|s| s.into()),
             root: receipt.root.map(|r| r.into()),
-            // todo
+            // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/504
             logs_bloom: Default::default(),
             transaction_type: receipt.transaction_type.map(|t| t.into()),
             effective_gas_price: receipt.effective_gas_price.map(|p| p.into()),

--- a/module-system/module-implementations/sov-evm/src/tests/tx_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/tx_tests.rs
@@ -190,7 +190,7 @@ async fn send_tx_test_to_eth() -> Result<(), Box<dyn std::error::Error>> {
 
     let from_addr = Address::from_str("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266").unwrap();
 
-    let test_client = TestClient::new_anvil_client(chain_id, key, from_addr, contract).await;
-    //let test_client = TestClient::new_demo_rollup_client(chain_id, key, from_addr, contract).await;
+    //let test_client = TestClient::new_anvil_client(chain_id, key, from_addr, contract).await;
+    let test_client = TestClient::new_demo_rollup_client(chain_id, key, from_addr, contract).await;
     test_client.execute().await
 }

--- a/module-system/module-implementations/sov-evm/src/tests/tx_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/tx_tests.rs
@@ -141,10 +141,10 @@ impl TestClient {
                 .to(contract_address)
                 .chain_id(self.chain_id)
                 .nonce(1u64)
+                .data(self.contract.set_call_data(set_arg))
                 .max_priority_fee_per_gas(10u64)
                 .max_fee_per_gas(MAX_FEE_PER_GAS)
-                .gas(900000u64)
-                .data(self.contract.set_call_data(set_arg));
+                .gas(900000u64);
 
             let typed_transaction = TypedTransaction::Eip1559(request);
 
@@ -162,11 +162,13 @@ impl TestClient {
                 .from(self.from_addr)
                 .to(contract_address)
                 .chain_id(self.chain_id)
-                .data(self.contract.get_call_data());
+                .nonce(2u64)
+                .data(self.contract.get_call_data())
+                .gas(900000u64);
 
-            let tx = TypedTransaction::Eip1559(request);
+            let typed_transaction = TypedTransaction::Eip1559(request);
 
-            let response = self.client.call(&tx, None).await?;
+            let response = self.client.call(&typed_transaction, None).await?;
 
             let resp_array: [u8; 32] = response.to_vec().try_into().unwrap();
             let get_arg = ethereum_types::U256::from(resp_array);
@@ -190,7 +192,7 @@ async fn send_tx_test_to_eth() -> Result<(), Box<dyn std::error::Error>> {
 
     let from_addr = Address::from_str("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266").unwrap();
 
-    //let test_client = TestClient::new_anvil_client(chain_id, key, from_addr, contract).await;
-    let test_client = TestClient::new_demo_rollup_client(chain_id, key, from_addr, contract).await;
+    let test_client = TestClient::new_anvil_client(chain_id, key, from_addr, contract).await;
+    // let test_client = TestClient::new_demo_rollup_client(chain_id, key, from_addr, contract).await;
     test_client.execute().await
 }


### PR DESCRIPTION
# Description
This PR introduces the following changes:
1. Implementation of the `get_transaction_receipt` endpoint. Currently, the receipts are stored in the module state.
2. Implementation of the `eth_call` endpoint.

With these changes, the `send_tx_test_to_eth` test now functions correctly, proving that the EVM module can interact with an external wallet. The current implementation is very basic, and the pull request contains "todo" items that will be addressed in future PRs (together with documentation & tests). 

## Testing
Tests will be added in the following PRs.

## Docs
Docs will be provided in the following PRs.
