### PR TITLE
Add shell wrappers for checking prover and rollup benchmark thresholds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -188,7 +188,7 @@ jobs:
           BLOCKS: 1
           TXNS_PER_BLOCK: 10
           NUM_PUB_KEYS: 100
-        run: cargo bench --bench prover_bench --features bench
+        run: sh ci_prover_count_check.sh
 
   bench_check:
     name: bench_check
@@ -264,7 +264,7 @@ jobs:
           BLOCKS: 10
           TXNS_PER_BLOCK: 10000
           NUM_PUB_KEYS: 100
-        run: cd examples/demo-rollup make basic
+        run: sh ci_rollup_count_check.sh
 
   # Check that every combination of features is working properly.
   hack:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -228,6 +228,44 @@ jobs:
           NUM_PUB_KEYS: 100
         run: cargo bench
 
+  rollup_bench_check:
+    name: rollup_bench_check
+    needs: check
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rui314/setup-mold@v1
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          version: "23.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Rust
+        run: rustup show && rustup install nightly && rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
+      - name: Install cargo-risczero
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-risczero@0.19
+      - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
+        run: cargo risczero install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-provider: "buildjet"
+          shared-key: cargo-check-cache
+          save-if: ${{ github.ref == 'refs/heads/nightly' }}
+          workspaces: |
+            .
+            fuzz
+      - name: cargo bench check
+        env:
+          BLOCKS: 1
+          TXNS_PER_BLOCK: 10
+          NUM_PUB_KEYS: 100
+        run: cd examples/demo-rollup && BLOCKS=10 TXNS_PER_BLOCK=10000 make basic
+
   # Check that every combination of features is working properly.
   hack:
     name: features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -259,12 +259,12 @@ jobs:
           workspaces: |
             .
             fuzz
-      - name: cargo bench check
+      - name: rollup bench check
         env:
-          BLOCKS: 1
-          TXNS_PER_BLOCK: 10
+          BLOCKS: 10
+          TXNS_PER_BLOCK: 10000
           NUM_PUB_KEYS: 100
-        run: cd examples/demo-rollup && BLOCKS=10 TXNS_PER_BLOCK=10000 make basic
+        run: cd examples/demo-rollup make basic
 
   # Check that every combination of features is working properly.
   hack:

--- a/ci_prover_count_check.sh
+++ b/ci_prover_count_check.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+export BLOCKS=1
+export TXNS_PER_BLOCK=10
+export NUM_PUB_KEYS=100
+export CYCLE_COUNT=1000000
+cargo bench --bench prover_bench --features bench 2>&1 | tee output.log
+
+output_file="output.log"
+
+verify_line=$(grep -w "verify" $output_file)
+
+if [ -z "$verify_line" ]; then
+    echo "The line containing 'verify' was not found."
+    exit 1
+else
+    average_cycles=$(echo $verify_line | awk '{print $4}' | sed 's/,//g') # Remove commas if present
+
+    if [ -n "$average_cycles" ] && [ "$average_cycles" -lt $CYCLE_COUNT ]; then
+        echo "The value for 'verify' is less than $CYCLE_COUNT. Passing the check. Value: $average_cycles"
+        exit 0
+    elif [ -n "$average_cycles" ]; then
+        echo "The value for 'verify' is greater than $CYCLE_COUNT. Failing the check. Value: $average_cycles"
+        exit 0
+    else
+        echo "Unable to extract the 'Average Cycles' value."
+        exit 1
+    fi
+fi
+exit 1

--- a/ci_rollup_count_check.sh
+++ b/ci_rollup_count_check.sh
@@ -13,7 +13,7 @@ if [ -z "$verify_line" ]; then
     exit 1
 else
     tps_count=$(echo $verify_line | awk -F '|' '{print $3}' | sed 's/,//g')
-    result=$(awk -v val="$tps_count" -v threshold="$TPS" 'BEGIN {print (val <g threshold) ? "FAIL" : "PASS"}')
+    result=$(awk -v val="$tps_count" -v threshold="$TPS" 'BEGIN {print (val < threshold) ? "FAIL" : "PASS"}')
     if [ "$result" = "FAIL" ]; then
         echo "The value for TPS is less than $TPS. Failing the check. Value: $tps_count"
         exit 1

--- a/ci_rollup_count_check.sh
+++ b/ci_rollup_count_check.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+export BLOCKS=10
+export TXNS_PER_BLOCK=10000
+export TPS=1000
+(cd examples/demo-rollup/benches/node && make basic 2>&1) | tee output.log
+
+output_file="output.log"
+
+verify_line=$(grep -w "Transactions per sec (TPS)" $output_file)
+
+if [ -z "$verify_line" ]; then
+    echo "The line containing 'verify' was not found."
+    exit 1
+else
+    tps_count=$(echo $verify_line | awk -F '|' '{print $3}' | sed 's/,//g')
+    result=$(awk -v val="$tps_count" -v threshold="$TPS" 'BEGIN {print (val < threshold) ? "FAIL" : "PASS"}')
+    if [ "$result" = "FAIL" ]; then
+        echo "The value for TPS is less than $TPS. Failing the check. Value: $tps_count"
+        exit 0
+    else
+        echo "The value for TPS is greater than $TPS. Passing the check. Value: $tps_count"
+        exit 1
+    fi
+fi
+exit 1

--- a/ci_rollup_count_check.sh
+++ b/ci_rollup_count_check.sh
@@ -13,7 +13,7 @@ if [ -z "$verify_line" ]; then
     exit 1
 else
     tps_count=$(echo $verify_line | awk -F '|' '{print $3}' | sed 's/,//g')
