### PR TITLE
Preferred sequencer in registry

### DIFF
--- a/examples/demo-stf/src/genesis_config.rs
+++ b/examples/demo-stf/src/genesis_config.rs
@@ -45,6 +45,7 @@ pub fn create_demo_genesis_config<C: Context>(
             amount: LOCKED_AMOUNT,
             token_address,
         },
+        preferred_sequencer: None,
     };
 
     let value_setter_config = ValueSetterConfig {

--- a/module-system/module-implementations/sov-sequencer-registry/src/call.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/src/call.rs
@@ -12,6 +12,7 @@ use crate::SequencerRegistry;
     derive(schemars::JsonSchema)
 )]
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
+// TODO: Replace with DA address generic, when AddressTrait is split
 pub enum CallMessage {
     Register { da_address: Vec<u8> },
     Exit { da_address: Vec<u8> },
@@ -48,6 +49,12 @@ impl<C: sov_modules_api::Context> SequencerRegistry<C> {
         }
 
         self.allowed_sequencers.delete(&da_address, working_set);
+
+        if let Some(preferred_sequencer) = self.preferred_sequencer.get(working_set) {
+            if da_address == preferred_sequencer {
+                self.preferred_sequencer.delete(working_set);
+            }
+        }
 
         self.bank
             .transfer_from(locker, sequencer, coins, working_set)?;

--- a/module-system/module-implementations/sov-sequencer-registry/src/call.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/src/call.rs
@@ -48,6 +48,15 @@ impl<C: sov_modules_api::Context> SequencerRegistry<C> {
             bail!("Unauthorized exit attempt");
         }
 
+        self.delete(da_address, working_set);
+
+        self.bank
+            .transfer_from(locker, sequencer, coins, working_set)?;
+
+        Ok(CallResponse::default())
+    }
+
+    pub(crate) fn delete(&self, da_address: Vec<u8>, working_set: &mut WorkingSet<C::Storage>) {
         self.allowed_sequencers.delete(&da_address, working_set);
 
         if let Some(preferred_sequencer) = self.preferred_sequencer.get(working_set) {
@@ -55,10 +64,5 @@ impl<C: sov_modules_api::Context> SequencerRegistry<C> {
                 self.preferred_sequencer.delete(working_set);
             }
         }
-
-        self.bank
-            .transfer_from(locker, sequencer, coins, working_set)?;
-
-        Ok(CallResponse::default())
     }
 }

--- a/module-system/module-implementations/sov-sequencer-registry/src/genesis.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/src/genesis.rs
@@ -15,6 +15,13 @@ impl<C: sov_modules_api::Context> SequencerRegistry<C> {
             &config.seq_rollup_address,
             working_set,
         )?;
+        if let Some(preferred_sequencer) = &config.preferred_sequencer {
+            if &config.seq_da_address != preferred_sequencer {
+                anyhow::bail!("Preferred sequencer is not in list of allowed sequencers");
+            }
+            self.preferred_sequencer
+                .set(preferred_sequencer, working_set);
+        }
 
         Ok(())
     }

