### PR TITLE
Remove `associated_type_defaults` making Sovereign SDK stable compatible

### DIFF
--- a/module-system/module-implementations/sov-blob-storage/src/lib.rs
+++ b/module-system/module-implementations/sov-blob-storage/src/lib.rs
@@ -58,4 +58,5 @@ impl<C: sov_modules_api::Context> BlobStorage<C> {
 impl<C: sov_modules_api::Context> Module for BlobStorage<C> {
     type Context = C;
     type Config = ();
+    type CallMessage = sov_modules_api::NonInstantiable;
 }

--- a/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -135,6 +135,8 @@ impl<Ctx: sov_modules_api::Context, Cond: ValidityCondition> sov_modules_api::Mo
 
     type Config = ChainStateConfig;
 
+    type CallMessage = sov_modules_api::NonInstantiable;
+
     fn genesis(
         &self,
         config: &Self::Config,

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(associated_type_defaults)]
+#![doc = include_str!("../README.md")]
 
 mod bech32;
 pub mod default_context;
@@ -294,7 +294,7 @@ pub trait Module {
     type Config;
 
     /// Module defined argument to the call method.
-    type CallMessage: Debug + BorshSerialize + BorshDeserialize = NonInstantiable;
+    type CallMessage: Debug + BorshSerialize + BorshDeserialize;
 
     /// Genesis is called when a rollup is deployed and can be used to set initial state values in the module.
     fn genesis(


### PR DESCRIPTION
# Description

Remove default associated types and make modules to set call message explicitly.

## Linked Issues

- Related to #29

## Testing
No changes in tests

## Docs
No changes in docs
