### PR TITLE
chore: fix markdown syntax

### DIFF
--- a/rollup-interface/README.md
+++ b/rollup-interface/README.md
@@ -13,7 +13,7 @@ The Sovereign SDK is a free and open-source toolkit for building zk-rollups **th
 
 ## How does it work?
 
-To learn how the Sovereign SDK works, see the ![Sovereign SDK Overview](./specs/overview.md).
+To learn how the Sovereign SDK works, see the [Sovereign SDK Overview](./specs/overview.md).
 
 ## Warning
 


### PR DESCRIPTION
remove `!`  to let the syntax work as a link syntax
before:
![1720256251267](https://github.com/Sovereign-Labs/sovereign-sdk/assets/170403630/52f1f3fa-1a9f-47f0-a77b-91208bbc6bad)

after:
![1720256253162](https://github.com/Sovereign-Labs/sovereign-sdk/assets/170403630/d1dc7b62-9467-46d0-927e-fe15e8c20d37)
