### PR TITLE
Use `Strorage` generic instead of `Context` for `Delta` and `AccessoryDelta`

### DIFF
--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -195,7 +195,7 @@ pub trait Spec {
     type Address: RollupAddress + BorshSerialize + BorshDeserialize;
 
     /// Authenticated state storage used by the rollup. Typically some variant of a merkle-patricia trie.
-    type Storage: Storage + Clone + Send + Sync;
+    type Storage: Storage + Send + Sync;
 
     /// The public key used for digital signatures
     #[cfg(feature = "native")]

--- a/module-system/sov-modules-api/src/state/containers/accessory_map.rs
+++ b/module-system/sov-modules-api/src/state/containers/accessory_map.rs
@@ -173,7 +173,7 @@ where
 
     /// Deletes a key-value pair from the map.
     ///
-    /// This is equivalent to [`AccessoryStateMap::remove`], 
+    /// This is equivalent to [`AccessoryStateMap::remove`],
     /// but doesn't deserialize and return the value before deletion.
     pub fn delete<Q, C>(&self, key: &Q, working_set: &mut AccessoryWorkingSet<C>)
     where

--- a/module-system/sov-modules-api/src/state/containers/accessory_map.rs
+++ b/module-system/sov-modules-api/src/state/containers/accessory_map.rs
@@ -173,8 +173,8 @@ where
 
     /// Deletes a key-value pair from the map.
     ///
-    /// This is equivalent to [`AccessoryStateMap::remove`], but doesn't deserialize and
-    /// return the value beforing deletion.
+    /// This is equivalent to [`AccessoryStateMap::remove`], 
+    /// but doesn't deserialize and return the value before deletion.
     pub fn delete<Q, C>(&self, key: &Q, working_set: &mut AccessoryWorkingSet<C>)
     where
         Codec::KeyCodec: EncodeKeyLike<Q, K>,
@@ -197,7 +197,7 @@ where
     /// Generates an arbitrary [`AccessoryStateMap`] instance.
     ///
     /// See the [`arbitrary`] crate for more information.
-    pub fn arbitrary_workset<C>(
+    pub fn arbitrary_working_set<C>(
         u: &mut arbitrary::Unstructured<'a>,
         working_set: &mut AccessoryWorkingSet<C>,
     ) -> arbitrary::Result<Self>

--- a/module-system/sov-modules-api/src/state/containers/map.rs
+++ b/module-system/sov-modules-api/src/state/containers/map.rs
@@ -195,7 +195,7 @@ where
     /// Deletes a key-value pair from the map.
     ///
     /// This is equivalent to [`StateMap::remove`], but doesn't deserialize and
-    /// return the value beforing deletion.
+    /// return the value before deletion.
     pub fn delete<Q, C>(&self, key: &Q, working_set: &mut WorkingSet<C>)
     where
         Codec: StateCodec,
@@ -219,7 +219,7 @@ where
     /// Returns an arbitrary [`StateMap`] instance.
     ///
     /// See the [`arbitrary`] crate for more information.
-    pub fn arbitrary_workset<C>(
+    pub fn arbitrary_working_set<C>(
         u: &mut arbitrary::Unstructured<'a>,
         working_set: &mut WorkingSet<C>,
     ) -> arbitrary::Result<Self>

--- a/module-system/sov-modules-api/src/state/scratchpad.rs
+++ b/module-system/sov-modules-api/src/state/scratchpad.rs
@@ -268,10 +268,6 @@ where
 }
 
 impl<T: StateReaderAndWriter> StateReaderAndWriter for RevertableWriter<T> {
-    fn delete(&mut self, key: &StorageKey) {
-        self.writes.insert(key.to_cache_key(), None);
-    }
-
     fn get(&mut self, key: &StorageKey) -> Option<StorageValue> {
         if let Some(value) = self.writes.get(&key.to_cache_key()) {
             value.as_ref().cloned().map(Into::into)
@@ -283,6 +279,10 @@ impl<T: StateReaderAndWriter> StateReaderAndWriter for RevertableWriter<T> {
     fn set(&mut self, key: &StorageKey, value: StorageValue) {
         self.writes
             .insert(key.to_cache_key(), Some(value.into_cache_value()));
+    }
+
+    fn delete(&mut self, key: &StorageKey) {
+        self.writes.insert(key.to_cache_key(), None);
     }
 }
 

--- a/module-system/sov-modules-api/src/state/scratchpad.rs
+++ b/module-system/sov-modules-api/src/state/scratchpad.rs
@@ -17,7 +17,7 @@ pub struct Delta<S: Storage> {
     cache: StorageInternalCache,
 }
 
-impl<S: Storage + Send + Sync> Delta<S> {
+impl<S: Storage> Delta<S> {
     fn new(inner: S) -> Self {
         Self::with_witness(inner, Default::default())
     }

--- a/module-system/sov-state/src/lib.rs
+++ b/module-system/sov-state/src/lib.rs
@@ -37,7 +37,7 @@ pub use crate::witness::{ArrayWitness, TreeWitnessReader, Witness};
 
 /// A prefix prepended to each key before insertion and retrieval from the storage.
 ///
-/// When interacing with state containers, you will usually use the same working set instance to
+/// When interacting with state containers, you will usually use the same working set instance to
 /// access them, as required by the module API. This also means that you might get key collisions,
 /// so it becomes necessary to prepend a prefix to each key.
 #[derive(


### PR DESCRIPTION
# Description

Refactoring, that might be used for re-orgs


## Testing
Existing tests are passing

## Docs
Documentation has not been updated
