### PR TITLE
Require Daspec: Clone

### DIFF
--- a/adapters/celestia/src/verifier/mod.rs
+++ b/adapters/celestia/src/verifier/mod.rs
@@ -96,7 +96,7 @@ impl From<TmHash> for [u8; 32] {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct CelestiaSpec;
 
 impl DaSpec for CelestiaSpec {

--- a/rollup-interface/src/state_machine/da.rs
+++ b/rollup-interface/src/state_machine/da.rs
@@ -10,7 +10,7 @@ use crate::zk::ValidityCondition;
 use crate::BasicAddress;
 
 /// A specification for the types used by a DA layer.
-pub trait DaSpec: 'static + Debug + PartialEq + Eq {
+pub trait DaSpec: 'static + Debug + PartialEq + Eq + Clone {
     /// The hash of a DA layer block
     type SlotHash: BlockHashTrait;
 


### PR DESCRIPTION
# Description
The Hermes team has asked that we add a `Clone` bound to `CelestiaSpec`. This PR makes the change and ensures that it's implemented for all `DaSpec`s. This seems reasonable, since the `Spec` implementation should always be a ZST and this allows for more accurate `derive`s on higher level types.

