### PR TITLE
feat: add `serde` feature for non-native serialization

### DIFF
--- a/examples/demo-rollup/stf/Cargo.toml
+++ b/examples/demo-rollup/stf/Cargo.toml
@@ -69,8 +69,18 @@ native = [
     "sov-mock-da/native",
     "sov-modules-stf-template/native",
     "clap",
+    "serde",
     "serde_json",
     "jsonrpsee",
     "tokio",
     "toml",
+]
+serde = [
+    "sov-bank/serde",
+    "sov-sequencer-registry/serde",
+    "sov-blob-storage/serde",
+    "sov-value-setter/serde",
+    "sov-accounts/serde",
+    "sov-nft-module/serde",
+    "sov-evm?/serde",
 ]

--- a/examples/demo-rollup/stf/src/runtime.rs
+++ b/examples/demo-rollup/stf/src/runtime.rs
@@ -66,10 +66,7 @@ use crate::genesis_config::GenesisPaths;
 #[cfg_attr(feature = "native", derive(CliWallet), expose_rpc)]
 #[derive(Genesis, DispatchCall, MessageCodec, DefaultRuntime)]
 #[serialization(borsh::BorshDeserialize, borsh::BorshSerialize)]
-#[cfg_attr(
-    feature = "native",
-    serialization(serde::Serialize, serde::Deserialize)
-)]
+#[cfg_attr(feature = "serde", serialization(serde::Serialize, serde::Deserialize))]
 pub struct Runtime<C: Context, Da: DaSpec> {
     /// The Bank module.
     pub bank: sov_bank::Bank<C>,

--- a/module-system/module-implementations/examples/sov-value-setter/Cargo.toml
+++ b/module-system/module-implementations/examples/sov-value-setter/Cargo.toml
@@ -32,4 +32,5 @@ clap = { workspace = true, optional = true }
 
 [features]
 default = []
-native = ["serde_json", "jsonrpsee", "schemars", "clap", "sov-modules-api/native", "sov-state/native"]
+native = ["serde", "serde_json", "jsonrpsee", "schemars", "clap", "sov-modules-api/native", "sov-state/native"]
+serde = []

--- a/module-system/module-implementations/examples/sov-value-setter/src/call.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/call.rs
@@ -9,12 +9,11 @@ use thiserror::Error;
 use super::ValueSetter;
 
 /// This enumeration represents the available call messages for interacting with the `sov-value-setter` module.
+#[cfg_attr(feature = "native", derive(CliWalletArg), derive(schemars::JsonSchema))]
 #[cfg_attr(
-    feature = "native",
+    feature = "serde",
     derive(serde::Serialize),
-    derive(serde::Deserialize),
-    derive(CliWalletArg),
-    derive(schemars::JsonSchema)
+    derive(serde::Deserialize)
 )]
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
 pub enum CallMessage {

--- a/module-system/module-implementations/sov-accounts/Cargo.toml
+++ b/module-system/module-implementations/sov-accounts/Cargo.toml
@@ -42,4 +42,5 @@ arbitrary = [
     "sov-modules-api/arbitrary",
     "sov-state/arbitrary"
 ]
-native = ["serde_json", "jsonrpsee", "schemars", "clap", "sov-state/native", "sov-modules-api/native"]
+native = ["serde", "serde_json", "jsonrpsee", "schemars", "clap", "sov-state/native", "sov-modules-api/native"]
+serde = []

--- a/module-system/module-implementations/sov-accounts/src/call.rs
+++ b/module-system/module-implementations/sov-accounts/src/call.rs
@@ -9,14 +9,17 @@ pub const UPDATE_ACCOUNT_MSG: [u8; 32] = [1; 32];
 /// Represents the available call messages for interacting with the sov-accounts module.
 #[cfg_attr(
     feature = "native",
-    derive(serde::Serialize),
-    derive(serde::Deserialize),
     derive(schemars::JsonSchema),
     derive(sov_modules_api::macros::CliWalletArg),
     schemars(
         bound = "C::PublicKey: ::schemars::JsonSchema, C::Signature: ::schemars::JsonSchema",
         rename = "CallMessage"
     )
+)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize),
+    derive(serde::Deserialize)
 )]
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
 pub enum CallMessage<C: Context> {

--- a/module-system/module-implementations/sov-bank/Cargo.toml
+++ b/module-system/module-implementations/sov-bank/Cargo.toml
@@ -31,5 +31,6 @@ tempfile = { workspace = true }
 
 [features]
 default = []
-native = ["serde_json", "jsonrpsee", "clap", "schemars", "sov-state/native", "sov-modules-api/native", ]
+native = ["serde", "serde_json", "jsonrpsee", "clap", "schemars", "sov-state/native", "sov-modules-api/native", ]
 cli = ["native"]
+serde = []

--- a/module-system/module-implementations/sov-bank/src/call.rs
+++ b/module-system/module-implementations/sov-bank/src/call.rs
@@ -8,11 +8,14 @@ use crate::{Amount, Bank, Coins, Token};
 /// This enumeration represents the available call messages for interacting with the sov-bank module.
 #[cfg_attr(
     feature = "native",
-    derive(serde::Serialize),
-    derive(serde::Deserialize),
     derive(CliWalletArg),
     derive(schemars::JsonSchema),
     schemars(bound = "C::Address: ::schemars::JsonSchema", rename = "CallMessage")
+)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize),
+    derive(serde::Deserialize)
 )]
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
 pub enum CallMessage<C: sov_modules_api::Context> {

--- a/module-system/module-implementations/sov-blob-storage/Cargo.toml
+++ b/module-system/module-implementations/sov-blob-storage/Cargo.toml
@@ -41,3 +41,4 @@ jmt = { workspace = true }
 [features]
 default = []
 native = ["jsonrpsee", "schemars", "serde", "serde_json", "sov-modules-api/native", "sov-state/native", "sov-sequencer-registry/native", "clap"]
+serde = ["dep:serde"]

--- a/module-system/module-implementations/sov-blob-storage/src/call.rs
+++ b/module-system/module-implementations/sov-blob-storage/src/call.rs
@@ -7,10 +7,13 @@ use crate::BlobStorage;
 /// A call message for the blob storage module
 #[cfg_attr(
     feature = "native",
-    derive(serde::Serialize),
-    derive(serde::Deserialize),
     derive(sov_modules_api::macros::CliWalletArg),
     derive(schemars::JsonSchema)
+)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize),
+    derive(serde::Deserialize)
 )]
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
 pub enum CallMessage {

--- a/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/module-system/module-implementations/sov-evm/Cargo.toml
@@ -71,4 +71,5 @@ native = [
     "sov-modules-api/native",
 ]
 experimental = ["native"]
+serde = ["dep:serde"]
 smart_contracts = ["experimental"]

--- a/module-system/module-implementations/sov-evm/src/call.rs
+++ b/module-system/module-implementations/sov-evm/src/call.rs
@@ -12,7 +12,7 @@ use crate::experimental::PendingTransaction;
 use crate::Evm;
 
 #[cfg_attr(
-    feature = "native",
+    feature = "serde",
     derive(serde::Serialize),
     derive(serde::Deserialize)
 )]

