### PR TITLE
Use prebuilt CI docker image

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,13 +20,6 @@ runs:
       # See <https://github.com/rust-lang/rustup/issues/3635>.
       run: rustup show && rustup toolchain install nightly --component rustfmt --profile minimal
     # Install ZKVM toolchains
-    - name: Install cargo-risczero toolchain
-      uses: taiki-e/install-action@v2
-      if: ${{ inputs.install_zkvm == '1' }}
-      env:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
-      with:
-        tool: cargo-risczero@2.0
     - name: Install risc0-zkvm toolchain # Use the risc0 cargo extension to install the risc0 std library for the current toolchain
       shell: bash
       if: ${{ inputs.install_zkvm == '1' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,10 +101,8 @@ jobs:
 
   check:
     name: check
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
-      - nscloud-cache-tag-cache-dev
-      - nscloud-cache-size-100gb
+    # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
+    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -271,10 +269,8 @@ jobs:
 
   doctests:
     name: doctests
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
-      - nscloud-cache-tag-cache-doctests
-      - nscloud-cache-size-100gb
+    # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
+    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
     timeout-minutes: 60
     env:
       SKIP_GUEST_BUILD: "1"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -217,7 +217,7 @@ jobs:
   nextest:
     name: nextest
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"
@@ -234,7 +234,7 @@ jobs:
   nextest_all_features:
     name: nextest_all_features
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -249,7 +249,7 @@ jobs:
   nextest:
     name: nextest
     runs-on:
-      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
+      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x32-with-cache
       - nscloud-cache-tag-cache-test
       - nscloud-cache-size-100gb
       # Privileged feature is needed for proper `io_uring` functionality needed by NOMT

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -265,15 +265,12 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - run: make test-default-features
 
   nextest_all_features:
     name: nextest_all_features
     runs-on:
-      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
+      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x32-with-cache
       - nscloud-cache-tag-cache-test
       - nscloud-cache-size-100gb
       # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
@@ -288,9 +285,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - run: make test-all
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -298,7 +292,7 @@ jobs:
   doctests:
     name: doctests
     runs-on:
-      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
+      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x32-with-cache
       - nscloud-cache-tag-cache-doctests
       - nscloud-cache-size-100gb
     timeout-minutes: 60
@@ -310,10 +304,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          install_zkvm: "0"
       # `cargo-nextest` does not support doctests (yet?), so we have to run them
       # separately.
       # TODO: https://github.com/nextest-rs/nextest/issues/16
@@ -322,7 +312,7 @@ jobs:
   coverage:
     name: coverage
     runs-on:
-      - nscloud-ubuntu-22.04-amd64-16x32-with-cache
+      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x32-with-cache
       - nscloud-cache-tag-cache-coverage
       - nscloud-cache-size-150gb
       # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
@@ -337,10 +327,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          install_zkvm: "0"
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -248,12 +248,8 @@ jobs:
 
   nextest:
     name: nextest
-    runs-on:
-      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
-      - nscloud-cache-tag-cache-test
-      - nscloud-cache-size-100gb
-      # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-      - nscloud-exp-features:privileged;host-pid-namespace
+    # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
+    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"
@@ -269,12 +265,8 @@ jobs:
 
   nextest_all_features:
     name: nextest_all_features
-    runs-on:
-      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
-      - nscloud-cache-tag-cache-test
-      - nscloud-cache-size-100gb
-      # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-      - nscloud-exp-features:privileged;host-pid-namespace
+    # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
+    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"
@@ -291,10 +283,7 @@ jobs:
 
   doctests:
     name: doctests
-    runs-on:
-      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x32-with-cache
-      - nscloud-cache-tag-cache-doctests
-      - nscloud-cache-size-100gb
+    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
     timeout-minutes: 60
     env:
       SKIP_GUEST_BUILD: "1"
@@ -311,12 +300,8 @@ jobs:
 
   coverage:
     name: coverage
-    runs-on:
-      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
-      - nscloud-cache-tag-cache-coverage
-      - nscloud-cache-size-150gb
-      # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-      - nscloud-exp-features:privileged;host-pid-namespace
+    # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
+    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 90
     env:
       SKIP_GUEST_BUILD: "1"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -110,9 +110,6 @@ jobs:
         with:
           cache: rust
           path: ./crates/fuzz/target
-      - uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run lint
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
@@ -142,9 +139,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo bench --no-run
         env:
           SOV_BENCH_BLOCKS: 1
@@ -162,9 +156,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: rollup bench check
         env:
           SOV_BENCH_BLOCKS: 10
@@ -194,10 +185,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          install_zkvm: "0"
       # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       - name: cargo hack
         run: make check-features
@@ -225,10 +212,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          install_zkvm: "0"
       - name: cargo hack
         run: make check-features-default-targets
 
@@ -280,10 +263,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          install_zkvm: "0"
       # `cargo-nextest` does not support doctests (yet?), so we have to run them
       # separately.
       # TODO: https://github.com/nextest-rs/nextest/issues/16

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -249,7 +249,7 @@ jobs:
   nextest:
     name: nextest
     runs-on:
-      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x32-with-cache
+      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
       - nscloud-cache-tag-cache-test
       - nscloud-cache-size-100gb
       # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
@@ -270,7 +270,7 @@ jobs:
   nextest_all_features:
     name: nextest_all_features
     runs-on:
-      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x32-with-cache
+      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
       - nscloud-cache-tag-cache-test
       - nscloud-cache-size-100gb
       # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
@@ -312,7 +312,7 @@ jobs:
   coverage:
     name: coverage
     runs-on:
-      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x32-with-cache
+      - namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
       - nscloud-cache-tag-cache-coverage
       - nscloud-cache-size-150gb
       # Privileged feature is needed for proper `io_uring` functionality needed by NOMT

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,8 +52,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
-  # This is faster for CI: https://github.com/dtolnay/rust-toolchain/issues/26.
-  CARGO_INCREMENTAL: "0"
   CARGO_NET_GIT_FETCH_WITH_CLI: true
   NO_COLOR: 1
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,8 +101,7 @@ jobs:
 
   check:
     name: check
-    # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-dev-250gb-1-88
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -170,7 +169,7 @@ jobs:
     # building dependencies, only checking them, so we can share caches
     # effectively.
     needs: check
-    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-dev-250gb-1-88
     strategy:
       matrix:
         partition: [1, 2, 3]
@@ -197,7 +196,7 @@ jobs:
     # building dependencies, only checking them, so we can share caches
     # effectively.
     needs: check
-    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-dev-250gb-1-88
     strategy:
       matrix:
         partition: [1, 2, 3]
@@ -218,7 +217,7 @@ jobs:
   nextest:
     name: nextest
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"
@@ -235,7 +234,7 @@ jobs:
   nextest_all_features:
     name: nextest_all_features
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"
@@ -252,8 +251,7 @@ jobs:
 
   doctests:
     name: doctests
-    # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-test-250gb-1-88
     timeout-minutes: 60
     env:
       SKIP_GUEST_BUILD: "1"
@@ -263,8 +261,7 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      # `cargo-nextest` does not support doctests (yet?), so we have to run them
-      # separately.
+      # `cargo-nextest` does not support doctests (yet?), so we have to run them separately.
       # TODO: https://github.com/nextest-rs/nextest/issues/16
       - run: make doctest
 
@@ -466,20 +463,13 @@ jobs:
       - run: chmod +x demo-rollup-readme.sh && ./demo-rollup-readme.sh
 
   check-constant-overriding-is-disabled-in-release-mode:
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
-      - nscloud-cache-tag-check-constant-overriding-is-disabled-in-release-mode
-      - nscloud-cache-size-20gb
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-test-250gb-1-88
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Setup Zkvm toolchains + Rust
-        uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - run: make check-constant-overriding-is-disabled-in-release-mode
 
   validate-packages-to-publish-yml:
@@ -491,19 +481,12 @@ jobs:
         working-directory: .
 
   cargo-switcheroo-default:
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-4x16-with-cache
-      - nscloud-cache-tag-cargo-switcheroo
-      - nscloud-cache-size-20gb
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-dev-250gb-1-88
     steps:
       - uses: actions/checkout@v4
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Setup Zkvm toolchains + Rust
-        uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo switcheroo set default
         # Exit status 0 means no changes were made.
       - run: git diff --exit-code

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -217,7 +217,7 @@ jobs:
   nextest:
     name: nextest
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"
@@ -234,7 +234,7 @@ jobs:
   nextest_all_features:
     name: nextest_all_features
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"
@@ -267,6 +267,7 @@ jobs:
 
   coverage:
     name: coverage
+    # TODO:try coverage 32x64
     runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-coverage-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 90
     env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -283,7 +283,10 @@ jobs:
 
   doctests:
     name: doctests
-    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
+    runs-on:
+      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
+      - nscloud-cache-tag-cache-doctests
+      - nscloud-cache-size-100gb
     timeout-minutes: 60
     env:
       SKIP_GUEST_BUILD: "1"
@@ -293,6 +296,10 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
+      - uses: ./.github/actions/setup
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          install_zkvm: "0"
       # `cargo-nextest` does not support doctests (yet?), so we have to run them
       # separately.
       # TODO: https://github.com/nextest-rs/nextest/issues/16
@@ -300,8 +307,12 @@ jobs:
 
   coverage:
     name: coverage
-    # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache;container.privileged=true;container.host-pid-namespace=true
+    runs-on:
+      - nscloud-ubuntu-22.04-amd64-16x32-with-cache
+      - nscloud-cache-tag-cache-coverage
+      - nscloud-cache-size-150gb
+      # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
+      - nscloud-exp-features:privileged;host-pid-namespace
     timeout-minutes: 90
     env:
       SKIP_GUEST_BUILD: "1"
@@ -312,6 +323,10 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
+      - uses: ./.github/actions/setup
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          install_zkvm: "0"
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,8 +101,10 @@ jobs:
 
   check:
     name: check
-    # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache;container.privileged=true;container.host-pid-namespace=true
+    runs-on:
+      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
+      - nscloud-cache-tag-cache-dev
+      - nscloud-cache-size-100gb
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -405,10 +405,7 @@ jobs:
         run: git diff --exit-code
 
   check-demo-rollup-bash-commands:
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
-      - nscloud-cache-tag-demo-rollup
-      - nscloud-cache-size-100gb
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-demo-rollup-250gb-1-88
     needs:
       - check
     timeout-minutes: 60
@@ -427,20 +424,13 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Setup Zkvm toolchains + Rust
-        uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile README.md to Bash
         run: bashtestmd --input examples/demo-rollup/README_CELESTIA.md --output demo-rollup-readme.sh --tag test-ci
       - run: cat demo-rollup-readme.sh
       - run: chmod +x demo-rollup-readme.sh && ./demo-rollup-readme.sh
 
   check-demo-rollup-bash-commands-mock-da:
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
-      - nscloud-cache-tag-demo-rollup
-      - nscloud-cache-size-100gb
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-demo-rollup-250gb-1-88
     needs:
       - check
     timeout-minutes: 60
@@ -453,10 +443,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Setup Zkvm toolchains + Rust
-        uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Compile README.md to Bash
         run: bashtestmd --input examples/demo-rollup/README.md --output demo-rollup-readme.sh --tag test-ci
       - run: cat demo-rollup-readme.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,10 +101,8 @@ jobs:
 
   check:
     name: check
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
-      - nscloud-cache-tag-cache-dev
-      - nscloud-cache-size-100gb
+    # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
+    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -136,10 +134,8 @@ jobs:
   bench_check:
     name: bench_check
     needs: check
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-16x64-with-cache
-      - nscloud-cache-tag-cache-bench
-      - nscloud-cache-size-100gb
+    # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
+    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -158,10 +154,8 @@ jobs:
   rollup_tps_validation:
     name: rollup_tps_validation
     needs: check
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
-      - nscloud-cache-tag-cache-bench
-      - nscloud-cache-size-100gb
+    # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
+    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -185,10 +179,7 @@ jobs:
     # building dependencies, only checking them, so we can share caches
     # effectively.
     needs: check
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
-      - nscloud-cache-tag-cache-dev
-      - nscloud-cache-size-100gb
+    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
     strategy:
       matrix:
         partition: [1, 2, 3]
@@ -219,10 +210,7 @@ jobs:
     # building dependencies, only checking them, so we can share caches
     # effectively.
     needs: check
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-8x32-with-cache
-      - nscloud-cache-tag-cache-dev
-      - nscloud-cache-size-100gb
+    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache
     strategy:
       matrix:
         partition: [1, 2, 3]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -217,7 +217,7 @@ jobs:
   nextest:
     name: nextest
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"
@@ -234,7 +234,7 @@ jobs:
   nextest_all_features:
     name: nextest_all_features
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -131,7 +131,7 @@ jobs:
     name: bench_check
     needs: check
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-bench-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -148,7 +148,7 @@ jobs:
     name: rollup_tps_validation
     needs: check
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-rust-amd64-ubuntu-24-04-16x64-with-cache;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-bench-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
@@ -267,12 +267,7 @@ jobs:
 
   coverage:
     name: coverage
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-16x32-with-cache
-      - nscloud-cache-tag-cache-coverage
-      - nscloud-cache-size-150gb
-      # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-      - nscloud-exp-features:privileged;host-pid-namespace
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-coverage-250gb-1-88;container.privileged=true;container.host-pid-namespace=true
     timeout-minutes: 90
     env:
       SKIP_GUEST_BUILD: "1"
@@ -283,10 +278,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - uses: ./.github/actions/setup
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          install_zkvm: "0"
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -396,7 +396,7 @@ jobs:
         run: git diff --exit-code
 
   check-demo-rollup-bash-commands:
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-demo-rollup-250gb-1-88
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-demo-rollup-250gb-1-88
     needs:
       - check
     timeout-minutes: 60
@@ -421,7 +421,7 @@ jobs:
       - run: chmod +x demo-rollup-readme.sh && ./demo-rollup-readme.sh
 
   check-demo-rollup-bash-commands-mock-da:
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-demo-rollup-250gb-1-88
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-demo-rollup-250gb-1-88
     needs:
       - check
     timeout-minutes: 60

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -20,7 +20,7 @@
     "--message-format=json",
     "--keep-going"
   ],
-  "rust-analyzer.rustfmt.extraArgs": [],
+  "rust-analyzer.rustfmt.extraArgs": ["+nightly", "--config-path", "rustfmt.nightly.toml "],
   "json.schemas": [
     {
       "fileMatch": ["bank.json"],

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -20,7 +20,7 @@
     "--message-format=json",
     "--keep-going"
   ],
-  "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
+  "rust-analyzer.rustfmt.extraArgs": [],
   "json.schemas": [
     {
       "fileMatch": ["bank.json"],

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -20,7 +20,7 @@
     "--message-format=json",
     "--keep-going"
   ],
-  "rust-analyzer.rustfmt.extraArgs": ["+nightly", "--config-path", "rustfmt.nightly.toml "],
+  "rust-analyzer.rustfmt.overrideCommand": ["rustfmt", "+nightly", "--edition=2024", "--config-path=${workspaceFolder}/rustfmt.nightly.toml"],
   "json.schemas": [
     {
       "fileMatch": ["bank.json"],

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,30 @@ total-clean:
     done;
 	rm -rf "examples/demo-rollup/tests/evm/uniswap/node_modules"
 
+check-mold: ## Check mold version if available
+	@if command -v mold > /dev/null 2>&1; then \
+		echo "mold version:"; \
+		mold --version; \
+	else \
+		echo "mold is not available"; \
+	fi
+
+remove-clang-linker: ## Remove linker = "clang" from ~/.cargo/config.toml if present
+	@if [ -f ~/.cargo/config.toml ]; then \
+		if grep -q '^[[:space:]]*linker[[:space:]]*=[[:space:]]*"clang"' ~/.cargo/config.toml; then \
+			sed -i.bak '/^[[:space:]]*linker[[:space:]]*=[[:space:]]*"clang"[[:space:]]*$$/d' ~/.cargo/config.toml; \
+			echo "Removed linker = \"clang\" line from ~/.cargo/config.toml"; \
+		else \
+			echo "linker = \"clang\" not found in ~/.cargo/config.toml"; \
+		fi; \
+	else \
+		echo "~/.cargo/config.toml does not exist"; \
+	fi
+
+
+
+test: check-mold
+test: remove-clang-linker
 test:  ## Runs test suite using next test
 	@cargo nextest run --no-fail-fast --status-level skip --all-features
 
@@ -59,6 +83,8 @@ test-all: ## Runs test suite using nextest, across the whole workspace
 	$(MAKE) test
 	cargo switcheroo set _backup
 
+test-default-features: check-mold
+test-default-features: remove-clang-linker
 test-default-features:  ## Runs test suite using default features
 	@cargo nextest run --no-fail-fast --status-level skip
 

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ test-all: ## Runs test suite using nextest, across the whole workspace
 test-default-features:  ## Runs test suite using default features
 	@cargo nextest run --no-fail-fast --status-level skip
 
-install-dev-tools:  ## Installs all necessary cargo helpers
-install-dev-tools: install-risc0-toolchain install-sp1-toolchain
+install-dev-tools:  ## Installs all necessary dev tools
+install-dev-tools: install-cargo-tools install-risc0-toolchain install-sp1-toolchain
 	rustup update nightly
 	## Backup VS Code settings to `.vscode/settings.json.bak`.
 	cp .vscode/settings.json .vscode/settings.json.bak || true
@@ -79,6 +79,16 @@ install-dev-tools: install-risc0-toolchain install-sp1-toolchain
 	cargo install zepter
 	cargo +stable install cargo-dylint dylint-link
 	rustup target add wasm32-unknown-unknown
+
+install-cargo-tools:  ## Installs all necessary cargo helpers
+	cargo install cargo-llvm-cov
+	cargo install cargo-hack
+	cargo install cargo-udeps
+	cargo install cargo-deny
+	cargo install flaky-finder
+	cargo install cargo-insta
+	cargo install cargo-nextest --locked
+	cargo install zepter
 
 install-risc0-toolchain:  ## install risc0 toolchain
 	curl -L https://risczero.com/install | bash

--- a/Makefile
+++ b/Makefile
@@ -50,30 +50,6 @@ total-clean:
     done;
 	rm -rf "examples/demo-rollup/tests/evm/uniswap/node_modules"
 
-check-mold: ## Check mold version if available
-	@if command -v mold > /dev/null 2>&1; then \
-		echo "mold version:"; \
-		mold --version; \
-	else \
-		echo "mold is not available"; \
-	fi
-
-remove-clang-linker: ## Remove linker = "clang" from ~/.cargo/config.toml if present
-	@if [ -f ~/.cargo/config.toml ]; then \
-		if grep -q '^[[:space:]]*linker[[:space:]]*=[[:space:]]*"clang"' ~/.cargo/config.toml; then \
-			sed -i.bak '/^[[:space:]]*linker[[:space:]]*=[[:space:]]*"clang"[[:space:]]*$$/d' ~/.cargo/config.toml; \
-			echo "Removed linker = \"clang\" line from ~/.cargo/config.toml"; \
-		else \
-			echo "linker = \"clang\" not found in ~/.cargo/config.toml"; \
-		fi; \
-	else \
-		echo "~/.cargo/config.toml does not exist"; \
-	fi
-
-
-
-test: check-mold
-test: remove-clang-linker
 test:  ## Runs test suite using next test
 	@cargo nextest run --no-fail-fast --status-level skip --all-features
 
@@ -83,8 +59,6 @@ test-all: ## Runs test suite using nextest, across the whole workspace
 	$(MAKE) test
 	cargo switcheroo set _backup
 
-test-default-features: check-mold
-test-default-features: remove-clang-linker
 test-default-features:  ## Runs test suite using default features
 	@cargo nextest run --no-fail-fast --status-level skip
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean: ## Cleans compiled
 check-provers:   ## cargo check in non attached crates
 	@set -e; for dir in $(PROVER_DIRS); do \
 		echo "$$(date) Running cargo fmt + check in $$dir"; \
-		cargo +nightly fmt --all --check --quiet --manifest-path "$$dir/Cargo.toml"; \
+		cargo fmt --all --check --quiet --manifest-path "$$dir/Cargo.toml"; \
 		cargo check --all-targets --all-features --manifest-path "$$dir/Cargo.toml"; \
 	done
 
@@ -108,7 +108,7 @@ install-sp1-toolchain:  ## install SP1 toolchain
 
 lint:  ## cargo fmt, check and clippy.
 	## fmt first, because it's the cheapest
-	cargo +nightly fmt --all --check
+	cargo fmt --all --check
 	cargo check --all-targets --all-features
 	## Invokes Zepter multiple times because fixes sometimes unveal more underlying issues.
 	zepter
@@ -137,7 +137,7 @@ cargo-deny-check:   ## Runs a global cargo-deny check, not just the licenses.
 	cargo deny check --hide-inclusion-graph
 
 lint-fix:  ## cargo fmt, fix and clippy. Skip clippy on guest code since it's not supported by risc0
-	cargo +nightly fmt --all
+	cargo fmt --all
 	cargo fix --allow-dirty
 	SKIP_GUEST_BUILD=1 cargo clippy --fix --allow-dirty -- -A clippy::too_many_arguments
 
@@ -156,9 +156,6 @@ check-constant-overriding-is-disabled-in-release-mode:
 		exit 1; \
 	fi
 	@echo "Check succeeded!"
-
-find-unused-deps: ## Prints unused dependencies for project. Note: requires nightly
-	cargo +nightly udeps --all-targets --all-features
 
 find-flaky-tests:  ## Runs tests over and over to find if there's flaky tests
 	flaky-finder -j16 -r320 --continue "cargo test -- --nocapture"

--- a/crates/fuzz/Makefile
+++ b/crates/fuzz/Makefile
@@ -15,7 +15,7 @@ clean:
 
 # Needs nightly for `-Z sanitizer=address`
 build-target: ## Build the target fuzz
-	cargo +nightly rustc --bin $(TARGET) $(ARGS) -- \
+	cargo rustc --bin $(TARGET) $(ARGS) -- \
 		-C debuginfo=full \
 		-C debug-assertions \
 		-C passes='sancov-module' \

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs
@@ -17,6 +17,7 @@ pub trait Data:
     + Eq
     + PartialEq
     + std::fmt::Debug
+    + Default
     + serde::Serialize
     + serde::de::DeserializeOwned
     + borsh::BorshSerialize

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.stderr
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.stderr
@@ -119,7 +119,7 @@ note: expected this to be `T`
     = note: required for the cast from `&QueryModule<S, <T as TestSpec>::Data>` to `&dyn sov_modules_api::ModuleInfo<Spec = T>`
     = note: this error originates in the derive macro `Genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `impl ::sov_modules_api::GenesisState<<Self as ::sov_modules_api::Genesis>::Spec>: GenesisState<S>` is not satisfied
+error[E0277]: the trait bound `impl ::sov_modules_api::GenesisState<<Self as ::sov_modules_api::Genesis>::Spec>: GenesisState<...>` is not satisfied
    --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:19
     |
 111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
@@ -133,6 +133,7 @@ note: required by a bound in `sov_modules_api::Genesis::genesis`
 ...
     |         state: &mut impl GenesisState<Self::Spec>,
     |                          ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Genesis::genesis`
+    = note: consider using `--verbose` to print the full type name to the console
     = note: this error originates in the derive macro `Genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.stderr
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:16
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:16
     |
-111 | struct Runtime<T: TestSpec, S: Spec> {
+112 | struct Runtime<T: TestSpec, S: Spec> {
     |                ^ the trait `sov_modules_api::Spec` is not implemented for `T`
     |
 note: required by a bound in `sov_modules_api::Genesis::Spec`
@@ -11,25 +11,25 @@ note: required by a bound in `sov_modules_api::Genesis::Spec`
     |                ^^^^ required by this bound in `Genesis::Spec`
 help: consider further restricting type parameter `T` with trait `Spec`
     |
-111 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
+112 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
     |                            +++++++++++++++++++++++
 
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:110:19
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:19
     |
-110 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                   ^^^^^^^ the trait `sov_modules_api::Spec` is not implemented for `T`
     |
     = note: this error originates in the derive macro `Genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `T` with trait `Spec`
     |
-111 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
+112 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
     |                            +++++++++++++++++++++++
 
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:109:1
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:110:1
     |
-109 | #[expose_rpc]
+110 | #[expose_rpc]
     | ^^^^^^^^^^^^^ the trait `sov_modules_api::Spec` is not implemented for `T`
     |
 note: required by a bound in `ApiState`
@@ -40,13 +40,13 @@ note: required by a bound in `ApiState`
     = note: this error originates in the attribute macro `expose_rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `T` with trait `Spec`
     |
-111 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
+112 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
     |                            +++++++++++++++++++++++
 
 error[E0277]: `ActualSpec` doesn't implement `std::fmt::Debug`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:118:19
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:119:19
     |
-118 | impl TestSpec for ActualSpec {
+119 | impl TestSpec for ActualSpec {
     |                   ^^^^^^^^^^ `ActualSpec` cannot be formatted using `{:?}`
     |
     = help: the trait `std::fmt::Debug` is not implemented for `ActualSpec`
@@ -60,14 +60,14 @@ note: required by a bound in `TestSpec`
     |                             ^^^^^^^^^^^^^^^ required by this bound in `TestSpec`
 help: consider annotating `ActualSpec` with `#[derive(Debug)]`
     |
-116 + #[derive(Debug)]
-117 | struct ActualSpec;
+117 + #[derive(Debug)]
+118 | struct ActualSpec;
     |
 
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:16
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:16
     |
-111 | struct Runtime<T: TestSpec, S: Spec> {
+112 | struct Runtime<T: TestSpec, S: Spec> {
     |                ^ the trait `sov_modules_api::Spec` is not implemented for `T`
     |
 note: required by a bound in `sov_modules_api::DispatchCall::Spec`
@@ -77,13 +77,13 @@ note: required by a bound in `sov_modules_api::DispatchCall::Spec`
     |                ^^^^ required by this bound in `DispatchCall::Spec`
 help: consider further restricting type parameter `T` with trait `Spec`
     |
-111 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
+112 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
     |                            +++++++++++++++++++++++
 
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:110:28
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:28
     |
-110 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^ the trait `sov_modules_api::Spec` is not implemented for `T`
     |
 note: required by a bound in `StateProvider`
@@ -94,23 +94,23 @@ note: required by a bound in `StateProvider`
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `T` with trait `Spec`
     |
-111 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
+112 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
     |                            +++++++++++++++++++++++
 
 error[E0271]: type mismatch resolving `<QueryModule<S, <T as TestSpec>::Data> as ModuleInfo>::Spec == T`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:110:19
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:19
     |
-110 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                   ^^^^^^^ type mismatch resolving `<QueryModule<S, <T as TestSpec>::Data> as ModuleInfo>::Spec == T`
-111 | struct Runtime<T: TestSpec, S: Spec> {
+112 | struct Runtime<T: TestSpec, S: Spec> {
     |                -            - found type parameter
     |                |
     |                expected type parameter
     |
 note: expected this to be `T`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:38:28
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:39:28
     |
-38  |     pub struct QueryModule<S: Spec, D: Data> {
+39  |     pub struct QueryModule<S: Spec, D: Data> {
     |                            ^
     = note: expected type parameter `T`
                found type parameter `S`
@@ -120,9 +120,9 @@ note: expected this to be `T`
     = note: this error originates in the derive macro `Genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `impl ::sov_modules_api::GenesisState<<Self as ::sov_modules_api::Genesis>::Spec>: GenesisState<S>` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:110:19
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:19
     |
-110 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                   ^^^^^^^ the trait `GenesisState<S>` is not implemented for `impl ::sov_modules_api::GenesisState<<Self as ::sov_modules_api::Genesis>::Spec>`
     |
 note: required by a bound in `sov_modules_api::Genesis::genesis`
@@ -136,9 +136,9 @@ note: required by a bound in `sov_modules_api::Genesis::genesis`
     = note: this error originates in the derive macro `Genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:110:28
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:28
     |
-110 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^ the trait `sov_modules_api::Spec` is not implemented for `T`
     |
     = note: required for `WorkingSet<T, I>` to implement `GasMeter`
@@ -154,15 +154,15 @@ note: required by a bound in `sov_modules_api::Module::call`
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `T` with trait `Spec`
     |
-111 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
+112 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
     |                            +++++++++++++++++++++++
 
 error[E0271]: type mismatch resolving `<WorkingSet<T, I> as GasMeter>::Spec == S`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:110:28
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:28
     |
-110 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^ expected type parameter `S`, found type parameter `T`
-111 | struct Runtime<T: TestSpec, S: Spec> {
+112 | struct Runtime<T: TestSpec, S: Spec> {
     |                -            - expected type parameter
     |                |
     |                found type parameter
@@ -183,14 +183,14 @@ note: required by a bound in `sov_modules_api::Module::call`
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:110:28
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:28
     |
-110 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^
     |                            |
     |                            expected `&Context<S>`, found `&Context<T>`
     |                            arguments to this function are incorrect
-111 | struct Runtime<T: TestSpec, S: Spec> {
+112 | struct Runtime<T: TestSpec, S: Spec> {
     |                -            - expected type parameter
     |                |
     |                found type parameter
@@ -207,19 +207,19 @@ note: method defined here
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<QueryModule<S, <T as TestSpec>::Data> as ModuleInfo>::Spec == T`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:110:28
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:28
     |
-110 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^ type mismatch resolving `<QueryModule<S, <T as TestSpec>::Data> as ModuleInfo>::Spec == T`
-111 | struct Runtime<T: TestSpec, S: Spec> {
+112 | struct Runtime<T: TestSpec, S: Spec> {
     |                -            - found type parameter
     |                |
     |                expected type parameter
     |
 note: expected this to be `T`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:38:28
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:39:28
     |
-38  |     pub struct QueryModule<S: Spec, D: Data> {
+39  |     pub struct QueryModule<S: Spec, D: Data> {
     |                            ^
     = note: expected type parameter `T`
                found type parameter `S`
@@ -228,22 +228,10 @@ note: expected this to be `T`
     = note: required for the cast from `&QueryModule<S, <T as TestSpec>::Data>` to `&dyn sov_modules_api::ModuleInfo<Spec = T>`
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `<T as TestSpec>::Data: std::default::Default` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:8
-    |
-111 | struct Runtime<T: TestSpec, S: Spec> {
-    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::default::Default` is not implemented for `<T as TestSpec>::Data`
-    |
-note: required for `Runtime<T, S>` to implement `std::default::Default`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:110:10
-    |
-110 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
-    |          ^^^^^^^ unsatisfied trait bound introduced in this `derive` macro
-
 error[E0599]: the method `clone` exists for struct `ApiState<T>`, but its trait bounds were not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:109:1
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:110:1
     |
-109 | #[expose_rpc]
+110 | #[expose_rpc]
     | ^^^^^^^^^^^^^ method cannot be called on `ApiState<T>` due to unsatisfied trait bounds
     |
    ::: $WORKSPACE/crates/module-system/sov-modules-api/src/rest/mod.rs
@@ -257,5 +245,5 @@ error[E0599]: the method `clone` exists for struct `ApiState<T>`, but its trait 
     = note: this error originates in the attribute macro `expose_rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting the type parameter to satisfy the trait bound
     |
-109 | #[expose_rpc] where T: sov_modules_api::Spec
+110 | #[expose_rpc] where T: sov_modules_api::Spec
     |               ++++++++++++++++++++++++++++++

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -31,8 +31,8 @@ ENV RUSTUP_HOME=/home/runner/.rustup \
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88.0 --profile minimal \
     && . /home/runner/.cargo/env \
-    && rustup component add clippy --toolchain 1.88.0 \
-    && rustup toolchain install nightly --component rustfmt --profile minimal \
+    && rustup component add clippy rust-src llvm-tools-preview --toolchain 1.88.0 \
+    && rustup toolchain install nightly --component rustfmt --component rust-src --profile minimal \
     && rustup target add wasm32-unknown-unknown
 
 # Install Node.js 20.x

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -9,7 +9,7 @@ FROM ${NAMESPACE_BASE_IMAGE_REF} AS base
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN sudo apt-get update && sudo apt-get install -y \
     build-essential \
     pkg-config \
     libssl-dev \
@@ -24,63 +24,68 @@ RUN apt-get update && apt-get install -y \
     lld \
     zstd \
     unzip \
-    && rm -rf /var/lib/apt/lists/*
+    && sudo rm -rf /var/lib/apt/lists/*
 
-# Install Rust
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+# Install Rust as user
+# The base image runs as runner user with home at /home/runner
+ENV RUSTUP_HOME=/home/runner/.rustup \
+    CARGO_HOME=/home/runner/.cargo \
+    PATH=/home/runner/.cargo/bin:$PATH
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88.0 --profile minimal \
+    && . /home/runner/.cargo/env \
     && rustup component add clippy --toolchain 1.88.0 \
     && rustup toolchain install nightly --component rustfmt --profile minimal \
     && rustup target add wasm32-unknown-unknown
 
 # Install Node.js 20.x
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y nodejs \
-    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | sudo bash - \
+    && sudo apt-get install -y nodejs \
+    && sudo rm -rf /var/lib/apt/lists/*
 
 # Install pnpm
-RUN npm install -g pnpm@9
+RUN sudo npm install -g pnpm@9
 
 # Install yq for YAML processing
-RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq \
-    && chmod +x /usr/bin/yq
+RUN sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq \
+    && sudo chmod +x /usr/bin/yq
 
 # Install Node.js tools
-RUN npm install -g doctoc
+RUN sudo npm install -g doctoc
 
 # Install protoc v23.2
 RUN PROTOC_VERSION="23.2" \
     && PROTOC_ZIP="protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
     && curl -OL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}" \
-    && unzip -o "${PROTOC_ZIP}" -d /usr/local bin/protoc \
-    && unzip -o "${PROTOC_ZIP}" -d /usr/local 'include/*' \
+    && sudo unzip -o "${PROTOC_ZIP}" -d /usr/local bin/protoc \
+    && sudo unzip -o "${PROTOC_ZIP}" -d /usr/local 'include/*' \
     && rm -f "${PROTOC_ZIP}"
 
 # Install RISC0 toolchain
 SHELL ["/bin/bash", "-c"]
-RUN curl -L https://risczero.com/install | bash \
-    && export PATH="/root/.risc0/bin:$PATH" \
-    && rzup install cargo-risczero 2.0.2 \
-    && rzup install rust 1.88.0 \
-    && rzup install cpp 2024.1.5 \
-    && rm -rf $CARGO_HOME/registry \
-    && rm -rf $CARGO_HOME/git
+RUN . /home/runner/.cargo/env \
+    && curl -L https://risczero.com/install | bash \
+    && export PATH="/home/runner/.risc0/bin:$PATH" \
+    && /home/runner/.risc0/bin/rzup install cargo-risczero 2.0.2 \
+    && /home/runner/.risc0/bin/rzup install rust 1.88.0 \
+    && /home/runner/.risc0/bin/rzup install cpp 2024.1.5 \
+    && rm -rf /home/runner/.cargo/registry \
+    && rm -rf /home/runner/.cargo/git
 SHELL ["/bin/sh", "-c"]
 
 # Install SP1 toolchain
-RUN curl -L https://raw.githubusercontent.com/succinctlabs/sp1/main/sp1up/install | bash \
-    && ~/.sp1/bin/sp1up --version 5.0.8 \
-    && ~/.sp1/bin/cargo-prove prove install-toolchain \
-    && rm -rf $CARGO_HOME/registry \
-    && rm -rf $CARGO_HOME/git
+RUN . /home/runner/.cargo/env \
+    && curl -L https://raw.githubusercontent.com/succinctlabs/sp1/main/sp1up/install | bash \
+    && /home/runner/.sp1/bin/sp1up --version 5.0.8 \
+    && /home/runner/.sp1/bin/cargo-prove prove install-toolchain \
+    && rm -rf /home/runner/.cargo/registry \
+    && rm -rf /home/runner/.cargo/git
 
 ## Move it to bottom for now for faster iteration
 
 # Install core Rust development tools
-RUN cargo install cargo-hack --locked \
+RUN . /home/runner/.cargo/env \
+    && cargo install cargo-hack --locked \
     && cargo install cargo-nextest@0.9.96 --locked \
     && cargo install cargo-llvm-cov --locked \
     && cargo install cargo-deny@0.16.1 --locked \
@@ -88,18 +93,19 @@ RUN cargo install cargo-hack --locked \
     && cargo install zepter@1.5.0 --locked \
     && cargo install bashtestmd@0.5.0 --locked \
     # Clear cargo cache to reduce image size
-    && rm -rf $CARGO_HOME/registry \
-    && rm -rf $CARGO_HOME/git \
+    && rm -rf /home/runner/.cargo/registry \
+    && rm -rf /home/runner/.cargo/git \
     && rm -rf /tmp/cargo-*
 
 # Install additional tools on nightly
-RUN cargo +nightly install cargo-udeps --locked \
-    && rm -rf $CARGO_HOME/registry \
-    && rm -rf $CARGO_HOME/git
+RUN . /home/runner/.cargo/env \
+    && cargo +nightly install cargo-udeps --locked \
+    && rm -rf /home/runner/.cargo/registry \
+    && rm -rf /home/runner/.cargo/git
 
 # Set environment variables
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true \
-    PATH="/root/.risc0/bin:/root/.sp1/bin:${PATH}" \
+    PATH="/home/runner/.risc0/bin:/home/runner/.sp1/bin:/home/runner/.cargo/bin:${PATH}" \
     RISC0_RUST_TOOLCHAIN_VERSION=1.88.0 \
     RISC0_CPP_TOOLCHAIN_VERSION=2024.1.5
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -86,7 +86,6 @@ RUN . /home/runner/.cargo/env \
     && cargo install cargo-insta@1.43.1 --locked \
     && cargo install zepter@1.78.2 --locked \
     && cargo install bashtestmd@0.5.0 --locked \
-    && cargo +nightly install cargo-udeps@0.1.57 --locked \
     # Clear cargo cache to reduce image size
     && rm -rf /home/runner/.cargo/registry \
     && rm -rf /home/runner/.cargo/git \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -79,23 +79,18 @@ RUN . /home/runner/.cargo/env \
 
 # Install core Rust development tools
 RUN . /home/runner/.cargo/env \
-    && cargo install cargo-hack --locked \
-    && cargo install cargo-nextest@0.9.96 --locked \
-    && cargo install cargo-llvm-cov --locked \
-    && cargo install cargo-deny@0.16.1 --locked \
-    && cargo install cargo-insta@1.42.1 --locked \
-    && cargo install zepter@1.5.0 --locked \
+    && cargo install cargo-hack@0.6.37 --locked \
+    && cargo install cargo-nextest@0.9.100 --locked \
+    && cargo install cargo-llvm-cov@0.6.18 --locked \
+    && cargo install cargo-deny@0.18.3 --locked \
+    && cargo install cargo-insta@1.43.1 --locked \
+    && cargo install zepter@1.78.2 --locked \
     && cargo install bashtestmd@0.5.0 --locked \
+    && cargo +nightly install cargo-udeps@0.1.57 --locked \
     # Clear cargo cache to reduce image size
     && rm -rf /home/runner/.cargo/registry \
     && rm -rf /home/runner/.cargo/git \
     && rm -rf /tmp/cargo-*
-
-# Install additional tools on nightly
-RUN . /home/runner/.cargo/env \
-    && cargo +nightly install cargo-udeps --locked \
-    && rm -rf /home/runner/.cargo/registry \
-    && rm -rf /home/runner/.cargo/git
 
 # Important step to make cache mountable
 RUN rm -rf /home/runner/.cargo/.global-cache

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -23,6 +23,16 @@ RUN sudo apt-get update && sudo apt-get install -y \
     unzip \
     && sudo rm -rf /var/lib/apt/lists/*
 
+# Build and install mold linker from source
+RUN git clone https://github.com/rui314/mold.git /tmp/mold \
+    && cd /tmp/mold \
+    && git checkout $(git describe --tags --abbrev=0) \
+    && cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=clang++ \
+    && cmake --build build -j$(nproc) \
+    && sudo cmake --build build --target install \
+    && cd / \
+    && rm -rf /tmp/mold
+
 # Install Rust as user
 # The base image runs as runner user with home at /home/runner
 ENV RUSTUP_HOME=/home/runner/.rustup \
@@ -34,6 +44,12 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
     && rustup component add clippy rustfmt rust-src llvm-tools-preview --toolchain 1.88.0 \
     && rustup toolchain install nightly --component rustfmt --component rust-src --profile minimal \
     && rustup target add wasm32-unknown-unknown
+
+# Configure cargo to use mold linker
+RUN mkdir -p /home/runner/.cargo \
+    && echo '[target.x86_64-unknown-linux-gnu]' >> /home/runner/.cargo/config.toml \
+    && echo 'linker = "clang"' >> /home/runner/.cargo/config.toml \
+    && echo 'rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]' >> /home/runner/.cargo/config.toml
 
 # Install Node.js 20.x
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | sudo bash - \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -31,7 +31,7 @@ ENV RUSTUP_HOME=/home/runner/.rustup \
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88.0 --profile minimal \
     && . /home/runner/.cargo/env \
-    && rustup component add clippy rust-src llvm-tools-preview --toolchain 1.88.0 \
+    && rustup component add clippy rustfmt rust-src llvm-tools-preview --toolchain 1.88.0 \
     && rustup toolchain install nightly --component rustfmt --component rust-src --profile minimal \
     && rustup target add wasm32-unknown-unknown
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -48,7 +48,6 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
 # Configure cargo to use mold linker
 RUN mkdir -p /home/runner/.cargo \
     && echo '[target.x86_64-unknown-linux-gnu]' >> /home/runner/.cargo/config.toml \
-    && echo 'linker = "clang"' >> /home/runner/.cargo/config.toml \
     && echo 'rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]' >> /home/runner/.cargo/config.toml
 
 # Install Node.js 20.x

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -97,6 +97,9 @@ RUN . /home/runner/.cargo/env \
     && rm -rf /home/runner/.cargo/registry \
     && rm -rf /home/runner/.cargo/git
 
+# Important step to make cache mountable
+RUN rm -rf /home/runner/.cargo/.global-cache
+
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true \
     PATH="/home/runner/.risc0/bin:/home/runner/.sp1/bin:/home/runner/.cargo/bin:${PATH}" \
     RISC0_RUST_TOOLCHAIN_VERSION=1.88.0 \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,9 +1,6 @@
 ARG NAMESPACE_BASE_IMAGE_REF=""
-
 # Your image must build FROM NAMESPACE_BASE_IMAGE_REF
 FROM ${NAMESPACE_BASE_IMAGE_REF} AS base
-# Multi-stage build for efficiency
-#FROM ubuntu:24.04 AS base
 
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
@@ -43,15 +40,12 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | sudo bash - \
     && sudo apt-get install -y nodejs \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Install pnpm
-RUN sudo npm install -g pnpm@9
+# Install pnpm and Node.js tools
+RUN sudo npm install -g pnpm@9 doctoc
 
 # Install yq for YAML processing
 RUN sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq \
     && sudo chmod +x /usr/bin/yq
-
-# Install Node.js tools
-RUN sudo npm install -g doctoc
 
 # Install protoc v23.2
 RUN PROTOC_VERSION="23.2" \
@@ -61,25 +55,25 @@ RUN PROTOC_VERSION="23.2" \
     && sudo unzip -o "${PROTOC_ZIP}" -d /usr/local 'include/*' \
     && rm -f "${PROTOC_ZIP}"
 
-# Install RISC0 toolchain
+# Install RISC0 toolchain (AMD64 only - RISC0 doesn't support ARM64)
 SHELL ["/bin/bash", "-c"]
 RUN . /home/runner/.cargo/env \
-    && curl -L https://risczero.com/install | bash \
-    && export PATH="/home/runner/.risc0/bin:$PATH" \
-    && /home/runner/.risc0/bin/rzup install cargo-risczero 2.0.2 \
-    && /home/runner/.risc0/bin/rzup install rust 1.88.0 \
-    && /home/runner/.risc0/bin/rzup install cpp 2024.1.5 \
-    && rm -rf /home/runner/.cargo/registry \
-    && rm -rf /home/runner/.cargo/git
+        && curl -L https://risczero.com/install | bash \
+        && export PATH="/home/runner/.risc0/bin:$PATH" \
+        && /home/runner/.risc0/bin/rzup install cargo-risczero 2.0.2 \
+        && /home/runner/.risc0/bin/rzup install rust 1.88.0 \
+        && /home/runner/.risc0/bin/rzup install cpp 2024.1.5 \
+        && rm -rf /home/runner/.cargo/registry \
+        && rm -rf /home/runner/.cargo/git;
 SHELL ["/bin/sh", "-c"]
 
-# Install SP1 toolchain
+# Install SP1 toolchain (AMD64 only - SP1 doesn't support ARM64)
 RUN . /home/runner/.cargo/env \
-    && curl -L https://raw.githubusercontent.com/succinctlabs/sp1/main/sp1up/install | bash \
-    && /home/runner/.sp1/bin/sp1up --version 5.0.8 \
-    && /home/runner/.sp1/bin/cargo-prove prove install-toolchain \
-    && rm -rf /home/runner/.cargo/registry \
-    && rm -rf /home/runner/.cargo/git
+        && curl -L https://raw.githubusercontent.com/succinctlabs/sp1/main/sp1up/install | bash \
+        && /home/runner/.sp1/bin/sp1up --version 5.0.8 \
+        && /home/runner/.sp1/bin/cargo-prove prove install-toolchain \
+        && rm -rf /home/runner/.cargo/registry \
+        && rm -rf /home/runner/.cargo/git
 
 ## Move it to bottom for now for faster iteration
 
@@ -103,13 +97,7 @@ RUN . /home/runner/.cargo/env \
     && rm -rf /home/runner/.cargo/registry \
     && rm -rf /home/runner/.cargo/git
 
-# Set environment variables
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true \
     PATH="/home/runner/.risc0/bin:/home/runner/.sp1/bin:/home/runner/.cargo/bin:${PATH}" \
     RISC0_RUST_TOOLCHAIN_VERSION=1.88.0 \
     RISC0_CPP_TOOLCHAIN_VERSION=2024.1.5
-
-# Set working directory
-WORKDIR /workspace
-
-CMD ["/bin/bash"]

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,0 +1,109 @@
+ARG NAMESPACE_BASE_IMAGE_REF=""
+
+# Your image must build FROM NAMESPACE_BASE_IMAGE_REF
+FROM ${NAMESPACE_BASE_IMAGE_REF} AS base
+# Multi-stage build for efficiency
+#FROM ubuntu:24.04 AS base
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    git \
+    curl \
+    wget \
+    jq \
+    protobuf-compiler \
+    clang \
+    cmake \
+    libclang-dev \
+    lld \
+    zstd \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88.0 --profile minimal \
+    && rustup component add clippy --toolchain 1.88.0 \
+    && rustup toolchain install nightly --component rustfmt --profile minimal \
+    && rustup target add wasm32-unknown-unknown
+
+# Install Node.js 20.x
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install pnpm
+RUN npm install -g pnpm@9
+
+# Install yq for YAML processing
+RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq \
+    && chmod +x /usr/bin/yq
+
+# Install Node.js tools
+RUN npm install -g doctoc
+
+# Install protoc v23.2
+RUN PROTOC_VERSION="23.2" \
+    && PROTOC_ZIP="protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
+    && curl -OL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${PROTOC_ZIP}" \
+    && unzip -o "${PROTOC_ZIP}" -d /usr/local bin/protoc \
+    && unzip -o "${PROTOC_ZIP}" -d /usr/local 'include/*' \
+    && rm -f "${PROTOC_ZIP}"
+
+# Install RISC0 toolchain
+SHELL ["/bin/bash", "-c"]
+RUN curl -L https://risczero.com/install | bash \
+    && export PATH="/root/.risc0/bin:$PATH" \
+    && rzup install cargo-risczero 2.0.2 \
+    && rzup install rust 1.88.0 \
+    && rzup install cpp 2024.1.5 \
+    && rm -rf $CARGO_HOME/registry \
+    && rm -rf $CARGO_HOME/git
+SHELL ["/bin/sh", "-c"]
+
+# Install SP1 toolchain
+RUN curl -L https://raw.githubusercontent.com/succinctlabs/sp1/main/sp1up/install | bash \
+    && ~/.sp1/bin/sp1up --version 5.0.8 \
+    && ~/.sp1/bin/cargo-prove prove install-toolchain \
+    && rm -rf $CARGO_HOME/registry \
+    && rm -rf $CARGO_HOME/git
+
+## Move it to bottom for now for faster iteration
+
+# Install core Rust development tools
+RUN cargo install cargo-hack --locked \
+    && cargo install cargo-nextest@0.9.96 --locked \
+    && cargo install cargo-llvm-cov --locked \
+    && cargo install cargo-deny@0.16.1 --locked \
+    && cargo install cargo-insta@1.42.1 --locked \
+    && cargo install zepter@1.5.0 --locked \
+    && cargo install bashtestmd@0.5.0 --locked \
+    # Clear cargo cache to reduce image size
+    && rm -rf $CARGO_HOME/registry \
+    && rm -rf $CARGO_HOME/git \
+    && rm -rf /tmp/cargo-*
+
+# Install additional tools on nightly
+RUN cargo +nightly install cargo-udeps --locked \
+    && rm -rf $CARGO_HOME/registry \
+    && rm -rf $CARGO_HOME/git
+
+# Set environment variables
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true \
+    PATH="/root/.risc0/bin:/root/.sp1/bin:${PATH}" \
+    RISC0_RUST_TOOLCHAIN_VERSION=1.88.0 \
+    RISC0_CPP_TOOLCHAIN_VERSION=2024.1.5
+
+# Set working directory
+WORKDIR /workspace
+
+CMD ["/bin/bash"]

--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -1,0 +1,5 @@
+## 
+
+This folder contains [Dockerfile](./Dockerfile) used for [Custom Base Image for Namespace CI](https://namespace.so/changelog#profile-dockerfile-based-custom-base-images)
+
+ - It shou

--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -1,11 +1,31 @@
 # Namespace CI Docker Base Image
 
+Using pre-built image allows skipping setting up the necessary environment for each job. 
+This allows saving time and increase stability of a CI job, as there's a less opportunity for a failure, which has been observed with installation of ZKVMs
+
 This folder contains the [Dockerfile](./Dockerfile) used for [Custom Base Image for Namespace CI](https://namespace.so/docs/solutions/github-actions/custom-base-images).
+
+## When to update base image
+
+Base image needs to be updated any time the environment changes: rust toolchain upgrade, ZKVM version upgrade, new tool added to the job
+
+## High-level steps
+
+1. Update and verify [`Dockerfile`](./Dockerfile)
+2. Create/update profiles on Namespace
+3. Update workflow file
+
+## Updating and verify [`Dockerfile`]
 
 Before starting, [install the Namespace CLI tool `nsc`](https://namespace.so/docs/reference/cli/installation).
 
+The contents of Dockerfile are pasted as plaintext into Namespace WEB ui, so it should be self-contained. 
+No `COPY` or `ADD` commands. 
+This results in duplication between Makefile, but it is acceptable.
+
+
 The base image runs as the runner user by default (to match GitHub's runners), which requires using sudo for commands like apt-get.
-To iterate on the build faster, you can trigger the build using the nsc CLI instead. 
+To iterate on the build faster, you can trigger the build using the `nsc` CLI instead. 
 
 This will give you the output right in your terminal from this folder:
 ```
@@ -14,8 +34,31 @@ nsc github build-base-image --os-label ubuntu-24.04 --platform linux/amd64 -f Do
 
 The `nsc` tool will run the build and give you the output in case of an error.
 This allows for debugging the build but will not push the final image.
-Once you have a successful build, you will have to copy the Dockerfile back into the web UI and `profiles` section.
-A final build will then be kicked off once you save the profile. You can see the status of this on the profile page:
-When you go to the profile page, to the top right of the Dockerfile box should be a status badge saying "building" or "Done".
+Once you have a successful build, continue to the next phase.
+
+## How to build a new Namespace profile.
+
+1. Log in into namepspace 
+2. Got to "Profiles" section
+3. Click new profile
+4. Enter new tag you wish to use (more on tags below) and enter the following values:
+    - OS: linux on amd64 
+    - Base Image: Custom Ubuntu 24.04
+    - Ubuntu-based Custom Image: select "Custom Dockerfile" and paste new Dockerfile you've just updated and tested before.
+    - Caching: enable, set the desired size and enable "container images", "git checkouts" and "toolchain download"
+5. Click "Update Profile". The icon "Building" next to "Ubuntu-based custom image" will appear. Wait  till it becomes ready.
+
+Now this profile is ready to be used.
 
 More information at the [configure your runners](https://namespace.so/docs/solutions/github-actions#configure-your-runners) section.
+
+### Tags and cache with pre-built images
+
+TBD
+
+## Updating workflow file
+
+After profile is ready, it is possible to copy `runs-on` value needed
+
+TBD: Note on features for I/O uring
+

--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -45,7 +45,8 @@ Once you have a successful build, continue to the next phase.
     - OS: linux on amd64 
     - Base Image: Custom Ubuntu 24.04
     - Ubuntu-based Custom Image: select "Custom Dockerfile" and paste new Dockerfile you've just updated and tested before.
-    - Caching: enable, set the desired size and enable "container images", "git checkouts" and "toolchain download"
+    - Caching: enable, set the desired size and enable "container images", "git checkouts" and "toolchain download".
+      For advanaced section of caching set `nightly` as protected branch
 5. Click "Update Profile". The icon "Building" next to "Ubuntu-based custom image" will appear. Wait  till it becomes ready.
 
 Now this profile is ready to be used.
@@ -55,6 +56,8 @@ More information at the [configure your runners](https://namespace.so/docs/solut
 ### Tags and cache with pre-built images
 
 TBD
+
+sov-ubuntu-24.04-amd64-16x32-test-250gb-1-88
 
 ## Updating workflow file
 

--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -1,7 +1,21 @@
-## 
+# Namespace CI Docker Base Image
 
-This folder contains [Dockerfile](./Dockerfile) used for [Custom Base Image for Namespace CI](https://namespace.so/changelog#profile-dockerfile-based-custom-base-images)
+This folder contains the [Dockerfile](./Dockerfile) used for [Custom Base Image for Namespace CI](https://namespace.so/docs/solutions/github-actions/custom-base-images).
 
- - It shou
+Before starting, [install the Namespace CLI tool `nsc`](https://namespace.so/docs/reference/cli/installation).
 
-https://namespace.so/docs/reference/cli/installation
+The base image runs as the runner user by default (to match GitHub's runners), which requires using sudo for commands like apt-get.
+To iterate on the build faster, you can trigger the build using the nsc CLI instead. 
+
+This will give you the output right in your terminal from this folder:
+```
+nsc github build-base-image --os-label ubuntu-24.04 --platform linux/amd64 -f Dockerfile
+```
+
+The `nsc` tool will run the build and give you the output in case of an error.
+This allows for debugging the build but will not push the final image.
+Once you have a successful build, you will have to copy the Dockerfile back into the web UI and `profiles` section.
+A final build will then be kicked off once you save the profile. You can see the status of this on the profile page:
+When you go to the profile page, to the top right of the Dockerfile box should be a status badge saying "building" or "Done".
+
+More information at the [configure your runners](https://namespace.so/docs/solutions/github-actions#configure-your-runners) section.

--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -3,3 +3,5 @@
 This folder contains [Dockerfile](./Dockerfile) used for [Custom Base Image for Namespace CI](https://namespace.so/changelog#profile-dockerfile-based-custom-base-images)
 
  - It shou
+
+https://namespace.so/docs/reference/cli/installation

--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -1,13 +1,13 @@
 # Namespace CI Docker Base Image
 
-Using pre-built image allows skipping setting up the necessary environment for each job. 
-This allows saving time and increase stability of a CI job, as there's a less opportunity for a failure, which has been observed with installation of ZKVMs
+Using a pre-built image allows skipping the setup of the necessary environment for each job. 
+This saves time and increases the stability of CI jobs, as there are fewer opportunities for failure, which has been observed with the installation of ZKVMs
 
 This folder contains the [Dockerfile](./Dockerfile) used for [Custom Base Image for Namespace CI](https://namespace.so/docs/solutions/github-actions/custom-base-images).
 
 ## When to update base image
 
-Base image needs to be updated any time the environment changes: rust toolchain upgrade, ZKVM version upgrade, new tool added to the job
+The base image needs to be updated any time the environment changes: Rust toolchain upgrade, ZKVM version upgrade, new tool added to the job
 
 ## High-level steps
 
@@ -15,13 +15,13 @@ Base image needs to be updated any time the environment changes: rust toolchain 
 2. Create/update profiles on Namespace
 3. Update workflow file
 
-## Updating and verify [`Dockerfile`]
+## Updating and verifying `Dockerfile`
 
 Before starting, [install the Namespace CLI tool `nsc`](https://namespace.so/docs/reference/cli/installation).
 
-The contents of Dockerfile are pasted as plaintext into Namespace WEB ui, so it should be self-contained. 
-No `COPY` or `ADD` commands. 
-This results in duplication between Makefile, but it is acceptable.
+The contents of the Dockerfile are pasted as plaintext into the Namespace web UI, so it should be self-contained. 
+No `COPY` or `ADD` commands should be used. 
+This results in duplication with the Makefile, but it is acceptable.
 
 
 The base image runs as the runner user by default (to match GitHub's runners), which requires using sudo for commands like apt-get.
@@ -36,18 +36,18 @@ The `nsc` tool will run the build and give you the output in case of an error.
 This allows for debugging the build but will not push the final image.
 Once you have a successful build, continue to the next phase.
 
-## How to build a new Namespace profile.
+## How to build a new Namespace profile
 
-1. Log in into [Namepspace](https://namespace.so/) Web UI
-2. Got to "Profiles" section
+1. Log in to the [Namespace](https://namespace.so/) web UI
+2. Go to the "Profiles" section
 3. Click "New Profile"
 4. Enter the new tag you wish to use (more on tags below) and enter the following values:
     - OS: linux on amd64 
     - Base Image: Custom Ubuntu 24.04
-    - Ubuntu-based Custom Image: select "Custom Dockerfile" and paste new Dockerfile you've just updated and tested before.
-    - Caching: enable, set the desired size and enable "container images", "git checkouts" and "toolchain download".
-      For advanced section of caching set `nightly` as protected branch
-5. Click "Update Profile". The icon "Building" next to "Ubuntu-based custom image" will appear. Wait  till it becomes ready.
+    - Ubuntu-based Custom Image: select "Custom Dockerfile" and paste the new Dockerfile you've just updated and tested
+    - Caching: enable, set the desired size, and enable "container images", "git checkouts", and "toolchain downloads".
+      For the advanced section of caching, set `nightly` as a protected branch
+5. Click "Update Profile". The "Building" icon next to "Ubuntu-based custom image" will appear. Wait until it becomes ready.
 
 Now this profile is ready to be used.
 
@@ -55,21 +55,21 @@ More information at the [configure your runners](https://namespace.so/docs/solut
 
 ### Tags and cache with pre-built images
 
-Custom-based images profile does not support a combination of cache volume tags. 
+Custom-based image profiles do not support a combination of cache volume tags. 
 This means that if the same container profile needs different caches, it needs to be a different profile.
 
 Some details from Namespace:
 
-Custom-based images profile enables container image caching.
-This means that Namepsace keeping pulled and unpacked images in the cache.
+Custom-based image profiles enable container image caching.
+This means that Namespace keeps pulled and unpacked images in the cache.
 This caching includes also your new custom base image.
 The fact that the custom base image also lives in the cache is a performance optimization today so that subsequent runs do not need to pull it.
-But it also means that the image takes space from here.
-It also implies that while the runner is running, and files created in your run will allocate space from the cache while the run is ongoing.
+However, it also means that the image takes space from the cache.
+Additionally, while the runner is running, any files created during your run will allocate space from the cache.
 
 ## Updating the Workflow file
 
-After profile is ready, it is possible to copy `runs-on` value needed
+After the profile is ready, you can copy the `runs-on` value needed
 
-If container needs io_uring, for instance for NOMT or tests, append `;container.privileged=true;container.host-pid-namespace=true` to the runs on label from namespace
+If the container needs io_uring (for instance, for NOMT or tests), append `;container.privileged=true;container.host-pid-namespace=true` to the runs-on label from Namespace
 

--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -38,15 +38,15 @@ Once you have a successful build, continue to the next phase.
 
 ## How to build a new Namespace profile.
 
-1. Log in into namepspace 
+1. Log in into [Namepspace](https://namespace.so/) Web UI
 2. Got to "Profiles" section
-3. Click new profile
-4. Enter new tag you wish to use (more on tags below) and enter the following values:
+3. Click "New Profile"
+4. Enter the new tag you wish to use (more on tags below) and enter the following values:
     - OS: linux on amd64 
     - Base Image: Custom Ubuntu 24.04
     - Ubuntu-based Custom Image: select "Custom Dockerfile" and paste new Dockerfile you've just updated and tested before.
     - Caching: enable, set the desired size and enable "container images", "git checkouts" and "toolchain download".
-      For advanaced section of caching set `nightly` as protected branch
+      For advanced section of caching set `nightly` as protected branch
 5. Click "Update Profile". The icon "Building" next to "Ubuntu-based custom image" will appear. Wait  till it becomes ready.
 
 Now this profile is ready to be used.
@@ -55,13 +55,21 @@ More information at the [configure your runners](https://namespace.so/docs/solut
 
 ### Tags and cache with pre-built images
 
-TBD
+Custom-based images profile does not support a combination of cache volume tags. 
+This means that if the same container profile needs different caches, it needs to be a different profile.
 
-sov-ubuntu-24.04-amd64-16x32-test-250gb-1-88
+Some details from Namespace:
 
-## Updating workflow file
+Custom-based images profile enables container image caching.
+This means that Namepsace keeping pulled and unpacked images in the cache.
+This caching includes also your new custom base image.
+The fact that the custom base image also lives in the cache is a performance optimization today so that subsequent runs do not need to pull it.
+But it also means that the image takes space from here.
+It also implies that while the runner is running, and files created in your run will allocate space from the cache while the run is ongoing.
+
+## Updating the Workflow file
 
 After profile is ready, it is possible to copy `runs-on` value needed
 
-TBD: Note on features for I/O uring
+If container needs io_uring, for instance for NOMT or tests, append `;container.privileged=true;container.host-pid-namespace=true` to the runs on label from namespace
 

--- a/rustfmt.nightly.toml
+++ b/rustfmt.nightly.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,0 @@
-# Until stable supports these options, it remains commented out
-# To avoid warnings in CI, which can confuse people
-#group_imports = "StdExternalCrate"
-#imports_granularity = "Module"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
-# Keep those and have warnings on CI or remove it and don't have it locally?
+# Until stable supports these options, it remains commented out
+# To avoid warnings in CI, which can confuse people
 #group_imports = "StdExternalCrate"
 #imports_granularity = "Module"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
-group_imports = "StdExternalCrate"
-imports_granularity = "Module"
+# Keep those and have warnings on CI or remove it and don't have it locally?
+#group_imports = "StdExternalCrate"
+#imports_granularity = "Module"


### PR DESCRIPTION
# Summary

Port of https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/3272

* Switch to pre-built docker images and remove setup step for all important jobs.
* Add intsruction on how and when do an upgrade of the pre-built images
* Enabled incremenetal compilation
* Switched fmt to be on the same toolchain as the repo. Updates .vscode configuration. **Please make sure your local non default settings won't interfere.**
* Removed obsolete `cargo risczero` install step from setup
* Remove `udeps` from Makefile as it only works on nightly
* Updated trybuild test - mold triggered some new errors: it matching what I've observed on dev-box

## New available runners:

 * `namespace-profile-sov-ubuntu-24-04-amd64-16x32-dev-250gb-1-88`
 * `namespace-profile-sov-ubuntu-24-04-amd64-16x32-test-250gb-1-88` - Not used at the moment due to OOM issues
 * `namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-250gb-1-88`
 * `namespace-profile-sov-ubuntu-24-04-amd64-32x64-test-250gb-1-88` - Not used, can be tried for shorter CI times
 * `namespace-profile-sov-ubuntu-24-04-amd64-16x64-coverage-250gb-1-88`
 * `namespace-profile-sov-ubuntu-24-04-amd64-16x32-bench-250gb-1-88`
 * `namespace-profile-sov-ubuntu-24-04-amd64-16x64-bench-250gb-1-88` - Not used at the moment, prepared for future in case of quick bump in RAM is needed
 * `namespace-profile-sov-ubuntu-24-04-amd64-16x32-demo-rollup-250gb-1-88` - Not used, had OOM issues
 * `namespace-profile-sov-ubuntu-24-04-amd64-32x64-demo-rollup-250gb-1-88`

## Workers configuration

Current configuration of runners:

| Job Name                                              | Runs-on Machine    | Cache Tag                                             | Cache Size | Need Privilege                |
|-------------------------------------------------------|--------------------|-------------------------------------------------------|------------|-------------------------------|
| check-aggregate                                       | ubuntu-22.04-2x4   |                                                       |            |                               |
| check                                                 | ubuntu-22.04-8x32  | cache-dev                                             | 100gb      |                               |
| bench_check                                           | ubuntu-22.04-16x64 | cache-bench                                           | 100gb      |                               |
| rollup_tps_validation                                 | ubuntu-22.04-8x32  | cache-bench                                           | 100gb      |                               |
| hack                                                  | ubuntu-22.04-8x32  | cache-dev                                             | 100gb      |                               |
| hack_default_targets                                  | ubuntu-22.04-8x32  | cache-dev                                             | 100gb      |                               |
| nextest                                               | ubuntu-22.04-8x32  | cache-test                                            | 100gb      | privileged;host-pid-namespace |
| nextest_all_features                                  | ubuntu-22.04-8x32  | cache-test                                            | 100gb      | privileged;host-pid-namespace |
| doctests                                              | ubuntu-22.04-8x32  | cache-doctests                                        | 100gb      |                               |
| coverage                                              | ubuntu-22.04-16x32 | cache-coverage                                        | 150gb      | privileged;host-pid-namespace |
| cargo-deny-check-licenses                             | ubuntu-22.04-2x4   |                                                       |            |                               |
| cargo-doc-artifact                                    | ubuntu-22.04-8x32  | cache-dev                                             | 100gb      |                               |
| deploy-github-pages                                   | ubuntu-22.04-2x4   |                                                       |            |                               |
| check-demo-rollup-table-of-contents                   | ubuntu-22.04-2x4   |                                                       |            |                               |
| check-demo-rollup-bash-commands                       | ubuntu-22.04-8x32  | demo-rollup                                           | 100gb      |                               |
| check-demo-rollup-bash-commands-mock-da               | ubuntu-22.04-8x32  | demo-rollup                                           | 100gb      |                               |
| check-constant-overriding-is-disabled-in-release-mode | ubuntu-22.04-8x32  | check-constant-overriding-is-disabled-in-release-mode | 20gb       |                               |
| validate-packages-to-publish-yml                      | ubuntu-22.04-2x4   |                                                       |            |                               |
| cargo-switcheroo-default                              | ubuntu-22.04-4x16  | cargo-switcheroo                                      | 20gb       |                               |
| check-web3-js-sdk-integration                         | ubuntu-22.04-8x32  | demo-rollup                                           | 100gb      |                               |

New configuration of runners:

| Job Name                                              | New Runs-on                                         |
|-------------------------------------------------------|-----------------------------------------------------|
| check-aggregate                                       | nscloud-ubuntu-22.04-amd64-2x4                      |
| check                                                 | sov-ubuntu-24-04-amd64-16x32-dev-250gb-1-88         |
| bench_check                                           | sov-ubuntu-24-04-amd64-16x32-bench-250gb-1-88       |
| rollup_tps_validation                                 | sov-ubuntu-24-04-amd64-16x32-bench-250gb-1-88       |
| hack                                                  | sov-ubuntu-24-04-amd64-16x32-dev-250gb-1-88         |
| hack_default_targets                                  | sov-ubuntu-24-04-amd64-16x32-dev-250gb-1-88         |
| nextest                                               | sov-ubuntu-24-04-amd64-16x64-test-250gb-1-88        |
| nextest_all_features                                  | sov-ubuntu-24-04-amd64-16x64-test-250gb-1-88        |
| doctests                                              | sov-ubuntu-24-04-amd64-16x32-test-250gb-1-88        |
| coverage                                              | sov-ubuntu-24-04-amd64-16x64-coverage-250gb-1-88    |
| cargo-deny-check-licenses                             | nscloud-ubuntu-22.04-amd64-2x4                      |
| cargo-doc-artifact                                    | sov-ubuntu-24-04-amd64-16x32-dev-250gb-1-88         |
| deploy-github-pages                                   | nscloud-ubuntu-22.04-amd64-2x4                      |
| check-demo-rollup-table-of-contents                   | nscloud-ubuntu-22.04-amd64-2x4                      |
| check-demo-rollup-bash-commands                       | sov-ubuntu-24-04-amd64-32x64-demo-rollup-250gb-1-88 |
| check-demo-rollup-bash-commands-mock-da               | sov-ubuntu-24-04-amd64-32x64-demo-rollup-250gb-1-88 |
| check-constant-overriding-is-disabled-in-release-mode | sov-ubuntu-24-04-amd64-16x32-test-250gb-1-88        |
| validate-packages-to-publish-yml                      | nscloud-ubuntu-22.04-amd64-2x4                      |
| cargo-switcheroo-default                              | sov-ubuntu-24-04-amd64-16x32-dev-250gb-1-88         |
| check-web3-js-sdk-integration                         | sov-ubuntu-24-04-amd64-16x32-demo-rollup-250gb-1-88 |


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
Existing CI should pass

## Docs
Added a README in `docker/ci`