-    result=$(awk -v val="$tps_count" -v threshold="$TPS" 'BEGIN {print (val < threshold) ? "FAIL" : "PASS"}')
+    result=$(awk -v val="$tps_count" -v threshold="$TPS" 'BEGIN {print (val > threshold) ? "FAIL" : "PASS"}')
     if [ "$result" = "FAIL" ]; then
         echo "The value for TPS is less than $TPS. Failing the check. Value: $tps_count"
         exit 0

--- a/ci_rollup_count_check.sh
+++ b/ci_rollup_count_check.sh
@@ -13,13 +13,13 @@ if [ -z "$verify_line" ]; then
     exit 1
 else
     tps_count=$(echo $verify_line | awk -F '|' '{print $3}' | sed 's/,//g')
-    result=$(awk -v val="$tps_count" -v threshold="$TPS" 'BEGIN {print (val > threshold) ? "FAIL" : "PASS"}')
+    result=$(awk -v val="$tps_count" -v threshold="$TPS" 'BEGIN {print (val <g threshold) ? "FAIL" : "PASS"}')
     if [ "$result" = "FAIL" ]; then
         echo "The value for TPS is less than $TPS. Failing the check. Value: $tps_count"
-        exit 0
+        exit 1
     else
         echo "The value for TPS is greater than $TPS. Passing the check. Value: $tps_count"
-        exit 1
+        exit 0
     fi
 fi
 exit 1

--- a/examples/demo-rollup/benches/node/rollup_coarse_measure.rs
+++ b/examples/demo-rollup/benches/node/rollup_coarse_measure.rs
@@ -125,7 +125,7 @@ async fn main() -> Result<(), anyhow::Error> {
     >::new();
 
     let demo_genesis_config = {
-        let integ_test_conf_dir: &Path = "../../test-data/genesis/integration-tests".as_ref();
+        let integ_test_conf_dir: &Path = "../test-data/genesis/integration-tests".as_ref();
         let rt_params =
             get_genesis_config::<DefaultContext, _>(&GenesisPaths::from_dir(integ_test_conf_dir))
                 .unwrap();

--- a/examples/demo-rollup/benches/node/rollup_config.toml
+++ b/examples/demo-rollup/benches/node/rollup_config.toml
@@ -21,3 +21,6 @@ start_height = 1
 # the host and port to bind the rpc server for
 bind_host = "127.0.0.1"
 bind_port = 12345
+
+[prover_service]
+aggregated_proof_block_jump = 0

--- a/examples/demo-rollup/benches/node/rollup_config.toml
+++ b/examples/demo-rollup/benches/node/rollup_config.toml
@@ -23,4 +23,4 @@ bind_host = "127.0.0.1"
 bind_port = 12345
 
 [prover_service]
-aggregated_proof_block_jump = 0
+aggregated_proof_block_jump = 1


### PR DESCRIPTION
## Description
`prover_bench` is already being checked for sanity. This PR adds `rollup_bench` as well - specifically rollup_coarse_measure.rs which runs a small workload to get the TPS. This PR adds 2 shell scripts which cover the sanity check (to catch script breakage) as well as checking relaxed thresholds to catch issues such as accelerated patches not being applied. 
* `ci_prover_count_check.sh`: this script checks for the number of riscv cycles taken by the `verify` function and exits with code 1 if the number cycles are > 1,000,000. The number of cycles with acceleration should be  700k or better
```
+----------------------+----------------+-----------+
| Function             | Average Cycles | Num Calls |
+----------------------+----------------+-----------+
| Cycles per block     | 8101853        | 2         |
+----------------------+----------------+-----------+
| apply_blob           | 4986497        | 2         |
+----------------------+----------------+-----------+
| pre_process_batch    | 4465276        | 2         |
+----------------------+----------------+-----------+
| verify_txs_stateless | 4423303        | 2         |
+----------------------+----------------+-----------+
| end_slot             | 2056091        | 2         |
+----------------------+----------------+-----------+
| jmt_verify_update    | 1159849        | 2         |
+----------------------+----------------+-----------+
| jmt_verify_existence | 817044         | 2         |
+----------------------+----------------+-----------+
| verify               | 745055         | 11        |
+----------------------+----------------+-----------+
| apply_txs            | 487083         | 2         |
+----------------------+----------------+-----------+
| begin_slot           | 89594          | 2         |
+----------------------+----------------+-----------+
| deserialize          | 28928          | 11        |
+----------------------+----------------+-----------+
| decode_txs           | 27021          | 2         |
+----------------------+----------------+-----------+
| deserialize_batch    | 8720           | 2         |
+----------------------+----------------+-----------+
| hash                 | 6026           | 11        |
+----------------------+----------------+-----------+
| commit               | 7              | 2         |
+----------------------+----------------+-----------+

Total cycles consumed for test: 16203706

The value for 'verify' is less than 1000000. Passing the check. Value: 745055
```

* `ci_rollup_count_check.sh`: this script checks for the TPS count for a small workload.. 10 blocks, 10k transactions per block. if the TPS < 1000 it fails
```
+----------------------------------------+----------------------+
| Blocks                                 | 10                   |
+----------------------------------------+----------------------+
| Transactions per block                 | 10000                |
+----------------------------------------+----------------------+
| Processed transactions (success/total) | 100000/100000        |
+----------------------------------------+----------------------+
| Total                                  | 10s 153ms 198us 6ns  |
+----------------------------------------+----------------------+
| Apply block                            | 9s 417ms 695us 790ns |
+----------------------------------------+----------------------+
| Transactions per sec (TPS)             | 9849.1               |
+----------------------------------------+----------------------+
The value for TPS is greater than 1000. Passing the check. Value:  9849.1 
```

