### PR TITLE
WIP Fix demo-rollup `token_address` in `demo-rollup` readme.

### DIFF
--- a/examples/demo-rollup/README.md
+++ b/examples/demo-rollup/README.md
@@ -221,7 +221,7 @@ Here's an example of a JSON representing the above call:
     "to": "sov1zgfpyysjzgfpyysjzgfpyysjzgfpyysjzgfpyysjzgfpyysjzgfqve8h6h",
     "coins": {
       "amount": 200,
-      "token_address": "sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"
+      "token_address": "sov16m8fxq0x5wc5aw75fx9rus2p7g2l22zf4re72c3m058g77cdjemsavg2ft"
     }
   }
 }
@@ -267,7 +267,7 @@ Adding the following transaction to batch:
       "to": "sov1l6n2cku82yfqld30lanm2nfw43n2auc8clw7r5u5m6s7p8jrm4zqrr8r94",
       "coins": {
         "amount": 200,
-        "token_address": "sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"
+        "token_address": "sov16m8fxq0x5wc5aw75fx9rus2p7g2l22zf4re72c3m058g77cdjemsavg2ft"
       }
     }
   }
@@ -290,7 +290,7 @@ This command will use your default private key.
 #### 4. Verify the Token Supply
 
 ```bash,test-ci,bashtestmd:compare-output
-$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"bank_supplyOf","params":["sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"],"id":1}' http://127.0.0.1:12345
+$ curl -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"bank_supplyOf","params":["sov16m8fxq0x5wc5aw75fx9rus2p7g2l22zf4re72c3m058g77cdjemsavg2ft"],"id":1}' http://127.0.0.1:12345
 {"jsonrpc":"2.0","result":{"amount":1000},"id":1}
 ```
 

--- a/examples/demo-rollup/rollup_config.toml
+++ b/examples/demo-rollup/rollup_config.toml
@@ -1,6 +1,6 @@
 [da]
 # The JWT used to authenticate with the celestia light client. Instructions for generating this token can be found in the README
-celestia_rpc_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.87iRcKYH3n3SXfQgB2q8y_SRNllN9bu43mryK3ePCLQ"
+celestia_rpc_auth_token = "MY.SECRET.TOKEN"
 # The address of the *trusted* Celestia light client to interact with
 celestia_rpc_address = "http://127.0.0.1:26658"
 # The largest response the rollup will accept from the Celestia node. Defaults to 100 MB

--- a/examples/demo-rollup/rollup_config.toml
+++ b/examples/demo-rollup/rollup_config.toml
@@ -1,6 +1,6 @@
 [da]
 # The JWT used to authenticate with the celestia light client. Instructions for generating this token can be found in the README
-celestia_rpc_auth_token = "MY.SECRET.TOKEN"
+celestia_rpc_auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJwdWJsaWMiLCJyZWFkIiwid3JpdGUiLCJhZG1pbiJdfQ.87iRcKYH3n3SXfQgB2q8y_SRNllN9bu43mryK3ePCLQ"
 # The address of the *trusted* Celestia light client to interact with
 celestia_rpc_address = "http://127.0.0.1:26658"
 # The largest response the rollup will accept from the Celestia node. Defaults to 100 MB

--- a/examples/demo-simple-stf/src/lib.rs
+++ b/examples/demo-simple-stf/src/lib.rs
@@ -8,7 +8,7 @@ use sov_rollup_interface::stf::{BatchReceipt, SlotResult, StateTransitionFunctio
 use sov_rollup_interface::zk::{ValidityCondition, Zkvm};
 
 /// An implementation of the
-/// [`StateTransitionFunction`](sov_rollup_interface::stf::StateTransitionFunction)
+/// [`StateTransitionFunction`]
 /// that is specifically designed to check if someone knows a preimage of a specific hash.
 #[derive(PartialEq, Debug, Clone, Eq, serde::Serialize, serde::Deserialize, Default)]
 pub struct CheckHashPreimageStf<Cond> {

--- a/examples/test-data/requests/mint.json
+++ b/examples/test-data/requests/mint.json
@@ -2,7 +2,7 @@
   "Mint": {
     "coins": {
       "amount": 3000,
-      "token_address": "sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"
+      "token_address": "sov16m8fxq0x5wc5aw75fx9rus2p7g2l22zf4re72c3m058g77cdjemsavg2ft"
     },
     "minter_address": "sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqwr57gc"
   }

--- a/examples/test-data/requests/transfer.json
+++ b/examples/test-data/requests/transfer.json
@@ -3,7 +3,7 @@
     "to": "sov1l6n2cku82yfqld30lanm2nfw43n2auc8clw7r5u5m6s7p8jrm4zqklh0qh",
     "coins": {
       "amount": 200,
-      "token_address": "sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"
+      "token_address": "sov16m8fxq0x5wc5aw75fx9rus2p7g2l22zf4re72c3m058g77cdjemsavg2ft"
     }
   }
 }


### PR DESCRIPTION
# Description
The `token_address` in the `demo-rollup/Readme` was outdated. See #989.

## Linked Issues
- Related to #989

## Testing
Tested the fix manually.

## Docs
`demo-rollup/Readme` updated.