--- a/module-system/module-implementations/sov-sequencer-registry/src/hooks.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/src/hooks.rs
@@ -29,7 +29,7 @@ impl<C: Context> ApplyBlobHooks for SequencerRegistry<C> {
         match result {
             SequencerOutcome::Completed => (),
             SequencerOutcome::Slashed { sequencer } => {
-                self.allowed_sequencers.delete(&sequencer, working_set);
+                self.delete(sequencer, working_set);
             }
         }
         Ok(())

--- a/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
@@ -13,6 +13,7 @@ pub struct SequencerConfig<C: sov_modules_api::Context> {
     pub seq_rollup_address: C::Address,
     pub seq_da_address: Vec<u8>,
     pub coins_to_lock: sov_bank::Coins<C>,
+    pub preferred_sequencer: Option<C::Address>,
 }
 
 #[cfg_attr(feature = "native", derive(sov_modules_macros::ModuleCallJsonSchema))]
@@ -31,6 +32,12 @@ pub struct SequencerRegistry<C: sov_modules_api::Context> {
     ///
     #[state]
     pub(crate) allowed_sequencers: StateMap<Vec<u8>, C::Address>,
+
+    /// Optional preferred sequencer
+    /// If set, batches from this sequencer will be processed first in block,
+    /// So this sequencer can guarantee soft confirmation time for transactions
+    #[state]
+    pub(crate) preferred_sequencer: StateValue<C::Address>,
 
     /// Coin's that will be slashed if the sequencer is malicious.
     /// The coins will be transferred from `self.seq_rollup_address` to `self.address`
@@ -108,5 +115,13 @@ impl<C: sov_modules_api::Context> SequencerRegistry<C> {
             .set(&da_address, rollup_address, working_set);
 
         Ok(())
+    }
+
+    /// Return preferred sequencer if it was set
+    pub fn get_preferred_sequencer(
+        &self,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Option<C::Address> {
+        self.preferred_sequencer.get(working_set)
     }
 }

--- a/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
@@ -9,11 +9,14 @@ use sov_modules_macros::ModuleInfo;
 use sov_state::{StateMap, StateValue, WorkingSet};
 
 /// Initial configuration for the sov_sequencer_registry module.
+/// TODO: Should we allow multiple sequencers in genesis?
 pub struct SequencerConfig<C: sov_modules_api::Context> {
     pub seq_rollup_address: C::Address,
+    // TODO: Replace with DA address generic, when AddressTrait is split
     pub seq_da_address: Vec<u8>,
     pub coins_to_lock: sov_bank::Coins<C>,
-    pub preferred_sequencer: Option<C::Address>,
+    // TODO: Replace with DA address generic, when AddressTrait is split
+    pub preferred_sequencer: Option<Vec<u8>>,
 }
 
 #[cfg_attr(feature = "native", derive(sov_modules_macros::ModuleCallJsonSchema))]
@@ -37,7 +40,7 @@ pub struct SequencerRegistry<C: sov_modules_api::Context> {
     /// If set, batches from this sequencer will be processed first in block,
     /// So this sequencer can guarantee soft confirmation time for transactions
     #[state]
-    pub(crate) preferred_sequencer: StateValue<C::Address>,
+    pub(crate) preferred_sequencer: StateValue<Vec<u8>>,
 
     /// Coin's that will be slashed if the sequencer is malicious.
     /// The coins will be transferred from `self.seq_rollup_address` to `self.address`
@@ -118,10 +121,11 @@ impl<C: sov_modules_api::Context> SequencerRegistry<C> {
     }
 
     /// Return preferred sequencer if it was set
+    /// TODO: Replace with DA address generic, when AddressTrait is split
     pub fn get_preferred_sequencer(
         &self,
         working_set: &mut WorkingSet<C::Storage>,
-    ) -> Option<C::Address> {
+    ) -> Option<Vec<u8>> {
         self.preferred_sequencer.get(working_set)
     }
 }

--- a/module-system/module-implementations/sov-sequencer-registry/tests/helpers/mod.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/tests/helpers/mod.rs
@@ -94,6 +94,7 @@ pub fn create_sequencer_config(
             amount: LOCKED_AMOUNT,
             token_address,
         },
+        preferred_sequencer: None,
     }
 }
 

--- a/module-system/module-implementations/sov-sequencer-registry/tests/hooks_test.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/tests/hooks_test.rs
@@ -6,7 +6,7 @@ mod helpers;
 use helpers::*;
 use sov_modules_api::Address;
 use sov_rollup_interface::mocks::TestBlob;
