### PR TITLE
feat: add `key show` to display give identifier key info

### DIFF
--- a/module-system/sov-cli/src/workflows/keys.rs
+++ b/module-system/sov-cli/src/workflows/keys.rs
@@ -49,6 +49,12 @@ pub enum KeyWorkflow<C: sov_modules_api::Context> {
         #[clap(subcommand)]
         identifier: KeyIdentifier<C>,
     },
+    /// Show a key info from the wallet
+    Show {
+        /// The identifier of the key to show
+        #[clap(subcommand)]
+        identifier: KeyIdentifier<C>,
+    },
 }
 
 impl<C: sov_modules_api::Context> KeyWorkflow<C> {
@@ -79,6 +85,10 @@ impl<C: sov_modules_api::Context> KeyWorkflow<C> {
                 wallet_state
                     .addresses
                     .add(address, nickname, public_key, path);
+            }
+            KeyWorkflow::Show { identifier } => {
+                let addr = wallet_state.addresses.get_address(&identifier);
+                println!("{}", serde_json::to_string_pretty(&addr)?)
             }
             KeyWorkflow::List => {
                 println!("{}", serde_json::to_string_pretty(&wallet_state.addresses)?)

--- a/module-system/sov-cli/tests/keys.rs
+++ b/module-system/sov-cli/tests/keys.rs
@@ -96,3 +96,59 @@ fn test_activate() {
     let current_active_wallet = wallet_state.addresses.default_address().unwrap();
     assert!(current_active_wallet.is_nicknamed("key1"));
 }
+
+#[test]
+fn test_show() {
+    // Setup a wallet with mock key
+    let app_dir = tempfile::tempdir().unwrap();
+    let mut wallet_state =
+        WalletState::<RuntimeCall<DefaultContext, Da>, DefaultContext>::default();
+    let workflow = KeyWorkflow::Generate {
+        nickname: Some("mockkey".into()),
+    };
+    workflow.run(&mut wallet_state, &app_dir).unwrap();
+
+    // show mockkey by nickname
+    let workflow = KeyWorkflow::Show {
+        identifier: KeyIdentifier::ByNickname {
+            nickname: "mockkey".to_string(),
+        },
+    };
+    workflow.run(&mut wallet_state, &app_dir).unwrap();
+
+    let addr_entry = wallet_state
+        .addresses
+        .get_address(&KeyIdentifier::ByNickname {
+            nickname: "mockkey".to_string(),
+        })
+        .unwrap();
+
+    // show mockkey by address
+    let workflow = KeyWorkflow::Show {
+        identifier: KeyIdentifier::ByAddress {
+            address: addr_entry.address,
+        },
+    };
+    workflow.run(&mut wallet_state, &app_dir).unwrap();
+}
+
+#[test]
+fn test_list() {
+    // Setup a wallet with key1 and key2
+    let app_dir = tempfile::tempdir().unwrap();
+    let mut wallet_state =
+        WalletState::<RuntimeCall<DefaultContext, Da>, DefaultContext>::default();
+
+    let workflow = KeyWorkflow::Generate {
+        nickname: Some("key1".into()),
+    };
+    workflow.run(&mut wallet_state, &app_dir).unwrap();
+
+    let workflow = KeyWorkflow::Generate {
+        nickname: Some("key2".into()),
+    };
+    workflow.run(&mut wallet_state, &app_dir).unwrap();
+
+    let workflow = KeyWorkflow::List {};
+    workflow.run(&mut wallet_state, &app_dir).unwrap();
+}


### PR DESCRIPTION
# Description
This pr added a new subcommand `key show` to display give identifier key info, this is useful when there are many addresses and we can use `key show` to display key info quickly instead of searching it in terminal output.

## Linked Issues

## Testing
Added two new tests for `key show` and `key list`
