### PR TITLE
State: Add serde support for `StateMap, StateValue..` etc structures

### DIFF
--- a/module-system/sov-state/src/containers/accessory_map.rs
+++ b/module-system/sov-state/src/containers/accessory_map.rs
@@ -15,7 +15,15 @@ use crate::{AccessoryWorkingSet, Prefix, StateReaderAndWriter, Storage};
 /// - a key type `K`;
 /// - a value type `V`;
 /// - a [`StateValueCodec`] `VC`.
-#[derive(Debug, Clone, PartialEq, borsh::BorshDeserialize, borsh::BorshSerialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    borsh::BorshDeserialize,
+    borsh::BorshSerialize,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub struct AccessoryStateMap<K, V, VC = BorshCodec> {
     _phantom: (PhantomData<K>, PhantomData<V>),
     value_codec: VC,

--- a/module-system/sov-state/src/containers/accessory_value.rs
+++ b/module-system/sov-state/src/containers/accessory_value.rs
@@ -8,7 +8,16 @@ use crate::{AccessoryWorkingSet, Prefix, StateReaderAndWriter, Storage};
 
 /// Container for a single value stored as "accessory" state, outside of the
 /// JMT.
-#[derive(Debug, PartialEq, Eq, Clone, BorshDeserialize, BorshSerialize)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    BorshDeserialize,
+    BorshSerialize,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub struct AccessoryStateValue<V, VC = BorshCodec> {
     _phantom: PhantomData<V>,
     codec: VC,

--- a/module-system/sov-state/src/containers/map.rs
+++ b/module-system/sov-state/src/containers/map.rs
@@ -15,7 +15,15 @@ use crate::{Prefix, StateReaderAndWriter, Storage, WorkingSet};
 /// - a key type `K`;
 /// - a value type `V`;
 /// - a [`StateValueCodec`] `VC`.
-#[derive(Debug, Clone, PartialEq, borsh::BorshDeserialize, borsh::BorshSerialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    borsh::BorshDeserialize,
+    borsh::BorshSerialize,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub struct StateMap<K, V, VC = BorshCodec> {
     _phantom: (PhantomData<K>, PhantomData<V>),
     value_codec: VC,

--- a/module-system/sov-state/src/containers/value.rs
+++ b/module-system/sov-state/src/containers/value.rs
@@ -1,13 +1,20 @@
 use std::marker::PhantomData;
 
-use borsh::{BorshDeserialize, BorshSerialize};
 use thiserror::Error;
 
 use crate::codec::{BorshCodec, StateValueCodec};
 use crate::{Prefix, StateReaderAndWriter, Storage, WorkingSet};
 
 /// Container for a single value.
-#[derive(Debug, PartialEq, Eq, Clone, BorshDeserialize, BorshSerialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    borsh::BorshDeserialize,
+    borsh::BorshSerialize,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub struct StateValue<V, VC = BorshCodec> {
     _phantom: PhantomData<V>,
     codec: VC,

--- a/module-system/sov-state/src/lib.rs
+++ b/module-system/sov-state/src/lib.rs
@@ -40,7 +40,16 @@ pub use crate::witness::{ArrayWitness, TreeWitnessReader, Witness};
 // All the collection types in this crate are backed by the same storage instance, this means that insertions of the same key
 // to two different `StorageMaps` would collide with each other. We solve it by instantiating every collection type with a unique
 // prefix that is prepended to each key.
-#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Eq, Clone)]
+#[derive(
+    borsh::BorshDeserialize,
+    borsh::BorshSerialize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Prefix {
     prefix: AlignedVec,

--- a/module-system/sov-state/src/utils.rs
+++ b/module-system/sov-state/src/utils.rs
@@ -2,7 +2,16 @@
 // This makes certain operations cheaper in zk-context (concatenation)
 // TODO: Currently the implementation defaults to `stc::vec::Vec` see:
 // https://github.com/Sovereign-Labs/sovereign-sdk/issues/47
-#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Eq, Clone)]
+#[derive(
+    borsh::BorshDeserialize,
+    borsh::BorshSerialize,
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub struct AlignedVec {
     inner: Vec<u8>,
 }


### PR DESCRIPTION
# Description
This PR adds `serde` support for `StateXX` structures so they can be serialized recursively with different codecs than `borsh`

## Testing
CI passes.

## Docs
No doc changes.
