### PR TITLE
feat: add addressable trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7405,7 +7405,6 @@ dependencies = [
  "sov-state",
  "syn 1.0.109",
  "tempfile",
- "toml 0.8.0",
  "trybuild",
 ]
 

--- a/adapters/celestia/src/celestia.rs
+++ b/adapters/celestia/src/celestia.rs
@@ -423,7 +423,7 @@ fn next_pfb(mut data: &mut BlobRefIterator) -> Result<(MsgPayForBlobs, TxPositio
     ))
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "native"))]
 mod tests {
     use crate::{CelestiaHeaderResponse, CompactHeader};
 

--- a/examples/demo-prover/methods/guest/Cargo.lock
+++ b/examples/demo-prover/methods/guest/Cargo.lock
@@ -210,8 +210,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
-source = "git+https://github.com/rust-lang/cc-rs?rev=e5bbdfa#e5bbdfa1fa468c028cb38fee6c35a3cf2e5a2736"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -620,7 +624,7 @@ dependencies = [
  "bytes",
  "hex",
  "informalsystems-pbjson",
- "prost",
+ "prost 0.11.9",
  "ripemd",
  "serde",
  "sha2 0.10.6",
@@ -697,12 +701,6 @@ checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -846,12 +844,12 @@ checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.25"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -860,7 +858,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
@@ -879,27 +877,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.1",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.11.9"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
+checksum = "8bdf592881d821b83d471f8af290226c8d51402259e9bb5be7f9f8bdebbb11ac"
 dependencies = [
  "bytes",
  "heck",
  "itertools",
- "lazy_static",
  "log",
  "multimap",
+ "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.12.1",
+ "prost-types 0.12.1",
  "regex",
- "syn 1.0.109",
+ "syn 2.0.37",
  "tempfile",
  "which",
 ]
@@ -918,12 +926,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
+dependencies = [
+ "prost 0.12.1",
 ]
 
 [[package]]
@@ -1199,15 +1229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,9 +1317,9 @@ dependencies = [
  "hex",
  "hex-literal",
  "nmt-rs",
- "prost",
+ "prost 0.11.9",
  "prost-build",
- "prost-types",
+ "prost-types 0.11.9",
  "risc0-zkvm",
  "risc0-zkvm-platform",
  "serde",
@@ -1387,8 +1408,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "schemars",
+ "serde_json",
  "syn 1.0.109",
- "toml 0.8.0",
 ]
 
 [[package]]
@@ -1599,8 +1620,8 @@ dependencies = [
  "futures",
  "num-traits",
  "once_cell",
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -1624,8 +1645,8 @@ dependencies = [
  "flex-error",
  "num-derive 0.3.3",
  "num-traits",
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "serde",
  "serde_bytes",
  "subtle-encoding",
@@ -1686,40 +1707,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c226a7bba6d859b63c92c4b4fe69c5b6b72d0cb897dbc8e6012298e6154cb56e"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff63e60a958cefbb518ae1fd6566af80d9d4be430a33f3723dfc47d1d411d95"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -1855,15 +1842,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "winnow"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "zeroize"

--- a/full-node/sov-sequencer/src/lib.rs
+++ b/full-node/sov-sequencer/src/lib.rs
@@ -134,6 +134,7 @@ pub enum SubmitTransactionResponse {
 #[cfg(test)]
 mod tests {
 
+    #[cfg(feature = "native")]
     use sov_rollup_interface::da::BlobReaderTrait;
     use sov_rollup_interface::mocks::{MockAddress, MockDaService};
 
@@ -190,6 +191,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "native")]
     async fn test_submit_happy_path() {
         let tx1 = vec![1, 2, 3];
         let tx2 = vec![3, 4, 5];
@@ -212,6 +214,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "native")]
     async fn test_accept_tx() {
         let batch_builder = MockBatchBuilder { mempool: vec![] };
         let da_service = MockDaService::new(MockAddress::default());

--- a/full-node/sov-stf-runner/Cargo.toml
+++ b/full-node/sov-stf-runner/Cargo.toml
@@ -37,6 +37,7 @@ sov-bank = { path = "../../module-system/module-implementations/sov-bank", featu
 sov-modules-stf-template = { path = "../../module-system/sov-modules-stf-template", features = ["native"] }
 sov-value-setter = { path = "../../module-system/module-implementations/examples/sov-value-setter", features = ["native"] }
 sov-accounts = { path = "../../module-system/module-implementations/sov-accounts", features = ["native"] }
+sov-celestia-adapter = { path = "../../adapters/celestia", features = ["native"] }
 
 [features]
 default = []

--- a/module-system/module-implementations/sov-accounts/src/lib.rs
+++ b/module-system/module-implementations/sov-accounts/src/lib.rs
@@ -8,7 +8,7 @@ mod genesis;
 mod query;
 #[cfg(feature = "native")]
 pub use query::*;
-#[cfg(test)]
+#[cfg(all(test, feature = "native"))]
 mod tests;
 
 pub use call::{CallMessage, UPDATE_ACCOUNT_MSG};

--- a/module-system/module-implementations/sov-bank/Cargo.toml
+++ b/module-system/module-implementations/sov-bank/Cargo.toml
@@ -33,3 +33,23 @@ tempfile = { workspace = true }
 default = []
 native = ["serde", "serde_json", "jsonrpsee", "clap", "schemars", "sov-state/native", "sov-modules-api/native", ]
 cli = ["native"]
+
+[[test]]
+name = "burn_test"
+required-features = ["native"]
+
+[[test]]
+name = "create_token_test"
+required-features = ["native"]
+
+[[test]]
+name = "freeze_test"
+required-features = ["native"]
+
+[[test]]
+name = "mint_test"
+required-features = ["native"]
+
+[[test]]
+name = "transfer_test"
+required-features = ["native"]

--- a/module-system/sov-modules-api/src/tests.rs
+++ b/module-system/sov-modules-api/src/tests.rs
@@ -3,7 +3,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use crate::default_context::DefaultContext;
 use crate::default_signature::private_key::DefaultPrivateKey;
 use crate::default_signature::{DefaultPublicKey, DefaultSignature};
-use crate::{Address, ModuleInfo, PrivateKey, Signature};
+use crate::{Address, Addressable, PrivateKey, Signature};
 
 #[test]
 fn test_account_bech32m_display() {
@@ -82,7 +82,7 @@ fn test_sorting_modules() {
         dependencies: vec![module_a.address, module_b.address],
     };
 
-    let modules: Vec<(&dyn ModuleInfo<Context = DefaultContext>, i32)> =
+    let modules: Vec<(&dyn Addressable<Context = DefaultContext>, i32)> =
         vec![(&module_b, 2), (&module_c, 3), (&module_a, 1)];
 
     let sorted_modules = crate::sort_values_by_modules_dependencies(modules).unwrap();
@@ -102,7 +102,7 @@ fn test_sorting_modules_missing_module() {
         dependencies: vec![module_a_address, module_b.address],
     };
 
-    let modules: Vec<(&dyn ModuleInfo<Context = DefaultContext>, i32)> =
+    let modules: Vec<(&dyn Addressable<Context = DefaultContext>, i32)> =
         vec![(&module_b, 2), (&module_c, 3)];
 
     let sorted_modules = crate::sort_values_by_modules_dependencies(modules);
@@ -132,7 +132,7 @@ fn test_sorting_modules_cycle() {
         dependencies: vec![module_a.address, module_d.address],
     };
 
-    let modules: Vec<(&dyn ModuleInfo<Context = DefaultContext>, i32)> = vec![
+    let modules: Vec<(&dyn Addressable<Context = DefaultContext>, i32)> = vec![
         (&module_b, 2),
         (&module_d, 3),
         (&module_a, 1),
@@ -161,7 +161,7 @@ fn test_sorting_modules_duplicate() {
         dependencies: vec![],
     };
 
-    let modules: Vec<(&dyn ModuleInfo<Context = DefaultContext>, u32)> =
+    let modules: Vec<(&dyn Addressable<Context = DefaultContext>, u32)> =
         vec![(&module_b, 3), (&module_a, 1), (&module_a2, 2)];
 
     let sorted_modules = crate::sort_values_by_modules_dependencies(modules);

--- a/module-system/sov-modules-macros/src/dispatch/genesis.rs
+++ b/module-system/sov-modules-macros/src/dispatch/genesis.rs
@@ -68,7 +68,7 @@ impl GenesisMacro {
         });
 
         quote::quote! {
-                let modules: ::std::vec::Vec<(&dyn ::sov_modules_api::ModuleInfo<Context = <Self as sov_modules_api::Genesis>::Context>, usize)> = ::std::vec![#(#idents),*];
+                let modules: ::std::vec::Vec<(&dyn ::sov_modules_api::Addressable<Context = <Self as sov_modules_api::Genesis>::Context>, usize)> = ::std::vec![#(#idents),*];
                 let sorted_modules = ::sov_modules_api::sort_values_by_modules_dependencies(modules)?;
                 for module in sorted_modules {
                      match module {

--- a/rollup-interface/src/state_machine/stf.rs
+++ b/rollup-interface/src/state_machine/stf.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::da::DaSpec;
 use crate::zk::{ValidityCondition, Zkvm};
 
-#[cfg(any(test, feature = "fuzzing"))]
+#[cfg(any(all(test, feature = "sha2"), feature = "fuzzing"))]
 pub mod fuzzing;
 
 /// The configuration of a full node of the rollup which creates zk proofs.

--- a/rollup-interface/src/state_machine/stf/fuzzing.rs
+++ b/rollup-interface/src/state_machine/stf/fuzzing.rs
@@ -16,7 +16,7 @@ pub trait FuzzHasher {
 
 /// The default hasher to use for fuzzing
 fn default_fuzz_hasher() -> Box<dyn FuzzHasher> {
-    Box::new(::sha2::Sha256::new())
+    Box::new(sha2::Sha256::new())
 }
 
 impl<T: Digest<OutputSize = U32> + Clone> FuzzHasher for T {


### PR DESCRIPTION
Prior to this commit, the module info was the sole responsible to
provide a module address with its dependencies.

If the module info is ever to increase in complexity, such complexity
will be leaked to functionality that expects to handle only its
addresses, such as sort modules per deps/check cyclic dependencies.

This commit introduces `Addressable`, a trait that will be implemented
for every `ModuleInfo` and will provide the addresses, when required.