### PR TITLE
Split AddressTrait

### DIFF
--- a/adapters/celestia/src/celestia.rs
+++ b/adapters/celestia/src/celestia.rs
@@ -1,6 +1,4 @@
-use std::fmt::{Display, Formatter};
 use std::ops::Range;
-use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 use base64::engine::general_purpose::STANDARD as B64_ENGINE;
@@ -12,7 +10,6 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::da::{BlockHeaderTrait as BlockHeader, CountedBufReader};
 use sov_rollup_interface::services::da::SlotData;
-use sov_rollup_interface::BasicAddress;
 pub use tendermint::block::Header as TendermintHeader;
 use tendermint::block::Height;
 use tendermint::crypto::default::Sha256;
@@ -347,48 +344,6 @@ impl AsRef<[u8]> for Sha2Hash {
         self.0.as_ref()
     }
 }
-
-#[derive(Deserialize, Serialize, PartialEq, Debug, Clone, Eq, Hash)]
-pub struct H160(#[serde(deserialize_with = "hex::deserialize")] pub [u8; 20]);
-
-impl AsRef<[u8]> for H160 {
-    fn as_ref(&self) -> &[u8] {
-        self.0.as_ref()
-    }
-}
-
-impl<'a> TryFrom<&'a [u8]> for H160 {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
-        if value.len() == 20 {
-            let mut addr = [0u8; 20];
-            addr.copy_from_slice(value);
-            return Ok(Self(addr));
-        }
-        anyhow::bail!("Adress is not exactly 20 bytes");
-    }
-}
-
-impl FromStr for H160 {
-    type Err = hex::FromHexError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Remove the "0x" prefix, if it exists.
-        let s = s.strip_prefix("0x").unwrap_or(s);
-        let mut output = [0u8; 20];
-        hex::decode_to_slice(s, &mut output)?;
-        Ok(H160(output))
-    }
-}
-
-impl Display for H160 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "0x{}", hex::encode(self.0))
-    }
-}
-
-impl BasicAddress for H160 {}
 
 pub fn parse_pfb_namespace(
     group: NamespaceGroup,

--- a/adapters/celestia/src/celestia.rs
+++ b/adapters/celestia/src/celestia.rs
@@ -12,7 +12,7 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::da::{BlockHeaderTrait as BlockHeader, CountedBufReader};
 use sov_rollup_interface::services::da::SlotData;
-use sov_rollup_interface::{BasicAddress, RollupAddress};
+use sov_rollup_interface::BasicAddress;
 pub use tendermint::block::Header as TendermintHeader;
 use tendermint::block::Height;
 use tendermint::crypto::default::Sha256;
@@ -370,14 +370,6 @@ impl<'a> TryFrom<&'a [u8]> for H160 {
     }
 }
 
