### PR TITLE
Allow modules to query token names

### DIFF
--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -256,6 +256,16 @@ impl<C: sov_modules_api::Context> Bank<C> {
             .get(&token_address, working_set)
             .and_then(|token| token.balances.get(&user_address, working_set))
     }
+
+    /// Get the name of a token by address
+    pub fn get_token_name(
+        &self,
+        token_address: &C::Address,
+        working_set: &mut WorkingSet<C::Storage>,
+    ) -> Option<String> {
+        let token = self.tokens.get(&token_address, working_set);
+        token.map(|token| token.name)
+    }
 }
 
 /// Creates a new prefix from an already existing prefix `parent_prefix` and a `token_address`

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -263,7 +263,7 @@ impl<C: sov_modules_api::Context> Bank<C> {
         token_address: &C::Address,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> Option<String> {
-        let token = self.tokens.get(&token_address, working_set);
+        let token = self.tokens.get(token_address, working_set);
         token.map(|token| token.name)
     }
 }

--- a/module-system/module-implementations/sov-bank/tests/create_token_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/create_token_test.rs
@@ -24,7 +24,7 @@ fn initial_and_deployed_token() {
     let token_address = get_token_address::<C>(&token_name, sender_address.as_ref(), salt);
     let create_token_message = CallMessage::CreateToken::<C> {
         salt,
-        token_name,
+        token_name: token_name.clone(),
         initial_balance,
         minter_address,
         authorized_minters: vec![minter_address],
@@ -37,6 +37,11 @@ fn initial_and_deployed_token() {
 
     let sender_balance = bank.get_balance_of(sender_address, token_address, &mut working_set);
     assert!(sender_balance.is_none());
+
+    let observed_token_name = bank
+        .get_token_name(&token_address, &mut working_set)
+        .expect("Token is missing its name");
+    assert_eq!(&token_name, &observed_token_name);
 
     let minter_balance = bank.get_balance_of(minter_address, token_address, &mut working_set);
 


### PR DESCRIPTION
# Description
IBC needs to be able to fetch the name of a token. This PR adds a `getter` to the bank enabling that. 
