### PR TITLE
Implement `Default` for `PairOfCodecs`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,12 +41,8 @@ name: Rust
 on:
   push:
     branches: ["nightly", "stable"]
-    paths-ignore:
-      - "**.md"
   pull_request:
     branches: ["nightly", "stable"]
-    paths-ignore:
-      - "**.md"
 
 env:
   CARGO_TERM_COLOR: always

--- a/module-system/sov-state/src/codec.rs
+++ b/module-system/sov-state/src/codec.rs
@@ -112,6 +112,7 @@ where
 
 /// A [`StateCodec`] that uses two different codecs under the hood, one for keys
 /// and one for values.
+#[derive(Default, Debug, Clone)]
 pub struct PairOfCodecs<KC, VC> {
     pub key_codec: KC,
     pub value_codec: VC,


### PR DESCRIPTION
Fixes one of the pain points around `PairOfCodecs` with the `state` macro attribute.