-impl From<[u8; 32]> for H160 {
-    fn from(value: [u8; 32]) -> Self {
-        let mut addr = [0u8; 20];
-        addr.copy_from_slice(&value[12..]);
-        Self(addr)
-    }
-}
-
 impl FromStr for H160 {
     type Err = hex::FromHexError;
 
@@ -397,8 +389,6 @@ impl Display for H160 {
 }
 
 impl BasicAddress for H160 {}
-// TODO: Remove this
-impl RollupAddress for H160 {}
 
 pub fn parse_pfb_namespace(
     group: NamespaceGroup,

--- a/adapters/celestia/src/celestia.rs
+++ b/adapters/celestia/src/celestia.rs
@@ -12,7 +12,7 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::da::{BlockHeaderTrait as BlockHeader, CountedBufReader};
 use sov_rollup_interface::services::da::SlotData;
-use sov_rollup_interface::AddressTrait;
+use sov_rollup_interface::{BasicAddress, RollupAddress};
 pub use tendermint::block::Header as TendermintHeader;
 use tendermint::block::Height;
 use tendermint::crypto::default::Sha256;
@@ -396,7 +396,9 @@ impl Display for H160 {
     }
 }
 
-impl AddressTrait for H160 {}
+impl BasicAddress for H160 {}
+// TODO: Remove this
+impl RollupAddress for H160 {}
 
 pub fn parse_pfb_namespace(
     group: NamespaceGroup,

--- a/adapters/celestia/src/verifier/address.rs
+++ b/adapters/celestia/src/verifier/address.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use bech32::WriteBase32;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::AddressTrait;
+use sov_rollup_interface::RollupAddress;
 use thiserror::Error;
 
 /// Human Readable Part: "celestia" for Celestia network
@@ -116,7 +116,9 @@ impl FromStr for CelestiaAddress {
     }
 }
 
-impl AddressTrait for CelestiaAddress {}
+impl sov_rollup_interface::BasicAddress for CelestiaAddress {}
+// TODO: Remove this
+impl RollupAddress for CelestiaAddress {}
 
 #[cfg(test)]
 mod tests {

--- a/adapters/celestia/src/verifier/address.rs
+++ b/adapters/celestia/src/verifier/address.rs
@@ -4,7 +4,6 @@ use std::str::FromStr;
 use bech32::WriteBase32;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::RollupAddress;
 use thiserror::Error;
 
 /// Human Readable Part: "celestia" for Celestia network
@@ -49,17 +48,6 @@ impl<'a> TryFrom<&'a [u8]> for CelestiaAddress {
             raw_address[idx] = item;
         }
         Ok(Self(raw_address))
-    }
-}
-
-/// Panics if any element is not in range 0..32 (u5)
-/// TODO: Will be removed after https://github.com/Sovereign-Labs/sovereign-sdk/issues/493
-impl From<[u8; 32]> for CelestiaAddress {
-    fn from(value: [u8; 32]) -> Self {
-        for item in value {
-            bech32::u5::try_from_u8(item).unwrap();
-        }
-        Self(value)
     }
 }
 
@@ -117,8 +105,6 @@ impl FromStr for CelestiaAddress {
 }
 
 impl sov_rollup_interface::BasicAddress for CelestiaAddress {}
-// TODO: Remove this
-impl RollupAddress for CelestiaAddress {}
 
 #[cfg(test)]
 mod tests {
@@ -233,13 +219,6 @@ mod tests {
         #[test]
         fn test_borsh(input in proptest::array::uniform20(0u8..=255)) {
             check_borsh(input);
-        }
-
-        #[test]
-        fn test_try_from_array(arr in proptest::array::uniform32(0u8..32)) {
-            let address = CelestiaAddress::from(arr);
-            let output = format!("{}", address);
-            prop_assert!(output.starts_with("celestia"));
         }
     }
 }

--- a/examples/demo-rollup/src/lib.rs
+++ b/examples/demo-rollup/src/lib.rs
@@ -12,7 +12,7 @@ use demo_stf::runtime::GenesisConfig;
 pub use rollup::{new_rollup_with_celestia_da, Rollup};
 use sov_db::ledger_db::LedgerDB;
 use sov_modules_api::default_context::DefaultContext;
-use sov_rollup_interface::AddressTrait;
+use sov_rollup_interface::RollupAddress;
 
 /// The rollup stores its data in the namespace b"sov-test" on Celestia
 /// You can change this constant to point your rollup at a different namespace
