### PR TITLE
Expose `ModuleInfo::prefix(&self)`

### DIFF
--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -348,7 +348,7 @@ pub trait ModuleInfo {
     /// Returns address of the module.
     fn address(&self) -> &<Self::Context as Spec>::Address;
 
-    /// Returns address of the module.
+    /// Returns the prefix of the module.
     fn prefix(&self) -> Prefix;
 
     /// Returns addresses of all the other modules this module is dependent on

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -348,6 +348,9 @@ pub trait ModuleInfo {
     /// Returns address of the module.
     fn address(&self) -> &<Self::Context as Spec>::Address;
 
+    /// Returns address of the module.
+    fn prefix(&self) -> Prefix;
+
     /// Returns addresses of all the other modules this module is dependent on
     fn dependencies(&self) -> Vec<&<Self::Context as Spec>::Address>;
 }

--- a/module-system/sov-modules-api/src/tests.rs
+++ b/module-system/sov-modules-api/src/tests.rs
@@ -58,6 +58,10 @@ impl crate::ModuleInfo for Module {
         &self.address
     }
 
+    fn prefix(&self) -> crate::Prefix {
+        crate::Prefix::new_module(module_path!(), "Module")
+    }
+
     fn dependencies(&self) -> Vec<&<Self::Context as crate::Spec>::Address> {
         self.dependencies.iter().collect()
     }


### PR DESCRIPTION
# Description
IBC needs to be able to identify the prefix where a module's data lives in the state trie. This PR exposes the necessary machinery.
