### PR TITLE
Fix benchmark genesis address to match block production address

### DIFF
--- a/examples/demo-rollup/benches/rng_xfers.rs
+++ b/examples/demo-rollup/benches/rng_xfers.rs
@@ -14,7 +14,7 @@ use sov_rollup_interface::mocks::{
 };
 use sov_rollup_interface::services::da::DaService;
 
-pub(crate) const SEQUENCER_DA_ADDRESS: [u8; 32] = [99; 32];
+pub const SEQUENCER_DA_ADDRESS: [u8; 32] = [99; 32];
 
 #[derive(Clone)]
 /// A simple DaService for a random number generator.

--- a/examples/demo-rollup/benches/rollup_coarse_measure.rs
+++ b/examples/demo-rollup/benches/rollup_coarse_measure.rs
@@ -117,7 +117,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // data generation
     let mut blobs = vec![];
     let mut blocks = vec![];
-    for height in start_height..end_height + 1 {
+    for height in start_height..=end_height {
         let num_bytes = height.to_le_bytes();
         let mut barray = [0u8; 32];
         barray[..num_bytes.len()].copy_from_slice(&num_bytes);
@@ -139,7 +139,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // rollup processing
     let total = Instant::now();
     let mut apply_block_time = Duration::new(0, 0);
-    for height in start_height..end_height + 1 {
+    for height in start_height..=end_height {
         let filtered_block = &blocks[height as usize];
 
         let mut data_to_commit = SlotCommit::new(filtered_block.clone());
@@ -168,7 +168,13 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let total = total.elapsed();
     if timer_output {
-        print_times(total, apply_block_time, end_height, num_txns_per_block,num_success_txns);
+        print_times(
+            total,
+            apply_block_time,
+            end_height,
+            num_txns_per_block,
+            num_success_txns,
+        );
     }
     if prometheus_output {
         println!("{:#?}", registry.gather());

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -177,7 +177,6 @@ where
             .take()
             .expect("Working_set was initialized in begin_slot")
             .to_revertable();
-
         let selected_blobs = self
             .runtime
             .get_blobs_for_this_slot(blobs, &mut batch_workspace)
@@ -191,7 +190,6 @@ where
         self.checkpoint = Some(batch_workspace.checkpoint());
 
         let mut batch_receipts = vec![];
-
         for (blob_idx, mut blob) in selected_blobs.into_iter().enumerate() {
             let batch_receipt = self
                 .apply_blob(blob.as_mut_ref())


### PR DESCRIPTION
### Summary
This PR addresses an issue with our benchmarking script that used a sequencer address without first registering it with the rollup. This caused all blocks to have their transactions skipped, leading to misleadingly high throughput measurements.

### Changes
1. **Register correct address**: Now the RNG block generator used in benchmarking produces blocks that match the sequencer address registered during genesis. This ensures the benchmark properly processes the blocks.
2. **Benchmark Output**: A new row has been added to the benchmark output that shows the number of successfully processed transactions. This serves as an additional layer of verification for the user

### Root Cause
- The benchmark script and the main code were using different types (and addresses) for sequencer addresses in genesis.
- Type checking was not in place, allowing the discrepancy to go unnoticed.
- Benchmark script was using CelestiaAddress in the genesis and rng_xfers.rs was using a default MockAddress [99u8;32] in the headers for the blocks it produced

### Test Plan
1. Run the benchmark script to ensure that it no longer rejects all blocks.
2. Verify that the throughput measurement is now accurate/reasonable.
3. Confirm that the new row in the benchmark output shows the correct number of successfully processed transactions.
