### PR TITLE
Enable logging for `test_check_no_reorgs_longer`

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
@@ -362,6 +362,8 @@ async fn test_check_no_reorgs() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_check_no_reorgs_longer() -> anyhow::Result<()> {
+    // sov_test_utils::logging::initialize_or_change_logging_with_filter("info,sov_metrics=error,integration=debug");
+    sov_test_utils::logging::initialize_or_change_logging_with_filter("debug,sov_metrics=error,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info");
     tokio::time::timeout(
         TEST_TIMEOUT,
         test_stream_of_transactions(StreamOfTransactionsArgs {


### PR DESCRIPTION
# Description

As it often fails in CI and I was unable to reproduce it anywhere locally.

Started with sanitized debug, will change later if  trace is needed somewhere.

- [x] Internal change ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
All existing tests are passing

## Docs
No updates