### PR TITLE
EVM: Storage improvements , Blocks, Transactions, Receipts

### DIFF
--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -69,7 +69,7 @@ revm = { workspace = true }
 
 
 [features]
-default = []
+default = ["experimental"]
 experimental = ["sov-ethereum/experimental", "reth-primitives", "secp256k1"]
 
 [[bench]]

--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -69,7 +69,7 @@ revm = { workspace = true }
 
 
 [features]
-default = ["experimental"]
+default = []
 experimental = ["sov-ethereum/experimental", "reth-primitives", "secp256k1"]
 
 [[bench]]

--- a/examples/demo-rollup/tests/evm/mod.rs
+++ b/examples/demo-rollup/tests/evm/mod.rs
@@ -192,6 +192,7 @@ async fn send_tx_test_to_eth(rpc_address: SocketAddr) -> Result<(), Box<dyn std:
     test_client.execute().await
 }
 
+#[cfg(feature = "experimental")]
 #[tokio::test]
 async fn evm_tx_tests() -> Result<(), anyhow::Error> {
     let (port_tx, port_rx) = tokio::sync::oneshot::channel();

--- a/examples/demo-stf/src/hooks_impl.rs
+++ b/examples/demo-stf/src/hooks_impl.rs
@@ -90,13 +90,12 @@ impl<C: Context, Da: DaSpec> SlotHooks<Da> for Runtime<C, Da> {
 
     fn end_slot_hook(
         &self,
-        #[allow(unused_variables)] root_hash: [u8; 32],
         #[allow(unused_variables)] working_set: &mut sov_state::WorkingSet<
             <Self::Context as Spec>::Storage,
         >,
     ) {
         #[cfg(feature = "experimental")]
-        self.evm.end_slot_hook(root_hash, working_set);
+        self.evm.end_slot_hook(working_set);
     }
 
     fn finalize_slot_hook(

--- a/examples/demo-stf/src/hooks_impl.rs
+++ b/examples/demo-stf/src/hooks_impl.rs
@@ -4,7 +4,7 @@ use sov_modules_api::{Context, Spec};
 use sov_modules_stf_template::SequencerOutcome;
 use sov_rollup_interface::da::{BlobReaderTrait, DaSpec};
 use sov_sequencer_registry::SequencerRegistry;
-use sov_state::WorkingSet;
+use sov_state::{AccessoryWorkingSet, WorkingSet};
 use tracing::info;
 
 use crate::runtime::Runtime;
@@ -97,5 +97,17 @@ impl<C: Context, Da: DaSpec> SlotHooks<Da> for Runtime<C, Da> {
     ) {
         #[cfg(feature = "experimental")]
         self.evm.end_slot_hook(root_hash, working_set);
+    }
+
+    fn finalize_slot_hook(
+        &self,
+        #[allow(unused_variables)] root_hash: [u8; 32],
+        #[allow(unused_variables)] accesorry_working_set: &mut AccessoryWorkingSet<
+            <Self::Context as Spec>::Storage,
+        >,
+    ) {
+        #[cfg(feature = "experimental")]
+        self.evm
+            .finalize_slot_hook(root_hash, accesorry_working_set);
     }
 }

--- a/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
+++ b/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
@@ -72,8 +72,16 @@ impl<C: Context, Da: DaSpec> SlotHooks<Da> for TestRuntime<C, Da> {
 
     fn end_slot_hook(
         &self,
-        _root_hash: [u8; 32],
         _working_set: &mut sov_state::WorkingSet<<Self::Context as Spec>::Storage>,
+    ) {
+    }
+
+    fn finalize_slot_hook(
+        &self,
+        _root_hash: [u8; 32],
+        _accesorry_working_set: &mut sov_state::AccessoryWorkingSet<
+            <Self::Context as Spec>::Storage,
+        >,
     ) {
     }
 }

--- a/module-system/module-implementations/sov-chain-state/src/hooks.rs
+++ b/module-system/module-implementations/sov-chain-state/src/hooks.rs
@@ -1,6 +1,6 @@
 use sov_modules_api::hooks::SlotHooks;
 use sov_modules_api::{Context, SlotData, Spec};
-use sov_state::{Storage, WorkingSet};
+use sov_state::{AccessoryWorkingSet, Storage, WorkingSet};
 
 use super::ChainState;
 use crate::{StateTransitionId, TransitionInProgress};
@@ -65,6 +65,13 @@ impl<C: Context, Da: sov_modules_api::DaSpec> SlotHooks<Da> for ChainState<C, Da
         &self,
         _root_hash: [u8; 32],
         _working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
+    ) {
+    }
+
+    fn finalize_slot_hook(
+        &self,
+        _root_hash: [u8; 32],
+        _accesorry_working_set: &mut AccessoryWorkingSet<<Self::Context as Spec>::Storage>,
     ) {
     }
 }

--- a/module-system/module-implementations/sov-chain-state/src/hooks.rs
+++ b/module-system/module-implementations/sov-chain-state/src/hooks.rs
@@ -61,12 +61,7 @@ impl<C: Context, Da: sov_modules_api::DaSpec> SlotHooks<Da> for ChainState<C, Da
         );
     }
 
-    fn end_slot_hook(
-        &self,
-        _root_hash: [u8; 32],
-        _working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
-    ) {
-    }
+    fn end_slot_hook(&self, _working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>) {}
 
     fn finalize_slot_hook(
         &self,

--- a/module-system/module-implementations/sov-evm/src/call.rs
+++ b/module-system/module-implementations/sov-evm/src/call.rs
@@ -74,7 +74,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
                 },
                 // TODO: Do we want failed transactions to use all gas?
                 gas_used: 0,
