### PR TITLE
Upgrade Risc0 to `v0.19.0`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,7 +88,7 @@ jobs:
       with:
         allowed-skips: deploy-github-pages
         jobs: ${{ toJSON(needs) }}
- 
+
   check:
     name: check
     runs-on: buildjet-4vcpu-ubuntu-2204

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,7 +88,7 @@ jobs:
       with:
         allowed-skips: deploy-github-pages
         jobs: ${{ toJSON(needs) }}
-
+ 
   check:
     name: check
     runs-on: buildjet-4vcpu-ubuntu-2204
@@ -362,7 +362,7 @@ jobs:
         # up to date.
         run: git diff --exit-code
   check-demo-rollup-bash-commands:
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: buildjet-4vcpu-ubuntu-2204
     needs: nextest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -103,6 +103,14 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust
         run: rustup show && rustup install nightly && rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu # Nightly is needed for our configuration of cargo fmt
+      - name: Install cargo-risczero
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-risczero@0.19
+      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
+        run: cargo risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-provider: "buildjet"
@@ -111,10 +119,6 @@ jobs:
           workspaces: |
             .
             fuzz
-      - name: Install cargo-risc0 # Risc0 v0.17 and higher require a cargo extension to build the guest code
-        run: cargo install cargo-risczero
-      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
-        run: cargo risczero install
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run lint
@@ -194,6 +198,14 @@ jobs:
         with:
           version: "23.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cargo-risczero
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-risczero@0.19
+      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
+        run: cargo risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # `cargo-nextest` is much faster than standard `cargo test`.
       - uses: taiki-e/install-action@nextest
       - name: Install Rust
@@ -202,12 +214,6 @@ jobs:
         with:
           cache-provider: "buildjet"
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
-      - name: Install cargo-risc0 # Risc0 v0.17 and higher require a cargo extension to build the guest code
-        run: cargo install cargo-risczero
-      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
-        run: cargo risczero install
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo nextest run --workspace --all-features
   test:
     name: test
@@ -221,18 +227,20 @@ jobs:
         with:
           version: "23.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cargo-risczero
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-risczero@0.19
+      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
+        run: cargo risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust
         run: rustup show
       - uses: Swatinem/rust-cache@v2
         with:
           cache-provider: "buildjet"
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
-      - name: Install cargo-risc0 # Risc0 v0.17 and higher require a cargo extension to build the guest code
-        run: cargo install cargo-risczero
-      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
-        run: cargo risczero install
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # `cargo-nextest` does not support doctests (yet?), so we have to run them
       # separately.
       # TODO: https://github.com/nextest-rs/nextest/issues/16
@@ -257,16 +265,18 @@ jobs:
         run: rustup component add llvm-tools-preview
       - name: cargo install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install cargo-risczero
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-risczero@0.19
+      - name: Install risc0-zkvm toolchain
+        run: cargo risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-provider: "buildjet"
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
-      - name: Install cargo-risc0 # Risc0 v0.17 and higher require a cargo extension to build the guest code
-        run: cargo install cargo-risczero
-      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
-        run: cargo risczero install
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
@@ -362,18 +372,20 @@ jobs:
         with:
           version: "23.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cargo-risczero
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-risczero@0.19
+      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
+        run: cargo risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust
         run: rustup show
       - uses: Swatinem/rust-cache@v2
         with:
           cache-provider: "buildjet"
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
-      - name: Install cargo-risc0 # Risc0 v0.17 and higher require a cargo extension to build the guest code
-        run: cargo install cargo-risczero
-      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
-        run: cargo risczero install
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile README.md to Bash
         run: cargo run --bin bashtestmd -- --input examples/demo-rollup/README.md --output demo-rollup-readme.sh --tag test-ci
       - run: cat demo-rollup-readme.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -364,6 +364,7 @@ jobs:
   check-demo-rollup-bash-commands:
     runs-on: buildjet-4vcpu-ubuntu-2204
     needs: nextest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,26 +34,17 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
