### PR TITLE
Make "native" feature non default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "demo-nft-module",
  "jsonrpsee 0.18.2",
  "serde",
  "sov-data-generators",
@@ -3682,6 +3683,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "module-template",
  "schemars",
  "serde",
  "serde_json",
@@ -6808,6 +6810,7 @@ dependencies = [
  "serde_json",
  "sov-bank",
  "sov-modules-api",
+ "sov-prover-incentives",
  "sov-rollup-interface",
  "sov-state",
  "tempfile",

--- a/adapters/celestia/Cargo.toml
+++ b/adapters/celestia/Cargo.toml
@@ -11,6 +11,8 @@ borsh = { workspace = true, features = ["bytes"] }
 bech32 = { workspace = true }
 prost = "0.11"
 prost-types = "0.11"
+# I keep this commented as a reminder to opportunity to optimze this crate for non native compilation
+#tendermint = { version = "0.32", default-features = false, features = ["std"] }
 tendermint = "0.32"
 tendermint-proto = "0.32"
 
@@ -23,13 +25,13 @@ hex = { version = "0.4.3", features = ["serde"] }
 hex-literal = "0.4.1"
 jsonrpsee = { version = "0.16.2", features = ["http-client"], optional = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-zk-cycle-macros = {path = "../../utils/zk-cycle-macros", optional=true}
-risc0-zkvm = { version = "0.16", default-features = false, features = ["std"], optional=true}
-risc0-zkvm-platform = { version = "0.16", optional=true}
+zk-cycle-macros = { path = "../../utils/zk-cycle-macros", optional = true }
+risc0-zkvm = { version = "0.16", default-features = false, features = ["std"], optional = true }
+risc0-zkvm-platform = { version = "0.16", optional = true }
 
 sov-rollup-interface = { path = "../../rollup-interface" }
 nmt-rs = { git = "https://github.com/Sovereign-Labs/nmt-rs.git", rev = "dd37588444fca72825d11fe4a46838f66525c49f", features = ["serde", "borsh"] }
@@ -45,7 +47,7 @@ wiremock = "0.5"
 prost-build = { version = "0.11" }
 
 [features]
-default = ["native"]
-native = ["dep:tokio", "dep:jsonrpsee"]
-bench = ["zk-cycle-macros/bench","risc0-zkvm","risc0-zkvm-platform"]
+default = []
+native = ["dep:tokio", "dep:jsonrpsee", "dep:serde_json", "tendermint/default"]
+bench = ["zk-cycle-macros/bench", "risc0-zkvm", "risc0-zkvm-platform"]
 verifier = []

--- a/adapters/risc0/Cargo.toml
+++ b/adapters/risc0/Cargo.toml
@@ -14,18 +14,18 @@ readme = "README.md"
 [dependencies]
 anyhow = { workspace = true }
 bincode = { workspace = true }
-risc0-zkvm = { version = "0.16", default-features = false, features = ['std'] }
+risc0-zkvm = { version = "0.16", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "0.16" }
 risc0-zkp = { version = "0.16", optional = true }
 risc0-circuit-rv32im = { version = "0.16", optional = true }
 serde = { workspace = true }
 bytemuck = "1.13.1"
-once_cell = { version = "1.7.2", optional = true}
-parking_lot = { version = "0.12.1", optional = true}
-zk-cycle-utils = { path = "../../utils/zk-cycle-utils"}
+once_cell = { version = "1.7.2", optional = true }
+parking_lot = { version = "0.12.1", optional = true }
+zk-cycle-utils = { path = "../../utils/zk-cycle-utils" }
 sov-rollup-interface = { path = "../../rollup-interface" }
 
 [features]
-default = ["native"]
+default = []
 native = ["risc0-zkvm/prove", "dep:risc0-zkp", "dep:risc0-circuit-rv32im"]
-bench = ["once_cell","parking_lot"]
+bench = ["once_cell", "parking_lot"]

--- a/examples/demo-nft-module/Cargo.toml
+++ b/examples/demo-nft-module/Cargo.toml
@@ -14,8 +14,8 @@ anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 serde = { workspace = true, optional = true }
 
-sov-modules-api = { path = "../../module-system/sov-modules-api", default-features = false, features = ["macros"] }
-sov-state = { path = "../../module-system/sov-state", default-features = false }
+sov-modules-api = { path = "../../module-system/sov-modules-api" }
+sov-state = { path = "../../module-system/sov-state" }
 
 jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 
@@ -23,9 +23,11 @@ jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], 
 sov-rollup-interface = { path = "../../rollup-interface" }
 sov-data-generators = { path = "../../module-system/utils/sov-data-generators" }
 tempfile = { workspace = true }
+demo-nft-module = { version = "*", features = ["native"], path = "." }
 
 
 [features]
-default = ["native"]
+default = []
 serde = ["dep:serde"]
 native = ["serde", "sov-state/native", "sov-modules-api/native", "jsonrpsee"]
+test = ["native"]

--- a/examples/demo-prover/Cargo.lock
+++ b/examples/demo-prover/Cargo.lock
@@ -149,7 +149,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -233,7 +233,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -377,7 +377,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -571,7 +571,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1215,7 +1215,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2219,7 +2219,7 @@ checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2295,7 +2295,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2463,7 +2463,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2517,7 +2517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92139198957b410250d43fad93e630d956499a625c527eda65175c8680f83387"
 dependencies = [
  "proc-macro2",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2871,7 +2871,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "risc0-circuit-rv32im",
  "risc0-zkp",
  "risc0-zkvm",
@@ -3253,9 +3253,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.173"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91f70896d6720bc714a4a57d22fc91f1db634680e65c8efe13323f1fa38d53f"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
@@ -3281,13 +3281,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.173"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6250dde8342e0232232be9ca3db7aa40aceb5a3e5dd9bddbc00d99a007cde49"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3320,7 +3320,7 @@ checksum = "1d89a8107374290037607734c0b73a85db7ed80cae314b3c5791f192a496e731"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3712,6 +3712,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode",
  "borsh",
  "bytes",
  "digest 0.10.7",
@@ -3874,9 +3875,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3987,7 +3988,7 @@ checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4091,7 +4092,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4242,7 +4243,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4322,7 +4323,7 @@ checksum = "d836cd032f71d90cbaa3c1f85ce84266af23659766d8c0b1c4c6524a0fb4c36f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4450,7 +4451,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -4484,7 +4485,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4694,7 +4695,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/examples/demo-prover/host/Cargo.toml
+++ b/examples/demo-prover/host/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true }
-bincode = {workspace = true}
+bincode = { workspace = true }
 hex = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 risc0-zkvm = { workspace = true }
@@ -19,21 +19,21 @@ tokio = { workspace = true }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 
-celestia = { path = "../../../adapters/celestia", features = ["native","bench"] }
-demo-stf = { path = "../../demo-stf" }
+celestia = { path = "../../../adapters/celestia", features = ["native", "bench"] }
+demo-stf = { path = "../../demo-stf", features = ["native"] }
 sov-rollup-interface = { path = "../../../rollup-interface" }
-risc0-adapter = { path = "../../../adapters/risc0" }
+risc0-adapter = { path = "../../../adapters/risc0", features = ["native"] }
 const-rollup-config = { path = "../../const-rollup-config" }
 sov-modules-api = { path = "../../../module-system/sov-modules-api", features = ["native"] }
 sov-state = { path = "../../../module-system/sov-state", features = ["native"] }
-zk-cycle-macros = { path = "../../../utils/zk-cycle-macros", optional=true }
+zk-cycle-macros = { path = "../../../utils/zk-cycle-macros", optional = true }
 sov-stf-runner = { path = "../../../full-node/sov-stf-runner" }
 
 methods = { path = "../methods" }
 
 
 [dev-dependencies]
-sov-demo-rollup = {path = "../../demo-rollup"}
+sov-demo-rollup = { path = "../../demo-rollup" }
 tempfile = { workspace = true }
 once_cell = "1.7.2"
 parking_lot = "0.11.1"

--- a/examples/demo-prover/methods/guest/Cargo.lock
+++ b/examples/demo-prover/methods/guest/Cargo.lock
@@ -292,7 +292,6 @@ dependencies = [
  "risc0-zkvm",
  "risc0-zkvm-platform",
  "serde",
- "serde_json",
  "sha2 0.10.6",
  "sov-rollup-interface",
  "tendermint",
@@ -518,7 +517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05213e96f184578b5f70105d4d0a644a168e99e12d7bea0b200c15d67b5c182"
 dependencies = [
  "futures",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "thiserror",
  "tokio",
@@ -589,7 +588,6 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519 1.5.3",
- "rand 0.7.3",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -1492,34 +1490,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1545,15 +1522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1850,9 +1818,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
@@ -1868,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2058,7 +2026,6 @@ dependencies = [
  "demo-stf",
  "directories",
  "downloader",
- "log",
  "risc0-adapter",
  "risc0-zkvm",
  "risc0-zkvm-platform",
@@ -2072,7 +2039,6 @@ dependencies = [
  "sov-sequencer-registry",
  "sov-state",
  "tempfile",
- "tracing",
  "zip",
 ]
 
@@ -2107,7 +2073,6 @@ dependencies = [
  "risc0-zkvm",
  "risc0-zkvm-platform",
  "serde",
- "serde_json",
  "sha2 0.10.6",
  "sov-modules-macros",
  "sov-rollup-interface",
@@ -2154,6 +2119,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode",
  "borsh",
  "bytes",
  "digest 0.10.7",

--- a/examples/demo-prover/methods/guest/Cargo.toml
+++ b/examples/demo-prover/methods/guest/Cargo.toml
@@ -11,19 +11,15 @@ anyhow = "1.0.68"
 risc0-zkvm = { version = "0.16", default-features = false, features = ["std"] }
 risc0-zkvm-platform = "0.16"
 borsh = { version = "0.10.3", features = ["bytes"] }
-celestia = { path = "../../../../adapters/celestia", default-features = false }
-demo-stf = { path = "../../../demo-stf", default-features = false }
+celestia = { path = "../../../../adapters/celestia" }
+demo-stf = { path = "../../../demo-stf" }
 sov-rollup-interface = { path = "../../../../rollup-interface", default-features = false}
-risc0-adapter = { path = "../../../../adapters/risc0", default-features = false }
+risc0-adapter = { path = "../../../../adapters/risc0" }
 const-rollup-config = { path = "../../../const-rollup-config" }
 sov-modules-stf-template = {path = "../../../../module-system/sov-modules-stf-template", optional=true}
 sov-state = {path = "../../../../module-system/sov-state", default-features = false, optional=true}
 sov-modules-api = {path = "../../../../module-system/sov-modules-api", default-features = false, optional=true}
 sov-sequencer-registry = {path = "../../../../module-system/module-implementations/sov-sequencer-registry", default-features = false, optional=true}
-
-# TODO: Just for test
-tracing = "0.1.37"
-log = "0.4.17"
 
 [build-dependencies]
 directories = "5.0"

--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -27,19 +27,19 @@ futures = "0.3"
 tokio = { workspace = true }
 tracing-subscriber = "0.3.17"
 
-celestia = { path = "../../adapters/celestia" }
+celestia = { path = "../../adapters/celestia", features = ["native"] }
 demo-stf = { path = "../demo-stf", features = ["native"] }
 sov-rollup-interface = { path = "../../rollup-interface" }
 sov-db = { path = "../../full-node/db/sov-db" }
 sov-ethereum = { path = "../../full-node/sov-ethereum", optional = true }
 sov-sequencer = { path = "../../full-node/sov-sequencer" }
 sov-stf-runner = { path = "../../full-node/sov-stf-runner" }
-risc0-adapter = { path = "../../adapters/risc0" }
+risc0-adapter = { path = "../../adapters/risc0", features = ["native"] }
 sov-modules-stf-template = { path = "../../module-system/sov-modules-stf-template" }
 
-sov-bank = { path = "../../module-system/module-implementations/sov-bank", default-features = false }
-sov-election = { path = "../../module-system/module-implementations/examples/sov-election", default-features = false }
-sov-value-setter = { path = "../../module-system/module-implementations/examples/sov-value-setter", default-features = false }
+sov-bank = { path = "../../module-system/module-implementations/sov-bank", features = ["native"] }
+sov-election = { path = "../../module-system/module-implementations/examples/sov-election", features = ["native"] }
+sov-value-setter = { path = "../../module-system/module-implementations/examples/sov-value-setter", features = ["native"] }
 sov-modules-api = { path = "../../module-system/sov-modules-api", features = ["native"] }
 sov-state = { path = "../../module-system/sov-state", features = ["native"] }
 const-rollup-config = { path = "../const-rollup-config" }

--- a/examples/demo-rollup/Makefile
+++ b/examples/demo-rollup/Makefile
@@ -91,7 +91,7 @@ else
 endif
 
 build-sov-cli:
-	cd ../demo-stf && cargo build --bin sov-cli
+	cd ../demo-stf && cargo build --bin sov-cli --features=native
 
 test-generate-create-token-tx: check-container-running build-sov-cli
 	$(SOV_CLI_REL_PATH) generate-transaction-from-json ../test-data/keys/token_deployer_private_key.json Bank ../test-data/requests/create_token.json 0

--- a/examples/demo-stf/Cargo.toml
+++ b/examples/demo-stf/Cargo.toml
@@ -28,19 +28,19 @@ tracing = { workspace = true }
 
 const-rollup-config = { path = "../const-rollup-config" }
 sov-rollup-interface = { path = "../../rollup-interface" }
-sov-election = { path = "../../module-system/module-implementations/examples/sov-election", default-features = false }
-sov-sequencer-registry = { path = "../../module-system/module-implementations/sov-sequencer-registry", default-features = false }
-sov-blob-storage = { path = "../../module-system/module-implementations/sov-blob-storage", default-features = false }
-sov-bank = { path = "../../module-system/module-implementations/sov-bank", default-features = false }
-sov-modules-stf-template = { path = "../../module-system/sov-modules-stf-template", default-features = false  }
-sov-value-setter = { path = "../../module-system/module-implementations/examples/sov-value-setter", default-features = false }
-sov-accounts = { path = "../../module-system/module-implementations/sov-accounts", default-features = false }
-sov-state = { path = "../../module-system/sov-state", default-features = false }
-sov-modules-api = { path = "../../module-system/sov-modules-api", default-features = false, features = ["macros"] }
+sov-election = { path = "../../module-system/module-implementations/examples/sov-election" }
+sov-sequencer-registry = { path = "../../module-system/module-implementations/sov-sequencer-registry" }
+sov-blob-storage = { path = "../../module-system/module-implementations/sov-blob-storage" }
+sov-bank = { path = "../../module-system/module-implementations/sov-bank" }
+sov-modules-stf-template = { path = "../../module-system/sov-modules-stf-template" }
+sov-value-setter = { path = "../../module-system/module-implementations/examples/sov-value-setter" }
+sov-accounts = { path = "../../module-system/module-implementations/sov-accounts" }
+sov-state = { path = "../../module-system/sov-state" }
+sov-modules-api = { path = "../../module-system/sov-modules-api" }
 sov-sequencer = { path = "../../full-node/sov-sequencer", optional = true }
 sov-stf-runner = { path = "../../full-node/sov-stf-runner", optional = true }
 # Only enable the evm on "experimental" feature
-sov-evm = { path = "../../module-system/module-implementations/sov-evm", default-features = false, optional = true }
+sov-evm = { path = "../../module-system/module-implementations/sov-evm", optional = true }
 
 [dev-dependencies]
 sov-rollup-interface = { path = "../../rollup-interface", features = ["mocks"] }
@@ -49,9 +49,8 @@ tempfile = { workspace = true }
 rand = "0.8"
 
 [features]
-default = ["native"]
+default = []
 experimental = ["sov-evm/experimental"]
-
 native = [
     "sov-bank/native",
     "sov-accounts/native",
@@ -61,6 +60,7 @@ native = [
     "sov-value-setter/native",
     "sov-modules-api/native",
     "sov-rollup-interface/mocks",
+    "sov-modules-stf-template/native",
     "sov-sequencer",
     "sov-stf-runner",
     "clap",

--- a/full-node/db/sov-db/Cargo.toml
+++ b/full-node/db/sov-db/Cargo.toml
@@ -30,6 +30,3 @@ bincode = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-
-[features]
-default = []

--- a/full-node/sov-ethereum/Cargo.toml
+++ b/full-node/sov-ethereum/Cargo.toml
@@ -14,9 +14,9 @@ resolver = "2"
 jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 sov-rollup-interface = { path = "../../rollup-interface" }
 
-sov-evm = { path = "../../module-system/module-implementations/sov-evm", default-features = false }
+sov-evm = { path = "../../module-system/module-implementations/sov-evm" }
 demo-stf = { path = "../../examples/demo-stf", features = ["native"] }
-sov-modules-api = { path = "../../module-system/sov-modules-api", default-features = false }
+sov-modules-api = { path = "../../module-system/sov-modules-api" }
 const-rollup-config = { path = "../../examples/const-rollup-config" }
 celestia = { path = "../../adapters/celestia", features = ["native"] }
 
@@ -34,7 +34,6 @@ tokio = { workspace = true }
 
 
 [features]
-default = ["native"]
+default = []
 experimental = ["demo-stf/experimental", "sov-evm/experimental"]
-
 native = ["demo-stf/native", "sov-evm/native"]

--- a/full-node/sov-sequencer/Cargo.toml
+++ b/full-node/sov-sequencer/Cargo.toml
@@ -21,7 +21,7 @@ serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
 
 sov-rollup-interface = { path = "../../rollup-interface" }
-sov-modules-api = { path = "../../module-system/sov-modules-api" }
+sov-modules-api = { path = "../../module-system/sov-modules-api", features = ["native"] }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/full-node/sov-stf-runner/Cargo.toml
+++ b/full-node/sov-stf-runner/Cargo.toml
@@ -25,17 +25,28 @@ tracing-subscriber = "0.3.17"
 
 sov-db = { path = "../db/sov-db" }
 sov-rollup-interface = { path = "../../rollup-interface", version = "0.1" }
-sov-state = { path = "../../module-system/sov-state", version = "0.1"}
-sov-modules-api = { path = "../../module-system/sov-modules-api", version = "0.1" }
-celestia = { path = "../../adapters/celestia" }
+sov-state = { path = "../../module-system/sov-state", version = "0.1", features = ["native"] }
+sov-modules-api = { path = "../../module-system/sov-modules-api", version = "0.1", features = ["native"] }
+celestia = { path = "../../adapters/celestia", features = ["native"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
 rand = { workspace = true }
 
-sov-election = { path = "../../module-system/module-implementations/examples/sov-election", default-features = false }
-sov-sequencer-registry = { path = "../../module-system/module-implementations/sov-sequencer-registry", default-features = false }
-sov-bank = { path = "../../module-system/module-implementations/sov-bank", default-features = false }
-sov-modules-stf-template = { path = "../../module-system/sov-modules-stf-template" }
-sov-value-setter = { path = "../../module-system/module-implementations/examples/sov-value-setter", default-features = false }
-sov-accounts = { path = "../../module-system/module-implementations/sov-accounts", default-features = false }
+sov-election = { path = "../../module-system/module-implementations/examples/sov-election", features = ["native"] }
+sov-sequencer-registry = { path = "../../module-system/module-implementations/sov-sequencer-registry", features = ["native"] }
+sov-bank = { path = "../../module-system/module-implementations/sov-bank", features = ["native"] }
+sov-modules-stf-template = { path = "../../module-system/sov-modules-stf-template", features = ["native"] }
+sov-value-setter = { path = "../../module-system/module-implementations/examples/sov-value-setter", features = ["native"] }
+sov-accounts = { path = "../../module-system/module-implementations/sov-accounts", features = ["native"] }
+
+#[features]
+#default = []
+#native = [
+#    "sov-election/native",
+#    "sov-sequencer-registry/native",
+#    "sov-bank/native",
+#    "sov-value-setter/native",
+#    "sov-accounts/native",
+#    "jupiter/native",
+#]

--- a/full-node/sov-stf-runner/src/lib.rs
+++ b/full-node/sov-stf-runner/src/lib.rs
@@ -98,7 +98,7 @@ where
         })
     }
 
-    /// Starts an rpc server with provided rpc methods.
+    /// Starts a RPC server with provided rpc methods.
     pub async fn start_rpc_server(&self, methods: RpcModule<()>) {
         let listen_address = self.listen_address;
         let _handle = tokio::spawn(async move {

--- a/module-system/module-implementations/examples/sov-election/Cargo.toml
+++ b/module-system/module-implementations/examples/sov-election/Cargo.toml
@@ -22,15 +22,14 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 
-sov-modules-api = { path = "../../../sov-modules-api", default-features = false, features = ["macros"] }
-sov-state = { path = "../../../sov-state", default-features = false }
+sov-modules-api = { path = "../../../sov-modules-api" }
+sov-state = { path = "../../../sov-state" }
 sov-rollup-interface = { path = "../../../../rollup-interface" }
 
 [dev-dependencies]
-sov-modules-api = { path = "../../../sov-modules-api" }
 tempfile = { workspace = true }
 
 [features]
-default = ["native"]
+default = []
 serde = ["dep:serde", "dep:serde_json"]
-native = ["serde", "sov-modules-api/native", "dep:jsonrpsee", "dep:schemars", "dep:clap"]
+native = ["serde", "dep:jsonrpsee", "dep:schemars", "dep:clap", "sov-state/native", "sov-modules-api/native"]

--- a/module-system/module-implementations/examples/sov-value-setter/Cargo.toml
+++ b/module-system/module-implementations/examples/sov-value-setter/Cargo.toml
@@ -13,13 +13,12 @@ resolver = "2"
 publish = false
 
 [dev-dependencies]
-sov-modules-api = { path = "../../../sov-modules-api" }
 tempfile = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-sov-modules-api = { path = "../../../sov-modules-api", default-features = false, features = ["macros"] }
-sov-state = { path = "../../../sov-state", default-features = false }
+sov-modules-api = { path = "../../../sov-modules-api" }
+sov-state = { path = "../../../sov-state" }
 sov-rollup-interface = { path = "../../../../rollup-interface" }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -30,6 +29,6 @@ jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], 
 clap = { workspace = true, optional = true }
 
 [features]
-default = ["native"]
+default = []
 serde = ["dep:serde", "dep:serde_json"]
-native = ["serde", "sov-modules-api/native", "dep:jsonrpsee", "dep:schemars", "dep:clap"]
+native = ["serde", "sov-modules-api/native", "dep:jsonrpsee", "dep:schemars", "dep:clap", "sov-state/native"]

--- a/module-system/module-implementations/integration-tests/Cargo.toml
+++ b/module-system/module-implementations/integration-tests/Cargo.toml
@@ -16,13 +16,13 @@ anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 tempfile = { workspace = true }
 
-sov-modules-api = { path = "../../sov-modules-api" }
-sov-state = { path = "../../sov-state" }
+sov-modules-api = { path = "../../sov-modules-api", features = ["native"] }
+sov-state = { path = "../../sov-state", features = ["native"] }
 sov-rollup-interface = { path = "../../../rollup-interface" }
 sov-schema-db = { path = "../../../full-node/db/sov-schema-db" }
 sov-data-generators = { path = "../../utils/sov-data-generators" }
-sov-modules-stf-template = { path = "../../sov-modules-stf-template" }
-sov-modules-macros = { path = "../../sov-modules-macros" }
+sov-modules-stf-template = { path = "../../sov-modules-stf-template", features = ["native"] }
+sov-modules-macros = { path = "../../sov-modules-macros", features = ["native"] }
 
-sov-chain-state = { path = "../sov-chain-state" }
-sov-value-setter = { path = "../examples/sov-value-setter" }
+sov-chain-state = { path = "../sov-chain-state", features = ["native"] }
+sov-value-setter = { path = "../examples/sov-value-setter", features = ["native"] }

--- a/module-system/module-implementations/module-template/Cargo.toml
+++ b/module-system/module-implementations/module-template/Cargo.toml
@@ -13,9 +13,9 @@ resolver = "2"
 
 [dependencies]
 anyhow = { workspace = true }
-sov-bank = { path = "../sov-bank", default-features = false }
-sov-modules-api = { path = "../../sov-modules-api", default-features = false, features = ["macros"] }
-sov-state = { path = "../../sov-state", default-features = false }
+sov-bank = { path = "../sov-bank" }
+sov-modules-api = { path = "../../sov-modules-api" }
+sov-state = { path = "../../sov-state" }
 sov-rollup-interface = { path = "../../../rollup-interface" }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -24,10 +24,10 @@ thiserror = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 
 [dev-dependencies]
-sov-modules-api = { path = "../../sov-modules-api" }
 tempfile = { workspace = true }
+module-template = { path = ".", version = "*", features = ["native"] }
 
 [features]
-default = ["native"]
+default = []
 serde = ["dep:serde", "dep:serde_json"]
 native = ["serde", "sov-modules-api/native", "dep:schemars"]

--- a/module-system/module-implementations/module-template/tests/value_setter.rs
+++ b/module-system/module-implementations/module-template/tests/value_setter.rs
@@ -1,13 +1,20 @@
 use module_template::{CallMessage, ExampleModule, ExampleModuleConfig, Response};
 use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
+#[cfg(feature = "native")]
+use sov_modules_api::default_context::DefaultContext;
+use sov_modules_api::default_context::ZkDefaultContext;
 use sov_modules_api::{Address, Context, Module};
 use sov_rollup_interface::stf::Event;
-use sov_state::{ProverStorage, WorkingSet, ZkStorage};
+use sov_state::{DefaultStorageSpec, ProverStorage, WorkingSet, ZkStorage};
 
 #[test]
 fn test_value_setter() {
     let tmpdir = tempfile::tempdir().unwrap();
-    let mut working_set = WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
+
+    #[cfg(feature = "native")]
+    let mut working_set =
+        WorkingSet::new(ProverStorage::<DefaultStorageSpec>::with_path(tmpdir.path()).unwrap());
+
     let admin = Address::from([1; 32]);
     // Test Native-Context
     #[cfg(feature = "native")]
@@ -47,6 +54,7 @@ fn test_value_setter_helper<C: Context>(
     }
 
     // Test query
+    #[cfg(feature = "native")]
     {
         let query_response = module.query_value(working_set);
         assert_eq!(

--- a/module-system/module-implementations/module-template/tests/value_setter.rs
+++ b/module-system/module-implementations/module-template/tests/value_setter.rs
@@ -1,5 +1,4 @@
 use module_template::{CallMessage, ExampleModule, ExampleModuleConfig, Response};
-use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
 #[cfg(feature = "native")]
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::default_context::ZkDefaultContext;

--- a/module-system/module-implementations/sov-accounts/Cargo.toml
+++ b/module-system/module-implementations/sov-accounts/Cargo.toml
@@ -21,15 +21,14 @@ thiserror = { workspace = true }
 clap = { workspace = true, optional = true }
 jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1", default-features = false, features = ["macros"] }
-sov-state = { path = "../../sov-state", version = "0.1", default-features = false }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
+sov-state = { path = "../../sov-state", version = "0.1" }
 
 
 [dev-dependencies]
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
 tempfile = { workspace = true }
 
 [features]
-default = ["native"]
+default = []
 serde = ["dep:serde", "dep:serde_json"]
-native = ["serde", "sov-state/native", "sov-modules-api/native", "dep:jsonrpsee", "dep:schemars", "dep:clap"]
+native = ["serde", "dep:jsonrpsee", "dep:schemars", "dep:clap", "sov-state/native", "sov-modules-api/native"]

--- a/module-system/module-implementations/sov-bank/Cargo.toml
+++ b/module-system/module-implementations/sov-bank/Cargo.toml
@@ -20,18 +20,17 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1", default-features = false, features = ["macros"] }
-sov-state = { path = "../../sov-state", version = "0.1", default-features = false }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
+sov-state = { path = "../../sov-state", version = "0.1" }
 sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1" }
 thiserror = { workspace = true }
 hex = { workspace = true }
 
 [dev-dependencies]
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
 tempfile = { workspace = true }
 
 [features]
-default = ["native"]
+default = []
 serde = ["dep:serde", "dep:serde_json"]
-native = ["serde", "sov-state/native", "dep:jsonrpsee", "sov-modules-api/native", "dep:clap", "dep:schemars"]
+native = ["serde", "dep:jsonrpsee", "dep:clap", "dep:schemars", "sov-state/native", "sov-modules-api/native", ]
 cli = ["native"]

--- a/module-system/module-implementations/sov-blob-storage/Cargo.toml
+++ b/module-system/module-implementations/sov-blob-storage/Cargo.toml
@@ -21,27 +21,27 @@ tracing = { workspace = true }
 hex = { workspace = true }
 
 sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1" }
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1", default-features = false, features = ["macros"] }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
 sov-modules-macros = { path = "../../sov-modules-macros", version = "0.1" }
-sov-state = { path = "../../sov-state", version = "0.1", default-features = false }
-sov-sequencer-registry = { path = "../sov-sequencer-registry", version = "0.1", default-features = false }
+sov-state = { path = "../../sov-state", version = "0.1" }
+sov-sequencer-registry = { path = "../sov-sequencer-registry", version = "0.1" }
 
 
 # TODO: these 5 can be deleted, after: https://github.com/Sovereign-Labs/sovereign-sdk/issues/524
-serde = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 jsonrpsee = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
 sov-rollup-interface = { path = "../../../rollup-interface", features = ["mocks"] }
 sov-bank = { path = "../sov-bank", version = "0.1" }
 tempfile = { workspace = true }
 
 [features]
-default = ["native"]
+default = []
+serde = ["dep:serde", "dep:serde_json"]
 native = [
     "sov-modules-api/native",
     "sov-state/native",
@@ -50,5 +50,4 @@ native = [
     "jsonrpsee",
     "schemars",
     "serde",
-    "serde_json",
 ]

--- a/module-system/module-implementations/sov-chain-state/Cargo.toml
+++ b/module-system/module-implementations/sov-chain-state/Cargo.toml
@@ -13,26 +13,24 @@ resolver = "2"
 
 [dependencies]
 anyhow = { workspace = true }
-sov-modules-api = { path = "../../sov-modules-api", default-features = false }
-sov-modules-macros = { path = "../../sov-modules-macros" }
-sov-state = { path = "../../sov-state", default-features = false }
-sov-rollup-interface = { path = "../../../rollup-interface" }
+borsh = { workspace = true, features = ["rc"] }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-borsh = { workspace = true, features = ["rc"] }
-
 jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 
+sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
+sov-modules-macros = { path = "../../sov-modules-macros", version = "0.1" }
+sov-state = { path = "../../sov-state", version = "0.1" }
+sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1" }
+
 [dev-dependencies]
-sov-modules-api = { path = "../../sov-modules-api" }
-sov-bank = { path = "../sov-bank", default-features = false }
+sov-bank = { path = "../sov-bank" }
 sov-value-setter = { path = "../examples/sov-value-setter" }
-sov-state = { path = "../../sov-state", default-features = false }
 sov-modules-stf-template = { path = "../../sov-modules-stf-template" }
 sov-data-generators = { path = "../../utils/sov-data-generators" }
 tempfile = { workspace = true }
 
 [features]
-default = ["native"]
+default = []
 serde = ["dep:serde", "dep:serde_json"]
-native = ["serde", "sov-modules-api/native", "dep:jsonrpsee"]
+native = ["serde", "dep:jsonrpsee", "sov-state/native", "sov-modules-api/native", ]

--- a/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/module-system/module-implementations/sov-evm/Cargo.toml
@@ -14,8 +14,8 @@ resolver = "2"
 
 [dependencies]
 
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1", default-features = false, features = ["macros"] }
-sov-state = { path = "../../sov-state", version = "0.1", default-features = false }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
+sov-state = { path = "../../sov-state", version = "0.1" }
 
 anyhow = { workspace = true }
 thiserror = { workspace = true }
@@ -47,18 +47,16 @@ reth-revm = { workspace = true }
 
 
 [dev-dependencies]
-
 primitive-types = "0.12.1"
 tokio = { workspace = true }
 tempfile = { workspace = true }
 bytes = { workspace = true }
 secp256k1 = { workspace = true }
 
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1", features = ["macros"] }
 
 [features]
-default = ["native"]
+default = []
 serde = ["dep:serde", "dep:serde_json"]
-native = ["serde", "sov-state/native", "dep:jsonrpsee", "dep:schemars", "sov-modules-api/native", "dep:clap"]
+native = ["serde", "dep:jsonrpsee", "dep:schemars", "dep:clap", "sov-state/native", "sov-modules-api/native", ]
 experimental = ["native"]
 

--- a/module-system/module-implementations/sov-prover-incentives/Cargo.toml
+++ b/module-system/module-implementations/sov-prover-incentives/Cargo.toml
@@ -13,22 +13,25 @@ resolver = "2"
 
 [dev-dependencies]
 sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1", features = ["mocks"] }
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1", features = ["macros"] }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.1", features = ["native"] }
 tempfile = { workspace = true }
+sov-prover-incentives = { version = "*", features = ["native"], path = "." }
 
 [dependencies]
 anyhow = { workspace = true }
-sov-bank = { path = "../sov-bank", version = "0.1", default-features = false }
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1", default-features = false, features = ["macros"] }
-sov-state = { path = "../../sov-state", version = "0.1", default-features = false }
+sov-bank = { path = "../sov-bank", version = "0.1" }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
+sov-state = { path = "../../sov-state", version = "0.1" }
 sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1" }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true }
+serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 borsh = { workspace = true, features = ["rc"] }
 bincode = { workspace = true }
 
 
 [features]
-default = ["native"]
-native = ["sov-modules-api/native", "dep:schemars", "dep:serde_json"]
+default = []
+serde = ["dep:serde", "dep:serde_json"]
+native = ["serde", "dep:schemars", "sov-state/native", "sov-modules-api/native"]
+test = ["native"]

--- a/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
+++ b/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
@@ -13,16 +13,15 @@ readme = "README.md"
 resolver = "2"
 
 [dev-dependencies]
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
 sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1", features = ["mocks"] }
 tempfile = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, optional = true }
-sov-bank = { path = "../sov-bank", version = "0.1", default-features = false }
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1", default-features = false, features = ["macros"] }
-sov-state = { path = "../../sov-state", version = "0.1", default-features = false }
+sov-bank = { path = "../sov-bank", version = "0.1" }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
+sov-state = { path = "../../sov-state", version = "0.1" }
 sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1" }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -36,6 +35,6 @@ zk-cycle-utils = {path = "../../../utils/zk-cycle-utils", optional=true}
 
 [features]
 bench = ["zk-cycle-macros/bench", "risc0-zkvm","risc0-zkvm-platform","zk-cycle-utils"]
-default = ["native"]
+default = []
 serde = ["dep:serde", "dep:serde_json"]
-native = ["serde", "sov-modules-api/native", "sov-state/native", "sov-bank/native", "dep:jsonrpsee", "dep:schemars", "dep:clap"]
+native = ["serde", "sov-bank/native", "dep:jsonrpsee", "dep:schemars", "dep:clap", "sov-state/native", "sov-modules-api/native"]

--- a/module-system/module-schemas/Cargo.toml
+++ b/module-system/module-schemas/Cargo.toml
@@ -16,10 +16,10 @@ sov-modules-api = { path = "../sov-modules-api" }
 sov-rollup-interface = { path = "../../rollup-interface", features = ["mocks"] }
 
 # Modules
-sov-accounts = { path = "../module-implementations/sov-accounts" }
-sov-bank = { path = "../module-implementations/sov-bank" }
-sov-prover-incentives = { path = "../module-implementations/sov-prover-incentives" }
-sov-sequencer-registry = { path = "../module-implementations/sov-sequencer-registry" }
+sov-accounts = { path = "../module-implementations/sov-accounts", features = ["native"] }
+sov-bank = { path = "../module-implementations/sov-bank", features = ["native"] }
+sov-prover-incentives = { path = "../module-implementations/sov-prover-incentives", features = ["native"] }
+sov-sequencer-registry = { path = "../module-implementations/sov-sequencer-registry", features = ["native"] }
 sov-evm = { path = "../module-implementations/sov-evm", features = ["experimental"] }
-sov-election = { path = "../module-implementations/examples/sov-election" }
-sov-value-setter = { path = "../module-implementations/examples/sov-value-setter" }
+sov-election = { path = "../module-implementations/examples/sov-election", features = ["native"] }
+sov-value-setter = { path = "../module-implementations/examples/sov-value-setter", features = ["native"] }

--- a/module-system/sov-cli/Cargo.toml
+++ b/module-system/sov-cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 
 [dependencies]
-demo-stf = { path = "../../examples/demo-stf" }
+demo-stf = { path = "../../examples/demo-stf", features = ["native"] }
 sov-modules-api = { path = "../sov-modules-api", version = "0.1", features = ["native"] }
 directories = "5.0.1"
 anyhow = { workspace = true }

--- a/module-system/sov-modules-api/Cargo.toml
+++ b/module-system/sov-modules-api/Cargo.toml
@@ -12,9 +12,9 @@ readme = "README.md"
 resolver = "2"
 
 [dependencies]
-jsonrpsee = { workspace = true, optional = true } 
+jsonrpsee = { workspace = true, optional = true }
 anyhow = { workspace = true }
-sov-state = { path = "../sov-state", version = "0.1", default-features = false }
+sov-state = { path = "../sov-state", version = "0.1" }
 sov-rollup-interface = { path = "../../rollup-interface", version = "0.1" }
 sov-modules-macros = { path = "../sov-modules-macros", version = "0.1", optional = true }
 serde = { workspace = true }
@@ -23,24 +23,25 @@ thiserror = { workspace = true }
 sha2 = { workspace = true }
 bech32 = { workspace = true }
 derive_more = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, optional = true }
 hex = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true, features = [] }
 
-ed25519-dalek = { version = "1.0.1", default-features = false, features = ["alloc", "u64_backend"] }
+# TODO: try update 2.x
+ed25519-dalek = { version = "1.0.1", default-features = false, features = ["u64_backend"] }
 rand = { version = "0.7", optional = true }
 
-zk-cycle-macros = {path = "../../utils/zk-cycle-macros", optional=true }
-risc0-zkvm = { version = "0.16", default-features = false, features = ["std"],optional=true }
-risc0-zkvm-platform = { version = "0.16",optional=true}
+zk-cycle-macros = { path = "../../utils/zk-cycle-macros", optional = true }
+risc0-zkvm = { version = "0.16", default-features = false, features = ["std"], optional = true }
+risc0-zkvm-platform = { version = "0.16", optional = true }
 
 [dev-dependencies]
-serde_json = { workspace = true }
 bincode = { workspace = true }
 
 [features]
-bench = ["zk-cycle-macros","risc0-zkvm","risc0-zkvm-platform"]
-default = ["native", "macros"]
-native = ["sov-state/native", "rand", "hex", "schemars", "ed25519-dalek/default", "clap", "jsonrpsee", "macros", "sov-modules-macros/native"]
+bench = ["zk-cycle-macros", "risc0-zkvm", "risc0-zkvm-platform"]
+default = ["macros"]
+serde = ["dep:serde_json"]
+native = ["serde", "rand", "hex", "schemars", "ed25519-dalek/default", "clap", "jsonrpsee", "macros", "sov-modules-macros/native", "sov-state/native"]
 macros = ["sov-modules-macros"]

--- a/module-system/sov-modules-macros/Cargo.toml
+++ b/module-system/sov-modules-macros/Cargo.toml
@@ -25,8 +25,8 @@ tempfile = "3"
 jsonrpsee = { workspace = true, features = ["macros", "http-client", "server"] }
 trybuild = "1.0"
 
-sov-modules-api = { path = "../sov-modules-api", version = "0.1", default-features = false }
-sov-state = { path = "../sov-state", version = "0.1", default-features = false }
+sov-modules-api = { path = "../sov-modules-api", version = "0.1" }
+sov-state = { path = "../sov-state", version = "0.1" }
 sov-bank = { path = "../module-implementations/sov-bank", version = "0.1", features = ["native"] }
 serde = { workspace = true }
 clap = { workspace = true }

--- a/module-system/sov-modules-stf-template/Cargo.toml
+++ b/module-system/sov-modules-stf-template/Cargo.toml
@@ -21,14 +21,17 @@ jmt = { workspace = true }
 hex = { workspace = true }
 
 sov-rollup-interface = { path = "../../rollup-interface", version = "0.1" }
-sov-state = { path = "../sov-state", version = "0.1", default-features = false }
-sov-modules-api = { path = "../sov-modules-api", version = "0.1", default-features = false }
-zk-cycle-macros = {path = "../../utils/zk-cycle-macros", optional=true}
-risc0-zkvm = { version = "0.16", default-features = false, features = ["std"], optional=true}
-risc0-zkvm-platform = { version = "0.16", optional=true}
-zk-cycle-utils = {path = "../../utils/zk-cycle-utils", optional=true}
+sov-state = { path = "../sov-state", version = "0.1" }
+sov-modules-api = { path = "../sov-modules-api", version = "0.1" }
+zk-cycle-macros = { path = "../../utils/zk-cycle-macros", optional = true }
+risc0-zkvm = { version = "0.16", default-features = false, features = ["std"], optional = true }
+risc0-zkvm-platform = { version = "0.16", optional = true }
+zk-cycle-utils = { path = "../../utils/zk-cycle-utils", optional = true }
 
 [features]
-bench = ["zk-cycle-macros/bench","zk-cycle-utils", "risc0-zkvm","risc0-zkvm-platform"]
-default = ["native"]
-native = []
+bench = ["zk-cycle-macros/bench", "zk-cycle-utils", "risc0-zkvm", "risc0-zkvm-platform"]
+default = []
+native = [
+    "sov-state/native",
+    "sov-modules-api/native",
+]

--- a/module-system/sov-state/Cargo.toml
+++ b/module-system/sov-state/Cargo.toml
@@ -16,21 +16,21 @@ anyhow = { workspace = true }
 borsh = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.1"}
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.1" }
 sov-db = { path = "../../full-node/db/sov-db", version = "0.1", optional = true }
 sov-first-read-last-write-cache = { path = "../utils/sov-first-read-last-write-cache", version = "0.1" }
 jmt = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true }
 
-zk-cycle-macros = {path = "../../utils/zk-cycle-macros", optional=true }
-risc0-zkvm = { version = "0.16", default-features = false, features = ["std"], optional=true }
-risc0-zkvm-platform = { version = "0.16", optional=true}
+zk-cycle-macros = { path = "../../utils/zk-cycle-macros", optional = true }
+risc0-zkvm = { version = "0.16", default-features = false, features = ["std"], optional = true }
+risc0-zkvm-platform = { version = "0.16", optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
 
 [features]
-bench = ["zk-cycle-macros","risc0-zkvm","risc0-zkvm-platform"]
-default = ["native"]
+bench = ["zk-cycle-macros", "risc0-zkvm", "risc0-zkvm-platform"]
+default = []
 native = ["sov-db"]

--- a/module-system/utils/sov-data-generators/Cargo.toml
+++ b/module-system/utils/sov-data-generators/Cargo.toml
@@ -13,26 +13,15 @@ resolver = "2"
 
 
 [dependencies]
-sov-modules-api = { path = "../../sov-modules-api", default-features = false }
-sov-modules-stf-template = { path = "../../sov-modules-stf-template" }
-sov-value-setter = { path = "../../module-implementations/examples/sov-value-setter", default-features = false }
-sov-election = { path = "../../module-implementations/examples/sov-election", default-features = false }
-sov-bank = { path = "../../module-implementations/sov-bank", default-features = false }
-sov-state = { path = "../../sov-state", default-features = false }
+sov-modules-api = { path = "../../sov-modules-api", features = ["native"] }
+sov-modules-stf-template = { path = "../../sov-modules-stf-template", features = ["native"] }
+sov-value-setter = { path = "../../module-implementations/examples/sov-value-setter", features = ["native"] }
+sov-election = { path = "../../module-implementations/examples/sov-election", features = ["native"] }
+sov-bank = { path = "../../module-implementations/sov-bank", features = ["native"] }
+sov-state = { path = "../../sov-state" }
 sov-rollup-interface = { path = "../../../rollup-interface", features = ["mocks"] }
 
 borsh = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
-
-[features]
-default = ["mocks", "native"]
-mocks = []
-native = [
-    "sov-modules-api/native",
-    "sov-state/native",
-    "sov-bank/native",
-    "sov-election/native",
-    "sov-value-setter/native",
-]

--- a/module-system/utils/sov-data-generators/src/lib.rs
+++ b/module-system/utils/sov-data-generators/src/lib.rs
@@ -1,25 +1,17 @@
-#[cfg(feature = "native")]
 use std::rc::Rc;
 
 use borsh::ser::BorshSerialize;
-#[cfg(feature = "native")]
 use sov_modules_api::transaction::Transaction;
 pub use sov_modules_api::EncodeCall;
-#[cfg(feature = "native")]
-use sov_modules_api::{Context, Module, Spec};
-#[cfg(feature = "native")]
-use sov_modules_stf_template::RawTx;
-use sov_modules_stf_template::{Batch, SequencerOutcome, TxEffect};
+use sov_modules_api::{Address, Context, Module, Spec};
+use sov_modules_stf_template::{Batch, RawTx, SequencerOutcome, TxEffect};
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::mocks::{MockAddress, MockBlob, MockDaSpec};
 use sov_rollup_interface::stf::BatchReceipt;
 use sov_rollup_interface::AddressTrait;
 
-#[cfg(feature = "native")]
 pub mod bank_data;
-#[cfg(feature = "native")]
 pub mod election_data;
-#[cfg(feature = "native")]
 pub mod value_setter_data;
 
 pub fn new_test_blob_from_batch(
@@ -43,7 +35,6 @@ pub fn has_tx_events<A: AddressTrait>(
     events.peekable().peek().is_some()
 }
 
-#[cfg(feature = "native")]
 /// A generic message object used to create transactions.
 pub struct Message<C: Context, Mod: Module> {
     /// The sender's private key.
@@ -54,7 +45,6 @@ pub struct Message<C: Context, Mod: Module> {
     pub nonce: u64,
 }
 
-#[cfg(feature = "native")]
 impl<C: Context, Mod: Module> Message<C, Mod> {
     fn new(sender_key: Rc<<C as Spec>::PrivateKey>, content: Mod::CallMessage, nonce: u64) -> Self {
         Self {
@@ -65,7 +55,6 @@ impl<C: Context, Mod: Module> Message<C, Mod> {
     }
 }
 
-#[cfg(feature = "native")]
 /// Trait used to generate messages from the DA layer to automate module testing
 pub trait MessageGenerator {
     /// Module where the messages originate from.

--- a/module-system/utils/sov-data-generators/src/lib.rs
+++ b/module-system/utils/sov-data-generators/src/lib.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use borsh::ser::BorshSerialize;
 use sov_modules_api::transaction::Transaction;
 pub use sov_modules_api::EncodeCall;
-use sov_modules_api::{Address, Context, Module, Spec};
+use sov_modules_api::{Context, Module, Spec};
 use sov_modules_stf_template::{Batch, RawTx, SequencerOutcome, TxEffect};
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::mocks::{MockAddress, MockBlob, MockDaSpec};


### PR DESCRIPTION
# Description

## Problem

Currently, when module developer imports other modules, it needs to declare it in Cargo.toml with `default-features = false`. If they forgot it, then it will only pop up during prover checks and it will be hard to identify, if there's several modules where added with multiple dependencies.

New approach makes `native` feature non default, so only crates that need it, import it explicitly.

Pros:

* Developer of the new module can just import dependency with default features
* If something is not available in native it will be clear in which module
* It is visible explicitly which crates are native only: `demo-rollup`, or `demo-prover/host` 

Cons:

* For some tests this hack should be applied, so native code needs to be tests:

```toml
[dev-dependencies]
this_crate = { version = "*", features = ["native"], path = "." }
```

* Developers need to enable "native" feature in their IDE, so they can see all the code inspected properly.


## Other observations:

* `sov-stf-runner` is effectively native right now, but that will need to change.
* `sov-data-generators` is native only crate, because it is used only for testing.
* `macros` feature from sov-modules-api is default, so do not import it by default

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Existing tests have passed

## Docs

**(!) TBD**
