### PR TITLE
`StateVec` PR followup

### DIFF
--- a/module-system/sov-state/src/codec.rs
+++ b/module-system/sov-state/src/codec.rs
@@ -114,8 +114,19 @@ where
 /// and one for values.
 #[derive(Default, Debug, Clone)]
 pub struct PairOfCodecs<KC, VC> {
-    pub key_codec: KC,
-    pub value_codec: VC,
+    key_codec: KC,
+    value_codec: VC,
+}
+
+impl<KC, VC> PairOfCodecs<KC, VC> {
+    /// Creates a new [`PairOfCodecs`] from a [`StateKeyCodec`] and a
+    /// [`StateValueCodec`].
+    pub fn new(key_codec: KC, value_codec: VC) -> Self {
+        Self {
+            key_codec,
+            value_codec,
+        }
+    }
 }
 
 impl<K, KC, VC> StateKeyCodec<K> for PairOfCodecs<KC, VC>

--- a/module-system/sov-state/src/lib.rs
+++ b/module-system/sov-state/src/lib.rs
@@ -28,7 +28,7 @@ mod state_tests;
 use std::fmt::Display;
 use std::str;
 
-pub use map::StateMap;
+pub use map::{MapError, StateMap};
 #[cfg(feature = "native")]
 pub use prover_storage::{delete_storage, ProverStorage};
 pub use scratchpad::*;
@@ -83,6 +83,19 @@ impl Prefix {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.prefix.is_empty()
+    }
+
+    pub fn extended(&self, bytes: &[u8]) -> Self {
+        let mut prefix = self.clone();
+        prefix.extend(bytes.iter().copied());
+        prefix
+    }
+}
+
+impl Extend<u8> for Prefix {
+    fn extend<T: IntoIterator<Item = u8>>(&mut self, iter: T) {
+        self.prefix
+            .extend(&AlignedVec::new(iter.into_iter().collect()))
     }
 }
 

--- a/module-system/sov-state/src/value.rs
+++ b/module-system/sov-state/src/value.rs
@@ -26,7 +26,7 @@ where
     BorshCodec: StateValueCodec<V>,
 {
     /// Crates a new [`StateValue`] with the given prefix and the default
-    /// [`StateCodec`] (i.e. [`BorshCodec`]).
+    /// [`StateValueCodec`] (i.e. [`BorshCodec`]).
     pub fn new(prefix: Prefix) -> Self {
         Self {
             _phantom: PhantomData,


### PR DESCRIPTION
# Description
This is a followup PR to https://github.com/Sovereign-Labs/sovereign-sdk/pull/685, making some small changes:

- Instead of storing both the vector's length and elements inside a single key space, this PR splits all state management of `StateVec` into a `StateValue` (for the length) and a `StateMap` (for vector elements). Performance impact should be negligible and we can always optimize things later. The resulting code is simpler and less bug-prone.
- Codec-related logic is simpler as we rely on `StateValue`/`StateMap` APIs.
- Iterator support. It's not yet a `DoubleEndedIterator`, but it can be supported if necessary.

## Linked Issues
Closes https://github.com/Sovereign-Labs/sovereign-sdk/issues/33.

cc @eyusufatik.
