### PR TITLE
Add docs to `DispatchCall` macro

### DIFF
--- a/module-system/sov-modules-macros/src/dispatch/dispatch_call.rs
+++ b/module-system/sov-modules-macros/src/dispatch/dispatch_call.rs
@@ -14,6 +14,7 @@ impl<'a> StructDef<'a> {
                 let ty = &field.ty;
 
                 quote::quote!(
+                    #[doc = "Module call message."]
                     #name(<#ty as sov_modules_api::Module>::CallMessage),
                 )
             })


### PR DESCRIPTION
# Description
This PR adds doc generation to the `DispatchCall` macro.

## Linked Issues
- Related #438

## Testing
Tested with cargo expand.

## Docs
Generates missing docs
