### PR TITLE
Add missing docs to `sov-state`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6827,6 +6827,7 @@ dependencies = [
  "borsh",
  "hex",
  "jmt",
+ "proptest",
  "risc0-zkvm",
  "risc0-zkvm-platform",
  "serde",

--- a/module-system/sov-state/Cargo.toml
+++ b/module-system/sov-state/Cargo.toml
@@ -32,6 +32,7 @@ risc0-zkvm-platform = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+proptest = { workspace = true }
 
 [features]
 bench = ["sov-zk-cycle-macros", "risc0-zkvm", "risc0-zkvm-platform"]

--- a/module-system/sov-state/src/codec/bcs_codec.rs
+++ b/module-system/sov-state/src/codec/bcs_codec.rs
@@ -1,7 +1,7 @@
 use super::{StateCodec, StateKeyCodec};
 use crate::codec::StateValueCodec;
 
-/// A [`StateValueCodec`] that uses [`bcs`] for all keys and values.
+/// A [`StateCodec`] that uses [`bcs`] for all keys and values.
 #[derive(Debug, Default, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BcsCodec;
 
@@ -32,6 +32,7 @@ where
 impl StateCodec for BcsCodec {
     type KeyCodec = Self;
     type ValueCodec = Self;
+
     fn key_codec(&self) -> &Self::KeyCodec {
         self
     }

--- a/module-system/sov-state/src/codec/borsh_codec.rs
+++ b/module-system/sov-state/src/codec/borsh_codec.rs
@@ -1,7 +1,7 @@
 use super::{StateCodec, StateKeyCodec};
 use crate::codec::StateValueCodec;
 
-/// A [`StateValueCodec`] that uses [`borsh`] for all values.
+/// A [`StateCodec`] that uses [`borsh`] for all keys and values.
 #[derive(Debug, Default, PartialEq, Eq, Clone, borsh::BorshDeserialize, borsh::BorshSerialize)]
 pub struct BorshCodec;
 
@@ -10,7 +10,7 @@ where
     K: borsh::BorshSerialize + borsh::BorshDeserialize,
 {
     fn encode_key(&self, value: &K) -> Vec<u8> {
-        value.try_to_vec().expect("Failed to serialize value")
+        value.try_to_vec().expect("Failed to serialize key")
     }
 }
 
@@ -32,6 +32,7 @@ where
 impl StateCodec for BorshCodec {
     type KeyCodec = Self;
     type ValueCodec = Self;
+
     fn key_codec(&self) -> &Self::KeyCodec {
         self
     }

--- a/module-system/sov-state/src/codec/json_codec.rs
+++ b/module-system/sov-state/src/codec/json_codec.rs
@@ -3,7 +3,7 @@ use serde_json;
 use super::{StateCodec, StateKeyCodec};
 use crate::codec::StateValueCodec;
 
-/// A [`StateValueCodec`] that uses [`serde_json`] for all values.
+/// A [`StateCodec`] that uses [`serde_json`] for all keys and values.
 #[derive(Debug, Default, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct JsonCodec;
 
@@ -12,7 +12,7 @@ where
     K: serde::Serialize,
 {
     fn encode_key(&self, key: &K) -> Vec<u8> {
-        serde_json::to_vec(key).expect("Failed to serialize value")
+        serde_json::to_vec(key).expect("Failed to serialize key")
     }
 }
 

--- a/module-system/sov-state/src/codec/split_codec.rs
+++ b/module-system/sov-state/src/codec/split_codec.rs
@@ -5,7 +5,9 @@ use super::{StateCodec, StateKeyCodec, StateValueCodec};
 /// A [`StateValueCodec`] that uses one pre-existing codec for keys and a different one values.
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct SplitCodec<KC, VC> {
+    /// The codec to use for keys.
     pub key_codec: KC,
+    /// The codec to use for values.
     pub value_codec: VC,
 }
 
@@ -36,6 +38,7 @@ where
 impl<KC, VC> StateCodec for SplitCodec<KC, VC> {
     type KeyCodec = KC;
     type ValueCodec = VC;
+
     fn key_codec(&self) -> &Self::KeyCodec {
         &self.key_codec
     }

--- a/module-system/sov-state/src/config.rs
+++ b/module-system/sov-state/src/config.rs
@@ -1,7 +1,11 @@
+//! Configuration options for [`Storage`](crate::storage::Storage) types.
+
 use std::path::PathBuf;
 
+/// Configuration options for [`ProverStorage`](crate::ProverStorage)
+/// initialization.
 #[derive(serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Config {
-    /// Path to folder where storage files will be stored
+    /// Path to folder where storage files will be stored.
     pub path: PathBuf,
 }

--- a/module-system/sov-state/src/containers/accessory_map.rs
+++ b/module-system/sov-state/src/containers/accessory_map.rs
@@ -190,6 +190,9 @@ where
     Codec::KeyCodec: StateKeyCodec<K>,
     Codec::ValueCodec: StateValueCodec<V>,
 {
+    /// Generates an arbitrary [`AccessoryStateMap`] instance.
+    ///
+    /// See the [`arbitrary`] crate for more information.
     pub fn arbitrary_workset<S>(
         u: &mut arbitrary::Unstructured<'a>,
         working_set: &mut AccessoryWorkingSet<S>,

--- a/module-system/sov-state/src/containers/accessory_vec.rs
+++ b/module-system/sov-state/src/containers/accessory_vec.rs
@@ -183,14 +183,12 @@ where
         }
     }
 
+    /// Returns the last value in the [`AccessoryStateVec`], or [`None`] is
+    /// empty.
     pub fn last<S: Storage>(&self, working_set: &mut AccessoryWorkingSet<S>) -> Option<V> {
         let len = self.len(working_set);
-
-        if len == 0usize {
-            None
-        } else {
-            self.elems.get(&(len - 1), working_set)
-        }
+        let i = len.checked_sub(1)?;
+        self.elems.get(&i, working_set)
     }
 }
 

--- a/module-system/sov-state/src/containers/accessory_vec.rs
+++ b/module-system/sov-state/src/containers/accessory_vec.rs
@@ -183,7 +183,7 @@ where
         }
     }
 
