### PR TITLE
Stabilize NOMT concurrent storages test

### DIFF
--- a/crates/full-node/sov-db/src/config.rs
+++ b/crates/full-node/sov-db/src/config.rs
@@ -51,7 +51,7 @@ impl RollupDbConfig {
             path,
             user_commit_concurrency: Some(4),
             user_hashtable_buckets: Some(if cfg!(debug_assertions) {
-                1_000_000
+                100_000
             } else {
                 15_000_000
             }),

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -355,7 +355,7 @@ fn try_commit_overlay_with_backoff<H>(
 where
     H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync,
 {
-    let mut start_wait = COMMIT_START_DELAY;
+    let mut current_wait = COMMIT_START_DELAY;
     for attempt in 0..COMMIT_RETRY_ATTEMPTS {
         match overlay.try_commit_nonblocking(nomt)? {
             None => {
@@ -365,18 +365,26 @@ where
             Some(returned) => {
                 match attempt {
                     n if n > 20 => {
-                        tracing::warn!(%attempt, wait_time = ?start_wait, "Failed to commit overlay, retrying...");
+                        tracing::warn!(%attempt, wait_time = ?current_wait, "Failed to commit overlay, retrying...");
                     }
                     n if n > 10 => {
-                        tracing::info!(%attempt, wait_time = ?start_wait, "Failed to commit overlay, retrying...");
+                        tracing::info!(%attempt, wait_time = ?current_wait, "Failed to commit overlay, retrying...");
                     }
                     _ => {
-                        tracing::debug!(%attempt, wait_time = ?start_wait, "Failed to commit overlay, retrying...");
+                        tracing::debug!(%attempt, wait_time = ?current_wait, "Failed to commit overlay, retrying...");
                     }
                 };
                 overlay = returned;
-                std::thread::sleep(start_wait);
-                start_wait *= 2;
+                std::thread::sleep(current_wait);
+                // Apply exponential backoff with factor 1.5
+                // Use saturating operations to prevent overflow
+                let next_nanos = current_wait
+                    .as_nanos()
+                    .saturating_mul(3) // multiply by 3
+                    .saturating_div(2); // then divide by 2 to get 1.5x
+
+                current_wait =
+                    std::time::Duration::from_nanos(next_nanos.min(u64::MAX as u128) as u64);
             }
         }
     }

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -376,15 +376,16 @@ where
                 };
                 overlay = returned;
                 std::thread::sleep(current_wait);
-                // Apply exponential backoff with factor 1.5
+                // Apply exponential backoff with factor 1.5:
+                // multiply by 3 then divide by 2 to get 1.5x
                 // Use saturating operations to prevent overflow
-                let next_nanos = current_wait
-                    .as_nanos()
-                    .saturating_mul(3) // multiply by 3
-                    .saturating_div(2); // then divide by 2 to get 1.5x
+                let next_nanos = current_wait.as_nanos().saturating_mul(3).saturating_div(2);
 
-                current_wait =
-                    std::time::Duration::from_nanos(next_nanos.min(u64::MAX as u128) as u64);
+                current_wait = std::time::Duration::from_nanos(
+                    next_nanos
+                        .try_into()
+                        .expect("Nanos overflow for NOMT commit retry"),
+                );
             }
         }
     }

--- a/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
@@ -287,7 +287,7 @@ impl<S: Spec> StateRootBackgroundTaskState<S> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, VecDeque};
 
     use arbitrary::{Arbitrary, Unstructured};
     use rand::rngs::StdRng;
