### PR TITLE
fix typos

### DIFF
--- a/full-node/sov-ethereum/src/gas_price/gas_oracle.rs
+++ b/full-node/sov-ethereum/src/gas_price/gas_oracle.rs
@@ -215,7 +215,7 @@ impl<C: sov_modules_api::Context> GasPriceOracle<C> {
         // sort the transactions by effective tip
         // but first filter those that should be ignored
 
-        // get the transactions (block.transactions is a enum but we only care about the 2nd arm)
+        // get the transactions (block.transactions is an enum but we only care about the 2nd arm)
         let txs = match &block.transactions {
             BlockTransactions::Full(txs) => txs,
             _ => return Ok(None),

--- a/full-node/sov-stf-runner/src/runner.rs
+++ b/full-node/sov-stf-runner/src/runner.rs
@@ -141,7 +141,7 @@ where
         })
     }
 
-    /// Starts a RPC server with provided rpc methods.
+    /// Starts an RPC server with provided rpc methods.
     pub async fn start_rpc_server(
         &self,
         methods: RpcModule<()>,

--- a/module-system/module-implementations/sov-bank/src/token.rs
+++ b/module-system/module-implementations/sov-bank/src/token.rs
@@ -237,7 +237,7 @@ impl<C: sov_modules_api::Context> Token<C> {
 
     /// Creates a token from a given set of parameters.
     /// The `token_name`, `sender` address (as a `u8` slice), and the `salt` (`u64` number) are used as an input
-    /// to an hash function that computes the token address. Then the initial accounts and balances are populated
+    /// to a hash function that computes the token address. Then the initial accounts and balances are populated
     /// from the `address_and_balances` slice and the `total_supply` of tokens is updated each time.
     /// Returns a tuple containing the computed `token_address` and the created `token` object.
     pub(crate) fn create(


### PR DESCRIPTION
This pull request addresses grammatical errors in documentation comments across multiple files in the repository. The changes improve the readability and accuracy of the comments, ensuring a more polished codebase.

### Files Updated
1. **`gas_oracle.rs`**
   - Corrected "a enum" to "an enum."

2. **`runner.rs`**
   - Corrected "a RPC server" to "an RPC server."

3. **`token.rs`**
   - Corrected "to a hash function" to "to an hash function."