### PR TITLE
Feature gate `jsonrpsee` in `sov-modules-macros`

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+# This file is left as a placholder due to https://github.com/nextest-rs/nextest/issues/926. 
+# If you're reading this on some day that isn't August 2, 2023 please delete this file

--- a/module-system/sov-modules-api/Cargo.toml
+++ b/module-system/sov-modules-api/Cargo.toml
@@ -37,5 +37,5 @@ serde_json = { workspace = true }
 
 [features]
 default = ["native", "macros"]
-native = ["sov-state/native", "rand", "hex", "schemars", "ed25519-dalek/default", "clap", "jsonrpsee"]
+native = ["sov-state/native", "rand", "hex", "schemars", "ed25519-dalek/default", "clap", "jsonrpsee", "macros", "sov-modules-macros/native"]
 macros = ["sov-modules-macros"]

--- a/module-system/sov-modules-macros/Cargo.toml
+++ b/module-system/sov-modules-macros/Cargo.toml
@@ -21,20 +21,23 @@ path = "tests/all_tests.rs"
 
 [dev-dependencies]
 serde_json = "1"
-jsonrpsee = { workspace = true, features = ["macros", "http-client", "server"] }
+jsonrpsee = { workspace = true, features = ["macros", "http-client", "server"]}
 trybuild = "1.0"
 
 sov-modules-api = { path = "../sov-modules-api", version = "0.1", default-features = false }
 sov-state = { path = "../sov-state", version = "0.1", default-features = false }
 sov-bank = { path = "../module-implementations/sov-bank", version = "0.1", features = ["native"] }
-clap = { workspace = true }
 serde = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true }
-jsonrpsee = { workspace = true, features = ["http-client", "server"] }
+jsonrpsee = { workspace = true, features = ["http-client", "server"], optional = true }
 proc-macro2 = "1.0"
 quote = "1.0"
 schemars = { workspace = true }
 syn = { version = "1.0", features = ["full"] }
+
+[features]
+default = []
+native = ["dep:jsonrpsee"]

