### PR TITLE
Improve generated cli help

### DIFF
--- a/module-system/module-implementations/sov-accounts/src/call.rs
+++ b/module-system/module-implementations/sov-accounts/src/call.rs
@@ -23,7 +23,12 @@ pub const UPDATE_ACCOUNT_MSG: [u8; 32] = [1; 32];
 pub enum CallMessage<C: sov_modules_api::Context> {
     /// Updates a public key for the corresponding Account.
     /// The sender must be in possession of the new key.
-    UpdatePublicKey(C::PublicKey, C::Signature),
+    UpdatePublicKey(
+        /// The new public key
+        C::PublicKey,
+        /// A valid signature from the new public key
+        C::Signature,
+    ),
 }
 
 impl<C: sov_modules_api::Context> Accounts<C> {

--- a/module-system/sov-modules-macros/src/cli_parser.rs
+++ b/module-system/sov-modules-macros/src/cli_parser.rs
@@ -206,6 +206,7 @@ pub(crate) fn derive_cli_wallet_arg(
                     Fields::Unnamed(_) => {
                         variants_with_named_fields.push(quote! {
                             #( #variant_docs )*
+                            #[command(arg_required_else_help(true))]
                             #variant_name {#(#named_variant_fields),* }
                         });
                         convert_cases.push(quote! {
@@ -215,6 +216,7 @@ pub(crate) fn derive_cli_wallet_arg(
                     Fields::Named(_) => {
                         variants_with_named_fields.push(quote! {
                             #( #variant_docs )*
+                            #[command(arg_required_else_help(true))]
                             #variant_name {#(#named_variant_fields),* }
                         });
                         convert_cases.push(quote! {


### PR DESCRIPTION
# Description
Improve the help messages generated by sov-cli. 

Before:
```
$  cargo run generate-transaction accounts update-public-key
error: the following required arguments were not provided:
  <FIELD0>
  <FIELD1>

Usage: main generate-transaction accounts update-public-key <FIELD0> <FIELD1>

For more information, try '--help'.
```

After:
```
$ cargo run generate-transaction accounts update-public-key --help
Updates a public key for the corresponding Account. The sender must be in possession of the new key

Usage: main generate-transaction accounts update-public-key <FIELD0> <FIELD1>

Arguments:
  <FIELD0>  The new public key
  <FIELD1>  A valid signature from the new public key

Options:
  -h, --help  Print help
```

