### PR TITLE
Allow modules to mint on their own authority

### DIFF
--- a/module-system/module-implementations/sov-attester-incentives/src/call.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/call.rs
@@ -217,7 +217,7 @@ impl<
 
         // Mint tokens and send them
         self.bank
-            .mint(
+            .mint_from_eoa(
                 &coins,
                 context.sender(),
                 &C::new(reward_address),

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -137,7 +137,8 @@ impl<C: sov_modules_api::Context> Bank<C> {
         Ok(CallResponse::default())
     }
 
-    /// Mints the `coins`to the address `mint_to_address` using `context.sender()` as the authorizer.
+    /// Mints the `coins`to the address `mint_to_address` using the externally owned account ("EOA") supplied by 
+    /// `context.sender()` as the authorizer.
     /// Returns an error if the token address doesn't exist or `context.sender()` is not authorized to mint tokens.
     /// Calls the [`Token::mint`] function and update the `self.tokens` set to store the new balance.
     pub fn mint_from_eoa(
@@ -146,7 +147,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
         mint_to_address: &C::Address,
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
-    ) -> Result<CallResponse> {
+    ) -> Result<()> {
         self.mint(coins, mint_to_address, context.sender(), working_set)
     }
 
@@ -159,10 +160,10 @@ impl<C: sov_modules_api::Context> Bank<C> {
         mint_to_address: &C::Address,
         authorizer: &C::Address,
         working_set: &mut WorkingSet<C::Storage>,
-    ) -> Result<CallResponse> {
+    ) -> Result<()> {
         let context_logger = || {
             format!(
-                "Failed mint coins({}) to {} by minter {}",
+                "Failed mint coins({}) to {} by authorizer {}",
                 coins, mint_to_address, authorizer
             )
         };
@@ -175,7 +176,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
             .with_context(context_logger)?;
         self.tokens.set(&coins.token_address, &token, working_set);
 
-        Ok(CallResponse::default())
+        Ok(())
     }
 
     /// Tries to freeze the token address `token_address`.

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -64,7 +64,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
     /// Creates a token from a set of configuration parameters.
     /// Checks if a token already exists at that address. If so return an error.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn create_token(
+    pub fn create_token(
         &self,
         token_name: String,
         salt: u64,
@@ -73,7 +73,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
         authorized_minters: Vec<C::Address>,
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
-    ) -> Result<CallResponse> {
+    ) -> Result<C::Address> {
         let (token_address, token) = Token::<C>::create(
             &token_name,
             &[(minter_address, initial_balance)],
@@ -93,7 +93,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
         }
 
         self.tokens.set(&token_address, &token, working_set);
-        Ok(CallResponse::default())
+        Ok(token_address)
     }
 
     /// Transfers the set of `coins` to the address specified by `to`.
@@ -171,7 +171,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
             .get_or_err(&coins.token_address, working_set)
             .with_context(context_logger)?;
         token
-            .mint_from_eoa(authorizer, mint_to_address, coins.amount, working_set)
+            .mint(authorizer, mint_to_address, coins.amount, working_set)
             .with_context(context_logger)?;
         self.tokens.set(&coins.token_address, &token, working_set);
 

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -137,7 +137,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
         Ok(CallResponse::default())
     }
 
-    /// Mints the `coins`to the address `mint_to_address` using the externally owned account ("EOA") supplied by 
+    /// Mints the `coins`to the address `mint_to_address` using the externally owned account ("EOA") supplied by
     /// `context.sender()` as the authorizer.
     /// Returns an error if the token address doesn't exist or `context.sender()` is not authorized to mint tokens.
     /// Calls the [`Token::mint`] function and update the `self.tokens` set to store the new balance.

--- a/module-system/module-implementations/sov-bank/src/lib.rs
+++ b/module-system/module-implementations/sov-bank/src/lib.rs
@@ -102,7 +102,10 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
             call::CallMessage::Mint {
                 coins,
                 minter_address,
-            } => Ok(self.mint_from_eoa(&coins, &minter_address, context, working_set)?),
+            } => { 
+                self.mint_from_eoa(&coins, &minter_address, context, working_set)?;
+                Ok(CallResponse::default())  
+            },
 
             call::CallMessage::Freeze { token_address } => {
                 Ok(self.freeze(token_address, context, working_set)?)

--- a/module-system/module-implementations/sov-bank/src/lib.rs
+++ b/module-system/module-implementations/sov-bank/src/lib.rs
@@ -102,10 +102,10 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
             call::CallMessage::Mint {
                 coins,
                 minter_address,
-            } => { 
+            } => {
                 self.mint_from_eoa(&coins, &minter_address, context, working_set)?;
-                Ok(CallResponse::default())  
-            },
+                Ok(CallResponse::default())
+            }
 
             call::CallMessage::Freeze { token_address } => {
                 Ok(self.freeze(token_address, context, working_set)?)

--- a/module-system/module-implementations/sov-bank/src/lib.rs
+++ b/module-system/module-implementations/sov-bank/src/lib.rs
@@ -9,7 +9,7 @@ mod utils;
 
 /// Specifies the call methods using in that module.
 pub use call::CallMessage;
-use sov_modules_api::{Error, ModuleInfo};
+use sov_modules_api::{CallResponse, Error, ModuleInfo};
 use sov_state::WorkingSet;
 use token::Token;
 /// Specifies an interfact to interact with tokens.
@@ -80,15 +80,18 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
                 initial_balance,
                 minter_address,
                 authorized_minters,
-            } => Ok(self.create_token(
-                token_name,
-                salt,
-                initial_balance,
-                minter_address,
-                authorized_minters,
-                context,
-                working_set,
-            )?),
+            } => {
+                self.create_token(
+                    token_name,
+                    salt,
+                    initial_balance,
+                    minter_address,
+                    authorized_minters,
+                    context,
+                    working_set,
+                )?;
+                Ok(CallResponse::default())
+            }
 
             call::CallMessage::Transfer { to, coins } => {
                 Ok(self.transfer(to, coins, context, working_set)?)

--- a/module-system/module-implementations/sov-bank/src/lib.rs
+++ b/module-system/module-implementations/sov-bank/src/lib.rs
@@ -99,7 +99,7 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
             call::CallMessage::Mint {
                 coins,
                 minter_address,
-            } => Ok(self.mint(&coins, &minter_address, context, working_set)?),
+            } => Ok(self.mint_from_eoa(&coins, &minter_address, context, working_set)?),
 
             call::CallMessage::Freeze { token_address } => {
                 Ok(self.freeze(token_address, context, working_set)?)

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -168,9 +168,9 @@ impl<C: sov_modules_api::Context> Token<C> {
     /// Checks that the `authorized_minters` set is not empty for the token and that the `sender`
     /// is an `authorized_minter`. If so, update the balances of token for the `mint_to_address` by
     /// adding the minted tokens. Updates the `total_supply` of that token.
-    pub(crate) fn mint_from_eoa(
+    pub(crate) fn mint(
         &mut self,
-        sender: &C::Address,
+        authorizer: &C::Address,
         mint_to_address: &C::Address,
         amount: Amount,
         working_set: &mut WorkingSet<C::Storage>,
@@ -179,7 +179,7 @@ impl<C: sov_modules_api::Context> Token<C> {
             bail!("Attempt to mint frozen token {}", self.name)
         }
 
-        self.is_authorized_minter(sender)?;
+        self.is_authorized_minter(authorizer)?;
         let to_balance: Amount = self
             .balances
             .get(mint_to_address, working_set)

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -164,14 +164,14 @@ impl<C: sov_modules_api::Context> Token<C> {
         Ok(())
     }
 
-    /// Mints a given `amount` of token sent by `sender` to the specified `minter_address`.
+    /// Mints a given `amount` of token sent by `sender` to the specified `mint_to_address`.
     /// Checks that the `authorized_minters` set is not empty for the token and that the `sender`
-    /// is an `authorized_minter`. If so, update the balances of token for the `minter_address` by
+    /// is an `authorized_minter`. If so, update the balances of token for the `mint_to_address` by
     /// adding the minted tokens. Updates the `total_supply` of that token.
-    pub(crate) fn mint(
+    pub(crate) fn mint_from_eoa(
         &mut self,
         sender: &C::Address,
-        minter_address: &C::Address,
+        mint_to_address: &C::Address,
         amount: Amount,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<()> {
@@ -182,14 +182,14 @@ impl<C: sov_modules_api::Context> Token<C> {
         self.is_authorized_minter(sender)?;
         let to_balance: Amount = self
             .balances
-            .get(minter_address, working_set)
+            .get(mint_to_address, working_set)
             .unwrap_or_default()
             .checked_add(amount)
             .ok_or(anyhow::Error::msg(
                 "Account balance overflow in the mint method of bank module",
             ))?;
 
-        self.balances.set(minter_address, &to_balance, working_set);
+        self.balances.set(mint_to_address, &to_balance, working_set);
         self.total_supply = self
             .total_supply
             .checked_add(amount)

--- a/module-system/module-implementations/sov-bank/tests/freeze_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/freeze_test.rs
@@ -147,7 +147,7 @@ fn freeze_token() {
     assert!(chain.next().is_none());
     assert_eq!(
         format!(
-            "Failed mint coins(token_address={} amount={}) to {} by minter {}",
+            "Failed mint coins(token_address={} amount={}) to {} by authorizer {}",
             token_address, mint_amount, new_holder, minter_address
         ),
         message_1

--- a/module-system/module-implementations/sov-bank/tests/mint_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/mint_test.rs
@@ -155,7 +155,7 @@ fn mint_token() {
     assert!(chain.next().is_none());
     assert_eq!(
         format!(
-            "Failed mint coins(token_address={} amount={}) to {} by minter {}",
+            "Failed mint coins(token_address={} amount={}) to {} by authorizer {}",
             token_address, mint_amount, new_holder, minter_address,
         ),
         message_1
@@ -223,7 +223,7 @@ fn mint_token() {
     assert!(chain.next().is_none());
     assert_eq!(
         format!(
-            "Failed mint coins(token_address={} amount={}) to {} by minter {}",
+            "Failed mint coins(token_address={} amount={}) to {} by authorizer {}",
             token_address,
             u64::MAX,
             new_holder,
@@ -262,7 +262,7 @@ fn mint_token() {
     assert!(chain.next().is_none());
     assert_eq!(
         format!(
-            "Failed mint coins(token_address={} amount={}) to {} by minter {}",
+            "Failed mint coins(token_address={} amount={}) to {} by authorizer {}",
             token_address,
             u64::MAX - 1,
             new_holder,

--- a/module-system/module-implementations/sov-bank/tests/mint_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/mint_test.rs
@@ -99,7 +99,7 @@ fn mint_token() {
 
     assert_eq!(
         format!(
-            "Failed mint coins(token_address={} amount={}) to {} by minter {}",
+            "Failed mint coins(token_address={} amount={}) to {} by authorizer {}",
             token_address, mint_amount, new_holder, unauthorized_address
         ),
         message_1


### PR DESCRIPTION
# Description
IBC requires modules to be able to mint tokens on their own authority, rather than using `context.sender()` as the authorizer of the mint. This change enables that functionality. 
