### PR TITLE
CI workflow to manually delete caches

### DIFF
--- a/.github/workflows/delete_cache.yml
+++ b/.github/workflows/delete_cache.yml
@@ -1,0 +1,21 @@
+# See <https://github.com/BuildJet/cache-delete>. Useful for debugging/solving
+# caching issues.
+
+name: Manually delete a BuildJet cache entry
+
+on:
+  workflow_dispatch:
+    inputs:
+      cache_key:
+        description: 'BuildJet cache key to delete'
+        required: true
+        type: string
+
+jobs:
+  manually-delete-buildjet-cache:
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v3
+      - uses: buildjet/cache-delete@v1
+        with:
+          cache_key: ${{ inputs.cache_key }}


### PR DESCRIPTION
# Description
The GH Actions UI offers a way to list and manually delete cache entries. There's no UI solution for BuildJet, but we can use a custom workflow to manually delete entries. I'm not yet sure if listing cache entries if possible, for now the cache entry key to delete must be copy-pasted from logs.