### PR TITLE
Prover Storage Manager 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8965,6 +8965,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sov-prover-storage-manager"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "sov-db",
+ "sov-mock-da",
+ "sov-rollup-interface",
+ "sov-schema-db",
+ "sov-state",
+ "tempfile",
+]
+
+[[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "full-node/sov-ethereum",
     "full-node/sov-ledger-rpc",
     "full-node/sov-stf-runner",
+    "full-node/sov-prover-storage-manager",
     # Utils
     "utils/zk-cycle-macros",
     "utils/zk-cycle-utils",

--- a/adapters/avail/src/spec/hash.rs
+++ b/adapters/avail/src/spec/hash.rs
@@ -2,7 +2,7 @@ use primitive_types::H256;
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::da::BlockHashTrait;
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct AvailHash(H256);
 
 impl AvailHash {

--- a/adapters/mock-da/src/types/mod.rs
+++ b/adapters/mock-da/src/types/mod.rs
@@ -1,6 +1,7 @@
 mod address;
 
 use std::fmt::Formatter;
+use std::hash::Hasher;
 
 pub use address::{MockAddress, MOCK_SEQUENCER_DA_ADDRESS};
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -42,6 +43,13 @@ impl From<[u8; 32]> for MockHash {
 impl From<MockHash> for [u8; 32] {
     fn from(value: MockHash) -> Self {
         value.0
+    }
+}
+
+impl std::hash::Hash for MockHash {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(&self.0);
+        state.finish();
     }
 }
 

--- a/full-node/db/sov-db/src/schema/tables.rs
+++ b/full-node/db/sov-db/src/schema/tables.rs
@@ -208,7 +208,6 @@ macro_rules! define_table_with_seek_key_codec {
     };
 }
 
-// fn deser(target: &mut &[u8]) -> Result<Self, DeserializationError>;
 define_table_with_seek_key_codec!(
     /// The primary source for slot data
     (SlotByNumber) SlotNumber => StoredSlot

--- a/full-node/db/sov-schema-db/src/lib.rs
+++ b/full-node/db/sov-schema-db/src/lib.rs
@@ -311,14 +311,13 @@ impl SchemaBatch {
         column_writes.insert(key, operation);
     }
 
-    #[allow(dead_code)]
     pub(crate) fn read<S: Schema>(
         &self,
         key: &impl KeyCodec<S>,
-    ) -> anyhow::Result<Option<Operation>> {
+    ) -> anyhow::Result<Option<&Operation>> {
         let key = key.encode_key()?;
         if let Some(column_writes) = self.last_writes.get(&S::COLUMN_FAMILY_NAME) {
-            return Ok(column_writes.get(&key).cloned());
+            return Ok(column_writes.get(&key));
         }
         Ok(None)
     }

--- a/full-node/db/sov-schema-db/src/snapshot.rs
+++ b/full-node/db/sov-schema-db/src/snapshot.rs
@@ -35,6 +35,12 @@ impl<T> ReadOnlyLock<T> {
     }
 }
 
+impl<T> From<Arc<RwLock<T>>> for ReadOnlyLock<T> {
+    fn from(value: Arc<RwLock<T>>) -> Self {
+        Self::new(value)
+    }
+}
+
 /// Wrapper around [`QueryManager`] that allows to read from snapshots
 pub struct DbSnapshot<Q> {
     id: SnapshotId,
@@ -142,5 +148,18 @@ fn decode_operation<S: Schema>(operation: &Operation) -> anyhow::Result<Option<S
             Ok(Some(value))
         }
         Operation::Delete => Ok(None),
+    }
+}
+
+/// QueryManager, which never returns any values
+pub struct NoopQueryManager;
+
+impl QueryManager for NoopQueryManager {
+    fn get<S: Schema>(
+        &self,
+        _snapshot_id: SnapshotId,
+        _key: &impl KeyCodec<S>,
+    ) -> anyhow::Result<Option<S::Value>> {
+        Ok(None)
     }
 }

