### PR TITLE
Fix after CelestiaAddress refactoring: correct comparison for sender

### DIFF
--- a/adapters/celestia/src/verifier/mod.rs
+++ b/adapters/celestia/src/verifier/mod.rs
@@ -239,7 +239,7 @@ impl da::DaVerifier for CelestiaVerifier {
                     continue;
                 }
                 let tx: &BlobWithSender = tx_iter.next().ok_or(ValidationError::MissingTx)?;
-                if tx.sender.as_ref() != pfb.signer.as_bytes() {
+                if tx.sender.to_string() != pfb.signer {
                     return Err(ValidationError::InvalidSigner);
                 }
 


### PR DESCRIPTION
# Description

Previously we were operating string as bytes everywhere and now it has changed


## Testing
Manually run demo-prover

## Docs

No docs update
