### PR TITLE
chore: cleanup TODOs for celestia adapter

### DIFF
--- a/adapters/celestia/src/celestia.rs
+++ b/adapters/celestia/src/celestia.rs
@@ -35,7 +35,8 @@ pub const GENESIS_PLACEHOLDER_HASH: &[u8; 32] = &[255; 32];
 /// a tendermint::block::Header from being deserialized in most formats except JSON. However
 /// it also provides a significant efficiency benefit over the standard tendermint type, which
 /// performs a complete protobuf serialization every time `.hash()` is called.
-#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)] // TODO: , BorshDeserialize, BorshSerialize)]
+// TODO: derive borsh Serialize, Deserialize <https://github.com/eigerco/celestia-node-rs/issues/155>
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 pub struct CompactHeader {
     /// Header version
     pub version: Vec<u8>,
@@ -158,7 +159,8 @@ impl CompactHeader {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)] // TODO:, BorshSerialize, BorshDeserialize)]
+// TODO: derive borsh Serialize, Deserialize <https://github.com/eigerco/celestia-node-rs/issues/155>
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CelestiaHeader {
     pub dah: DataAvailabilityHeader,
     pub header: CompactHeader,
@@ -193,7 +195,8 @@ impl From<celestia_types::ExtendedHeader> for CelestiaHeader {
     }
 }
 
-#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)] // TODO: , BorshDeserialize, BorshSerialize)]
+// TODO: derive borsh Serialize, Deserialize <https://github.com/eigerco/celestia-node-rs/issues/155>
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct BlobWithSender {
     pub blob: CountedBufReader<BlobIterator>,
     pub sender: CelestiaAddress,

--- a/adapters/celestia/src/types.rs
+++ b/adapters/celestia/src/types.rs
@@ -22,7 +22,8 @@ use crate::utils::BoxError;
 use crate::verifier::{ChainValidityCondition, PARITY_SHARES_NAMESPACE, PFB_NAMESPACE};
 use crate::{parse_pfb_namespace, CelestiaHeader, TxPosition};
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)] // TODO: , BorshSerialize, BorshDeserialize)]
+// TODO: derive borsh Serialize, Deserialize <https://github.com/eigerco/celestia-node-rs/issues/155>
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct FilteredCelestiaBlock {
     pub header: CelestiaHeader,
     pub rollup_data: NamespaceGroup,
@@ -202,7 +203,8 @@ impl ExtendedDataSquareExt for ExtendedDataSquare {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize)] // TODO: , BorshSerialize, BorshDeserialize)]
+// TODO: derive borsh Serialize, Deserialize <https://github.com/eigerco/celestia-node-rs/issues/155>
+#[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Row {
     pub shares: Vec<Vec<u8>>,
     pub root: NamespacedHash,

--- a/adapters/celestia/src/verifier/proofs.rs
+++ b/adapters/celestia/src/verifier/proofs.rs
@@ -6,12 +6,14 @@ use serde::{Deserialize, Serialize};
 use super::CelestiaSpec;
 use crate::types::FilteredCelestiaBlock;
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)] // TODO:, BorshDeserialize, BorshSerialize)]
+// TODO: derive borsh Serialize, Deserialize <https://github.com/eigerco/celestia-node-rs/issues/155>
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct EtxProof {
     pub proof: Vec<EtxRangeProof>,
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)] // TODO:, BorshDeserialize, BorshSerialize)]
+// TODO: derive borsh Serialize, Deserialize <https://github.com/eigerco/celestia-node-rs/issues/155>
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct EtxRangeProof {
     pub shares: Vec<Vec<u8>>,
     pub proof: NamespaceProof,

--- a/docker/run-validator.sh
+++ b/docker/run-validator.sh
@@ -86,7 +86,9 @@ provision_bridge_nodes() {
   for node_idx in $(seq 0 "$last_node_idx"); do
     # TODO: <https://github.com/celestiaorg/celestia-app/issues/2869>
     # we need to transfer the coins for each node in separate
-    # block, or the signing of all but the first one will fail
+    # block, or the signing of all but the first one will fail.
+    # Unfortunately multi-send only works with >= 2 bridge nodes,
+    # so we still rely on this hack.
     wait_for_block $((start_block + node_idx))
 
     local bridge_name="bridge-$node_idx"

--- a/docker/run-validator.sh
+++ b/docker/run-validator.sh
@@ -84,7 +84,7 @@ provision_bridge_nodes() {
   local start_block=2
 
   for node_idx in $(seq 0 "$last_node_idx"); do
-    # TODO: create an issue in celestia-app and link it here
+    # TODO: <https://github.com/celestiaorg/celestia-app/issues/2869>
     # we need to transfer the coins for each node in separate
     # block, or the signing of all but the first one will fail
     wait_for_block $((start_block + node_idx))

--- a/docker/run-validator.sh
+++ b/docker/run-validator.sh
@@ -56,6 +56,8 @@ provision_bridge_nodes() {
   echo "Saving a genesis hash to $GENESIS_HASH_FILE"
   echo "$genesis_hash" > "$GENESIS_HASH_FILE"
 
+  local bridge_nodes=()
+
   # Get or create the keys for bridge nodes
   for node_idx in $(seq 0 "$last_node_idx"); do
     local bridge_name="bridge-$node_idx"
@@ -76,31 +78,21 @@ provision_bridge_nodes() {
       echo "password" | celestia-appd keys import "$bridge_name" "$key_file" \
         --keyring-backend="test"
     fi
+
+    bridge_nodes+=("$(node_address "$bridge_name")")
   done
 
   # Transfer the coins to bridge nodes addresses
   # Coins transfer need to be after validator registers EVM address, which happens in block 2.
   # see `setup_private_validator`
-  local start_block=2
+  wait_for_block 2
 
-  for node_idx in $(seq 0 "$last_node_idx"); do
-    # TODO: <https://github.com/celestiaorg/celestia-app/issues/2869>
-    # we need to transfer the coins for each node in separate
-    # block, or the signing of all but the first one will fail
-    wait_for_block $((start_block + node_idx))
-
-    local bridge_name="bridge-$node_idx"
-    local bridge_address
-
-    bridge_address=$(node_address "$bridge_name")
-
-    echo "Transferring $BRIDGE_COINS coins to the $bridge_name"
-    echo "y" | celestia-appd tx bank send \
-      "$NODE_NAME" \
-      "$bridge_address" \
-      "$BRIDGE_COINS" \
-      --fees 21000utia
-  done
+  echo "Transferring $BRIDGE_COINS coins to the bridge nodes:" "${bridge_nodes[@]}"
+  echo "y" | celestia-appd tx bank multi-send \
+    "$NODE_NAME" \
+    "${bridge_nodes[@]}" \
+    "$BRIDGE_COINS" \
+    --fees 21000utia
 
   # !! This is the last log entry that indicates the setup has finished for all the nodes
   echo "Provisioning finished."

--- a/examples/demo-rollup/Makefile
+++ b/examples/demo-rollup/Makefile
@@ -50,7 +50,6 @@ compose-logs: check-docker
 # check if docker is installed
 check-docker:
 	@command -v docker > /dev/null 2>&1 || { echo "Docker is not installed"; exit 1; }
-	@# TODO: check docker compose too
 
 # check if celestia network is running
 check-compose-running: check-docker


### PR DESCRIPTION
# Description

Cleanup the todos from the celestia adapter update. Created appropriate issues in celestia-node-rs and celestia-app and removed the todo about checking docker compose. If someone follows official docker installation steps he should have the compose plugin installed, the other way was deprecated a few years ago (namely `docker-compose`)