-dependencies = [
- "cpp_demangle 0.4.3",
- "fallible-iterator",
- "gimli 0.27.3",
- "memmap2",
- "object 0.31.1",
- "rustc-demangle",
- "smallvec 1.11.2",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
+ "cpp_demangle 0.4.3",
+ "fallible-iterator 0.3.0",
  "gimli 0.28.0",
+ "memmap2",
+ "object 0.32.1",
+ "rustc-demangle",
+ "smallvec 1.11.2",
 ]
 
 [[package]]
@@ -1077,9 +1068,9 @@ checksum = "3190f92dfe48224adc92881c620f08ccf37ff62b91a094bb357fe53bd5e84647"
 
 [[package]]
 name = "bonsai-sdk"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94478e373742b9d1de02e13399633348e5b230dfe6364f65e80056c7df7438c5"
+checksum = "441d1092e11977985946b6564251df91d80ae36982128e53be52a32548ad8762"
 dependencies = [
  "reqwest",
  "serde",
@@ -2451,10 +2442,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker-generate"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf673e0848ef09fa4aeeba78e681cf651c0c7d35f76ee38cec8e55bc32fa111"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "downloader"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05213e96f184578b5f70105d4d0a644a168e99e12d7bea0b200c15d67b5c182"
+dependencies = [
+ "digest 0.10.7",
+ "futures",
+ "rand 0.8.5",
+ "reqwest",
+ "thiserror",
+ "tokio",
+]
 
 [[package]]
 name = "dunce"
@@ -3101,6 +3112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fast-float"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3463,7 +3480,7 @@ version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 dependencies = [
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "indexmap 1.9.3",
  "stable_deref_trait",
 ]
