### PR TITLE
Hotfix: prevent node crashes when restarting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3952,15 +3952,15 @@ dependencies = [
 
 [[package]]
 name = "ics23"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442d4bab37956e76f739c864f246c825d87c0bb7f9afa65660c57833c91bf6d4"
+checksum = "661e2d6f79952a65bc92b1c81f639ebd37228dae6ff412a5aba7d474bdc4b957"
 dependencies = [
  "anyhow",
  "bytes",
  "hex",
  "informalsystems-pbjson",
- "prost 0.11.9",
+ "prost 0.12.2",
  "ripemd",
  "serde",
  "sha2 0.10.8",
@@ -4321,9 +4321,8 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jmt"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f1cb339f7d5288603665c0ccbef7ad33a782ced36e18b6b207f175479eb3b7"
+version = "0.9.0"
+source = "git+https://github.com/penumbra-zone/jmt.git?rev=1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6#1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6"
 dependencies = [
  "anyhow",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,8 @@ repository = "https://github.com/sovereign-labs/sovereign-sdk"
 
 [workspace.dependencies]
 # Dependencies maintained by Sovereign
-jmt = "0.8.0"
+jmt = { git = "https://github.com/penumbra-zone/jmt.git", rev = "1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6" }
+
 
 # External dependencies
 async-trait = "0.1.71"

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -421,7 +421,7 @@ version = "0.1.0"
 source = "git+https://github.com/eigerco/celestia-node-rs.git?rev=66b7c6c#66b7c6cd58213c0cbf79207ba549cef82764ddca"
 dependencies = [
  "anyhow",
- "prost 0.12.1",
+ "prost",
  "prost-build",
  "prost-types",
  "serde",
@@ -992,15 +992,15 @@ dependencies = [
 
 [[package]]
 name = "ics23"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442d4bab37956e76f739c864f246c825d87c0bb7f9afa65660c57833c91bf6d4"
+checksum = "661e2d6f79952a65bc92b1c81f639ebd37228dae6ff412a5aba7d474bdc4b957"
 dependencies = [
  "anyhow",
  "bytes",
  "hex",
  "informalsystems-pbjson",
- "prost 0.11.9",
+ "prost",
  "ripemd",
  "serde",
  "sha2 0.10.8",
@@ -1091,9 +1091,8 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jmt"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f1cb339f7d5288603665c0ccbef7ad33a782ced36e18b6b207f175479eb3b7"
+version = "0.9.0"
+source = "git+https://github.com/penumbra-zone/jmt.git?rev=1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6#1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1471,22 +1470,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive 0.11.9",
-]
-
-[[package]]
-name = "prost"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
 dependencies = [
  "bytes",
- "prost-derive 0.12.1",
+ "prost-derive",
 ]
 
 [[package]]
@@ -1503,25 +1492,12 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost 0.12.1",
+ "prost",
  "prost-types",
  "regex",
  "syn 2.0.38",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1543,7 +1519,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e081b29f63d83a4bc75cfc9f3fe424f9156cf92d8a4f0c9407cce9a1b67327cf"
 dependencies = [
- "prost 0.12.1",
+ "prost",
 ]
 
 [[package]]
@@ -2054,7 +2030,7 @@ dependencies = [
  "celestia-types",
  "hex",
  "nmt-rs",
- "prost 0.12.1",
+ "prost",
  "risc0-zkvm",
  "risc0-zkvm-platform",
  "serde",
@@ -2396,7 +2372,7 @@ dependencies = [
  "instant",
  "num-traits",
  "once_cell",
- "prost 0.12.1",
+ "prost",
  "prost-types",
  "serde",
  "serde_bytes",
@@ -2420,7 +2396,7 @@ dependencies = [
  "flex-error",
  "num-derive 0.3.3",
  "num-traits",
- "prost 0.12.1",
+ "prost",
  "prost-types",
  "serde",
  "serde_bytes",

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "ics23"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442d4bab37956e76f739c864f246c825d87c0bb7f9afa65660c57833c91bf6d4"
+checksum = "661e2d6f79952a65bc92b1c81f639ebd37228dae6ff412a5aba7d474bdc4b957"
 dependencies = [
  "anyhow",
  "bytes",
@@ -452,9 +452,8 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jmt"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23f1cb339f7d5288603665c0ccbef7ad33a782ced36e18b6b207f175479eb3b7"
+version = "0.9.0"
+source = "git+https://github.com/penumbra-zone/jmt.git?rev=1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6#1d007e11cb68aa5ca13e9a5af4a12e6439d5f7b6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -619,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.9"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -629,15 +628,15 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.38",
 ]
 
 [[package]]

--- a/full-node/db/sov-db/src/state_db.rs
+++ b/full-node/db/sov-db/src/state_db.rs
@@ -1,9 +1,10 @@
+use std::array::IntoIter;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use jmt::storage::{TreeReader, TreeWriter};
 use jmt::{KeyHash, Version};
-use sov_schema_db::DB;
+use sov_schema_db::{SchemaBatch, DB};
 
 use crate::rocks_db_config::gen_rocksdb_options;
 use crate::schema::tables::{JmtNodes, JmtValues, KeyHashToKey, STATE_TABLES};
@@ -46,8 +47,15 @@ impl StateDB {
 
     /// Put the preimage of a hashed key into the database. Note that the preimage is not checked for correctness,
     /// since the DB is unaware of the hash function used by the JMT.
-    pub fn put_preimage(&self, key_hash: KeyHash, key: &Vec<u8>) -> Result<(), anyhow::Error> {
-        self.db.put::<KeyHashToKey>(&key_hash.0, key)
+    pub fn put_preimages<'a>(
+        &self,
+        items: impl IntoIterator<Item = (KeyHash, &'a Vec<u8>)>,
+    ) -> Result<(), anyhow::Error> {
+        let mut batch = SchemaBatch::new();
+        for (key_hash, key) in items.into_iter() {
+            batch.put::<KeyHashToKey>(&key_hash.0, key)?;
+        }
+        self.db.write_schemas(batch)
     }
 
     /// Get an optional value from the database, given a version and a key hash.
@@ -127,8 +135,9 @@ impl TreeReader for StateDB {
 
 impl TreeWriter for StateDB {
     fn write_node_batch(&self, node_batch: &jmt::storage::NodeBatch) -> anyhow::Result<()> {
+        let mut batch = SchemaBatch::new();
         for (node_key, node) in node_batch.nodes() {
-            self.db.put::<JmtNodes>(node_key, node)?;
+            batch.put::<JmtNodes>(node_key, node)?;
         }
 
         for ((version, key_hash), value) in node_batch.values() {
@@ -138,8 +147,9 @@ impl TreeWriter for StateDB {
                     .ok_or(anyhow::format_err!(
                         "Could not find preimage for key hash {key_hash:?}. Has `StateDB::put_preimage` been called for this key?"
                     ))?;
-            self.db.put::<JmtValues>(&(key_preimage, *version), value)?;
+            batch.put::<JmtValues>(&(key_preimage, *version), value)?;
         }
+        self.db.write_schemas(batch)?;
         Ok(())
     }
 }
@@ -236,7 +246,7 @@ mod state_db_tests {
         let key = vec![2u8; 100];
         let value = [8u8; 150];
 
-        db.put_preimage(key_hash, &key).unwrap();
+        db.put_preimages(vec![(key_hash, &key)]).unwrap();
         let mut batch = NodeBatch::default();
         batch.extend(vec![], vec![((0, key_hash), Some(value.to_vec()))]);
         db.write_node_batch(&batch).unwrap();

--- a/full-node/db/sov-db/src/state_db.rs
+++ b/full-node/db/sov-db/src/state_db.rs
@@ -1,4 +1,3 @@
-use std::array::IntoIter;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -95,11 +94,11 @@ impl StateDB {
     }
 
     fn last_version_written(db: &DB) -> anyhow::Result<Option<Version>> {
-        let mut iter = db.iter::<JmtValues>()?;
+        let mut iter = db.iter::<JmtNodes>()?;
         iter.seek_to_last();
 
         let version = match iter.next() {
-            Some(Ok(((_, version), _))) => Some(version),
+            Some(Ok((key, _))) => Some(key.version()),
             _ => None,
         };
         Ok(version)


### PR DESCRIPTION
# Description
This PR fixes three issues with the state database.
1. Each item from the `jmt::NodeBatch` was committed individually, which was inefficient and allowed the tree to get into an inconsistent state if node halted at an inopportune moment. This PR batches those writes.
2. The StateDb was committed before the NativeDb, which could allow the `nativeDb` updates to be lost if the node shutdown at the wrong moment. This PR fixes the issue by committing the `statedb` last. This ensures that the block will be reprocessed if the node crashes during the `commit` phase, so no data can be lost.
3. The `Jmt*` tables in the database encoded their keys using `borsh`, which caused `versions` to be serialized in little-endian order. Since RocksDB orders keys lexicographically, this caused jmt keys/values to be stored out of order, which caused the `StateDb::last_version_written` method to fail as a side effect. This PR fixes the issue for the `JmtNodes` table, which is sufficient to prevent crashes. A follow-up will fix the `JmtValues` table - which should improve node performance under load.

##  Future Work
There are four remaining items from this PR
1. Find a solution to prevent little-endianness from leaking into versions - possibly by disallowing `borsh` as a `KeyCodec`
2. Fix the ordering of the `JmtValues` table
3. Switch back to a released version of the `jmt` once the necessary updates land
4. Add tests to ensure that the StateDb is ordered as expected


## Testing
Tests to be added in the follow-up.
