### PR TITLE
feat(rpc): implement `ledger_getEvents`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8621,6 +8621,7 @@ name = "sov-ledger-rpc"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "futures",
  "jsonrpsee 0.20.1",
  "serde",

--- a/full-node/sov-ledger-rpc/Cargo.toml
+++ b/full-node/sov-ledger-rpc/Cargo.toml
@@ -17,7 +17,7 @@ jsonrpsee = { workspace = true }
 serde = "1"
 sov-rollup-interface = { path = "../../rollup-interface", features = ["native"] }
 # Client dependencies
-# (None)
+async-trait = { workspace = true, optional = true }
 # Server dependencies
 anyhow = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
@@ -33,4 +33,4 @@ sov-ledger-rpc = { path = ".", features = ["client", "server"] }
 [features]
 default = ["client", "server"]
 server = ["anyhow", "futures", "jsonrpsee/server", "sov-modules-api"]
-client = ["jsonrpsee/client", "jsonrpsee/macros"]
+client = ["jsonrpsee/client", "jsonrpsee/macros", "async-trait"]

--- a/full-node/sov-ledger-rpc/src/server.rs
+++ b/full-node/sov-ledger-rpc/src/server.rs
@@ -71,7 +71,11 @@ where
             .map_err(|e| to_jsonrpsee_error_object(e, LEDGER_RPC_ERROR))
     })?;
     rpc.register_method("ledger_getEvents", move |params, db| {
-        let ids: Vec<EventIdentifier> = params.parse()?;
+        let ids: Vec<EventIdentifier> = if params.as_str().is_some() {
+            params.parse()?
+        } else {
+            vec![]
+        };
         db.get_events(&ids)
             .map_err(|e| to_jsonrpsee_error_object(e, LEDGER_RPC_ERROR))
     })?;

--- a/full-node/sov-ledger-rpc/tests/empty_ledger.rs
+++ b/full-node/sov-ledger-rpc/tests/empty_ledger.rs
@@ -4,10 +4,13 @@ use std::sync::Arc;
 use jsonrpsee::core::client::{ClientT, SubscriptionClientT};
 use jsonrpsee::core::params::ArrayParams;
 use sov_db::ledger_db::LedgerDB;
-use sov_ledger_rpc::client::RpcClient;
+use sov_ledger_rpc::client::{RpcClient, RpcExt};
 use sov_ledger_rpc::server::rpc_module;
 use sov_ledger_rpc::HexHash;
-use sov_rollup_interface::rpc::{BatchResponse, QueryMode, SlotResponse, TxResponse};
+use sov_rollup_interface::rpc::{
+    BatchResponse, EventIdentifier, QueryMode, SlotResponse, TxIdAndOffset, TxIdentifier,
+    TxResponse,
+};
 use tempfile::tempdir;
 
 async fn rpc_server() -> (jsonrpsee::server::ServerHandle, SocketAddr) {
@@ -96,6 +99,18 @@ async fn getters_succeed() {
         .unwrap();
     rpc_client
         .get_txs_range(0, 1, QueryMode::Compact)
+        .await
+        .unwrap();
+
+    rpc_client.get_events(vec![]).await.unwrap();
+    rpc_client
+        .get_events(vec![
+            EventIdentifier::Number(1),
+            EventIdentifier::TxIdAndOffset(TxIdAndOffset {
+                tx_id: TxIdentifier::Number(10),
+                offset: 10,
+            }),
+        ])
         .await
         .unwrap();
 }


### PR DESCRIPTION
# Description

Implement `ledger_getEvents` through the extension trait. Not a fan of this solution but it saves you from the pain of having to handroll your own rpc macro.

## Linked Issues
- Fixes #1037

## Testing
Added `ledger_getEvents` to `getters_succeed` test
