### PR TITLE
Implement ZK proof submissin for `MockDa`

### DIFF
--- a/adapters/avail/src/service.rs
+++ b/adapters/avail/src/service.rs
@@ -306,7 +306,7 @@ impl DaService for DaProvider {
         Ok(())
     }
 
-    async fn send_aggrgated_zk_proof(&self, _proof: &[u8]) -> Result<u64, Self::Error> {
+    async fn send_aggregated_zk_proof(&self, _proof: &[u8]) -> Result<u64, Self::Error> {
         unimplemented!()
     }
 

--- a/adapters/celestia/src/da_service.rs
+++ b/adapters/celestia/src/da_service.rs
@@ -268,7 +268,7 @@ impl DaService for CelestiaService {
         Ok(())
     }
 
-    async fn send_aggrgated_zk_proof(&self, aggregated_proof: &[u8]) -> Result<u64, Self::Error> {
+    async fn send_aggregated_zk_proof(&self, aggregated_proof: &[u8]) -> Result<u64, Self::Error> {
         let gas_limit = get_gas_limit_for_bytes(aggregated_proof.len()) as u64;
         let fee = gas_limit * GAS_PRICE as u64;
         let blob = JsonBlob::new(self.rollup_proof_namespace, aggregated_proof.to_vec())?;
@@ -708,7 +708,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        da_service.send_aggrgated_zk_proof(&zk_proof).await?;
+        da_service.send_aggregated_zk_proof(&zk_proof).await?;
 
         Ok(())
     }

--- a/adapters/mock-da/src/service.rs
+++ b/adapters/mock-da/src/service.rs
@@ -79,6 +79,62 @@ impl MockDaService {
         }
         anyhow::bail!("No blob at height={height} has been sent in time")
     }
+
+    async fn add_blob(&self, blob: &[u8], zkp_proof: Vec<u8>) -> Result<u64, anyhow::Error> {
+        let mut blocks = self.blocks.write().await;
+
+        let (previous_block_hash, height) = match blocks.iter().last().map(|b| b.header().clone()) {
+            None => (MockHash::from([0; 32]), 0),
+            Some(block_header) => (block_header.hash(), block_header.height + 1),
+        };
+        let data_hash = hash_to_array(blob);
+        let proof_hash = hash_to_array(&zkp_proof);
+        // Hash only from single blob
+        let block_hash = block_hash(height, data_hash, proof_hash, previous_block_hash.into());
+
+        let blob = MockBlob::new_with_zkp_proof(
+            blob.to_vec(),
+            vec![zkp_proof],
+            self.sequencer_da_address,
+            data_hash,
+        );
+        let header = MockBlockHeader {
+            prev_hash: previous_block_hash,
+            hash: block_hash,
+            height,
+            time: Time::now(),
+        };
+        let block = MockBlock {
+            header,
+            validity_cond: Default::default(),
+            blobs: vec![blob],
+        };
+        blocks.push_back(block);
+
+        // Enough blocks to finalize block
+        if blocks.len() > self.blocks_to_finality as usize {
+            let oldest_available_height = blocks[0].header().height();
+            let last_finalized_height = self.last_finalized_height.load(Ordering::Acquire);
+            let last_finalized_index = last_finalized_height
+                .checked_sub(oldest_available_height)
+                .unwrap();
+            let next_index_to_finalize = blocks.len() - self.blocks_to_finality as usize - 1;
+
+            if last_finalized_index > 0 {
+                assert_eq!(next_index_to_finalize as u64, last_finalized_index + 1);
+            }
+
+            self.finalized_header_sender
+                .send(blocks[next_index_to_finalize].header().clone())
+                .unwrap();
+
+            let this_finalized_height = oldest_available_height + next_index_to_finalize as u64;
+            self.last_finalized_height
+                .store(this_finalized_height, Ordering::Release);
+        }
+
+        Ok(height)
+    }
 }
 
 #[pin_project]
