### PR TITLE
Update `end_slot_hook`

### DIFF
--- a/examples/demo-stf/src/runtime.rs
+++ b/examples/demo-stf/src/runtime.rs
@@ -119,8 +119,10 @@ impl<C: Context, Cond: ValidityCondition> SlotHooks<Cond> for Runtime<C> {
 
     fn end_slot_hook(
         &self,
-        _working_set: &mut sov_state::WorkingSet<<Self::Context as sov_modules_api::Spec>::Storage>,
+        working_set: &mut sov_state::WorkingSet<<Self::Context as sov_modules_api::Spec>::Storage>,
+        root_hash: [u8; 32],
     ) {
+        // self.evm.end_slot_hook(working_set, root_hash);
     }
 }
 

--- a/examples/demo-stf/src/runtime.rs
+++ b/examples/demo-stf/src/runtime.rs
@@ -122,7 +122,8 @@ impl<C: Context, Cond: ValidityCondition> SlotHooks<Cond> for Runtime<C> {
         root_hash: [u8; 32],
         working_set: &mut sov_state::WorkingSet<<Self::Context as sov_modules_api::Spec>::Storage>,
     ) {
-        // self.evm.end_slot_hook(working_set, root_hash);
+        #[cfg(feature = "experimental")]
+        self.evm.end_slot_hook(root_hash, working_set);
     }
 }
 

--- a/examples/demo-stf/src/runtime.rs
+++ b/examples/demo-stf/src/runtime.rs
@@ -119,8 +119,8 @@ impl<C: Context, Cond: ValidityCondition> SlotHooks<Cond> for Runtime<C> {
 
     fn end_slot_hook(
         &self,
-        working_set: &mut sov_state::WorkingSet<<Self::Context as sov_modules_api::Spec>::Storage>,
         root_hash: [u8; 32],
+        working_set: &mut sov_state::WorkingSet<<Self::Context as sov_modules_api::Spec>::Storage>,
     ) {
         // self.evm.end_slot_hook(working_set, root_hash);
     }

--- a/examples/demo-stf/src/runtime.rs
+++ b/examples/demo-stf/src/runtime.rs
@@ -119,8 +119,10 @@ impl<C: Context, Cond: ValidityCondition> SlotHooks<Cond> for Runtime<C> {
 
     fn end_slot_hook(
         &self,
-        root_hash: [u8; 32],
-        working_set: &mut sov_state::WorkingSet<<Self::Context as sov_modules_api::Spec>::Storage>,
+        #[allow(unused_variables)] root_hash: [u8; 32],
+        #[allow(unused_variables)] working_set: &mut sov_state::WorkingSet<
+            <Self::Context as sov_modules_api::Spec>::Storage,
+        >,
     ) {
         #[cfg(feature = "experimental")]
         self.evm.end_slot_hook(root_hash, working_set);

--- a/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
+++ b/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
@@ -72,7 +72,12 @@ impl<C: Context, Cond: ValidityCondition> SlotHooks<Cond> for TestRuntime<C, Con
         self.chain_state.begin_slot_hook(slot_data, working_set)
     }
 
-    fn end_slot_hook(&self, _working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>) {}
+    fn end_slot_hook(
+        &self,
+        _root_hash: [u8; 32],
+        _working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
+    ) {
+    }
 }
 
 impl<C: Context, Cond: ValidityCondition> BlobSelector for TestRuntime<C, Cond> {

--- a/module-system/module-implementations/sov-chain-state/src/hooks.rs
+++ b/module-system/module-implementations/sov-chain-state/src/hooks.rs
@@ -63,5 +63,10 @@ impl<Ctx: Context, Cond: ValidityCondition> SlotHooks<Cond> for ChainState<Ctx, 
         );
     }
 
-    fn end_slot_hook(&self, _working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>) {}
+    fn end_slot_hook(
+        &self,
+        _root_hash: [u8; 32],
+        _working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
+    ) {
+    }
 }

--- a/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -4,6 +4,6 @@ use crate::Evm;
 
 impl<C: sov_modules_api::Context> Evm<C> {
     pub fn end_slot_hook(&self, _root_hash: [u8; 32], _working_set: &mut WorkingSet<C::Storage>) {
-        //TODO
+        // TODO implement block creation logic.
     }
 }

--- a/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -1,0 +1,9 @@
+use sov_state::WorkingSet;
+
+use crate::Evm;
+
+impl<C: sov_modules_api::Context> Evm<C> {
+    pub fn end_slot_hook(&self, _root_hash: [u8; 32], _working_set: &mut WorkingSet<C::Storage>) {
+        //TODO
+    }
+}

--- a/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/module-system/module-implementations/sov-evm/src/lib.rs
@@ -4,7 +4,7 @@ pub mod call;
 pub mod evm;
 #[cfg(feature = "experimental")]
 pub mod genesis;
-#[cfg(feature = "smart_contracts")]
+#[cfg(feature = "experimental")]
 pub mod hooks;
 #[cfg(feature = "native")]
 #[cfg(feature = "experimental")]

--- a/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/module-system/module-implementations/sov-evm/src/lib.rs
@@ -4,6 +4,8 @@ pub mod call;
 pub mod evm;
 #[cfg(feature = "experimental")]
 pub mod genesis;
+#[cfg(feature = "smart_contracts")]
+pub mod hooks;
 #[cfg(feature = "native")]
 #[cfg(feature = "experimental")]
 pub mod query;

--- a/module-system/sov-modules-api/src/hooks.rs
+++ b/module-system/sov-modules-api/src/hooks.rs
@@ -65,7 +65,7 @@ pub trait SlotHooks<Condition: ValidityCondition> {
 
     fn end_slot_hook(
         &self,
-        working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
         root_hash: [u8; 32],
+        working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     );
 }

--- a/module-system/sov-modules-api/src/hooks.rs
+++ b/module-system/sov-modules-api/src/hooks.rs
@@ -63,5 +63,9 @@ pub trait SlotHooks<Condition: ValidityCondition> {
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     );
 
-    fn end_slot_hook(&self, working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>);
+    fn end_slot_hook(
+        &self,
+        working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
+        root_hash: [u8; 32],
+    );
 }

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -99,7 +99,7 @@ where
             .expect("jellyfish merkle tree update must succeed");
 
         let mut working_set = WorkingSet::new(self.current_storage.clone());
-        self.runtime.end_slot_hook(&mut working_set, root_hash);
+        self.runtime.end_slot_hook(root_hash, &mut working_set);
 
         (jmt::RootHash(root_hash), witness)
     }

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -99,8 +99,7 @@ where
             .expect("jellyfish merkle tree update must succeed");
 
         let mut working_set = WorkingSet::new(self.current_storage.clone());
-
-        self.runtime.end_slot_hook(&mut working_set);
+        self.runtime.end_slot_hook(&mut working_set, root_hash);
 
         (jmt::RootHash(root_hash), witness)
     }


### PR DESCRIPTION
# Description
This PR adds `state_root` to the `end_slot_hook` (which the EVM module requires). We do it as a separate PR because it influences the #615 discussion. 

## Linked Issues
- Related to #737 

## Testing
Ci passes.

## Docs
No update.
