### PR TITLE
`ValueSetter` module: read `genesis` config from a file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7106,6 +7106,7 @@ dependencies = [
  "serde_json",
  "sov-modules-api",
  "sov-state",
+ "sov-value-setter",
  "tempfile",
  "thiserror",
 ]

--- a/examples/test-data/genesis/value_setter.json
+++ b/examples/test-data/genesis/value_setter.json
@@ -1,0 +1,3 @@
+{
+    "admin":"sov1l6n2cku82yfqld30lanm2nfw43n2auc8clw7r5u5m6s7p8jrm4zqrr8r94"
+}

--- a/module-system/module-implementations/examples/sov-value-setter/Cargo.toml
+++ b/module-system/module-implementations/examples/sov-value-setter/Cargo.toml
@@ -12,7 +12,9 @@ readme = "README.md"
 resolver = "2"
 publish = false
 
+
 [dev-dependencies]
+sov-value-setter = { path = ".", features = ["native"] }
 tempfile = { workspace = true }
 
 [dependencies]

--- a/module-system/module-implementations/examples/sov-value-setter/src/lib.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/lib.rs
@@ -15,6 +15,7 @@ pub use query::*;
 use sov_modules_api::{Error, ModuleInfo, WorkingSet};
 
 /// Initial configuration for sov-value-setter module.
+//#[derive(serde::Serialize, serde::Deserialize)]
 pub struct ValueSetterConfig<C: sov_modules_api::Context> {
     /// Admin of the module.
     pub admin: C::Address,

--- a/module-system/module-implementations/examples/sov-value-setter/src/lib.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/lib.rs
@@ -15,7 +15,7 @@ pub use query::*;
 use sov_modules_api::{Error, ModuleInfo, WorkingSet};
 
 /// Initial configuration for sov-value-setter module.
-//#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
 pub struct ValueSetterConfig<C: sov_modules_api::Context> {
     /// Admin of the module.
     pub admin: C::Address,

--- a/module-system/module-implementations/examples/sov-value-setter/src/lib.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/lib.rs
@@ -15,7 +15,10 @@ pub use query::*;
 use sov_modules_api::{Error, ModuleInfo, WorkingSet};
 
 /// Initial configuration for sov-value-setter module.
-#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "native",
+    derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)
+)]
 pub struct ValueSetterConfig<C: sov_modules_api::Context> {
     /// Admin of the module.
     pub admin: C::Address,

--- a/module-system/module-implementations/examples/sov-value-setter/src/tests.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/tests.rs
@@ -5,6 +5,17 @@ use sov_state::{ProverStorage, ZkStorage};
 use super::ValueSetter;
 use crate::{call, query, ValueSetterConfig};
 
+/*
+#[test]
+fn test_config_serialization() {
+    let admin = Address::from([1; 32]);
+    let config = ValueSetterConfig { admin };
+
+    let config_str = serde_json::to_string(&config).unwrap();
+
+    println!("config_str {:?}", config_str);
+}
+*/
 #[test]
 fn test_value_setter() {
     let tmpdir = tempfile::tempdir().unwrap();

--- a/module-system/module-implementations/examples/sov-value-setter/src/tests.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/tests.rs
@@ -5,17 +5,20 @@ use sov_state::{ProverStorage, ZkStorage};
 use super::ValueSetter;
 use crate::{call, query, ValueSetterConfig};
 
-/*
 #[test]
 fn test_config_serialization() {
     let admin = Address::from([1; 32]);
-    let config = ValueSetterConfig { admin };
+    let config = ValueSetterConfig::<DefaultContext> { admin };
 
-    let config_str = serde_json::to_string(&config).unwrap();
+    let data = r#"
+    {
+        "admin":"sov1qyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqs259tk3"
+    }"#;
 
-    println!("config_str {:?}", config_str);
+    let parsed_config: ValueSetterConfig<DefaultContext> = serde_json::from_str(data).unwrap();
+    assert_eq!(parsed_config, config);
 }
-*/
+
 #[test]
 fn test_value_setter() {
     let tmpdir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
# Description
Read `genesis` configuration for `ValueSetter` module from a file rather than having these values hard-coded in the code.
Once this approach has been reviewed and approved, we have two tasks to complete:
1. Make the same change for all the modules
2. Pass all the required paths (for all modules) as parameters to the `get_genesis_config`

## Linked Issues
- Related to #872

## Testing
CI passes.

## Docs
No doc changes
