### PR TITLE
Allow all `Runtime` macros to handle multiple generics

### DIFF
--- a/examples/demo-rollup/src/main.rs
+++ b/examples/demo-rollup/src/main.rs
@@ -153,7 +153,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // so we use that to initialize the RPC server.
     let storage = demo_runner.get_storage();
     let is_storage_empty = storage.is_empty();
-    let mut methods = get_rpc_methods(storage);
+    let mut methods = get_rpc_methods::<DefaultContext>(storage);
     let ledger_rpc_module =
         ledger_rpc::get_ledger_rpc::<DemoBatchReceipt, DemoTxReceipt>(ledger_db.clone());
     methods

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -1,4 +1,4 @@
-// #![feature(associated_type_defaults)]
+#![feature(associated_type_defaults)]
 
 mod bech32;
 pub mod default_context;
@@ -228,7 +228,7 @@ pub trait Spec {
 /// Context objects also implement the [`Spec`] trait, which specifies the types to be used in this
 /// instance of the state transition function. By making modules generic over a `Context`, developers
 /// can easily update their cryptography to conform to the needs of different zk-proof systems.
-pub trait Context: Send + Sync + Spec + Clone + Debug + PartialEq + 'static {
+pub trait Context: Spec + Clone + Debug + PartialEq + 'static {
     /// Sender of the transaction.
     fn sender(&self) -> &Self::Address;
 
@@ -263,7 +263,7 @@ pub trait Module {
     type Config;
 
     /// Module defined argument to the call method.
-    type CallMessage: Debug + BorshSerialize + BorshDeserialize;
+    type CallMessage: Debug + BorshSerialize + BorshDeserialize = NonInstantiable;
 
     /// Genesis is called when a rollup is deployed and can be used to set initial state values in the module.
     fn genesis(

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(associated_type_defaults)]
+// #![feature(associated_type_defaults)]
 
 mod bech32;
 pub mod default_context;
@@ -228,7 +228,7 @@ pub trait Spec {
 /// Context objects also implement the [`Spec`] trait, which specifies the types to be used in this
 /// instance of the state transition function. By making modules generic over a `Context`, developers
 /// can easily update their cryptography to conform to the needs of different zk-proof systems.
-pub trait Context: Spec + Clone + Debug + PartialEq + 'static {
+pub trait Context: Send + Sync + Spec + Clone + Debug + PartialEq + 'static {
     /// Sender of the transaction.
     fn sender(&self) -> &Self::Address;
 
@@ -263,7 +263,7 @@ pub trait Module {
     type Config;
 
     /// Module defined argument to the call method.
-    type CallMessage: Debug + BorshSerialize + BorshDeserialize = NonInstantiable;
+    type CallMessage: Debug + BorshSerialize + BorshDeserialize;
 
     /// Genesis is called when a rollup is deployed and can be used to set initial state values in the module.
     fn genesis(

--- a/module-system/sov-modules-macros/src/common.rs
+++ b/module-system/sov-modules-macros/src/common.rs
@@ -375,13 +375,13 @@ pub(crate) fn generics_for_field(
     outer_generics: &Generics,
     field_generic_types: &PathArguments,
 ) -> Generics {
-    let generic_bounds = extract_generic_type_bounds(&outer_generics);
+    let generic_bounds = extract_generic_type_bounds(outer_generics);
     match field_generic_types {
         PathArguments::AngleBracketed(angle_bracketed_data) => {
             let mut args_with_bounds = Punctuated::<GenericParam, syn::token::Comma>::new();
             for generic_arg in &angle_bracketed_data.args {
                 if let syn::GenericArgument::Type(syn::Type::Path(type_path)) = generic_arg {
-                    let ident = extract_ident(&type_path);
+                    let ident = extract_ident(type_path);
                     let bounds = generic_bounds.get(type_path).cloned().unwrap_or_default();
 
                     // Construct a "type param" with the appropriate bounds. This corresponds to a syntax

--- a/module-system/sov-modules-macros/src/common.rs
+++ b/module-system/sov-modules-macros/src/common.rs
@@ -5,8 +5,8 @@ use quote::{format_ident, ToTokens};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
-    DataStruct, Fields, GenericParam, Generics, ImplGenerics, Meta, PathSegment, TypeGenerics,
-    TypeParamBound, TypePath, WhereClause, WherePredicate,
+    DataStruct, Fields, GenericParam, Generics, ImplGenerics, Meta, PathArguments, PathSegment,
+    TypeGenerics, TypeParamBound, TypePath, WhereClause, WherePredicate,
 };
 
 #[derive(Clone)]
@@ -358,6 +358,63 @@ pub fn extract_ident(type_path: &syn::TypePath) -> &Ident {
         .last()
         .expect("Type path must have at least one segment")
         .ident
+}
+
+/// Build the generics for a field based on the generics of the outer struct.
+/// For example, given the following struct:
+/// ```rust,ignore
+/// struct MyStruct<T: SomeTrait, U: SomeOtherTrait> {
+///    field1: PhantomData<T>,
+///    field2: Vec<U>
+/// }
+/// ```
+///
+/// This function will return a `syn::Generics` corresponding to `<T: SomeTrait>` when
+/// invoked on the PathArguments for field1.
+pub(crate) fn generics_for_field(
+    outer_generics: &Generics,
+    field_generic_types: &PathArguments,
+) -> Generics {
+    let generic_bounds = extract_generic_type_bounds(&outer_generics);
+    match field_generic_types {
+        PathArguments::AngleBracketed(angle_bracketed_data) => {
+            let mut args_with_bounds = Punctuated::<GenericParam, syn::token::Comma>::new();
+            for generic_arg in &angle_bracketed_data.args {
+                if let syn::GenericArgument::Type(syn::Type::Path(type_path)) = generic_arg {
+                    let ident = extract_ident(&type_path);
+                    let bounds = generic_bounds.get(type_path).cloned().unwrap_or_default();
+
+                    // Construct a "type param" with the appropriate bounds. This corresponds to a syntax
+                    // tree like `T: Trait1 + Trait2`
+                    let generic_type_param_with_bounds = syn::TypeParam {
+                        attrs: Vec::new(),
+                        ident: ident.clone(),
+                        colon_token: Some(syn::token::Colon {
+                            spans: [type_path.span()],
+                        }),
+                        bounds: bounds.clone(),
+                        eq_token: None,
+                        default: None,
+                    };
+                    args_with_bounds.push(GenericParam::Type(generic_type_param_with_bounds))
+                }
+            }
+            // Construct a `Generics` struct with the generic type parameters and their bounds.
+            // This corresponds to a syntax tree like `<T: Trait1 + Trait2>`
+            syn::Generics {
+                lt_token: Some(syn::token::Lt {
+                    spans: [field_generic_types.span()],
+                }),
+                params: args_with_bounds,
+                gt_token: Some(syn::token::Gt {
+                    spans: [field_generic_types.span()],
+                }),
+                where_clause: None,
+            }
+        }
+        // We don't need to do anything if the generic type parameters are not angle bracketed
+        _ => Default::default(),
+    }
 }
 
 #[cfg(test)]

--- a/module-system/sov-modules-macros/src/dispatch/genesis.rs
+++ b/module-system/sov-modules-macros/src/dispatch/genesis.rs
@@ -1,5 +1,5 @@
-use proc_macro2::{Ident, Span};
-use syn::{DeriveInput, TypeGenerics};
+use proc_macro2::Span;
+use syn::{DeriveInput, ImplGenerics, TypeGenerics, WhereClause};
 
 use crate::common::{get_generics_type_param, StructFieldExtractor, StructNamedField};
 
@@ -29,7 +29,8 @@ impl GenesisMacro {
 
         let fields = self.field_extractor.get_fields_from_struct(&data)?;
         let generic_param = get_generics_type_param(&generics, Span::call_site())?;
-        let genesis_config = Self::make_genesis_config(&fields, &type_generics, &generic_param);
+        let genesis_config =
+            Self::make_genesis_config(&fields, &impl_generics, &type_generics, where_clause);
         let genesis_fn_body = Self::make_genesis_fn_body(&fields);
 
         // Implements the Genesis trait
@@ -64,8 +65,9 @@ impl GenesisMacro {
 
     fn make_genesis_config(
         fields: &[StructNamedField],
+        impl_generics: &ImplGenerics,
         type_generics: &TypeGenerics,
-        generic_param: &Ident,
+        where_clause: Option<&WhereClause>,
     ) -> proc_macro2::TokenStream {
         let field_names = fields.iter().map(|field| &field.ident);
 
@@ -83,11 +85,11 @@ impl GenesisMacro {
 
         quote::quote! {
             #[doc = "Initial configuration for the rollup."]
-            pub struct GenesisConfig<#generic_param: sov_modules_api::Context>{
+            pub struct GenesisConfig #impl_generics #where_clause{
                 #(pub #fields)*
             }
 
-            impl<#generic_param: sov_modules_api::Context> GenesisConfig #type_generics {
+            impl #impl_generics GenesisConfig #type_generics #where_clause {
                 pub fn new(#(#fields)*) -> Self {
                     Self {
                         #(#field_names),*

--- a/module-system/sov-modules-macros/src/dispatch/message_codec.rs
+++ b/module-system/sov-modules-macros/src/dispatch/message_codec.rs
@@ -24,7 +24,7 @@ impl<'a> StructDef<'a> {
             quote::quote! {
                 #[doc = #call_doc]
                 pub fn #fn_call_name(data: <#ty as sov_modules_api::Module>::CallMessage) -> std::vec::Vec<u8> {
-                    let call = #call_enum::<C>::#variant(data);
+                    let call = #call_enum:: #ty_generics ::#variant(data);
                     ::borsh::BorshSerialize::try_to_vec(&call).unwrap()
                 }
             }

--- a/module-system/sov-modules-macros/src/lib.rs
+++ b/module-system/sov-modules-macros/src/lib.rs
@@ -1,7 +1,6 @@
 //! Procedural macros to assist in the creation of Sovereign modules.
 
 #![deny(missing_docs)]
-#![feature(log_syntax)]
 
 mod cli_parser;
 mod common;
@@ -217,8 +216,9 @@ pub fn codec(input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn rpc_gen(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr: Vec<syn::NestedMeta> = parse_macro_input!(attr);
     let input = parse_macro_input!(item as syn::ItemImpl);
-    handle_macro_error(rpc::rpc_gen(attr.into(), input).map(|ok| ok.into()))
+    handle_macro_error(rpc::rpc_gen(attr, input).map(|ok| ok.into()))
 }
 
 fn handle_macro_error(result: Result<proc_macro::TokenStream, syn::Error>) -> TokenStream {
@@ -231,13 +231,11 @@ fn handle_macro_error(result: Result<proc_macro::TokenStream, syn::Error>) -> To
 /// This proc macro generates the actual implementations for the trait created above for the module
 /// It iterates over each struct
 #[proc_macro_attribute]
-pub fn expose_rpc(attr: TokenStream, input: TokenStream) -> TokenStream {
-    let context_type = parse_macro_input!(attr);
-
+pub fn expose_rpc(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let original = input.clone();
     let input = parse_macro_input!(input);
     let expose_macro = ExposeRpcMacro::new("Expose");
-    handle_macro_error(expose_macro.generate_rpc(original, input, context_type))
+    handle_macro_error(expose_macro.generate_rpc(original, input))
 }
 
 /// Generates a CLI arguments parser for the specified runtime.

--- a/module-system/sov-modules-macros/src/rpc/expose_rpc.rs
+++ b/module-system/sov-modules-macros/src/rpc/expose_rpc.rs
@@ -1,7 +1,7 @@
 use quote::quote;
 use syn::DeriveInput;
 
-use crate::common::StructFieldExtractor;
+use crate::common::{generics_for_field, StructFieldExtractor};
 
 pub(crate) struct ExposeRpcMacro {
     field_extractor: StructFieldExtractor,
@@ -18,9 +18,23 @@ impl ExposeRpcMacro {
         &self,
         original: proc_macro::TokenStream,
         input: DeriveInput,
-        context_type: syn::Type,
     ) -> Result<proc_macro::TokenStream, syn::Error> {
-        let DeriveInput { data, .. } = input;
+        let DeriveInput { data, generics, .. } = input;
+        let (impl_generics, _ty_generics, where_clause) = generics.split_for_impl();
+        let context_type = generics
+            .params
+            .iter()
+            .find_map(|item| {
+                if let syn::GenericParam::Type(type_param) = item {
+                    Some(type_param.ident.clone())
+                } else {
+                    None
+                }
+            })
+            .ok_or(syn::Error::new_spanned(
+                &generics,
+                "a runtime must be generic over a sov_modules_api::Context to derive CliWallet",
+            ))?;
 
         let fields = self.field_extractor.get_fields_from_struct(&data)?;
 
@@ -40,6 +54,14 @@ impl ExposeRpcMacro {
                 _ => panic!("Expected a path type"),
             };
 
+            let field_path_args = &ty
+                .path
+                .segments
+                .last()
+                .expect("A type path must have at least one segment")
+                .arguments;
+            let field_generics = generics_for_field(&generics, &field_path_args);
+
             let module_ident = ty.path.segments.last().unwrap().clone().ident;
 
             let rpc_trait_ident =
@@ -50,15 +72,15 @@ impl ExposeRpcMacro {
 
             let merge_operation = quote! {
                 module
-                    .merge(#rpc_server_ident::into_rpc(r.clone()))
+                    .merge(#rpc_server_ident:: #field_path_args ::into_rpc(r.clone()))
                     .unwrap();
             };
 
             merge_operations.extend(merge_operation);
 
             let rpc_trait_impl = quote! {
-                impl <C: ::sov_modules_api::Context> #rpc_trait_ident<C> for RpcStorage<C>{
-                    fn get_working_set(&self) -> ::sov_state::WorkingSet<<C as ::sov_modules_api::Spec>::Storage>
+                impl #field_generics #rpc_trait_ident #field_path_args for RpcStorage<#context_type> {
+                    fn get_working_set(&self) -> ::sov_state::WorkingSet<<#context_type as ::sov_modules_api::Spec>::Storage>
                     {
                         ::sov_state::WorkingSet::new(self.storage.clone())
                     }
@@ -67,8 +89,8 @@ impl ExposeRpcMacro {
             rpc_trait_impls.extend(rpc_trait_impl);
         }
 
-        let get_rpc_methods = quote! {
-            pub fn get_rpc_methods(storage: <#context_type as ::sov_modules_api::Spec>::Storage) -> jsonrpsee::RpcModule<()> {
+        let get_rpc_methods: proc_macro2::TokenStream = quote! {
+            pub fn get_rpc_methods #impl_generics (storage: <#context_type as ::sov_modules_api::Spec>::Storage) -> jsonrpsee::RpcModule<()> #where_clause{
                 let mut module = jsonrpsee::RpcModule::new(());
                 let r = RpcStorage::<#context_type> {
                     storage: storage.clone(),

--- a/module-system/sov-modules-macros/src/rpc/expose_rpc.rs
+++ b/module-system/sov-modules-macros/src/rpc/expose_rpc.rs
@@ -60,7 +60,7 @@ impl ExposeRpcMacro {
                 .last()
                 .expect("A type path must have at least one segment")
                 .arguments;
-            let field_generics = generics_for_field(&generics, &field_path_args);
+            let field_generics = generics_for_field(&generics, field_path_args);
 
             let module_ident = ty.path.segments.last().unwrap().clone().ident;
 

--- a/module-system/sov-modules-macros/src/rpc/rpc_gen.rs
+++ b/module-system/sov-modules-macros/src/rpc/rpc_gen.rs
@@ -218,11 +218,9 @@ fn wrap_in_jsonprsee_result(return_type: &syn::ReturnType) -> syn::ReturnType {
 
 fn add_server_bounds_attr_if_missing(attrs: &mut Vec<syn::NestedMeta>) {
     for attr in attrs.iter() {
-        if let syn::NestedMeta::Meta(attr) = attr {
-            if let syn::Meta::List(syn::MetaList { path, .. }) = attr {
-                if path.is_ident("server_bounds") {
-                    return;
-                }
+        if let syn::NestedMeta::Meta(syn::Meta::List(syn::MetaList { path, .. })) = attr {
+            if path.is_ident("server_bounds") {
+                return;
             }
         }
     }

--- a/module-system/sov-modules-macros/src/rpc/rpc_gen.rs
+++ b/module-system/sov-modules-macros/src/rpc/rpc_gen.rs
@@ -79,21 +79,7 @@ impl RpcImplBlock {
     fn build_rpc_impl_trait(&self) -> proc_macro2::TokenStream {
         let type_name = &self.type_name;
         let generics = &self.generics;
-        let generics_params = generics
-            .params
-            .iter()
-            .map(|param| {
-                if let syn::GenericParam::Type(syn::TypeParam { ident, .. }) = param {
-                    return quote! { #ident };
-                }
-                unreachable!("Expected a type parameter")
-            })
-            .collect::<Vec<_>>();
-
-        // let debug_var = quote! { println!("STUFF {:?}", #(#generics_params)*,); };
-        // println!("DBG1: {}", debug_var);
-        // let debug_var = quote! { println!("STUFF {:?}", #type_name) };
-        // println!("DBG2: {}", debug_var);
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
         let mut blanket_impl_methods = vec![];
         let mut impl_trait_methods = vec![];
@@ -139,7 +125,7 @@ impl RpcImplBlock {
 
                 quote! {
                     #signature {
-                        <#type_name <#(#generics_params)*,> as ::std::default::Default>::default().#method_name(#(#pre_working_set_args,)* &mut Self::get_working_set(self), #(#post_working_set_args),* )
+                        <#type_name #ty_generics as ::std::default::Default>::default().#method_name(#(#pre_working_set_args,)* &mut Self::get_working_set(self), #(#post_working_set_args),* )
                     }
                 }
             } else {
@@ -149,7 +135,7 @@ impl RpcImplBlock {
                     .filter(|arg| arg.to_string() != quote! { self }.to_string());
                 quote! {
                     #signature {
-                        <#type_name <#(#generics_params)*,> as ::std::default::Default>::default().#method_name(#(#arg_values),*)
+                        <#type_name  #ty_generics as ::std::default::Default>::default().#method_name(#(#arg_values),*)
                     }
                 }
             };
@@ -163,13 +149,13 @@ impl RpcImplBlock {
                 let post_working_set_args = arg_values.clone().skip(idx + 1);
                 quote! {
                     #signature {
-                        Ok(<Self as #impl_trait_name < #(#generics_params)*, >>::#method_name(#(#pre_working_set_args,)* #(#post_working_set_args),* ))
+                        Ok(<Self as #impl_trait_name #ty_generics >::#method_name(#(#pre_working_set_args,)* #(#post_working_set_args),* ))
                     }
                 }
             } else {
                 quote! {
                     #signature {
-                        Ok(<Self as #impl_trait_name < #(#generics_params)*, >>::#method_name(#(#arg_values),*))
+                        Ok(<Self as #impl_trait_name #ty_generics >::#method_name(#(#arg_values),*))
                     }
                 }
             };
@@ -192,7 +178,6 @@ impl RpcImplBlock {
             }
         };
 
-        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
         let blanket_impl_generics = quote! {
             #impl_generics
         }
@@ -232,14 +217,17 @@ fn wrap_in_jsonprsee_result(return_type: &syn::ReturnType) -> syn::ReturnType {
 }
 
 fn build_rpc_trait(
-    attrs: &proc_macro2::TokenStream,
+    mut attrs: Vec<syn::NestedMeta>,
     type_name: Ident,
     mut input: syn::ItemImpl,
 ) -> Result<proc_macro2::TokenStream, syn::Error> {
     let intermediate_trait_name = format_ident!("{}Rpc", type_name);
+    attrs.push(syn::NestedMeta::Meta(syn::Meta::List(
+        syn::parse_quote! { server_bounds() },
+    )));
 
     let wrapped_attr_args = quote! {
-        (#attrs)
+        ( #(#attrs),* )
     };
     let rpc_attribute = syn::Attribute {
         pound_token: syn::token::Pound {
@@ -340,7 +328,7 @@ fn build_rpc_trait(
 }
 
 pub(crate) fn rpc_gen(
-    attrs: proc_macro2::TokenStream,
+    attrs: Vec<syn::NestedMeta>,
     input: syn::ItemImpl,
 ) -> Result<proc_macro2::TokenStream, syn::Error> {
     let type_name = match *input.self_ty {
@@ -348,7 +336,7 @@ pub(crate) fn rpc_gen(
         _ => return Err(syn::Error::new_spanned(input.self_ty, "Invalid type")),
     };
 
-    build_rpc_trait(&attrs, type_name.clone(), input)
+    build_rpc_trait(attrs, type_name.clone(), input)
 }
 
 struct TypeList(pub Punctuated<Type, syn::token::Comma>);

--- a/module-system/sov-modules-macros/tests/dispatch/derive_dispatch.rs
+++ b/module-system/sov-modules-macros/tests/dispatch/derive_dispatch.rs
@@ -1,4 +1,5 @@
 mod modules;
+use modules::third_test_module::{self, ModuleThreeStorable};
 use modules::{first_test_module, second_test_module};
 use sov_modules_api::default_context::ZkDefaultContext;
 use sov_modules_api::macros::DefaultRuntime;
@@ -7,18 +8,23 @@ use sov_state::ZkStorage;
 
 #[derive(Genesis, DispatchCall, MessageCodec, DefaultRuntime)]
 #[serialization(borsh::BorshDeserialize, borsh::BorshSerialize)]
-struct Runtime<C: Context> {
+struct Runtime<C, T>
+where
+    C: Context,
+    T: ModuleThreeStorable,
+{
     pub first: first_test_module::FirstTestStruct<C>,
     pub second: second_test_module::SecondTestStruct<C>,
+    pub third: third_test_module::ThirdTestStruct<C, T>,
 }
 
 fn main() {
-    type RT = Runtime<ZkDefaultContext>;
+    type RT = Runtime<ZkDefaultContext, u32>;
     let runtime = &mut RT::default();
 
     let storage = ZkStorage::new([1u8; 32]);
     let mut working_set = &mut sov_state::WorkingSet::new(storage);
-    let config = GenesisConfig::new((), ());
+    let config = GenesisConfig::new((), (), ());
     runtime.genesis(&config, working_set).unwrap();
     let context = ZkDefaultContext::new(Address::try_from([0; 32].as_ref()).unwrap());
 

--- a/module-system/sov-modules-macros/tests/dispatch/derive_genesis.rs
+++ b/module-system/sov-modules-macros/tests/dispatch/derive_genesis.rs
@@ -1,5 +1,6 @@
 mod modules;
 
+use modules::third_test_module::{self, ModuleThreeStorable};
 use modules::{first_test_module, second_test_module};
 use sov_modules_api::default_context::ZkDefaultContext;
 use sov_modules_api::macros::DefaultRuntime;
@@ -9,20 +10,22 @@ use sov_state::ZkStorage;
 // Debugging hint: To expand the macro in tests run: `cargo expand --test tests`
 #[derive(Genesis, DispatchCall, MessageCodec, DefaultRuntime)]
 #[serialization(borsh::BorshDeserialize, borsh::BorshSerialize)]
-struct Runtime<C>
+struct Runtime<C, T>
 where
     C: Context,
+    T: ModuleThreeStorable,
 {
     pub first: first_test_module::FirstTestStruct<C>,
     pub second: second_test_module::SecondTestStruct<C>,
+    pub third: third_test_module::ThirdTestStruct<C, T>,
 }
 
 fn main() {
     type C = ZkDefaultContext;
     let storage = ZkStorage::new([1u8; 32]);
     let mut working_set = &mut sov_state::WorkingSet::new(storage);
-    let runtime = &mut Runtime::<C>::default();
-    let config = GenesisConfig::new((), ());
+    let runtime = &mut Runtime::<C, u32>::default();
+    let config = GenesisConfig::new((), (), ());
     runtime.genesis(&config, working_set).unwrap();
 
     {
@@ -33,5 +36,10 @@ fn main() {
     {
         let response = runtime.second.get_state_value(&mut working_set);
         assert_eq!(response, 2);
+    }
+
+    {
+        let response = runtime.third.get_state_value(&mut working_set);
+        assert_eq!(response, Some(0));
     }
 }


### PR DESCRIPTION
# Description
Previously, many of the macros on `Runtime` could not handle more than one generic argument. This PR allows all of our macros to handle multiple generics appropriately.

## Linked Issues
- Fixes #275 

## Testing
Unit tests have been updated. I also added a dummy generic to `Bank` and derived/ran the code for demo-rollup with multiple generics.

