### PR TITLE
Add missing `derive(serde..)` to `BcsCodec & JsonCodec`

### DIFF
--- a/module-system/sov-state/src/codec/bcs_codec.rs
+++ b/module-system/sov-state/src/codec/bcs_codec.rs
@@ -1,7 +1,7 @@
 use crate::codec::StateValueCodec;
 
 /// A [`StateValueCodec`] that uses [`bcs`] for all keys and values.
-#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BcsCodec;
 
 impl<V> StateValueCodec<V> for BcsCodec

--- a/module-system/sov-state/src/codec/json_codec.rs
+++ b/module-system/sov-state/src/codec/json_codec.rs
@@ -3,7 +3,7 @@ use serde_json;
 use crate::codec::StateValueCodec;
 
 /// A [`StateValueCodec`] that uses [`serde_json`] for all values.
-#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct JsonCodec;
 
 impl<V> StateValueCodec<V> for JsonCodec


### PR DESCRIPTION
# Description
This PR adds missing serde derive for `BcsCodec & JsonCodec`

## Testing
Ci passes.

## Docs
No doc changes.
