### PR TITLE
Fix evm tests

### DIFF
--- a/examples/demo-rollup/tests/evm/mod.rs
+++ b/examples/demo-rollup/tests/evm/mod.rs
@@ -195,7 +195,7 @@ async fn execute(client: &TestClient) -> Result<(), Box<dyn std::error::Error>> 
             }
             client.send_publish_batch_request().await;
         }
-
+        tokio::time::sleep(Duration::from_millis(1000)).await;
         // get gas price
         let latest_gas_price = client.eth_gas_price().await;
 

--- a/examples/demo-rollup/tests/evm/mod.rs
+++ b/examples/demo-rollup/tests/evm/mod.rs
@@ -3,7 +3,6 @@ mod test_client;
 use std::net::SocketAddr;
 use std::str::FromStr;
 
-use crate::test_helpers::start_rollup;
 use demo_stf::genesis_config::GenesisPaths;
 use ethers_core::abi::Address;
 use ethers_signers::{LocalWallet, Signer};
@@ -11,6 +10,8 @@ use sov_evm::SimpleStorageContract;
 use sov_stf_runner::RollupProverConfig;
 use test_client::TestClient;
 use tokio::time::{sleep, Duration};
+
+use crate::test_helpers::start_rollup;
 
 #[cfg(feature = "experimental")]
 #[tokio::test]

--- a/examples/demo-rollup/tests/evm/mod.rs
+++ b/examples/demo-rollup/tests/evm/mod.rs
@@ -3,14 +3,14 @@ mod test_client;
 use std::net::SocketAddr;
 use std::str::FromStr;
 
+use crate::test_helpers::start_rollup;
 use demo_stf::genesis_config::GenesisPaths;
 use ethers_core::abi::Address;
 use ethers_signers::{LocalWallet, Signer};
 use sov_evm::SimpleStorageContract;
 use sov_stf_runner::RollupProverConfig;
 use test_client::TestClient;
-
-use crate::test_helpers::start_rollup;
+use tokio::time::{sleep, Duration};
 
 #[cfg(feature = "experimental")]
 #[tokio::test]
@@ -195,7 +195,7 @@ async fn execute(client: &TestClient) -> Result<(), Box<dyn std::error::Error>> 
             }
             client.send_publish_batch_request().await;
         }
-        tokio::time::sleep(Duration::from_millis(1000)).await;
+        sleep(Duration::from_millis(2000)).await;
         // get gas price
         let latest_gas_price = client.eth_gas_price().await;
 


### PR DESCRIPTION
# Description
Fix for:
```
thread 'evm::evm_tx_tests' panicked at examples/demo-rollup/tests/evm/mod.rs:204:9:
assertion failed: latest_gas_price > initial_gas_price
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Added a new issue: https://github.com/Sovereign-Labs/sovereign-sdk/issues/1200