-    /// Returns the last value in the [`AccessoryStateVec`], or [`None`] is
+    /// Returns the last value in the [`AccessoryStateVec`], or [`None`] if
     /// empty.
     pub fn last<S: Storage>(&self, working_set: &mut AccessoryWorkingSet<S>) -> Option<V> {
         let len = self.len(working_set);

--- a/module-system/sov-state/src/containers/accessory_vec.rs
+++ b/module-system/sov-state/src/containers/accessory_vec.rs
@@ -6,6 +6,8 @@ use crate::{
     AccessoryStateMap, AccessoryStateValue, AccessoryWorkingSet, Prefix, StateVecError, Storage,
 };
 
+/// A variant of [`StateVec`](crate::StateVec) that stores its elements as
+/// "accessory" state, instead of in the JMT.
 #[derive(
     Debug,
     Clone,
@@ -139,6 +141,7 @@ where
         Some(elem)
     }
 
+    /// Removes all values from this [`AccessoryStateVec`].
     pub fn clear<S: Storage>(&self, working_set: &mut AccessoryWorkingSet<S>) {
         let len = self.len_value.remove(working_set).unwrap_or_default();
 

--- a/module-system/sov-state/src/containers/map.rs
+++ b/module-system/sov-state/src/containers/map.rs
@@ -31,6 +31,7 @@ pub struct StateMap<K, V, Codec = BorshCodec> {
 /// Error type for the [`StateMap::get`] method.
 #[derive(Debug, Error)]
 pub enum StateMapError {
+    /// Value not found.
     #[error("Value not found for prefix: {0} and: storage key {1}")]
     MissingValue(Prefix, StorageKey),
 }
@@ -53,6 +54,7 @@ impl<K, V, Codec> StateMap<K, V, Codec> {
         }
     }
 
+    /// Returns a reference to the codec used by this [`StateMap`].
     pub fn codec(&self) -> &Codec {
         &self.codec
     }
@@ -206,6 +208,9 @@ where
     Codec::KeyCodec: StateKeyCodec<K>,
     Codec::ValueCodec: StateValueCodec<V>,
 {
+    /// Returns an arbitrary [`StateMap`] instance.
+    ///
+    /// See the [`arbitrary`] crate for more information.
     pub fn arbitrary_workset<S>(
         u: &mut arbitrary::Unstructured<'a>,
         working_set: &mut WorkingSet<S>,

--- a/module-system/sov-state/src/containers/value.rs
+++ b/module-system/sov-state/src/containers/value.rs
@@ -24,6 +24,7 @@ pub struct StateValue<V, Codec = BorshCodec> {
 /// Error type for `StateValue` get method.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// Value not found.
     #[error("Value not found for prefix: {0}")]
     MissingValue(Prefix),
 }

--- a/module-system/sov-state/src/containers/vec.rs
+++ b/module-system/sov-state/src/containers/vec.rs
@@ -6,6 +6,17 @@ use thiserror::Error;
 use crate::codec::{BorshCodec, StateCodec, StateKeyCodec, StateValueCodec};
 use crate::{Prefix, StateMap, StateValue, Storage, WorkingSet};
 
+/// A growable array of values stored as JMT-backed state.
+///
+/// # An Example
+///
+/// ```
+/// use sov_state::StateVec;
+///
+/// let mut state_vec = StateVec::<u32>::new(b"test".to_vec());
+///
+/// assert_eq!(state_vec.len(), 0);
+/// ```
 #[derive(
     Debug,
     Clone,
@@ -25,8 +36,10 @@ pub struct StateVec<V, Codec = BorshCodec> {
 /// Error type for `StateVec` get method.
 #[derive(Debug, Error)]
 pub enum Error {
+    /// Operation failed because the index was out of bounds.
     #[error("Index out of bounds for index: {0}")]
     IndexOutOfBounds(usize),
+    /// Value not found.
     #[error("Value not found for prefix: {0} and index: {1}")]
     MissingValue(Prefix, usize),
 }
@@ -141,6 +154,7 @@ where
         Some(elem)
     }
 
+    /// Removes all values from this [`StateVec`].
     pub fn clear<S: Storage>(&self, working_set: &mut WorkingSet<S>) {
         let len = self.len_value.remove(working_set).unwrap_or_default();
 
@@ -193,7 +207,7 @@ where
     }
 }
 
-/// An [`Iterator`] over a [`StateVec`]
+/// An [`Iterator`] over a [`StateVec`].
 ///
 /// See [`StateVec::iter`] for more details.
 pub struct StateVecIter<'a, 'ws, V, Codec, S>

--- a/module-system/sov-state/src/containers/vec.rs
+++ b/module-system/sov-state/src/containers/vec.rs
@@ -7,16 +7,6 @@ use crate::codec::{BorshCodec, StateCodec, StateKeyCodec, StateValueCodec};
 use crate::{Prefix, StateMap, StateValue, Storage, WorkingSet};
 
 /// A growable array of values stored as JMT-backed state.
-///
-/// # An Example
-///
-/// ```
-/// use sov_state::StateVec;
-///
-/// let mut state_vec = StateVec::<u32>::new(b"test".to_vec());
-///
-/// assert_eq!(state_vec.len(), 0);
-/// ```
 #[derive(
     Debug,
     Clone,

--- a/module-system/sov-state/src/containers/vec.rs
+++ b/module-system/sov-state/src/containers/vec.rs
@@ -186,14 +186,12 @@ where
         }
     }
 
