### PR TITLE
Fix dead-lock in `NomtProverStorage::compute_state_update`

### DIFF
--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -12,6 +12,7 @@ use crate::metrics::nomt::{NomtBeginSessionMetric, NomtDbMetric};
 
 const KERNEL: &str = "kernel_state";
 const USER: &str = "user_state";
+const BOTH: &str = "user_and_kernel_state";
 
 const COMMIT_START_DELAY: std::time::Duration = std::time::Duration::from_millis(1);
 const COMMIT_RETRY_ATTEMPTS: usize = 26;
@@ -261,6 +262,14 @@ impl<H, K> NomtSessionBuilder<H, K> {
     }
 }
 
+/// Container for both sessions, to remove error in passing them
+pub struct SessionsContainer<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> {
+    #[allow(missing_docs)]
+    pub user: nomt::Session<BinaryHasher<H>>,
+    #[allow(missing_docs)]
+    pub kernel: nomt::Session<BinaryHasher<H>>,
+}
+
 impl<H, K> NomtSessionBuilder<H, K>
 where
     K: Eq + std::hash::Hash,
@@ -348,6 +357,62 @@ where
             });
         });
         Ok(session)
+    }
+
+    /// Begins both sessions at the same time.
+    /// Should be used if both sessions are needed in same context. Prevents dead lock.
+    pub fn begin_both_sessions(&self) -> anyhow::Result<SessionsContainer<H>> {
+        let start = std::time::Instant::now();
+        let (kernel_params, user_params) = {
+            let mut kernel_overlays = Vec::with_capacity(self.relevant_snapshot_refs.len());
+            let mut user_overlays = Vec::with_capacity(self.relevant_snapshot_refs.len());
+            let snapshots = self.all_snapshots.read().expect("Snapshots lock poisoned");
+            for overlay_ref in &self.relevant_snapshot_refs {
+                let Some(state_overlay) = snapshots.get(overlay_ref) else {
+                    tracing::debug!(
+                        "Cannot find snapshot from reference, assuming it has been committed"
+                    );
+                    continue;
+                };
+                kernel_overlays.push(&state_overlay.kernel);
+                user_overlays.push(&state_overlay.user);
+            }
+            let kernel_params = SessionParams::default()
+                .overlay(kernel_overlays)
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to construct session params for kernel session: {:?}",
+                        e
+                    )
+                })?
+                .witness_mode(WitnessMode::read_write());
+            let user_params = SessionParams::default()
+                .overlay(user_overlays)
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Failed to construct session params for user session: {:?}",
+                        e
+                    )
+                })?
+                .witness_mode(WitnessMode::read_write());
+            (kernel_params, user_params)
+        };
+        let kernel_session = self.state_db.kernel.begin_session(kernel_params);
+        let user_session = self.state_db.user.begin_session(user_params);
+        let init_time = start.elapsed();
+        let overlays = self.relevant_snapshot_refs.len();
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit(NomtBeginSessionMetric {
+                db: BOTH,
+                overlays,
+                init_time,
+            });
+        });
+
+        Ok(SessionsContainer {
+            user: user_session,
+            kernel: kernel_session,
+        })
     }
 }
 

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -601,14 +601,10 @@ where
         };
         let storage_root_historical = self.get_root_hash_unbound(version_to_use)?;
         if self.should_check_dbs_sync(version_to_use) {
-            let SessionsContainer {
-                user: user_session,
-                kernel: kernel_session,
-            } = self.state_session_builder.begin_both_sessions()?;
-            let user_root = user_session.prev_root();
-            let kernel_root = kernel_session.prev_root();
-            drop(user_session);
-            drop(kernel_session);
+            let session_container = self.state_session_builder.begin_both_sessions()?;
+            let user_root = session_container.user.prev_root();
+            let kernel_root = session_container.kernel.prev_root();
+            drop(session_container);
             let prev_root_nomt = StorageRoot::new(user_root.into_inner(), kernel_root.into_inner());
             assert_eq!(
                 storage_root_historical, prev_root_nomt,

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -10,7 +10,7 @@ use nomt::FinishedSession;
 use sov_db::accessory_db::AccessoryDb;
 use sov_db::historical_state::HistoricalStateReader;
 use sov_db::namespaces::{KernelNamespace, UserNamespace};
-use sov_db::state_db_nomt::NomtSessionBuilder;
+use sov_db::state_db_nomt::{NomtSessionBuilder, SessionsContainer};
 use sov_db::storage_manager::{
     InitializableNativeNomtStorage, NomtChangeSet, StateFinishedSession,
 };
@@ -409,9 +409,11 @@ where
     ) -> anyhow::Result<(Self::Root, Self::StateUpdate)> {
         let start = std::time::Instant::now();
         let next_version = self.historical_state.get_next_version();
-        // Open 2 sessions close to each other
-        let user_session = self.state_session_builder.begin_user_session()?;
-        let kernel_session = self.state_session_builder.begin_kernel_session()?;
+        // Open 2 sessions at the same time
+        let SessionsContainer {
+            user: user_session,
+            kernel: kernel_session,
+        } = self.state_session_builder.begin_both_sessions()?;
         let starting_session_time = start.elapsed();
         tracing::debug!(%prev_state_root, %next_version, sesssion_starting_time = ?starting_session_time, "computing state update, sessions are live");
 
@@ -599,11 +601,13 @@ where
         };
         let storage_root_historical = self.get_root_hash_unbound(version_to_use)?;
         if self.should_check_dbs_sync(version_to_use) {
-            let user_session = self.state_session_builder.begin_user_session()?;
+            let SessionsContainer {
+                user: user_session,
+                kernel: kernel_session,
+            } = self.state_session_builder.begin_both_sessions()?;
             let user_root = user_session.prev_root();
-            drop(user_session);
-            let kernel_session = self.state_session_builder.begin_kernel_session()?;
             let kernel_root = kernel_session.prev_root();
+            drop(user_session);
             drop(kernel_session);
             let prev_root_nomt = StorageRoot::new(user_root.into_inner(), kernel_root.into_inner());
             assert_eq!(


### PR DESCRIPTION
# Description

## Root cause

Nomt can commit data only if there are no live sessions. But in rare cases if NomtStorage manager tries to commit in very bad time, it will dead lock. Code explanation below.


```rust

pub struct NomtStorageManager<Da: DaSpec, H, S: InitializableNativeNomtStorage<H, Da::SlotHash>> {
    nomt_snapshots: Arc<RwLock<HashMap<Da::SlotHash, StateOverlay>>>,
    // other things
}

pub struct NomtSessionBuilder<H, K> {
    state_db: Arc<NomtStateDb<H>>,
    // In revered chronological order, as [`nomt::SessionParams::overlay`] expects
    relevant_snapshot_refs: Vec<K>,
    // Reference to snapshots for all blocks currently available in a storage manager.
    // Used to get reference to state overlays and build session.
    // Same thing from above
    all_snapshots: Arc<RwLock<HashMap<K, StateOverlay>>>,
}

impl NomtProverStorage {

    fn compute_state_update(&self, ...) {
        // Takes and releases the read lock
        let user_session = self.state_session_builder.begin_user_session()?;
        // Here storage manager takes write lock, and tries to commit several times,
        // but not succeeeds, because user_session is alive and compute_state_update never complietes, because line below waits for acquiring read lock
        let kernel_session = self.state_session_builder.begin_kernel_session()?;
        
    }
}
```

## Solution

Add new method, which starts both sessions from same ReadLock, so both sessions can finish.

- [x] Internal change ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
Existing tests are passing

## Docs
No updates
