### PR TITLE
Make genesis config serializable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3542,6 +3542,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-chain-state",
  "sov-data-generators",
  "sov-modules-api",

--- a/examples/demo-prover/methods/guest-celestia/Cargo.lock
+++ b/examples/demo-prover/methods/guest-celestia/Cargo.lock
@@ -384,6 +384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
 dependencies = [
  "pkcs8",
+ "serde",
  "signature",
 ]
 
@@ -408,6 +409,7 @@ checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "serde",
  "sha2 0.10.6",
 ]
 
@@ -1274,6 +1276,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-state",
  "thiserror",
@@ -1285,6 +1288,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
@@ -1419,6 +1423,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-modules-macros",
  "sov-state",
@@ -1459,6 +1464,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-bank",
  "sov-modules-api",
  "sov-state",
@@ -1500,6 +1506,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-state",
  "thiserror",

--- a/examples/demo-prover/methods/guest-mock/Cargo.lock
+++ b/examples/demo-prover/methods/guest-mock/Cargo.lock
@@ -309,6 +309,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
 dependencies = [
+ "serde",
  "signature",
 ]
 
@@ -320,6 +321,7 @@ checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "serde",
  "sha2",
 ]
 
@@ -860,6 +862,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-state",
  "thiserror",
@@ -871,6 +874,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
@@ -978,6 +982,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-modules-macros",
  "sov-state",
@@ -1019,6 +1024,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-bank",
  "sov-modules-api",
  "sov-state",
@@ -1060,6 +1066,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-state",
  "thiserror",

--- a/examples/simple-nft-module/Cargo.toml
+++ b/examples/simple-nft-module/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 
 sov-modules-api = { path = "../../module-system/sov-modules-api" }
 sov-state = { path = "../../module-system/sov-state" }
@@ -27,6 +27,5 @@ simple-nft-module = { version = "*", features = ["native"], path = "." }
 
 [features]
 default = []
-serde = ["dep:serde"]
-native = ["serde", "sov-state/native", "sov-modules-api/native", "jsonrpsee"]
+native = ["sov-state/native", "sov-modules-api/native", "jsonrpsee"]
 test = ["native"]

--- a/examples/simple-nft-module/src/lib.rs
+++ b/examples/simple-nft-module/src/lib.rs
@@ -8,6 +8,7 @@ mod genesis;
 mod query;
 #[cfg(feature = "native")]
 pub use query::*;
+use serde::{Deserialize, Serialize};
 use sov_modules_api::{CallResponse, Context, Error, Module, ModuleInfo, WorkingSet};
 
 #[derive(ModuleInfo, Clone)]