@@ -218,57 +274,12 @@ impl DaService for MockDaService {
     }
 
     async fn send_transaction(&self, blob: &[u8]) -> Result<(), Self::Error> {
-        let mut blocks = self.blocks.write().await;
-
-        let (previous_block_hash, height) = match blocks.iter().last().map(|b| b.header().clone()) {
-            None => (MockHash::from([0; 32]), 0),
-            Some(block_header) => (block_header.hash(), block_header.height + 1),
-        };
-        let data_hash = hash_to_array(blob);
-        // Hash only from single blob
-        let block_hash = block_hash(height, data_hash, previous_block_hash.into());
-
-        let blob = MockBlob::new(blob.to_vec(), self.sequencer_da_address, data_hash);
-        let header = MockBlockHeader {
-            prev_hash: previous_block_hash,
-            hash: block_hash,
-            height,
-            time: Time::now(),
-        };
-        let block = MockBlock {
-            header,
-            validity_cond: Default::default(),
-            blobs: vec![blob],
-        };
-        blocks.push_back(block);
-
-        // Enough blocks to finalize block
-        if blocks.len() > self.blocks_to_finality as usize {
-            let oldest_available_height = blocks[0].header().height();
-            let last_finalized_height = self.last_finalized_height.load(Ordering::Acquire);
-            let last_finalized_index = last_finalized_height
-                .checked_sub(oldest_available_height)
-                .unwrap();
-            let next_index_to_finalize = blocks.len() - self.blocks_to_finality as usize - 1;
-
-            if last_finalized_index > 0 {
-                assert_eq!(next_index_to_finalize as u64, last_finalized_index + 1);
-            }
-
-            self.finalized_header_sender
-                .send(blocks[next_index_to_finalize].header().clone())
-                .unwrap();
-
-            let this_finalized_height = oldest_available_height + next_index_to_finalize as u64;
-            self.last_finalized_height
-                .store(this_finalized_height, Ordering::Release);
-        }
-
+        let _ = self.add_blob(blob, Default::default()).await;
         Ok(())
     }
 
