### PR TITLE
Add missing doc for the `sov-modules-stf-template` crate.

### DIFF
--- a/examples/demo-stf/src/sov-cli/main.rs
+++ b/examples/demo-stf/src/sov-cli/main.rs
@@ -14,7 +14,7 @@ use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
 use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{AddressBech32, PublicKey, Spec};
-use sov_modules_stf_template::RawTx;
+pub use sov_modules_stf_template::RawTx;
 use sov_sequencer::SubmitTransaction;
 
 type C = DefaultContext;

--- a/examples/demo-stf/src/sov-cli/main.rs
+++ b/examples/demo-stf/src/sov-cli/main.rs
@@ -14,7 +14,7 @@ use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
 use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{AddressBech32, PublicKey, Spec};
-pub use sov_modules_stf_template::RawTx;
+use sov_modules_stf_template::RawTx;
 use sov_sequencer::SubmitTransaction;
 
 type C = DefaultContext;

--- a/module-system/sov-modules-stf-template/Cargo.toml
+++ b/module-system/sov-modules-stf-template/Cargo.toml
@@ -11,7 +11,8 @@ version = { workspace = true }
 readme = "README.md"
 resolver = "2"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+doctest = false
 
 [dependencies]
 anyhow = { workspace = true }

--- a/module-system/sov-modules-stf-template/Cargo.toml
+++ b/module-system/sov-modules-stf-template/Cargo.toml
@@ -11,9 +11,6 @@ version = { workspace = true }
 readme = "README.md"
 resolver = "2"
 
-[lib]
-doctest = false
-
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true }

--- a/module-system/sov-modules-stf-template/README.md
+++ b/module-system/sov-modules-stf-template/README.md
@@ -4,7 +4,7 @@
 
 This crate contains an implementation of a `StateTransitionFunction` called `AppTemplate` that is specifically designed to work with the Module System. The `AppTemplate` relies on a set of traits that, when combined, define the logic for transitioning the rollup state.
 