@@ -3473,6 +3490,10 @@ name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+dependencies = [
+ "fallible-iterator 0.3.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
@@ -5545,22 +5566,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
-dependencies = [
- "flate2",
- "memchr",
- "ruzstd",
-]
-
-[[package]]
-name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
+ "flate2",
  "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -6063,7 +6075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7915b33ed60abc46040cbcaa25ffa1c7ec240668e0477c4f3070786f5916d451"
 dependencies = [
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "futures-util",
  "log",
  "tokio",
@@ -6079,7 +6091,7 @@ dependencies = [
  "base64 0.21.5",
  "byteorder",
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "hmac 0.12.1",
  "md-5",
  "memchr",
@@ -6095,7 +6107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
 dependencies = [
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "postgres-protocol",
 ]
 
@@ -7248,9 +7260,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede27631e6b2a946a43db812063453c9701d5d2544d82f9abec2cc12574ebb8e"
+checksum = "923c85a23cb9a9475b8cd4479ad3a06252604a361626e9ae7dc0dc635af22c22"
 dependencies = [
  "anyhow",
  "elf",
@@ -7262,37 +7274,70 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703b79671cd148f6535e1f78b8a74f665c920493eb6546c516c67ab0bc0bbde1"
+checksum = "e58d4cc25e243e52d1ccd75d357b0aa55081736bf3052c65a823fdf169586843"
 dependencies = [
+ "anyhow",
  "cargo_metadata",
+ "docker-generate",
  "risc0-binfmt",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
 name = "risc0-build-kernel"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b88d565a721641f355cb889fee75c12c719dec7b910aa42ecabffa30d99f87"
+checksum = "9061315fc75f1e8573e1aaca32b856b01a325f756c8482a63547b796cfbe7940"
 dependencies = [
  "cc",
  "directories",
- "glob",
  "hex",
  "sha2 0.10.8",
  "tempfile",
 ]
 
 [[package]]
-name = "risc0-circuit-rv32im"
-version = "0.18.0"
+name = "risc0-circuit-recursion"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e00222152fdc94cacc9b6682b5c0cbe8138f1ee82e80c24a64d9ad2c6d7415"
+checksum = "97547e10e9fdaaab8b64ffb45dc158b31f023b1a68015c6ce9f12fe3e403012a"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "downloader",
+ "log",
+ "rand 0.8.5",
+ "rayon",
+ "risc0-circuit-recursion-sys",
+ "risc0-core",
+ "risc0-zkp",
+ "sha2 0.10.8",
+ "tracing",
+ "zip",
+]
+
+[[package]]
+name = "risc0-circuit-recursion-sys"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c61bb8d8021f0a96bae24b305ea64169d6f36637bb2717ae24de77abfc30760"
+dependencies = [
+ "glob",
+ "risc0-build-kernel",
+ "risc0-core",
+]
+
+[[package]]
+name = "risc0-circuit-rv32im"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a269d01b18cba24ee1a08f68726fc3623e8705ed79d158377d12e9129dcde2e"
 dependencies = [
  "anyhow",
  "log",
@@ -7300,7 +7345,6 @@ dependencies = [
  "rayon",
  "risc0-circuit-rv32im-sys",
  "risc0-core",
- "risc0-sys",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "tracing",
@@ -7308,21 +7352,20 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca6ec6b1a7aad859af0009d19946ffdded8e3bd5d9accf893846b6bf996ac08"
+checksum = "344208fab2ea159915c4c747aca9037c74e3cc4b10692389aa1f8d712e3b552d"
 dependencies = [
  "glob",
  "risc0-build-kernel",
  "risc0-core",
- "risc0-sys",
 ]
 
 [[package]]
 name = "risc0-core"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08605aec93ea22ed83f7f81f42e2d7287a5b0c749d8671f94de9d5994020045c"
+checksum = "477e0bb8d2ec0b7955088b521eb596901e652d0faa2ea73bda0b77e05af5c07d"
 dependencies = [
  "bytemuck",
  "rand_core 0.6.4",
@@ -7330,21 +7373,18 @@ dependencies = [
 
 [[package]]
 name = "risc0-sys"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d308c2ebc79e32c100f57722914b3172d2f0d69321703b684ea0c302e4f3a9"
+checksum = "a2a0523c55e53a860f4a8fb3d2ca7c2bf3ce4b8aa3feddb42d08648bdcc458ac"
 dependencies = [
- "cc",
- "glob",
  "risc0-build-kernel",
- "risc0-core",
 ]
 
 [[package]]
 name = "risc0-zkp"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28166926bb177824939f4e91083198f9f3da8137aeac32361bd34548c0526fa5"
+checksum = "d5abb1a0cf847d3f9aed1e563b76c358107e7ba66dbfab28f7144252c990bd82"
 dependencies = [
  "anyhow",
  "blake2",
@@ -7369,11 +7409,11 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec972152bcaa1a2967e412e22a84f6e2984a95c701bcc7943ca8ca10126ee0a2"
+checksum = "3cf80df202c038efc2199be34fda8114b38bfc5b2b51c60cbbdf1f425b07b384"
 dependencies = [
- "addr2line 0.20.0",
+ "addr2line 0.21.0",
  "anyhow",
  "bincode",
  "bonsai-sdk",
@@ -7385,34 +7425,38 @@ dependencies = [
  "getrandom 0.2.11",
  "hex",
  "lazy-regex",
- "libm",
  "log",
  "num-derive 0.4.1",
  "num-traits",
  "prost 0.12.2",
  "prost-build",
  "protobuf-src",
- "rand 0.8.5",
  "rayon",
  "risc0-binfmt",
+ "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",
+ "semver 1.0.20",
  "serde",
  "sha2 0.10.8",
  "tempfile",
- "thiserror",
  "tracing",
  "typetag",
 ]
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8524b46783b58b00e9b2a4712e837093c975b23cf25bfaf99e1cf69e9011bf6b"
+checksum = "2dcd6b66f7a4972001db0acf3f06d99b7851c8d9f0de1f7e0fb4496c66c5cd02"
+dependencies = [
+ "bytemuck",
+ "getrandom 0.2.11",
+ "libm",
+]
 
 [[package]]
 name = "rlp"
@@ -7618,12 +7662,12 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a15e661f0f9dac21f3494fe5d23a6338c0ac116a2d22c2b63010acd89467ffe"
+checksum = "ac3ffab8f9715a0d455df4bbb9d21e91135aab3cd3ca187af0cd0c3c3f868fdc"
 dependencies = [
  "byteorder",
- "thiserror",
+ "thiserror-core",
  "twox-hash",
 ]
 
@@ -10286,6 +10330,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-core"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d97345f6437bb2004cd58819d8a9ef8e36cdd7661c2abc4bbde0a7c40d9f497"
+dependencies = [
+ "thiserror-core-impl",
+]
+
+[[package]]
+name = "thiserror-core-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ac1c5050e43014d16b2f94d0d2ce79e65ffdd8b38d8048f9c8f6a8a6da62ac"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "thiserror-impl"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10469,7 +10533,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "futures-channel",
  "futures-util",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,7 @@ name = "bashtestmd"
 version = "0.3.0"
 dependencies = [
  "clap 4.4.8",
+ "indoc",
  "markdown",
  "shell-escape",
 ]
@@ -4213,6 +4214,12 @@ dependencies = [
  "hashbrown 0.14.2",
  "serde",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "infer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,11 +102,11 @@ tempfile = "3.8"
 tokio = { version = "1", features = ["full"] }
 lazy_static = "1.4.0"
 num_cpus = "1.0"
-risc0-zkvm = { version = "0.18", default-features = false }
-risc0-zkvm-platform = { version = "0.18" }
-risc0-zkp = "0.18"
-risc0-circuit-rv32im = "0.18"
-risc0-build = "0.18"
+risc0-zkvm = { version = "0.19", default-features = false }
+risc0-zkvm-platform = { version = "0.19" }
+risc0-zkp = "0.19"
+risc0-circuit-rv32im = "0.19"
+risc0-build = "0.19"
 
 # EVM dependencies
 ethereum-types = "0.14.1"
@@ -126,11 +126,7 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "e83d3aa" }
 revm = { git = "https://github.com/bluealloy/revm", rev = "516f62cc" }
 revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "516f62cc" }
 
-secp256k1 = { version = "0.27.0", default-features = false, features = [
-    "global-context",
-    "rand-std",
-    "recovery",
-] }
+secp256k1 = { version = "0.27.0", default-features = false, features = ["global-context", "rand-std", "recovery"] }
 
 [patch.'https://github.com/eigerco/celestia-node-rs.git']
 # Uncomment to apply local changes

--- a/adapters/risc0/README.md
+++ b/adapters/risc0/README.md
@@ -1,11 +1,10 @@
 # Risc0 Adapter
 
-This package adapts Risc0 version 0.18 to work as a zkVM for the Sovereign SDK.
+This package adapts Risc0 version 0.19 to work as a zkVM for the Sovereign SDK.
 
 ## Limitations
 
-Since in-VM recursion is not included in the 0.18 release, this adapter is currently limited. Individual "slots" may
-be proven, but those proofs cannot be recursively combined to facilitate bridging or ultra-fast sync ("user recursion" is not supported).
+While in-VM recursion is included in the Risc0 0.19 release, this adapter doesn't currently implement it. Individual "slots" may be proven, but those proofs cannot be recursively combined to facilitate bridging or ultra-fast sync ("user recursion" is not supported).
 
 ## Warning
 

--- a/adapters/risc0/src/host.rs
+++ b/adapters/risc0/src/host.rs
@@ -1,19 +1,14 @@
-//! This module implements the `ZkvmHost` trait for the RISC0 VM.
+//! This module implements the [`ZkvmHost`] trait for the RISC0 VM.
 
-use risc0_zkvm::serde::to_vec;
-use risc0_zkvm::{Executor, ExecutorEnvBuilder, InnerReceipt, Receipt, Session};
+use risc0_zkvm::{ExecutorEnvBuilder, ExecutorImpl, InnerReceipt, Receipt, Session};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sov_rollup_interface::zk::{Proof, Zkvm, ZkvmHost};
-#[cfg(feature = "bench")]
-use sov_zk_cycle_utils::{cycle_count_callback, get_syscall_name, get_syscall_name_cycles};
 
 use crate::guest::Risc0Guest;
-#[cfg(feature = "bench")]
-use crate::metrics::metrics_callback;
 use crate::Risc0MethodId;
 
-/// A Risc0Host stores a binary to execute in the Risc0 VM, and accumulates hints to be
+/// A [`Risc0Host`] stores a binary to execute in the Risc0 VM, and accumulates hints to be
 /// provided to its execution.
 #[derive(Clone)]
 pub struct Risc0Host<'a> {
@@ -29,6 +24,10 @@ fn add_benchmarking_callbacks(env: ExecutorEnvBuilder<'_>) -> ExecutorEnvBuilder
 
 #[cfg(feature = "bench")]
 fn add_benchmarking_callbacks(mut env: ExecutorEnvBuilder<'_>) -> ExecutorEnvBuilder<'_> {
+    use sov_zk_cycle_utils::{cycle_count_callback, get_syscall_name, get_syscall_name_cycles};
+
+    use crate::metrics::metrics_callback;
+
     let metrics_syscall_name = get_syscall_name();
     env.io_callback(metrics_syscall_name, metrics_callback);
 
@@ -47,15 +46,15 @@ impl<'a> Risc0Host<'a> {
         }
     }
 
-    /// Run a computation in the zkvm without generating a receipt.
+    /// Run a computation in the zkVM without generating a receipt.
     /// This creates the "Session" trace without invoking the heavy cryptographic machinery.
     pub fn run_without_proving(&mut self) -> anyhow::Result<Session> {
         let env = add_benchmarking_callbacks(ExecutorEnvBuilder::default())
-            .add_input(&self.env)
+            .write_slice(&self.env)
             .build()
             .unwrap();
-        let mut executor = Executor::from_elf(env, self.elf)?;
-        executor.run()
+        let mut executor = ExecutorImpl::from_elf(env, self.elf)?;
+        Ok(executor.run()?)
     }
     /// Run a computation in the zkvm and generate a receipt.
     pub fn run(&mut self) -> anyhow::Result<Receipt> {
@@ -68,8 +67,18 @@ impl<'a> ZkvmHost for Risc0Host<'a> {
     type Guest = Risc0Guest;
 
     fn add_hint<T: serde::Serialize>(&mut self, item: T) {
-        let serialized = to_vec(&item).expect("Serialization to vec is infallible");
-        self.env.extend_from_slice(&serialized[..]);
+        // We use the in-memory size of `item` as an indication of how much
+        // space to reserve. This is in no way guaranteed to be exact, but
+        // usually the in-memory size and serialized data size are quite close.
+        //
+        // Note: this is just an optimization to avoid frequent reallocations,
+        // it's not actually required.
+        self.env
+            .reserve(std::mem::size_of::<T>() / std::mem::size_of::<u32>());
+
+        let mut serializer = risc0_zkvm::serde::Serializer::new(&mut self.env);
+        item.serialize(&mut serializer)
+            .expect("Risc0 hint serialization is infallible");
     }
 
     fn simulate_with_hints(&mut self) -> Self::Guest {
@@ -78,8 +87,8 @@ impl<'a> ZkvmHost for Risc0Host<'a> {
 
     fn run(&mut self, with_proof: bool) -> Result<Proof, anyhow::Error> {
         if with_proof {
-            let jurnal = self.run()?.journal;
-            Ok(Proof::Data(jurnal))
+            let journal = self.run()?.journal;
+            Ok(Proof::Data(journal.bytes))
         } else {
             self.run_without_proving()?;
             Ok(Proof::Empty)

--- a/adapters/risc0/tests/native.rs
+++ b/adapters/risc0/tests/native.rs
@@ -10,15 +10,25 @@ struct TestStruct {
 
 #[test]
 fn test_hints_roundtrip() {
-    let hint = TestStruct {
+    let mut host = Risc0Host::new(&[]);
+
+    let hint_a = TestStruct {
         ints: vec![1, 2, 3, 4, 5],
         string: "hello".to_string(),
     };
-    let mut host = Risc0Host::new(&[]);
+    let hint_b = TestStruct {
+        ints: vec![1, 2, 3, 4, 5],
+        string: "hello".to_string(),
+    };
 
-    host.add_hint(&hint);
+    host.add_hint(&hint_a);
+    host.add_hint(&hint_b);
 
     let guest = host.simulate_with_hints();
-    let received = guest.read_from_host();
-    assert_eq!(hint, received);
+
+    let mut received;
+    received = guest.read_from_host();
+    assert_eq!(hint_a, received);
+    received = guest.read_from_host();
+    assert_eq!(hint_b, received);
 }

--- a/examples/demo-rollup/README.md
+++ b/examples/demo-rollup/README.md
@@ -80,7 +80,7 @@ $ cd examples/demo-rollup/
 
 4. Spin up a local Celestia instance as your DA layer. We've built a small Makefile to simplify that process:
 
-```sh,test-ci,bashtestmd:long-running
+```sh,test-ci,bashtestmd:long-running,bashtestmd:wait-until=genesis.json
 $ make clean
 # Make sure to run `make stop` or `make clean` when you're done with this demo!
 $ make start
@@ -100,7 +100,7 @@ $ git status
 
 Now run the demo-rollup full node, as shown below. You will see it consuming blocks from the Celestia node running inside Docker:
 
-```sh,test-ci,bashtestmd:long-running,bashtestmd:wait-until=RPC
+```sh,test-ci,bashtestmd:long-running
 # Make sure you're still in the examples/demo-rollup directory.
 $ cargo run
 2023-06-07T10:03:25.473920Z  INFO sov_celestia_adapter::da_service: Fetching header at height=1...

--- a/examples/demo-rollup/provers/risc0/build.rs
+++ b/examples/demo-rollup/provers/risc0/build.rs
@@ -31,6 +31,7 @@ fn get_guest_options() -> HashMap<&'static str, risc0_build::GuestOptions> {
         "sov-demo-prover-guest-mock",
         risc0_build::GuestOptions {
             features: vec!["bench".to_string()],
+            ..Default::default()
         },
     );
     guest_pkg_to_options

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -702,6 +702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede27631e6b2a946a43db812063453c9701d5d2544d82f9abec2cc12574ebb8e"
+checksum = "923c85a23cb9a9475b8cd4479ad3a06252604a361626e9ae7dc0dc635af22c22"
 dependencies = [
  "anyhow",
  "elf",
@@ -1660,10 +1666,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "risc0-circuit-rv32im"
-version = "0.18.0"
+name = "risc0-circuit-recursion"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e00222152fdc94cacc9b6682b5c0cbe8138f1ee82e80c24a64d9ad2c6d7415"
+checksum = "97547e10e9fdaaab8b64ffb45dc158b31f023b1a68015c6ce9f12fe3e403012a"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "log",
+ "risc0-core",
+ "risc0-zkp",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-circuit-rv32im"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a269d01b18cba24ee1a08f68726fc3623e8705ed79d158377d12e9129dcde2e"
 dependencies = [
  "anyhow",
  "log",
@@ -1675,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08605aec93ea22ed83f7f81f42e2d7287a5b0c749d8671f94de9d5994020045c"
+checksum = "477e0bb8d2ec0b7955088b521eb596901e652d0faa2ea73bda0b77e05af5c07d"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -1685,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28166926bb177824939f4e91083198f9f3da8137aeac32361bd34548c0526fa5"
+checksum = "d5abb1a0cf847d3f9aed1e563b76c358107e7ba66dbfab28f7144252c990bd82"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1706,34 +1726,40 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec972152bcaa1a2967e412e22a84f6e2984a95c701bcc7943ca8ca10126ee0a2"
+checksum = "3cf80df202c038efc2199be34fda8114b38bfc5b2b51c60cbbdf1f425b07b384"
 dependencies = [
  "anyhow",
  "bytemuck",
  "cfg-if",
  "getrandom",
  "hex",
- "libm",
  "log",
  "num-derive 0.4.0",
  "num-traits",
  "risc0-binfmt",
+ "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
  "risc0-zkp",
  "risc0-zkvm-platform",
+ "rrs-lib",
+ "semver 1.0.19",
  "serde",
- "tempfile",
  "tracing",
 ]
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8524b46783b58b00e9b2a4712e837093c975b23cf25bfaf99e1cf69e9011bf6b"
+checksum = "2dcd6b66f7a4972001db0acf3f06d99b7851c8d9f0de1f7e0fb4496c66c5cd02"
+dependencies = [
+ "bytemuck",
+ "getrandom",
+ "libm",
+]
 
 [[package]]
 name = "rlp"
@@ -1743,6 +1769,16 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "rrs-lib"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4382d3af3a4ebdae7f64ba6edd9114fff92c89808004c4943b393377a25d001"
+dependencies = [
+ "downcast-rs",
+ "paste",
 ]
 
 [[package]]

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.toml
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.toml
@@ -8,8 +8,8 @@ resolver = "2"
 
 [dependencies]
 anyhow = "1.0.68"
-risc0-zkvm = { version = "0.18", default-features = false, features = ["std"] }
-risc0-zkvm-platform = "0.18"
+risc0-zkvm = { version = "0.19", default-features = false, features = ["std"] }
+risc0-zkvm-platform = "0.19"
 demo-stf = { path = "../../../stf" }
 sov-risc0-adapter = { path = "../../../../../adapters/risc0" }
 const-rollup-config = { path = "../../../../const-rollup-config" }
@@ -35,6 +35,4 @@ lto = true
 opt-level = 3
 
 [features]
-bench = [
-	"sov-celestia-adapter/bench",
-]
+bench = ["sov-celestia-adapter/bench"]

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -302,6 +302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede27631e6b2a946a43db812063453c9701d5d2544d82f9abec2cc12574ebb8e"
+checksum = "923c85a23cb9a9475b8cd4479ad3a06252604a361626e9ae7dc0dc635af22c22"
 dependencies = [
  "anyhow",
  "elf",
@@ -748,10 +754,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "risc0-circuit-rv32im"
-version = "0.18.0"
+name = "risc0-circuit-recursion"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e00222152fdc94cacc9b6682b5c0cbe8138f1ee82e80c24a64d9ad2c6d7415"
+checksum = "97547e10e9fdaaab8b64ffb45dc158b31f023b1a68015c6ce9f12fe3e403012a"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "log",
+ "risc0-core",
+ "risc0-zkp",
+ "tracing",
+]
+
+[[package]]
+name = "risc0-circuit-rv32im"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a269d01b18cba24ee1a08f68726fc3623e8705ed79d158377d12e9129dcde2e"
 dependencies = [
  "anyhow",
  "log",
@@ -763,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08605aec93ea22ed83f7f81f42e2d7287a5b0c749d8671f94de9d5994020045c"
+checksum = "477e0bb8d2ec0b7955088b521eb596901e652d0faa2ea73bda0b77e05af5c07d"
 dependencies = [
  "bytemuck",
  "rand_core",
@@ -773,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28166926bb177824939f4e91083198f9f3da8137aeac32361bd34548c0526fa5"
+checksum = "d5abb1a0cf847d3f9aed1e563b76c358107e7ba66dbfab28f7144252c990bd82"
 dependencies = [
  "anyhow",
  "blake2",
@@ -794,34 +814,50 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec972152bcaa1a2967e412e22a84f6e2984a95c701bcc7943ca8ca10126ee0a2"
+checksum = "3cf80df202c038efc2199be34fda8114b38bfc5b2b51c60cbbdf1f425b07b384"
 dependencies = [
  "anyhow",
  "bytemuck",
  "cfg-if",
  "getrandom",
  "hex",
- "libm",
  "log",
  "num-derive 0.4.1",
  "num-traits",
  "risc0-binfmt",
+ "risc0-circuit-recursion",
  "risc0-circuit-rv32im",
  "risc0-core",
  "risc0-zkp",
  "risc0-zkvm-platform",
+ "rrs-lib",
+ "semver",
  "serde",
- "tempfile",
  "tracing",
 ]
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8524b46783b58b00e9b2a4712e837093c975b23cf25bfaf99e1cf69e9011bf6b"
+checksum = "2dcd6b66f7a4972001db0acf3f06d99b7851c8d9f0de1f7e0fb4496c66c5cd02"
+dependencies = [
+ "bytemuck",
+ "getrandom",
+ "libm",
+]
+
+[[package]]
+name = "rrs-lib"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4382d3af3a4ebdae7f64ba6edd9114fff92c89808004c4943b393377a25d001"
+dependencies = [
+ "downcast-rs",
+ "paste",
+]
 
 [[package]]
 name = "rustc_version"

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.toml
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.toml
@@ -8,8 +8,8 @@ resolver = "2"
 
 [dependencies]
 anyhow = "1.0.68"
-risc0-zkvm = { version = "0.18", default-features = false, features = ["std"] }
-risc0-zkvm-platform = "0.18"
+risc0-zkvm = { version = "0.19", default-features = false, features = ["std"] }
+risc0-zkvm-platform = "0.19"
 sov-mock-da = { path = "../../../../../adapters/mock-da" }
 demo-stf = { path = "../../../stf" }
 sov-risc0-adapter = { path = "../../../../../adapters/risc0" }
@@ -34,5 +34,4 @@ lto = true
 opt-level = 3
 
 [features]
-bench = ["sov-modules-api/bench","sov-state/bench", "sov-modules-stf-blueprint/bench"]
-
+bench = ["sov-modules-api/bench", "sov-state/bench", "sov-modules-stf-blueprint/bench"]

--- a/utils/bashtestmd/Cargo.toml
+++ b/utils/bashtestmd/Cargo.toml
@@ -13,5 +13,6 @@ autotests = false
 
 [dependencies]
 clap = { workspace = true }
+indoc = "2"
 markdown = "1.0.0-alpha.15"
 shell-escape = "0.1.5"

--- a/utils/bashtestmd/src/main.rs
+++ b/utils/bashtestmd/src/main.rs
@@ -57,7 +57,7 @@ impl Command {
 
         if self.long_running {
             writeln!(w, "{} &", self.cmd)?;
-            writeln!(w, "sleep 20")?;
+            writeln!(w, "sleep 60")?;
             return Ok(());
         }
 


### PR DESCRIPTION
# Description
This PR upgrades Risc0 from `v0.18` to [`v0.19`](https://github.com/risc0/risc0/releases/tag/v0.19.0). While the API changes are minimal, the "big" new feature seems to be in-VM recursion. This PR does not test in-VM recursion to see if behavior is as expected or if more changes are needed from our part to support it.

Starting from `v0.19`, Risc0 also makes available precompiled `cargo-risczero` binaries as part of GH release artifacts (for x86_64 Linux and Apple Silicon), which means we can skip compilation and install those directly in CI. Fixes #1036.
