### PR TITLE
separate out nextest and test into separate jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -120,7 +120,7 @@ jobs:
         run: make check-features
   nextest:
     name: nextest
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
@@ -140,7 +140,7 @@ jobs:
       - run: cargo nextest run --workspace --all-features
   test:
     name: test
-    runs-on: buildjet-16vcpu-ubuntu-2204
+    runs-on: buildjet-4vcpu-ubuntu-2204
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -133,6 +133,10 @@ jobs:
         run: cargo risczero install
         # `cargo-nextest` is much faster than standard `cargo test`.
       - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-provider: "buildjet"
+          save-if: ${{ github.ref == 'refs/heads/nightly' }}
       - run: cargo nextest run --workspace --all-features
   test:
     name: test
@@ -147,6 +151,10 @@ jobs:
         run: cargo install cargo-risczero
       - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
         run: cargo risczero install
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-provider: "buildjet"
+          save-if: ${{ github.ref == 'refs/heads/nightly' }}
       # `cargo-nextest` does not support doctests (yet?), so we have to run them
       # separately.
       # TODO: https://github.com/nextest-rs/nextest/issues/16

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,6 +118,27 @@ jobs:
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       - name: cargo hack
         run: make check-features
+  nextest:
+    name: nextest
+    runs-on: buildjet-16vcpu-ubuntu-2204
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rui314/setup-mold@v1
+      - name: Install Rust
+        run: rustup show
+      - name: Install cargo-risc0 # Risc0 v0.17 and higher require a cargo extension to build the guest code
+        run: cargo install cargo-risczero
+      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
+        run: cargo risczero install
+        # `cargo-nextest` is much faster than standard `cargo test`.
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-provider: "buildjet"
+          shared-key: cargo-build
+          save-if: ${{ github.ref == 'refs/heads/nightly' }}
+      - run: cargo nextest run --workspace --all-features
   test:
     name: test
     runs-on: buildjet-16vcpu-ubuntu-2204
@@ -127,18 +148,15 @@ jobs:
       - uses: rui314/setup-mold@v1
       - name: Install Rust
         run: rustup show
-      # `cargo-nextest` is much faster than standard `cargo test`.
       - name: Install cargo-risc0 # Risc0 v0.17 and higher require a cargo extension to build the guest code
         run: cargo install cargo-risczero
       - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
         run: cargo risczero install
-      - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
           cache-provider: "buildjet"
           shared-key: cargo-build
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
-      - run: cargo nextest run --workspace --all-features
       # `cargo-nextest` does not support doctests (yet?), so we have to run them
       # separately.
       # TODO: https://github.com/nextest-rs/nextest/issues/16

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -133,11 +133,6 @@ jobs:
         run: cargo risczero install
         # `cargo-nextest` is much faster than standard `cargo test`.
       - uses: taiki-e/install-action@nextest
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-provider: "buildjet"
-          shared-key: cargo-build
-          save-if: ${{ github.ref == 'refs/heads/nightly' }}
       - run: cargo nextest run --workspace --all-features
   test:
     name: test
@@ -152,11 +147,6 @@ jobs:
         run: cargo install cargo-risczero
       - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
         run: cargo risczero install
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-provider: "buildjet"
-          shared-key: cargo-build
-          save-if: ${{ github.ref == 'refs/heads/nightly' }}
       # `cargo-nextest` does not support doctests (yet?), so we have to run them
       # separately.
       # TODO: https://github.com/nextest-rs/nextest/issues/16


### PR DESCRIPTION
# Description
`nextest` doesn't currently support docs, so we run `test --doc` as a separate step. This possibly causes disk space issues, so to avoid that we're separating them into two different jobs (as opposed to steps)