### PR TITLE
Make MockDA return current time

### DIFF
--- a/adapters/mock-da/src/types/mod.rs
+++ b/adapters/mock-da/src/types/mod.rs
@@ -109,7 +109,7 @@ impl BlockHeaderTrait for MockBlockHeader {
     }
 
     fn time(&self) -> Time {
-        Time::from_secs(JAN_1_2023 + (self.height as i64) * 15)
+        Time::now()
     }
 }
 

--- a/adapters/mock-da/src/types/mod.rs
+++ b/adapters/mock-da/src/types/mod.rs
@@ -12,8 +12,6 @@ use sov_rollup_interface::Bytes;
 
 use crate::validity_condition::MockValidityCond;
 
-const JAN_1_2023: i64 = 1672531200;
-
 /// A mock hash digest.
 #[derive(
     Clone,

--- a/adapters/mock-da/src/types/mod.rs
+++ b/adapters/mock-da/src/types/mod.rs
@@ -59,7 +59,7 @@ impl std::hash::Hash for MockHash {
 impl BlockHashTrait for MockHash {}
 
 /// A mock block header used for testing.
-#[derive(Serialize, Deserialize, PartialEq, core::fmt::Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, PartialEq, core::fmt::Debug, Clone)]
 pub struct MockBlockHeader {
     /// The hash of the previous block.
     pub prev_hash: MockHash,
@@ -67,6 +67,8 @@ pub struct MockBlockHeader {
     pub hash: MockHash,
     /// The height of this block
     pub height: u64,
+    /// The time at which this block was created
+    pub time: Time,
 }
 
 impl Default for MockBlockHeader {
@@ -75,6 +77,7 @@ impl Default for MockBlockHeader {
             prev_hash: MockHash([0u8; 32]),
             hash: MockHash([1u8; 32]),
             height: 0,
+            time: Time::now(),
         }
     }
 }
@@ -107,7 +110,7 @@ impl BlockHeaderTrait for MockBlockHeader {
     }
 
     fn time(&self) -> Time {
-        Time::now()
+        self.time.clone()
     }
 }
 
@@ -168,6 +171,7 @@ impl Default for MockBlock {
                 prev_hash: [0; 32].into(),
                 hash: [1; 32].into(),
                 height: 0,
+                time: Default::default(),
             },
             validity_cond: Default::default(),
             blobs: Default::default(),

--- a/examples/demo-rollup/benches/node/rollup_bench.rs
+++ b/examples/demo-rollup/benches/node/rollup_bench.rs
@@ -14,6 +14,7 @@ use sov_modules_stf_blueprint::kernels::basic::BasicKernel;
 use sov_modules_stf_blueprint::StfBlueprint;
 use sov_risc0_adapter::host::Risc0Verifier;
 use sov_rng_da_service::{RngDaService, RngDaSpec};
+use sov_rollup_interface::da::Time;
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::stf::StateTransitionFunction;
 use sov_rollup_interface::storage::StorageManager;
@@ -76,6 +77,7 @@ fn rollup_bench(_bench: &mut Criterion) {
                 hash: barray.into(),
                 prev_hash: [0u8; 32].into(),
                 height,
+                time: Time::now(),
             },
             validity_cond: Default::default(),
             blobs: Default::default(),

--- a/examples/demo-rollup/benches/node/rollup_coarse_measure.rs
+++ b/examples/demo-rollup/benches/node/rollup_coarse_measure.rs
@@ -18,6 +18,7 @@ use sov_modules_stf_blueprint::kernels::basic::BasicKernel;
 use sov_modules_stf_blueprint::{StfBlueprint, TxEffect};
 use sov_risc0_adapter::host::Risc0Verifier;
 use sov_rng_da_service::{RngDaService, RngDaSpec};
+use sov_rollup_interface::da::Time;
 use sov_rollup_interface::services::da::DaService;
 use sov_rollup_interface::stf::StateTransitionFunction;
 use sov_rollup_interface::storage::StorageManager;
