### PR TITLE
Fix `cargo risczero install` 403s by setting `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,6 +88,8 @@ jobs:
         run: cargo install cargo-risczero
       - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
         run: cargo risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run lint
         run: |
           if ! make lint ; then
@@ -152,6 +154,8 @@ jobs:
         run: cargo install cargo-risczero
       - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
         run: cargo risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo nextest run --workspace --all-features
   test:
     name: test
@@ -175,6 +179,8 @@ jobs:
         run: cargo install cargo-risczero
       - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
         run: cargo risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # `cargo-nextest` does not support doctests (yet?), so we have to run them
       # separately.
       # TODO: https://github.com/nextest-rs/nextest/issues/16
@@ -207,6 +213,8 @@ jobs:
         run: cargo install cargo-risczero
       - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
         run: cargo risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
@@ -314,6 +322,8 @@ jobs:
         run: cargo install cargo-risczero
       - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
         run: cargo risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile README.md to Bash
         run: cargo run --bin bashtestmd -- --input examples/demo-rollup/README.md --output demo-rollup-readme.sh --tag test-ci
       - run: cat demo-rollup-readme.sh


### PR DESCRIPTION
# Description
Fixes this kind of failure: https://github.com/Sovereign-Labs/sovereign-sdk/actions/runs/6552450394/job/17795872741.
Context: https://github.com/risc0/risc0/issues/834.

