### PR TITLE
Add prover_bench to CI to catch potential breakages resulting from format/serialization changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -167,7 +167,11 @@ jobs:
           version: "23.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust
-        run: rustup show
+        run: rustup show && rustup install nightly && rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
+      - name: Install cargo-risczero
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-risczero@0.19
       - uses: Swatinem/rust-cache@v2
         with:
           cache-provider: "buildjet"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -201,6 +201,14 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust
         run: rustup show && rustup install nightly && rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
+      - name: Install cargo-risczero
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-risczero@0.19
+      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
+        run: cargo risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-provider: "buildjet"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -151,6 +151,8 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
       - name: Run check
         run: make check-no-std
+      - name: Run bench
+        run: cargo bench --features bench --bench prover_bench
 
   # Check that every combination of features is working properly.
   hack:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -152,9 +152,8 @@ jobs:
       - name: Run check
         run: make check-no-std
 
-  # Check that every combination of features is working properly.
-  bench_check:
-    name: bench_check
+  prover_bench_check:
+    name: prover_bench_check
     needs: check
     runs-on: buildjet-8vcpu-ubuntu-2204
     timeout-minutes: 120
@@ -184,8 +183,34 @@ jobs:
           workspaces: |
             .
             fuzz
-      - name: cargo bench check
+      - name: cargo prover bench check
         run: cargo bench --bench prover_bench --features bench
+
+  bench_check:
+    name: bench_check
+    needs: check
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rui314/setup-mold@v1
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          version: "23.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Rust
+        run: rustup show && rustup install nightly && rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-provider: "buildjet"
+          shared-key: cargo-check-cache
+          save-if: ${{ github.ref == 'refs/heads/nightly' }}
+          workspaces: |
+            .
+            fuzz
+      - name: cargo bench check
+        run: cargo bench
 
   # Check that every combination of features is working properly.
   hack:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -185,7 +185,7 @@ jobs:
             .
             fuzz
       - name: cargo bench check
-        run: cargo check --bench prover_bench --features bench
+        run: cargo bench --bench prover_bench --features bench
 
   # Check that every combination of features is working properly.
   hack:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -172,6 +172,10 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-risczero@0.19
+      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
+        run: cargo risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: Swatinem/rust-cache@v2
         with:
           cache-provider: "buildjet"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -127,6 +127,8 @@ jobs:
             echo "Linting or formatting errors detected, please run 'make lint-fix' to fix it";
             exit 1
           fi
+      - name: Run bench
+        run: cargo bench --features bench --bench prover_bench
 
   check_no_std:
     runs-on: ubuntu-latest
@@ -151,8 +153,6 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
       - name: Run check
         run: make check-no-std
-      - name: Run bench
-        run: cargo bench --features bench --bench prover_bench
 
   # Check that every combination of features is working properly.
   hack:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -127,8 +127,6 @@ jobs:
             echo "Linting or formatting errors detected, please run 'make lint-fix' to fix it";
             exit 1
           fi
-      - name: Run bench
-        run: cargo bench --features bench --bench prover_bench
 
   check_no_std:
     runs-on: ubuntu-latest
@@ -153,6 +151,33 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/nightly' }}
       - name: Run check
         run: make check-no-std
+
+  # Check that every combination of features is working properly.
+  bench_check:
+    name: bench_check
+    needs: check
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rui314/setup-mold@v1
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          version: "23.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Rust
+        run: rustup show
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-provider: "buildjet"
+          shared-key: cargo-check-cache
+          save-if: ${{ github.ref == 'refs/heads/nightly' }}
+          workspaces: |
+            .
+            fuzz
+      - name: cargo bench check
+        run: cargo check --bench prover_bench --features bench
 
   # Check that every combination of features is working properly.
   hack:


### PR DESCRIPTION
# Description

Adding the prover bench to CI to ensure bugs in it are caught. 
We've had a couple of issues in the past where serialization changes etc caused the benchmark to break and this has only been caught when prover_bench was manually run. To avoid that, we want to run the bench in CI as well.
prover_bench.rs runs without actually proving i.e. just performs the riscv compilation and execution of the ELF to capture the cycles (without actually proving the riscv instructions) so it should be relatively fast. As of recent test it was 6-8 minutes, and since it runs in parallel with cargo hack, it has room to get 4-5x worse before it blocks CI.