-                log_index_start: log_index_start,
+                log_index_start,
                 error: Some(match err {
                     EVMError::Transaction(err) => EVMError::Transaction(err),
                     EVMError::PrevrandaoNotSet => EVMError::PrevrandaoNotSet,

--- a/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -10,7 +10,7 @@ use revm::primitives::{
 };
 use thiserror::Error;
 
-use super::transaction::{BlockEnv, RlpEvmTransaction};
+use super::transaction::{BlockEnv, RlpEvmTransaction, TransactionSignedAndRecovered};
 use super::AccountInfo;
 
 impl From<AccountInfo> for ReVmAccountInfo {
@@ -40,7 +40,7 @@ impl From<&BlockEnv> for ReVmBlockEnv {
         Self {
             number: U256::from(block_env.number),
             coinbase: block_env.coinbase,
-            timestamp: block_env.timestamp,
+            timestamp: U256::from(block_env.timestamp),
             // TODO: handle difficulty
             difficulty: U256::ZERO,
             prevrandao: block_env.prevrandao,
@@ -122,6 +122,15 @@ impl TryFrom<RlpEvmTransaction> for TransactionSignedEcRecovered {
     }
 }
 
+impl From<TransactionSignedAndRecovered> for TransactionSignedEcRecovered {
+    fn from(value: TransactionSignedAndRecovered) -> Self {
+        TransactionSignedEcRecovered::from_signed_transaction(
+            value.signed_transaction,
+            value.signer,
+        )
+    }
+}
+
 // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/576
 // https://github.com/paradigmxyz/reth/blob/d8677b4146f77c7c82d659c59b79b38caca78778/crates/rpc/rpc/src/eth/revm_utils.rs#L201
 pub fn prepare_call_env(request: CallRequest) -> TxEnv {
@@ -146,8 +155,4 @@ pub fn prepare_call_env(request: CallRequest) -> TxEnv {
         // TODO handle access list
         access_list: Default::default(),
     }
-}
-
-pub fn to_u64(value: U256) -> u64 {
-    value.try_into().unwrap()
 }

--- a/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -41,9 +41,8 @@ impl From<&BlockEnv> for ReVmBlockEnv {
             number: U256::from(block_env.number),
             coinbase: block_env.coinbase,
             timestamp: U256::from(block_env.timestamp),
-            // TODO: handle difficulty
             difficulty: U256::ZERO,
-            prevrandao: block_env.prevrandao,
+            prevrandao: Some(block_env.prevrandao),
             basefee: U256::from(block_env.basefee),
             gas_limit: U256::from(block_env.gas_limit),
         }

--- a/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -10,7 +10,7 @@ use super::transaction::BlockEnv;
 
 pub(crate) fn execute_tx<DB: Database<Error = Infallible> + DatabaseCommit>(
     db: DB,
-    block_env: BlockEnv,
+    block_env: &BlockEnv,
     tx: &TransactionSignedEcRecovered,
     config_env: CfgEnv,
 ) -> Result<ExecutionResult, EVMError<Infallible>> {
@@ -29,7 +29,7 @@ pub(crate) fn execute_tx<DB: Database<Error = Infallible> + DatabaseCommit>(
 
 pub(crate) fn inspect<DB: Database<Error = Infallible> + DatabaseCommit>(
     db: DB,
-    block_env: BlockEnv,
+    block_env: &BlockEnv,
     tx: TxEnv,
     config_env: CfgEnv,
 ) -> Result<ResultAndState, EVMError<Infallible>> {

--- a/module-system/module-implementations/sov-evm/src/evm/mod.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/mod.rs
@@ -59,12 +59,12 @@ impl DbAccount {
     }
 }
 
-pub(crate) fn contract_address(result: ExecutionResult) -> Option<B160> {
+pub(crate) fn contract_address(result: &ExecutionResult) -> Option<B160> {
     match result {
         ExecutionResult::Success {
             output: Output::Create(_, Some(addr)),
             ..
-        } => Some(addr),
+        } => Some(*addr),
         _ => None,
     }
 }

--- a/module-system/module-implementations/sov-evm/src/evm/mod.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/mod.rs
@@ -1,6 +1,5 @@
 use reth_primitives::{Address, H256, U256};
 use revm::primitives::specification::SpecId;
-use revm::primitives::{ExecutionResult, Output, B160};
 use serde::{Deserialize, Serialize};
 use sov_state::{Prefix, StateMap};
 
@@ -56,16 +55,6 @@ impl DbAccount {
         let mut prefix = parent_prefix.as_aligned_vec().clone().into_inner();
         prefix.extend_from_slice(&address.0);
         Prefix::new(prefix)
-    }
-}
-
-pub(crate) fn contract_address(result: &ExecutionResult) -> Option<B160> {
-    match result {
-        ExecutionResult::Success {
-            output: Output::Create(_, Some(addr)),
-            ..
-        } => Some(*addr),
-        _ => None,
     }
 }
 

--- a/module-system/module-implementations/sov-evm/src/evm/tests.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/tests.rs
@@ -71,8 +71,8 @@ fn simple_contract_execution<DB: Database<Error = Infallible> + DatabaseCommit +
             gas_limit: reth_primitives::constants::ETHEREUM_BLOCK_GAS_LIMIT,
             ..Default::default()
         };
-        let result = executor::execute_tx(&mut evm_db, block_env, tx, CfgEnv::default()).unwrap();
-        contract_address(result).expect("Expected successful contract creation")
+        let result = executor::execute_tx(&mut evm_db, &block_env, tx, CfgEnv::default()).unwrap();
+        contract_address(&result).expect("Expected successful contract creation")
     };
 
     let set_arg = 21989;
@@ -89,7 +89,7 @@ fn simple_contract_execution<DB: Database<Error = Infallible> + DatabaseCommit +
             .unwrap();
 
         let tx = &tx.try_into().unwrap();
-        executor::execute_tx(&mut evm_db, BlockEnv::default(), tx, CfgEnv::default()).unwrap();
+        executor::execute_tx(&mut evm_db, &BlockEnv::default(), tx, CfgEnv::default()).unwrap();
     }
 
     let get_res = {
@@ -105,7 +105,7 @@ fn simple_contract_execution<DB: Database<Error = Infallible> + DatabaseCommit +
 
         let tx = &tx.try_into().unwrap();
         let result =
-            executor::execute_tx(&mut evm_db, BlockEnv::default(), tx, CfgEnv::default()).unwrap();
+            executor::execute_tx(&mut evm_db, &BlockEnv::default(), tx, CfgEnv::default()).unwrap();
 
         let out = output(result);
         ethereum_types::U256::from(out.as_ref())

--- a/module-system/module-implementations/sov-evm/src/evm/transaction.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/transaction.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use reth_primitives::{Address, SealedHeader, TransactionSigned, H256};
+use reth_primitives::{Address, Header, SealedHeader, TransactionSigned, H256};
 use revm::primitives::EVMError;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, Clone)]
@@ -62,6 +62,29 @@ pub(crate) struct TransactionSignedAndRecovered {
 )]
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct Block {
+    /// Block header.
+    pub(crate) header: Header,
+
+    /// Transactions in this block.
+    pub(crate) transactions: Range<u64>,
+}
+
+impl Block {
+    pub(crate) fn seal(self) -> SealedBlock {
+        SealedBlock {
+            header: self.header.seal_slow(),
+            transactions: self.transactions,
+        }
+    }
+}
+
+#[cfg_attr(
+    feature = "native",
+    derive(serde::Serialize),
+    derive(serde::Deserialize)
+)]
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) struct SealedBlock {
     /// Block header.
     pub(crate) header: SealedHeader,
 

--- a/module-system/module-implementations/sov-evm/src/evm/transaction.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/transaction.rs
@@ -8,7 +8,7 @@ pub(crate) struct BlockEnv {
     pub(crate) coinbase: Address,
     pub(crate) timestamp: u64,
     /// Prevrandao is used after Paris (aka TheMerge) instead of the difficulty value.
-    pub(crate) prevrandao: Option<H256>,
+    pub(crate) prevrandao: H256,
     /// basefee is added in EIP1559 London upgrade
     pub(crate) basefee: u64,
     pub(crate) gas_limit: u64,
@@ -20,7 +20,7 @@ impl Default for BlockEnv {
             number: Default::default(),
             coinbase: Default::default(),
             timestamp: Default::default(),
-            prevrandao: Some(Default::default()),
+            prevrandao: Default::default(),
             basefee: Default::default(),
             gas_limit: reth_primitives::constants::ETHEREUM_BLOCK_GAS_LIMIT,
         }
@@ -45,13 +45,13 @@ pub struct RlpEvmTransaction {
     derive(serde::Deserialize)
 )]
 #[derive(Debug, PartialEq, Clone)]
-pub struct TransactionSignedAndRecovered {
+pub(crate) struct TransactionSignedAndRecovered {
     /// Signer of the transaction
-    pub signer: Address,
+    pub(crate) signer: Address,
     /// Signed transaction
-    pub signed_transaction: TransactionSigned,
+    pub(crate) signed_transaction: TransactionSigned,
     /// Block the transaction was added to
-    pub block_number: u64,
+    pub(crate) block_number: u64,
 }
 
 #[cfg_attr(
@@ -60,12 +60,12 @@ pub struct TransactionSignedAndRecovered {
     derive(serde::Deserialize)
 )]
 #[derive(Debug, PartialEq, Clone)]
-pub struct Block {
+pub(crate) struct Block {
     /// Block header.
-    pub header: SealedHeader,
+    pub(crate) header: SealedHeader,
 
     /// Transactions in this block.
-    pub transactions: Range<u64>,
+    pub(crate) transactions: Range<u64>,
 }
 
 #[cfg_attr(
@@ -74,8 +74,8 @@ pub struct Block {
     derive(serde::Deserialize)
 )]
 #[derive(Debug, PartialEq, Clone)]
-pub struct Receipt {
-    pub receipt: reth_primitives::Receipt,
-    pub gas_used: u64,
-    pub log_index_start: u64,
+pub(crate) struct Receipt {
+    pub(crate) receipt: reth_primitives::Receipt,
+    pub(crate) gas_used: u64,
+    pub(crate) log_index_start: u64,
 }

--- a/module-system/module-implementations/sov-evm/src/evm/transaction.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/transaction.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 
 use reth_primitives::{Address, SealedHeader, TransactionSigned, H256};
+use revm::primitives::EVMError;
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, Clone)]
 pub(crate) struct BlockEnv {
@@ -78,4 +79,5 @@ pub(crate) struct Receipt {
     pub(crate) receipt: reth_primitives::Receipt,
     pub(crate) gas_used: u64,
     pub(crate) log_index_start: u64,
+    pub(crate) error: Option<EVMError<u8>>,
 }

--- a/module-system/module-implementations/sov-evm/src/evm/transaction.rs
+++ b/module-system/module-implementations/sov-evm/src/evm/transaction.rs
@@ -1,10 +1,12 @@
-use reth_primitives::{Address, H256, U256};
+use std::ops::Range;
+
+use reth_primitives::{Address, SealedHeader, TransactionSigned, H256};
 
 #[derive(serde::Deserialize, serde::Serialize, Debug, PartialEq, Clone)]
 pub(crate) struct BlockEnv {
     pub(crate) number: u64,
     pub(crate) coinbase: Address,
-    pub(crate) timestamp: U256,
+    pub(crate) timestamp: u64,
     /// Prevrandao is used after Paris (aka TheMerge) instead of the difficulty value.
     pub(crate) prevrandao: Option<H256>,
     /// basefee is added in EIP1559 London upgrade
@@ -29,11 +31,51 @@ impl Default for BlockEnv {
 #[cfg_attr(
     feature = "native",
     derive(serde::Serialize),
-    derive(serde::Deserialize),
-    derive(schemars::JsonSchema)
+    derive(serde::Deserialize)
 )]
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
 pub struct RlpEvmTransaction {
     /// Rlp data.
     pub rlp: Vec<u8>,
+}
+
+#[cfg_attr(
+    feature = "native",
+    derive(serde::Serialize),
+    derive(serde::Deserialize)
+)]
+#[derive(Debug, PartialEq, Clone)]
+pub struct TransactionSignedAndRecovered {
+    /// Signer of the transaction
+    pub signer: Address,
+    /// Signed transaction
+    pub signed_transaction: TransactionSigned,
+    /// Block the transaction was added to
+    pub block_number: u64,
+}
+
+#[cfg_attr(
+    feature = "native",
+    derive(serde::Serialize),
+    derive(serde::Deserialize)
+)]
+#[derive(Debug, PartialEq, Clone)]
+pub struct Block {
+    /// Block header.
+    pub header: SealedHeader,
+
+    /// Transactions in this block.
+    pub transactions: Range<u64>,
+}
+
+#[cfg_attr(
+    feature = "native",
+    derive(serde::Serialize),
+    derive(serde::Deserialize)
+)]
+#[derive(Debug, PartialEq, Clone)]
+pub struct Receipt {
+    pub receipt: reth_primitives::Receipt,
+    pub gas_used: u64,
+    pub log_index_start: u64,
 }

--- a/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use reth_primitives::constants::{EMPTY_RECEIPTS, EMPTY_TRANSACTIONS};
 use reth_primitives::{Bloom, Bytes, EMPTY_OMMER_ROOT, H256, KECCAK_EMPTY, U256};
-use reth_rpc_types::{Block, BlockTransactions, Header};
 use revm::primitives::SpecId;
 use sov_state::WorkingSet;
 
 use crate::evm::db_init::InitEvmDb;
+use crate::evm::transaction::Block;
 use crate::evm::{AccountInfo, EvmChainConfig};
 use crate::Evm;
 
@@ -79,17 +79,17 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
         let header = header.seal_slow();
 
