### PR TITLE
feat: add chain-id to transaction

### DIFF
--- a/module-system/sov-cli/src/wallet_state.rs
+++ b/module-system/sov-cli/src/wallet_state.rs
@@ -1,17 +1,25 @@
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::{fmt, fs};
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use sov_modules_api::{clap, PrivateKey};
+use sov_modules_api::{clap, ChainId, PrivateKey};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(bound = "Tx: Serialize + DeserializeOwned")]
+pub struct UnsentTransaction<Tx> {
+    pub tx: Tx,
+    pub chain_id: ChainId,
+    pub gas_tip: u64,
+}
 
 /// A struct representing the current state of the CLI wallet
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "Ctx::Address: Serialize + DeserializeOwned, Tx: Serialize + DeserializeOwned")]
 pub struct WalletState<Tx, Ctx: sov_modules_api::Context> {
     /// The accumulated transactions to be submitted to the DA layer
-    pub unsent_transactions: Vec<Tx>,
+    pub unsent_transactions: Vec<UnsentTransaction<Tx>>,
     /// The addresses in the wallet
     pub addresses: AddressList<Ctx>,
     /// The addresses in the wallet

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -34,9 +34,10 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "native")]
 pub use sov_modules_core::PrivateKey;
 pub use sov_modules_core::{
-    runtime, AccessoryWorkingSet, Address, AddressBech32, CallResponse, Context, DispatchCall,
-    EncodeCall, GasUnit, Genesis, Module, ModuleCallJsonSchema, ModuleError, ModuleError as Error,
-    ModuleInfo, ModulePrefix, PublicKey, Signature, Spec, StateCheckpoint, WorkingSet,
+    runtime, AccessoryWorkingSet, Address, AddressBech32, CallResponse, ChainId, Context,
+    DispatchCall, EncodeCall, GasUnit, Genesis, Module, ModuleCallJsonSchema, ModuleError,
+    ModuleError as Error, ModuleInfo, ModulePrefix, PublicKey, Signature, Spec, StateCheckpoint,
+    WorkingSet,
 };
 pub use sov_rollup_interface::da::{BlobReaderTrait, DaSpec};
 pub use sov_rollup_interface::services::da::SlotData;

--- a/module-system/sov-modules-core/src/module/spec.rs
+++ b/module-system/sov-modules-core/src/module/spec.rs
@@ -10,6 +10,11 @@ use sov_rollup_interface::RollupAddress;
 use crate::common::{GasUnit, PublicKey, Signature, Witness};
 use crate::storage::Storage;
 
+/// The chain ID of the rollup.
+// TODO: This might be an associated type of `Spec` and a `&'static [u8]` defined via
+// `constants.json`. However, deserialize isn't implemented for such static types.
+pub type ChainId = [u8; 32];
+
 /// The `Spec` trait configures certain key primitives to be used by a by a particular instance of a rollup.
 /// `Spec` is almost always implemented on a Context object; since all Modules are generic
 /// over a Context, rollup developers can easily optimize their code for different environments


### PR DESCRIPTION
This commit introduces `chain-id` to `Transaction`, a constant that will prevent transactions from being replayed on different chains.

It also includes `gas_tip`, a scalar value to be added to the runtime gas amount so sequencers can prioritize a broadcasted transaction.