### PR TITLE
Implement display for blockhashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8559,6 +8559,7 @@ dependencies = [
  "borsh",
  "bytes",
  "futures",
+ "hex",
  "parity-scale-codec",
  "pin-project",
  "primitive-types",

--- a/adapters/avail/Cargo.toml
+++ b/adapters/avail/Cargo.toml
@@ -34,6 +34,7 @@ reqwest = { version = "0.11", features = ["json"], optional = true }
 thiserror = { workspace = true }
 sp-keyring = { version = "24", optional = true }
 sp-core = { version = "21", optional = true }
+hex = { workspace = true }
 
 [features]
 default = ["native"]

--- a/adapters/avail/src/spec/hash.rs
+++ b/adapters/avail/src/spec/hash.rs
@@ -13,6 +13,12 @@ impl AvailHash {
 
 impl BlockHashTrait for AvailHash {}
 
+impl core::fmt::Display for AvailHash {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0x{}", hex::encode(&self.0))
+    }
+}
+
 impl AsRef<[u8]> for AvailHash {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()

--- a/adapters/avail/src/spec/hash.rs
+++ b/adapters/avail/src/spec/hash.rs
@@ -15,7 +15,7 @@ impl BlockHashTrait for AvailHash {}
 
 impl core::fmt::Display for AvailHash {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "0x{}", hex::encode(&self.0))
+        write!(f, "0x{}", hex::encode(self.0))
     }
 }
 

--- a/adapters/celestia/src/verifier/mod.rs
+++ b/adapters/celestia/src/verifier/mod.rs
@@ -68,6 +68,12 @@ impl AsRef<[u8]> for TmHash {
     }
 }
 
+impl core::fmt::Display for TmHash {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0x{}", hex::encode(&self.0))
+    }
+}
+
 impl TmHash {
     pub fn inner(&self) -> &[u8; 32] {
         match self.0 {

--- a/adapters/celestia/src/verifier/mod.rs
+++ b/adapters/celestia/src/verifier/mod.rs
@@ -70,7 +70,7 @@ impl AsRef<[u8]> for TmHash {
 
 impl core::fmt::Display for TmHash {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "0x{}", hex::encode(&self.0))
+        write!(f, "0x{}", hex::encode(self.0))
     }
 }
 

--- a/adapters/mock-da/src/types/mod.rs
+++ b/adapters/mock-da/src/types/mod.rs
@@ -31,6 +31,12 @@ impl Debug for MockHash {
     }
 }
 
+impl core::fmt::Display for MockHash {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0x{}", hex::encode(&self.0))
+    }
+}
+
 impl AsRef<[u8]> for MockHash {
     fn as_ref(&self) -> &[u8] {
         &self.0

--- a/adapters/mock-da/src/types/mod.rs
+++ b/adapters/mock-da/src/types/mod.rs
@@ -33,7 +33,7 @@ impl Debug for MockHash {
 
 impl core::fmt::Display for MockHash {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "0x{}", hex::encode(&self.0))
+        write!(f, "0x{}", hex::encode(self.0))
     }
 }
 

--- a/rollup-interface/src/state_machine/da.rs
+++ b/rollup-interface/src/state_machine/da.rs
@@ -187,7 +187,7 @@ pub trait BlockHashTrait:
 /// A block header, typically used in the context of an underlying DA blockchain.
 pub trait BlockHeaderTrait: PartialEq + Debug + Clone + Serialize + DeserializeOwned {
     /// Each block header must have a unique canonical hash.
-    type Hash: Clone;
+    type Hash: Clone + core::fmt::Display;
 
     /// Each block header must contain the hash of the previous block.
     fn prev_hash(&self) -> Self::Hash;


### PR DESCRIPTION
# Description
Add a `core::fmt::Display` bound to the `Da::BlockHash` type. This should close #1244, since `BasicAddress` already has a `Display` bound. 

@citizen-stig, please confirm that there are no other bounds which need to be added.

## Linked Issues
- Fixes #1244

