### PR TITLE
CI improvements: dependabot frequency, experimental testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
     - package-ecosystem: cargo
       directory: "/"
       schedule:
-          interval: daily
+          interval: weekly
+          day: monday
           time: "15:00"
           timezone: "Europe/Warsaw"
       open-pull-requests-limit: 10

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,12 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Automatically cancels a job if a new commit if pushed to the same PR, branch, or tag.
+# Source: <https://stackoverflow.com/a/72408109/5148606>
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,6 +89,19 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.3
       - name: Run cargo test
         run: cargo test
+  test-experimental:
+    runs-on:
+      group: 8-cores_32GB_Ubuntu Group
+    timeout-minutes: 60
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - uses: mozilla-actions/sccache-action@v0.0.3
+      - name: Run cargo test --features experimental
+        run: cargo test --features experimental
   coverage:
     runs-on:
       group: 8-cores_32GB_Ubuntu Group

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -177,7 +177,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Setup Rust toolchain
+        run: rustup show
       - run: cargo install cargo-deny
       - run: cargo deny check licenses
   cargo-doc-artifact:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -177,7 +177,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain
+      - uses: actions-rs/toolchain@v1
       - run: cargo install cargo-deny
       - run: cargo deny check licenses
   cargo-doc-artifact:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -166,6 +166,14 @@ jobs:
             echo "Curl failed, retrying in 5 seconds..."
             sleep 5
           done
+  check-licenses:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain
+      - run: cargo install cargo-deny
+      - run: cargo deny check licenses
   cargo-doc-artifact:
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -184,6 +184,11 @@ jobs:
   cargo-doc-artifact:
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # We only deploy `cargo doc` to GH pages on `stable`, but let's at least
+    # build it on `nightly` as well to avoid nasty surprises when merging
+    # `nightly` into `stable`. Running it on every PR would be excessive,
+    # though.
+    if: (github.ref == 'refs/heads/stable') || (github.ref == 'refs/heads/nightly')
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
@@ -205,7 +210,6 @@ jobs:
   deploy-github-pages:
     needs: cargo-doc-artifact
     timeout-minutes: 5
-    # No point in deploying if we're not on `stable`, as it will just fail.
     if: github.ref == 'refs/heads/stable'
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:

--- a/adapters/celestia/Cargo.toml
+++ b/adapters/celestia/Cargo.toml
@@ -2,6 +2,7 @@
 name = "jupiter"
 version = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,24 @@
+[licenses]
+# Deny crates that do not have a license.
+unlicensed = "deny"
+allow = [
+	"Apache-2.0",
+	"MIT",
+	"Unlicense",
+	"Unicode-DFS-2016",
+	"MPL-2.0",
+	"ISC",
+	"CC0-1.0",
+	"BSD-2-Clause",
+	"BSD-3-Clause",
+	"OpenSSL",
+]
+
+[[licenses.clarify]]
+name = "ring"
+# ring is derived from BoringSSL and has a bit of a special licensing situation,
+# but we can effectively treat is as OpenSSL-like licensing.
+expression = "OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]

--- a/examples/const-rollup-config/Cargo.toml
+++ b/examples/const-rollup-config/Cargo.toml
@@ -3,5 +3,6 @@ name = "const-rollup-config"
 version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
+license = { workspace = true }
 homepage = "sovereign.xyz"
 publish = false

--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -3,6 +3,7 @@ name = "sov-demo-rollup"
 version = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }
+license = { workspace = true }
 homepage = "sovereign.xyz"
 publish = false
 resolver = "2"

--- a/examples/demo-simple-stf/Cargo.toml
+++ b/examples/demo-simple-stf/Cargo.toml
@@ -4,6 +4,7 @@ version = { workspace = true }
 edition = { workspace = true } 
 resolver = "2"
 authors = { workspace = true } 
+license = { workspace = true } 
 homepage = "sovereign.xyz"
 publish = false
 

--- a/examples/demo-stf/Cargo.toml
+++ b/examples/demo-stf/Cargo.toml
@@ -4,6 +4,7 @@ version = { workspace = true }
 edition = { workspace = true }
 resolver = "2"
 authors = { workspace = true }
+license = { workspace = true }
 homepage = "sovereign.xyz"
 publish = false
 


### PR DESCRIPTION
# Description
- Run dependabot weekly instead of daily.
- Add any missing license fields to our Cargo manifests.
- Enable experimental feature testing on CI.
- Add `cargo-deny` for license checking. This will coexist with `actions/dependency-review-action@v3` for a while, but the intention is to eventually phase out the latter.

CI minutes saving strategies:
- Cancel all jobs when a new job is pushed to the same PR, branch, or tag.
- Only build `cargo doc` on `nightly` or `stable`, instead of every commit.

## Linked Issues
Related to #188.

