### PR TITLE
Minor sov-db improvements

### DIFF
--- a/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -166,7 +166,7 @@ impl LedgerDB {
         let iter = raw_iter.take(max_items);
         let mut out = Vec::with_capacity(max_items);
         for res in iter {
-            let (_, batch) = res?;
+            let batch = res?.value;
             out.push(batch)
         }
         Ok(out)
@@ -307,7 +307,7 @@ impl LedgerDB {
         iter.seek_to_last();
 
         match iter.next() {
-            Some(Ok((version, _))) => Ok(Some(version.into())),
+            Some(Ok(item)) => Ok(Some(item.key.into())),
             Some(Err(e)) => Err(e),
             _ => Ok(None),
         }
@@ -319,7 +319,7 @@ impl LedgerDB {
         iter.seek_to_last();
 
         match iter.next() {
-            Some(Ok((slot_number, slot))) => Ok(Some((slot_number, slot))),
+            Some(Ok(item)) => Ok(Some(item.to_tuple())),
             Some(Err(e)) => Err(e),
             _ => Ok(None),
         }

--- a/full-node/db/sov-db/src/ledger_db/mod.rs
+++ b/full-node/db/sov-db/src/ledger_db/mod.rs
@@ -319,7 +319,7 @@ impl LedgerDB {
         iter.seek_to_last();
 
         match iter.next() {
-            Some(Ok(item)) => Ok(Some(item.to_tuple())),
+            Some(Ok(item)) => Ok(Some(item.into_tuple())),
             Some(Err(e)) => Err(e),
             _ => Ok(None),
         }

--- a/full-node/db/sov-db/src/native_db.rs
+++ b/full-node/db/sov-db/src/native_db.rs
@@ -50,7 +50,7 @@ impl NativeDB {
         let found = iter.next();
         match found {
             Some(result) => {
-                let ((found_key, found_version), value) = result?.to_tuple();
+                let ((found_key, found_version), value) = result?.into_tuple();
                 if &found_key == key {
                     anyhow::ensure!(found_version <= version, "Bug! iterator isn't returning expected values. expected a version <= {version:} but found {found_version:}");
                     Ok(value)

--- a/full-node/db/sov-db/src/native_db.rs
+++ b/full-node/db/sov-db/src/native_db.rs
@@ -50,7 +50,7 @@ impl NativeDB {
         let found = iter.next();
         match found {
             Some(result) => {
-                let ((found_key, found_version), value) = result?;
+                let ((found_key, found_version), value) = result?.to_tuple();
                 if &found_key == key {
                     anyhow::ensure!(found_version <= version, "Bug! iterator isn't returning expected values. expected a version <= {version:} but found {found_version:}");
                     Ok(value)

--- a/full-node/db/sov-db/src/state_db.rs
+++ b/full-node/db/sov-db/src/state_db.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use jmt::storage::{TreeReader, TreeWriter};
+use jmt::storage::{HasPreimage, TreeReader, TreeWriter};
 use jmt::{KeyHash, Version};
 use sov_schema_db::{SchemaBatch, DB};
 
@@ -150,6 +150,12 @@ impl TreeWriter for StateDB {
         }
         self.db.write_schemas(batch)?;
         Ok(())
+    }
+}
+
+impl HasPreimage for StateDB {
+    fn preimage(&self, key_hash: KeyHash) -> anyhow::Result<Option<Vec<u8>>> {
+        self.db.get::<KeyHashToKey>(&key_hash.0)
     }
 }
 

--- a/full-node/db/sov-db/src/state_db.rs
+++ b/full-node/db/sov-db/src/state_db.rs
@@ -69,7 +69,7 @@ impl StateDB {
         let found = iter.next();
         match found {
             Some(result) => {
-                let ((found_key, found_version), value) = result?;
+                let ((found_key, found_version), value) = result?.to_tuple();
                 if &found_key == key {
                     anyhow::ensure!(found_version <= version, "Bug! iterator isn't returning expected values. expected a version <= {version:} but found {found_version:}");
                     Ok(value)
@@ -98,7 +98,7 @@ impl StateDB {
         iter.seek_to_last();
 
         let version = match iter.next() {
-            Some(Ok((key, _))) => Some(key.version()),
+            Some(Ok(item)) => Some(item.key.version()),
             _ => None,
         };
         Ok(version)

--- a/full-node/db/sov-db/src/state_db.rs
+++ b/full-node/db/sov-db/src/state_db.rs
@@ -69,7 +69,7 @@ impl StateDB {
         let found = iter.next();
         match found {
             Some(result) => {
-                let ((found_key, found_version), value) = result?.to_tuple();
+                let ((found_key, found_version), value) = result?.into_tuple();
                 if &found_key == key {
                     anyhow::ensure!(found_version <= version, "Bug! iterator isn't returning expected values. expected a version <= {version:} but found {found_version:}");
                     Ok(value)

--- a/full-node/db/sov-schema-db/src/iterator.rs
+++ b/full-node/db/sov-schema-db/src/iterator.rs
@@ -136,7 +136,7 @@ pub struct IteratorOutput<K, V> {
 }
 
 impl<K, V> IteratorOutput<K, V> {
-    pub fn to_tuple(self) -> (K, V) {
+    pub fn into_tuple(self) -> (K, V) {
         (self.key, self.value)
     }
 }

--- a/full-node/db/sov-schema-db/src/lib.rs
+++ b/full-node/db/sov-schema-db/src/lib.rs
@@ -31,6 +31,7 @@ use metrics::{
     SCHEMADB_BATCH_COMMIT_BYTES, SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS, SCHEMADB_DELETES,
     SCHEMADB_GET_BYTES, SCHEMADB_GET_LATENCY_SECONDS, SCHEMADB_PUT_BYTES,
 };
+pub use rocksdb;
 use rocksdb::ReadOptions;
 pub use rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
 use thiserror::Error;
@@ -39,8 +40,6 @@ use tracing::info;
 pub use crate::schema::Schema;
 use crate::schema::{ColumnFamilyName, KeyCodec, ValueCodec};
 pub use crate::schema_batch::{SchemaBatch, SchemaBatchIterator};
-
-pub use rocksdb;
 
 /// This DB is a schematized RocksDB wrapper where all data passed in and out are typed according to
 /// [`Schema`]s.

--- a/full-node/db/sov-schema-db/src/lib.rs
+++ b/full-node/db/sov-schema-db/src/lib.rs
@@ -40,6 +40,8 @@ pub use crate::schema::Schema;
 use crate::schema::{ColumnFamilyName, KeyCodec, ValueCodec};
 pub use crate::schema_batch::{SchemaBatch, SchemaBatchIterator};
 
+pub use rocksdb;
+
 /// This DB is a schematized RocksDB wrapper where all data passed in and out are typed according to
 /// [`Schema`]s.
 #[derive(Debug)]

--- a/full-node/db/sov-schema-db/src/lib.rs
+++ b/full-node/db/sov-schema-db/src/lib.rs
@@ -129,7 +129,7 @@ impl DB {
         let k = schema_key.encode_key()?;
         let cf_handle = self.get_cf_handle(S::COLUMN_FAMILY_NAME)?;
 
-        let result = self.inner.get_cf(cf_handle, k)?;
+        let result = self.inner.get_pinned_cf(cf_handle, k)?;
         SCHEMADB_GET_BYTES
             .with_label_values(&[S::COLUMN_FAMILY_NAME])
             .observe(result.as_ref().map_or(0.0, |v| v.len() as f64));

--- a/full-node/db/sov-schema-db/tests/db_test.rs
+++ b/full-node/db/sov-schema-db/tests/db_test.rs
@@ -132,7 +132,7 @@ fn test_schema_put_get() {
 fn collect_values<S: Schema>(db: &TestDB) -> Vec<(S::Key, S::Value)> {
     let mut iter = db.iter::<S>().expect("Failed to create iterator.");
     iter.seek_to_first();
-    iter.map(|res| res.map(|item| item.to_tuple()))
+    iter.map(|res| res.map(|item| item.into_tuple()))
         .collect::<Result<Vec<_>, anyhow::Error>>()
         .unwrap()
 }

--- a/full-node/db/sov-schema-db/tests/db_test.rs
+++ b/full-node/db/sov-schema-db/tests/db_test.rs
@@ -132,7 +132,9 @@ fn test_schema_put_get() {
 fn collect_values<S: Schema>(db: &TestDB) -> Vec<(S::Key, S::Value)> {
     let mut iter = db.iter::<S>().expect("Failed to create iterator.");
     iter.seek_to_first();
-    iter.collect::<Result<Vec<_>, anyhow::Error>>().unwrap()
+    iter.map(|res| res.map(|item| item.to_tuple()))
+        .collect::<Result<Vec<_>, anyhow::Error>>()
+        .unwrap()
 }
 
 fn gen_expected_values(values: &[(u32, u32)]) -> Vec<(TestField, TestField)> {

--- a/full-node/db/sov-schema-db/tests/iterator_test.rs
+++ b/full-node/db/sov-schema-db/tests/iterator_test.rs
@@ -19,7 +19,7 @@ define_schema!(TestSchema, TestCompositeField, TestField, "TestCF");
 type S = TestSchema;
 
 fn collect_values(iter: SchemaIterator<S>) -> Vec<u32> {
-    iter.map(|row| row.unwrap().1 .0).collect()
+    iter.map(|row| row.unwrap().value.0).collect()
 }
 
 fn decode_key(key: &[u8]) -> TestCompositeField {


### PR DESCRIPTION
# Description
This PR makes three minor changes to the `sov-db` crate:
- Re-export the `rocksdb` crate so that consumers can access its public types. This is useful for configuration. 
- Add the size of the serialized value to the item yielded by `DB::Iterator`.
- Use `get_pinned_cf` instead of `get_cf` inside of the `get<T>` method to avoid an unnecessary allocation.

## Testing
This change is covered by existing tests.

