### PR TITLE
Re-org capabilities for `MockDa`

### DIFF
--- a/adapters/mock-da/src/service.rs
+++ b/adapters/mock-da/src/service.rs
@@ -59,10 +59,8 @@ impl PlannedFork {
 #[derive(Clone)]
 /// DaService used in tests.
 /// Currently only supports single blob per block.
-/// Finalized blocks are removed after being read, except last one.
-/// Height of the first submitted block is 0.
-/// It can be used in multithreaded environment with single reader and multiple submitters
-/// Multiple consumers produce inconsistent results.
+/// Height of the first submitted block is 1.
+/// Submitted blocks are kept indefinitely in memory.
 pub struct MockDaService {
     sequencer_da_address: MockAddress,
     blocks: Arc<RwLock<VecDeque<MockBlock>>>,
@@ -301,10 +299,7 @@ impl DaService for MockDaService {
                 height
             ))?;
 
-        // We still return error, as it is possible, that block has been consumed between `wait` and locking blocks
-        let block = blocks.get(index as usize).unwrap().clone();
-
-        Ok(block)
+        Ok(blocks.get(index as usize).unwrap().clone())
     }
 
     async fn get_last_finalized_block_header(


### PR DESCRIPTION
# Description

This PR adds capability to emulate forks in `MockDa`.

It can be done in 2 ways:

1. Directly by calling `MockDa::fork_at(&self, height: u64, blobs: Vec<Vec<u8>>)`, where `height` is any non finalized height.
2. Indirectly by setting `PlannedFork`: `MockDa::set_planned_fork(&self, planned_fork: PlannedFork)`:

```rust
pub struct PlannedFork {
    trigger_at_height: u64,
    fork_height: u64,
    blobs: Vec<Vec<u8>>,
}
```

Which will perform fork when `get_block` will be called with height equal to `trigger_at_height`.


### Another changes

 * `MockDa` now stores submitted blocks forever. It simplifies internal machinery of the `MockDa` and also makes it more flexible to use, as blocks won't disappear. Downside of potential memory leak is considered acceptable.


## Linked Issues
- Fixes #1222 
- Related to #1023 

## Testing
Tests have been added

## Docs
Documentation has been updated
