### PR TITLE
Run `demo-rollup`'s README checker on a better runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -301,9 +301,7 @@ jobs:
         run: git diff --exit-code
   check-demo-rollup-bash-commands:
     runs-on: buildjet-2vcpu-ubuntu-2204
-    # `test` has already built dependencies, so we can share
-    # caches (the profile is `dev` in both cases).
-    needs: test
+    needs: nextest
     steps:
       - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -300,7 +300,7 @@ jobs:
         # up to date.
         run: git diff --exit-code
   check-demo-rollup-bash-commands:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-2vcpu-ubuntu-2204
     # `test` has already built dependencies, so we can share
     # caches (the profile is `dev` in both cases).
     needs: test


### PR DESCRIPTION
Some recent changes to the `demo-rollup` README and `Makefile` seem to have made `check-demo-rollup-bash-commands` significantly slower to run, and it's become the main bottleneck in CI besides the usual suspect `hack`. A 2vCPU runner can probably help us a lot here, at low cost.