### PR TITLE
Remove `jmt::SimpleHasher` from rollup interface; Add PrivateKey trait

### DIFF
--- a/adapters/celestia/src/verifier/mod.rs
+++ b/adapters/celestia/src/verifier/mod.rs
@@ -1,10 +1,10 @@
 use nmt_rs::NamespaceId;
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::crypto::SimpleHasher;
 use sov_rollup_interface::da::{
     self, BlobTransactionTrait, BlockHashTrait as BlockHash, BlockHeaderTrait, CountedBufReader,
     DaSpec,
 };
+use sov_rollup_interface::digest::Digest;
 use sov_rollup_interface::zk::ValidityCondition;
 use sov_rollup_interface::Buf;
 use thiserror::Error;
@@ -68,7 +68,7 @@ impl TmHash {
             tendermint::Hash::Sha256(ref h) => h,
             // Hack: when the hash is None, we return a hash of all 255s as a placeholder.
             // TODO: add special casing for the genesis block at a higher level
-            tendermint::Hash::None => unreachable!("Only the genesis block has a None hash, and we use a placholder in that corner case") 
+            tendermint::Hash::None => unreachable!("Only the genesis block has a None hash, and we use a placeholder in that corner case")
         }
     }
 }
@@ -119,7 +119,7 @@ pub enum ValidityConditionError {
 
 impl ValidityCondition for ChainValidityCondition {
     type Error = ValidityConditionError;
-    fn combine<H: SimpleHasher>(&self, rhs: Self) -> Result<Self, Self::Error> {
+    fn combine<H: Digest>(&self, rhs: Self) -> Result<Self, Self::Error> {
         if self.block_hash != rhs.prev_hash {
             return Err(ValidityConditionError::BlocksNotConsecutive);
         }
@@ -140,7 +140,7 @@ impl da::DaVerifier for CelestiaVerifier {
         }
     }
 
-    fn verify_relevant_tx_list<H: SimpleHasher>(
+    fn verify_relevant_tx_list<H: Digest>(
         &self,
         block_header: &<Self::Spec as DaSpec>::BlockHeader,
         txs: &[<Self::Spec as DaSpec>::BlobTransaction],

--- a/examples/demo-nft-module/README.md
+++ b/examples/demo-nft-module/README.md
@@ -379,16 +379,13 @@ use demo_nft_module::OwnerResponse;
 use demo_nft_module::{NonFungibleToken, NonFungibleTokenConfig};
 use serde::de::DeserializeOwned;
 use sov_modules_api::default_context::DefaultContext;
-use sov_modules_api::{Address, Context, Hasher, Module, ModuleInfo, Spec};
+use sov_modules_api::{Address, Context, Hasher, Module, ModuleInfo, Spec, test_utils::generate_address};
 use sov_state::{DefaultStorageSpec, ProverStorage, WorkingSet};
 
 pub type C = DefaultContext;
 pub type Storage = ProverStorage<DefaultStorageSpec>;
 
-pub fn generate_address(key: &str) -> <C as Spec>::Address {
-    let hash = <C as Spec>::Hasher::hash(key.as_bytes());
-    Address::from(hash)
-}
+
 #[test]
 #[ignore = "Not implemented yet"]
 fn genesis_and_mint() {}
@@ -408,11 +405,11 @@ Here's an example of setting up a module and calling its methods:
 #[test]
 fn transfer() {
     // Preparation
-    let admin = generate_address("admin");
+    let admin = generate_address::<C>("admin");
     let admin_context = C::new(admin.clone());
-    let owner1 = generate_address("owner2");
+    let owner1 = generate_address::<C>("owner2");
     let owner1_context = C::new(owner1.clone());
-    let owner2 = generate_address("owner2");
+    let owner2 = generate_address::<C>("owner2");
     let config: NonFungibleTokenConfig<C> = NonFungibleTokenConfig {
         admin: admin.clone(),
         owners: vec![(0, admin.clone()), (1, owner1.clone()), (2, owner2.clone())],

--- a/examples/demo-nft-module/tests/nft_test.rs
+++ b/examples/demo-nft-module/tests/nft_test.rs
@@ -2,16 +2,15 @@ use demo_nft_module::call::CallMessage;
 use demo_nft_module::query::OwnerResponse;
 use demo_nft_module::{NonFungibleToken, NonFungibleTokenConfig};
 use sov_modules_api::default_context::DefaultContext;
-use sov_modules_api::{Address, Context, Hasher, Module, Spec};
+use sov_modules_api::test_utils::generate_address as gen_addr_generic;
+use sov_modules_api::{Address, Context, Module};
 use sov_rollup_interface::stf::Event;
 use sov_state::{DefaultStorageSpec, ProverStorage, WorkingSet};
 
 pub type C = DefaultContext;
 pub type Storage = ProverStorage<DefaultStorageSpec>;
-
-pub fn generate_address(key: &str) -> <C as Spec>::Address {
-    let hash = <C as Spec>::Hasher::hash(key.as_bytes());
-    Address::from(hash)
+fn generate_address(name: &str) -> Address {
+    gen_addr_generic::<DefaultContext>(name)
 }
 
 #[test]

--- a/examples/demo-prover/host/src/main.rs
+++ b/examples/demo-prover/host/src/main.rs
@@ -12,7 +12,7 @@ use jupiter::BlobWithSender;
 use methods::{ROLLUP_ELF, ROLLUP_ID};
 use risc0_adapter::host::Risc0Host;
 use serde::Deserialize;
-use sov_modules_api::{RpcRunner, PrivateKey};
+use sov_modules_api::{PrivateKey, RpcRunner};
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::services::stf_runner::StateTransitionRunner;
 use sov_rollup_interface::stf::StateTransitionFunction;

--- a/examples/demo-prover/host/src/main.rs
+++ b/examples/demo-prover/host/src/main.rs
@@ -12,7 +12,7 @@ use jupiter::BlobWithSender;
 use methods::{ROLLUP_ELF, ROLLUP_ID};
 use risc0_adapter::host::Risc0Host;
 use serde::Deserialize;
-use sov_modules_api::RpcRunner;
+use sov_modules_api::{RpcRunner, PrivateKey};
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::services::stf_runner::StateTransitionRunner;
 use sov_rollup_interface::stf::StateTransitionFunction;

--- a/examples/demo-prover/methods/.cargo/config.toml
+++ b/examples/demo-prover/methods/.cargo/config.toml
@@ -1,0 +1,2 @@
+[patch.crates-io]
+cc = { git = "https://github.com/rust-lang/cc-rs", rev = "e5bbdfa" }

--- a/examples/demo-rollup/benches/rollup_bench.rs
+++ b/examples/demo-rollup/benches/rollup_bench.rs
@@ -15,6 +15,7 @@ use sov_db::ledger_db::{LedgerDB, SlotCommit};
 use sov_demo_rollup::config::RollupConfig;
 use sov_demo_rollup::rng_xfers::RngDaService;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
+use sov_modules_api::PrivateKey;
 use sov_rollup_interface::mocks::{TestBlob, TestBlock, TestBlockHeader, TestHash};
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::services::stf_runner::StateTransitionRunner;

--- a/examples/demo-rollup/benches/rollup_coarse_measure.rs
+++ b/examples/demo-rollup/benches/rollup_coarse_measure.rs
@@ -15,6 +15,7 @@ use sov_db::ledger_db::{LedgerDB, SlotCommit};
 use sov_demo_rollup::config::RollupConfig;
 use sov_demo_rollup::rng_xfers::RngDaService;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
+use sov_modules_api::PrivateKey;
 use sov_rollup_interface::mocks::{TestBlob, TestBlock, TestBlockHeader, TestHash};
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::services::stf_runner::StateTransitionRunner;

--- a/examples/demo-rollup/src/rng_xfers.rs
+++ b/examples/demo-rollup/src/rng_xfers.rs
@@ -9,7 +9,7 @@ use sov_bank::{CallMessage, Coins};
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
 use sov_modules_api::transaction::Transaction;
-use sov_modules_api::{Address, AddressBech32, PublicKey, Spec};
+use sov_modules_api::{Address, AddressBech32, PrivateKey, PublicKey, Spec};
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::mocks::{TestBlob, TestBlock, TestBlockHeader, TestHash};
 use sov_rollup_interface::services::da::DaService;

--- a/examples/demo-stf/src/batch_builder.rs
+++ b/examples/demo-stf/src/batch_builder.rs
@@ -140,7 +140,7 @@ mod tests {
     use sov_modules_api::default_signature::DefaultPublicKey;
     use sov_modules_api::macros::DefaultRuntime;
     use sov_modules_api::transaction::Transaction;
-    use sov_modules_api::{Context, DispatchCall, Genesis, MessageCodec};
+    use sov_modules_api::{Context, DispatchCall, Genesis, MessageCodec, PrivateKey};
     use sov_rollup_interface::services::batch_builder::BatchBuilder;
     use sov_state::{DefaultStorageSpec, ProverStorage, Storage};
     use sov_value_setter::{CallMessage, ValueSetterConfig};

--- a/examples/demo-stf/src/genesis_config.rs
+++ b/examples/demo-stf/src/genesis_config.rs
@@ -3,7 +3,8 @@ use sov_election::ElectionConfig;
 use sov_evm::{AccountData, EvmConfig};
 pub use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
-use sov_modules_api::{Context, Hasher, PublicKey, Spec};
+use sov_modules_api::test_utils::generate_address;
+use sov_modules_api::{Context, PrivateKey, PublicKey};
 pub use sov_state::config::Config as StorageConfig;
 use sov_value_setter::ValueSetterConfig;
 
@@ -79,11 +80,6 @@ pub fn create_demo_genesis_config<C: Context>(
             }],
         },
     )
-}
-
-pub fn generate_address<C: Context>(key: &str) -> <C as Spec>::Address {
-    let hash = <C as Spec>::Hasher::hash(key.as_bytes());
-    <C as Spec>::Address::from(hash)
 }
 
 pub fn create_demo_config(

--- a/examples/demo-stf/src/sov-cli/native.rs
+++ b/examples/demo-stf/src/sov-cli/native.rs
@@ -13,7 +13,7 @@ use jsonrpsee::http_client::HttpClientBuilder;
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
 use sov_modules_api::transaction::Transaction;
-use sov_modules_api::{AddressBech32, PublicKey, Spec};
+use sov_modules_api::{AddressBech32, PrivateKey, PublicKey, Spec};
 use sov_modules_stf_template::RawTx;
 use sov_sequencer::SubmitTransaction;
 
@@ -348,7 +348,7 @@ mod test {
     use demo_stf::genesis_config::{create_demo_config, DEMO_SEQUENCER_DA_ADDRESS, LOCKED_AMOUNT};
     use demo_stf::runner_config::Config;
     use demo_stf::runtime::GenesisConfig;
-    use sov_modules_api::Address;
+    use sov_modules_api::{Address, PrivateKey};
     use sov_modules_stf_template::{Batch, RawTx, SequencerOutcome};
     use sov_rollup_interface::mocks::MockZkvm;
     use sov_rollup_interface::services::stf_runner::StateTransitionRunner;

--- a/examples/demo-stf/src/tests/data_generation/election_data.rs
+++ b/examples/demo-stf/src/tests/data_generation/election_data.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use sov_modules_api::default_context::DefaultContext;
+use sov_modules_api::PrivateKey;
 
 use super::*;
 

--- a/examples/demo-stf/src/tests/stf_tests.rs
+++ b/examples/demo-stf/src/tests/stf_tests.rs
@@ -2,6 +2,7 @@
 pub mod test {
     use sov_modules_api::default_context::DefaultContext;
     use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
+    use sov_modules_api::PrivateKey;
     use sov_modules_stf_template::{Batch, SequencerOutcome};
     use sov_rollup_interface::mocks::MockZkvm;
     use sov_rollup_interface::stf::StateTransitionFunction;

--- a/examples/demo-stf/src/tests/tx_revert_tests.rs
+++ b/examples/demo-stf/src/tests/tx_revert_tests.rs
@@ -4,7 +4,7 @@ use sov_accounts::Response;
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
 use sov_modules_api::transaction::Transaction;
-use sov_modules_api::PublicKey;
+use sov_modules_api::{PrivateKey, PublicKey};
 use sov_modules_stf_template::{Batch, RawTx, SequencerOutcome, SlashingReason};
 use sov_rollup_interface::mocks::MockZkvm;
 use sov_rollup_interface::stf::StateTransitionFunction;

--- a/module-system/module-implementations/examples/sov-election/src/tests.rs
+++ b/module-system/module-implementations/examples/sov-election/src/tests.rs
@@ -1,6 +1,6 @@
 use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
-use sov_modules_api::{Address, Context, Module, PublicKey};
+use sov_modules_api::{Address, Context, Module, PrivateKey, PublicKey};
 use sov_state::{ProverStorage, WorkingSet, ZkStorage};
 
 use super::call::CallMessage;

--- a/module-system/module-implementations/sov-accounts/src/call.rs
+++ b/module-system/module-implementations/sov-accounts/src/call.rs
@@ -23,7 +23,12 @@ pub const UPDATE_ACCOUNT_MSG: [u8; 32] = [1; 32];
 pub enum CallMessage<C: sov_modules_api::Context> {
     /// Updates a public key for the corresponding Account.
     /// The sender must be in possession of the new key.
-    UpdatePublicKey(C::PublicKey, C::Signature),
+    UpdatePublicKey(
+        /// The new public key
+        C::PublicKey,
+        /// A valid signature from the new public key
+        C::Signature,
+    ),
 }
 
 impl<C: sov_modules_api::Context> Accounts<C> {

--- a/module-system/module-implementations/sov-accounts/src/call.rs
+++ b/module-system/module-implementations/sov-accounts/src/call.rs
@@ -51,7 +51,7 @@ impl<C: sov_modules_api::Context> Accounts<C> {
         );
 
         // Proof that the sender is in possession of the `new_pub_key`.
-        signature.verify(&new_pub_key, UPDATE_ACCOUNT_MSG)?;
+        signature.verify(&new_pub_key, &UPDATE_ACCOUNT_MSG)?;
 
         // Update the public key (account data remains the same).
         self.accounts.set(&new_pub_key, &account, working_set);

--- a/module-system/module-implementations/sov-accounts/src/tests.rs
+++ b/module-system/module-implementations/sov-accounts/src/tests.rs
@@ -1,6 +1,6 @@
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
-use sov_modules_api::{AddressBech32, Context, Module, PublicKey, Spec};
+use sov_modules_api::{AddressBech32, Context, Module, PrivateKey, PublicKey, Spec};
 use sov_state::{ProverStorage, WorkingSet};
 
 use crate::query::{self, Response};
@@ -74,7 +74,7 @@ fn test_update_account() {
     {
         let priv_key = DefaultPrivateKey::generate();
         let new_pub_key = priv_key.pub_key();
-        let sig = priv_key.sign(call::UPDATE_ACCOUNT_MSG);
+        let sig = priv_key.sign(&call::UPDATE_ACCOUNT_MSG);
         accounts
             .call(
                 call::CallMessage::<C>::UpdatePublicKey(new_pub_key.clone(), sig),
@@ -118,7 +118,7 @@ fn test_update_account_fails() {
 
     let priv_key = DefaultPrivateKey::generate();
     let sender_2 = priv_key.pub_key();
-    let sig_2 = priv_key.sign(call::UPDATE_ACCOUNT_MSG);
+    let sig_2 = priv_key.sign(&call::UPDATE_ACCOUNT_MSG);
 
     accounts
         .create_default_account(sender_2.clone(), native_working_set)
@@ -150,7 +150,7 @@ fn test_get_account_after_pub_key_update() {
 
     let priv_key = DefaultPrivateKey::generate();
     let new_pub_key = priv_key.pub_key();
-    let sig = priv_key.sign(call::UPDATE_ACCOUNT_MSG);
+    let sig = priv_key.sign(&call::UPDATE_ACCOUNT_MSG);
     accounts
         .call(
             call::CallMessage::<C>::UpdatePublicKey(new_pub_key.clone(), sig),

--- a/module-system/module-implementations/sov-bank/src/utils.rs
+++ b/module-system/module-implementations/sov-bank/src/utils.rs
@@ -1,4 +1,4 @@
-use sov_modules_api::Hasher;
+use sov_modules_api::digest::Digest;
 
 use crate::genesis::DEPLOYER;
 
@@ -9,11 +9,11 @@ pub fn get_token_address<C: sov_modules_api::Context>(
     salt: u64,
 ) -> C::Address {
     let mut hasher = C::Hasher::new();
-    hasher.update(sender.as_ref());
+    hasher.update(sender);
     hasher.update(token_name.as_bytes());
-    hasher.update(&salt.to_le_bytes());
+    hasher.update(salt.to_le_bytes());
 
-    let hash = hasher.finalize();
+    let hash: [u8; 32] = hasher.finalize().into();
     C::Address::from(hash)
 }
 

--- a/module-system/module-implementations/sov-bank/tests/create_token_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/create_token_test.rs
@@ -1,4 +1,5 @@
 use sov_bank::{get_token_address, Bank, CallMessage};
+use sov_modules_api::test_utils::generate_address;
 use sov_modules_api::{Context, Module};
 use sov_state::{ProverStorage, WorkingSet};
 
@@ -14,9 +15,9 @@ fn initial_and_deployed_token() {
     let bank = Bank::default();
     bank.genesis(&bank_config, &mut working_set).unwrap();
 
-    let sender_address = generate_address("sender");
+    let sender_address = generate_address::<C>("sender");
     let sender_context = C::new(sender_address.clone());
-    let minter_address = generate_address("minter");
+    let minter_address = generate_address::<C>("minter");
     let initial_balance = 500;
     let token_name = "Token1".to_owned();
     let salt = 1;

--- a/module-system/module-implementations/sov-bank/tests/freeze_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/freeze_test.rs
@@ -1,5 +1,7 @@
-use helpers::{generate_address, C};
+use helpers::C;
 use sov_bank::{get_token_address, Bank, BankConfig, CallMessage, Coins, TotalSupplyResponse};
+use sov_modules_api::default_context::DefaultContext;
+use sov_modules_api::test_utils::generate_address;
 use sov_modules_api::{Address, Context, Error, Module};
 use sov_state::{DefaultStorageSpec, ProverStorage, WorkingSet};
 
@@ -15,7 +17,7 @@ fn freeze_token() {
     let empty_bank_config = BankConfig::<C> { tokens: vec![] };
     bank.genesis(&empty_bank_config, &mut working_set).unwrap();
 
-    let minter_address = generate_address("minter");
+    let minter_address = generate_address::<DefaultContext>("minter");
     let minter_context = C::new(minter_address.clone());
 
     let salt = 0;
@@ -92,7 +94,7 @@ fn freeze_token() {
     assert!(working_set.events().is_empty());
 
     // Try to freeze with a non authorized minter
-    let unauthorized_address = generate_address("unauthorized_address");
+    let unauthorized_address = generate_address::<C>("unauthorized_address");
     let unauthorized_context = C::new(unauthorized_address.clone());
     let freeze_message = CallMessage::Freeze {
         token_address: token_address_2.clone(),
@@ -122,7 +124,7 @@ fn freeze_token() {
 
     // Try to mint a frozen token
     let mint_amount = 10;
-    let new_holder = generate_address("new_holder");
+    let new_holder = generate_address::<C>("new_holder");
     let mint_message = CallMessage::Mint {
         coins: Coins {
             amount: mint_amount,

--- a/module-system/module-implementations/sov-bank/tests/helpers/mod.rs
+++ b/module-system/module-implementations/sov-bank/tests/helpers/mod.rs
@@ -1,12 +1,15 @@
 use sov_bank::{BankConfig, TokenConfig};
 use sov_modules_api::default_context::DefaultContext;
-use sov_modules_api::{Address, Hasher, Spec};
+use sov_modules_api::test_utils::generate_address as gen_address_generic;
+use sov_modules_api::Address;
 
 pub type C = DefaultContext;
 
-pub fn generate_address(key: &str) -> <C as Spec>::Address {
-    let hash = <C as Spec>::Hasher::hash(key.as_bytes());
-    Address::from(hash)
+// This code is not actually dead; rustc treats each test file as a separate crate
+// so this code looks unused during some of the compilations.
+#[allow(dead_code)]
+pub fn generate_address(name: &str) -> Address {
+    gen_address_generic::<C>(name)
 }
 
 #[allow(dead_code)]

--- a/module-system/module-implementations/sov-bank/tests/mint_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/mint_test.rs
@@ -1,5 +1,6 @@
-use helpers::{generate_address, C};
+use helpers::C;
 use sov_bank::{get_token_address, Bank, BankConfig, CallMessage, Coins, TotalSupplyResponse};
+use sov_modules_api::test_utils::generate_address;
 use sov_modules_api::{Address, Context, Error, Module};
 use sov_state::{DefaultStorageSpec, ProverStorage, WorkingSet};
 
@@ -15,7 +16,7 @@ fn mint_token() {
     let empty_bank_config = BankConfig::<C> { tokens: vec![] };
     bank.genesis(&empty_bank_config, &mut working_set).unwrap();
 
-    let minter_address = generate_address("minter");
+    let minter_address = generate_address::<C>("minter");
     let minter_context = C::new(minter_address.clone());
 
     let salt = 0;
@@ -56,7 +57,7 @@ fn mint_token() {
     // -----
     // Mint Additional
     let mint_amount = 10;
-    let new_holder = generate_address("new_holder");
+    let new_holder = generate_address::<C>("new_holder");
     let mint_message = CallMessage::Mint {
         coins: Coins {
             amount: mint_amount,
@@ -82,7 +83,7 @@ fn mint_token() {
     assert_eq!(Some(100), bal);
 
     // Mint with an un-authorized user
-    let unauthorized_address = generate_address("unauthorized_address");
+    let unauthorized_address = generate_address::<C>("unauthorized_address");
     let unauthorized_context = C::new(unauthorized_address.clone());
     let unauthorized_mint = bank.call(mint_message, &unauthorized_context, &mut working_set);
 
@@ -115,8 +116,8 @@ fn mint_token() {
     let token_name = "Token_New".to_owned();
     let initial_balance = 100;
     let token_address = get_token_address::<C>(&token_name, minter_address.as_ref(), salt);
-    let authorized_minter_address_1 = generate_address("authorized_minter_1");
-    let authorized_minter_address_2 = generate_address("authorized_minter_2");
+    let authorized_minter_address_1 = generate_address::<C>("authorized_minter_1");
+    let authorized_minter_address_2 = generate_address::<C>("authorized_minter_2");
     // ---
     // Deploying token
     let mint_message = CallMessage::CreateToken {
@@ -137,7 +138,7 @@ fn mint_token() {
 
     // Try to mint new token with original token creator, in this case minter_context
     let mint_amount = 10;
-    let new_holder = generate_address("new_holder_2");
+    let new_holder = generate_address::<C>("new_holder_2");
     let mint_message = CallMessage::Mint {
         coins: Coins {
             amount: mint_amount,
@@ -241,7 +242,7 @@ fn mint_token() {
     assert_eq!(Some(120), supply);
 
     // Overflow test 2 - total supply
-    let new_holder = generate_address("new_holder_3");
+    let new_holder = generate_address::<C>("new_holder_3");
     let overflow_mint_message = CallMessage::Mint {
         coins: Coins {
             amount: u64::MAX - 1,

--- a/module-system/module-implementations/sov-bank/tests/transfer_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/transfer_test.rs
@@ -5,6 +5,7 @@ use sov_bank::{
     get_genesis_token_address, get_token_address, Bank, BankConfig, CallMessage, Coins,
     TotalSupplyResponse,
 };
+use sov_modules_api::test_utils::generate_address;
 use sov_modules_api::{Address, Context, Error, Module};
 use sov_state::{DefaultStorageSpec, ProverStorage, WorkingSet};
 
@@ -154,7 +155,7 @@ fn transfer_initial_token() {
 
     // Sender does not exist
     {
-        let unknown_sender = generate_address("non_existing_sender");
+        let unknown_sender = generate_address::<C>("non_existing_sender");
         let unknown_sender_context = C::new(unknown_sender.clone());
 
         let sender_balance = query_user_balance(unknown_sender.clone(), &mut working_set);
@@ -208,7 +209,7 @@ fn transfer_initial_token() {
 
     // Receiver does not exist
     {
-        let unknown_receiver = generate_address("non_existing_receiver");
+        let unknown_receiver = generate_address::<C>("non_existing_receiver");
 
         let receiver_balance_before =
             query_user_balance(unknown_receiver.clone(), &mut working_set);
@@ -262,8 +263,8 @@ fn transfer_deployed_token() {
     let empty_bank_config = BankConfig::<C> { tokens: vec![] };
     bank.genesis(&empty_bank_config, &mut working_set).unwrap();
 
-    let sender_address = generate_address("just_sender");
-    let receiver_address = generate_address("just_receiver");
+    let sender_address = generate_address::<C>("just_sender");
+    let receiver_address = generate_address::<C>("just_receiver");
 
     let salt = 10;
     let token_name = "Token1".to_owned();

--- a/module-system/module-implementations/sov-evm/src/tests/call_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/call_tests.rs
@@ -44,6 +44,7 @@ fn create_messages(contract_addr: EthAddress, set_arg: u32) -> Vec<CallMessage> 
 
 #[test]
 fn evm_test() {
+    use sov_modules_api::PublicKey;
     let tmpdir = tempfile::tempdir().unwrap();
     let working_set = &mut WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
 

--- a/module-system/module-implementations/sov-evm/src/tests/call_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/call_tests.rs
@@ -1,7 +1,7 @@
 use revm::primitives::{KECCAK_EMPTY, U256};
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
-use sov_modules_api::{Context, Module, PublicKey, Spec};
+use sov_modules_api::{Context, Module, PrivateKey, Spec};
 use sov_state::{ProverStorage, WorkingSet};
 
 use crate::call::CallMessage;

--- a/module-system/module-implementations/sov-prover-incentives/src/tests.rs
+++ b/module-system/module-implementations/sov-prover-incentives/src/tests.rs
@@ -1,5 +1,6 @@
 use sov_modules_api::default_context::DefaultContext;
-use sov_modules_api::{Address, Hasher, Module, Spec};
+use sov_modules_api::digest::Digest;
+use sov_modules_api::{Address, Module, Spec};
 use sov_rollup_interface::mocks::{MockCodeCommitment, MockProof, MockZkvm};
 use sov_state::{ProverStorage, WorkingSet};
 
@@ -11,7 +12,7 @@ const BOND_AMOUNT: u64 = 1000;
 const MOCK_CODE_COMMITMENT: MockCodeCommitment = MockCodeCommitment([0u8; 32]);
 
 pub fn generate_address(key: &str) -> <C as Spec>::Address {
-    let hash = <C as Spec>::Hasher::hash(key.as_bytes());
+    let hash: [u8; 32] = <C as Spec>::Hasher::digest(key.as_bytes()).into();
     Address::from(hash)
 }
 

--- a/module-system/module-implementations/sov-sequencer-registry/tests/helpers/mod.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/tests/helpers/mod.rs
@@ -1,6 +1,7 @@
 use jsonrpsee::core::RpcResult;
 use sov_modules_api::default_context::DefaultContext;
-use sov_modules_api::{Address, Hasher, Module, Spec};
+use sov_modules_api::digest::Digest;
+use sov_modules_api::{Address, Module, Spec};
 use sov_sequencer_registry::{SequencerConfig, SequencerRegistry};
 use sov_state::WorkingSet;
 
@@ -120,6 +121,6 @@ pub fn create_test_sequencer() -> TestSequencer {
 }
 
 pub fn generate_address(key: &str) -> <C as Spec>::Address {
-    let hash = <C as Spec>::Hasher::hash(key.as_bytes());
+    let hash: [u8; 32] = <C as Spec>::Hasher::digest(key.as_bytes()).into();
     Address::from(hash)
 }

--- a/module-system/sov-modules-api/src/default_context.rs
+++ b/module-system/sov-modules-api/src/default_context.rs
@@ -1,11 +1,13 @@
 #[cfg(feature = "native")]
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::crypto::SimpleHasher;
+use sha2::Digest;
 use sov_rollup_interface::AddressTrait;
 #[cfg(feature = "native")]
 use sov_state::ProverStorage;
 use sov_state::{ArrayWitness, DefaultStorageSpec, ZkStorage};
 
+#[cfg(feature = "native")]
+use crate::default_signature::private_key::DefaultPrivateKey;
 use crate::default_signature::{DefaultPublicKey, DefaultSignature};
 use crate::{Address, Context, PublicKey, Spec};
 
@@ -20,6 +22,7 @@ impl Spec for DefaultContext {
     type Address = Address;
     type Storage = ProverStorage<DefaultStorageSpec>;
     type PublicKey = DefaultPublicKey;
+    type PrivateKey = DefaultPrivateKey;
     type Hasher = sha2::Sha256;
     type Signature = DefaultSignature;
     type Witness = ArrayWitness;
@@ -46,6 +49,8 @@ impl Spec for ZkDefaultContext {
     type Address = Address;
     type Storage = ZkStorage<DefaultStorageSpec>;
     type PublicKey = DefaultPublicKey;
+    #[cfg(feature = "native")]
+    type PrivateKey = DefaultPrivateKey;
     type Hasher = sha2::Sha256;
     type Signature = DefaultSignature;
     type Witness = ArrayWitness;
@@ -63,7 +68,11 @@ impl Context for ZkDefaultContext {
 
 impl PublicKey for DefaultPublicKey {
     fn to_address<A: AddressTrait>(&self) -> A {
-        let pub_key_hash = <ZkDefaultContext as Spec>::Hasher::hash(self.pub_key);
+        let pub_key_hash = {
+            let mut hasher = <ZkDefaultContext as Spec>::Hasher::new();
+            hasher.update(self.pub_key);
+            hasher.finalize().into()
+        };
         A::from(pub_key_hash)
     }
 }

--- a/module-system/sov-modules-api/src/default_signature.rs
+++ b/module-system/sov-modules-api/src/default_signature.rs
@@ -201,11 +201,7 @@ impl BorshSerialize for DefaultSignature {
 impl Signature for DefaultSignature {
     type PublicKey = DefaultPublicKey;
 
-    fn verify(
-        &self,
-        pub_key: &Self::PublicKey,
-        msg: &[u8],
-    ) -> Result<(), SigVerificationError> {
+    fn verify(&self, pub_key: &Self::PublicKey, msg: &[u8]) -> Result<(), SigVerificationError> {
         pub_key
             .pub_key
             .verify_strict(msg, &self.msg_sig)

--- a/module-system/sov-modules-api/src/default_signature.rs
+++ b/module-system/sov-modules-api/src/default_signature.rs
@@ -19,7 +19,7 @@ pub mod private_key {
     use thiserror::Error;
 
     use super::{DefaultPublicKey, DefaultSignature};
-    use crate::{Address, PublicKey};
+    use crate::{Address, PrivateKey, PublicKey};
 
     #[derive(Error, Debug)]
     pub enum DefaultPrivateKeyHexDeserializationError {
@@ -29,12 +29,37 @@ pub mod private_key {
         PrivateKeyError(#[from] SignatureError),
     }
 
+    /// A private key for the default signature scheme.
+    /// This struct also stores the corresponding public key.
     pub struct DefaultPrivateKey {
         key_pair: Keypair,
     }
 
-    impl DefaultPrivateKey {
-        pub fn generate() -> Self {
+    impl core::fmt::Debug for DefaultPrivateKey {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("DefaultPrivateKey")
+                .field("public_key", &self.key_pair.public)
+                .field("private_key", &"***REDACTED***")
+                .finish()
+        }
+    }
+
+    impl TryFrom<&[u8]> for DefaultPrivateKey {
+        type Error = anyhow::Error;
+
+        fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+            let key_pair = Keypair::from_bytes(value)?;
+            key_pair.secret.to_bytes();
+            Ok(Self { key_pair })
+        }
+    }
+
+    impl PrivateKey for DefaultPrivateKey {
+        type PublicKey = DefaultPublicKey;
+
+        type Signature = DefaultSignature;
+
+        fn generate() -> Self {
             let mut csprng = OsRng;
 
             Self {
@@ -42,18 +67,20 @@ pub mod private_key {
             }
         }
 
-        pub fn sign(&self, msg: [u8; 32]) -> DefaultSignature {
-            DefaultSignature {
-                msg_sig: self.key_pair.sign(&msg),
-            }
-        }
-
-        pub fn pub_key(&self) -> DefaultPublicKey {
+        fn pub_key(&self) -> Self::PublicKey {
             DefaultPublicKey {
                 pub_key: self.key_pair.public,
             }
         }
 
+        fn sign(&self, msg: &[u8]) -> Self::Signature {
+            DefaultSignature {
+                msg_sig: self.key_pair.sign(msg),
+            }
+        }
+    }
+
+    impl DefaultPrivateKey {
         pub fn as_hex(&self) -> String {
             hex::encode(self.key_pair.to_bytes())
         }
@@ -177,11 +204,11 @@ impl Signature for DefaultSignature {
     fn verify(
         &self,
         pub_key: &Self::PublicKey,
-        msg_hash: [u8; 32],
+        msg: &[u8],
     ) -> Result<(), SigVerificationError> {
         pub_key
             .pub_key
-            .verify_strict(&msg_hash, &self.msg_sig)
+            .verify_strict(msg, &self.msg_sig)
             .map_err(|e| SigVerificationError::BadSignature(e.to_string()))
     }
 }

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -30,7 +30,9 @@ pub use sov_modules_macros::{
 /// Procedural macros to assist with creating new modules.
 #[cfg(feature = "macros")]
 pub mod macros {
-    pub use sov_modules_macros::{expose_rpc, rpc_gen, CliWallet, CliWalletArg, DefaultRuntime};
+    pub use sov_modules_macros::DefaultRuntime;
+    #[cfg(feature = "native")]
+    pub use sov_modules_macros::{expose_rpc, rpc_gen, CliWallet, CliWalletArg};
 }
 
 use core::fmt::{self, Debug, Display};
@@ -136,7 +138,7 @@ pub trait PublicKey {
     fn to_address<A: AddressTrait>(&self) -> A;
 }
 
-/// PublicKey used in the Module System.
+/// A PrivateKey used in the Module System.
 #[cfg(feature = "native")]
 pub trait PrivateKey {
     type PublicKey: PublicKey;

--- a/module-system/sov-modules-api/src/prefix.rs
+++ b/module-system/sov-modules-api/src/prefix.rs
@@ -1,4 +1,6 @@
-use crate::{Context, Hasher};
+use sha2::Digest;
+
+use crate::Context;
 
 // separator == "/"
 const DOMAIN_SEPARATOR: [u8; 1] = [47];
@@ -58,7 +60,9 @@ impl Prefix {
 
     pub fn hash<C: Context>(&self) -> [u8; 32] {
         let combined_prefix = self.combine_prefix();
-        C::Hasher::hash(combined_prefix)
+        let mut hasher = C::Hasher::new();
+        hasher.update(combined_prefix);
+        hasher.finalize().into()
     }
 }
 

--- a/module-system/sov-modules-api/src/test_utils.rs
+++ b/module-system/sov-modules-api/src/test_utils.rs
@@ -1,0 +1,6 @@
+use crate::{Context, Digest, Spec};
+
+pub fn generate_address<C: Context>(key: &str) -> <C as Spec>::Address {
+    let hash: [u8; 32] = <C as Spec>::Hasher::digest(key.as_bytes()).into();
+    C::Address::from(hash)
+}

--- a/module-system/sov-modules-api/src/tests.rs
+++ b/module-system/sov-modules-api/src/tests.rs
@@ -3,7 +3,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use crate::default_context::DefaultContext;
 use crate::default_signature::private_key::DefaultPrivateKey;
 use crate::default_signature::{DefaultPublicKey, DefaultSignature};
-use crate::{Address, ModuleInfo, Signature};
+use crate::{Address, ModuleInfo, PrivateKey, Signature};
 
 #[test]
 fn test_account_bech32m_display() {
@@ -29,13 +29,13 @@ fn test_signature_serialization() {
     let msg = [1; 32];
     let priv_key = DefaultPrivateKey::generate();
 
-    let sig = priv_key.sign(msg);
+    let sig = priv_key.sign(&msg);
     let serialized_sig = sig.try_to_vec().unwrap();
     let deserialized_sig = DefaultSignature::try_from_slice(&serialized_sig).unwrap();
     assert_eq!(sig, deserialized_sig);
 
     let pub_key = priv_key.pub_key();
-    deserialized_sig.verify(&pub_key, msg).unwrap()
+    deserialized_sig.verify(&pub_key, &msg).unwrap()
 }
 
 #[test]
@@ -136,4 +136,13 @@ fn test_sorting_modules_cycle() {
     assert!(sorted_modules.is_err());
     let error_string = sorted_modules.err().unwrap().to_string();
     assert_eq!("Cyclic dependency of length 2 detected: [AddressBech32 { value: \"sov1qszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqnu4g3u\" }, AddressBech32 { value: \"sov1q5zs2pg9q5zs2pg9q5zs2pg9q5zs2pg9q5zs2pg9q5zs2pg9q5zskwvj87\" }]", error_string);
+}
+
+#[test]
+fn test_default_signature_roundtrip() {
+    let key = DefaultPrivateKey::generate();
+    let msg = b"hello, world";
+    let sig = key.sign(msg);
+    sig.verify(&key.pub_key(), msg)
+        .expect("Roundtrip verification failed");
 }

--- a/module-system/sov-modules-api/src/transaction.rs
+++ b/module-system/sov-modules-api/src/transaction.rs
@@ -2,9 +2,9 @@
 use crate::default_context::DefaultContext;
 #[cfg(feature = "native")]
 use crate::default_signature::private_key::DefaultPrivateKey;
-#[cfg(feature = "native")]
-use crate::{Spec, PrivateKey};
 use crate::{Context, Signature};
+#[cfg(feature = "native")]
+use crate::{PrivateKey, Spec};
 
 /// A Transaction object that is compatible with the module-system/sov-default-stf.
 #[derive(Debug, PartialEq, Eq, Clone, borsh::BorshDeserialize, borsh::BorshSerialize)]

--- a/module-system/sov-modules-api/src/transaction.rs
+++ b/module-system/sov-modules-api/src/transaction.rs
@@ -3,8 +3,8 @@ use crate::default_context::DefaultContext;
 #[cfg(feature = "native")]
 use crate::default_signature::private_key::DefaultPrivateKey;
 #[cfg(feature = "native")]
-use crate::Spec;
-use crate::{Context, PrivateKey, Signature};
+use crate::{Spec, PrivateKey};
+use crate::{Context, Signature};
 
 /// A Transaction object that is compatible with the module-system/sov-default-stf.
 #[derive(Debug, PartialEq, Eq, Clone, borsh::BorshDeserialize, borsh::BorshSerialize)]
@@ -38,7 +38,7 @@ impl<C: Context> Transaction<C> {
             Vec::with_capacity(self.runtime_msg().len() + std::mem::size_of::<u64>());
         serialized_tx.extend_from_slice(self.runtime_msg());
         serialized_tx.extend_from_slice(&self.nonce().to_le_bytes());
-        self.signature().verify(self.pub_key(), &serialized_tx)?;
+        self.signature().verify(&self.pub_key, &serialized_tx)?;
 
         Ok(())
     }

--- a/module-system/sov-modules-macros/src/cli_parser.rs
+++ b/module-system/sov-modules-macros/src/cli_parser.rs
@@ -206,6 +206,7 @@ pub(crate) fn derive_cli_wallet_arg(
                     Fields::Unnamed(_) => {
                         variants_with_named_fields.push(quote! {
                             #( #variant_docs )*
+                            #[command(arg_required_else_help(true))]
                             #variant_name {#(#named_variant_fields),* }
                         });
                         convert_cases.push(quote! {
@@ -215,6 +216,7 @@ pub(crate) fn derive_cli_wallet_arg(
                     Fields::Named(_) => {
                         variants_with_named_fields.push(quote! {
                             #( #variant_docs )*
+                            #[command(arg_required_else_help(true))]
                             #variant_name {#(#named_variant_fields),* }
                         });
                         convert_cases.push(quote! {

--- a/module-system/sov-modules-macros/src/module_info.rs
+++ b/module-system/sov-modules-macros/src/module_info.rs
@@ -328,7 +328,7 @@ fn make_init_address(
             ),
         )),
         None => Ok(quote::quote! {
-            use sov_modules_api::Hasher;
+            use ::sov_modules_api::digest::Digest;
             let module_path = module_path!();
             let prefix = sov_modules_api::Prefix::new_module(module_path, stringify!(#struct_ident));
             let #field_ident : <#generic_param as sov_modules_api::Spec>::Address =

--- a/module-system/sov-modules-macros/tests/module_info/parse.rs
+++ b/module-system/sov-modules-macros/tests/module_info/parse.rs
@@ -64,12 +64,13 @@ fn main() {
         .into()
     );
 
-    use sov_modules_api::Hasher;
+    use sov_modules_api::digest::Digest;
     let mut hasher = <C as sov_modules_api::Spec>::Hasher::new();
     hasher.update("trybuild000::test_module/TestStruct/".as_bytes());
+    let hash: [u8; 32] = hasher.finalize().into();
 
     assert_eq!(
-        &sov_modules_api::Address::try_from(hasher.finalize().as_ref()).unwrap(),
+        &sov_modules_api::Address::try_from(hash).unwrap(),
         test_struct.address()
     );
 }

--- a/module-system/sov-modules-stf-template/src/tx_verifier.rs
+++ b/module-system/sov-modules-stf-template/src/tx_verifier.rs
@@ -3,7 +3,8 @@ use std::io::Cursor;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sov_modules_api::transaction::Transaction;
-use sov_modules_api::{Context, Hasher, Spec};
+use sov_modules_api::{Context, Spec};
+use sov_rollup_interface::digest::Digest;
 use tracing::debug;
 
 type RawTxHash = [u8; 32];
@@ -22,7 +23,7 @@ pub struct RawTx {
 
 impl RawTx {
     fn hash<C: Context>(&self) -> [u8; 32] {
-        <C as Spec>::Hasher::hash(&self.data)
+        <C as Spec>::Hasher::digest(&self.data).into()
     }
 }
 

--- a/module-system/sov-state/src/lib.rs
+++ b/module-system/sov-state/src/lib.rs
@@ -81,10 +81,10 @@ pub trait MerkleProofSpec {
     /// The structure that accumulates the witness data
     type Witness: Witness;
     /// The hash function used to compute the merkle root
-    type Hasher: sov_rollup_interface::crypto::SimpleHasher;
+    type Hasher: Digest<OutputSize = sha2::digest::typenum::U32>;
 }
 
-use sha2::Sha256;
+use sha2::{Digest, Sha256};
 
 #[derive(Clone)]
 pub struct DefaultStorageSpec;

--- a/module-system/sov-state/src/zk_storage.rs
+++ b/module-system/sov-state/src/zk_storage.rs
@@ -2,7 +2,6 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use jmt::{JellyfishMerkleTree, KeyHash, Version};
-use sov_rollup_interface::crypto::SimpleHasher;
 
 use crate::internal_cache::OrderedReadsAndWrites;
 use crate::storage::{StorageKey, StorageValue};
@@ -55,7 +54,7 @@ impl<S: MerkleProofSpec> Storage for ZkStorage<S> {
 
         // For each value that's been read from the tree, verify the provided smt proof
         for (key, read_value) in state_accesses.ordered_reads {
-            let key_hash = KeyHash(S::Hasher::hash(key.key.as_ref()));
+            let key_hash = KeyHash::with::<S::Hasher>(key.key.as_ref());
             // TODO: Switch to the batch read API once it becomes available
             let proof: jmt::proof::SparseMerkleProof<S::Hasher> = witness.get_hint();
             match read_value {
@@ -73,7 +72,7 @@ impl<S: MerkleProofSpec> Storage for ZkStorage<S> {
             .ordered_writes
             .into_iter()
             .map(|(key, value)| {
-                let key_hash = KeyHash(S::Hasher::hash(key.key.as_ref()));
+                let key_hash = KeyHash::with::<S::Hasher>(key.key.as_ref());
                 (
                     key_hash,
                     value.map(|v| Arc::try_unwrap(v.value).unwrap_or_else(|arc| (*arc).clone())),

--- a/rollup-interface/Cargo.toml
+++ b/rollup-interface/Cargo.toml
@@ -23,7 +23,7 @@ borsh = { workspace = true, features = ["rc"] }
 serde = { workspace = true }
 bytes = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
-jmt = { workspace = true }
+digest = { workspace = true }
 
 sha2 = { workspace = true, optional = true }
 

--- a/rollup-interface/src/lib.rs
+++ b/rollup-interface/src/lib.rs
@@ -10,3 +10,4 @@ mod node;
 
 pub use borsh::maybestd;
 pub use node::*;
+pub use digest;

--- a/rollup-interface/src/lib.rs
+++ b/rollup-interface/src/lib.rs
@@ -9,5 +9,5 @@ pub use state_machine::*;
 mod node;
 
 pub use borsh::maybestd;
-pub use node::*;
 pub use digest;
+pub use node::*;

--- a/rollup-interface/src/state_machine/crypto/mod.rs
+++ b/rollup-interface/src/state_machine/crypto/mod.rs
@@ -1,3 +1,3 @@
 //! Defines useful cryptographic primitives that are needed by all sovereign-sdk rollups.
 mod simple_hasher;
-pub use simple_hasher::{NoOpHasher, SimpleHasher};
+pub use simple_hasher::NoOpHasher;

--- a/rollup-interface/src/state_machine/crypto/simple_hasher.rs
+++ b/rollup-interface/src/state_machine/crypto/simple_hasher.rs
@@ -1,16 +1,82 @@
-pub use jmt::SimpleHasher;
+use digest::typenum::U32;
+use digest::{Digest, FixedOutput, FixedOutputReset, OutputSizeUser, Reset, Update};
 
 /// A SimpleHasher implementation which always returns the digest `[0;32]`
 pub struct NoOpHasher;
 
-impl SimpleHasher for NoOpHasher {
+impl OutputSizeUser for NoOpHasher {
+    type OutputSize = U32;
+}
+
+impl Update for NoOpHasher {
+    fn update(&mut self, _data: &[u8]) {}
+}
+
+impl Reset for NoOpHasher {
+    fn reset(&mut self) {}
+}
+
+impl FixedOutput for NoOpHasher {
+    fn finalize_into(self, out: &mut digest::Output<Self>) {
+        *out = [0u8; 32].into();
+    }
+}
+
+impl FixedOutputReset for NoOpHasher {
+    fn finalize_into_reset(&mut self, out: &mut digest::Output<Self>) {
+        *out = [0u8; 32].into();
+    }
+}
+
+impl Digest for NoOpHasher {
     fn new() -> Self {
         Self
     }
 
-    fn update(&mut self, _data: &[u8]) {}
+    fn new_with_prefix(_data: impl AsRef<[u8]>) -> Self {
+        Self
+    }
 
-    fn finalize(self) -> [u8; 32] {
-        [0u8; 32]
+    fn update(&mut self, _data: impl AsRef<[u8]>) {}
+
+    fn chain_update(self, _data: impl AsRef<[u8]>) -> Self {
+        Self
+    }
+
+    fn finalize(self) -> digest::Output<Self> {
+        [0u8; 32].into()
+    }
+
+    fn finalize_into(self, out: &mut digest::Output<Self>) {
+        <Self as FixedOutput>::finalize_into(self, out)
+    }
+
+    fn finalize_reset(&mut self) -> digest::Output<Self>
+    where
+        Self: digest::FixedOutputReset,
+    {
+        [0u8; 32].into()
+    }
+
+    fn finalize_into_reset(&mut self, out: &mut digest::Output<Self>)
+    where
+        Self: digest::FixedOutputReset,
+    {
+        <Self as FixedOutputReset>::finalize_into_reset(self, out)
+    }
+
+    fn reset(&mut self)
+    where
+        Self: digest::Reset,
+    {
+        <Self as Reset>::reset(self)
+    }
+
+    fn output_size() -> usize {
+        32
+    }
+
+    fn digest(_data: impl AsRef<[u8]>) -> digest::Output<Self> {
+        [0u8; 32].into()
     }
 }

--- a/rollup-interface/src/state_machine/da.rs
+++ b/rollup-interface/src/state_machine/da.rs
@@ -6,10 +6,10 @@ use std::io::Read;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use bytes::Buf;
+use digest::Digest;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use crate::crypto::SimpleHasher;
 use crate::zk::ValidityCondition;
 use crate::AddressTrait;
 
@@ -59,7 +59,7 @@ pub trait DaVerifier {
     fn new(params: <Self::Spec as DaSpec>::ChainParams) -> Self;
 
     /// Verify a claimed set of transactions against a block header.
-    fn verify_relevant_tx_list<H: SimpleHasher>(
+    fn verify_relevant_tx_list<H: Digest>(
         &self,
         block_header: &<Self::Spec as DaSpec>::BlockHeader,
         txs: &[<Self::Spec as DaSpec>::BlobTransaction],

--- a/rollup-interface/src/state_machine/stf/fuzzing.rs
+++ b/rollup-interface/src/state_machine/stf/fuzzing.rs
@@ -1,9 +1,10 @@
 //! Implements fuzzing strategies for structs in the stf module
 
+use digest::typenum::U32;
+use digest::Digest;
 use proptest::prelude::{any, Arbitrary};
 use proptest::strategy::{BoxedStrategy, Strategy};
 
-use super::super::crypto::SimpleHasher;
 use super::{BatchReceipt, Event, TransactionReceipt};
 
 /// An object-safe hashing trait, which is blanket implemented for all
@@ -18,11 +19,11 @@ fn default_fuzz_hasher() -> Box<dyn FuzzHasher> {
     Box::new(::sha2::Sha256::new())
 }
 
-impl<T: SimpleHasher + Clone> FuzzHasher for T {
+impl<T: Digest<OutputSize = U32> + Clone> FuzzHasher for T {
     fn hash(&self, data: &[u8]) -> [u8; 32] {
         let mut hasher = T::new();
         hasher.update(data);
-        hasher.finalize()
+        hasher.finalize().into()
     }
 }
 

--- a/rollup-interface/src/state_machine/zk/mod.rs
+++ b/rollup-interface/src/state_machine/zk/mod.rs
@@ -8,10 +8,9 @@
 //! maintained by the Sovereign Labs team.
 use core::fmt::Debug;
 
+use digest::Digest;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-
-use crate::crypto::SimpleHasher;
 
 /// A trait implemented by the prover ("host") of a zkVM program.
 pub trait ZkvmHost: Zkvm {
@@ -54,7 +53,7 @@ pub trait ValidityCondition: Serialize + DeserializeOwned {
     type Error: Into<anyhow::Error>;
     /// Combine two conditions into one (typically run inside a recursive proof).
     /// Returns an error if the two conditions cannot be combined
-    fn combine<H: SimpleHasher>(&self, rhs: Self) -> Result<Self, Self::Error>;
+    fn combine<H: Digest>(&self, rhs: Self) -> Result<Self, Self::Error>;
 }
 
 /// The public output of a SNARK proof in Sovereign, this struct makes a claim that


### PR DESCRIPTION
# Description
Remove `jmt::SimpleHasher` from the rollup interface and replace it with `Digest` from the `digest` crate.  (See #225)

Add PrivateKey trait and implement it for `DefaultPrivateKey`. In the process, change our `sign/verify` APIs to work on messages rather than message hashes. This reduces the risk of accidental misuse, since not all hashes can be combined with all signature schemes.

## Linked Issues
- Fixes #225 
- Related to #552 

## Testing
Tests have been adjusted. I added one test to ensure that a "roundtrip" sign and verify cycle worked as expected using the new traits.

## Docs
Docs have been updated to reflect the API changes.
