### PR TITLE
Remove default `module::call` implementation. 

### DIFF
--- a/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -208,6 +208,16 @@ impl<C: sov_modules_api::Context, Da: sov_modules_api::DaSpec> sov_modules_api::
 
     type Event = ();
 
+    fn call(
+        &self,
+        _msg: Self::CallMessage,
+        _context: &Self::Context,
+        _working_set: &mut WorkingSet<C>,
+    ) -> Result<sov_modules_api::CallResponse, Error> {
+        Ok(sov_modules_api::CallResponse{})
+    }
+
+
     fn genesis(&self, config: &Self::Config, working_set: &mut WorkingSet<C>) -> Result<(), Error> {
         // The initialization logic
         Ok(self.init_module(config, working_set)?)

--- a/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -214,9 +214,8 @@ impl<C: sov_modules_api::Context, Da: sov_modules_api::DaSpec> sov_modules_api::
         _context: &Self::Context,
         _working_set: &mut WorkingSet<C>,
     ) -> Result<sov_modules_api::CallResponse, Error> {
-        Ok(sov_modules_api::CallResponse{})
+        Ok(sov_modules_api::CallResponse {})
     }
-
 
     fn genesis(&self, config: &Self::Config, working_set: &mut WorkingSet<C>) -> Result<(), Error> {
         // The initialization logic

--- a/module-system/sov-modules-api/src/reexport_macros.rs
+++ b/module-system/sov-modules-api/src/reexport_macros.rs
@@ -19,9 +19,8 @@ pub use sov_modules_macros::MessageCodec;
 /// ```
 /// use std::marker::PhantomData;
 ///
-/// use sov_modules_api::{Context, Module, ModuleInfo, ModuleCallJsonSchema, StateMap};
+/// use sov_modules_api::{WorkingSet,Error, CallResponse, Context, Module, ModuleInfo, ModuleCallJsonSchema, StateMap};
 /// use sov_modules_api::default_context::ZkDefaultContext;
-/// use sov_bank::CallMessage;
 ///
 /// #[derive(ModuleInfo, ModuleCallJsonSchema)]
 /// struct TestModule<C: Context> {
@@ -35,8 +34,17 @@ pub use sov_modules_macros::MessageCodec;
 /// impl<C: Context> Module for TestModule<C> {
 ///     type Context = C;
 ///     type Config = PhantomData<C>;
-///     type CallMessage = CallMessage<C>;
+///     type CallMessage = ();
 ///     type Event = ();
+///     
+///     fn call(
+///        &self,
+///        _msg: Self::CallMessage,
+///        _context: &Self::Context,
+///        _working_set: &mut WorkingSet<C>,
+///     ) -> Result<CallResponse, Error> {
+///        Ok(CallResponse {})
+///     }
 /// }
 ///
 /// println!("JSON Schema: {}", TestModule::<ZkDefaultContext>::json_schema());

--- a/module-system/sov-modules-core/src/module/mod.rs
+++ b/module-system/sov-modules-core/src/module/mod.rs
@@ -50,9 +50,7 @@ pub trait Module {
         _message: Self::CallMessage,
         _context: &Self::Context,
         _working_set: &mut WorkingSet<Self::Context>,
-    ) -> Result<CallResponse, ModuleError> {
-        unreachable!()
-    }
+    ) -> Result<CallResponse, ModuleError>;
 
     /// Attempts to charge the provided amount of gas from the working set.
     ///


### PR DESCRIPTION
# Description
Removes the default `call` implementation in the Module trait.

## Testing
CI passes.

