### PR TITLE
Split `rng_xfers` into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8533,6 +8533,7 @@ dependencies = [
  "sov-modules-stf-template",
  "sov-nft-module",
  "sov-risc0-adapter",
+ "sov-rng-da-service",
  "sov-rollup-interface",
  "sov-sequencer",
  "sov-state",
@@ -8755,6 +8756,20 @@ dependencies = [
  "serde",
  "sov-rollup-interface",
  "sov-zk-cycle-utils",
+]
+
+[[package]]
+name = "sov-rng-da-service"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "borsh",
+ "demo-stf",
+ "serde",
+ "sov-bank",
+ "sov-modules-api",
+ "sov-rollup-interface",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "utils/zk-cycle-macros",
     "utils/zk-cycle-utils",
     "utils/bashtestmd",
+    "utils/rng-da-service",
 
     "module-system/sov-cli",
     "module-system/sov-modules-stf-template",

--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -22,13 +22,13 @@ sov-modules-api = { path = "../../module-system/sov-modules-api", features = ["n
 sov-nft-module = { path = "../../module-system/module-implementations/sov-nft-module" }
 demo-stf = { path = "./stf", features = ["native"] }
 risc0 = { path = "./provers/risc0" }
-borsh = { workspace = true, features = ["bytes"]}
+borsh = { workspace = true, features = ["bytes"] }
 async-trait = { workspace = true, optional = true }
 anyhow = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-tracing = { workspace = true}
+tracing = { workspace = true }
 hex = { workspace = true, optional = true }
 secp256k1 = { workspace = true, optional = true }
 
@@ -39,17 +39,18 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 sov-db = { path = "../../full-node/db/sov-db" }
 sov-ethereum = { path = "../../full-node/sov-ethereum", optional = true }
-sov-sequencer = { path = "../../full-node/sov-sequencer"}
+sov-sequencer = { path = "../../full-node/sov-sequencer" }
 sov-risc0-adapter = { path = "../../adapters/risc0", features = ["native"] }
 sov-state = { path = "../../module-system/sov-state", features = ["native"] }
 sov-cli = { path = "../../module-system/sov-cli" }
-clap = { workspace = true}
+clap = { workspace = true }
 
 [dev-dependencies]
+sov-rng-da-service = { path = "../../utils/rng-da-service" }
 sov-rollup-interface = { path = "../../rollup-interface", features = ["fuzzing"] }
 sov-evm = { path = "../../module-system/module-implementations/sov-evm", features = ["smart_contracts"] }
 sov-bank = { path = "../../module-system/module-implementations/sov-bank", features = ["native"] }
-sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros"}
+sov-zk-cycle-macros = { path = "../../utils/zk-cycle-macros" }
 
 borsh = { workspace = true }
 bincode = { workspace = true }
@@ -79,9 +80,10 @@ log4rs = "1.0"
 regex = "1.5"
 
 [features]
-default = [] # Deviate from convention by making the "native" feature active by default. This aligns with how this package is meant to be used (as a binary first, library second).
-experimental = ["default", "sov-ethereum/experimental", "reth-primitives", "secp256k1", "demo-stf/experimental", "sov-ethereum/local"]  
-	
+default = [
+] # Deviate from convention by making the "native" feature active by default. This aligns with how this package is meant to be used (as a binary first, library second).
+experimental = ["default", "sov-ethereum/experimental", "reth-primitives", "secp256k1", "demo-stf/experimental", "sov-ethereum/local"]
+
 bench = ["async-trait", "hex", "sov-risc0-adapter/bench", "sov-zk-cycle-macros/bench", "risc0/bench"]
 offchain = ["demo-stf/offchain"]
 
@@ -96,12 +98,6 @@ name = "rollup_coarse_measure"
 path = "benches/node/rollup_coarse_measure.rs"
 harness = false
 required-features = ["bench"]
-
-[[bench]]
-name = "rng_xfers"
-path = "benches/node/rng_xfers.rs"
-required-features = ["bench"]
-
 
 [[bench]]
 name = "prover_bench"
@@ -121,4 +117,3 @@ path = "src/bin/sov_nft_script.rs"
 [[bin]]
 name = "sov-demo-rollup"
 path = "src/main.rs"
-

--- a/examples/demo-rollup/benches/node/rollup_bench.rs
+++ b/examples/demo-rollup/benches/node/rollup_bench.rs
@@ -1,4 +1,3 @@
-mod rng_xfers;
 use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -8,9 +7,9 @@ use anyhow::Context;
 use criterion::{criterion_group, criterion_main, Criterion};
 use demo_stf::genesis_config::{get_genesis_config, GenesisPaths};
 use demo_stf::App;
-use rng_xfers::{RngDaService, RngDaSpec};
 use sov_db::ledger_db::{LedgerDB, SlotCommit};
 use sov_risc0_adapter::host::Risc0Verifier;
+use sov_rng_da_service::{RngDaService, RngDaSpec};
 use sov_rollup_interface::mocks::{
     MockAddress, MockBlock, MockBlockHeader, MOCK_SEQUENCER_DA_ADDRESS,
 };

--- a/examples/demo-rollup/benches/node/rollup_coarse_measure.rs
+++ b/examples/demo-rollup/benches/node/rollup_coarse_measure.rs
@@ -1,4 +1,3 @@
-mod rng_xfers;
 use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -8,9 +7,9 @@ use anyhow::Context;
 use demo_stf::genesis_config::{get_genesis_config, GenesisPaths};
 use demo_stf::App;
 use prometheus::{Histogram, HistogramOpts, Registry};
-use rng_xfers::{RngDaService, RngDaSpec};
 use sov_db::ledger_db::{LedgerDB, SlotCommit};
 use sov_risc0_adapter::host::Risc0Verifier;
+use sov_rng_da_service::{RngDaService, RngDaSpec};
 use sov_rollup_interface::mocks::{
     MockAddress, MockBlock, MockBlockHeader, MOCK_SEQUENCER_DA_ADDRESS,
 };

--- a/utils/rng-da-service/Cargo.toml
+++ b/utils/rng-da-service/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sov-rng-da-service"
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+resolver = "2"
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+borsh = { workspace = true }
+serde = { workspace = true }
+# Sovereign dependencies
+demo-stf = { path = "../../examples/demo-rollup/stf" }
+sov-bank = { path = "../../module-system/module-implementations/sov-bank" }
+sov-modules-api = { path = "../../module-system/sov-modules-api" }
+sov-rollup-interface = { path = "../../rollup-interface" }

--- a/utils/rng-da-service/Cargo.toml
+++ b/utils/rng-da-service/Cargo.toml
@@ -18,5 +18,5 @@ serde = { workspace = true }
 # Sovereign dependencies
 demo-stf = { path = "../../examples/demo-rollup/stf" }
 sov-bank = { path = "../../module-system/module-implementations/sov-bank" }
-sov-modules-api = { path = "../../module-system/sov-modules-api" }
-sov-rollup-interface = { path = "../../rollup-interface" }
+sov-modules-api = { path = "../../module-system/sov-modules-api", features = ["native"] }
+sov-rollup-interface = { path = "../../rollup-interface", features = ["native"] }

--- a/utils/rng-da-service/src/lib.rs
+++ b/utils/rng-da-service/src/lib.rs
@@ -16,6 +16,8 @@ use sov_rollup_interface::mocks::{
 use sov_rollup_interface::services::da::DaService;
 
 pub fn sender_address_with_pkey() -> (Address, DefaultPrivateKey) {
+    // TODO: maybe generate address and private key randomly, instead of
+    // hardcoding them?
     let addr_bytes = "sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqmlyjd6".to_string();
     let addr = Address::from(
         AddressBech32::try_from(addr_bytes)

--- a/utils/rng-da-service/src/lib.rs
+++ b/utils/rng-da-service/src/lib.rs
@@ -18,7 +18,7 @@ use sov_rollup_interface::services::da::DaService;
 pub fn sender_address_with_pkey() -> (Address, DefaultPrivateKey) {
     let addr_bytes = "sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqmlyjd6".to_string();
     let addr = Address::from(
-        AddressBech32::try_from(addr_bytes as &[u8])
+        AddressBech32::try_from(addr_bytes)
             .unwrap_or_else(|e| panic!("Failed generating sender address: {:?}", e)),
     );
 
@@ -188,4 +188,15 @@ pub fn generate_create(start_nonce: u64) -> Vec<u8> {
     let ser_tx = tx.try_to_vec().unwrap();
     message_vec.push(ser_tx);
     message_vec.try_to_vec().unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sender_address_with_pkey_okay() {
+        // Checks that it doesn't crash.
+        sender_address_with_pkey();
+    }
 }

--- a/utils/rng-da-service/src/lib.rs
+++ b/utils/rng-da-service/src/lib.rs
@@ -16,7 +16,7 @@ use sov_rollup_interface::mocks::{
 use sov_rollup_interface::services::da::DaService;
 
 pub fn sender_address_with_pkey() -> (Address, DefaultPrivateKey) {
-    let addr_bytes = b"sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqmlyjd6";
+    let addr_bytes = "sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqmlyjd6".to_string();
     let addr = Address::from(
         AddressBech32::try_from(addr_bytes as &[u8])
             .unwrap_or_else(|e| panic!("Failed generating sender address: {:?}", e)),

--- a/utils/rng-da-service/src/lib.rs
+++ b/utils/rng-da-service/src/lib.rs
@@ -15,78 +15,26 @@ use sov_rollup_interface::mocks::{
 };
 use sov_rollup_interface::services::da::DaService;
 
-#[derive(Clone)]
-/// A simple DaService for a random number generator.
-pub struct RngDaService;
-
-fn generate_transfers(n: usize, start_nonce: u64) -> Vec<u8> {
-    let sender_address =
-        "sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqmlyjd6".to_string();
-    let token_name = "sov-test-token";
-    let sa = Address::from(
-        AddressBech32::try_from(sender_address)
-            .unwrap_or_else(|_e| panic!("Failed generating transfers")),
+pub fn sender_address_with_pkey() -> (Address, DefaultPrivateKey) {
+    let addr_bytes = b"sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqmlyjd6";
+    let addr = Address::from(
+        AddressBech32::try_from(addr_bytes as &[u8])
+            .unwrap_or_else(|e| panic!("Failed generating sender address: {:?}", e)),
     );
-    let token_address = sov_bank::get_token_address::<DefaultContext>(token_name, sa.as_ref(), 11);
-    let mut message_vec = vec![];
-    for i in 1..(n + 1) {
-        let priv_key = DefaultPrivateKey::generate();
-        let address: <DefaultContext as Spec>::Address = priv_key.pub_key().to_address();
-        let pk = DefaultPrivateKey::from_hex("236e80cb222c4ed0431b093b3ac53e6aa7a2273fe1f4351cd354989a823432a27b758bf2e7670fafaf6bf0015ce0ff5aa802306fc7e3f45762853ffc37180fe6").unwrap();
-        let msg: sov_bank::CallMessage<DefaultContext> = CallMessage::<DefaultContext>::Transfer {
-            to: address,
-            coins: Coins {
-                amount: 1,
-                token_address,
-            },
-        };
-        let enc_msg =
-            <Runtime<DefaultContext, RngDaSpec> as EncodeCall<Bank<DefaultContext>>>::encode_call(
-                msg,
-            );
-        let tx =
-            Transaction::<DefaultContext>::new_signed_tx(&pk, enc_msg, start_nonce + (i as u64));
-        let ser_tx = tx.try_to_vec().unwrap();
-        message_vec.push(ser_tx)
-    }
-    message_vec.try_to_vec().unwrap()
-}
-
-fn generate_create(start_nonce: u64) -> Vec<u8> {
-    let sender_address =
-        "sov15vspj48hpttzyvxu8kzq5klhvaczcpyxn6z6k0hwpwtzs4a6wkvqmlyjd6".to_string();
-    let mut message_vec = vec![];
 
     let pk = DefaultPrivateKey::from_hex("236e80cb222c4ed0431b093b3ac53e6aa7a2273fe1f4351cd354989a823432a27b758bf2e7670fafaf6bf0015ce0ff5aa802306fc7e3f45762853ffc37180fe6").unwrap();
-    let minter_address = Address::from(
-        AddressBech32::try_from(sender_address)
-            .unwrap_or_else(|_e| panic!("Failed generating token create transaction")),
-    );
-    let msg: sov_bank::CallMessage<DefaultContext> = CallMessage::<DefaultContext>::CreateToken {
-        salt: 11,
-        token_name: "sov-test-token".to_string(),
-        initial_balance: 100000000,
-        minter_address,
-        authorized_minters: vec![minter_address],
-    };
-    let enc_msg =
-        <Runtime<DefaultContext, RngDaSpec> as EncodeCall<Bank<DefaultContext>>>::encode_call(msg);
-    let tx = Transaction::<DefaultContext>::new_signed_tx(&pk, enc_msg, start_nonce);
-    let ser_tx = tx.try_to_vec().unwrap();
-    message_vec.push(ser_tx);
-    message_vec.try_to_vec().unwrap()
+
+    (addr, pk)
 }
+
+#[derive(Clone, Default)]
+/// A simple [`DaService`] for a random number generator.
+pub struct RngDaService;
 
 impl RngDaService {
-    /// Instantiate a new [`RngDaService`]
+    /// Instantiates a new [`RngDaService`].
     pub fn new() -> Self {
         RngDaService
-    }
-}
-
-impl Default for RngDaService {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -194,4 +142,50 @@ impl DaVerifier for RngDaVerifier {
     ) -> Result<<Self::Spec as DaSpec>::ValidityCondition, Self::Error> {
         Ok(MockValidityCond { is_valid: true })
     }
+}
+
+pub fn generate_transfers(n: usize, start_nonce: u64) -> Vec<u8> {
+    let token_name = "sov-test-token";
+    let (sa, pk) = sender_address_with_pkey();
+    let token_address = sov_bank::get_token_address::<DefaultContext>(token_name, sa.as_ref(), 11);
+    let mut message_vec = vec![];
+    for i in 1..(n + 1) {
+        let priv_key = DefaultPrivateKey::generate();
+        let address: <DefaultContext as Spec>::Address = priv_key.pub_key().to_address();
+        let msg: sov_bank::CallMessage<DefaultContext> = CallMessage::<DefaultContext>::Transfer {
+            to: address,
+            coins: Coins {
+                amount: 1,
+                token_address,
+            },
+        };
+        let enc_msg =
+            <Runtime<DefaultContext, RngDaSpec> as EncodeCall<Bank<DefaultContext>>>::encode_call(
+                msg,
+            );
+        let tx =
+            Transaction::<DefaultContext>::new_signed_tx(&pk, enc_msg, start_nonce + (i as u64));
+        let ser_tx = tx.try_to_vec().unwrap();
+        message_vec.push(ser_tx)
+    }
+    message_vec.try_to_vec().unwrap()
+}
+
+pub fn generate_create(start_nonce: u64) -> Vec<u8> {
+    let mut message_vec = vec![];
+
+    let (minter_address, pk) = sender_address_with_pkey();
+    let msg: sov_bank::CallMessage<DefaultContext> = CallMessage::<DefaultContext>::CreateToken {
+        salt: 11,
+        token_name: "sov-test-token".to_string(),
+        initial_balance: 100000000,
+        minter_address,
+        authorized_minters: vec![minter_address],
+    };
+    let enc_msg =
+        <Runtime<DefaultContext, RngDaSpec> as EncodeCall<Bank<DefaultContext>>>::encode_call(msg);
+    let tx = Transaction::<DefaultContext>::new_signed_tx(&pk, enc_msg, start_nonce);
+    let ser_tx = tx.try_to_vec().unwrap();
+    message_vec.push(ser_tx);
+    message_vec.try_to_vec().unwrap()
 }


### PR DESCRIPTION
# Description
I'm splitting off `rng_xfers` into its own utility crate, to facilitate code reuse with the block explorer. 

## Testing
I'm mostly relying on existing tests, which covert pretty much all of this logic.