### PR TITLE
Add Clone bound to MockDaSpec

### DIFF
--- a/adapters/mock-da/src/verifier.rs
+++ b/adapters/mock-da/src/verifier.rs
@@ -29,7 +29,7 @@ impl BlobReaderTrait for MockBlob {
 }
 
 /// A [`sov_rollup_interface::da::DaSpec`] suitable for testing.
-#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct MockDaSpec;
 
 impl DaSpec for MockDaSpec {


### PR DESCRIPTION
# Description
Because Rust's `Derive` bound inference is broken, `MockDaSpec` needs to be clone in order to allow deriving `Clone` on any type that has a `DaSpec` generic when using the mocks. This change was requested by the Hermes team to simplify testing for IBC.

