### PR TITLE
Remove `NativeDB::set_value` in favour of `set_values`

### DIFF
--- a/full-node/db/sov-db/src/native_db.rs
+++ b/full-node/db/sov-db/src/native_db.rs
@@ -43,11 +43,6 @@ impl NativeDB {
             .map(Option::flatten)
     }
 
-    /// Sets a key-value pair in the [`NativeDB`].
-    pub fn set_value(&self, key: Vec<u8>, value: Option<Vec<u8>>) -> anyhow::Result<()> {
-        self.set_values(vec![(key, value)])
-    }
-
     /// Sets a sequence of key-value pairs in the [`NativeDB`]. The write is atomic.
     pub fn set_values(
         &self,
@@ -160,7 +155,7 @@ mod tests {
         let db = NativeDB::with_path(tmpdir.path()).unwrap();
 
         let key = b"deleted".to_vec();
-        db.set_value(key.clone(), None).unwrap();
+        db.set_values(vec![(key.clone(), None)]).unwrap();
         assert_eq!(db.get_value_option(&key).unwrap(), None);
     }
 

--- a/full-node/db/sov-db/src/native_db.rs
+++ b/full-node/db/sov-db/src/native_db.rs
@@ -46,7 +46,7 @@ impl NativeDB {
     /// Sets a sequence of key-value pairs in the [`NativeDB`]. The write is atomic.
     pub fn set_values(
         &self,
-        key_value_pairs: Vec<(Vec<u8>, Option<Vec<u8>>)>,
+        key_value_pairs: impl IntoIterator<Item = (Vec<u8>, Option<Vec<u8>>)>,
     ) -> anyhow::Result<()> {
         let batch = SchemaBatch::default();
         for (key, value) in key_value_pairs {

--- a/full-node/db/sov-schema-db/src/lib.rs
+++ b/full-node/db/sov-schema-db/src/lib.rs
@@ -55,7 +55,7 @@ impl DB {
         column_families: impl IntoIterator<Item = impl Into<String>>,
         db_opts: &rocksdb::Options,
     ) -> anyhow::Result<Self> {
-        let db = DB::open_cf(
+        let db = DB::open_with_cfds(
             db_opts,
             path,
             name,
@@ -69,7 +69,8 @@ impl DB {
     }
 
     /// Open RocksDB with the provided column family descriptors.
-    fn open_cf(
+    /// This allows to configure options for each column family.
+    pub fn open_with_cfds(
         db_opts: &rocksdb::Options,
         path: impl AsRef<Path>,
         name: &'static str,

--- a/module-system/sov-state/src/prover_storage.rs
+++ b/module-system/sov-state/src/prover_storage.rs
@@ -167,8 +167,7 @@ impl<S: MerkleProofSpec> Storage for ProverStorage<S> {
                 accessory_writes
                     .ordered_writes
                     .iter()
-                    .map(|(k, v_opt)| (k.key.to_vec(), v_opt.as_ref().map(|v| v.value.to_vec())))
-                    .collect(),
+                    .map(|(k, v_opt)| (k.key.to_vec(), v_opt.as_ref().map(|v| v.value.to_vec()))),
             )
             .expect("native db write must succeed");
 


### PR DESCRIPTION
As it is only used in test.

Explicit use of `anyhow::Result` instead of importing it, I believe it improves readability.

This is ongoing effort of simplifying public interface of `sov-db` and `sov-schema-db`