@@ -29,6 +30,7 @@ pub struct NonFungibleToken<C: Context> {
 
 /// Config for the NonFungibleToken module.
 /// Sets admin and existing owners.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NonFungibleTokenConfig<C: Context> {
     /// Admin of the NonFungibleToken module.
     pub admin: C::Address,

--- a/module-system/module-implementations/examples/sov-value-setter/Cargo.toml
+++ b/module-system/module-implementations/examples/sov-value-setter/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = { workspace = true }
 sov-modules-api = { path = "../../../sov-modules-api" }
 sov-state = { path = "../../../sov-state" }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
@@ -31,4 +31,4 @@ clap = { workspace = true, optional = true }
 
 [features]
 default = []
-native = ["serde", "serde_json", "jsonrpsee", "schemars", "clap", "sov-modules-api/native", "sov-state/native"]
+native = ["serde_json", "jsonrpsee", "schemars", "clap", "sov-modules-api/native", "sov-state/native"]

--- a/module-system/module-implementations/examples/sov-value-setter/src/lib.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/lib.rs
@@ -15,10 +15,7 @@ pub use query::*;
 use sov_modules_api::{Error, ModuleInfo, WorkingSet};
 
 /// Initial configuration for sov-value-setter module.
-#[cfg_attr(
-    feature = "native",
-    derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)
-)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
 pub struct ValueSetterConfig<C: sov_modules_api::Context> {
     /// Admin of the module.
     pub admin: C::Address,

--- a/module-system/module-implementations/examples/sov-vec-setter/Cargo.toml
+++ b/module-system/module-implementations/examples/sov-vec-setter/Cargo.toml
@@ -22,7 +22,7 @@ sov-modules-api = { path = "../../../sov-modules-api", default-features = false,
 sov-state = { path = "../../../sov-state", default-features = false }
 sov-rollup-interface = { path = "../../../../rollup-interface" }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
@@ -31,4 +31,4 @@ clap = { workspace = true, optional = true }
 
 [features]
 default = ["native"]
-native = ["serde", "serde_json", "jsonrpsee", "schemars", "clap", "sov-modules-api/native"]
+native = ["serde_json", "jsonrpsee", "schemars", "clap", "sov-modules-api/native"]

--- a/module-system/module-implementations/examples/sov-vec-setter/src/lib.rs
+++ b/module-system/module-implementations/examples/sov-vec-setter/src/lib.rs
@@ -9,9 +9,11 @@ mod query;
 pub use call::CallMessage;
 #[cfg(feature = "native")]
 pub use query::*;
+use serde::{Deserialize, Serialize};
 use sov_modules_api::{Error, ModuleInfo, WorkingSet};
 
 /// Initial configuration for sov-vec-setter module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VecSetterConfig<C: sov_modules_api::Context> {
     /// Admin of the module.
     pub admin: C::Address,

--- a/module-system/module-implementations/integration-tests/Cargo.toml
+++ b/module-system/module-implementations/integration-tests/Cargo.toml
@@ -15,6 +15,7 @@ resolver = "2"
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 tempfile = { workspace = true }
+serde = { workspace = true }
 
 sov-modules-api = { path = "../../sov-modules-api", features = ["native"] }
 sov-state = { path = "../../sov-state", features = ["native"] }

--- a/module-system/module-implementations/module-template/Cargo.toml
+++ b/module-system/module-implementations/module-template/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 thiserror = { workspace = true }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 
 sov-bank = { path = "../sov-bank" }
@@ -31,4 +31,4 @@ module-template = { path = ".", version = "*", features = ["native"] }
 
 [features]
 default = []
-native = ["serde", "serde_json", "schemars", "sov-modules-api/native"]
+native = ["serde_json", "schemars", "sov-modules-api/native"]

--- a/module-system/module-implementations/module-template/src/lib.rs
+++ b/module-system/module-implementations/module-template/src/lib.rs
@@ -5,8 +5,10 @@ mod query;
 pub use call::CallMessage;
 #[cfg(feature = "native")]
 pub use query::*;
+use serde::{Deserialize, Serialize};
 use sov_modules_api::{Error, ModuleInfo, WorkingSet};
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExampleModuleConfig {}
 
 /// A new module:

--- a/module-system/module-implementations/sov-accounts/Cargo.toml
+++ b/module-system/module-implementations/sov-accounts/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
 borsh = { workspace = true, features = ["rc"] }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 clap = { workspace = true, optional = true }
@@ -33,4 +33,4 @@ tempfile = { workspace = true }
 [features]
 default = []
 arbitrary = ["dep:arbitrary", "sov-state/arbitrary", "sov-modules-api/arbitrary"]
-native = ["serde", "serde_json", "jsonrpsee", "schemars", "clap", "sov-state/native", "sov-modules-api/native"]
+native = ["serde_json", "jsonrpsee", "schemars", "clap", "sov-state/native", "sov-modules-api/native"]

--- a/module-system/module-implementations/sov-accounts/src/lib.rs
+++ b/module-system/module-implementations/sov-accounts/src/lib.rs
@@ -15,7 +15,8 @@ pub use call::{CallMessage, UPDATE_ACCOUNT_MSG};
 use sov_modules_api::{Context, Error, ModuleInfo, WorkingSet};
 
 /// Initial configuration for sov-accounts module.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(bound = "C::PublicKey: serde::Serialize + serde::de::DeserializeOwned")]
 pub struct AccountConfig<C: Context> {
     /// Public keys to initialize the rollup.
     pub pub_keys: Vec<C::PublicKey>,

--- a/module-system/module-implementations/sov-bank/Cargo.toml
+++ b/module-system/module-implementations/sov-bank/Cargo.toml
@@ -17,7 +17,7 @@ borsh = { workspace = true, features = ["rc"] }
 clap = { workspace = true, optional = true, features = ["derive"] }
 jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
@@ -32,5 +32,5 @@ tempfile = { workspace = true }
 
 [features]
 default = []
-native = ["serde", "serde_json", "jsonrpsee", "clap", "schemars", "sov-state/native", "sov-modules-api/native", ]
+native = ["serde_json", "jsonrpsee", "clap", "schemars", "sov-state/native", "sov-modules-api/native", ]
 cli = ["native"]

--- a/module-system/module-implementations/sov-bank/src/lib.rs
+++ b/module-system/module-implementations/sov-bank/src/lib.rs
@@ -12,6 +12,7 @@ pub mod utils;
 
 /// Specifies the call methods using in that module.
 pub use call::CallMessage;
+use serde::{Deserialize, Serialize};
 use sov_modules_api::{CallResponse, Error, ModuleInfo, WorkingSet};
 use token::Token;
 /// Specifies an interface to interact with tokens.
@@ -21,6 +22,7 @@ pub use utils::{get_genesis_token_address, get_token_address};
 
 /// [`TokenConfig`] specifies a configuration used when generating a token for the bank
 /// module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TokenConfig<C: sov_modules_api::Context> {
     /// The name of the token.
     pub token_name: String,
@@ -33,6 +35,7 @@ pub struct TokenConfig<C: sov_modules_api::Context> {
 }
 
 /// Initial configuration for sov-bank module.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BankConfig<C: sov_modules_api::Context> {
     /// A list of configurations for the initial tokens.
     pub tokens: Vec<TokenConfig<C>>,

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -6,6 +6,7 @@ use std::fmt::Formatter;
 use std::num::ParseIntError;
 
 use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
 use sov_modules_api::WorkingSet;
 use sov_state::Prefix;
 #[cfg(feature = "native")]
@@ -21,13 +22,13 @@ pub type Amount = u64;
 /// (type [`sov_modules_api::Spec::Address`]).
 #[cfg_attr(
     feature = "native",
-    derive(serde::Serialize),
-    derive(serde::Deserialize),
     derive(clap::Parser),
     derive(schemars::JsonSchema),
     schemars(bound = "C::Address: ::schemars::JsonSchema", rename = "Coins")
 )]
-#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
+#[derive(
+    borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone, Serialize, Deserialize,
+)]
 pub struct Coins<C: sov_modules_api::Context> {
     /// An `amount` of coins stored.
     pub amount: Amount,

--- a/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -147,6 +147,7 @@ pub struct ChainState<C: sov_modules_api::Context, Da: sov_modules_api::DaSpec> 
 }
 
 /// Initial configuration of the chain state
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChainStateConfig {
     /// Initial slot height
     pub initial_slot_height: TransitionHeight,

--- a/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/module-system/module-implementations/sov-evm/src/lib.rs
@@ -48,7 +48,7 @@ mod experimental {
     };
 
     /// Evm account.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
     pub struct AccountData {
         /// Account address.
         pub address: Address,
@@ -75,7 +75,7 @@ mod experimental {
     }
 
     /// Genesis configuration.
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
     pub struct EvmConfig {
         /// Genesis accounts.
         pub data: Vec<AccountData>,

--- a/module-system/module-implementations/sov-nft-module/Cargo.toml
+++ b/module-system/module-implementations/sov-nft-module/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 schemars =  { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
@@ -29,6 +29,5 @@ sov-nft-module = { version = "*", features = ["native"], path = "." }
 
 [features]
 default = []
-serde = ["dep:serde"]
-native = ["serde", "serde_json", "jsonrpsee", "schemars", "sov-state/native", "sov-modules-api/native", ]
+native = ["serde_json", "jsonrpsee", "schemars", "sov-state/native", "sov-modules-api/native", ]
 test = ["native"]

--- a/module-system/module-implementations/sov-nft-module/src/lib.rs
+++ b/module-system/module-implementations/sov-nft-module/src/lib.rs
@@ -14,6 +14,7 @@ use nft::*;
 mod query;
 #[cfg(feature = "native")]
 pub use query::*;
+use serde::{Deserialize, Serialize};
 use sov_modules_api::{CallResponse, Context, Error, Module, ModuleInfo, StateMap, WorkingSet};
 /// Utility functions.
 pub mod utils;
@@ -38,6 +39,7 @@ pub struct NonFungibleToken<C: Context> {
 
 /// Config for the NonFungibleToken module.
 /// Sets admin and existing owners.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NonFungibleTokenConfig {}
 
 impl<C: Context> Module for NonFungibleToken<C> {

--- a/module-system/module-implementations/sov-prover-incentives/Cargo.toml
+++ b/module-system/module-implementations/sov-prover-incentives/Cargo.toml
@@ -22,7 +22,7 @@ anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 bincode = { workspace = true }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 
 sov-bank = { path = "../sov-bank", version = "0.2" }
@@ -32,4 +32,4 @@ sov-state = { path = "../../sov-state", version = "0.2" }
 
 [features]
 default = []
-native = ["serde", "serde_json", "schemars", "sov-state/native", "sov-modules-api/native"]
+native = ["serde_json", "schemars", "sov-state/native", "sov-modules-api/native"]

--- a/module-system/module-implementations/sov-prover-incentives/src/lib.rs
+++ b/module-system/module-implementations/sov-prover-incentives/src/lib.rs
@@ -14,6 +14,7 @@ pub use call::CallMessage;
 /// The response type used by RPC queries.
 #[cfg(feature = "native")]
 pub use query::*;
+use serde::{Deserialize, Serialize};
 use sov_modules_api::{Context, Error, ModuleInfo, WorkingSet, Zkvm};
 use sov_state::codec::BcsCodec;
 
@@ -21,6 +22,7 @@ use sov_state::codec::BcsCodec;
 /// address of the bonding token, the minimum bond, the commitment to
 /// the allowed verifier method and a set of initial provers with their
 /// bonding amount.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProverIncentivesConfig<C: Context, Vm: Zkvm> {
     /// The address of the token to be used for bonding.
     bonding_token_address: C::Address,

--- a/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
+++ b/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
@@ -24,7 +24,7 @@ sov-bank = { path = "../sov-bank", version = "0.2" }
 sov-modules-api = { path = "../../sov-modules-api", version = "0.2" }
 sov-state = { path = "../../sov-state", version = "0.2" }
 schemars = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 serde_json = { workspace = true, optional = true }
 borsh = { workspace = true, features = ["rc"] }
 jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
@@ -37,7 +37,6 @@ sov-zk-cycle-utils = { path = "../../../utils/zk-cycle-utils", version = "0.2", 
 bench = ["sov-zk-cycle-macros/bench", "risc0-zkvm", "risc0-zkvm-platform", "sov-zk-cycle-utils"]
 default = []
 native = [
-    "serde",
     "serde_json",
     "jsonrpsee",
     "schemars",

--- a/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
@@ -16,6 +16,7 @@ mod query;
 pub use call::CallMessage;
 #[cfg(feature = "native")]
 pub use query::*;
+use serde::{Deserialize, Serialize};
 use sov_modules_api::{CallResponse, Error, ModuleInfo, StateMap, StateValue, WorkingSet};
 use sov_state::codec::BcsCodec;
 
@@ -25,6 +26,7 @@ use sov_state::codec::BcsCodec;
 /// [`Module::genesis`](sov_modules_api::Module::genesis).
 ///
 // TODO: Should we allow multiple sequencers in genesis?
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SequencerConfig<C: sov_modules_api::Context, Da: sov_modules_api::DaSpec> {
     /// The rollup address of the sequencer.
     pub seq_rollup_address: C::Address,

--- a/module-system/sov-modules-api/Cargo.toml
+++ b/module-system/sov-modules-api/Cargo.toml
@@ -32,7 +32,7 @@ hex = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true, features = [] }
 
-ed25519-dalek = { version = "2.0.0", default-features = false }
+ed25519-dalek = { version = "2.0.0", default-features = false, features = ["serde"] }
 rand = { version = "0.8", optional = true }
 
 sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.2", optional = true }
@@ -55,7 +55,6 @@ native = [
 	"hex",
 	"schemars",
 	"ed25519-dalek/default",
-	"ed25519-dalek/serde",
 	"ed25519-dalek/rand_core",
 	"clap",
 	"jsonrpsee",

--- a/module-system/sov-modules-api/src/default_signature.rs
+++ b/module-system/sov-modules-api/src/default_signature.rs
@@ -166,11 +166,8 @@ pub mod private_key {
     }
 }
 
-#[cfg_attr(
-    feature = "native",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
-)]
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "native", derive(schemars::JsonSchema))]
+#[derive(PartialEq, Eq, Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct DefaultPublicKey {
     #[cfg_attr(
         feature = "native",

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -153,7 +153,16 @@ pub enum NonInstantiable {}
 
 /// PublicKey used in the Module System.
 pub trait PublicKey:
-    borsh::BorshDeserialize + borsh::BorshSerialize + Eq + Hash + Clone + Debug + Send + Sync
+    borsh::BorshDeserialize
+    + borsh::BorshSerialize
+    + Eq
+    + Hash
+    + Clone
+    + Debug
+    + Send
+    + Sync
+    + Serialize
+    + for<'a> Deserialize<'a>
 {
     fn to_address<A: RollupAddress>(&self) -> A;
 }
@@ -210,11 +219,7 @@ pub trait Spec {
 
     /// The public key used for digital signatures
     #[cfg(feature = "native")]
-    type PublicKey: PublicKey
-        + Serialize
-        + for<'a> Deserialize<'a>
-        + ::schemars::JsonSchema
-        + FromStr<Err = anyhow::Error>;
+    type PublicKey: PublicKey + ::schemars::JsonSchema + FromStr<Err = anyhow::Error>;
 
     #[cfg(not(feature = "native"))]
     type PublicKey: PublicKey;

--- a/module-system/sov-modules-macros/src/dispatch/genesis.rs
+++ b/module-system/sov-modules-macros/src/dispatch/genesis.rs
@@ -101,6 +101,7 @@ impl GenesisMacro {
 
         quote::quote! {
             #[doc = "Initial configuration for the rollup."]
+            #[derive(::serde::Deserialize, ::serde::Serialize)]
             pub struct GenesisConfig #impl_generics #where_clause{
                 #(#[doc = "Module configuration"] pub #fields)*
             }


### PR DESCRIPTION
# Description
This PR makes the rollup `genesis` config serializable. This will allow us to read it from a file.

## Linked Issues
- Fixes 
- Related to #915 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