-use sov_sequencer_registry::SequencerOutcome;
+use sov_sequencer_registry::{SequencerOutcome, SequencerRegistry};
 
 #[test]
 fn begin_blob_hook_known_sequencer() {
@@ -134,6 +134,69 @@ fn end_blob_hook_slash() {
         .registry
         .sequencer_address(GENESIS_SEQUENCER_DA_ADDRESS.to_vec(), working_set);
     assert!(resp.address.is_none());
+}
+
+#[test]
+fn end_blob_hook_slash_preferred_sequencer() {
+    let bank = sov_bank::Bank::<C>::default();
+    let (bank_config, seq_rollup_address) = create_bank_config();
+
+    let token_address = sov_bank::get_genesis_token_address::<C>(
+        &bank_config.tokens[0].token_name,
+        bank_config.tokens[0].salt,
+    );
+
+    let registry = SequencerRegistry::<C>::default();
+    let mut sequencer_config = create_sequencer_config(seq_rollup_address, token_address);
+
+    sequencer_config.preferred_sequencer = Some(sequencer_config.seq_da_address.clone());
+
+    let mut test_sequencer = TestSequencer {
+        bank,
+        bank_config,
+        registry,
+        sequencer_config,
+    };
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let working_set = &mut WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
+    test_sequencer.genesis(working_set);
+    let balance_after_genesis = {
+        let resp = test_sequencer.query_balance_via_bank(working_set);
+        resp.amount.unwrap()
+    };
+    assert_eq!(INITIAL_BALANCE - LOCKED_AMOUNT, balance_after_genesis);
+
+    let mut test_blob = TestBlob::new(
+        Vec::new(),
+        Address::from(GENESIS_SEQUENCER_DA_ADDRESS),
+        [0_u8; 32],
+    );
+
+    test_sequencer
+        .registry
+        .begin_blob_hook(&mut test_blob, working_set)
+        .unwrap();
+
+    let result = SequencerOutcome::Slashed {
+        sequencer: GENESIS_SEQUENCER_DA_ADDRESS.to_vec(),
+    };
+    test_sequencer
+        .registry
+        .end_blob_hook(result, working_set)
+        .unwrap();
+
+    let resp = test_sequencer.query_balance_via_bank(working_set);
+    assert_eq!(balance_after_genesis, resp.amount.unwrap());
+    let resp = test_sequencer
+        .registry
+        .sequencer_address(GENESIS_SEQUENCER_DA_ADDRESS.to_vec(), working_set);
+    assert!(resp.address.is_none());
+
+    assert!(test_sequencer
+        .registry
+        .get_preferred_sequencer(working_set)
+        .is_none());
 }
 
 #[test]

--- a/module-system/module-implementations/sov-sequencer-registry/tests/sequencer_registry_test.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/tests/sequencer_registry_test.rs
@@ -5,6 +5,7 @@ use sov_state::{ProverStorage, WorkingSet};
 mod helpers;
 
 use helpers::*;
+use sov_sequencer_registry::SequencerRegistry;
 
 // Happy path for registration and exit
 // This test checks:
@@ -213,4 +214,83 @@ fn test_allow_exit_last_sequencer() {
         .registry
         .call(exit_message, &sender_context, working_set)
         .expect("Last sequencer exit has failed");
+}
+
+#[test]
+fn test_preferred_sequencer_returned_and_removed() {
+    let bank = sov_bank::Bank::<C>::default();
+    let (bank_config, seq_rollup_address) = create_bank_config();
+
+    let token_address = sov_bank::get_genesis_token_address::<C>(
+        &bank_config.tokens[0].token_name,
+        bank_config.tokens[0].salt,
+    );
+
+    let registry = SequencerRegistry::<C>::default();
+    let mut sequencer_config = create_sequencer_config(seq_rollup_address, token_address);
+
+    sequencer_config.preferred_sequencer = Some(sequencer_config.seq_da_address.clone());
+
+    let mut test_sequencer = TestSequencer {
+        bank,
+        bank_config,
+        registry,
+        sequencer_config,
+    };
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let working_set = &mut WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
+    test_sequencer.genesis(working_set);
+
+    assert_eq!(
+        test_sequencer.sequencer_config.preferred_sequencer,
+        test_sequencer.registry.get_preferred_sequencer(working_set)
+    );
+
+    let sequencer_address = generate_address(GENESIS_SEQUENCER_KEY);
+    let sender_context = C::new(sequencer_address);
+    let exit_message = CallMessage::Exit {
+        da_address: GENESIS_SEQUENCER_DA_ADDRESS.to_vec(),
+    };
+    test_sequencer
+        .registry
+        .call(exit_message, &sender_context, working_set)
+        .expect("Last sequencer exit has failed");
+
+    // Preferred sequencer exited, so result is none
+    assert!(test_sequencer
+        .registry
+        .get_preferred_sequencer(working_set)
+        .is_none());
+}
+
+#[test]
+fn test_preferred_sequencer_not_allowed_sequencers() {
+    let bank = sov_bank::Bank::<C>::default();
+    let (bank_config, seq_rollup_address) = create_bank_config();
+
+    let token_address = sov_bank::get_genesis_token_address::<C>(
+        &bank_config.tokens[0].token_name,
+        bank_config.tokens[0].salt,
+    );
+
+    let some_da_address = UNKNOWN_SEQUENCER_DA_ADDRESS.to_vec();
+
+    let registry = SequencerRegistry::<C>::default();
+    let mut sequencer_config = create_sequencer_config(seq_rollup_address, token_address);
+
+    sequencer_config.preferred_sequencer = Some(some_da_address);
+
+    let tmpdir = tempfile::tempdir().unwrap();
+    let working_set = &mut WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
+
+    bank.genesis(&bank_config, working_set).unwrap();
+    let genesis_result = registry.genesis(&sequencer_config, working_set);
+    assert!(genesis_result.is_err());
+
+    let message = genesis_result.err().unwrap().to_string();
+    assert_eq!(
+        "Preferred sequencer is not in list of allowed sequencers",
+        message
+    );
 }


### PR DESCRIPTION
# Description

Adds notion of preferred sequencer to sequencer registry. This is required feature for "Based sequencer with soft confirmations"

In first version, preferred sequencer can be added only in genesis and later can be only removed if preferred sequencer exits or slashed. Feature for implementing that: https://github.com/Sovereign-Labs/sovereign-sdk/issues/543

## Linked Issues
- Related to #408

## Testing
Automated tests have been added

## Docs
Docs for public methods have been added
