### PR TITLE
EVM: Fix Sequencer Nonce

### DIFF
--- a/full-node/sov-ethereum/src/lib.rs
+++ b/full-node/sov-ethereum/src/lib.rs
@@ -8,7 +8,6 @@ pub use sov_evm::DevSigner;
 #[cfg(feature = "experimental")]
 pub mod experimental {
     use std::array::TryFromSliceError;
-    use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
 
     use borsh::ser::BorshSerialize;
@@ -16,9 +15,7 @@ pub mod experimental {
     use ethers::types::{Bytes, H256};
     use jsonrpsee::types::ErrorObjectOwned;
     use jsonrpsee::RpcModule;
-    use reth_primitives::{
-        Address as RethAddress, TransactionSignedNoHash as RethTransactionSignedNoHash, U128, U256,
-    };
+    use reth_primitives::{TransactionSignedNoHash as RethTransactionSignedNoHash, U128, U256};
     use reth_rpc_types::{CallRequest, TransactionRequest, TypedTransactionRequest};
     use sov_evm::{CallMessage, Evm, RlpEvmTransaction};
     use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
@@ -58,7 +55,7 @@ pub mod experimental {
     }
 
     pub struct Ethereum<C: sov_modules_api::Context, Da: DaService> {
-        nonces: Mutex<HashMap<RethAddress, u64>>,
+        nonce: Mutex<u64>,
         da_service: Da,
         batch_builder: Arc<Mutex<EthBatchBuilder>>,
         eth_rpc_config: EthRpcConfig,
@@ -67,14 +64,14 @@ pub mod experimental {
 
     impl<C: sov_modules_api::Context, Da: DaService> Ethereum<C, Da> {
         fn new(
-            nonces: Mutex<HashMap<RethAddress, u64>>,
+            nonce: Mutex<u64>,
             da_service: Da,
             batch_builder: Arc<Mutex<EthBatchBuilder>>,
             eth_rpc_config: EthRpcConfig,
             storage: C::Storage,
         ) -> Self {
             Self {
-                nonces,
+                nonce,
                 da_service,
                 batch_builder,
                 eth_rpc_config,
@@ -91,12 +88,8 @@ pub mod experimental {
             let signed_transaction: RethTransactionSignedNoHash = raw_tx.clone().try_into()?;
 
             let tx_hash = signed_transaction.hash();
-            let sender = signed_transaction
-                .recover_signer()
-                .ok_or(sov_evm::EthApiError::InvalidTransactionSignature)?;
 
-            let mut nonces = self.nonces.lock().unwrap();
-            let nonce = *nonces.entry(sender).and_modify(|n| *n += 1).or_insert(0);
+            let mut nonce = self.nonce.lock().unwrap();
 
             let tx = CallMessage { tx: raw_tx };
             let message = <Runtime<DefaultContext, Da::Spec> as EncodeCall<
@@ -106,8 +99,11 @@ pub mod experimental {
             let tx = Transaction::<DefaultContext>::new_signed_tx(
                 &self.eth_rpc_config.sov_tx_signer_priv_key,
                 message,
-                nonce,
+                *nonce,
             );
+
+            *nonce += 1;
+
             Ok((H256::from(tx_hash), tx.try_to_vec()?))
         }
 


### PR DESCRIPTION
# Description
Sequencer only uses its own private key to wrap & sign EVM transactions. However current implementation tries to use original sender's nonce while signing, which fails on stateful verification.

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?