@@ -40,7 +40,7 @@ pub struct HexKey {
 /// ```rust,no_run
 /// const SEQUENCER_DA_ADDRESS: [u8;47] = *b"celestia1qp09ysygcx6npted5yc0au6k9lner05yvs9208";
 /// ```
-pub fn get_genesis_config<D: AddressTrait>(
+pub fn get_genesis_config<D: RollupAddress>(
     sequencer_da_address: D,
 ) -> GenesisConfig<DefaultContext> {
     let hex_key: HexKey = serde_json::from_slice(include_bytes!(

--- a/examples/demo-rollup/src/lib.rs
+++ b/examples/demo-rollup/src/lib.rs
@@ -12,7 +12,7 @@ use demo_stf::runtime::GenesisConfig;
 pub use rollup::{new_rollup_with_celestia_da, Rollup};
 use sov_db::ledger_db::LedgerDB;
 use sov_modules_api::default_context::DefaultContext;
-use sov_rollup_interface::RollupAddress;
+use sov_rollup_interface::BasicAddress;
 
 /// The rollup stores its data in the namespace b"sov-test" on Celestia
 /// You can change this constant to point your rollup at a different namespace
@@ -38,10 +38,10 @@ pub struct HexKey {
 /// address, simply change the value of the SEQUENCER_DA_ADDRESS to your own address.
 /// For example:
 /// ```rust,no_run
-/// const SEQUENCER_DA_ADDRESS: [u8;47] = *b"celestia1qp09ysygcx6npted5yc0au6k9lner05yvs9208";
+/// const SEQUENCER_DA_ADDRESS: &str = "celestia1qp09ysygcx6npted5yc0au6k9lner05yvs9208";
 /// ```
-pub fn get_genesis_config<D: RollupAddress>(
-    sequencer_da_address: D,
+pub fn get_genesis_config<A: BasicAddress>(
+    sequencer_da_address: A,
 ) -> GenesisConfig<DefaultContext> {
     let hex_key: HexKey = serde_json::from_slice(include_bytes!(
         "../../test-data/keys/token_deployer_private_key.json"

--- a/examples/demo-simple-stf/README.md
+++ b/examples/demo-simple-stf/README.md
@@ -162,7 +162,8 @@ pub struct DaAddress {
     pub addr: [u8; 32],
 }
 
-impl AddressTrait for DaAddress {}
+impl BasicAddress for DaAddress {}
+impl RollupAddress for DaAddress {}
 
 ```
 

--- a/examples/demo-simple-stf/tests/stf_test.rs
+++ b/examples/demo-simple-stf/tests/stf_test.rs
@@ -1,75 +1,21 @@
-use std::fmt::Display;
-use std::str::FromStr;
-
 use demo_simple_stf::{ApplySlotResult, CheckHashPreimageStf};
-use sov_rollup_interface::mocks::{MockBlob, MockBlock, MockValidityCond, MockZkvm};
+use sov_rollup_interface::mocks::{MockAddress, MockBlob, MockBlock, MockValidityCond, MockZkvm};
 use sov_rollup_interface::stf::StateTransitionFunction;
-use sov_rollup_interface::AddressTrait;
-
-#[derive(PartialEq, Debug, Clone, Eq, serde::Serialize, serde::Deserialize, Hash)]
-pub struct DaAddress {
-    pub addr: [u8; 32],
-}
-
-impl AddressTrait for DaAddress {}
-
-impl AsRef<[u8]> for DaAddress {
-    fn as_ref(&self) -> &[u8] {
-        &self.addr
-    }
-}
-
-impl From<[u8; 32]> for DaAddress {
-    fn from(addr: [u8; 32]) -> Self {
-        DaAddress { addr }
-    }
-}
-
-impl FromStr for DaAddress {
-    type Err = hex::FromHexError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Remove the "0x" prefix, if it exists.
-        let s = s.strip_prefix("0x").unwrap_or(s);
-        let mut addr = [0u8; 32];
-        hex::decode_to_slice(s, &mut addr)?;
-        Ok(DaAddress { addr })
-    }
-}
-
-impl<'a> TryFrom<&'a [u8]> for DaAddress {
-    type Error = anyhow::Error;
-
-    fn try_from(addr: &'a [u8]) -> Result<Self, Self::Error> {
-        if addr.len() != 32 {
-            anyhow::bail!("Address must be 32 bytes long");
-        }
-        let mut addr_bytes = [0u8; 32];
-        addr_bytes.copy_from_slice(addr);
-        Ok(Self { addr: addr_bytes })
-    }
-}
-
-impl Display for DaAddress {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.addr)
-    }
-}
 
 #[test]
 fn test_stf() {
-    let address = DaAddress { addr: [1; 32] };
+    let address = MockAddress { addr: [1; 32] };
     let preimage = vec![0; 32];
 
-    let test_blob = MockBlob::<DaAddress>::new(preimage, address, [0; 32]);
+    let test_blob = MockBlob::<MockAddress>::new(preimage, address, [0; 32]);
     let stf = &mut CheckHashPreimageStf::<MockValidityCond>::default();
 
     let data = MockBlock::default();
     let mut blobs = [test_blob];
 
-    StateTransitionFunction::<MockZkvm, MockBlob<DaAddress>>::init_chain(stf, ());
+    StateTransitionFunction::<MockZkvm, MockBlob<MockAddress>>::init_chain(stf, ());
 
-    let result = StateTransitionFunction::<MockZkvm, MockBlob<DaAddress>>::apply_slot(
+    let result = StateTransitionFunction::<MockZkvm, MockBlob<MockAddress>>::apply_slot(
         stf,
         (),
         &data,

--- a/module-system/module-implementations/sov-blob-storage/src/lib.rs
+++ b/module-system/module-implementations/sov-blob-storage/src/lib.rs
@@ -67,7 +67,7 @@ impl<C: sov_modules_api::Context> BlobStorage<C> {
             .collect()
     }
 
-    // TODO: Migrate to AddressTrait generic: https://github.com/Sovereign-Labs/sovereign-sdk/issues/622
+    // TODO: Migrate to generic: https://github.com/Sovereign-Labs/sovereign-sdk/issues/622
     pub(crate) fn get_preferred_sequencer(
         &self,
         working_set: &mut WorkingSet<C::Storage>,

--- a/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
@@ -180,7 +180,7 @@ impl<C: sov_modules_api::Context> SequencerRegistry<C> {
     }
 
     /// Checks whether `sender` is a registered sequencer.
-    pub fn is_sender_allowed<T: sov_modules_api::RollupAddress>(
+    pub fn is_sender_allowed<T: sov_rollup_interface::BasicAddress>(
         &self,
         sender: &T,
         working_set: &mut WorkingSet<C::Storage>,

--- a/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
@@ -180,7 +180,7 @@ impl<C: sov_modules_api::Context> SequencerRegistry<C> {
     }
 
     /// Checks whether `sender` is a registered sequencer.
-    pub fn is_sender_allowed<T: sov_modules_api::AddressTrait>(
+    pub fn is_sender_allowed<T: sov_modules_api::RollupAddress>(
         &self,
         sender: &T,
         working_set: &mut WorkingSet<C::Storage>,

--- a/module-system/sov-modules-api/src/default_context.rs
+++ b/module-system/sov-modules-api/src/default_context.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "native")]
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
-use sov_rollup_interface::AddressTrait;
+use sov_rollup_interface::RollupAddress;
 #[cfg(feature = "native")]
 use sov_state::ProverStorage;
 use sov_state::{ArrayWitness, DefaultStorageSpec, ZkStorage};
@@ -67,7 +67,7 @@ impl Context for ZkDefaultContext {
 }
 
 impl PublicKey for DefaultPublicKey {
-    fn to_address<A: AddressTrait>(&self) -> A {
+    fn to_address<A: RollupAddress>(&self) -> A {
         let pub_key_hash = {
             let mut hasher = <ZkDefaultContext as Spec>::Hasher::new();
             hasher.update(self.pub_key);

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -53,9 +53,7 @@ pub use error::Error;
 pub use prefix::Prefix;
 pub use response::CallResponse;
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::BasicAddress;
-// TODO: Check this.
-pub use sov_rollup_interface::{digest, RollupAddress};
+pub use sov_rollup_interface::{digest, BasicAddress, RollupAddress};
 use sov_state::{Storage, Witness, WorkingSet};
 use thiserror::Error;
 

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -54,6 +54,7 @@ pub use prefix::Prefix;
 pub use response::CallResponse;
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::BasicAddress;
+// TODO: Check this.
 pub use sov_rollup_interface::{digest, RollupAddress};
 use sov_state::{Storage, Witness, WorkingSet};
 use thiserror::Error;

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -53,7 +53,8 @@ pub use error::Error;
 pub use prefix::Prefix;
 pub use response::CallResponse;
 use serde::{Deserialize, Serialize};
-pub use sov_rollup_interface::{digest, AddressTrait};
+use sov_rollup_interface::BasicAddress;
+pub use sov_rollup_interface::{digest, RollupAddress};
 use sov_state::{Storage, Witness, WorkingSet};
 use thiserror::Error;
 
@@ -65,7 +66,8 @@ impl AsRef<[u8]> for Address {
     }
 }
 
-impl AddressTrait for Address {}
+impl BasicAddress for Address {}
+impl RollupAddress for Address {}
 
 #[cfg_attr(feature = "native", derive(schemars::JsonSchema))]
 #[derive(PartialEq, Clone, Copy, Eq, borsh::BorshDeserialize, borsh::BorshSerialize, Hash)]
@@ -142,7 +144,7 @@ pub enum NonInstantiable {}
 
 /// PublicKey used in the Module System.
 pub trait PublicKey {
-    fn to_address<A: AddressTrait>(&self) -> A;
+    fn to_address<A: RollupAddress>(&self) -> A;
 }
 
 /// A PrivateKey used in the Module System.
@@ -153,7 +155,7 @@ pub trait PrivateKey {
     fn generate() -> Self;
     fn pub_key(&self) -> Self::PublicKey;
     fn sign(&self, msg: &[u8]) -> Self::Signature;
-    fn to_address<A: AddressTrait>(&self) -> A {
+    fn to_address<A: RollupAddress>(&self) -> A {
         self.pub_key().to_address::<A>()
     }
 }
@@ -170,7 +172,7 @@ pub trait PrivateKey {
 pub trait Spec {
     /// The Address type used on the rollup. Typically calculated as the hash of a public key.
     #[cfg(feature = "native")]
-    type Address: AddressTrait
+    type Address: RollupAddress
         + BorshSerialize
         + BorshDeserialize
         + Sync
@@ -183,7 +185,7 @@ pub trait Spec {
 
     /// The Address type used on the rollup. Typically calculated as the hash of a public key.
     #[cfg(not(feature = "native"))]
-    type Address: AddressTrait + BorshSerialize + BorshDeserialize;
+    type Address: RollupAddress + BorshSerialize + BorshDeserialize;
 
     /// Authenticated state storage used by the rollup. Typically some variant of a merkle-patricia trie.
     type Storage: Storage + Clone + Send + Sync;

--- a/module-system/sov-modules-macros/tests/module_info/use_address_trait.rs
+++ b/module-system/sov-modules-macros/tests/module_info/use_address_trait.rs
@@ -2,7 +2,7 @@
 
 #![allow(unused_imports)]
 
-use sov_modules_api::{AddressTrait, Context, ModuleInfo};
+use sov_modules_api::{Context, ModuleInfo, RollupAddress};
 
 #[derive(ModuleInfo)]
 struct TestModule<C: Context> {

--- a/module-system/sov-modules-stf-template/src/app_template.rs
+++ b/module-system/sov-modules-stf-template/src/app_template.rs
@@ -4,7 +4,7 @@ use borsh::BorshDeserialize;
 use sov_modules_api::{Context, DispatchCall};
 use sov_rollup_interface::da::{BlobReaderTrait, CountedBufReader, DaSpec};
 use sov_rollup_interface::stf::{BatchReceipt, TransactionReceipt};
-use sov_rollup_interface::{AddressTrait, Buf};
+use sov_rollup_interface::{Buf, RollupAddress};
 use sov_state::StateCheckpoint;
 use tracing::{debug, error};
 
@@ -39,7 +39,7 @@ pub struct AppTemplate<
     phantom_da: PhantomData<DA>,
 }
 
-pub(crate) enum ApplyBatchError<A: AddressTrait> {
+pub(crate) enum ApplyBatchError<A: RollupAddress> {
     // Contains batch hash
     Ignored([u8; 32]),
     Slashed {
@@ -50,7 +50,7 @@ pub(crate) enum ApplyBatchError<A: AddressTrait> {
     },
 }
 
-impl<A: AddressTrait> From<ApplyBatchError<A>> for BatchReceipt<SequencerOutcome<A>, TxEffect> {
+impl<A: RollupAddress> From<ApplyBatchError<A>> for BatchReceipt<SequencerOutcome<A>, TxEffect> {
     fn from(value: ApplyBatchError<A>) -> Self {
         match value {
             ApplyBatchError::Ignored(hash) => BatchReceipt {

--- a/module-system/sov-modules-stf-template/src/app_template.rs
+++ b/module-system/sov-modules-stf-template/src/app_template.rs
@@ -4,7 +4,7 @@ use borsh::BorshDeserialize;
 use sov_modules_api::{Context, DispatchCall};
 use sov_rollup_interface::da::{BlobReaderTrait, CountedBufReader, DaSpec};
 use sov_rollup_interface::stf::{BatchReceipt, TransactionReceipt};
-use sov_rollup_interface::{Buf, RollupAddress};
+use sov_rollup_interface::{BasicAddress, Buf};
 use sov_state::StateCheckpoint;
 use tracing::{debug, error};
 
@@ -39,7 +39,7 @@ pub struct AppTemplate<
     phantom_da: PhantomData<DA>,
 }
 
-pub(crate) enum ApplyBatchError<A: RollupAddress> {
+pub(crate) enum ApplyBatchError<A: BasicAddress> {
     // Contains batch hash
     Ignored([u8; 32]),
     Slashed {
@@ -50,7 +50,7 @@ pub(crate) enum ApplyBatchError<A: RollupAddress> {
     },
 }
 
-impl<A: RollupAddress> From<ApplyBatchError<A>> for BatchReceipt<SequencerOutcome<A>, TxEffect> {
+impl<A: BasicAddress> From<ApplyBatchError<A>> for BatchReceipt<SequencerOutcome<A>, TxEffect> {
     fn from(value: ApplyBatchError<A>) -> Self {
         match value {
             ApplyBatchError::Ignored(hash) => BatchReceipt {

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -13,7 +13,7 @@ use sov_rollup_interface::da::{BlobReaderTrait, DaSpec};
 use sov_rollup_interface::services::da::SlotData;
 use sov_rollup_interface::stf::{SlotResult, StateTransitionFunction};
 use sov_rollup_interface::zk::{ValidityCondition, Zkvm};
-use sov_rollup_interface::AddressTrait;
+use sov_rollup_interface::RollupAddress;
 use sov_state::{StateCheckpoint, Storage, WorkingSet};
 use tracing::info;
 pub use tx_verifier::RawTx;
@@ -42,7 +42,7 @@ pub enum TxEffect {
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 /// Represents the different outcomes that can occur for a sequencer after batch processing.
-pub enum SequencerOutcome<A: AddressTrait> {
+pub enum SequencerOutcome<A: RollupAddress> {
     /// Sequencer receives reward amount in defined token and can withdraw its deposit
     Rewarded(u64),
     /// Sequencer loses its deposit and receives no reward

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -13,7 +13,7 @@ use sov_rollup_interface::da::{BlobReaderTrait, DaSpec};
 use sov_rollup_interface::services::da::SlotData;
 use sov_rollup_interface::stf::{SlotResult, StateTransitionFunction};
 use sov_rollup_interface::zk::{ValidityCondition, Zkvm};
-use sov_rollup_interface::RollupAddress;
+use sov_rollup_interface::BasicAddress;
 use sov_state::{StateCheckpoint, Storage, WorkingSet};
 use tracing::info;
 pub use tx_verifier::RawTx;
@@ -42,7 +42,7 @@ pub enum TxEffect {
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 /// Represents the different outcomes that can occur for a sequencer after batch processing.
-pub enum SequencerOutcome<A: RollupAddress> {
+pub enum SequencerOutcome<A: BasicAddress> {
     /// Sequencer receives reward amount in defined token and can withdraw its deposit
     Rewarded(u64),
     /// Sequencer loses its deposit and receives no reward

--- a/module-system/utils/sov-data-generators/src/lib.rs
+++ b/module-system/utils/sov-data-generators/src/lib.rs
@@ -8,7 +8,7 @@ use sov_modules_stf_template::{Batch, RawTx, SequencerOutcome, TxEffect};
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::mocks::{MockAddress, MockBlob, MockDaSpec};
 use sov_rollup_interface::stf::BatchReceipt;
-use sov_rollup_interface::AddressTrait;
+use sov_rollup_interface::RollupAddress;
 
 pub mod bank_data;
 pub mod election_data;
@@ -24,7 +24,7 @@ pub fn new_test_blob_from_batch(
     MockBlob::new(data, address, hash)
 }
 
-pub fn has_tx_events<A: AddressTrait>(
+pub fn has_tx_events<A: RollupAddress>(
     apply_blob_outcome: &BatchReceipt<SequencerOutcome<A>, TxEffect>,
 ) -> bool {
     let events = apply_blob_outcome

--- a/rollup-interface/src/state_machine/da.rs
+++ b/rollup-interface/src/state_machine/da.rs
@@ -11,7 +11,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 use crate::zk::ValidityCondition;
-use crate::RollupAddress;
+use crate::BasicAddress;
 
 /// A specification for the types used by a DA layer.
 pub trait DaSpec {
@@ -166,7 +166,7 @@ pub trait BlobReaderTrait: Serialize + DeserializeOwned + Send + Sync + 'static 
     type Data: Buf;
 
     /// The type used to represent addresses on the DA layer.
-    type Address: RollupAddress;
+    type Address: BasicAddress;
 
     /// Returns the address (on the DA layer) of the entity which submitted the blob transaction
     fn sender(&self) -> Self::Address;

--- a/rollup-interface/src/state_machine/da.rs
+++ b/rollup-interface/src/state_machine/da.rs
@@ -11,7 +11,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 use crate::zk::ValidityCondition;
-use crate::AddressTrait;
+use crate::RollupAddress;
 
 /// A specification for the types used by a DA layer.
 pub trait DaSpec {
@@ -166,7 +166,7 @@ pub trait BlobReaderTrait: Serialize + DeserializeOwned + Send + Sync + 'static 
     type Data: Buf;
 
     /// The type used to represent addresses on the DA layer.
-    type Address: AddressTrait;
+    type Address: RollupAddress;
 
     /// Returns the address (on the DA layer) of the entity which submitted the blob transaction
     fn sender(&self) -> Self::Address;

--- a/rollup-interface/src/state_machine/mocks/da.rs
+++ b/rollup-interface/src/state_machine/mocks/da.rs
@@ -81,22 +81,18 @@ impl RollupAddress for MockAddress {}
 )]
 
 /// A mock BlobTransaction from a DA layer used for testing.
-pub struct MockBlob<Address> {
-    address: Address,
+pub struct MockBlob<A> {
+    address: A,
     hash: [u8; 32],
     data: CountedBufReader<Bytes>,
 }
 
-impl<Address: RollupAddress> BlobReaderTrait for MockBlob<Address> {
+impl<A: BasicAddress> BlobReaderTrait for MockBlob<A> {
     type Data = Bytes;
-    type Address = Address;
+    type Address = A;
 
     fn sender(&self) -> Self::Address {
         self.address.clone()
-    }
-
-    fn hash(&self) -> [u8; 32] {
-        self.hash
     }
 
     fn data_mut(&mut self) -> &mut CountedBufReader<Self::Data> {
@@ -106,11 +102,15 @@ impl<Address: RollupAddress> BlobReaderTrait for MockBlob<Address> {
     fn data(&self) -> &CountedBufReader<Self::Data> {
         &self.data
     }
+
+    fn hash(&self) -> [u8; 32] {
+        self.hash
+    }
 }
 
-impl<Address: RollupAddress> MockBlob<Address> {
+impl<A: BasicAddress> MockBlob<A> {
     /// Creates a new mock blob with the given data, claiming to have been published by the provided address.
-    pub fn new(data: Vec<u8>, address: Address, hash: [u8; 32]) -> Self {
+    pub fn new(data: Vec<u8>, address: A, hash: [u8; 32]) -> Self {
         Self {
             address,
             data: CountedBufReader::new(bytes::Bytes::from(data)),

--- a/rollup-interface/src/state_machine/mod.rs
+++ b/rollup-interface/src/state_machine/mod.rs
@@ -26,6 +26,7 @@ pub trait BasicAddress:
     + std::hash::Hash
     + AsRef<[u8]>
     + for<'a> TryFrom<&'a [u8], Error = anyhow::Error>
+    + std::str::FromStr
     + Serialize
     + DeserializeOwned
     + 'static

--- a/rollup-interface/src/state_machine/mod.rs
+++ b/rollup-interface/src/state_machine/mod.rs
@@ -14,21 +14,23 @@ pub mod mocks;
 
 pub mod optimistic;
 
-/// A marker trait for addresses.
-pub trait AddressTrait:
-    PartialEq
+/// A marker trait for general addresses.
+pub trait BasicAddress:
+    Eq
+    + PartialEq
     + core::fmt::Debug
-    + Clone
-    + AsRef<[u8]>
-    + for<'a> TryFrom<&'a [u8], Error = anyhow::Error>
-    + Eq
-    + Serialize
-    + DeserializeOwned
-    + From<[u8; 32]>
+    + core::fmt::Display
     + Send
     + Sync
-    + core::fmt::Display
+    + Clone
     + std::hash::Hash
+    + AsRef<[u8]>
+    + for<'a> TryFrom<&'a [u8], Error = anyhow::Error>
+    + Serialize
+    + DeserializeOwned
     + 'static
 {
 }
+
+/// An address used inside rollup
+pub trait RollupAddress: BasicAddress + From<[u8; 32]> {}

--- a/rollup-interface/src/state_machine/zk/mod.rs
+++ b/rollup-interface/src/state_machine/zk/mod.rs
@@ -13,7 +13,7 @@ use digest::Digest;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use crate::AddressTrait;
+use crate::RollupAddress;
 
 /// A trait implemented by the prover ("host") of a zkVM program.
 pub trait ZkvmHost: Zkvm {
@@ -46,7 +46,7 @@ pub trait Zkvm {
     /// TODO: specify a deserializer for the output
     fn verify_and_extract_output<
         C: ValidityCondition,
-        Add: AddressTrait + BorshDeserialize + BorshSerialize,
+        Add: RollupAddress + BorshDeserialize + BorshSerialize,
     >(
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,


### PR DESCRIPTION
# Description


1. Splits `AddressTrait` into 2 traits:

 * `BasicAddress` - general address trait, that we require for address to be nicely used. Has no requirement on underlying structure
 
 * `RollupAddress` - trait that is build on top of `BasicAddress`, but adds requirements it to be convertable from 32 bytes array without error.

2. Adds `FromStr` bound to `BasicAddress`

All addresses needs to be displayed anyway, so having a way to initiate it from string will simplify configs, and call messages

3. Remove `DaAddress` and use `MockAddress` from `sov-rollup-inteface` instead


## Linked Issues
- Fixes #493


## Testing

Existing test are passing

## Docs

Updated