@@ -131,6 +132,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 prev_hash: [0u8; 32].into(),
                 hash: barray.into(),
                 height,
+                time: Time::now(),
             },
             validity_cond: Default::default(),
             blobs: Default::default(),

--- a/examples/demo-rollup/benches/prover/prover_bench.rs
+++ b/examples/demo-rollup/benches/prover/prover_bench.rs
@@ -187,7 +187,7 @@ async fn main() -> Result<(), anyhow::Error> {
             hex::encode(prev_state_root.0)
         );
         let filtered_block = &blocks[height as usize];
-        host.add_hint(filtered_block.header);
+        host.add_hint(filtered_block.header.clone());
         let (mut blob_txs, inclusion_proof, completeness_proof) = da_service
             .extract_relevant_blobs_with_proof(filtered_block)
             .await;

--- a/examples/demo-rollup/src/test_rpc.rs
+++ b/examples/demo-rollup/src/test_rpc.rs
@@ -8,6 +8,7 @@ use serde_json::json;
 use sov_db::ledger_db::{LedgerDB, SlotCommit};
 #[cfg(test)]
 use sov_mock_da::{MockBlock, MockBlockHeader, MockHash};
+use sov_rollup_interface::da::Time;
 use sov_rollup_interface::services::da::SlotData;
 use sov_rollup_interface::stf::fuzzing::BatchReceiptStrategyArgs;
 use sov_rollup_interface::stf::{BatchReceipt, Event, TransactionReceipt};
@@ -97,6 +98,7 @@ fn regular_test_helper(payload: serde_json::Value, expected: &serde_json::Value)
             prev_hash: sha2::Sha256::digest(b"prev_header").into(),
             hash: sha2::Sha256::digest(b"slot_data").into(),
             height: 0,
+            time: Time::now(),
         },
         validity_cond: Default::default(),
         blobs: Default::default(),
@@ -302,6 +304,7 @@ prop_compose! {
                 hash: hash.into(),
                     prev_hash,
                 height: 0,
+                time: Time::now(),
                 },
                 validity_cond: Default::default(),
                 blobs: Default::default()

