### PR TITLE
EVM: Placeholder for the `begin_slot_hook`

### DIFF
--- a/examples/demo-stf/src/hooks_impl.rs
+++ b/examples/demo-stf/src/hooks_impl.rs
@@ -1,4 +1,4 @@
-use sov_modules_api::hooks::{ApplyBlobHooks, TxHooks};
+use sov_modules_api::hooks::{ApplyBlobHooks, SlotHooks, TxHooks};
 use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{Context, Spec};
 use sov_modules_stf_template::SequencerOutcome;
@@ -71,5 +71,31 @@ impl<C: Context, Da: DaSpec> ApplyBlobHooks<Da::BlobTransaction> for Runtime<C, 
                 )
             }
         }
+    }
+}
+
+impl<C: Context, Da: DaSpec> SlotHooks<Da> for Runtime<C, Da> {
+    type Context = C;
+
+    fn begin_slot_hook(
+        &self,
+        #[allow(unused_variables)] slot_data: &impl sov_rollup_interface::services::da::SlotData,
+        #[allow(unused_variables)] working_set: &mut sov_state::WorkingSet<
+            <Self::Context as Spec>::Storage,
+        >,
+    ) {
+        #[cfg(feature = "experimental")]
+        self.evm.begin_slot_hook(working_set);
+    }
+
+    fn end_slot_hook(
+        &self,
+        #[allow(unused_variables)] root_hash: [u8; 32],
+        #[allow(unused_variables)] working_set: &mut sov_state::WorkingSet<
+            <Self::Context as Spec>::Storage,
+        >,
+    ) {
+        #[cfg(feature = "experimental")]
+        self.evm.end_slot_hook(root_hash, working_set);
     }
 }

--- a/examples/demo-stf/src/runtime.rs
+++ b/examples/demo-stf/src/runtime.rs
@@ -12,7 +12,6 @@ use sov_evm::query::{EvmRpcImpl, EvmRpcServer};
 use sov_modules_api::capabilities::{BlobRefOrOwned, BlobSelector};
 #[cfg(feature = "native")]
 pub use sov_modules_api::default_context::DefaultContext;
-use sov_modules_api::hooks::SlotHooks;
 use sov_modules_api::macros::DefaultRuntime;
 #[cfg(feature = "native")]
 use sov_modules_api::macros::{expose_rpc, CliWallet};
@@ -105,32 +104,6 @@ pub struct Runtime<C: Context, Da: DaSpec> {
     pub accounts: sov_accounts::Accounts<C>,
     #[cfg_attr(feature = "native", cli_skip)]
     pub evm: sov_evm::Evm<C>,
-}
-
-impl<C: Context, Da: DaSpec> SlotHooks<Da> for Runtime<C, Da> {
-    type Context = C;
-
-    fn begin_slot_hook(
-        &self,
-        #[allow(unused_variables)] slot_data: &impl sov_rollup_interface::services::da::SlotData,
-        #[allow(unused_variables)] working_set: &mut sov_state::WorkingSet<
-            <Self::Context as Spec>::Storage,
-        >,
-    ) {
-        #[cfg(feature = "experimental")]
-        self.evm.begin_slot_hook(working_set);
-    }
-
-    fn end_slot_hook(
-        &self,
-        #[allow(unused_variables)] root_hash: [u8; 32],
-        #[allow(unused_variables)] working_set: &mut sov_state::WorkingSet<
-            <Self::Context as Spec>::Storage,
-        >,
-    ) {
-        #[cfg(feature = "experimental")]
-        self.evm.end_slot_hook(root_hash, working_set);
-    }
 }
 
 impl<C, Da> sov_modules_stf_template::Runtime<C, Da> for Runtime<C, Da>

--- a/examples/demo-stf/src/runtime.rs
+++ b/examples/demo-stf/src/runtime.rs
@@ -112,9 +112,13 @@ impl<C: Context, Da: DaSpec> SlotHooks<Da> for Runtime<C, Da> {
 
     fn begin_slot_hook(
         &self,
-        _slot_data: &impl sov_rollup_interface::services::da::SlotData,
-        _working_set: &mut sov_state::WorkingSet<<Self::Context as Spec>::Storage>,
+        #[allow(unused_variables)] slot_data: &impl sov_rollup_interface::services::da::SlotData,
+        #[allow(unused_variables)] working_set: &mut sov_state::WorkingSet<
+            <Self::Context as Spec>::Storage,
+        >,
     ) {
+        #[cfg(feature = "experimental")]
+        self.evm.begin_slot_hook(working_set);
     }
 
     fn end_slot_hook(

--- a/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -3,6 +3,8 @@ use sov_state::WorkingSet;
 use crate::Evm;
 
 impl<C: sov_modules_api::Context> Evm<C> {
+    pub fn begin_slot_hook(&self, _working_set: &mut WorkingSet<C::Storage>) {}
+
     pub fn end_slot_hook(&self, _root_hash: [u8; 32], _working_set: &mut WorkingSet<C::Storage>) {
         // TODO implement block creation logic.
     }


### PR DESCRIPTION
# Description
Adds placeholder for the `EVM::begin_slot_hook`

## Testing
CI passes.

## Docs
No changes