@@ -542,7 +542,7 @@ mod tests {
 
         let mut storage_manager = SimpleNomtStorageManager::<TestStorageSpec>::new();
         storage_manager.set_strict_mode(false);
-        test_compute_competing_storages::<TestNomtSpec, _>(storage_manager, 0).await;
+        test_compute_competing_storages::<TestNomtSpec, _>(storage_manager, 1).await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -552,7 +552,7 @@ mod tests {
         test_compute_competing_storages::<TestNomtSpec, _>(storage_manager, 3).await;
         let storage_manager =
             CommitingStorageManager::<NomtStorageManager<MockDaSpec, TestHasher, _>, _>::new();
-        test_compute_competing_storages::<TestNomtSpec, _>(storage_manager, 0).await;
+        test_compute_competing_storages::<TestNomtSpec, _>(storage_manager, 1).await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -582,57 +582,50 @@ mod tests {
         S::Storage: NativeStorage,
         <S::Storage as Storage>::Root: Copy,
     {
+        assert!(seq_ahead_by > 0, "Test only works with seq_ahead_by > 0");
+        let _ahead_by_span =
+            tracing::debug_span!("competing_storages", seq_ahead_by = seq_ahead_by).entered();
         genesis::<S, Sm>(&mut storage_manager);
+        let preparation_start = std::time::Instant::now();
         let (task, handle, shutdown_sender) = start_background_task::<S>();
-        const BLOCKS: usize = 100;
+        // Double it to fill the channel
+        const BLOCKS: usize = NUM_STATE_ROOT_COMPUTE_REQUESTS * 2;
 
-        let mut receivers = Vec::new();
-
+        let mut receivers = Vec::with_capacity(BLOCKS);
         // First, build some "batches", which just writes only StateAccesses.
+        // Those batches are going to be consumed by the node
         let batches = generate_test_batches(BLOCKS);
         let mut canonical_root_hashes = Vec::with_capacity(BLOCKS);
+        let mut sequencer_cumulative_accesses = Vec::with_capacity(BLOCKS);
 
-        // Then emulate sequencer and node, where the sequencer constantly running forward for several batches
+        // Then building cumulative batches for sequencer.
+        // Each iteration(block) contains `seq_ahead_by` number of cumulative batches.
+        // The first cumulative batch has only data from `block - seq_ahead_by`,
+        // The second contains data from the first + data from the next, etc.
         for seq_idx in 0..BLOCKS {
             let start = seq_idx.saturating_sub(seq_ahead_by);
             let end = seq_idx;
 
-            let range = start..=end;
+            let range = start..end;
             let cumulative_accesses = cumulative_accesses_between_batches(&batches[range.clone()]);
+            sequencer_cumulative_accesses.push(cumulative_accesses);
+        }
+        let mut batches: VecDeque<StateAccesses> = batches.into();
+        tracing::info!(time = ?preparation_start.elapsed(), "Preparation is completed");
 
-            tracing::info!("-------");
-            for (idx, cumulative_batch) in range.zip(cumulative_accesses.into_iter()) {
+        //
+        for (seq_idx, seq_batches) in sequencer_cumulative_accesses.into_iter().enumerate() {
+            // Sequencer has received data and wants to compute state roots
+            let start = seq_idx.saturating_sub(seq_ahead_by);
+            let end = seq_idx;
+            let range = start..end;
+            let sequencer_storage = storage_manager.create_api_storage();
+            for (idx, cumulative_batch) in range.zip(seq_batches.into_iter()) {
                 let rollup_height = RollupHeight::new(idx as u64 + 1);
                 let slot_number = SlotNumber::new(idx as u64 + 1);
                 tracing::info!(%rollup_height, "sequencer iteration");
 
-                let sequencer_storage = storage_manager.create_api_storage();
                 let (response_channel, response_receiver) = oneshot::channel();
-
-                if seq_ahead_by == 0 && idx == start {
-                    let _span = tracing::debug_span!(
-                        "compute_state_update",
-                        scope = "node-like",
-                        rollup_height = %rollup_height,
-                        slot_number = %slot_number,
-                    )
-                    .entered();
-                    let node_storage = storage_manager.create_prover_storage();
-                    let prev_root = node_storage
-                        .get_root_hash(node_storage.latest_version())
-                        .unwrap();
-                    let node_batch = batches.get(idx).unwrap().clone();
-                    let (node_new_root, changes) = node_storage
-                        .compute_state_update(node_batch, &Default::default(), prev_root)
-                        .unwrap();
-                    tracing::info!(
-                        root_hash = %node_new_root,
-                        %rollup_height,
-                        "commiting state update"
-                    );
-                    canonical_root_hashes.push(node_new_root);
-                    storage_manager.commit_state_update(node_storage, changes, node_new_root);
-                }
                 task.request_sender
                     .send(StateRootComputeRequest {
                         state_accesses: cumulative_batch,
@@ -646,35 +639,35 @@ mod tests {
 
                 receivers.push(response_receiver);
             }
-
-            if seq_ahead_by > 0 {
-                if let Some(idx_for_node) = seq_idx.checked_sub(seq_ahead_by) {
-                    let _span = tracing::debug_span!(
-                        "compute_state_update",
-                        scope = "node-like",
-                        rollup_height = idx_for_node + 1,
-                        slot_number = idx_for_node + 1
-                    )
-                    .entered();
-                    let node_storage = storage_manager.create_prover_storage();
-                    let prev_root = node_storage
-                        .get_root_hash(node_storage.latest_version())
-                        .unwrap();
-                    let node_batch = batches.get(idx_for_node).unwrap().clone();
-                    let (node_new_root, changes) = node_storage
-                        .compute_state_update(node_batch, &Default::default(), prev_root)
-                        .unwrap();
-                    tracing::info!(
-                        root_hash = %node_new_root,
-                        rollup_height= idx_for_node + 1,
-                        "commiting state update"
-                    );
-                    canonical_root_hashes.push(node_new_root);
-                    storage_manager.commit_state_update(node_storage, changes, node_new_root);
-                }
+            // Emulates part where node receives something from the DA layer, executes it and commits
+            if let Some(idx_for_node) = seq_idx.checked_sub(seq_ahead_by) {
+                let start = std::time::Instant::now();
+                let rollup_height = idx_for_node + 1;
+                let _node_state_compute_span = tracing::debug_span!(
+                    "compute_state_update",
+                    scope = "node-like",
+                    rollup_height,
+                )
+                .entered();
+                let node_batch = batches.pop_front().unwrap();
+                let node_storage = storage_manager.create_prover_storage();
+                let prev_root = node_storage
+                    .get_root_hash(node_storage.latest_version())
+                    .unwrap();
+                let (node_new_root, changes) = node_storage
+                    .compute_state_update(node_batch, &Default::default(), prev_root)
+                    .unwrap();
+                canonical_root_hashes.push(node_new_root);
+                storage_manager.commit_state_update(node_storage, changes, node_new_root);
+                tracing::info!(
+                    root_hash = %node_new_root,
+                    %rollup_height,
+                    time = ?start.elapsed(),
+                    "commited state update");
             }
         }
 
+        // Validating the results
         let mut results = BTreeMap::<RollupHeight, <S::Storage as Storage>::Root>::new();
         for receiver in receivers {
             let (height, root_hash) = receiver.await.unwrap();
@@ -687,16 +680,17 @@ mod tests {
         }
 
         let received_keys = results.keys().cloned().collect::<Vec<_>>();
-        let expected_keys = (0..BLOCKS)
-            .map(|i| RollupHeight::new(i as u64 + 1))
+        // The first block is empty, thus 1 less root hash
+        let expected_keys = (1..BLOCKS)
+            .map(|i| RollupHeight::new(i as u64))
             .collect::<Vec<_>>();
         assert_eq!(received_keys, expected_keys);
 
-        for ((rollup_height, received_root_hash), canoncial_root_hash) in
+        for ((rollup_height, received_root_hash), canonical_root_hash) in
             results.iter().zip(canonical_root_hashes.iter())
         {
             assert!(
-                user_roots_match(received_root_hash, canoncial_root_hash),
+                user_roots_match(received_root_hash, canonical_root_hash),
                 "Received different user roots for the same height {rollup_height}"
             );
         }

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -407,6 +407,7 @@ where
         witness: &Self::Witness,
         prev_state_root: Self::Root,
     ) -> anyhow::Result<(Self::Root, Self::StateUpdate)> {
+        let start = std::time::Instant::now();
         let next_version = self.historical_state.get_next_version();
         tracing::trace!(%prev_state_root, %next_version, "NomtProverStorage, computing state update");
         // Open 2 sessions close to each other
@@ -459,7 +460,7 @@ where
         let kernel_root = kernel_finished_session.root();
         let root = StorageRoot::new(user_root.into_inner(), kernel_root.into_inner());
 
-        tracing::debug!(state_root = %root, %next_version, "computed next state root");
+        tracing::debug!(state_root = %root, %next_version, time = ?start.elapsed(), "computed next state root");
 
         let state_update = NomtStateUpdate {
             user: user_finished_session,


### PR DESCRIPTION
# Description

Port of https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/3305
Test `test_nomt_state_compute_competing_storages_repro_real_storage_manager` has shown flakyness.

During investigation, I've discovered, that under background load or slow disc performance it is possible that tasks that computes state roots for sequencer might hold active session for longer than NOMT-based storage manager allows. especially it shows closer to the end of the test, when channel with state root requests is filled faster than consumed.

## Solution

Test is rewritten for easier understanding. 

* Separate data preparation and actual test. This reduces resources usage during test critical section.
* Changed exponent from 2.0 to 1.5 and increased number of attempts, so committing thread tries more often
* Reduced number of NOMT buckets for default dev config. This should improve start time, as less data needs to be allocated
* Add compute_state_update time to the logs for easier debugging in the future

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
Test is passing under load

## Docs
Added comprehensive comment through the test.
