### PR TITLE
Demo rollup readme: use `RISC0_DEV_MODE`

### DIFF
--- a/crates/module-system/sov-cli/src/workflows/node.rs
+++ b/crates/module-system/sov-cli/src/workflows/node.rs
@@ -172,7 +172,7 @@ impl<S: sov_modules_api::Spec + Serialize + DeserializeOwned> NodeWorkflows<S> {
                     .await?;
             }
             NodeWorkflows::WaitForAggregatedProof { timeout_secs } => {
-                let timeout = std::time::Duration::from_secs(timeout_secs.unwrap_or(180));
+                let timeout = std::time::Duration::from_secs(timeout_secs.unwrap_or(300));
                 tracing::info!(?timeout, "Subscribing for aggregated proofs");
                 let mut aggregated_proofs = api_client.client.subscribe_aggregated_proof().await?;
                 let aggregated_proof = tokio::time::timeout(timeout, aggregated_proofs.next())

--- a/crates/module-system/sov-cli/src/workflows/node.rs
+++ b/crates/module-system/sov-cli/src/workflows/node.rs
@@ -172,7 +172,7 @@ impl<S: sov_modules_api::Spec + Serialize + DeserializeOwned> NodeWorkflows<S> {
                     .await?;
             }
             NodeWorkflows::WaitForAggregatedProof { timeout_secs } => {
-                let timeout = std::time::Duration::from_secs(timeout_secs.unwrap_or(120));
+                let timeout = std::time::Duration::from_secs(timeout_secs.unwrap_or(180));
                 tracing::info!(?timeout, "Subscribing for aggregated proofs");
                 let mut aggregated_proofs = api_client.client.subscribe_aggregated_proof().await?;
                 let aggregated_proof = tokio::time::timeout(timeout, aggregated_proofs.next())

--- a/examples/demo-rollup/README.md
+++ b/examples/demo-rollup/README.md
@@ -76,7 +76,9 @@ This setup works with an in-memory DA that is easy to set up for testing purpose
 
 ```shell,test-ci
 $ cd examples/demo-rollup/
-$ export RISC0_DEV_MODE=true && make build
+$ export RISC0_DEV_MODE=true
+$ export SOV_PROVER_MODE=execute
+$ make build
 ```
 
 2. Clean up the existing database.
@@ -87,10 +89,6 @@ $ make clean
 ```
 
 3. Now run the demo-rollup full node, as shown below.
-
-```sh,test-ci
-$ export SOV_PROVER_MODE=execute
-```
 
 ```sh,test-ci,bashtestmd:long-running,bashtestmd:wait-until=rest_address
 $ RISC0_DEV_MODE=true ../../target/debug/sov-demo-rollup

--- a/examples/demo-rollup/README.md
+++ b/examples/demo-rollup/README.md
@@ -76,7 +76,7 @@ This setup works with an in-memory DA that is easy to set up for testing purpose
 
 ```shell,test-ci
 $ cd examples/demo-rollup/
-$ make build
+$ echo "R0 _ $RISC0_DEV_MODE _" && make build
 ```
 
 2. Clean up the existing database.
@@ -93,7 +93,7 @@ $ export SOV_PROVER_MODE=execute
 ```
 
 ```sh,test-ci,bashtestmd:long-running,bashtestmd:wait-until=rest_address
-$ cargo run --release
+$ ../../target/debug/sov-demo-rollup
 ```
 
 Leave it running while you proceed with the rest of the demo.

--- a/examples/demo-rollup/README.md
+++ b/examples/demo-rollup/README.md
@@ -76,7 +76,7 @@ This setup works with an in-memory DA that is easy to set up for testing purpose
 
 ```shell,test-ci
 $ cd examples/demo-rollup/
-$ echo "R0 _ $RISC0_DEV_MODE _" && make build
+$ export RISC0_DEV_MODE=true && make build
 ```
 
 2. Clean up the existing database.
@@ -93,7 +93,7 @@ $ export SOV_PROVER_MODE=execute
 ```
 
 ```sh,test-ci,bashtestmd:long-running,bashtestmd:wait-until=rest_address
-$ ../../target/debug/sov-demo-rollup
+$ RISC0_DEV_MODE=true ../../target/debug/sov-demo-rollup
 ```
 
 Leave it running while you proceed with the rest of the demo.


### PR DESCRIPTION
# Description

This PR reduces CI job time for demo rollup on mock da by approximately 10 minutes, by switching back to debug compilation from release.

* Uses [`RISC0_DEV_MODE`](https://dev.risczero.com/api/generating-proofs/dev-mode) to simplify proof generation
* Increases client side timeout

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Existing tests are passing

## Docs
No updates
