### PR TITLE
feat: add `sov-modules-wallet-blueprint`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8664,6 +8664,7 @@ dependencies = [
  "sov-modules-api",
  "sov-modules-rollup-blueprint",
  "sov-modules-stf-blueprint",
+ "sov-modules-wallet-blueprint",
  "sov-nft-module",
  "sov-risc0-adapter",
  "sov-rng-da-service",
@@ -8927,6 +8928,22 @@ dependencies = [
  "sov-zk-cycle-utils",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "sov-modules-wallet-blueprint"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "borsh",
+ "serde",
+ "serde_json",
+ "sov-cli",
+ "sov-mock-da",
+ "sov-modules-api",
+ "sov-modules-rollup-blueprint",
+ "sov-rollup-interface",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "module-system/sov-cli",
     "module-system/sov-modules-stf-blueprint",
     "module-system/sov-modules-rollup-blueprint",
+    "module-system/sov-modules-wallet-blueprint",
     "module-system/sov-modules-macros",
     "module-system/sov-modules-core",
     "module-system/sov-state",

--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -21,6 +21,7 @@ sov-rollup-interface = { path = "../../rollup-interface", features = ["native"] 
 
 sov-modules-rollup-blueprint = { path = "../../module-system/sov-modules-rollup-blueprint" }
 sov-modules-stf-blueprint = { path = "../../module-system/sov-modules-stf-blueprint", features = ["native"] }
+sov-modules-wallet-blueprint = { path = "../../module-system/sov-modules-wallet-blueprint", features = ["cli"] }
 sov-modules-api = { path = "../../module-system/sov-modules-api", features = ["native"] }
 sov-nft-module = { path = "../../module-system/module-implementations/sov-nft-module" }
 demo-stf = { path = "./stf", features = ["native"] }

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -5,9 +5,10 @@ use sov_celestia_adapter::verifier::{CelestiaSpec, CelestiaVerifier, RollupParam
 use sov_celestia_adapter::{CelestiaConfig, CelestiaService};
 use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
 use sov_modules_api::Spec;
-use sov_modules_rollup_blueprint::{RollupBlueprint, WalletBlueprint};
+use sov_modules_rollup_blueprint::RollupBlueprint;
 use sov_modules_stf_blueprint::kernels::basic::BasicKernel;
 use sov_modules_stf_blueprint::StfBlueprint;
+use sov_modules_wallet_blueprint::cli::CliWalletBlueprint;
 use sov_risc0_adapter::host::Risc0Host;
 use sov_rollup_interface::zk::ZkvmHost;
 use sov_state::storage_manager::ProverStorageManager;
@@ -114,4 +115,4 @@ impl RollupBlueprint for CelestiaDemoRollup {
     }
 }
 
-impl WalletBlueprint for CelestiaDemoRollup {}
+impl CliWalletBlueprint for CelestiaDemoRollup {}

--- a/examples/demo-rollup/src/sov-cli/main.rs
+++ b/examples/demo-rollup/src/sov-cli/main.rs
@@ -1,7 +1,7 @@
 use demo_stf::runtime::RuntimeSubcommand;
 use sov_demo_rollup::CelestiaDemoRollup;
 use sov_modules_api::cli::{FileNameArg, JsonStringArg};
-use sov_modules_rollup_blueprint::WalletBlueprint;
+use sov_modules_wallet_blueprint::cli::CliWalletBlueprint;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {

--- a/module-system/sov-modules-rollup-blueprint/src/lib.rs
+++ b/module-system/sov-modules-rollup-blueprint/src/lib.rs
@@ -2,7 +2,6 @@
 #![doc = include_str!("../README.md")]
 
 mod runtime_rpc;
-mod wallet;
 use std::net::SocketAddr;
 
 use async_trait::async_trait;
@@ -18,7 +17,6 @@ use sov_state::storage::NativeStorage;
 use sov_state::Storage;
 use sov_stf_runner::{ProverService, RollupConfig, RollupProverConfig, StateTransitionRunner};
 use tokio::sync::oneshot;
-pub use wallet::*;
 
 /// This trait defines how to crate all the necessary dependencies required by a rollup.
 #[async_trait]

--- a/module-system/sov-modules-wallet-blueprint/Cargo.toml
+++ b/module-system/sov-modules-wallet-blueprint/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "sov-modules-wallet-blueprint"
+description = "Defines the interface of the Sovereign SDK wallet"
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+version = { workspace = true }
+readme = "README.md"
+resolver = "2"
+
+[dependencies]
+anyhow = { workspace = true, optional = true }
+async-trait = { workspace = true, optional = true }
+borsh = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+sov-cli = { path = "../sov-cli", optional = true }
+sov-mock-da = { path = "../../adapters/mock-da", version = "0.3", optional = true }
+sov-modules-api = { path = "../sov-modules-api", version = "0.3" }
+sov-modules-rollup-blueprint = { path = "../sov-modules-rollup-blueprint", optional = true }
+sov-rollup-interface = { path = "../../rollup-interface", version = "0.3" }
+
+[features]
+default = ["cli", "default-impl"]
+cli = [
+    "anyhow",
+    "async-trait",
+    "borsh",
+    "serde",
+    "serde_json",
+    "sov-cli",
+    "sov-modules-rollup-blueprint",
+]
+default-impl = ["sov-mock-da"]
+native = [
+    "sov-mock-da?/native",
+    "sov-modules-api/native",
+    "sov-rollup-interface/native",
+]

--- a/module-system/sov-modules-wallet-blueprint/Cargo.toml
+++ b/module-system/sov-modules-wallet-blueprint/Cargo.toml
@@ -29,6 +29,7 @@ cli = [
     "anyhow",
     "async-trait",
     "borsh",
+    "native",
     "serde",
     "serde_json",
     "sov-cli",

--- a/module-system/sov-modules-wallet-blueprint/src/lib.rs
+++ b/module-system/sov-modules-wallet-blueprint/src/lib.rs
@@ -1,0 +1,29 @@
+use sov_modules_api::Context;
+use sov_rollup_interface::da::DaSpec;
+
+#[cfg(feature = "cli")]
+pub mod cli;
+
+/// Blueprint definition for a module wallet.
+///
+/// The associated types of this trait are expected to be implemented concretely as binary
+/// endpoints depends on resolved generics in order to compile properly.
+///
+/// The `DefaultWalletBlueprint` contains concrete types for the default implementations on
+/// `sov-modules-api`. It lives behind a feature flag 'default-impl'.
+pub trait WalletBlueprint {
+    /// Context used to define the asymetric cryptography for keys generation and signing.
+    type Context: Context;
+    /// DA specification used to declare runtime call message of the module, that is signed by the
+    /// wallet.
+    type DaSpec: DaSpec;
+}
+
+#[cfg(feature = "default-impl")]
+pub struct DefaultWalletBlueprint;
+
+#[cfg(feature = "default-impl")]
+impl WalletBlueprint for DefaultWalletBlueprint {
+    type Context = sov_modules_api::default_context::ZkDefaultContext;
+    type DaSpec = sov_mock_da::MockDaSpec;
+}

--- a/packages_to_publish.yml
+++ b/packages_to_publish.yml
@@ -14,6 +14,7 @@
 - sov-modules-stf-blueprint
 - sov-stf-runner
 - sov-modules-rollup-blueprint
+- sov-modules-wallet-blueprint
 - sov-ledger-rpc
 
 # Modules


### PR DESCRIPTION
This commit introduces `sov-modules-wallet-blueprint`, a blueprint unlocks wallet implementations for signed runtime calls.

The `WalletBlueprint` trait exposes the required types to declare `RuntimeCall` so these can be embeded into wallet modules.