### PR TITLE
Removing `Storage::backing` method

### DIFF
--- a/module-system/module-implementations/sov-attester-incentives/src/call.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/call.rs
@@ -223,10 +223,8 @@ where
         state_root: <C::Storage as Storage>::Root,
         proof: StorageProof<<C::Storage as Storage>::Proof>,
         expected_key: &C::Address,
-        working_set: &mut WorkingSet<C>,
     ) -> Result<Option<StorageValue>, anyhow::Error> {
-        let storage = working_set.backing();
-        let (storage_key, storage_value) = storage.open_proof(state_root, proof)?;
+        let (storage_key, storage_value) = C::Storage::open_proof(state_root, proof)?;
         let prefix = self.bonded_attesters.prefix();
         let codec = self.bonded_attesters.codec();
 
@@ -524,7 +522,6 @@ where
                 bonding_root,
                 attestation.proof_of_bond.proof.clone(),
                 context.sender(),
-                working_set,
             )
             .map_err(|_err| AttesterIncentiveErrors::InvalidBondingProof)?;
 

--- a/module-system/module-implementations/sov-attester-incentives/src/query.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/query.rs
@@ -62,9 +62,7 @@ where
     where
         C::Storage: NativeStorage,
     {
-        let prefix = self.bonded_attesters.prefix();
-        let codec = self.bonded_attesters.codec();
-        working_set.get_with_proof(StorageKey::new(prefix, &address, codec))
+        working_set.get_with_proof(self.get_attester_storage_key(address))
     }
 
     /// TODO: Make the unbonding amount queryable:

--- a/module-system/module-implementations/sov-attester-incentives/src/query.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/query.rs
@@ -1,7 +1,7 @@
 //! Defines the query methods for the attester incentives module
 use serde::{Deserialize, Serialize};
 use sov_modules_api::{Spec, ValidityConditionChecker, WorkingSet};
-use sov_state::storage::{Storage, StorageKey, StorageProof};
+use sov_state::storage::{NativeStorage, Storage, StorageKey, StorageProof};
 
 use super::AttesterIncentives;
 use crate::call::Role;
@@ -54,12 +54,14 @@ where
     /// Used by attesters to get a proof that they were bonded before starting to produce attestations.
     /// A bonding proof is valid for `max_finality_period` blocks, the attester can only produce transition
     /// attestations for this specific amount of time.
-    #[cfg(feature = "native")]
     pub fn get_bond_proof(
         &self,
         address: C::Address,
         working_set: &mut WorkingSet<C>,
-    ) -> StorageProof<<C::Storage as Storage>::Proof> {
+    ) -> StorageProof<<C::Storage as Storage>::Proof>
+    where
+        C::Storage: NativeStorage,
+    {
         let prefix = self.bonded_attesters.prefix();
         let codec = self.bonded_attesters.codec();
         working_set.get_with_proof(StorageKey::new(prefix, &address, codec))

--- a/module-system/module-implementations/sov-attester-incentives/src/query.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/query.rs
@@ -1,7 +1,7 @@
 //! Defines the query methods for the attester incentives module
 use serde::{Deserialize, Serialize};
 use sov_modules_api::{Spec, ValidityConditionChecker, WorkingSet};
-use sov_state::storage::{NativeStorage, Storage, StorageKey, StorageProof};
+use sov_state::storage::{Storage, StorageKey};
 
 use super::AttesterIncentives;
 use crate::call::Role;
@@ -44,22 +44,11 @@ where
         }
     }
 
