### PR TITLE
Example of hashing Bank data types using EIP712

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10731,6 +10731,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sov-eip-712"
+version = "0.3.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "anyhow",
+ "hex",
+ "k256",
+]
+
+[[package]]
 name = "sov-eth-client"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/utils/nearly-linear",
     "crates/utils/sov-zkvm-utils",
     "crates/utils/sov-build",
+    "crates/utils/sov-eip-712",
     # Module System
     "crates/module-system/sov-cli",
     "crates/module-system/sov-modules-stf-blueprint",
@@ -267,6 +268,7 @@ ethers-signers = { version = "=2.0.14", default-features = false }
 ethers-middleware = { version = "=2.0.14", default-features = false }
 # ea25df7ed3b02c951c1d6ed49cee1ba40728f3f9, just couple days after 1.0.4
 alloy-primitives = { version = "=0.7.7", default-features = false }
+alloy-sol-types = { version = "=0.7.7", default-features = false }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ea25df7ed3b02c951c1d6ed49cee1ba40728f3f9", default-features = false }
 reth-rpc-types = { git = "https://github.com/paradigmxyz/reth", rev = "ea25df7ed3b02c951c1d6ed49cee1ba40728f3f9", default-features = false }
 reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "ea25df7ed3b02c951c1d6ed49cee1ba40728f3f9", default-features = false }

--- a/crates/utils/sov-eip-712/Cargo.toml
+++ b/crates/utils/sov-eip-712/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "sov-eip-712"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+publish.workspace = true
+repository.workspace = true
+
+[dependencies]
+alloy-primitives.workspace = true
+alloy-sol-types.workspace = true
+anyhow.workspace = true
+k256 = { workspace = true, features = ["ecdsa"] }
+hex.workspace = true
+
+[lints]
+workspace = true

--- a/crates/utils/sov-eip-712/src/main.rs
+++ b/crates/utils/sov-eip-712/src/main.rs
@@ -1,9 +1,10 @@
 //! Example of EIP-712 signatures for Sovereign SDK rollup operations.
 
 use alloy_primitives::{address, B256};
-use alloy_sol_types::{eip712_domain, SolStruct, sol};
+use alloy_sol_types::{eip712_domain, sol, SolStruct};
 use anyhow::Result;
