### PR TITLE
Re-export anyhow from rollup-interface

### DIFF
--- a/rollup-interface/src/lib.rs
+++ b/rollup-interface/src/lib.rs
@@ -8,7 +8,6 @@ pub use state_machine::*;
 
 mod node;
 
-pub use anyhow;
 pub use borsh::maybestd;
-pub use digest;
 pub use node::*;
+pub use {anyhow, digest};

--- a/rollup-interface/src/lib.rs
+++ b/rollup-interface/src/lib.rs
@@ -8,6 +8,7 @@ pub use state_machine::*;
 
 mod node;
 
+pub use anyhow;
 pub use borsh::maybestd;
 pub use digest;
 pub use node::*;


### PR DESCRIPTION
# Description
Re-export anyhow from `sov-rollup-interface`. This makes it easier to avoid version mismatches.
