### PR TITLE
Add `channel_size` metric to`PreferredSequencerChannelMetrics`

### DIFF
--- a/crates/full-node/sov-sequencer/src/metrics.rs
+++ b/crates/full-node/sov-sequencer/src/metrics.rs
@@ -54,6 +54,7 @@ impl Metric for PreferredSequencerUpdateStateMetrics {
 pub struct PreferredSequencerChannelMetrics {
     pub duration: std::time::Duration,
     pub reason: &'static str,
+    pub channel_size: u32,
 }
 
 impl Metric for PreferredSequencerChannelMetrics {
@@ -64,10 +65,11 @@ impl Metric for PreferredSequencerChannelMetrics {
     fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
         write!(
             buffer,
-            "{},reason={} duration_us={}",
+            "{},reason={} duration_us={},channel_size={}",
             self.measurement_name(),
             self.reason,
             self.duration.as_micros(),
+            self.channel_size,
         )
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -1,6 +1,6 @@
 use std::num::NonZero;
 use std::ops::Deref;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -95,6 +95,7 @@ where
     inner: &'a mut Inner<S, Rt>,
     reason: &'static str,
     start_time: std::time::Instant,
+    channel_size: u32,
 }
 
 impl<'a, S, Rt> InnerGuard<'a, S, Rt>
@@ -103,11 +104,12 @@ where
     Rt: Runtime<S>,
 {
     /// Create a new inner guard.
-    pub fn new(inner: &'a mut Inner<S, Rt>, reason: &'static str) -> Self {
+    pub fn new(inner: &'a mut Inner<S, Rt>, reason: &'static str, channel_size: u32) -> Self {
         Self {
             inner,
             reason,
             start_time: std::time::Instant::now(),
+            channel_size,
         }
     }
 }
@@ -142,6 +144,7 @@ where
         self.inner.metrics.push(PreferredSequencerChannelMetrics {
             duration: self.start_time.elapsed(),
             reason: self.reason,
+            channel_size: self.channel_size,
         });
         if self.inner.metrics.len() >= METRICS_BATCH_SIZE {
             sov_metrics::track_metrics(|t| {
@@ -809,13 +812,16 @@ where
         stop_at_rollup_height,
     };
 
+    let channel_size =  Arc::new(AtomicU32::new(0));
     (
         SynchronizedSequencerState {
             inner,
+            channel_size: channel_size.clone(),
             message_receiver,
         },
         SequencerStateUpdator {
             message_sender,
+            channel_size,
             shutdown_sender,
         },
     )
@@ -826,6 +832,7 @@ where
     S: Spec,
     Rt: Runtime<S>,
 {
+    channel_size: Arc<AtomicU32>,
     message_sender: mpsc::Sender<Message<S, Rt>>,
     shutdown_sender: watch::Sender<()>,
 }
@@ -1054,6 +1061,8 @@ where
     }
 
     async fn send(&self, message: Message<S, Rt>) {
+        self.channel_size
+            .fetch_add(1, Ordering::Relaxed);
         if self.message_sender.send(message).await.is_err() {
             info!("SynchronizedSequencerState(send) task exited, this is ok if the sequencer is shutting down.");
             exit_rollup(&self.shutdown_sender).await;
@@ -1077,6 +1086,7 @@ where
     Rt: Runtime<S>,
 {
     inner: Inner<S, Rt>,
+    channel_size: Arc<AtomicU32>,
     message_receiver: mpsc::Receiver<Message<S, Rt>>,
 }
 
@@ -1270,7 +1280,8 @@ where
 
     #[tracing::instrument(skip_all, level = "debug")]
     async fn get_inner_with_timing(&mut self, reason: &'static str) -> InnerGuard<S, Rt> {
-        InnerGuard::new(&mut self.inner, reason)
+        let channel_size = self.channel_size.fetch_sub(1, Ordering::Relaxed);
+        InnerGuard::new(&mut self.inner, reason, channel_size)
     }
 
     async fn process_next_sequence_number(&mut self, reason: &'static str) -> SequenceNumber {

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -1,6 +1,6 @@
 use std::num::NonZero;
 use std::ops::Deref;
-use std::sync::atomic::{AtomicU64, AtomicU32, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -812,7 +812,7 @@ where
         stop_at_rollup_height,
     };
 
-    let channel_size =  Arc::new(AtomicU32::new(0));
+    let channel_size = Arc::new(AtomicU32::new(0));
     (
         SynchronizedSequencerState {
             inner,
@@ -1061,8 +1061,7 @@ where
     }
 
     async fn send(&self, message: Message<S, Rt>) {
-        self.channel_size
-            .fetch_add(1, Ordering::Relaxed);
+        self.channel_size.fetch_add(1, Ordering::Relaxed);
         if self.message_sender.send(message).await.is_err() {
             info!("SynchronizedSequencerState(send) task exited, this is ok if the sequencer is shutting down.");
             exit_rollup(&self.shutdown_sender).await;


### PR DESCRIPTION
# Description

Adds a new field in the `PreferredSequencerChannelMetrics`. This tracks the size of the `message_channel`. 
<img width="1097" height="343" alt="Screenshot 2025-07-30 at 14 15 10" src="https://github.com/user-attachments/assets/a762be6b-7bc9-4eb6-b0cf-e0f9d23a0bf0" />

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