--- a/full-node/sov-prover-storage-manager/src/lib.rs
+++ b/full-node/sov-prover-storage-manager/src/lib.rs
@@ -250,6 +250,7 @@ mod tests {
 
     use sov_db::rocks_db_config::gen_rocksdb_options;
     use sov_mock_da::{MockBlockHeader, MockHash};
+    use sov_rollup_interface::da::Time;
     use sov_schema_db::snapshot::FrozenDbSnapshot;
 
     use super::*;
@@ -368,6 +369,7 @@ mod tests {
             prev_hash: MockHash::from([1; 32]),
             hash: MockHash::from([2; 32]),
             height: 1,
+            time: Time::now(),
         };
 
         let _storage = storage_manager
@@ -408,6 +410,7 @@ mod tests {
             prev_hash: MockHash::from([0; 32]),
             hash: MockHash::from([1; 32]),
             height: 1,
+            time: Time::now(),
         };
 
         let storage_1 = storage_manager
@@ -453,6 +456,7 @@ mod tests {
             prev_hash: MockHash::from([1; 32]),
             hash: MockHash::from([1; 32]),
             height: 1,
+            time: Time::now(),
         };
 
         storage_manager
@@ -478,11 +482,13 @@ mod tests {
             prev_hash: MockHash::from([1; 32]),
             hash: MockHash::from([2; 32]),
             height: 1,
+            time: Time::now(),
         };
         let block_b = MockBlockHeader {
             prev_hash: MockHash::from([2; 32]),
             hash: MockHash::from([1; 32]),
             height: 2,
+            time: Time::now(),
         };
 
         let _storage_a = storage_manager.get_native_storage_on(&block_a).unwrap();
@@ -510,6 +516,7 @@ mod tests {
             prev_hash: MockHash::from([1; 32]),
             hash: MockHash::from([2; 32]),
             height: 1,
+            time: Time::now(),
         };
 
         assert!(storage_manager.is_empty());
@@ -538,6 +545,7 @@ mod tests {
             prev_hash: MockHash::from([1; 32]),
             hash: MockHash::from([2; 32]),
             height: 1,
+            time: Time::now(),
         };
 
         let snapshot_1 = {
@@ -577,12 +585,14 @@ mod tests {
             prev_hash: MockHash::from([0; 32]),
             hash: MockHash::from([1; 32]),
             height: 1,
+            time: Time::now(),
         };
 
         let block_b = MockBlockHeader {
             prev_hash: MockHash::from([2; 32]),
             hash: MockHash::from([3; 32]),
             height: 2,
+            time: Time::now(),
         };
 
         let (snapshot_alien_1, snapshot_alien_2) = {
@@ -636,6 +646,7 @@ mod tests {
             prev_hash: MockHash::from([i; 32]),
             hash: MockHash::from([i + 1; 32]),
             height: i as u64 + 1,
+            time: Time::now(),
         };
 
         for i in 0u8..4 {
@@ -682,6 +693,7 @@ mod tests {
                 prev_hash: MockHash::from([prev_hash; 32]),
                 hash: MockHash::from([next_hash; 32]),
                 height: height as u64,
+                time: Time::now(),
             };
             let storage = storage_manager.get_native_storage_on(&block).unwrap();
             storage_manager.save_change_set(&block, storage).unwrap();
@@ -692,6 +704,7 @@ mod tests {
                 prev_hash: MockHash::from([prev_hash; 32]),
                 hash: MockHash::from([prev_hash + 1; 32]),
                 height: prev_hash as u64 + 1,
+                time: Time::now(),
             };
             storage_manager.finalize(&block).unwrap();
             validate_internal_consistency(&storage_manager);
@@ -748,56 +761,67 @@ mod tests {
             prev_hash: MockHash::from([0; 32]),
             hash: MockHash::from([1; 32]),
             height: 1,
+            time: Time::now(),
         };
         let block_b = MockBlockHeader {
             prev_hash: MockHash::from([1; 32]),
             hash: MockHash::from([2; 32]),
             height: 2,
+            time: Time::now(),
         };
         let block_c = MockBlockHeader {
             prev_hash: MockHash::from([2; 32]),
             hash: MockHash::from([3; 32]),
             height: 3,
+            time: Time::now(),
         };
         let block_d = MockBlockHeader {
             prev_hash: MockHash::from([3; 32]),
             hash: MockHash::from([4; 32]),
             height: 4,
+            time: Time::now(),
         };
         let block_e = MockBlockHeader {
             prev_hash: MockHash::from([4; 32]),
             hash: MockHash::from([5; 32]),
             height: 5,
+            time: Time::now(),
         };
         let block_f = MockBlockHeader {
             prev_hash: MockHash::from([1; 32]),
             hash: MockHash::from([32; 32]),
             height: 2,
+            time: Time::now(),
         };
         let block_g = MockBlockHeader {
             prev_hash: MockHash::from([2; 32]),
             hash: MockHash::from([23; 32]),
             height: 3,
+            time: Time::now(),
         };
         let block_h = MockBlockHeader {
             prev_hash: MockHash::from([23; 32]),
             hash: MockHash::from([24; 32]),
             height: 4,
+            time: Time::now(),
         };
         let block_k = MockBlockHeader {
             prev_hash: MockHash::from([32; 32]),
             hash: MockHash::from([33; 32]),
             height: 3,
+            time: Time::now(),
         };
         let block_l = MockBlockHeader {
             prev_hash: MockHash::from([2; 32]),
             hash: MockHash::from([13; 32]),
             height: 3,
+            time: Time::now(),
         };
         let block_m = MockBlockHeader {
             prev_hash: MockHash::from([13; 32]),
             hash: MockHash::from([14; 32]),
             height: 4,
+            time: Time::now(),
         };
 
         // Data

--- a/full-node/sov-stf-runner/tests/prover_tests.rs
+++ b/full-node/sov-stf-runner/tests/prover_tests.rs
@@ -2,6 +2,7 @@ use sov_mock_da::{
     MockBlockHeader, MockDaService, MockDaSpec, MockDaVerifier, MockHash, MockValidityCond,
 };
 use sov_mock_zkvm::MockZkvm;
+use sov_rollup_interface::da::Time;
 use sov_stf_runner::mock::MockStf;
 use sov_stf_runner::{
     ParallelProverService, ProofProcessingStatus, ProofSubmissionStatus, ProverService,
@@ -216,6 +217,7 @@ fn make_transition_data(
             prev_hash: [0; 32].into(),
             hash: header_hash,
             height: 0,
+            time: Time::now(),
         },
         inclusion_proof: [0; 32],
         completeness_proof: (),

--- a/module-system/module-implementations/integration-tests/src/chain_state/tests.rs
+++ b/module-system/module-implementations/integration-tests/src/chain_state/tests.rs
@@ -8,6 +8,7 @@ use sov_modules_api::storage::StorageManager;
 use sov_modules_api::{Spec, WorkingSet};
 use sov_modules_stf_blueprint::kernels::basic::BasicKernel;
 use sov_modules_stf_blueprint::{SequencerOutcome, StfBlueprint};
+use sov_rollup_interface::da::Time;
 use sov_rollup_interface::stf::StateTransitionFunction;
 use sov_state::storage_manager::ProverStorageManager;
 use sov_state::Storage;
@@ -58,6 +59,7 @@ fn test_simple_value_setter_with_chain_state() {
             prev_hash: [0; 32].into(),
             hash: [10; 32].into(),
             height: 0,
+            time: Time::now(),
         },
         validity_cond: MockValidityCond::default(),
         blobs: Default::default(),
@@ -126,6 +128,7 @@ fn test_simple_value_setter_with_chain_state() {
             prev_hash: [10; 32].into(),
             hash: [20; 32].into(),
             height: 1,
+            time: Time::now(),
         },
         validity_cond: MockValidityCond::default(),
         blobs: Default::default(),

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
@@ -8,6 +8,7 @@ use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::hooks::SlotHooks;
 use sov_modules_api::utils::generate_address;
 use sov_modules_api::{Address, Genesis, Spec, ValidityConditionChecker, WorkingSet};
+use sov_rollup_interface::da::Time;
 use sov_state::storage::{NativeStorage, Storage, StorageProof};
 use sov_state::{DefaultStorageSpec, ProverStorage};
 
@@ -169,6 +170,7 @@ pub(crate) fn execution_simulation<Checker: ValidityConditionChecker<MockValidit
                 prev_hash: [i; 32].into(),
                 hash: [i + 1; 32].into(),
                 height: INIT_HEIGHT + u64::from(i + 1),
+                time: Time::now(),
             },
             validity_cond: MockValidityCond { is_valid: true },
             blobs: Default::default(),

--- a/module-system/module-implementations/sov-blob-storage/tests/capability_tests.rs
+++ b/module-system/module-implementations/sov-blob-storage/tests/capability_tests.rs
@@ -2,6 +2,7 @@ use sov_bank::TokenConfig;
 use sov_blob_storage::{BlobStorage, DEFERRED_SLOTS_COUNT};
 use sov_chain_state::ChainStateConfig;
 use sov_mock_da::{MockAddress, MockBlob, MockBlock, MockBlockHeader, MockDaSpec};
+use sov_modules_api::da::Time;
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::hooks::SlotHooks;
 use sov_modules_api::macros::DefaultRuntime;
@@ -134,6 +135,7 @@ fn do_deferred_blob_test(
                 prev_hash: [slot_number_u8; 32].into(),
                 hash: [slot_number_u8 + 1; 32].into(),
                 height: slot_number,
+                time: Time::now(),
             },
             validity_cond: Default::default(),
             blobs: slots_iterator.next().unwrap(),
@@ -482,6 +484,7 @@ fn test_blobs_from_non_registered_sequencers_are_not_saved() {
                 prev_hash: [slot_number_u8; 32].into(),
                 hash: [slot_number_u8 + 1; 32].into(),
                 height: slot_number,
+                time: Time::now(),
             },
             validity_cond: Default::default(),
             blobs: if slot_number == 0 {
@@ -531,6 +534,7 @@ fn test_blobs_not_deferred_without_preferred_sequencer() {
             prev_hash: [0; 32].into(),
             hash: [1; 32].into(),
             height: 1,
+            time: Time::now(),
         },
         validity_cond: Default::default(),
         blobs: slot_1_blobs,
@@ -557,6 +561,7 @@ fn test_blobs_not_deferred_without_preferred_sequencer() {
             prev_hash: slot_1_data.header.hash,
             hash: [2; 32].into(),
             height: 2,
+            time: Time::now(),
         },
         validity_cond: Default::default(),
         blobs: Vec::new(),

--- a/module-system/module-implementations/sov-chain-state/tests/all_tests.rs
+++ b/module-system/module-implementations/sov-chain-state/tests/all_tests.rs
@@ -1,6 +1,6 @@
 use sov_chain_state::{ChainState, ChainStateConfig, StateTransitionId, TransitionInProgress};
 use sov_mock_da::{MockBlock, MockBlockHeader, MockDaSpec, MockValidityCond};
-use sov_modules_api::da::BlockHeaderTrait;
+use sov_modules_api::da::{BlockHeaderTrait, Time};
 use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::hooks::SlotHooks;
 use sov_modules_api::storage::StorageManager;
@@ -61,6 +61,7 @@ fn test_simple_chain_state() {
             prev_hash: [0; 32].into(),
             hash: [1; 32].into(),
             height: INIT_HEIGHT,
+            time: Time::now(),
         },
         validity_cond: MockValidityCond { is_valid: true },
         blobs: Default::default(),
@@ -119,6 +120,7 @@ fn test_simple_chain_state() {
             prev_hash: [1; 32].into(),
             hash: [2; 32].into(),
             height: INIT_HEIGHT,
+            time: Time::now(),
         },
         validity_cond: MockValidityCond { is_valid: false },
         blobs: Default::default(),

--- a/rollup-interface/src/state_machine/da.rs
+++ b/rollup-interface/src/state_machine/da.rs
@@ -246,6 +246,7 @@ impl Time {
         }
     }
 
+    #[cfg(feature = "std")]
     /// Get the current time
     pub fn now() -> Self {
         let current_time = std::time::SystemTime::now()

--- a/rollup-interface/src/state_machine/da.rs
+++ b/rollup-interface/src/state_machine/da.rs
@@ -246,6 +246,17 @@ impl Time {
         }
     }
 
+    /// Get the current time
+    pub fn now() -> Self {
+        let current_time = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Time went backwards");
+        Time {
+            secs: current_time.as_secs() as i64,
+            nanos: current_time.subsec_nanos(),
+        }
+    }
+
     /// Create a time from the specified number of whole seconds.
     pub const fn from_secs(secs: i64) -> Self {
         Time { secs, nanos: 0 }

--- a/utils/rng-da-service/src/lib.rs
+++ b/utils/rng-da-service/src/lib.rs
@@ -12,7 +12,7 @@ use sov_modules_api::default_context::DefaultContext;
 use sov_modules_api::default_signature::private_key::DefaultPrivateKey;
 use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{Address, AddressBech32, EncodeCall, PrivateKey, PublicKey, Spec};
-use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec, DaVerifier};
+use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec, DaVerifier, Time};
 use sov_rollup_interface::services::da::{DaService, SlotData};
 
 const DEFAULT_CHAIN_ID: u64 = 0;
@@ -91,6 +91,7 @@ impl DaService for RngDaService {
                 hash: barray.into(),
                 prev_hash: [0u8; 32].into(),
                 height,
+                time: Time::now(),
             },
             validity_cond: MockValidityCond { is_valid: true },
             blobs: Default::default(),


### PR DESCRIPTION
# Description
Make MockDA return current time instead of time depending only on the block height. This was requested by Hermes to simplify testing for IBC.
