### PR TITLE
feat: update `StateMap` to take borrowee of keys

### DIFF
--- a/module-system/module-implementations/sov-evm/src/call.rs
+++ b/module-system/module-implementations/sov-evm/src/call.rs
@@ -35,7 +35,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let cfg_env = get_cfg_env(&block_env, cfg, None);
 
         let hash = evm_tx_recovered.hash();
-        self.transactions.set(&hash, &tx, working_set);
+        self.transactions.set(&hash[..], &tx, working_set);
 
         let evm_db: EvmDb<'_, C> = self.get_db(working_set);
 

--- a/module-system/module-implementations/sov-evm/src/query.rs
+++ b/module-system/module-implementations/sov-evm/src/query.rs
@@ -62,7 +62,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> RpcResult<Option<Transaction>> {
         info!("evm module: eth_getTransactionByHash");
-        let evm_transaction = self.transactions.get(&hash.into(), working_set);
+        let evm_transaction = self.transactions.get(&hash[..], working_set);
         let result = evm_transaction.map(Transaction::try_from).transpose();
         result.map_err(|e| to_jsonrpsee_error_object(e, "ETH_RPC_ERROR"))
     }
@@ -75,7 +75,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> RpcResult<Option<TransactionReceipt>> {
         info!("evm module: eth_getTransactionReceipt");
-        let receipt = self.receipts.get(&hash.into(), working_set);
+        let receipt = self.receipts.get(&hash[..], working_set);
         Ok(receipt.map(|r| r.into()))
     }
 

--- a/module-system/sov-state/src/map.rs
+++ b/module-system/sov-state/src/map.rs
@@ -1,4 +1,5 @@
-use std::marker::PhantomData;
+use core::borrow::Borrow;
+use core::marker::PhantomData;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use thiserror::Error;
@@ -21,8 +22,13 @@ pub enum Error {
     MissingValue(Prefix, StorageKey),
 }
 