-```rust
+```rust ignore
 pub struct AppTemplate<C: Context, RT, Vm> {
     pub current_storage: C::Storage,
     pub runtime: RT,
@@ -35,7 +35,7 @@ where
 
 Both the `DispatchCall` and `Genesis` traits can be automatically derived (see `RT` in the above snippet) for any set of modules:
 
-```rust
+```rust ignore
 #[derive(Genesis, DispatchCall, MessageCodec)]
 #[serialization(borsh::BorshDeserialize, borsh::BorshSerialize)]
 pub struct Runtime<C: Context> {

--- a/module-system/sov-modules-stf-template/src/app_template.rs
+++ b/module-system/sov-modules-stf-template/src/app_template.rs
@@ -14,11 +14,11 @@ use crate::{Batch, SequencerOutcome, SlashingReason, TxEffect};
 
 type ApplyBatchResult<T> = Result<T, ApplyBatchError>;
 
-/// This implementation of the `StateTransitionFunction` hat is specifically designed to work with the Module System. The `AppTemplate` relies on a set of traits that, when combined, define the logic for transitioning the rollup state.
+/// This implementation of the `StateTransitionFunction` that is specifically designed to work with the module-system.
 pub struct AppTemplate<C: Context, RT, Vm, B> {
     /// State storage used by te rollup.
     pub current_storage: C::Storage,
-    /// Runtime contains all the modules supported by the rollup.
+    /// The runtime includes all the modules that the rollup supports.
     pub runtime: RT,
     pub(crate) checkpoint: Option<StateCheckpoint<C::Storage>>,
     phantom_vm: PhantomData<Vm>,

--- a/module-system/sov-modules-stf-template/src/app_template.rs
+++ b/module-system/sov-modules-stf-template/src/app_template.rs
@@ -69,7 +69,7 @@ where
         + TxHooks<Context = C>
         + ApplyBlobHooks<Context = C, BlobResult = SequencerOutcome>,
 {
-    /// AppTemplate constructor.
+    /// [`AppTemplate`] constructor.
     pub fn new(storage: C::Storage, runtime: RT) -> Self {
         Self {
             runtime,

--- a/module-system/sov-modules-stf-template/src/app_template.rs
+++ b/module-system/sov-modules-stf-template/src/app_template.rs
@@ -14,7 +14,7 @@ use crate::{Batch, SequencerOutcome, SlashingReason, TxEffect};
 
 type ApplyBatchResult<T> = Result<T, ApplyBatchError>;
 
-/// This implementation of the `StateTransitionFunction` that is specifically designed to work with the module-system.
+/// This is an implementation of the `StateTransitionFunction` that is specifically designed to work with the module-system.
 pub struct AppTemplate<C: Context, RT, Vm, B> {
     /// State storage used by the rollup.
     pub current_storage: C::Storage,

--- a/module-system/sov-modules-stf-template/src/app_template.rs
+++ b/module-system/sov-modules-stf-template/src/app_template.rs
@@ -14,7 +14,9 @@ use crate::{Batch, SequencerOutcome, SlashingReason, TxEffect};
 
 type ApplyBatchResult<T> = Result<T, ApplyBatchError>;
 
-/// This is an implementation of the `StateTransitionFunction` that is specifically designed to work with the module-system.
+/// An implementation of the
+/// [`StateTransitionFunction`](sov_rollup_interface::stf::StateTransitionFunction)
+/// that is specifically designed to work with the module-system.
 pub struct AppTemplate<C: Context, RT, Vm, B> {
     /// State storage used by the rollup.
     pub current_storage: C::Storage,

--- a/module-system/sov-modules-stf-template/src/app_template.rs
+++ b/module-system/sov-modules-stf-template/src/app_template.rs
@@ -16,7 +16,7 @@ type ApplyBatchResult<T> = Result<T, ApplyBatchError>;
 
 /// This implementation of the `StateTransitionFunction` that is specifically designed to work with the module-system.
 pub struct AppTemplate<C: Context, RT, Vm, B> {
-    /// State storage used by te rollup.
+    /// State storage used by the rollup.
     pub current_storage: C::Storage,
     /// The runtime includes all the modules that the rollup supports.
     pub runtime: RT,

--- a/module-system/sov-modules-stf-template/src/app_template.rs
+++ b/module-system/sov-modules-stf-template/src/app_template.rs
@@ -14,8 +14,11 @@ use crate::{Batch, SequencerOutcome, SlashingReason, TxEffect};
 
 type ApplyBatchResult<T> = Result<T, ApplyBatchError>;
 
+/// This implementation of the `StateTransitionFunction` hat is specifically designed to work with the Module System. The `AppTemplate` relies on a set of traits that, when combined, define the logic for transitioning the rollup state.
 pub struct AppTemplate<C: Context, RT, Vm, B> {
+    /// State storage used by te rollup.
     pub current_storage: C::Storage,
+    /// Runtime contains all the modules supported by the rollup.
     pub runtime: RT,
     pub(crate) checkpoint: Option<StateCheckpoint<C::Storage>>,
     phantom_vm: PhantomData<Vm>,
@@ -23,10 +26,10 @@ pub struct AppTemplate<C: Context, RT, Vm, B> {
 }
 
 pub(crate) enum ApplyBatchError {
-    /// Contains batch hash
+    // Contains batch hash
     Ignored([u8; 32]),
     Slashed {
-        /// Contains batch hash
+        // Contains batch hash
         hash: [u8; 32],
         reason: SlashingReason,
         sequencer_da_address: Vec<u8>,
@@ -64,6 +67,7 @@ where
         + TxHooks<Context = C>
         + ApplyBlobHooks<Context = C, BlobResult = SequencerOutcome>,
 {
+    /// AppTemplate constructor.
     pub fn new(storage: C::Storage, runtime: RT) -> Self {
         Self {
             runtime,
@@ -272,7 +276,7 @@ where
         &self,
         batch: Batch,
     ) -> Result<Vec<TransactionAndRawHash<C>>, SlashingReason> {
-        match verify_txs_stateless(batch.take_transactions()) {
+        match verify_txs_stateless(batch.txs) {
             Ok(txs) => Ok(txs),
             Err(e) => {
                 error!("Stateless verification error - the sequencer included a transaction which was known to be invalid. {}\n", e);

--- a/module-system/sov-modules-stf-template/src/batch.rs
+++ b/module-system/sov-modules-stf-template/src/batch.rs
@@ -1,20 +1,11 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
-// use sov_rollup_interface::traits::TransactionTrait;
 use crate::tx_verifier::RawTx;
 
+/// Contains taw transactions obtined from the DA blob.
 #[derive(Debug, PartialEq, Clone, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 pub struct Batch {
+    /// Raw transactions.
     pub txs: Vec<RawTx>,
-}
-
-impl Batch {
-    pub fn transactions(&self) -> &[RawTx] {
-        &self.txs
-    }
-
-    pub fn take_transactions(self) -> Vec<RawTx> {
-        self.txs
-    }
 }

--- a/module-system/sov-modules-stf-template/src/batch.rs
+++ b/module-system/sov-modules-stf-template/src/batch.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::tx_verifier::RawTx;
 
-/// Contains taw transactions obtined from the DA blob.
+/// Contains raw transactions obtained from the DA blob.
 #[derive(Debug, PartialEq, Clone, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 pub struct Batch {
     /// Raw transactions.

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -25,7 +25,7 @@ pub enum TxEffect {
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 // TODO: Should be generic for Address for pretty printing https://github.com/Sovereign-Labs/sovereign-sdk/issues/465
-/// The `SequencerOutcome` enum represents the different outcomes that can occur for a sequencer after batch processing.
+/// Represents the different outcomes that can occur for a sequencer after batch processing.
 pub enum SequencerOutcome {
     /// Sequencer receives reward amount in defined token and can withdraw its deposit
     Rewarded(u64),

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -1,4 +1,6 @@
-pub mod app_template;
+//!TODO
+#![deny(missing_docs)]
+mod app_template;
 mod batch;
 mod tx_verifier;
 
@@ -12,33 +14,43 @@ use sov_rollup_interface::zk::Zkvm;
 use sov_state::{StateCheckpoint, Storage};
 pub use tx_verifier::RawTx;
 
+/// The receipts of all the transactions in a batch.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum TxEffect {
+    /// Batch was reverted.
     Reverted,
+    /// Batch was processed successfully.
     Successful,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 // TODO: Should be generic for Address for pretty printing https://github.com/Sovereign-Labs/sovereign-sdk/issues/465
+/// TODO
 pub enum SequencerOutcome {
     /// Sequencer receives reward amount in defined token and can withdraw its deposit
     Rewarded(u64),
     /// Sequencer loses its deposit and receives no reward
     Slashed {
+        /// Reason why sequencer was slashed.
         reason: SlashingReason,
         // Keep this comment for so it doesn't need to investigate serde issue again.
         // https://github.com/Sovereign-Labs/sovereign-sdk/issues/465
         // #[serde(bound(deserialize = ""))]
+        /// Sequencer address on DA.
         sequencer_da_address: Vec<u8>,
     },
     /// Batch was ignored, sequencer deposit left untouched.
     Ignored,
 }
 
+/// Reason why sequencer was slashed.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SlashingReason {
+    /// This status indicates problem with batch deserialization.
     InvalidBatchEncoding,
+    /// Stateless verification failed, for example deserialized transactions have invalid signatures.
     StatelessVerificationFailed,
+    /// This status indicates problem with transaction deserialization.
     InvalidTransactionEncoding,
 }
 

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -25,7 +25,7 @@ pub enum TxEffect {
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 // TODO: Should be generic for Address for pretty printing https://github.com/Sovereign-Labs/sovereign-sdk/issues/465
-/// TODO
+//The `SequencerOutcome` enum represents the different outcomes that can occur for a sequencer after batch processing.
 pub enum SequencerOutcome {
     /// Sequencer receives reward amount in defined token and can withdraw its deposit
     Rewarded(u64),

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -1,5 +1,5 @@
-//!TODO
 #![deny(missing_docs)]
+#![doc = include_str!("../README.md")]
 mod app_template;
 mod batch;
 mod tx_verifier;
@@ -25,7 +25,7 @@ pub enum TxEffect {
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 // TODO: Should be generic for Address for pretty printing https://github.com/Sovereign-Labs/sovereign-sdk/issues/465
-//The `SequencerOutcome` enum represents the different outcomes that can occur for a sequencer after batch processing.
+/// The `SequencerOutcome` enum represents the different outcomes that can occur for a sequencer after batch processing.
 pub enum SequencerOutcome {
     /// Sequencer receives reward amount in defined token and can withdraw its deposit
     Rewarded(u64),

--- a/module-system/sov-modules-stf-template/src/tx_verifier.rs
+++ b/module-system/sov-modules-stf-template/src/tx_verifier.rs
@@ -16,6 +16,7 @@ pub(crate) struct TransactionAndRawHash<C: Context> {
 /// RawTx represents a serialized rollup transaction received from the DA.
 #[derive(Debug, PartialEq, Clone, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
 pub struct RawTx {
+    /// Serialized transaction.
     pub data: Vec<u8>,
 }
 


### PR DESCRIPTION
# Description
`sov-modules-stf-template` crate compiles with the `#![deny(missing_docs)]` lint.

## Linked Issues
- Related to #438

## Testing
No impact on tests.

## Docs
Missing docs provided.
