### PR TITLE
feat: add `UnsignedTransaction`

### DIFF
--- a/examples/demo-rollup/Makefile
+++ b/examples/demo-rollup/Makefile
@@ -77,7 +77,7 @@ build-sov-cli:
 	cargo build --bin sov-cli
 
 test-generate-create-token-tx: wait-compose-ready build-sov-cli
-	$(SOV_CLI_REL_PATH) transactions import from-file bank --path ../test-data/requests/create_token.json
+	$(SOV_CLI_REL_PATH) transactions import from-file bank --chain-id 0 --path ../test-data/requests/create_token.json
 
 set-rpc-url: build-sov-cli
 	$(SOV_CLI_REL_PATH) rpc set-url http://127.0.0.1:12345

--- a/examples/demo-rollup/README.md
+++ b/examples/demo-rollup/README.md
@@ -223,7 +223,7 @@ Let's go ahead and import the transaction into the wallet
 
 
 ```bash,test-ci,bashtestmd:compare-output
-$ cargo run --bin sov-cli -- transactions import from-file bank --path ../test-data/requests/transfer.json
+$ cargo run --bin sov-cli -- transactions import from-file bank --chain-id 0 --path ../test-data/requests/transfer.json
 Adding the following transaction to batch:
 {
   "tx": {

--- a/examples/demo-rollup/README.md
+++ b/examples/demo-rollup/README.md
@@ -226,15 +226,19 @@ Let's go ahead and import the transaction into the wallet
 $ cargo run --bin sov-cli -- transactions import from-file bank --path ../test-data/requests/transfer.json
 Adding the following transaction to batch:
 {
-  "bank": {
-    "Transfer": {
-      "to": "sov1l6n2cku82yfqld30lanm2nfw43n2auc8clw7r5u5m6s7p8jrm4zqrr8r94",
-      "coins": {
-        "amount": 200,
-        "token_address": "sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"
+  "tx": {
+    "bank": {
+      "Transfer": {
+        "to": "sov1l6n2cku82yfqld30lanm2nfw43n2auc8clw7r5u5m6s7p8jrm4zqrr8r94",
+        "coins": {
+          "amount": 200,
+          "token_address": "sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"
+        }
       }
     }
-  }
+  },
+  "chain_id": 0,
+  "gas_tip": 0
 }
 ```
 

--- a/examples/demo-rollup/README_CELESTIA.md
+++ b/examples/demo-rollup/README_CELESTIA.md
@@ -263,7 +263,7 @@ Options:
 Let's go ahead and import the transaction into the wallet
 
 ```bash,test-ci,bashtestmd:compare-output
-$ cargo run --bin sov-cli -- transactions import from-file bank --path ../test-data/requests/transfer.json
+$ cargo run --bin sov-cli -- transactions import from-file bank --chain-id 0 --path ../test-data/requests/transfer.json
 Adding the following transaction to batch:
 {
   "tx": {

--- a/examples/demo-rollup/README_CELESTIA.md
+++ b/examples/demo-rollup/README_CELESTIA.md
@@ -266,15 +266,19 @@ Let's go ahead and import the transaction into the wallet
 $ cargo run --bin sov-cli -- transactions import from-file bank --path ../test-data/requests/transfer.json
 Adding the following transaction to batch:
 {
-  "bank": {
-    "Transfer": {
-      "to": "sov1l6n2cku82yfqld30lanm2nfw43n2auc8clw7r5u5m6s7p8jrm4zqrr8r94",
-      "coins": {
-        "amount": 200,
-        "token_address": "sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"
+  "tx": {
+    "bank": {
+      "Transfer": {
+        "to": "sov1l6n2cku82yfqld30lanm2nfw43n2auc8clw7r5u5m6s7p8jrm4zqrr8r94",
+        "coins": {
+          "amount": 200,
+          "token_address": "sov1zdwj8thgev2u3yyrrlekmvtsz4av4tp3m7dm5mx5peejnesga27svq9m72"
+        }
       }
     }
-  }
+  },
+  "chain_id": 0,
+  "gas_tip": 0
 }
 ```
 

--- a/examples/demo-rollup/src/bin/sov_nft_script.rs
+++ b/examples/demo-rollup/src/bin/sov_nft_script.rs
@@ -40,9 +40,13 @@ pub fn build_transaction(
     nonce: u64,
 ) -> Transaction<DefaultContext> {
     let runtime_encoded_message = RuntimeCall::<DefaultContext, MockDaSpec>::nft(message);
+    let chain_id = 0;
+    let gas_tip = 0;
     Transaction::<DefaultContext>::new_signed_tx(
         signer,
         runtime_encoded_message.try_to_vec().unwrap(),
+        chain_id,
+        gas_tip,
         nonce,
     )
 }

--- a/examples/demo-rollup/tests/bank/mod.rs
+++ b/examples/demo-rollup/tests/bank/mod.rs
@@ -60,7 +60,16 @@ async fn send_test_create_token_tx(rpc_address: SocketAddr) -> Result<(), anyhow
         minter_address: user_address,
         authorized_minters: vec![],
     });
-    let tx = Transaction::<DefaultContext>::new_signed_tx(&key, msg.try_to_vec().unwrap(), 0);
+    let chain_id = 0;
+    let gas_tip = 0;
+    let nonce = 0;
+    let tx = Transaction::<DefaultContext>::new_signed_tx(
+        &key,
+        msg.try_to_vec().unwrap(),
+        chain_id,
+        gas_tip,
+        nonce,
+    );
 
     let port = rpc_address.port();
     let client = SimpleClient::new("localhost", port).await?;

