### PR TITLE
Sequencer: Stop creating batches when the sequencer reaches stop_at_rollup_height.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -205,6 +205,17 @@ where
             return Ok(());
         }
 
+        if let Some(height_to_stop_at) = self.stop_at_rollup_height {
+            let current_height = self.current_height();
+            if current_height >= height_to_stop_at {
+                debug!(%current_height, %height_to_stop_at,"The sequencer is at stop height and tried to create a batch (aborted due to stop height).");
+                return Err(BatchCreationError::PreferredSequencerAtStopHeight {
+                    current_height,
+                    height_to_stop_at,
+                });
+            }
+        }
+
         if self.blob_sender_busy().is_some() {
             warn!("The blob sender is busy, no batch could be started at this time.");
             return Err(BatchCreationError::BlobSenderBusy);
@@ -589,7 +600,7 @@ where
 
         if let Some(height_to_stop_at) = height_to_stop_at {
             let current_height = self.current_height();
-            if current_height > height_to_stop_at {
+            if current_height >= height_to_stop_at {
                 return Err(SequencerNotReadyDetails::PreferredSequencerAtStopHeight {
                     current_height,
                     height_to_stop_at,

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -958,6 +958,17 @@ where
                     BatchCreationError::DatabaseError(e) => {
                         return Err(database_error_500(e));
                     }
+                    BatchCreationError::PreferredSequencerAtStopHeight {
+                        height_to_stop_at,
+                        current_height,
+                    } => {
+                        return Err(error_not_fully_synced(
+                            SequencerNotReadyDetails::PreferredSequencerAtStopHeight {
+                                height_to_stop_at,
+                                current_height,
+                            },
+                        ));
+                    }
                 },
                 AcceptTxError::TxTooBig {
                     current_batch_size,
@@ -1251,6 +1262,16 @@ pub enum BatchCreationError {
     /// The sequencer was not able to start a batch because it has consumed its whole buffer of finalized slots.
     #[error("The sequencer is temporarily overloaded. Try again in a few seconds")]
     NoFinalizedSlotAvailable,
+    /// The prefered sequencer has reached the stop height and is no longer creating new batches.
+    #[error(
+        "The sequencer is halted for a chain upgrade. Please wait for the upgrade to complete. height_to_stop_at: {height_to_stop_at}, current_height: {current_height}" 
+    )]
+    PreferredSequencerAtStopHeight {
+        /// The current rollup height of the preferred sequencer.
+        current_height: RollupHeight,
+        /// The rollup height at which the preferred sequencer will stop creating new batches.
+        height_to_stop_at: RollupHeight,
+    },
 }
 
 #[cfg(test)]

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -126,7 +126,7 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
 }
 
 async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
-    let stop_at_height = RollupHeight::new(15);
+    let stop_at_height = RollupHeight::new((finalization_blocks + 12) as u64);
 
     let (test_rollup, admin) = create_test_rollup(
         0,
@@ -143,35 +143,40 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
     );
 
     let test_rollup = test_rollup.unwrap();
+    let mut slot_subscription = test_rollup.client.client.subscribe_slots().await.unwrap();
 
     let client = test_rollup.client.clone();
 
-    test_rollup
-        .da_service
-        .produce_n_blocks_now(10)
-        .await
-        .unwrap();
+    for _ in 0..finalization_blocks + 3 {
+        test_rollup.da_service.produce_block_now().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
 
     let api_client = test_rollup.api_client.clone();
 
     let mut nonce = 0;
     let mut current_height = get_height(&client).await.unwrap();
 
-    let mut slot_subscription = test_rollup.client.client.subscribe_slots().await.unwrap();
     while current_height.get() < stop_at_height.get() {
-        test_rollup.da_service.produce_block_now().await.unwrap();
-        slot_subscription.next().await;
-        tokio::time::sleep(Duration::from_millis(300)).await;
-        current_height = get_height(&client).await.unwrap();
         // All transactions should be accepted until the stop height is reached.
         send_tx(&admin, nonce, &api_client).await.unwrap();
         nonce += 1;
+
+        test_rollup.da_service.produce_block_now().await.unwrap();
+        slot_subscription.next().await;
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        current_height = get_height(&client).await.unwrap();
     }
 
     // After the stop height is reached, the sequencer should not accept any transactions. Until the height is finalized.
     for _ in 0..finalization_blocks {
+        let current_height = get_height(&client).await.unwrap();
+        assert_eq!(current_height, stop_at_height);
+
         test_rollup.da_service.produce_block_now().await.unwrap();
         slot_subscription.next().await;
+
         tokio::time::sleep(Duration::from_millis(300)).await;
         let err = send_tx(&admin, nonce, &api_client).await.unwrap_err();
         nonce += 1;
@@ -211,7 +216,7 @@ async fn rollup_operates_only_on_finalized_blocks_if_stop_at_height_set(finaliza
 
     let mut current_height = get_height(&client).await.unwrap();
     let mut slot_subscription = test_rollup.client.client.subscribe_slots().await.unwrap();
-    while current_height.get() < stop_at_height.get() + finalization_blocks as u64 {
+    while current_height < stop_at_height {
         test_rollup.da_service.produce_block_now().await.unwrap();
         slot_subscription.next().await;
         // We need to wait a bit so the new block is visible to the sequencer.
@@ -220,12 +225,16 @@ async fn rollup_operates_only_on_finalized_blocks_if_stop_at_height_set(finaliza
         current_height = get_height(&client).await.unwrap();
     }
 
-    test_rollup.da_service.produce_block_now().await.unwrap();
-    slot_subscription.next().await;
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    for _ in 0..finalization_blocks + 1 {
+        current_height = get_height(&client).await.unwrap();
+        assert_eq!(current_height, stop_at_height);
+        test_rollup.da_service.produce_block_now().await.unwrap();
+        slot_subscription.next().await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
 
     test_rollup
-        .wait_for_rollup_to_shutdown(Duration::from_secs(1))
+        .wait_for_rollup_to_shutdown(Duration::from_secs(3))
         .await;
 }
 
@@ -253,17 +262,21 @@ async fn check_start_at(finalization_blocks: u32) {
     let mut shutdown_rec = test_rollup.shutdown_sender.subscribe();
     let mut slot_subscription = test_rollup.client.client.subscribe_slots().await.unwrap();
 
+    let mut last_height = RollupHeight::new(0);
     tokio::time::timeout(Duration::from_secs(25), async {
         // Wait until the rollup reaches `stop_at_height`. At that point, we shutdown and `get_height` is expected to return errors.
         // The sleep is used to prevent a busy loop, not for correctness.
-        while let Ok(_ok) = get_height(&client).await {
+        while let Ok(height) = get_height(&client).await {
             test_rollup.da_service.produce_block_now().await.unwrap();
             slot_subscription.next().await;
             tokio::time::sleep(Duration::from_millis(100)).await;
+            last_height = height;
         }
     })
     .await
     .unwrap();
+
+    assert_eq!(last_height, stop_at_height);
 
     // Let's wait for the shutdown.
     shutdown_rec.changed().await.unwrap();

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -147,10 +147,14 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
 
     let client = test_rollup.client.clone();
 
+    let da = test_rollup.da_service.clone();
+    let mut da_sub = da.subscribe_finalized_header().await.unwrap();
+    // We just need at least one finalized block to proceed with the tests.
     for _ in 0..finalization_blocks + 3 {
         test_rollup.da_service.produce_block_now().await.unwrap();
         tokio::time::sleep(Duration::from_millis(300)).await;
     }
+    da_sub.next().await;
 
     let api_client = test_rollup.api_client.clone();
 

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -187,8 +187,11 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
         assert!(err.contains(&expected_error));
     }
 
-    test_rollup.da_service.produce_block_now().await.unwrap();
-    slot_subscription.next().await;
+    for _ in 0..3 {
+        test_rollup.da_service.produce_block_now().await.unwrap();
+        slot_subscription.next().await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
 
     test_rollup
         .wait_for_rollup_to_shutdown(Duration::from_secs(1))


### PR DESCRIPTION
# Description

Sequencer shouldnt create batches when it reaaches the `stop_at_rollup_height`.

The fix is extracted from:
https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/3168

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