+    /// Returns the last value in the [`StateVec`], or [`None`] if
+    /// empty.
     pub fn last<S: Storage>(&self, working_set: &mut WorkingSet<S>) -> Option<V> {
         let len = self.len(working_set);
-
-        if len == 0usize {
-            None
-        } else {
-            self.elems.get(&(len - 1), working_set)
-        }
+        let i = len.checked_sub(1)?;
+        self.elems.get(&i, working_set)
     }
 }
 

--- a/module-system/sov-state/src/lib.rs
+++ b/module-system/sov-state/src/lib.rs
@@ -42,18 +42,11 @@ use utils::AlignedVec;
 pub use crate::witness::{ArrayWitness, TreeWitnessReader, Witness};
 
 /// A prefix prepended to each key before insertion and retrieval from the storage.
-/// All the collection types in this crate are backed by the same storage instance, this means that insertions of the same key
-/// to two different `StorageMaps` would collide with each other. We solve it by instantiating every collection type with a unique
-/// prefix that is prepended to each key.
 ///
-/// # Examples
-///
-/// ```
-/// use sov_state::Prefix;
-///
-/// let prefix = Prefix::new(b"test".to_vec());
-/// assert_eq!(prefix.len(), "4");
-/// ```
+/// When interfacing with state containers like [`StateMap`] or [`StateVec`],
+/// you will usually use the same [`WorkingSet`] instance to access them, as
+/// required by the module API. This also means that you might get key
+/// collisions, so it becomes necessary to prepend a prefix to each key.
 #[derive(
     borsh::BorshDeserialize,
     borsh::BorshSerialize,

