### PR TITLE
Increase number of retry attempts on storage commit

### DIFF
--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -14,7 +14,7 @@ const KERNEL: &str = "kernel_state";
 const USER: &str = "user_state";
 
 const COMMIT_START_DELAY: std::time::Duration = std::time::Duration::from_millis(1);
-const COMMIT_RETRY_ATTEMPTS: usize = 15;
+const COMMIT_RETRY_ATTEMPTS: usize = 26;
 
 /// Contains all the most recent rollup data.
 pub struct NomtStateDb<H> {

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -91,7 +91,12 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
 
         let in_progress_commit_status = CommitStatus::InProgress(kernel.root().into_inner());
 
-        try_commit_overlay_with_backoff(&self.kernel, kernel).context("kernel namespace commit")?;
+        {
+            let _span = tracing::debug_span!("namespace_commit", namespace = "kernel").entered();
+            try_commit_overlay_with_backoff(&self.kernel, kernel)
+                .context("kernel namespace commit")?;
+        }
+
         // If the kernel commit fails, the flag is untouched, meaning DB remains synced on previous state.
         // Write IN-PROGRESS status after kernel committed successfully.
 
@@ -127,7 +132,11 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
 
         debug_assert_eq!(self.commit_flag.read_status()?, in_progress_commit_status);
 
-        try_commit_overlay_with_backoff(&self.user, user).context("user namespace commit")?;
+        {
+            let _span = tracing::debug_span!("namespace_commit", namespace = "user").entered();
+            try_commit_overlay_with_backoff(&self.user, user).context("user namespace commit")?;
+        }
+
         self.commit_flag
             .write_status(CommitStatus::Completed)
             .with_context(|| {

--- a/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
@@ -49,6 +49,7 @@ impl<S: Spec> StateRootCacheEntry<S> {
             compute_state_root::<S>(state_accesses, storage.clone(), rollup_height, slot_number)
                 .await;
         if user_roots_match(&self.root, &new_root) {
+            tracing::trace!(%rollup_height, %slot_number, "User state root is consistent");
             return (rollup_height, new_root);
         }
         tracing::debug!("User roots don't match, verify if storage became stale");
@@ -401,7 +402,7 @@ mod tests {
         received_root
     }
 
-    // Start background task, sender compute request, shutdown, return root computed.
+    // Start a background task, sender compute request, shutdown, return root computed.
     async fn one_off_check_state_root_computation<S: Spec>(
         storage: S::Storage,
         state_accesses: StateAccesses,
@@ -547,7 +548,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_nomt_state_compute_competing_storages_repro_real_storage_manager() {
-        let _guard = sov_test_utils::logging::initialize_logging_with_filter("error,sov_sequencer::preferred::state_root_compute=trace,sov_db::state_db_nomt=trace,sov_state::nomt::prover_storage=debug");
+        sov_test_utils::logging::initialize_logging_with_filter("error,sov_sequencer::preferred=trace,sov_db::state_db_nomt=trace,sov_state::nomt::prover_storage=debug");
         let storage_manager =
             CommitingStorageManager::<NomtStorageManager<MockDaSpec, TestHasher, _>, _>::new();
         test_compute_competing_storages::<TestNomtSpec, _>(storage_manager, 3).await;
@@ -621,6 +622,7 @@ mod tests {
             let end = seq_idx;
             let range = start..end;
             let sequencer_storage = storage_manager.create_api_storage();
+            let mut sent = 0;
             for (idx, cumulative_batch) in range.zip(seq_batches.into_iter()) {
                 let rollup_height = RollupHeight::new(idx as u64 + 1);
                 let slot_number = SlotNumber::new(idx as u64 + 1);
@@ -637,9 +639,11 @@ mod tests {
                     })
                     .await
                     .unwrap();
-
+                tracing::info!("sent state root compute request");
+                sent += 1;
                 receivers.push(response_receiver);
             }
+            tracing::info!(%seq_idx, %sent, "All state root compute requests this iteration has been sent");
             // Emulates part where node receives something from the DA layer, executes it and commits
             if let Some(idx_for_node) = seq_idx.checked_sub(seq_ahead_by) {
                 let start = std::time::Instant::now();

--- a/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
@@ -548,7 +548,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_nomt_state_compute_competing_storages_repro_real_storage_manager() {
-        sov_test_utils::logging::initialize_logging_with_filter("error,sov_sequencer::preferred=trace,sov_db::state_db_nomt=trace,sov_state::nomt::prover_storage=debug");
+        sov_test_utils::logging::initialize_or_change_logging_with_filter("error,sov_sequencer::preferred=trace,sov_db::state_db_nomt=trace,sov_state::nomt::prover_storage=debug");
         let storage_manager =
             CommitingStorageManager::<NomtStorageManager<MockDaSpec, TestHasher, _>, _>::new();
         test_compute_competing_storages::<TestNomtSpec, _>(storage_manager, 3).await;

--- a/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
@@ -547,6 +547,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_nomt_state_compute_competing_storages_repro_real_storage_manager() {
+        let _guard = sov_test_utils::logging::initialize_logging_with_filter("error,sov_sequencer::preferred::state_root_compute=trace,sov_db::state_db_nomt=trace,sov_state::nomt::prover_storage=debug");
         let storage_manager =
             CommitingStorageManager::<NomtStorageManager<MockDaSpec, TestHasher, _>, _>::new();
         test_compute_competing_storages::<TestNomtSpec, _>(storage_manager, 3).await;

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -409,10 +409,11 @@ where
     ) -> anyhow::Result<(Self::Root, Self::StateUpdate)> {
         let start = std::time::Instant::now();
         let next_version = self.historical_state.get_next_version();
-        tracing::trace!(%prev_state_root, %next_version, "NomtProverStorage, computing state update");
         // Open 2 sessions close to each other
         let user_session = self.state_session_builder.begin_user_session()?;
         let kernel_session = self.state_session_builder.begin_kernel_session()?;
+        let starting_session_time = start.elapsed();
+        tracing::debug!(%prev_state_root, %next_version, sesssion_starting_time = ?starting_session_time, "computing state update, sessions are live");
 
         let current_prev_user_root = user_session.prev_root().into_inner();
         let current_prev_kernel_root = kernel_session.prev_root().into_inner();

--- a/crates/module-system/sov-test-utils/src/logging.rs
+++ b/crates/module-system/sov-test-utils/src/logging.rs
@@ -1,10 +1,14 @@
 use std::str::FromStr;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{fmt, EnvFilter, Layer};
+use tracing_subscriber::{fmt, reload, EnvFilter, Layer};
+
+// Global handle to reload the filter
+static FILTER_RELOAD_HANDLE: OnceLock<reload::Handle<EnvFilter, tracing_subscriber::Registry>> =
+    OnceLock::new();
 
 /// Collects logs from the rollup.
 #[derive(Clone)]
@@ -56,13 +60,29 @@ impl tracing::field::Visit for MessageVisitor<'_> {
 
 /// Initialize logging with an explicit filter.
 /// When guard is deallocated, different subscriber can be used again.
-pub fn initialize_logging_with_filter(filter: &str) {
-    let enf_filter = EnvFilter::from_str(filter).unwrap();
-    let fmt_layer = fmt::layer().with_filter(enf_filter);
+pub fn initialize_or_change_logging_with_filter(filter: &str) {
+    if let Some(handle) = FILTER_RELOAD_HANDLE.get() {
+        let new_env_filter = EnvFilter::from_str(filter).unwrap();
+        handle.modify(|filter| *filter = new_env_filter).unwrap();
+    } else {
+        initialize_logging_with_filter(filter);
+    }
+}
 
-    // I want something like this, but across all threads
-    // tracing::subscriber::set_default(subscriber)
-    if let Err(error) = tracing_subscriber::registry().with(fmt_layer).try_init() {
+fn initialize_logging_with_filter(filter: &str) {
+    let env_filter = EnvFilter::from_str(filter).unwrap();
+    let (filter_layer, reload_handle) = reload::Layer::new(env_filter);
+
+    // Store the reload handle globally so we can update the filter later
+    FILTER_RELOAD_HANDLE.set(reload_handle).ok();
+
+    let fmt_layer = fmt::layer();
+
+    if let Err(error) = tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(fmt_layer)
+        .try_init()
+    {
         tracing::warn!(%error, "Cannot init logging, already happened.");
     }
 }

--- a/crates/module-system/sov-test-utils/src/logging.rs
+++ b/crates/module-system/sov-test-utils/src/logging.rs
@@ -3,6 +3,7 @@ use std::sync::{Arc, Mutex};
 
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{fmt, EnvFilter, Layer};
 
 /// Collects logs from the rollup.
@@ -55,11 +56,13 @@ impl tracing::field::Visit for MessageVisitor<'_> {
 
 /// Initialize logging with an explicit filter.
 /// When guard is deallocated, different subscriber can be used again.
-pub fn initialize_logging_with_filter(filter: &str) -> tracing::subscriber::DefaultGuard {
+pub fn initialize_logging_with_filter(filter: &str) {
     let enf_filter = EnvFilter::from_str(filter).unwrap();
     let fmt_layer = fmt::layer().with_filter(enf_filter);
 
-    let subscriber = tracing_subscriber::registry().with(fmt_layer);
-
-    tracing::subscriber::set_default(subscriber)
+    // I want something like this, but across all threads
+    // tracing::subscriber::set_default(subscriber)
+    if let Err(error) = tracing_subscriber::registry().with(fmt_layer).try_init() {
+        tracing::warn!(%error, "Cannot init logging, already happened.");
+    }
 }

--- a/crates/module-system/sov-test-utils/src/logging.rs
+++ b/crates/module-system/sov-test-utils/src/logging.rs
@@ -1,7 +1,9 @@
+use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
 use tracing::{Event, Level, Subscriber};
-use tracing_subscriber::Layer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::{fmt, EnvFilter, Layer};
 
 /// Collects logs from the rollup.
 #[derive(Clone)]
@@ -49,4 +51,15 @@ impl tracing::field::Visit for MessageVisitor<'_> {
             self.0.push_str(&format!("{value:?}"));
         }
     }
+}
+
+/// Initialize logging with an explicit filter.
+/// When guard is deallocated, different subscriber can be used again.
+pub fn initialize_logging_with_filter(filter: &str) -> tracing::subscriber::DefaultGuard {
+    let enf_filter = EnvFilter::from_str(filter).unwrap();
+    let fmt_layer = fmt::layer().with_filter(enf_filter);
+
+    let subscriber = tracing_subscriber::registry().with(fmt_layer);
+
+    tracing::subscriber::set_default(subscriber)
 }


### PR DESCRIPTION
Follow up of https://github.com/Sovereign-Labs/sovereign-sdk/pull/1429

Increased number of retries will allow to wait up to a minute.

Add loggging, so future failures on CI can be investigated more thoroughly