### PR TITLE
Update `module-system` readme with `JsonSchema` derivation for `CallMessage`

### DIFF
--- a/module-system/README.md
+++ b/module-system/README.md
@@ -330,7 +330,15 @@ about this distinction.
 For more information on `Context` and `Spec`, and to see some example implementations, check out the [`sov_modules_api`](./sov-modules-api/) docs.
 
 
-### Module data serialization.
-Structures related to modules are parameterized by `C::Context`. These structures must implement `serde::Serialize` and `serde::Deserialize`. However, due to limitations, `serde` may not always be able to automatically infer the correct trait bounds. Therefore, we need to provide additional information to `serde` to ensure that the types have the correct bounds.
-This is why we use the `bound` attribute. For example:
-Without the additional hints `schemars(bound = "C::Address: ::schemars::JsonSchema", rename = "CallMessage")` we would get the following error in the `bank` module:
+### Module CallMessage.
+Like in the `bank` module the `CallMessage` can be parameterized by `C::Context`. To ensure a smooth wallet experience, we need the `CallMessag`' to implement `schemars::JsonSchema` trait. However, simply adding `derive(schemars::JsonSchema)` to the `CallMessage` definition results in the following error:
+`the trait JsonSchema is not implemented for C`.  
+
+
+The reason for this issue is that the standard derive mechanism for `JsonSchema` cannot determine the correct trait bounds for the `Context`. To resolve this, we need to provide the following hint:
+
+`schemars(bound = "C::Address: ::schemars::JsonSchema", rename = "CallMessage")`
+
+Now, the schemars::derive understands that it is sufficient for only C::Address to implement schemars::JsonSche
+
+I a `CallMessage` in your module uses an associated type from `Context` you might need to provide a similar hint.

--- a/module-system/README.md
+++ b/module-system/README.md
@@ -331,7 +331,7 @@ For more information on `Context` and `Spec`, and to see some example implementa
 
 
 ### Module CallMessage and `schemars::JsonSchema`.
-Like in the `bank` module the `CallMessage` can be parameterized by `C::Context`. To ensure a smooth wallet experience, we need the `CallMessag`' to implement `schemars::JsonSchema` trait. However, simply adding `derive(schemars::JsonSchema)` to the `CallMessage` definition results in the following error:
+Like in the `bank` module the `CallMessage` can be parameterized by `C::Context`. To ensure a smooth wallet experience, we need the `CallMessage` to implement `schemars::JsonSchema` trait. However, simply adding `derive(schemars::JsonSchema)` to the `CallMessage` definition results in the following error:
 
 ```
 the trait JsonSchema is not implemented for C

--- a/module-system/README.md
+++ b/module-system/README.md
@@ -330,15 +330,20 @@ about this distinction.
 For more information on `Context` and `Spec`, and to see some example implementations, check out the [`sov_modules_api`](./sov-modules-api/) docs.
 
 
-### Module CallMessage.
+### Module CallMessage and `schemars::JsonSchema`.
 Like in the `bank` module the `CallMessage` can be parameterized by `C::Context`. To ensure a smooth wallet experience, we need the `CallMessag`' to implement `schemars::JsonSchema` trait. However, simply adding `derive(schemars::JsonSchema)` to the `CallMessage` definition results in the following error:
-`the trait JsonSchema is not implemented for C`.  
+
+```
+the trait JsonSchema is not implemented for C
+```
 
 
 The reason for this issue is that the standard derive mechanism for `JsonSchema` cannot determine the correct trait bounds for the `Context`. To resolve this, we need to provide the following hint:
 
-`schemars(bound = "C::Address: ::schemars::JsonSchema", rename = "CallMessage")`
+```rust
+schemars(bound = "C::Address: ::schemars::JsonSchema", rename = "CallMessage")
+```
 
-Now, the schemars::derive understands that it is sufficient for only C::Address to implement schemars::JsonSche
+Now, the `schemars::derive` understands that it is sufficient for only `C::Address` to implement `schemars::JsonSchema`
 
-I a `CallMessage` in your module uses an associated type from `Context` you might need to provide a similar hint.
+If `CallMessage` in your module uses an associated type from `Context` you might need to provide a similar hint.

--- a/module-system/README.md
+++ b/module-system/README.md
@@ -328,3 +328,9 @@ its data from a set of "hints" provided by the prover. Because all the rollups m
 about this distinction.
 
 For more information on `Context` and `Spec`, and to see some example implementations, check out the [`sov_modules_api`](./sov-modules-api/) docs.
+
+
+### Module data serialization.
+Structures related to modules are parameterized by `C::Context`. These structures must implement `serde::Serialize` and `serde::Deserialize`. However, due to limitations, `serde` may not always be able to automatically infer the correct trait bounds. Therefore, we need to provide additional information to `serde` to ensure that the types have the correct bounds.
+This is why we use the `bound` attribute. For example:
+Without the additional hints `schemars(bound = "C::Address: ::schemars::JsonSchema", rename = "CallMessage")` we would get the following error in the `bank` module:


### PR DESCRIPTION
# Description
Added a section in `module-system/Readme` to explain why we need ` schemars(bound = ??)` in `CallMessage`

## Testing
No changes.

## Docs
Docs updated.
