### PR TITLE
feat: add transaction id to DaService

### DIFF
--- a/adapters/avail/src/service.rs
+++ b/adapters/avail/src/service.rs
@@ -189,6 +189,7 @@ impl DaService for DaProvider {
 
     type FilteredBlock = AvailBlock;
     type HeaderStream = AvailBlockHeaderStream;
+    type TransactionId = ();
 
     type Error = anyhow::Error;
 

--- a/adapters/celestia/src/da_service.rs
+++ b/adapters/celestia/src/da_service.rs
@@ -135,6 +135,7 @@ impl DaService for CelestiaService {
 
     type FilteredBlock = FilteredCelestiaBlock;
     type HeaderStream = CelestiaBlockHeaderSubscription;
+    type TransactionId = ();
 
     type Error = BoxError;
 

--- a/adapters/mock-da/src/service.rs
+++ b/adapters/mock-da/src/service.rs
@@ -114,6 +114,7 @@ impl DaService for MockDaService {
     type Verifier = MockDaVerifier;
     type FilteredBlock = MockBlock;
     type HeaderStream = MockDaBlockHeaderStream;
+    type TransactionId = ();
     type Error = anyhow::Error;
 
     /// Gets block at given height

--- a/rollup-interface/src/node/services/da.rs
+++ b/rollup-interface/src/node/services/da.rs
@@ -35,6 +35,9 @@ pub trait DaService: Send + Sync + 'static {
         Item = Result<<Self::Spec as DaSpec>::BlockHeader, Self::Error>,
     >;
 
+    /// A transaction ID, used to identify the transaction in the DA layer.
+    type TransactionId: PartialEq + Eq + PartialOrd + Ord + core::hash::Hash;
+
     /// The error type for fallible methods.
     type Error: core::fmt::Debug + Send + Sync + core::fmt::Display;
 
@@ -105,7 +108,7 @@ pub trait DaService: Send + Sync + 'static {
     /// Send a transaction directly to the DA layer.
     /// blob is the serialized and signed transaction.
     /// Returns nothing if the transaction was successfully sent.
-    async fn send_transaction(&self, blob: &[u8]) -> Result<(), Self::Error>;
+    async fn send_transaction(&self, blob: &[u8]) -> Result<Self::TransactionId, Self::Error>;
 }
 
 /// `SlotData` is the subset of a DA layer block which is stored in the rollup's database.

--- a/utils/rng-da-service/src/lib.rs
+++ b/utils/rng-da-service/src/lib.rs
@@ -75,6 +75,7 @@ impl DaService for RngDaService {
     type Verifier = RngDaVerifier;
     type FilteredBlock = MockBlock;
     type HeaderStream = RngHeaderStream;
+    type TransactionId = ();
     type Error = anyhow::Error;
 
     async fn get_block_at(&self, height: u64) -> Result<Self::FilteredBlock, Self::Error> {


### PR DESCRIPTION
This commit introduces an associated type `TransactionId` to `DaService`.

It will unlock the ability to track a submitted transaction after when it is sent to the DA, and before it is included on a block.