### PR TITLE
feat: add try_from slice for signature & keys

### DIFF
--- a/module-system/sov-modules-api/src/transaction.rs
+++ b/module-system/sov-modules-api/src/transaction.rs
@@ -43,6 +43,21 @@ impl<C: Context> Transaction<C> {
 
         Ok(())
     }
+
+    /// New transaction.
+    pub fn new(
+        pub_key: C::PublicKey,
+        message: Vec<u8>,
+        signature: C::Signature,
+        nonce: u64,
+    ) -> Self {
+        Self {
+            signature,
+            runtime_msg: message,
+            pub_key,
+            nonce,
+        }
+    }
 }
 
 #[cfg(feature = "native")]
@@ -60,21 +75,6 @@ impl<C: Context> Transaction<C> {
         // Don't forget to truncate the message back to its original length!
         message.truncate(original_length);
 
-        Self {
-            signature,
-            runtime_msg: message,
-            pub_key,
-            nonce,
-        }
-    }
-
-    /// New transaction.
-    pub fn new(
-        pub_key: C::PublicKey,
-        message: Vec<u8>,
-        signature: C::Signature,
-        nonce: u64,
-    ) -> Self {
         Self {
             signature,
             runtime_msg: message,

--- a/module-system/sov-modules-core/src/common/key.rs
+++ b/module-system/sov-modules-core/src/common/key.rs
@@ -10,7 +10,16 @@ use sov_rollup_interface::RollupAddress;
 use crate::common::SigVerificationError;
 
 /// Signature used in the Module System.
-pub trait Signature: BorshDeserialize + BorshSerialize + Eq + Clone + Debug + Send + Sync {
+pub trait Signature:
+    BorshDeserialize
+    + BorshSerialize
+    + for<'a> TryFrom<&'a [u8], Error = anyhow::Error>
+    + Eq
+    + Clone
+    + Debug
+    + Send
+    + Sync
+{
     /// The public key associated with the key pair of the signature.
     type PublicKey;
 
@@ -22,6 +31,7 @@ pub trait Signature: BorshDeserialize + BorshSerialize + Eq + Clone + Debug + Se
 pub trait PublicKey:
     BorshDeserialize
     + BorshSerialize
+    + for<'a> TryFrom<&'a [u8], Error = anyhow::Error>
     + Eq
     + Hash
     + Clone


### PR DESCRIPTION
This commit introduces a trait bound requirement for PublicKey and Signature that will allow it to be recreated from bytes.

Prior to this commit, such implementation existed only for `FromStr` in native. However, in some cases - such as in the wallet - the public keys will be recreated from raw bytes computed from 3rd party libraries. The serialization of such crypto primitives is a standard, so they can safely interop with our implementations.