### PR TITLE
`demo-prover` dependency cleanup. 

### DIFF
--- a/examples/demo-prover/host/Cargo.toml
+++ b/examples/demo-prover/host/Cargo.toml
@@ -33,7 +33,6 @@ methods = { path = "../methods" }
 
 
 [dev-dependencies]
-sov-demo-rollup = { path = "../../demo-rollup" }
 tempfile = { workspace = true }
 once_cell = "1.7.2"
 parking_lot = "0.11.1"


### PR DESCRIPTION
# Description
Removes `demo-rollup` reps from `demo-prover`,