--- a/full-node/db/sov-schema-db/src/snapshot.rs
+++ b/full-node/db/sov-schema-db/src/snapshot.rs
@@ -107,7 +107,7 @@ pub struct FrozenDbSnapshot {
 
 impl FrozenDbSnapshot {
     /// Get value from its own cache
-    pub fn get<S: Schema>(&self, key: &impl KeyCodec<S>) -> anyhow::Result<Option<Operation>> {
+    pub fn get<S: Schema>(&self, key: &impl KeyCodec<S>) -> anyhow::Result<Option<&Operation>> {
         self.cache.read(key)
     }
 
@@ -135,10 +135,10 @@ impl From<FrozenDbSnapshot> for SchemaBatch {
     }
 }
 
-fn decode_operation<S: Schema>(operation: Operation) -> anyhow::Result<Option<S::Value>> {
+fn decode_operation<S: Schema>(operation: &Operation) -> anyhow::Result<Option<S::Value>> {
     match operation {
         Operation::Put { value } => {
-            let value = S::Value::decode_value(&value)?;
+            let value = S::Value::decode_value(value)?;
             Ok(Some(value))
         }
         Operation::Delete => Ok(None),

--- a/full-node/db/sov-schema-db/src/snapshot.rs
+++ b/full-node/db/sov-schema-db/src/snapshot.rs
@@ -10,7 +10,8 @@ pub type SnapshotId = u64;
 
 /// A trait to make nested calls to several [`SchemaBatch`]s and eventually [`crate::DB`]
 pub trait QueryManager {
-    /// Get a value from snapshot or its parents
+    /// Get a value from parents of given [`SnapshotId`]
+    /// In case of unknown [`SnapshotId`] return `Ok(None)`
     fn get<S: Schema>(
         &self,
         snapshot_id: SnapshotId,

--- a/full-node/db/sov-schema-db/tests/snapshot_test.rs
+++ b/full-node/db/sov-schema-db/tests/snapshot_test.rs
@@ -69,7 +69,7 @@ impl QueryManager for LinearSnapshotManager {
         for snapshot in self.snapshots[..snapshot_id as usize].iter().rev() {
             if let Some(operation) = snapshot.get(key)? {
                 return match operation {
-                    Operation::Put { value } => Ok(Some(S::Value::decode_value(&value)?)),
+                    Operation::Put { value } => Ok(Some(S::Value::decode_value(value)?)),
                     Operation::Delete => Ok(None),
                 };
             }

--- a/full-node/sov-prover-storage-manager/Cargo.toml
+++ b/full-node/sov-prover-storage-manager/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "sov-prover-storage-manager"
+description = "Storage manager for prover storage"
+license = { workspace = true }
+edition = { workspace = true }
+authors = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+
+version = { workspace = true }
+readme = "README.md"
+resolver = "2"
+
+[dependencies]
+anyhow = { workspace = true }
+sov-rollup-interface = { path = "../../rollup-interface" }
+sov-db = { path = "../db/sov-db" }
+sov-schema-db = { path = "../db/sov-schema-db" }
+sov-state = { path = "../../module-system/sov-state", features = ["native"] }
+# TODO: Remove this after integrated with `sov-db` fully
+byteorder = { workspace = true, default-features = true }
+
+[dev-dependencies]
+sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
+tempfile = { workspace = true }

--- a/full-node/sov-prover-storage-manager/Cargo.toml
+++ b/full-node/sov-prover-storage-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sov-prover-storage-manager"
-description = "Storage manager for prover storage"
+description = "Hierarchical storage manager for prover storage"
 license = { workspace = true }
 edition = { workspace = true }
 authors = { workspace = true }

--- a/full-node/sov-prover-storage-manager/README.md
+++ b/full-node/sov-prover-storage-manager/README.md
@@ -1,0 +1,3 @@
+# `sov-prover-storage-manager`
+
+Implementation of `StorageManager` for `ProverStorage` that can handle forks and re-orgs

--- a/full-node/sov-prover-storage-manager/src/dummy_storage.rs
+++ b/full-node/sov-prover-storage-manager/src/dummy_storage.rs
@@ -1,3 +1,5 @@
+// This module is used as a temporary filler for `ProverStorage`, until this module is integrated.
+// It is going to be deleted after integration has been completed
 use std::marker::PhantomData;
 
 use byteorder::{BigEndian, ReadBytesExt};
@@ -6,7 +8,7 @@ use sov_schema_db::snapshot::{DbSnapshot, QueryManager};
 use sov_schema_db::{define_schema, CodecError};
 use sov_state::MerkleProofSpec;
 
-/// Oversimplified representation of [`sov_state::ProverStorage`]
+// Oversimplified representation of [`sov_state::ProverStorage`]
 pub struct NewProverStorage<Mps: MerkleProofSpec, Q> {
     state_db: DbSnapshot<Q>,
     native_db: DbSnapshot<Q>,

--- a/full-node/sov-prover-storage-manager/src/dummy_storage.rs
+++ b/full-node/sov-prover-storage-manager/src/dummy_storage.rs
@@ -1,0 +1,145 @@
+use std::marker::PhantomData;
+
+use byteorder::{BigEndian, ReadBytesExt};
+use sov_schema_db::schema::{KeyDecoder, KeyEncoder, Result as CodecResult, ValueCodec};
+use sov_schema_db::snapshot::{DbSnapshot, QueryManager};
+use sov_schema_db::{define_schema, CodecError};
+use sov_state::MerkleProofSpec;
+
+/// Oversimplified representation of [`sov_state::ProverStorage`]
+pub struct NewProverStorage<Mps: MerkleProofSpec, Q> {
+    state_db: DbSnapshot<Q>,
+    native_db: DbSnapshot<Q>,
+    p: PhantomData<Mps>,
+}
+
+impl<Mps: MerkleProofSpec, Q: QueryManager> NewProverStorage<Mps, Q> {
+    pub(crate) fn with_db_handlers(
+        state_db_snapshot: DbSnapshot<Q>,
+        native_db_snapshot: DbSnapshot<Q>,
+    ) -> Self {
+        NewProverStorage {
+            state_db: state_db_snapshot,
+            native_db: native_db_snapshot,
+            p: Default::default(),
+        }
+    }
+
+    pub(crate) fn freeze(self) -> (DbSnapshot<Q>, DbSnapshot<Q>) {
+        let NewProverStorage {
+            state_db,
+            native_db,
+            ..
+        } = self;
+        (state_db, native_db)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn read_state(&self, key: u64) -> anyhow::Result<Option<u64>> {
+        let key = DummyField(key);
+        Ok(self
+            .state_db
+            .read::<DummyStateSchema>(&key)?
+            .map(Into::into))
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn write_state(&self, key: u64, value: u64) -> anyhow::Result<()> {
+        let key = DummyField(key);
+        let value = DummyField(value);
+        self.state_db.put::<DummyStateSchema>(&key, &value)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn read_native(&self, key: u64) -> anyhow::Result<Option<u64>> {
+        let key = DummyField(key);
+        Ok(self
+            .native_db
+            .read::<DummyNativeSchema>(&key)?
+            .map(Into::into))
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn write_native(&self, key: u64, value: u64) -> anyhow::Result<()> {
+        let key = DummyField(key);
+        let value = DummyField(value);
+        self.native_db.put::<DummyNativeSchema>(&key, &value)
+    }
+}
+
+// --------------
+// The code below used to emulate native and state db, but on oversimplified level
+
+pub(crate) const DUMMY_STATE_CF: &str = "DummyStateCF";
+pub(crate) const DUMMY_NATIVE_CF: &str = "DummyNativeCF";
+
+define_schema!(DummyStateSchema, DummyField, DummyField, DUMMY_STATE_CF);
+define_schema!(DummyNativeSchema, DummyField, DummyField, DUMMY_NATIVE_CF);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct DummyField(pub(crate) u64);
+
+impl From<DummyField> for u64 {
+    fn from(value: DummyField) -> Self {
+        value.0
+    }
+}
+
+impl DummyField {
+    fn as_bytes(&self) -> Vec<u8> {
+        self.0.to_be_bytes().to_vec()
+    }
+
+    fn from_bytes(data: &[u8]) -> CodecResult<Self> {
+        let mut reader = std::io::Cursor::new(data);
+        Ok(Self(
+            reader
+                .read_u64::<BigEndian>()
+                .map_err(|e| CodecError::Wrapped(e.into()))?,
+        ))
+    }
+}
+
+impl KeyEncoder<DummyStateSchema> for DummyField {
+    fn encode_key(&self) -> CodecResult<Vec<u8>> {
+        Ok(self.as_bytes())
+    }
+}
+
+impl KeyDecoder<DummyStateSchema> for DummyField {
+    fn decode_key(data: &[u8]) -> CodecResult<Self> {
+        Self::from_bytes(data)
+    }
+}
+
+impl ValueCodec<DummyStateSchema> for DummyField {
+    fn encode_value(&self) -> CodecResult<Vec<u8>> {
+        Ok(self.as_bytes())
+    }
+
+    fn decode_value(data: &[u8]) -> CodecResult<Self> {
+        Self::from_bytes(data)
+    }
+}
+
+impl KeyEncoder<DummyNativeSchema> for DummyField {
+    fn encode_key(&self) -> CodecResult<Vec<u8>> {
+        Ok(self.as_bytes())
+    }
+}
+
+impl KeyDecoder<DummyNativeSchema> for DummyField {
+    fn decode_key(data: &[u8]) -> CodecResult<Self> {
+        Self::from_bytes(data)
+    }
+}
+
+impl ValueCodec<DummyNativeSchema> for DummyField {
+    fn encode_value(&self) -> CodecResult<Vec<u8>> {
+        Ok(self.as_bytes())
+    }
+
+    fn decode_value(data: &[u8]) -> CodecResult<Self> {
+        Self::from_bytes(data)
+    }
+}

--- a/full-node/sov-prover-storage-manager/src/dummy_storage.rs
+++ b/full-node/sov-prover-storage-manager/src/dummy_storage.rs
@@ -34,7 +34,7 @@ impl<Mps: MerkleProofSpec, Q: QueryManager> NewProverStorage<Mps, Q> {
         (state_db, native_db)
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn read_state(&self, key: u64) -> anyhow::Result<Option<u64>> {
         let key = DummyField(key);
         Ok(self
@@ -43,14 +43,20 @@ impl<Mps: MerkleProofSpec, Q: QueryManager> NewProverStorage<Mps, Q> {
             .map(Into::into))
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn write_state(&self, key: u64, value: u64) -> anyhow::Result<()> {
         let key = DummyField(key);
         let value = DummyField(value);
         self.state_db.put::<DummyStateSchema>(&key, &value)
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
+    pub(crate) fn delete_state(&self, key: u64) -> anyhow::Result<()> {
+        let key = DummyField(key);
+        self.state_db.delete::<DummyStateSchema>(&key)
+    }
+
+    #[cfg(test)]
     pub(crate) fn read_native(&self, key: u64) -> anyhow::Result<Option<u64>> {
         let key = DummyField(key);
         Ok(self
@@ -59,11 +65,16 @@ impl<Mps: MerkleProofSpec, Q: QueryManager> NewProverStorage<Mps, Q> {
             .map(Into::into))
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn write_native(&self, key: u64, value: u64) -> anyhow::Result<()> {
         let key = DummyField(key);
         let value = DummyField(value);
         self.native_db.put::<DummyNativeSchema>(&key, &value)
+    }
+
+    pub(crate) fn delete_native(&self, key: u64) -> anyhow::Result<()> {
+        let key = DummyField(key);
+        self.native_db.delete::<DummyNativeSchema>(&key)
     }
 }
 

--- a/full-node/sov-prover-storage-manager/src/dummy_storage.rs
+++ b/full-node/sov-prover-storage-manager/src/dummy_storage.rs
@@ -72,6 +72,7 @@ impl<Mps: MerkleProofSpec, Q: QueryManager> NewProverStorage<Mps, Q> {
         self.native_db.put::<DummyNativeSchema>(&key, &value)
     }
 
+    #[cfg(test)]
     pub(crate) fn delete_native(&self, key: u64) -> anyhow::Result<()> {
         let key = DummyField(key);
         self.native_db.delete::<DummyNativeSchema>(&key)

--- a/full-node/sov-prover-storage-manager/src/lib.rs
+++ b/full-node/sov-prover-storage-manager/src/lib.rs
@@ -1,0 +1,502 @@
+mod dummy_storage;
+mod snapshot_manager;
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::marker::PhantomData;
+use std::sync::{Arc, RwLock};
+
+use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec};
+use sov_rollup_interface::storage::HierarchicalStorageManager;
+use sov_schema_db::snapshot::{DbSnapshot, FrozenDbSnapshot, ReadOnlyLock, SnapshotId};
+use sov_state::MerkleProofSpec;
+
+use crate::dummy_storage::NewProverStorage;
+use crate::snapshot_manager::SnapshotManager;
+
+struct NewProverStorageManager<Da: DaSpec, S: MerkleProofSpec> {
+    // L1 forks representation
+    // Chain: prev_block -> child_blocks
+    chain_forks: HashMap<Da::SlotHash, Vec<Da::SlotHash>>,
+    // Reverse: child_block -> parent
+    blocks_to_parent: HashMap<Da::SlotHash, Da::SlotHash>,
+
+    latest_snapshot_id: SnapshotId,
+    block_hash_to_snapshot_id: HashMap<Da::SlotHash, SnapshotId>,
+    // Same reference for individual managers
+    snapshot_id_to_parent: Arc<RwLock<HashMap<SnapshotId, SnapshotId>>>,
+
+    state_snapshot_manager: Arc<RwLock<SnapshotManager>>,
+    native_snapshot_manager: Arc<RwLock<SnapshotManager>>,
+
+    phantom_mp_spec: PhantomData<S>,
+}
+
+impl<Da: DaSpec, S: MerkleProofSpec> NewProverStorageManager<Da, S> {
+    #[allow(dead_code)]
+    pub fn new(state_db: sov_schema_db::DB, native_db: sov_schema_db::DB) -> Self {
+        let snapshot_id_to_parent = Arc::new(RwLock::new(HashMap::new()));
+
+        let state_snapshot_manager = SnapshotManager::new(state_db, snapshot_id_to_parent.clone());
+        let native_snapshot_manager =
+            SnapshotManager::new(native_db, snapshot_id_to_parent.clone());
+
+        Self {
+            chain_forks: Default::default(),
+            blocks_to_parent: Default::default(),
+            latest_snapshot_id: 0,
+            block_hash_to_snapshot_id: Default::default(),
+            snapshot_id_to_parent,
+            state_snapshot_manager: Arc::new(RwLock::new(state_snapshot_manager)),
+            native_snapshot_manager: Arc::new(RwLock::new(native_snapshot_manager)),
+            phantom_mp_spec: Default::default(),
+        }
+    }
+
+    #[cfg(test)]
+    fn is_empty(&self) -> bool {
+        self.chain_forks.is_empty()
+            && self.blocks_to_parent.is_empty()
+            && self.block_hash_to_snapshot_id.is_empty()
+            && self.snapshot_id_to_parent.read().unwrap().is_empty()
+            && self.state_snapshot_manager.read().unwrap().is_empty()
+            && self.native_snapshot_manager.read().unwrap().is_empty()
+    }
+}
+
+impl<Da: DaSpec, S: MerkleProofSpec> HierarchicalStorageManager<Da>
+    for NewProverStorageManager<Da, S>
+where
+    Da::SlotHash: Hash,
+{
+    type NativeStorage = NewProverStorage<S, SnapshotManager>;
+    type NativeChangeSet = NewProverStorage<S, SnapshotManager>;
+
+    fn get_native_storage_on(
+        &mut self,
+        block_header: &Da::BlockHeader,
+    ) -> anyhow::Result<Self::NativeStorage> {
+        let current_block_hash = block_header.hash();
+        let prev_block_hash = block_header.prev_hash();
+        assert_ne!(
+            current_block_hash, prev_block_hash,
+            "Cannot provide storage for corrupt block"
+        );
+
+        let new_snapshot_id = match self.block_hash_to_snapshot_id.get(&current_block_hash) {
+            // Storage for this block has been requested before
+            Some(snapshot_id) => {
+                // TODO: Do consistency checks here?
+
+                *snapshot_id
+            }
+            // Storage requested first time
+            None => {
+                let new_snapshot_id = self.latest_snapshot_id + 1;
+                if let Some(parent_snapshot_id) =
+                    self.block_hash_to_snapshot_id.get(&prev_block_hash)
+                {
+                    let mut snapshot_id_to_parent = self.snapshot_id_to_parent.write().unwrap();
+                    snapshot_id_to_parent.insert(new_snapshot_id, *parent_snapshot_id);
+                }
+
+                self.block_hash_to_snapshot_id
+                    .insert(current_block_hash.clone(), new_snapshot_id);
+
+                self.chain_forks
+                    .entry(prev_block_hash.clone())
+                    .or_default()
+                    .push(current_block_hash.clone());
+
+                self.blocks_to_parent
+                    .insert(current_block_hash, prev_block_hash);
+
+                // Update latest snapshot id
+                self.latest_snapshot_id = new_snapshot_id;
+                new_snapshot_id
+            }
+        };
+        println!(
+            "BLOCK HEIGHT={} SNAP_ID={}",
+            block_header.height(),
+            new_snapshot_id
+        );
+
+        let state_db_snapshot = DbSnapshot::new(
+            new_snapshot_id,
+            ReadOnlyLock::new(self.state_snapshot_manager.clone()),
+        );
+
+        let native_db_snapshot = DbSnapshot::new(
+            new_snapshot_id,
+            ReadOnlyLock::new(self.native_snapshot_manager.clone()),
+        );
+
+        Ok(NewProverStorage::with_db_handlers(
+            state_db_snapshot,
+            native_db_snapshot,
+        ))
+    }
+
+    fn save_change_set(
+        &mut self,
+        block_header: &Da::BlockHeader,
+        change_set: Self::NativeChangeSet,
+    ) -> anyhow::Result<()> {
+        if !self.chain_forks.contains_key(&block_header.prev_hash()) {
+            anyhow::bail!("Attempt to save changeset for unknown block header");
+        }
+        let (state_db, native_db) = change_set.freeze();
+        let state_snapshot: FrozenDbSnapshot = state_db.into();
+        let native_snapshot: FrozenDbSnapshot = native_db.into();
+        let snapshot_id = state_snapshot.get_id();
+        if snapshot_id != native_snapshot.get_id() {
+            anyhow::bail!(
+                "State id={} and Native id={} snapshots have different are not matching",
+                snapshot_id,
+                native_snapshot.get_id()
+            );
+        }
+
+        // Obviously alien
+        println!("L={} S={}", self.latest_snapshot_id, snapshot_id);
+        if snapshot_id > self.latest_snapshot_id {
+            anyhow::bail!("Attempt to save unknown snapshot with id={}", snapshot_id);
+        }
+
+        {
+            let existing_snapshot_id = self
+                .block_hash_to_snapshot_id
+                .get(&block_header.hash())
+                .expect("Inconsistent block_hash_to_snapshot_id");
+            if *existing_snapshot_id != snapshot_id {
+                anyhow::bail!("Attempt to save unknown snapshot with id={}", snapshot_id);
+            }
+        }
+
+        {
+            let mut state_manager = self.state_snapshot_manager.write().unwrap();
+            let mut native_manager = self.native_snapshot_manager.write().unwrap();
+
+            state_manager.add_snapshot(state_snapshot);
+            native_manager.add_snapshot(native_snapshot);
+        }
+
+        Ok(())
+    }
+
+    fn finalize(&mut self, block_header: &Da::BlockHeader) -> anyhow::Result<()> {
+        let current_block_hash = block_header.hash();
+        let prev_block_hash = block_header.prev_hash();
+
+        let snapshot_id = self
+            .block_hash_to_snapshot_id
+            .remove(&current_block_hash)
+            .ok_or(anyhow::anyhow!("Attempt to finalize non existing snapshot"))?;
+
+        let mut state_manager = self.state_snapshot_manager.write().unwrap();
+        let mut native_manager = self.native_snapshot_manager.write().unwrap();
+
+        // Return error here, as underlying database can return error
+        state_manager.commit_snapshot(&snapshot_id)?;
+        native_manager.commit_snapshot(&snapshot_id)?;
+
+        // All siblings of current snapshot
+        let mut to_discard: Vec<_> = self
+            .chain_forks
+            .remove(&prev_block_hash)
+            .expect("Inconsistent chain_forks")
+            .into_iter()
+            .filter(|bh| bh != &current_block_hash)
+            .collect();
+
+        while let Some(block_hash) = to_discard.pop() {
+            let child_block_hashes = self.chain_forks.remove(&block_hash).unwrap_or_default();
+            self.blocks_to_parent.remove(&block_hash).unwrap();
+            let snapshot_id = self.block_hash_to_snapshot_id.remove(&block_hash).unwrap();
+
+            state_manager.discard_snapshot(&snapshot_id);
+            native_manager.discard_snapshot(&snapshot_id);
+
+            to_discard.extend(child_block_hashes);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path;
+
+    use sov_db::rocks_db_config::gen_rocksdb_options;
+    use sov_mock_da::{MockBlockHeader, MockHash};
+    use sov_schema_db::snapshot::FrozenDbSnapshot;
+
+    use super::*;
+    use crate::dummy_storage::{
+        DummyField, DummyNativeSchema, DummyStateSchema, DUMMY_NATIVE_CF, DUMMY_STATE_CF,
+    };
+
+    type Da = sov_mock_da::MockDaSpec;
+    type S = sov_state::DefaultStorageSpec;
+
+    fn build_dbs(
+        state_path: &path::Path,
+        native_path: &path::Path,
+    ) -> (sov_schema_db::DB, sov_schema_db::DB) {
+        let state_tables = vec![DUMMY_STATE_CF.to_string()];
+        let state_db = sov_schema_db::DB::open(
+            state_path,
+            "state_db",
+            state_tables,
+            &gen_rocksdb_options(&Default::default(), false),
+        )
+        .unwrap();
+        let native_tables = vec![DUMMY_NATIVE_CF.to_string()];
+        let native_db = sov_schema_db::DB::open(
+            native_path,
+            "native_db",
+            native_tables,
+            &gen_rocksdb_options(&Default::default(), false),
+        )
+        .unwrap();
+
+        (state_db, native_db)
+    }
+
+    #[test]
+    fn initiate_new() {
+        let state_tmpdir = tempfile::tempdir().unwrap();
+        let native_tmpdir = tempfile::tempdir().unwrap();
+
+        let (state_db, native_db) = build_dbs(state_tmpdir.path(), native_tmpdir.path());
+
+        let storage_manager = NewProverStorageManager::<Da, S>::new(state_db, native_db);
+        assert!(storage_manager.is_empty());
+    }
+
+    #[test]
+    fn get_new_storage() {
+        let state_tmpdir = tempfile::tempdir().unwrap();
+        let native_tmpdir = tempfile::tempdir().unwrap();
+
+        let (state_db, native_db) = build_dbs(state_tmpdir.path(), native_tmpdir.path());
+
+        let mut storage_manager = NewProverStorageManager::<Da, S>::new(state_db, native_db);
+        assert!(storage_manager.is_empty());
+
+        let block_header = MockBlockHeader {
+            prev_hash: MockHash::from([1; 32]),
+            hash: MockHash::from([2; 32]),
+            height: 1,
+        };
+
+        let _storage = storage_manager
+            .get_native_storage_on(&block_header)
+            .unwrap();
+
+        assert!(!storage_manager.is_empty());
+        assert!(!storage_manager.chain_forks.is_empty());
+        assert!(!storage_manager.block_hash_to_snapshot_id.is_empty());
+        assert!(storage_manager
+            .snapshot_id_to_parent
+            .read()
+            .unwrap()
+            .is_empty());
+        assert!(storage_manager
+            .state_snapshot_manager
+            .read()
+            .unwrap()
+            .is_empty());
+        assert!(storage_manager
+            .native_snapshot_manager
+            .read()
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn try_get_new_storage_same_block() {
+        let state_tmpdir = tempfile::tempdir().unwrap();
+        let native_tmpdir = tempfile::tempdir().unwrap();
+
+        let (state_db, native_db) = build_dbs(state_tmpdir.path(), native_tmpdir.path());
+
+        let mut storage_manager = NewProverStorageManager::<Da, S>::new(state_db, native_db);
+        assert!(storage_manager.is_empty());
+
+        let block_header = MockBlockHeader {
+            prev_hash: MockHash::from([1; 32]),
+            hash: MockHash::from([2; 32]),
+            height: 1,
+        };
+
+        let storage_1 = storage_manager
+            .get_native_storage_on(&block_header)
+            .unwrap();
+
+        let storage_2 = storage_manager
+            .get_native_storage_on(&block_header)
+            .unwrap();
+
+        // We just check, that both storage have same underlying id.
+        // This is more tight with implementation.
+        // More black box way to check would be:
+        //   - have some data in db
+        //   - have some parent snapshots
+        //   - make sure that writing to each individual storage do not propagate to another
+        //   - both storage have same view of the previous state, for example they don't look into siblings
+        let (state_db_1, native_db_1) = storage_1.freeze();
+        let state_snapshot_1 = FrozenDbSnapshot::from(state_db_1);
+        let native_snapshot_1 = FrozenDbSnapshot::from(native_db_1);
+        let (state_db_2, native_db_2) = storage_2.freeze();
+        let state_snapshot_2 = FrozenDbSnapshot::from(state_db_2);
+        let native_snapshot_2 = FrozenDbSnapshot::from(native_db_2);
+
+        assert_eq!(state_snapshot_1.get_id(), state_snapshot_2.get_id());
+        assert_eq!(native_snapshot_1.get_id(), native_snapshot_2.get_id());
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot provide storage for corrupt block")]
+    fn try_get_new_storage_corrupt_block() {
+        let state_tmpdir = tempfile::tempdir().unwrap();
+        let native_tmpdir = tempfile::tempdir().unwrap();
+
+        let (state_db, native_db) = build_dbs(state_tmpdir.path(), native_tmpdir.path());
+
+        let mut storage_manager = NewProverStorageManager::<Da, S>::new(state_db, native_db);
+        assert!(storage_manager.is_empty());
+
+        let block_header = MockBlockHeader {
+            prev_hash: MockHash::from([1; 32]),
+            hash: MockHash::from([1; 32]),
+            height: 1,
+        };
+
+        let _storage_1 = storage_manager
+            .get_native_storage_on(&block_header)
+            .unwrap();
+    }
+
+    #[test]
+    #[ignore = "TBD"]
+    fn save_change_set() {}
+
+    #[test]
+    fn try_save_unknown_changeset() {
+        let state_tmpdir_1 = tempfile::tempdir().unwrap();
+        let native_tmpdir_1 = tempfile::tempdir().unwrap();
+
+        let state_tmpdir_2 = tempfile::tempdir().unwrap();
+        let native_tmpdir_2 = tempfile::tempdir().unwrap();
+
+        let block_a = MockBlockHeader {
+            prev_hash: MockHash::from([1; 32]),
+            hash: MockHash::from([2; 32]),
+            height: 1,
+        };
+
+        let snapshot_1 = {
+            let (state_db, native_db) = build_dbs(state_tmpdir_1.path(), native_tmpdir_1.path());
+            let mut storage_manager_temp =
+                NewProverStorageManager::<Da, S>::new(state_db, native_db);
+            storage_manager_temp
+                .get_native_storage_on(&block_a)
+                .unwrap()
+        };
+
+        let (state_db, native_db) = build_dbs(state_tmpdir_2.path(), native_tmpdir_2.path());
+        let mut storage_manager = NewProverStorageManager::<Da, S>::new(state_db, native_db);
+
+        let unknown_id = storage_manager.save_change_set(&block_a, snapshot_1);
+        assert!(unknown_id.is_err());
+        assert!(unknown_id
+            .err()
+            .unwrap()
+            .to_string()
+            .starts_with("Attempt to save unknown snapshot with id="));
+
+        // TODO: Unknown block
+
+        // TODO: Block / snapshot_id mismatch
+    }
+
+    #[test]
+    fn lifecycle_simulation() {
+        let state_tmpdir = tempfile::tempdir().unwrap();
+        let native_tmpdir = tempfile::tempdir().unwrap();
+
+        let (state_db, native_db) = build_dbs(state_tmpdir.path(), native_tmpdir.path());
+
+        // State DB has following values initially:
+        // x = 1
+        // y = 2
+
+        let x = DummyField(1);
+        let y = DummyField(2);
+        let _z = DummyField(3);
+
+        state_db
+            .put::<DummyStateSchema>(&x, &DummyField(1))
+            .unwrap();
+        state_db
+            .put::<DummyStateSchema>(&y, &DummyField(2))
+            .unwrap();
+
+        // Native DB has following values initially
+        // 10 = 10
+        // 20 = 20
+
+        native_db
+            .put::<DummyNativeSchema>(&x, &DummyField(100))
+            .unwrap();
+        native_db
+            .put::<DummyNativeSchema>(&y, &DummyField(200))
+            .unwrap();
+
+        let mut storage_manager = NewProverStorageManager::<Da, S>::new(state_db, native_db);
+        assert!(storage_manager.is_empty());
+
+        //      / -> D
+        // A -> B -> C -> D -> E
+        // |    \ -> G -> H
+        // \ -> F -> K
+        //
+
+        // Block A
+        let block_a = MockBlockHeader {
+            prev_hash: MockHash::from([0; 32]),
+            hash: MockHash::from([1; 32]),
+            height: 1,
+        };
+
+        let storage_a = storage_manager.get_native_storage_on(&block_a).unwrap();
+
+        let state_x_actual = storage_a.read_state(x.0).unwrap();
+        assert_eq!(Some(1), state_x_actual);
+
+        let native_x_actual = storage_a.read_native(x.0).unwrap();
+        assert_eq!(Some(100), native_x_actual);
+
+        storage_a.write_state(x.0, 2).unwrap();
+        storage_a.write_native(x.0, 20).unwrap();
+
+        storage_manager
+            .save_change_set(&block_a, storage_a)
+            .unwrap();
+
+        // Block B
+        let block_b = MockBlockHeader {
+            prev_hash: MockHash::from([1; 32]),
+            hash: MockHash::from([2; 32]),
+            height: 1,
+        };
+
+        let storage_b = storage_manager.get_native_storage_on(&block_b).unwrap();
+
+        assert_eq!(Some(2), storage_b.read_state(x.0).unwrap());
+        assert_eq!(Some(20), storage_b.read_native(x.0).unwrap());
+    }
+}

--- a/full-node/sov-prover-storage-manager/src/lib.rs
+++ b/full-node/sov-prover-storage-manager/src/lib.rs
@@ -94,11 +94,7 @@ where
 
         let new_snapshot_id = match self.block_hash_to_snapshot_id.get(&current_block_hash) {
             // Storage for this block has been requested before
-            Some(snapshot_id) => {
-                // TODO: Do consistency checks here?
-
-                *snapshot_id
-            }
+            Some(snapshot_id) => *snapshot_id,
             // Storage requested first time
             None => {
                 let new_snapshot_id = self.latest_snapshot_id + 1;

--- a/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
+++ b/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
@@ -37,7 +37,7 @@ impl SnapshotManager {
     pub(crate) fn discard_snapshot(&mut self, snapshot_id: &SnapshotId) {
         self.snapshots
             .remove(snapshot_id)
-            .expect("Attempt to remove unknown snapshot");
+            .expect("Attempt to discard unknown snapshot");
     }
 
     pub(crate) fn commit_snapshot(&mut self, snapshot_id: &SnapshotId) -> anyhow::Result<()> {
@@ -83,4 +83,153 @@ impl QueryManager for SnapshotManager {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::{Arc, RwLock};
+
+    use sov_db::rocks_db_config::gen_rocksdb_options;
+    use sov_schema_db::snapshot::{DbSnapshot, NoopQueryManager};
+
+    use crate::dummy_storage::DUMMY_STATE_CF;
+    use crate::snapshot_manager::SnapshotManager;
+
+    fn create_test_db(path: &std::path::Path) -> sov_schema_db::DB {
+        let tables = vec![DUMMY_STATE_CF.to_string()];
+        let db = sov_schema_db::DB::open(
+            path,
+            "test_db",
+            tables,
+            &gen_rocksdb_options(&Default::default(), false),
+        )
+        .unwrap();
+        db
+    }
+
+    #[test]
+    fn test_empty() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let db = create_test_db(tempdir.path());
+        let snapshot_manager = SnapshotManager::new(db, Arc::new(RwLock::new(HashMap::new())));
+        assert!(snapshot_manager.is_empty());
+    }
+
+    #[test]
+    fn test_add_and_discard_snapshot() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let db = create_test_db(tempdir.path());
+        let to_parent = Arc::new(RwLock::new(HashMap::new()));
+        let mut snapshot_manager = SnapshotManager::new(db, to_parent.clone());
+        let query_manager = Arc::new(RwLock::new(NoopQueryManager));
+
+        let snapshot_id = 1;
+        let db_snapshot = DbSnapshot::new(snapshot_id, query_manager.clone().into());
+
+        snapshot_manager.add_snapshot(db_snapshot.into());
+        assert!(!snapshot_manager.is_empty());
+        snapshot_manager.discard_snapshot(&snapshot_id);
+        assert!(snapshot_manager.is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "Attempt to double save same snapshot")]
+    fn test_add_twice() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let db = create_test_db(tempdir.path());
+        let to_parent = Arc::new(RwLock::new(HashMap::new()));
+        let mut snapshot_manager = SnapshotManager::new(db, to_parent.clone());
+        let query_manager = Arc::new(RwLock::new(NoopQueryManager));
+
+        let snapshot_id = 1;
+        // Both share the same ID
+        let db_snapshot_1 = DbSnapshot::new(snapshot_id, query_manager.clone().into());
+        let db_snapshot_2 = DbSnapshot::new(snapshot_id, query_manager.clone().into());
+
+        snapshot_manager.add_snapshot(db_snapshot_1.into());
+        assert!(!snapshot_manager.is_empty());
+        snapshot_manager.add_snapshot(db_snapshot_2.into());
+    }
+
+    #[test]
+    #[should_panic(expected = "Attempt to commit unknown snapshot")]
+    fn test_commit_unknown() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let db = create_test_db(tempdir.path());
+        let to_parent = Arc::new(RwLock::new(HashMap::new()));
+        let mut snapshot_manager = SnapshotManager::new(db, to_parent.clone());
+
+        snapshot_manager.commit_snapshot(&1).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Attempt to discard unknown snapshot")]
+    fn test_discard_unknown() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let db = create_test_db(tempdir.path());
+        let to_parent = Arc::new(RwLock::new(HashMap::new()));
+        let mut snapshot_manager = SnapshotManager::new(db, to_parent.clone());
+
+        snapshot_manager.discard_snapshot(&1);
+    }
+
+    #[test]
+    fn test_commit_snapshot() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let db = create_test_db(tempdir.path());
+        let to_parent = Arc::new(RwLock::new(HashMap::new()));
+        let mut snapshot_manager = SnapshotManager::new(db, to_parent.clone());
+        let query_manager = Arc::new(RwLock::new(NoopQueryManager));
+
+        let snapshot_id = 1;
+        let db_snapshot = DbSnapshot::new(snapshot_id, query_manager.clone().into());
+
+        snapshot_manager.add_snapshot(db_snapshot.into());
+        let result = snapshot_manager.commit_snapshot(&snapshot_id);
+        assert!(result.is_ok());
+        assert!(snapshot_manager.is_empty());
+    }
+
+    #[test]
+    #[ignore = "TBD"]
+    fn test_query_lifecycle() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let db = create_test_db(tempdir.path());
+        let to_parent = Arc::new(RwLock::new(HashMap::new()));
+        {
+            //            / -> 6 -> 7
+            // DB -> 1 -> 2 -> 3
+            //       \ -> 4 -> 5
+            let mut edit = to_parent.write().unwrap();
+            edit.insert(3, 2);
+            edit.insert(2, 1);
+            edit.insert(4, 1);
+            edit.insert(5, 4);
+            edit.insert(6, 2);
+            edit.insert(7, 6);
+        }
+        let _snapshot_manager = SnapshotManager::new(db, to_parent.clone());
+        let _query_manager = Arc::new(RwLock::new(NoopQueryManager));
+
+        // Operations:
+        // | snapshot_id | key | operation |
+        // | DB          |   1 |  write(1) |
+        // | 1           |   1 |  write(2) |
+        // | 1           |   2 |  write(3) |
+        // | 2           |   1 |  delete   |
+        // | 2           |   2 |  write(4) |
+        // | 4           |   1 |  write(5) |
+        // | 4           |   3 |  write(6) |
+        // | 6           |   1 |  write(7) |
+
+        // View:
+        // | from s_id   | key | value |
+        // | 3           |   1 |  None |
+        // | 3           |   2 |     3 |
+        // | 3           |   3 |  None |
+        // | 5           |   1 |     5 |
+        // | 5           |   2 |     4 |
+        // | 5           |   3 |     6 |
+        // | 7           |   1 |     7 |
+        // | 7           |   2 |     4 |
+        // | 7           |   3 |  None |
+    }
+}

--- a/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
+++ b/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
@@ -35,9 +35,7 @@ impl SnapshotManager {
     }
 
     pub(crate) fn discard_snapshot(&mut self, snapshot_id: &SnapshotId) {
-        self.snapshots
-            .remove(snapshot_id)
-            .expect("Attempt to discard unknown snapshot");
+        self.snapshots.remove(snapshot_id);
     }
 
     pub(crate) fn commit_snapshot(&mut self, snapshot_id: &SnapshotId) -> anyhow::Result<()> {
@@ -65,7 +63,7 @@ impl QueryManager for SnapshotManager {
             let parent_snapshot = self
                 .snapshots
                 .get(parent_snapshot_id)
-                .expect("Inconsistency between snapshots and to_parent");
+                .expect("Inconsistency between `self.snapshots` and `self.to_parent`");
 
             // Some operation has been found
             if let Some(operation) = parent_snapshot.get(key)? {
@@ -164,8 +162,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Attempt to discard unknown snapshot")]
     fn test_discard_unknown() {
+        // Discarding unknown snapshots are fine.
+        // As it possible that caller didn't save it previously.
         let tempdir = tempfile::tempdir().unwrap();
         let db = create_test_db(tempdir.path());
         let to_parent = Arc::new(RwLock::new(HashMap::new()));

--- a/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
+++ b/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
@@ -52,7 +52,6 @@ impl SnapshotManager {
         self.snapshots.is_empty()
     }
 
-    #[cfg(test)]
     pub(crate) fn contains_snapshot(&self, snapshot_id: &SnapshotId) -> bool {
         self.snapshots.contains_key(snapshot_id)
     }

--- a/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
+++ b/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
@@ -51,6 +51,11 @@ impl SnapshotManager {
     pub(crate) fn is_empty(&self) -> bool {
         self.snapshots.is_empty()
     }
+
+    #[cfg(test)]
+    pub(crate) fn contains_snapshot(&self, snapshot_id: &SnapshotId) -> bool {
+        self.snapshots.contains_key(snapshot_id)
+    }
 }
 
 impl QueryManager for SnapshotManager {

--- a/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
+++ b/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
@@ -101,14 +101,13 @@ mod tests {
 
     fn create_test_db(path: &std::path::Path) -> sov_schema_db::DB {
         let tables = vec![DUMMY_STATE_CF.to_string()];
-        let db = sov_schema_db::DB::open(
+        sov_schema_db::DB::open(
             path,
             "test_db",
             tables,
             &gen_rocksdb_options(&Default::default(), false),
         )
-        .unwrap();
-        db
+        .unwrap()
     }
 
     #[test]
@@ -258,17 +257,17 @@ mod tests {
             edit.insert(7, 6);
         }
 
-        let one = DummyField(1);
-        let two = DummyField(2);
-        let three = DummyField(3);
-        let four = DummyField(4);
-        let five = DummyField(5);
-        let six = DummyField(6);
-        let seven = DummyField(7);
-        let eight = DummyField(8);
+        let f1 = DummyField(1);
+        let f2 = DummyField(2);
+        let f3 = DummyField(3);
+        let f4 = DummyField(4);
+        let f5 = DummyField(5);
+        let f6 = DummyField(6);
+        let f7 = DummyField(7);
+        let f8 = DummyField(8);
 
         let mut db_data = SchemaBatch::new();
-        db_data.put::<Schema>(&one, &one).unwrap();
+        db_data.put::<Schema>(&f1, &f1).unwrap();
         db.write_schemas(db_data).unwrap();
 
         let mut snapshot_manager = SnapshotManager::new(db, to_parent.clone());
@@ -287,14 +286,14 @@ mod tests {
 
         // 1
         let db_snapshot = DbSnapshot::new(1, query_manager.clone().into());
-        db_snapshot.put::<Schema>(&two, &two).unwrap();
-        db_snapshot.put::<Schema>(&three, &four).unwrap();
+        db_snapshot.put::<Schema>(&f2, &f2).unwrap();
+        db_snapshot.put::<Schema>(&f3, &f4).unwrap();
         snapshot_manager.add_snapshot(db_snapshot.into());
 
         // 2
         let db_snapshot = DbSnapshot::new(2, query_manager.clone().into());
-        db_snapshot.put::<Schema>(&one, &five).unwrap();
-        db_snapshot.delete::<Schema>(&two).unwrap();
+        db_snapshot.put::<Schema>(&f1, &f5).unwrap();
+        db_snapshot.delete::<Schema>(&f2).unwrap();
         snapshot_manager.add_snapshot(db_snapshot.into());
 
         // 3
@@ -303,7 +302,7 @@ mod tests {
 
         // 4
         let db_snapshot = DbSnapshot::new(4, query_manager.clone().into());
-        db_snapshot.put::<Schema>(&three, &six).unwrap();
+        db_snapshot.put::<Schema>(&f3, &f6).unwrap();
         snapshot_manager.add_snapshot(db_snapshot.into());
 
         // 5
@@ -312,8 +311,8 @@ mod tests {
 
         // 6
         let db_snapshot = DbSnapshot::new(6, query_manager.clone().into());
-        db_snapshot.put::<Schema>(&one, &seven).unwrap();
-        db_snapshot.put::<Schema>(&two, &eight).unwrap();
+        db_snapshot.put::<Schema>(&f1, &f7).unwrap();
+        db_snapshot.put::<Schema>(&f2, &f8).unwrap();
         snapshot_manager.add_snapshot(db_snapshot.into());
 
         // 7
@@ -331,39 +330,15 @@ mod tests {
         // | 7           |   1 |     7 |
         // | 7           |   2 |     8 |
         // | 7           |   3 |     4 |
-        assert_eq!(
-            Some(five.clone()),
-            snapshot_manager.get::<Schema>(3, &one).unwrap()
-        );
-        assert_eq!(None, snapshot_manager.get::<Schema>(3, &two).unwrap());
-        assert_eq!(
-            Some(four.clone()),
-            snapshot_manager.get::<Schema>(3, &three).unwrap()
-        );
-        assert_eq!(
-            Some(one.clone()),
-            snapshot_manager.get::<Schema>(5, &one).unwrap()
-        );
-        assert_eq!(
-            Some(two.clone()),
-            snapshot_manager.get::<Schema>(5, &two).unwrap()
-        );
-        assert_eq!(
-            Some(six.clone()),
-            snapshot_manager.get::<Schema>(5, &three).unwrap()
-        );
+        assert_eq!(Some(f5), snapshot_manager.get::<Schema>(3, &f1).unwrap());
+        assert_eq!(None, snapshot_manager.get::<Schema>(3, &f2).unwrap());
+        assert_eq!(Some(f4), snapshot_manager.get::<Schema>(3, &f3).unwrap());
+        assert_eq!(Some(f1), snapshot_manager.get::<Schema>(5, &f1).unwrap());
+        assert_eq!(Some(f2), snapshot_manager.get::<Schema>(5, &f2).unwrap());
+        assert_eq!(Some(f6), snapshot_manager.get::<Schema>(5, &f3).unwrap());
 
-        assert_eq!(
-            Some(seven),
-            snapshot_manager.get::<Schema>(7, &one).unwrap()
-        );
-        assert_eq!(
-            Some(eight),
-            snapshot_manager.get::<Schema>(7, &two).unwrap()
-        );
-        assert_eq!(
-            Some(four),
-            snapshot_manager.get::<Schema>(7, &three).unwrap()
-        );
+        assert_eq!(Some(f7), snapshot_manager.get::<Schema>(7, &f1).unwrap());
+        assert_eq!(Some(f8), snapshot_manager.get::<Schema>(7, &f2).unwrap());
+        assert_eq!(Some(f4), snapshot_manager.get::<Schema>(7, &f3).unwrap());
     }
 }

--- a/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
+++ b/full-node/sov-prover-storage-manager/src/snapshot_manager.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use sov_schema_db::schema::{KeyCodec, ValueCodec};
+use sov_schema_db::snapshot::{FrozenDbSnapshot, QueryManager, SnapshotId};
+use sov_schema_db::{Operation, Schema};
+
+/// Snapshot manager holds snapshots associated with particular DB and can traverse them backwards
+/// down to DB level
+/// Managed externally by [`NewProverStorageManager`]
+pub struct SnapshotManager {
+    db: sov_schema_db::DB,
+    snapshots: HashMap<SnapshotId, FrozenDbSnapshot>,
+    /// Hierarchical
+    to_parent: Arc<RwLock<HashMap<SnapshotId, SnapshotId>>>,
+}
+
+impl SnapshotManager {
+    pub(crate) fn new(
+        db: sov_schema_db::DB,
+        to_parent: Arc<RwLock<HashMap<SnapshotId, SnapshotId>>>,
+    ) -> Self {
+        Self {
+            db,
+            snapshots: HashMap::new(),
+            to_parent,
+        }
+    }
+
+    pub(crate) fn add_snapshot(&mut self, snapshot: FrozenDbSnapshot) {
+        let snapshot_id = snapshot.get_id();
+        if self.snapshots.insert(snapshot_id, snapshot).is_some() {
+            panic!("Attempt to double save same snapshot");
+        }
+    }
+
+    pub(crate) fn discard_snapshot(&mut self, snapshot_id: &SnapshotId) {
+        self.snapshots
+            .remove(snapshot_id)
+            .expect("Attempt to remove unknown snapshot");
+    }
+
+    pub(crate) fn commit_snapshot(&mut self, snapshot_id: &SnapshotId) -> anyhow::Result<()> {
+        if !self.snapshots.contains_key(snapshot_id) {
+            anyhow::bail!("Attempt to commit unknown snapshot");
+        }
+
+        let snapshot = self.snapshots.remove(snapshot_id).unwrap();
+        self.db.write_schemas(snapshot.into())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.snapshots.is_empty()
+    }
+}
+
+impl QueryManager for SnapshotManager {
+    fn get<S: Schema>(
+        &self,
+        mut snapshot_id: SnapshotId,
+        key: &impl KeyCodec<S>,
+    ) -> anyhow::Result<Option<S::Value>> {
+        while let Some(parent_snapshot_id) = self.to_parent.read().unwrap().get(&snapshot_id) {
+            let parent_snapshot = self
+                .snapshots
+                .get(parent_snapshot_id)
+                .expect("Inconsistent snapshots tree");
+
+            // Some operation has been found
+            if let Some(operation) = parent_snapshot.get(key)? {
+                return match operation {
+                    Operation::Put { value } => Ok(Some(S::Value::decode_value(value)?)),
+                    Operation::Delete => Ok(None),
+                };
+            }
+
+            snapshot_id = *parent_snapshot_id;
+        }
+
+        self.db.get(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/packages_to_publish.yml
+++ b/packages_to_publish.yml
@@ -7,6 +7,7 @@
 - sov-zk-cycle-utils
 - sov-modules-core
 - sov-state
+- sov-prover-storage-manager
 - sov-modules-macros # Requires --no-verify because it writes outside of OUT_DIR.
 - sov-modules-api
 - sov-sequencer

--- a/rollup-interface/src/state_machine/da.rs
+++ b/rollup-interface/src/state_machine/da.rs
@@ -179,6 +179,8 @@ pub trait BlobReaderTrait: Serialize + DeserializeOwned + Send + Sync + 'static 
 
 /// Trait with collection of trait bounds for a block hash.
 pub trait BlockHashTrait:
+    // TODO: Can we replace `Into<[u8; 32]>` with std::hash::Hash 
+    // so it is compatible with StorageManager implementation?
     Serialize + DeserializeOwned + PartialEq + Debug + Send + Sync + Clone + Eq + Into<[u8; 32]>
 {
 }

--- a/rollup-interface/src/state_machine/da.rs
+++ b/rollup-interface/src/state_machine/da.rs
@@ -180,7 +180,7 @@ pub trait BlobReaderTrait: Serialize + DeserializeOwned + Send + Sync + 'static 
 /// Trait with collection of trait bounds for a block hash.
 pub trait BlockHashTrait:
     // so it is compatible with StorageManager implementation?
-    Serialize + DeserializeOwned + PartialEq + Debug + Send + Sync + Clone + Eq + Into<[u8; 32]> + std::hash::Hash
+    Serialize + DeserializeOwned + PartialEq + Debug + Send + Sync + Clone + Eq + Into<[u8; 32]> + core::hash::Hash
 {
 }
 

--- a/rollup-interface/src/state_machine/da.rs
+++ b/rollup-interface/src/state_machine/da.rs
@@ -179,9 +179,8 @@ pub trait BlobReaderTrait: Serialize + DeserializeOwned + Send + Sync + 'static 
 
 /// Trait with collection of trait bounds for a block hash.
 pub trait BlockHashTrait:
-    // TODO: Can we replace `Into<[u8; 32]>` with std::hash::Hash 
     // so it is compatible with StorageManager implementation?
-    Serialize + DeserializeOwned + PartialEq + Debug + Send + Sync + Clone + Eq + Into<[u8; 32]>
+    Serialize + DeserializeOwned + PartialEq + Debug + Send + Sync + Clone + Eq + Into<[u8; 32]> + std::hash::Hash
 {
 }
 

--- a/rollup-interface/src/state_machine/storage.rs
+++ b/rollup-interface/src/state_machine/storage.rs
@@ -30,7 +30,7 @@ pub trait HierarchicalStorageManager<Da: DaSpec> {
         block_header: &Da::BlockHeader,
     ) -> anyhow::Result<Self::NativeStorage>;
 
-    /// Adds [`Self::ChangeSet`] to the storage.
+    /// Adds [`Self::NativeChangeSet`] to the storage.
     /// [`DaSpec::BlockHeader`] must be provided for efficient consistency checking.
     fn save_change_set(
         &mut self,

--- a/rollup-interface/src/state_machine/storage.rs
+++ b/rollup-interface/src/state_machine/storage.rs
@@ -31,7 +31,7 @@ pub trait HierarchicalStorageManager<Da: DaSpec> {
     ) -> anyhow::Result<Self::NativeStorage>;
 
     /// Adds [`Self::ChangeSet`] to the storage.
-    /// [`Da::BlockHeader`] must be provided for efficient consistency checking.
+    /// [`DaSpec::BlockHeader`] must be provided for efficient consistency checking.
     fn save_change_set(
         &mut self,
         block_header: &Da::BlockHeader,

--- a/rollup-interface/src/state_machine/storage.rs
+++ b/rollup-interface/src/state_machine/storage.rs
@@ -1,6 +1,8 @@
 //! Trait that represents life time of the state
 //!
 
+use crate::da::DaSpec;
+
 /// Storage manager persistence and allows to work on state
 /// Temporal placeholder for ForkManager
 pub trait StorageManager {
@@ -11,4 +13,31 @@ pub trait StorageManager {
 
     /// Get latest native state
     fn get_native_storage(&self) -> Self::NativeStorage;
+}
+
+/// Storage manager, that supports tree-like hierarchy of snapshots
+/// So different rollup state can be mapped to DA state 1 to 1, including chain forks.
+pub trait HierarchicalStorageManager<Da: DaSpec> {
+    /// Type that can be consumed by `[crate::state_machine::stf::StateTransitionFunction]` in native context.
+    type NativeStorage;
+    /// Type that is produced by `[crate::state_machine::stf::StateTransitionFunction]`.
+    type NativeChangeSet;
+
+    /// Creates storage based on given Da block header,
+    /// meaning that at will have access to previous blocks state in same fork.
+    fn get_native_storage_on(
+        &mut self,
+        block_header: &Da::BlockHeader,
+    ) -> anyhow::Result<Self::NativeStorage>;
+
+    /// Adds [`Self::ChangeSet`] to the storage.
+    /// [`Da::BlockHeader`] must be provided for efficient consistency checking.
+    fn save_change_set(
+        &mut self,
+        block_header: &Da::BlockHeader,
+        change_set: Self::NativeChangeSet,
+    ) -> anyhow::Result<()>;
+
+    /// Finalizes snapshot on given block header
+    fn finalize(&mut self, block_header: &Da::BlockHeader) -> anyhow::Result<()>;
 }


### PR DESCRIPTION
# Description

* Adds `HierarchicalStorageManager` trait to rollup interface, which will replace `StorageManager` after these changes are integrated
* Adds crate `sov-prover-storage-manager`, which have implmenetations for `HierarchicalStorageManager` and `sov-schema-db::snapshot::QueryManager` traits.
* Adds `std::hash::Hash` bound to `rollup_interface::BlockHashTrait`. 
* Minor interface improvement for `DbSnapshot` to use references instead of value.

Note, this change will require performance benchmark after being integrated.

## Linked Issues
- Related to #1023 

## Testing
Unit tests have been added to new crate

## Docs
Rust documentation have been updated