-        self.blocks.set(
-            &genesis_block_number,
+        let mut accessory_state = working_set.accessory_state();
+
+        self.block_hashes
+            .set(&header.hash, &genesis_block_number, &mut accessory_state);
+
+        self.blocks.push(
             &Block {
-                header: Header::from_primitive_with_hash(header),
-                total_difficulty: None,
-                uncles: vec![],
-                transactions: BlockTransactions::Hashes(vec![]),
-                size: None,
-                withdrawals: None,
+                header,
+                transactions: 0u64..0u64,
             },
-            &mut working_set.accessory_state(),
+            &mut accessory_state,
         );
 
         Ok(())

--- a/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -76,20 +76,23 @@ impl<C: sov_modules_api::Context> Evm<C> {
             extra_data: Bytes::default(),
         };
 
-        let header = header.seal_slow();
-
-        let mut accessory_state = working_set.accessory_state();
-
-        self.block_hashes
-            .set(&header.hash, &genesis_block_number, &mut accessory_state);
-
         let block = Block {
             header,
             transactions: 0u64..0u64,
         };
 
-        self.blocks.push(&block, &mut accessory_state);
         self.head.set(&block, working_set);
+
+        let sealead_block = block.seal();
+
+        let mut accessory_state = working_set.accessory_state();
+
+        self.block_hashes.set(
+            &sealead_block.header.hash,
+            &genesis_block_number,
+            &mut accessory_state,
+        );
+        self.blocks.push(&sealead_block, &mut accessory_state);
 
         Ok(())
     }

