### PR TITLE
Update to mainline bcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,15 +692,6 @@ dependencies = [
 
 [[package]]
 name = "bcs"
-version = "0.1.4"
-source = "git+https://github.com/preston-evans98/bcs.git?rev=e4f1861#e4f1861509a996408baa540cda1f88c290214ce1"
-dependencies = [
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "bcs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
@@ -8531,7 +8522,7 @@ name = "sov-attester-incentives"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "bcs 0.1.4",
+ "bcs",
  "borsh",
  "jmt",
  "serde",
@@ -9237,7 +9228,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "bcs 0.1.6",
+ "bcs",
  "borsh",
  "hex",
  "jmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ borsh = { version = "0.10.3", default-features = false }
 # TODO: Consider replacing this serialization format
 #     https://github.com/Sovereign-Labs/sovereign-sdk/issues/283
 bincode = "1.3.3"
-bcs = "0.1.5"
+bcs = "0.1.6"
 byteorder = { version = "1.5.0", default-features = false }
 bytes = { version = "1.2.1", default-features = false }
 digest = { version = "0.10.6", default-features = false, features = ["alloc"] }

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -224,9 +224,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bcs"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd3ffe8b19a604421a5d461d4a70346223e535903fbc3067138bddbebddcf77"
+checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
 dependencies = [
  "serde",
  "thiserror",

--- a/module-system/module-implementations/sov-attester-incentives/Cargo.toml
+++ b/module-system/module-implementations/sov-attester-incentives/Cargo.toml
@@ -25,7 +25,7 @@ sov-prover-storage-manager = { path = "../../../full-node/sov-prover-storage-man
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
-bcs = { git = "https://github.com/preston-evans98/bcs.git", rev = "e4f1861" }
+bcs =  { workspace = true }
 jmt = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
# Description
This PR switches from my private fork of bcs to the main upstream. This is possible since our PR for deserialization `from_reader` is now merged.

