### PR TITLE
chore: freeze clap version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ tiny-keccak = "2.0.2"
 tracing = "0.1.40"
 bech32 = "0.9.1"
 derive_more = "0.99.11"
-clap = { version = "4.2.7", features = ["derive"] }
+clap = { version = "4.4.5", features = ["derive"] }
 toml = "0.8.0"
 jsonrpsee = { version = "0.20.1", features = ["jsonrpsee-types"] }
 schemars = { version = "0.8.12", features = ["derive"] }

--- a/adapters/solana/da_client/Cargo.toml
+++ b/adapters/solana/da_client/Cargo.toml
@@ -10,7 +10,7 @@ anchor-lang = "0.28.0"
 anchor-client = "0.28.0"
 solana-sdk = "1.16"
 bs58 = "0.5.0"
-clap = {version="4.4.6", features = ['derive']}
+clap = { workspace = true }
 blockroot = {path = "../solana_da_programs/programs/blockroot", features = ["no-entrypoint"]}
 solana-runtime = "1.16"
 solana-rpc-client = "1.16"

--- a/examples/simple-nft-module/Cargo.toml
+++ b/examples/simple-nft-module/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true }
 sov-modules-api = { path = "../../module-system/sov-modules-api" }
 sov-state = { path = "../../module-system/sov-state" }
 
-clap = { workspace = true, optional = true, features = ["derive"] }
+clap = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }

--- a/module-system/module-implementations/sov-bank/Cargo.toml
+++ b/module-system/module-implementations/sov-bank/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
-clap = { workspace = true, optional = true, features = ["derive"] }
+clap = { workspace = true, optional = true }
 jsonrpsee = { workspace = true, features = ["macros", "client-core", "server"], optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }

--- a/utils/bashtestmd/Cargo.toml
+++ b/utils/bashtestmd/Cargo.toml
@@ -12,6 +12,6 @@ publish = false
 autotests = false
 
 [dependencies]
-clap = { version = "4.4", features = ["derive"] }
+clap = { workspace = true }
 markdown = "1.0.0-alpha.14"
 shell-escape = "0.1.5"

--- a/utils/zk-cycle-utils/tracer/Cargo.toml
+++ b/utils/zk-cycle-utils/tracer/Cargo.toml
@@ -13,4 +13,4 @@ regex = "1.5.4"
 prettytable-rs = "^0.10"
 textwrap = "0.16.0"
 indicatif = "0.17.6"
-clap = {version = "4.3.21", features = ['derive']}
+clap = { workspace = true }


### PR DESCRIPTION
Clap introduced a change that breaks as it requires rustc to be 1.66, and stable might be behind that.

This might be a violation of SEMVER, but it is debatable, as the rust guidelines suggests compiler updates to be introduced as patch - which is a rather questionable decision as this might break.

This commit freezes the clap version so it will be updated manually, when required. With that, we don't incur risks of breaking changes on patch update.

Reference issue:
https://github.com/clap-rs/clap/issues/5158