### PR TITLE
Refactor Generics to use Specs

### DIFF
--- a/adapters/celestia/src/verifier/mod.rs
+++ b/adapters/celestia/src/verifier/mod.rs
@@ -86,6 +86,7 @@ impl AsRef<TmHash> for tendermint::Hash {
 
 impl BlockHash for TmHash {}
 
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct CelestiaSpec;
 
 impl DaSpec for CelestiaSpec {

--- a/examples/demo-rollup/benches/rng_xfers.rs
+++ b/examples/demo-rollup/benches/rng_xfers.rs
@@ -92,6 +92,7 @@ impl Default for RngDaService {
 }
 
 /// A simple DaSpec for a random number generator.
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct RngDaSpec;
 
 impl DaSpec for RngDaSpec {

--- a/examples/demo-rollup/src/register_rpc.rs
+++ b/examples/demo-rollup/src/register_rpc.rs
@@ -42,8 +42,8 @@ pub fn register_ledger(
 
 #[cfg(feature = "experimental")]
 /// register ethereum methods.
-pub fn register_ethereum<DA: DaService>(
-    da_service: DA,
+pub fn register_ethereum<Da: DaService>(
+    da_service: Da,
     eth_rpc_config: EthRpcConfig,
     methods: &mut jsonrpsee::RpcModule<()>,
 ) -> Result<(), anyhow::Error> {

--- a/examples/demo-stf/src/cli.rs
+++ b/examples/demo-stf/src/cli.rs
@@ -35,7 +35,8 @@ pub struct App<Da: DaSpec> {
     workflow: Workflows<Da>,
 }
 
-pub async fn run<Da: DaSpec>() -> Result<(), anyhow::Error> {
+pub async fn run<Da: DaSpec + serde::Serialize + serde::de::DeserializeOwned>(
+) -> Result<(), anyhow::Error> {
     let app_dir = wallet_dir()?;
     std::fs::create_dir_all(app_dir.as_ref())?;
     let wallet_state_path = app_dir.as_ref().join("wallet_state.json");

--- a/examples/demo-stf/src/runtime.rs
+++ b/examples/demo-stf/src/runtime.rs
@@ -136,7 +136,7 @@ where
 {
 }
 
-impl<C: Context, Da: DaSpec> BlobSelector<Da::BlobTransaction> for Runtime<C, Da> {
+impl<C: Context, Da: DaSpec> BlobSelector<Da> for Runtime<C, Da> {
     type Context = C;
 
     fn get_blobs_for_this_slot<'a, I>(
@@ -147,7 +147,10 @@ impl<C: Context, Da: DaSpec> BlobSelector<Da::BlobTransaction> for Runtime<C, Da
     where
         I: IntoIterator<Item = &'a mut Da::BlobTransaction>,
     {
-        self.blob_storage
-            .get_blobs_for_this_slot(current_blobs, working_set)
+        <sov_blob_storage::BlobStorage<C> as BlobSelector<Da>>::get_blobs_for_this_slot(
+            &self.blob_storage,
+            current_blobs,
+            working_set,
+        )
     }
 }

--- a/examples/demo-stf/src/runtime.rs
+++ b/examples/demo-stf/src/runtime.rs
@@ -20,7 +20,6 @@ use sov_modules_api::{Context, DispatchCall, Genesis, MessageCodec, Spec};
 use sov_rollup_interface::da::DaSpec;
 #[cfg(feature = "native")]
 use sov_sequencer_registry::{SequencerRegistryRpcImpl, SequencerRegistryRpcServer};
-use sov_state::WorkingSet;
 #[cfg(feature = "native")]
 use sov_value_setter::query::{ValueSetterRpcImpl, ValueSetterRpcServer};
 
@@ -82,7 +81,7 @@ pub struct Runtime<C: Context, Da: DaSpec> {
     #[cfg_attr(feature = "native", cli_skip)]
     pub blob_storage: sov_blob_storage::BlobStorage<C>,
     #[cfg_attr(feature = "native", cli_skip)]
-    pub chain_state: sov_chain_state::ChainState<C, Da::ValidityCondition>,
+    pub chain_state: sov_chain_state::ChainState<C, Da>,
     pub value_setter: sov_value_setter::ValueSetter<C>,
     pub accounts: sov_accounts::Accounts<C>,
 }
@@ -101,20 +100,20 @@ pub struct Runtime<C: Context, Da: DaSpec> {
     #[cfg_attr(feature = "native", cli_skip)]
     pub blob_storage: sov_blob_storage::BlobStorage<C>,
     #[cfg_attr(feature = "native", cli_skip)]
-    pub chain_state: sov_chain_state::ChainState<C, Da::ValidityCondition>,
+    pub chain_state: sov_chain_state::ChainState<C, Da>,
     pub value_setter: sov_value_setter::ValueSetter<C>,
     pub accounts: sov_accounts::Accounts<C>,
     #[cfg_attr(feature = "native", cli_skip)]
     pub evm: sov_evm::Evm<C>,
 }
 
-impl<C: Context, Da: DaSpec> SlotHooks<Da::ValidityCondition> for Runtime<C, Da> {
+impl<C: Context, Da: DaSpec> SlotHooks<Da> for Runtime<C, Da> {
     type Context = C;
 
     fn begin_slot_hook(
         &self,
         _slot_data: &impl sov_rollup_interface::services::da::SlotData,
-        _working_set: &mut sov_state::WorkingSet<<Self::Context as sov_modules_api::Spec>::Storage>,
+        _working_set: &mut sov_state::WorkingSet<<Self::Context as Spec>::Storage>,
     ) {
     }
 
@@ -122,7 +121,7 @@ impl<C: Context, Da: DaSpec> SlotHooks<Da::ValidityCondition> for Runtime<C, Da>
         &self,
         #[allow(unused_variables)] root_hash: [u8; 32],
         #[allow(unused_variables)] working_set: &mut sov_state::WorkingSet<
-            <Self::Context as sov_modules_api::Spec>::Storage,
+            <Self::Context as Spec>::Storage,
         >,
     ) {
         #[cfg(feature = "experimental")]
@@ -130,8 +129,7 @@ impl<C: Context, Da: DaSpec> SlotHooks<Da::ValidityCondition> for Runtime<C, Da>
     }
 }
 
-impl<C, Da> sov_modules_stf_template::Runtime<C, Da::ValidityCondition, Da::BlobTransaction>
-    for Runtime<C, Da>
+impl<C, Da> sov_modules_stf_template::Runtime<C, Da> for Runtime<C, Da>
 where
     C: Context,
     Da: DaSpec,
@@ -144,7 +142,7 @@ impl<C: Context, Da: DaSpec> BlobSelector<Da::BlobTransaction> for Runtime<C, Da
     fn get_blobs_for_this_slot<'a, I>(
         &self,
         current_blobs: I,
-        working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
+        working_set: &mut sov_state::WorkingSet<<Self::Context as Spec>::Storage>,
     ) -> anyhow::Result<Vec<BlobRefOrOwned<'a, Da::BlobTransaction>>>
     where
         I: IntoIterator<Item = &'a mut Da::BlobTransaction>,

--- a/full-node/sov-ethereum/src/lib.rs
+++ b/full-node/sov-ethereum/src/lib.rs
@@ -32,10 +32,10 @@ pub mod experimental {
         pub tx_signer_priv_key: DefaultPrivateKey,
     }
 
-    pub fn get_ethereum_rpc<DA: DaService>(
-        da_service: DA,
+    pub fn get_ethereum_rpc<Da: DaService>(
+        da_service: Da,
         eth_rpc_config: EthRpcConfig,
-    ) -> RpcModule<Ethereum<DA>> {
+    ) -> RpcModule<Ethereum<Da>> {
         let mut rpc = RpcModule::new(Ethereum::new(
             Default::default(),
             da_service,
@@ -47,17 +47,17 @@ pub mod experimental {
         rpc
     }
 
-    pub struct Ethereum<DA: DaService> {
+    pub struct Ethereum<Da: DaService> {
         nonces: Mutex<HashMap<EthAddress, u64>>,
-        da_service: DA,
+        da_service: Da,
         batch_builder: Arc<Mutex<EthBatchBuilder>>,
         eth_rpc_config: EthRpcConfig,
     }
 
-    impl<DA: DaService> Ethereum<DA> {
+    impl<Da: DaService> Ethereum<Da> {
         fn new(
             nonces: Mutex<HashMap<EthAddress, u64>>,
-            da_service: DA,
+            da_service: Da,
             batch_builder: Arc<Mutex<EthBatchBuilder>>,
             eth_rpc_config: EthRpcConfig,
         ) -> Self {
@@ -116,8 +116,8 @@ pub mod experimental {
         }
     }
 
-    fn register_rpc_methods<DA: DaService>(
-        rpc: &mut RpcModule<Ethereum<DA>>,
+    fn register_rpc_methods<Da: DaService>(
+        rpc: &mut RpcModule<Ethereum<Da>>,
     ) -> Result<(), jsonrpsee::core::Error> {
         rpc.register_async_method("eth_publishBatch", |params, ethereum| async move {
             let mut params_iter = params.sequence();

--- a/full-node/sov-stf-runner/src/lib.rs
+++ b/full-node/sov-stf-runner/src/lib.rs
@@ -30,42 +30,42 @@ type InitialState<ST, Vm, DA> = <ST as StateTransitionFunction<
 >>::InitialState;
 
 /// Combines `DaService` with `StateTransitionFunction` and "runs" the rollup.
-pub struct StateTransitionRunner<ST, DA, Vm>
+pub struct StateTransitionRunner<ST, Da, Vm>
 where
-    DA: DaService,
+    Da: DaService,
     Vm: Zkvm,
     ST: StateTransitionFunction<
         Vm,
-        <<DA as DaService>::Spec as DaSpec>::BlobTransaction,
-        Condition = <DA::Spec as DaSpec>::ValidityCondition,
+        <<Da as DaService>::Spec as DaSpec>::BlobTransaction,
+        Condition = <Da::Spec as DaSpec>::ValidityCondition,
     >,
 {
     start_height: u64,
-    da_service: DA,
+    da_service: Da,
     app: ST,
     ledger_db: LedgerDB,
-    state_root: StateRoot<ST, Vm, DA>,
+    state_root: StateRoot<ST, Vm, Da>,
     listen_address: SocketAddr,
 }
 
-impl<ST, DA, Vm> StateTransitionRunner<ST, DA, Vm>
+impl<ST, Da, Vm> StateTransitionRunner<ST, Da, Vm>
 where
-    DA: DaService<Error = anyhow::Error> + Clone + Send + Sync + 'static,
+    Da: DaService<Error = anyhow::Error> + Clone + Send + Sync + 'static,
     Vm: Zkvm,
     ST: StateTransitionFunction<
         Vm,
-        <<DA as DaService>::Spec as DaSpec>::BlobTransaction,
-        Condition = <DA::Spec as DaSpec>::ValidityCondition,
+        <<Da as DaService>::Spec as DaSpec>::BlobTransaction,
+        Condition = <Da::Spec as DaSpec>::ValidityCondition,
     >,
 {
     /// Creates a new `StateTransitionRunner` runner.
     pub fn new(
         runner_config: RunnerConfig,
-        da_service: DA,
+        da_service: Da,
         ledger_db: LedgerDB,
         mut app: ST,
         should_init_chain: bool,
-        genesis_config: InitialState<ST, Vm, DA>,
+        genesis_config: InitialState<ST, Vm, Da>,
     ) -> Result<Self, anyhow::Error> {
         let rpc_config = runner_config.rpc_config;
 

--- a/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
+++ b/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
@@ -77,7 +77,7 @@ impl<C: Context, Da: DaSpec> SlotHooks<Da> for TestRuntime<C, Da> {
     }
 }
 
-impl<C, Da> BlobSelector<Da::BlobTransaction> for TestRuntime<C, Da>
+impl<C, Da> BlobSelector<Da> for TestRuntime<C, Da>
 where
     C: Context,
     Da: DaSpec,

--- a/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
+++ b/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
@@ -116,8 +116,8 @@ pub(crate) fn create_demo_genesis_config<C: Context, Cond: ValidityCondition>(
 }
 
 /// Clones the [`AppTemplate`]'s [`Storage`] and extract the underlying [`WorkingSet`]
-pub(crate) fn get_working_set<C: Context, DA: DaSpec>(
-    app_template: &AppTemplate<C, DA, MockZkvm, TestRuntime<C, DA::ValidityCondition>>,
+pub(crate) fn get_working_set<C: Context, Da: DaSpec>(
+    app_template: &AppTemplate<C, Da, MockZkvm, TestRuntime<C, Da::ValidityCondition>>,
 ) -> WorkingSet<<C as Spec>::Storage> {
     WorkingSet::new(app_template.current_storage.clone())
 }

--- a/module-system/module-implementations/integration-tests/src/chain_state/tests.rs
+++ b/module-system/module-implementations/integration-tests/src/chain_state/tests.rs
@@ -27,12 +27,10 @@ fn test_simple_value_setter_with_chain_state() {
         ProverStorage::with_path(tmpdir.path()).unwrap();
 
     let mut app_template =
-        AppTemplate::<C, MockDaSpec, MockZkvm, TestRuntime<C, MockValidityCond>>::new(
-            storage, runtime,
-        );
+        AppTemplate::<C, MockDaSpec, MockZkvm, TestRuntime<C, MockDaSpec>>::new(storage, runtime);
 
     let value_setter_messages = ValueSetterMessages::default();
-    let value_setter = value_setter_messages.create_raw_txs::<TestRuntime<C, MockValidityCond>>();
+    let value_setter = value_setter_messages.create_raw_txs::<TestRuntime<C, MockDaSpec>>();
 
     let admin_pub_key = value_setter_messages.messages[0].admin.default_address();
 

--- a/module-system/module-implementations/sov-attester-incentives/src/call.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/call.rs
@@ -25,7 +25,7 @@ pub enum CallMessage<C: sov_modules_api::Context> {
     EndUnbondingAttester,
     /// Bonds a challenger, the parameter is the bond amount
     BondChallenger(Amount),
-    /// Unbinds a challenger
+    /// Unbonds a challenger
     UnbondChallenger,
     /// Processes an attestation.
     ProcessAttestation(Attestation<StorageProof<<<C as Spec>::Storage as Storage>::Proof>>),

--- a/module-system/module-implementations/sov-attester-incentives/src/call.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/call.rs
@@ -1,15 +1,13 @@
 use core::result::Result::Ok;
 use std::fmt::Debug;
 
-use anyhow::Result;
 use borsh::{BorshDeserialize, BorshSerialize};
 use sov_bank::{Amount, Coins};
 use sov_chain_state::TransitionHeight;
-use sov_modules_api::{CallResponse, Context, Spec};
+use sov_modules_api::{CallResponse, Spec};
+use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::optimistic::Attestation;
-use sov_rollup_interface::zk::{
-    StateTransition, ValidityCondition, ValidityConditionChecker, Zkvm,
-};
+use sov_rollup_interface::zk::{StateTransition, ValidityConditionChecker, Zkvm};
 use sov_state::storage::StorageProof;
 use sov_state::{Storage, WorkingSet};
 use thiserror::Error;
@@ -18,35 +16,32 @@ use crate::{AttesterIncentives, UnbondingInfo};
 
 /// This enumeration represents the available call messages for interacting with the `AttesterIncentives` module.
 #[derive(BorshDeserialize, BorshSerialize, Debug)]
-pub enum CallMessage<C>
-where
-    C: Context,
-{
+pub enum CallMessage<C: sov_modules_api::Context> {
     /// Bonds an attester, the parameter is the bond amount
     BondAttester(Amount),
-    /// Start the first phase of the two phase unbonding process
+    /// Start the first phase of the two-phase unbonding process
     BeginUnbondingAttester,
     /// Finish the two phase unbonding
     EndUnbondingAttester,
     /// Bonds a challenger, the parameter is the bond amount
     BondChallenger(Amount),
-    /// Unbonds a challenger
+    /// Unbinds a challenger
     UnbondChallenger,
-    /// Proccesses an attestation.
+    /// Processes an attestation.
     ProcessAttestation(Attestation<StorageProof<<<C as Spec>::Storage as Storage>::Proof>>),
     /// Processes a challenge. The challenge is encoded as a [`Vec<u8>`]. The second parameter is the transition number
     ProcessChallenge(Vec<u8>, TransitionHeight),
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
-/// Error type that explains why an user is slashed
+/// Error type that explains why a user is slashed
 pub enum SlashingReason {
-    #[error("Transition not found")]
+    #[error("Transition isn't found")]
     /// The specified transition does not exist
     TransitionNotFound,
 
-    #[error("The attestation does not contain the right block hash and post state transition")]
-    /// The specified transition is invalid (block hash, post root hash or validity condition)
+    #[error("The attestation does not contain the right block hash and post-state transition")]
+    /// The specified transition is invalid (block hash, post-root hash or validity condition)
     TransitionInvalid,
 
     #[error("The initial hash of the transition is invalid")]
@@ -62,7 +57,7 @@ pub enum SlashingReason {
     NoInvalidTransition,
 }
 
-/// Error raised while processessing the attester incentives
+/// Error raised while processing the attester incentives
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum AttesterIncentiveErrors {
     #[error("Attester slashed")]
@@ -85,28 +80,28 @@ pub enum AttesterIncentiveErrors {
     /// User is not trying to unbond at the time of the transaction
     AttesterIsNotUnbonding,
 
-    #[error("First phase unbonding has not been finalized")]
-    /// The attester is trying to finish the two phase unbonding too soon
+    #[error("The first phase of unbonding has not been finalized")]
+    /// The attester is trying to finish the two-phase unbonding too soon
     UnbondingNotFinalized,
 
-    #[error("The bond is not a 64 bit number")]
-    /// The bond is not a 64 bit number
+    #[error("The bond is not a 64-bit number")]
+    /// The bond is not a 64-bit number
     InvalidBondFormat,
 
     #[error("User is not bonded at the time of the transaction")]
     /// User is not bonded at the time of the transaction
     UserNotBonded,
 
-    #[error("Transition invariant not respected")]
-    /// Transition invariant not respected
+    #[error("Transition invariant isn't respected")]
+    /// Transition invariant isn't respected
     InvalidTransitionInvariant,
 
-    #[error("Error occured when transfered funds")]
-    /// An error occured when transfered funds
+    #[error("Error occurred when transferred funds")]
+    /// An error occurred when transferred funds
     TransferFailure,
 
     #[error("Error when trying to mint the reward token")]
-    /// An error occured when trying to mint the reward token
+    /// An error occurred when trying to mint the reward token
     MintFailure,
 }
 
@@ -119,12 +114,12 @@ pub enum Role {
     Challenger,
 }
 
-impl<
-        C: sov_modules_api::Context,
-        Vm: Zkvm,
-        Cond: ValidityCondition,
-        Checker: ValidityConditionChecker<Cond> + BorshDeserialize + BorshSerialize,
-    > AttesterIncentives<C, Vm, Cond, Checker>
+impl<C, Vm, Da, Checker> AttesterIncentives<C, Vm, Da, Checker>
+where
+    C: sov_modules_api::Context,
+    Vm: Zkvm,
+    Da: DaSpec,
+    Checker: ValidityConditionChecker<Da::ValidityCondition>,
 {
     /// This returns the address of the reward token supply
     pub fn get_reward_token_supply_address(
@@ -145,7 +140,8 @@ impl<
     ) -> u64 {
         let bonded_set = match role {
             Role::Attester => {
-                // We have to remove the attester from the unbonding set to prevent him from skiping the first phase
+                // We have to remove the attester from the unbonding set
+                // to prevent him from skipping the first phase
                 // unbonding if he bonds himself again.
                 self.unbonding_attesters.remove(user, working_set);
 
@@ -237,7 +233,7 @@ impl<
         role: Role,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Result<CallResponse, AttesterIncentiveErrors> {
-        // If the user is an attester we have to check that he's not trying to unbond
+        // If the user is an attester, we have to check that he's not trying to unbond
         if role == Role::Attester
             && self
                 .unbonding_attesters
@@ -286,7 +282,7 @@ impl<
         &self,
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
-    ) -> Result<sov_modules_api::CallResponse> {
+    ) -> anyhow::Result<CallResponse> {
         // Get the user's old balance.
         if let Some(old_balance) = self.bonded_challengers.get(context.sender(), working_set) {
             // Transfer the bond amount from the sender to the module's address.
@@ -303,14 +299,15 @@ impl<
         Ok(CallResponse::default())
     }
 
-    /// The attester starts the first phase of the two phase unbonding. We put the current max
-    /// finalized height with the attester address in the set of unbonding attesters iff the attester
+    /// The attester starts the first phase of the two-phase unbonding.
+    /// We put the current max finalized height with the attester address
+    /// in the set of unbonding attesters if the attester
     /// is already present in the unbonding set
     pub(crate) fn begin_unbond_attester(
         &self,
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
-    ) -> Result<sov_modules_api::CallResponse, AttesterIncentiveErrors> {
+    ) -> anyhow::Result<CallResponse, AttesterIncentiveErrors> {
         // First get the bonded attester
         if let Some(bond) = self.bonded_attesters.get(context.sender(), working_set) {
             let finalized_height = self
@@ -339,7 +336,7 @@ impl<
         &self,
         context: &C,
         working_set: &mut WorkingSet<C::Storage>,
-    ) -> Result<sov_modules_api::CallResponse, AttesterIncentiveErrors> {
+    ) -> anyhow::Result<CallResponse, AttesterIncentiveErrors> {
         // We have to ensure that the attester is unbonding, and that the unbonding transaction
         // occurred at least `finality_period` blocks ago to let the attester unbond
         if let Some(unbonding_info) = self.unbonding_attesters.get(context.sender(), working_set) {
@@ -390,7 +387,7 @@ impl<
         context: &C,
         attestation: &Attestation<StorageProof<<C::Storage as Storage>::Proof>>,
         working_set: &mut WorkingSet<C::Storage>,
-    ) -> Result<(), AttesterIncentiveErrors> {
+    ) -> anyhow::Result<(), AttesterIncentiveErrors> {
         let bonding_root = {
             // If we cannot get the transition before the current one, it means that we are trying
             // to get the genesis state root
@@ -441,7 +438,7 @@ impl<
         attester: &C::Address,
         attestation: &Attestation<StorageProof<<C::Storage as Storage>::Proof>>,
         working_set: &mut WorkingSet<C::Storage>,
-    ) -> Result<sov_modules_api::CallResponse, AttesterIncentiveErrors> {
+    ) -> anyhow::Result<CallResponse, AttesterIncentiveErrors> {
         if let Some(curr_tx) = self
             .chain_state
             .historical_transitions
@@ -477,7 +474,7 @@ impl<
         attester: &C::Address,
         attestation: &Attestation<StorageProof<<C::Storage as Storage>::Proof>>,
         working_set: &mut WorkingSet<C::Storage>,
-    ) -> Result<sov_modules_api::CallResponse, AttesterIncentiveErrors> {
+    ) -> anyhow::Result<CallResponse, AttesterIncentiveErrors> {
         // Normal state
         if let Some(transition) = self
             .chain_state
@@ -536,13 +533,13 @@ impl<
         Ok(CallResponse::default())
     }
 
-    /// Try to process an attestation, if the attester is bonded
+    /// Try to process an attestation if the attester is bonded
     pub(crate) fn process_attestation(
         &self,
         context: &C,
         attestation: Attestation<StorageProof<<C::Storage as Storage>::Proof>>,
         working_set: &mut WorkingSet<C::Storage>,
-    ) -> Result<sov_modules_api::CallResponse, AttesterIncentiveErrors> {
+    ) -> anyhow::Result<CallResponse, AttesterIncentiveErrors> {
         // We first need to check that the attester is still in the bonding set
         if self
             .bonded_attesters
@@ -614,7 +611,7 @@ impl<
         );
 
         // Now we have to check whether the claimed_transition_num is the max_attested_height.
-        // If so update the maximum attested height and reward the sender
+        // If so, update the maximum attested height and reward the sender
         if attestation.proof_of_bond.claimed_transition_num == new_height_to_attest {
             // Update the maximum attested height
             self.maximum_attested_height
@@ -636,11 +633,11 @@ impl<
 
     fn check_challenge_outputs_against_transition(
         &self,
-        public_outputs: StateTransition<Cond, C::Address>,
+        public_outputs: StateTransition<Da::ValidityCondition, C::Address>,
         height: &TransitionHeight,
-        condition_checker: &mut impl ValidityConditionChecker<Cond>,
+        condition_checker: &mut impl ValidityConditionChecker<Da::ValidityCondition>,
         working_set: &mut WorkingSet<C::Storage>,
-    ) -> Result<(), SlashingReason> {
+    ) -> anyhow::Result<(), SlashingReason> {
         let transition = self
             .chain_state
             .historical_transitions
@@ -682,14 +679,14 @@ impl<
         Ok(())
     }
 
-    /// Try to process a zk proof, if the challenger is bonded.
+    /// Try to process a zk proof if the challenger is bonded.
     pub(crate) fn process_challenge(
         &self,
         context: &C,
         proof: &[u8],
         transition_num: &TransitionHeight,
         working_set: &mut WorkingSet<C::Storage>,
-    ) -> Result<sov_modules_api::CallResponse, AttesterIncentiveErrors> {
+    ) -> anyhow::Result<CallResponse, AttesterIncentiveErrors> {
         // Get the challenger's old balance.
         // Revert if they aren't bonded
         let old_balance = self
@@ -726,9 +723,12 @@ impl<
                 )
             })?;
 
-        let public_outputs_opt: Result<StateTransition<Cond, C::Address>> =
-            Vm::verify_and_extract_output::<Cond, C::Address>(proof, &code_commitment)
-                .map_err(|e| anyhow::format_err!("{:?}", e));
+        let public_outputs_opt: anyhow::Result<StateTransition<Da::ValidityCondition, C::Address>> =
+            Vm::verify_and_extract_output::<Da::ValidityCondition, C::Address>(
+                proof,
+                &code_commitment,
+            )
+            .map_err(|e| anyhow::format_err!("{:?}", e));
 
         // Don't return an error for invalid proofs - those are expected and shouldn't cause reverts.
         match public_outputs_opt {

--- a/module-system/module-implementations/sov-attester-incentives/src/genesis.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/genesis.rs
@@ -1,19 +1,20 @@
 use anyhow::Result;
 use borsh::{BorshDeserialize, BorshSerialize};
-use sov_rollup_interface::zk::{ValidityCondition, ValidityConditionChecker, Zkvm};
+use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::zk::{ValidityConditionChecker, Zkvm};
 use sov_state::{Storage, WorkingSet};
 
 use crate::call::Role;
 use crate::AttesterIncentives;
 
-impl<C, Vm, S, P, Cond, Checker> AttesterIncentives<C, Vm, Cond, Checker>
+impl<C, Vm, S, P, Da, Checker> AttesterIncentives<C, Vm, Da, Checker>
 where
     C: sov_modules_api::Context<Storage = S>,
     Vm: Zkvm,
     S: Storage<Proof = P>,
     P: BorshDeserialize + BorshSerialize,
-    Cond: ValidityCondition,
-    Checker: ValidityConditionChecker<Cond>,
+    Da: DaSpec,
+    Checker: ValidityConditionChecker<Da::ValidityCondition>,
 {
     pub(crate) fn init_module(
         &self,

--- a/module-system/module-implementations/sov-attester-incentives/src/lib.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/lib.rs
@@ -21,18 +21,18 @@ use sov_bank::Amount;
 use sov_chain_state::TransitionHeight;
 use sov_modules_api::{Context, Error};
 use sov_modules_macros::ModuleInfo;
-use sov_rollup_interface::zk::{
-    StoredCodeCommitment, ValidityCondition, ValidityConditionChecker, Zkvm,
-};
+use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::zk::{StoredCodeCommitment, ValidityConditionChecker, Zkvm};
 use sov_state::{Storage, WorkingSet};
 
 /// Configuration of the attester incentives module
-pub struct AttesterIncentivesConfig<
+pub struct AttesterIncentivesConfig<C, Vm, Da, Checker>
+where
     C: Context,
     Vm: Zkvm,
-    Cond: ValidityCondition,
-    Checker: ValidityConditionChecker<Cond>,
-> {
+    Da: DaSpec,
+    Checker: ValidityConditionChecker<Da::ValidityCondition>,
+{
     /// The address of the token to be used for bonding.
     pub bonding_token_address: C::Address,
     /// The address of the account holding the reward token supply
@@ -54,10 +54,10 @@ pub struct AttesterIncentivesConfig<
     /// The validity condition checker used to check validity conditions
     pub validity_condition_checker: Checker,
     /// Phantom data that contains the validity condition
-    phantom_data: PhantomData<Cond>,
+    phantom_data: PhantomData<Da::ValidityCondition>,
 }
 
-/// The information about an attester's unbonding
+/// The information about an attender's unbonding
 #[derive(BorshDeserialize, BorshSerialize, Clone, Debug)]
 pub struct UnbondingInfo {
     /// The height at which an attester started unbonding
@@ -71,12 +71,13 @@ pub struct UnbondingInfo {
 /// - Must contain `[address]` field
 /// - Can contain any number of ` #[state]` or `[module]` fields
 #[derive(ModuleInfo)]
-pub struct AttesterIncentives<
-    C: sov_modules_api::Context,
+pub struct AttesterIncentives<C, Vm, Da, Checker>
+where
+    C: Context,
     Vm: Zkvm,
-    Cond: ValidityCondition,
-    Checker: ValidityConditionChecker<Cond>,
-> {
+    Da: DaSpec,
+    Checker: ValidityConditionChecker<Da::ValidityCondition>,
+{
     /// Address of the module.
     #[address]
     pub address: C::Address,
@@ -92,7 +93,7 @@ pub struct AttesterIncentives<
     pub bonding_token_address: sov_state::StateValue<C::Address>,
 
     /// The address of the account holding the reward token supply
-    /// TODO: maybe mint the token before transfering it? The mint method is private in bank
+    /// TODO: maybe mint the token before transferring it? The mint method is private in bank
     /// so we need a reward address that contains the supply.
     #[state]
     pub reward_token_supply_address: sov_state::StateValue<C::Address>,
@@ -146,22 +147,21 @@ pub struct AttesterIncentives<
 
     /// Reference to the chain state module, used to check the initial hashes of the state transition.
     #[module]
-    pub(crate) chain_state: sov_chain_state::ChainState<C, Cond>,
+    pub(crate) chain_state: sov_chain_state::ChainState<C, Da>,
 }
 
-impl<C, Vm, S, P, Cond, Checker> sov_modules_api::Module
-    for AttesterIncentives<C, Vm, Cond, Checker>
+impl<C, Vm, S, P, Da, Checker> sov_modules_api::Module for AttesterIncentives<C, Vm, Da, Checker>
 where
     C: sov_modules_api::Context<Storage = S>,
     Vm: Zkvm,
     S: Storage<Proof = P>,
     P: BorshDeserialize + BorshSerialize,
-    Cond: ValidityCondition,
-    Checker: ValidityConditionChecker<Cond>,
+    Da: DaSpec,
+    Checker: ValidityConditionChecker<Da::ValidityCondition>,
 {
     type Context = C;
 
-    type Config = AttesterIncentivesConfig<C, Vm, Cond, Checker>;
+    type Config = AttesterIncentivesConfig<C, Vm, Da, Checker>;
 
     type CallMessage = call::CallMessage<C>;
 

--- a/module-system/module-implementations/sov-attester-incentives/src/query.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/query.rs
@@ -1,8 +1,8 @@
 //! Defines the query methods for the attester incentives module
-use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sov_modules_api::Spec;
-use sov_rollup_interface::zk::{ValidityCondition, ValidityConditionChecker, Zkvm};
+use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::zk::{ValidityConditionChecker, Zkvm};
 use sov_state::storage::{NativeStorage, StorageProof};
 use sov_state::{Storage, WorkingSet};
 
@@ -17,12 +17,12 @@ pub struct BondAmountResponse {
 }
 
 // TODO: implement rpc_gen macro
-impl<C, Vm, Cond, Checker> AttesterIncentives<C, Vm, Cond, Checker>
+impl<C, Vm, Da, Checker> AttesterIncentives<C, Vm, Da, Checker>
 where
     C: sov_modules_api::Context,
     Vm: Zkvm,
-    Cond: ValidityCondition,
-    Checker: ValidityConditionChecker<Cond> + BorshDeserialize + BorshSerialize,
+    Da: DaSpec,
+    Checker: ValidityConditionChecker<Da::ValidityCondition>,
 {
     /// Queries the state of the module.
     pub fn get_bond_amount(
@@ -32,22 +32,18 @@ where
         working_set: &mut WorkingSet<C::Storage>,
     ) -> BondAmountResponse {
         match role {
-            Role::Attester => {
-                BondAmountResponse {
-                    value: self
-                        .bonded_attesters
-                        .get(&address, working_set)
-                        .unwrap_or_default(), // self.value.get(working_set),
-                }
-            }
-            Role::Challenger => {
-                BondAmountResponse {
-                    value: self
-                        .bonded_challengers
-                        .get(&address, working_set)
-                        .unwrap_or_default(), // self.value.get(working_set),
-                }
-            }
+            Role::Attester => BondAmountResponse {
+                value: self
+                    .bonded_attesters
+                    .get(&address, working_set)
+                    .unwrap_or_default(),
+            },
+            Role::Challenger => BondAmountResponse {
+                value: self
+                    .bonded_challengers
+                    .get(&address, working_set)
+                    .unwrap_or_default(),
+            },
         }
     }
 
@@ -70,13 +66,13 @@ where
         )
     }
 
-    /// TODO: Make the unbonding amount queriable:
+    /// TODO: Make the unbonding amount queryable:
     pub fn get_unbonding_amount(
         &self,
         _address: C::Address,
         _witness: &<<C as Spec>::Storage as Storage>::Witness,
         _working_set: &mut WorkingSet<C::Storage>,
     ) -> u64 {
-        todo!("Make the unbonding amount queriable: https://github.com/Sovereign-Labs/sovereign-sdk/issues/675")
+        todo!("Make the unbonding amount queryable: https://github.com/Sovereign-Labs/sovereign-sdk/issues/675")
     }
 }

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/challenger.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/challenger.rs
@@ -1,7 +1,7 @@
 use borsh::BorshSerialize;
 use sov_modules_api::default_context::DefaultContext;
 use sov_rollup_interface::mocks::{
-    MockCodeCommitment, MockProof, MockValidityCond, MockValidityCondChecker,
+    MockCodeCommitment, MockDaSpec, MockProof, MockValidityCond, MockValidityCondChecker,
 };
 use sov_rollup_interface::zk::StateTransition;
 use sov_state::{ProverStorage, WorkingSet};
@@ -141,7 +141,7 @@ fn invalid_proof_helper(
     module: &crate::AttesterIncentives<
         DefaultContext,
         sov_rollup_interface::mocks::MockZkvm,
-        MockValidityCond,
+        MockDaSpec,
         MockValidityCondChecker<MockValidityCond>,
     >,
     working_set: &mut WorkingSet<ProverStorage<sov_state::DefaultStorageSpec>>,

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
@@ -5,7 +5,7 @@ use sov_modules_api::hooks::SlotHooks;
 use sov_modules_api::utils::generate_address;
 use sov_modules_api::{Address, Genesis, Spec};
 use sov_rollup_interface::mocks::{
-    MockBlock, MockBlockHeader, MockCodeCommitment, MockHash, MockValidityCond,
+    MockBlock, MockBlockHeader, MockCodeCommitment, MockDaSpec, MockHash, MockValidityCond,
     MockValidityCondChecker, MockZkvm,
 };
 use sov_rollup_interface::zk::ValidityConditionChecker;
@@ -140,7 +140,7 @@ pub(crate) struct ExecutionSimulationVars {
 /// with associated bonding proofs, as long as the last state root
 pub(crate) fn execution_simulation<Checker: ValidityConditionChecker<MockValidityCond>>(
     rounds: u8,
-    module: &AttesterIncentives<C, MockZkvm, MockValidityCond, Checker>,
+    module: &AttesterIncentives<C, MockZkvm, MockDaSpec, Checker>,
     storage: &ProverStorage<DefaultStorageSpec>,
     attester_address: <C as Spec>::Address,
     mut working_set: WorkingSet<<C as Spec>::Storage>,

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
@@ -75,7 +75,7 @@ pub(crate) fn create_bank_config_with_token(
 pub(crate) fn setup(
     working_set: &mut WorkingSet<<C as Spec>::Storage>,
 ) -> (
-    AttesterIncentives<C, MockZkvm, MockValidityCond, MockValidityCondChecker<MockValidityCond>>,
+    AttesterIncentives<C, MockZkvm, MockDaSpec, MockValidityCondChecker<MockValidityCond>>,
     Address,
     Address,
     Address,
@@ -98,7 +98,7 @@ pub(crate) fn setup(
         initial_slot_height: INIT_HEIGHT,
     };
 
-    let chain_state = sov_chain_state::ChainState::<C, MockValidityCond>::default();
+    let chain_state = sov_chain_state::ChainState::<C, MockDaSpec>::default();
     chain_state
         .genesis(&chain_state_config, working_set)
         .expect("Chain state genesis must succeed");
@@ -107,7 +107,7 @@ pub(crate) fn setup(
     let module = AttesterIncentives::<
         C,
         MockZkvm,
-        MockValidityCond,
+        MockDaSpec,
         MockValidityCondChecker<MockValidityCond>,
     >::default();
     let config = crate::AttesterIncentivesConfig {

--- a/module-system/module-implementations/sov-blob-storage/src/capabilities.rs
+++ b/module-system/module-implementations/sov-blob-storage/src/capabilities.rs
@@ -1,25 +1,25 @@
 use sov_modules_api::capabilities::{BlobRefOrOwned, BlobSelector};
 use sov_modules_api::{Context, Spec};
-use sov_rollup_interface::da::BlobReaderTrait;
+use sov_rollup_interface::da::{BlobReaderTrait, DaSpec};
 use sov_state::WorkingSet;
 use tracing::info;
 
 use crate::BlobStorage;
 
-impl<C: Context, B: BlobReaderTrait> BlobSelector<B> for BlobStorage<C> {
+impl<C: Context, Da: DaSpec> BlobSelector<Da> for BlobStorage<C> {
     type Context = C;
 
     fn get_blobs_for_this_slot<'a, I>(
         &self,
         current_blobs: I,
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
-    ) -> anyhow::Result<Vec<BlobRefOrOwned<'a, B>>>
+    ) -> anyhow::Result<Vec<BlobRefOrOwned<'a, Da::BlobTransaction>>>
     where
-        I: IntoIterator<Item = &'a mut B>,
+        I: IntoIterator<Item = &'a mut Da::BlobTransaction>,
     {
         // TODO: Chain-state module: https://github.com/Sovereign-Labs/sovereign-sdk/pull/598/
         let current_slot: u64 = self.get_current_slot_number(working_set);
-        let past_deferred: Vec<B> = current_slot
+        let past_deferred: Vec<Da::BlobTransaction> = current_slot
             .checked_sub(self.get_deferred_slots_count(working_set))
             .map(|pull_from_slot| self.take_blobs_for_block_number(pull_from_slot, working_set))
             .unwrap_or_default();
@@ -38,7 +38,7 @@ impl<C: Context, B: BlobReaderTrait> BlobSelector<B> for BlobStorage<C> {
         };
 
         let mut priority_blobs = Vec::new();
-        let mut to_defer: Vec<&mut B> = Vec::new();
+        let mut to_defer: Vec<&mut Da::BlobTransaction> = Vec::new();
 
         for blob in current_blobs {
             if blob.sender().as_ref() == &preferred_sequencer[..] {
@@ -54,7 +54,7 @@ impl<C: Context, B: BlobReaderTrait> BlobSelector<B> for BlobStorage<C> {
         if !to_defer.is_empty() {
             // TODO: https://github.com/Sovereign-Labs/sovereign-sdk/issues/655
             // Gas metering suppose to prevent saving blobs from not allowed senders if they exit mid-slot
-            let to_defer: Vec<&B> = to_defer
+            let to_defer: Vec<&Da::BlobTransaction> = to_defer
                 .iter()
                 .filter(|b| {
                     let is_allowed = self

--- a/module-system/module-implementations/sov-chain-state/src/call.rs
+++ b/module-system/module-implementations/sov-chain-state/src/call.rs
@@ -1,13 +1,12 @@
-use borsh::{BorshDeserialize, BorshSerialize};
-use sov_rollup_interface::zk::ValidityCondition;
+use sov_rollup_interface::da::DaSpec;
 use sov_state::WorkingSet;
 
 use crate::{ChainState, StateTransitionId, TransitionHeight};
 
-impl<C, Cond> ChainState<C, Cond>
+impl<C, Da> ChainState<C, Da>
 where
     C: sov_modules_api::Context,
-    Cond: ValidityCondition + BorshSerialize + BorshDeserialize,
+    Da: DaSpec,
 {
     /// Increment the current slot height
     pub(crate) fn increment_slot_height(&self, working_set: &mut WorkingSet<C::Storage>) {
@@ -23,7 +22,7 @@ where
     pub(crate) fn store_state_transition(
         &self,
         height: TransitionHeight,
-        transition: StateTransitionId<Cond>,
+        transition: StateTransitionId<Da::ValidityCondition>,
         working_set: &mut WorkingSet<C::Storage>,
     ) {
         self.historical_transitions

--- a/module-system/module-implementations/sov-chain-state/src/genesis.rs
+++ b/module-system/module-implementations/sov-chain-state/src/genesis.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
-use sov_rollup_interface::zk::ValidityCondition;
+use sov_rollup_interface::da::DaSpec;
 use sov_state::WorkingSet;
 
 use crate::ChainState;
 
-impl<C: sov_modules_api::Context, Cond: ValidityCondition> ChainState<C, Cond> {
+impl<C: sov_modules_api::Context, Da: DaSpec> ChainState<C, Da> {
     pub(crate) fn init_module(
         &self,
         config: &<Self as sov_modules_api::Module>::Config,

--- a/module-system/module-implementations/sov-chain-state/src/hooks.rs
+++ b/module-system/module-implementations/sov-chain-state/src/hooks.rs
@@ -1,18 +1,18 @@
 use sov_modules_api::hooks::SlotHooks;
 use sov_modules_api::{Context, Spec};
+use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::services::da::SlotData;
-use sov_rollup_interface::zk::ValidityCondition;
 use sov_state::{Storage, WorkingSet};
 
 use super::ChainState;
 use crate::{StateTransitionId, TransitionInProgress};
 
-impl<C: Context, Cond: ValidityCondition> SlotHooks<Cond> for ChainState<C, Cond> {
+impl<C: Context, Da: DaSpec> SlotHooks<Da> for ChainState<C, Da> {
     type Context = C;
 
     fn begin_slot_hook(
         &self,
-        slot: &impl SlotData<Cond = Cond>,
+        slot: &impl SlotData<Cond = Da::ValidityCondition>,
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     ) {
         if self.genesis_hash.get(working_set).is_none() {
@@ -26,7 +26,7 @@ impl<C: Context, Cond: ValidityCondition> SlotHooks<Cond> for ChainState<C, Cond
                 working_set,
             )
         } else {
-            let transition: StateTransitionId<Cond> = {
+            let transition: StateTransitionId<Da::ValidityCondition> = {
                 let last_transition_in_progress = self
                     .in_progress_transition
                     .get(working_set)

--- a/module-system/module-implementations/sov-chain-state/src/query.rs
+++ b/module-system/module-implementations/sov-chain-state/src/query.rs
@@ -1,12 +1,12 @@
 use jsonrpsee::core::RpcResult;
 use sov_modules_api::macros::rpc_gen;
-use sov_rollup_interface::zk::ValidityCondition;
+use sov_rollup_interface::da::DaSpec;
 use sov_state::WorkingSet;
 
 use crate::{ChainState, TransitionHeight};
 
 #[rpc_gen(client, server, namespace = "chainState")]
-impl<C: sov_modules_api::Context, Cond: ValidityCondition> ChainState<C, Cond> {
+impl<C: sov_modules_api::Context, Da: DaSpec> ChainState<C, Da> {
     /// Get the height of the current slot.
     /// Panics if the slot height is not set
     #[rpc_method(name = "getSlotHeight")]

--- a/module-system/module-implementations/sov-chain-state/tests/all_tests.rs
+++ b/module-system/module-implementations/sov-chain-state/tests/all_tests.rs
@@ -2,7 +2,9 @@ use sov_chain_state::{ChainState, ChainStateConfig, StateTransitionId, Transitio
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::hooks::SlotHooks;
 use sov_modules_api::Genesis;
-use sov_rollup_interface::mocks::{MockBlock, MockBlockHeader, MockHash, MockValidityCond};
+use sov_rollup_interface::mocks::{
+    MockBlock, MockBlockHeader, MockDaSpec, MockHash, MockValidityCond,
+};
 use sov_state::{ProverStorage, Storage, WorkingSet};
 
 /// This simply tests that the chain_state reacts properly with the invocation of the `begin_slot`
@@ -19,7 +21,7 @@ fn test_simple_chain_state() {
 
     let mut working_set = WorkingSet::new(storage.clone());
 
-    let chain_state = ChainState::<DefaultContext, MockValidityCond>::default();
+    let chain_state = ChainState::<DefaultContext, MockDaSpec>::default();
     let config = ChainStateConfig {
         initial_slot_height: INIT_HEIGHT,
     };

--- a/module-system/sov-modules-api/src/capabilities.rs
+++ b/module-system/sov-modules-api/src/capabilities.rs
@@ -7,7 +7,7 @@
 //! and write a state transition function from scratch.
 //! [See here for docs](https://github.com/Sovereign-Labs/sovereign-sdk/blob/nightly/examples/demo-stf/README.md)
 
-use sov_rollup_interface::da::BlobReaderTrait;
+use sov_rollup_interface::da::{BlobReaderTrait, DaSpec};
 use sov_state::WorkingSet;
 
 use crate::{Context, Spec};
@@ -43,11 +43,11 @@ impl<'a, B: BlobReaderTrait> From<&'a mut B> for BlobRefOrOwned<'a, B> {
 }
 
 /// BlobSelector decides which blobs to process in a current slot.
-pub trait BlobSelector<B: BlobReaderTrait> {
+pub trait BlobSelector<Da: DaSpec> {
     /// Context type
     type Context: Context;
 
-    /// It takes 2 arguments:
+    /// It takes two arguments.
     /// 1. `current_blobs` - blobs that were received from the network for the current slot.
     /// 2. `working_set` - the working to access storage.
     /// It returns a vector containing a mix of borrowed and owned blobs.
@@ -55,7 +55,7 @@ pub trait BlobSelector<B: BlobReaderTrait> {
         &self,
         current_blobs: I,
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
-    ) -> anyhow::Result<Vec<BlobRefOrOwned<'a, B>>>
+    ) -> anyhow::Result<Vec<BlobRefOrOwned<'a, Da::BlobTransaction>>>
     where
-        I: IntoIterator<Item = &'a mut B>;
+        I: IntoIterator<Item = &'a mut Da::BlobTransaction>;
 }

--- a/module-system/sov-modules-api/src/default_context.rs
+++ b/module-system/sov-modules-api/src/default_context.rs
@@ -22,8 +22,8 @@ pub struct DefaultContext {
 impl Spec for DefaultContext {
     type Address = Address;
     type Storage = ProverStorage<DefaultStorageSpec>;
-    type PublicKey = DefaultPublicKey;
     type PrivateKey = DefaultPrivateKey;
+    type PublicKey = DefaultPublicKey;
     type Hasher = sha2::Sha256;
     type Signature = DefaultSignature;
     type Witness = ArrayWitness;

--- a/module-system/sov-modules-api/src/hooks.rs
+++ b/module-system/sov-modules-api/src/hooks.rs
@@ -1,6 +1,5 @@
-use sov_rollup_interface::da::BlobReaderTrait;
+use sov_rollup_interface::da::{BlobReaderTrait, DaSpec};
 use sov_rollup_interface::services::da::SlotData;
-use sov_rollup_interface::zk::ValidityCondition;
 use sov_state::WorkingSet;
 
 use crate::transaction::Transaction;
@@ -54,12 +53,12 @@ pub trait ApplyBlobHooks<B: BlobReaderTrait> {
 }
 
 /// Hooks that execute during the `StateTransitionFunction::begin_slot` and `end_slot` functions.
-pub trait SlotHooks<Condition: ValidityCondition> {
+pub trait SlotHooks<Da: DaSpec> {
     type Context: Context;
 
     fn begin_slot_hook(
         &self,
-        slot_data: &impl SlotData<Cond = Condition>,
+        slot_data: &impl SlotData<Cond = Da::ValidityCondition>,
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     );
 

--- a/module-system/sov-modules-macros/src/dispatch/dispatch_call.rs
+++ b/module-system/sov-modules-macros/src/dispatch/dispatch_call.rs
@@ -15,7 +15,7 @@ impl<'a> StructDef<'a> {
 
                 quote::quote!(
                     #[doc = "Module call message."]
-                    #name(<#ty as sov_modules_api::Module>::CallMessage),
+                    #name(<#ty as ::sov_modules_api::Module>::CallMessage),
                 )
             })
             .collect()
@@ -30,7 +30,7 @@ impl<'a> StructDef<'a> {
 
             quote::quote!(
                 #enum_ident::#name(message)=>{
-                    sov_modules_api::Module::call(&self.#name, message, context, working_set)
+                    ::sov_modules_api::Module::call(&self.#name, message, context, working_set)
                 },
             )
         });
@@ -41,7 +41,7 @@ impl<'a> StructDef<'a> {
 
             quote::quote!(
                 #enum_ident::#name(message)=>{
-                   <#ty as sov_modules_api::ModuleInfo>::address(&self.#name)
+                   <#ty as ::sov_modules_api::ModuleInfo>::address(&self.#name)
                 },
             )
         });
@@ -54,21 +54,21 @@ impl<'a> StructDef<'a> {
         let call_enum = self.enum_ident(CALL);
 
         quote::quote! {
-            impl #impl_generics sov_modules_api::DispatchCall for #ident #type_generics #where_clause {
+            impl #impl_generics ::sov_modules_api::DispatchCall for #ident #type_generics #where_clause {
                 type Context = #generic_param;
                 type Decodable = #call_enum #ty_generics;
 
-                fn decode_call(serialized_message: &[u8]) -> core::result::Result<Self::Decodable, std::io::Error> {
-                    let mut data = std::io::Cursor::new(serialized_message);
+                fn decode_call(serialized_message: &[u8]) -> ::core::result::Result<Self::Decodable, std::io::Error> {
+                    let mut data = ::std::io::Cursor::new(serialized_message);
                     <#call_enum #ty_generics as ::borsh::BorshDeserialize>::deserialize_reader(&mut data)
                 }
 
                 fn dispatch_call(
                     &self,
                     decodable: Self::Decodable,
-                    working_set: &mut sov_state::WorkingSet<<Self::Context as sov_modules_api::Spec>::Storage>,
+                    working_set: &mut ::sov_state::WorkingSet<<Self::Context as ::sov_modules_api::Spec>::Storage>,
                     context: &Self::Context,
-                ) -> core::result::Result<sov_modules_api::CallResponse, sov_modules_api::Error> {
+                ) -> ::core::result::Result<::sov_modules_api::CallResponse, ::sov_modules_api::Error> {
 
                     match decodable {
                         #(#match_legs)*
@@ -76,7 +76,7 @@ impl<'a> StructDef<'a> {
 
                 }
 
-                fn module_address(&self, decodable: &Self::Decodable) -> &<Self::Context as sov_modules_api::Spec>::Address {
+                fn module_address(&self, decodable: &Self::Decodable) -> &<Self::Context as ::sov_modules_api::Spec>::Address {
                     match decodable {
                         #(#match_legs_address)*
                     }

--- a/module-system/sov-modules-stf-template/src/app_template.rs
+++ b/module-system/sov-modules-stf-template/src/app_template.rs
@@ -14,9 +14,9 @@ use crate::{Batch, Runtime, SequencerOutcome, SlashingReason, TxEffect};
 type ApplyBatchResult<T, A> = Result<T, ApplyBatchError<A>>;
 
 #[allow(type_alias_bounds)]
-type ApplyBatch<DA: DaSpec> = ApplyBatchResult<
-    BatchReceipt<SequencerOutcome<<DA::BlobTransaction as BlobReaderTrait>::Address>, TxEffect>,
-    <DA::BlobTransaction as BlobReaderTrait>::Address,
+type ApplyBatch<Da: DaSpec> = ApplyBatchResult<
+    BatchReceipt<SequencerOutcome<<Da::BlobTransaction as BlobReaderTrait>::Address>, TxEffect>,
+    <Da::BlobTransaction as BlobReaderTrait>::Address,
 >;
 #[cfg(all(target_os = "zkvm", feature = "bench"))]
 use zk_cycle_macros::cycle_tracker;
@@ -26,9 +26,9 @@ use zk_cycle_macros::cycle_tracker;
 /// that is specifically designed to work with the module-system.
 pub struct AppTemplate<
     C: Context,
-    DA: DaSpec,
+    Da: DaSpec,
     Vm,
-    RT: Runtime<C, DA::ValidityCondition, DA::BlobTransaction>,
+    RT: Runtime<C, Da::ValidityCondition, Da::BlobTransaction>,
 > {
     /// State storage used by the rollup.
     pub current_storage: C::Storage,
@@ -36,7 +36,7 @@ pub struct AppTemplate<
     pub runtime: RT,
     pub(crate) checkpoint: Option<StateCheckpoint<C::Storage>>,
     phantom_vm: PhantomData<Vm>,
-    phantom_da: PhantomData<DA>,
+    phantom_da: PhantomData<Da>,
 }
 
 pub(crate) enum ApplyBatchError<A: BasicAddress> {
@@ -74,11 +74,11 @@ impl<A: BasicAddress> From<ApplyBatchError<A>> for BatchReceipt<SequencerOutcome
     }
 }
 
-impl<C, Vm, DA, RT> AppTemplate<C, DA, Vm, RT>
+impl<C, Vm, Da, RT> AppTemplate<C, Da, Vm, RT>
 where
     C: Context,
-    DA: DaSpec,
-    RT: Runtime<C, DA::ValidityCondition, DA::BlobTransaction>,
+    Da: DaSpec,
+    RT: Runtime<C, Da::ValidityCondition, Da::BlobTransaction>,
 {
     /// [`AppTemplate`] constructor.
     pub fn new(storage: C::Storage, runtime: RT) -> Self {
@@ -92,7 +92,7 @@ where
     }
 
     #[cfg_attr(all(target_os = "zkvm", feature = "bench"), cycle_tracker)]
-    pub(crate) fn apply_blob(&mut self, blob: &mut DA::BlobTransaction) -> ApplyBatch<DA> {
+    pub(crate) fn apply_blob(&mut self, blob: &mut Da::BlobTransaction) -> ApplyBatch<Da> {
         debug!(
             "Applying batch from sequencer: 0x{}",
             hex::encode(blob.sender())

--- a/module-system/sov-modules-stf-template/src/app_template.rs
+++ b/module-system/sov-modules-stf-template/src/app_template.rs
@@ -24,12 +24,7 @@ use zk_cycle_macros::cycle_tracker;
 /// An implementation of the
 /// [`StateTransitionFunction`](sov_rollup_interface::stf::StateTransitionFunction)
 /// that is specifically designed to work with the module-system.
-pub struct AppTemplate<
-    C: Context,
-    Da: DaSpec,
-    Vm,
-    RT: Runtime<C, Da::ValidityCondition, Da::BlobTransaction>,
-> {
+pub struct AppTemplate<C: Context, Da: DaSpec, Vm, RT: Runtime<C, Da>> {
     /// State storage used by the rollup.
     pub current_storage: C::Storage,
     /// The runtime includes all the modules that the rollup supports.
@@ -78,7 +73,7 @@ impl<C, Vm, Da, RT> AppTemplate<C, Da, Vm, RT>
 where
     C: Context,
     Da: DaSpec,
-    RT: Runtime<C, Da::ValidityCondition, Da::BlobTransaction>,
+    RT: Runtime<C, Da>,
 {
     /// [`AppTemplate`] constructor.
     pub fn new(storage: C::Storage, runtime: RT) -> Self {

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -68,18 +68,18 @@ pub enum SlashingReason {
     InvalidTransactionEncoding,
 }
 
-impl<C, RT, Vm, DA> AppTemplate<C, DA, Vm, RT>
+impl<C, RT, Vm, Da> AppTemplate<C, Da, Vm, RT>
 where
     C: Context,
     Vm: Zkvm,
-    DA: DaSpec,
-    RT: Runtime<C, DA::ValidityCondition, DA::BlobTransaction>,
+    Da: DaSpec,
+    RT: Runtime<C, Da::ValidityCondition, Da::BlobTransaction>,
 {
     #[cfg_attr(all(target_os = "zkvm", feature = "bench"), cycle_tracker)]
     fn begin_slot(
         &mut self,
-        slot_data: &impl SlotData<Cond = DA::ValidityCondition>,
-        witness: <Self as StateTransitionFunction<Vm, DA::BlobTransaction>>::Witness,
+        slot_data: &impl SlotData<Cond = Da::ValidityCondition>,
+        witness: <Self as StateTransitionFunction<Vm, Da::BlobTransaction>>::Witness,
     ) {
         let state_checkpoint = StateCheckpoint::with_witness(self.current_storage.clone(), witness);
         let mut working_set = state_checkpoint.to_revertable();
@@ -105,12 +105,12 @@ where
     }
 }
 
-impl<C, RT, Vm, DA> StateTransitionFunction<Vm, DA::BlobTransaction> for AppTemplate<C, DA, Vm, RT>
+impl<C, RT, Vm, Da> StateTransitionFunction<Vm, Da::BlobTransaction> for AppTemplate<C, Da, Vm, RT>
 where
     C: Context,
-    DA: DaSpec,
+    Da: DaSpec,
     Vm: Zkvm,
-    RT: Runtime<C, DA::ValidityCondition, DA::BlobTransaction>,
+    RT: Runtime<C, Da::ValidityCondition, Da::BlobTransaction>,
 {
     type StateRoot = jmt::RootHash;
 
@@ -118,11 +118,11 @@ where
 
     type TxReceiptContents = TxEffect;
 
-    type BatchReceiptContents = SequencerOutcome<<DA::BlobTransaction as BlobReaderTrait>::Address>;
+    type BatchReceiptContents = SequencerOutcome<<Da::BlobTransaction as BlobReaderTrait>::Address>;
 
     type Witness = <<C as Spec>::Storage as Storage>::Witness;
 
-    type Condition = DA::ValidityCondition;
+    type Condition = Da::ValidityCondition;
 
     fn init_chain(&mut self, params: Self::InitialState) -> jmt::RootHash {
         let mut working_set = StateCheckpoint::new(self.current_storage.clone()).to_revertable();
@@ -153,7 +153,7 @@ where
         Self::Witness,
     >
     where
-        I: IntoIterator<Item = &'a mut DA::BlobTransaction>,
+        I: IntoIterator<Item = &'a mut Da::BlobTransaction>,
         Data: SlotData<Cond = Self::Condition>,
     {
         self.begin_slot(slot_data, witness);

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -32,7 +32,7 @@ pub trait Runtime<C: Context, Da: DaSpec>:
         BlobResult = SequencerOutcome<
             <<Da as DaSpec>::BlobTransaction as BlobReaderTrait>::Address,
         >,
-    > + BlobSelector<Da::BlobTransaction, Context = C>
+    > + BlobSelector<Da, Context = C>
 {
 }
 

--- a/rollup-interface/src/state_machine/da.rs
+++ b/rollup-interface/src/state_machine/da.rs
@@ -14,7 +14,7 @@ use crate::zk::ValidityCondition;
 use crate::BasicAddress;
 
 /// A specification for the types used by a DA layer.
-pub trait DaSpec: 'static {
+pub trait DaSpec: Serialize + DeserializeOwned + 'static {
     /// The hash of a DA layer block
     type SlotHash: BlockHashTrait;
 

--- a/rollup-interface/src/state_machine/da.rs
+++ b/rollup-interface/src/state_machine/da.rs
@@ -14,7 +14,7 @@ use crate::zk::ValidityCondition;
 use crate::BasicAddress;
 
 /// A specification for the types used by a DA layer.
-pub trait DaSpec: Serialize + DeserializeOwned + 'static {
+pub trait DaSpec: 'static {
     /// The hash of a DA layer block
     type SlotHash: BlockHashTrait;
 

--- a/rollup-interface/src/state_machine/mocks/da.rs
+++ b/rollup-interface/src/state_machine/mocks/da.rs
@@ -206,6 +206,7 @@ impl SlotData for MockBlock {
 }
 
 /// A [`DaSpec`] suitable for testing.
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct MockDaSpec;
 
 impl DaSpec for MockDaSpec {


### PR DESCRIPTION
# Description

* Renames `DA` generic to `Da`
* Replace the Cond: ValidityCondition generic with a reference to D::ValidityCondition in chain-state module and top level hooks. Internal chain state structures are left deliberately untouched.
* Replace the B: BlobTransactionTrait generic with a reference to Da::BlobTransaction wherever it appeared

## Linked Issues
- Related to #755 to make it smaller

## Testing
Tests have been updated to use new generics

## Docs
Minor spell checks in docs
