### PR TITLE
refactor: simplify CliWalletArg decodable message

### DIFF
--- a/examples/demo-rollup/src/sov-cli/main.rs
+++ b/examples/demo-rollup/src/sov-cli/main.rs
@@ -1,13 +1,15 @@
 use demo_stf::runtime::RuntimeSubcommand;
 use sov_demo_rollup::CelestiaDemoRollup;
-use sov_modules_api::cli::{FileNameArg, JsonStringArg};
+use sov_modules_api::cli::{JsonFileNameArg, JsonStringArg};
 use sov_modules_rollup_blueprint::WalletBlueprint;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     CelestiaDemoRollup::run_wallet::<
-        RuntimeSubcommand<FileNameArg, _, _>,
+        RuntimeSubcommand<JsonFileNameArg, _, _>,
         RuntimeSubcommand<JsonStringArg, _, _>,
+        _,
+        _,
     >()
     .await
 }

--- a/module-system/sov-cli/tests/transactions.rs
+++ b/module-system/sov-cli/tests/transactions.rs
@@ -4,7 +4,7 @@ use demo_stf::runtime::{Runtime, RuntimeCall, RuntimeSubcommand};
 use sov_cli::wallet_state::WalletState;
 use sov_cli::workflows::transactions::{ImportTransaction, TransactionWorkflow};
 use sov_mock_da::MockDaSpec;
-use sov_modules_api::cli::{FileNameArg, JsonStringArg};
+use sov_modules_api::cli::{JsonFileNameArg, JsonStringArg};
 use sov_modules_api::default_context::DefaultContext;
 
 type Da = MockDaSpec;
@@ -27,7 +27,7 @@ fn test_import_transaction_from_string() {
         RuntimeSubcommand<JsonStringArg, DefaultContext, Da>,
     >::FromFile(subcommand));
     workflow
-        .run::<Runtime<DefaultContext, Da>, _, _, _, _, _>(&mut wallet_state, app_dir)
+        .run::<Runtime<DefaultContext, Da>, _, _, _>(&mut wallet_state, app_dir)
         .unwrap();
 
     assert_eq!(wallet_state.unsent_transactions.len(), 1);
