### PR TITLE
TestRollup: Use in-memory MockDa to relief I/O for competing tests

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/utils.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/utils.rs
@@ -259,6 +259,7 @@ pub async fn new_test_rollup<RT: Runtime<TestSpec> + HasRestApi<TestSpec>>(
         c.max_concurrent_blobs = TEST_MAX_CONCURRENT_BLOBS;
     })
     .set_da_config(|c| c.sender_address = seq_da_address)
+    .set_persistent_da()
     .with_preferred_seq_min_profit_per_tx(minimum_profit_per_tx)
     .with_preferred_seq_recovery_strategy(sov_sequencer::preferred::RecoveryStrategy::TryToSave);
 

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -232,7 +232,6 @@ impl<R: FullNodeBlueprint<Native>, StoragePath: AsPath> RollupBuilder<R, Storage
             },
             with_secondary_sequencer: None,
         }
-        .set_da_connection_string()
     }
 
     /// See [`PreferredSequencerConfig::minimum_profit_per_tx`].
@@ -292,8 +291,7 @@ impl<R: FullNodeBlueprint<Native>, StoragePath: AsPath> RollupBuilder<R, Storage
         config_f: impl FnOnce(&mut RollupBuilderConfig<R::Spec, StoragePath>),
     ) -> Self {
         config_f(&mut self.config);
-        // Storage path might have changed.
-        self.set_da_connection_string()
+        self
     }
 
     /// Allows to modify DA configuration options.
@@ -316,13 +314,14 @@ impl<R: FullNodeBlueprint<Native>, StoragePath: AsPath> RollupBuilder<R, Storage
         self
     }
 
-    fn set_da_connection_string(self) -> Self {
+    /// If rollup needs to be restarted, this needs to be activated.
+    pub fn set_persistent_da(mut self) -> Self {
         // We store DA data in the same directory as the rollup data. This
         // ensures that, when reusing the same path, we restore not only node
         // data but also DA history.
-        // self.da_config.connection_string =
-        //     MockDaConfig::sqlite_in_dir(self.config.storage.as_path())
-        //         .expect("storage folder should exist by this time");
+        self.da_config.connection_string =
+            MockDaConfig::sqlite_in_dir(self.config.storage.as_path())
+                .expect("storage folder should exist by this time");
         self
     }
 }
@@ -799,6 +798,10 @@ where
         stop_at_height: Option<RollupHeight>,
     ) -> anyhow::Result<Self> {
         let builder = self.shutdown().await?;
+        let in_memory = MockDaConfig::sqlite_in_memory();
+        if builder.da_config.connection_string.contains(&in_memory) {
+            anyhow::bail!("Cannot restart in-memory DA, call `set_persistent_da` on RollupBuilder before starting");
+        }
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         let builder = builder.set_config(|c| {
             c.start_at_rollup_height = start_at_height;

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -196,7 +196,7 @@ impl<R: FullNodeBlueprint<Native>, StoragePath: AsPath> RollupBuilder<R, Storage
             // This will be set later based on the storage path. In case of a bug,
             // SQLite will simply fail to open the file and we'll immediately get a
             // panic, so it's not dangerous.
-            connection_string: "WILL_BE_SET_LATER".to_string(),
+            connection_string: MockDaConfig::sqlite_in_memory(),
             // This value is important and should match `examples/test-data/genesis/integration-tests/sequencer_registry.json`
             // Otherwise batches are going to be rejected in `examples/demo-rollup` tests.
             sender_address: MockAddress::new([0; 32]),
@@ -316,13 +316,13 @@ impl<R: FullNodeBlueprint<Native>, StoragePath: AsPath> RollupBuilder<R, Storage
         self
     }
 
-    fn set_da_connection_string(mut self) -> Self {
+    fn set_da_connection_string(self) -> Self {
         // We store DA data in the same directory as the rollup data. This
         // ensures that, when reusing the same path, we restore not only node
         // data but also DA history.
-        self.da_config.connection_string =
-            MockDaConfig::sqlite_in_dir(self.config.storage.as_path())
-                .expect("storage folder should exist by this time");
+        // self.da_config.connection_string =
+        //     MockDaConfig::sqlite_in_dir(self.config.storage.as_path())
+        //         .expect("storage folder should exist by this time");
         self
     }
 }

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -90,6 +90,7 @@ async fn start_stop_empty(
                 }
                 c.aggregated_proof_block_jump = 10;
             })
+            .set_persistent_da()
             .start(),
         )
         .await

--- a/examples/demo-rollup/tests/resync/mod.rs
+++ b/examples/demo-rollup/tests/resync/mod.rs
@@ -320,6 +320,7 @@ async fn sync_rollup_with_path(
             c.aggregated_proof_block_jump = 10;
             c.max_concurrent_blobs = 92;
         })
+        .set_persistent_da()
         .start(),
     )
     .await


### PR DESCRIPTION
# Description

We can increase CPU or RAM for CI runners. But we cannot guarantee to have fast I/O.
It is possible that several heavy I/O tests run concurrently on the same not so fast disk, probably competing with other runs.

This PR makes default parameter for MockDa on TestRollup to be in-memory. 
We only need persistent DA for restart tests. So those tests should explictly set it.
Added guard in `restart` method that checks if its attempted to be called on in-memory DA.

Check CI run on this one: less flakyness and restarts!

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existing tests are updated and passed

## Docs
No updates