### PR TITLE
Migrate to buildjet

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,15 +62,14 @@ concurrency:
 jobs:
   check:
     name: check
-    runs-on:
-      group: 4-cores_16GB_Ubuntu Group
+    runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
       - name: Install Rust
         run: rustup show
-      - uses: Swatinem/rust-cache@v2
+      - uses: astriaorg/buildjet-rust-cache@v2.5.1
         with:
           shared-key: cargo-check
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
@@ -90,8 +89,7 @@ jobs:
     # building dependencies, only chceking them, so we can share caches
     # effectively.
     needs: check
-    runs-on:
-      group: 4-cores_16GB_Ubuntu Group
+    runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
@@ -100,7 +98,7 @@ jobs:
         run: rustup show
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
-      - uses: Swatinem/rust-cache@v2
+      - uses: astriaorg/buildjet-rust-cache@v2.5.1
         with:
           shared-key: cargo-check
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
@@ -111,8 +109,7 @@ jobs:
       - name: cargo hack
         run: make check-features
   test:
-    runs-on:
-      group: 4-cores_16GB_Ubuntu Group
+    runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
@@ -121,7 +118,7 @@ jobs:
         run: rustup show
       # `cargo-nextest` is much faster than standard `cargo test`.
       - uses: taiki-e/install-action@nextest
-      - uses: Swatinem/rust-cache@v2
+      - uses: astriaorg/buildjet-rust-cache@v2.5.1
         with:
           shared-key: cargo-build
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
@@ -137,14 +134,13 @@ jobs:
     # `test` has already built dependencies, so we can share
     # caches (the profile is `dev` in both cases).
     needs: test
-    runs-on:
-      group: 8-cores_32GB_Ubuntu Group
+    runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
       - name: Install Rust
         run: rustup show
-      - uses: Swatinem/rust-cache@v2
+      - uses: astriaorg/buildjet-rust-cache@v2.5.1
         with:
           shared-key: cargo-build
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
@@ -201,15 +197,14 @@ jobs:
   # profile from the rest of the codebase, so caches can't be shared.
   check-demo-prover:
     name: check demo prover
-    runs-on:
-      group: 4-cores_16GB_Ubuntu Group
+    runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
       - name: Install Rust
         run: rustup show
-      - uses: Swatinem/rust-cache@v2
+      - uses: astriaorg/buildjet-rust-cache@v2.5.1
         with:
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
           workspaces: |
@@ -226,8 +221,7 @@ jobs:
             exit 1
           fi
   coverage:
-    runs-on:
-      group: 8-cores_32GB_Ubuntu Group
+    runs-on: buildjet-8vcpu-ubuntu-2204
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
@@ -240,7 +234,7 @@ jobs:
         run: rustup component add llvm-tools-preview
       - name: cargo install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: Swatinem/rust-cache@v2
+      - uses: astriaorg/buildjet-rust-cache@v2.5.1
         with:
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
           workspaces: |
@@ -276,7 +270,7 @@ jobs:
       - uses: rui314/setup-mold@v1
       - name: Install Rust
         run: rustup show
-      - uses: Swatinem/rust-cache@v2
+      - uses: astriaorg/buildjet-rust-cache@v2.5.1
         with:
           shared-key: cargo-check
           save-if: ${{ github.ref == 'refs/heads/nightly' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,8 +69,9 @@ jobs:
       - uses: rui314/setup-mold@v1
       - name: Install Rust
         run: rustup show
-      - uses: astriaorg/buildjet-rust-cache@v2.5.1
+      - uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: "buildjet"
           shared-key: cargo-check
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
           workspaces: |
@@ -98,8 +99,9 @@ jobs:
         run: rustup show
       - name: cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
-      - uses: astriaorg/buildjet-rust-cache@v2.5.1
+      - uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: "buildjet"
           shared-key: cargo-check
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
           workspaces: |
@@ -118,8 +120,9 @@ jobs:
         run: rustup show
       # `cargo-nextest` is much faster than standard `cargo test`.
       - uses: taiki-e/install-action@nextest
-      - uses: astriaorg/buildjet-rust-cache@v2.5.1
+      - uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: "buildjet"
           shared-key: cargo-build
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
           workspaces: |
@@ -140,8 +143,9 @@ jobs:
       - uses: rui314/setup-mold@v1
       - name: Install Rust
         run: rustup show
-      - uses: astriaorg/buildjet-rust-cache@v2.5.1
+      - uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: "buildjet"
           shared-key: cargo-build
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
           workspaces: |
@@ -204,8 +208,9 @@ jobs:
       - uses: rui314/setup-mold@v1
       - name: Install Rust
         run: rustup show
-      - uses: astriaorg/buildjet-rust-cache@v2.5.1
+      - uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: "buildjet"
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
           workspaces: |
             .
@@ -234,8 +239,9 @@ jobs:
         run: rustup component add llvm-tools-preview
       - name: cargo install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
-      - uses: astriaorg/buildjet-rust-cache@v2.5.1
+      - uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: "buildjet"
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
           workspaces: |
             .
@@ -270,8 +276,9 @@ jobs:
       - uses: rui314/setup-mold@v1
       - name: Install Rust
         run: rustup show
-      - uses: astriaorg/buildjet-rust-cache@v2.5.1
+      - uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: "buildjet"
           shared-key: cargo-check
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
           workspaces: |


### PR DESCRIPTION
# Description
Switch to CI to buildjet, which is cheaper, faster, and allows larger caches

