### PR TITLE
Run CI even for `*.md` changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,12 +41,8 @@ name: Rust
 on:
   push:
     branches: ["nightly", "stable"]
-    paths-ignore:
-      - "**.md"
   pull_request:
     branches: ["nightly", "stable"]
-    paths-ignore:
-      - "**.md"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Fixes the issues that we're seeing with CI not running in PRs like #687 and #683. Motivation:

- We now have a Table of Contents automatic check based on https://github.com/thlorenz/doctoc, so changes to `.md` can break CI.
- We use `#![doc = include_str!("../README.md")]` in several places, which makes is important to re-run CI for all changes to documentation.