### PR TITLE
Move `BlobReader` bound from to trait in `BlobSelector`

### DIFF
--- a/examples/demo-stf/src/runtime.rs
+++ b/examples/demo-stf/src/runtime.rs
@@ -132,16 +132,15 @@ where
 {
 }
 
-impl<C: Context> BlobSelector for Runtime<C> {
+impl<C: Context, B: BlobReaderTrait> BlobSelector<B> for Runtime<C> {
     type Context = C;
 
-    fn get_blobs_for_this_slot<'a, I, B>(
+    fn get_blobs_for_this_slot<'a, I>(
         &self,
         current_blobs: I,
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     ) -> anyhow::Result<Vec<BlobRefOrOwned<'a, B>>>
     where
-        B: BlobReaderTrait,
         I: IntoIterator<Item = &'a mut B>,
     {
         self.blob_storage

--- a/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
+++ b/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
@@ -80,16 +80,20 @@ impl<C: Context, Cond: ValidityCondition> SlotHooks<Cond> for TestRuntime<C, Con
     }
 }
 
-impl<C: Context, Cond: ValidityCondition> BlobSelector for TestRuntime<C, Cond> {
+impl<C, Cond, B> BlobSelector<B> for TestRuntime<C, Cond>
+where
+    C: Context,
+    Cond: ValidityCondition,
+    B: BlobReaderTrait,
+{
     type Context = C;
 
-    fn get_blobs_for_this_slot<'a, I, B>(
+    fn get_blobs_for_this_slot<'a, I>(
         &self,
         current_blobs: I,
         _working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     ) -> anyhow::Result<Vec<BlobRefOrOwned<'a, B>>>
     where
-        B: BlobReaderTrait,
         I: IntoIterator<Item = &'a mut B>,
     {
         Ok(current_blobs.into_iter().map(Into::into).collect())

--- a/module-system/module-implementations/sov-blob-storage/src/capabilities.rs
+++ b/module-system/module-implementations/sov-blob-storage/src/capabilities.rs
@@ -6,16 +6,15 @@ use tracing::info;
 
 use crate::BlobStorage;
 
-impl<C: Context> BlobSelector for BlobStorage<C> {
+impl<C: Context, B: BlobReaderTrait> BlobSelector<B> for BlobStorage<C> {
     type Context = C;
 
-    fn get_blobs_for_this_slot<'a, I, B>(
+    fn get_blobs_for_this_slot<'a, I>(
         &self,
         current_blobs: I,
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     ) -> anyhow::Result<Vec<BlobRefOrOwned<'a, B>>>
     where
-        B: BlobReaderTrait,
         I: IntoIterator<Item = &'a mut B>,
     {
         // TODO: Chain-state module: https://github.com/Sovereign-Labs/sovereign-sdk/pull/598/

--- a/module-system/sov-modules-api/src/capabilities.rs
+++ b/module-system/sov-modules-api/src/capabilities.rs
@@ -43,7 +43,7 @@ impl<'a, B: BlobReaderTrait> From<&'a mut B> for BlobRefOrOwned<'a, B> {
 }
 
 /// BlobSelector decides which blobs to process in a current slot.
-pub trait BlobSelector {
+pub trait BlobSelector<B: BlobReaderTrait> {
     /// Context type
     type Context: Context;
 
@@ -51,12 +51,11 @@ pub trait BlobSelector {
     /// 1. `current_blobs` - blobs that were received from the network for the current slot.
     /// 2. `working_set` - the working to access storage.
     /// It returns a vector containing a mix of borrowed and owned blobs.
-    fn get_blobs_for_this_slot<'a, I, B>(
+    fn get_blobs_for_this_slot<'a, I>(
         &self,
         current_blobs: I,
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     ) -> anyhow::Result<Vec<BlobRefOrOwned<'a, B>>>
     where
-        B: BlobReaderTrait,
         I: IntoIterator<Item = &'a mut B>;
 }

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -27,7 +27,7 @@ pub trait Runtime<C: Context, Cond: ValidityCondition, B: BlobReaderTrait>:
     + TxHooks<Context = C>
     + SlotHooks<Cond, Context = C>
     + ApplyBlobHooks<B, Context = C, BlobResult = SequencerOutcome<B::Address>>
-    + BlobSelector<Context = C>
+    + BlobSelector<B, Context = C>
 {
 }
 


### PR DESCRIPTION
# Description

So It will simplify integration with `DaSpec` bound from Runtime.

This is preparation for chain_state module integration
