### PR TITLE
Introduce: `PublicKeyHex` in `sov-modules-api`

### DIFF
--- a/examples/demo-prover/methods/guest-celestia/Cargo.lock
+++ b/examples/demo-prover/methods/guest-celestia/Cargo.lock
@@ -1374,6 +1374,7 @@ dependencies = [
  "borsh",
  "derive_more",
  "ed25519-dalek",
+ "hex",
  "jmt",
  "serde",
  "sha2 0.10.6",

--- a/examples/demo-prover/methods/guest-mock/Cargo.lock
+++ b/examples/demo-prover/methods/guest-mock/Cargo.lock
@@ -933,6 +933,7 @@ dependencies = [
  "borsh",
  "derive_more",
  "ed25519-dalek",
+ "hex",
  "jmt",
  "serde",
  "sha2",

--- a/module-system/sov-modules-api/Cargo.toml
+++ b/module-system/sov-modules-api/Cargo.toml
@@ -28,7 +28,7 @@ bech32 = { workspace = true }
 derive_more = { workspace = true }
 jmt = { workspace = true }
 serde_json = { workspace = true, optional = true }
-hex = { workspace = true, optional = true }
+hex = { workspace = true }
 clap = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true, features = [] }
 
@@ -52,7 +52,6 @@ default = ["macros"]
 native = [
 	"serde_json",
 	"rand",
-	"hex",
 	"schemars",
 	"ed25519-dalek/default",
 	"ed25519-dalek/serde",

--- a/module-system/sov-modules-api/src/default_signature.rs
+++ b/module-system/sov-modules-api/src/default_signature.rs
@@ -257,15 +257,8 @@ impl FromStr for DefaultPublicKey {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = hex::decode(s)?;
-
-        let bytes: [u8; PUBLIC_KEY_LENGTH] = bytes
-            .try_into()
-            .map_err(|_| anyhow::anyhow!("Invalid public key size"))?;
-
-        let pub_key = DalekPublicKey::from_bytes(&bytes)
-            .map_err(|_| anyhow::anyhow!("Invalid public key"))?;
-        Ok(DefaultPublicKey { pub_key })
+        let pk_hex = crate::pub_key_hex::PublicKeyHex::try_from(s)?;
+        pk_hex.try_into()
     }
 }
 

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!("../README.md")]
 
 mod bech32;
-mod pub_key_hex;
 pub mod capabilities;
 #[cfg(feature = "native")]
 pub mod cli;
@@ -11,6 +10,7 @@ mod dispatch;
 mod encode;
 mod error;
 pub mod hooks;
+mod pub_key_hex;
 
 #[cfg(feature = "macros")]
 mod reexport_macros;

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod bech32;
+mod pub_key_hex;
 pub mod capabilities;
 #[cfg(feature = "native")]
 pub mod cli;

--- a/module-system/sov-modules-api/src/pub_key_hex.rs
+++ b/module-system/sov-modules-api/src/pub_key_hex.rs
@@ -1,6 +1,7 @@
 use derive_more::Display;
 use ed25519_dalek::{VerifyingKey as DalekPublicKey, PUBLIC_KEY_LENGTH};
 
+/// A hexadecimal representation of a PublicKey.
 use crate::default_signature::DefaultPublicKey;
 #[derive(
     serde::Serialize,

