### PR TITLE
EVM: pass DA `root_hash` to the evm module

### DIFF
--- a/examples/demo-stf/src/hooks_impl.rs
+++ b/examples/demo-stf/src/hooks_impl.rs
@@ -85,7 +85,7 @@ impl<C: Context, Da: DaSpec> SlotHooks<Da> for Runtime<C, Da> {
         >,
     ) {
         #[cfg(feature = "experimental")]
-        self.evm.begin_slot_hook(working_set);
+        self.evm.begin_slot_hook(slot_data.hash(), working_set);
     }
 
     fn end_slot_hook(

--- a/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -4,7 +4,12 @@ use sov_state::WorkingSet;
 use crate::Evm;
 
 impl<C: sov_modules_api::Context> Evm<C> {
-    pub fn begin_slot_hook(&self, _working_set: &mut WorkingSet<C::Storage>) {}
+    pub fn begin_slot_hook(
+        &self,
+        _da_root_hash: [u8; 32],
+        _working_set: &mut WorkingSet<C::Storage>,
+    ) {
+    }
 
     pub fn end_slot_hook(&self, _root_hash: [u8; 32], working_set: &mut WorkingSet<C::Storage>) {
         // TODO implement block creation logic.


### PR DESCRIPTION
# Description
Pass `da_root_hash` to `begin_slot_hook` in the `EVM`

## Testing
CI passes.

## Docs
No changes.
