### PR TITLE
Update API state before sending accepted tx response

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
@@ -139,8 +139,8 @@ where
                         .insert(contents.accepted_tx.clone())
                         .await;
                     // If the receiver is no longer listening, just don't send the confirmation.
-                    let _ = contents.oneshot_sender.send(contents.accepted_tx);
                     self.update_api_state_with_changes(contents.tx_changes);
+                    let _ = contents.oneshot_sender.send(contents.accepted_tx);
                 }
             }
             ExecutorEvent::CloseBatch(batch, checkpoint) => {


### PR DESCRIPTION
# Description

This tiny PR fixes a (probably inconsequential) race condition which made it possible for a user to see a response to their transaction, and then query the API and *not* see the effects. In practice, the duration of the race was extremely short so this is exceedingly unlikely to ever have been an issue for queries that were not running over localhost - but it was causing some test flakiness. 

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