--- a/module-system/sov-modules-api/src/pub_key_hex.rs
+++ b/module-system/sov-modules-api/src/pub_key_hex.rs
@@ -1,0 +1,55 @@
+use derive_more::Display;
+
+use crate::default_signature::DefaultPublicKey;
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    borsh::BorshDeserialize,
+    borsh::BorshSerialize,
+    Debug,
+    PartialEq,
+    Clone,
+    Eq,
+    Display,
+)]
+#[serde(try_from = "String", into = "String")]
+#[display(fmt = "{}", "hex")]
+pub struct PublicKeyHex {
+    hex: String,
+}
+
+impl PublicKeyHex {
+    pub fn new(hex: String) -> Self {
+        todo!();
+    }
+}
+
+impl TryFrom<String> for PublicKeyHex {
+    type Error = String;
+
+    fn try_from(hex: String) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl From<PublicKeyHex> for String {
+    fn from(value: PublicKeyHex) -> Self {
+        todo!()
+    }
+}
+
+impl TryFrom<DefaultPublicKey> for PublicKeyHex {
+    type Error = String;
+
+    fn try_from(value: DefaultPublicKey) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}
+
+impl TryFrom<PublicKeyHex> for DefaultPublicKey {
+    type Error = String;
+
+    fn try_from(value: PublicKeyHex) -> Result<Self, Self::Error> {
+        todo!()
+    }
+}

--- a/module-system/sov-modules-api/src/pub_key_hex.rs
+++ b/module-system/sov-modules-api/src/pub_key_hex.rs
@@ -28,6 +28,14 @@ pub enum HexConversionError {
     InvalidHexCharacter { c: char, index: usize },
 }
 
+impl TryFrom<&str> for PublicKeyHex {
+    type Error = HexConversionError;
+
+    fn try_from(hex: &str) -> Result<Self, Self::Error> {
+        Self::try_from(hex.to_owned())
+    }
+}
+
 impl TryFrom<String> for PublicKeyHex {
     type Error = HexConversionError;
 
@@ -73,6 +81,16 @@ impl TryFrom<PublicKeyHex> for DefaultPublicKey {
         let pub_key = DalekPublicKey::from_bytes(&bytes)
             .map_err(|_| anyhow::anyhow!("Invalid public key"))?;
 
-        Ok(DefaultPublicKey { pub_key: pub_key })
+        Ok(DefaultPublicKey { pub_key })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pub_key_hex() {
+        let pk_hex = PublicKeyHex::try_from("z").unwrap();
     }
 }

--- a/module-system/sov-modules-api/src/pub_key_hex.rs
+++ b/module-system/sov-modules-api/src/pub_key_hex.rs
@@ -89,11 +89,7 @@ mod tests {
     fn test_pub_key_hex() {
         let pub_key = DefaultPrivateKey::generate().pub_key();
         let pub_key_hex = PublicKeyHex::try_from(pub_key.clone()).unwrap();
-
-        println!("{}", pub_key_hex);
-
         let converted_pub_key = DefaultPublicKey::try_from(pub_key_hex).unwrap();
-
         assert_eq!(pub_key, converted_pub_key);
     }
 

--- a/module-system/sov-modules-api/src/pub_key_hex.rs
+++ b/module-system/sov-modules-api/src/pub_key_hex.rs
@@ -1,8 +1,7 @@
-use crate::default_signature::DefaultPublicKey;
 use derive_more::Display;
-
 use ed25519_dalek::{VerifyingKey as DalekPublicKey, PUBLIC_KEY_LENGTH};
-use thiserror::Error;
+
+use crate::default_signature::DefaultPublicKey;
 #[derive(
     serde::Serialize,
     serde::Deserialize,
@@ -20,16 +19,8 @@ pub struct PublicKeyHex {
     hex: String,
 }
 
-#[derive(Error, Debug)]
-pub enum HexConversionError {
-    #[error("todo")]
-    OddLength,
-    #[error("todo")]
-    InvalidHexCharacter { c: char, index: usize },
-}
-
 impl TryFrom<&str> for PublicKeyHex {
-    type Error = HexConversionError;
+    type Error = anyhow::Error;
 
     fn try_from(hex: &str) -> Result<Self, Self::Error> {
         Self::try_from(hex.to_owned())
@@ -37,18 +28,21 @@ impl TryFrom<&str> for PublicKeyHex {
 }
 
 impl TryFrom<String> for PublicKeyHex {
-    type Error = HexConversionError;
+    type Error = anyhow::Error;
 
     fn try_from(hex: String) -> Result<Self, Self::Error> {
         if hex.len() & 1 != 0 {
-            return Err(HexConversionError::OddLength);
+            anyhow::bail!("Bad hex conversion: odd input length")
         }
 
         if let Some((index, c)) = hex.chars().enumerate().find(|(_, c)| {
-            !matches!(c, '0'..='9' | 'a'..='f')
-            //Case::Upper => !matches!(c, '0'..='9' | 'A'..='F'),
+            !(matches!(c, '0'..='9' | 'a'..='f') || matches!(c, '0'..='9' | 'A'..='F'))
         }) {
-            return Err(HexConversionError::InvalidHexCharacter { c, index });
+            anyhow::bail!(
+                "Bad hex conversion: wrong character `{}` at index {}",
+                c,
+                index
+            )
         }
 
         Ok(Self { hex })
@@ -88,9 +82,46 @@ impl TryFrom<PublicKeyHex> for DefaultPublicKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::default_signature::private_key::DefaultPrivateKey;
+    use crate::PrivateKey;
 
     #[test]
     fn test_pub_key_hex() {
-        let pk_hex = PublicKeyHex::try_from("z").unwrap();
+        let pub_key = DefaultPrivateKey::generate().pub_key();
+        let pub_key_hex = PublicKeyHex::try_from(pub_key.clone()).unwrap();
+
+        println!("{}", pub_key_hex);
+
+        let converted_pub_key = DefaultPublicKey::try_from(pub_key_hex).unwrap();
+
+        assert_eq!(pub_key, converted_pub_key);
+    }
+
+    #[test]
+    fn test_pub_key_hex_str() {
+        let key = "022e229198d957bf0c0a504e7d7bcec99a1d62cccc7861ed2452676ad0323ad8";
+        let pub_key_hex_lower: PublicKeyHex = key.try_into().unwrap();
+        let pub_key_hex_upper: PublicKeyHex = key.to_uppercase().try_into().unwrap();
+
+        let pub_key_lower = DefaultPublicKey::try_from(pub_key_hex_lower).unwrap();
+        let pub_key_upper = DefaultPublicKey::try_from(pub_key_hex_upper).unwrap();
+
+        assert_eq!(pub_key_lower, pub_key_upper)
+    }
+
+    #[test]
+    fn test_bad_pub_key_hex_str() {
+        let key = "022e229198d957Zf0c0a504e7d7bcec99a1d62cccc7861ed2452676ad0323ad8";
+        let err = PublicKeyHex::try_from(key).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Bad hex conversion: wrong character `Z` at index 14"
+        );
+
+        let key = "022";
+        let err = PublicKeyHex::try_from(key).unwrap_err();
+
+        assert_eq!(err.to_string(), "Bad hex conversion: odd input length")
     }
 }


### PR DESCRIPTION
# Description
This PR introduces `PublicKeyHex` as the serialization format for `PublicKey` by serde.

## Testing
Unit tests added.

## Docs
Public types documented. 
