### PR TITLE
feat: add gas total to tx receipt

### DIFF
--- a/constants.json
+++ b/constants.json
@@ -26,6 +26,8 @@
   },
   "constants": {
     "DEFERRED_SLOTS_COUNT": 2,
-    "GAS_TOKEN_ADDRESS": "sov1p9xxgsh78u3nxsl0zhfq4eazy0y4c8m5psjv3k3vrv45859jgazq3x72sg"
+    "GAS_TOKEN_ADDRESS": "sov1p9xxgsh78u3nxsl0zhfq4eazy0y4c8m5psjv3k3vrv45859jgazq3x72sg",
+    "GAS_TX_FIXED_COST": [0, 0],
+    "GAS_TX_COST_PER_BYTE": [0, 0]
   }
 }

--- a/constants.test.json
+++ b/constants.test.json
@@ -2,6 +2,8 @@
   "comment": "Sovereign SDK constants",
   "constants": {
     "GAS_TOKEN_ADDRESS": "sov1p9xxgsh78u3nxsl0zhfq4eazy0y4c8m5psjv3k3vrv45859jgazq3x72sg",
+    "GAS_TX_FIXED_COST": [0, 0],
+    "GAS_TX_COST_PER_BYTE": [0, 0],
     "TEST_U32": 42,
     "TEST_BOOL": true,
     "TEST_STRING": "Some Other String",
@@ -47,6 +49,11 @@
       11,
       11,
       11,
+      11,
+      11,
+      11
+    ],
+    "TEST_SLICE": [
       11,
       11,
       11

--- a/examples/demo-rollup/src/test_rpc.rs
+++ b/examples/demo-rollup/src/test_rpc.rs
@@ -88,6 +88,7 @@ fn batch2_tx_receipts() -> Vec<TransactionReceipt<u32>> {
             body_to_save: Some(b"tx body".to_vec()),
             events: vec![],
             receipt: 0,
+            gas_total: vec![0, 0],
         })
         .collect()
 }
@@ -113,6 +114,7 @@ fn regular_test_helper(payload: serde_json::Value, expected: &serde_json::Value)
                     body_to_save: Some(b"tx1 body".to_vec()),
                     events: vec![],
                     receipt: 0,
+                    gas_total: vec![0, 0],
                 },
                 TransactionReceipt::<u32> {
                     tx_hash: ::sha2::Sha256::digest(b"tx2"),
@@ -122,6 +124,7 @@ fn regular_test_helper(payload: serde_json::Value, expected: &serde_json::Value)
                         Event::new("event2_key", "event2_value"),
                     ],
                     receipt: 1,
+                    gas_total: vec![2, 3],
                 },
             ],
             inner: 0,

--- a/examples/demo-rollup/src/test_rpc.rs
+++ b/examples/demo-rollup/src/test_rpc.rs
@@ -88,7 +88,7 @@ fn batch2_tx_receipts() -> Vec<TransactionReceipt<u32>> {
             body_to_save: Some(b"tx body".to_vec()),
             events: vec![],
             receipt: 0,
-            gas_total: vec![0, 0],
+            gas_used: vec![0, 0],
         })
         .collect()
 }
@@ -114,7 +114,7 @@ fn regular_test_helper(payload: serde_json::Value, expected: &serde_json::Value)
                     body_to_save: Some(b"tx1 body".to_vec()),
                     events: vec![],
                     receipt: 0,
-                    gas_total: vec![0, 0],
+                    gas_used: vec![0, 0],
                 },
                 TransactionReceipt::<u32> {
                     tx_hash: ::sha2::Sha256::digest(b"tx2"),
@@ -124,7 +124,7 @@ fn regular_test_helper(payload: serde_json::Value, expected: &serde_json::Value)
                         Event::new("event2_key", "event2_value"),
                     ],
                     receipt: 1,
-                    gas_total: vec![2, 3],
+                    gas_used: vec![2, 3],
                 },
             ],
             inner: 0,

