### PR TITLE
Fix job cancellation in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,7 +59,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   # Except in `nightly` and `stable` branches! Any cancelled job will cause the
   # CI run to fail, and we want to keep a clean history for major branches.
-  cancel-in-progress: ${{ (github.ref == 'refs/heads/nightly') || (github.ref == 'refs/heads/stable') }}
+  cancel-in-progress: ${{ (github.ref != 'refs/heads/nightly') && (github.ref != 'refs/heads/stable') }}
 
 jobs:
   check:


### PR DESCRIPTION
Fixes the job cancellation in CI introduced in https://github.com/Sovereign-Labs/sovereign-sdk/pull/741: instead of cancelling jobs *only* on `nightly` and `stable`, we want to cancel jobs in all branches but those. Opsie, my bad 😄 
