### PR TITLE
Remove `array_chunks` nightly feature, as it seems to be unused

### DIFF
--- a/adapters/celestia/src/lib.rs
+++ b/adapters/celestia/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(array_windows)]
-#![feature(array_chunks)]
 pub mod celestia;
 pub mod shares;
 pub use celestia::*;


### PR DESCRIPTION
# Description

Simple as it speaks for itself.

Related to:

* https://github.com/Sovereign-Labs/sovereign-sdk/issues/29