--- a/module-system/module-implementations/sov-bank/src/hooks.rs
+++ b/module-system/module-implementations/sov-bank/src/hooks.rs
@@ -21,12 +21,6 @@ use crate::{Bank, Coins};
 // https://github.com/Sovereign-Labs/sovereign-sdk/issues/1234
 const GAS_TOKEN_ADDRESS: &'static str;
 
-#[config_constant]
-const GAS_TX_FIXED_COST: &[u64];
-
-#[config_constant]
-const GAS_TX_COST_PER_BYTE: &[u64];
-
 /// The computed addresses of a pre-dispatch tx hook.
 pub struct BankTxHook<C: Context> {
     /// The tx sender address

--- a/module-system/module-implementations/sov-bank/src/hooks.rs
+++ b/module-system/module-implementations/sov-bank/src/hooks.rs
@@ -3,7 +3,7 @@ use core::str::FromStr;
 use sov_modules_api::hooks::TxHooks;
 use sov_modules_api::macros::config_constant;
 use sov_modules_api::transaction::Transaction;
-use sov_modules_api::{Context, WorkingSet};
+use sov_modules_api::{Context, GasUnit, WorkingSet};
 
 use crate::{Bank, Coins};
 
@@ -20,6 +20,12 @@ use crate::{Bank, Coins};
 // TODO: fetch address as constant
 // https://github.com/Sovereign-Labs/sovereign-sdk/issues/1234
 const GAS_TOKEN_ADDRESS: &'static str;
+
+#[config_constant]
+const GAS_TX_FIXED_COST: &[u64];
+
+#[config_constant]
+const GAS_TX_COST_PER_BYTE: &[u64];
 
 /// The computed addresses of a pre-dispatch tx hook.
 pub struct BankTxHook<C: Context> {
@@ -41,8 +47,32 @@ impl<C: Context> TxHooks for Bank<C> {
         hook: &BankTxHook<C>,
     ) -> anyhow::Result<()> {
         let BankTxHook { sender, sequencer } = hook;
-        let amount = tx.gas_limit().saturating_add(tx.gas_tip());
 
+        // Charge the base tx gas cost
+        let gas_fixed_cost = tx.gas_fixed_cost();
+        if working_set.charge_gas(&gas_fixed_cost).is_err() {
+            let amount = gas_fixed_cost.value(working_set.gas_price());
+            let token_address = C::Address::from_str(GAS_TOKEN_ADDRESS)
+                .map_err(|_| anyhow::anyhow!("failed to parse gas token address"))?;
+            let coins = Coins {
+                amount,
+                token_address,
+            };
+
+            // If the sender's account balance is insufficient to cover the base global cost, the
+            // transaction execution should be halted and the deficiency should be deducted from
+            // the sequencer's account. It is expected that a sequencer would have adequate funds,
+            // as the staked amount ought to be sufficient for executing any transaction count they
+            // choose. However, if a sequencer lacks sufficient staked funds, it indicates a
+            // critical design flaw in the sequencer registry.
+            self.burn(coins, sequencer, working_set).expect("Unrecoverable error: the sequencer doesn't have enough funds to pay for the transaction base cost.");
+
+            anyhow::bail!(
+                "Transaction sender doesn't have enough funds to pay for the transaction base cost"
+            );
+        }
+
+        let amount = tx.gas_limit().saturating_add(tx.gas_tip());
         if amount > 0 {
             let token_address = C::Address::from_str(GAS_TOKEN_ADDRESS)
                 .map_err(|_| anyhow::anyhow!("failed to parse gas token address"))?;

--- a/module-system/sov-modules-core/src/common/gas.rs
+++ b/module-system/sov-modules-core/src/common/gas.rs
@@ -1,5 +1,6 @@
 //! Gas unit definitions and implementations.
 
+use alloc::vec::Vec;
 use core::fmt;
 
 use anyhow::Result;

--- a/module-system/sov-modules-core/src/common/gas.rs
+++ b/module-system/sov-modules-core/src/common/gas.rs
@@ -13,7 +13,7 @@ pub trait GasUnit: fmt::Debug + Clone + Send + Sync {
     fn from_arbitrary_dimensions(dimensions: &[u64]) -> Self;
 
     /// Creates a multi-dimensional representation of the unit.
-    fn into_dimensions(&self) -> Vec<u64>;
+    fn to_dimensions(&self) -> Vec<u64>;
 
     /// Converts the unit into a scalar value, given a price.
     fn value(&self, price: &Self) -> u64;
@@ -43,7 +43,7 @@ impl<const N: usize> GasUnit for TupleGasUnit<N> {
         unit
     }
 
-    fn into_dimensions(&self) -> Vec<u64> {
+    fn to_dimensions(&self) -> Vec<u64> {
         self.to_vec()
     }
 

--- a/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -477,8 +477,8 @@ impl<C: Context> WorkingSet<C> {
     }
 
     /// Returns the total gas incurred.
-    pub const fn gas_total(&self) -> &C::GasUnit {
-        self.gas_meter.gas_total()
+    pub const fn gas_used(&self) -> &C::GasUnit {
+        self.gas_meter.gas_used()
     }
 
     /// Fetches given value and provides a proof of it presence/absence.

--- a/module-system/sov-modules-core/src/storage/scratchpad.rs
+++ b/module-system/sov-modules-core/src/storage/scratchpad.rs
@@ -471,6 +471,16 @@ impl<C: Context> WorkingSet<C> {
         self.gas_meter.charge_gas(gas)
     }
 
+    /// Returns the gas price.
+    pub const fn gas_price(&self) -> &C::GasUnit {
+        self.gas_meter.gas_price()
+    }
+
+    /// Returns the total gas incurred.
+    pub const fn gas_total(&self) -> &C::GasUnit {
+        self.gas_meter.gas_total()
+    }
+
     /// Fetches given value and provides a proof of it presence/absence.
     pub fn get_with_proof(
         &mut self,

--- a/module-system/sov-modules-macros/tests/constants/create_constant.rs
+++ b/module-system/sov-modules-macros/tests/constants/create_constant.rs
@@ -6,6 +6,9 @@ pub const TEST_U32: u32;
 pub const TEST_ARRAY_OF_U8: [u8; 32];
 
 #[config_constant]
+pub const TEST_SLICE: &[u8];
+
+#[config_constant]
 /// This one has a doc attr
 pub const TEST_NESTED_ARRAY: [[u8; 3]; 2];
 
@@ -19,6 +22,7 @@ const TEST_STRING: &str;
 fn main() {
     assert_eq!(TEST_U32, 42);
     assert_eq!(TEST_ARRAY_OF_U8, [11; 32]);
+    assert_eq!(TEST_SLICE, &[11; 3]);
     assert_eq!(TEST_NESTED_ARRAY, [[7; 3]; 2]);
     assert_eq!(TEST_BOOL, true);
     assert_eq!(TEST_STRING, "Some Other String");

--- a/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
+++ b/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
@@ -203,7 +203,7 @@ where
                     // Don't revert any state changes made by the pre_dispatch_hook even if the Tx is rejected.
                     // For example nonce for the relevant account is incremented.
                     error!("Stateful verification error - the sequencer included an invalid transaction: {}", e);
-                    let gas_total = batch_workspace.gas_total().into_dimensions();
+                    let gas_total = batch_workspace.gas_total().to_dimensions();
                     let receipt = TransactionReceipt {
                         tx_hash: raw_tx_hash,
                         body_to_save: None,
@@ -251,7 +251,7 @@ where
             };
             debug!("Tx {} effect: {:?}", hex::encode(raw_tx_hash), tx_effect);
 
-            let gas_total = batch_workspace.gas_total().into_dimensions();
+            let gas_total = batch_workspace.gas_total().to_dimensions();
             let receipt = TransactionReceipt {
                 tx_hash: raw_tx_hash,
                 body_to_save: None,

--- a/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
+++ b/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
@@ -203,17 +203,20 @@ where
                     // Don't revert any state changes made by the pre_dispatch_hook even if the Tx is rejected.
                     // For example nonce for the relevant account is incremented.
                     error!("Stateful verification error - the sequencer included an invalid transaction: {}", e);
+                    let gas_total = batch_workspace.gas_total().into_dimensions();
                     let receipt = TransactionReceipt {
                         tx_hash: raw_tx_hash,
                         body_to_save: None,
                         events: batch_workspace.take_events(),
                         receipt: TxEffect::Reverted,
+                        gas_total,
                     };
 
                     tx_receipts.push(receipt);
                     continue;
                 }
             };
+
             // Commit changes after pre_dispatch_tx_hook
             batch_workspace = batch_workspace.checkpoint().to_revertable();
 
@@ -248,11 +251,13 @@ where
             };
             debug!("Tx {} effect: {:?}", hex::encode(raw_tx_hash), tx_effect);
 
+            let gas_total = batch_workspace.gas_total().into_dimensions();
             let receipt = TransactionReceipt {
                 tx_hash: raw_tx_hash,
                 body_to_save: None,
                 events,
                 receipt: tx_effect,
+                gas_total,
             };
 
             tx_receipts.push(receipt);

--- a/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
+++ b/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs
@@ -203,13 +203,13 @@ where
                     // Don't revert any state changes made by the pre_dispatch_hook even if the Tx is rejected.
                     // For example nonce for the relevant account is incremented.
                     error!("Stateful verification error - the sequencer included an invalid transaction: {}", e);
-                    let gas_total = batch_workspace.gas_total().to_dimensions();
+                    let gas_used = batch_workspace.gas_used().to_dimensions();
                     let receipt = TransactionReceipt {
                         tx_hash: raw_tx_hash,
                         body_to_save: None,
                         events: batch_workspace.take_events(),
                         receipt: TxEffect::Reverted,
-                        gas_total,
+                        gas_used,
                     };
 
                     tx_receipts.push(receipt);
@@ -251,13 +251,13 @@ where
             };
             debug!("Tx {} effect: {:?}", hex::encode(raw_tx_hash), tx_effect);
 
-            let gas_total = batch_workspace.gas_total().to_dimensions();
+            let gas_used = batch_workspace.gas_used().to_dimensions();
             let receipt = TransactionReceipt {
                 tx_hash: raw_tx_hash,
                 body_to_save: None,
                 events,
                 receipt: tx_effect,
-                gas_total,
+                gas_used,
             };
 
             tx_receipts.push(receipt);

--- a/rollup-interface/src/state_machine/stf.rs
+++ b/rollup-interface/src/state_machine/stf.rs
@@ -55,6 +55,8 @@ pub struct TransactionReceipt<R> {
     /// Any additional structured data to be saved in the database and served over RPC
     /// For example, this might contain a status code.
     pub receipt: R,
+    /// Total gas incurred for this transaction.
+    pub gas_total: Vec<u64>,
 }
 
 /// A receipt for a batch of transactions. These receipts are stored in the rollup's database

--- a/rollup-interface/src/state_machine/stf.rs
+++ b/rollup-interface/src/state_machine/stf.rs
@@ -56,7 +56,7 @@ pub struct TransactionReceipt<R> {
     /// For example, this might contain a status code.
     pub receipt: R,
     /// Total gas incurred for this transaction.
-    pub gas_total: Vec<u64>,
+    pub gas_used: Vec<u64>,
 }
 
 /// A receipt for a batch of transactions. These receipts are stored in the rollup's database

--- a/rollup-interface/src/state_machine/stf/fuzzing.rs
+++ b/rollup-interface/src/state_machine/stf/fuzzing.rs
@@ -133,18 +133,18 @@ impl<R: proptest::arbitrary::Arbitrary + 'static> proptest::arbitrary::Arbitrary
                 proptest::collection::vec(any::<u64>(), 0..args.gas_unit_dimensions),
             )
                 .prop_map(
-                    move |(tx_hash, body_to_save, events, receipt, mut gas_total)| {
+                    move |(tx_hash, body_to_save, events, receipt, mut gas_used)| {
                         let tx_hash = match (args.hasher.as_ref(), body_to_save.as_ref()) {
                             (Some(hasher), Some(body)) => hasher.hash(body),
                             _ => tx_hash,
                         };
-                        gas_total.resize(args.gas_unit_dimensions, 0);
+                        gas_used.resize(args.gas_unit_dimensions, 0);
                         Self {
                             tx_hash,
                             body_to_save,
                             events,
                             receipt,
-                            gas_total,
+                            gas_used,
                         }
                     },
                 )

--- a/rollup-interface/src/state_machine/stf/fuzzing.rs
+++ b/rollup-interface/src/state_machine/stf/fuzzing.rs
@@ -95,6 +95,8 @@ pub struct TransactionReceiptStrategyArgs {
     /// Whether to generate entries for the `body_to_save` field of the `TransactionReceipt`.
     /// Values are guaranteed to be `Some` if this is `Always`, and `None` if this is `Never`.
     pub generate_tx_bodies: Frequency,
+    /// The gas unit dimensions count.
+    pub gas_unit_dimensions: usize,
 }
 
 impl Default for TransactionReceiptStrategyArgs {
@@ -103,6 +105,7 @@ impl Default for TransactionReceiptStrategyArgs {
             hasher: Some(default_fuzz_hasher()),
             max_events: 10,
             generate_tx_bodies: Frequency::Sometimes,
+            gas_unit_dimensions: 2,
         }
     }
 }
@@ -127,19 +130,24 @@ impl<R: proptest::arbitrary::Arbitrary + 'static> proptest::arbitrary::Arbitrary
                 tx_body_strategy,
                 proptest::collection::vec(any::<Event>(), 0..args.max_events),
                 any::<R>(),
+                proptest::collection::vec(any::<u64>(), 0..args.gas_unit_dimensions),
             )
-                .prop_map(move |(tx_hash, body_to_save, events, receipt)| {
-                    let tx_hash = match (args.hasher.as_ref(), body_to_save.as_ref()) {
-                        (Some(hasher), Some(body)) => hasher.hash(body),
-                        _ => tx_hash,
-                    };
-                    Self {
-                        tx_hash,
-                        body_to_save,
-                        events,
-                        receipt,
-                    }
-                })
+                .prop_map(
+                    move |(tx_hash, body_to_save, events, receipt, mut gas_total)| {
+                        let tx_hash = match (args.hasher.as_ref(), body_to_save.as_ref()) {
+                            (Some(hasher), Some(body)) => hasher.hash(body),
+                            _ => tx_hash,
+                        };
+                        gas_total.resize(args.gas_unit_dimensions, 0);
+                        Self {
+                            tx_hash,
+                            body_to_save,
+                            events,
+                            receipt,
+                            gas_total,
+                        }
+                    },
+                )
                 .boxed()
         }
     }


### PR DESCRIPTION
This commit introduces the "gas total" as a new attribute in the transaction receipt. With this addition, the gas price elasticity can be calculated based on the demand of previous blocks.

This feature also allows setting a base fee for every transaction, which is paid by the sender to cover processing costs such as deserialization and signature verification. Insufficient funds from the sender will cause the fee to be charged to the sequencer, leading to a failed transaction and thwarting potential attacks. The sequencer should have sufficient funds available from their staked amount to cover these expenses; the implementation of the sequencer registry is responsible for ensuring the sequencer possesses adequate funds for selecting transactions to assemble into a blob.

To define the base cost constant, an adjustment was made to make this feature available under the `sov-modules-macros`. Due to the need for defining slices of unknown size for the constants file, this functionality had to be provided there as well.