--- a/module-system/module-implementations/sov-nft-module/Cargo.toml
+++ b/module-system/module-implementations/sov-nft-module/Cargo.toml
@@ -34,5 +34,6 @@ sov-nft-module = { version = "*", features = ["native"], path = "." }
 [features]
 default = []
 offchain = ["postgres","tokio","tracing"]
-native = ["serde_json", "jsonrpsee", "schemars", "sov-state/native", "sov-modules-api/native", ]
+native = ["serde", "serde_json", "jsonrpsee", "schemars", "sov-state/native", "sov-modules-api/native", ]
+serde = []
 test = ["native"]

--- a/module-system/module-implementations/sov-nft-module/src/call.rs
+++ b/module-system/module-implementations/sov-nft-module/src/call.rs
@@ -7,10 +7,13 @@ use crate::{Collection, CollectionAddress, Nft, NftIdentifier, NonFungibleToken,
 
 #[cfg_attr(
     feature = "native",
-    derive(serde::Serialize),
-    derive(serde::Deserialize),
     derive(schemars::JsonSchema),
     schemars(bound = "C::Address: ::schemars::JsonSchema", rename = "CallMessage")
+)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize),
+    derive(serde::Deserialize)
 )]
 #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
 /// A transaction handled by the NFT module. Mints, Transfers, or Burns an NFT by id

