### PR TITLE
EVM: Implement getTransactionCount query

### DIFF
--- a/examples/demo-rollup/tests/evm/mod.rs
+++ b/examples/demo-rollup/tests/evm/mod.rs
@@ -157,7 +157,7 @@ impl TestClient {
 
         count.as_u64()
     }
-  
+
     async fn eth_get_block_by_number(&self, block_number: Option<String>) -> Block<TxHash> {
         self.http_client
             .request("eth_getBlockByNumber", rpc_params![block_number, false])

--- a/examples/demo-rollup/tests/evm/mod.rs
+++ b/examples/demo-rollup/tests/evm/mod.rs
@@ -88,8 +88,9 @@ impl TestClient {
         &self,
         contract_address: H160,
         set_arg: u32,
-        nonce: u64,
     ) -> PendingTransaction<'_, Http> {
+        let nonce = self.eth_get_transaction_count(self.from_addr).await;
+
         let req = Eip1559TransactionRequest::new()
             .from(self.from_addr)
             .to(contract_address)
@@ -111,8 +112,9 @@ impl TestClient {
     async fn query_contract(
         &self,
         contract_address: H160,
-        nonce: u64,
     ) -> Result<ethereum_types::U256, Box<dyn std::error::Error>> {
+        let nonce = self.eth_get_transaction_count(self.from_addr).await;
+
         let req = Eip1559TransactionRequest::new()
             .from(self.from_addr)
             .to(contract_address)
@@ -146,7 +148,21 @@ impl TestClient {
         chain_id.as_u64()
     }
 
+    async fn eth_get_transaction_count(&self, address: Address) -> u64 {
+        let count: ethereum_types::U64 = self
+            .http_client
+            .request("eth_getTransactionCount", rpc_params![address, "latest"])
+            .await
+            .unwrap();
+
+        count.as_u64()
+    }
+
     async fn execute(self) -> Result<(), Box<dyn std::error::Error>> {
+        // Nonce should be 0 in genesis
+        let nonce = self.eth_get_transaction_count(self.from_addr).await;
+        assert_eq!(0, nonce);
+
         let contract_address = {
             let deploy_contract_req = self.deploy_contract().await?;
             self.send_publish_batch_request().await;
@@ -158,25 +174,27 @@ impl TestClient {
                 .unwrap()
         };
 
+        // Nonce should be 1 after the deploy
+        let nonce = self.eth_get_transaction_count(self.from_addr).await;
+        assert_eq!(1, nonce);
+
         let set_arg = 923;
         {
-            let set_value_req = self.set_value(contract_address, set_arg, 1).await;
+            let set_value_req = self.set_value(contract_address, set_arg).await;
             self.send_publish_batch_request().await;
             set_value_req.await.unwrap();
         }
 
         {
-            let get_arg = self.query_contract(contract_address, 2).await?;
+            let get_arg = self.query_contract(contract_address).await?;
             assert_eq!(set_arg, get_arg.as_u32());
         }
 
         // Create a blob with multiple transactions.
         let mut requests = Vec::default();
-        let mut nonce = 2;
         for value in 100..103 {
-            let set_value_req = self.set_value(contract_address, value, nonce).await;
+            let set_value_req = self.set_value(contract_address, value).await;
             requests.push(set_value_req);
-            nonce += 1
         }
 
         self.send_publish_batch_request().await;
@@ -186,7 +204,7 @@ impl TestClient {
         }
 
         {
-            let get_arg = self.query_contract(contract_address, nonce).await?;
+            let get_arg = self.query_contract(contract_address).await?;
             assert_eq!(102, get_arg.as_u32());
         }
 

--- a/module-system/module-implementations/sov-evm/src/query.rs
+++ b/module-system/module-implementations/sov-evm/src/query.rs
@@ -75,6 +75,27 @@ impl<C: sov_modules_api::Context> Evm<C> {
         Ok(Some(block.into()))
     }
 
+    #[rpc_method(name = "getTransactionCount")]
+    pub fn get_transaction_count(
+        &self,
+        address: reth_primitives::Address,
+        _block_number: Option<String>,
+        working_set: &mut WorkingSet<C>,
+    ) -> RpcResult<reth_primitives::U64> {
+        info!("evm module: eth_getTransactionCount");
+
+        // TODO: Implement block_number once we have archival state #882
+        // https://github.com/Sovereign-Labs/sovereign-sdk/issues/882
+
+        let nonce = self
+            .accounts
+            .get(&address, working_set)
+            .map(|account| account.info.nonce)
+            .unwrap_or_default();
+
+        Ok(nonce.into())
+    }
+
     // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
     #[rpc_method(name = "feeHistory")]
     pub fn fee_history(


### PR DESCRIPTION
# Description
Implements eth_getTransactionCount call, aka nonce retrieval. It only supports latest block until we have archival state implementation ready.

## Linked Issues
- Related to #502 #882 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?
Integration tests added.

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
