### PR TITLE
fix: broken fuzz lib

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,9 @@ jobs:
           cache-provider: "buildjet"
           shared-key: cargo-check
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
+          workspaces: |
+            .
+            fuzz
       - name: Run lint
         run: |
           if ! make lint ; then
@@ -109,6 +112,9 @@ jobs:
           cache-provider: "buildjet"
           shared-key: cargo-check
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
+          workspaces: |
+            .
+            fuzz
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       - name: cargo hack
         run: make check-features

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,11 @@ install-dev-tools:  ## Installs all necessary cargo helpers
 	cargo install cargo-risczero
 	cargo risczero install
 
-lint: check-fuzz  ## cargo check and clippy. Skip clippy on guest code since it's not supported by risc0
+lint:  ## cargo check and clippy. Skip clippy on guest code since it's not supported by risc0
 	## fmt first, because it's the cheapest
 	cargo +nightly fmt --all --check
 	cargo check --all-targets --all-features
+	$(MAKE) check-fuzz
 	CI_SKIP_GUEST_BUILD=1 cargo clippy --all-targets --all-features
 
 lint-fix:  ## cargo fmt, fix and clippy. Skip clippy on guest code since it's not supported by risc0

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install-dev-tools:  ## Installs all necessary cargo helpers
 	cargo install cargo-risczero
 	cargo risczero install
 
-lint:  ## cargo check and clippy. Skip clippy on guest code since it's not supported by risc0
+lint: check-fuzz  ## cargo check and clippy. Skip clippy on guest code since it's not supported by risc0
 	## fmt first, because it's the cheapest
 	cargo +nightly fmt --all --check
 	cargo check --all-targets --all-features

--- a/fuzz/fuzz_targets/accounts_call.rs
+++ b/fuzz/fuzz_targets/accounts_call.rs
@@ -42,7 +42,7 @@ fuzz_target!(|input: (u16, [u8; 32], Vec<DefaultPrivateKey>)| -> Corpus {
     let storage = <C as Spec>::Storage::with_path(tmpdir.path()).unwrap();
     let working_set = &mut WorkingSet::new(storage);
 
-    let config: AccountConfig = keys.iter().map(|k| k.pub_key()).collect();
+    let config: AccountConfig<C> = keys.iter().map(|k| k.pub_key()).collect();
     let accounts: Accounts<C> = Accounts::default();
     accounts.genesis(&config, working_set).unwrap();
 


### PR DESCRIPTION
Prior to this commit, there was no CI check for the fuzz library.

Since it is isolated from the workspace (so it won't be affected by fuzz specific build configuration), it could be silently broken by a breaking change.

This commit introduces a fix to `AccountConfig`, and adds the fuzz check to the link job of the `Makefile`.