### PR TITLE
EVM related performance features enablement 

### DIFF
--- a/crates/module-system/sov-address/Cargo.toml
+++ b/crates/module-system/sov-address/Cargo.toml
@@ -35,7 +35,7 @@ alloy-primitives = { workspace = true, default-features = false, features = [
     "rlp",
     "serde",
     "std",
-    "k256"
+    "k256",
 ], optional = true }
 k256 = { workspace = true, features = ["serde", "ecdsa", "ecdsa-core"], optional = true }
 
@@ -66,6 +66,8 @@ arbitrary = [
 native = [
     "dep:rand",
     "alloy-primitives?/std",
+    "alloy-primitives?/asm-keccak",
+    "k256?/precomputed-tables",
     "sov-rollup-interface/native",
     "sov-address/native",
     "sov-modules-api/native"


### PR DESCRIPTION
# Description

Port of https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/3248

## Summary from Claude

#### Summary of asm-keccak Feature Impact

The asm-keccak feature in alloy-primitives enables assembly-optimized Keccak-256 hashing with these impacts:

Performance Benefits:
  - Significantly faster Keccak-256 operations compared to pure Rust implementations
  - Particularly beneficial for compute-heavy operations like address generation, transaction hashing, and cryptographic operations
  - Part of Alloy's overall performance improvements (up to 60% faster U256 arithmetic, 10x faster ABI encoding)

Platform Support:
  - Full support: x86_64 (Linux, macOS, Windows)
  - Partial support: aarch64 (ARM64) - compiles but not fully tested
  - Limited support: powerpc, riscv32/64, mips

Potential Considerations:
  - Assembly code is "somewhat tested" - may have less test coverage than pure Rust implementations
  - Platform-specific - won't provide benefits on unsupported architectures
  - Adds a dependency on external assembly code maintained separately

When to Use:
  - High-performance applications (MEV bots, indexers, DeFi protocols)
  - Applications with heavy Keccak usage
  - Production systems on x86_64 platforms

When to Avoid:
  - Cross-platform applications targeting diverse architectures
  - Security-critical applications requiring extensive auditing
  - Development on non-x86_64 platforms
  
#### Summary of precomputed-tables Feature Impact in k256

  The precomputed-tables feature in the k256 crate enables precomputed lookup tables for scalar multiplication operations with these impacts:

  Performance Benefits:
  - Reduces scalar multiplication from ~256 point additions to ~32 additions (8x speedup)
  - Particularly effective for fixed-point multiplication (e.g., public key generation)
  - Nearly as fast as single scalar multiplication when using precomputed values

  Memory Trade-offs:
  - Uses 4-bit windows (16 entries per bucket) as optimal balance
  - Tables must fit in L1 cache (~32KB) to avoid performance degradation
  - Larger tables (5-bit windows) may perform better on systems with big caches but worse on memory-constrained systems

Implementation Details:
  - Precomputed multiples of powers of 16 multiplied with generator point
  - Branch-free conditional moves for constant-time access (security)
  - Default feature in k256 (enabled unless explicitly disabled)

  When to Use:
  - Applications with repeated operations on fixed points
  - Performance-critical ECDSA/Schnorr signature operations
  - Systems with adequate L1 cache

  When to Avoid:
  - Memory-constrained environments (embedded systems)
  - One-off operations where precomputation cost isn't amortized
  - Systems with very small CPU caches

  Security Note:
  The tables are accessed using constant-time algorithms to prevent side-channel attacks that could leak secret key information through timing analysis.

------

- [x] Unrelated ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)



## Testing
All existing tests are passing

## Docs
No updates