--- a/module-system/sov-modules-macros/Cargo.toml
+++ b/module-system/sov-modules-macros/Cargo.toml
@@ -28,6 +28,7 @@ sov-modules-api = { path = "../sov-modules-api", version = "0.1", default-featur
 sov-state = { path = "../sov-state", version = "0.1", default-features = false }
 sov-bank = { path = "../module-implementations/sov-bank", version = "0.1", features = ["native"] }
 serde = { workspace = true }
+clap = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/module-system/sov-modules-macros/src/common.rs
+++ b/module-system/sov-modules-macros/src/common.rs
@@ -18,6 +18,7 @@ pub(crate) struct StructNamedField {
 }
 
 impl StructNamedField {
+    #[cfg_attr(not(feature = "native"), allow(unused))]
     pub(crate) fn filter_attrs(&mut self, filter: impl FnMut(&syn::Attribute) -> bool) {
         self.attrs = std::mem::take(&mut self.attrs)
             .into_iter()
@@ -68,6 +69,7 @@ impl StructFieldExtractor {
 
     /// Extract the named fields from a struct, or generate named fields matching the fields of an unnamed struct.
     /// Names follow the pattern `field0`, `field1`, etc.
+    #[cfg_attr(not(feature = "native"), allow(unused))]
     pub(crate) fn get_or_generate_named_fields(fields: &Fields) -> Vec<StructNamedField> {
         match fields {
             Fields::Unnamed(unnamed_fields) => unnamed_fields
@@ -306,6 +308,8 @@ pub(crate) fn get_serialization_attrs(
 /// let our_bounds = extract_generic_type_bounds(&test_struct.generics);
 /// assert_eq!(our_bounds.get(T), Some(&desired_bounds_for_t.bounds));
 /// ```
+///
+#[cfg_attr(not(feature = "native"), allow(unused))]
 pub(crate) fn extract_generic_type_bounds(
     generics: &Generics,
 ) -> HashMap<TypePath, Punctuated<TypeParamBound, syn::token::Add>> {
@@ -351,6 +355,7 @@ pub(crate) fn extract_generic_type_bounds(
 }
 
 /// Extract the type ident from a `TypePath`.
+#[cfg_attr(not(feature = "native"), allow(unused))]
 pub fn extract_ident(type_path: &syn::TypePath) -> &Ident {
     &type_path
         .path
@@ -371,6 +376,7 @@ pub fn extract_ident(type_path: &syn::TypePath) -> &Ident {
 ///
 /// This function will return a `syn::Generics` corresponding to `<T: SomeTrait>` when
 /// invoked on the PathArguments for field1.
+#[cfg_attr(not(feature = "native"), allow(unused))]
 pub(crate) fn generics_for_field(
     outer_generics: &Generics,
     field_generic_types: &PathArguments,

--- a/module-system/sov-modules-macros/src/lib.rs
+++ b/module-system/sov-modules-macros/src/lib.rs
@@ -217,6 +217,7 @@ pub fn codec(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 #[proc_macro_attribute]
+#[cfg(feature = "native")]
 pub fn rpc_gen(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr: Vec<syn::NestedMeta> = parse_macro_input!(attr);
     let input = parse_macro_input!(item as syn::ItemImpl);
@@ -232,6 +233,7 @@ fn handle_macro_error(result: Result<proc_macro::TokenStream, syn::Error>) -> To
 
 /// This proc macro generates the actual implementations for the trait created above for the module
 /// It iterates over each struct
+#[cfg(feature = "native")]
 #[proc_macro_attribute]
 pub fn expose_rpc(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let original = input.clone();
@@ -255,6 +257,7 @@ pub fn expose_rpc(_attr: TokenStream, input: TokenStream) -> TokenStream {
 ///     // ...
 /// }
 /// ```
+#[cfg(feature = "native")]
 #[proc_macro_derive(CliWallet, attributes(cli_skip))]
 pub fn cli_parser(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input);
@@ -320,6 +323,7 @@ pub fn cli_parser(input: TokenStream) -> TokenStream {
 ///     type CliStringRepr = MyEnumWithNamedFields;
 /// }
 /// ```
+#[cfg(feature = "native")]
 #[proc_macro_derive(CliWalletArg)]
 pub fn custom_enum_clap(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input);

--- a/module-system/sov-modules-macros/src/lib.rs
+++ b/module-system/sov-modules-macros/src/lib.rs
@@ -2,14 +2,17 @@
 
 #![deny(missing_docs)]
 
+#[cfg(feature = "native")]
 mod cli_parser;
 mod common;
 mod default_runtime;
 mod dispatch;
 mod module_call_json_schema;
 mod module_info;
+#[cfg(feature = "native")]
 mod rpc;
 
+#[cfg(feature = "native")]
 use cli_parser::{derive_cli_wallet_arg, CliParserMacro};
 use default_runtime::DefaultRuntimeMacro;
 use dispatch::dispatch_call::DispatchCallMacro;
@@ -17,8 +20,9 @@ use dispatch::genesis::GenesisMacro;
 use dispatch::message_codec::MessageCodec;
 use module_call_json_schema::derive_module_call_json_schema;
 use proc_macro::TokenStream;
+#[cfg(feature = "native")]
 use rpc::ExposeRpcMacro;
-use syn::{parse_macro_input, DeriveInput};
+use syn::parse_macro_input;
 
 /// Derives the [`ModuleInfo`](trait.ModuleInfo.html) trait for the underlying `struct`.
 ///
@@ -326,6 +330,6 @@ pub fn cli_parser(input: TokenStream) -> TokenStream {
 #[cfg(feature = "native")]
 #[proc_macro_derive(CliWalletArg)]
 pub fn custom_enum_clap(input: TokenStream) -> TokenStream {
-    let input: DeriveInput = parse_macro_input!(input);
+    let input: syn::DeriveInput = parse_macro_input!(input);
     handle_macro_error(derive_cli_wallet_arg(input))
 }

--- a/module-system/sov-modules-macros/tests/all_tests.rs
+++ b/module-system/sov-modules-macros/tests/all_tests.rs
@@ -20,12 +20,14 @@ fn module_dispatch_tests() {
     t.compile_fail("tests/dispatch/missing_serialization.rs");
 }
 
+#[cfg(feature = "native")]
 #[test]
 fn rpc_tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/derive_rpc.rs");
 }
 
+#[cfg(feature = "native")]
 #[test]
 fn cli_wallet_arg_tests() {
     let t: trybuild::TestCases = trybuild::TestCases::new();


### PR DESCRIPTION
# Description
Currently, `sov-modules-macros` introduces an unconditional dependency on `jsonrpsee` - which causes it to be compiled into the binary for SNARKing. It will probably get stripped out by the compiler since its unused, but removing it will reduce build times and might prevent issues. This PR does that.

## Linked Issues
- Fixes #609 