-    async fn send_aggregated_zk_proof(&self, _proof: &[u8]) -> Result<u64, Self::Error> {
-        todo!()
+    async fn send_aggregated_zk_proof(&self, proof: &[u8]) -> Result<u64, Self::Error> {
+        self.add_blob(Default::default(), proof.to_vec()).await
     }
 
     async fn get_aggregated_proofs_at(&self, _height: u64) -> Result<Vec<Vec<u8>>, Self::Error> {
@@ -286,9 +297,15 @@ fn hash_to_array(bytes: &[u8]) -> [u8; 32] {
         .expect("SHA256 should be 32 bytes")
 }
 
-fn block_hash(height: u64, data_hash: [u8; 32], prev_hash: [u8; 32]) -> MockHash {
+fn block_hash(
+    height: u64,
+    data_hash: [u8; 32],
+    proof_hash: [u8; 32],
+    prev_hash: [u8; 32],
+) -> MockHash {
     let mut block_to_hash = height.to_be_bytes().to_vec();
     block_to_hash.extend_from_slice(&data_hash[..]);
+    block_to_hash.extend_from_slice(&proof_hash[..]);
     block_to_hash.extend_from_slice(&prev_hash[..]);
 
     MockHash::from(hash_to_array(&block_to_hash))

--- a/adapters/mock-da/src/service.rs
+++ b/adapters/mock-da/src/service.rs
@@ -87,6 +87,7 @@ impl MockDaService {
             None => (MockHash::from([0; 32]), 0),
             Some(block_header) => (block_header.hash(), block_header.height + 1),
         };
+
         let data_hash = hash_to_array(blob);
         let proof_hash = hash_to_array(&zkp_proof);
         // Hash only from single blob
@@ -274,7 +275,7 @@ impl DaService for MockDaService {
     }
 
     async fn send_transaction(&self, blob: &[u8]) -> Result<(), Self::Error> {
-        let _ = self.add_blob(blob, Default::default()).await;
+        let _ = self.add_blob(blob, Default::default()).await?;
         Ok(())
     }
 

--- a/adapters/mock-da/src/service.rs
+++ b/adapters/mock-da/src/service.rs
@@ -94,7 +94,7 @@ impl MockDaService {
 
         let blob = MockBlob::new_with_zkp_proof(
             blob.to_vec(),
-            vec![zkp_proof],
+            zkp_proof,
             self.sequencer_da_address,
             data_hash,
         );

--- a/adapters/mock-da/src/service.rs
+++ b/adapters/mock-da/src/service.rs
@@ -267,7 +267,7 @@ impl DaService for MockDaService {
         Ok(())
     }
 
-    async fn send_aggrgated_zk_proof(&self, _proof: &[u8]) -> Result<u64, Self::Error> {
+    async fn send_aggregated_zk_proof(&self, _proof: &[u8]) -> Result<u64, Self::Error> {
         todo!()
     }
 

--- a/adapters/mock-da/src/types/mod.rs
+++ b/adapters/mock-da/src/types/mod.rs
@@ -140,7 +140,7 @@ pub struct MockBlob {
     pub(crate) hash: [u8; 32],
     /// Actual data from the blob. Public for testing purposes.
     pub data: CountedBufReader<Bytes>,
-    pub(crate) zk_proofs_data: Vec<Vec<u8>>,
+    pub(crate) zk_proofs_data: Vec<u8>,
 }
 
 impl MockBlob {
@@ -157,7 +157,7 @@ impl MockBlob {
     /// Creates a new mock blob with the given data and an aggretated zkp proof, claiming to have been published by the provided address.
     pub fn new_with_zkp_proof(
         data: Vec<u8>,
-        zk_proofs_data: Vec<Vec<u8>>,
+        zk_proofs_data: Vec<u8>,
         address: MockAddress,
         hash: [u8; 32],
     ) -> Self {

--- a/adapters/mock-da/src/types/mod.rs
+++ b/adapters/mock-da/src/types/mod.rs
@@ -140,6 +140,7 @@ pub struct MockBlob {
     pub(crate) hash: [u8; 32],
     /// Actual data from the blob. Public for testing purposes.
     pub data: CountedBufReader<Bytes>,
+    // Data for the aggregated ZK proof.
     pub(crate) zk_proofs_data: Vec<u8>,
 }
 

--- a/adapters/mock-da/src/types/mod.rs
+++ b/adapters/mock-da/src/types/mod.rs
@@ -140,14 +140,21 @@ pub struct MockBlob {
     pub(crate) hash: [u8; 32],
     /// Actual data from the blob. Public for testing purposes.
     pub data: CountedBufReader<Bytes>,
+    pub(crate) zk_proofs_data: Vec<Vec<u8>>,
 }
 
 impl MockBlob {
     /// Creates a new mock blob with the given data, claiming to have been published by the provided address.
-    pub fn new(data: Vec<u8>, address: MockAddress, hash: [u8; 32]) -> Self {
+    pub fn new(
+        data: Vec<u8>,
+        //  zk_proofs_data: Vec<Vec<u8>>,
+        address: MockAddress,
+        hash: [u8; 32],
+    ) -> Self {
         Self {
             address,
             data: CountedBufReader::new(Bytes::from(data)),
+            zk_proofs_data: Default::default(),
             hash,
         }
     }

--- a/adapters/mock-da/src/types/mod.rs
+++ b/adapters/mock-da/src/types/mod.rs
@@ -145,17 +145,27 @@ pub struct MockBlob {
 
 impl MockBlob {
     /// Creates a new mock blob with the given data, claiming to have been published by the provided address.
-    pub fn new(
-        data: Vec<u8>,
-        //  zk_proofs_data: Vec<Vec<u8>>,
-        address: MockAddress,
-        hash: [u8; 32],
-    ) -> Self {
+    pub fn new(data: Vec<u8>, address: MockAddress, hash: [u8; 32]) -> Self {
         Self {
             address,
             data: CountedBufReader::new(Bytes::from(data)),
             zk_proofs_data: Default::default(),
             hash,
+        }
+    }
+
+    /// Creates a new mock blob with the given data and an aggretated zkp proof, claiming to have been published by the provided address.
+    pub fn new_with_zkp_proof(
+        data: Vec<u8>,
+        zk_proofs_data: Vec<Vec<u8>>,
+        address: MockAddress,
+        hash: [u8; 32],
+    ) -> Self {
+        Self {
+            address,
+            hash,
+            data: CountedBufReader::new(Bytes::from(data)),
+            zk_proofs_data,
         }
     }
 }

--- a/rollup-interface/src/node/services/da.rs
+++ b/rollup-interface/src/node/services/da.rs
@@ -111,7 +111,7 @@ pub trait DaService: Send + Sync + 'static {
     async fn send_transaction(&self, blob: &[u8]) -> Result<Self::TransactionId, Self::Error>;
 
     /// Sends am aggrgated zk proof to the DA.
-    async fn send_aggrgated_zk_proof(
+    async fn send_aggregated_zk_proof(
         &self,
         aggregated_proof_data: &[u8],
     ) -> Result<u64, Self::Error>;

--- a/utils/rng-da-service/src/lib.rs
+++ b/utils/rng-da-service/src/lib.rs
@@ -156,7 +156,7 @@ impl DaService for RngDaService {
         unimplemented!()
     }
 
-    async fn send_aggrgated_zk_proof(&self, _proof: &[u8]) -> Result<u64, Self::Error> {
+    async fn send_aggregated_zk_proof(&self, _proof: &[u8]) -> Result<u64, Self::Error> {
         unimplemented!()
     }
 


### PR DESCRIPTION
# Description
This PR adds implementation of  `send_aggregated_zk_proof & get_aggregated_proofs_at` for `MockDa`

## Testing
Added a unit test.

## Docs
No changes.