--- a/module-system/sov-state/src/lib.rs
+++ b/module-system/sov-state/src/lib.rs
@@ -37,7 +37,7 @@ pub use scratchpad::*;
 pub use sov_first_read_last_write_cache::cache::CacheLog;
 use sov_rollup_interface::digest::Digest;
 pub use storage::Storage;
-use utils::AlignedVec;
+pub use utils::AlignedVec;
 
 pub use crate::witness::{ArrayWitness, TreeWitnessReader, Witness};
 
@@ -84,7 +84,8 @@ impl Prefix {
         }
     }
 
-    pub(crate) fn as_aligned_vec(&self) -> &AlignedVec {
+    /// Returns a reference to the [`AlignedVec`] containing the prefix.
+    pub fn as_aligned_vec(&self) -> &AlignedVec {
         &self.prefix
     }
 

--- a/module-system/sov-state/src/lib.rs
+++ b/module-system/sov-state/src/lib.rs
@@ -84,8 +84,7 @@ impl Prefix {
         }
     }
 
-    /// Returns a reference to the internal [`AlignedVec`] used by this prefix.
-    pub fn as_aligned_vec(&self) -> &AlignedVec {
+    pub(crate) fn as_aligned_vec(&self) -> &AlignedVec {
         &self.prefix
     }
 

--- a/module-system/sov-state/src/lib.rs
+++ b/module-system/sov-state/src/lib.rs
@@ -1,3 +1,7 @@
+//! Storage and state management interfaces for Sovereign SDK modules.
+
+#![deny(missing_docs)]
+
 pub mod codec;
 mod internal_cache;
 
@@ -12,6 +16,7 @@ mod tree_db;
 
 mod scratchpad;
 
+/// Trait and type definitions related to the [`Storage`] trait.
 pub mod storage;
 
 mod utils;
@@ -36,10 +41,19 @@ use utils::AlignedVec;
 
 pub use crate::witness::{ArrayWitness, TreeWitnessReader, Witness};
 
-// A prefix prepended to each key before insertion and retrieval from the storage.
-// All the collection types in this crate are backed by the same storage instance, this means that insertions of the same key
-// to two different `StorageMaps` would collide with each other. We solve it by instantiating every collection type with a unique
-// prefix that is prepended to each key.
+/// A prefix prepended to each key before insertion and retrieval from the storage.
+/// All the collection types in this crate are backed by the same storage instance, this means that insertions of the same key
+/// to two different `StorageMaps` would collide with each other. We solve it by instantiating every collection type with a unique
+/// prefix that is prepended to each key.
+///
+/// # Examples
+///
+/// ```
+/// use sov_state::Prefix;
+///
+/// let prefix = Prefix::new(b"test".to_vec());
+/// assert_eq!(prefix.len(), "4");
+/// ```
 #[derive(
     borsh::BorshDeserialize,
     borsh::BorshSerialize,
@@ -70,25 +84,31 @@ impl Display for Prefix {
 }
 
 impl Prefix {
+    /// Creates a new prefix from a byte vector.
     pub fn new(prefix: Vec<u8>) -> Self {
         Self {
             prefix: AlignedVec::new(prefix),
         }
     }
 
+    /// Returns a reference to the internal [`AlignedVec`] used by this prefix.
     pub fn as_aligned_vec(&self) -> &AlignedVec {
         &self.prefix
     }
 
+    /// Returns the length in bytes of the prefix.
     pub fn len(&self) -> usize {
         self.prefix.len()
     }
 
+    /// Returns `true` if the prefix is empty, `false` otherwise.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.prefix.is_empty()
     }
 
+    /// Returns a new prefix allocated on the fly, by extending the current
+    /// prefix with the given bytes.
     pub fn extended(&self, bytes: &[u8]) -> Self {
         let mut prefix = self.clone();
         prefix.extend(bytes.iter().copied());
@@ -114,6 +134,9 @@ pub trait MerkleProofSpec {
 
 use sha2::Sha256;
 
+/// The default [`MerkleProofSpec`] implementation.
+///
+/// This type is typically found as a type parameter for [`ProverStorage`].
 #[derive(Clone)]
 pub struct DefaultStorageSpec;
 

--- a/module-system/sov-state/src/prover_storage.rs
+++ b/module-system/sov-state/src/prover_storage.rs
@@ -15,6 +15,8 @@ use crate::tree_db::TreeReadLogger;
 use crate::witness::Witness;
 use crate::{MerkleProofSpec, Storage};
 
+/// A [`Storage`] implementation to be used by the prover in a native execution
+/// environment (outside of the zkVM).
 pub struct ProverStorage<S: MerkleProofSpec> {
     db: StateDB,
     native_db: NativeDB,
@@ -32,6 +34,8 @@ impl<S: MerkleProofSpec> Clone for ProverStorage<S> {
 }
 
 impl<S: MerkleProofSpec> ProverStorage<S> {
+    /// Creates a new [`ProverStorage`] instance at the specified path, opening
+    /// or creating the necessary RocksDB database(s) at the specified path.
     pub fn with_path(path: impl AsRef<Path>) -> Result<Self, anyhow::Error> {
         let state_db = StateDB::with_path(&path)?;
         let native_db = NativeDB::with_path(&path)?;
@@ -217,6 +221,7 @@ impl<S: MerkleProofSpec> NativeStorage for ProverStorage<S> {
     }
 }
 
+/// Deletes the storage at the specified path.
 pub fn delete_storage(path: impl AsRef<Path>) {
     fs::remove_dir_all(&path)
         .or_else(|_| fs::remove_file(&path))
@@ -229,6 +234,15 @@ mod test {
 
     use super::*;
     use crate::{DefaultStorageSpec, StateReaderAndWriter, WorkingSet};
+
+    #[test]
+    fn delete_storage_works() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path();
+        assert!(path.exists());
+        delete_storage(path);
+        assert!(!path.exists());
+    }
 
     #[derive(Clone)]
     struct TestCase {

--- a/module-system/sov-state/src/scratchpad.rs
+++ b/module-system/sov-state/src/scratchpad.rs
@@ -60,14 +60,19 @@ impl<S: Storage> StateReaderAndWriter for Delta<S> {
 
 type RevertableWrites = HashMap<CacheKey, Option<CacheValue>>;
 
-/// This structure is responsible for storing the `read-write` set
-/// and is obtained from the `WorkingSet` by using either the `commit` or `revert` method.
+/// This structure is responsible for storing the `read-write` set.
+///
+/// A [`StateCheckpoint`] can be obtained from a [`WorkingSet`] in two ways:
+///  1. With [`WorkingSet::checkpoint`].
+///  2. With [`WorkingSet::revert`].
 pub struct StateCheckpoint<S: Storage> {
     delta: Delta<S>,
     accessory_delta: AccessoryDelta<S>,
 }
 
 impl<S: Storage> StateCheckpoint<S> {
+    /// Creates a new [`StateCheckpoint`] instance without any changes, backed
+    /// by the given [`Storage`].
     pub fn new(inner: S) -> Self {
         Self {
             delta: Delta::new(inner.clone()),
@@ -75,10 +80,13 @@ impl<S: Storage> StateCheckpoint<S> {
         }
     }
 
+    /// Fetches a value from the underlying storage.
     pub fn get(&mut self, key: &StorageKey) -> Option<StorageValue> {
         self.delta.get(key)
     }
 
+    /// Creates a new [`StateCheckpoint`] instance without any changes, backed
+    /// by the given [`Storage`] and witness.
     pub fn with_witness(inner: S, witness: S::Witness) -> Self {
         Self {
             delta: Delta::with_witness(inner.clone(), witness),
@@ -86,6 +94,7 @@ impl<S: Storage> StateCheckpoint<S> {
         }
     }
 
+    /// Transforms this [`StateCheckpoint`] back into a [`WorkingSet`].
     pub fn to_revertable(self) -> WorkingSet<S> {
         WorkingSet {
             delta: RevertableWriter::new(self.delta),
@@ -94,10 +103,21 @@ impl<S: Storage> StateCheckpoint<S> {
         }
     }
 
+    /// Extracts ordered reads, writes, and witness from this [`StateCheckpoint`].
+    ///
+    /// You can then use these to call [`Storage::validate_and_commit`] or some
+    /// of the other related [`Storage`] methods. Note that this data is moved
+    /// **out** of the [`StateCheckpoint`] i.e. it can't be extracted twice.
     pub fn freeze(&mut self) -> (OrderedReadsAndWrites, S::Witness) {
         self.delta.freeze()
     }
 
+    /// Extracts ordered reads and writes of accessory state from this
+    /// [`StateCheckpoint`].
+    ///
+    /// You can then use these to call
+    /// [`Storage::validate_and_commit_with_accessory_update`], together with
+    /// the data extracted with [`StateCheckpoint::freeze`].
     pub fn freeze_non_provable(&mut self) -> OrderedReadsAndWrites {
         self.accessory_delta.freeze()
     }
@@ -259,18 +279,31 @@ impl<T: StateReaderAndWriter> StateReaderAndWriter for RevertableWriter<T> {
 }
 
 impl<S: Storage> WorkingSet<S> {
+    /// Creates a new [`WorkingSet`] instance backed by the given [`Storage`].
+    ///
+    /// The witness value is set to [`Default::default`]. Use
+    /// [`WorkingSet::with_witness`] to set a custom witness value.
     pub fn new(inner: S) -> Self {
         StateCheckpoint::new(inner).to_revertable()
     }
 
+    /// Returns a handler for the accessory state (non-JMT state).
+    ///
+    /// You can use this method when calling getters and setters on accessory
+    /// state containers, like [`AccessoryStateMap`](crate::AccessoryStateMap).
     pub fn accessory_state(&mut self) -> AccessoryWorkingSet<S> {
         AccessoryWorkingSet { ws: self }
     }
 
+    /// Creates a new [`WorkingSet`] instance backed by the given [`Storage`]
+    /// and a custom witness value.
     pub fn with_witness(inner: S, witness: S::Witness) -> Self {
         StateCheckpoint::with_witness(inner, witness).to_revertable()
     }
 
+    /// Turns this [`WorkingSet`] into a [`StateCheckpoint`], in preparation for
+    /// committing the changes to the underlying [`Storage`] via
+    /// [`StateCheckpoint::freeze`].
     pub fn checkpoint(self) -> StateCheckpoint<S> {
         StateCheckpoint {
             delta: self.delta.commit(),
@@ -278,6 +311,8 @@ impl<S: Storage> WorkingSet<S> {
         }
     }
 
+    /// Reverts the most recent changes to this [`WorkingSet`], returning a pristine
+    /// [`StateCheckpoint`] instance.
     pub fn revert(self) -> StateCheckpoint<S> {
         StateCheckpoint {
             delta: self.delta.revert(),
@@ -285,18 +320,24 @@ impl<S: Storage> WorkingSet<S> {
         }
     }
 
+    /// Adds an event to the working set.
     pub fn add_event(&mut self, key: &str, value: &str) {
         self.events.push(Event::new(key, value));
     }
 
+    /// Extracts all events from this working set.
     pub fn take_events(&mut self) -> Vec<Event> {
         std::mem::take(&mut self.events)
     }
 
+    /// Returns an immutable slice of all events that have been previously
+    /// written to this working set.
     pub fn events(&self) -> &[Event] {
         &self.events
     }
 
+    /// Returns an immutable reference to the [`Storage`] instance backing this
+    /// working set.
     pub fn backing(&self) -> &S {
         &self.delta.inner.inner
     }

--- a/module-system/sov-state/src/storage.rs
+++ b/module-system/sov-state/src/storage.rs
@@ -14,7 +14,8 @@ use crate::utils::AlignedVec;
 use crate::witness::Witness;
 use crate::{Prefix, StateMap};
 
-// `Key` type for the `Storage`
+/// The key type suitable for use in [`Storage::get`] and other getter methods of
+/// [`Storage`]. Cheaply-clonable.
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, BorshDeserialize, BorshSerialize)]
 pub struct StorageKey {
     key: Arc<Vec<u8>>,
@@ -27,16 +28,19 @@ impl From<CacheKey> for StorageKey {
 }
 
 impl StorageKey {
+    /// Returns a new [`Arc`] reference to the bytes of this key.
     pub fn key(&self) -> Arc<Vec<u8>> {
         self.key.clone()
     }
 
+    /// Converts this key into a [`CacheKey`] via cloning.
     pub fn to_cache_key(&self) -> CacheKey {
         CacheKey {
             key: self.key.clone(),
         }
     }
 
+    /// Converts this key into a [`CacheKey`].
     pub fn into_cache_key(self) -> CacheKey {
         CacheKey { key: self.key }
     }
@@ -55,7 +59,7 @@ impl Display for StorageKey {
 }
 
 impl StorageKey {
-    /// Creates a new StorageKey that combines a prefix and a key.
+    /// Creates a new [`StorageKey`] that combines a prefix and a key.
     pub fn new<K, Q, KC>(prefix: &Prefix, key: &Q, codec: &KC) -> Self
     where
         KC: EncodeKeyLike<Q, K>,
@@ -74,7 +78,7 @@ impl StorageKey {
         }
     }
 
-    /// Creates a new StorageKey that combines a prefix and a key.
+    /// Creates a new [`StorageKey`] that combines a prefix and a key.
     pub fn singleton(prefix: &Prefix) -> Self {
         Self {
             key: Arc::new(prefix.as_aligned_vec().clone().into_inner()),
@@ -82,7 +86,8 @@ impl StorageKey {
     }
 }
 
-/// A serialized value suitable for storing. Internally uses an [`Arc<Vec<u8>>`] for cheap cloning.
+/// A serialized value suitable for storing. Internally uses an [`Arc<Vec<u8>>`]
+/// for cheap cloning.
 #[derive(
     Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize, Default,
 )]
@@ -159,12 +164,20 @@ pub trait Storage: Clone {
     /// State update that will be committed to the database.
     type StateUpdate;
 
+    /// Creates a new instance of this [`Storage`] type, with some configuration
+    /// options.
     fn with_config(config: Self::RuntimeConfig) -> Result<Self, anyhow::Error>;
 
     /// Returns the value corresponding to the key or None if key is absent.
     fn get(&self, key: &StorageKey, witness: &Self::Witness) -> Option<StorageValue>;
 
     /// Returns the value corresponding to the key or None if key is absent.
+    ///
+    /// # About accessory state
+    /// This method is blanket-implemented to return [`None`]. **Only native
+    /// execution environments** (i.e. outside of the zmVM) **SHOULD** override
+    /// this method to return a value. This is because accessory state **MUST
+    /// NOT** be readable from within the zmVM.
     fn get_accessory(&self, _key: &StorageKey) -> Option<StorageValue> {
         None
     }
@@ -222,6 +235,8 @@ pub trait Storage: Clone {
         proof: StorageProof<Self::Proof>,
     ) -> Result<(StorageKey, Option<StorageValue>), anyhow::Error>;
 
+    /// Verifies the key-value pair returned by [`Storage::open_proof`] against
+    /// a [`StateMap`] entry.
     fn verify_proof<K, V, Codec>(
         &self,
         state_root: [u8; 32],
@@ -244,7 +259,7 @@ pub trait Storage: Clone {
     }
 
     /// Indicates if storage is empty or not.
-    /// Useful during initialization
+    /// Useful during initialization.
     fn is_empty(&self) -> bool;
 }
 
@@ -268,6 +283,8 @@ impl From<&'static str> for StorageValue {
     }
 }
 
+/// A [`Storage`] that is suitable for use in native execution environments
+/// (outside of the zkVM).
 pub trait NativeStorage: Storage {
     /// Returns the value corresponding to the key or None if key is absent and a proof to
     /// get the value. Panics if [`get_with_proof_from_state_map`](NativeStorage::get_with_proof_from_state_map)
@@ -275,6 +292,8 @@ pub trait NativeStorage: Storage {
     fn get_with_proof(&self, key: StorageKey, witness: &Self::Witness)
         -> StorageProof<Self::Proof>;
 
+    /// Same as [`get_with_proof`](NativeStorage::get_with_proof) but uses a
+    /// [`StateMap`] entry as a key.
     fn get_with_proof_from_state_map<Q, K, V, Codec>(
         &self,
         key: &Q,

--- a/module-system/sov-state/src/utils.rs
+++ b/module-system/sov-state/src/utils.rs
@@ -1,5 +1,5 @@
-// AlignedVec keeps a vec whose length is guaranteed to be aligned to 4 bytes.
-// This makes certain operations cheaper in zk-context (concatenation)
+/// A [`Vec`] of bytes whose length is guaranteed to be aligned to 4 bytes.
+/// This makes certain operations cheaper in zk-context (namely, concatenation).
 // TODO: Currently the implementation defaults to `stc::vec::Vec` see:
 // https://github.com/Sovereign-Labs/sovereign-sdk/issues/47
 #[derive(
@@ -20,12 +20,13 @@ impl AlignedVec {
     /// The length of the chunks of the aligned vector.
     pub const ALIGNMENT: usize = 4;
 
-    // Creates a new AlignedVec whose length is aligned to [Self::ALIGNMENT] bytes.
+    /// Creates a new [`AlignedVec`] whose length is aligned to
+    /// [`AlignedVec::ALIGNMENT`] bytes.
     pub fn new(vector: Vec<u8>) -> Self {
         Self { inner: vector }
     }
 
-    // Extends self with the contents of the other AlignedVec.
+    /// Extends `self` with the contents of the other [`AlignedVec`].
     pub fn extend(&mut self, other: &Self) {
         // TODO check if the standard extend method does the right thing.
         // debug_assert_eq!(
@@ -36,14 +37,17 @@ impl AlignedVec {
         self.inner.extend(&other.inner);
     }
 
+    /// Consumes `self` and returns the underlying [`Vec`] of bytes.
     pub fn into_inner(self) -> Vec<u8> {
         self.inner
     }
 
+    /// Returns the length in bytes of the prefix.
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
+    /// Returns `true` if the prefix is empty, `false` otherwise.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0

--- a/module-system/sov-state/src/witness.rs
+++ b/module-system/sov-state/src/witness.rs
@@ -6,18 +6,37 @@ use jmt::storage::TreeReader;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
+/// A witness is a value produced during native execution that is then used by
+/// the zkVM circuit to produce proofs.
+///
+/// Witnesses are typically used to abstract away storage access from inside the
+/// zkVM. For every read operation performed by the native code, a hint can be
+/// added and the zkVM circuit can then read the same hint. Hints are replayed
+/// to [`Witness::get_hint`] in the same order
+/// they were added via [`Witness::add_hint`].
 // TODO: Refactor witness trait so it only require Serialize / Deserialize
 //   https://github.com/Sovereign-Labs/sovereign-sdk/issues/263
 pub trait Witness: Default + Serialize + DeserializeOwned {
+    /// Adds a serializable "hint" to the witness value, which can be later
+    /// read by the zkVM circuit.
+    ///
+    /// This method **SHOULD** only be called from the native execution
+    /// environment.
     fn add_hint<T: BorshSerialize>(&self, hint: T);
+
+    /// Retrieves a "hint" from the witness value.
     fn get_hint<T: BorshDeserialize>(&self) -> T;
+
+    /// Adds all hints from `rhs` to `self`.
     fn merge(&self, rhs: &Self);
 }
 
+/// A wrapper around a [`Witness`] that implements [`TreeReader`].
 #[derive(Debug)]
 pub struct TreeWitnessReader<'a, T: Witness>(&'a T);
 
 impl<'a, T: Witness> TreeWitnessReader<'a, T> {
+    /// Wraps the given witness.
     pub fn new(witness: &'a T) -> Self {
         Self(witness)
     }
@@ -50,6 +69,21 @@ impl<'a, T: Witness> TreeReader for TreeWitnessReader<'a, T> {
     }
 }
 
+/// A [`Vec`]-based implementation of [`Witness`] with no special logic.
+///
+/// # Example
+///
+/// ```
+/// use sov_state::{ArrayWitness, Witness};
+///
+/// let witness = ArrayWitness::default();
+///
+/// witness.add_hint(1u64);
+/// witness.add_hint(2u64);
+///
+/// assert_eq!(witness.get_hint::<u64>(), 1u64);
+/// assert_eq!(witness.get_hint::<u64>(), 2u64);
+/// ```
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct ArrayWitness {
     next_idx: AtomicUsize,

--- a/module-system/sov-state/src/zk_storage.rs
+++ b/module-system/sov-state/src/zk_storage.rs
@@ -14,6 +14,7 @@ use crate::{MerkleProofSpec, Storage};
 #[cfg(all(target_os = "zkvm", feature = "bench"))]
 extern crate risc0_zkvm;
 
+/// A [`Storage`] implementation designed to be used inside the zkVM.
 #[derive(Default)]
 pub struct ZkStorage<S: MerkleProofSpec> {
     _phantom_hasher: PhantomData<S::Hasher>,
@@ -28,6 +29,7 @@ impl<S: MerkleProofSpec> Clone for ZkStorage<S> {
 }
 
 impl<S: MerkleProofSpec> ZkStorage<S> {
+    /// Creates a new [`ZkStorage`] instance. Identical to [`Default::default`].
     pub fn new() -> Self {
         Self {
             _phantom_hasher: Default::default(),


### PR DESCRIPTION
# Description
Add `#![missing_docs]` to `sov-state`.

Part of the https://github.com/Sovereign-Labs/sovereign-sdk/issues/438 epic.
