### PR TITLE
Typo fix Readme.md

### DIFF
--- a/examples/demo-rollup/tests/evm/uniswap/Readme.md
+++ b/examples/demo-rollup/tests/evm/uniswap/Readme.md
@@ -1,4 +1,4 @@
-### Uniswap demo folow these steps:
+### Uniswap demo follow these steps:
 
 1. Deploys `uniswap-v2` contracts.
 2. Adds liquidity to the USDT <> USDC pair.


### PR DESCRIPTION
# Pull Request: Fix Typo in `Readme.md`

## Description
This pull request corrects a typo in the `Readme.md` file. The word "folow" has been corrected to "follow."

## Changes Made
- Corrected "folow" to "follow" in the `Readme.md` file.

## Why This Change Is Important
This fix ensures the README file is free from spelling errors, improving clarity and professionalism in the documentation.

## Testing
No additional testing is required, as this is a minor spelling fix.

## Related Issues
- None
