### PR TITLE
Change STF to work on block level instead of batch level

### DIFF
--- a/adapters/celestia/src/verifier/mod.rs
+++ b/adapters/celestia/src/verifier/mod.rs
@@ -2,8 +2,7 @@ use nmt_rs::NamespaceId;
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::crypto::SimpleHasher;
 use sov_rollup_interface::da::{
-    self, BlobTransactionTrait, BlockHashTrait as BlockHash, BlockHeaderTrait, CountedBufReader,
-    DaSpec,
+    self, BlobReaderTrait, BlockHashTrait as BlockHash, BlockHeaderTrait, CountedBufReader, DaSpec,
 };
 use sov_rollup_interface::zk::ValidityCondition;
 use sov_rollup_interface::Buf;
@@ -27,7 +26,7 @@ pub struct CelestiaVerifier {
 pub const PFB_NAMESPACE: NamespaceId = NamespaceId(hex_literal::hex!("0000000000000004"));
 pub const PARITY_SHARES_NAMESPACE: NamespaceId = NamespaceId(hex_literal::hex!("ffffffffffffffff"));
 
-impl BlobTransactionTrait for BlobWithSender {
+impl BlobReaderTrait for BlobWithSender {
     type Data = BlobIterator;
     type Address = CelestiaAddress;
 

--- a/adapters/risc0/src/host.rs
+++ b/adapters/risc0/src/host.rs
@@ -23,7 +23,7 @@ impl<'a> Risc0Host<'a> {
     }
 
     /// Run a computation in the zkvm without generating a receipt.
-    /// This creates the "Session" trace without invoking the heavy cryptoraphic machinery.
+    /// This creates the "Session" trace without invoking the heavy cryptographic machinery.
     pub fn run_without_proving(&mut self) -> anyhow::Result<Session> {
         let env = self.env.borrow_mut().build()?;
         let mut executor = LocalExecutor::from_elf(env, self.elf)?;

--- a/examples/demo-prover/Cargo.lock
+++ b/examples/demo-prover/Cargo.lock
@@ -3079,12 +3079,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "clap",
  "jsonrpsee",
  "schemars",
  "serde",
  "serde_json",
  "sov-modules-api",
  "sov-state",
+ "thiserror",
 ]
 
 [[package]]
@@ -3093,12 +3095,16 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "clap",
+ "hex",
  "jsonrpsee",
  "schemars",
  "serde",
  "serde_json",
  "sov-modules-api",
+ "sov-rollup-interface",
  "sov-state",
+ "thiserror",
 ]
 
 [[package]]
@@ -3147,11 +3153,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "clap",
+ "hex",
  "jsonrpsee",
  "schemars",
  "serde",
  "serde_json",
  "sov-modules-api",
+ "sov-rollup-interface",
  "sov-state",
 ]
 
@@ -3169,6 +3178,7 @@ dependencies = [
  "anyhow",
  "bech32",
  "borsh",
+ "clap",
  "derive_more",
  "ed25519-dalek",
  "hex",
@@ -3256,6 +3266,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "clap",
  "jsonrpsee",
  "schemars",
  "serde",
@@ -3288,6 +3299,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "clap",
  "jsonrpsee",
  "schemars",
  "serde",

--- a/examples/demo-prover/host/src/main.rs
+++ b/examples/demo-prover/host/src/main.rs
@@ -73,9 +73,10 @@ async fn main() -> Result<(), anyhow::Error> {
         demo.init_chain(genesis_config);
     }
 
-    demo.begin_slot(Default::default());
-    let (prev_state_root, _) = demo.end_slot();
-    let mut prev_state_root = prev_state_root.0;
+    let mut prev_state_root = {
+        let res = demo.apply_slot(Default::default(), []);
+        res.state_root.0
+    };
 
     for height in rollup_config.start_height.. {
         let mut host = Risc0Host::new(ROLLUP_ELF);
@@ -88,41 +89,31 @@ async fn main() -> Result<(), anyhow::Error> {
         let filtered_block = da_service.get_finalized_at(height).await?;
         let header_hash = hex::encode(filtered_block.header.header.hash());
         host.write_to_guest(&filtered_block.header);
-        let (blob_txs, inclusion_proof, completeness_proof) = da_service
+        let (mut blobs, inclusion_proof, completeness_proof) = da_service
             .extract_relevant_txs_with_proof(&filtered_block)
             .await;
 
+        info!(
+            "Extracted {} relevant blobs at height {} header 0x{}",
+            blobs.len(),
+            height,
+            header_hash,
+        );
+
         host.write_to_guest(&inclusion_proof);
         host.write_to_guest(&completeness_proof);
+        host.write_to_guest(&blobs);
 
-        demo.begin_slot(Default::default());
-        if blob_txs.is_empty() {
-            info!(
-                "Block at height {} with header 0x{} has no batches, skip proving",
-                height, header_hash
-            );
-            continue;
-        }
-        info!("Block has {} batches", blob_txs.len());
-        for mut blob in blob_txs.clone() {
-            let receipt = demo.apply_blob(&mut blob, None);
-            info!(
-                "batch with hash=0x{} has been applied",
-                hex::encode(receipt.batch_hash)
-            );
-        }
-        // Write txs only after they been read, so verification can be done properly
-        host.write_to_guest(&blob_txs);
+        let result = demo.apply_slot(Default::default(), &mut blobs);
 
-        let (next_state_root, witness) = demo.end_slot();
-        host.write_to_guest(&witness);
+        host.write_to_guest(&result.witness);
 
         info!("Starting proving...");
         let receipt = host.run().expect("Prover should run successfully");
         info!("Start verifying..");
         receipt.verify(ROLLUP_ID).expect("Receipt should be valid");
 
-        prev_state_root = next_state_root.0;
+        prev_state_root = result.state_root.0;
         info!("Completed proving and verifying block {height}");
     }
 

--- a/examples/demo-prover/methods/guest/Cargo.lock
+++ b/examples/demo-prover/methods/guest/Cargo.lock
@@ -2297,6 +2297,7 @@ dependencies = [
  "borsh",
  "sov-modules-api",
  "sov-state",
+ "thiserror",
 ]
 
 [[package]]
@@ -2305,8 +2306,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "hex",
  "sov-modules-api",
+ "sov-rollup-interface",
  "sov-state",
+ "thiserror",
 ]
 
 [[package]]
@@ -2338,7 +2342,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "hex",
  "sov-modules-api",
+ "sov-rollup-interface",
  "sov-state",
 ]
 

--- a/examples/demo-prover/methods/guest/src/bin/rollup.rs
+++ b/examples/demo-prover/methods/guest/src/bin/rollup.rs
@@ -36,13 +36,13 @@ pub fn main() {
     env::write(&"Prev root hash read\n");
     // Step 1: read tx list
     let header: CelestiaHeader = guest.read_from_host();
-    env::write(&"header read\n");
+    env::write(&"header has been read\n");
     let inclusion_proof: <CelestiaSpec as DaSpec>::InclusionMultiProof = guest.read_from_host();
-    env::write(&"inclusion proof read\n");
+    env::write(&"inclusion proof has been read\n");
     let completeness_proof: <CelestiaSpec as DaSpec>::CompletenessProof = guest.read_from_host();
-    env::write(&"completeness proof read\n");
+    env::write(&"completeness proof has been read\n");
     let mut blobs: Vec<BlobWithSender> = guest.read_from_host();
-    env::write(&"txs read\n");
+    env::write(&"blobs have been read\n");
 
     // Step 2: Apply blobs
     let mut demo_runner = <ZkAppRunner<Risc0Guest, BlobWithSender> as StateTransitionRunner<
@@ -53,21 +53,18 @@ pub fn main() {
     let demo = demo_runner.inner_mut();
 
     let witness: ArrayWitness = guest.read_from_host();
-    env::write(&"Witness read\n");
+    env::write(&"Witness have been read\n");
 
-    demo.begin_slot(witness);
-    env::write(&"Slot has begun\n");
-    for blob in &mut blobs {
-        demo.apply_blob(blob, None);
-        env::write(&"Blob applied\n");
-    }
-    let (state_root, _) = demo.end_slot();
-    env::write(&"Slot has ended\n");
+    env::write(&"Applying slot...\n");
+    let result = demo.apply_slot(witness, &mut blobs);
+
+    env::write(&"Slot has been applied\n");
 
     // Step 3: Verify tx list
     let verifier = CelestiaVerifier::new(jupiter::verifier::RollupParams {
         namespace: ROLLUP_NAMESPACE,
     });
+
     let validity_condition = verifier
         .verify_relevant_tx_list::<NoOpHasher>(&header, &blobs, inclusion_proof, completeness_proof)
         .expect("Transaction list must be correct");
@@ -75,7 +72,7 @@ pub fn main() {
 
     let output = StateTransition {
         initial_state_root: prev_state_root_hash,
-        final_state_root: state_root.0,
+        final_state_root: result.state_root.0,
         validity_condition,
     };
     env::commit(&output);

--- a/examples/demo-rollup/benches/rollup_bench.rs
+++ b/examples/demo-rollup/benches/rollup_bench.rs
@@ -58,8 +58,8 @@ fn rollup_bench(_bench: &mut Criterion) {
     let _prev_state_root = {
         // Check if the rollup has previously been initialized
         demo.init_chain(demo_genesis_config);
-        demo.begin_slot(Default::default());
-        let (prev_state_root, _) = demo.end_slot();
+        let apply_block_result = demo.apply_slot(Default::default(), []);
+        let prev_state_root = apply_block_result.state_root;
         prev_state_root.0
     };
 
@@ -89,14 +89,12 @@ fn rollup_bench(_bench: &mut Criterion) {
             let filtered_block = &blocks[height as usize];
 
             let mut data_to_commit = SlotCommit::new(filtered_block.clone());
-            demo.begin_slot(Default::default());
 
-            for blob in &mut blobs[height as usize] {
-                let receipts = demo.apply_blob(blob, None);
-                // println!("{:?}", receipts);
+            let apply_block_result =
+                demo.apply_slot(Default::default(), &mut blobs[height as usize]);
+            for receipts in apply_block_result.batch_receipts {
                 data_to_commit.add_batch(receipts);
             }
-            let (_next_state_root, _witness) = demo.end_slot();
 
             ledger_db.commit_slot(data_to_commit).unwrap();
             height += 1;

--- a/examples/demo-rollup/benches/rollup_coarse_measure.rs
+++ b/examples/demo-rollup/benches/rollup_coarse_measure.rs
@@ -26,22 +26,13 @@ extern crate prettytable;
 
 use prettytable::Table;
 
-fn print_times(
-    total: Duration,
-    begin_slot_time: Duration,
-    end_slot_time: Duration,
-    apply_blob_time: Duration,
-    blocks: u64,
-    num_txns: u64,
-) {
+fn print_times(total: Duration, apply_block_time: Duration, blocks: u64, num_txns: u64) {
     let mut table = Table::new();
 
     table.add_row(row!["Blocks", format!("{:?}", blocks)]);
     table.add_row(row!["Txns per Block", format!("{:?}", num_txns)]);
     table.add_row(row!["Total", format!("{:?}", total)]);
-    table.add_row(row!["Begin slot", format!("{:?}", begin_slot_time)]);
-    table.add_row(row!["End slot", format!("{:?}", end_slot_time)]);
-    table.add_row(row!["Apply Blob", format!("{:?}", apply_blob_time)]);
+    table.add_row(row!["Apply Block", format!("{:?}", apply_block_time)]);
     table.add_row(row![
         "Txns per sec (TPS)",
         format!(
@@ -57,30 +48,15 @@ fn print_times(
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let registry = Registry::new();
-    let h_apply_blob = Histogram::with_opts(HistogramOpts::new(
-        "block_processing_apply_blob",
+    let h_apply_block = Histogram::with_opts(HistogramOpts::new(
+        "block_processing_apply_block",
         "Histogram of block processing - apply blob times",
     ))
     .expect("Failed to create histogram");
-    let h_begin_slot = Histogram::with_opts(HistogramOpts::new(
-        "block_processing_begin_slot",
-        "Histogram of block processing - begin slot times",
-    ))
-    .expect("Failed to create histogram");
-    let h_end_slot = Histogram::with_opts(HistogramOpts::new(
-        "block_processing_end_slot",
-        "Histogram of block processing - end slot times",
-    ))
-    .expect("Failed to create histogram");
+
     registry
-        .register(Box::new(h_apply_blob.clone()))
+        .register(Box::new(h_apply_block.clone()))
         .expect("Failed to register apply blob histogram");
-    registry
-        .register(Box::new(h_begin_slot.clone()))
-        .expect("Failed to register begin slot histogram");
-    registry
-        .register(Box::new(h_end_slot.clone()))
-        .expect("Failed to register end slot histogram");
 
     let start_height: u64 = 0u64;
     let mut end_height: u64 = 10u64;
@@ -130,8 +106,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let _prev_state_root = {
         // Check if the rollup has previously been initialized
         demo.init_chain(demo_genesis_config);
-        demo.begin_slot(Default::default());
-        let (prev_state_root, _) = demo.end_slot();
+        let apply_block_result = demo.apply_slot(Default::default(), []);
+        let prev_state_root = apply_block_result.state_root;
         prev_state_root.0
     };
 
@@ -153,50 +129,34 @@ async fn main() -> Result<(), anyhow::Error> {
         blocks.push(filtered_block.clone());
 
         let blob_txs = da_service.extract_relevant_txs(&filtered_block);
-        blobs.push(blob_txs.clone());
+        blobs.push(blob_txs);
     }
 
     // rollup processing
-    let total = std::time::Instant::now();
-    let mut begin_slot_time = Duration::new(0, 0);
-    let mut end_slot_time = Duration::new(0, 0);
-    let mut apply_blob_time = Duration::new(0, 0);
+    let total = Instant::now();
+    let mut apply_block_time = Duration::new(0, 0);
     for height in start_height..end_height {
         let filtered_block = &blocks[height as usize];
 
         let mut data_to_commit = SlotCommit::new(filtered_block.clone());
 
         let now = Instant::now();
-        demo.begin_slot(Default::default());
-        begin_slot_time += now.elapsed();
-        h_begin_slot.observe(now.elapsed().as_secs_f64());
 
-        for blob in &mut blobs[height as usize] {
-            let now = Instant::now();
-            let receipts = demo.apply_blob(blob, None);
-            apply_blob_time += now.elapsed();
-            h_apply_blob.observe(now.elapsed().as_secs_f64());
-            data_to_commit.add_batch(receipts);
+        let apply_block_results = demo.apply_slot(Default::default(), &mut blobs[height as usize]);
+
+        apply_block_time += now.elapsed();
+        h_apply_block.observe(now.elapsed().as_secs_f64());
+
+        for receipt in apply_block_results.batch_receipts {
+            data_to_commit.add_batch(receipt);
         }
-
-        let now = Instant::now();
-        let (_next_state_root, _witness) = demo.end_slot();
-        end_slot_time += now.elapsed();
-        h_end_slot.observe(now.elapsed().as_secs_f64());
 
         ledger_db.commit_slot(data_to_commit).unwrap();
     }
 
     let total = total.elapsed();
     if timer_output {
-        print_times(
-            total,
-            begin_slot_time,
-            end_slot_time,
-            apply_blob_time,
-            end_height,
-            num_txns,
-        );
+        print_times(total, apply_block_time, end_height, num_txns);
     }
     if prometheus_output {
         println!("{:#?}", registry.gather());

--- a/examples/demo-rollup/src/main.rs
+++ b/examples/demo-rollup/src/main.rs
@@ -190,11 +190,10 @@ async fn main() -> Result<(), anyhow::Error> {
             debug!("Chain is already initialized. Skipping initialization.");
         }
 
+        let res = demo.apply_slot(Default::default(), []);
         // HACK: Tell the rollup that you're running an empty DA layer block so that it will return the latest state root.
         // This will be removed shortly.
-        demo.begin_slot(Default::default());
-        let (prev_state_root, _) = demo.end_slot();
-        prev_state_root.0
+        res.state_root.0
     };
 
     // Start the main rollup loop
@@ -218,32 +217,19 @@ async fn main() -> Result<(), anyhow::Error> {
         // simply download the data from Celestia without extracting and checking a merkle proof here,
         let mut blobs = da_service.extract_relevant_txs(&filtered_block);
 
-        info!("Received {} blobs at height {}", blobs.len(), height);
+        info!(
+            "Extracted {} relevant blobs at height {}",
+            blobs.len(),
+            height
+        );
 
         let mut data_to_commit = SlotCommit::new(filtered_block.clone());
-        demo.begin_slot(Default::default());
-        for (blob_idx, blob) in blobs.iter_mut().enumerate() {
-            let batch_receipt = demo.apply_blob(blob, None);
-            info!(
-                "blob #{} at height {} with blob_hash 0x{} has been applied with #{} transactions, sequencer outcome {:?}",
-                blob_idx,
-                height,
-                hex::encode(batch_receipt.batch_hash),
-                batch_receipt.tx_receipts.len(),
-                batch_receipt.inner
-            );
-            for (i, tx_receipt) in batch_receipt.tx_receipts.iter().enumerate() {
-                info!(
-                    "tx #{} hash: 0x{} result {:?}",
-                    i,
-                    hex::encode(tx_receipt.tx_hash),
-                    tx_receipt.receipt
-                );
-            }
 
-            data_to_commit.add_batch(batch_receipt);
+        let slot_result = demo.apply_slot(Default::default(), &mut blobs);
+        for receipt in slot_result.batch_receipts {
+            data_to_commit.add_batch(receipt);
         }
-        let (next_state_root, _witness) = demo.end_slot();
+        let next_state_root = slot_result.state_root;
 
         let (inclusion_proof, completeness_proof) = da_service
             .get_extraction_proof(&filtered_block, &blobs)

--- a/examples/demo-simple-stf/src/lib.rs
+++ b/examples/demo-simple-stf/src/lib.rs
@@ -1,8 +1,8 @@
 use std::io::Read;
 
 use sha2::Digest;
-use sov_rollup_interface::da::BlobTransactionTrait;
-use sov_rollup_interface::stf::{BatchReceipt, StateTransitionFunction};
+use sov_rollup_interface::da::BlobReaderTrait;
+use sov_rollup_interface::stf::{BatchReceipt, SlotResult, StateTransitionFunction};
 use sov_rollup_interface::zk::Zkvm;
 
 #[derive(PartialEq, Debug, Clone, Eq, serde::Serialize, serde::Deserialize)]
@@ -15,7 +15,7 @@ pub enum ApplyBlobResult {
     Success,
 }
 
-impl<Vm: Zkvm, B: BlobTransactionTrait> StateTransitionFunction<Vm, B> for CheckHashPreimageStf {
+impl<Vm: Zkvm, B: BlobReaderTrait> StateTransitionFunction<Vm, B> for CheckHashPreimageStf {
     // Since our rollup is stateless, we don't need to consider the StateRoot.
     type StateRoot = ();
 
@@ -32,59 +32,63 @@ impl<Vm: Zkvm, B: BlobTransactionTrait> StateTransitionFunction<Vm, B> for Check
     // However, in this tutorial, we won't use it.
     type Witness = ();
 
-    // This represents a proof of misbehavior by the sequencer, but we won't utilize it in this tutorial.
-    type MisbehaviorProof = ();
-
     // Perform one-time initialization for the genesis block.
     fn init_chain(&mut self, _params: Self::InitialState) {
         // Do nothing
     }
 
-    // Called at the beginning of each DA-layer block - whether or not that block contains any
-    // data relevant to the rollup.
-    fn begin_slot(&mut self, _witness: Self::Witness) {
-        // Do nothing
-    }
-
-    // The core logic of our rollup.
-    fn apply_blob(
+    fn apply_slot<'a, I>(
         &mut self,
-        blob: &mut B,
-        _misbehavior_hint: Option<Self::MisbehaviorProof>,
-    ) -> BatchReceipt<Self::BatchReceiptContents, Self::TxReceiptContents> {
-        let blob_data = blob.data_mut();
+        _witness: Self::Witness,
+        blobs: I,
+    ) -> SlotResult<
+        Self::StateRoot,
+        Self::BatchReceiptContents,
+        Self::TxReceiptContents,
+        Self::Witness,
+    >
+    where
+        I: IntoIterator<Item = &'a mut B>,
+    {
+        let mut receipts = vec![];
+        for blob in blobs {
+            let blob_data = blob.data_mut();
 
-        // Read the data from the blob as a byte vec.
-        let mut data = Vec::new();
+            // Read the data from the blob as a byte vec.
+            let mut data = Vec::new();
 
-        // Panicking within the `StateTransitionFunction` is generally not recommended.
-        // But here if we encounter an error while reading the bytes, it suggests a serious issue with the DA layer or our setup.
-        blob_data
-            .read_to_end(&mut data)
-            .unwrap_or_else(|e| panic!("Unable to read blob data {}", e));
+            // Panicking within the `StateTransitionFunction` is generally not recommended.
+            // But here, if we encounter an error while reading the bytes,
+            // it suggests a serious issue with the DA layer or our setup.
+            blob_data
+                .read_to_end(&mut data)
+                .unwrap_or_else(|e| panic!("Unable to read blob data {}", e));
 
-        // Check if the sender submitted the preimage of the hash.
-        let hash = sha2::Sha256::digest(&data).into();
-        let desired_hash = [
-            102, 104, 122, 173, 248, 98, 189, 119, 108, 143, 193, 139, 142, 159, 142, 32, 8, 151,
-            20, 133, 110, 226, 51, 179, 144, 42, 89, 29, 13, 95, 41, 37,
-        ];
+            // Check if the sender submitted the preimage of the hash.
+            let hash = sha2::Sha256::digest(&data).into();
+            let desired_hash = [
+                102, 104, 122, 173, 248, 98, 189, 119, 108, 143, 193, 139, 142, 159, 142, 32, 8,
+                151, 20, 133, 110, 226, 51, 179, 144, 42, 89, 29, 13, 95, 41, 37,
+            ];
 
-        let result = if hash == desired_hash {
-            ApplyBlobResult::Success
-        } else {
-            ApplyBlobResult::Failure
-        };
+            let result = if hash == desired_hash {
+                ApplyBlobResult::Success
+            } else {
+                ApplyBlobResult::Failure
+            };
 
-        // Return the `BatchReceipt`
-        BatchReceipt {
-            batch_hash: hash,
-            tx_receipts: vec![],
-            inner: result,
+            // Return the `BatchReceipt`
+            receipts.push(BatchReceipt {
+                batch_hash: hash,
+                tx_receipts: vec![],
+                inner: result,
+            });
         }
-    }
 
-    fn end_slot(&mut self) -> (Self::StateRoot, Self::Witness) {
-        ((), ())
+        SlotResult {
+            state_root: (),
+            batch_receipts: receipts,
+            witness: (),
+        }
     }
 }

--- a/examples/demo-simple-stf/tests/stf_test.rs
+++ b/examples/demo-simple-stf/tests/stf_test.rs
@@ -61,18 +61,17 @@ fn test_stf() {
     let address = DaAddress { addr: [1; 32] };
     let preimage = vec![0; 32];
 
-    let mut test_blob = TestBlob::<DaAddress>::new(preimage, address, [0; 32]);
+    let test_blob = TestBlob::<DaAddress>::new(preimage, address, [0; 32]);
     let stf = &mut CheckHashPreimageStf {};
 
+    let mut blobs = [test_blob];
+
     StateTransitionFunction::<MockZkvm, TestBlob<DaAddress>>::init_chain(stf, ());
-    StateTransitionFunction::<MockZkvm, TestBlob<DaAddress>>::begin_slot(stf, ());
 
-    let receipt = StateTransitionFunction::<MockZkvm, TestBlob<DaAddress>>::apply_blob(
-        stf,
-        &mut test_blob,
-        None,
-    );
+    let result =
+        StateTransitionFunction::<MockZkvm, TestBlob<DaAddress>>::apply_slot(stf, (), &mut blobs);
+
+    assert_eq!(1, result.batch_receipts.len());
+    let receipt = result.batch_receipts[0].clone();
     assert_eq!(receipt.inner, ApplyBlobResult::Success);
-
-    StateTransitionFunction::<MockZkvm, TestBlob<DaAddress>>::end_slot(stf);
 }

--- a/examples/demo-stf/src/app.rs
+++ b/examples/demo-stf/src/app.rs
@@ -10,7 +10,7 @@ use sov_modules_api::RpcRunner;
 use sov_modules_api::Spec;
 pub use sov_modules_stf_template::Batch;
 use sov_modules_stf_template::{AppTemplate, SequencerOutcome, TxEffect};
-use sov_rollup_interface::da::BlobTransactionTrait;
+use sov_rollup_interface::da::BlobReaderTrait;
 use sov_rollup_interface::services::stf_runner::StateTransitionRunner;
 #[cfg(feature = "native")]
 use sov_rollup_interface::stf::ProverConfig;
@@ -25,7 +25,7 @@ use crate::batch_builder::FiFoStrictBatchBuilder;
 use crate::runner_config::Config;
 use crate::runtime::Runtime;
 
-pub struct DemoAppRunner<C: Context, Vm: Zkvm, B: BlobTransactionTrait> {
+pub struct DemoAppRunner<C: Context, Vm: Zkvm, B: BlobReaderTrait> {
     pub stf: DemoApp<C, Vm, B>,
     pub batch_builder: Option<FiFoStrictBatchBuilder<Runtime<C>, C>>,
 }
@@ -43,7 +43,7 @@ pub type DemoBatchReceipt = SequencerOutcome;
 pub type DemoTxReceipt = TxEffect;
 
 #[cfg(feature = "native")]
-impl<Vm: Zkvm, B: BlobTransactionTrait> StateTransitionRunner<ProverConfig, Vm, B>
+impl<Vm: Zkvm, B: BlobReaderTrait> StateTransitionRunner<ProverConfig, Vm, B>
     for DemoAppRunner<DefaultContext, Vm, B>
 {
     type RuntimeConfig = Config;
@@ -80,7 +80,7 @@ impl<Vm: Zkvm, B: BlobTransactionTrait> StateTransitionRunner<ProverConfig, Vm, 
     }
 }
 
-impl<Vm: Zkvm, B: BlobTransactionTrait> StateTransitionRunner<ZkConfig, Vm, B>
+impl<Vm: Zkvm, B: BlobReaderTrait> StateTransitionRunner<ZkConfig, Vm, B>
     for DemoAppRunner<ZkDefaultContext, Vm, B>
 {
     type RuntimeConfig = [u8; 32];
@@ -119,7 +119,7 @@ impl<Vm: Zkvm, B: BlobTransactionTrait> StateTransitionRunner<ZkConfig, Vm, B>
 }
 
 #[cfg(feature = "native")]
-impl<Vm: Zkvm, B: BlobTransactionTrait> RpcRunner for DemoAppRunner<DefaultContext, Vm, B> {
+impl<Vm: Zkvm, B: BlobReaderTrait> RpcRunner for DemoAppRunner<DefaultContext, Vm, B> {
     type Context = DefaultContext;
     fn get_storage(&self) -> <Self::Context as Spec>::Storage {
         self.inner().current_storage.clone()

--- a/examples/demo-stf/src/hooks_impl.rs
+++ b/examples/demo-stf/src/hooks_impl.rs
@@ -2,7 +2,7 @@ use sov_modules_api::hooks::{ApplyBlobHooks, TxHooks};
 use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{Context, Spec};
 use sov_modules_stf_template::SequencerOutcome;
-use sov_rollup_interface::da::BlobTransactionTrait;
+use sov_rollup_interface::da::BlobReaderTrait;
 use sov_state::WorkingSet;
 use tracing::info;
 
@@ -34,7 +34,7 @@ impl<C: Context> ApplyBlobHooks for Runtime<C> {
 
     fn begin_blob_hook(
         &self,
-        blob: &mut impl BlobTransactionTrait,
+        blob: &mut impl BlobReaderTrait,
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     ) -> anyhow::Result<()> {
         self.sequencer_registry.begin_blob_hook(blob, working_set)

--- a/examples/demo-stf/src/sov-cli/native.rs
+++ b/examples/demo-stf/src/sov-cli/native.rs
@@ -506,20 +506,24 @@ mod test {
         txs: Vec<RawTx>,
     ) {
         StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(demo, config);
-        StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(demo, Default::default());
 
-        let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
+        let blob = new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS);
+        let mut blobs = [blob];
+
+        let apply_block_result = StateTransitionFunction::<MockZkvm, TestBlob>::apply_slot(
             demo,
-            &mut new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
-            None,
-        )
-        .inner;
+            Default::default(),
+            &mut blobs,
+        );
+
+        assert_eq!(1, apply_block_result.batch_receipts.len());
+        let apply_blob_outcome = apply_block_result.batch_receipts[0].clone();
+
         assert_eq!(
             SequencerOutcome::Rewarded(0),
-            apply_blob_outcome,
+            apply_blob_outcome.inner,
             "Sequencer execution should have succeeded but failed",
         );
-        StateTransitionFunction::<MockZkvm, TestBlob>::end_slot(demo);
     }
 
     fn get_balance(

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -28,19 +28,20 @@ pub mod test {
             let mut demo = create_new_demo(path);
 
             StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(&mut demo, config);
-            StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(
-                &mut demo,
-                Default::default(),
-            );
 
             let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
+            let blob = new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS);
 
-            let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
+            let mut blobs = [blob];
+
+            let result = StateTransitionFunction::<MockZkvm, TestBlob>::apply_slot(
                 &mut demo,
-                &mut new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
-                None,
+                Default::default(),
+                &mut blobs,
             );
 
+            assert_eq!(1, result.batch_receipts.len());
+            let apply_blob_outcome = result.batch_receipts[0].clone();
             assert_eq!(
                 SequencerOutcome::Rewarded(0),
                 apply_blob_outcome.inner,
@@ -48,8 +49,6 @@ pub mod test {
             );
 
             assert!(has_tx_events(&apply_blob_outcome),);
-
-            StateTransitionFunction::<MockZkvm, TestBlob>::end_slot(&mut demo);
         }
 
         // Generate a new storage instance after dumping data to the db.
@@ -89,15 +88,20 @@ pub mod test {
         );
 
         StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(&mut demo, config);
-        StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(&mut demo, Default::default());
 
         let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
-        let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
+        let blob = new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS);
+        let mut blobs = [blob];
+
+        let apply_block_result = StateTransitionFunction::<MockZkvm, TestBlob>::apply_slot(
             &mut demo,
-            &mut new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
-            None,
+            Default::default(),
+            &mut blobs,
         );
+
+        assert_eq!(1, apply_block_result.batch_receipts.len());
+        let apply_blob_outcome = apply_block_result.batch_receipts[0].clone();
 
         assert_eq!(
             SequencerOutcome::Rewarded(0),
@@ -106,8 +110,6 @@ pub mod test {
         );
 
         assert!(has_tx_events(&apply_blob_outcome),);
-
-        StateTransitionFunction::<MockZkvm, TestBlob>::end_slot(&mut demo);
 
         let runtime = &mut Runtime::<DefaultContext>::default();
         let mut working_set = WorkingSet::new(demo.current_storage.clone());
@@ -128,6 +130,7 @@ pub mod test {
     }
 
     #[test]
+    #[ignore = "end_slot is removed from STF trait"]
     fn test_demo_values_not_in_db() {
         let tempdir = tempfile::tempdir().unwrap();
         let path = tempdir.path();
@@ -144,22 +147,23 @@ pub mod test {
             let mut demo = create_new_demo(path);
 
             StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(&mut demo, config);
-            StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(
-                &mut demo,
-                Default::default(),
-            );
 
             let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
+            let blob = new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS);
+            let mut blobs = [blob];
 
-            let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
+            let apply_block_result = StateTransitionFunction::<MockZkvm, TestBlob>::apply_slot(
                 &mut demo,
-                &mut new_test_blob(Batch { txs }, &DEMO_SEQUENCER_DA_ADDRESS),
-                None,
-            )
-            .inner;
+                Default::default(),
+                &mut blobs,
+            );
+
+            assert_eq!(1, apply_block_result.batch_receipts.len());
+            let apply_blob_outcome = apply_block_result.batch_receipts[0].clone();
+
             assert_eq!(
                 SequencerOutcome::Rewarded(0),
-                apply_blob_outcome,
+                apply_blob_outcome.inner,
                 "Sequencer execution should have succeeded but failed",
             );
         }
@@ -200,16 +204,20 @@ pub mod test {
         let mut demo = create_new_demo(path);
 
         StateTransitionFunction::<MockZkvm, TestBlob>::init_chain(&mut demo, config);
-        StateTransitionFunction::<MockZkvm, TestBlob>::begin_slot(&mut demo, Default::default());
-
-        let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
 
         let some_sequencer: [u8; 32] = [121; 32];
-        let apply_blob_outcome = StateTransitionFunction::<MockZkvm, TestBlob>::apply_blob(
+        let txs = simulate_da(value_setter_admin_private_key, election_admin_private_key);
+        let blob = new_test_blob(Batch { txs }, &some_sequencer);
+        let mut blobs = [blob];
+
+        let apply_block_result = StateTransitionFunction::<MockZkvm, TestBlob>::apply_slot(
             &mut demo,
-            &mut new_test_blob(Batch { txs }, &some_sequencer),
-            None,
+            Default::default(),
+            &mut blobs,
         );
+
+        assert_eq!(1, apply_block_result.batch_receipts.len());
+        let apply_blob_outcome = apply_block_result.batch_receipts[0].clone();
 
         assert_eq!(
             SequencerOutcome::Ignored,

--- a/module-system/module-implementations/sov-blob-storage/src/lib.rs
+++ b/module-system/module-implementations/sov-blob-storage/src/lib.rs
@@ -3,7 +3,7 @@
 //! Blob storage module allows to save DA blobs in the state
 
 use sov_modules_api::{Module, ModuleInfo};
-use sov_rollup_interface::da::BlobTransactionTrait;
+use sov_rollup_interface::da::BlobReaderTrait;
 use sov_state::{StateMap, WorkingSet};
 
 /// Blob storage contains only address and vector of blobs
@@ -24,7 +24,7 @@ pub struct BlobStorage<C: sov_modules_api::Context> {
 /// Non standard methods for blob storage
 impl<C: sov_modules_api::Context> BlobStorage<C> {
     /// Store blobs for given block number, overwrite if already exists
-    pub fn store_blobs<B: BlobTransactionTrait>(
+    pub fn store_blobs<B: BlobReaderTrait>(
         &self,
         block_number: u64,
         blobs: &[B],
@@ -40,7 +40,7 @@ impl<C: sov_modules_api::Context> BlobStorage<C> {
 
     /// Take all blobs for given block number, return empty vector if not exists
     /// Returned blobs are removed from the storage
-    pub fn take_blobs_for_block_number<B: BlobTransactionTrait>(
+    pub fn take_blobs_for_block_number<B: BlobReaderTrait>(
         &self,
         block_number: u64,
         working_set: &mut WorkingSet<C::Storage>,

--- a/module-system/module-implementations/sov-sequencer-registry/src/hooks.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/src/hooks.rs
@@ -1,6 +1,6 @@
 use sov_modules_api::hooks::ApplyBlobHooks;
 use sov_modules_api::Context;
-use sov_rollup_interface::da::BlobTransactionTrait;
+use sov_rollup_interface::da::BlobReaderTrait;
 use sov_state::WorkingSet;
 
 use crate::{SequencerOutcome, SequencerRegistry};
@@ -11,7 +11,7 @@ impl<C: Context> ApplyBlobHooks for SequencerRegistry<C> {
 
     fn begin_blob_hook(
         &self,
-        blob: &mut impl BlobTransactionTrait,
+        blob: &mut impl BlobReaderTrait,
         working_set: &mut WorkingSet<<Self::Context as sov_modules_api::Spec>::Storage>,
     ) -> anyhow::Result<()> {
         // Clone to satisfy StateMap API

--- a/module-system/sov-modules-api/src/hooks.rs
+++ b/module-system/sov-modules-api/src/hooks.rs
@@ -1,4 +1,4 @@
-use sov_rollup_interface::da::BlobTransactionTrait;
+use sov_rollup_interface::da::BlobReaderTrait;
 use sov_state::WorkingSet;
 
 use crate::transaction::Transaction;
@@ -38,7 +38,7 @@ pub trait ApplyBlobHooks {
     /// If this hook returns Err, batch is not applied
     fn begin_blob_hook(
         &self,
-        blob: &mut impl BlobTransactionTrait,
+        blob: &mut impl BlobReaderTrait,
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     ) -> anyhow::Result<()>;
 

--- a/module-system/sov-modules-stf-template/src/app_template.rs
+++ b/module-system/sov-modules-stf-template/src/app_template.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use borsh::BorshDeserialize;
 use sov_modules_api::hooks::{ApplyBlobHooks, TxHooks};
 use sov_modules_api::{Context, DispatchCall, Genesis};
-use sov_rollup_interface::da::{BlobTransactionTrait, CountedBufReader};
+use sov_rollup_interface::da::{BlobReaderTrait, CountedBufReader};
 use sov_rollup_interface::stf::{BatchReceipt, TransactionReceipt};
 use sov_rollup_interface::Buf;
 use sov_state::StateCheckpoint;
@@ -62,7 +62,7 @@ impl From<ApplyBatchError> for BatchReceipt<SequencerOutcome, TxEffect> {
     }
 }
 
-impl<C: Context, RT, Vm, B: BlobTransactionTrait> AppTemplate<C, RT, Vm, B>
+impl<C: Context, RT, Vm, B: BlobReaderTrait> AppTemplate<C, RT, Vm, B>
 where
     RT: DispatchCall<Context = C>
         + Genesis<Context = C>

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -8,10 +8,11 @@ pub use app_template::AppTemplate;
 pub use batch::Batch;
 use sov_modules_api::hooks::{ApplyBlobHooks, TxHooks};
 use sov_modules_api::{Context, DispatchCall, Genesis, Spec};
-use sov_rollup_interface::da::BlobTransactionTrait;
-use sov_rollup_interface::stf::{BatchReceipt, StateTransitionFunction};
+use sov_rollup_interface::da::BlobReaderTrait;
+use sov_rollup_interface::stf::{SlotResult, StateTransitionFunction};
 use sov_rollup_interface::zk::Zkvm;
 use sov_state::{StateCheckpoint, Storage};
+use tracing::info;
 pub use tx_verifier::RawTx;
 
 /// The receipts of all the transactions in a batch.
@@ -54,7 +55,25 @@ pub enum SlashingReason {
     InvalidTransactionEncoding,
 }
 
-impl<C: Context, RT, Vm: Zkvm, B: BlobTransactionTrait> StateTransitionFunction<Vm, B>
+impl<C: Context, RT, Vm: Zkvm, B: BlobReaderTrait> AppTemplate<C, RT, Vm, B> {
+    fn begin_slot(&mut self, witness: <<C as Spec>::Storage as Storage>::Witness) {
+        self.checkpoint = Some(StateCheckpoint::with_witness(
+            self.current_storage.clone(),
+            witness,
+        ));
+    }
+
+    fn end_slot(&mut self) -> (jmt::RootHash, <<C as Spec>::Storage as Storage>::Witness) {
+        let (cache_log, witness) = self.checkpoint.take().unwrap().freeze();
+        let root_hash = self
+            .current_storage
+            .validate_and_commit(cache_log, &witness)
+            .expect("jellyfish merkle tree update must succeed");
+        (jmt::RootHash(root_hash), witness)
+    }
+}
+
+impl<C: Context, RT, Vm: Zkvm, B: BlobReaderTrait> StateTransitionFunction<Vm, B>
     for AppTemplate<C, RT, Vm, B>
 where
     RT: DispatchCall<Context = C>
@@ -72,8 +91,6 @@ where
 
     type Witness = <<C as Spec>::Storage as Storage>::Witness;
 
-    type MisbehaviorProof = ();
-
     fn init_chain(&mut self, params: Self::InitialState) {
         let mut working_set = StateCheckpoint::new(self.current_storage.clone()).to_revertable();
 
@@ -87,30 +104,48 @@ where
             .expect("Storage update must succeed");
     }
 
-    fn begin_slot(&mut self, witness: Self::Witness) {
-        self.checkpoint = Some(StateCheckpoint::with_witness(
-            self.current_storage.clone(),
-            witness,
-        ));
-    }
-
-    fn apply_blob(
+    fn apply_slot<'a, I>(
         &mut self,
-        blob: &mut B,
-        _misbehavior_hint: Option<Self::MisbehaviorProof>,
-    ) -> BatchReceipt<Self::BatchReceiptContents, Self::TxReceiptContents> {
-        match self.apply_blob(blob) {
-            Ok(batch) => batch,
-            Err(e) => e.into(),
-        }
-    }
+        witness: Self::Witness,
+        blobs: I,
+    ) -> SlotResult<
+        Self::StateRoot,
+        Self::BatchReceiptContents,
+        Self::TxReceiptContents,
+        Self::Witness,
+    >
+    where
+        I: IntoIterator<Item = &'a mut B>,
+    {
+        self.begin_slot(witness);
 
-    fn end_slot(&mut self) -> (Self::StateRoot, Self::Witness) {
-        let (cache_log, witness) = self.checkpoint.take().unwrap().freeze();
-        let root_hash = self
-            .current_storage
-            .validate_and_commit(cache_log, &witness)
-            .expect("jellyfish merkle tree update must succeed");
-        (jmt::RootHash(root_hash), witness)
+        let mut batch_receipts = vec![];
+        for (blob_idx, blob) in blobs.into_iter().enumerate() {
+            let batch_receipt = self.apply_blob(blob).unwrap_or_else(Into::into);
+            info!(
+                "blob #{} with blob_hash 0x{} has been applied with #{} transactions, sequencer outcome {:?}",
+                blob_idx,
+                hex::encode(batch_receipt.batch_hash),
+                batch_receipt.tx_receipts.len(),
+                batch_receipt.inner
+            );
+            for (i, tx_receipt) in batch_receipt.tx_receipts.iter().enumerate() {
+                info!(
+                    "tx #{} hash: 0x{} result {:?}",
+                    i,
+                    hex::encode(tx_receipt.tx_hash),
+                    tx_receipt.receipt
+                );
+            }
+            batch_receipts.push(batch_receipt);
+        }
+
+        let (state_root, witness) = self.end_slot();
+
+        SlotResult {
+            state_root,
+            batch_receipts,
+            witness,
+        }
     }
 }

--- a/rollup-interface/src/node/services/stf_runner.rs
+++ b/rollup-interface/src/node/services/stf_runner.rs
@@ -1,6 +1,6 @@
 //! This module defines the traits that are used by the full node to
 //! instantiate and run the state transition function.
-use crate::da::BlobTransactionTrait;
+use crate::da::BlobReaderTrait;
 use crate::services::batch_builder::BatchBuilder;
 use crate::stf::{StateTransitionConfig, StateTransitionFunction};
 use crate::zk::Zkvm;
@@ -24,7 +24,7 @@ use crate::zk::Zkvm;
 /// and a `impl StateTransitionRunner<ZkConfig, Vm> for MyRunner` which instead uses a state root as its runtime config.
 ///
 /// TODO: Why is it called runner? It only creates. Creator, Factory: <https://github.com/Sovereign-Labs/sovereign-sdk/issues/447>
-pub trait StateTransitionRunner<T: StateTransitionConfig, Vm: Zkvm, B: BlobTransactionTrait> {
+pub trait StateTransitionRunner<T: StateTransitionConfig, Vm: Zkvm, B: BlobReaderTrait> {
     /// The parameters of the state transition function which are set at runtime. For example,
     /// the runtime config might contain path to a data directory.
     type RuntimeConfig;

--- a/rollup-interface/src/state_machine/da.rs
+++ b/rollup-interface/src/state_machine/da.rs
@@ -22,7 +22,7 @@ pub trait DaSpec {
     type BlockHeader: BlockHeaderTrait<Hash = Self::SlotHash>;
 
     /// The transaction type used by the DA layer.
-    type BlobTransaction: BlobTransactionTrait;
+    type BlobTransaction: BlobReaderTrait;
 
     /// A proof that each tx in a set of blob transactions is included in a given block.
     type InclusionMultiProof: Serialize + DeserializeOwned;
@@ -128,7 +128,7 @@ impl<B: Buf> Read for CountedBufReader<B> {
 }
 
 /// A transaction on a data availability layer, including the address of the sender.
-pub trait BlobTransactionTrait: Serialize + DeserializeOwned + Send + Sync {
+pub trait BlobReaderTrait: Serialize + DeserializeOwned + Send + Sync + 'static {
     /// The type of the raw data of the blob. For example, the "calldata" of an Ethereum rollup transaction
     type Data: Buf;
 

--- a/rollup-interface/src/state_machine/mocks.rs
+++ b/rollup-interface/src/state_machine/mocks.rs
@@ -9,7 +9,7 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 
-use crate::da::{BlobTransactionTrait, BlockHashTrait, BlockHeaderTrait, CountedBufReader, DaSpec};
+use crate::da::{BlobReaderTrait, BlockHashTrait, BlockHeaderTrait, CountedBufReader, DaSpec};
 use crate::services::da::SlotData;
 use crate::zk::{Matches, Zkvm};
 use crate::AddressTrait;
@@ -173,7 +173,7 @@ pub struct TestBlob<Address> {
     data: CountedBufReader<Bytes>,
 }
 
-impl<Address: AddressTrait> BlobTransactionTrait for TestBlob<Address> {
+impl<Address: AddressTrait> BlobReaderTrait for TestBlob<Address> {
     type Data = Bytes;
     type Address = Address;
 

--- a/rollup-interface/src/state_machine/mod.rs
+++ b/rollup-interface/src/state_machine/mod.rs
@@ -27,5 +27,6 @@ pub trait AddressTrait:
     + Sync
     + core::fmt::Display
     + std::hash::Hash
+    + 'static
 {
 }

--- a/rollup-interface/src/state_machine/stf.rs
+++ b/rollup-interface/src/state_machine/stf.rs
@@ -7,7 +7,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use crate::da::BlobTransactionTrait;
+use crate::da::BlobReaderTrait;
 use crate::zk::Zkvm;
 
 #[cfg(any(test, feature = "fuzzing"))]
@@ -69,14 +69,29 @@ pub struct BatchReceipt<BatchReceiptContents, TxReceiptContents> {
     pub inner: BatchReceiptContents,
 }
 
+/// Result of applying a slot to current state
+/// Where:
+///  - S - generic for state root
+///  - B - generic for batch receipt contents
+///  - T - generic for transaction receipt contents
+///  - W - generic for witness
+pub struct SlotResult<S, B, T, W> {
+    /// Final state root after all blobs were applied
+    pub state_root: S,
+    /// Receipt for each applied batch
+    pub batch_receipts: Vec<BatchReceipt<B, T>>,
+    /// Witness after applying the whole block
+    pub witness: W,
+}
+
 // TODO(@preston-evans98): update spec with simplified API
 /// State transition function defines business logic that responsible for changing state.
 /// Terminology:
 ///  - state root: root hash of state merkle tree
 ///  - block: DA layer block
 ///  - batch: Set of transactions grouped together, or block on L2
-///  - blob: Non serialised batch
-pub trait StateTransitionFunction<Vm: Zkvm, B: BlobTransactionTrait> {
+///  - blob: Non serialised batch or anything else that can be posted on DA layer, like attestation or proof.
+pub trait StateTransitionFunction<Vm: Zkvm, B: BlobReaderTrait> {
     /// Root hash of state merkle tree
     type StateRoot;
     /// The initial state of the rollup.
@@ -91,39 +106,32 @@ pub trait StateTransitionFunction<Vm: Zkvm, B: BlobTransactionTrait> {
     /// or validated together with proof during verification
     type Witness: Default + Serialize;
 
-    /// A proof that the sequencer has misbehaved. For example, this could be a merkle proof of a transaction
-    /// with an invalid signature
-    type MisbehaviorProof;
-
     /// Perform one-time initialization for the genesis block.
     fn init_chain(&mut self, params: Self::InitialState);
 
-    /// Called at the beginning of each **DA-layer block** - whether or not that block contains any
+    /// Called at each **DA-layer block** - whether or not that block contains any
     /// data relevant to the rollup.
     /// If slot is started in Full Node mode, default witness should be provided.
     /// If slot is started in Zero Knowledge mode, witness from execution should be provided.
-    fn begin_slot(&mut self, witness: Self::Witness);
-
-    /// Apply a blob/batch of transactions to the rollup, slashing the sequencer who proposed the blob on failure.
-    /// The concrete blob type is defined by the DA layer implementation, which is why we use a generic here instead
-    /// of an associated type.
-    /// Misbehavior hint allows prover optimizations - the sequencer can be slashed
-    /// for including a transaction which fails stateless checks (i.e. has an invalid signature) -
-    /// and in that case we ignore his entire batch.
-    /// This method lets you give a hint to the prover telling
-    /// it where that invalid signature is, so that it can skip signature checks on other transactions.
-    /// (If the misbehavior hint is wrong, then the host is malicious so we can
-    /// just panic - which means that no proof will be created).
-    fn apply_blob(
-        &mut self,
-        blob: &mut B,
-        misbehavior_hint: Option<Self::MisbehaviorProof>,
-    ) -> BatchReceipt<Self::BatchReceiptContents, Self::TxReceiptContents>;
-
-    /// Called once at the *end* of each DA layer block (i.e. after all rollup blobs have been processed)
-    /// Commits state changes to the database
     ///
-    fn end_slot(&mut self) -> (Self::StateRoot, Self::Witness);
+    /// Applies batches of transactions to the rollup,
+    /// slashing the sequencer who proposed the blob on failure.
+    /// The concrete blob type is defined by the DA layer implementation,
+    /// which is why we use a generic here instead of an associated type.
+    ///
+    /// Commits state changes to the database
+    fn apply_slot<'a, I>(
+        &mut self,
+        witness: Self::Witness,
+        blobs: I,
+    ) -> SlotResult<
+        Self::StateRoot,
+        Self::BatchReceiptContents,
+        Self::TxReceiptContents,
+        Self::Witness,
+    >
+    where
+        I: IntoIterator<Item = &'a mut B>;
 }
 
 /// A key-value pair representing a change to the rollup state


### PR DESCRIPTION
# Summary of Proposed Changes

We propose a significant refactor to improve the logic and efficiency of how blobs are processed in each block, specifically in the context of sequencing with soft confirmation. These changes impact several key components and introduce new types. This write-up will detail the adjustments and their motivation, aiming for clarity and comprehension.

## Changes to `StateTransitionFunction`

I've condensed the three existing methods - `begin_slot`, `apply_blob`, and `end_slot` - into a single method called `apply_slot`. This change hands over the block handling logic to individual StateTransitionFunction (STF) implementations.

New design for `StateTransitionFunction` is as follows:

```rust
pub trait StateTransitionFunction<Vm: Zkvm, B: BlobReaderTrait> {
    type StateRoot;
    type TxReceiptContents: Serialize + DeserializeOwned + Clone;
    type BatchReceiptContents: Serialize + DeserializeOwned + Clone;
    type Witness: Default + Serialize + 'static;
    
    fn apply_slot<'a, I>(
        &mut self,
        witness: Self::Witness,
        blobs: I,
    ) -> SlotResult<
        Self::StateRoot,
        Self::BatchReceiptContents,
        Self::TxReceiptContents,
        Self::Witness,
    >
    where
        I: IntoIterator<Item = &'a mut B>;
}
```

## New or Revised Types

###  Removing `MisbehaviorHint`

As it is currently unused and makes changes of interface more convoluted, we've decided to remove it for now,  and introduce it as part of the `Witness` type


### Introduction of `SlotResult`

`SlotResult` is a new container type, designed to streamline the output from the previous methods `apply_blob` and `end_slot`.

Previously, these methods looked like this:

```rust

    fn apply_blob(
        &mut self,
        blob: &mut B,
        misbehavior_hint: Option<Self::MisbehaviorProof>,
    ) -> BatchReceipt<Self::BatchReceiptContents, Self::TxReceiptContents>;

    fn end_slot(&mut self) -> (Self::StateRoot, Self::Witness);
```

Now, I introduce `SlotResult`:

```rust
///  - S - generic for state root
///  - B - generic for batch receipt contents
///  - T - generic for transaction receipt contents
///  - W - generic for witness
pub struct SlotResult<S, B, T, W> {
    pub state_root: S,
    pub batch_receipts: Vec<BatchReceipt<B, T>>,
    pub witness: W,
}
```

I decided to introduce `SlotResult` instead of using a type alias for a three-element tuple to increase readability.

### `BlobTransactionTrait` renamed to `BlobReaderTrait`

I've renamed `BlobTransactionTrait` to `BlobReaderTrait` to better reflect its actual role. This trait doesn't carry any transaction-specific aspects and might be used for Attestations or Proofs in the future.


## Motivations behind the changes

### 'static bound for some traits

Traits like `BlobReaderTrait`, `AddressTrait` and `STF::Witness` associated type  now carry a `'static` bound. This constraint implies that only owned types can implement these traits, which I consider a reasonable requirement, though we're open to feedback on this matter.


### Other Noteworthy Changes

* Benchmarks now solely measure apply_slot. While this reduces granularity, it better represents our new design choice.
* Tests that previously checked whether a result is saved if end_slot isn't called are now ignored. I plan to transition these to a new testing strategy, where execution fails mid-way through applying blobs or even mid-transaction.

## Linked Issues
- Related to #408 

## Testing
Automated tests have been updated

## Docs
Doc strings have been updated
