### PR TITLE
Add timestamp postfix to prevent file name clashes

### DIFF
--- a/crates/universal-wallet/schema/src/schema/tests.rs
+++ b/crates/universal-wallet/schema/src/schema/tests.rs
@@ -36,19 +36,29 @@ macro_rules! encode_decode_tests_simple {
         let json = serde_json::to_string(&$item).unwrap();
 
         if cfg!(feature = "test-vectors") {
+            use std::time::{SystemTime, UNIX_EPOCH};
+
+            let timestamp_nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
             let dir = std::env::var("SOV_UNIVERSAL_WALLET_TEST_VECTORS_DIR")
                 .unwrap_or_else(|_| "test-vectors".to_string());
             std::fs::create_dir_all(&dir).unwrap();
 
             let th = std::thread::current();
-            let test_name = th.name().unwrap();
+            let test_path = th.name().unwrap();
+            let test_name = test_path
+                .split("::")
+                .last()
+                .expect("this shouldnt be possible");
             let vector = TestVector {
                 input: json.clone(),
                 output: hex::encode(&borsh_ser),
                 schema: serde_json::to_string(&$schema).unwrap(),
             };
 
-            let file = format!("{dir}/{test_name}.json");
+            let file = format!("{dir}/{test_name}-{timestamp_nanos}.json");
             std::fs::write(file, serde_json::to_string_pretty(&vector).unwrap()).unwrap();
         }
 


### PR DESCRIPTION
# Description

Adds a timestamp postfix to avoid name clashes as this is called more than once per test

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
