### PR TITLE
Rename `CI_SKIP_GUEST_BUILD`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -104,7 +104,7 @@ jobs:
     runs-on: buildjet-8vcpu-ubuntu-2204
     timeout-minutes: 60
     env:
-      CI_SKIP_GUEST_BUILD: "1"
+      SKIP_GUEST_BUILD: "1"
     steps:
       - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
@@ -229,7 +229,7 @@ jobs:
     timeout-minutes: 90
     env:
       RUSTDOCFLAGS: "-D warnings"
-      CI_SKIP_GUEST_BUILD: "1"
+      SKIP_GUEST_BUILD: "1"
     steps:
       - uses: actions/checkout@v3
         # Not sure installing `mold` is actually needed, but it's what the

--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,12 @@ lint:  ## cargo check and clippy. Skip clippy on guest code since it's not suppo
 	cargo +nightly fmt --all --check
 	cargo check --all-targets --all-features
 	$(MAKE) check-fuzz
-	CI_SKIP_GUEST_BUILD=1 cargo clippy --all-targets --all-features
+	SKIP_GUEST_BUILD=1 cargo clippy --all-targets --all-features
 
 lint-fix:  ## cargo fmt, fix and clippy. Skip clippy on guest code since it's not supported by risc0
 	cargo +nightly fmt --all
 	cargo fix --allow-dirty
-	CI_SKIP_GUEST_BUILD=1 cargo clippy --fix --allow-dirty
+	SKIP_GUEST_BUILD=1 cargo clippy --fix --allow-dirty
 
 check-features: ## Checks that project compiles with all combinations of features.
 	cargo hack check --workspace --feature-powerset --exclude-features --all-targets

--- a/examples/demo-rollup/provers/risc0/build.rs
+++ b/examples/demo-rollup/provers/risc0/build.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 fn main() {
-    if std::env::var("CI_SKIP_GUEST_BUILD").is_ok() {
+    if std::env::var("SKIP_GUEST_BUILD").is_ok() {
         println!("Skipping guest build for CI run");
         let out_dir = std::env::var_os("OUT_DIR").unwrap();
         let out_dir = std::path::Path::new(&out_dir);

--- a/sov-rollup-starter/provers/risc0/build.rs
+++ b/sov-rollup-starter/provers/risc0/build.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 fn main() {
-    if std::env::var("CI_SKIP_GUEST_BUILD").is_ok() {
+    if std::env::var("SKIP_GUEST_BUILD").is_ok() {
         println!("Skipping guest build for CI run");
         let out_dir = std::env::var_os("OUT_DIR").unwrap();
         let out_dir = std::path::Path::new(&out_dir);


### PR DESCRIPTION
Non-functional change: rename `CI_SKIP_GUEST_BUILD` to `SKIP_GUEST_BUILD`. I'd argue the name shouldn't mention CI, as the functionality is independent of CI, it just happens to be used in CI.