@@ -40,8 +40,8 @@ fn test_import_transaction_from_file() {
         WalletState::<RuntimeCall<DefaultContext, Da>, DefaultContext>::default();
 
     let test_token_path = make_test_path("requests/create_token.json");
-    let subcommand = RuntimeSubcommand::<FileNameArg, DefaultContext, Da>::bank {
-        contents: FileNameArg {
+    let subcommand = RuntimeSubcommand::<JsonFileNameArg, DefaultContext, Da>::bank {
+        contents: JsonFileNameArg {
             path: test_token_path.to_str().unwrap().into(),
         },
     };
@@ -51,7 +51,7 @@ fn test_import_transaction_from_file() {
         RuntimeSubcommand<JsonStringArg, DefaultContext, Da>,
     >::FromFile(subcommand));
     workflow
-        .run::<Runtime<DefaultContext, Da>, _, _, _, _, _>(&mut wallet_state, app_dir)
+        .run::<Runtime<DefaultContext, Da>, _, _, _>(&mut wallet_state, app_dir)
         .unwrap();
 
     assert_eq!(wallet_state.unsent_transactions.len(), 1);

--- a/module-system/sov-modules-api/src/cli.rs
+++ b/module-system/sov-modules-api/src/cli.rs
@@ -1,4 +1,18 @@
-use crate::CliWallet;
+use std::fs;
+
+use serde::de::DeserializeOwned;
+use sov_modules_core::DispatchCall;
+
+/// An argument definition for a sov-cli application that decodes into a runtime call message.
+///
+/// Typically, this is a string representation of common formats, such as JSON.
+pub trait CliWalletArg<RT: DispatchCall> {
+    /// The decoding error representation.
+    type Error;
+
+    /// Decoded the instance into a runtime call message.
+    fn decode_call_from_readable(self) -> Result<RT::Decodable, Self::Error>;
+}
 
 /// An argument to the cli containing a json string
 #[derive(clap::Args, PartialEq, core::fmt::Debug, Clone, PartialOrd, Ord, Eq, Hash)]
@@ -10,23 +24,33 @@ pub struct JsonStringArg {
 
 /// An argument to the cli containing a path to a file
 #[derive(clap::Args, PartialEq, core::fmt::Debug, Clone, PartialOrd, Ord, Eq, Hash)]
-pub struct FileNameArg {
+pub struct JsonFileNameArg {
     /// The json formatted transaction data
     #[arg(long, help = "The JSON formatted transaction")]
     pub path: String,
 }
 
-impl TryFrom<FileNameArg> for JsonStringArg {
-    type Error = std::io::Error;
-    fn try_from(arg: FileNameArg) -> Result<Self, Self::Error> {
-        let json = std::fs::read_to_string(arg.path)?;
-        Ok(JsonStringArg { json })
+impl<RT> CliWalletArg<RT> for JsonStringArg
+where
+    RT: DispatchCall,
+    RT::Decodable: DeserializeOwned,
+{
+    type Error = anyhow::Error;
+
+    fn decode_call_from_readable(self) -> anyhow::Result<RT::Decodable> {
+        Ok(serde_json::from_str(&self.json)?)
     }
 }
 
-pub trait CliFrontEnd<RT>
+impl<RT> CliWalletArg<RT> for JsonFileNameArg
 where
-    RT: CliWallet,
+    RT: DispatchCall,
+    RT::Decodable: DeserializeOwned,
 {
-    type CliIntermediateRepr<U>;
+    type Error = anyhow::Error;
+
+    fn decode_call_from_readable(self) -> anyhow::Result<RT::Decodable> {
+        let contents = fs::read_to_string(&self.path)?;
+        Ok(serde_json::from_str(&contents)?)
+    }
 }

--- a/module-system/sov-modules-api/src/lib.rs
+++ b/module-system/sov-modules-api/src/lib.rs
@@ -184,23 +184,3 @@ where
 
     Ok(sorted_values)
 }
-
-/// This trait is implemented by types that can be used as arguments in the sov-cli wallet.
-/// The recommended way to implement this trait is using the provided derive macro (`#[derive(CliWalletArg)]`).
-/// Currently, this trait is a thin wrapper around [`clap::Parser`]
-#[cfg(feature = "native")]
-pub trait CliWalletArg: From<Self::CliStringRepr> {
-    /// The type that is used to represent this type in the CLI. Typically,
-    /// this type implements the clap::Subcommand trait.
-    type CliStringRepr;
-}
-
-/// A trait that needs to be implemented for a *runtime* to be used with the CLI wallet
-#[cfg(feature = "native")]
-pub trait CliWallet: sov_modules_core::DispatchCall {
-    /// The type that is used to represent this type in the CLI. Typically,
-    /// this type implements the clap::Subcommand trait. This type is generic to
-    /// allow for different representations of the same type in the interface; a
-    /// typical end-usage will impl traits only in the case where `CliStringRepr<T>: Into::RuntimeCall`
-    type CliStringRepr<T>;
-}

--- a/module-system/sov-modules-macros/src/cli_parser.rs
+++ b/module-system/sov-modules-macros/src/cli_parser.rs
@@ -199,24 +199,6 @@ impl CliParserMacro {
                 }
             }
 
-            /*
-            impl #impl_generics_with_inner ::core::convert::TryFrom<RuntimeSubcommand #ty_generics_with_inner> for Vec<u8> #where_clause_with_deserialize_bounds, __Inner: ::clap::Args + TryInto<Vec<u8>, Error = ::anyhow::Error> {
-                type Error = ::anyhow::Error;
-
-                fn try_from(item: RuntimeSubcommand #ty_generics_with_inner ) -> Result<Self, Self::Error>
-                 {
-                    match item {
-                        #( #try_from_subcommand_bytes_match_arms )*
-                        RuntimeSubcommand::____phantom(_) => unreachable!(),
-                    }
-                }
-            }
-
-            impl #impl_generics_with_inner ::sov_modules_api::cli::CliFrontEnd<#ident #ty_generics> for RuntimeSubcommand #ty_generics_with_inner #where_clause_with_deserialize_bounds, __Inner: ::clap::Args {
-                type CliIntermediateRepr<__Dest> = RuntimeMessage #ty_generics_for_dest;
-            }
-            */
-
             /// An intermediate enum between the RuntimeSubcommand (which must implement `clap`) and the
             /// final RT::Decodable type. Like the RuntimeSubcommand, this type contains one variant for each cli-enabled module.
             #[allow(non_camel_case_types)]


### PR DESCRIPTION
This commit removes the `CliWallet` and `CliFrontEnd` traits. Additionally, it refactors the `CliWalletArg` to encode runtime call messages directly into a readable format, thereby eradicating an intermediary representation.

The prior implementation employed an intermediary representation that was adjustable by users but necessitated manual conversion into a decodable message format. As of now, this step is deemed superfluous because the readable transaction can embody the new `CliWalletArg` and offer decoding functionality instantaneously. Typically, the input will be a string that can be translated from a common serialization format like JSON or YAML. By default, JSON is utilized; however, other common serialization formats can also be supported.

The changeset aims to make frontend portrayal of superstructures possible for runtime call messages. It simplifies the decoding process so that it can be seamlessly plugged into wrapper superstructures containing additional metadata. One potential instance is `UnsignedTransaction` as a wrapping superstructure for runtime call data, with relevant protocol-level information pertaining to the rollup.

Moreover, this commit renames `sov_modules_api::cli::FileNameArg` to `JsonFileNameArg`. This type inherently represents the path to a JSON file; hence, the name must reflect that. This allows for effortless addition of paths symbolizing other formats in the future (e.g., `YamlFileNameArg`).