### PR TITLE
`sov-stf-runner` handle fork change

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 # On Rust, GitHub Actions, and caching
 # ===========
-# Here's a list of things to keep in mind if you find yourself maintaing this
+# Here's a list of things to keep in mind if you find yourself maintaining this
 # CI:
 #
 # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
@@ -26,7 +26,7 @@ name: Rust
 # - Learn cache invalidation rules of `Swatinem/rust-cache` before making
 #   changes, e.g. what happens when `rustc --version` changes or `Cargo.lock`
 #   changes (or is missing).
-# - The jobs dependency tree is the way it is to accomodate for sharing caches,
+# - The jobs dependency tree is the way it is to accommodate for sharing caches,
 #   not necessarily because it makes logical sense to run one job after the
 #   other. This is due to the fact that we can't share caches between jobs that
 #   run in parallel.
@@ -156,7 +156,7 @@ jobs:
   hack:
     name: features
     # `cargo-hack` uses the same profile as `cargo check` and doesn't require
-    # building dependencies, only chceking them, so we can share caches
+    # building dependencies, only checking them, so we can share caches
     # effectively.
     needs: check
     runs-on: buildjet-8vcpu-ubuntu-2204

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9231,6 +9231,7 @@ dependencies = [
  "tokio",
  "toml 0.8.8",
  "tracing",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]

--- a/examples/demo-rollup/tests/evm/mod.rs
+++ b/examples/demo-rollup/tests/evm/mod.rs
@@ -6,7 +6,6 @@ use std::str::FromStr;
 use demo_stf::genesis_config::GenesisPaths;
 use ethers_core::abi::Address;
 use ethers_signers::{LocalWallet, Signer};
-use sov_demo_rollup::initialize_logging;
 use sov_evm::SimpleStorageContract;
 use sov_stf_runner::RollupProverConfig;
 use test_client::TestClient;
