### PR TITLE
fix: shadow trait imports for macros

### DIFF
--- a/full-node/db/sov-db/src/schema/tables.rs
+++ b/full-node/db/sov-db/src/schema/tables.rs
@@ -165,8 +165,8 @@ macro_rules! define_table_with_seek_key_codec {
 
         impl ::sov_schema_db::schema::KeyEncoder<$table_name> for $key {
             fn encode_key(&self) -> ::std::result::Result<::sov_rollup_interface::maybestd::vec::Vec<u8>, ::sov_schema_db::CodecError> {
-                use ::anyhow::Context;
-                use ::bincode::Options;
+                use ::anyhow::Context as _;
+                use ::bincode::Options as _;
 
                 let bincode_options = ::bincode::options()
                     .with_fixint_encoding()
@@ -178,8 +178,8 @@ macro_rules! define_table_with_seek_key_codec {
 
         impl ::sov_schema_db::schema::KeyDecoder<$table_name> for $key {
             fn decode_key(data: &[u8]) -> ::std::result::Result<Self, ::sov_schema_db::CodecError> {
-                use ::anyhow::Context;
-                use ::bincode::Options;
+                use ::anyhow::Context as _;
+                use ::bincode::Options as _;
 
                 let bincode_options = ::bincode::options()
                     .with_fixint_encoding()

--- a/module-system/sov-modules-macros/src/cli_parser.rs
+++ b/module-system/sov-modules-macros/src/cli_parser.rs
@@ -138,7 +138,7 @@ impl CliParserMacro {
             /// Borsh encode a transaction parsed from the CLI
             pub fn borsh_encode_cli_tx #impl_generics (cmd: CliTransactionParser #ty_generics) -> ::std::vec::Vec<u8>
             #where_clause {
-                use ::borsh::BorshSerialize;
+                use ::borsh::BorshSerialize as _;
                 match cmd {
                     #(#parse_match_arms)*
                     _ => panic!("unknown module name"),

--- a/module-system/sov-modules-macros/src/default_runtime.rs
+++ b/module-system/sov-modules-macros/src/default_runtime.rs
@@ -33,7 +33,7 @@ impl DefaultRuntimeMacro {
         Ok(quote::quote! {
         impl #impl_generics ::std::default::Default for #ident #type_generics #where_clause {
             fn default() -> Self {
-                use ::sov_modules_api::ModuleInfo;
+                use ::sov_modules_api::ModuleInfo as _;
 
                 Self {
                    #(#runtime_fn_body)*

--- a/module-system/sov-modules-macros/src/module_call_json_schema.rs
+++ b/module-system/sov-modules-macros/src/module_call_json_schema.rs
@@ -10,7 +10,7 @@ pub fn derive_module_call_json_schema(
     let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
 
     let tokens = quote::quote! {
-        use ::schemars::JsonSchema;
+        use ::schemars::JsonSchema as _;
 
         impl #impl_generics ::sov_modules_api::ModuleCallJsonSchema for #ident #type_generics #where_clause {
             fn json_schema() -> ::std::string::String {

--- a/module-system/sov-modules-macros/src/module_info.rs
+++ b/module-system/sov-modules-macros/src/module_info.rs
@@ -327,7 +327,7 @@ fn make_init_address(
             ),
         )),
         None => Ok(quote::quote! {
-            use ::sov_modules_api::digest::Digest;
+            use ::sov_modules_api::digest::Digest as _;
             let module_path = module_path!();
             let prefix = sov_modules_api::Prefix::new_module(module_path, stringify!(#struct_ident));
             let #field_ident : <#generic_param as sov_modules_api::Spec>::Address =


### PR DESCRIPTION
# Description

This commit introduces a pattern to shadow trait imports under macro implementations.

This is considered a good practice as such imports will never conflict with other imports performed by the consumer of the macro.

## Linked Issues
- Related to #635