### PR TITLE
Fix typo Update README.md

### DIFF
--- a/examples/demo-rollup/stf/README.md
+++ b/examples/demo-rollup/stf/README.md
@@ -7,7 +7,7 @@
   - [Implementing Runtime: Pick Your Modules](#implementing-runtime-pick-your-modules)
     - [Implementing Hooks for the Runtime:](#implementing-hooks-for-the-runtime)
     - [Exposing RPC](#exposing-rpc)
-  - [Make Full Node Itegrations Simpler with the State Transition Runner:](#make-full-node-itegrations-simpler-with-the-state-transition-runner)
+  - [Make Full Node Integrations Simpler with the State Transition Runner:](#make-full-node-itegrations-simpler-with-the-state-transition-runner)
     - [Using State Transition Runner](#using-state-transition-runner)
   - [Wrapping Up](#wrapping-up)
 


### PR DESCRIPTION
# Pull Request Title: Fix Typo in README.md (Itegrations to Integrations)

## Description:
This pull request corrects a typographical error in the `examples/demo-rollup/stf/README.md` file. The word "Itegrations" has been corrected to "Integrations" in the section titled "Make Full Node Integrations Simpler with the State Transition Runner."

## Changes:
- Corrected "Itegrations" to "Integrations" in `examples/demo-rollup/stf/README.md`.

## File(s) Modified:
- `examples/demo-rollup/stf/README.md`

## Reasoning:
Clear and professional documentation is essential for usability and understanding. This fix enhances the readability and accuracy of the README.

## Checklist:
- [x] Typographical error corrected.
- [x] Changes adhere to the repository's contribution guidelines.
- [x] No code functionality affected.

## Related Issues:
N/A

## Additional Notes:
This change is strictly documentation-related and does not introduce any changes to code or logic.