-impl<K: BorshSerialize, V: BorshSerialize + BorshDeserialize> StateMap<K, V> {
-    pub fn new(prefix: Prefix) -> Self {
+impl<K, V> StateMap<K, V>
+where
+    K: BorshSerialize,
+    V: BorshSerialize + BorshDeserialize,
+{
+    /// Creates a new `StateMap`.
+    pub const fn new(prefix: Prefix) -> Self {
         Self {
             _phantom: (PhantomData, PhantomData),
             prefix,
@@ -30,48 +36,102 @@ impl<K: BorshSerialize, V: BorshSerialize + BorshDeserialize> StateMap<K, V> {
     }
 
     /// Inserts a key-value pair into the map.
-    pub fn set<S: Storage>(&self, key: &K, value: &V, working_set: &mut WorkingSet<S>) {
-        working_set.set_value(self.prefix(), key, value)
+    pub fn set<S, Q>(&self, key: &Q, value: &V, working_set: &mut WorkingSet<S>)
+    where
+        S: Storage,
+        Q: BorshSerialize + ?Sized,
+        K: Borrow<Q>,
+    {
+        working_set.set_value(self.prefix(), &key, value)
     }
 
     /// Returns the value corresponding to the key or None if key is absent in the StateMap.
-    pub fn get<S: Storage>(&self, key: &K, working_set: &mut WorkingSet<S>) -> Option<V> {
-        working_set.get_value(self.prefix(), key)
+    ///
+    /// # Examples
+    ///
+    /// We can use as argument any type that can be borrowed by the key.
+    ///
+    /// ```rust
+    ///
+    /// fn foo<S>(map: StateMap<Vec<u8>, u64>, key: &[u8], ws: &mut WorkingSet<S>) -> Option<u64>
+    /// where
+    ///     S: Storage,
+    /// {
+    ///     // we perform the `get` with a slice, and not the `Vec`. it is so because `Vec` borrows
+    ///     // `[T]`.
+    ///     map.get(&key[..], ws)
+    /// }
+    /// ```
+    ///
+    /// However, some concrete types won't implement `Borrow`, but we can easily cast them into
+    /// common types that will
+    ///
+    /// ```rust
+    ///
+    /// fn foo<S>(map: StateMap<Vec<u8>, u64>, key: [u8; 32], ws: &mut WorkingSet<S>) -> Option<u64>
+    /// where
+    ///     S: Storage,
+    /// {
+    ///     map.get(&key[..], ws)
+    /// }
+    /// ```
+    pub fn get<S, Q>(&self, key: &Q, working_set: &mut WorkingSet<S>) -> Option<V>
+    where
+        S: Storage,
+        Q: BorshSerialize + ?Sized,
+        K: Borrow<Q>,
+    {
+        working_set.get_value(self.prefix(), &key)
     }
 
     /// Returns the value corresponding to the key or Error if key is absent in the StateMap.
-    pub fn get_or_err<S: Storage>(
-        &self,
-        key: &K,
-        working_set: &mut WorkingSet<S>,
-    ) -> Result<V, Error> {
+    ///
+    /// For reference, check [Self::get].
+    pub fn get_or_err<S, Q>(&self, key: &Q, working_set: &mut WorkingSet<S>) -> Result<V, Error>
+    where
+        S: Storage,
+        Q: BorshSerialize + ?Sized,
+        K: Borrow<Q>,
+    {
         self.get(key, working_set).ok_or_else(|| {
-            Error::MissingValue(self.prefix().clone(), StorageKey::new(self.prefix(), key))
+            Error::MissingValue(self.prefix().clone(), StorageKey::new(self.prefix(), &key))
         })
     }
 
     /// Removes a key from the StateMap, returning the corresponding value (or None if the key is absent).
-    pub fn remove<S: Storage>(&self, key: &K, working_set: &mut WorkingSet<S>) -> Option<V> {
-        working_set.remove_value(self.prefix(), key)
+    pub fn remove<S, Q>(&self, key: &Q, working_set: &mut WorkingSet<S>) -> Option<V>
+    where
+        S: Storage,
+        Q: BorshSerialize + ?Sized,
+        K: Borrow<Q>,
+    {
+        working_set.remove_value(self.prefix(), &key)
     }
 
     /// Removes a key from the StateMap, returning the corresponding value (or Error if the key is absent).
-    pub fn remove_or_err<S: Storage>(
-        &self,
-        key: &K,
-        working_set: &mut WorkingSet<S>,
-    ) -> Result<V, Error> {
-        self.remove(key, working_set).ok_or_else(|| {
-            Error::MissingValue(self.prefix().clone(), StorageKey::new(self.prefix(), key))
+    pub fn remove_or_err<S, Q>(&self, key: &Q, working_set: &mut WorkingSet<S>) -> Result<V, Error>
+    where
+        S: Storage,
+        Q: BorshSerialize + ?Sized,
+        K: Borrow<Q>,
+    {
+        self.remove(&key, working_set).ok_or_else(|| {
+            Error::MissingValue(self.prefix().clone(), StorageKey::new(self.prefix(), &key))
         })
     }
 
     /// Deletes a key from the StateMap.
-    pub fn delete<S: Storage>(&self, key: &K, working_set: &mut WorkingSet<S>) {
-        working_set.delete_value(self.prefix(), key);
+    pub fn delete<S, Q>(&self, key: &Q, working_set: &mut WorkingSet<S>)
+    where
+        S: Storage,
+        Q: BorshSerialize + ?Sized,
+        K: Borrow<Q>,
+    {
+        working_set.delete_value(self.prefix(), &key);
     }
 
-    pub fn prefix(&self) -> &Prefix {
+    /// Returns the storage prefix for the instance.
+    pub const fn prefix(&self) -> &Prefix {
         &self.prefix
     }
 }

--- a/module-system/sov-state/src/map.rs
+++ b/module-system/sov-state/src/map.rs
@@ -52,6 +52,7 @@ where
     /// We can use as argument any type that can be borrowed by the key.
     ///
     /// ```rust
+    /// use sov_state::{StateMap, Storage, WorkingSet};
     ///
     /// fn foo<S>(map: StateMap<Vec<u8>, u64>, key: &[u8], ws: &mut WorkingSet<S>) -> Option<u64>
     /// where
@@ -59,7 +60,7 @@ where
     /// {
     ///     // we perform the `get` with a slice, and not the `Vec`. it is so because `Vec` borrows
     ///     // `[T]`.
-    ///     map.get(&key[..], ws)
+    ///     map.get(key, ws)
     /// }
     /// ```
     ///
@@ -67,6 +68,7 @@ where
     /// common types that will
     ///
     /// ```rust
+    /// use sov_state::{StateMap, Storage, WorkingSet};
     ///
     /// fn foo<S>(map: StateMap<Vec<u8>, u64>, key: [u8; 32], ws: &mut WorkingSet<S>) -> Option<u64>
     /// where
@@ -115,7 +117,7 @@ where
         Q: BorshSerialize + ?Sized,
         K: Borrow<Q>,
     {
-        self.remove(&key, working_set).ok_or_else(|| {
+        self.remove(key, working_set).ok_or_else(|| {
             Error::MissingValue(self.prefix().clone(), StorageKey::new(self.prefix(), &key))
         })
     }

--- a/module-system/sov-state/src/prover_storage.rs
+++ b/module-system/sov-state/src/prover_storage.rs
@@ -41,7 +41,7 @@ impl<S: MerkleProofSpec> ProverStorage<S> {
         })
     }
 
-    fn read_value(&self, key: StorageKey) -> Option<StorageValue> {
+    fn read_value(&self, key: &StorageKey) -> Option<StorageValue> {
         match self
             .db
             .get_value_option_by_key(self.db.get_next_version(), key.as_ref())
@@ -68,7 +68,7 @@ impl<S: MerkleProofSpec> Storage for ProverStorage<S> {
         Self::with_path(config.path.as_path())
     }
 
-    fn get(&self, key: StorageKey, witness: &Self::Witness) -> Option<StorageValue> {
+    fn get(&self, key: &StorageKey, witness: &Self::Witness) -> Option<StorageValue> {
         let val = self.read_value(key);
         witness.add_hint(val.clone());
         val
@@ -240,7 +240,7 @@ mod test {
                     .validate_and_commit(cache, &witness)
                     .expect("storage is valid");
 
-                assert_eq!(test.value, prover_storage.get(test.key, &witness).unwrap());
+                assert_eq!(test.value, prover_storage.get(&test.key, &witness).unwrap());
                 assert_eq!(prover_storage.db.get_next_version(), test.version + 1)
             }
         }
@@ -251,7 +251,7 @@ mod test {
             for test in tests {
                 assert_eq!(
                     test.value,
-                    storage.get(test.key, &Default::default()).unwrap()
+                    storage.get(&test.key, &Default::default()).unwrap()
                 );
             }
         }
@@ -284,7 +284,10 @@ mod test {
         {
             let prover_storage = ProverStorage::<DefaultStorageSpec>::with_path(path).unwrap();
             assert!(!prover_storage.is_empty());
-            assert_eq!(value, prover_storage.get(key, &Default::default()).unwrap());
+            assert_eq!(
+                value,
+                prover_storage.get(&key, &Default::default()).unwrap()
+            );
         }
     }
 }

--- a/module-system/sov-state/src/storage.rs
+++ b/module-system/sov-state/src/storage.rs
@@ -31,8 +31,11 @@ impl StorageKey {
     }
 
     pub fn as_cache_key(&self) -> &CacheKey {
-        debug_assert_eq!(self.key, {
-            let CacheKey { key } = unsafe { core::mem::transmute(self) };
+        debug_assert_eq!({
+            let StorageKey { key } = self;
+            key
+        }, {
+            let CacheKey { key } = unsafe { core::mem::transmute::<_, &CacheKey>(self) };
             key
         }, "the structure of the CacheKey must be exactly equal to the StorageKey so the unsafe transformation will work as expected");
 

--- a/module-system/sov-state/src/storage.rs
+++ b/module-system/sov-state/src/storage.rs
@@ -29,7 +29,13 @@ impl StorageKey {
         self.key.clone()
     }
 
-    pub fn as_cache_key(self) -> CacheKey {
+    pub fn as_cache_key(&self) -> &CacheKey {
+        // Safety: they are currently equivalent
+        // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/643
+        unsafe { core::mem::transmute(self) }
+    }
+
+    pub fn to_cache_key(self) -> CacheKey {
         CacheKey { key: self.key }
     }
 }
@@ -137,7 +143,7 @@ pub trait Storage: Clone {
     fn with_config(config: Self::RuntimeConfig) -> Result<Self, anyhow::Error>;
 
     /// Returns the value corresponding to the key or None if key is absent.
-    fn get(&self, key: StorageKey, witness: &Self::Witness) -> Option<StorageValue>;
+    fn get(&self, key: &StorageKey, witness: &Self::Witness) -> Option<StorageValue>;
 
     /// Returns the latest state root hash from the storage.
     fn get_state_root(&self, witness: &Self::Witness) -> anyhow::Result<[u8; 32]>;

--- a/module-system/sov-state/src/storage.rs
+++ b/module-system/sov-state/src/storage.rs
@@ -14,6 +14,7 @@ use crate::Prefix;
 
 // `Key` type for the `Storage`
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, BorshDeserialize, BorshSerialize)]
+#[repr(transparent)]
 pub struct StorageKey {
     key: Arc<Vec<u8>>,
 }
@@ -30,6 +31,11 @@ impl StorageKey {
     }
 
     pub fn as_cache_key(&self) -> &CacheKey {
+        debug_assert_eq!(self.key, {
+            let CacheKey { key } = unsafe { core::mem::transmute(self) };
+            key
+        }, "the structure of the CacheKey must be exactly equal to the StorageKey so the unsafe transformation will work as expected");
+
         // Safety: they are currently equivalent
         // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/643
         unsafe { core::mem::transmute(self) }

--- a/module-system/sov-state/src/zk_storage.rs
+++ b/module-system/sov-state/src/zk_storage.rs
@@ -42,7 +42,7 @@ impl<S: MerkleProofSpec> Storage for ZkStorage<S> {
         Ok(Self::new(config))
     }
 
-    fn get(&self, _key: StorageKey, witness: &Self::Witness) -> Option<StorageValue> {
+    fn get(&self, _key: &StorageKey, witness: &Self::Witness) -> Option<StorageValue> {
         witness.get_hint()
     }
 

--- a/module-system/utils/sov-first-read-last-write-cache/src/lib.rs
+++ b/module-system/utils/sov-first-read-last-write-cache/src/lib.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 pub use access::MergeError;
 
 #[derive(Error, Debug, Eq, PartialEq, Clone, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
 pub struct CacheKey {
     pub key: Arc<Vec<u8>>,
 }


### PR DESCRIPTION
# Description

This commit updates the API of `StateMap` to behave as common map implementations in Rust: the argument of a get method will receive a value that can be borrowed from the concrete key type.

This is useful for recurrent situations such as when we want to perform a get from a map of `Vec<u8>` without cloning the key index, by using a slice.

The focus of the PR is to touch the public API of the map and trait, without changing too much the internals. A new issue is introduced to propose an upgrade: #643

It also updates the public interface of the storage to take references by default, instead of owned values. It will allow the user to perform storage queries without necessarily cloning the values.

## Linked Issues

- Resolves #427

## Testing

An example of the new API is included as doctest