### PR TITLE
Use `MockAddress` in `sov-sequencer-registry` tests. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7018,6 +7018,7 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-rollup-interface",
+ "sov-sequencer-registry",
  "sov-state",
  "tempfile",
  "zk-cycle-macros",

--- a/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
+++ b/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 resolver = "2"
 
 [dev-dependencies]
+sov-sequencer-registry = {path = ".", features = ["native"]}
 sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1", features = ["mocks"] }
 tempfile = { workspace = true }
 

--- a/module-system/module-implementations/sov-sequencer-registry/tests/hooks_test.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/tests/hooks_test.rs
@@ -4,8 +4,7 @@ use sov_state::{ProverStorage, WorkingSet};
 mod helpers;
 
 use helpers::*;
-use sov_modules_api::Address;
-use sov_rollup_interface::mocks::MockBlob;
+use sov_rollup_interface::mocks::{MockAddress, MockBlob};
 use sov_sequencer_registry::{SequencerOutcome, SequencerRegistry};
 
 #[test]
@@ -23,7 +22,7 @@ fn begin_blob_hook_known_sequencer() {
 
     let mut test_blob = MockBlob::new(
         Vec::new(),
-        Address::from(GENESIS_SEQUENCER_DA_ADDRESS),
+        MockAddress::from(GENESIS_SEQUENCER_DA_ADDRESS),
         [0_u8; 32],
     );
 
@@ -50,7 +49,7 @@ fn begin_blob_hook_unknown_sequencer() {
 
     let mut test_blob = MockBlob::new(
         Vec::new(),
-        Address::from(UNKNOWN_SEQUENCER_DA_ADDRESS),
+        MockAddress::from(UNKNOWN_SEQUENCER_DA_ADDRESS),
         [0_u8; 32],
     );
 
@@ -60,7 +59,7 @@ fn begin_blob_hook_unknown_sequencer() {
     assert!(result.is_err());
     let expected_message = format!(
         "sender {} is not allowed to submit blobs",
-        Address::from(UNKNOWN_SEQUENCER_DA_ADDRESS)
+        MockAddress::from(UNKNOWN_SEQUENCER_DA_ADDRESS)
     );
     let actual_message = result.err().unwrap().to_string();
     assert_eq!(expected_message, actual_message);
@@ -80,7 +79,7 @@ fn end_blob_hook_success() {
 
     let mut test_blob = MockBlob::new(
         Vec::new(),
-        Address::from(GENESIS_SEQUENCER_DA_ADDRESS),
+        MockAddress::from(GENESIS_SEQUENCER_DA_ADDRESS),
         [0_u8; 32],
     );
 
@@ -89,7 +88,7 @@ fn end_blob_hook_success() {
         .begin_blob_hook(&mut test_blob, working_set)
         .unwrap();
 
-    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob<Address>>>::end_blob_hook(
+    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob<MockAddress>>>::end_blob_hook(
         &test_sequencer.registry,
         SequencerOutcome::Completed,
         working_set,
@@ -118,7 +117,7 @@ fn end_blob_hook_slash() {
 
     let mut test_blob = MockBlob::new(
         Vec::new(),
-        Address::from(GENESIS_SEQUENCER_DA_ADDRESS),
+        MockAddress::from(GENESIS_SEQUENCER_DA_ADDRESS),
         [0_u8; 32],
     );
 
@@ -130,7 +129,7 @@ fn end_blob_hook_slash() {
     let result = SequencerOutcome::Slashed {
         sequencer: GENESIS_SEQUENCER_DA_ADDRESS.to_vec(),
     };
-    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob<Address>>>::end_blob_hook(
+    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob<MockAddress>>>::end_blob_hook(
         &test_sequencer.registry,
         result,
         working_set,
@@ -179,7 +178,7 @@ fn end_blob_hook_slash_preferred_sequencer() {
 
     let mut test_blob = MockBlob::new(
         Vec::new(),
-        Address::from(GENESIS_SEQUENCER_DA_ADDRESS),
+        MockAddress::from(GENESIS_SEQUENCER_DA_ADDRESS),
         [0_u8; 32],
     );
 
@@ -191,7 +190,7 @@ fn end_blob_hook_slash_preferred_sequencer() {
     let result = SequencerOutcome::Slashed {
         sequencer: GENESIS_SEQUENCER_DA_ADDRESS.to_vec(),
     };
-    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob<Address>>>::end_blob_hook(
+    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob<MockAddress>>>::end_blob_hook(
         &test_sequencer.registry,
         result,
         working_set,
@@ -221,7 +220,7 @@ fn end_blob_hook_slash_unknown_sequencer() {
 
     let mut test_blob = MockBlob::new(
         Vec::new(),
-        Address::from(GENESIS_SEQUENCER_DA_ADDRESS),
+        MockAddress::from(GENESIS_SEQUENCER_DA_ADDRESS),
         [0_u8; 32],
     );
 
@@ -239,7 +238,7 @@ fn end_blob_hook_slash_unknown_sequencer() {
     let result = SequencerOutcome::Slashed {
         sequencer: UNKNOWN_SEQUENCER_DA_ADDRESS.to_vec(),
     };
-    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob<Address>>>::end_blob_hook(
+    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob<MockAddress>>>::end_blob_hook(
         &test_sequencer.registry,
         result,
         working_set,


### PR DESCRIPTION
# Description
This PR:
1. updates tests in `sov-sequencer-registry` to use the correct `MockAddress`
needed for #724
2. Adds `native` flag in `dev-dependencies` (so cargo test in the crate root works)

## Linked Issues
- Related to #724

## Testing
Ci Pass.

## Docs
No changes