--- a/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -55,7 +55,6 @@ impl<C: sov_modules_api::Context> Evm<C> {
         self.cfg.set(&chain_cfg, working_set);
 
         let genesis_block_number = 0u64;
-        self.head_number.set(&genesis_block_number, working_set);
 
         let header = reth_primitives::Header {
             parent_hash: H256::default(),
@@ -84,13 +83,13 @@ impl<C: sov_modules_api::Context> Evm<C> {
         self.block_hashes
             .set(&header.hash, &genesis_block_number, &mut accessory_state);
 
-        self.blocks.push(
-            &Block {
-                header,
-                transactions: 0u64..0u64,
-            },
-            &mut accessory_state,
-        );
+        let block = Block {
+            header,
+            transactions: 0u64..0u64,
+        };
+
+        self.blocks.push(&block, &mut accessory_state);
+        self.head.set(&block, working_set);
 
         Ok(())
     }

--- a/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -1,7 +1,5 @@
-use reth_primitives::U256;
 use sov_state::WorkingSet;
 
-use crate::evm::conversions::to_u64;
 use crate::evm::transaction::BlockEnv;
 use crate::experimental::PendingTransaction;
 use crate::Evm;
@@ -13,23 +11,23 @@ impl<C: sov_modules_api::Context> Evm<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) {
         let block_number: u64 = self.head_number.get(working_set).unwrap();
-        let parent_block: reth_rpc_types::Block = self
+        let parent_block = self
             .blocks
-            .get(&block_number, &mut working_set.accessory_state())
-            .expect("Head block should always be set");
+            .get(block_number as usize, &mut working_set.accessory_state())
+            .expect("Head block should always be set")
+            .header;
         let cfg = self.cfg.get(working_set).unwrap_or_default();
         let new_pending_block = BlockEnv {
             number: block_number + 1,
             coinbase: cfg.coinbase,
-            timestamp: parent_block.header.timestamp + U256::from(cfg.block_timestamp_delta),
+            timestamp: parent_block.timestamp + cfg.block_timestamp_delta,
             prevrandao: Some(da_root_hash.into()),
             basefee: reth_primitives::basefee::calculate_next_block_base_fee(
-                to_u64(parent_block.header.gas_used),
+                parent_block.gas_used,
                 cfg.block_gas_limit,
                 parent_block
-                    .header
                     .base_fee_per_gas
-                    .map_or(reth_primitives::constants::MIN_PROTOCOL_BASE_FEE, to_u64),
+                    .unwrap_or(reth_primitives::constants::MIN_PROTOCOL_BASE_FEE),
             ),
             gas_limit: cfg.block_gas_limit,
         };
@@ -39,18 +37,20 @@ impl<C: sov_modules_api::Context> Evm<C> {
     pub fn end_slot_hook(&self, _root_hash: [u8; 32], working_set: &mut WorkingSet<C::Storage>) {
         // TODO implement block creation logic.
 
+        // let _pending_block = self
+        //     .pending_block
+        //     .get(working_set)
+        //     .expect("Pending block should always be set");
+
         let mut accessory_state = working_set.accessory_state();
         let mut transactions: Vec<PendingTransaction> =
             Vec::with_capacity(self.pending_transactions.len(&mut accessory_state));
 
         while let Some(PendingTransaction {
-            mut transaction,
-            mut receipt,
+            transaction,
+            receipt,
         }) = self.pending_transactions.pop(&mut accessory_state)
         {
-            transaction.block_hash = Some(reth_primitives::H256::default());
-            receipt.block_hash = transaction.block_hash;
-
             // TODO fill all data that is set by: from_recovered_with_block_context
             // tx.gas_price
             // tx.max_fee_per_gas
@@ -62,18 +62,24 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
         transactions.reverse();
 
-        for pending in transactions {
-            self.transactions.set(
-                &pending.transaction.hash,
-                &pending.transaction,
+        let start_tx_index = self.transactions.len(&mut accessory_state);
+        let mut tx_index = start_tx_index;
+
+        for PendingTransaction {
+            transaction,
+            receipt,
+        } in transactions
+        {
+            self.transactions.push(&transaction, &mut accessory_state);
+            self.receipts.push(&receipt, &mut accessory_state);
+
+            self.transaction_hashes.set(
+                &transaction.signed_transaction.hash,
+                &(tx_index as u64),
                 &mut accessory_state,
             );
 
-            self.receipts.set(
-                &pending.transaction.hash,
-                &pending.receipt,
-                &mut accessory_state,
-            );
+            tx_index += 1;
         }
 
         self.pending_transactions.clear(&mut accessory_state);

--- a/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -1,5 +1,5 @@
 use reth_primitives::{Bloom, Bytes, U256};
-use sov_state::WorkingSet;
+use sov_state::{AccessoryWorkingSet, WorkingSet};
 
 use crate::evm::transaction::{Block, BlockEnv};
 use crate::experimental::PendingTransaction;
@@ -120,5 +120,12 @@ impl<C: sov_modules_api::Context> Evm<C> {
         self.blocks.push(&block, &mut accessory_state);
         self.head.set(&block, working_set); // ?
         self.pending_transactions.clear(working_set); // ?
+    }
+
+    pub fn finalize_slot_hook(
+        &self,
+        _root_hash: [u8; 32],
+        _accesorry_working_set: &mut AccessoryWorkingSet<C::Storage>,
+    ) {
     }
 }

--- a/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -15,29 +15,23 @@ impl<C: sov_modules_api::Context> Evm<C> {
             .head
             .get(working_set)
             .expect("Head block should always be set");
+
+        // parent_block.header.state_root = root_hash.into();
+        // self.head.set(&parent_block, working_set);
+
         let cfg = self.cfg.get(working_set).unwrap_or_default();
         let new_pending_block = BlockEnv {
             number: parent_block.header.number + 1,
             coinbase: cfg.coinbase,
             timestamp: parent_block.header.timestamp + cfg.block_timestamp_delta,
             prevrandao: da_root_hash.into(),
-            basefee: reth_primitives::basefee::calculate_next_block_base_fee(
-                parent_block.header.gas_used,
-                cfg.block_gas_limit,
-                parent_block
-                    .header
-                    .base_fee_per_gas
-                    .unwrap_or(reth_primitives::constants::MIN_PROTOCOL_BASE_FEE),
-            ),
+            basefee: parent_block.header.next_block_base_fee().unwrap(),
             gas_limit: cfg.block_gas_limit,
         };
         self.pending_block.set(&new_pending_block, working_set);
-
-        // println!("new_pending_block: {:?}", new_pending_block);
-        // self.pending_transactions.clear(working_set); ?
     }
 
-    pub fn end_slot_hook(&self, root_hash: [u8; 32], working_set: &mut WorkingSet<C::Storage>) {
+    pub fn end_slot_hook(&self, working_set: &mut WorkingSet<C::Storage>) {
         let pending_block = self
             .pending_block
             .get(working_set)
@@ -46,33 +40,15 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let parent_block = self
             .head
             .get(working_set)
-            .expect("Head block should always be set");
+            .expect("Head block should always be set")
+            .seal();
 
         let pending_transactions: Vec<PendingTransaction> =
             self.pending_transactions.iter(working_set).collect();
 
         self.pending_transactions.clear(working_set);
 
-        let mut accessory_state = working_set.accessory_state();
-        let start_tx_index = self.transactions.len(&mut accessory_state) as u64;
-        let mut tx_index = start_tx_index;
-
-        for PendingTransaction {
-            transaction,
-            receipt,
-        } in &pending_transactions
-        {
-            self.transactions.push(transaction, &mut accessory_state);
-            self.receipts.push(receipt, &mut accessory_state);
-
-            self.transaction_hashes.set(
-                &transaction.signed_transaction.hash,
-                &tx_index,
-                &mut accessory_state,
-            );
-
-            tx_index += 1
-        }
+        let start_tx_index = parent_block.transactions.end + 1;
 
         let gas_used = pending_transactions
             .last()
@@ -94,7 +70,8 @@ impl<C: sov_modules_api::Context> Evm<C> {
             number: pending_block.number,
             ommers_hash: reth_primitives::constants::EMPTY_OMMER_ROOT,
             beneficiary: parent_block.header.beneficiary,
-            state_root: root_hash.into(),
+            // This will be set in finalize_slot_hook or in the next begin_slot_hook
+            state_root: reth_primitives::constants::KECCAK_EMPTY,
             transactions_root: reth_primitives::proofs::calculate_transaction_root(
                 transactions.as_slice(),
             ),
@@ -113,19 +90,56 @@ impl<C: sov_modules_api::Context> Evm<C> {
         };
 
         let block = Block {
-            header: header.seal_slow(),
-            transactions: start_tx_index..tx_index - 1,
+            header,
+            transactions: start_tx_index..start_tx_index + pending_transactions.len() as u64,
         };
 
-        self.blocks.push(&block, &mut accessory_state);
-        self.head.set(&block, working_set); // ?
-        self.pending_transactions.clear(working_set); // ?
+        self.head.set(&block, working_set);
+
+        let mut accessory_state = working_set.accessory_state();
+        self.pending_head.set(&block, &mut accessory_state);
+
+        let mut tx_index = start_tx_index;
+        for PendingTransaction {
+            transaction,
+            receipt,
+        } in &pending_transactions
+        {
+            self.transactions.push(transaction, &mut accessory_state);
+            self.receipts.push(receipt, &mut accessory_state);
+
+            self.transaction_hashes.set(
+                &transaction.signed_transaction.hash,
+                &tx_index,
+                &mut accessory_state,
+            );
+
+            tx_index += 1
+        }
+
+        self.pending_transactions.clear(working_set);
     }
 
     pub fn finalize_slot_hook(
         &self,
-        _root_hash: [u8; 32],
-        _accesorry_working_set: &mut AccessoryWorkingSet<C::Storage>,
+        root_hash: [u8; 32],
+        accesorry_working_set: &mut AccessoryWorkingSet<C::Storage>,
     ) {
+        let mut block = self
+            .pending_head
+            .get(accesorry_working_set)
+            .expect("Pending head must be set");
+
+        block.header.state_root = root_hash.into();
+
+        let sealed_block = block.seal();
+
+        self.blocks.push(&sealed_block, accesorry_working_set);
+        self.block_hashes.set(
+            &sealed_block.header.hash,
+            &sealed_block.header.number,
+            accesorry_working_set,
+        );
+        self.pending_head.delete(accesorry_working_set);
     }
 }

--- a/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -48,7 +48,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
         self.pending_transactions.clear(working_set);
 
-        let start_tx_index = parent_block.transactions.end + 1;
+        let start_tx_index = parent_block.transactions.end;
 
         let gas_used = pending_transactions
             .last()

--- a/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/module-system/module-implementations/sov-evm/src/lib.rs
@@ -64,6 +64,12 @@ mod experimental {
         pub block_timestamp_delta: u64,
     }
 
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+    pub struct PendingTransaction {
+        pub transaction: reth_rpc_types::Transaction,
+        pub receipt: reth_rpc_types::TransactionReceipt,
+    }
+
     impl Default for EvmConfig {
         fn default() -> Self {
             Self {
@@ -112,7 +118,7 @@ mod experimental {
 
         #[state]
         pub(crate) pending_transactions:
-            sov_state::AccessoryStateVec<reth_rpc_types::Transaction, JsonCodec>,
+            sov_state::AccessoryStateVec<PendingTransaction, JsonCodec>,
 
         #[state]
         pub(crate) transactions: sov_state::AccessoryStateMap<
@@ -123,7 +129,7 @@ mod experimental {
 
         #[state]
         pub(crate) receipts: sov_state::AccessoryStateMap<
-            reth_primitives::U256,
+            reth_primitives::H256,
             reth_rpc_types::TransactionReceipt,
             JsonCodec,
         >,

--- a/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/module-system/module-implementations/sov-evm/src/lib.rs
@@ -66,9 +66,9 @@ mod experimental {
     }
 
     #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-    pub struct PendingTransaction {
-        pub transaction: TransactionSignedAndRecovered,
-        pub receipt: Receipt,
+    pub(crate) struct PendingTransaction {
+        pub(crate) transaction: TransactionSignedAndRecovered,
+        pub(crate) receipt: Receipt,
     }
 
     impl Default for EvmConfig {
@@ -104,10 +104,10 @@ mod experimental {
         pub(crate) pending_block: sov_state::StateValue<BlockEnv, BcsCodec>,
 
         #[state]
-        pub(crate) pending_transactions: sov_state::AccessoryStateVec<PendingTransaction, BcsCodec>,
+        pub(crate) pending_transactions: sov_state::StateVec<PendingTransaction, BcsCodec>,
 
         #[state]
-        pub(crate) head_number: sov_state::StateValue<u64>,
+        pub(crate) head: sov_state::StateValue<Block, BcsCodec>,
 
         #[state]
         pub(crate) blocks: sov_state::AccessoryStateVec<Block, BcsCodec>,

--- a/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/module-system/module-implementations/sov-evm/src/lib.rs
@@ -32,7 +32,7 @@ mod experimental {
     use super::evm::db::EvmDb;
     use super::evm::transaction::BlockEnv;
     use super::evm::{DbAccount, EvmChainConfig};
-    use crate::evm::transaction::{Block, Receipt, TransactionSignedAndRecovered};
+    use crate::evm::transaction::{Block, Receipt, SealedBlock, TransactionSignedAndRecovered};
     #[derive(Clone, Debug)]
     pub struct AccountData {
         pub address: Address,
@@ -110,7 +110,10 @@ mod experimental {
         pub(crate) head: sov_state::StateValue<Block, BcsCodec>,
 
         #[state]
-        pub(crate) blocks: sov_state::AccessoryStateVec<Block, BcsCodec>,
+        pub(crate) pending_head: sov_state::AccessoryStateValue<Block, BcsCodec>,
+
+        #[state]
+        pub(crate) blocks: sov_state::AccessoryStateVec<SealedBlock, BcsCodec>,
 
         #[state]
         pub(crate) block_hashes: sov_state::AccessoryStateMap<reth_primitives::H256, u64, BcsCodec>,

--- a/module-system/module-implementations/sov-evm/src/query.rs
+++ b/module-system/module-implementations/sov-evm/src/query.rs
@@ -97,7 +97,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
     #[rpc_method(name = "getTransactionReceipt")]
     pub fn get_transaction_receipt(
         &self,
-        hash: reth_primitives::U256,
+        hash: reth_primitives::H256,
         working_set: &mut WorkingSet<C::Storage>,
     ) -> RpcResult<Option<reth_rpc_types::TransactionReceipt>> {
         info!("evm module: eth_getTransactionReceipt");
@@ -145,7 +145,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         let evm_db: EvmDb<'_, C> = self.get_db(working_set);
 
         // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/505
-        let result = executor::inspect(evm_db, block_env, tx_env, cfg_env).unwrap();
+        let result = executor::inspect(evm_db, &block_env, tx_env, cfg_env).unwrap();
         let output = match result.result {
             revm::primitives::ExecutionResult::Success { output, .. } => output,
             _ => todo!(),

--- a/module-system/module-implementations/sov-evm/src/query.rs
+++ b/module-system/module-implementations/sov-evm/src/query.rs
@@ -99,20 +99,17 @@ impl<C: sov_modules_api::Context> Evm<C> {
             let tx = self
                 .transactions
                 .get(number as usize, &mut accessory_state)
-                .expect(
-                    format!(
-                        "Transaction with known hash {} and number {} must be set in all {} transaction",
-                        hash,
-                        number,
-                        self.transactions.len(&mut accessory_state)
-                    )
-                    .as_str(),
-                );
+                .unwrap_or_else(|| panic!("Transaction with known hash {} and number {} must be set in all {} transaction",                
+                hash,
+                number,
+                self.transactions.len(&mut accessory_state)));
 
             let block = self
                 .blocks
                 .get(tx.block_number as usize, &mut accessory_state)
-                .expect("Block number for known transaction must be set");
+                .unwrap_or_else(|| panic!("Block with number {} for known transaction {} must be set",
+                    tx.block_number,
+                    tx.signed_transaction.hash));
 
             reth_rpc_types::Transaction::from_recovered_with_block_context(
                 tx.into(),

--- a/module-system/module-implementations/sov-evm/src/query.rs
+++ b/module-system/module-implementations/sov-evm/src/query.rs
@@ -9,7 +9,7 @@ use tracing::info;
 
 use crate::call::get_cfg_env;
 use crate::evm::db::EvmDb;
-use crate::evm::transaction::{Block, Receipt, TransactionSignedAndRecovered};
+use crate::evm::transaction::{Receipt, SealedBlock, TransactionSignedAndRecovered};
 use crate::evm::{executor, prepare_call_env};
 use crate::Evm;
 
@@ -222,7 +222,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
 // modified from: https://github.com/paradigmxyz/reth/blob/cc576bc8690a3e16e6e5bf1cbbbfdd029e85e3d4/crates/rpc/rpc/src/eth/api/transactions.rs#L849
 pub(crate) fn build_rpc_receipt(
-    block: Block,
+    block: SealedBlock,
     tx: TransactionSignedAndRecovered,
     tx_number: u64,
     receipt: Receipt,

--- a/module-system/module-implementations/sov-evm/src/query.rs
+++ b/module-system/module-implementations/sov-evm/src/query.rs
@@ -95,26 +95,25 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
         let tx_number = self.transaction_hashes.get(&hash, &mut accessory_state);
 
-        let transaction = tx_number
-            .map(|number| {
-                self.transactions
-                    .get(number as usize, &mut accessory_state)
-                    .expect("Transaction with known hash must be set")
-            })
-            .map(|tx| {
-                let block = self
-                    .blocks
-                    .get(tx.block_number as usize, &mut accessory_state)
-                    .expect("Block number for known transaction must be set");
+        let transaction = tx_number.map(|number| {
+            let tx = self
+                .transactions
+                .get(number as usize, &mut accessory_state)
+                .expect("Transaction with known hash must be set");
 
-                reth_rpc_types::Transaction::from_recovered_with_block_context(
-                    tx.into(),
-                    block.header.hash,
-                    block.header.number,
-                    block.header.base_fee_per_gas,
-                    U256::from(tx_number.unwrap() - block.transactions.start),
-                )
-            });
+            let block = self
+                .blocks
+                .get(tx.block_number as usize, &mut accessory_state)
+                .expect("Block number for known transaction must be set");
+
+            reth_rpc_types::Transaction::from_recovered_with_block_context(
+                tx.into(),
+                block.header.hash,
+                block.header.number,
+                block.header.base_fee_per_gas,
+                U256::from(tx_number.unwrap() - block.transactions.start),
+            )
+        });
 
         Ok(transaction)
     }
@@ -132,25 +131,23 @@ impl<C: sov_modules_api::Context> Evm<C> {
 
         let tx_number = self.transaction_hashes.get(&hash, &mut accessory_state);
 
-        let receipt = tx_number
-            .map(|number| {
-                self.transactions
-                    .get(number as usize, &mut accessory_state)
-                    .expect("Transaction with known hash must be set")
-            })
-            .map(|tx| {
-                let block = self
-                    .blocks
-                    .get(tx.block_number as usize, &mut accessory_state)
-                    .expect("Block number for known transaction must be set");
+        let receipt = tx_number.map(|number| {
+            let tx = self
+                .transactions
+                .get(number as usize, &mut accessory_state)
+                .expect("Transaction with known hash must be set");
+            let block = self
+                .blocks
+                .get(tx.block_number as usize, &mut accessory_state)
+                .expect("Block number for known transaction must be set");
 
-                let receipt = self
-                    .receipts
-                    .get(tx_number.unwrap() as usize, &mut accessory_state)
-                    .expect("Receipt for known transaction must be set");
+            let receipt = self
+                .receipts
+                .get(tx_number.unwrap() as usize, &mut accessory_state)
+                .expect("Receipt for known transaction must be set");
 
-                build_rpc_receipt(block, tx, tx_number.unwrap(), receipt)
-            });
+            build_rpc_receipt(block, tx, tx_number.unwrap(), receipt)
+        });
 
         Ok(receipt)
     }

--- a/module-system/module-implementations/sov-evm/src/query.rs
+++ b/module-system/module-implementations/sov-evm/src/query.rs
@@ -1,10 +1,15 @@
+use ethereum_types::U64;
 use jsonrpsee::core::RpcResult;
+use reth_primitives::contract::create_address;
+use reth_primitives::TransactionKind::{Call, Create};
+use reth_primitives::{TransactionSignedEcRecovered, U128, U256};
 use sov_modules_api::macros::rpc_gen;
 use sov_state::WorkingSet;
 use tracing::info;
 
 use crate::call::get_cfg_env;
 use crate::evm::db::EvmDb;
+use crate::evm::transaction::{Block, Receipt, TransactionSignedAndRecovered};
 use crate::evm::{executor, prepare_call_env};
 use crate::Evm;
 
@@ -86,11 +91,32 @@ impl<C: sov_modules_api::Context> Evm<C> {
         working_set: &mut WorkingSet<C::Storage>,
     ) -> RpcResult<Option<reth_rpc_types::Transaction>> {
         info!("evm module: eth_getTransactionByHash");
-        //let evm_transaction = self.transactions.get(&hash, working_set);
-        let evm_transaction = self
-            .transactions
-            .get(&hash, &mut working_set.accessory_state());
-        Ok(evm_transaction)
+        let mut accessory_state = working_set.accessory_state();
+
+        let tx_number = self.transaction_hashes.get(&hash, &mut accessory_state);
+
+        let transaction = tx_number
+            .map(|number| {
+                self.transactions
+                    .get(number as usize, &mut accessory_state)
+                    .expect("Transaction with known hash must be set")
+            })
+            .map(|tx| {
+                let block = self
+                    .blocks
+                    .get(tx.block_number as usize, &mut accessory_state)
+                    .expect("Block number for known transaction must be set");
+
+                reth_rpc_types::Transaction::from_recovered_with_block_context(
+                    tx.into(),
+                    block.header.hash,
+                    block.header.number,
+                    block.header.base_fee_per_gas,
+                    U256::from(tx_number.unwrap() - block.transactions.start),
+                )
+            });
+
+        Ok(transaction)
     }
 
     // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
@@ -102,7 +128,30 @@ impl<C: sov_modules_api::Context> Evm<C> {
     ) -> RpcResult<Option<reth_rpc_types::TransactionReceipt>> {
         info!("evm module: eth_getTransactionReceipt");
 
-        let receipt = self.receipts.get(&hash, &mut working_set.accessory_state());
+        let mut accessory_state = working_set.accessory_state();
+
+        let tx_number = self.transaction_hashes.get(&hash, &mut accessory_state);
+
+        let receipt = tx_number
+            .map(|number| {
+                self.transactions
+                    .get(number as usize, &mut accessory_state)
+                    .expect("Transaction with known hash must be set")
+            })
+            .map(|tx| {
+                let block = self
+                    .blocks
+                    .get(tx.block_number as usize, &mut accessory_state)
+                    .expect("Block number for known transaction must be set");
+
+                let receipt = self
+                    .receipts
+                    .get(tx_number.unwrap() as usize, &mut accessory_state)
+                    .expect("Receipt for known transaction must be set");
+
+                build_rpc_receipt(block, tx, tx_number.unwrap(), receipt)
+            });
+
         Ok(receipt)
     }
 
@@ -171,5 +220,67 @@ impl<C: sov_modules_api::Context> Evm<C> {
         _working_set: &mut WorkingSet<C::Storage>,
     ) -> RpcResult<reth_primitives::U256> {
         unimplemented!("eth_blockNumber not implemented")
+    }
+}
+
+// modified from: https://github.com/paradigmxyz/reth/blob/cc576bc8690a3e16e6e5bf1cbbbfdd029e85e3d4/crates/rpc/rpc/src/eth/api/transactions.rs#L849
+pub(crate) fn build_rpc_receipt(
+    block: Block,
+    tx: TransactionSignedAndRecovered,
+    tx_number: u64,
+    receipt: Receipt,
+) -> reth_rpc_types::TransactionReceipt {
+    let transaction: TransactionSignedEcRecovered = tx.into();
+    let transaction_kind = transaction.kind();
+
+    let transaction_hash = Some(transaction.hash);
+    let transaction_index = Some(U256::from(tx_number - block.transactions.start));
+    let block_hash = Some(block.header.hash);
+    let block_number = Some(U256::from(block.header.number));
+
+    reth_rpc_types::TransactionReceipt {
+        transaction_hash,
+        transaction_index,
+        block_hash,
+        block_number,
+        from: transaction.signer(),
+        to: match transaction_kind {
+            Create => None,
+            Call(addr) => Some(*addr),
+        },
+        cumulative_gas_used: U256::from(receipt.receipt.cumulative_gas_used),
+        gas_used: Some(U256::from(receipt.gas_used)),
+        contract_address: match transaction_kind {
+            Create => Some(create_address(transaction.signer(), transaction.nonce())),
+            Call(_) => None,
+        },
+        effective_gas_price: U128::from(
+            transaction.effective_gas_price(block.header.base_fee_per_gas),
+        ),
+        transaction_type: transaction.tx_type().into(),
+        logs_bloom: receipt.receipt.bloom_slow(),
+        status_code: if receipt.receipt.success {
+            Some(U64::from(1))
+        } else {
+            Some(U64::from(0))
+        },
+        state_root: None, // Pre https://eips.ethereum.org/EIPS/eip-658 (pre-byzantium) and won't be used
+        logs: receipt
+            .receipt
+            .logs
+            .into_iter()
+            .enumerate()
+            .map(|(idx, log)| reth_rpc_types::Log {
+                address: log.address,
+                topics: log.topics,
+                data: log.data,
+                block_hash,
+                block_number,
+                transaction_hash,
+                transaction_index,
+                log_index: Some(U256::from(receipt.log_index_start + idx as u64)),
+                removed: false,
+            })
+            .collect(),
     }
 }

--- a/module-system/module-implementations/sov-evm/src/query.rs
+++ b/module-system/module-implementations/sov-evm/src/query.rs
@@ -99,7 +99,15 @@ impl<C: sov_modules_api::Context> Evm<C> {
             let tx = self
                 .transactions
                 .get(number as usize, &mut accessory_state)
-                .expect("Transaction with known hash must be set");
+                .expect(
+                    format!(
+                        "Transaction with known hash {} and number {} must be set in all {} transaction",
+                        hash,
+                        number,
+                        self.transactions.len(&mut accessory_state)
+                    )
+                    .as_str(),
+                );
 
             let block = self
                 .blocks

--- a/module-system/module-implementations/sov-evm/src/tests/call_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/call_tests.rs
@@ -2,30 +2,34 @@ use reth_primitives::{Address, TransactionKind};
 use revm::primitives::{SpecId, KECCAK_EMPTY, U256};
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
-use sov_modules_api::{Context, Module, PrivateKey, Spec};
-use sov_state::{ProverStorage, WorkingSet};
+use sov_modules_api::{Context, Module, PrivateKey, PublicKey, Spec};
 
 use crate::call::CallMessage;
+use crate::evm::transaction::Receipt;
 use crate::smart_contracts::SimpleStorageContract;
 use crate::tests::dev_signer::TestSigner;
-use crate::{AccountData, Evm, EvmConfig};
+use crate::tests::genesis_tests::get_evm;
+use crate::{AccountData, EvmConfig};
 type C = DefaultContext;
 
 fn create_messages(
     contract_addr: Address,
     set_arg: u32,
     dev_signer: TestSigner,
+    create_contract: bool,
 ) -> Vec<CallMessage> {
     let mut transactions = Vec::default();
     let contract = SimpleStorageContract::default();
+    let mut nonce = 0;
 
     // Contract creation.
-    {
+    if create_contract {
         let signed_tx = dev_signer
             .sign_default_transaction(TransactionKind::Create, contract.byte_code().to_vec(), 0)
             .unwrap();
 
         transactions.push(CallMessage { tx: signed_tx });
+        nonce += 1;
     }
 
     // Update contract state.
@@ -34,7 +38,7 @@ fn create_messages(
             .sign_default_transaction(
                 TransactionKind::Call(contract_addr),
                 hex::decode(hex::encode(&contract.set_call_data(set_arg))).unwrap(),
-                1,
+                nonce,
             )
             .unwrap();
 
@@ -46,36 +50,22 @@ fn create_messages(
 
 #[test]
 fn evm_test() {
-    use sov_modules_api::PublicKey;
-    let tmpdir = tempfile::tempdir().unwrap();
-    let working_set = &mut WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
-
-    let priv_key = DefaultPrivateKey::generate();
-
-    let sender = priv_key.pub_key();
-    let sender_addr = sender.to_address::<<C as Spec>::Address>();
-    let sender_context = C::new(sender_addr);
-
     let dev_signer: TestSigner = TestSigner::new_random();
-    let caller = dev_signer.address();
-
-    let evm = Evm::<C>::default();
-
-    let data = AccountData {
-        address: caller,
-        balance: U256::from(1000000000),
-        code_hash: KECCAK_EMPTY,
-        code: vec![],
-        nonce: 0,
-    };
 
     let config = EvmConfig {
-        data: vec![data],
+        data: vec![AccountData {
+            address: dev_signer.address(),
+            balance: U256::from(1000000000),
+            code_hash: KECCAK_EMPTY,
+            code: vec![],
+            nonce: 0,
+        }],
         spec: vec![(0, SpecId::LATEST)].into_iter().collect(),
         ..Default::default()
     };
 
-    evm.genesis(&config, working_set).unwrap();
+    let (evm, mut working_set) = get_evm(&config);
+    let working_set = &mut working_set;
 
     let contract_addr: Address = Address::from_slice(
         hex::decode("819c5497b157177315e1204f52e588b393771719")
@@ -86,8 +76,13 @@ fn evm_test() {
     evm.begin_slot_hook([5u8; 32], working_set);
 
     let set_arg = 999;
+    let sender_context = C::new(
+        DefaultPrivateKey::generate()
+            .pub_key()
+            .to_address::<<C as Spec>::Address>(),
+    );
 
-    for tx in create_messages(contract_addr, set_arg, dev_signer) {
+    for tx in create_messages(contract_addr, set_arg, dev_signer, true) {
         evm.call(tx, &sender_context, working_set).unwrap();
     }
 
@@ -96,5 +91,85 @@ fn evm_test() {
     let db_account = evm.accounts.get(&contract_addr, working_set).unwrap();
     let storage_value = db_account.storage.get(&U256::ZERO, working_set).unwrap();
 
-    assert_eq!(U256::from(set_arg), storage_value)
+    assert_eq!(U256::from(set_arg), storage_value);
+    assert_eq!(
+        evm.receipts
+            .iter(&mut working_set.accessory_state())
+            .collect::<Vec<_>>(),
+        [
+            Receipt {
+                receipt: reth_primitives::Receipt {
+                    tx_type: reth_primitives::TxType::EIP1559,
+                    success: true,
+                    cumulative_gas_used: 132943,
+                    logs: vec![]
+                },
+                gas_used: 132943,
+                log_index_start: 0,
+                error: None
+            },
+            Receipt {
+                receipt: reth_primitives::Receipt {
+                    tx_type: reth_primitives::TxType::EIP1559,
+                    success: true,
+                    cumulative_gas_used: 176673,
+                    logs: vec![]
+                },
+                gas_used: 43730,
+                log_index_start: 0,
+                error: None
+            }
+        ]
+    )
+}
+
+#[test]
+fn failed_transaction_test() {
+    let dev_signer: TestSigner = TestSigner::new_random();
+
+    let (evm, mut working_set) = get_evm(&EvmConfig::default());
+    let working_set = &mut working_set;
+
+    let contract_addr: Address = Address::from_slice(
+        hex::decode("819c5497b157177315e1204f52e588b393771719")
+            .unwrap()
+            .as_slice(),
+    );
+
+    evm.begin_slot_hook([5u8; 32], working_set);
+
+    let set_arg = 999;
+    let sender_context = C::new(
+        DefaultPrivateKey::generate()
+            .pub_key()
+            .to_address::<<C as Spec>::Address>(),
+    );
+
+    for tx in create_messages(contract_addr, set_arg, dev_signer, false) {
+        evm.call(tx, &sender_context, working_set).unwrap();
+    }
+
+    evm.end_slot_hook(working_set);
+
+    assert_eq!(
+        evm.receipts
+            .iter(&mut working_set.accessory_state())
+            .collect::<Vec<_>>(),
+        [Receipt {
+            receipt: reth_primitives::Receipt {
+                tx_type: reth_primitives::TxType::EIP1559,
+                success: false,
+                cumulative_gas_used: 0,
+                logs: vec![]
+            },
+            gas_used: 0,
+            log_index_start: 0,
+            error: Some(revm::primitives::EVMError::Transaction(
+                revm::primitives::InvalidTransaction::LackOfFundForGasLimit {
+                    gas_limit: U256::from(0xd59f80),
+                    balance: U256::ZERO
+                }
+            ))
+        }]
+    )
 }

--- a/module-system/module-implementations/sov-evm/src/tests/call_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/call_tests.rs
@@ -91,7 +91,7 @@ fn evm_test() {
         evm.call(tx, &sender_context, working_set).unwrap();
     }
 
-    evm.end_slot_hook([5u8; 32], working_set);
+    evm.end_slot_hook(working_set);
 
     let db_account = evm.accounts.get(&contract_addr, working_set).unwrap();
     let storage_value = db_account.storage.get(&U256::ZERO, working_set).unwrap();

--- a/module-system/module-implementations/sov-evm/src/tests/call_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/call_tests.rs
@@ -83,11 +83,15 @@ fn evm_test() {
             .as_slice(),
     );
 
+    evm.begin_slot_hook([5u8; 32], working_set);
+
     let set_arg = 999;
 
     for tx in create_messages(contract_addr, set_arg, dev_signer) {
         evm.call(tx, &sender_context, working_set).unwrap();
     }
+
+    evm.end_slot_hook([5u8; 32], working_set);
 
     let db_account = evm.accounts.get(&contract_addr, working_set).unwrap();
     let storage_value = db_account.storage.get(&U256::ZERO, working_set).unwrap();

--- a/module-system/module-implementations/sov-evm/src/tests/dev_signer.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/dev_signer.rs
@@ -67,7 +67,8 @@ impl DevSigner {
             input: RethBytes::from(data),
             nonce,
             chain_id: 1,
-            gas_limit: reth_primitives::constants::ETHEREUM_BLOCK_GAS_LIMIT / 2,
+            gas_limit: 1_000_000u64,
+            max_fee_per_gas: u128::from(reth_primitives::constants::MIN_PROTOCOL_BASE_FEE * 2),
             ..Default::default()
         };
 

--- a/module-system/module-implementations/sov-evm/src/tests/genesis_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/genesis_tests.rs
@@ -1,14 +1,13 @@
-use ethereum_types::H64;
 use lazy_static::lazy_static;
 use reth_primitives::constants::{EMPTY_RECEIPTS, EMPTY_TRANSACTIONS, ETHEREUM_BLOCK_GAS_LIMIT};
 use reth_primitives::hex_literal::hex;
-use reth_primitives::{Address, Bloom, Bytes, EMPTY_OMMER_ROOT, H256};
-use reth_rpc_types::{Block, BlockTransactions, Header};
+use reth_primitives::{Address, Bloom, Bytes, Header, SealedHeader, EMPTY_OMMER_ROOT, H256};
 use revm::primitives::{SpecId, KECCAK_EMPTY, U256};
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::Module;
 use sov_state::{DefaultStorageSpec, ProverStorage, WorkingSet};
 
+use crate::evm::transaction::Block;
 // use crate::evm::db;
 use crate::{evm::EvmChainConfig, AccountData, Evm, EvmConfig};
 type C = DefaultContext;
@@ -76,39 +75,37 @@ fn genesis_block() {
 
     let block = evm
         .blocks
-        .get(&0u64, &mut working_set.accessory_state())
+        .get(0usize, &mut working_set.accessory_state())
         .unwrap();
 
     assert_eq!(
         block,
         Block {
-            header: Header {
-                parent_hash: H256::default(),
-                state_root: KECCAK_EMPTY,
-                transactions_root: EMPTY_TRANSACTIONS,
-                receipts_root: EMPTY_RECEIPTS,
-                logs_bloom: Bloom::default(),
-                difficulty: U256::ZERO,
-                number: Some(U256::ZERO),
-                gas_limit: U256::from(ETHEREUM_BLOCK_GAS_LIMIT),
-                gas_used: U256::ZERO,
-                timestamp: U256::from(50),
-                extra_data: Bytes::default(),
-                mix_hash: H256::default(),
-                nonce: Some(H64::default()),
-                base_fee_per_gas: Some(U256::from(70)),
-                hash: Some(H256(hex!(
+            header: SealedHeader {
+                header: Header {
+                    parent_hash: H256::default(),
+                    state_root: KECCAK_EMPTY,
+                    transactions_root: EMPTY_TRANSACTIONS,
+                    receipts_root: EMPTY_RECEIPTS,
+                    logs_bloom: Bloom::default(),
+                    difficulty: U256::ZERO,
+                    number: 0,
+                    gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
+                    gas_used: 0,
+                    timestamp: 50,
+                    extra_data: Bytes::default(),
+                    mix_hash: H256::default(),
+                    nonce: 0,
+                    base_fee_per_gas: Some(70),
+                    ommers_hash: EMPTY_OMMER_ROOT,
+                    beneficiary: Address::from([3u8; 20]),
+                    withdrawals_root: None
+                },
+                hash: H256(hex!(
                     "d57423e4375c45bc114cd137146aab671dbd3f6304f05b31bdd416301b4a99f0"
-                ))),
-                uncles_hash: EMPTY_OMMER_ROOT,
-                miner: Address::from([3u8; 20]),
-                withdrawals_root: None
+                ))
             },
-            transactions: BlockTransactions::Hashes(vec![]),
-            total_difficulty: None,
-            uncles: vec![],
-            size: None,
-            withdrawals: None
+            transactions: (0u64..0u64),
         }
     );
 }

--- a/module-system/module-implementations/sov-evm/src/tests/genesis_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/genesis_tests.rs
@@ -7,7 +7,7 @@ use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::Module;
 use sov_state::{DefaultStorageSpec, ProverStorage, WorkingSet};
 
-use crate::evm::transaction::Block;
+use crate::evm::transaction::SealedBlock;
 // use crate::evm::db;
 use crate::{evm::EvmChainConfig, AccountData, Evm, EvmConfig};
 type C = DefaultContext;
@@ -80,7 +80,7 @@ fn genesis_block() {
 
     assert_eq!(
         block,
-        Block {
+        SealedBlock {
             header: SealedHeader {
                 header: Header {
                     parent_hash: H256::default(),

--- a/module-system/module-implementations/sov-evm/src/tests/hooks_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/hooks_tests.rs
@@ -14,7 +14,7 @@ fn begin_slot_hook_creates_pending_block() {
             number: 1,
             coinbase: Address::from([3u8; 20]),
             timestamp: 52,
-            prevrandao: Some(H256::from([5u8; 32])),
+            prevrandao: H256::from([5u8; 32]),
             basefee: 62,
             gas_limit: 30000000,
         }

--- a/module-system/module-implementations/sov-evm/src/tests/hooks_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/hooks_tests.rs
@@ -26,7 +26,7 @@ fn begin_slot_hook_creates_pending_block() {
             coinbase: *BENEFICIARY,
             timestamp: TEST_CONFIG.genesis_timestamp + TEST_CONFIG.block_timestamp_delta,
             prevrandao: *DA_ROOT_HASH,
-            basefee: TEST_CONFIG.starting_base_fee,
+            basefee: 62u64,
             gas_limit: TEST_CONFIG.block_gas_limit,
         }
     );

--- a/module-system/module-implementations/sov-evm/src/tests/hooks_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/hooks_tests.rs
@@ -1,22 +1,169 @@
-use reth_primitives::{Address, H256};
+use lazy_static::lazy_static;
+use reth_primitives::hex_literal::hex;
+use reth_primitives::{
+    Address, Bloom, Bytes, Header, Signature, TransactionSigned, EMPTY_OMMER_ROOT, H256,
+    KECCAK_EMPTY, U256,
+};
 
 use super::genesis_tests::{get_evm, TEST_CONFIG};
-use crate::evm::transaction::BlockEnv;
+use crate::evm::transaction::{Block, BlockEnv, Receipt, TransactionSignedAndRecovered};
+use crate::experimental::PendingTransaction;
+use crate::tests::genesis_tests::{BENEFICIARY, GENESIS_HASH};
+
+lazy_static! {
+    pub(crate) static ref DA_ROOT_HASH: H256 = H256::from([5u8; 32]);
+}
 
 #[test]
 fn begin_slot_hook_creates_pending_block() {
     let (evm, mut working_set) = get_evm(&TEST_CONFIG);
-    evm.begin_slot_hook([5u8; 32], &mut working_set);
+    evm.begin_slot_hook(DA_ROOT_HASH.0, &mut working_set);
     let pending_block = evm.pending_block.get(&mut working_set).unwrap();
     assert_eq!(
         pending_block,
         BlockEnv {
             number: 1,
-            coinbase: Address::from([3u8; 20]),
-            timestamp: 52,
-            prevrandao: H256::from([5u8; 32]),
-            basefee: 62,
-            gas_limit: 30000000,
+            coinbase: *BENEFICIARY,
+            timestamp: TEST_CONFIG.genesis_timestamp + TEST_CONFIG.block_timestamp_delta,
+            prevrandao: *DA_ROOT_HASH,
+            basefee: TEST_CONFIG.starting_base_fee,
+            gas_limit: TEST_CONFIG.block_gas_limit,
         }
     );
+}
+
+#[test]
+fn end_slot_hook_sets_head() {
+    let (evm, mut working_set) = get_evm(&TEST_CONFIG);
+    evm.begin_slot_hook(DA_ROOT_HASH.0, &mut working_set);
+
+    evm.pending_transactions.push(
+        &create_pending_transaction(H256::from([1u8; 32]), 1),
+        &mut working_set,
+    );
+
+    evm.pending_transactions.push(
+        &create_pending_transaction(H256::from([2u8; 32]), 2),
+        &mut working_set,
+    );
+
+    evm.end_slot_hook(&mut working_set);
+    let head = evm.head.get(&mut working_set).unwrap();
+    let pending_head = evm
+        .pending_head
+        .get(&mut working_set.accessory_state())
+        .unwrap();
+
+    assert_eq!(head, pending_head);
+    assert_eq!(
+        head,
+        Block {
+            header: Header {
+                parent_hash: GENESIS_HASH,
+                ommers_hash: EMPTY_OMMER_ROOT,
+                beneficiary: TEST_CONFIG.coinbase,
+                state_root: KECCAK_EMPTY,
+                transactions_root: H256(hex!(
+                    "30eb5f6050df7ea18ca34cf3503f4713119315a2d3c11f892c5c8920acf816f4"
+                )),
+                receipts_root: H256(hex!(
+                    "27036187b3f5e87d4306b396cf06c806da2cc9a0fef9b07c042e3b4304e01c64"
+                )),
+                withdrawals_root: None,
+                logs_bloom: Bloom::default(),
+                difficulty: U256::ZERO,
+                number: 1,
+                gas_limit: TEST_CONFIG.block_gas_limit,
+                gas_used: 200u64,
+                timestamp: TEST_CONFIG.genesis_timestamp + TEST_CONFIG.block_timestamp_delta,
+                mix_hash: *DA_ROOT_HASH,
+                nonce: 0,
+                base_fee_per_gas: Some(62u64),
+                extra_data: Bytes::default()
+            },
+            transactions: 0..2
+        }
+    );
+}
+
+#[test]
+fn end_slot_hook_moves_transactions_and_receipts() {
+    let (evm, mut working_set) = get_evm(&TEST_CONFIG);
+    evm.begin_slot_hook(DA_ROOT_HASH.0, &mut working_set);
+
+    let tx1 = create_pending_transaction(H256::from([1u8; 32]), 1);
+    evm.pending_transactions.push(&tx1, &mut working_set);
+
+    let tx2 = create_pending_transaction(H256::from([2u8; 32]), 2);
+    evm.pending_transactions.push(&tx2, &mut working_set);
+
+    evm.end_slot_hook(&mut working_set);
+
+    let tx1_hash = tx1.transaction.signed_transaction.hash;
+    let tx2_hash = tx2.transaction.signed_transaction.hash;
+
+    assert_eq!(
+        evm.transactions
+            .iter(&mut working_set.accessory_state())
+            .collect::<Vec<_>>(),
+        [tx1.transaction, tx2.transaction]
+    );
+
+    assert_eq!(
+        evm.receipts
+            .iter(&mut working_set.accessory_state())
+            .collect::<Vec<_>>(),
+        [tx1.receipt, tx2.receipt]
+    );
+
+    assert_eq!(
+        evm.transaction_hashes
+            .get(&tx1_hash, &mut working_set.accessory_state())
+            .unwrap(),
+        0
+    );
+
+    assert_eq!(
+        evm.transaction_hashes
+            .get(&tx2_hash, &mut working_set.accessory_state())
+            .unwrap(),
+        1
+    );
+
+    assert_eq!(evm.pending_transactions.len(&mut working_set), 0);
+}
+
+fn create_pending_transaction(hash: H256, index: u64) -> PendingTransaction {
+    PendingTransaction {
+        transaction: TransactionSignedAndRecovered {
+            signer: Address::from([1u8; 20]),
+            signed_transaction: TransactionSigned {
+                hash,
+                signature: Signature::default(),
+                transaction: reth_primitives::Transaction::Eip1559(reth_primitives::TxEip1559 {
+                    chain_id: 1u64,
+                    nonce: 1u64,
+                    gas_limit: 1000u64,
+                    max_fee_per_gas: 2000u64 as u128,
+                    max_priority_fee_per_gas: 3000u64 as u128,
+                    to: reth_primitives::TransactionKind::Call(Address::from([3u8; 20])),
+                    value: 4000u64 as u128,
+                    access_list: reth_primitives::AccessList::default(),
+                    input: Bytes::from([4u8; 20]),
+                }),
+            },
+            block_number: 1,
+        },
+        receipt: Receipt {
+            receipt: reth_primitives::Receipt {
+                tx_type: reth_primitives::TxType::EIP1559,
+                success: true,
+                cumulative_gas_used: 100u64 * index,
+                logs: vec![],
+            },
+            gas_used: 100u64,
+            log_index_start: 0,
+            error: None,
+        },
+    }
 }

--- a/module-system/module-implementations/sov-evm/src/tests/hooks_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/hooks_tests.rs
@@ -1,4 +1,4 @@
-use reth_primitives::{Address, H256, U256};
+use reth_primitives::{Address, H256};
 
 use super::genesis_tests::{get_evm, TEST_CONFIG};
 use crate::evm::transaction::BlockEnv;
@@ -13,7 +13,7 @@ fn begin_slot_hook_creates_pending_block() {
         BlockEnv {
             number: 1,
             coinbase: Address::from([3u8; 20]),
-            timestamp: U256::from(52),
+            timestamp: 52,
             prevrandao: Some(H256::from([5u8; 32])),
             basefee: 62,
             gas_limit: 30000000,

--- a/module-system/module-schemas/build.rs
+++ b/module-system/module-schemas/build.rs
@@ -8,7 +8,6 @@ use sov_rollup_interface::mocks::MockZkvm;
 fn main() -> io::Result<()> {
     store_json_schema::<sov_bank::Bank<C>>("sov-bank.json")?;
     store_json_schema::<sov_accounts::Accounts<C>>("sov-accounts.json")?;
-    store_json_schema::<sov_evm::Evm<C>>("sov-evm.json")?;
     store_json_schema::<sov_value_setter::ValueSetter<C>>("sov-value-setter.json")?;
     store_json_schema::<sov_prover_incentives::ProverIncentives<C, MockZkvm>>(
         "sov-prover-incentives.json",

--- a/module-system/sov-modules-api/src/hooks.rs
+++ b/module-system/sov-modules-api/src/hooks.rs
@@ -62,12 +62,7 @@ pub trait SlotHooks<Da: DaSpec> {
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
     );
 
-    fn end_slot_hook(
-        &self,
-        //TODO remove
-        root_hash: [u8; 32],
-        working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
-    );
+    fn end_slot_hook(&self, working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>);
 
     fn finalize_slot_hook(
         &self,

--- a/module-system/sov-modules-api/src/hooks.rs
+++ b/module-system/sov-modules-api/src/hooks.rs
@@ -1,6 +1,6 @@
 use sov_rollup_interface::da::{BlobReaderTrait, DaSpec};
 use sov_rollup_interface::services::da::SlotData;
-use sov_state::WorkingSet;
+use sov_state::{AccessoryWorkingSet, WorkingSet};
 
 use crate::transaction::Transaction;
 use crate::{Context, Spec};
@@ -64,7 +64,14 @@ pub trait SlotHooks<Da: DaSpec> {
 
     fn end_slot_hook(
         &self,
+        //TODO remove
         root_hash: [u8; 32],
         working_set: &mut WorkingSet<<Self::Context as Spec>::Storage>,
+    );
+
+    fn finalize_slot_hook(
+        &self,
+        root_hash: [u8; 32],
+        accesorry_working_set: &mut AccessoryWorkingSet<<Self::Context as Spec>::Storage>,
     );
 }

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -94,17 +94,24 @@ where
 
     #[cfg_attr(all(target_os = "zkvm", feature = "bench"), cycle_tracker)]
     fn end_slot(&mut self) -> (jmt::RootHash, <<C as Spec>::Storage as Storage>::Witness) {
-        let mut checkpoint = self.checkpoint.take().unwrap();
-        let (cache_log, witness) = checkpoint.freeze();
+        let checkpoint = self.checkpoint.take().unwrap();
 
+        // Run end end_slot_hook
         let mut working_set = checkpoint.to_revertable();
+        self.runtime.end_slot_hook([0; 32], &mut working_set);
+        // Save checkpoint
+        let mut checkpoint = working_set.checkpoint();
+
+        let (cache_log, witness) = checkpoint.freeze();
 
         let (root_hash, authenticated_node_batch) = self
             .current_storage
             .compute_state_update(cache_log, &witness)
             .expect("jellyfish merkle tree update must succeed");
 
-        self.runtime.end_slot_hook(root_hash, &mut working_set);
+        let mut working_set = checkpoint.to_revertable();
+        self.runtime
+            .finalize_slot_hook([0; 32], &mut working_set.accessory_state());
 
         let accessory_log = working_set.checkpoint().freeze_non_provable();
 

--- a/module-system/sov-modules-stf-template/src/lib.rs
+++ b/module-system/sov-modules-stf-template/src/lib.rs
@@ -98,7 +98,7 @@ where
 
         // Run end end_slot_hook
         let mut working_set = checkpoint.to_revertable();
-        self.runtime.end_slot_hook([0; 32], &mut working_set);
+        self.runtime.end_slot_hook(&mut working_set);
         // Save checkpoint
         let mut checkpoint = working_set.checkpoint();
 

--- a/module-system/sov-state/src/containers/accessory_vec.rs
+++ b/module-system/sov-state/src/containers/accessory_vec.rs
@@ -179,6 +179,16 @@ where
             next_i: 0,
         }
     }
+
+    pub fn last<S: Storage>(&self, working_set: &mut AccessoryWorkingSet<S>) -> Option<V> {
+        let len = self.len(working_set);
+
+        if len == 0usize {
+            None
+        } else {
+            self.elems.get(&(len - 1), working_set)
+        }
+    }
 }
 
 /// An [`Iterator`] over a [`AccessoryStateVec`]

--- a/module-system/sov-state/src/containers/accessory_vec.rs
+++ b/module-system/sov-state/src/containers/accessory_vec.rs
@@ -247,6 +247,23 @@ where
 {
 }
 
+impl<'a, 'ws, V, Codec, S> DoubleEndedIterator for AccessoryStateVecIter<'a, 'ws, V, Codec, S>
+where
+    Codec: StateCodec + Clone,
+    Codec::ValueCodec: StateValueCodec<V> + StateValueCodec<usize>,
+    Codec::KeyCodec: StateKeyCodec<usize>,
+    S: Storage,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.len == 0 {
+            return None;
+        }
+
+        self.len -= 1;
+        self.state_vec.get(self.len, self.ws)
+    }
+}
+
 #[cfg(all(test, feature = "native"))]
 mod test {
     use std::fmt::Debug;
@@ -257,10 +274,12 @@ mod test {
     enum TestCaseAction<T> {
         Push(T),
         Pop(T),
+        Last(T),
         Set(usize, T),
         SetAll(Vec<T>),
         CheckLen(usize),
         CheckContents(Vec<T>),
+        CheckContentsReverse(Vec<T>),
         CheckGet(usize, Option<T>),
         Clear,
     }
@@ -294,6 +313,8 @@ mod test {
             TestCaseAction::CheckGet(0, None),
             TestCaseAction::SetAll(vec![1, 2, 3]),
             TestCaseAction::CheckContents(vec![1, 2, 3]),
+            TestCaseAction::CheckContentsReverse(vec![3, 2, 1]),
+            TestCaseAction::Last(3),
         ]
     }
 
@@ -352,6 +373,14 @@ mod test {
             }
             TestCaseAction::Clear => {
                 state_vec.clear(ws);
+            }
+            TestCaseAction::Last(expected) => {
+                let actual = state_vec.last(ws);
+                assert_eq!(actual, Some(expected));
+            }
+            TestCaseAction::CheckContentsReverse(expected) => {
+                let contents: Vec<T> = state_vec.iter(ws).rev().collect();
+                assert_eq!(expected, contents);
             }
         }
     }

--- a/module-system/sov-state/src/containers/vec.rs
+++ b/module-system/sov-state/src/containers/vec.rs
@@ -181,6 +181,16 @@ where
             next_i: 0,
         }
     }
+
+    pub fn last<S: Storage>(&self, working_set: &mut WorkingSet<S>) -> Option<V> {
+        let len = self.len(working_set);
+
+        if len == 0usize {
+            None
+        } else {
+            self.elems.get(&(len - 1), working_set)
+        }
+    }
 }
 
 /// An [`Iterator`] over a [`StateVec`]
@@ -237,6 +247,23 @@ where
     Codec::KeyCodec: StateKeyCodec<usize>,
     S: Storage,
 {
+}
+
+impl<'a, 'ws, V, Codec, S> DoubleEndedIterator for StateVecIter<'a, 'ws, V, Codec, S>
+where
+    Codec: StateCodec + Clone,
+    Codec::ValueCodec: StateValueCodec<V> + StateValueCodec<usize>,
+    Codec::KeyCodec: StateKeyCodec<usize>,
+    S: Storage,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let elem = self.state_vec.get(self.len - 1, self.ws);
+        if elem.is_some() {
+            self.len -= 1;
+        }
+
+        elem
+    }
 }
 
 #[cfg(all(test, feature = "native"))]

--- a/module-system/sov-state/src/containers/vec.rs
+++ b/module-system/sov-state/src/containers/vec.rs
@@ -257,12 +257,12 @@ where
     S: Storage,
 {
     fn next_back(&mut self) -> Option<Self::Item> {
-        let elem = self.state_vec.get(self.len - 1, self.ws);
-        if elem.is_some() {
-            self.len -= 1;
+        if self.len == 0 {
+            return None;
         }
 
-        elem
+        self.len -= 1;
+        self.state_vec.get(self.len, self.ws)
     }
 }
 
@@ -276,10 +276,12 @@ mod test {
     enum TestCaseAction<T> {
         Push(T),
         Pop(T),
+        Last(T),
         Set(usize, T),
         SetAll(Vec<T>),
         CheckLen(usize),
         CheckContents(Vec<T>),
+        CheckContentsReverse(Vec<T>),
         CheckGet(usize, Option<T>),
         Clear,
     }
@@ -313,6 +315,8 @@ mod test {
             TestCaseAction::CheckGet(0, None),
             TestCaseAction::SetAll(vec![1, 2, 3]),
             TestCaseAction::CheckContents(vec![1, 2, 3]),
+            TestCaseAction::CheckContentsReverse(vec![3, 2, 1]),
+            TestCaseAction::Last(3),
         ]
     }
 
@@ -367,6 +371,14 @@ mod test {
             }
             TestCaseAction::Clear => {
                 state_vec.clear(ws);
+            }
+            TestCaseAction::Last(expected) => {
+                let actual = state_vec.last(ws);
+                assert_eq!(actual, Some(expected));
+            }
+            TestCaseAction::CheckContentsReverse(expected) => {
+                let contents: Vec<T> = state_vec.iter(ws).rev().collect();
+                assert_eq!(expected, contents);
             }
         }
     }


### PR DESCRIPTION
# Description
- Implements `DoubleEndedIterator` and `last` on `AccessoryStateVec` and `StateVec`.
- Splits `end_slot_hook` into `end_slot_hook` (zk-context) and `finalize_slot_hook` (only non-zk-context)
- In `sov-evm` module:
  - `evm` state fields are properly split between `state` and `AccessoryState` types. Using Reth domain types where possible. Enclosing it in our types for `Block`, `Transaction` and `Receipt`. All serialized with binary serialization.
  - `execute_call` now properly creates pending transaction and receipt (for both successful and failed transactions)
  - `begin_slot_hook` properly creates `pending_block`
  - `end_slot_hook` creates final block and sets `head`, moves transactions from `pending_transactions` to `transactions` and `receipts`.
  - `finalize_slot_hook` - finalizes head block and moves it to `blocks` for RPC
  - Implements `eth_getTransactionByHash` and `eth_getTransactionReceipt` with new model

## Linked Issues
- Fixes #737, #504, #503 
- Related to #640, #502, #413

## Testing
Unit test + existing integration tests
