### PR TITLE
Rename DaService method extract_relevant_txs to extract_relevant_blobs

### DIFF
--- a/adapters/celestia/src/da_service.rs
+++ b/adapters/celestia/src/da_service.rs
@@ -215,7 +215,7 @@ impl DaService for CelestiaService {
         self.get_finalized_at(height).await
     }
 
-    fn extract_relevant_txs(
+    fn extract_relevant_blobs(
         &self,
         block: &Self::FilteredBlock,
     ) -> Vec<<Self::Spec as sov_rollup_interface::da::DaSpec>::BlobTransaction> {

--- a/examples/demo-prover/benches/prover_bench.rs
+++ b/examples/demo-prover/benches/prover_bench.rs
@@ -199,7 +199,7 @@ async fn main() -> Result<(), anyhow::Error> {
         let _header_hash = hex::encode(filtered_block.header.header.hash());
         host.add_hint(&filtered_block.header);
         let (mut blob_txs, inclusion_proof, completeness_proof) = da_service
-            .extract_relevant_txs_with_proof(filtered_block)
+            .extract_relevant_blobs_with_proof(filtered_block)
             .await;
 
         host.add_hint(&inclusion_proof);

--- a/examples/demo-rollup/benches/rng_xfers.rs
+++ b/examples/demo-rollup/benches/rng_xfers.rs
@@ -135,7 +135,7 @@ impl DaService for RngDaService {
         unimplemented!()
     }
 
-    fn extract_relevant_txs(
+    fn extract_relevant_blobs(
         &self,
         block: &Self::FilteredBlock,
     ) -> Vec<<Self::Spec as DaSpec>::BlobTransaction> {

--- a/examples/demo-rollup/benches/rollup_bench.rs
+++ b/examples/demo-rollup/benches/rollup_bench.rs
@@ -70,7 +70,7 @@ fn rollup_bench(_bench: &mut Criterion) {
         };
         blocks.push(filtered_block.clone());
 
-        let blob_txs = da_service.extract_relevant_txs(&filtered_block);
+        let blob_txs = da_service.extract_relevant_blobs(&filtered_block);
         blobs.push(blob_txs.clone());
     }
 

--- a/examples/demo-rollup/benches/rollup_coarse_measure.rs
+++ b/examples/demo-rollup/benches/rollup_coarse_measure.rs
@@ -127,7 +127,7 @@ async fn main() -> Result<(), anyhow::Error> {
         };
         blocks.push(filtered_block.clone());
 
-        let blob_txs = da_service.extract_relevant_txs(&filtered_block);
+        let blob_txs = da_service.extract_relevant_blobs(&filtered_block);
         blobs.push(blob_txs);
     }
 

--- a/full-node/sov-stf-runner/src/runner.rs
+++ b/full-node/sov-stf-runner/src/runner.rs
@@ -152,7 +152,7 @@ where
             debug!("Requesting data for height {}", height,);
 
             let filtered_block = self.da_service.get_finalized_at(height).await?;
-            let mut blobs = self.da_service.extract_relevant_txs(&filtered_block);
+            let mut blobs = self.da_service.extract_relevant_blobs(&filtered_block);
 
             info!(
                 "Extracted {} relevant blobs at height {}: {:?}",

--- a/rollup-interface/specs/interfaces/da.md
+++ b/rollup-interface/specs/interfaces/da.md
@@ -173,7 +173,7 @@ peer network (likely via JSON-RPC requests to a local light node), and for conve
 which can be efficiently verified in the SNARK. The DA service exists outside of the rollup's state machine, so it will not be proven
 in-circuit. For this reason, implementers are encouraged to prioritize readability and maintainability over efficiency.
 
-### Method:`extract_relevant_txs`
+### Method:`extract_relevant_blobs`
 
 - **Usage:**
 
@@ -194,12 +194,12 @@ in-circuit. For this reason, implementers are encouraged to prioritize readabili
 | ----- | --------------------------- | ------------------------------------------------------------ |
 | `txs` | `iterable<BlobTransaction>` | A list of L1 transactions ("data blobs"), with their senders |
 
-### Method:`extract_relevant_txs_with_proof`
+### Method:`extract_relevant_blobs_with_proof`
 
 - **Usage:**
 
-  - An adaptation of the `extract_relevant_txs` method designed for use by provers. This method
-    returns the same list of transactions that would be returned by `extract_relevant_txs`, in addition
+  - An adaptation of the `extract_relevant_blobs` method designed for use by provers. This method
+    returns the same list of transactions that would be returned by `extract_relevant_blobs`, in addition
     to a witness proving the inclusion of these transactions in the DA layer block, and a witness
     showing the completeness of the provided list. The output of this function is intended to be
     passed to the `DaVerifier`.

--- a/rollup-interface/src/node/services/da.rs
+++ b/rollup-interface/src/node/services/da.rs
@@ -41,7 +41,7 @@ pub trait DaService: Send + Sync + 'static {
 
     /// Extract the relevant transactions from a block. For example, this method might return
     /// all of the blob transactions in rollup's namespace on Celestia.
-    fn extract_relevant_txs(
+    fn extract_relevant_blobs(
         &self,
         block: &Self::FilteredBlock,
     ) -> Vec<<Self::Spec as DaSpec>::BlobTransaction>;
@@ -62,7 +62,7 @@ pub trait DaService: Send + Sync + 'static {
     /// together with a range proof against the root of the namespaced-merkle-tree, demonstrating that the entire
     /// rollup namespace has been covered.
     #[allow(clippy::type_complexity)]
-    async fn extract_relevant_txs_with_proof(
+    async fn extract_relevant_blobs_with_proof(
         &self,
         block: &Self::FilteredBlock,
     ) -> (
@@ -70,7 +70,7 @@ pub trait DaService: Send + Sync + 'static {
         <Self::Spec as DaSpec>::InclusionMultiProof,
         <Self::Spec as DaSpec>::CompletenessProof,
     ) {
-        let relevant_txs = self.extract_relevant_txs(block);
+        let relevant_txs = self.extract_relevant_blobs(block);
 
         let (etx_proofs, rollup_row_proofs) = self
             .get_extraction_proof(block, relevant_txs.as_slice())

--- a/rollup-interface/src/state_machine/mocks/da.rs
+++ b/rollup-interface/src/state_machine/mocks/da.rs
@@ -325,7 +325,7 @@ impl DaService for MockDaService {
         self.get_finalized_at(height).await
     }
 
-    fn extract_relevant_txs(
+    fn extract_relevant_blobs(
         &self,
         block: &Self::FilteredBlock,
     ) -> Vec<<Self::Spec as DaSpec>::BlobTransaction> {


### PR DESCRIPTION
# Description
* Renaming the following functions
 *  extract_relevant_txs to extract_relevant_blobs
 * extract_relevant_txs_with_proof to extract_relevant_blobs_with_proof

The reason for this rename is to make a clearer distinction in the naming so that developers know this refers to DA blob transactions and not the rollup transactions

## Linked Issues
- Fixes (#706)
