### PR TITLE
Add doc generation to the `genesis` macro.

### DIFF
--- a/module-system/sov-modules-macros/src/dispatch/genesis.rs
+++ b/module-system/sov-modules-macros/src/dispatch/genesis.rs
@@ -103,7 +103,7 @@ impl GenesisMacro {
         quote::quote! {
             #[doc = "Initial configuration for the rollup."]
             pub struct GenesisConfig #impl_generics #where_clause{
-                #(#[doc = "Module configuration"] #fields)*
+                #(#[doc = "Module configuration"] pub #fields)*
             }
 
             impl #impl_generics GenesisConfig #type_generics #where_clause {

--- a/module-system/sov-modules-macros/src/dispatch/genesis.rs
+++ b/module-system/sov-modules-macros/src/dispatch/genesis.rs
@@ -41,7 +41,6 @@ impl GenesisMacro {
                 type Context = #generic_param;
                 type Config = GenesisConfig #type_generics;
 
-                
                 fn genesis(&self, config: &Self::Config, working_set: &mut sov_state::WorkingSet<<<Self as sov_modules_api::Genesis>::Context as sov_modules_api::Spec>::Storage>) -> core::result::Result<(), sov_modules_api::Error> {
                     #genesis_fn_body
                     Ok(())

--- a/module-system/sov-modules-macros/src/dispatch/genesis.rs
+++ b/module-system/sov-modules-macros/src/dispatch/genesis.rs
@@ -41,6 +41,7 @@ impl GenesisMacro {
                 type Context = #generic_param;
                 type Config = GenesisConfig #type_generics;
 
+                
                 fn genesis(&self, config: &Self::Config, working_set: &mut sov_state::WorkingSet<<<Self as sov_modules_api::Genesis>::Context as sov_modules_api::Spec>::Storage>) -> core::result::Result<(), sov_modules_api::Error> {
                     #genesis_fn_body
                     Ok(())
@@ -102,10 +103,11 @@ impl GenesisMacro {
         quote::quote! {
             #[doc = "Initial configuration for the rollup."]
             pub struct GenesisConfig #impl_generics #where_clause{
-                #(pub #fields)*
+                #(#[doc = "Module configuration"] #fields)*
             }
 
             impl #impl_generics GenesisConfig #type_generics #where_clause {
+                #[doc = "GenesisConfig constructor."]
                 pub fn new(#(#fields)*) -> Self {
                     Self {
                         #(#field_names),*


### PR DESCRIPTION
# Description
This PR adds doc generation to the `genesis` macro.

## Linked Issues
- Related #438

## Testing
Tested with cargo expand.

## Docs
Generates missing docs
