### PR TITLE
EVM Remove #501 todos

### DIFF
--- a/module-system/module-implementations/sov-evm/src/query.rs
+++ b/module-system/module-implementations/sov-evm/src/query.rs
@@ -127,10 +127,8 @@ impl<C: sov_modules_api::Context> Evm<C> {
     #[rpc_method(name = "call")]
     pub fn get_call(
         &self,
-        // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/501
         request: reth_rpc_types::CallRequest,
         _block_number: Option<reth_primitives::BlockId>,
-        // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/501
         _state_overrides: Option<reth_rpc_types::state::StateOverride>,
         _block_overrides: Option<Box<reth_rpc_types::BlockOverrides>>,
         working_set: &mut WorkingSet<C::Storage>,
@@ -157,7 +155,6 @@ impl<C: sov_modules_api::Context> Evm<C> {
     #[rpc_method(name = "sendTransaction")]
     pub fn send_transaction(
         &self,
-        // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/501
         _request: reth_rpc_types::TransactionRequest,
         _working_set: &mut WorkingSet<C::Storage>,
     ) -> RpcResult<reth_primitives::U256> {


### PR DESCRIPTION
# Description
This PR cleans up todos in `sov-evm/query.rs`, all the anvil types have been removed.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
CI passes.

## Docs
No changes