--- a/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
+++ b/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
@@ -41,6 +41,7 @@ bench = ["sov-zk-cycle-macros/bench", "risc0-zkvm", "risc0-zkvm-platform", "sov-
 default = []
 arbitrary = ["dep:arbitrary", "dep:proptest", "dep:proptest-derive"]
 native = [
+    "serde",
     "serde_json",
     "jsonrpsee",
     "schemars",
@@ -50,3 +51,4 @@ native = [
     # This:
     "sov-bank/native",
 ]
+serde = []

--- a/module-system/module-implementations/sov-sequencer-registry/src/call.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/src/call.rs
@@ -7,12 +7,11 @@ use crate::SequencerRegistry;
 
 /// This enumeration represents the available call messages for interacting with
 /// the `sov-sequencer-registry` module.
+#[cfg_attr(feature = "native", derive(schemars::JsonSchema), derive(CliWalletArg))]
 #[cfg_attr(
-    feature = "native",
+    feature = "serde",
     derive(serde::Serialize),
-    derive(serde::Deserialize),
-    derive(schemars::JsonSchema),
-    derive(CliWalletArg)
+    derive(serde::Deserialize)
 )]
 #[cfg_attr(
     feature = "arbitrary",

--- a/module-system/sov-modules-api/Cargo.toml
+++ b/module-system/sov-modules-api/Cargo.toml
@@ -61,6 +61,7 @@ native = [
     "serde_json",
     "rand",
     "schemars",
+    "serde",
     "ed25519-dalek/default",
     "ed25519-dalek/rand_core",
     "clap",
@@ -71,3 +72,4 @@ native = [
     "sov-state/native",
 ]
 macros = ["sov-modules-macros"]
+serde = ["sov-modules-core/serde"]

--- a/module-system/sov-modules-api/src/default_context.rs
+++ b/module-system/sov-modules-api/src/default_context.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "native")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 use sov_modules_core::{Address, Context, PublicKey, Spec, TupleGasUnit};
@@ -43,7 +43,7 @@ impl Context for DefaultContext {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "native", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ZkDefaultContext {
     pub sender: Address,
 }

--- a/module-system/sov-modules-api/src/default_signature.rs
+++ b/module-system/sov-modules-api/src/default_signature.rs
@@ -198,10 +198,8 @@ impl BorshSerialize for DefaultPublicKey {
     }
 }
 
-#[cfg_attr(
-    feature = "native",
-    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
-)]
+#[cfg_attr(feature = "native", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct DefaultSignature {
     #[cfg_attr(

--- a/module-system/sov-modules-core/Cargo.toml
+++ b/module-system/sov-modules-core/Cargo.toml
@@ -61,6 +61,7 @@ std = [
     "sync",
     "thiserror",
 ]
+serde = []
 sync = [
     "borsh/rc",
     "serde/rc",

--- a/module-system/sov-modules-core/src/module/spec.rs
+++ b/module-system/sov-modules-core/src/module/spec.rs
@@ -77,8 +77,14 @@ pub trait Spec {
         + schemars::JsonSchema;
 
     /// The digital signature scheme used by the rollup
-    #[cfg(not(all(feature = "native", feature = "std")))]
+    #[cfg(all(not(all(feature = "native", feature = "std")), not(feature = "serde")))]
     type Signature: Signature<PublicKey = Self::PublicKey>;
+
+    /// The digital signature scheme used by the rollup
+    #[cfg(all(not(all(feature = "native", feature = "std")), feature = "serde"))]
+    type Signature: Signature<PublicKey = Self::PublicKey>
+        + serde::Serialize
+        + for<'a> serde::Deserialize<'a>;
 
     /// A structure containing the non-deterministic inputs from the prover to the zk-circuit
     type Witness: Witness;

--- a/module-system/sov-modules-macros/src/new_types.rs
+++ b/module-system/sov-modules-macros/src/new_types.rs
@@ -17,6 +17,7 @@ pub fn address_type_helper(input: DeriveInput) -> Result<TokenStream, syn::Error
         pub struct #name<C: Context>(C::Address);
 
         #[cfg(not(feature = "native"))]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Clone, Debug, PartialEq, Eq, Hash)]
         #(#attrs)*
         pub struct #name<C: Context>(C::Address);


### PR DESCRIPTION
Currently, serde serialization is enabled only if `native` feature is available. This aims to protect ZK targets to be bloated with functionality it won't use, increasing the binary size; hence, verification cost.

However, serde is required outside ZK space, and without native features. One example is the wallet where we will perform JSON deserialization of a runtime call message inside of a WASM environment. WASM cannot have native (because it derives tokio), and must have serde available.

This commit splits `serde` from `native`, making `native` optional for such functionality, but preserves the mandatory serde implementations under `native`.