-use k256::ecdsa::{SigningKey, signature::hazmat::{PrehashSigner, PrehashVerifier}};
+use k256::ecdsa::signature::hazmat::{PrehashSigner, PrehashVerifier};
+use k256::ecdsa::SigningKey;
 
 sol! {
     #[derive(Debug)]
@@ -19,7 +20,9 @@ sol! {
 }
 
 fn main() -> Result<()> {
-    let signing_key = SigningKey::from_slice(&hex::decode("0000000000000000000000000000000000000000000000000000000000000001")?)?;
+    let signing_key = SigningKey::from_slice(&hex::decode(
+        "0000000000000000000000000000000000000000000000000000000000000001",
+    )?)?;
 
     let domain = eip712_domain! {
         name: "CallMessage",
@@ -43,8 +46,10 @@ fn main() -> Result<()> {
     println!("Signature: 0x{}", hex::encode(signature.to_bytes()));
 
     let verifying_key = signing_key.verifying_key();
-    let is_valid = verifying_key.verify_prehash(hash.as_slice(), &signature).is_ok();
+    let is_valid = verifying_key
+        .verify_prehash(hash.as_slice(), &signature)
+        .is_ok();
     println!("Signature valid: {}", is_valid);
-    
+
     Ok(())
 }

--- a/crates/utils/sov-eip-712/src/main.rs
+++ b/crates/utils/sov-eip-712/src/main.rs
@@ -41,7 +41,7 @@ fn main() -> Result<()> {
     let hash = msg.eip712_signing_hash(&domain);
     let signature: k256::ecdsa::Signature = signing_key.sign_prehash(hash.as_slice())?;
 
-    println!("Message: {:?}", msg);
+    println!("Message: {msg:?}");
     println!("Hash: 0x{}", hex::encode(hash));
     println!("Signature: 0x{}", hex::encode(signature.to_bytes()));
 
@@ -49,7 +49,7 @@ fn main() -> Result<()> {
     let is_valid = verifying_key
         .verify_prehash(hash.as_slice(), &signature)
         .is_ok();
-    println!("Signature valid: {}", is_valid);
+    println!("Signature valid: {is_valid}");
 
     Ok(())
 }

--- a/crates/utils/sov-eip-712/src/main.rs
+++ b/crates/utils/sov-eip-712/src/main.rs
@@ -1,0 +1,50 @@
+//! Example of EIP-712 signatures for Sovereign SDK rollup operations.
+
+use alloy_primitives::{address, B256};
+use alloy_sol_types::{eip712_domain, SolStruct, sol};
+use anyhow::Result;
+use k256::ecdsa::{SigningKey, signature::hazmat::{PrehashSigner, PrehashVerifier}};
+
+sol! {
+    #[derive(Debug)]
+    struct Coins {
+        uint128 amount;
+        bytes32 token_id;
+    }
+    #[derive(Debug)]
+    struct Transfer {
+        address to;
+        Coins coins;
+    }
+}
+
+fn main() -> Result<()> {
+    let signing_key = SigningKey::from_slice(&hex::decode("0000000000000000000000000000000000000000000000000000000000000001")?)?;
+
+    let domain = eip712_domain! {
+        name: "CallMessage",
+        version: "1",
+        chain_id: 4321,
+        verifying_contract: address!("0000000000000000000000000000000000000000"),
+    };
+    let msg = Transfer {
+        to: address!("0000000000000000000000000000000000000000"),
+        coins: Coins {
+            amount: 1000,
+            token_id: B256::ZERO,
+        },
+    };
+
+    let hash = msg.eip712_signing_hash(&domain);
+    let signature: k256::ecdsa::Signature = signing_key.sign_prehash(hash.as_slice())?;
+
+    println!("Message: {:?}", msg);
+    println!("Hash: 0x{}", hex::encode(hash));
+    println!("Signature: 0x{}", hex::encode(signature.to_bytes()));
+
+    let verifying_key = signing_key.verifying_key();
+    let is_valid = verifying_key.verify_prehash(hash.as_slice(), &signature).is_ok();
+    println!("Signature valid: {}", is_valid);
+    
+    Ok(())
+}

--- a/deny.toml
+++ b/deny.toml
@@ -91,6 +91,11 @@ expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
 license-files = []
 
 [[licenses.clarify]]
+name = "sov-eip-712"
+expression = "LicenseRef-Sovereign-Labs-Community-Software-License"
+license-files = []
+
+[[licenses.clarify]]
 name = "sov-eth-client"
 expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
 license-files = []

--- a/deny.toml
+++ b/deny.toml
@@ -92,7 +92,7 @@ license-files = []
 
 [[licenses.clarify]]
 name = "sov-eip-712"
-expression = "LicenseRef-Sovereign-Labs-Community-Software-License"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
 license-files = []
 
 [[licenses.clarify]]


### PR DESCRIPTION
# Description

This PR is the first one on the road to implement `EIP712` authenticator.
For now I've converted the `Bank` data types manually and used the sol! macro to generate `EIP712` hashing for them.
This code is a scratch so I've put it in a new package in `utils/sov-eip-712`. Please let me know if you see a better place

The next steps will be:
* Writing an authenticator that accepts a bank CallMessage and checks it's EIP712 signature using approach from the test above
* Generate sol! definitions automagically using proc macros from UniversalWallet schemas

I've skipped CHANGELOG entry because the only thing I modify in demo-rollup is criterion version bump. Doesn't seem to be relevant to the user

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
You can run `cargo run` in this package. It compiles and prints the EIP712 hash.
I was trying to use local signer to generate and verify the signature but the dependency clashes of different versions of native FFI crypto libraries won.

## Docs
No docs yet as this is just first step and arch will change later

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/leo/eip712-support/index.html`
