### PR TITLE
fix: add `risc0` feature to celestia adapter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ lint-fix:  ## cargo fmt, fix and clippy. Skip clippy on guest code since it's no
 	cargo fix --allow-dirty
 	CI_SKIP_GUEST_BUILD=1 cargo clippy --fix --allow-dirty
 
-check-features: ## Checks that project compiles with all combinations of features. default is not needed because we never check `cfg(default)`, we only use it as an alias.
-	cargo hack check --workspace --feature-powerset --exclude-features default
+check-features: ## Checks that project compiles with all combinations of features.
+	cargo hack check --workspace --feature-powerset --exclude-features --all-targets
 
 check-fuzz: ## Checks that fuzz member compiles
 	$(MAKE) -C fuzz check

--- a/adapters/celestia/Cargo.toml
+++ b/adapters/celestia/Cargo.toml
@@ -37,9 +37,7 @@ tokio = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros", version = "0.2", optional = true }
-risc0-zkvm = { workspace = true, default-features = false, features = [
-  "std",
-], optional = true }
+risc0-zkvm = { workspace = true, default-features = false, features = ["std"], optional = true }
 risc0-zkvm-platform = { workspace = true, optional = true }
 
 sov-rollup-interface = { path = "../../rollup-interface", version = "0.2" }
@@ -61,5 +59,12 @@ native = [
   "tendermint/default",
   "sov-rollup-interface/native",
 ]
-bench = ["sov-zk-cycle-macros/bench", "risc0-zkvm", "risc0-zkvm-platform"]
+risc0 = [
+  "dep:risc0-zkvm",
+  "dep:risc0-zkvm-platform"
+]
+bench = [
+    "sov-zk-cycle-macros/bench",
+    "risc0"
+]
 verifier = []

--- a/adapters/celestia/src/celestia.rs
+++ b/adapters/celestia/src/celestia.rs
@@ -420,6 +420,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "risc0")]
     fn test_zkvm_serde_celestia_header() {
         // regression https://github.com/eigerco/celestia-tendermint-rs/pull/12
         for header_json in HEADER_JSON_RESPONSES {

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -402,8 +402,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
-source = "git+https://github.com/rust-lang/cc-rs?rev=e5bbdfa#e5bbdfa1fa468c028cb38fee6c35a3cf2e5a2736"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "celestia-proto"
@@ -2729,6 +2733,11 @@ dependencies = [
  "quote",
  "syn 2.0.38",
 ]
+
+[[patch.unused]]
+name = "cc"
+version = "1.0.79"
+source = "git+https://github.com/rust-lang/cc-rs?rev=e5bbdfa#e5bbdfa1fa468c028cb38fee6c35a3cf2e5a2736"
 
 [[patch.unused]]
 name = "sha2"


### PR DESCRIPTION
The tests are currently breaking as they require an optional `risc0-zkvm` dependency, assuming it is always available. A new feature is required to shield such case.

This commit also introduces a check on `cargo hack` to inspect all targets. This will prevent the same problem from happening in the future. Finally, it removes the unused `default` argument from `cargo hack`, as it conflicts with `all-targets`.