### PR TITLE
Make tests independent of OS and language.

### DIFF
--- a/examples/demo-stf/src/runner_config.rs
+++ b/examples/demo-stf/src/runner_config.rs
@@ -86,9 +86,6 @@ mod tests {
         let config: anyhow::Result<Config> = from_toml_path(path);
 
         assert!(config.is_err());
-        assert_eq!(
-            config.unwrap_err().to_string(),
-            "No such file or directory (os error 2)"
-        );
+        assert!(config.unwrap_err().to_string().ends_with("(os error 2)"));
     }
 }


### PR DESCRIPTION
# Description
- Test was dependent on locale, meaning that with language pack it will fail.
- Make test_non_existent_config not dependent on OS and language.