### PR TITLE
Skip `default` feature checking when running `make check-features`, don't cancel jobs on `nightly`/`stable`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,9 @@ env:
 # Source: <https://stackoverflow.com/a/72408109/5148606>
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Except in `nightly` and `stable` branches! Any cancelled job will cause the
+  # CI run to fail, and we want to keep a clean history for major branches.
+  cancel-in-progress: ${{ (github.ref == 'refs/heads/nightly') || (github.ref == 'refs/heads/stable') }}
 
 jobs:
   check:

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ lint-fix:  ## cargo fmt, fix and clippy
 	cargo fix --allow-dirty
 	cargo clippy --fix --allow-dirty
 
-check-features: ## Checks that project compiles with all combinations of features
-	cargo hack --feature-powerset check
+check-features: ## Checks that project compiles with all combinations of features. default is not needed because we never check `cfg(default)`, we only use it as an alias.
+	cargo hack check --workspace --feature-powerset --exclude-features default
 
 find-unused-deps: ## Prints unused dependencies for project. Note: requires nightly
 	cargo udeps --all-targets --all-features


### PR DESCRIPTION
- Skips the `default` feature in CI. We only ever use `default` as an alias for other features and we never actually do conditional compilation with `#[cfg(feature = "default")]`. We can cut down the `cargo-hack` time significantly by removing it from the set of tested features.
- Don't cancel jobs when a new commit is pushed to `nightly` or `stable`.