--- a/full-node/sov-ethereum/src/batch_builder.rs
+++ b/full-node/sov-ethereum/src/batch_builder.rs
@@ -34,9 +34,15 @@ impl<C: sov_modules_api::Context> EthBatchBuilder<C> {
         let nonce = self.nonce.borrow_mut();
 
         while let Some(raw_message) = self.mempool.pop_front() {
+            // TODO define a strategy to expose chain id and gas tip for ethereum frontend
+            let chain_id = 0;
+            let gas_tip = 0;
+
             let raw_tx = Transaction::<C>::new_signed_tx(
                 &self.sov_tx_signer_private_key,
                 raw_message,
+                chain_id,
+                gas_tip,
                 *nonce,
             )
             .try_to_vec()

--- a/full-node/sov-sequencer/src/batch_builder.rs
+++ b/full-node/sov-sequencer/src/batch_builder.rs
@@ -209,8 +209,11 @@ mod tests {
     fn generate_valid_tx(private_key: &DefaultPrivateKey, value: u32) -> Vec<u8> {
         let msg = CallMessage::SetValue(value);
         let msg = <TestRuntime<C> as EncodeCall<ValueSetter<DefaultContext>>>::encode_call(msg);
+        let chain_id = 0;
+        let gas_tip = 0;
+        let nonce = 1;
 
-        Transaction::<DefaultContext>::new_signed_tx(private_key, msg, 1)
+        Transaction::<DefaultContext>::new_signed_tx(private_key, msg, chain_id, gas_tip, nonce)
             .try_to_vec()
             .unwrap()
     }
@@ -225,7 +228,11 @@ mod tests {
 
     fn generate_signed_tx_with_invalid_payload(private_key: &DefaultPrivateKey) -> Vec<u8> {
         let msg = generate_random_bytes();
-        Transaction::<DefaultContext>::new_signed_tx(private_key, msg, 1)
+        let chain_id = 0;
+        let gas_tip = 0;
+        let nonce = 1;
+
+        Transaction::<DefaultContext>::new_signed_tx(private_key, msg, chain_id, gas_tip, nonce)
             .try_to_vec()
             .unwrap()
     }

--- a/module-system/module-implementations/sov-nft-module/README.md
+++ b/module-system/module-implementations/sov-nft-module/README.md
@@ -170,7 +170,7 @@ This imports two keys:
 Execute the following commands to create a new NFT collection:
 
 ```bash
-cargo run --bin sov-cli transactions import from-file nft --path examples/test-data/requests/nft/create_collection.json
+cargo run --bin sov-cli transactions import from-file nft --chain-id 0 --path examples/test-data/requests/nft/create_collection.json
 cargo run --bin sov-cli rpc submit-batch by-nickname nft_creator
 ```
 
@@ -195,7 +195,7 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
 To mint an NFT, execute the following commands:
 
 ```bash
-cargo run --bin sov-cli transactions import from-file nft --path examples/test-data/requests/nft/mint_nft.json
+cargo run --bin sov-cli transactions import from-file nft --chain-id 0 --path examples/test-data/requests/nft/mint_nft.json
 cargo run --bin sov-cli rpc submit-batch by-nickname nft_creator
 ```
 
@@ -212,7 +212,7 @@ curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","metho
 To transfer the ownership of an NFT, execute the following commands:
 
 ```bash
-cargo run --bin sov-cli transactions import from-file nft --path examples/test-data/requests/nft/transfer_nft.json
+cargo run --bin sov-cli transactions import from-file nft --chain-id 0 --path examples/test-data/requests/nft/transfer_nft.json
 cargo run --bin sov-cli rpc submit-batch by-nickname nft_owner
 ```
 

--- a/module-system/sov-cli/src/wallet_state.rs
+++ b/module-system/sov-cli/src/wallet_state.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use sov_modules_api::transaction::UnsignedTransaction;
 use sov_modules_api::{clap, PrivateKey};
 
 /// A struct representing the current state of the CLI wallet
@@ -11,7 +12,7 @@ use sov_modules_api::{clap, PrivateKey};
 #[serde(bound = "Ctx::Address: Serialize + DeserializeOwned, Tx: Serialize + DeserializeOwned")]
 pub struct WalletState<Tx, Ctx: sov_modules_api::Context> {
     /// The accumulated transactions to be submitted to the DA layer
-    pub unsent_transactions: Vec<Tx>,
+    pub unsent_transactions: Vec<UnsignedTransaction<Tx>>,
     /// The addresses in the wallet
     pub addresses: AddressList<Ctx>,
     /// The addresses in the wallet

--- a/module-system/sov-cli/src/wallet_state.rs
+++ b/module-system/sov-cli/src/wallet_state.rs
@@ -2,15 +2,19 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sov_modules_api::transaction::UnsignedTransaction;
-use sov_modules_api::{clap, PrivateKey};
+use sov_modules_api::{clap, Context, PrivateKey};
 
 /// A struct representing the current state of the CLI wallet
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "Ctx::Address: Serialize + DeserializeOwned, Tx: Serialize + DeserializeOwned")]
-pub struct WalletState<Tx, Ctx: sov_modules_api::Context> {
+pub struct WalletState<Tx, Ctx: sov_modules_api::Context>
+where
+    Tx: BorshSerialize + BorshDeserialize,
+{
     /// The accumulated transactions to be submitted to the DA layer
     pub unsent_transactions: Vec<UnsignedTransaction<Tx>>,
     /// The addresses in the wallet
@@ -19,8 +23,10 @@ pub struct WalletState<Tx, Ctx: sov_modules_api::Context> {
     pub rpc_url: Option<String>,
 }
 
-impl<Tx: Serialize + DeserializeOwned, Ctx: sov_modules_api::Context> Default
-    for WalletState<Tx, Ctx>
+impl<Tx, Ctx> Default for WalletState<Tx, Ctx>
+where
+    Tx: Serialize + DeserializeOwned + BorshSerialize + BorshDeserialize,
+    Ctx: Context,
 {
     fn default() -> Self {
         Self {
@@ -33,7 +39,11 @@ impl<Tx: Serialize + DeserializeOwned, Ctx: sov_modules_api::Context> Default
     }
 }
 
-impl<Tx: Serialize + DeserializeOwned, Ctx: sov_modules_api::Context> WalletState<Tx, Ctx> {
+impl<Tx, Ctx> WalletState<Tx, Ctx>
+where
+    Tx: Serialize + DeserializeOwned + BorshSerialize + BorshDeserialize,
+    Ctx: Context,
+{
     /// Load the wallet state from the given path on disk
     pub fn load(path: impl AsRef<Path>) -> Result<Self, anyhow::Error> {
         let path = path.as_ref();

--- a/module-system/sov-cli/src/workflows/rpc.rs
+++ b/module-system/sov-cli/src/workflows/rpc.rs
@@ -141,6 +141,10 @@ impl<C: sov_modules_api::Context + Serialize + DeserializeOwned + Send + Sync> R
                     Some(nonce) => *nonce,
                     None => get_nonce_for_account(&client, account).await?,
                 };
+
+                let chain_id = 0;
+                let gas_tip = 0;
+
                 let txs = std::mem::take(&mut wallet_state.unsent_transactions)
                     .into_iter()
                     .enumerate()
@@ -148,6 +152,8 @@ impl<C: sov_modules_api::Context + Serialize + DeserializeOwned + Send + Sync> R
                         Transaction::<C>::new_signed_tx(
                             &private_key,
                             tx.try_to_vec().unwrap(),
+                            chain_id,
+                            gas_tip,
                             nonce + offset as u64,
                         )
                         .try_to_vec()

--- a/module-system/sov-cli/src/workflows/rpc.rs
+++ b/module-system/sov-cli/src/workflows/rpc.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use anyhow::Context;
-use borsh::BorshSerialize;
+use borsh::{BorshDeserialize, BorshSerialize};
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::http_client::HttpClientBuilder;
 use serde::de::DeserializeOwned;
@@ -54,10 +54,13 @@ pub enum RpcWorkflows<C: sov_modules_api::Context> {
 }
 
 impl<C: sov_modules_api::Context> RpcWorkflows<C> {
-    fn resolve_account<'wallet, Tx: BorshSerialize>(
+    fn resolve_account<'wallet, Tx>(
         &self,
         wallet_state: &'wallet mut WalletState<Tx, C>,
-    ) -> Result<&'wallet AddressEntry<C>, anyhow::Error> {
+    ) -> Result<&'wallet AddressEntry<C>, anyhow::Error>
+    where
+        Tx: Serialize + DeserializeOwned + BorshSerialize + BorshDeserialize,
+    {
         let account_id = match self {
             RpcWorkflows::SetUrl { .. } => None,
             RpcWorkflows::GetNonce { account } => account.as_ref(),
@@ -81,11 +84,14 @@ impl<C: sov_modules_api::Context> RpcWorkflows<C> {
 
 impl<C: sov_modules_api::Context + Serialize + DeserializeOwned + Send + Sync> RpcWorkflows<C> {
     /// Run the rpc workflow
-    pub async fn run<Tx: BorshSerialize>(
+    pub async fn run<Tx>(
         &self,
         wallet_state: &mut WalletState<Tx, C>,
         _app_dir: impl AsRef<Path>,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), anyhow::Error>
+    where
+        Tx: Serialize + DeserializeOwned + BorshSerialize + BorshDeserialize,
+    {
         // If the user is just setting the RPC url, we can skip the usual setup
         if let RpcWorkflows::SetUrl { rpc_url } = self {
             let _client = HttpClientBuilder::default()

--- a/module-system/sov-cli/src/workflows/transactions.rs
+++ b/module-system/sov-cli/src/workflows/transactions.rs
@@ -2,6 +2,8 @@
 
 use std::path::Path;
 
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sov_modules_api::clap::{self, Subcommand};
 use sov_modules_api::cli::{CliFrontEnd, CliTxImportArg};
@@ -40,7 +42,7 @@ impl<File: Subcommand, Json: Subcommand> TransactionWorkflow<File, Json> {
         File: TryInto<RT::CliStringRepr<V>, Error = E1>,
         Json: TryInto<RT::CliStringRepr<V>, Error = E2>,
         RT::CliStringRepr<V>: TryInto<RT::Decodable, Error = E3>,
-        RT::Decodable: Serialize,
+        RT::Decodable: BorshSerialize + BorshDeserialize + Serialize + DeserializeOwned,
         E1: Into<anyhow::Error> + Send + Sync,
         E2: Into<anyhow::Error> + Send + Sync,
         E3: Into<anyhow::Error> + Send + Sync,
@@ -105,7 +107,7 @@ where
         Json: TryInto<RT::CliStringRepr<U>, Error = E1>,
         File: TryInto<RT::CliStringRepr<U>, Error = E2>,
         RT::CliStringRepr<U>: TryInto<RT::Decodable, Error = E3>,
-        RT::Decodable: Serialize,
+        RT::Decodable: BorshSerialize + BorshDeserialize + Serialize + DeserializeOwned,
         E1: Into<anyhow::Error> + Send + Sync,
         E2: Into<anyhow::Error> + Send + Sync,
         E3: Into<anyhow::Error> + Send + Sync,

--- a/module-system/sov-cli/src/workflows/transactions.rs
+++ b/module-system/sov-cli/src/workflows/transactions.rs
@@ -4,7 +4,8 @@ use std::path::Path;
 
 use serde::Serialize;
 use sov_modules_api::clap::{self, Subcommand};
-use sov_modules_api::cli::CliFrontEnd;
+use sov_modules_api::cli::{CliFrontEnd, CliTxImportArg};
+use sov_modules_api::transaction::UnsignedTransaction;
 use sov_modules_api::CliWallet;
 
 use crate::wallet_state::WalletState;
@@ -34,8 +35,8 @@ impl<File: Subcommand, Json: Subcommand> TransactionWorkflow<File, Json> {
         _app_dir: impl AsRef<Path>,
     ) -> Result<(), anyhow::Error>
     where
-        File: CliFrontEnd<RT>,
-        Json: CliFrontEnd<RT>,
+        File: CliFrontEnd<RT> + CliTxImportArg,
+        Json: CliFrontEnd<RT> + CliTxImportArg,
         File: TryInto<RT::CliStringRepr<V>, Error = E1>,
         Json: TryInto<RT::CliStringRepr<V>, Error = E2>,
         RT::CliStringRepr<V>: TryInto<RT::Decodable, Error = E3>,
@@ -99,8 +100,8 @@ where
         wallet_state: &mut WalletState<RT::Decodable, C>,
     ) -> Result<(), anyhow::Error>
     where
-        Json: CliFrontEnd<RT>,
-        File: CliFrontEnd<RT>,
+        Json: CliFrontEnd<RT> + CliTxImportArg,
+        File: CliFrontEnd<RT> + CliTxImportArg,
         Json: TryInto<RT::CliStringRepr<U>, Error = E1>,
         File: TryInto<RT::CliStringRepr<U>, Error = E2>,
         RT::CliStringRepr<U>: TryInto<RT::Decodable, Error = E3>,
@@ -109,21 +110,33 @@ where
         E2: Into<anyhow::Error> + Send + Sync,
         E3: Into<anyhow::Error> + Send + Sync,
     {
+        let chain_id;
+        let gas_tip;
+
         let intermediate_repr: RT::CliStringRepr<U> = match self {
             ImportTransaction::FromFile(file) => {
+                chain_id = file.chain_id();
+                gas_tip = file.gas_tip();
                 file.try_into().map_err(Into::<anyhow::Error>::into)?
             }
             ImportTransaction::FromString(json) => {
+                chain_id = json.chain_id();
+                gas_tip = json.gas_tip();
                 json.try_into().map_err(Into::<anyhow::Error>::into)?
             }
         };
 
-        let tx = intermediate_repr
+        let tx: RT::Decodable = intermediate_repr
             .try_into()
             .map_err(Into::<anyhow::Error>::into)?;
+
+        let tx = UnsignedTransaction::new(tx, chain_id, gas_tip);
+
         println!("Adding the following transaction to batch:");
         println!("{}", serde_json::to_string_pretty(&tx)?);
+
         wallet_state.unsent_transactions.push(tx);
+
         Ok(())
     }
 }

--- a/module-system/sov-cli/tests/transactions.rs
+++ b/module-system/sov-cli/tests/transactions.rs
@@ -19,6 +19,8 @@ fn test_import_transaction_from_string() {
     let subcommand = RuntimeSubcommand::<JsonStringArg, DefaultContext, Da>::bank {
         contents: JsonStringArg {
             json: std::fs::read_to_string(test_token_path).unwrap(),
+            chain_id: 0,
+            gas_tip: 0,
         },
     };
 
@@ -43,6 +45,8 @@ fn test_import_transaction_from_file() {
     let subcommand = RuntimeSubcommand::<FileNameArg, DefaultContext, Da>::bank {
         contents: FileNameArg {
             path: test_token_path.to_str().unwrap().into(),
+            chain_id: 0,
+            gas_tip: 0,
         },
     };
 

--- a/module-system/sov-modules-api/src/cli.rs
+++ b/module-system/sov-modules-api/src/cli.rs
@@ -25,7 +25,7 @@ pub struct JsonStringArg {
     pub json: String,
 
     /// The chain ID of the transaction.
-    #[arg(long, help = "The chain ID of the transaction.", default_value = "0")]
+    #[arg(long, help = "The chain ID of the transaction.")]
     pub chain_id: u64,
 
     /// The gas tip for the sequencer.
@@ -41,7 +41,7 @@ pub struct FileNameArg {
     pub path: String,
 
     /// The chain ID of the transaction.
-    #[arg(long, help = "The chain ID of the transaction.", default_value = "0")]
+    #[arg(long, help = "The chain ID of the transaction.")]
     pub chain_id: u64,
 
     /// The gas tip for the sequencer.

--- a/module-system/sov-modules-api/src/transaction.rs
+++ b/module-system/sov-modules-api/src/transaction.rs
@@ -1,6 +1,6 @@
-use std::{fmt, io, marker};
-
-use serde::ser::SerializeStruct;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 #[cfg(feature = "native")]
 use sov_modules_core::PrivateKey;
 use sov_modules_core::{Context, Signature};
@@ -23,8 +23,12 @@ pub struct Transaction<C: Context> {
 }
 
 /// An unsent transaction with the required data to be submitted to the DA layer
-#[derive(Debug)]
-pub struct UnsignedTransaction<Tx> {
+#[derive(Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[serde(bound = "Tx: serde::Serialize + serde::de::DeserializeOwned")]
+pub struct UnsignedTransaction<Tx>
+where
+    Tx: BorshSerialize + BorshDeserialize,
+{
     /// The underlying transaction
     pub tx: Tx,
     /// The ID of the target chain
@@ -131,146 +135,15 @@ impl<C: Context> Transaction<C> {
     }
 }
 
-impl<Tx> UnsignedTransaction<Tx> {
+impl<Tx> UnsignedTransaction<Tx>
+where
+    Tx: Serialize + DeserializeOwned + BorshSerialize + BorshDeserialize,
+{
     pub const fn new(tx: Tx, chain_id: u64, gas_tip: u64) -> Self {
         Self {
             tx,
             chain_id,
             gas_tip,
         }
-    }
-}
-
-impl<Tx> borsh::BorshSerialize for UnsignedTransaction<Tx>
-where
-    Tx: borsh::BorshSerialize,
-{
-    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
-        self.tx.serialize(writer)?;
-        self.chain_id.serialize(writer)?;
-        self.gas_tip.serialize(writer)?;
-
-        Ok(())
-    }
-}
-
-impl<Tx> borsh::BorshDeserialize for UnsignedTransaction<Tx>
-where
-    Tx: borsh::BorshDeserialize,
-{
-    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-        let tx = Tx::deserialize_reader(reader)?;
-        let chain_id = u64::deserialize_reader(reader)?;
-        let gas_tip = u64::deserialize_reader(reader)?;
-
-        Ok(Self {
-            tx,
-            chain_id,
-            gas_tip,
-        })
-    }
-}
-
-impl<Tx> serde::Serialize for UnsignedTransaction<Tx>
-where
-    Tx: serde::Serialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_struct("UnsignedTransaction", 3)?;
-        state.serialize_field("tx", &self.tx)?;
-        state.serialize_field("chain_id", &self.chain_id)?;
-        state.serialize_field("gas_tip", &self.gas_tip)?;
-        state.end()
-    }
-}
-
-impl<'de, Tx> serde::Deserialize<'de> for UnsignedTransaction<Tx>
-where
-    Tx: serde::Deserialize<'de>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use serde::de;
-
-        #[derive(serde::Deserialize)]
-        #[serde(field_identifier)]
-        #[allow(non_camel_case_types)]
-        enum Field {
-            tx,
-            chain_id,
-            gas_tip,
-        }
-
-        struct UnsignedTransactionVisitor<Tx>(marker::PhantomData<Tx>);
-
-        impl<'de, Tx> de::Visitor<'de> for UnsignedTransactionVisitor<Tx>
-        where
-            Tx: serde::Deserialize<'de>,
-        {
-            type Value = UnsignedTransaction<Tx>;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct UnsignedTransaction")
-            }
-
-            fn visit_seq<V>(self, mut seq: V) -> Result<UnsignedTransaction<Tx>, V::Error>
-            where
-                V: de::SeqAccess<'de>,
-            {
-                let tx = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                let chain_id = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                let gas_tip = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(2, &self))?;
-
-                Ok(UnsignedTransaction::new(tx, chain_id, gas_tip))
-            }
-
-            fn visit_map<V>(self, mut map: V) -> Result<UnsignedTransaction<Tx>, V::Error>
-            where
-                V: de::MapAccess<'de>,
-            {
-                let mut tx = None;
-                let mut chain_id = None;
-                let mut gas_tip = None;
-
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::tx if tx.is_some() => return Err(de::Error::duplicate_field("tx")),
-                        Field::tx => tx = Some(map.next_value()?),
-                        Field::chain_id if chain_id.is_some() => {
-                            return Err(de::Error::duplicate_field("chain_id"))
-                        }
-                        Field::chain_id => chain_id = Some(map.next_value()?),
-                        Field::gas_tip if gas_tip.is_some() => {
-                            return Err(de::Error::duplicate_field("gas_tip"))
-                        }
-                        Field::gas_tip => gas_tip = Some(map.next_value()?),
-                    }
-                }
-
-                let tx = tx.ok_or_else(|| de::Error::missing_field("tx"))?;
-                let chain_id = chain_id.ok_or_else(|| de::Error::missing_field("chain_id"))?;
-                let gas_tip = gas_tip.ok_or_else(|| de::Error::missing_field("gas_tip"))?;
-
-                Ok(UnsignedTransaction::new(tx, chain_id, gas_tip))
-            }
-        }
-
-        const FIELDS: &[&str] = &["tx", "chain_id", "gas_tip"];
-        deserializer.deserialize_struct(
-            "UnsignedTransaction",
-            FIELDS,
-            UnsignedTransactionVisitor::<Tx>(marker::PhantomData),
-        )
     }
 }

--- a/module-system/sov-modules-api/src/transaction.rs
+++ b/module-system/sov-modules-api/src/transaction.rs
@@ -1,8 +1,13 @@
+use std::{fmt, io, marker};
+
+use serde::ser::SerializeStruct;
 #[cfg(feature = "native")]
 use sov_modules_core::PrivateKey;
 use sov_modules_core::{Context, Signature};
 #[cfg(all(target_os = "zkvm", feature = "bench"))]
 use sov_zk_cycle_macros::cycle_tracker;
+
+const EXTEND_MESSAGE_LEN: usize = 3 * core::mem::size_of::<u64>();
 
 /// A Transaction object that is compatible with the module-system/sov-default-stf.
 #[derive(
@@ -12,7 +17,20 @@ pub struct Transaction<C: Context> {
     signature: C::Signature,
     pub_key: C::PublicKey,
     runtime_msg: Vec<u8>,
+    chain_id: u64,
+    gas_tip: u64,
     nonce: u64,
+}
+
+/// An unsent transaction with the required data to be submitted to the DA layer
+#[derive(Debug)]
+pub struct UnsignedTransaction<Tx> {
+    /// The underlying transaction
+    pub tx: Tx,
+    /// The ID of the target chain
+    pub chain_id: u64,
+    /// The gas tip for the sequencer
+    pub gas_tip: u64,
 }
 
 impl<C: Context> Transaction<C> {
@@ -28,17 +46,28 @@ impl<C: Context> Transaction<C> {
         &self.runtime_msg
     }
 
-    pub fn nonce(&self) -> u64 {
+    pub const fn nonce(&self) -> u64 {
         self.nonce
+    }
+
+    pub const fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+
+    pub const fn gas_tip(&self) -> u64 {
+        self.gas_tip
     }
 
     /// Check whether the transaction has been signed correctly.
     #[cfg_attr(all(target_os = "zkvm", feature = "bench"), cycle_tracker)]
     pub fn verify(&self) -> anyhow::Result<()> {
-        let mut serialized_tx =
-            Vec::with_capacity(self.runtime_msg().len() + std::mem::size_of::<u64>());
+        let mut serialized_tx = Vec::with_capacity(self.runtime_msg().len() + EXTEND_MESSAGE_LEN);
+
         serialized_tx.extend_from_slice(self.runtime_msg());
+        serialized_tx.extend_from_slice(&self.chain_id().to_le_bytes());
+        serialized_tx.extend_from_slice(&self.gas_tip().to_le_bytes());
         serialized_tx.extend_from_slice(&self.nonce().to_le_bytes());
+
         self.signature().verify(&self.pub_key, &serialized_tx)?;
 
         Ok(())
@@ -49,12 +78,16 @@ impl<C: Context> Transaction<C> {
         pub_key: C::PublicKey,
         message: Vec<u8>,
         signature: C::Signature,
+        chain_id: u64,
+        gas_tip: u64,
         nonce: u64,
     ) -> Self {
         Self {
             signature,
             runtime_msg: message,
             pub_key,
+            chain_id,
+            gas_tip,
             nonce,
         }
     }
@@ -63,23 +96,180 @@ impl<C: Context> Transaction<C> {
 #[cfg(feature = "native")]
 impl<C: Context> Transaction<C> {
     /// New signed transaction.
-    pub fn new_signed_tx(priv_key: &C::PrivateKey, mut message: Vec<u8>, nonce: u64) -> Self {
+    pub fn new_signed_tx(
+        priv_key: &C::PrivateKey,
+        mut message: Vec<u8>,
+        chain_id: u64,
+        gas_tip: u64,
+        nonce: u64,
+    ) -> Self {
         // Since we own the message already, try to add the serialized nonce in-place.
         // This lets us avoid a copy if the message vec has at least 8 bytes of extra capacity.
-        let original_length = message.len();
-        message.extend_from_slice(&nonce.to_le_bytes());
+        let len = message.len();
+
+        // resizes once to avoid potential multiple realloc
+        message.resize(len + EXTEND_MESSAGE_LEN, 0);
+
+        message[len..len + 8].copy_from_slice(&chain_id.to_le_bytes());
+        message[len + 8..len + 16].copy_from_slice(&gas_tip.to_le_bytes());
+        message[len + 16..len + 24].copy_from_slice(&nonce.to_le_bytes());
 
         let pub_key = priv_key.pub_key();
         let signature = priv_key.sign(&message);
 
         // Don't forget to truncate the message back to its original length!
-        message.truncate(original_length);
+        message.truncate(len);
 
         Self {
             signature,
             runtime_msg: message,
             pub_key,
+            chain_id,
+            gas_tip,
             nonce,
         }
+    }
+}
+
+impl<Tx> UnsignedTransaction<Tx> {
+    pub const fn new(tx: Tx, chain_id: u64, gas_tip: u64) -> Self {
+        Self {
+            tx,
+            chain_id,
+            gas_tip,
+        }
+    }
+}
+
+impl<Tx> borsh::BorshSerialize for UnsignedTransaction<Tx>
+where
+    Tx: borsh::BorshSerialize,
+{
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        self.tx.serialize(writer)?;
+        self.chain_id.serialize(writer)?;
+        self.gas_tip.serialize(writer)?;
+
+        Ok(())
+    }
+}
+
+impl<Tx> borsh::BorshDeserialize for UnsignedTransaction<Tx>
+where
+    Tx: borsh::BorshDeserialize,
+{
+    fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        let tx = Tx::deserialize_reader(reader)?;
+        let chain_id = u64::deserialize_reader(reader)?;
+        let gas_tip = u64::deserialize_reader(reader)?;
+
+        Ok(Self {
+            tx,
+            chain_id,
+            gas_tip,
+        })
+    }
+}
+
+impl<Tx> serde::Serialize for UnsignedTransaction<Tx>
+where
+    Tx: serde::Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("UnsignedTransaction", 3)?;
+        state.serialize_field("tx", &self.tx)?;
+        state.serialize_field("chain_id", &self.chain_id)?;
+        state.serialize_field("gas_tip", &self.gas_tip)?;
+        state.end()
+    }
+}
+
+impl<'de, Tx> serde::Deserialize<'de> for UnsignedTransaction<Tx>
+where
+    Tx: serde::Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de;
+
+        #[derive(serde::Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Tx,
+            ChainId,
+            GasTip,
+        }
+
+        struct UnsignedTransactionVisitor<Tx>(marker::PhantomData<Tx>);
+
+        impl<'de, Tx> de::Visitor<'de> for UnsignedTransactionVisitor<Tx>
+        where
+            Tx: serde::Deserialize<'de>,
+        {
+            type Value = UnsignedTransaction<Tx>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct UnsignedTransaction")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<UnsignedTransaction<Tx>, V::Error>
+            where
+                V: de::SeqAccess<'de>,
+            {
+                let tx = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let chain_id = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                let gas_tip = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+
+                Ok(UnsignedTransaction::new(tx, chain_id, gas_tip))
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<UnsignedTransaction<Tx>, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mut tx = None;
+                let mut chain_id = None;
+                let mut gas_tip = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Tx if tx.is_some() => return Err(de::Error::duplicate_field("tx")),
+                        Field::Tx => tx = Some(map.next_value()?),
+                        Field::ChainId if chain_id.is_some() => {
+                            return Err(de::Error::duplicate_field("chain_id"))
+                        }
+                        Field::ChainId => chain_id = Some(map.next_value()?),
+                        Field::GasTip if gas_tip.is_some() => {
+                            return Err(de::Error::duplicate_field("gas_tip"))
+                        }
+                        Field::GasTip => gas_tip = Some(map.next_value()?),
+                    }
+                }
+
+                let tx = tx.ok_or_else(|| de::Error::missing_field("tx"))?;
+                let chain_id = chain_id.ok_or_else(|| de::Error::missing_field("chain_id"))?;
+                let gas_tip = gas_tip.ok_or_else(|| de::Error::missing_field("gas_tip"))?;
+
+                Ok(UnsignedTransaction::new(tx, chain_id, gas_tip))
+            }
+        }
+
+        const FIELDS: &[&str] = &["tx", "chain_id", "gas_tip"];
+        deserializer.deserialize_struct(
+            "UnsignedTransaction",
+            FIELDS,
+            UnsignedTransactionVisitor::<Tx>(marker::PhantomData),
+        )
     }
 }

--- a/module-system/sov-modules-api/src/transaction.rs
+++ b/module-system/sov-modules-api/src/transaction.rs
@@ -198,11 +198,12 @@ where
         use serde::de;
 
         #[derive(serde::Deserialize)]
-        #[serde(field_identifier, rename_all = "lowercase")]
+        #[serde(field_identifier)]
+        #[allow(non_camel_case_types)]
         enum Field {
-            Tx,
-            ChainId,
-            GasTip,
+            tx,
+            chain_id,
+            gas_tip,
         }
 
         struct UnsignedTransactionVisitor<Tx>(marker::PhantomData<Tx>);
@@ -244,16 +245,16 @@ where
 
                 while let Some(key) = map.next_key()? {
                     match key {
-                        Field::Tx if tx.is_some() => return Err(de::Error::duplicate_field("tx")),
-                        Field::Tx => tx = Some(map.next_value()?),
-                        Field::ChainId if chain_id.is_some() => {
+                        Field::tx if tx.is_some() => return Err(de::Error::duplicate_field("tx")),
+                        Field::tx => tx = Some(map.next_value()?),
+                        Field::chain_id if chain_id.is_some() => {
                             return Err(de::Error::duplicate_field("chain_id"))
                         }
-                        Field::ChainId => chain_id = Some(map.next_value()?),
-                        Field::GasTip if gas_tip.is_some() => {
+                        Field::chain_id => chain_id = Some(map.next_value()?),
+                        Field::gas_tip if gas_tip.is_some() => {
                             return Err(de::Error::duplicate_field("gas_tip"))
                         }
-                        Field::GasTip => gas_tip = Some(map.next_value()?),
+                        Field::gas_tip => gas_tip = Some(map.next_value()?),
                     }
                 }
 

--- a/module-system/sov-modules-macros/tests/cli_wallet_arg/derive_wallet.rs
+++ b/module-system/sov-modules-macros/tests/cli_wallet_arg/derive_wallet.rs
@@ -126,6 +126,8 @@ fn main() {
             "first",
             "--json",
             r#"{"first_field": 1, "str_field": "hello"}"#,
+            "--chain-id",
+            "0",
         ])
         .expect("parsing must succed")
         .into();
@@ -139,6 +141,8 @@ fn main() {
             "second",
             "--json",
             r#"{"Bar": 2}"#,
+            "--chain-id",
+            "0",
         ])
         .expect("parsing must succed")
         .into();

--- a/module-system/sov-modules-rollup-blueprint/src/wallet.rs
+++ b/module-system/sov-modules-rollup-blueprint/src/wallet.rs
@@ -6,7 +6,7 @@ use sov_cli::workflows::rpc::RpcWorkflows;
 use sov_cli::workflows::transactions::TransactionWorkflow;
 use sov_cli::{clap, wallet_dir};
 use sov_modules_api::clap::Parser;
-use sov_modules_api::cli::{CliFrontEnd, JsonStringArg};
+use sov_modules_api::cli::{CliFrontEnd, CliTxImportArg, JsonStringArg};
 use sov_modules_api::{CliWallet, Context, DispatchCall};
 
 use crate::RollupBlueprint;
@@ -54,8 +54,8 @@ where
     async fn run_wallet<File: clap::Subcommand, Json: clap::Subcommand>(
     ) -> Result<(), anyhow::Error>
     where
-        File: CliFrontEnd<<Self as RollupBlueprint>::NativeRuntime> + Send + Sync,
-        Json: CliFrontEnd<<Self as RollupBlueprint>::NativeRuntime> + Send + Sync,
+        File: CliFrontEnd<<Self as RollupBlueprint>::NativeRuntime> + CliTxImportArg + Send + Sync,
+        Json: CliFrontEnd<<Self as RollupBlueprint>::NativeRuntime> + CliTxImportArg + Send + Sync,
 
         File: TryInto<
             <<Self as RollupBlueprint>::NativeRuntime as CliWallet>::CliStringRepr<JsonStringArg>,

--- a/module-system/sov-modules-rollup-blueprint/src/wallet.rs
+++ b/module-system/sov-modules-rollup-blueprint/src/wallet.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
-use borsh::BorshSerialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use sov_cli::wallet_state::WalletState;
 use sov_cli::workflows::keys::KeyWorkflow;
 use sov_cli::workflows::rpc::RpcWorkflows;
@@ -54,6 +56,8 @@ where
     async fn run_wallet<File: clap::Subcommand, Json: clap::Subcommand>(
     ) -> Result<(), anyhow::Error>
     where
+        <<Self as RollupBlueprint>::NativeRuntime as DispatchCall>::Decodable:
+            BorshSerialize + BorshDeserialize + Serialize + DeserializeOwned,
         File: CliFrontEnd<<Self as RollupBlueprint>::NativeRuntime> + CliTxImportArg + Send + Sync,
         Json: CliFrontEnd<<Self as RollupBlueprint>::NativeRuntime> + CliTxImportArg + Send + Sync,
 

--- a/module-system/utils/sov-data-generators/src/lib.rs
+++ b/module-system/utils/sov-data-generators/src/lib.rs
@@ -38,15 +38,27 @@ pub struct Message<C: Context, Mod: Module> {
     pub sender_key: Rc<<C as Spec>::PrivateKey>,
     /// The message content.
     pub content: Mod::CallMessage,
+    /// The ID of the chain.
+    pub chain_id: u64,
+    /// The gas tip for the sequencer.
+    pub gas_tip: u64,
     /// The message nonce.
     pub nonce: u64,
 }
 
 impl<C: Context, Mod: Module> Message<C, Mod> {
-    fn new(sender_key: Rc<<C as Spec>::PrivateKey>, content: Mod::CallMessage, nonce: u64) -> Self {
+    fn new(
+        sender_key: Rc<<C as Spec>::PrivateKey>,
+        content: Mod::CallMessage,
+        chain_id: u64,
+        gas_tip: u64,
+        nonce: u64,
+    ) -> Self {
         Self {
             sender_key,
             content,
+            chain_id,
+            gas_tip,
             nonce,
         }
     }
@@ -70,6 +82,10 @@ pub trait MessageGenerator {
         sender: &<Self::Context as Spec>::PrivateKey,
         // The message itself
         message: <Self::Module as Module>::CallMessage,
+        // The ID of the chain
+        chain_id: u64,
+        // A gas tip for the sequencer
+        gas_tip: u64,
         // The message nonce
         nonce: u64,
         // A boolean that indicates whether this message is the last one to be sent.
@@ -87,6 +103,8 @@ pub trait MessageGenerator {
             let tx = self.create_tx::<Encoder>(
                 &message.sender_key,
                 message.content,
+                message.chain_id,
+                message.gas_tip,
                 message.nonce,
                 is_last,
             );

--- a/module-system/utils/sov-data-generators/src/value_setter_data.rs
+++ b/module-system/utils/sov-data-generators/src/value_setter_data.rs
@@ -8,6 +8,9 @@ use sov_value_setter::ValueSetter;
 use super::*;
 use crate::EncodeCall;
 
+const DEFAULT_CHAIN_ID: u64 = 0;
+const DEFAULT_GAS_TIP: u64 = 0;
+
 pub struct ValueSetterMessage<C: Context> {
     pub admin: Rc<C::PrivateKey>,
     pub messages: Vec<u32>,
@@ -51,6 +54,8 @@ impl<C: Context> MessageGenerator for ValueSetterMessages<C> {
                 messages.push(Message::new(
                     admin.clone(),
                     set_value_msg,
+                    DEFAULT_CHAIN_ID,
+                    DEFAULT_GAS_TIP,
                     value_setter_admin_nonce.try_into().unwrap(),
                 ));
             }
@@ -62,10 +67,12 @@ impl<C: Context> MessageGenerator for ValueSetterMessages<C> {
         &self,
         sender: &C::PrivateKey,
         message: <Self::Module as Module>::CallMessage,
+        chain_id: u64,
+        gas_tip: u64,
         nonce: u64,
         _is_last: bool,
     ) -> Transaction<C> {
         let message = Encoder::encode_call(message);
-        Transaction::<C>::new_signed_tx(sender, message, nonce)
+        Transaction::<C>::new_signed_tx(sender, message, chain_id, gas_tip, nonce)
     }
 }

--- a/utils/rng-da-service/src/lib.rs
+++ b/utils/rng-da-service/src/lib.rs
@@ -15,6 +15,9 @@ use sov_modules_api::{Address, AddressBech32, EncodeCall, PrivateKey, PublicKey,
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec, DaVerifier};
 use sov_rollup_interface::services::da::{DaService, SlotData};
 
+const DEFAULT_CHAIN_ID: u64 = 0;
+const DEFAULT_GAS_TIP: u64 = 0;
+
 pub fn sender_address_with_pkey() -> (Address, DefaultPrivateKey) {
     // TODO: maybe generate address and private key randomly, instead of
     // hard-coding them?
@@ -194,8 +197,13 @@ pub fn generate_transfers(n: usize, start_nonce: u64) -> Vec<u8> {
             <Runtime<DefaultContext, RngDaSpec> as EncodeCall<Bank<DefaultContext>>>::encode_call(
                 msg,
             );
-        let tx =
-            Transaction::<DefaultContext>::new_signed_tx(&pk, enc_msg, start_nonce + (i as u64));
+        let tx = Transaction::<DefaultContext>::new_signed_tx(
+            &pk,
+            enc_msg,
+            DEFAULT_CHAIN_ID,
+            DEFAULT_GAS_TIP,
+            start_nonce + (i as u64),
+        );
         let ser_tx = tx.try_to_vec().unwrap();
         message_vec.push(ser_tx)
     }
@@ -216,7 +224,13 @@ pub fn generate_create(start_nonce: u64) -> Vec<u8> {
         };
     let enc_msg =
         <Runtime<DefaultContext, RngDaSpec> as EncodeCall<Bank<DefaultContext>>>::encode_call(msg);
-    let tx = Transaction::<DefaultContext>::new_signed_tx(&pk, enc_msg, start_nonce);
+    let tx = Transaction::<DefaultContext>::new_signed_tx(
+        &pk,
+        enc_msg,
+        DEFAULT_CHAIN_ID,
+        DEFAULT_GAS_TIP,
+        start_nonce,
+    );
     let ser_tx = tx.try_to_vec().unwrap();
     message_vec.push(ser_tx);
     message_vec.try_to_vec().unwrap()


### PR DESCRIPTION
This commit introduces `UnsignedTransaction`, an intermediary type that will contain transaction metadata before it is signed.

To maintain consistency with the JSON runtime call messages serialized format, we preserve this format because the serialization occurs prior to the unsigned transaction serialization. The runtime will define a module name for its implementation; therefore, the runtime call will have a custom field name, so it must be serialized beforehand.

In order to maintain simplicity, two CLI arguments are added to sov-cli to contain the two new scalar attributes of the transaction: chain id and gas tip.

The chain ID is introduced to prevent cross-chain transaction reproduction. The signed transaction will also take the chain id field as part of the signature; therefore, a signature is valid only for a specified chain.

The gas tip is an incentive for the sequencer to pick the given transaction from the pool.

## Linked Issues
- Fixes #624