### PR TITLE
feat: use json as manifest constants instead of toml

### DIFF
--- a/constants.json
+++ b/constants.json
@@ -1,0 +1,3 @@
+{
+    "comment": "Sovereign SDK constants"
+}

--- a/constants.toml
+++ b/constants.toml
@@ -1,1 +1,0 @@
-# Base SDK configuration file

--- a/module-system/sov-modules-macros/Cargo.toml
+++ b/module-system/sov-modules-macros/Cargo.toml
@@ -23,7 +23,6 @@ path = "tests/all_tests.rs"
 clap = { workspace = true }
 jsonrpsee = { workspace = true, features = ["macros", "http-client", "server"] }
 serde = { workspace = true }
-serde_json = { workspace = true }
 tempfile = { workspace = true }
 trybuild = "1.0"
 
@@ -39,8 +38,8 @@ jsonrpsee = { workspace = true, features = ["http-client", "server"], optional =
 proc-macro2 = "1.0"
 quote = "1.0"
 schemars = { workspace = true }
+serde_json = { workspace = true }
 syn = { version = "1.0", features = ["full"] }
-toml = "0.8"
 
 [features]
 default = []

--- a/module-system/sov-modules-macros/src/manifest.rs
+++ b/module-system/sov-modules-macros/src/manifest.rs
@@ -96,7 +96,7 @@ impl Manifest {
 
             current_path = current_path.parent().ok_or_else(|| {
                 Self::err(
-                    &current_path,
+                    current_path,
                     parent,
                     format!("Could not find a parent `{manifest}`"),
                 )
@@ -104,7 +104,7 @@ impl Manifest {
         }
 
         let manifest = fs::read_to_string(&path)
-            .map_err(|e| Self::err(&current_path, parent, format!("failed to read file: {e}")))?;
+            .map_err(|e| Self::err(current_path, parent, format!("failed to read file: {e}")))?;
 
         Self::read_str(manifest, path, parent)
     }

--- a/module-system/sov-modules-macros/src/manifest.rs
+++ b/module-system/sov-modules-macros/src/manifest.rs
@@ -104,13 +104,13 @@ impl Manifest {
         let root = self
             .value
             .as_object()
-            .ok_or_else(|| self.err(&parent, "manifest is not an object"))?
+            .ok_or_else(|| self.err(parent, "manifest is not an object"))?
             .get("gas")
-            .ok_or_else(|| self.err(&parent, "manifest does not contain a `gas` attribute"))?
+            .ok_or_else(|| self.err(parent, "manifest does not contain a `gas` attribute"))?
             .as_object()
             .ok_or_else(|| {
                 self.err(
-                    &parent,
+                    parent,
                     format!("`gas` attribute of `{}` is not an object", parent),
                 )
             })?;
@@ -119,7 +119,7 @@ impl Manifest {
             Some(Value::Object(m)) => m,
             Some(_) => {
                 return Err(self.err(
-                    &parent,
+                    parent,
                     format!(
                         "matching constants entry `{}` is not an object",
                         &parent.to_string()
@@ -133,19 +133,19 @@ impl Manifest {
         for (k, v) in root {
             let k: Ident = syn::parse_str(k).map_err(|e| {
                 self.err(
-                    &parent,
+                    parent,
                     format!("failed to parse key attribyte `{}`: {}", k, e),
                 )
             })?;
 
             let v = v
                 .as_array()
-                .ok_or_else(|| self.err(&parent, format!("`{}` attribute is not an array", k)))?
-                .into_iter()
+                .ok_or_else(|| self.err(parent, format!("`{}` attribute is not an array", k)))?
+                .iter()
                 .map(|v| {
                     v.as_u64().ok_or_else(|| {
                         self.err(
-                            &parent,
+                            parent,
                             format!("`{}` attribute is not an array of integers", k),
                         )
                     })

--- a/module-system/sov-modules-macros/src/module_info.rs
+++ b/module-system/sov-modules-macros/src/module_info.rs
@@ -449,7 +449,7 @@ pub mod parsing {
         } else {
             Err(syn::Error::new_spanned(
                 ident,
-                "This field is missing an attribute: add `#[module]`, `#[state]` or `#[address]`.",
+                format!("The field `{}` is missing an attribute: add `#[module]`, `#[state]` or `#[address]`.", ident),
             ))
         }
     }

--- a/module-system/sov-modules-macros/tests/module_info/field_missing_attribute.stderr
+++ b/module-system/sov-modules-macros/tests/module_info/field_missing_attribute.stderr
@@ -1,4 +1,4 @@
-error: This field is missing an attribute: add `#[module]`, `#[state]` or `#[address]`.
+error: The field `test_state1` is missing an attribute: add `#[module]`, `#[state]` or `#[address]`.
  --> tests/module_info/field_missing_attribute.rs:8:5
   |
 8 |     test_state1: StateMap<u32, u32>,


### PR DESCRIPTION
Currently, we parse the manifest file as TOML. However, we will use JSON
for the genesis format. For improved consistency, it is desirable to
have the constants manifest file with the same format.