### PR TITLE
Rename generic `DaServiceConfig` to `CelestiaConfig`

### DIFF
--- a/adapters/celestia/src/lib.rs
+++ b/adapters/celestia/src/lib.rs
@@ -7,6 +7,6 @@ mod utils;
 pub mod verifier;
 
 #[cfg(feature = "native")]
-pub use da_service::{CelestiaService, DaServiceConfig};
+pub use da_service::{CelestiaConfig, CelestiaService};
 
 pub use crate::celestia::*;

--- a/examples/demo-rollup/benches/node/rollup_bench.rs
+++ b/examples/demo-rollup/benches/node/rollup_bench.rs
@@ -30,7 +30,7 @@ fn rollup_bench(_bench: &mut Criterion) {
         .sample_size(10)
         .measurement_time(Duration::from_secs(20));
     let rollup_config_path = "benches/node/rollup_config.toml".to_string();
-    let mut rollup_config: RollupConfig<sov_celestia_adapter::DaServiceConfig> =
+    let mut rollup_config: RollupConfig<sov_celestia_adapter::CelestiaConfig> =
         from_toml_path(&rollup_config_path)
             .context("Failed to read rollup configuration")
             .unwrap();

--- a/examples/demo-rollup/benches/node/rollup_coarse_measure.rs
+++ b/examples/demo-rollup/benches/node/rollup_coarse_measure.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<(), anyhow::Error> {
     }
 
     let rollup_config_path = "benches/node/rollup_config.toml".to_string();
-    let mut rollup_config: RollupConfig<sov_celestia_adapter::DaServiceConfig> =
+    let mut rollup_config: RollupConfig<sov_celestia_adapter::CelestiaConfig> =
         from_toml_path(&rollup_config_path)
             .context("Failed to read rollup configuration")
             .unwrap();

--- a/examples/demo-rollup/benches/prover/prover_bench.rs
+++ b/examples/demo-rollup/benches/prover/prover_bench.rs
@@ -141,7 +141,7 @@ async fn main() -> Result<(), anyhow::Error> {
     }
 
     let rollup_config_path = "benches/prover/rollup_config.toml".to_string();
-    let mut rollup_config: RollupConfig<sov_celestia_adapter::DaServiceConfig> =
+    let mut rollup_config: RollupConfig<sov_celestia_adapter::CelestiaConfig> =
         from_toml_path(&rollup_config_path)
             .context("Failed to read rollup configuration")
             .unwrap();

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use demo_stf::genesis_config::StorageConfig;
 use demo_stf::runtime::Runtime;
 use sov_celestia_adapter::verifier::{CelestiaSpec, CelestiaVerifier, RollupParams};
-use sov_celestia_adapter::{CelestiaService, DaServiceConfig};
+use sov_celestia_adapter::{CelestiaConfig, CelestiaService};
 use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
 use sov_modules_api::Spec;
 use sov_modules_rollup_template::{RollupTemplate, WalletTemplate};
@@ -21,7 +21,7 @@ pub struct CelestiaDemoRollup {}
 impl RollupTemplate for CelestiaDemoRollup {
     type DaService = CelestiaService;
     type DaSpec = CelestiaSpec;
-    type DaConfig = DaServiceConfig;
+    type DaConfig = CelestiaConfig;
     type Vm = Risc0Host<'static>;
 
     type ZkContext = ZkDefaultContext;

--- a/examples/demo-rollup/src/main.rs
+++ b/examples/demo-rollup/src/main.rs
@@ -74,7 +74,7 @@ async fn new_rollup_with_celestia_da(
         rollup_config_path
     );
 
-    let rollup_config: RollupConfig<sov_celestia_adapter::DaServiceConfig> =
+    let rollup_config: RollupConfig<sov_celestia_adapter::CelestiaConfig> =
         from_toml_path(rollup_config_path).context("Failed to read rollup configuration")?;
 
     let mock_rollup = CelestiaDemoRollup {};

--- a/full-node/sov-stf-runner/src/config.rs
+++ b/full-node/sov-stf-runner/src/config.rs
@@ -89,7 +89,7 @@ mod tests {
 
         let config_file = create_config_from(config);
 
-        let config: RollupConfig<sov_celestia_adapter::DaServiceConfig> =
+        let config: RollupConfig<sov_celestia_adapter::CelestiaConfig> =
             from_toml_path(config_file.path()).unwrap();
         let expected = RollupConfig {
             runner: RunnerConfig {
@@ -100,7 +100,7 @@ mod tests {
                 },
             },
 
-            da: sov_celestia_adapter::DaServiceConfig {
+            da: sov_celestia_adapter::CelestiaConfig {
                 celestia_rpc_auth_token: "SECRET_RPC_TOKEN".to_string(),
                 celestia_rpc_address: "http://localhost:11111/".into(),
                 max_celestia_response_body_size: 980,


### PR DESCRIPTION
So it is clear where it belongs
