### PR TITLE
feat: add `tokio` as part of `native` feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -128,12 +128,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Rust
+      - name: Install Rust Bare Metal
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           target: thumbv6m-none-eabi
           override: true
+      - name: Install Rust WASM
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+      - name: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/nightly' }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-# no-std packages to be checked
-NO_STD := "sov-rollup-interface"
-
 .PHONY: help
 
 help: ## Display this help message
@@ -47,16 +44,7 @@ check-fuzz: ## Checks that fuzz member compiles
 	$(MAKE) -C fuzz check
 
 check-no-std: ## Checks that project compiles without std
-	@for package in $(NO_STD); do \
-		echo "Checking no-std $${package}..."; \
-		cargo check -p $$package \
-			--target thumbv6m-none-eabi \
-			--no-default-features ; \
-		cargo check -p $$package \
-			--target thumbv6m-none-eabi \
-			--no-default-features \
-			--features native ; \
-	done
+	$(MAKE) -C ./rollup-interface $@
 
 find-unused-deps: ## Prints unused dependencies for project. Note: requires nightly
 	cargo udeps --all-targets --all-features

--- a/full-node/db/sov-db/Cargo.toml
+++ b/full-node/db/sov-db/Cargo.toml
@@ -17,7 +17,7 @@ resolver = "2"
 # Maintained by sovereign labs
 jmt = { workspace = true }
 sov-schema-db = { path = "../sov-schema-db", version = "0.3" }
-sov-rollup-interface = { path = "../../../rollup-interface", version = "0.3", features = ["native", "mocks", "tokio"] }
+sov-rollup-interface = { path = "../../../rollup-interface", version = "0.3", features = ["native", "mocks"] }
 
 # External
 anyhow = { workspace = true, default-features = true }

--- a/rollup-interface/Cargo.toml
+++ b/rollup-interface/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 
 
 [dependencies]
-anyhow = { workspace = true, default-features = false }
+anyhow = { workspace = true }
 async-trait = { workspace = true }
 borsh = { workspace = true }
 bytes = { workspace = true, optional = true, default-features = true }
@@ -43,9 +43,9 @@ proptest-derive = { workspace = true }
 
 [features]
 default = ["std"]
-native = []
+native = ["std", "tokio"]
 fuzzing = ["proptest", "proptest-derive", "sha2", "std"]
-mocks = ["sha2", "bytes/serde"]
+mocks = ["sha2", "bytes/serde", "std"]
 std = [
     "anyhow/default",
     "bincode",
@@ -59,4 +59,3 @@ std = [
     "sha2?/default",
     "thiserror"
 ]
-tokio = ["dep:tokio", "std"]

--- a/rollup-interface/Makefile
+++ b/rollup-interface/Makefile
@@ -1,0 +1,10 @@
+.PHONY: help
+
+help: ## Display this help message
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+check-no-std: ## Checks that project compiles without std
+	# check bare metal
+	cargo hack check --feature-powerset \
+		--exclude-features default,fuzzing,mocks,std,native \
+		--target thumbv6m-none-eabi

--- a/rollup-interface/src/node/rpc/mod.rs
+++ b/rollup-interface/src/node/rpc/mod.rs
@@ -302,7 +302,6 @@ pub trait LedgerRpcProvider {
     ) -> Result<Vec<Option<TxResponse<T>>>, anyhow::Error>;
 
     /// Get a notification each time a slot is processed
-    #[cfg(feature = "tokio")]
     fn subscribe_slots(&self) -> Result<tokio::sync::broadcast::Receiver<u64>, anyhow::Error>;
 }
 

--- a/rollup-interface/src/state_machine/mocks/mod.rs
+++ b/rollup-interface/src/state_machine/mocks/mod.rs
@@ -2,7 +2,7 @@
 //! for testing, fuzzing, and benchmarking.
 
 mod da;
-#[cfg(all(feature = "native", feature = "tokio"))]
+#[cfg(feature = "native")]
 mod service;
 #[cfg(feature = "std")]
 mod use_std;
@@ -12,7 +12,7 @@ pub use da::{
     MockAddress, MockBlockHeader, MockDaConfig, MockDaSpec, MockDaVerifier, MockHash,
     MOCK_SEQUENCER_DA_ADDRESS,
 };
-#[cfg(all(feature = "native", feature = "tokio"))]
+#[cfg(feature = "native")]
 pub use service::MockDaService;
 #[cfg(feature = "std")]
 pub use use_std::{MockBlob, MockBlock};


### PR DESCRIPTION
Prior to this commit, `tokio` was split from the `rollup-interface` native feature so the ledger functionality would be available for no-std.

This commit simplifies the structure and will require `std/tokio` when `native` is active.