### PR TITLE
feat: update sov-celestia-adapter to celestia-node 0.11.0-rc15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "celestia-proto"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/celestia-node-rs.git?rev=925836a#925836a889b2b2a372743583208c6f11fe9855c9"
+source = "git+https://github.com/eigerco/celestia-node-rs.git?rev=1fa61eb#1fa61ebd6be6a3663f12e61cf23618342e3a910f"
 dependencies = [
  "anyhow",
  "prost 0.12.1",
@@ -1259,7 +1259,7 @@ dependencies = [
 [[package]]
 name = "celestia-rpc"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/celestia-node-rs.git?rev=925836a#925836a889b2b2a372743583208c6f11fe9855c9"
+source = "git+https://github.com/eigerco/celestia-node-rs.git?rev=1fa61eb#1fa61ebd6be6a3663f12e61cf23618342e3a910f"
 dependencies = [
  "celestia-types",
  "http",
@@ -1272,7 +1272,7 @@ dependencies = [
 [[package]]
 name = "celestia-types"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/celestia-node-rs.git?rev=925836a#925836a889b2b2a372743583208c6f11fe9855c9"
+source = "git+https://github.com/eigerco/celestia-node-rs.git?rev=1fa61eb#1fa61ebd6be6a3663f12e61cf23618342e3a910f"
 dependencies = [
  "base64 0.21.4",
  "bech32",

--- a/adapters/celestia/Cargo.toml
+++ b/adapters/celestia/Cargo.toml
@@ -14,9 +14,9 @@ prost = "0.12"
 # I keep this commented as a reminder to opportunity to optimze this crate for non native compilation
 #tendermint = { version = "0.32", default-features = false, features = ["std"] }
 
-celestia-proto = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "925836a" }
-celestia-rpc = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "925836a", default-features = false, optional = true }
-celestia-types = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "925836a", default-features = false }
+celestia-proto = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "1fa61eb" }
+celestia-rpc = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "1fa61eb", default-features = false, optional = true }
+celestia-types = { git = "https://github.com/eigerco/celestia-node-rs.git", rev = "1fa61eb", default-features = false }
 tendermint = { git = "https://github.com/eigerco/celestia-tendermint-rs.git", rev = "1f8b574", default-features = false }
 tendermint-proto = { git = "https://github.com/eigerco/celestia-tendermint-rs.git", rev = "1f8b574" }
 nmt-rs = { git = "https://github.com/Sovereign-Labs/nmt-rs.git", rev = "d821332", features = [

--- a/adapters/celestia/src/da_service.rs
+++ b/adapters/celestia/src/da_service.rs
@@ -111,10 +111,9 @@ impl DaService for CelestiaService {
 
         // Fetch the rollup namespace shares, etx data and extended data square
         debug!("Fetching rollup data...");
-        let rollup_rows_future =
-            client.share_get_shares_by_namespace(&header.dah, rollup_namespace);
-        let etx_rows_future = client.share_get_shares_by_namespace(&header.dah, PFB_NAMESPACE);
-        let data_square_future = client.share_get_eds(&header.dah);
+        let rollup_rows_future = client.share_get_shares_by_namespace(&header, rollup_namespace);
+        let etx_rows_future = client.share_get_shares_by_namespace(&header, PFB_NAMESPACE);
+        let data_square_future = client.share_get_eds(&header);
 
         let (rollup_rows, etx_rows, data_square) =
             tokio::try_join!(rollup_rows_future, etx_rows_future, data_square_future)?;

--- a/docker/Dockerfile.bridge
+++ b/docker/Dockerfile.bridge
@@ -8,8 +8,8 @@ ENV CELESTIA_HOME=/root
 RUN apk update && apk add --no-cache bash jq
 
 # Copy in the binary
-COPY --from=ghcr.io/celestiaorg/celestia-node:v0.11.0-rc14 /bin/celestia /bin/celestia
-COPY --from=ghcr.io/celestiaorg/celestia-node:v0.11.0-rc14 /bin/cel-key /bin/cel-key
+COPY --from=ghcr.io/celestiaorg/celestia-node:v0.11.0-rc15 /bin/celestia /bin/celestia
+COPY --from=ghcr.io/celestiaorg/celestia-node:v0.11.0-rc15 /bin/cel-key /bin/cel-key
 
 COPY ./run-bridge.sh /opt/entrypoint.sh
 

--- a/docker/Dockerfile.validator
+++ b/docker/Dockerfile.validator
@@ -8,7 +8,7 @@ ENV CELESTIA_HOME=/root
 RUN apk update && apk add --no-cache bash jq
 
 # Copy in the binary
-COPY --from=ghcr.io/celestiaorg/celestia-app:v1.0.0-rc17 /bin/celestia-appd /bin/celestia-appd
+COPY --from=ghcr.io/celestiaorg/celestia-app:v1.0.0 /bin/celestia-appd /bin/celestia-appd
 
 COPY ./run-validator.sh /opt/entrypoint.sh
 

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
 [[package]]
 name = "celestia-proto"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/celestia-node-rs.git?rev=925836a#925836a889b2b2a372743583208c6f11fe9855c9"
+source = "git+https://github.com/eigerco/celestia-node-rs.git?rev=1fa61eb#1fa61ebd6be6a3663f12e61cf23618342e3a910f"
 dependencies = [
  "anyhow",
  "prost 0.12.1",
@@ -410,7 +410,7 @@ dependencies = [
 [[package]]
 name = "celestia-types"
 version = "0.1.0"
-source = "git+https://github.com/eigerco/celestia-node-rs.git?rev=925836a#925836a889b2b2a372743583208c6f11fe9855c9"
+source = "git+https://github.com/eigerco/celestia-node-rs.git?rev=1fa61eb#1fa61ebd6be6a3663f12e61cf23618342e3a910f"
 dependencies = [
  "base64 0.21.4",
  "bech32",


### PR DESCRIPTION
# Description

Updates `sov-celestia-adapter` to [celestia-node 0.11.0-rc15](https://github.com/celestiaorg/celestia-node/releases/tag/v0.11.0-rc15). It had a few api-breaking changes but nothing big, `share` apis now take whole `ExtendedHeader` as an input, instaed of `DataAvailabilityHeader`.
Yesterday all celestia testnets were updated to this node version.

## Testing
Ran `demo-rollup` with `DemoProverConfig::Execute` and `make test-create-token`

## Docs
n/a
