### PR TITLE
Custom serde serialization for DefaultPublicKey

### DIFF
--- a/examples/demo-stf/src/genesis_config.rs
+++ b/examples/demo-stf/src/genesis_config.rs
@@ -93,7 +93,7 @@ fn create_genesis_config<C: Context, Da: DaSpec>(
     let accounts_data = std::fs::read_to_string(accounts_genesis_path)
         .with_context(|| format!("Failed to read genesis from {}", accounts_genesis_path))?;
 
-    let accounts_config: AccountConfig = serde_json::from_str(&accounts_data)
+    let accounts_config: AccountConfig<C> = serde_json::from_str(&accounts_data)
         .with_context(|| format!("Failed to parse genesis from {}", accounts_genesis_path))?;
 
     let nft_config = sov_nft_module::NonFungibleTokenConfig {};

--- a/module-system/module-implementations/sov-accounts/src/genesis.rs
+++ b/module-system/module-implementations/sov-accounts/src/genesis.rs
@@ -9,13 +9,12 @@ impl<C: sov_modules_api::Context> Accounts<C> {
         config: &<Self as sov_modules_api::Module>::Config,
         working_set: &mut WorkingSet<C>,
     ) -> Result<()> {
-        for pub_key_hex in config.pub_keys.iter() {
-            let pub_key = pub_key_hex.try_into()?;
-            if self.accounts.get(&pub_key, working_set).is_some() {
+        for pub_key in config.pub_keys.iter() {
+            if self.accounts.get(pub_key, working_set).is_some() {
                 bail!("Account already exists")
             }
 
-            self.create_default_account(pub_key, working_set)?;
+            self.create_default_account(pub_key.clone(), working_set)?;
         }
 
         Ok(())

--- a/module-system/module-implementations/sov-accounts/src/genesis.rs
+++ b/module-system/module-implementations/sov-accounts/src/genesis.rs
@@ -14,7 +14,7 @@ impl<C: sov_modules_api::Context> Accounts<C> {
                 bail!("Account already exists")
             }
 
-            self.create_default_account(pub_key.clone(), working_set)?;
+            self.create_default_account(pub_key, working_set)?;
         }
 
         Ok(())
@@ -22,7 +22,7 @@ impl<C: sov_modules_api::Context> Accounts<C> {
 
     pub(crate) fn create_default_account(
         &self,
-        pub_key: C::PublicKey,
+        pub_key: &C::PublicKey,
         working_set: &mut WorkingSet<C>,
     ) -> Result<Account<C>> {
         let default_address = pub_key.to_address();

--- a/module-system/module-implementations/sov-accounts/src/genesis.rs
+++ b/module-system/module-implementations/sov-accounts/src/genesis.rs
@@ -33,10 +33,10 @@ impl<C: sov_modules_api::Context> Accounts<C> {
             nonce: 0,
         };
 
-        self.accounts.set(&pub_key, &new_account, working_set);
+        self.accounts.set(pub_key, &new_account, working_set);
 
         self.public_keys
-            .set(&default_address, &pub_key, working_set);
+            .set(&default_address, pub_key, working_set);
         Ok(new_account)
     }
 

--- a/module-system/module-implementations/sov-accounts/src/genesis.rs
+++ b/module-system/module-implementations/sov-accounts/src/genesis.rs
@@ -35,8 +35,7 @@ impl<C: sov_modules_api::Context> Accounts<C> {
 
         self.accounts.set(pub_key, &new_account, working_set);
 
-        self.public_keys
-            .set(&default_address, pub_key, working_set);
+        self.public_keys.set(&default_address, pub_key, working_set);
         Ok(new_account)
     }
 

--- a/module-system/module-implementations/sov-accounts/src/hooks.rs
+++ b/module-system/module-implementations/sov-accounts/src/hooks.rs
@@ -14,9 +14,9 @@ impl<C: Context> TxHooks for Accounts<C> {
     ) -> anyhow::Result<<Self::Context as Spec>::Address> {
         let pub_key = tx.pub_key();
 
-        let account = match self.accounts.get(&pub_key, working_set) {
+        let account = match self.accounts.get(pub_key, working_set) {
             Some(acc) => Ok(acc),
-            None => self.create_default_account(&pub_key, working_set),
+            None => self.create_default_account(pub_key, working_set),
         }?;
 
         let tx_nonce = tx.nonce();

--- a/module-system/module-implementations/sov-accounts/src/hooks.rs
+++ b/module-system/module-implementations/sov-accounts/src/hooks.rs
@@ -12,11 +12,11 @@ impl<C: Context> TxHooks for Accounts<C> {
         tx: &Transaction<C>,
         working_set: &mut WorkingSet<C>,
     ) -> anyhow::Result<<Self::Context as Spec>::Address> {
-        let pub_key = tx.pub_key().clone();
+        let pub_key = tx.pub_key();
 
         let account = match self.accounts.get(&pub_key, working_set) {
             Some(acc) => Ok(acc),
-            None => self.create_default_account(pub_key, working_set),
+            None => self.create_default_account(&pub_key, working_set),
         }?;
 
         let tx_nonce = tx.nonce();

--- a/module-system/module-implementations/sov-accounts/src/tests.rs
+++ b/module-system/module-implementations/sov-accounts/src/tests.rs
@@ -17,8 +17,8 @@ fn test_config_serialization() {
     )
     .unwrap();
 
-    let config = AccountConfig {
-        pub_keys: vec![pub_key.clone().try_into().unwrap()],
+    let config = AccountConfig::<DefaultContext> {
+        pub_keys: vec![pub_key.clone()],
     };
 
     let data = r#"
@@ -26,7 +26,7 @@ fn test_config_serialization() {
         "pub_keys":["1cd4e2d9d5943e6f3d12589d31feee6bb6c11e7b8cd996a393623e207da72cbf"]
     }"#;
 
-    let parsed_config: AccountConfig = serde_json::from_str(data).unwrap();
+    let parsed_config: AccountConfig<DefaultContext> = serde_json::from_str(data).unwrap();
     assert_eq!(parsed_config, config);
 }
 

--- a/module-system/module-implementations/sov-accounts/src/tests.rs
+++ b/module-system/module-implementations/sov-accounts/src/tests.rs
@@ -37,7 +37,7 @@ fn test_config_account() {
     let init_pub_key_addr = init_pub_key.to_address::<<C as Spec>::Address>();
 
     let account_config = AccountConfig {
-        pub_keys: vec![init_pub_key.clone().try_into().unwrap()],
+        pub_keys: vec![init_pub_key.clone()],
     };
 
     let accounts = &mut Accounts::<C>::default();

--- a/module-system/module-implementations/sov-accounts/src/tests.rs
+++ b/module-system/module-implementations/sov-accounts/src/tests.rs
@@ -76,7 +76,7 @@ fn test_update_account() {
     // Test new account creation
     {
         accounts
-            .create_default_account(sender.clone(), native_working_set)
+            .create_default_account(&sender, native_working_set)
             .unwrap();
 
         let query_response = accounts
@@ -135,7 +135,7 @@ fn test_update_account_fails() {
     let sender_context_1 = C::new(sender_1.to_address());
 
     accounts
-        .create_default_account(sender_1, native_working_set)
+        .create_default_account(&sender_1, native_working_set)
         .unwrap();
 
     let priv_key = DefaultPrivateKey::generate();
@@ -143,7 +143,7 @@ fn test_update_account_fails() {
     let sig_2 = priv_key.sign(&call::UPDATE_ACCOUNT_MSG);
 
     accounts
-        .create_default_account(sender_2.clone(), native_working_set)
+        .create_default_account(&sender_2, native_working_set)
         .unwrap();
 
     // The new public key already exists and the call fails.
@@ -167,7 +167,7 @@ fn test_get_account_after_pub_key_update() {
     let sender_context_1 = C::new(sender_1_addr);
 
     accounts
-        .create_default_account(sender_1, native_working_set)
+        .create_default_account(&sender_1, native_working_set)
         .unwrap();
 
     let priv_key = DefaultPrivateKey::generate();

--- a/module-system/sov-modules-api/src/default_signature.rs
+++ b/module-system/sov-modules-api/src/default_signature.rs
@@ -167,7 +167,7 @@ pub mod private_key {
 }
 
 #[cfg_attr(feature = "native", derive(schemars::JsonSchema))]
-#[derive(PartialEq, Eq, Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct DefaultPublicKey {
     #[cfg_attr(
         feature = "native",

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -21,6 +21,7 @@ pub use reexport_macros::*;
 mod prefix;
 mod response;
 mod serde_address;
+mod serde_pub_key;
 mod state;
 #[cfg(test)]
 mod tests;

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -167,7 +167,6 @@ pub trait PublicKey:
     + Sync
     + Serialize
     + for<'a> Deserialize<'a>
-    + for<'a> TryFrom<&'a PublicKeyHex, Error = anyhow::Error>
 {
     fn to_address<A: RollupAddress>(&self) -> A;
 }

--- a/module-system/sov-modules-api/src/pub_key_hex.rs
+++ b/module-system/sov-modules-api/src/pub_key_hex.rs
@@ -56,8 +56,8 @@ impl From<PublicKeyHex> for String {
     }
 }
 
-impl From<DefaultPublicKey> for PublicKeyHex {
-    fn from(pub_key: DefaultPublicKey) -> Self {
+impl From<&DefaultPublicKey> for PublicKeyHex {
+    fn from(pub_key: &DefaultPublicKey) -> Self {
         let hex = hex::encode(pub_key.pub_key.as_bytes());
         Self { hex }
     }

--- a/module-system/sov-modules-api/src/pub_key_hex.rs
+++ b/module-system/sov-modules-api/src/pub_key_hex.rs
@@ -89,7 +89,7 @@ mod tests {
     #[test]
     fn test_pub_key_hex() {
         let pub_key = DefaultPrivateKey::generate().pub_key();
-        let pub_key_hex = PublicKeyHex::try_from(pub_key.clone()).unwrap();
+        let pub_key_hex = PublicKeyHex::try_from(&pub_key).unwrap();
         let converted_pub_key = DefaultPublicKey::try_from(&pub_key_hex).unwrap();
         assert_eq!(pub_key, converted_pub_key);
     }

--- a/module-system/sov-modules-api/src/serde_pub_key.rs
+++ b/module-system/sov-modules-api/src/serde_pub_key.rs
@@ -1,0 +1,40 @@
+use ed25519_dalek::VerifyingKey as DalekPublicKey;
+
+use crate::{default_signature::DefaultPublicKey, PublicKeyHex};
+
+impl serde::Serialize for DefaultPublicKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            // TODO remove clone
+            serde::Serialize::serialize(&PublicKeyHex::from(self.clone()), serializer)
+        } else {
+            serde::Serialize::serialize(&self.pub_key, serializer)
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for DefaultPublicKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let pub_key_hex: PublicKeyHex = serde::Deserialize::deserialize(deserializer)?;
+            Ok(DefaultPublicKey::try_from(&pub_key_hex).map_err(serde::de::Error::custom)?)
+        } else {
+            let pub_key: DalekPublicKey = serde::Deserialize::deserialize(deserializer)?;
+            Ok(DefaultPublicKey { pub_key })
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_pub_key() {}
+}

--- a/module-system/sov-modules-api/src/serde_pub_key.rs
+++ b/module-system/sov-modules-api/src/serde_pub_key.rs
@@ -10,7 +10,7 @@ impl serde::Serialize for DefaultPublicKey {
     {
         if serializer.is_human_readable() {
             // TODO remove clone
-            serde::Serialize::serialize(&PublicKeyHex::from(self.clone()), serializer)
+            serde::Serialize::serialize(&PublicKeyHex::from(self), serializer)
         } else {
             serde::Serialize::serialize(&self.pub_key, serializer)
         }

--- a/module-system/sov-modules-api/src/serde_pub_key.rs
+++ b/module-system/sov-modules-api/src/serde_pub_key.rs
@@ -9,7 +9,6 @@ impl serde::Serialize for DefaultPublicKey {
         S: serde::Serializer,
     {
         if serializer.is_human_readable() {
-            // TODO remove clone
             serde::Serialize::serialize(&PublicKeyHex::from(self), serializer)
         } else {
             serde::Serialize::serialize(&self.pub_key, serializer)

--- a/module-system/sov-modules-api/src/serde_pub_key.rs
+++ b/module-system/sov-modules-api/src/serde_pub_key.rs
@@ -34,8 +34,24 @@ impl<'de> serde::Deserialize<'de> for DefaultPublicKey {
 
 #[cfg(test)]
 mod test {
-    
+    use super::*;
 
     #[test]
-    fn test_pub_key() {}
+    fn test_pub_key_json() {
+        let pub_key_hex: PublicKeyHex =
+            "022e229198d957bf0c0a504e7d7bcec99a1d62cccc7861ed2452676ad0323ad8"
+                .try_into()
+                .unwrap();
+
+        let pub_key = DefaultPublicKey::try_from(&pub_key_hex).unwrap();
+        let pub_key_str: String = serde_json::to_string(&pub_key).unwrap();
+
+        assert_eq!(
+            pub_key_str,
+            r#""022e229198d957bf0c0a504e7d7bcec99a1d62cccc7861ed2452676ad0323ad8""#
+        );
+
+        let deserialized: DefaultPublicKey = serde_json::from_str(&pub_key_str).unwrap();
+        assert_eq!(deserialized, pub_key);
+    }
 }

--- a/module-system/sov-modules-api/src/serde_pub_key.rs
+++ b/module-system/sov-modules-api/src/serde_pub_key.rs
@@ -1,6 +1,7 @@
 use ed25519_dalek::VerifyingKey as DalekPublicKey;
 
-use crate::{default_signature::DefaultPublicKey, PublicKeyHex};
+use crate::default_signature::DefaultPublicKey;
+use crate::PublicKeyHex;
 
 impl serde::Serialize for DefaultPublicKey {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -33,7 +34,7 @@ impl<'de> serde::Deserialize<'de> for DefaultPublicKey {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    
 
     #[test]
     fn test_pub_key() {}


### PR DESCRIPTION
# Description
This PR introduces custom serde serialization and deserialization for the `DefaultPublicKey` type. This means that the public key can now be automatically serialized as hexadecimal without requiring manual conversion to `DefaultPublicKeyHex`

## Testing
Unit test added.

## Docs
No changes.
