### PR TITLE
Fix warning on MacOS `make check-fuzz` warning on MacOS

### DIFF
--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help
 
-BINARIES := $(shell awk -F' = ' '/^\[\[bin\]\]/,/^$$/{ if ($$1 == "name") { gsub(/"/, "", $$2); print $$2 } }' Cargo.toml)
+BINARIES := $(shell awk -F'=[[:space:]]*"|"[[:space:]]*$$' '/^\[\[bin\]\]/,/^$$/{ if ($$1 ~ /name[[:space:]]*/) { print $$2 } }' Cargo.toml)
 PROFILE ?= debug
 ARGS ?=
 

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help
 
-BINARIES := $(shell sed -n '/^\[\[bin\]\]/,/^$$/ { /name\s*=\s*"\(.*\)"/s//\1/p }' Cargo.toml)
+BINARIES := $(shell awk -F' = ' '/^\[\[bin\]\]/,/^$$/{ if ($$1 == "name") { gsub(/"/, "", $$2); print $$2 } }' Cargo.toml)
 PROFILE ?= debug
 ARGS ?=
 
@@ -11,7 +11,7 @@ check: ## Checks that fuzz member compiles
 	cargo check
 
 build-target: ## Build the target fuzz
-	cargo rustc --bin $(TARGET) $(ARGS) -- \
+	cargo +nightly rustc --bin $(TARGET) $(ARGS) -- \
 		-C debuginfo=full \
 		-C debug-assertions \
 		-C passes='sancov-module' \

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -10,6 +10,7 @@ help: ## Display this help message
 check: ## Checks that fuzz member compiles
 	cargo check
 
+# Needs nightly for `-Z sanitizer=address`
 build-target: ## Build the target fuzz
 	cargo +nightly rustc --bin $(TARGET) $(ARGS) -- \
 		-C debuginfo=full \


### PR DESCRIPTION
# Description

Switch to awk for better cross platform support
