### PR TITLE
Remove `array_windows` feature to be closer to stable rust

### DIFF
--- a/adapters/celestia/src/lib.rs
+++ b/adapters/celestia/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(array_windows)]
 #![feature(array_chunks)]
 pub mod celestia;
 pub mod shares;

--- a/adapters/celestia/src/verifier/mod.rs
+++ b/adapters/celestia/src/verifier/mod.rs
@@ -174,8 +174,10 @@ impl da::DaVerifier for CelestiaVerifier {
 
             // Verify each sub-proof and flatten the shares back into a sequential array
             // First, enforce that the sub-proofs cover a contiguous range of shares
-            for [l, r] in tx_proof.proof.array_windows::<2>() {
-                assert_eq!(l.start_share_idx + l.shares.len(), r.start_share_idx)
+            for i in 1..tx_proof.proof.len() {
+                let l = &tx_proof.proof[i - 1];
+                let r = &tx_proof.proof[i];
+                assert_eq!(l.start_share_idx + l.shares.len(), r.start_share_idx);
             }
             let mut tx_shares = Vec::new();
             // Then, verify the sub proofs


### PR DESCRIPTION
# Description

In order to be closer to stable rust this PR suggest simple replacement for nightly feature `array_windows`:

* https://github.com/rust-lang/rust/issues/75027

## Linked Issues
- Related to #29

## Testing
Manual tests have passed

## Docs
Not applicable
