### PR TITLE
Allow modules to burn coins

### DIFF
--- a/module-system/module-implementations/sov-bank/src/lib.rs
+++ b/module-system/module-implementations/sov-bank/src/lib.rs
@@ -97,7 +97,9 @@ impl<C: sov_modules_api::Context> sov_modules_api::Module for Bank<C> {
                 Ok(self.transfer(to, coins, context, working_set)?)
             }
 
-            call::CallMessage::Burn { coins } => Ok(self.burn(coins, context, working_set)?),
+            call::CallMessage::Burn { coins } => {
+                Ok(self.burn_from_eoa(coins, context, working_set)?)
+            }
 
             call::CallMessage::Mint {
                 coins,

--- a/module-system/module-implementations/sov-bank/tests/burn_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/burn_test.rs
@@ -88,7 +88,7 @@ fn burn_deployed_tokens() {
     assert!(chain.next().is_none());
     assert_eq!(
         format!(
-            "Failed burn coins(token_address={} amount={}) by sender {}",
+            "Failed to burn coins(token_address={} amount={}) from owner {}",
             token_address, burn_amount, sender_address
         ),
         message_1
@@ -137,7 +137,7 @@ fn burn_deployed_tokens() {
     assert!(chain.next().is_none());
     assert_eq!(
         format!(
-            "Failed burn coins(token_address={} amount={}) by sender {}",
+            "Failed to burn coins(token_address={} amount={}) from owner {}",
             token_address,
             initial_balance + 10,
             minter_address
@@ -168,7 +168,7 @@ fn burn_deployed_tokens() {
     assert!(chain.next().is_none());
     assert_eq!(
         format!(
-            "Failed burn coins(token_address={} amount={}) by sender {}",
+            "Failed to burn coins(token_address={} amount={}) from owner {}",
             token_address, 1, minter_address
         ),
         message_1


### PR DESCRIPTION
# Description
For IBC, the token bridge needs to be able to burn coins. This PR implements functionality to allow modules to burn tokens from user accounts.