-    /// Used by attesters to get a proof that they were bonded before starting to produce attestations.
-    /// A bonding proof is valid for `max_finality_period` blocks, the attester can only produce transition
-    /// attestations for this specific amount of time.
-    pub fn get_bond_proof(
-        &self,
-        address: C::Address,
-        witness: &<<C as Spec>::Storage as Storage>::Witness,
-        working_set: &mut WorkingSet<C>,
-    ) -> StorageProof<<C::Storage as Storage>::Proof>
-    where
-        C::Storage: NativeStorage,
-    {
+    /// Gives storage key for given address
+    pub fn get_attester_storage_key(&self, address: C::Address) -> StorageKey {
         let prefix = self.bonded_attesters.prefix();
         let codec = self.bonded_attesters.codec();
-        let storage = working_set.backing();
-        storage.get_with_proof(StorageKey::new(prefix, &address, codec), witness)
+        StorageKey::new(prefix, &address, codec)
     }
 
     /// TODO: Make the unbonding amount queryable:

--- a/module-system/module-implementations/sov-attester-incentives/src/query.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/query.rs
@@ -1,7 +1,7 @@
 //! Defines the query methods for the attester incentives module
 use serde::{Deserialize, Serialize};
 use sov_modules_api::{Spec, ValidityConditionChecker, WorkingSet};
-use sov_state::storage::{Storage, StorageKey};
+use sov_state::storage::{Storage, StorageKey, StorageProof};
 
 use super::AttesterIncentives;
 use crate::call::Role;
@@ -49,6 +49,20 @@ where
         let prefix = self.bonded_attesters.prefix();
         let codec = self.bonded_attesters.codec();
         StorageKey::new(prefix, &address, codec)
+    }
+
+    /// Used by attesters to get a proof that they were bonded before starting to produce attestations.
+    /// A bonding proof is valid for `max_finality_period` blocks, the attester can only produce transition
+    /// attestations for this specific amount of time.
+    #[cfg(feature = "native")]
+    pub fn get_bond_proof(
+        &self,
+        address: C::Address,
+        working_set: &mut WorkingSet<C>,
+    ) -> StorageProof<<C::Storage as Storage>::Proof> {
+        let prefix = self.bonded_attesters.prefix();
+        let codec = self.bonded_attesters.codec();
+        working_set.get_with_proof(StorageKey::new(prefix, &address, codec))
     }
 
     /// TODO: Make the unbonding amount queryable:

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
@@ -8,7 +8,7 @@ use sov_rollup_interface::mocks::{
     MockBlock, MockBlockHeader, MockCodeCommitment, MockDaSpec, MockValidityCond,
     MockValidityCondChecker, MockZkvm,
 };
-use sov_state::storage::StorageProof;
+use sov_state::storage::{NativeStorage, StorageProof};
 use sov_state::{DefaultStorageSpec, ProverStorage, Storage};
 
 use crate::AttesterIncentives;
@@ -156,13 +156,14 @@ pub(crate) fn execution_simulation<Checker: ValidityConditionChecker<MockValidit
         let (root_hash, w_set) = commit_get_new_working_set(storage, working_set);
         working_set = w_set;
 
+        let bond_proof = storage.get_with_proof(
+            module.get_attester_storage_key(attester_address),
+            &Default::default(),
+        );
+
         ret_exec_vars.push(ExecutionSimulationVars {
             state_root: root_hash,
-            state_proof: module.get_bond_proof(
-                attester_address,
-                &Default::default(),
-                &mut working_set,
-            ),
+            state_proof: bond_proof,
         });
 
         // Then process the first transaction. Only sets the genesis hash and a transition in progress.

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
@@ -8,7 +8,7 @@ use sov_rollup_interface::mocks::{
     MockBlock, MockBlockHeader, MockCodeCommitment, MockDaSpec, MockValidityCond,
     MockValidityCondChecker, MockZkvm,
 };
-use sov_state::storage::{NativeStorage, StorageProof};
+use sov_state::storage::StorageProof;
 use sov_state::{DefaultStorageSpec, ProverStorage, Storage};
 
 use crate::AttesterIncentives;
@@ -156,10 +156,9 @@ pub(crate) fn execution_simulation<Checker: ValidityConditionChecker<MockValidit
         let (root_hash, w_set) = commit_get_new_working_set(storage, working_set);
         working_set = w_set;
 
