### PR TITLE
Release `v0.2.0-alpha`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
 name = "const-rollup-config"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "constant_time_eq"
@@ -1482,7 +1482,7 @@ checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
 
 [[package]]
 name = "demo-nft-module"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "demo-simple-stf"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "demo-stf"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3715,7 +3715,7 @@ dependencies = [
 
 [[package]]
 name = "module-template"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6466,7 +6466,7 @@ dependencies = [
 
 [[package]]
 name = "sov-accessory-state"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "borsh",
  "jsonrpsee",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "sov-accounts"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6496,7 +6496,7 @@ dependencies = [
 
 [[package]]
 name = "sov-attester-incentives"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6516,7 +6516,7 @@ dependencies = [
 
 [[package]]
 name = "sov-bank"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6535,7 +6535,7 @@ dependencies = [
 
 [[package]]
 name = "sov-blob-storage"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6559,7 +6559,7 @@ dependencies = [
 
 [[package]]
 name = "sov-celestia-adapter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6592,7 +6592,7 @@ dependencies = [
 
 [[package]]
 name = "sov-chain-state"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6612,7 +6612,7 @@ dependencies = [
 
 [[package]]
 name = "sov-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6632,7 +6632,7 @@ dependencies = [
 
 [[package]]
 name = "sov-data-generators"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "borsh",
  "proptest",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "sov-db"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6663,7 +6663,7 @@ dependencies = [
 
 [[package]]
 name = "sov-demo-rollup"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6716,7 +6716,7 @@ dependencies = [
 
 [[package]]
 name = "sov-ethereum"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6737,7 +6737,7 @@ dependencies = [
 
 [[package]]
 name = "sov-evm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "sov-first-read-last-write-cache"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proptest",
  "thiserror",
@@ -6782,7 +6782,7 @@ dependencies = [
 
 [[package]]
 name = "sov-module-schemas"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "sov-accounts",
  "sov-bank",
@@ -6796,7 +6796,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -6827,7 +6827,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6850,7 +6850,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-stf-template"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6870,7 +6870,7 @@ dependencies = [
 
 [[package]]
 name = "sov-prover-incentives"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6888,7 +6888,7 @@ dependencies = [
 
 [[package]]
 name = "sov-risc0-adapter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "sov-rollup-interface"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6925,7 +6925,7 @@ dependencies = [
 
 [[package]]
 name = "sov-schema-db"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6939,7 +6939,7 @@ dependencies = [
 
 [[package]]
 name = "sov-sequencer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6954,7 +6954,7 @@ dependencies = [
 
 [[package]]
 name = "sov-sequencer-registry"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6977,7 +6977,7 @@ dependencies = [
 
 [[package]]
 name = "sov-state"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -7000,7 +7000,7 @@ dependencies = [
 
 [[package]]
 name = "sov-stf-runner"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7029,7 +7029,7 @@ dependencies = [
 
 [[package]]
 name = "sov-value-setter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7046,7 +7046,7 @@ dependencies = [
 
 [[package]]
 name = "sov-vec-setter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7064,7 +7064,7 @@ dependencies = [
 
 [[package]]
 name = "sov-zk-cycle-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7080,7 +7080,7 @@ dependencies = [
 
 [[package]]
 name = "sov-zk-cycle-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "risc0-zkvm",
  "risc0-zkvm-platform",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcs"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd3ffe8b19a604421a5d461d4a70346223e535903fbc3067138bddbebddcf77"
+dependencies = [
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "bech32"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6214,7 +6224,7 @@ name = "sov-attester-incentives"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "bcs",
+ "bcs 0.1.4",
  "borsh",
  "jmt",
  "serde",
@@ -6693,7 +6703,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "bcs",
+ "bcs 0.1.5",
  "borsh",
  "hex",
  "jmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Sovereign Labs <info@sovereign.xyz>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ borsh = { version = "0.10.3", features = ["rc", "bytes"] }
 # TODO: Consider replacing this serialization format
 #     https://github.com/Sovereign-Labs/sovereign-sdk/issues/283
 bincode = "1.3.3"
-bcs = { git = "https://github.com/preston-evans98/bcs.git", rev = "e4f1861" } 
+bcs = "0.1.5"
 byteorder = "1.4.3"
 bytes = "1.2.1"
 hex = "0.4.3"

--- a/Releases.md
+++ b/Releases.md
@@ -1,39 +1,88 @@
 # Releases
 
-This document describes how to cut a release of the Sovereign SDK
+This document describes how to cut a release of the Sovereign SDK.
+
+<!-- https://github.com/thlorenz/doctoc -->
+<!-- doctoc Releases.md --github --notitle --maxlevel 2 -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Before starting](#before-starting)
+- [Pick a version number](#pick-a-version-number)
+- [Make sure the documentation and tutorials are up to date](#make-sure-the-documentation-and-tutorials-are-up-to-date)
+- [Update all crate versions](#update-all-crate-versions)
+- [Prepare the PR](#prepare-the-pr)
+- [Release to `crates.io`](#release-to-cratesio)
+- [Create a tag and a GitHub release](#create-a-tag-and-a-github-release)
+- [Merge to `nightly` and `stable`](#merge-to-nightly-and-stable)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Before starting
+
+Before starting, ensure your local copy of the repository is up to date with the latest commit on `nightly` and has no untracked or uncommitted changes. Making a fresh clone of the repository is a good way to ensure this.
 
 ## Pick a version number
 
 - [ ] Decide a new version number. During alpha, This should have the form `vA.B.C-alpha` where `A, B, C` are natural numbers. Since we're pre `1.0` releases which are not backwards compatible should
       get a new `minor` version, while releases which are backwards compatible only receive a `patch` version bump. Since almost all of our releases contain breaking changes, we'll almost always bump the minor version (i.e. from `v0.1.0-alpha` to `v0.2.0-alpha`)
   - [ ] Don't forget the `v`!
+- [ ] Create a new local branch named `release/{version}` (e.g. `release/v0.2.0-alpha`) from `nightly`.
 
-## Check Consistency
-- [ ] Make a fresh clone of the repo or ensure your local copy is up to date and has no untracked/uncommitted changes.
-- [ ] Audit the getting-started documentation
-  - [ ] Manually run the steps from `demo-rollup/README.md` to ensure there is no breakage
-  - [ ] Manually run the steps from `demo-prover/README.md`
-- [ ] Review all tutorials and ensure explanations are up to date
-  - [ ] demo-nft-module/README.md
-  - [ ] demo-simple-stf/README.md
-  - [ ] demo-stf/README.md
-  - [ ] demo-nft-module/README.md
-- [ ] Audit `packages_to_publish.txt` and ensure that all relevant _library_ packages are included. Binaries (such as demo-rollup) should not be included.
+## Make sure the documentation and tutorials are up to date
+- [ ] Audit the getting-started documentation and ensure there's no breakages:
+  - [ ] Manually run the steps from `examples/demo-rollup/README.md`.
+  - [ ] Manually run the steps from `examples/demo-prover/README.md`.
+- [ ] Review all the other tutorials and ensure explanations are up to date:
+  - [ ] `examples/demo-nft-module/README.md`
+  - [ ] `examples/demo-simple-stf/README.md`
+  - [ ] `examples/demo-stf/README.md`
+  - [ ] `examples/demo-nft-module/README.md`
+- [ ] Audit `packages_to_publish.txt` and ensure that all relevant _library_ crates are included. Binaries (such as `demo-rollup`) and other internal crates not intended to be used by SDK users (such as `sov-modules-schemas`) should not be included. The list must remain pre-sorted by dependencies, so that crates are published in the correct order.
 - [ ] Commit any changes.
-- [ ] Change the `package.version` field of all workspace crates from `workspace = true` to the _old_ version number
-- [ ] Commit any changes.
-- [ ] Bump the workspace `package.version` (this is safe, since now no crates depend on it)
-- [ ] Create a new PR (e.g. `release/{version}`) against nightly. Ensure all tests and lints pass but _DO NOT MERGE_
-- [ ] Wait for the PR to be approved before merging
 
-## Cut the Release
+## Update all crate versions
 
-- [ ] Release all packages from `packages_to_publish.txt` _in order_ (it's pre-sorted by dependencies)
-  - [ ] For each crate: change its `package.version` back to `workspace = true`. Bump the versions of all of its `sovereign-sdk` dependencies.
-  - [ ] run `cargo publish --dry-run {crate}` to ensure there are no issues
-  - [ ] run `cargo publish {crate}` to release the crate
-- [ ] Bump the versions and dependency versions of all unreleased crates
-- [ ] Commit all changes and push. Be sure to tag your commit with the version.
-- [ ] Once CI passes, merge your PR to nightly.
-- [ ] Merge from nightly to stable
-- [ ] Push the tag (`git push origin {version} `)[^1]
+For each and every crate in this repository, you'll need to do three things:
+
+1. [ ] Update the crate's version number.
+2. [ ] Update the crate's `sov-*` dependencies to the new version, unless they are sourced from a relative `path = "..."` instead of a version number. In that case there's no dependency version to update, and you can skip it.
+3. [ ] Update the crate's `sov-*` dev-dependencies to the new version, just like you did in step 2.
+
+The `cargo set-version` subcommand supplied by [`cargo-edit`](https://github.com/killercup/cargo-edit) does all of this for you automatically. Invoke it like this:
+
+```
+$ cargo set-version 0.2.0  # From the root of the repository
+```
+
+Note that `cargo set-version` only acts **within** the current workspace, so you'll have to **run it once for every workspace** in the repository. You can find all workspaces by searching for `[workspace]`.
+
+Dependencies across workspace boundaries will not be updated automatically by `cargo set-version`. After running the command, do a final search for the old version number and ensure that it's not used anywhere (except possibly by unrelated 3rd-party dependencies). The good news is that even if you miss any dependency during this step, it will not block the release because only crates within the root workspaces are published to <https://crates.io>.
+
+## Prepare the PR
+
+At this point, the branch you're working on should contain two kinds of changes:
+
+1. (Optional.) Documentation updates, tutorial fixes, etc..
+2. Updated Cargo manifests.
+3. Updated `Cargo.lock` files.
+
+After committing these changes, you should open a new PR **against `nightly`**. Ensure all tests and lints pass but **do not merge just yet!**
+
+## Release to `crates.io`
+
+**After** the PR is approved but **before** it's merged, you should release the crates in `packages_to_publish.txt` to <https://crates.io>. Go through the list of crates to release _in order_ and run these commands:
+
+- [ ] `$ cargo publish --dry-run -p {crate}` to ensure there are no issues.
+- [ ] `$ cargo publish -p {crate}` to actually release the crate.
+
+## Create a tag and a GitHub release
+
+- [ ] Create a new tag named `{version}` (e.g. `v0.2.0-alpha`) from the `release/{version}` branch.
+- [ ] Push the tag (`git push origin {version}`)
+- [ ] Create a new GitHub release from the tag [here](https://github.com/Sovereign-Labs/sovereign-sdk/releases/new). The release title should be the version number (e.g. `v0.2.0-alpha`). Consult the team to decide on a good release description.
+
+## Merge to `nightly` and `stable`
+
+- [ ] Merge your PR to `nightly`.
+- [ ] Merge `nightly` to `stable` with a new PR. Make sure no commits that are not part of the release get merged accidentally into `stable`.

--- a/adapters/celestia/Cargo.toml
+++ b/adapters/celestia/Cargo.toml
@@ -29,12 +29,15 @@ serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", optional = true }
+sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.2", optional = true }
 risc0-zkvm = { version = "0.16", default-features = false, features = ["std"], optional = true }
 risc0-zkvm-platform = { version = "0.16", optional = true }
 
-sov-rollup-interface = { path = "../../rollup-interface" }
-nmt-rs = { git = "https://github.com/Sovereign-Labs/nmt-rs.git", rev = "dd37588444fca72825d11fe4a46838f66525c49f", features = ["serde", "borsh"] }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.2" }
+nmt-rs = { git = "https://github.com/Sovereign-Labs/nmt-rs.git", rev = "dd37588444fca72825d11fe4a46838f66525c49f", features = [
+	"serde",
+	"borsh",
+] }
 
 
 [dev-dependencies]

--- a/adapters/risc0/Cargo.toml
+++ b/adapters/risc0/Cargo.toml
@@ -22,8 +22,8 @@ serde = { workspace = true }
 bytemuck = "1.13.1"
 once_cell = { version = "1.7.2", optional = true }
 parking_lot = { version = "0.12.1", optional = true }
-sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils" }
-sov-rollup-interface = { path = "../../rollup-interface" }
+sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils", version = "0.2" }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.2" }
 
 [features]
 default = []

--- a/adapters/risc0/Cargo.toml
+++ b/adapters/risc0/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "sov-risc0-adapter"
 authors = { workspace = true }
+description = "An adapter allowing Risc0 to be used with the Sovereign SDK"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/examples/demo-prover/Cargo.lock
+++ b/examples/demo-prover/Cargo.lock
@@ -582,7 +582,7 @@ checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
 name = "const-rollup-config"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "constant_time_eq"
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "demo-stf"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "methods"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "risc0-build",
 ]
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "sov-accounts"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3595,7 +3595,7 @@ dependencies = [
 
 [[package]]
 name = "sov-bank"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3613,7 +3613,7 @@ dependencies = [
 
 [[package]]
 name = "sov-blob-storage"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3632,7 +3632,7 @@ dependencies = [
 
 [[package]]
 name = "sov-celestia-adapter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "sov-chain-state"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3676,7 +3676,7 @@ dependencies = [
 
 [[package]]
 name = "sov-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3693,7 +3693,7 @@ dependencies = [
 
 [[package]]
 name = "sov-db"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "sov-demo-prover-host"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "sov-demo-rollup"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3778,14 +3778,14 @@ dependencies = [
 
 [[package]]
 name = "sov-first-read-last-write-cache"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "sov-modules-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-stf-template"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3839,7 +3839,7 @@ dependencies = [
 
 [[package]]
 name = "sov-risc0-adapter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "sov-rollup-interface"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "sov-schema-db"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "sov-sequencer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "sov-sequencer-registry"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "sov-state"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "sov-stf-runner"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3954,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "sov-value-setter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "sov-zk-cycle-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "sov-zk-cycle-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "risc0-zkvm",
  "risc0-zkvm-platform",

--- a/examples/demo-prover/README.md
+++ b/examples/demo-prover/README.md
@@ -1,22 +1,31 @@
-# Demo Prover
+# Demo Prover ![Time - ~10 mins](https://img.shields.io/badge/Time-~10_mins-informational)
 
-This is a demo running a simple Sovereign SDK rollup **prover** on [Celestia](https://celestia.org/)
-with [RiscZero](https://www.risczero.com/) prover.
-None of its code is suitable for production use.
-It contains known security flaws and numerous inefficiencies.
+This is a demo running a simple Sovereign SDK rollup **prover** on [Celestia](https://celestia.org/), with [RiscZero](https://www.risczero.com/) as a prover.
+
+<p align="center">
+  <img width="50%" src="../../assets/discord-banner.png">
+  <br>
+  <i>Stuck, facing problems, or unsure about something?</i>
+  <br>
+  <i>Join our <a href="https://discord.gg/kbykCcPrcA">Discord</a> and ask your questions in <code>#support</code>!</i>
+</p>
+
+### Disclaimer
+
+> ⚠️ Warning! ⚠️
+
+`demo-prover` is a prototype! It contains known vulnerabilities and inefficiencies, and no part of its code not be used in production under any circumstances.
 
 ## What is it?
 
-This demo shows how to integrate RiscZero prover into rollup workflow.
-This code reads blocks from Celestia, executes them and inside the RiscZero ZKVM, and creates a proof of the result.
+This demo shows how to integrate the [RiscZero](https://risczero.com) prover into a rollup built with the Sovereign SDK. It reads blocks from Celestia, executes them inside the RiscZero zkVM, and creates a cryptographic proof of the result.
 
 This package implements the same logic as [`demo-rollup`](../demo-rollup/), but it splits the logic between
-the "host" and "guest" (prover and zk-circuit) to create actual zk-proofs. This separation makes it slightly
-harder to follow at first glance, so we recommend diving into the `demo-rollup` before attempting to use this package.
+a "host" and a "guest" (respectively the prover and ZK-circuit) to create actual ZK proofs. This separation makes it slightly harder to follow at first glance, so we recommend diving into the `demo-rollup` before attempting to use this package.
 
 ## Prerequisites
 
-Running this example requires at least 96GB of RAM for x86 CPU architecture.
+You'll need at least 96GiB of RAM to run this example on a x86_64 CPU. If you don't have that much memory available, you can still still run the demo but skip proof generation by setting the environment variable `SKIP_PROVER`.
 
 ## Getting Started
 
@@ -30,7 +39,7 @@ Running this example requires at least 96GB of RAM for x86 CPU architecture.
 
 ## Development
 
-[IDE integration](./ide_setup.md) described in separate document.
+Follow our [IDE integration](./ide_setup.md) guide document.
 
 ## License
 

--- a/examples/demo-prover/host/Cargo.toml
+++ b/examples/demo-prover/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sov-demo-prover-host"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 resolver = "2"

--- a/examples/demo-prover/methods/Cargo.toml
+++ b/examples/demo-prover/methods/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "methods"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 resolver = "2"
 

--- a/examples/demo-prover/methods/guest/Cargo.lock
+++ b/examples/demo-prover/methods/guest/Cargo.lock
@@ -307,7 +307,7 @@ checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
 name = "const-rollup-config"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "constant_time_eq"
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "demo-stf"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "sov-accounts"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "sov-bank"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "sov-blob-storage"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "sov-celestia-adapter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "sov-chain-state"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "sov-demo-prover-guest"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2086,14 +2086,14 @@ dependencies = [
 
 [[package]]
 name = "sov-first-read-last-write-cache"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "sov-modules-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "sov-modules-stf-template"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2146,7 +2146,7 @@ dependencies = [
 
 [[package]]
 name = "sov-risc0-adapter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "sov-rollup-interface"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "sov-sequencer-registry"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "sov-state"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bcs",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "sov-value-setter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "sov-zk-cycle-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "sov-zk-cycle-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "risc0-zkvm",
  "risc0-zkvm-platform",

--- a/examples/demo-prover/methods/guest/Cargo.toml
+++ b/examples/demo-prover/methods/guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sov-demo-prover-guest"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 resolver = "2"
 

--- a/examples/demo-rollup/README.md
+++ b/examples/demo-rollup/README.md
@@ -133,12 +133,8 @@ The `make test-create-token` command above was useful to test if everything is r
 You'll need the `sov-cli` binary in order to create transactions. Build it with these commands:
 
 ```sh
-$ cd ../demo-stf   # Assuming you're still in examples/demo-rollup/
-$ cargo build --bin sov-cli
-$ cd ../..   # Go back to the root of the repository
-$ ./target/debug/sov-cli -h
-Main entry point for CLI
-
+# Make sure you're still in `examples/demo-rollup`
+$ cargo run --bin sov-cli
 Usage: sov-cli <COMMAND>
 
 Commands:
@@ -204,7 +200,7 @@ pub enum CallMessage<C: sov_modules_api::Context> {
 }
 ```
 
-In the above snippet, we can see that `CallMessage` in `Bank` supports five different types of calls. The `sov-cli` has the ability to parse a JSON file that aligns with any of these calls and subsequently serialize them. The structure of the JSON file, which represents the call, closely mirrors that of the Enum member. Consider the `Transfer` message as an example:
+In the above snippet, we can see that `CallMessage` in `Bank` supports five different types of calls. The `sov-cli` has the ability to parse a JSON file that aligns with any of these calls and subsequently serialize them. The structure of the JSON file, which represents the call, closely mirrors that of the Enum member. You can view the relevant JSON Schema for `Bank` [here](../../module-system/module-schemas/schemas/sov-bank.json) Consider the `Transfer` message as an example:
 
 ```rust
 use sov_bank::Coins;
@@ -233,7 +229,7 @@ Here's an example of a JSON representing the above call:
 
 #### 2. Generate the Transaction
 
-The JSON above is the contents of the file `examples/test-data/requests/transfer.json`. We'll use this transaction as our example for the rest of the tutorial. In order to send the transaction, we need to perform 2 operations:
+The JSON above is the contents of the file [`examples/test-data/requests/transfer.json`](../../examples/test-data/requests/transfer.json). We'll use this transaction as our example for the rest of the tutorial. In order to send the transaction, we need to perform 2 operations:
 
 - Import the transaction data into the wallet
 - Sign and submit the transaction
@@ -243,7 +239,7 @@ Note: we're able to make a `Transfer` call here because we already created the t
 To generate transactions you can use the `transactions import from-file` subcommand, as shown below:
 
 ```sh
-$ ./target/debug/sov-cli transactions import from-file -h
+$ cargo run --bin sov-cli -- transactions import from-file -h
 Import a transaction from a JSON file at the provided path
 
 Usage: sov-cli transactions import from-file <COMMAND>
@@ -251,7 +247,6 @@ Usage: sov-cli transactions import from-file <COMMAND>
 Commands:
   bank                Generates a transaction for the `bank` module
   sequencer-registry  Generates a transaction for the `sequencer_registry` module
-  election            Generates a transaction for the `election` module
   value-setter        Generates a transaction for the `value_setter` module
   accounts            Generates a transaction for the `accounts` module
   help                Print this message or the help of the given subcommand(s)
@@ -263,7 +258,7 @@ Options:
 Let's go ahead and import the transaction into the wallet
 
 ```bash
-$ ./target/debug/sov-cli transactions import from-file bank --path ./examples/test-data/requests/transfer.json
+$ cargo run --bin sov-cli -- transactions import from-file bank --path ../test-data/requests/transfer.json
 Adding the following transaction to batch:
 {
   "bank": {
@@ -286,10 +281,10 @@ You now have a batch with a single transaction in your wallet. If you want to su
 batch, you can import them now. Finally, let's submit your transaction to the rollup.
 
 ```bash
-$ ./target/debug/sov-cli rpc submit-batch by-address sov1l6n2cku82yfqld30lanm2nfw43n2auc8clw7r5u5m6s7p8jrm4zqrr8r94
+$ cargo run --bin sov-cli rpc submit-batch by-address sov1l6n2cku82yfqld30lanm2nfw43n2auc8clw7r5u5m6s7p8jrm4zqrr8r94
 ```
 
-This command will use your default private key
+This command will use your default private key.
 
 #### 4. Verify the Token Supply
 

--- a/full-node/db/sov-db/Cargo.toml
+++ b/full-node/db/sov-db/Cargo.toml
@@ -16,8 +16,8 @@ resolver = "2"
 [dependencies]
 # Maintained by sovereign labs
 jmt = { workspace = true }
-sov-schema-db = { path = "../sov-schema-db", version = "0.1" }
-sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1", features = ["native", "mocks"] }
+sov-schema-db = { path = "../sov-schema-db", version = "0.2" }
+sov-rollup-interface = { path = "../../../rollup-interface", version = "0.2", features = ["native", "mocks"] }
 
 # External
 anyhow = { workspace = true }

--- a/full-node/sov-sequencer/Cargo.toml
+++ b/full-node/sov-sequencer/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "sov-sequencer"
 authors = { workspace = true }
+description = "A simple implementation of a sequencer for Sovereign SDK rollups"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/full-node/sov-sequencer/Cargo.toml
+++ b/full-node/sov-sequencer/Cargo.toml
@@ -16,10 +16,10 @@ resolver = "2"
 anyhow = { workspace = true }
 borsh = { workspace = true }
 hex = { workspace = true }
-jsonrpsee = { workspace = true, features = ["client", "server",] }
+jsonrpsee = { workspace = true, features = ["client", "server"] }
 serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
-sov-rollup-interface = { path = "../../rollup-interface" }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.2" }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/full-node/sov-stf-runner/Cargo.toml
+++ b/full-node/sov-stf-runner/Cargo.toml
@@ -23,11 +23,11 @@ tracing = { workspace = true }
 futures = "0.3"
 tracing-subscriber = "0.3.17"
 
-sov-db = { path = "../db/sov-db", optional = true }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.1" }
-sov-state = { path = "../../module-system/sov-state", version = "0.1" }
-sov-modules-api = { path = "../../module-system/sov-modules-api", version = "0.1" }
-sov-celestia-adapter = { path = "../../adapters/celestia" }
+sov-db = { path = "../db/sov-db", version = "0.2", optional = true }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.2" }
+sov-state = { path = "../../module-system/sov-state", version = "0.2", features = ["native"] }
+sov-modules-api = { path = "../../module-system/sov-modules-api", version = "0.2", features = ["native"] }
+sov-celestia-adapter = { path = "../../adapters/celestia", version = "0.2", features = ["native"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
@@ -42,8 +42,8 @@ sov-accounts = { path = "../../module-system/module-implementations/sov-accounts
 [features]
 default = []
 native = [
-	"sov-db",
-	"sov-celestia-adapter/native",
+    "sov-db",
+    "sov-celestia-adapter/native",
     "sov-sequencer-registry/native",
     "sov-bank/native",
     "sov-state/native",

--- a/full-node/sov-stf-runner/Cargo.toml
+++ b/full-node/sov-stf-runner/Cargo.toml
@@ -25,9 +25,9 @@ tracing-subscriber = "0.3.17"
 
 sov-db = { path = "../db/sov-db", version = "0.2", optional = true }
 sov-rollup-interface = { path = "../../rollup-interface", version = "0.2" }
-sov-state = { path = "../../module-system/sov-state", version = "0.2", features = ["native"] }
-sov-modules-api = { path = "../../module-system/sov-modules-api", version = "0.2", features = ["native"] }
-sov-celestia-adapter = { path = "../../adapters/celestia", version = "0.2", features = ["native"] }
+sov-state = { path = "../../module-system/sov-state", version = "0.2" }
+sov-modules-api = { path = "../../module-system/sov-modules-api", version = "0.2" }
+sov-celestia-adapter = { path = "../../adapters/celestia", version = "0.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sovereign-sdk-fuzz"
-version = "0.1.0"
+version = "0.2.0"
 publish = false
 edition = "2021"
 

--- a/module-system/module-implementations/sov-accounts/Cargo.toml
+++ b/module-system/module-implementations/sov-accounts/Cargo.toml
@@ -22,8 +22,8 @@ thiserror = { workspace = true }
 clap = { workspace = true, optional = true }
 jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
-sov-state = { path = "../../sov-state", version = "0.1" }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.2" }
+sov-state = { path = "../../sov-state", version = "0.2" }
 
 
 [dev-dependencies]

--- a/module-system/module-implementations/sov-attester-incentives/Cargo.toml
+++ b/module-system/module-implementations/sov-attester-incentives/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 resolver = "2"
 
 [dev-dependencies]
-sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1", features = ["mocks"] }
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
+sov-rollup-interface = { path = "../../../rollup-interface", version = "0.2", features = ["mocks"] }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.2" }
 sov-attester-incentives = { path = ".", features = ["native"] }
 tempfile = { workspace = true }
 
@@ -26,10 +26,10 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 
-sov-bank = { path = "../sov-bank", version = "0.1" }
-sov-chain-state = { path = "../sov-chain-state", version = "0.1" }
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
-sov-state = { path = "../../sov-state", version = "0.1" }
+sov-bank = { path = "../sov-bank", version = "0.2" }
+sov-chain-state = { path = "../sov-chain-state", version = "0.2" }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.2" }
+sov-state = { path = "../../sov-state", version = "0.2" }
 
 
 [features]

--- a/module-system/module-implementations/sov-attester-incentives/Cargo.toml
+++ b/module-system/module-implementations/sov-attester-incentives/Cargo.toml
@@ -20,7 +20,7 @@ tempfile = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
-bcs = { workspace = true }
+bcs = { git = "https://github.com/preston-evans98/bcs.git", rev = "e4f1861" }
 jmt = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/module-system/module-implementations/sov-bank/Cargo.toml
+++ b/module-system/module-implementations/sov-bank/Cargo.toml
@@ -22,9 +22,9 @@ serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 hex = { workspace = true }
 
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
-sov-state = { path = "../../sov-state", version = "0.1" }
-sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1" }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.2" }
+sov-state = { path = "../../sov-state", version = "0.2" }
+sov-rollup-interface = { path = "../../../rollup-interface", version = "0.2" }
 
 
 [dev-dependencies]

--- a/module-system/module-implementations/sov-blob-storage/Cargo.toml
+++ b/module-system/module-implementations/sov-blob-storage/Cargo.toml
@@ -20,9 +20,9 @@ bincode = { workspace = true }
 tracing = { workspace = true }
 hex = { workspace = true }
 
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
-sov-state = { path = "../../sov-state", version = "0.1" }
-sov-sequencer-registry = { path = "../sov-sequencer-registry", version = "0.1" }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.2" }
+sov-state = { path = "../../sov-state", version = "0.2" }
+sov-sequencer-registry = { path = "../sov-sequencer-registry", version = "0.2" }
 sov-chain-state = { path = "../sov-chain-state" }
 
 schemars = { workspace = true, optional = true }

--- a/module-system/module-implementations/sov-blob-storage/Cargo.toml
+++ b/module-system/module-implementations/sov-blob-storage/Cargo.toml
@@ -23,7 +23,7 @@ hex = { workspace = true }
 sov-modules-api = { path = "../../sov-modules-api", version = "0.2" }
 sov-state = { path = "../../sov-state", version = "0.2" }
 sov-sequencer-registry = { path = "../sov-sequencer-registry", version = "0.2" }
-sov-chain-state = { path = "../sov-chain-state" }
+sov-chain-state = { path = "../sov-chain-state", version = "0.2" }
 
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
@@ -40,12 +40,4 @@ tempfile = { workspace = true }
 
 [features]
 default = []
-native = [
-    "jsonrpsee",
-    "schemars",
-    "serde",
-    "serde_json",
-    "sov-modules-api/native",
-    "sov-state/native",
-    "sov-sequencer-registry/native",
-]
+native = ["jsonrpsee", "schemars", "serde", "serde_json", "sov-modules-api/native", "sov-state/native", "sov-sequencer-registry/native"]

--- a/module-system/module-implementations/sov-chain-state/Cargo.toml
+++ b/module-system/module-implementations/sov-chain-state/Cargo.toml
@@ -18,10 +18,9 @@ serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
-sov-state = { path = "../../sov-state", version = "0.1" }
-sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1" }
-
+sov-modules-api = { path = "../../sov-modules-api", version = "0.2" }
+sov-state = { path = "../../sov-state", version = "0.2" }
+sov-rollup-interface = { path = "../../../rollup-interface", version = "0.2" }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/module-system/module-implementations/sov-chain-state/Cargo.toml
+++ b/module-system/module-implementations/sov-chain-state/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "sov-chain-state"
 authors = { workspace = true }
+description = "A Sovereign SDK module for storing a rollup's historical state"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/module-system/module-implementations/sov-chain-state/Cargo.toml
+++ b/module-system/module-implementations/sov-chain-state/Cargo.toml
@@ -8,7 +8,6 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 readme = "README.md"
-publish = false
 resolver = "2"
 
 [dependencies]

--- a/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/module-system/module-implementations/sov-evm/Cargo.toml
@@ -14,8 +14,8 @@ resolver = "2"
 
 [dependencies]
 
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
-sov-state = { path = "../../sov-state", version = "0.1" }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.2" }
+sov-state = { path = "../../sov-state", version = "0.2" }
 
 anyhow = { workspace = true }
 thiserror = { workspace = true }

--- a/module-system/module-implementations/sov-prover-incentives/Cargo.toml
+++ b/module-system/module-implementations/sov-prover-incentives/Cargo.toml
@@ -15,7 +15,7 @@ resolver = "2"
 sov-rollup-interface = { path = "../../../rollup-interface", version = "0.2", features = ["mocks"] }
 sov-modules-api = { path = "../../sov-modules-api", version = "0.2", features = ["native"] }
 tempfile = { workspace = true }
-sov-prover-incentives = { version = "*", features = ["native"], path = "." }
+sov-prover-incentives = { features = ["native"], path = "." }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/module-system/module-implementations/sov-prover-incentives/Cargo.toml
+++ b/module-system/module-implementations/sov-prover-incentives/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 resolver = "2"
 
 [dev-dependencies]
-sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1", features = ["mocks"] }
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1", features = ["native"] }
+sov-rollup-interface = { path = "../../../rollup-interface", version = "0.2", features = ["mocks"] }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.2", features = ["native"] }
 tempfile = { workspace = true }
 sov-prover-incentives = { version = "*", features = ["native"], path = "." }
 
@@ -25,9 +25,9 @@ schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 
-sov-bank = { path = "../sov-bank", version = "0.1" }
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
-sov-state = { path = "../../sov-state", version = "0.1" }
+sov-bank = { path = "../sov-bank", version = "0.2" }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.2" }
+sov-state = { path = "../../sov-state", version = "0.2" }
 
 
 [features]

--- a/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
+++ b/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
@@ -28,10 +28,10 @@ serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 borsh = { workspace = true, features = ["rc"] }
 jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
-sov-zk-cycle-macros = { path = "../../../utils/zk-cycle-macros", optional = true }
+sov-zk-cycle-macros = { path = "../../../utils/zk-cycle-macros", version = "0.2", optional = true }
 risc0-zkvm = { version = "0.16", default-features = false, features = ["std"], optional = true }
 risc0-zkvm-platform = { version = "0.16", optional = true }
-sov-zk-cycle-utils = { path = "../../../utils/zk-cycle-utils", optional = true }
+sov-zk-cycle-utils = { path = "../../../utils/zk-cycle-utils", version = "0.2", optional = true }
 
 [features]
 bench = ["sov-zk-cycle-macros/bench", "risc0-zkvm", "risc0-zkvm-platform", "sov-zk-cycle-utils"]

--- a/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
+++ b/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
@@ -14,15 +14,15 @@ resolver = "2"
 
 [dev-dependencies]
 sov-sequencer-registry = { path = ".", features = ["native"] }
-sov-rollup-interface = { path = "../../../rollup-interface", version = "0.1", features = ["mocks"] }
+sov-rollup-interface = { path = "../../../rollup-interface", version = "0.2", features = ["mocks"] }
 tempfile = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, optional = true }
-sov-bank = { path = "../sov-bank", version = "0.1" }
-sov-modules-api = { path = "../../sov-modules-api", version = "0.1" }
-sov-state = { path = "../../sov-state", version = "0.1" }
+sov-bank = { path = "../sov-bank", version = "0.2" }
+sov-modules-api = { path = "../../sov-modules-api", version = "0.2" }
+sov-state = { path = "../../sov-state", version = "0.2" }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }

--- a/module-system/sov-cli/Cargo.toml
+++ b/module-system/sov-cli/Cargo.toml
@@ -17,9 +17,9 @@ path = "src/lib.rs"
 
 
 [dependencies]
-sov-modules-api = { path = "../sov-modules-api", version = "0.1", features = ["native"] }
-sov-bank = { path = "../module-implementations/sov-bank", version = "0.1", features = ["native"] }
-sov-accounts = { path = "../module-implementations/sov-accounts", version = "0.1", features = ["native"] }
+sov-modules-api = { path = "../sov-modules-api", version = "0.2", features = ["native"] }
+sov-bank = { path = "../module-implementations/sov-bank", version = "0.2", features = ["native"] }
+sov-accounts = { path = "../module-implementations/sov-accounts", version = "0.2", features = ["native"] }
 directories = "5.0.1"
 anyhow = { workspace = true }
 hex = { workspace = true, features = ["serde"] }

--- a/module-system/sov-modules-api/Cargo.toml
+++ b/module-system/sov-modules-api/Cargo.toml
@@ -18,7 +18,7 @@ arbitrary = { workspace = true, optional = true }
 sov-state = { path = "../sov-state", version = "0.2" }
 sov-rollup-interface = { path = "../../rollup-interface", version = "0.2" }
 sov-modules-macros = { path = "../sov-modules-macros", version = "0.2", optional = true }
-sov-sequencer = { path = "../../full-node/sov-sequencer", optional = true }
+sov-sequencer = { path = "../../full-node/sov-sequencer", version = "0.2", optional = true }
 serde = { workspace = true }
 borsh = { workspace = true }
 thiserror = { workspace = true }
@@ -33,7 +33,7 @@ schemars = { workspace = true, optional = true, features = [] }
 ed25519-dalek = { version = "2.0.0", default-features = false }
 rand = { version = "0.8", optional = true }
 
-sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", optional = true }
+sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.2", optional = true }
 risc0-zkvm = { version = "0.16", default-features = false, features = ["std"], optional = true }
 risc0-zkvm-platform = { version = "0.16", optional = true }
 
@@ -45,5 +45,19 @@ sov-bank = { path = "../module-implementations/sov-bank", version = "0.2", featu
 [features]
 bench = ["sov-zk-cycle-macros", "risc0-zkvm", "risc0-zkvm-platform"]
 default = ["macros"]
-native = ["serde_json", "rand", "hex", "schemars", "ed25519-dalek/default", "ed25519-dalek/serde", "ed25519-dalek/rand_core", "clap", "jsonrpsee", "macros", "sov-modules-macros/native", "sov-state/native", "sov-sequencer"]
+native = [
+	"serde_json",
+	"rand",
+	"hex",
+	"schemars",
+	"ed25519-dalek/default",
+	"ed25519-dalek/serde",
+	"ed25519-dalek/rand_core",
+	"clap",
+	"jsonrpsee",
+	"macros",
+	"sov-modules-macros/native",
+	"sov-state/native",
+	"sov-sequencer",
+]
 macros = ["sov-modules-macros"]

--- a/module-system/sov-modules-api/Cargo.toml
+++ b/module-system/sov-modules-api/Cargo.toml
@@ -40,7 +40,7 @@ risc0-zkvm-platform = { version = "0.16", optional = true }
 [dev-dependencies]
 bincode = { workspace = true }
 sov-modules-api = { path = ".", features = ["native"] }
-sov-bank = { path = "../module-implementations/sov-bank", version = "0.2", features = ["native"] }
+sov-bank = { path = "../module-implementations/sov-bank", features = ["native"] }
 
 [features]
 bench = ["sov-zk-cycle-macros", "risc0-zkvm", "risc0-zkvm-platform"]

--- a/module-system/sov-modules-api/Cargo.toml
+++ b/module-system/sov-modules-api/Cargo.toml
@@ -15,9 +15,9 @@ resolver = "2"
 jsonrpsee = { workspace = true, optional = true }
 anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
-sov-state = { path = "../sov-state", version = "0.1" }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.1" }
-sov-modules-macros = { path = "../sov-modules-macros", version = "0.1", optional = true }
+sov-state = { path = "../sov-state", version = "0.2" }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.2" }
+sov-modules-macros = { path = "../sov-modules-macros", version = "0.2", optional = true }
 sov-sequencer = { path = "../../full-node/sov-sequencer", optional = true }
 serde = { workspace = true }
 borsh = { workspace = true }
@@ -40,7 +40,7 @@ risc0-zkvm-platform = { version = "0.16", optional = true }
 [dev-dependencies]
 bincode = { workspace = true }
 sov-modules-api = { path = ".", features = ["native"] }
-sov-bank = { path = "../module-implementations/sov-bank", version = "0.1", features = ["native"] }
+sov-bank = { path = "../module-implementations/sov-bank", version = "0.2", features = ["native"] }
 
 [features]
 bench = ["sov-zk-cycle-macros", "risc0-zkvm", "risc0-zkvm-platform"]

--- a/module-system/sov-modules-macros/Cargo.toml
+++ b/module-system/sov-modules-macros/Cargo.toml
@@ -27,9 +27,9 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 trybuild = "1.0"
 
-sov-modules-api = { path = "../sov-modules-api", version = "0.2" }
-sov-state = { path = "../sov-state", version = "0.2" }
-sov-bank = { path = "../module-implementations/sov-bank", version = "0.2", features = ["native"] }
+sov-modules-api = { path = "../sov-modules-api" }
+sov-state = { path = "../sov-state" }
+sov-bank = { path = "../module-implementations/sov-bank", features = ["native"] }
 sov-modules-macros = { path = ".", features = ["native"] }
 
 [dependencies]

--- a/module-system/sov-modules-macros/Cargo.toml
+++ b/module-system/sov-modules-macros/Cargo.toml
@@ -27,9 +27,9 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 trybuild = "1.0"
 
-sov-modules-api = { path = "../sov-modules-api", version = "0.1" }
-sov-state = { path = "../sov-state", version = "0.1" }
-sov-bank = { path = "../module-implementations/sov-bank", version = "0.1", features = ["native"] }
+sov-modules-api = { path = "../sov-modules-api", version = "0.2" }
+sov-state = { path = "../sov-state", version = "0.2" }
+sov-bank = { path = "../module-implementations/sov-bank", version = "0.2", features = ["native"] }
 sov-modules-macros = { path = ".", features = ["native"] }
 
 [dependencies]

--- a/module-system/sov-modules-stf-template/Cargo.toml
+++ b/module-system/sov-modules-stf-template/Cargo.toml
@@ -20,9 +20,9 @@ tracing = { workspace = true }
 jmt = { workspace = true }
 hex = { workspace = true }
 
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.1" }
-sov-state = { path = "../sov-state", version = "0.1" }
-sov-modules-api = { path = "../sov-modules-api", version = "0.1" }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.2" }
+sov-state = { path = "../sov-state", version = "0.2" }
+sov-modules-api = { path = "../sov-modules-api", version = "0.2" }
 sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", optional = true }
 sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils", optional = true }
 risc0-zkvm = { version = "0.16", default-features = false, features = ["std"], optional = true }

--- a/module-system/sov-modules-stf-template/Cargo.toml
+++ b/module-system/sov-modules-stf-template/Cargo.toml
@@ -23,8 +23,8 @@ hex = { workspace = true }
 sov-rollup-interface = { path = "../../rollup-interface", version = "0.2" }
 sov-state = { path = "../sov-state", version = "0.2" }
 sov-modules-api = { path = "../sov-modules-api", version = "0.2" }
-sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", optional = true }
-sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils", optional = true }
+sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.2", optional = true }
+sov-zk-cycle-utils = { path = "../../utils/zk-cycle-utils", version = "0.2", optional = true }
 risc0-zkvm = { version = "0.16", default-features = false, features = ["std"], optional = true }
 risc0-zkvm-platform = { version = "0.16", optional = true }
 

--- a/module-system/sov-state/Cargo.toml
+++ b/module-system/sov-state/Cargo.toml
@@ -19,9 +19,9 @@ bcs = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-sov-rollup-interface = { path = "../../rollup-interface", version = "0.1" }
-sov-db = { path = "../../full-node/db/sov-db", version = "0.1", optional = true }
-sov-first-read-last-write-cache = { path = "../utils/sov-first-read-last-write-cache", version = "0.1" }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.2" }
+sov-db = { path = "../../full-node/db/sov-db", version = "0.2", optional = true }
+sov-first-read-last-write-cache = { path = "../utils/sov-first-read-last-write-cache", version = "0.2" }
 jmt = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true }

--- a/module-system/sov-state/Cargo.toml
+++ b/module-system/sov-state/Cargo.toml
@@ -26,7 +26,7 @@ jmt = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true }
 
-sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", optional = true }
+sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.2", optional = true }
 risc0-zkvm = { version = "0.16", default-features = false, features = ["std"], optional = true }
 risc0-zkvm-platform = { version = "0.16", optional = true }
 

--- a/packages_to_publish.txt
+++ b/packages_to_publish.txt
@@ -3,12 +3,21 @@ sov-first-read-last-write-cache
 sov-schema-db
 sov-db
 sov-sequencer
+sov-zk-cycle-macros
+sov-zk-cycle-utils
 sov-state
-sov-modules-api
 sov-modules-macros
+sov-modules-api
 sov-modules-stf-template
+
+# Modules
 sov-accounts
 sov-bank
 sov-sequencer-registry
 sov-prover-incentives
+sov-chain-state
 sov-blob-storage
+
+# Adapters
+sov-risc0-adapter
+sov-celestia-adapter

--- a/packages_to_publish.txt
+++ b/packages_to_publish.txt
@@ -20,4 +20,4 @@ sov-blob-storage
 
 # Adapters
 sov-risc0-adapter
-sov-celestia-adapter
+# TODO: sov-celestia-adapter (https://github.com/Sovereign-Labs/nmt-rs/issues/17)

--- a/utils/zk-cycle-utils/Cargo.toml
+++ b/utils/zk-cycle-utils/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "sov-zk-cycle-utils"
 authors = { workspace = true }
+description = "Utilities for counting risc0 cycles consumed by Sovereign SDK functions"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }

--- a/utils/zk-cycle-utils/tracer/Cargo.lock
+++ b/utils/zk-cycle-utils/tracer/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "tracer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "capstone",
  "clap",

--- a/utils/zk-cycle-utils/tracer/Cargo.toml
+++ b/utils/zk-cycle-utils/tracer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracer"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 [workspace]


### PR DESCRIPTION
## Description
This PR makes the following changes:
- Updates a few outdated README tutorials which contained the wrong commands to run.
- Revamps the release process docs to make them more comprehensive and more detailed. Feedback is greatly appreciated here, I'm sure I've missed something.
- Fixes all Cargo manifests of crates that couldn't be published due to issues in their manifests.
- Updates `packages_to_publish.txt`.
- Finally, bumps the version number of all crates to 0.2.0 in preparation for the `v0.2.0-alpha` release.

## Testing
I've tested the release steps locally as much as I could. There's a good chance we'll still find problems along the way, as this is our first release in quite some time.

There is room for improvement in CI to make sure that crates are ready to be published at all times. Commit https://github.com/Sovereign-Labs/sovereign-sdk/commit/b71151461db1ff3af3605a4ae74f166c8287bf4b includes a fix for Cargo manifests that lacked version numbers for some dependencies, which caused errors when I run `cargo publish --dry-run -p ...`. Short of running `cargo publish --dry-run` on CI, I'm not sure there's a way for us to catch those beforehand. I'll try and think of something.

## Docs
I've updated `Releases.md`, `packages_to_publish.txt`, and a few outdated READMEs.
