### PR TITLE
Nit: Fixed typos on sov-db

### DIFF
--- a/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -23,7 +23,7 @@ const LEDGER_DB_PATH_SUFFIX: &str = "ledger";
 #[derive(Clone, Debug)]
 /// A database which stores the ledger history (slots, transactions, events, etc).
 /// Ledger data is first ingested into an in-memory map before being fed to the state-transition function.
-/// Once the state-transition function has been executed and finalzied, the results are committed to the final db
+/// Once the state-transition function has been executed and finalized, the results are committed to the final db
 pub struct LedgerDB {
     /// The database which stores the committed ledger. Uses an optimized layout which
     /// requires transactions to be executed before being committed.
@@ -47,7 +47,7 @@ pub struct ItemNumbers {
     pub event_number: u64,
 }
 
-/// All of the data to be commited to the ledger db for a single slot.
+/// All of the data to be committed to the ledger db for a single slot.
 #[derive(Debug)]
 pub struct SlotCommit<S: SlotData, B, T> {
     slot_data: S,
@@ -279,7 +279,7 @@ impl LedgerDB {
         // Once all batches are inserted, Insert slot
         let slot_to_store = StoredSlot {
             hash: data_to_commit.slot_data.hash(),
-            // TODO: Add a method to the slotdata trait allowing additional data to be stored
+            // TODO: Add a method to the slot data trait allowing additional data to be stored
             extra_data: vec![].into(),
             batches: BatchNumber(first_batch_number)..BatchNumber(last_batch_number),
         };

--- a/full-node/db/sov-db/src/schema/tables.rs
+++ b/full-node/db/sov-db/src/schema/tables.rs
@@ -165,7 +165,7 @@ macro_rules! define_table_with_default_codec {
 
 /// Macro similar to [`define_table_with_default_codec`], but to be used when
 /// your key type should be [`SeekKeyEncoder`]. Borsh serializes integers as
-/// little-endian, but RocksDB uses lexigographic ordering which is only
+/// little-endian, but RocksDB uses lexicographic ordering which is only
 /// compatible with big-endian, so we use [`bincode`] with the big-endian option
 /// here.
 macro_rules! define_table_with_seek_key_codec {

--- a/full-node/db/sov-db/src/schema/types.rs
+++ b/full-node/db/sov-db/src/schema/types.rs
@@ -138,9 +138,9 @@ pub fn split_tx_for_storage<R: Serialize>(
 /// An identifier that specifies a single event
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum EventIdentifier {
-    /// A unique identifier for an event consiting of a [`TxIdentifier`] and an offset into that transaction's event list
+    /// A unique identifier for an event consisting of a [`TxIdentifier`] and an offset into that transaction's event list
     TxIdAndIndex((TxIdentifier, u64)),
-    /// A unique identifier for an event consiting of a [`TxIdentifier`] and an event key
+    /// A unique identifier for an event consisting of a [`TxIdentifier`] and an event key
     TxIdAndKey((TxIdentifier, EventKey)),
     /// The monotonically increasing number of the event, ordered by the DA layer For example, if the first tx
     /// contains 7 events, tx 2 contains 11 events, and tx 3 contains 7 txs,
@@ -153,7 +153,8 @@ pub enum EventIdentifier {
 pub enum EventGroupIdentifier {
     /// All of the events which occurred in a particular transaction
     TxId(TxIdentifier),
-    /// All events wich a particular key (typically, these events will have been emitted by several different transactions)
+    /// All events which a particular key
+    /// (typically, these events will have been emitted by several different transactions)
     Key(Vec<u8>),
 }
 

--- a/full-node/db/sov-schema-db/README.md
+++ b/full-node/db/sov-schema-db/README.md
@@ -39,7 +39,7 @@ To actually store and retrieve data, all we need to do is to implement a Schema:
 pub struct AccountBalanceSchema;
 
 impl Schema for AccountBalanceSchema {
-	const COLUMN_FAMILY_NAME = "account_balances"
+	const COLUMN_FAMILY_NAME: &str = "account_balances";
 	type Key = Account;
 	type Value = u64;
 }
@@ -49,7 +49,7 @@ impl KeyCodec<AccountBalanceSchema> for Account {
 		bincode::to_vec(self)
 	}
 
-	fn decode_key(key: Vec<u8>) -> {
+	fn decode_key(key: Vec<u8>) -> Self {
 		// elided
 	}
 }

--- a/full-node/db/sov-schema-db/src/schema.rs
+++ b/full-node/db/sov-schema-db/src/schema.rs
@@ -33,10 +33,10 @@ pub type Result<T, E = CodecError> = core::result::Result<T, E>;
 
 /// This trait defines a type that can serve as a [`Schema::Key`].
 ///
-/// [`KeyCodec`] is a marker trait with a blaket implementation for all types
+/// [`KeyCodec`] is a marker trait with a blanket implementation for all types
 /// that are both [`KeyEncoder`] and [`KeyDecoder`]. Having [`KeyEncoder`] and
 /// [`KeyDecoder`] as two standalone traits on top of [`KeyCodec`] may seem
-/// superflous, but it allows for zero-copy key encoding under specific
+/// superfluous, but it allows for zero-copy key encoding under specific
 /// circumstances. E.g.:
 ///
 /// ```rust

--- a/full-node/sov-sequencer/src/lib.rs
+++ b/full-node/sov-sequencer/src/lib.rs
@@ -127,7 +127,7 @@ impl SubmitTransaction {
 pub enum SubmitTransactionResponse {
     /// Submission succeeded
     Registered,
-    /// Submission faileds
+    /// Submission failed with given reason
     Failed(String),
 }
 

--- a/full-node/sov-sequencer/src/utils.rs
+++ b/full-node/sov-sequencer/src/utils.rs
@@ -3,6 +3,7 @@ use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
+use tracing::info;
 
 /// A simple client for the sequencer RPC.
 pub struct SimpleClient {
@@ -33,7 +34,7 @@ impl SimpleClient {
             .http_client
             .request("sequencer_publishBatch", batch)
             .await?;
-        println!("response: {:?}", response);
+        info!("publish batch response: {:?}", response);
         Ok(())
     }
 


### PR DESCRIPTION
While exploring package.

And change output for so-cli to tracing::info