-        let bond_proof = storage.get_with_proof(
-            module.get_attester_storage_key(attester_address),
-            &Default::default(),
-        );
+        let bond_proof = storage
+            .get_with_proof(module.get_attester_storage_key(attester_address))
+            .unwrap();
 
         ret_exec_vars.push(ExecutionSimulationVars {
             state_root: root_hash,

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
@@ -8,7 +8,7 @@ use sov_rollup_interface::mocks::{
     MockBlock, MockBlockHeader, MockCodeCommitment, MockDaSpec, MockValidityCond,
     MockValidityCondChecker, MockZkvm,
 };
-use sov_state::storage::StorageProof;
+use sov_state::storage::{NativeStorage, StorageProof};
 use sov_state::{DefaultStorageSpec, ProverStorage, Storage};
 
 use crate::AttesterIncentives;
@@ -156,9 +156,7 @@ pub(crate) fn execution_simulation<Checker: ValidityConditionChecker<MockValidit
         let (root_hash, w_set) = commit_get_new_working_set(storage, working_set);
         working_set = w_set;
 
-        let bond_proof = storage
-            .get_with_proof(module.get_attester_storage_key(attester_address))
-            .unwrap();
+        let bond_proof = storage.get_with_proof(module.get_attester_storage_key(attester_address));
 
         ret_exec_vars.push(ExecutionSimulationVars {
             state_root: root_hash,

--- a/module-system/sov-modules-api/src/state/scratchpad.rs
+++ b/module-system/sov-modules-api/src/state/scratchpad.rs
@@ -262,6 +262,15 @@ impl<C: Context> WorkingSet<C> {
     pub fn charge_gas(&mut self, gas: &C::GasUnit) -> anyhow::Result<()> {
         self.gas_meter.charge_gas(gas)
     }
+
+    #[cfg(feature = "native")]
+    pub fn get_with_proof(
+        &mut self,
+        key: StorageKey,
+    ) -> sov_state::storage::StorageProof<<C::Storage as Storage>::Proof> {
+        // First inner is `RevertableWriter` and second inner is actually a `Storage` instance
+        self.delta.inner.inner.get_with_proof(key).unwrap()
+    }
 }
 
 impl<C: Context> StateReaderAndWriter for WorkingSet<C> {

--- a/module-system/sov-modules-api/src/state/scratchpad.rs
+++ b/module-system/sov-modules-api/src/state/scratchpad.rs
@@ -247,12 +247,6 @@ impl<C: Context> WorkingSet<C> {
         &self.events
     }
 
-    /// Returns an immutable reference to the [`Storage`] instance backing this
-    /// working set.
-    pub fn backing(&self) -> &<C as Spec>::Storage {
-        &self.delta.inner.inner
-    }
-
     /// Returns the remaining gas funds.
     pub const fn gas_remaining_funds(&self) -> u64 {
         self.gas_meter.remaining_funds()

--- a/module-system/sov-modules-api/src/state/scratchpad.rs
+++ b/module-system/sov-modules-api/src/state/scratchpad.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::marker::PhantomData;
 
 use sov_first_read_last_write_cache::{CacheKey, CacheValue};
 use sov_rollup_interface::stf::Event;
@@ -17,7 +16,6 @@ pub struct Delta<S: Storage> {
     inner: S,
     witness: S::Witness,
     cache: StorageInternalCache,
-    parent: PhantomData<S>,
 }
 
 impl<S: Storage> Delta<S> {

--- a/module-system/sov-state/src/storage.rs
+++ b/module-system/sov-state/src/storage.rs
@@ -244,6 +244,13 @@ pub trait Storage: Clone {
     /// Indicates if storage is empty or not.
     /// Useful during initialization.
     fn is_empty(&self) -> bool;
+
+    /// Returns the value corresponding to the key or None if key is absent and a proof to
+    /// get the value.
+    /// Only supposed to be used in native context
+    fn get_with_proof(&self, _key: StorageKey) -> Option<StorageProof<Self::Proof>> {
+        None
+    }
 }
 
 // Used only in tests.

--- a/module-system/sov-state/src/storage.rs
+++ b/module-system/sov-state/src/storage.rs
@@ -237,7 +237,6 @@ pub trait Storage: Clone {
     /// Opens a storage access proof and validates it against a state root.
     /// It returns a result with the opened leaf (key, value) pair in case of success.
     fn open_proof(
-        &self,
         state_root: Self::Root,
         proof: StorageProof<Self::Proof>,
     ) -> Result<(StorageKey, Option<StorageValue>), anyhow::Error>;

--- a/module-system/sov-state/src/storage.rs
+++ b/module-system/sov-state/src/storage.rs
@@ -244,13 +244,6 @@ pub trait Storage: Clone {
     /// Indicates if storage is empty or not.
     /// Useful during initialization.
     fn is_empty(&self) -> bool;
-
-    /// Returns the value corresponding to the key or None if key is absent and a proof to
-    /// get the value.
-    /// Only supposed to be used in native context
-    fn get_with_proof(&self, _key: StorageKey) -> Option<StorageProof<Self::Proof>> {
-        None
-    }
 }
 
 // Used only in tests.
@@ -276,6 +269,5 @@ impl From<&str> for StorageValue {
 pub trait NativeStorage: Storage {
     /// Returns the value corresponding to the key or None if key is absent and a proof to
     /// get the value.
-    fn get_with_proof(&self, key: StorageKey, witness: &Self::Witness)
-        -> StorageProof<Self::Proof>;
+    fn get_with_proof(&self, key: StorageKey) -> StorageProof<Self::Proof>;
 }

--- a/module-system/sov-state/src/zk_storage.rs
+++ b/module-system/sov-state/src/zk_storage.rs
@@ -108,7 +108,6 @@ impl<S: MerkleProofSpec> Storage for ZkStorage<S> {
     }
 
     fn open_proof(
-        &self,
         state_root: Self::Root,
         state_proof: StorageProof<Self::Proof>,
     ) -> Result<(StorageKey, Option<StorageValue>), anyhow::Error> {


### PR DESCRIPTION
# Description
As it heavily leaks abstraction.

Replace it with `fn get_with_proof(&self, key: StorageKey) -> Option<StorageProof<Self::Proof>> ` which at least does not expose underlying storage.

## Testing
Current tests are passing

## Docs
No updates in documentation
