### PR TITLE
Change direction of the iterator

### DIFF
--- a/full-node/db/sov-schema-db/src/iterator.rs
+++ b/full-node/db/sov-schema-db/src/iterator.rs
@@ -81,6 +81,19 @@ where
         Ok(())
     }
 
+    /// Reverses iterator direction.
+    pub fn rev(self) -> Self {
+        let new_direction = match self.direction {
+            ScanDirection::Forward => ScanDirection::Backward,
+            ScanDirection::Backward => ScanDirection::Forward,
+        };
+        SchemaIterator {
+            db_iter: self.db_iter,
+            direction: new_direction,
+            phantom: Default::default(),
+        }
+    }
+
     fn next_impl(&mut self) -> Result<Option<(S::Key, S::Value)>> {
         let _timer = SCHEMADB_ITER_LATENCY_SECONDS
             .with_label_values(&[S::COLUMN_FAMILY_NAME])

--- a/full-node/db/sov-schema-db/src/lib.rs
+++ b/full-node/db/sov-schema-db/src/lib.rs
@@ -174,19 +174,6 @@ impl DB {
         self.iter_with_direction::<S>(opts, ScanDirection::Forward)
     }
 
-    /// Returns a backward [`SchemaIterator`] on a certain schema with the default read options.
-    pub fn rev_iter<S: Schema>(&self) -> anyhow::Result<SchemaIterator<S>> {
-        self.iter_with_direction::<S>(Default::default(), ScanDirection::Backward)
-    }
-
-    /// Returns a backward [`SchemaIterator`] on a certain schema with the provided read options.
-    pub fn rev_iter_with_opts<S: Schema>(
-        &self,
-        opts: ReadOptions,
-    ) -> anyhow::Result<SchemaIterator<S>> {
-        self.iter_with_direction::<S>(opts, ScanDirection::Backward)
-    }
-
     /// Writes a group of records wrapped in a [`SchemaBatch`].
     pub fn write_schemas(&self, batch: SchemaBatch) -> anyhow::Result<()> {
         let _timer = SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS

--- a/full-node/db/sov-schema-db/tests/iterator_test.rs
+++ b/full-node/db/sov-schema-db/tests/iterator_test.rs
@@ -141,7 +141,7 @@ impl TestDB {
     }
 
     fn rev_iter(&self) -> SchemaIterator<TestSchema> {
-        self.db.rev_iter().expect("Failed to create iterator.")
+        self.db.iter().expect("Failed to create iterator.").rev()
     }
 }
 


### PR DESCRIPTION
# Description

To simplify API, instead of having 2 methods `rev_iter()` and `rev_iter_with_opts()`, `rev()` can be called on iterator itself.

## Testing
Existing tests are passing

## Docs
Documentation has been updated
