### PR TITLE
feat: add associated types as tx hooks args

### DIFF
--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -4,7 +4,7 @@ use demo_stf::runtime::Runtime;
 use sov_celestia_adapter::verifier::{CelestiaSpec, CelestiaVerifier, RollupParams};
 use sov_celestia_adapter::{CelestiaConfig, CelestiaService};
 use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
-use sov_modules_api::Spec;
+use sov_modules_api::{Address, Spec};
 use sov_modules_rollup_blueprint::{RollupBlueprint, WalletBlueprint};
 use sov_modules_stf_blueprint::kernels::basic::BasicKernel;
 use sov_modules_stf_blueprint::StfBlueprint;
@@ -57,12 +57,15 @@ impl RollupBlueprint for CelestiaDemoRollup {
         ledger_db: &sov_db::ledger_db::LedgerDB,
         da_service: &Self::DaService,
     ) -> Result<jsonrpsee::RpcModule<()>, anyhow::Error> {
+        // TODO set the sequencer address
+        let sequencer = Address::new([0; 32]);
+
         #[allow(unused_mut)]
         let mut rpc_methods = sov_modules_rollup_blueprint::register_rpc::<
             Self::NativeRuntime,
             Self::NativeContext,
             Self::DaService,
-        >(storage, ledger_db, da_service)?;
+        >(storage, ledger_db, da_service, sequencer)?;
 
         #[cfg(feature = "experimental")]
         crate::eth::register_ethereum::<Self::DaService>(

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -4,7 +4,7 @@ use demo_stf::runtime::Runtime;
 use sov_db::ledger_db::LedgerDB;
 use sov_mock_da::{MockDaConfig, MockDaService, MockDaSpec};
 use sov_modules_api::default_context::{DefaultContext, ZkDefaultContext};
-use sov_modules_api::Spec;
+use sov_modules_api::{Address, Spec};
 use sov_modules_rollup_blueprint::RollupBlueprint;
 use sov_modules_stf_blueprint::kernels::basic::BasicKernel;
 use sov_modules_stf_blueprint::StfBlueprint;
@@ -55,12 +55,15 @@ impl RollupBlueprint for MockDemoRollup {
         ledger_db: &LedgerDB,
         da_service: &Self::DaService,
     ) -> Result<jsonrpsee::RpcModule<()>, anyhow::Error> {
+        // TODO set the sequencer address
+        let sequencer = Address::new([0; 32]);
+
         #[allow(unused_mut)]
         let mut rpc_methods = sov_modules_rollup_blueprint::register_rpc::<
             Self::NativeRuntime,
             Self::NativeContext,
             Self::DaService,
-        >(storage, ledger_db, da_service)?;
+        >(storage, ledger_db, da_service, sequencer)?;
 
         #[cfg(feature = "experimental")]
         crate::eth::register_ethereum::<Self::DaService>(

--- a/examples/demo-rollup/stf/src/hooks_impl.rs
+++ b/examples/demo-rollup/stf/src/hooks_impl.rs
@@ -13,8 +13,8 @@ use crate::runtime::Runtime;
 
 impl<C: Context, Da: DaSpec> TxHooks for Runtime<C, Da> {
     type Context = C;
-    type PreArg = u64;
-    type PreResult = C;
+    type PreArg = ();
+    type PreResult = C::Address;
     type PostArg = ();
     type PostResult = ();
 
@@ -22,14 +22,11 @@ impl<C: Context, Da: DaSpec> TxHooks for Runtime<C, Da> {
         &self,
         tx: &Transaction<Self::Context>,
         working_set: &mut WorkingSet<C>,
-        height: u64,
-    ) -> anyhow::Result<C> {
+        _arg: (),
+    ) -> anyhow::Result<C::Address> {
         // Before executing a transaction, retrieve the sender's address from the accounts module
         // and check the nonce
-        let sender_address = self.accounts.pre_dispatch_tx_hook(tx, working_set, ())?;
-        let ctx = C::new(sender_address, height);
-
-        Ok(ctx)
+        self.accounts.pre_dispatch_tx_hook(tx, working_set, ())
     }
 
     fn post_dispatch_tx_hook(

--- a/examples/simple-nft-module/tests/nft_test.rs
+++ b/examples/simple-nft-module/tests/nft_test.rs
@@ -17,6 +17,7 @@ fn genesis_and_mint() {
     let admin = generate_address("admin");
     let owner1 = generate_address("owner2");
     let owner2 = generate_address("owner2");
+    let sequencer = generate_address("sequencer");
     let config: NonFungibleTokenConfig<C> = NonFungibleTokenConfig {
         admin,
         owners: vec![(0, owner1)],
@@ -38,7 +39,7 @@ fn genesis_and_mint() {
 
     // Mint, anybody can mint
     let mint_message = CallMessage::Mint { id: 1 };
-    let owner2_context = C::new(owner2, 1);
+    let owner2_context = C::new(owner2, sequencer, 1);
     nft.call(mint_message.clone(), &owner2_context, &mut working_set)
         .expect("Minting failed");
 
@@ -61,9 +62,10 @@ fn genesis_and_mint() {
 fn transfer() {
     // Preparation
     let admin = generate_address("admin");
-    let admin_context = C::new(admin, 1);
+    let sequencer = generate_address("sequencer");
+    let admin_context = C::new(admin, sequencer, 1);
     let owner1 = generate_address("owner2");
-    let owner1_context = C::new(owner1, 1);
+    let owner1_context = C::new(owner1, sequencer, 1);
     let owner2 = generate_address("owner2");
     let config: NonFungibleTokenConfig<C> = NonFungibleTokenConfig {
         admin,
@@ -117,9 +119,10 @@ fn transfer() {
 fn burn() {
     // Preparation
     let admin = generate_address("admin");
-    let admin_context = C::new(admin, 1);
+    let sequencer = generate_address("sequencer");
+    let admin_context = C::new(admin, sequencer, 1);
     let owner1 = generate_address("owner2");
-    let owner1_context = C::new(owner1, 1);
+    let owner1_context = C::new(owner1, sequencer, 1);
     let config: NonFungibleTokenConfig<C> = NonFungibleTokenConfig {
         admin,
         owners: vec![(0, owner1)],

--- a/fuzz/fuzz_targets/bank_call.rs
+++ b/fuzz/fuzz_targets/bank_call.rs
@@ -9,12 +9,12 @@ use sov_state::ProverStorage;
 
 type C = DefaultContext;
 
-fuzz_target!(|input: (&[u8], [u8; 32])| {
-    let (data, sender) = input;
+fuzz_target!(|input: (&[u8], [u8; 32], [u8; 32])| {
+    let (data, sender, sequencer) = input;
     if let Ok(msgs) = serde_json::from_slice::<Vec<CallMessage<C>>>(data) {
         let tmpdir = tempfile::tempdir().unwrap();
         let mut working_set = WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
-        let ctx = C::new(sender.into(), 1);
+        let ctx = C::new(sender.into(), sequencer.into(), 1);
         let bank = Bank::default();
         for msg in msgs {
             bank.call(msg, &ctx, &mut working_set).ok();

--- a/module-system/module-implementations/examples/sov-accessory-state/tests/test.rs
+++ b/module-system/module-implementations/examples/sov-accessory-state/tests/test.rs
@@ -18,7 +18,8 @@ fn test_accessory_value_setter() {
     let mut working_set_for_check: WorkingSet<DefaultContext> = WorkingSet::new(storage.clone());
 
     let admin = Address::from([1; 32]);
-    let context = DefaultContext::new(admin, 1);
+    let sequencer = Address::from([2; 32]);
+    let context = DefaultContext::new(admin, sequencer, 1);
 
     let module = AccessorySetter::<DefaultContext>::default();
 

--- a/module-system/module-implementations/examples/sov-value-setter/src/tests.rs
+++ b/module-system/module-implementations/examples/sov-value-setter/src/tests.rs
@@ -10,11 +10,12 @@ fn test_value_setter() {
     let tmpdir = tempfile::tempdir().unwrap();
     let mut working_set = WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
     let admin = Address::from([1; 32]);
+    let sequencer = Address::from([2; 32]);
     // Test Native-Context
     #[cfg(feature = "native")]
     {
         let config = ValueSetterConfig { admin };
-        let context = DefaultContext::new(admin, 1);
+        let context = DefaultContext::new(admin, sequencer, 1);
         test_value_setter_helper(context, &config, &mut working_set);
     }
 
@@ -23,7 +24,7 @@ fn test_value_setter() {
     // Test Zk-Context
     {
         let config = ValueSetterConfig { admin };
-        let zk_context = ZkDefaultContext::new(admin, 1);
+        let zk_context = ZkDefaultContext::new(admin, sequencer, 1);
         let mut zk_working_set = WorkingSet::with_witness(ZkStorage::new(), witness);
         test_value_setter_helper(zk_context, &config, &mut zk_working_set);
     }
@@ -63,6 +64,7 @@ fn test_value_setter_helper<C: Context>(
 #[test]
 fn test_err_on_sender_is_not_admin() {
     let sender = Address::from([1; 32]);
+    let sequencer = Address::from([2; 32]);
 
     let tmpdir = tempfile::tempdir().unwrap();
     let backing_store = ProverStorage::with_path(tmpdir.path()).unwrap();
@@ -75,7 +77,7 @@ fn test_err_on_sender_is_not_admin() {
         let config = ValueSetterConfig {
             admin: sender_not_admin,
         };
-        let context = DefaultContext::new(sender, 1);
+        let context = DefaultContext::new(sender, sequencer, 1);
         test_err_on_sender_is_not_admin_helper(context, &config, &mut native_working_set);
     }
     let (_, witness) = native_working_set.checkpoint().freeze();
@@ -86,7 +88,7 @@ fn test_err_on_sender_is_not_admin() {
             admin: sender_not_admin,
         };
         let zk_backing_store = ZkStorage::new();
-        let zk_context = ZkDefaultContext::new(sender, 1);
+        let zk_context = ZkDefaultContext::new(sender, sequencer, 1);
         let zk_working_set = &mut WorkingSet::with_witness(zk_backing_store, witness);
         test_err_on_sender_is_not_admin_helper(zk_context, &config, zk_working_set);
     }

--- a/module-system/module-implementations/examples/sov-vec-setter/tests/tests.rs
+++ b/module-system/module-implementations/examples/sov-vec-setter/tests/tests.rs
@@ -5,24 +5,25 @@ use sov_vec_setter::{CallMessage, VecSetter, VecSetterConfig};
 
 // rustfmt doesn't like long lines, but it's easier to read in this case.
 #[rustfmt::skip]
-fn test_cases() -> Vec<(Address, CallMessage, Option<Vec<u32>>)> {
+fn test_cases() -> Vec<(Address, Address, CallMessage, Option<Vec<u32>>)> {
     let admin = Address::from([1; 32]);
     let not_admin = Address::from([2; 32]);
+    let sequencer = Address::from([3; 32]);
 
     // (sender, call, expected vec contents or None if call should fail)
     vec![
-        (admin, CallMessage::PushValue(1), Some(vec![1])),
-        (admin, CallMessage::PushValue(2), Some(vec![1, 2])),
-        (admin, CallMessage::PopValue, Some(vec![1])),
-        (not_admin, CallMessage::PopValue, None),
-        (admin, CallMessage::PopValue, Some(vec![])),
-        (not_admin, CallMessage::SetValue { index: 0, value: 10 }, None),
-        (admin, CallMessage::SetValue { index: 0, value: 10 }, None),
-        (admin, CallMessage::PushValue(8), Some(vec![8])),
-        (admin, CallMessage::SetValue { index: 0, value: 10 }, Some(vec![10])),
-        (admin, CallMessage::PushValue(0), Some(vec![10, 0])),
-        (admin, CallMessage::SetAllValues(vec![11, 12]), Some(vec![11, 12])),
-        (not_admin, CallMessage::SetAllValues(vec![]), None),
+        (admin, sequencer, CallMessage::PushValue(1), Some(vec![1])),
+        (admin, sequencer, CallMessage::PushValue(2), Some(vec![1, 2])),
+        (admin, sequencer, CallMessage::PopValue, Some(vec![1])),
+        (not_admin, sequencer, CallMessage::PopValue, None),
+        (admin, sequencer, CallMessage::PopValue, Some(vec![])),
+        (not_admin, sequencer, CallMessage::SetValue { index: 0, value: 10 }, None),
+        (admin, sequencer, CallMessage::SetValue { index: 0, value: 10 }, None),
+        (admin, sequencer, CallMessage::PushValue(8), Some(vec![8])),
+        (admin, sequencer, CallMessage::SetValue { index: 0, value: 10 }, Some(vec![10])),
+        (admin, sequencer, CallMessage::PushValue(0), Some(vec![10, 0])),
+        (admin, sequencer, CallMessage::SetAllValues(vec![11, 12]), Some(vec![11, 12])),
+        (not_admin, sequencer, CallMessage::SetAllValues(vec![]), None),
     ]
 }
 
@@ -39,8 +40,8 @@ fn test_vec_setter_calls() {
     let vec_setter = VecSetter::default();
     vec_setter.genesis(&config, &mut working_set).unwrap();
 
-    for (sender, call, expected_contents) in test_cases().iter().cloned() {
-        let context = DefaultContext::new(sender, 1);
+    for (sender, sequencer, call, expected_contents) in test_cases().iter().cloned() {
+        let context = DefaultContext::new(sender, sequencer, 1);
 
         let call_result = vec_setter.call(call, &context, &mut working_set);
 

--- a/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
+++ b/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
@@ -20,19 +20,27 @@ pub(crate) struct TestRuntime<C: Context, Da: DaSpec> {
 
 impl<C: Context, Da: DaSpec> TxHooks for TestRuntime<C, Da> {
     type Context = C;
+    type PreArg = u64;
+    type PreResult = C;
+    type PostArg = ();
+    type PostResult = ();
 
     fn pre_dispatch_tx_hook(
         &self,
         tx: &Transaction<Self::Context>,
         _working_set: &mut sov_modules_api::WorkingSet<C>,
-    ) -> anyhow::Result<<Self::Context as Spec>::Address> {
-        Ok(tx.pub_key().to_address())
+        height: u64,
+    ) -> anyhow::Result<C> {
+        let sender = tx.pub_key().to_address();
+        let ctx = C::new(sender, height);
+        Ok(ctx)
     }
 
     fn post_dispatch_tx_hook(
         &self,
         _tx: &Transaction<Self::Context>,
         _working_set: &mut sov_modules_api::WorkingSet<C>,
+        _arg: (),
     ) -> anyhow::Result<()> {
         Ok(())
     }

--- a/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
+++ b/module-system/module-implementations/integration-tests/src/chain_state/helpers.rs
@@ -19,9 +19,9 @@ pub(crate) struct TestRuntime<C: Context, Da: DaSpec> {
 }
 
 impl<C: Context, Da: DaSpec> TxHooks for TestRuntime<C, Da> {
-    type Context = C;
+    type Context = ();
     type PreArg = u64;
-    type PreResult = C;
+    type PreResult = C::Address;
     type PostArg = ();
     type PostResult = ();
 
@@ -29,11 +29,9 @@ impl<C: Context, Da: DaSpec> TxHooks for TestRuntime<C, Da> {
         &self,
         tx: &Transaction<Self::Context>,
         _working_set: &mut sov_modules_api::WorkingSet<C>,
-        height: u64,
-    ) -> anyhow::Result<C> {
-        let sender = tx.pub_key().to_address();
-        let ctx = C::new(sender, height);
-        Ok(ctx)
+        _arg: (),
+    ) -> anyhow::Result<C::Address> {
+        Ok(tx.pub_key().to_address())
     }
 
     fn post_dispatch_tx_hook(

--- a/module-system/module-implementations/module-template/tests/value_setter.rs
+++ b/module-system/module-implementations/module-template/tests/value_setter.rs
@@ -14,11 +14,13 @@ fn test_value_setter() {
         WorkingSet::new(ProverStorage::<DefaultStorageSpec>::with_path(tmpdir.path()).unwrap());
 
     let admin = Address::from([1; 32]);
+    let sequencer = Address::from([2; 32]);
+
     // Test Native-Context
     #[cfg(feature = "native")]
     {
         let config = ExampleModuleConfig {};
-        let context = DefaultContext::new(admin, 1);
+        let context = DefaultContext::new(admin, sequencer, 1);
         test_value_setter_helper(context, &config, &mut working_set);
     }
 
@@ -27,7 +29,7 @@ fn test_value_setter() {
     // Test Zk-Context
     {
         let config = ExampleModuleConfig {};
-        let zk_context = ZkDefaultContext::new(admin, 1);
+        let zk_context = ZkDefaultContext::new(admin, sequencer, 1);
         let mut zk_working_set = WorkingSet::with_witness(ZkStorage::new(), witness);
         test_value_setter_helper(zk_context, &config, &mut zk_working_set);
     }

--- a/module-system/module-implementations/sov-accounts/src/hooks.rs
+++ b/module-system/module-implementations/sov-accounts/src/hooks.rs
@@ -2,42 +2,62 @@ use sov_modules_api::hooks::TxHooks;
 use sov_modules_api::transaction::Transaction;
 use sov_modules_api::{Context, StateMapAccessor, WorkingSet};
 
-use crate::Accounts;
+use crate::{Account, Accounts};
+
+/// The computed addresses of a pre-dispatch tx hook.
+pub struct AccountsTxHook<C: Context> {
+    /// The tx sender address
+    pub sender: C::Address,
+    /// The sequencer address
+    pub sequencer: C::Address,
+}
+
+impl<C: Context> Accounts<C> {
+    fn get_or_create_default(
+        &self,
+        pubkey: &C::PublicKey,
+        working_set: &mut WorkingSet<C>,
+    ) -> anyhow::Result<Account<C>> {
+        self.accounts
+            .get(pubkey, working_set)
+            .map(Ok)
+            .unwrap_or_else(|| self.create_default_account(pubkey, working_set))
+    }
+}
 
 impl<C: Context> TxHooks for Accounts<C> {
     type Context = C;
-    type PreArg = ();
-    type PreResult = C::Address;
-    type PostArg = ();
-    type PostResult = ();
+    type PreArg = C::PublicKey;
+    type PreResult = AccountsTxHook<C>;
 
     fn pre_dispatch_tx_hook(
         &self,
         tx: &Transaction<C>,
         working_set: &mut WorkingSet<C>,
-        _arg: (),
-    ) -> anyhow::Result<C::Address> {
-        let pub_key = tx.pub_key();
-
-        let account = match self.accounts.get(pub_key, working_set) {
-            Some(acc) => Ok(acc),
-            None => self.create_default_account(pub_key, working_set),
-        }?;
-
+        sequencer: C::PublicKey,
+    ) -> anyhow::Result<AccountsTxHook<C>> {
+        let sender = self.get_or_create_default(tx.pub_key(), working_set)?;
+        let sequencer = self.get_or_create_default(&sequencer, working_set)?;
         let tx_nonce = tx.nonce();
-        let account_nonce = account.nonce;
+
         anyhow::ensure!(
-            account_nonce == tx_nonce,
-            "Tx bad nonce, expected: {account_nonce}, but found: {tx_nonce}",
+            sender.nonce == tx_nonce,
+            "Tx bad nonce, expected: {}, but found: {}",
+            tx_nonce,
+            sender.nonce
         );
-        Ok(account.addr)
+
+        Ok(AccountsTxHook {
+            sender: sender.addr,
+            sequencer: sequencer.addr,
+        })
     }
 
     fn post_dispatch_tx_hook(
         &self,
         tx: &Transaction<Self::Context>,
+        _ctx: &C,
         working_set: &mut WorkingSet<C>,
-        _arg: (),
     ) -> anyhow::Result<()> {
         let mut account = self.accounts.get_or_err(tx.pub_key(), working_set)?;
         account.nonce += 1;

--- a/module-system/module-implementations/sov-accounts/src/hooks.rs
+++ b/module-system/module-implementations/sov-accounts/src/hooks.rs
@@ -1,17 +1,22 @@
 use sov_modules_api::hooks::TxHooks;
 use sov_modules_api::transaction::Transaction;
-use sov_modules_api::{Context, Spec, StateMapAccessor, WorkingSet};
+use sov_modules_api::{Context, StateMapAccessor, WorkingSet};
 
 use crate::Accounts;
 
 impl<C: Context> TxHooks for Accounts<C> {
     type Context = C;
+    type PreArg = ();
+    type PreResult = C::Address;
+    type PostArg = ();
+    type PostResult = ();
 
     fn pre_dispatch_tx_hook(
         &self,
         tx: &Transaction<C>,
         working_set: &mut WorkingSet<C>,
-    ) -> anyhow::Result<<Self::Context as Spec>::Address> {
+        _arg: (),
+    ) -> anyhow::Result<C::Address> {
         let pub_key = tx.pub_key();
 
         let account = match self.accounts.get(pub_key, working_set) {
@@ -32,6 +37,7 @@ impl<C: Context> TxHooks for Accounts<C> {
         &self,
         tx: &Transaction<Self::Context>,
         working_set: &mut WorkingSet<C>,
+        _arg: (),
     ) -> anyhow::Result<()> {
         let mut account = self.accounts.get_or_err(tx.pub_key(), working_set)?;
         account.nonce += 1;

--- a/module-system/module-implementations/sov-accounts/src/lib.rs
+++ b/module-system/module-implementations/sov-accounts/src/lib.rs
@@ -14,6 +14,7 @@ pub use query::*;
 mod tests;
 
 pub use call::{CallMessage, UPDATE_ACCOUNT_MSG};
+pub use hooks::AccountsTxHook;
 use sov_modules_api::{Context, Error, ModuleInfo, WorkingSet};
 
 impl<C: Context> FromIterator<C::PublicKey> for AccountConfig<C> {

--- a/module-system/module-implementations/sov-accounts/src/tests.rs
+++ b/module-system/module-implementations/sov-accounts/src/tests.rs
@@ -47,10 +47,13 @@ fn test_update_account() {
     let accounts = &mut Accounts::<C>::default();
 
     let priv_key = DefaultPrivateKey::generate();
+    let sequencer_priv_key = DefaultPrivateKey::generate();
 
     let sender = priv_key.pub_key();
+    let sequencer = sequencer_priv_key.pub_key();
     let sender_addr = sender.to_address::<<C as Spec>::Address>();
-    let sender_context = C::new(sender_addr, 1);
+    let sequencer_addr = sequencer.to_address::<<C as Spec>::Address>();
+    let sender_context = C::new(sender_addr, sequencer_addr, 1);
 
     // Test new account creation
     {
@@ -111,7 +114,8 @@ fn test_update_account_fails() {
     let accounts = &mut Accounts::<C>::default();
 
     let sender_1 = DefaultPrivateKey::generate().pub_key();
-    let sender_context_1 = C::new(sender_1.to_address(), 1);
+    let sequencer = DefaultPrivateKey::generate().pub_key();
+    let sender_context_1 = C::new(sender_1.to_address(), sequencer.to_address(), 1);
 
     accounts
         .create_default_account(&sender_1, native_working_set)
@@ -142,8 +146,10 @@ fn test_get_account_after_pub_key_update() {
     let accounts = &mut Accounts::<C>::default();
 
     let sender_1 = DefaultPrivateKey::generate().pub_key();
+    let sequencer = DefaultPrivateKey::generate().pub_key();
     let sender_1_addr = sender_1.to_address::<<C as Spec>::Address>();
-    let sender_context_1 = C::new(sender_1_addr, 1);
+    let sequencer_addr = sequencer.to_address::<<C as Spec>::Address>();
+    let sender_context_1 = C::new(sender_1_addr, sequencer_addr, 1);
 
     accounts
         .create_default_account(&sender_1, native_working_set)

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/attestation_processing.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/attestation_processing.rs
@@ -14,7 +14,7 @@ fn test_process_valid_attestation() {
     let tmpdir = tempfile::tempdir().unwrap();
     let storage = ProverStorage::with_path(tmpdir.path()).unwrap();
     let mut working_set = WorkingSet::new(storage.clone());
-    let (module, token_address, attester_address, _) = setup(&mut working_set);
+    let (module, token_address, attester_address, _, sequencer) = setup(&mut working_set);
 
     // Assert that the attester has the correct bond amount before processing the proof
     assert_eq!(
@@ -33,7 +33,7 @@ fn test_process_valid_attestation() {
     let (mut exec_vars, mut working_set) =
         execution_simulation(3, &module, &storage, attester_address, working_set);
 
-    let context = DefaultContext::new(attester_address, 1);
+    let context = DefaultContext::new(attester_address, sequencer, 1);
 
     let transition_2 = exec_vars.pop().unwrap();
     let transition_1 = exec_vars.pop().unwrap();
@@ -102,7 +102,7 @@ fn test_burn_on_invalid_attestation() {
     let tmpdir = tempfile::tempdir().unwrap();
     let storage = ProverStorage::with_path(tmpdir.path()).unwrap();
     let mut working_set = WorkingSet::new(storage.clone());
-    let (module, _token_address, attester_address, _) = setup(&mut working_set);
+    let (module, _token_address, attester_address, _, sequencer) = setup(&mut working_set);
 
     // Assert that the prover has the correct bond amount before processing the proof
     assert_eq!(
@@ -125,7 +125,7 @@ fn test_burn_on_invalid_attestation() {
     let transition_1 = exec_vars.pop().unwrap();
     let initial_transition = exec_vars.pop().unwrap();
 
-    let context = DefaultContext::new(attester_address, 1);
+    let context = DefaultContext::new(attester_address, sequencer, 1);
 
     // Process an invalid proof for genesis: everything is correct except the storage proof.
     // Must simply return an error. Cannot burn the token at this point because we don't know if the

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/challenger.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/challenger.rs
@@ -19,7 +19,8 @@ fn test_valid_challenge() {
     let tmpdir = tempfile::tempdir().unwrap();
     let storage = ProverStorage::with_path(tmpdir.path()).unwrap();
     let mut working_set = WorkingSet::new(storage.clone());
-    let (module, token_address, attester_address, challenger_address) = setup(&mut working_set);
+    let (module, token_address, attester_address, challenger_address, sequencer) =
+        setup(&mut working_set);
 
     let (_, working_set) = commit_get_new_working_set(&storage, working_set);
 
@@ -58,7 +59,7 @@ fn test_valid_challenge() {
         .bad_transition_pool
         .set(&(INIT_HEIGHT + 1), &BOND_AMOUNT, &mut working_set);
 
-    let context = DefaultContext::new(challenger_address, INIT_HEIGHT + 2);
+    let context = DefaultContext::new(challenger_address, sequencer, INIT_HEIGHT + 2);
 
     {
         let transition = StateTransition::<MockDaSpec, _, _> {
@@ -170,7 +171,8 @@ fn test_invalid_challenge() {
     let tmpdir = tempfile::tempdir().unwrap();
     let storage = ProverStorage::with_path(tmpdir.path()).unwrap();
     let mut working_set = WorkingSet::new(storage.clone());
-    let (module, _token_address, attester_address, challenger_address) = setup(&mut working_set);
+    let (module, _token_address, attester_address, challenger_address, sequencer) =
+        setup(&mut working_set);
 
     let (_, working_set) = commit_get_new_working_set(&storage, working_set);
 
@@ -188,7 +190,7 @@ fn test_invalid_challenge() {
         .bad_transition_pool
         .set(&(INIT_HEIGHT + 1), &BOND_AMOUNT, &mut working_set);
 
-    let context = DefaultContext::new(challenger_address, INIT_HEIGHT + 2);
+    let context = DefaultContext::new(challenger_address, sequencer, INIT_HEIGHT + 2);
     let transition: StateTransition<MockDaSpec, _, _> = StateTransition {
         initial_state_root: initial_transition.state_root,
         slot_hash: [1; 32].into(),

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
@@ -84,7 +84,7 @@ pub(crate) fn setup(
 ) {
     // Initialize bank
     let (bank_config, mut addresses) =
-        create_bank_config_with_token(TOKEN_NAME.to_string(), SALT, 4, INITIAL_BOND_AMOUNT);
+        create_bank_config_with_token(TOKEN_NAME.to_string(), SALT, 3, INITIAL_BOND_AMOUNT);
     let bank = sov_bank::Bank::<C>::default();
     bank.genesis(&bank_config, working_set)
         .expect("bank genesis must succeed");
@@ -92,7 +92,7 @@ pub(crate) fn setup(
     let attester_address = addresses.pop().unwrap();
     let challenger_address = addresses.pop().unwrap();
     let reward_supply = addresses.pop().unwrap();
-    let sequencer = addresses.pop().unwrap();
+    let sequencer = reward_supply.clone();
 
     let token_address = sov_bank::get_genesis_token_address::<DefaultContext>(TOKEN_NAME, SALT);
 

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
@@ -92,7 +92,7 @@ pub(crate) fn setup(
     let attester_address = addresses.pop().unwrap();
     let challenger_address = addresses.pop().unwrap();
     let reward_supply = addresses.pop().unwrap();
-    let sequencer = reward_supply.clone();
+    let sequencer = generate_address::<C>("sequencer");
 
     let token_address = sov_bank::get_genesis_token_address::<DefaultContext>(TOKEN_NAME, SALT);
 

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/helpers.rs
@@ -72,6 +72,7 @@ pub(crate) fn create_bank_config_with_token(
 
 /// Creates a bank config with a token, and a prover incentives module.
 /// Returns the prover incentives module and the attester and challenger's addresses.
+#[allow(clippy::type_complexity)]
 pub(crate) fn setup(
     working_set: &mut WorkingSet<C>,
 ) -> (
@@ -79,10 +80,11 @@ pub(crate) fn setup(
     Address,
     Address,
     Address,
+    Address,
 ) {
     // Initialize bank
     let (bank_config, mut addresses) =
-        create_bank_config_with_token(TOKEN_NAME.to_string(), SALT, 3, INITIAL_BOND_AMOUNT);
+        create_bank_config_with_token(TOKEN_NAME.to_string(), SALT, 4, INITIAL_BOND_AMOUNT);
     let bank = sov_bank::Bank::<C>::default();
     bank.genesis(&bank_config, working_set)
         .expect("bank genesis must succeed");
@@ -90,6 +92,7 @@ pub(crate) fn setup(
     let attester_address = addresses.pop().unwrap();
     let challenger_address = addresses.pop().unwrap();
     let reward_supply = addresses.pop().unwrap();
+    let sequencer = addresses.pop().unwrap();
 
     let token_address = sov_bank::get_genesis_token_address::<DefaultContext>(TOKEN_NAME, SALT);
 
@@ -129,7 +132,13 @@ pub(crate) fn setup(
         .genesis(&config, working_set)
         .expect("prover incentives genesis must succeed");
 
-    (module, token_address, attester_address, challenger_address)
+    (
+        module,
+        token_address,
+        attester_address,
+        challenger_address,
+        sequencer,
+    )
 }
 
 pub(crate) struct ExecutionSimulationVars {

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/invariant.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/invariant.rs
@@ -15,7 +15,7 @@ fn test_transition_invariant() {
     let tmpdir = tempfile::tempdir().unwrap();
     let storage = ProverStorage::with_path(tmpdir.path()).unwrap();
     let mut working_set = WorkingSet::new(storage.clone());
-    let (module, _token_address, attester_address, _) = setup(&mut working_set);
+    let (module, _token_address, attester_address, _, sequencer) = setup(&mut working_set);
 
     // Assert that the attester has the correct bond amount before processing the proof
     assert_eq!(
@@ -34,7 +34,7 @@ fn test_transition_invariant() {
     let (exec_vars, mut working_set) =
         execution_simulation(20, &module, &storage, attester_address, working_set);
 
-    let context = DefaultContext::new(attester_address, INIT_HEIGHT + 2);
+    let context = DefaultContext::new(attester_address, sequencer, INIT_HEIGHT + 2);
 
     const NEW_LIGHT_CLIENT_FINALIZED_HEIGHT: u64 = DEFAULT_ROLLUP_FINALITY + INIT_HEIGHT + 1;
 

--- a/module-system/module-implementations/sov-attester-incentives/src/tests/unbonding.rs
+++ b/module-system/module-implementations/sov-attester-incentives/src/tests/unbonding.rs
@@ -14,7 +14,7 @@ fn test_two_phase_unbonding() {
     let tmpdir = tempfile::tempdir().unwrap();
     let storage = ProverStorage::with_path(tmpdir.path()).unwrap();
     let mut working_set = WorkingSet::new(storage.clone());
-    let (module, token_address, attester_address, _) = setup(&mut working_set);
+    let (module, token_address, attester_address, _, sequencer) = setup(&mut working_set);
 
     // Assert that the attester has the correct bond amount before processing the proof
     assert_eq!(
@@ -28,7 +28,7 @@ fn test_two_phase_unbonding() {
         BOND_AMOUNT
     );
 
-    let context = DefaultContext::new(attester_address, INIT_HEIGHT + 2);
+    let context = DefaultContext::new(attester_address, sequencer, INIT_HEIGHT + 2);
 
     // Try to skip the first phase of the two phase unbonding. Should fail
     {

--- a/module-system/module-implementations/sov-bank/tests/archival_query_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/archival_query_test.rs
@@ -10,7 +10,7 @@ use sov_state::{DefaultStorageSpec, ProverStorage, Storage};
 #[test]
 fn transfer_initial_token() {
     let initial_balance = 100;
-    let bank_config = create_bank_config_with_token(3, initial_balance);
+    let bank_config = create_bank_config_with_token(4, initial_balance);
     let tmpdir = tempfile::tempdir().unwrap();
     let prover_storage = ProverStorage::with_path(tmpdir.path()).unwrap();
     let mut working_set = WorkingSet::new(prover_storage.clone());
@@ -22,6 +22,7 @@ fn transfer_initial_token() {
         bank_config.tokens[0].salt,
     );
     let sender_address = bank_config.tokens[0].address_and_balances[0].0;
+    let sequencer_address = bank_config.tokens[0].address_and_balances[3].0;
     let receiver_address = bank_config.tokens[0].address_and_balances[1].0;
     assert_ne!(sender_address, receiver_address);
 
@@ -41,6 +42,7 @@ fn transfer_initial_token() {
         &bank,
         token_address,
         sender_address,
+        sequencer_address,
         receiver_address,
         10,
         &mut working_set,
@@ -62,6 +64,7 @@ fn transfer_initial_token() {
         &bank,
         token_address,
         sender_address,
+        sequencer_address,
         receiver_address,
         10,
         &mut working_set,
@@ -96,6 +99,7 @@ fn transfer_initial_token() {
         &bank,
         token_address,
         sender_address,
+        sequencer_address,
         receiver_address,
         5,
         &mut working_set,
@@ -126,6 +130,7 @@ fn transfer_initial_token() {
         &bank,
         token_address,
         sender_address,
+        sequencer_address,
         receiver_address,
         45,
         &mut working_set,
@@ -156,6 +161,7 @@ fn transfer_initial_token() {
         &bank,
         token_address,
         sender_address,
+        sequencer_address,
         receiver_address,
         10,
         &mut working_set,
@@ -183,6 +189,7 @@ fn transfer_initial_token() {
         &bank,
         token_address,
         sender_address,
+        sequencer_address,
         receiver_address,
         10,
         &mut working_set,
@@ -243,6 +250,7 @@ fn transfer(
     bank: &Bank<DefaultContext>,
     token_address: Address,
     sender_address: Address,
+    sequencer_address: Address,
     receiver_address: Address,
     transfer_amount: Amount,
     working_set: &mut WorkingSet<DefaultContext>,
@@ -255,7 +263,7 @@ fn transfer(
         },
     };
 
-    let sender_context = C::new(sender_address, 1);
+    let sender_context = C::new(sender_address, sequencer_address, 1);
 
     bank.call(transfer_message, &sender_context, working_set)
         .expect("Transfer call failed");

--- a/module-system/module-implementations/sov-bank/tests/burn_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/burn_test.rs
@@ -22,9 +22,10 @@ fn burn_deployed_tokens() {
     bank.genesis(&empty_bank_config, &mut working_set).unwrap();
 
     let sender_address = generate_address("just_sender");
-    let sender_context = C::new(sender_address, 1);
+    let sequencer_address = generate_address("sequencer");
+    let sender_context = C::new(sender_address, sequencer_address, 1);
     let minter_address = generate_address("minter");
-    let minter_context = C::new(minter_address, 1);
+    let minter_context = C::new(minter_address, sequencer_address, 1);
 
     let salt = 0;
     let token_name = "Token1".to_owned();
@@ -183,7 +184,7 @@ fn burn_deployed_tokens() {
 #[test]
 fn burn_initial_tokens() {
     let initial_balance = 100;
-    let bank_config = create_bank_config_with_token(1, initial_balance);
+    let bank_config = create_bank_config_with_token(2, initial_balance);
     let tmpdir = tempfile::tempdir().unwrap();
     let mut working_set = WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
     let bank = Bank::default();
@@ -194,6 +195,7 @@ fn burn_initial_tokens() {
         bank_config.tokens[0].salt,
     );
     let sender_address = bank_config.tokens[0].address_and_balances[0].0;
+    let sequencer_address = bank_config.tokens[0].address_and_balances[1].0;
 
     let query_user_balance =
         |user_address: Address, working_set: &mut WorkingSet<DefaultContext>| -> Option<u64> {
@@ -211,7 +213,7 @@ fn burn_initial_tokens() {
         },
     };
 
-    let context = C::new(sender_address, 1);
+    let context = C::new(sender_address, sequencer_address, 1);
     bank.call(burn_message, &context, &mut working_set)
         .expect("Failed to burn token");
     assert!(working_set.events().is_empty());

--- a/module-system/module-implementations/sov-bank/tests/create_token_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/create_token_test.rs
@@ -16,7 +16,8 @@ fn initial_and_deployed_token() {
     bank.genesis(&bank_config, &mut working_set).unwrap();
 
     let sender_address = generate_address::<C>("sender");
-    let sender_context = C::new(sender_address, 1);
+    let sequencer_address = generate_address::<C>("sequencer");
+    let sender_context = C::new(sender_address, sequencer_address, 1);
     let minter_address = generate_address::<C>("minter");
     let initial_balance = 500;
     let token_name = "Token1".to_owned();

--- a/module-system/module-implementations/sov-bank/tests/freeze_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/freeze_test.rs
@@ -18,7 +18,8 @@ fn freeze_token() {
     bank.genesis(&empty_bank_config, &mut working_set).unwrap();
 
     let minter_address = generate_address::<DefaultContext>("minter");
-    let minter_context = C::new(minter_address, 1);
+    let sequencer_address = generate_address::<DefaultContext>("sequencer");
+    let minter_context = C::new(minter_address, sequencer_address, 1);
 
     let salt = 0;
     let token_name = "Token1".to_owned();
@@ -91,7 +92,8 @@ fn freeze_token() {
 
     // Try to freeze with a non authorized minter
     let unauthorized_address = generate_address::<C>("unauthorized_address");
-    let unauthorized_context = C::new(unauthorized_address, 1);
+    let sequencer_address = generate_address::<C>("sequencer");
+    let unauthorized_context = C::new(unauthorized_address, sequencer_address, 1);
     let freeze_message = CallMessage::Freeze {
         token_address: token_address_2,
     };

--- a/module-system/module-implementations/sov-bank/tests/mint_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/mint_test.rs
@@ -18,7 +18,8 @@ fn mint_token() {
     bank.genesis(&empty_bank_config, &mut working_set).unwrap();
 
     let minter_address = generate_address::<C>("minter");
-    let minter_context = C::new(minter_address, 1);
+    let sequencer_address = generate_address::<C>("sequencer");
+    let minter_context = C::new(minter_address, sequencer_address, 1);
 
     let salt = 0;
     let token_name = "Token1".to_owned();
@@ -85,7 +86,8 @@ fn mint_token() {
 
     // Mint with an un-authorized user
     let unauthorized_address = generate_address::<C>("unauthorized_address");
-    let unauthorized_context = C::new(unauthorized_address, 1);
+    let sequencer_address = generate_address::<C>("sequencer");
+    let unauthorized_context = C::new(unauthorized_address, sequencer_address, 1);
     let unauthorized_mint = bank.call(mint_message, &unauthorized_context, &mut working_set);
 
     assert!(unauthorized_mint.is_err());
@@ -119,6 +121,7 @@ fn mint_token() {
     let token_address = get_token_address::<C>(&token_name, minter_address.as_ref(), salt);
     let authorized_minter_address_1 = generate_address::<C>("authorized_minter_1");
     let authorized_minter_address_2 = generate_address::<C>("authorized_minter_2");
+    let sequencer_address = generate_address::<C>("sequencer");
     // ---
     // Deploying token
     let mint_message = CallMessage::CreateToken {
@@ -168,7 +171,7 @@ fn mint_token() {
         message_2
     );
     // Try to mint new token with authorized sender 2
-    let authorized_minter_2_context = C::new(authorized_minter_address_2, 1);
+    let authorized_minter_2_context = C::new(authorized_minter_address_2, sequencer_address, 1);
     let mint_message = CallMessage::Mint {
         coins: Coins {
             amount: mint_amount,
@@ -185,7 +188,7 @@ fn mint_token() {
     assert_eq!(Some(110), supply);
 
     // Try to mint new token with authorized sender 1
-    let authorized_minter_1_context = C::new(authorized_minter_address_1, 1);
+    let authorized_minter_1_context = C::new(authorized_minter_address_1, sequencer_address, 1);
     let mint_message = CallMessage::Mint {
         coins: Coins {
             amount: mint_amount,

--- a/module-system/module-implementations/sov-bank/tests/transfer_test.rs
+++ b/module-system/module-implementations/sov-bank/tests/transfer_test.rs
@@ -16,7 +16,7 @@ pub type Storage = ProverStorage<DefaultStorageSpec>;
 fn transfer_initial_token() {
     let initial_balance = 100;
     let transfer_amount = 10;
-    let bank_config = create_bank_config_with_token(3, initial_balance);
+    let bank_config = create_bank_config_with_token(4, initial_balance);
     let token_name = bank_config.tokens[0].token_name.clone();
     let tmpdir = tempfile::tempdir().unwrap();
     let mut working_set = WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
@@ -29,6 +29,7 @@ fn transfer_initial_token() {
     );
     let sender_address = bank_config.tokens[0].address_and_balances[0].0;
     let receiver_address = bank_config.tokens[0].address_and_balances[1].0;
+    let sequencer_address = bank_config.tokens[0].address_and_balances[3].0;
     assert_ne!(sender_address, receiver_address);
 
     // Preparation
@@ -49,7 +50,7 @@ fn transfer_initial_token() {
 
     assert_eq!(Some(initial_balance), sender_balance_before);
     assert_eq!(sender_balance_before, receiver_balance_before);
-    let sender_context = C::new(sender_address, 1);
+    let sender_context = C::new(sender_address, sequencer_address, 1);
 
     // Transfer happy test
     {
@@ -156,7 +157,8 @@ fn transfer_initial_token() {
     // Sender does not exist
     {
         let unknown_sender = generate_address::<C>("non_existing_sender");
-        let unknown_sender_context = C::new(unknown_sender, 1);
+        let sequencer = generate_address::<C>("sequencer");
+        let unknown_sender_context = C::new(unknown_sender, sequencer, 1);
 
         let sender_balance = query_user_balance(unknown_sender, &mut working_set);
         assert!(sender_balance.is_none());
@@ -263,6 +265,7 @@ fn transfer_deployed_token() {
 
     let sender_address = generate_address::<C>("just_sender");
     let receiver_address = generate_address::<C>("just_receiver");
+    let sequencer_address = generate_address::<C>("just_sequencer");
 
     let salt = 10;
     let token_name = "Token1".to_owned();
@@ -289,7 +292,7 @@ fn transfer_deployed_token() {
 
     assert!(sender_balance_before.is_none());
     assert!(receiver_balance_before.is_none());
-    let sender_context = C::new(sender_address, 1);
+    let sender_context = C::new(sender_address, sequencer_address, 1);
 
     let mint_message = CallMessage::CreateToken {
         salt,

--- a/module-system/module-implementations/sov-evm/src/tests/call_tests.rs
+++ b/module-system/module-implementations/sov-evm/src/tests/call_tests.rs
@@ -42,7 +42,8 @@ fn call_test() {
     let set_arg = 999;
     {
         let sender_address = generate_address::<C>("sender");
-        let context = C::new(sender_address, 1);
+        let sequencer_address = generate_address::<C>("sequencer");
+        let context = C::new(sender_address, sequencer_address, 1);
 
         let messages = vec![
             create_contract_message(&dev_signer, 0),
@@ -101,7 +102,8 @@ fn failed_transaction_test() {
     evm.begin_slot_hook([5u8; 32], &[10u8; 32].into(), working_set);
     {
         let sender_address = generate_address::<C>("sender");
-        let context = C::new(sender_address, 1);
+        let sequencer_address = generate_address::<C>("sequencer");
+        let context = C::new(sender_address, sequencer_address, 1);
         let message = create_contract_message(&dev_signer, 0);
         evm.call(message, &context, working_set).unwrap();
     }

--- a/module-system/module-implementations/sov-nft-module/tests/nft_test.rs
+++ b/module-system/module-implementations/sov-nft-module/tests/nft_test.rs
@@ -17,14 +17,20 @@ const PK3: [u8; 32] = [
     233, 139, 68, 72, 169, 252, 229, 117, 72, 144, 47, 191, 13, 42, 32, 107, 190, 52, 102, 210,
     161, 208, 245, 116, 93, 84, 37, 87, 171, 44, 30, 239,
 ];
+const PK4: [u8; 32] = [
+    233, 139, 68, 72, 169, 252, 229, 117, 72, 149, 47, 191, 13, 42, 32, 107, 190, 52, 102, 210,
+    161, 208, 245, 116, 93, 84, 37, 87, 171, 44, 30, 239,
+];
 
 #[test]
 fn mints_and_transfers() {
     let creator_pk = DefaultPrivateKey::try_from(&PK1[..]).unwrap();
     let private_key_1 = DefaultPrivateKey::try_from(&PK2[..]).unwrap();
     let private_key_2 = DefaultPrivateKey::try_from(&PK3[..]).unwrap();
+    let sequencer_pk = DefaultPrivateKey::try_from(&PK4[..]).unwrap();
 
     let creator_address = creator_pk.default_address();
+    let sequencer_address = sequencer_pk.default_address();
     let collection_name = "Test Collection";
     let collection_uri = "http://foo.bar/test_collection";
     let collection_address =
@@ -40,7 +46,7 @@ fn mints_and_transfers() {
         collection_uri: collection_uri.to_string(),
     };
 
-    let creator_context = DefaultContext::new(creator_address, 1);
+    let creator_context = DefaultContext::new(creator_address, sequencer_address, 1);
 
     // Create Collection
     nft.call(
@@ -122,7 +128,7 @@ fn mints_and_transfers() {
         collection_uri: new_collection_uri.to_string(),
     };
 
-    let creator_context = DefaultContext::new(creator_address, 1);
+    let creator_context = DefaultContext::new(creator_address, sequencer_address, 1);
 
     nft.call(
         create_collection_message,
@@ -145,7 +151,7 @@ fn mints_and_transfers() {
         collection_name: ne_collection_name.to_string(),
     };
 
-    let creator_context = DefaultContext::new(creator_address, 1);
+    let creator_context = DefaultContext::new(creator_address, sequencer_address, 1);
 
     let freeze_response = nft.call(
         freeze_collection_message,
@@ -172,7 +178,7 @@ fn mints_and_transfers() {
         collection_name: collection_name.to_string(),
     };
 
-    let creator_context = DefaultContext::new(creator_address, 1);
+    let creator_context = DefaultContext::new(creator_address, sequencer_address, 1);
     nft.call(
         freeze_collection_message,
         &creator_context,
@@ -193,7 +199,7 @@ fn mints_and_transfers() {
         collection_uri: un_updated_collection_uri.to_string(),
     };
 
-    let creator_context = DefaultContext::new(creator_address, 1);
+    let creator_context = DefaultContext::new(creator_address, sequencer_address, 1);
 
     let update_response = nft.call(
         create_collection_message,
@@ -287,7 +293,7 @@ fn mints_and_transfers() {
 
     // transfer NFT with non-existent token id
     let target_address = private_key_2.default_address();
-    let owner_context = DefaultContext::new(*owner.get_address(), 1);
+    let owner_context = DefaultContext::new(*owner.get_address(), sequencer_address, 1);
     let transfer_nft_message = CallMessage::TransferNft {
         collection_address: collection_address.clone(),
         token_id: 1000,
@@ -312,7 +318,7 @@ fn mints_and_transfers() {
 
     // transfer NFT by owner
     let target_address = private_key_2.default_address();
-    let owner_context = DefaultContext::new(*owner.get_address(), 1);
+    let owner_context = DefaultContext::new(*owner.get_address(), sequencer_address, 1);
     let transfer_nft_message = CallMessage::TransferNft {
         collection_address: collection_address.clone(),
         token_id,
@@ -422,7 +428,7 @@ fn mints_and_transfers() {
     // transfer NFT by owner
     let target_address = private_key_1.default_address();
     let owner = private_key_2.default_address();
-    let owner_context = DefaultContext::new(owner, 1);
+    let owner_context = DefaultContext::new(owner, sequencer_address, 1);
     let transfer_nft_message = CallMessage::TransferNft {
         collection_address: collection_address.clone(),
         token_id,

--- a/module-system/module-implementations/sov-prover-incentives/src/tests.rs
+++ b/module-system/module-implementations/sov-prover-incentives/src/tests.rs
@@ -18,8 +18,13 @@ pub fn generate_address(key: &str) -> <C as Spec>::Address {
     Address::from(hash)
 }
 
-fn create_bank_config() -> (sov_bank::BankConfig<C>, <C as Spec>::Address) {
+fn create_bank_config() -> (
+    sov_bank::BankConfig<C>,
+    <C as Spec>::Address,
+    <C as Spec>::Address,
+) {
     let prover_address = generate_address("prover_pub_key");
+    let sequencer_address = generate_address("sequencer_pub_key");
 
     let token_config = sov_bank::TokenConfig {
         token_name: "InitialToken".to_owned(),
@@ -33,12 +38,13 @@ fn create_bank_config() -> (sov_bank::BankConfig<C>, <C as Spec>::Address) {
             tokens: vec![token_config],
         },
         prover_address,
+        sequencer_address,
     )
 }
 
-fn setup(working_set: &mut WorkingSet<C>) -> (ProverIncentives<C, MockZkvm>, Address) {
+fn setup(working_set: &mut WorkingSet<C>) -> (ProverIncentives<C, MockZkvm>, Address, Address) {
     // Initialize bank
-    let (bank_config, prover_address) = create_bank_config();
+    let (bank_config, prover_address, sequencer) = create_bank_config();
     let bank = sov_bank::Bank::<C>::default();
     bank.genesis(&bank_config, working_set)
         .expect("bank genesis must succeed");
@@ -60,14 +66,14 @@ fn setup(working_set: &mut WorkingSet<C>) -> (ProverIncentives<C, MockZkvm>, Add
     module
         .genesis(&config, working_set)
         .expect("prover incentives genesis must succeed");
-    (module, prover_address)
+    (module, prover_address, sequencer)
 }
 
 #[test]
 fn test_burn_on_invalid_proof() {
     let tmpdir = tempfile::tempdir().unwrap();
     let mut working_set = WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
-    let (module, prover_address) = setup(&mut working_set);
+    let (module, prover_address, sequencer) = setup(&mut working_set);
 
     // Assert that the prover has the correct bond amount before processing the proof
     assert_eq!(
@@ -79,7 +85,7 @@ fn test_burn_on_invalid_proof() {
 
     // Process an invalid proof
     {
-        let context = DefaultContext::new(prover_address, 1);
+        let context = DefaultContext::new(prover_address, sequencer, 1);
         let proof = MockProof {
             program_id: MOCK_CODE_COMMITMENT,
             is_valid: false,
@@ -103,7 +109,7 @@ fn test_burn_on_invalid_proof() {
 fn test_valid_proof() {
     let tmpdir = tempfile::tempdir().unwrap();
     let mut working_set = WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
-    let (module, prover_address) = setup(&mut working_set);
+    let (module, prover_address, sequencer) = setup(&mut working_set);
 
     // Assert that the prover has the correct bond amount before processing the proof
     assert_eq!(
@@ -115,7 +121,7 @@ fn test_valid_proof() {
 
     // Process a valid proof
     {
-        let context = DefaultContext::new(prover_address, 1);
+        let context = DefaultContext::new(prover_address, sequencer, 1);
         let proof = MockProof {
             program_id: MOCK_CODE_COMMITMENT,
             is_valid: true,
@@ -139,8 +145,8 @@ fn test_valid_proof() {
 fn test_unbonding() {
     let tmpdir = tempfile::tempdir().unwrap();
     let mut working_set = WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
-    let (module, prover_address) = setup(&mut working_set);
-    let context = DefaultContext::new(prover_address, 1);
+    let (module, prover_address, sequencer) = setup(&mut working_set);
+    let context = DefaultContext::new(prover_address, sequencer, 1);
     let token_address = module
         .bonding_token_address
         .get(&mut working_set)
@@ -190,8 +196,8 @@ fn test_unbonding() {
 fn test_prover_not_bonded() {
     let tmpdir = tempfile::tempdir().unwrap();
     let mut working_set = WorkingSet::new(ProverStorage::with_path(tmpdir.path()).unwrap());
-    let (module, prover_address) = setup(&mut working_set);
-    let context = DefaultContext::new(prover_address, 1);
+    let (module, prover_address, sequencer) = setup(&mut working_set);
+    let context = DefaultContext::new(prover_address, sequencer, 1);
 
     // Unbond the prover
     module

--- a/module-system/module-implementations/sov-sequencer-registry/tests/helpers/mod.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/tests/helpers/mod.rs
@@ -15,6 +15,8 @@ pub const ANOTHER_SEQUENCER_KEY: &str = "sequencer_2";
 pub const ANOTHER_SEQUENCER_DA_ADDRESS: [u8; 32] = [2; 32];
 pub const UNKNOWN_SEQUENCER_KEY: &str = "sequencer_3";
 #[allow(dead_code)]
+pub const REWARD_SEQUENCER_KEY: &str = "sequencer_4";
+#[allow(dead_code)]
 pub const UNKNOWN_SEQUENCER_DA_ADDRESS: [u8; 32] = [3; 32];
 pub const LOW_FUND_KEY: &str = "zero_funds";
 pub const INITIAL_BALANCE: u64 = 210;

--- a/module-system/module-implementations/sov-sequencer-registry/tests/sequencer_registry_test.rs
+++ b/module-system/module-implementations/sov-sequencer-registry/tests/sequencer_registry_test.rs
@@ -35,7 +35,8 @@ fn test_registration_lifecycle() {
     let da_address = MockAddress::from(ANOTHER_SEQUENCER_DA_ADDRESS);
 
     let sequencer_address = generate_address(ANOTHER_SEQUENCER_KEY);
-    let sender_context = C::new(sequencer_address, 1);
+    let reward_address = generate_address(REWARD_SEQUENCER_KEY);
+    let sender_context = C::new(sequencer_address, reward_address, 1);
 
     let balance_before = test_sequencer
         .query_balance(sequencer_address, working_set)
@@ -105,7 +106,8 @@ fn test_registration_not_enough_funds() {
     let da_address = MockAddress::from(ANOTHER_SEQUENCER_DA_ADDRESS);
 
     let sequencer_address = generate_address(LOW_FUND_KEY);
-    let sender_context = C::new(sequencer_address, 1);
+    let reward_address = generate_address(REWARD_SEQUENCER_KEY);
+    let sender_context = C::new(sequencer_address, reward_address, 1);
 
     let register_message = CallMessage::Register {
         da_address: da_address.as_ref().to_vec(),
@@ -158,7 +160,8 @@ fn test_registration_second_time() {
     let da_address = MockAddress::from(GENESIS_SEQUENCER_DA_ADDRESS);
 
     let sequencer_address = generate_address(GENESIS_SEQUENCER_KEY);
-    let sender_context = C::new(sequencer_address, 1);
+    let reward_address = generate_address(REWARD_SEQUENCER_KEY);
+    let sender_context = C::new(sequencer_address, reward_address, 1);
 
     let register_message = CallMessage::Register {
         da_address: da_address.as_ref().to_vec(),
@@ -182,9 +185,10 @@ fn test_exit_different_sender() {
     test_sequencer.genesis(working_set);
 
     let sequencer_address = generate_address(ANOTHER_SEQUENCER_KEY);
-    let sender_context = C::new(sequencer_address, 1);
+    let reward_address = generate_address(REWARD_SEQUENCER_KEY);
+    let sender_context = C::new(sequencer_address, reward_address, 1);
     let attacker_address = generate_address("some_random_key");
-    let attacker_context = C::new(attacker_address, 1);
+    let attacker_context = C::new(attacker_address, reward_address, 1);
 
     let register_message = CallMessage::Register {
         da_address: ANOTHER_SEQUENCER_DA_ADDRESS.to_vec(),
@@ -218,7 +222,8 @@ fn test_allow_exit_last_sequencer() {
     test_sequencer.genesis(working_set);
 
     let sequencer_address = generate_address(GENESIS_SEQUENCER_KEY);
-    let sender_context = C::new(sequencer_address, 1);
+    let rewards_address = generate_address(REWARD_SEQUENCER_KEY);
+    let sender_context = C::new(sequencer_address, rewards_address, 1);
     let exit_message = CallMessage::Exit {
         da_address: GENESIS_SEQUENCER_DA_ADDRESS.to_vec(),
     };
@@ -260,7 +265,8 @@ fn test_preferred_sequencer_returned_and_removed() {
     );
 
     let sequencer_address = generate_address(GENESIS_SEQUENCER_KEY);
-    let sender_context = C::new(sequencer_address, 1);
+    let reward_address = generate_address(REWARD_SEQUENCER_KEY);
+    let sender_context = C::new(sequencer_address, reward_address, 1);
     let exit_message = CallMessage::Exit {
         da_address: GENESIS_SEQUENCER_DA_ADDRESS.to_vec(),
     };

--- a/module-system/sov-modules-api/src/containers/kernel_value.rs
+++ b/module-system/sov-modules-api/src/containers/kernel_value.rs
@@ -336,6 +336,8 @@ mod tests {
 
         let prefix = Prefix::new(b"test".to_vec());
         let value = KernelStateValue::<u64>::new(prefix.clone());
+        let sender = Address::from([1; 32]);
+        let sequencer = Address::from([1; 32]);
 
         // Initialize a value in the kernel state during slot 4
         {
@@ -348,13 +350,13 @@ mod tests {
         {
             {
                 let mut versioned_state =
-                    working_set.versioned_state(&DefaultContext::new(Address::from([1; 32]), 1));
+                    working_set.versioned_state(&DefaultContext::new(sender, sequencer, 1));
                 // Try to read the value from user space with the slot number set to 1. Should fail.
                 assert_eq!(value.get(&mut versioned_state), None);
             }
             // Try to read the value from user space with the slot number set to 4. Should succeed.
             let mut versioned_state =
-                working_set.versioned_state(&DefaultContext::new(Address::from([1; 32]), 4));
+                working_set.versioned_state(&DefaultContext::new(sender, sequencer, 4));
             // Try to read the value from user space with the slot number set to 1. Should fail.
             assert_eq!(value.get(&mut versioned_state), Some(100));
         }
@@ -369,6 +371,8 @@ mod tests {
         let prefix = Prefix::new(b"test".to_vec());
         let value = KernelStateValue::<u64>::new(prefix.clone());
         let kernel = MockKernel::<DefaultContext, MockDaSpec>::new(4, 1);
+        let sender = Address::from([1; 32]);
+        let sequencer = Address::from([1; 32]);
 
         // Initialize a versioned value in the kernel state to be available starting at slot 2
         {
@@ -382,13 +386,13 @@ mod tests {
             use crate::StateValueAccessor;
             {
                 let mut versioned_state =
-                    working_set.versioned_state(&DefaultContext::new(Address::from([1; 32]), 1));
+                    working_set.versioned_state(&DefaultContext::new(sender, sequencer, 1));
                 // Try to read the value from user space with the slot number set to 1. Should fail.
                 assert_eq!(value.get(&mut versioned_state), None);
             }
             // Try to read the value from user space with the slot number set to 2. Should succeed.
             let mut versioned_state =
-                working_set.versioned_state(&DefaultContext::new(Address::from([1; 32]), 2));
+                working_set.versioned_state(&DefaultContext::new(sender, sequencer, 2));
 
             assert_eq!(value.get(&mut versioned_state), Some(100));
         }

--- a/module-system/sov-modules-api/src/default_context.rs
+++ b/module-system/sov-modules-api/src/default_context.rs
@@ -16,6 +16,7 @@ use crate::default_signature::{DefaultPublicKey, DefaultSignature};
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DefaultContext {
     pub sender: Address,
+    pub sequencer: Address,
     /// The height to report. This is set by the kernel when the context is created
     visible_height: u64,
 }
@@ -39,9 +40,14 @@ impl Context for DefaultContext {
         &self.sender
     }
 
-    fn new(sender: Self::Address, height: u64) -> Self {
+    fn sequencer(&self) -> &Self::Address {
+        &self.sequencer
+    }
+
+    fn new(sender: Self::Address, sequencer: Self::Address, height: u64) -> Self {
         Self {
             sender,
+            sequencer,
             visible_height: height,
         }
     }
@@ -55,6 +61,7 @@ impl Context for DefaultContext {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ZkDefaultContext {
     pub sender: Address,
+    pub sequencer: Address,
     /// The height to report. This is set by the kernel when the context is created
     visible_height: u64,
 }
@@ -77,9 +84,14 @@ impl Context for ZkDefaultContext {
         &self.sender
     }
 
-    fn new(sender: Self::Address, height: u64) -> Self {
+    fn sequencer(&self) -> &Self::Address {
+        &self.sequencer
+    }
+
+    fn new(sender: Self::Address, sequencer: Self::Address, height: u64) -> Self {
         Self {
             sender,
+            sequencer,
             visible_height: height,
         }
     }

--- a/module-system/sov-modules-api/src/hooks.rs
+++ b/module-system/sov-modules-api/src/hooks.rs
@@ -4,18 +4,24 @@ use sov_rollup_interface::da::{BlobReaderTrait, DaSpec};
 use crate::transaction::Transaction;
 
 /// Hooks that execute within the `StateTransitionFunction::apply_blob` function for each processed transaction.
+///
+/// The arguments consist of expected concretely implemented associated types for the hooks. At
+/// runtime, compatible implementations are selected and utilized by the system to construct its
+/// setup procedures and define post-execution routines.
 pub trait TxHooks {
     type Context: Context;
+    type PreArg;
+    type PreResult;
+    type PostArg;
+    type PostResult;
 
     /// Runs just before a transaction is dispatched to an appropriate module.
-    /// TODO: Why does it return address?
-    /// Does it implies that it should do signature verification.
-    /// Can other code rely on that assumption?
     fn pre_dispatch_tx_hook(
         &self,
         tx: &Transaction<Self::Context>,
         working_set: &mut WorkingSet<Self::Context>,
-    ) -> anyhow::Result<<Self::Context as Spec>::Address>;
+        arg: Self::PreArg,
+    ) -> anyhow::Result<Self::PreResult>;
 
     /// Runs after the tx is dispatched to an appropriate module.
     /// IF this hook returns error rollup panics
@@ -23,7 +29,8 @@ pub trait TxHooks {
         &self,
         tx: &Transaction<Self::Context>,
         working_set: &mut WorkingSet<Self::Context>,
-    ) -> anyhow::Result<()>;
+        arg: Self::PostArg,
+    ) -> anyhow::Result<Self::PostResult>;
 }
 
 /// Hooks related to the Sequencer functionality.

--- a/module-system/sov-modules-api/src/hooks.rs
+++ b/module-system/sov-modules-api/src/hooks.rs
@@ -12,8 +12,6 @@ pub trait TxHooks {
     type Context: Context;
     type PreArg;
     type PreResult;
-    type PostArg;
-    type PostResult;
 
     /// Runs just before a transaction is dispatched to an appropriate module.
     fn pre_dispatch_tx_hook(
@@ -28,9 +26,9 @@ pub trait TxHooks {
     fn post_dispatch_tx_hook(
         &self,
         tx: &Transaction<Self::Context>,
+        ctx: &Self::Context,
         working_set: &mut WorkingSet<Self::Context>,
-        arg: Self::PostArg,
-    ) -> anyhow::Result<Self::PostResult>;
+    ) -> anyhow::Result<()>;
 }
 
 /// Hooks related to the Sequencer functionality.

--- a/module-system/sov-modules-core/src/module/spec.rs
+++ b/module-system/sov-modules-core/src/module/spec.rs
@@ -104,8 +104,11 @@ pub trait Context: Spec + Clone + Debug + PartialEq + 'static {
     /// Sender of the transaction.
     fn sender(&self) -> &Self::Address;
 
+    /// Sequencer of the runtime.
+    fn sequencer(&self) -> &Self::Address;
+
     /// Constructor for the Context.
-    fn new(sender: Self::Address, height: u64) -> Self;
+    fn new(sender: Self::Address, sequencer: Self::Address, height: u64) -> Self;
 
     /// Returns the height of the current slot as reported by the kernel. This value is
     /// non-decreasing and is guaranteed to be less than or equal to the actual "objective" height of the rollup.

--- a/module-system/sov-modules-core/tests/working_set_tests.rs
+++ b/module-system/sov-modules-core/tests/working_set_tests.rs
@@ -35,9 +35,10 @@ fn test_versioned_workingset_get() {
     let storage_key = StorageKey::new(&prefix, &vec![4, 5, 6], &codec);
     let storage_value = StorageValue::new(&vec![7, 8, 9], &codec);
 
+    let sender = Address::from([1; 32]);
+    let sequencer = Address::from([2; 32]);
     let mut working_set = WorkingSet::<DefaultContext>::new(storage.clone());
-    let mut working_set =
-        working_set.versioned_state(&DefaultContext::new(Address::from([1; 32]), 1));
+    let mut working_set = working_set.versioned_state(&DefaultContext::new(sender, sequencer, 1));
     working_set.set(&storage_key, storage_value.clone());
 
     assert_eq!(Some(storage_value), working_set.get(&storage_key));

--- a/module-system/sov-modules-macros/tests/dispatch/derive_dispatch.rs
+++ b/module-system/sov-modules-macros/tests/dispatch/derive_dispatch.rs
@@ -28,7 +28,9 @@ fn main() {
     let mut working_set = &mut sov_modules_api::WorkingSet::new(storage);
     let config = GenesisConfig::new((), (), ());
     runtime.genesis(&config, working_set).unwrap();
-    let context = ZkDefaultContext::new(Address::try_from([0; 32].as_ref()).unwrap(), 1);
+    let sender = Address::try_from([0; 32].as_ref()).unwrap();
+    let sequencer = Address::try_from([1; 32].as_ref()).unwrap();
+    let context = ZkDefaultContext::new(sender, sequencer, 1);
 
     let value = 11;
     {

--- a/module-system/sov-modules-macros/tests/rpc/expose_rpc_associated_type_not_static.rs
+++ b/module-system/sov-modules-macros/tests/rpc/expose_rpc_associated_type_not_static.rs
@@ -121,7 +121,9 @@ fn main() {
     let serialized_message =
         <RT as EncodeCall<my_module::QueryModule<C, u32>>>::encode_call(message);
     let module = RT::decode_call(&serialized_message).unwrap();
-    let context = C::new(Address::try_from([11; 32].as_ref()).unwrap(), 1);
+    let sender = Address::try_from([11; 32].as_ref()).unwrap();
+    let sequencer = Address::try_from([11; 32].as_ref()).unwrap();
+    let context = C::new(sender, sequencer, 1);
 
     let _ = runtime
         .dispatch_call(module, working_set, &context)

--- a/module-system/sov-modules-macros/tests/rpc/expose_rpc_associated_types.rs
+++ b/module-system/sov-modules-macros/tests/rpc/expose_rpc_associated_types.rs
@@ -121,7 +121,9 @@ fn main() {
     let serialized_message =
         <RT as EncodeCall<my_module::QueryModule<C, u32>>>::encode_call(message);
     let module = RT::decode_call(&serialized_message).unwrap();
-    let context = C::new(Address::try_from([11; 32].as_ref()).unwrap(), 1);
+    let sender = Address::try_from([11; 32].as_ref()).unwrap();
+    let sequencer = Address::try_from([12; 32].as_ref()).unwrap();
+    let context = C::new(sender, sequencer, 1);
 
     let _ = runtime
         .dispatch_call(module, working_set, &context)

--- a/module-system/sov-modules-macros/tests/rpc/expose_rpc_associated_types_nested.rs
+++ b/module-system/sov-modules-macros/tests/rpc/expose_rpc_associated_types_nested.rs
@@ -132,7 +132,9 @@ fn main() {
     let serialized_message =
         <RT as EncodeCall<my_module::QueryModule<C, u32>>>::encode_call(message);
     let module = RT::decode_call(&serialized_message).unwrap();
-    let context = C::new(Address::try_from([11; 32].as_ref()).unwrap(), 1);
+    let sender = Address::try_from([11; 32].as_ref()).unwrap();
+    let sequencer = Address::try_from([12; 32].as_ref()).unwrap();
+    let context = C::new(sender, sequencer, 1);
 
     let _ = runtime
         .dispatch_call(module, working_set, &context)

--- a/module-system/sov-modules-macros/tests/rpc/expose_rpc_first_generic_not_context.rs
+++ b/module-system/sov-modules-macros/tests/rpc/expose_rpc_first_generic_not_context.rs
@@ -119,7 +119,9 @@ fn main() {
     let serialized_message =
         <RT as EncodeCall<my_module::QueryModule<C, u32>>>::encode_call(message);
     let module = RT::decode_call(&serialized_message).unwrap();
-    let context = C::new(Address::try_from([11; 32].as_ref()).unwrap(), 1);
+    let sender = Address::try_from([11; 32].as_ref()).unwrap();
+    let sequencer = Address::try_from([11; 32].as_ref()).unwrap();
+    let context = C::new(sender, sequencer, 1);
 
     let _ = runtime
         .dispatch_call(module, working_set, &context)

--- a/module-system/sov-modules-rollup-blueprint/src/runtime_rpc.rs
+++ b/module-system/sov-modules-rollup-blueprint/src/runtime_rpc.rs
@@ -10,6 +10,7 @@ pub fn register_rpc<RT, C, Da>(
     storage: &<C as Spec>::Storage,
     ledger_db: &LedgerDB,
     da_service: &Da,
+    sequencer: C::Address,
 ) -> Result<jsonrpsee::RpcModule<()>, anyhow::Error>
 where
     RT: RuntimeTrait<C, <Da as DaService>::Spec> + Send + Sync + 'static,
@@ -35,6 +36,7 @@ where
             u32::MAX as usize,
             RT::default(),
             storage.clone(),
+            sequencer,
         );
 
         let sequencer_rpc = sov_sequencer::get_sequencer_rpc(batch_builder, da_service.clone());

--- a/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -28,7 +28,7 @@ pub use tx_verifier::RawTx;
 pub trait Runtime<C: Context, Da: DaSpec>:
     DispatchCall<Context = C>
     + Genesis<Context = C, Config = Self::GenesisConfig>
-    + TxHooks<Context = C, PreArg = u64, PreResult = C, PostArg = ()>
+    + TxHooks<Context = C, PreArg = (), PreResult = C::Address, PostArg = ()>
     + SlotHooks<Da, Context = C>
     + FinalizeHook<Da, Context = C>
     + ApplyBlobHooks<

--- a/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -21,6 +21,14 @@ pub use stf_blueprint::StfBlueprint;
 use tracing::info;
 pub use tx_verifier::RawTx;
 
+/// The tx hook for a blueprint runtime
+pub struct RuntimeTxHook<C: Context> {
+    /// Height to initialize the context
+    pub height: u64,
+    /// Sequencer public key
+    pub sequencer: C::PublicKey,
+}
+
 /// This trait has to be implemented by a runtime in order to be used in `StfBlueprint`.
 ///
 /// The `TxHooks` implementation sets up a transaction context based on the height at which it is
@@ -28,7 +36,7 @@ pub use tx_verifier::RawTx;
 pub trait Runtime<C: Context, Da: DaSpec>:
     DispatchCall<Context = C>
     + Genesis<Context = C, Config = Self::GenesisConfig>
-    + TxHooks<Context = C, PreArg = (), PreResult = C::Address, PostArg = ()>
+    + TxHooks<Context = C, PreArg = RuntimeTxHook<C>, PreResult = C>
     + SlotHooks<Da, Context = C>
     + FinalizeHook<Da, Context = C>
     + ApplyBlobHooks<

--- a/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -22,10 +22,13 @@ use tracing::info;
 pub use tx_verifier::RawTx;
 
 /// This trait has to be implemented by a runtime in order to be used in `StfBlueprint`.
+///
+/// The `TxHooks` implementation sets up a transaction context based on the height at which it is
+/// to be executed.
 pub trait Runtime<C: Context, Da: DaSpec>:
     DispatchCall<Context = C>
     + Genesis<Context = C, Config = Self::GenesisConfig>
-    + TxHooks<Context = C>
+    + TxHooks<Context = C, PreArg = u64, PreResult = C, PostArg = ()>
     + SlotHooks<Da, Context = C>
     + FinalizeHook<Da, Context = C>
     + ApplyBlobHooks<

--- a/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
+++ b/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
@@ -179,7 +179,10 @@ where
             txs.into_iter().zip(messages.into_iter())
         {
             // Pre dispatch hook
-            let sender_address = match self.runtime.pre_dispatch_tx_hook(&tx, &mut batch_workspace)
+            let height = 1;
+            let ctx = match self
+                .runtime
+                .pre_dispatch_tx_hook(&tx, &mut batch_workspace, height)
             {
                 Ok(verified_tx) => verified_tx,
                 Err(e) => {
@@ -200,7 +203,6 @@ where
             // Commit changes after pre_dispatch_tx_hook
             batch_workspace = batch_workspace.checkpoint().to_revertable();
 
-            let ctx = C::new(sender_address.clone(), 1);
             let tx_result = self.runtime.dispatch_call(msg, &mut batch_workspace, &ctx);
 
             let events = batch_workspace.take_events();
@@ -233,7 +235,7 @@ where
 
             // TODO: `panic` will be covered in https://github.com/Sovereign-Labs/sovereign-sdk/issues/421
             self.runtime
-                .post_dispatch_tx_hook(&tx, &mut batch_workspace)
+                .post_dispatch_tx_hook(&tx, &mut batch_workspace, ())
                 .expect("Impossible happened: error in post_dispatch_tx_hook");
         }
 

--- a/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
+++ b/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
@@ -179,11 +179,11 @@ where
             txs.into_iter().zip(messages.into_iter())
         {
             // Pre dispatch hook
-            let height = 1;
-            let ctx = match self
-                .runtime
-                .pre_dispatch_tx_hook(&tx, &mut batch_workspace, height)
-            {
+            let sender_address = match self.runtime.pre_dispatch_tx_hook(
+                &tx,
+                &mut batch_workspace,
+                (),
+            ) {
                 Ok(verified_tx) => verified_tx,
                 Err(e) => {
                     // Don't revert any state changes made by the pre_dispatch_hook even if the Tx is rejected.
@@ -202,6 +202,9 @@ where
             };
             // Commit changes after pre_dispatch_tx_hook
             batch_workspace = batch_workspace.checkpoint().to_revertable();
+
+            let height = 1;
+            let ctx = C::new(sender_address, height);
 
             let tx_result = self.runtime.dispatch_call(msg, &mut batch_workspace, &ctx);
 

--- a/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
+++ b/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
@@ -9,7 +9,7 @@ use sov_rollup_interface::stf::{BatchReceipt, TransactionReceipt};
 use tracing::{debug, error};
 
 use crate::tx_verifier::{verify_txs_stateless, TransactionAndRawHash};
-use crate::{Batch, Runtime, SequencerOutcome, SlashingReason, TxEffect};
+use crate::{Batch, Runtime, RuntimeTxHook, SequencerOutcome, SlashingReason, TxEffect};
 
 type ApplyBatchResult<T, A> = Result<T, ApplyBatchError<A>>;
 
@@ -179,11 +179,15 @@ where
             txs.into_iter().zip(messages.into_iter())
         {
             // Pre dispatch hook
-            let sender_address = match self.runtime.pre_dispatch_tx_hook(
-                &tx,
-                &mut batch_workspace,
-                (),
-            ) {
+            // TODO set the sequencer pubkey
+            let hook = RuntimeTxHook {
+                height: 1,
+                sequencer: tx.pub_key().clone(),
+            };
+            let ctx = match self
+                .runtime
+                .pre_dispatch_tx_hook(&tx, &mut batch_workspace, hook)
+            {
                 Ok(verified_tx) => verified_tx,
                 Err(e) => {
                     // Don't revert any state changes made by the pre_dispatch_hook even if the Tx is rejected.
@@ -202,9 +206,6 @@ where
             };
             // Commit changes after pre_dispatch_tx_hook
             batch_workspace = batch_workspace.checkpoint().to_revertable();
-
-            let height = 1;
-            let ctx = C::new(sender_address, height);
 
             let tx_result = self.runtime.dispatch_call(msg, &mut batch_workspace, &ctx);
 
@@ -238,8 +239,8 @@ where
 
             // TODO: `panic` will be covered in https://github.com/Sovereign-Labs/sovereign-sdk/issues/421
             self.runtime
-                .post_dispatch_tx_hook(&tx, &mut batch_workspace, ())
-                .expect("Impossible happened: error in post_dispatch_tx_hook");
+                .post_dispatch_tx_hook(&tx, &ctx, &mut batch_workspace)
+                .expect("inconsistent state: error in post_dispatch_tx_hook");
         }
 
         // TODO: calculate the amount based of gas and fees


### PR DESCRIPTION
This commit introduces associated types to the `TxHooks` trait, enhancing its ability to define custom interactions between the trait and its implementing modules. The associated types allow for greater flexibility in the implementation of `TxHooks`, enabling diverse use cases beyond the current `Accounts` module.

The current `Accounts` implementation of `TxHooks` serves the purpose of extracting a public key from a transaction and mapping it to a rollup address, creating an execution context. This functionality is achieved through the `pre_dispatch_tx_hook` signature which returns a `C::Address`. However, this tight coupling with the `accounts` module restricts future expansions of `TxHooks`.

With this modification, hooks gain increased versatility and modules are free to implement them as per their requirements. Additionally, runtimes can consume these implementations, utilizing them as essential building blocks, while the banks module is empowered to enforce a gas cap on the pre-dispatch hook.