@@ -18,7 +17,6 @@ use crate::test_helpers::start_rollup;
 #[tokio::test]
 async fn evm_tx_tests() -> Result<(), anyhow::Error> {
     let (port_tx, port_rx) = tokio::sync::oneshot::channel();
-    initialize_logging();
 
     let rollup_task = tokio::spawn(async {
         // Don't provide a prover since the EVM is not currently provable

--- a/full-node/sov-stf-runner/Cargo.toml
+++ b/full-node/sov-stf-runner/Cargo.toml
@@ -46,7 +46,9 @@ sov-stf-runner = { path = ".", features = ["mock"] }
 
 sov-mock-da = { path = "../../adapters/mock-da", features = ["native"] }
 sov-mock-zkvm = { path = "../../adapters/mock-zkvm" }
-sov-prover-storage-manager = { path = "../sov-prover-storage-manager" }
+sov-prover-storage-manager = { path = "../sov-prover-storage-manager", features = ["test-utils"] }
+
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
 
 [features]

--- a/full-node/sov-stf-runner/src/runner.rs
+++ b/full-node/sov-stf-runner/src/runner.rs
@@ -215,6 +215,7 @@ where
                 .storage_manager
                 .create_storage_on(filtered_block.header())?;
             let slot_result = self.stf.apply_slot(
+                // TODO(https://github.com/Sovereign-Labs/sovereign-sdk/issues/1247): incorrect pre-state root in case of re-org
                 &self.state_root,
                 pre_state,
                 Default::default(),
@@ -234,6 +235,7 @@ where
 
             let transition_data: StateTransitionData<Stf::StateRoot, Stf::Witness, Da::Spec> =
                 StateTransitionData {
+                    // TODO(https://github.com/Sovereign-Labs/sovereign-sdk/issues/1247): incorrect pre-state root in case of re-org
                     pre_state_root: self.state_root.clone(),
                     da_block_header: filtered_block.header().clone(),
                     inclusion_proof,
@@ -280,7 +282,6 @@ where
 
             seen_receipts.push_back(data_to_commit);
 
-            // TODO: What about state root on reorg
             self.state_root = next_state_root;
             seen_block_headers.push_back(filtered_block.header().clone());
             height += 1;

--- a/full-node/sov-stf-runner/src/runner.rs
+++ b/full-node/sov-stf-runner/src/runner.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::net::SocketAddr;
 
 use jsonrpsee::RpcModule;
@@ -165,12 +166,32 @@ where
 
     /// Runs the rollup.
     pub async fn run_in_process(&mut self) -> Result<(), anyhow::Error> {
-        for height in self.start_height.. {
+        let mut seen_block_headers: VecDeque<<Da::Spec as DaSpec>::BlockHeader> = VecDeque::new();
+        let mut seen_receipts: VecDeque<_> = VecDeque::new();
+        let mut height = self.start_height;
+        loop {
             debug!("Requesting data for height {}", height);
-            // TODO(https://github.com/Sovereign-Labs/sovereign-sdk/issues/1217)
-            // STF runner should handle re-org
-            // Assumes we are on chains with instant finality and no change of head happens
-            let filtered_block = self.da_service.get_block_at(height).await?;
+            let mut filtered_block = self.da_service.get_block_at(height).await?;
+
+            // Checking if reorg happened or not.
+            if let Some(prev_block_header) = seen_block_headers.back() {
+                if prev_block_header.hash() != filtered_block.header().prev_hash() {
+                    tracing::warn!("Block at height={} does not belong in current chain. Chain has forked. Traversing backwards", height);
+                    while let Some(seen_block_header) = seen_block_headers.pop_back() {
+                        seen_receipts.pop_back();
+                        let block = self
+                            .da_service
+                            .get_block_at(seen_block_header.height())
+                            .await?;
+                        if block.header().prev_hash() == seen_block_header.prev_hash() {
+                            height = seen_block_header.height();
+                            filtered_block = block;
+                            break;
+                        }
+                    }
+                    tracing::info!("Resuming execution on height={}", height);
+                }
+            }
 
             let mut blobs = self.da_service.extract_relevant_blobs(&filtered_block);
 
@@ -223,12 +244,8 @@ where
 
             self.storage_manager
                 .save_change_set(filtered_block.header(), slot_result.change_set)?;
-            // TODO: This should be in different thread https://github.com/Sovereign-Labs/sovereign-sdk/issues/1217
-            let last_finalized = self.da_service.get_last_finalized_block_header().await?;
-            if last_finalized.height() >= filtered_block.header().height() {
-                self.storage_manager.finalize(filtered_block.header())?;
-            }
 
+            // ----------------
             // Create ZK proof.
             {
                 let header_hash = transition_data.da_block_header.hash();
@@ -261,11 +278,43 @@ where
             }
             let next_state_root = slot_result.state_root;
 
-            self.ledger_db.commit_slot(data_to_commit)?;
-            self.state_root = next_state_root;
-        }
+            seen_receipts.push_back(data_to_commit);
 
-        Ok(())
+            // TODO: What about state root on reorg
+            self.state_root = next_state_root;
+            seen_block_headers.push_back(filtered_block.header().clone());
+            height += 1;
+
+            // ----------------
+            // Finalization. Done after seen block for proper handling of instant finality
+            // Can be moved to another thread to improve throughput
+            let last_finalized = self.da_service.get_last_finalized_block_header().await?;
+            // For safety we finalize blocks one by one
+            tracing::info!(
+                "Last finalized header height is {}, ",
+                last_finalized.height()
+            );
+            // Checking all seen blocks, in case if there was delay in getting last finalized header.
+            while let Some(earliest_seen_header) = seen_block_headers.get(0) {
+                tracing::debug!(
+                    "Checking seen header height={}",
+                    earliest_seen_header.height()
+                );
+                if earliest_seen_header.height() <= last_finalized.height() {
+                    tracing::debug!(
+                        "Finalizing seen header height={}",
+                        earliest_seen_header.height()
+                    );
+                    self.storage_manager.finalize(earliest_seen_header)?;
+                    seen_block_headers.pop_front();
+                    let receipts = seen_receipts.pop_front().unwrap();
+                    self.ledger_db.commit_slot(receipts)?;
+                    continue;
+                }
+
+                break;
+            }
+        }
     }
 
     /// Allows to read current state root

--- a/full-node/sov-stf-runner/tests/hash_stf.rs
+++ b/full-node/sov-stf-runner/tests/hash_stf.rs
@@ -217,11 +217,7 @@ pub fn get_result_from_blocks(
                  ArrayWitness::default(),
                  &block.header,
                  &block.validity_cond,
-                 &mut blobs,
-        ProverServiceConfig {
-            aggregated_proof_block_jump: 1,
-        },
-    );
+                 &mut blobs);
 
         state_root = result.state_root;
         storage = result.change_set;

--- a/full-node/sov-stf-runner/tests/runner_initialization_tests.rs
+++ b/full-node/sov-stf-runner/tests/runner_initialization_tests.rs
@@ -1,0 +1,117 @@
+use sov_db::ledger_db::LedgerDB;
+use sov_mock_da::{
+    MockAddress, MockBlockHeader, MockDaConfig, MockDaService, MockDaSpec, MockDaVerifier,
+    MockValidityCond,
+};
+use sov_mock_zkvm::MockZkvm;
+use sov_prover_storage_manager::ProverStorageManager;
+use sov_rollup_interface::storage::HierarchicalStorageManager;
+use sov_state::{ArrayWitness, DefaultStorageSpec};
+use sov_stf_runner::{
+    InitVariant, ParallelProverService, RollupConfig, RollupProverConfig, RpcConfig, RunnerConfig,
+    StateTransitionRunner, StorageConfig,
+};
+
+mod hash_stf;
+
+use hash_stf::HashStf;
+
+type MockInitVariant = InitVariant<HashStf<MockValidityCond>, MockZkvm, MockDaSpec>;
+
+type S = DefaultStorageSpec;
+type StorageManager = ProverStorageManager<MockDaSpec, S>;
+
+#[tokio::test]
+async fn init_and_restart() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let genesis_params = vec![1, 2, 3, 4, 5];
+    let init_variant: MockInitVariant = InitVariant::Genesis {
+        block_header: MockBlockHeader::from_height(0),
+        genesis_params,
+    };
+
+    let state_root_after_genesis = {
+        let runner = initialize_runner(tmpdir.path(), init_variant);
+        *runner.get_state_root()
+    };
+
+    let init_variant_2: MockInitVariant = InitVariant::Initialized(state_root_after_genesis);
+
+    let runner_2 = initialize_runner(tmpdir.path(), init_variant_2);
+
+    let state_root_2 = *runner_2.get_state_root();
+
+    assert_eq!(state_root_after_genesis, state_root_2);
+}
+
+type MockProverService = ParallelProverService<
+    [u8; 32],
+    ArrayWitness,
+    MockDaService,
+    MockZkvm,
+    HashStf<MockValidityCond>,
+>;
+fn initialize_runner(
+    path: &std::path::Path,
+    init_variant: MockInitVariant,
+) -> StateTransitionRunner<
+    HashStf<MockValidityCond>,
+    StorageManager,
+    MockDaService,
+    MockZkvm,
+    MockProverService,
+> {
+    let address = MockAddress::new([11u8; 32]);
+    let rollup_config = RollupConfig::<MockDaConfig> {
+        storage: StorageConfig {
+            path: path.to_path_buf(),
+        },
+        runner: RunnerConfig {
+            start_height: 1,
+            rpc_config: RpcConfig {
+                bind_host: "127.0.0.1".to_string(),
+                bind_port: 0,
+            },
+        },
+        da: MockDaConfig {
+            sender_address: address,
+        },
+    };
+
+    let da_service = MockDaService::new(address);
+
+    let ledger_db = LedgerDB::with_path(path).unwrap();
+
+    let stf = HashStf::<MockValidityCond>::new();
+
+    let storage_config = sov_state::config::Config {
+        path: path.to_path_buf(),
+    };
+    let mut storage_manager = ProverStorageManager::new(storage_config).unwrap();
+
+    let vm = MockZkvm::default();
+    let verifier = MockDaVerifier::default();
+
+    let prover_config = RollupProverConfig::Prove;
+
+    let prover_service = ParallelProverService::new(
+        vm,
+        stf.clone(),
+        verifier,
+        prover_config,
+        // Should be ZkStorage, but we don't need it for this test
+        storage_manager.create_finalized_storage().unwrap(),
+        1,
+    );
+
+    StateTransitionRunner::new(
+        rollup_config.runner,
+        da_service,
+        ledger_db,
+        stf,
+        storage_manager,
+        init_variant,
+        prover_service,
+    )
+    .unwrap()
+}

--- a/full-node/sov-stf-runner/tests/runner_initialization_tests.rs
+++ b/full-node/sov-stf-runner/tests/runner_initialization_tests.rs
@@ -8,8 +8,8 @@ use sov_prover_storage_manager::ProverStorageManager;
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_state::{ArrayWitness, DefaultStorageSpec};
 use sov_stf_runner::{
-    InitVariant, ParallelProverService, RollupConfig, RollupProverConfig, RpcConfig, RunnerConfig,
-    StateTransitionRunner, StorageConfig,
+    InitVariant, ParallelProverService, ProverServiceConfig, RollupConfig, RollupProverConfig,
+    RpcConfig, RunnerConfig, StateTransitionRunner, StorageConfig,
 };
 
 mod hash_stf;
@@ -76,6 +76,9 @@ fn initialize_runner(
         da: MockDaConfig {
             sender_address: address,
         },
+        prover_service: ProverServiceConfig {
+            aggregated_proof_block_jump: 1,
+        },
     };
 
     let da_service = MockDaService::new(address);
@@ -102,6 +105,7 @@ fn initialize_runner(
         // Should be ZkStorage, but we don't need it for this test
         storage_manager.create_finalized_storage().unwrap(),
         1,
+        rollup_config.prover_service,
     );
 
     StateTransitionRunner::new(

--- a/full-node/sov-stf-runner/tests/runner_reorg_tests.rs
+++ b/full-node/sov-stf-runner/tests/runner_reorg_tests.rs
@@ -1,0 +1,215 @@
+use sov_mock_da::{
+    MockAddress, MockBlob, MockBlock, MockBlockHeader, MockDaConfig, MockDaService, MockDaSpec,
+    MockDaVerifier, MockValidityCond, PlannedFork,
+};
+use sov_mock_zkvm::MockZkvm;
+use sov_stf_runner::{
+    InitVariant, ParallelProverService, RollupConfig, RollupProverConfig, RpcConfig, RunnerConfig,
+    StateTransitionRunner, StorageConfig,
+};
+
+mod hash_stf;
+
+use hash_stf::{get_result_from_blocks, HashStf, Q, S};
+use sov_db::ledger_db::LedgerDB;
+use sov_prover_storage_manager::ProverStorageManager;
+use sov_rollup_interface::services::da::DaService;
+use sov_rollup_interface::storage::HierarchicalStorageManager;
+use sov_state::storage::NativeStorage;
+use sov_state::{ProverStorage, Storage};
+
+type MockInitVariant = InitVariant<HashStf<MockValidityCond>, MockZkvm, MockDaSpec>;
+#[tokio::test]
+async fn test_simple_reorg_case() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let sequencer_address = MockAddress::new([11u8; 32]);
+    let genesis_params = vec![1, 2, 3, 4, 5];
+
+    let main_chain_blobs = vec![
+        vec![1, 1, 1, 1],
+        vec![2, 2, 2, 2],
+        vec![3, 3, 3, 3],
+        vec![4, 4, 4, 4],
+    ];
+    let fork_blobs = vec![
+        vec![13, 13, 13, 13],
+        vec![14, 14, 14, 14],
+        vec![15, 15, 15, 15],
+    ];
+    let expected_final_blobs = vec![
+        vec![1, 1, 1, 1],
+        vec![2, 2, 2, 2],
+        vec![13, 13, 13, 13],
+        vec![14, 14, 14, 14],
+        vec![15, 15, 15, 15],
+    ];
+
+    let mut da_service = MockDaService::with_finality(sequencer_address, 4);
+    da_service.set_wait_attempts(2);
+
+    let genesis_header = da_service.get_last_finalized_block_header().await.unwrap();
+
+    let planned_fork = PlannedFork::new(5, 2, fork_blobs.clone());
+    da_service.set_planned_fork(planned_fork).await.unwrap();
+
+    for b in &main_chain_blobs {
+        da_service.send_transaction(b).await.unwrap();
+    }
+
+    let (expected_state_root, _expected_final_root_hash) =
+        get_expected_execution_hash_from(&genesis_params, expected_final_blobs);
+    let (_expected_committed_state_root, expected_committed_root_hash) =
+        get_expected_execution_hash_from(&genesis_params, vec![vec![1, 1, 1, 1]]);
+
+    let init_variant: MockInitVariant = InitVariant::Genesis {
+        block_header: genesis_header,
+        genesis_params,
+    };
+
+    let (before, after) = runner_execution(tmpdir.path(), init_variant, da_service).await;
+    assert_ne!(before, after);
+    assert_eq!(expected_state_root, after);
+
+    let committed_root_hash = get_saved_root_hash(tmpdir.path()).unwrap().unwrap();
+
+    assert_eq!(expected_committed_root_hash.unwrap(), committed_root_hash);
+}
+
+#[tokio::test]
+#[ignore = "TBD"]
+async fn test_several_reorgs() {}
+
+#[tokio::test]
+async fn test_instant_finality_data_stored() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let sequencer_address = MockAddress::new([11u8; 32]);
+    let genesis_params = vec![1, 2, 3, 4, 5];
+
+    let mut da_service = MockDaService::new(sequencer_address);
+    da_service.set_wait_attempts(2);
+
+    let genesis_header = da_service.get_last_finalized_block_header().await.unwrap();
+
+    da_service.send_transaction(&[1, 1, 1, 1]).await.unwrap();
+    da_service.send_transaction(&[2, 2, 2, 2]).await.unwrap();
+    da_service.send_transaction(&[3, 3, 3, 3]).await.unwrap();
+
+    let (expected_state_root, expected_root_hash) = get_expected_execution_hash_from(
+        &genesis_params,
+        vec![vec![1, 1, 1, 1], vec![2, 2, 2, 2], vec![3, 3, 3, 3]],
+    );
+
+    let init_variant: MockInitVariant = InitVariant::Genesis {
+        block_header: genesis_header,
+        genesis_params,
+    };
+
+    let (before, after) = runner_execution(tmpdir.path(), init_variant, da_service).await;
+    assert_ne!(before, after);
+    assert_eq!(expected_state_root, after);
+
+    let saved_root_hash = get_saved_root_hash(tmpdir.path()).unwrap().unwrap();
+
+    assert_eq!(expected_root_hash.unwrap(), saved_root_hash);
+}
+
+async fn runner_execution(
+    path: &std::path::Path,
+    init_variant: MockInitVariant,
+    da_service: MockDaService,
+) -> ([u8; 32], [u8; 32]) {
+    let rollup_config = RollupConfig::<MockDaConfig> {
+        storage: StorageConfig {
+            path: path.to_path_buf(),
+        },
+        runner: RunnerConfig {
+            start_height: 1,
+            rpc_config: RpcConfig {
+                bind_host: "127.0.0.1".to_string(),
+                bind_port: 0,
+            },
+        },
+        da: MockDaConfig {
+            sender_address: da_service.get_sequencer_address(),
+        },
+    };
+
+    let ledger_db = LedgerDB::with_path(path).unwrap();
+
+    let stf = HashStf::<MockValidityCond>::new();
+
+    let storage_config = sov_state::config::Config {
+        path: rollup_config.storage.path.clone(),
+    };
+    let mut storage_manager = ProverStorageManager::new(storage_config).unwrap();
+
+    let vm = MockZkvm::default();
+    let verifier = MockDaVerifier::default();
+    let prover_config = RollupProverConfig::Skip;
+
+    let prover_service = ParallelProverService::new(
+        vm,
+        stf.clone(),
+        verifier,
+        prover_config,
+        // Should be ZkStorage, but we don't need it for this test
+        storage_manager.create_finalized_storage().unwrap(),
+        1,
+    );
+
+    let mut runner = StateTransitionRunner::new(
+        rollup_config.runner,
+        da_service,
+        ledger_db,
+        stf,
+        storage_manager,
+        init_variant,
+        prover_service,
+    )
+    .unwrap();
+
+    let before = *runner.get_state_root();
+    let end = runner.run_in_process().await;
+    assert!(end.is_err());
+    let after = *runner.get_state_root();
+
+    (before, after)
+}
+
+fn get_saved_root_hash(
+    path: &std::path::Path,
+) -> anyhow::Result<Option<<ProverStorage<S, Q> as Storage>::Root>> {
+    let storage_config = sov_state::config::Config {
+        path: path.to_path_buf(),
+    };
+    let mut storage_manager = ProverStorageManager::<MockDaSpec, S>::new(storage_config).unwrap();
+    let finalized_storage = storage_manager.create_finalized_storage()?;
+
+    let ledger_db = LedgerDB::with_path(path).unwrap();
+
+    ledger_db
+        .get_head_slot()?
+        .map(|(number, _)| finalized_storage.get_root_hash(number.0))
+        .transpose()
+}
+
+fn get_expected_execution_hash_from(
+    genesis_params: &[u8],
+    blobs: Vec<Vec<u8>>,
+) -> ([u8; 32], Option<<ProverStorage<S, Q> as Storage>::Root>) {
+    let blocks: Vec<MockBlock> = blobs
+        .into_iter()
+        .enumerate()
+        .map(|(idx, blob)| MockBlock {
+            header: MockBlockHeader::from_height((idx + 1) as u64),
+            validity_cond: MockValidityCond::default(),
+            blobs: vec![MockBlob::new(
+                blob,
+                MockAddress::new([11u8; 32]),
+                [idx as u8; 32],
+            )],
+        })
+        .collect();
+
+    get_result_from_blocks(genesis_params, &blocks[..])
+}

--- a/full-node/sov-stf-runner/tests/runner_reorg_tests.rs
+++ b/full-node/sov-stf-runner/tests/runner_reorg_tests.rs
@@ -4,8 +4,8 @@ use sov_mock_da::{
 };
 use sov_mock_zkvm::MockZkvm;
 use sov_stf_runner::{
-    InitVariant, ParallelProverService, RollupConfig, RollupProverConfig, RpcConfig, RunnerConfig,
-    StateTransitionRunner, StorageConfig,
+    InitVariant, ParallelProverService, ProverServiceConfig, RollupConfig, RollupProverConfig,
+    RpcConfig, RunnerConfig, StateTransitionRunner, StorageConfig,
 };
 
 mod hash_stf;
@@ -132,6 +132,9 @@ async fn runner_execution(
         da: MockDaConfig {
             sender_address: da_service.get_sequencer_address(),
         },
+        prover_service: ProverServiceConfig {
+            aggregated_proof_block_jump: 1,
+        },
     };
 
     let ledger_db = LedgerDB::with_path(path).unwrap();
@@ -155,6 +158,7 @@ async fn runner_execution(
         // Should be ZkStorage, but we don't need it for this test
         storage_manager.create_finalized_storage().unwrap(),
         1,
+        rollup_config.prover_service,
     );
 
     let mut runner = StateTransitionRunner::new(


### PR DESCRIPTION
# Description

`StateTransitionRunner` handles reorgs:

* Tracing back to last seen block and starting from there
* Saving ledger DB only on finalization

## Linked Issues
- Fixes #1217 

## Testing
Integration tests for `StateTransitionRunner` has been added

## Docs
No relevant documentation update is required.
