### PR TITLE
Fixes for Rust 1.75 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8799,6 +8799,7 @@ dependencies = [
  "demo-stf",
  "ethers",
  "jsonrpsee 0.20.3",
+ "proptest",
  "reth-primitives",
  "reth-rpc-types",
  "schnellru",

--- a/full-node/sov-ethereum/Cargo.toml
+++ b/full-node/sov-ethereum/Cargo.toml
@@ -35,6 +35,7 @@ schnellru = "0.2.1"
 
 [dev-dependencies]
 tokio = { workspace = true }
+proptest = { workspace = true }
 
 
 [features]

--- a/full-node/sov-ethereum/src/gas_price/gas_oracle.rs
+++ b/full-node/sov-ethereum/src/gas_price/gas_oracle.rs
@@ -3,8 +3,6 @@
 
 // Adopted from: https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/gas_oracle.rs
 
-use std::array::TryFromSliceError;
-
 use reth_primitives::constants::GWEI_TO_WEI;
 use reth_primitives::{H256, U256, U64};
 use reth_rpc_types::BlockTransactions;
@@ -141,7 +139,7 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
         let mut results = Vec::new();
         let mut populated_blocks = 0;
 
-        let header_number = convert_u256_to_u64(header.number.unwrap()).unwrap();
+        let header_number = convert_u256_to_u64(header.number.unwrap());
 
         // we only check a maximum of 2 * max_block_history, or the number of blocks in the chain
         let max_blocks = if self.oracle_config.max_block_history * 2 > header_number {
@@ -303,14 +301,19 @@ fn effective_gas_tip(
     }
 }
 
-fn convert_u256_to_u64(u256: U256) -> Result<u64, TryFromSliceError> {
+/// Takes only 8 least significant bytes
+fn convert_u256_to_u64(u256: U256) -> u64 {
     let bytes: [u8; 32] = u256.to_be_bytes();
-    let bytes: [u8; 8] = bytes[24..].try_into()?;
-    Ok(u64::from_be_bytes(bytes))
+    // 32 - 24 = 8, so it should always fit into destination array.
+    // Unless allocation or something weird
+    let bytes: [u8; 8] = bytes[24..].try_into().unwrap();
+    u64::from_be_bytes(bytes)
 }
 
 #[cfg(test)]
 mod tests {
+    use proptest::arbitrary::any;
+    use proptest::proptest;
     use reth_primitives::constants::GWEI_TO_WEI;
 
     use super::*;
@@ -324,5 +327,29 @@ mod tests {
     #[test]
     fn ignore_price_sanity() {
         assert_eq!(DEFAULT_IGNORE_PRICE, U256::from(2u64));
+    }
+
+    proptest! {
+
+        #[test]
+        fn converts_back_and_forth(input in any::<u64>()) {
+            let mut bytes: [u8; 32] = [0; 32];
+            for (i, b) in input.to_be_bytes().into_iter().enumerate() {
+                let idx = 24 + i;
+                bytes[idx] = b;
+            }
+
+
+            let u256 = U256::from_be_slice(&bytes);
+            let output = convert_u256_to_u64(u256);
+
+            assert_eq!(input, output);
+        }
+
+        #[test]
+        fn convert_u256_to_u64_doesnt_panic(input in any::<[u8; 32]>()) {
+            let u256 = U256::from_be_slice(&input);
+            let _output = convert_u256_to_u64(u256);
+        }
     }
 }

--- a/full-node/sov-ethereum/src/gas_price/gas_oracle.rs
+++ b/full-node/sov-ethereum/src/gas_price/gas_oracle.rs
@@ -303,6 +303,12 @@ fn effective_gas_tip(
     }
 }
 
+fn convert_u256_to_u64(u256: U256) -> Result<u64, TryFromSliceError> {
+    let bytes: [u8; 32] = u256.to_be_bytes();
+    let bytes: [u8; 8] = bytes[24..].try_into()?;
+    Ok(u64::from_be_bytes(bytes))
+}
+
 #[cfg(test)]
 mod tests {
     use reth_primitives::constants::GWEI_TO_WEI;
@@ -319,10 +325,4 @@ mod tests {
     fn ignore_price_sanity() {
         assert_eq!(DEFAULT_IGNORE_PRICE, U256::from(2u64));
     }
-}
-
-fn convert_u256_to_u64(u256: reth_primitives::U256) -> Result<u64, TryFromSliceError> {
-    let bytes: [u8; 32] = u256.to_be_bytes();
-    let bytes: [u8; 8] = bytes[24..].try_into()?;
-    Ok(u64::from_be_bytes(bytes))
 }

--- a/full-node/sov-stf-runner/src/runner.rs
+++ b/full-node/sov-stf-runner/src/runner.rs
@@ -298,7 +298,7 @@ where
                 last_finalized.height()
             );
             // Checking all seen blocks, in case if there was delay in getting last finalized header.
-            while let Some(earliest_seen_header) = seen_block_headers.get(0) {
+            while let Some(earliest_seen_header) = seen_block_headers.front() {
                 tracing::debug!(
                     "Checking seen header height={}",
                     earliest_seen_header.height()

--- a/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -3,7 +3,6 @@
 
 /// Contains the call methods used by the module
 mod call;
-pub use call::*;
 #[cfg(test)]
 mod tests;
 

--- a/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -156,13 +156,13 @@ where
     pub fn finalize_hook(
         &self,
         root_hash: &<<C as Spec>::Storage as Storage>::Root,
-        accesorry_working_set: &mut AccessoryWorkingSet<C>,
+        accessory_working_set: &mut AccessoryWorkingSet<C>,
     ) {
-        let expected_block_number = self.blocks.len(accesorry_working_set) as u64;
+        let expected_block_number = self.blocks.len(accessory_working_set) as u64;
 
         let mut block = self
             .pending_head
-            .get(accesorry_working_set)
+            .get(accessory_working_set)
             .unwrap_or_else(|| {
                 panic!(
                     "Pending head must be set to block {}, but was empty",
@@ -181,12 +181,12 @@ where
 
         let sealed_block = block.seal();
 
-        self.blocks.push(&sealed_block, accesorry_working_set);
+        self.blocks.push(&sealed_block, accessory_working_set);
         self.block_hashes.set(
             &sealed_block.header.hash,
             &sealed_block.header.number,
-            accesorry_working_set,
+            accessory_working_set,
         );
-        self.pending_head.delete(accesorry_working_set);
+        self.pending_head.delete(accessory_working_set);
     }
 }

--- a/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/module-system/module-implementations/sov-evm/src/lib.rs
@@ -9,7 +9,7 @@ mod genesis;
 #[cfg(feature = "experimental")]
 mod hooks;
 #[cfg(feature = "experimental")]
-pub use {call::*, error::rpc::*, evm::*, genesis::*, hooks::*};
+pub use {call::*, error::rpc::*, evm::*, genesis::*};
 #[cfg(feature = "native")]
 #[cfg(feature = "experimental")]
 mod query;

--- a/module-system/module-implementations/sov-nft-module/src/offchain.rs
+++ b/module-system/module-implementations/sov-nft-module/src/offchain.rs
@@ -77,7 +77,7 @@ pub fn update_nft<C: sov_modules_api::Context>(nft: &Nft<C>, old_owner: Option<O
                 )
                 .unwrap();
 
-            let db_owner: Option<String> = rows.get(0).map(|row| row.get(0));
+            let db_owner: Option<String> = rows.first().map(|row| row.get(0));
 
             // Handle ownership change logic for top_owners table
             if let Some(db_owner_str) = db_owner {

--- a/module-system/sov-modules-api/src/pub_key_hex.rs
+++ b/module-system/sov-modules-api/src/pub_key_hex.rs
@@ -80,6 +80,14 @@ impl TryFrom<&PublicKeyHex> for DefaultPublicKey {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for PublicKeyHex {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let hex: String = hex::encode(String::arbitrary(u)?);
+        Ok(PublicKeyHex::try_from(hex).unwrap())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use sov_modules_core::PrivateKey;
@@ -90,7 +98,7 @@ mod tests {
     #[test]
     fn test_pub_key_hex() {
         let pub_key = DefaultPrivateKey::generate().pub_key();
-        let pub_key_hex = PublicKeyHex::try_from(&pub_key).unwrap();
+        let pub_key_hex = PublicKeyHex::from(&pub_key);
         let converted_pub_key = DefaultPublicKey::try_from(&pub_key_hex).unwrap();
         assert_eq!(pub_key, converted_pub_key);
     }
@@ -121,13 +129,5 @@ mod tests {
         let err = PublicKeyHex::try_from(key).unwrap_err();
 
         assert_eq!(err.to_string(), "Bad hex conversion: odd input length")
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> arbitrary::Arbitrary<'a> for PublicKeyHex {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let hex: String = hex::encode(String::arbitrary(u)?);
-        Ok(PublicKeyHex::try_from(hex).unwrap())
     }
 }

--- a/module-system/sov-modules-api/src/pub_key_hex.rs
+++ b/module-system/sov-modules-api/src/pub_key_hex.rs
@@ -3,6 +3,7 @@ use ed25519_dalek::{VerifyingKey as DalekPublicKey, PUBLIC_KEY_LENGTH};
 
 /// A hexadecimal representation of a PublicKey.
 use crate::default_signature::DefaultPublicKey;
+
 #[derive(
     serde::Serialize,
     serde::Deserialize,
@@ -83,8 +84,10 @@ impl TryFrom<&PublicKeyHex> for DefaultPublicKey {
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for PublicKeyHex {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let hex: String = hex::encode(String::arbitrary(u)?);
-        Ok(PublicKeyHex::try_from(hex).unwrap())
+        use sov_modules_core::PrivateKey;
+        let public_key =
+            crate::default_signature::private_key::DefaultPrivateKey::arbitrary(u)?.pub_key();
+        Ok(PublicKeyHex::from(&public_key))
     }
 }
 

--- a/module-system/sov-modules-macros/tests/rpc/expose_rpc_associated_type_not_static.stderr
+++ b/module-system/sov-modules-macros/tests/rpc/expose_rpc_associated_type_not_static.stderr
@@ -2,10 +2,13 @@ error[E0310]: the parameter type `S` may not live long enough
   --> tests/rpc/expose_rpc_associated_type_not_static.rs:98:1
    |
 98 | #[expose_rpc]
-   | ^^^^^^^^^^^^^ ...so that the type `S` will meet its required lifetime bounds
+   | ^^^^^^^^^^^^^
+   | |
+   | the parameter type `S` must be valid for the static lifetime...
+   | ...so that the type `S` will meet its required lifetime bounds
    |
    = note: this error originates in the attribute macro `expose_rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider adding an explicit lifetime bound...
+help: consider adding an explicit lifetime bound
    |
 101| struct Runtime<C: Context, S: TestSpec + 'static> {
    |                                        +++++++++


### PR DESCRIPTION
# Description
Clippy fixes for Rust 1.75 and macro stderr update.

Publish it as separate PR, so currently active PRs have less conflicts.


Errors fixed:

* `warning: items after a test module`
* `warning: unused import` for some `hooks::*` and `call::*`. When there are no public types of functions, but just impl blocks.
* `first()` and `.front()` instead of `get(0)`
* `warning: use of a fallible conversion when an infallible one could be used`

