### PR TITLE
EVM: add missing todos & move `eth_sendTransaction` to `sov-ethereum`.

### DIFF
--- a/full-node/sov-ethereum/src/lib.rs
+++ b/full-node/sov-ethereum/src/lib.rs
@@ -178,6 +178,14 @@ pub mod experimental {
             Ok::<_, ErrorObjectOwned>(ethereum.eth_rpc_config.eth_signer.signers())
         })?;
 
+        // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
+        rpc.register_async_method("eth_sendTransaction", |parameters, _ethereum| async move {
+            let _data: reth_rpc_types::TransactionRequest = parameters.one().unwrap();
+            #[allow(unreachable_code)]
+            Ok::<_, ErrorObjectOwned>(todo!())
+        })?;
+
+
         Ok(())
     }
 }

--- a/full-node/sov-ethereum/src/lib.rs
+++ b/full-node/sov-ethereum/src/lib.rs
@@ -181,10 +181,8 @@ pub mod experimental {
         // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
         rpc.register_async_method("eth_sendTransaction", |parameters, _ethereum| async move {
             let _data: reth_rpc_types::TransactionRequest = parameters.one().unwrap();
-            #[allow(unreachable_code)]
-            Ok::<_, ErrorObjectOwned>(todo!())
+            unimplemented!("eth_sendTransaction not implemented")
         })?;
-
 
         Ok(())
     }

--- a/module-system/module-implementations/sov-evm/src/call.rs
+++ b/module-system/module-implementations/sov-evm/src/call.rs
@@ -73,6 +73,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
                     logs: vec![],
                 },
                 // TODO: Do we want failed transactions to use all gas?
+                // https://github.com/Sovereign-Labs/sovereign-sdk/issues/505
                 gas_used: 0,
                 log_index_start,
                 error: Some(match err {

--- a/module-system/module-implementations/sov-evm/src/query.rs
+++ b/module-system/module-implementations/sov-evm/src/query.rs
@@ -211,6 +211,7 @@ impl<C: sov_modules_api::Context> Evm<C> {
         unimplemented!("eth_blockNumber not implemented")
     }
 
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
     #[rpc_method(name = "estimateGas")]
     pub fn eth_estimate_gas(
         &self,
@@ -218,6 +219,12 @@ impl<C: sov_modules_api::Context> Evm<C> {
         _block_number: Option<reth_primitives::BlockId>,
         _working_set: &mut WorkingSet<C::Storage>,
     ) -> RpcResult<reth_primitives::U256> {
+        unimplemented!("eth_sendTransaction not implemented")
+    }
+
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
+    #[rpc_method(name = "gasPrice")]
+    pub fn gas_price(&self) -> RpcResult<reth_primitives::U256> {
         unimplemented!("eth_sendTransaction not implemented")
     }
 }

--- a/module-system/module-implementations/sov-evm/src/query.rs
+++ b/module-system/module-implementations/sov-evm/src/query.rs
@@ -203,16 +203,6 @@ impl<C: sov_modules_api::Context> Evm<C> {
     }
 
     // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
-    #[rpc_method(name = "sendTransaction")]
-    pub fn send_transaction(
-        &self,
-        _request: reth_rpc_types::TransactionRequest,
-        _working_set: &mut WorkingSet<C::Storage>,
-    ) -> RpcResult<reth_primitives::U256> {
-        unimplemented!("eth_sendTransaction not implemented")
-    }
-
-    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
     #[rpc_method(name = "blockNumber")]
     pub fn block_number(
         &self,


### PR DESCRIPTION
# Description
This PR introduces the following changes:
1. Moves `eth_sendTransaction` to `sov-ethereum`.
2. Adds stub for `eth_gasPrice`
3. Adds `TODOs`

## Testing
CI passes.

## Docs
No doc changes.
