### PR TITLE
 Use MockAddress in demo-rollup benches.

### DIFF
--- a/examples/demo-rollup/benches/rng_xfers.rs
+++ b/examples/demo-rollup/benches/rng_xfers.rs
@@ -1,10 +1,7 @@
 use std::env;
-use std::str::FromStr;
 
 use async_trait::async_trait;
 use borsh::ser::BorshSerialize;
-use celestia::verifier::address::CelestiaAddress;
-use const_rollup_config::SEQUENCER_DA_ADDRESS;
 use demo_stf::runtime::Runtime;
 use sov_bank::{Bank, CallMessage, Coins};
 use sov_modules_api::default_context::DefaultContext;
@@ -13,9 +10,11 @@ use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{Address, AddressBech32, EncodeCall, PrivateKey, PublicKey, Spec};
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::mocks::{
-    MockBlob, MockBlock, MockBlockHeader, MockHash, MockValidityCond,
+    MockAddress, MockBlob, MockBlock, MockBlockHeader, MockHash, MockValidityCond,
 };
 use sov_rollup_interface::services::da::DaService;
+
+pub(crate) const SEQUENCER_DA_ADDRESS: [u8; 32] = [99; 32];
 
 #[derive(Clone)]
 /// A simple DaService for a random number generator.
@@ -95,7 +94,7 @@ pub struct RngDaSpec;
 impl DaSpec for RngDaSpec {
     type SlotHash = MockHash;
     type BlockHeader = MockBlockHeader;
-    type BlobTransaction = MockBlob<CelestiaAddress>;
+    type BlobTransaction = MockBlob<MockAddress>;
     type InclusionMultiProof = [u8; 32];
     type CompletenessProof = ();
     type ChainParams = ();
@@ -149,7 +148,7 @@ impl DaService for RngDaService {
             generate_transfers(num_txns, (block.height - 1) * (num_txns as u64))
         };
 
-        let address = CelestiaAddress::from_str(SEQUENCER_DA_ADDRESS).unwrap();
+        let address = MockAddress::from(SEQUENCER_DA_ADDRESS);
         let blob = MockBlob::new(data, address, [0u8; 32]);
 
         vec![blob]

--- a/examples/demo-rollup/benches/rollup_bench.rs
+++ b/examples/demo-rollup/benches/rollup_bench.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use celestia::verifier::address::CelestiaAddress;
 use criterion::{criterion_group, criterion_main, Criterion};
 use demo_stf::app::App;
 use demo_stf::genesis_config::create_demo_genesis_config;

--- a/examples/demo-rollup/benches/rollup_bench.rs
+++ b/examples/demo-rollup/benches/rollup_bench.rs
@@ -1,22 +1,20 @@
 mod rng_xfers;
 use std::env;
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
 use celestia::verifier::address::CelestiaAddress;
-use const_rollup_config::SEQUENCER_DA_ADDRESS;
 use criterion::{criterion_group, criterion_main, Criterion};
 use demo_stf::app::App;
 use demo_stf::genesis_config::create_demo_genesis_config;
 use risc0_adapter::host::Risc0Verifier;
-use rng_xfers::{RngDaService, RngDaSpec};
+use rng_xfers::{RngDaService, RngDaSpec, SEQUENCER_DA_ADDRESS};
 use sov_db::ledger_db::{LedgerDB, SlotCommit};
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
 use sov_modules_api::PrivateKey;
-use sov_rollup_interface::mocks::{MockBlock, MockBlockHeader, MockHash};
+use sov_rollup_interface::mocks::{MockAddress, MockBlock, MockBlockHeader, MockHash};
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::stf::StateTransitionFunction;
 use sov_stf_runner::{from_toml_path, RollupConfig};
@@ -49,7 +47,7 @@ fn rollup_bench(_bench: &mut Criterion) {
 
     let mut demo = demo_runner.stf;
     let sequencer_private_key = DefaultPrivateKey::generate();
-    let sequencer_da_address = CelestiaAddress::from_str(SEQUENCER_DA_ADDRESS).unwrap();
+    let sequencer_da_address = MockAddress::from(SEQUENCER_DA_ADDRESS);
     let demo_genesis_config = create_demo_genesis_config(
         100000000,
         sequencer_private_key.default_address(),


### PR DESCRIPTION
# Description
This PR updates rollup benchmarks  to use the correct `MockAddress`
needed for #724

## Linked Issues
- Related to #724

## Testing
Ci pass.

## Docs
No changes.
