### PR TITLE
Add `DbSnapshot` to `sov-db-schema`

### DIFF
--- a/full-node/db/sov-db/src/native_db.rs
+++ b/full-node/db/sov-db/src/native_db.rs
@@ -48,7 +48,7 @@ impl NativeDB {
         &self,
         key_value_pairs: impl IntoIterator<Item = (Vec<u8>, Option<Vec<u8>>)>,
     ) -> anyhow::Result<()> {
-        let batch = SchemaBatch::default();
+        let mut batch = SchemaBatch::default();
         for (key, value) in key_value_pairs {
             batch.put::<ModuleAccessoryState>(&key, &value)?;
         }

--- a/full-node/db/sov-schema-db/src/lib.rs
+++ b/full-node/db/sov-schema-db/src/lib.rs
@@ -285,7 +285,6 @@ pub enum Operation {
 /// they are added to the [`SchemaBatch`].
 #[derive(Debug, Default)]
 pub struct SchemaBatch {
-    // TODO: Why do we need a mutex here?
     last_writes: HashMap<ColumnFamilyName, HashMap<SchemaKey, Operation>>,
 }
 

--- a/full-node/db/sov-schema-db/src/lib.rs
+++ b/full-node/db/sov-schema-db/src/lib.rs
@@ -331,8 +331,10 @@ impl SchemaBatch {
         key: &impl KeyCodec<S>,
     ) -> anyhow::Result<Option<Operation>> {
         let key = key.encode_key()?;
-        let column_writes = self.last_writes.get(&S::COLUMN_FAMILY_NAME).unwrap();
-        Ok(column_writes.get(&key).cloned())
+        if let Some(column_writes) = self.last_writes.get(&S::COLUMN_FAMILY_NAME) {
+            return Ok(column_writes.get(&key).cloned());
+        }
+        Ok(None)
     }
 }
 

--- a/full-node/db/sov-schema-db/src/lib.rs
+++ b/full-node/db/sov-schema-db/src/lib.rs
@@ -398,7 +398,7 @@ mod tests {
         db_opts.create_if_missing(true);
         db_opts.create_missing_column_families(true);
 
-        let db = DB::open(&tmpdir.path(), "test_db_debug", column_families, &db_opts)
+        let db = DB::open(tmpdir.path(), "test_db_debug", column_families, &db_opts)
             .expect("Failed to open DB.");
 
         let db_debug = format!("{:?}", db);

--- a/full-node/db/sov-schema-db/src/lib.rs
+++ b/full-node/db/sov-schema-db/src/lib.rs
@@ -384,3 +384,25 @@ fn default_write_options() -> rocksdb::WriteOptions {
     opts.set_sync(true);
     opts
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_db_debug_output() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let column_families = vec![DEFAULT_COLUMN_FAMILY_NAME];
+
+        let mut db_opts = rocksdb::Options::default();
+        db_opts.create_if_missing(true);
+        db_opts.create_missing_column_families(true);
+
+        let db = DB::open(&tmpdir.path(), "test_db_debug", column_families, &db_opts)
+            .expect("Failed to open DB.");
+
+        let db_debug = format!("{:?}", db);
+        assert!(db_debug.contains("test_db_debug"));
+        assert!(db_debug.contains(tmpdir.path().to_str().unwrap()));
+    }
+}

--- a/full-node/db/sov-schema-db/src/snapshot.rs
+++ b/full-node/db/sov-schema-db/src/snapshot.rs
@@ -116,11 +116,7 @@ pub struct FrozenDbSnapshot {
 impl FrozenDbSnapshot {
     /// Get value from its own cache
     pub fn get<S: Schema>(&self, key: &impl KeyCodec<S>) -> anyhow::Result<Option<Operation>> {
-        if let Some(operation) = self.cache.read(key)? {
-            return Ok(Some(operation));
-        }
-
-        Ok(None)
+        Ok(self.cache.read(key)?)
     }
 
     /// Get id of this Snapshot

--- a/full-node/db/sov-schema-db/src/snapshot.rs
+++ b/full-node/db/sov-schema-db/src/snapshot.rs
@@ -24,7 +24,6 @@ pub struct ReadOnlyLock<T> {
 }
 
 impl<T> ReadOnlyLock<T> {
-    #[allow(dead_code)]
     /// Create new [`ReadOnlyLock`] from [`Arc<RwLock<T>>`].
     pub fn new(lock: Arc<RwLock<T>>) -> Self {
         Self { lock }
@@ -37,7 +36,6 @@ impl<T> ReadOnlyLock<T> {
 }
 
 /// Wrapper around [`DB`] that allows to read from snapshots
-#[allow(dead_code)]
 pub struct DbSnapshot<Q> {
     id: SnapshotId,
     cache: Mutex<SchemaBatch>,
@@ -45,7 +43,6 @@ pub struct DbSnapshot<Q> {
     db_reader: Arc<DB>,
 }
 
-#[allow(dead_code)]
 impl<Q: QueryManager> DbSnapshot<Q> {
     /// Create new [`DbSnapshot`]
     pub fn new(id: SnapshotId, manager: ReadOnlyLock<Q>, db_reader: Arc<DB>) -> Self {

--- a/full-node/db/sov-schema-db/src/snapshot.rs
+++ b/full-node/db/sov-schema-db/src/snapshot.rs
@@ -74,7 +74,7 @@ impl<Q: QueryManager> DbSnapshot<Q> {
             return decode_operation::<S>(operation);
         }
 
-        // Check parent
+        // 2. Check parent
         {
             let parent = self
                 .manager
@@ -85,8 +85,7 @@ impl<Q: QueryManager> DbSnapshot<Q> {
             }
         }
 
-        // Check db
-
+        // 3. Check db
         self.db_reader.get(key)
     }
 

--- a/full-node/db/sov-schema-db/src/snapshot.rs
+++ b/full-node/db/sov-schema-db/src/snapshot.rs
@@ -1,0 +1,108 @@
+//! Snapshot related logic
+
+use std::sync::{Arc, LockResult, RwLock, RwLockReadGuard};
+
+use crate::schema::{KeyCodec, ValueCodec};
+use crate::{Operation, Schema, SchemaBatch, DB};
+
+/// Id of database snapshot
+pub type SnapshotId = u64;
+
+/// A trait to make nested calls to several [`Schema`]
+pub trait QueryManager {
+    /// Get a value from snapshot or its parents
+    fn get<S: Schema>(
+        &self,
+        snapshot_id: SnapshotId,
+        key: &impl KeyCodec<S>,
+    ) -> anyhow::Result<Option<Operation>>;
+}
+
+/// Simple wrapper around `RwLock` that only allows read access.
+pub struct ReadOnlyLock<T> {
+    lock: Arc<RwLock<T>>,
+}
+
+impl<T> ReadOnlyLock<T> {
+    #[allow(dead_code)]
+    /// Create new [`ReadOnlyLock`] from [`Arc<RwLock<T>>`].
+    pub fn new(lock: Arc<RwLock<T>>) -> Self {
+        Self { lock }
+    }
+
+    /// Acquires a read lock on the underlying `RwLock`.
+    pub fn read(&self) -> LockResult<RwLockReadGuard<'_, T>> {
+        self.lock.read()
+    }
+}
+
+/// Wrapper around [`DB`] that allows to read from snapshots
+#[allow(dead_code)]
+pub struct DbSnapshot<Q> {
+    id: SnapshotId,
+    cache: SchemaBatch,
+    manager: ReadOnlyLock<Q>,
+    db_reader: Arc<DB>,
+}
+
+#[allow(dead_code)]
+impl<Q: QueryManager> DbSnapshot<Q> {
+    /// Create new [`DbSnapshot`]
+    pub fn new(id: SnapshotId, manager: ReadOnlyLock<Q>, db_reader: Arc<DB>) -> Self {
+        Self {
+            id,
+            cache: SchemaBatch::default(),
+            manager,
+            db_reader,
+        }
+    }
+
+    /// Get a value from current snapshot, its parents or underlying database
+    pub fn read<S: Schema>(&self, key: &impl KeyCodec<S>) -> anyhow::Result<Option<S::Value>> {
+        // Some(Operation) means that key was touched,
+        // but in case of deletion we early return None
+        // Only in case of not finding operation for key,
+        // we go deeper
+
+        // 1. Check in cache
+        if let Some(operation) = self.cache.read(key)? {
+            return decode_operation::<S>(operation);
+        }
+
+        // Check parent
+        {
+            let parent = self
+                .manager
+                .read()
+                .expect("Parent lock must not be poisoned");
+            if let Some(operation) = parent.get(self.id, key)? {
+                return decode_operation::<S>(operation);
+            }
+        }
+
+        // Check db
+
+        self.db_reader.get(key)
+    }
+
+    /// Store a value in snapshot
+    pub fn put<S: Schema>(
+        &self,
+        key: &impl KeyCodec<S>,
+        value: &impl ValueCodec<S>,
+    ) -> anyhow::Result<()> {
+        // TODO: Lock here?
+        self.cache.put(key, value)?;
+        Ok(())
+    }
+}
+
+fn decode_operation<S: Schema>(operation: Operation) -> anyhow::Result<Option<S::Value>> {
+    match operation {
+        Operation::Put { value } => {
+            let value = S::Value::decode_value(&value)?;
+            Ok(Some(value))
+        }
+        Operation::Delete => Ok(None),
+    }
+}

--- a/full-node/db/sov-schema-db/tests/db_test.rs
+++ b/full-node/db/sov-schema-db/tests/db_test.rs
@@ -209,7 +209,7 @@ fn gen_expected_values(values: &[(u32, u32)]) -> Vec<(TestField, TestField)> {
 fn test_single_schema_batch() {
     let db = TestDB::new();
 
-    let db_batch = SchemaBatch::new();
+    let mut db_batch = SchemaBatch::new();
     db_batch
         .put::<TestSchema1>(&TestField(0), &TestField(0))
         .unwrap();
@@ -247,7 +247,7 @@ fn test_single_schema_batch() {
 fn test_two_schema_batches() {
     let db = TestDB::new();
 
-    let db_batch1 = SchemaBatch::new();
+    let mut db_batch1 = SchemaBatch::new();
     db_batch1
         .put::<TestSchema1>(&TestField(0), &TestField(0))
         .unwrap();
@@ -265,7 +265,7 @@ fn test_two_schema_batches() {
         gen_expected_values(&[(0, 0), (1, 1)]),
     );
 
-    let db_batch2 = SchemaBatch::new();
+    let mut db_batch2 = SchemaBatch::new();
     db_batch2.delete::<TestSchema2>(&TestField(3)).unwrap();
     db_batch2
         .put::<TestSchema2>(&TestField(3), &TestField(3))
@@ -345,7 +345,7 @@ fn test_report_size() {
     let db = TestDB::new();
 
     for i in 0..1000 {
-        let db_batch = SchemaBatch::new();
+        let mut db_batch = SchemaBatch::new();
         db_batch
             .put::<TestSchema1>(&TestField(i), &TestField(i))
             .unwrap();

--- a/full-node/db/sov-schema-db/tests/snapshot_test.rs
+++ b/full-node/db/sov-schema-db/tests/snapshot_test.rs
@@ -1,0 +1,142 @@
+use std::path::Path;
+use std::sync::{Arc, RwLock};
+
+use byteorder::{BigEndian, ReadBytesExt};
+use rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
+use sov_schema_db::schema::{ColumnFamilyName, KeyCodec, KeyDecoder, KeyEncoder, ValueCodec};
+use sov_schema_db::snapshot::{
+    DbSnapshot, FrozenDbSnapshot, QueryManager, ReadOnlyLock, SnapshotId,
+};
+use sov_schema_db::{define_schema, CodecError, Operation, Schema, DB};
+
+define_schema!(TestSchema1, TestField, TestField, "TestCF1");
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub(crate) struct TestField(u32);
+
+impl TestField {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_be_bytes().to_vec()
+    }
+
+    fn from_bytes(data: &[u8]) -> sov_schema_db::schema::Result<Self> {
+        let mut reader = std::io::Cursor::new(data);
+        Ok(TestField(
+            reader
+                .read_u32::<BigEndian>()
+                .map_err(|e| CodecError::Wrapped(e.into()))?,
+        ))
+    }
+}
+
+impl KeyEncoder<TestSchema1> for TestField {
+    fn encode_key(&self) -> sov_schema_db::schema::Result<Vec<u8>> {
+        Ok(self.to_bytes())
+    }
+}
+
+impl KeyDecoder<TestSchema1> for TestField {
+    fn decode_key(data: &[u8]) -> sov_schema_db::schema::Result<Self> {
+        Self::from_bytes(data)
+    }
+}
+
+impl ValueCodec<TestSchema1> for TestField {
+    fn encode_value(&self) -> sov_schema_db::schema::Result<Vec<u8>> {
+        Ok(self.to_bytes())
+    }
+
+    fn decode_value(data: &[u8]) -> sov_schema_db::schema::Result<Self> {
+        Self::from_bytes(data)
+    }
+}
+
+#[derive(Default)]
+struct LinearSnapshotManager {
+    snapshots: Vec<FrozenDbSnapshot>,
+}
+
+impl LinearSnapshotManager {
+    fn add_snapshot(&mut self, snapshot: FrozenDbSnapshot) {
+        self.snapshots.push(snapshot);
+    }
+}
+
+impl QueryManager for LinearSnapshotManager {
+    fn get<S: Schema>(
+        &self,
+        snapshot_id: SnapshotId,
+        key: &impl KeyCodec<S>,
+    ) -> anyhow::Result<Option<Operation>> {
+        for snapshot in self.snapshots[..snapshot_id as usize].iter().rev() {
+            if let Some(operation) = snapshot.get(key)? {
+                return Ok(Some(operation));
+            }
+        }
+        Ok(None)
+    }
+}
+
+fn get_column_families() -> Vec<ColumnFamilyName> {
+    vec![DEFAULT_COLUMN_FAMILY_NAME, TestSchema1::COLUMN_FAMILY_NAME]
+}
+
+fn open_db(dir: impl AsRef<Path>) -> DB {
+    let mut db_opts = rocksdb::Options::default();
+    db_opts.create_if_missing(true);
+    db_opts.create_missing_column_families(true);
+
+    DB::open(dir, "test", get_column_families(), &db_opts).expect("Failed to open DB.")
+}
+
+#[test]
+fn snapshot_lifecycle() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let db = Arc::new(open_db(&tmpdir));
+    let manager = Arc::new(RwLock::new(LinearSnapshotManager::default()));
+
+    let key_1 = TestField(1);
+    let value_1 = TestField(1);
+    // 1 => 1 in db
+    db.put::<TestSchema1>(&key_1, &value_1).unwrap();
+
+    // Snapshot 1: reads from DB first, then sets 1 => 2
+    let snapshot_1 =
+        DbSnapshot::<LinearSnapshotManager>::new(0, ReadOnlyLock::new(manager.clone()), db.clone());
+    assert_eq!(
+        Some(value_1.clone()),
+        snapshot_1.read::<TestSchema1>(&key_1).unwrap(),
+        "Incorrect value, should be fetched from DB"
+    );
+    // 1 => 2 in snapshot 1
+    let value_2 = TestField(2);
+    snapshot_1.put(&key_1, &value_2).unwrap();
+    assert_eq!(
+        Some(value_2.clone()),
+        snapshot_1.read::<TestSchema1>(&key_1).unwrap(),
+        "Incorrect value, should be fetched from local cache"
+    );
+    {
+        let mut manager = manager.write().unwrap();
+        manager.add_snapshot(snapshot_1.into());
+    }
+
+    // Snapshot 2: reads value from snapshot 1, then deletes it
+    let snapshot_2 =
+        DbSnapshot::<LinearSnapshotManager>::new(1, ReadOnlyLock::new(manager.clone()), db.clone());
+    assert_eq!(
+        Some(value_2.clone()),
+        snapshot_2.read::<TestSchema1>(&key_1).unwrap()
+    );
+    snapshot_2.delete(&key_1).unwrap();
+    assert_eq!(None, snapshot_2.read::<TestSchema1>(&key_1).unwrap());
+    {
+        let mut manager = manager.write().unwrap();
+        manager.add_snapshot(snapshot_2.into());
+    }
+
+    // Snapshot 3: gets empty result, event value is still in DB, but it was deleted in previous snapshot
+    let snapshot_3 =
+        DbSnapshot::<LinearSnapshotManager>::new(2, ReadOnlyLock::new(manager.clone()), db.clone());
+    assert_eq!(None, snapshot_3.read::<TestSchema1>(&key_1).unwrap());
+}


### PR DESCRIPTION
# Description

This PR adds: `DbSnapshot`, a wrapper around `sov_schema_db::DB`, which has it's local cache in form of adapted `SchemaBatch` and link to `QueryManager`. This allows `DbSnapshot` read/write value to local cache, fetch them from parent snapshots or directly from DB.

Please note, that this functionality is added, but it is not integrated. Next step would be modifying `StateDB`, `NativeDB` and `LedgerDB` to work with `DbSnapshot` instead of `DB` directly.


Main modifications:

- *`sov_schema_db::SchemaBatch`: vector of operations replaced with HashMap, which allows efficient reads. 
- internal `Mutex` is removed from `SchemaBatch` and now it is responsibility of the caller to handle. Current usage of SchemaBatch is not concurrent. `DbSnapshot` uses `Mutex` over whole internal cache. Potentially related to https://github.com/Sovereign-Labs/sovereign-sdk/issues/791



## Linked Issues
- Related to #1023 

## Testing
New integration test has been added to test snapshot

## Docs
Documentation to the new modules have been added
