### PR TITLE
Fixing demo-prover

### DIFF
--- a/examples/demo-rollup/benches/prover/rollup_config.toml
+++ b/examples/demo-rollup/benches/prover/rollup_config.toml
@@ -20,3 +20,6 @@ start_height = 1
 # the host and port to bind the rpc server for
 bind_host = "127.0.0.1"
 bind_port = 12345
+
+[prover_service]
+aggregated_proof_block_jump = 0


### PR DESCRIPTION
# Description
The PR #1256 (Add extract_output methods to ZkvmHost) broke the demo-rollup bench. The origin of the issue is a change in the StateTransitionData structure definition - which caused a deserialization error.
I modified the existing bench by adding the StateTransitionData structure directly to the hints so that subsequent modifications of the latter are reported at compile time.

## Testing
Tested by running the benchmark locally