### PR TITLE
Add`da_layer` flag in `demp-rollup` binary.

### DIFF
--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -41,6 +41,7 @@ sov-modules-api = { path = "../../module-system/sov-modules-api", features = ["n
 sov-state = { path = "../../module-system/sov-state", features = ["native"] }
 const-rollup-config = { path = "../const-rollup-config" }
 sov-cli = { path = "../../module-system/sov-cli" }
+clap = { workspace = true }
 
 [dev-dependencies]
 sov-evm = { path = "../../module-system/module-implementations/sov-evm", features = ["smart_contracts"] }
@@ -50,7 +51,6 @@ reqwest = "0.11"
 tendermint = "0.32"
 tempfile = { workspace = true }
 proptest = { workspace = true }
-clap = { workspace = true }
 sov-rollup-interface = { path = "../../rollup-interface", features = ["fuzzing"] }
 prometheus = "0.11.0"
 prettytable-rs = "^0.10"

--- a/examples/demo-rollup/src/main.rs
+++ b/examples/demo-rollup/src/main.rs
@@ -1,7 +1,7 @@
-use std::env;
 use std::str::FromStr;
 
-use sov_demo_rollup::new_rollup_with_celestia_da;
+use clap::Parser;
+use sov_demo_rollup::{new_rollup_with_celestia_da, new_rollup_with_mock_da};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 
@@ -12,6 +12,17 @@ mod test_rpc;
 /// (or a default config if not provided). Then start checking the blocks sent to the DA layer in
 /// the main event loop.
 
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Data layer
+    #[arg(long, default_value = "celestia")]
+    da_layer: String,
+
+    #[arg(long, default_value = "rollup_config.toml")]
+    rollup_config_path: String,
+}
+
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Initializing logging
@@ -20,10 +31,18 @@ async fn main() -> Result<(), anyhow::Error> {
         .with(EnvFilter::from_str("info,sov_sequencer=warn").unwrap())
         .init();
 
-    let rollup_config_path = env::args()
-        .nth(1)
-        .unwrap_or_else(|| "rollup_config.toml".to_string());
+    let args = Args::parse();
+    let rollup_config_path = args.rollup_config_path.as_str();
 
-    let rollup = new_rollup_with_celestia_da(&rollup_config_path).await?;
-    rollup.run().await
+    match args.da_layer.as_str() {
+        "mock" => {
+            let rollup = new_rollup_with_mock_da(rollup_config_path)?;
+            rollup.run().await
+        }
+        "celestia" => {
+            let rollup = new_rollup_with_celestia_da(rollup_config_path).await?;
+            rollup.run().await
+        }
+        da => panic!("DA Layer not supported: {}", da),
+    }
 }

--- a/examples/demo-rollup/src/main.rs
+++ b/examples/demo-rollup/src/main.rs
@@ -15,10 +15,11 @@ mod test_rpc;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Data layer
+    /// The data layer type.
     #[arg(long, default_value = "celestia")]
     da_layer: String,
 
+    /// The path to the rollup config.
     #[arg(long, default_value = "rollup_config.toml")]
     rollup_config_path: String,
 }


### PR DESCRIPTION
# Description
This PR introduces `da_layer` flag in the demo rollup binary and sets `celestia` as default.  

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Tested manually by running the binary.

## Docs
`Celestia` is the default so no changes needed.  
