### PR TITLE
Remove  unnecessary generic from `MockBlob`

### DIFF
--- a/examples/demo-rollup/benches/rng_xfers.rs
+++ b/examples/demo-rollup/benches/rng_xfers.rs
@@ -94,7 +94,7 @@ pub struct RngDaSpec;
 impl DaSpec for RngDaSpec {
     type SlotHash = MockHash;
     type BlockHeader = MockBlockHeader;
-    type BlobTransaction = MockBlob<MockAddress>;
+    type BlobTransaction = MockBlob;
     type InclusionMultiProof = [u8; 32];
     type CompletenessProof = ();
     type ChainParams = ();

--- a/examples/demo-simple-stf/README.md
+++ b/examples/demo-simple-stf/README.md
@@ -170,15 +170,15 @@ fn test_stf() {
     let address = MockAddress { addr: [1; 32] };
     let preimage = vec![0; 32];
 
-    let test_blob = MockBlob::<MockAddress>::new(preimage, address, [0; 32]);
+    let test_blob = MockBlob::new(preimage, address, [0; 32]);
     let stf = &mut CheckHashPreimageStf::<MockValidityCond>::default();
 
     let data = MockBlock::default();
     let mut blobs = [test_blob];
 
-    StateTransitionFunction::<MockZkvm, MockBlob<MockAddress>>::init_chain(stf, ());
+    StateTransitionFunction::<MockZkvm, MockBlob>::init_chain(stf, ());
 
-    let result = StateTransitionFunction::<MockZkvm, MockBlob<MockAddress>>::apply_slot(
+    let result = StateTransitionFunction::<MockZkvm, MockBlob>::apply_slot(
         stf,
         (),
         &data,

--- a/examples/demo-simple-stf/tests/stf_test.rs
+++ b/examples/demo-simple-stf/tests/stf_test.rs
@@ -7,20 +7,16 @@ fn test_stf() {
     let address = MockAddress { addr: [1; 32] };
     let preimage = vec![0; 32];
 
-    let test_blob = MockBlob::<MockAddress>::new(preimage, address, [0; 32]);
+    let test_blob = MockBlob::new(preimage, address, [0; 32]);
     let stf = &mut CheckHashPreimageStf::<MockValidityCond>::default();
 
     let data = MockBlock::default();
     let mut blobs = [test_blob];
 
-    StateTransitionFunction::<MockZkvm, MockBlob<MockAddress>>::init_chain(stf, ());
+    StateTransitionFunction::<MockZkvm, MockBlob>::init_chain(stf, ());
 
-    let result = StateTransitionFunction::<MockZkvm, MockBlob<MockAddress>>::apply_slot(
-        stf,
-        (),
-        &data,
-        &mut blobs,
-    );
+    let result =
+        StateTransitionFunction::<MockZkvm, MockBlob>::apply_slot(stf, (), &data, &mut blobs);
 
     assert_eq!(1, result.batch_receipts.len());
     let receipt = result.batch_receipts[0].clone();

--- a/full-node/db/sov-db/src/ledger_db/rpc.rs
+++ b/full-node/db/sov-db/src/ledger_db/rpc.rs
@@ -438,10 +438,8 @@ mod tests {
         let db = LedgerDB::with_path(path).unwrap();
 
         let mut rx = db.subscribe_slots().unwrap();
-        db.commit_slot(SlotCommit::<_, MockBlob<MockAddress>, Vec<u8>>::new(
-            MockBlock::default(),
-        ))
-        .unwrap();
+        db.commit_slot(SlotCommit::<_, MockBlob, Vec<u8>>::new(MockBlock::default()))
+            .unwrap();
 
         assert_eq!(rx.blocking_recv().unwrap(), 1);
     }

--- a/full-node/db/sov-db/src/ledger_db/rpc.rs
+++ b/full-node/db/sov-db/src/ledger_db/rpc.rs
@@ -427,7 +427,7 @@ impl LedgerDB {
 
 #[cfg(test)]
 mod tests {
-    use sov_rollup_interface::mocks::{MockAddress, MockBlob, MockBlock};
+    use sov_rollup_interface::mocks::{MockBlob, MockBlock};
     use sov_rollup_interface::rpc::LedgerRpcProvider;
 
     use crate::ledger_db::{LedgerDB, SlotCommit};

--- a/module-system/module-implementations/sov-blob-storage/tests/blob_storage_tests.rs
+++ b/module-system/module-implementations/sov-blob-storage/tests/blob_storage_tests.rs
@@ -5,7 +5,7 @@ use sov_rollup_interface::mocks::{MockAddress, MockBlob};
 use sov_state::{ProverStorage, WorkingSet};
 
 type C = DefaultContext;
-type B = MockBlob<MockAddress>;
+type B = MockBlob;
 
 #[test]
 fn empty_test() {
@@ -51,11 +51,11 @@ fn store_and_retrieve_standard() {
     let blob_5 = B::new(vec![0, 1, 0], sender, dummy_hash);
 
     let slot_2_blobs = vec![blob_1, blob_2, blob_3];
-    let slot_2_blob_refs: Vec<&MockBlob<MockAddress>> = slot_2_blobs.iter().collect();
+    let slot_2_blob_refs: Vec<&MockBlob> = slot_2_blobs.iter().collect();
     let slot_3_blobs = vec![blob_4];
-    let slot_3_blob_refs: Vec<&MockBlob<MockAddress>> = slot_3_blobs.iter().collect();
+    let slot_3_blob_refs: Vec<&MockBlob> = slot_3_blobs.iter().collect();
     let slot_4_blobs = vec![blob_5];
-    let slot_4_blob_refs: Vec<&MockBlob<MockAddress>> = slot_4_blobs.iter().collect();
+    let slot_4_blob_refs: Vec<&MockBlob> = slot_4_blobs.iter().collect();
 
     blob_storage
         .store_blobs(2, &slot_2_blob_refs, &mut working_set)

--- a/module-system/module-implementations/sov-blob-storage/tests/capability_tests.rs
+++ b/module-system/module-implementations/sov-blob-storage/tests/capability_tests.rs
@@ -12,7 +12,7 @@ use sov_sequencer_registry::{SequencerConfig, SequencerRegistry};
 use sov_state::{ProverStorage, WorkingSet};
 
 type C = DefaultContext;
-type B = MockBlob<MockAddress>;
+type B = MockBlob;
 
 const PREFERRED_SEQUENCER_KEY: &str = "preferred";
 const REGULAR_SEQUENCER_KEY: &str = "regular";

--- a/module-system/module-implementations/sov-sequencer-registry/tests/hooks_test.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/tests/hooks_test.rs
@@ -88,7 +88,7 @@ fn end_blob_hook_success() {
         .begin_blob_hook(&mut test_blob, working_set)
         .unwrap();
 
-    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob<MockAddress>>>::end_blob_hook(
+    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob>>::end_blob_hook(
         &test_sequencer.registry,
         SequencerOutcome::Completed,
         working_set,
@@ -129,7 +129,7 @@ fn end_blob_hook_slash() {
     let result = SequencerOutcome::Slashed {
         sequencer: GENESIS_SEQUENCER_DA_ADDRESS.to_vec(),
     };
-    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob<MockAddress>>>::end_blob_hook(
+    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob>>::end_blob_hook(
         &test_sequencer.registry,
         result,
         working_set,
@@ -190,7 +190,7 @@ fn end_blob_hook_slash_preferred_sequencer() {
     let result = SequencerOutcome::Slashed {
         sequencer: GENESIS_SEQUENCER_DA_ADDRESS.to_vec(),
     };
-    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob<MockAddress>>>::end_blob_hook(
+    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob>>::end_blob_hook(
         &test_sequencer.registry,
         result,
         working_set,
@@ -238,7 +238,7 @@ fn end_blob_hook_slash_unknown_sequencer() {
     let result = SequencerOutcome::Slashed {
         sequencer: UNKNOWN_SEQUENCER_DA_ADDRESS.to_vec(),
     };
-    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob<MockAddress>>>::end_blob_hook(
+    <SequencerRegistry<C> as ApplyBlobHooks<MockBlob>>::end_blob_hook(
         &test_sequencer.registry,
         result,
         working_set,

--- a/rollup-interface/src/state_machine/mocks/da.rs
+++ b/rollup-interface/src/state_machine/mocks/da.rs
@@ -14,7 +14,17 @@ use crate::{BasicAddress, RollupAddress};
 
 /// A mock address type used for testing. Internally, this type is standard 32 byte array.
 #[derive(
-    Debug, PartialEq, Clone, Eq, Copy, serde::Serialize, serde::Deserialize, Hash, Default,
+    Debug,
+    PartialEq,
+    Clone,
+    Eq,
+    Copy,
+    serde::Serialize,
+    serde::Deserialize,
+    Hash,
+    Default,
+    borsh::BorshDeserialize,
+    borsh::BorshSerialize,
 )]
 pub struct MockAddress {
     /// Underlying mock address.
@@ -81,15 +91,15 @@ impl RollupAddress for MockAddress {}
 )]
 
 /// A mock BlobTransaction from a DA layer used for testing.
-pub struct MockBlob<A> {
-    address: A,
+pub struct MockBlob {
+    address: MockAddress,
     hash: [u8; 32],
     data: CountedBufReader<Bytes>,
 }
 
-impl<A: BasicAddress> BlobReaderTrait for MockBlob<A> {
+impl BlobReaderTrait for MockBlob {
     type Data = Bytes;
-    type Address = A;
+    type Address = MockAddress;
 
     fn sender(&self) -> Self::Address {
         self.address.clone()
@@ -108,9 +118,9 @@ impl<A: BasicAddress> BlobReaderTrait for MockBlob<A> {
     }
 }
 
-impl<A: BasicAddress> MockBlob<A> {
+impl MockBlob {
     /// Creates a new mock blob with the given data, claiming to have been published by the provided address.
-    pub fn new(data: Vec<u8>, address: A, hash: [u8; 32]) -> Self {
+    pub fn new(data: Vec<u8>, address: MockAddress, hash: [u8; 32]) -> Self {
         Self {
             address,
             data: CountedBufReader::new(bytes::Bytes::from(data)),
@@ -162,7 +172,7 @@ pub struct MockBlock {
     /// Validity condition
     pub validity_cond: MockValidityCond,
     /// Blobs
-    pub blobs: Vec<MockBlob<MockAddress>>,
+    pub blobs: Vec<MockBlob>,
 }
 
 impl Default for MockBlock {
@@ -202,7 +212,7 @@ pub struct MockDaSpec;
 impl DaSpec for MockDaSpec {
     type SlotHash = MockHash;
     type BlockHeader = MockBlockHeader;
-    type BlobTransaction = MockBlob<MockAddress>;
+    type BlobTransaction = MockBlob;
     type ValidityCondition = MockValidityCond;
     type InclusionMultiProof = [u8; 32];
     type CompletenessProof = ();
@@ -243,7 +253,7 @@ impl DaService for MockDaService {
         let data = data.unwrap();
         let hash = [0; 32];
 
-        let blob = MockBlob::<MockAddress>::new(data, self.sequencer_da_address, hash);
+        let blob = MockBlob::new(data, self.sequencer_da_address, hash);
 
         Ok(MockBlock {
             blobs: vec![blob],

--- a/rollup-interface/src/state_machine/mocks/da.rs
+++ b/rollup-interface/src/state_machine/mocks/da.rs
@@ -102,7 +102,7 @@ impl BlobReaderTrait for MockBlob {
     type Address = MockAddress;
 
     fn sender(&self) -> Self::Address {
-        self.address.clone()
+        self.address
     }
 
     fn data_mut(&mut self) -> &mut CountedBufReader<Self::Data> {


### PR DESCRIPTION
# Description
This PR sets the address in `MockBlob`  to `MockAddress` see #724. 

## Linked Issues
- Fixes #724
- Fixes #189

## Testing
Relevant tests updated.

## Docs
Relevant docs updated.
