### PR TITLE
Fix resync edge case + fix replica initial sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-07-30
+- #1447 Improved resync behaviour: fixed an edge case when resyncing under heavy rollup load, and fixed a bug that prevented replicas from syncing on startup. This should make replica sequencers usable for horizontal scaling of API queries.
+
 # 2025-07-23
 - #3283 **BREAKING CHANGE** Update the mock `code-commitment` to 8 bytes. This change requires modifying the `chain_state_xx.json` genesis files accordingly.
 - #3293 Extends `get_runtime_schema` to work with types which haven't implemented `Runtime` trait yet.

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -219,7 +219,6 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             Ok((receipt, remaining_slot_gas, execution_time_micros, tx_changes)) => {
                 let accepted_tx = self.process_tx_receipt(&receipt);
                 if let Some(writer) = self.startup_transaction_cache_writer.as_mut() {
-                    println!("block_executor: inserting tx into cache during startup replay, number: {}, hash: {}", accepted_tx.confirmation.tx_number, accepted_tx.tx_hash);
                     writer.insert(accepted_tx.clone()).await;
                 }
                 Ok((
@@ -372,8 +371,6 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             %tx_hash,
             "Re-applying state changes for the soft-confirmed transaction"
         );
-
-        println!("  ->executor: replaying tx {}", tx_hash);
 
         match self.apply_tx_to_in_progress_batch(tx).await {
             Ok((output, _tx_changes)) => {

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -219,6 +219,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             Ok((receipt, remaining_slot_gas, execution_time_micros, tx_changes)) => {
                 let accepted_tx = self.process_tx_receipt(&receipt);
                 if let Some(writer) = self.startup_transaction_cache_writer.as_mut() {
+                    println!("block_executor: inserting tx into cache during startup replay, number: {}, hash: {}", accepted_tx.confirmation.tx_number, accepted_tx.tx_hash);
                     writer.insert(accepted_tx.clone()).await;
                 }
                 Ok((
@@ -371,6 +372,8 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             %tx_hash,
             "Re-applying state changes for the soft-confirmed transaction"
         );
+
+        println!("  ->executor: replaying tx {}", tx_hash);
 
         match self.apply_tx_to_in_progress_batch(tx).await {
             Ok((output, _tx_changes)) => {

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -7,10 +7,10 @@ use std::time::Duration;
 use anyhow::anyhow;
 use sov_blob_sender::BlobInternalId;
 use sov_blob_storage::SequenceNumber;
-use sov_modules_api::capabilities::{BlobSelector, RollupHeight};
+use sov_modules_api::capabilities::RollupHeight;
 use sov_modules_api::{
-    DaSyncState, FullyBakedTx, GasArray, GasSpec, KernelStateAccessor, Runtime, Spec,
-    StateCheckpoint, StateUpdateInfo, VersionReader, VisibleSlotNumber,
+    DaSyncState, FullyBakedTx, GasArray, GasSpec, Runtime, Spec, StateCheckpoint, StateUpdateInfo,
+    VersionReader, VisibleSlotNumber,
 };
 use sov_state::{NativeStorage, Storage};
 use tokio::sync::{mpsc, oneshot, watch};
@@ -57,12 +57,6 @@ const CHANNEL_SIZE: usize = 128;
 type AcceptTxRet<S, Rt> =
     Result<oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>, AcceptTxError<S>>;
 
-/// The `Inner` sends the latest processed slot number when it finishes the starting sync.
-pub enum HasFinishedStartup {
-    No(watch::Sender<SequenceNumber>),
-    Yes,
-}
-
 /// A inner sequencer struct containing state that requires synchronized access.
 /// This struct accepts/rejects transactions, then hands them to the side effects task
 /// to be persisted.
@@ -86,6 +80,9 @@ where
     /// We need this rather than relying on `SequencerNotReadyDetails::Startup` because that state
     /// can be overwritten when the node is resyncing.
     has_finished_startup: bool,
+    /// Channel that sends a notification every time the executor is replaced after batch replay
+    /// finishes (at the end of update_state).
+    replay_notifier: watch::Sender<Option<SequenceNumber>>,
     metrics: Vec<PreferredSequencerChannelMetrics>,
     // Shared between sequencer and Inner.
     tx_queue_id: Arc<AtomicU64>,
@@ -780,7 +777,7 @@ pub(crate) fn create<S, Rt>(
     executor_events_sender: ExecutorEventsSender<S, Rt>,
     sequence_number_of_next_blob: SequenceNumber,
     in_flight_blobs: Arc<AtomicUsize>,
-    startup_notifier: oneshot::Sender<SequenceNumber>,
+    replay_notifier: watch::Sender<Option<SequenceNumber>>,
     stop_at_rollup_height: Option<RollupHeight>,
 ) -> (
     SynchronizedSequencerState<S, Rt>,
@@ -810,7 +807,8 @@ where
         executor_events_sender,
         sequence_number_of_next_blob,
         in_flight_blobs,
-        has_finished_startup: HasFinishedStartup::No(startup_notifier),
+        has_finished_startup: false,
+        replay_notifier,
         metrics: Vec::with_capacity(128),
         is_ready,
         stop_at_rollup_height,
@@ -1338,7 +1336,7 @@ where
         let ((batches_to_replay, fetch_batches_to_replay_metrics), is_startup) = {
             (
                 inner.completed_batches_to_replay(next_sequence_number_according_to_node, true),
-                matches!(inner.has_finished_startup, HasFinishedStartup::No(_)),
+                !inner.has_finished_startup,
             )
         };
         let is_resync = matches!(
@@ -1361,12 +1359,6 @@ where
         // `update_state`. That's no good.
         let current_visible_slot_number =
             current_visible_slot_number_according_to_node::<S, Rt>(info);
-
-        if inner.config.sequencer_kind_config.is_replica {
-            println!(" ----> replica update_state: current_visible_slot_number according to node: {current_visible_slot_number}; next sequence nmber according to node: {next_sequence_number_according_to_node}, our next sequence number: {next_sequence_number}. Replaying {} batches", batches_to_replay.len());
-        } else {
-            println!(" ->>>> master update_state: current_visible_slot_number_according_to_node: {current_visible_slot_number}; next sequence nmber according to node: {next_sequence_number_according_to_node}, our next sequence number: {next_sequence_number}");
-        }
 
         let condition_too_close_to_deferred_slots_count_for_comfort =
             info.slot_number.delta(current_visible_slot_number)
@@ -1396,7 +1388,6 @@ where
                     target_da_height: da_sync_state.target_da_height.load(Ordering::Relaxed),
                     synced_da_height: da_sync_state.synced_da_height.load(Ordering::Relaxed),
                 });
-                println!("    replica update_state: returning WaitForNodeResyncToTip, detected newer sequence number");
                 PreferredSeqOperation::WaitForNodeResyncToTip
             }
             (_, _, true, _) => {
@@ -1419,7 +1410,6 @@ where
                 PreferredSeqOperation::RecoverAndCatchUp
             }
             (false, false, false, _) => {
-                println!("    replica update_state: returning ReplaySoftConfirmationsOnTopOfNodeState, is_startup: {is_startup}, is_resync: {is_resync}");
                 PreferredSeqOperation::ReplaySoftConfirmationsOnTopOfNodeState(
                     is_startup || is_resync,
                     time_spent_fetching_batches,
@@ -1580,20 +1570,11 @@ where
         // The executor is now caught up. Swap it in
         inner.executor.replace_state(*executor).await;
         inner.is_ready = Ok(());
-        if let HasFinishedStartup::No(notifier) =
-            std::mem::replace(&mut inner.has_finished_startup, HasFinishedStartup::Yes)
-        {
-            let mut runtime = Rt::default();
-            let mut checkpoint = inner
-                .executor
-                .checkpoint
-                .clone_with_empty_witness_dropping_temp_cache(); // this extra clone is a bit ugly
-            let mut state =
-                KernelStateAccessor::from_checkpoint(&runtime.kernel(), &mut checkpoint);
-            let seq = runtime.kernel().next_sequence_number(&mut state);
-            println!("REPLICA: notifying replica sync task that we're caught up! Replayed batches up to sequence number {seq}");
-            let _ = notifier.send_replace(seq);
-        }
+        inner.has_finished_startup = true;
+        let last_replayed_sequence_number = inner.sequence_number_of_next_blob.checked_sub(1);
+        inner
+            .replay_notifier
+            .send_replace(last_replayed_sequence_number);
         inner.latest_info = info;
         let checkpoint = inner
             .executor
@@ -1627,7 +1608,6 @@ where
             .inner_do_batch_start(visible_slot_number_after_increase, visible_slots_to_advance)
             .await
         {
-            println!("Error in inner_do_batch_start: {err:?}");
             tracing::error!(
                 error = %err,
                 "Error: while calling inner_do_batch_start."
@@ -1727,7 +1707,7 @@ where
                 .executor_events_sender
                 .flush_transactions_cache(info.next_tx_number)
                 .await;
-        } else if matches!(inner.has_finished_startup, HasFinishedStartup::No(_)) {
+        } else if !inner.has_finished_startup {
             inner
                 .executor_events_sender
                 .flush_transactions_cache(info.next_tx_number)

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -59,7 +59,7 @@ type AcceptTxRet<S, Rt> =
 
 /// The `Inner` sends the latest processed slot number when it finishes the starting sync.
 pub enum HasFinishedStartup {
-    No(oneshot::Sender<SequenceNumber>),
+    No(watch::Sender<SequenceNumber>),
     Yes,
 }
 
@@ -303,7 +303,7 @@ where
                     target_visible_slot_number = %visible_slot_number_after_increase,
                     "Cannot calculate visible slots to advance for replica: target is not greater than current"
                 );
-                anyhow!("Invalid visible slot number progression for replica".to_string())
+                anyhow!(format!("Invalid visible slot number progression for replica: target is not greater than current. visible_slot_number_after_increase: {visible_slot_number_after_increase}, current_visible_slot_number: {current_visible_slot_number}"))
             })?;
 
         assert_eq!(
@@ -1361,6 +1361,13 @@ where
         // `update_state`. That's no good.
         let current_visible_slot_number =
             current_visible_slot_number_according_to_node::<S, Rt>(info);
+
+        if inner.config.sequencer_kind_config.is_replica {
+            println!(" ----> replica update_state: current_visible_slot_number according to node: {current_visible_slot_number}; next sequence nmber according to node: {next_sequence_number_according_to_node}, our next sequence number: {next_sequence_number}. Replaying {} batches", batches_to_replay.len());
+        } else {
+            println!(" ->>>> master update_state: current_visible_slot_number_according_to_node: {current_visible_slot_number}; next sequence nmber according to node: {next_sequence_number_according_to_node}, our next sequence number: {next_sequence_number}");
+        }
+
         let condition_too_close_to_deferred_slots_count_for_comfort =
             info.slot_number.delta(current_visible_slot_number)
                 > slot_count_delta_acceptable_lower_bound(
@@ -1389,6 +1396,7 @@ where
                     target_da_height: da_sync_state.target_da_height.load(Ordering::Relaxed),
                     synced_da_height: da_sync_state.synced_da_height.load(Ordering::Relaxed),
                 });
+                println!("    replica update_state: returning WaitForNodeResyncToTip, detected newer sequence number");
                 PreferredSeqOperation::WaitForNodeResyncToTip
             }
             (_, _, true, _) => {
@@ -1411,6 +1419,7 @@ where
                 PreferredSeqOperation::RecoverAndCatchUp
             }
             (false, false, false, _) => {
+                println!("    replica update_state: returning ReplaySoftConfirmationsOnTopOfNodeState, is_startup: {is_startup}, is_resync: {is_resync}");
                 PreferredSeqOperation::ReplaySoftConfirmationsOnTopOfNodeState(
                     is_startup || is_resync,
                     time_spent_fetching_batches,
@@ -1582,7 +1591,8 @@ where
             let mut state =
                 KernelStateAccessor::from_checkpoint(&runtime.kernel(), &mut checkpoint);
             let seq = runtime.kernel().next_sequence_number(&mut state);
-            let _ = notifier.send(seq);
+            println!("REPLICA: notifying replica sync task that we're caught up! Replayed batches up to sequence number {seq}");
+            let _ = notifier.send_replace(seq);
         }
         inner.latest_info = info;
         let checkpoint = inner
@@ -1617,6 +1627,7 @@ where
             .inner_do_batch_start(visible_slot_number_after_increase, visible_slots_to_advance)
             .await
         {
+            println!("Error in inner_do_batch_start: {err:?}");
             tracing::error!(
                 error = %err,
                 "Error: while calling inner_do_batch_start."

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -7,9 +7,10 @@ use std::time::Duration;
 use anyhow::anyhow;
 use sov_blob_sender::BlobInternalId;
 use sov_blob_storage::SequenceNumber;
-use sov_modules_api::capabilities::{RollupHeight, BlobSelector};
+use sov_modules_api::capabilities::{BlobSelector, RollupHeight};
 use sov_modules_api::{
-    DaSyncState, FullyBakedTx, GasArray, GasSpec, KernelStateAccessor, Runtime, Spec, StateCheckpoint, StateUpdateInfo, VersionReader, VisibleSlotNumber
+    DaSyncState, FullyBakedTx, GasArray, GasSpec, KernelStateAccessor, Runtime, Spec,
+    StateCheckpoint, StateUpdateInfo, VersionReader, VisibleSlotNumber,
 };
 use sov_state::{NativeStorage, Storage};
 use tokio::sync::{mpsc, oneshot, watch};
@@ -59,7 +60,7 @@ type AcceptTxRet<S, Rt> =
 /// The `Inner` sends the latest processed slot number when it finishes the starting sync.
 pub enum HasFinishedStartup {
     No(oneshot::Sender<SequenceNumber>),
-    Yes
+    Yes,
 }
 
 /// A inner sequencer struct containing state that requires synchronized access.
@@ -1018,7 +1019,6 @@ where
         transaction_cache_write_handle: TxResultWriter<S, Rt>,
         info: StateUpdateInfo<S::Storage>,
         da_sync_state: Arc<DaSyncState>,
-        is_master: bool,
         reason: &'static str,
     ) {
         self.send(Message::WaitNodeResync {
@@ -1026,7 +1026,6 @@ where
             transaction_cache_write_handle,
             info,
             da_sync_state,
-            is_master,
             reason,
         })
         .await;
@@ -1251,7 +1250,6 @@ where
                             transaction_cache_write_handle,
                             info,
                             da_sync_state,
-                            is_master,
                             reason,
                         )
                         .await;
@@ -1340,10 +1338,13 @@ where
         let ((batches_to_replay, fetch_batches_to_replay_metrics), is_startup) = {
             (
                 inner.completed_batches_to_replay(next_sequence_number_according_to_node, true),
-                matches!(self.has_finished_startup, HasFinishedStartup::No(_)),
+                matches!(inner.has_finished_startup, HasFinishedStartup::No(_)),
             )
         };
-        let is_resync = matches!(self.is_ready, Err(SequencerNotReadyDetails::Syncing { .. }));
+        let is_resync = matches!(
+            inner.is_ready,
+            Err(SequencerNotReadyDetails::Syncing { .. })
+        );
 
         let time_spent_fetching_batches = fetch_batches_to_replay_metrics.duration;
         sov_metrics::track_metrics(|t| {
@@ -1570,7 +1571,19 @@ where
         // The executor is now caught up. Swap it in
         inner.executor.replace_state(*executor).await;
         inner.is_ready = Ok(());
-        inner.has_finished_startup = true;
+        if let HasFinishedStartup::No(notifier) =
+            std::mem::replace(&mut inner.has_finished_startup, HasFinishedStartup::Yes)
+        {
+            let mut runtime = Rt::default();
+            let mut checkpoint = inner
+                .executor
+                .checkpoint
+                .clone_with_empty_witness_dropping_temp_cache(); // this extra clone is a bit ugly
+            let mut state =
+                KernelStateAccessor::from_checkpoint(&runtime.kernel(), &mut checkpoint);
+            let seq = runtime.kernel().next_sequence_number(&mut state);
+            let _ = notifier.send(seq);
+        }
         inner.latest_info = info;
         let checkpoint = inner
             .executor
@@ -1683,7 +1696,6 @@ where
         transaction_cache_write_handle: TxResultWriter<S, Rt>,
         info: StateUpdateInfo<S::Storage>,
         da_sync_state: Arc<DaSyncState>,
-        is_master: bool,
         reason: &'static str,
     ) {
         let mut inner = self.get_inner_with_timing(reason).await;
@@ -1704,7 +1716,7 @@ where
                 .executor_events_sender
                 .flush_transactions_cache(info.next_tx_number)
                 .await;
-        } else if matches!(self.has_finished_startup, HasFinishedStartup::No(_)) {
+        } else if matches!(inner.has_finished_startup, HasFinishedStartup::No(_)) {
             inner
                 .executor_events_sender
                 .flush_transactions_cache(info.next_tx_number)
@@ -1756,7 +1768,6 @@ where
     async fn process_close_current_batch(&mut self, reason: &'static str) {
         let mut inner = self.get_inner_with_timing(reason).await;
         inner.close_current_batch().await;
-
     }
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -7,10 +7,9 @@ use std::time::Duration;
 use anyhow::anyhow;
 use sov_blob_sender::BlobInternalId;
 use sov_blob_storage::SequenceNumber;
-use sov_modules_api::capabilities::RollupHeight;
+use sov_modules_api::capabilities::{RollupHeight, BlobSelector};
 use sov_modules_api::{
-    DaSyncState, FullyBakedTx, GasArray, GasSpec, Runtime, Spec, StateCheckpoint, StateUpdateInfo,
-    VersionReader, VisibleSlotNumber,
+    DaSyncState, FullyBakedTx, GasArray, GasSpec, KernelStateAccessor, Runtime, Spec, StateCheckpoint, StateUpdateInfo, VersionReader, VisibleSlotNumber
 };
 use sov_state::{NativeStorage, Storage};
 use tokio::sync::{mpsc, oneshot, watch};
@@ -57,6 +56,12 @@ const CHANNEL_SIZE: usize = 128;
 type AcceptTxRet<S, Rt> =
     Result<oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>, AcceptTxError<S>>;
 
+/// The `Inner` sends the latest processed slot number when it finishes the starting sync.
+pub enum HasFinishedStartup {
+    No(oneshot::Sender<SequenceNumber>),
+    Yes
+}
+
 /// A inner sequencer struct containing state that requires synchronized access.
 /// This struct accepts/rejects transactions, then hands them to the side effects task
 /// to be persisted.
@@ -76,7 +81,7 @@ where
     in_flight_blobs: Arc<AtomicUsize>,
     executor_events_sender: ExecutorEventsSender<S, Rt>,
     sequence_number_of_next_blob: SequenceNumber,
-    /// A boolean that indicates whether the sequencer has finished its startup phase.
+    /// Indicates whether the sequencer has finished its startup phase.
     /// We need this rather than relying on `SequencerNotReadyDetails::Startup` because that state
     /// can be overwritten when the node is resyncing.
     has_finished_startup: bool,
@@ -774,6 +779,7 @@ pub(crate) fn create<S, Rt>(
     executor_events_sender: ExecutorEventsSender<S, Rt>,
     sequence_number_of_next_blob: SequenceNumber,
     in_flight_blobs: Arc<AtomicUsize>,
+    startup_notifier: oneshot::Sender<SequenceNumber>,
     stop_at_rollup_height: Option<RollupHeight>,
 ) -> (
     SynchronizedSequencerState<S, Rt>,
@@ -803,7 +809,7 @@ where
         executor_events_sender,
         sequence_number_of_next_blob,
         in_flight_blobs,
-        has_finished_startup: false,
+        has_finished_startup: HasFinishedStartup::No(startup_notifier),
         metrics: Vec::with_capacity(128),
         is_ready,
         stop_at_rollup_height,
@@ -1012,6 +1018,7 @@ where
         transaction_cache_write_handle: TxResultWriter<S, Rt>,
         info: StateUpdateInfo<S::Storage>,
         da_sync_state: Arc<DaSyncState>,
+        is_master: bool,
         reason: &'static str,
     ) {
         self.send(Message::WaitNodeResync {
@@ -1019,6 +1026,7 @@ where
             transaction_cache_write_handle,
             info,
             da_sync_state,
+            is_master,
             reason,
         })
         .await;
@@ -1243,6 +1251,7 @@ where
                             transaction_cache_write_handle,
                             info,
                             da_sync_state,
+                            is_master,
                             reason,
                         )
                         .await;
@@ -1331,9 +1340,11 @@ where
         let ((batches_to_replay, fetch_batches_to_replay_metrics), is_startup) = {
             (
                 inner.completed_batches_to_replay(next_sequence_number_according_to_node, true),
-                !inner.has_finished_startup,
+                matches!(self.has_finished_startup, HasFinishedStartup::No(_)),
             )
         };
+        let is_resync = matches!(self.is_ready, Err(SequencerNotReadyDetails::Syncing { .. }));
+
         let time_spent_fetching_batches = fetch_batches_to_replay_metrics.duration;
         sov_metrics::track_metrics(|t| {
             t.submit(fetch_batches_to_replay_metrics);
@@ -1400,7 +1411,7 @@ where
             }
             (false, false, false, _) => {
                 PreferredSeqOperation::ReplaySoftConfirmationsOnTopOfNodeState(
-                    is_startup,
+                    is_startup || is_resync,
                     time_spent_fetching_batches,
                 )
             }
@@ -1672,6 +1683,7 @@ where
         transaction_cache_write_handle: TxResultWriter<S, Rt>,
         info: StateUpdateInfo<S::Storage>,
         da_sync_state: Arc<DaSyncState>,
+        is_master: bool,
         reason: &'static str,
     ) {
         let mut inner = self.get_inner_with_timing(reason).await;
@@ -1692,7 +1704,7 @@ where
                 .executor_events_sender
                 .flush_transactions_cache(info.next_tx_number)
                 .await;
-        } else if !inner.has_finished_startup {
+        } else if matches!(self.has_finished_startup, HasFinishedStartup::No(_)) {
             inner
                 .executor_events_sender
                 .flush_transactions_cache(info.next_tx_number)
@@ -1744,6 +1756,7 @@ where
     async fn process_close_current_batch(&mut self, reason: &'static str) {
         let mut inner = self.get_inner_with_timing(reason).await;
         inner.close_current_batch().await;
+
     }
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -1,5 +1,6 @@
 //! See [`PreferredSequencer`].
 
+#![allow(unused_imports)]
 mod async_batch;
 mod batch_size_tracker;
 mod block_executor;
@@ -1251,9 +1252,11 @@ pub(crate) async fn exit_rollup(shutdown_sender: &watch::Sender<()>) {
     if shutdown_sender.send(()).is_err() {
         tracing::error!("Failed to send shutdown signal");
     }
-    sleep(Duration::from_secs(5)).await;
-    tracing::info!("Calling std::process::exit(1).");
-    std::process::exit(1);
+    println!("\n\n\nEXIT_ROLLUP CALLED!!!\n\n\n");
+    // sleep(Duration::from_secs(5)).await;
+    // tracing::info!("Calling std::process::exit(1).");
+    // std::process::exit(1);
+    panic!();
 }
 
 /// An error that can occur when trying to create a new batch.

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -1,6 +1,5 @@
 //! See [`PreferredSequencer`].
 
-#![allow(unused_imports)]
 mod async_batch;
 mod batch_size_tracker;
 mod block_executor;
@@ -56,7 +55,7 @@ use sov_rollup_interface::node::DaSyncState;
 use sov_rollup_interface::TxHash;
 use state_root_compute::StateRootBackgroundTaskState;
 use tokio::sync::mpsc::{self, Sender};
-use tokio::sync::{broadcast, oneshot, watch};
+use tokio::sync::{broadcast, watch};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tracing::{debug, error, info, trace};
@@ -276,7 +275,7 @@ where
             startup_transaction_cache_writer: None, // The main executor must *not* write to the tx cache. That's handled by the side effects task
         };
 
-        let (replica_startup_sync_notifer, replica_startup_sync_receiver) = oneshot::channel();
+        let (replica_sync_notifer, replica_sync_receiver) = watch::channel(None);
 
         let tx_queue_id = Arc::new(AtomicU64::new(0));
         let (synchronized_state, synchronized_state_updator) = create(
@@ -290,7 +289,7 @@ where
             executor_events_sender,
             next_sequence_number,
             in_flight_blobs,
-            replica_startup_sync_notifer,
+            replica_sync_notifer,
             stop_at_rollup_height,
         );
 
@@ -337,7 +336,7 @@ where
                 spawn_replica_sync_task(
                     seq.clone(),
                     shutdown_receiver.clone(),
-                    replica_startup_sync_receiver,
+                    replica_sync_receiver,
                 )
                 .await,
             );
@@ -1252,11 +1251,9 @@ pub(crate) async fn exit_rollup(shutdown_sender: &watch::Sender<()>) {
     if shutdown_sender.send(()).is_err() {
         tracing::error!("Failed to send shutdown signal");
     }
-    println!("\n\n\nEXIT_ROLLUP CALLED!!!\n\n\n");
-    // sleep(Duration::from_secs(5)).await;
-    // tracing::info!("Calling std::process::exit(1).");
-    // std::process::exit(1);
-    panic!();
+    sleep(Duration::from_secs(5)).await;
+    tracing::info!("Calling std::process::exit(1).");
+    std::process::exit(1);
 }
 
 /// An error that can occur when trying to create a new batch.

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -55,7 +55,7 @@ use sov_rollup_interface::node::DaSyncState;
 use sov_rollup_interface::TxHash;
 use state_root_compute::StateRootBackgroundTaskState;
 use tokio::sync::mpsc::{self, Sender};
-use tokio::sync::{broadcast, oneshot, watch, Mutex};
+use tokio::sync::{broadcast, oneshot, watch};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tracing::{debug, error, info, trace};
@@ -336,8 +336,7 @@ where
                 spawn_replica_sync_task(
                     seq.clone(),
                     shutdown_receiver.clone(),
-                    connection_string.clone(),
-                    replica_startup_sync_receiver
+                    replica_startup_sync_receiver,
                 )
                 .await,
             );
@@ -538,7 +537,6 @@ where
                     self.transaction_cache.write_handle(),
                     info,
                     self.da_sync_state.clone(),
-                    self.is_master().await,
                     "wait_for_node_resync",
                 )
                 .await;
@@ -761,7 +759,6 @@ where
                 info,
                 timer_start,
                 is_startup_or_resync,
-                seq.is_master().await,
                 time_spent_fetching_batches,
             )
             .await?;

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -55,7 +55,7 @@ use sov_rollup_interface::node::DaSyncState;
 use sov_rollup_interface::TxHash;
 use state_root_compute::StateRootBackgroundTaskState;
 use tokio::sync::mpsc::{self, Sender};
-use tokio::sync::{broadcast, watch};
+use tokio::sync::{broadcast, oneshot, watch, Mutex};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tracing::{debug, error, info, trace};
@@ -198,7 +198,7 @@ where
             } else {
                 Box::new(RocksDbBackend::new(storage_path).await?)
             };
-        let (db, latest_db_event_id, next_sequence_number, db_cache) =
+        let (db, _latest_db_event_id, next_sequence_number, db_cache) =
             PreferredSequencerDb::<S, Rt>::new(
                 db_backend,
                 shutdown_sender.clone(),
@@ -275,6 +275,8 @@ where
             startup_transaction_cache_writer: None, // The main executor must *not* write to the tx cache. That's handled by the side effects task
         };
 
+        let (replica_startup_sync_notifer, replica_startup_sync_receiver) = oneshot::channel();
+
         let tx_queue_id = Arc::new(AtomicU64::new(0));
         let (synchronized_state, synchronized_state_updator) = create(
             latest_state_update.clone(),
@@ -287,6 +289,7 @@ where
             executor_events_sender,
             next_sequence_number,
             in_flight_blobs,
+            replica_startup_sync_notifer,
             stop_at_rollup_height,
         );
 
@@ -333,8 +336,8 @@ where
                 spawn_replica_sync_task(
                     seq.clone(),
                     shutdown_receiver.clone(),
-                    latest_state_update.clone(),
-                    latest_db_event_id,
+                    connection_string.clone(),
+                    replica_startup_sync_receiver
                 )
                 .await,
             );
@@ -535,6 +538,7 @@ where
                     self.transaction_cache.write_handle(),
                     info,
                     self.da_sync_state.clone(),
+                    self.is_master().await,
                     "wait_for_node_resync",
                 )
                 .await;
@@ -667,6 +671,10 @@ pub(crate) enum PreferredSeqOperation {
     // This is by far the most common scenario, i.e. a nominal
     // `update_state` call during sequencer execution with no unusual
     // conditions.
+    // (is_startup_or_resync, time_spent_fetching_batches)
+    // * is_startup_or_resync: true if the node just started, or just finished resyncing. This is
+    //   needed to update caches (i.e. the transaction_cache).
+    // * time_spent_fetching_batches: for metrics.
     ReplaySoftConfirmationsOnTopOfNodeState(bool, Duration),
 }
 
@@ -746,13 +754,14 @@ where
         }
 
         PreferredSeqOperation::ReplaySoftConfirmationsOnTopOfNodeState(
-            is_startup,
+            is_startup_or_resync,
             time_spent_fetching_batches,
         ) => {
             seq.replay_soft_confirmations_on_top_of_node_state(
                 info,
                 timer_start,
-                is_startup,
+                is_startup_or_resync,
+                seq.is_master().await,
                 time_spent_fetching_batches,
             )
             .await?;

--- a/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
@@ -13,8 +13,8 @@ use sov_modules_api::{FullyBakedTx, Runtime, Spec, TxHash, VisibleSlotNumber};
 use sov_rollup_interface::node::da::DaService;
 use sqlx::postgres::{PgListener, PgPoolOptions};
 use sqlx::{PgPool, Row};
-use tokio::sync::{oneshot, watch};
 use tokio::sync::oneshot::error::TryRecvError;
+use tokio::sync::{oneshot, watch};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, trace, warn};
 
@@ -110,8 +110,7 @@ enum CompletedEvent {
 pub async fn spawn_replica_sync_task<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     shutdown_receiver: watch::Receiver<()>,
-    connection_string: String,
-    startup_sync_receiver: oneshot::Receiver<SequenceNumber>
+    startup_sync_receiver: oneshot::Receiver<SequenceNumber>,
 ) -> JoinHandle<()>
 where
     S: Spec,
@@ -121,21 +120,8 @@ where
     tokio::spawn(replica_sync_task_inner(
         sequencer,
         shutdown_receiver,
-        startup_sync_receiver
+        startup_sync_receiver,
     ))
-    // tokio::spawn(async move {
-    //     if let Err(e) = ReplicationTask::connect_and_run(
-    //         sequencer.clone(),
-    //         &connection_string,
-    //         shutdown_receiver,
-    //         startup_sync_receiver,
-    //     )
-    //     .await
-    //     {
-    //         error!("Replication task failed: {e:?}");
-    //         exit_rollup(&sequencer.shutdown_sender).await;
-    //     }
-    // })
 }
 
 async fn replica_sync_task_inner<S, Rt, Da>(
@@ -260,7 +246,7 @@ where
                                 // Query the batch_close event with this sequence number to find the event_id
                                 // Set our latest_received_event_id to that event's id so we continue from there
                                 let event_id = query_event_id_for_batch_close(&query_pool, sequence_number).await?;
-                                *latest_received_event_id = Some(event_id);
+                                latest_received_event_id = Some(event_id);
                                 info!("Replica startup sync complete at sequence_number {}, event_id {}", sequence_number, event_id);
                             }
                             // We already received the sync earlier. Noop.
@@ -268,11 +254,11 @@ where
                         }
 
                         // Check for gaps and add backfill if needed
-                        if detect_gap(*latest_received_event_id, parsed_notification.event_id).is_some() {
+                        if detect_gap(latest_received_event_id, parsed_notification.event_id).is_some() {
                             let backfill_future = create_backfill_future(
                                 sequencer.clone(),
                                 query_pool,
-                                *latest_received_event_id,
+                                latest_received_event_id,
                                 parsed_notification.event_id,
                             );
                             pending_events.push_back(backfill_future);
@@ -280,7 +266,7 @@ where
                             continue;
                         }
 
-                        *latest_received_event_id = Some(parsed_notification.event_id);
+                        latest_received_event_id = Some(parsed_notification.event_id);
 
 
                         // Create future for current notification
@@ -538,7 +524,6 @@ async fn backfill_to_event_id<S: Spec, Rt: Runtime<S>, Da: DaService<Spec = S::D
         for row in events {
             let event_type_str: String = row.get("event_type");
             let sequence_number = row.get::<i64, _>("sequence_number") as u64;
-            let event_id = row.get::<i64, _>("event_id") as u64;
 
             let event_type: EventType = event_type_str
                 .parse()
@@ -562,7 +547,6 @@ async fn backfill_to_event_id<S: Spec, Rt: Runtime<S>, Da: DaService<Spec = S::D
                 EventType::BatchStart => {
                     let batch_data: Vec<u8> = row.get("data");
                     let batch_metadata = parse_serialized_batch(batch_data, sequence_number)?;
-                    println!("replica BACKFILLING batch start, event_id {event_id}, sequence number {sequence_number}");
 
                     do_batch_start(
                         sequencer.clone(),

--- a/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
@@ -13,8 +13,7 @@ use sov_modules_api::{FullyBakedTx, Runtime, Spec, TxHash, VisibleSlotNumber};
 use sov_rollup_interface::node::da::DaService;
 use sqlx::postgres::{PgListener, PgPoolOptions};
 use sqlx::{PgPool, Row};
-use tokio::sync::oneshot::error::TryRecvError;
-use tokio::sync::{oneshot, watch};
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, trace, warn};
 
@@ -103,7 +102,10 @@ type PendingEventFuture = Pin<Box<dyn Future<Output = anyhow::Result<CompletedEv
 #[derive(Debug)]
 enum CompletedEvent {
     Event(DbEvent),
-    Backfill,
+    Backfill {
+        current_latest: Option<u64>,
+        target: u64,
+    },
 }
 
 /// Background task for replica sequencers to sync state from the master sequencer's database.
@@ -111,7 +113,7 @@ enum CompletedEvent {
 pub async fn spawn_replica_sync_task<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     shutdown_receiver: watch::Receiver<()>,
-    startup_sync_receiver: oneshot::Receiver<SequenceNumber>,
+    replay_receiver: watch::Receiver<Option<SequenceNumber>>,
 ) -> JoinHandle<()>
 where
     S: Spec,
@@ -121,14 +123,14 @@ where
     tokio::spawn(replica_sync_task_inner(
         sequencer,
         shutdown_receiver,
-        startup_sync_receiver,
+        replay_receiver,
     ))
 }
 
 async fn replica_sync_task_inner<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     mut shutdown_receiver: watch::Receiver<()>,
-    mut startup_sync_receiver: oneshot::Receiver<SequenceNumber>,
+    mut replay_receiver: watch::Receiver<Option<SequenceNumber>>,
 ) where
     S: Spec,
     Rt: Runtime<S>,
@@ -190,7 +192,7 @@ async fn replica_sync_task_inner<S, Rt, Da>(
         &mut listener,
         &query_pool,
         &mut shutdown_receiver,
-        &mut startup_sync_receiver,
+        &mut replay_receiver,
     )
     .await
     {
@@ -205,7 +207,7 @@ async fn concurrent_event_processing_loop<S, Rt, Da>(
     listener: &mut PgListener,
     query_pool: &PgPool,
     shutdown_receiver: &mut watch::Receiver<()>,
-    startup_sync_receiver: &mut oneshot::Receiver<SequenceNumber>,
+    replay_receiver: &mut watch::Receiver<Option<SequenceNumber>>,
 ) -> anyhow::Result<()>
 where
     S: Spec,
@@ -225,6 +227,7 @@ where
     let mut pending_events: FuturesOrdered<PendingEventFuture> = FuturesOrdered::new();
 
     let mut latest_received_event_id: Option<u64> = None;
+    let mut last_fully_processed_batch: Option<SequenceNumber> = None;
     loop {
         tokio::select! {
             // Only poll listener if we have capacity
@@ -237,33 +240,40 @@ where
                         let parsed_notification = EventsNotificationPayload::parse_csv(payload)
                             .map_err(|e| anyhow!("Failed to parse CSV notification payload: {e}"))?;
 
-                        match startup_sync_receiver.try_recv() {
-                            // We're not synced yet - ignore all incoming events
-                            Err(TryRecvError::Empty) => {
-                                println!("Replica receiving event but not synced yet, ignoring. Event: {payload}");
+                        let replayed_sequence_number = *replay_receiver.borrow();
+                        match replayed_sequence_number {
+                            // Node is not synced yet - ignore all incoming events
+                            None => {
+                                trace!("Replica receiving event but node is not synced yet, ignoring. Event: {payload}");
                                 continue;
                             }
-                            // We just synced!
-                            Ok(sequence_number) => {
-                                // Query the batch_close event with this sequence number to find the event_id
-                                // Set our latest_received_event_id to that event's id so we continue from there
-                                let event_id = query_event_id_for_batch_close(query_pool, sequence_number).await?;
-                                println!("Replica receiving event and it just synced, replayed sequence number {sequence_number}! Event: {payload}. We're gonna be starting from event {event_id}");
-                                latest_received_event_id = Some(event_id);
-                                info!("Replica startup sync complete at sequence_number {}, event_id {}", sequence_number, event_id);
+                            // We are indeed synced. Is the last replayed batch ahead of our event
+                            // stream?
+                            Some(last_replayed_sequence_number) => {
+                                if last_fully_processed_batch.is_none_or(|seq| seq < last_replayed_sequence_number) {
+                                    // Query the batch_close event with this sequence number to find the event_id
+                                    // Set our latest_received_event_id to that event's id so we continue from there
+                                    let new_latest_event_id = query_event_id_for_batch_close(query_pool, last_replayed_sequence_number).await?;
+                                    if latest_received_event_id.is_some_and(|latest| latest >= new_latest_event_id) {
+                                        // Return an error rather than using assert! - this way the
+                                        // sequencer will call exit_rollup() cleanly
+                                        anyhow::bail!("Sanity check failed - update_state fast-forwarded our sequence number, but this would not have fast-forwarded our event ID");
+                                    }
+                                    latest_received_event_id = Some(new_latest_event_id);
+                                    last_fully_processed_batch = Some(last_replayed_sequence_number);
+                                    debug!("Replica event processing fast-forwarding to sequence_number {}, event_id {}, due to update_state running ahead", last_replayed_sequence_number, new_latest_event_id);
+                                }
                             }
-                            // We already received the sync earlier. Noop.
-                            Err(TryRecvError::Closed) => {}
                         }
 
                         // Check for gaps and add backfill if needed
                         if detect_gap(latest_received_event_id, parsed_notification.event_id).is_some() {
-                            let backfill_future = create_backfill_future(
-                                sequencer.clone(),
-                                query_pool,
-                                latest_received_event_id,
-                                parsed_notification.event_id,
-                            );
+                            let backfill_future: PendingEventFuture = Box::pin(async move {
+                                Ok(CompletedEvent::Backfill {
+                                    current_latest: latest_received_event_id,
+                                    target: parsed_notification.event_id,
+                                })
+                            });
                             pending_events.push_back(backfill_future);
                         } else if latest_received_event_id.map(|latest_id| parsed_notification.event_id <= latest_id).unwrap_or(false) {
                             continue;
@@ -288,10 +298,13 @@ where
             Some(completed_result) = pending_events.next() => {
                 match completed_result? {
                     CompletedEvent::Event(db_event) => {
-                        process_db_event(sequencer.clone(), db_event, query_pool).await?;
+                        process_db_event(sequencer.clone(), db_event, query_pool, &mut last_fully_processed_batch).await?;
                     }
-                    CompletedEvent::Backfill => {
-                        trace!("Backfill completed up to event_id");
+                    CompletedEvent::Backfill {
+                        current_latest,
+                        target,
+                    } => {
+                        backfill_to_event_id(sequencer.clone(), query_pool, current_latest, target).await?;
                     }
                 }
             },
@@ -368,32 +381,12 @@ fn create_event_future(
     }
 }
 
-/// Creates a future for backfilling a gap in events using existing backfill logic
-fn create_backfill_future<S, Rt, Da>(
-    sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
-    query_pool: &PgPool,
-    current_latest: Option<u64>,
-    target_event_id: u64,
-) -> PendingEventFuture
-where
-    S: Spec,
-    Rt: Runtime<S>,
-    Da: DaService<Spec = S::Da>,
-{
-    let sequencer = sequencer.clone();
-    let pool = query_pool.clone();
-
-    Box::pin(async move {
-        backfill_to_event_id(sequencer.clone(), &pool, current_latest, target_event_id).await?;
-        Ok(CompletedEvent::Backfill)
-    })
-}
-
 /// Processes a completed DB event
 async fn process_db_event<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     db_event: DbEvent,
     query_pool: &PgPool,
+    last_fully_processed_batch: &mut Option<u64>,
 ) -> anyhow::Result<()>
 where
     S: Spec,
@@ -402,7 +395,6 @@ where
 {
     match db_event {
         DbEvent::TxAccepted(baked_tx, tx_hash) => {
-            println!("Replica processed event tx_accepted, hash: {tx_hash}");
             sequencer
                 .synchronized_state_updator
                 .do_new_tx_msg(tx_hash, baked_tx, "replica_sync_task:do_new_tx")
@@ -410,7 +402,7 @@ where
             Ok(())
         }
         DbEvent::BatchClosed(_) => {
-            println!("Replica processed event batch_closed");
+            *last_fully_processed_batch = Some(last_fully_processed_batch.map_or(0, |n| n + 1));
             sequencer
                 .synchronized_state_updator
                 .close_current_batch_msg("replica_sync_task:close_current_batch")
@@ -418,11 +410,10 @@ where
             Ok(())
         }
         DbEvent::BatchStarted {
-            sequence_number,
+            sequence_number: _,
             visible_slot_number_after_increase,
             visible_slots_to_advance,
         } => {
-            println!("Replica processed event batch_started, sequence_number: {sequence_number}");
             do_batch_start(
                 sequencer,
                 visible_slot_number_after_increase,
@@ -495,7 +486,6 @@ async fn backfill_to_event_id<S: Spec, Rt: Runtime<S>, Da: DaService<Spec = S::D
 ) -> anyhow::Result<()> {
     let mut current_event_id = latest_received_event_id.map(|id| id + 1).unwrap_or(0);
 
-    println!("Replica backfilling from {latest_received_event_id:?} to {target_event_id}");
     // If we're already caught up, nothing to do
     if current_event_id > target_event_id {
         return Ok(());
@@ -532,7 +522,6 @@ async fn backfill_to_event_id<S: Spec, Rt: Runtime<S>, Da: DaService<Spec = S::D
         for row in events {
             let event_type: EventType = row.get("event_type");
             let sequence_number = row.get::<i64, _>("sequence_number") as u64;
-            println!(" -> backfilling event, type: {event_type:?}, full row: {row:?}");
 
             match event_type {
                 EventType::Transaction => {
@@ -552,8 +541,6 @@ async fn backfill_to_event_id<S: Spec, Rt: Runtime<S>, Da: DaService<Spec = S::D
                 EventType::BatchStart => {
                     let batch_data: Vec<u8> = row.get("data");
                     let batch_metadata = parse_serialized_batch(batch_data, sequence_number)?;
-
-                    println!(" --> backfill: batch_start: {batch_metadata:?}");
 
                     do_batch_start(
                         sequencer.clone(),
@@ -667,7 +654,7 @@ async fn query_event_id_for_batch_close(
     sequence_number: u64,
 ) -> anyhow::Result<u64> {
     let row = sqlx::query(
-        "SELECT event_id FROM events WHERE sequence_number = $1 AND event_type = 'batch_end' LIMIT 1"
+        "SELECT event_id FROM events WHERE sequence_number = $1 AND event_type = 'batch_end'",
     )
     .bind(i64::try_from(sequence_number)?)
     .fetch_one(query_pool)

--- a/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
@@ -23,8 +23,9 @@ use crate::preferred::{exit_rollup, DbEvent, PreferredSequencer};
 use crate::ProofBlobSender;
 
 /// Event type enum for type-safe parsing
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, sqlx::Type)]
 #[serde(rename_all = "snake_case")]
+#[sqlx(type_name = "event_type", rename_all = "snake_case")]
 enum EventType {
     Transaction,
     BatchStart,
@@ -239,13 +240,15 @@ where
                         match startup_sync_receiver.try_recv() {
                             // We're not synced yet - ignore all incoming events
                             Err(TryRecvError::Empty) => {
+                                println!("Replica receiving event but not synced yet, ignoring. Event: {payload}");
                                 continue;
                             }
                             // We just synced!
                             Ok(sequence_number) => {
                                 // Query the batch_close event with this sequence number to find the event_id
                                 // Set our latest_received_event_id to that event's id so we continue from there
-                                let event_id = query_event_id_for_batch_close(&query_pool, sequence_number).await?;
+                                let event_id = query_event_id_for_batch_close(query_pool, sequence_number).await?;
+                                println!("Replica receiving event and it just synced, replayed sequence number {sequence_number}! Event: {payload}. We're gonna be starting from event {event_id}");
                                 latest_received_event_id = Some(event_id);
                                 info!("Replica startup sync complete at sequence_number {}, event_id {}", sequence_number, event_id);
                             }
@@ -399,6 +402,7 @@ where
 {
     match db_event {
         DbEvent::TxAccepted(baked_tx, tx_hash) => {
+            println!("Replica processed event tx_accepted, hash: {tx_hash}");
             sequencer
                 .synchronized_state_updator
                 .do_new_tx_msg(tx_hash, baked_tx, "replica_sync_task:do_new_tx")
@@ -406,6 +410,7 @@ where
             Ok(())
         }
         DbEvent::BatchClosed(_) => {
+            println!("Replica processed event batch_closed");
             sequencer
                 .synchronized_state_updator
                 .close_current_batch_msg("replica_sync_task:close_current_batch")
@@ -413,10 +418,11 @@ where
             Ok(())
         }
         DbEvent::BatchStarted {
-            sequence_number: _,
+            sequence_number,
             visible_slot_number_after_increase,
             visible_slots_to_advance,
         } => {
+            println!("Replica processed event batch_started, sequence_number: {sequence_number}");
             do_batch_start(
                 sequencer,
                 visible_slot_number_after_increase,
@@ -488,6 +494,8 @@ async fn backfill_to_event_id<S: Spec, Rt: Runtime<S>, Da: DaService<Spec = S::D
     target_event_id: u64,
 ) -> anyhow::Result<()> {
     let mut current_event_id = latest_received_event_id.map(|id| id + 1).unwrap_or(0);
+
+    println!("Replica backfilling from {latest_received_event_id:?} to {target_event_id}");
     // If we're already caught up, nothing to do
     if current_event_id > target_event_id {
         return Ok(());
@@ -522,12 +530,9 @@ async fn backfill_to_event_id<S: Spec, Rt: Runtime<S>, Da: DaService<Spec = S::D
         .await?;
 
         for row in events {
-            let event_type_str: String = row.get("event_type");
+            let event_type: EventType = row.get("event_type");
             let sequence_number = row.get::<i64, _>("sequence_number") as u64;
-
-            let event_type: EventType = event_type_str
-                .parse()
-                .map_err(|e| anyhow::anyhow!("Invalid event type '{}': {}", event_type_str, e))?;
+            println!(" -> backfilling event, type: {event_type:?}, full row: {row:?}");
 
             match event_type {
                 EventType::Transaction => {
@@ -547,6 +552,8 @@ async fn backfill_to_event_id<S: Spec, Rt: Runtime<S>, Da: DaService<Spec = S::D
                 EventType::BatchStart => {
                     let batch_data: Vec<u8> = row.get("data");
                     let batch_metadata = parse_serialized_batch(batch_data, sequence_number)?;
+
+                    println!(" --> backfill: batch_start: {batch_metadata:?}");
 
                     do_batch_start(
                         sequencer.clone(),

--- a/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
@@ -8,11 +8,13 @@ use anyhow::anyhow;
 use futures::stream::FuturesOrdered;
 use futures::{Future, StreamExt};
 use serde::{Deserialize, Serialize};
-use sov_modules_api::{FullyBakedTx, Runtime, Spec, StateUpdateInfo, TxHash, VisibleSlotNumber};
+use sov_blob_storage::SequenceNumber;
+use sov_modules_api::{FullyBakedTx, Runtime, Spec, TxHash, VisibleSlotNumber};
 use sov_rollup_interface::node::da::DaService;
 use sqlx::postgres::{PgListener, PgPoolOptions};
 use sqlx::{PgPool, Row};
-use tokio::sync::watch;
+use tokio::sync::{oneshot, watch};
+use tokio::sync::oneshot::error::TryRecvError;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, trace, warn};
 
@@ -108,40 +110,38 @@ enum CompletedEvent {
 pub async fn spawn_replica_sync_task<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     shutdown_receiver: watch::Receiver<()>,
-    latest_state_update: StateUpdateInfo<S::Storage>,
-    latest_loaded_event_id: Option<u64>,
+    connection_string: String,
+    startup_sync_receiver: oneshot::Receiver<SequenceNumber>
 ) -> JoinHandle<()>
 where
     S: Spec,
     Rt: Runtime<S>,
     Da: DaService<Spec = S::Da>,
 {
-    if let Err(e) = sequencer
-        .replay_soft_confirmations_on_top_of_node_state(
-            latest_state_update,
-            std::time::Instant::now(),
-            true,
-            std::time::Duration::from_secs(0),
-        )
-        .await
-    {
-        error!(
-            "Replica failed to replay existing soft confirmation on startup: {e:?}. Shutting down."
-        );
-        exit_rollup(&sequencer.shutdown_sender).await;
-        unreachable!()
-    }
     tokio::spawn(replica_sync_task_inner(
         sequencer,
         shutdown_receiver,
-        latest_loaded_event_id,
+        startup_sync_receiver
     ))
+    // tokio::spawn(async move {
+    //     if let Err(e) = ReplicationTask::connect_and_run(
+    //         sequencer.clone(),
+    //         &connection_string,
+    //         shutdown_receiver,
+    //         startup_sync_receiver,
+    //     )
+    //     .await
+    //     {
+    //         error!("Replication task failed: {e:?}");
+    //         exit_rollup(&sequencer.shutdown_sender).await;
+    //     }
+    // })
 }
 
 async fn replica_sync_task_inner<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     mut shutdown_receiver: watch::Receiver<()>,
-    latest_loaded_event_id: Option<u64>,
+    mut startup_sync_receiver: oneshot::Receiver<SequenceNumber>,
 ) where
     S: Spec,
     Rt: Runtime<S>,
@@ -179,8 +179,6 @@ async fn replica_sync_task_inner<S, Rt, Da>(
         }
     };
 
-    let mut latest_received_event_id = latest_loaded_event_id;
-
     // Create a dedicated listener for PostgreSQL LISTEN/NOTIFY
     let mut listener = match PgListener::connect(connection_string).await {
         Ok(listener) => listener,
@@ -204,8 +202,8 @@ async fn replica_sync_task_inner<S, Rt, Da>(
         sequencer.clone(),
         &mut listener,
         &query_pool,
-        &mut latest_received_event_id,
         &mut shutdown_receiver,
+        &mut startup_sync_receiver,
     )
     .await
     {
@@ -219,8 +217,8 @@ async fn concurrent_event_processing_loop<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     listener: &mut PgListener,
     query_pool: &PgPool,
-    latest_received_event_id: &mut Option<u64>,
     shutdown_receiver: &mut watch::Receiver<()>,
+    startup_sync_receiver: &mut oneshot::Receiver<SequenceNumber>,
 ) -> anyhow::Result<()>
 where
     S: Spec,
@@ -239,6 +237,7 @@ where
     const MAX_CONCURRENT: usize = 1000;
     let mut pending_events: FuturesOrdered<PendingEventFuture> = FuturesOrdered::new();
 
+    let mut latest_received_event_id: Option<u64> = None;
     loop {
         tokio::select! {
             // Only poll listener if we have capacity
@@ -251,6 +250,23 @@ where
                         let parsed_notification = EventsNotificationPayload::parse_csv(payload)
                             .map_err(|e| anyhow!("Failed to parse CSV notification payload: {e}"))?;
 
+                        match startup_sync_receiver.try_recv() {
+                            // We're not synced yet - ignore all incoming events
+                            Err(TryRecvError::Empty) => {
+                                continue;
+                            }
+                            // We just synced!
+                            Ok(sequence_number) => {
+                                // Query the batch_close event with this sequence number to find the event_id
+                                // Set our latest_received_event_id to that event's id so we continue from there
+                                let event_id = query_event_id_for_batch_close(&query_pool, sequence_number).await?;
+                                *latest_received_event_id = Some(event_id);
+                                info!("Replica startup sync complete at sequence_number {}, event_id {}", sequence_number, event_id);
+                            }
+                            // We already received the sync earlier. Noop.
+                            Err(TryRecvError::Closed) => {}
+                        }
+
                         // Check for gaps and add backfill if needed
                         if detect_gap(*latest_received_event_id, parsed_notification.event_id).is_some() {
                             let backfill_future = create_backfill_future(
@@ -260,9 +276,12 @@ where
                                 parsed_notification.event_id,
                             );
                             pending_events.push_back(backfill_future);
+                        } else if latest_received_event_id.map(|latest_id| parsed_notification.event_id <= latest_id).unwrap_or(false) {
+                            continue;
                         }
 
                         *latest_received_event_id = Some(parsed_notification.event_id);
+
 
                         // Create future for current notification
                         let event_future = create_event_future(parsed_notification, query_pool);
@@ -507,7 +526,7 @@ async fn backfill_to_event_id<S: Spec, Rt: Runtime<S>, Da: DaService<Spec = S::D
 
         // Query and process events for this page
         let events = sqlx::query(
-            "SELECT sequence_number, index_in_batch, event_type, hash, data FROM events 
+            "SELECT event_id, sequence_number, index_in_batch, event_type, hash, data FROM events 
              WHERE event_id >= $1 AND event_id < $2
              ORDER BY event_id ASC",
         )
@@ -519,6 +538,7 @@ async fn backfill_to_event_id<S: Spec, Rt: Runtime<S>, Da: DaService<Spec = S::D
         for row in events {
             let event_type_str: String = row.get("event_type");
             let sequence_number = row.get::<i64, _>("sequence_number") as u64;
+            let event_id = row.get::<i64, _>("event_id") as u64;
 
             let event_type: EventType = event_type_str
                 .parse()
@@ -542,6 +562,7 @@ async fn backfill_to_event_id<S: Spec, Rt: Runtime<S>, Da: DaService<Spec = S::D
                 EventType::BatchStart => {
                     let batch_data: Vec<u8> = row.get("data");
                     let batch_metadata = parse_serialized_batch(batch_data, sequence_number)?;
+                    println!("replica BACKFILLING batch start, event_id {event_id}, sequence number {sequence_number}");
 
                     do_batch_start(
                         sequencer.clone(),
@@ -648,4 +669,19 @@ async fn query_proof_blob_from_db(
             sequence_number
         )),
     }
+}
+
+async fn query_event_id_for_batch_close(
+    query_pool: &PgPool,
+    sequence_number: u64,
+) -> anyhow::Result<u64> {
+    let row = sqlx::query(
+        "SELECT event_id FROM events WHERE sequence_number = $1 AND event_type = 'batch_end' LIMIT 1"
+    )
+    .bind(i64::try_from(sequence_number)?)
+    .fetch_one(query_pool)
+    .await?;
+
+    let event_id: i64 = row.get("event_id");
+    Ok(event_id as u64)
 }

--- a/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
@@ -43,7 +43,6 @@ type ArcInner<S, Rt> = Arc<tokio::sync::RwLock<TransactionCacheInner<S, Rt>>>;
 impl<S: Spec, Rt: Runtime<S>> TxResultWriter<S, Rt> {
     pub async fn insert(&self, tx: AcceptedTx<Confirmation<S, Rt>>) {
         let mut transaction_cache = self.inner.write().await;
-        println!("  cache-> inserting tx with number {}, hash {}. Next tx number should be {}", tx.confirmation.tx_number, tx.tx_hash, transaction_cache.next_tx_number);
         assert_eq!(
             tx.confirmation.tx_number, transaction_cache.next_tx_number,
             "Transactions must be inserted in order"
@@ -79,7 +78,6 @@ impl<S: Spec, Rt: Runtime<S>> TxResultWriter<S, Rt> {
             "Cleaning and overwriting transaction cache up to {}",
             tx_number
         );
-        println!(">cache: cleaning and overwriting, next_tx_number: {tx_number}");
         let mut transaction_cache = self.inner.write().await;
         transaction_cache.next_tx_number = tx_number;
         transaction_cache.cache.clear();
@@ -134,7 +132,6 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
 
 impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
     pub fn new(ledger_db: LedgerDb, next_tx_number: u64, broadcast_channel_size: usize) -> Self {
-        println!(">initializing TransactionCache, next_tx_number: {next_tx_number}");
         let (tx_response_sender, tx_response_receiver) = broadcast::channel(broadcast_channel_size);
         Self {
             inner: Arc::new(RwLock::new(TransactionCacheInner {
@@ -154,7 +151,6 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
             "Cleaning and overwriting transaction cache up to {}",
             tx_number
         );
-        println!(">cache: cleaning and overwriting, next_tx_number: {tx_number}");
         let mut transaction_cache = self.inner.write().await;
         transaction_cache.next_tx_number = tx_number;
         transaction_cache.cache.clear();

--- a/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
@@ -43,6 +43,7 @@ type ArcInner<S, Rt> = Arc<tokio::sync::RwLock<TransactionCacheInner<S, Rt>>>;
 impl<S: Spec, Rt: Runtime<S>> TxResultWriter<S, Rt> {
     pub async fn insert(&self, tx: AcceptedTx<Confirmation<S, Rt>>) {
         let mut transaction_cache = self.inner.write().await;
+        println!("  cache-> inserting tx with number {}, hash {}. Next tx number should be {}", tx.confirmation.tx_number, tx.tx_hash, transaction_cache.next_tx_number);
         assert_eq!(
             tx.confirmation.tx_number, transaction_cache.next_tx_number,
             "Transactions must be inserted in order"
@@ -78,6 +79,7 @@ impl<S: Spec, Rt: Runtime<S>> TxResultWriter<S, Rt> {
             "Cleaning and overwriting transaction cache up to {}",
             tx_number
         );
+        println!(">cache: cleaning and overwriting, next_tx_number: {tx_number}");
         let mut transaction_cache = self.inner.write().await;
         transaction_cache.next_tx_number = tx_number;
         transaction_cache.cache.clear();
@@ -132,6 +134,7 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
 
 impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
     pub fn new(ledger_db: LedgerDb, next_tx_number: u64, broadcast_channel_size: usize) -> Self {
+        println!(">initializing TransactionCache, next_tx_number: {next_tx_number}");
         let (tx_response_sender, tx_response_receiver) = broadcast::channel(broadcast_channel_size);
         Self {
             inner: Arc::new(RwLock::new(TransactionCacheInner {
@@ -144,6 +147,18 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
             ledger_db,
             tx_response_receiver,
         }
+    }
+
+    pub async fn clean_and_overwrite_next_tx_number(&self, tx_number: u64) {
+        tracing::debug!(
+            "Cleaning and overwriting transaction cache up to {}",
+            tx_number
+        );
+        println!(">cache: cleaning and overwriting, next_tx_number: {tx_number}");
+        let mut transaction_cache = self.inner.write().await;
+        transaction_cache.next_tx_number = tx_number;
+        transaction_cache.cache.clear();
+        transaction_cache.tx_hash_index.clear();
     }
 
     pub async fn list_events(

--- a/crates/full-node/sov-sequencer/src/preferred/update_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/update_state.rs
@@ -34,7 +34,6 @@ where
         info: StateUpdateInfo<S::Storage>,
         timer_start: Instant,
         is_startup_or_resync: bool,
-        is_master: bool,
         mut time_spent_fetching_batches: std::time::Duration, // The time already spent fetching batches to replay
     ) -> anyhow::Result<()> {
         // On shutdown exit early. This prevents duplicate subscriptions to the DB events channel, which would cause spurious warnings.
@@ -77,7 +76,9 @@ where
             .in_scope(|| info.storage.get_root_hash(info.slot_number))?;
 
         if is_startup_or_resync {
-            self.transaction_cache.clean_and_overwrite_next_tx_number(info.next_tx_number).await;
+            self.transaction_cache
+                .clean_and_overwrite_next_tx_number(info.next_tx_number)
+                .await;
         }
 
         // Repeatedly fetch all completed batches from the database that haven't yet been played on this sequencer and replay them

--- a/crates/full-node/sov-sequencer/src/preferred/update_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/update_state.rs
@@ -33,7 +33,8 @@ where
         &self,
         info: StateUpdateInfo<S::Storage>,
         timer_start: Instant,
-        is_startup: bool,
+        is_startup_or_resync: bool,
+        is_master: bool,
         mut time_spent_fetching_batches: std::time::Duration, // The time already spent fetching batches to replay
     ) -> anyhow::Result<()> {
         // On shutdown exit early. This prevents duplicate subscriptions to the DB events channel, which would cause spurious warnings.
@@ -53,7 +54,7 @@ where
 
         // During startup, we need to repopulate the transaction cache with any transactions from the soft-confirmed batches
         // Outside of this edge case, we don't want replay to affect the transaction cache, so we don't pass a writer.
-        let startup_transaction_cache_writer = if is_startup {
+        let startup_transaction_cache_writer = if is_startup_or_resync {
             Some(self.transaction_cache.write_handle())
         } else {
             None
@@ -74,6 +75,10 @@ where
 
         let node_state_root = tracing::trace_span!("root_hash")
             .in_scope(|| info.storage.get_root_hash(info.slot_number))?;
+
+        if is_startup_or_resync {
+            self.transaction_cache.clean_and_overwrite_next_tx_number(info.next_tx_number).await;
+        }
 
         // Repeatedly fetch all completed batches from the database that haven't yet been played on this sequencer and replay them
         let (in_progress_batch, mut db_event_subscription) = loop {

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1897,6 +1897,53 @@ async fn events_are_returned_in_tx_response() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_no_crashes_on_resync_with_transactions() {
+    let (test_rollup, admin) = create_test_rollup(
+        0,
+        TEST_MAX_BATCH_SIZE,
+        TEST_BLOB_PROCESSING_TIMEOUT,
+        MAX_BATCH_EXECUTION_TIME_MILLIS,
+    )
+    .await;
+
+    let Some(test_rollup) = test_rollup else {
+        return;
+    };
+
+    let (test_rollup, state) = setup_test_rollup_with_initial_state(test_rollup, &admin).await;
+
+    let actions = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }];
+    let (test_rollup, state) =
+        run_actions_against_test_rollup(actions, test_rollup, &admin.clone(), state).await;
+
+    let actions = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }].into_iter().cycle().take(160).collect(); // repeat for 40 blocks
+    let (test_rollup, state) =
+        run_actions_against_test_rollup(actions, test_rollup, &admin.clone(), state).await;
+
+    let builder = test_rollup.shutdown().await.unwrap();
+
+    let rollup_storage_path = builder.storage_path();
+    // Next, delete everything except the preferred sequencer DB. Resync again to verify that this
+    // doesn't interfere
+    for path in ["state", "accessory", "ledger", "blob_sender"] {
+        std::fs::remove_dir_all(rollup_storage_path.path().join(path)).unwrap();
+    }
+
+    let test_rollup = builder.start().await.unwrap();
+
+    // Let it resync
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Verify accepting actions works
+    let actions = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }, TestingAction::QuerySetValue];
+
+    let (test_rollup, _state) =
+        run_actions_against_test_rollup(actions, test_rollup, &admin.clone(), state).await;
+
+    test_rollup.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn delayed_tx_is_processed_after_delay() {
     let (test_rollup, admin) = create_test_rollup(
         0,

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1912,11 +1912,25 @@ async fn test_no_crashes_on_resync_with_transactions() {
 
     let (test_rollup, state) = setup_test_rollup_with_initial_state(test_rollup, &admin).await;
 
-    let actions = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }];
+    let actions = vec![
+        TestingAction::AcceptTx,
+        TestingAction::AcceptTx,
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+    ];
     let (test_rollup, state) =
         run_actions_against_test_rollup(actions, test_rollup, &admin.clone(), state).await;
 
-    let actions = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }].into_iter().cycle().take(160).collect(); // repeat for 40 blocks
+    let actions = vec![
+        TestingAction::AcceptTx,
+        TestingAction::AcceptTx,
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+    ]
+    .into_iter()
+    .cycle()
+    .take(160)
+    .collect(); // repeat for 40 blocks
     let (test_rollup, state) =
         run_actions_against_test_rollup(actions, test_rollup, &admin.clone(), state).await;
 
@@ -1935,7 +1949,13 @@ async fn test_no_crashes_on_resync_with_transactions() {
     tokio::time::sleep(Duration::from_secs(5)).await;
 
     // Verify accepting actions works
-    let actions = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }, TestingAction::QuerySetValue];
+    let actions = vec![
+        TestingAction::AcceptTx,
+        TestingAction::AcceptTx,
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+        TestingAction::QuerySetValue,
+    ];
 
     let (test_rollup, _state) =
         run_actions_against_test_rollup(actions, test_rollup, &admin.clone(), state).await;

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
@@ -317,7 +317,6 @@ async fn test_replica_resynced_from_scratch() {
     let (master, replicas, state) =
         test_actions_against_replicas(&admin, (master, replicas, state), actions).await;
 
-    println!("\nTEST: running for 40 blocks\n");
     // Run for 40 more blocks
     let slots = vec![
         TestingAction::AcceptTx,
@@ -332,7 +331,6 @@ async fn test_replica_resynced_from_scratch() {
     let (master, mut replicas, state) =
         test_actions_against_replicas(&admin, (master, replicas, state), slots).await;
 
-    println!("\nTEST: launching new replica\n");
     // Launch brand new replica
     let extra_replica = builder
         .launch_n_replicas(1, shared_da, false)
@@ -343,10 +341,8 @@ async fn test_replica_resynced_from_scratch() {
         .unwrap();
     replicas.push(Some(extra_replica));
     // Let it sync
-    println!("\nTEST: sleeping to sync replica...\n");
-    tokio::time::sleep(Duration::from_secs(10)).await;
+    tokio::time::sleep(Duration::from_secs(5)).await;
 
-    println!("\nTEST: sleep done, creating two new transactions and a new DA slot\n");
     // Verify rollup can still accept transactions, and state is consistent across replicas
     let actions = vec![
         TestingAction::AcceptTx,
@@ -357,7 +353,6 @@ async fn test_replica_resynced_from_scratch() {
     let (master, replicas, _state) =
         test_actions_against_replicas(&admin, (master, replicas, state), actions).await;
 
-    println!("\nTEST: shutting down\n");
     for replica in replicas {
         replica.unwrap().shutdown().await.unwrap();
     }

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
@@ -191,8 +191,8 @@ async fn seq_with_replicas() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_replica_resynced_from_scratch() {
-    // very ugly. currently copy-pastes code from create_test_rollups and new_test_rollup in order
-    // to access the launch_n_replicas interface. need to refactor
+    // Ugly: currently copy-pastes code from create_test_rollups and new_test_rollup in order
+    // to access the launch_n_replicas interface. Should probably be refactored
     let mut genesis_config =
         HighLevelOptimisticGenesisConfig::generate().add_accounts_with_default_balance(1);
     let admin = genesis_config.additional_accounts()[0].clone();
@@ -282,12 +282,13 @@ async fn test_replica_resynced_from_scratch() {
 
     let shared_da = builder.shared_da_for_replicas().await.unwrap();
 
+    // ACTUAL TEST BEGINS
     let test_rollups = builder.launch_n_replicas(1, shared_da.clone()).await.unwrap();
-
     let mut test_rollups = test_rollups.into_iter();
+
+    // Allow master to take over
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    // Identify initial master and replicas
     let (mut master, replicas) = identify_master_and_replicas(
         test_rollups.next().unwrap(),
         test_rollups.map(Some).collect(),
@@ -298,35 +299,33 @@ async fn test_replica_resynced_from_scratch() {
     let (master_with_state, state) = setup_test_rollup_with_initial_state(master, &admin).await;
     master = master_with_state;
 
+    // Sanity check once
     let actions = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }];
     let (master, replicas, state) =
         test_actions_against_replicas(&admin, (master, replicas, state), actions).await;
     println!("Basic actions succeeded. Now launching big DA block production...");
 
-    let slots = vec![TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }].into_iter().cycle().take(120).collect();
+    // Run for 40 more blocks
+    let slots = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }].into_iter().cycle().take(160).collect();
     let (master, mut replicas, state) =
         test_actions_against_replicas(&admin, (master, replicas, state), slots).await;
 
     println!("Block production succeeded. Launching brand new replica...");
+    // Launch brand new replica
     let extra_replica = builder.launch_n_replicas(1, shared_da).await.unwrap().into_iter().next().unwrap();
     replicas.push(Some(extra_replica));
+    // Let it sync
+    tokio::time::sleep(Duration::from_secs(10)).await;
 
-    println!("Sleeping...");
-    tokio::time::sleep(Duration::from_secs(25)).await;
-
-    println!("Inserting actions!");
+    println!("Inserting extra test actions!");
+    // Verify rollup can still accept transactions, and state is consistent across replicas
     let actions = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }];
     let (master, replicas, _state) =
         test_actions_against_replicas(&admin, (master, replicas, state), actions).await;
-    println!("Basic actions succeeded. Now launching big DA block production...");
 
     println!("Shutting everything down.");
     for replica in replicas {
         replica.unwrap().shutdown().await.unwrap();
     }
     master.shutdown().await.unwrap();
-
-    println!("Shut down everything except extra replica");
-
-    // extra_replica.shutdown().await.unwrap();
 }

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
@@ -9,7 +9,8 @@ use sov_sequencer::SequencerKindConfig;
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
 use sov_test_utils::test_rollup::{GenesisSource, RollupBuilder, TestRollup};
 use sov_test_utils::{
-    RtAgnosticBlueprint, TestSpec, TestUser, TEST_BLOB_PROCESSING_TIMEOUT, TEST_DEFAULT_USER_BALANCE, TEST_FINALIZATION_BLOCKS, TEST_MAX_BATCH_SIZE
+    RtAgnosticBlueprint, TestSpec, TestUser, TEST_BLOB_PROCESSING_TIMEOUT,
+    TEST_DEFAULT_USER_BALANCE, TEST_FINALIZATION_BLOCKS, TEST_MAX_BATCH_SIZE,
 };
 use sov_value_setter::ValueSetterConfig;
 
@@ -226,9 +227,9 @@ async fn test_replica_resynced_from_scratch() {
             },
             sequencers_to_register: [sequencer.da_address].as_ref().try_into().unwrap(),
         }]
-                .as_ref()
-                    .try_into()
-                    .unwrap(),
+        .as_ref()
+        .try_into()
+        .unwrap(),
     };
 
     let rt_genesis_config =
@@ -267,7 +268,13 @@ async fn test_replica_resynced_from_scratch() {
         }
         c.max_concurrent_blobs = 16;
     })
-    .set_da_config(|c| c.sender_address = genesis_params.runtime.sequencer_registry.sequencer_config.seq_da_address)
+    .set_da_config(|c| {
+        c.sender_address = genesis_params
+            .runtime
+            .sequencer_registry
+            .sequencer_config
+            .seq_da_address
+    })
     .with_preferred_seq_min_profit_per_tx(0)
     .with_preferred_seq_recovery_strategy(sov_sequencer::preferred::RecoveryStrategy::TryToSave);
 
@@ -283,7 +290,10 @@ async fn test_replica_resynced_from_scratch() {
     let shared_da = builder.shared_da_for_replicas().await.unwrap();
 
     // ACTUAL TEST BEGINS
-    let test_rollups = builder.launch_n_replicas(1, shared_da.clone()).await.unwrap();
+    let test_rollups = builder
+        .launch_n_replicas(1, shared_da.clone())
+        .await
+        .unwrap();
     let mut test_rollups = test_rollups.into_iter();
 
     // Allow master to take over
@@ -300,26 +310,51 @@ async fn test_replica_resynced_from_scratch() {
     master = master_with_state;
 
     // Sanity check once
-    let actions = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }];
+    let actions = vec![
+        TestingAction::AcceptTx,
+        TestingAction::AcceptTx,
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+    ];
     let (master, replicas, state) =
         test_actions_against_replicas(&admin, (master, replicas, state), actions).await;
     println!("Basic actions succeeded. Now launching big DA block production...");
 
     // Run for 40 more blocks
-    let slots = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }].into_iter().cycle().take(160).collect();
+    let slots = vec![
+        TestingAction::AcceptTx,
+        TestingAction::AcceptTx,
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+    ]
+    .into_iter()
+    .cycle()
+    .take(160)
+    .collect();
     let (master, mut replicas, state) =
         test_actions_against_replicas(&admin, (master, replicas, state), slots).await;
 
     println!("Block production succeeded. Launching brand new replica...");
     // Launch brand new replica
-    let extra_replica = builder.launch_n_replicas(1, shared_da).await.unwrap().into_iter().next().unwrap();
+    let extra_replica = builder
+        .launch_n_replicas(1, shared_da)
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
     replicas.push(Some(extra_replica));
     // Let it sync
     tokio::time::sleep(Duration::from_secs(10)).await;
 
     println!("Inserting extra test actions!");
     // Verify rollup can still accept transactions, and state is consistent across replicas
-    let actions = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }];
+    let actions = vec![
+        TestingAction::AcceptTx,
+        TestingAction::AcceptTx,
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+    ];
     let (master, replicas, _state) =
         test_actions_against_replicas(&admin, (master, replicas, state), actions).await;
 

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
@@ -273,7 +273,7 @@ async fn test_replica_resynced_from_scratch() {
             .runtime
             .sequencer_registry
             .sequencer_config
-            .seq_da_address
+            .seq_da_address;
     })
     .with_preferred_seq_min_profit_per_tx(0)
     .with_preferred_seq_recovery_strategy(sov_sequencer::preferred::RecoveryStrategy::TryToSave);
@@ -289,9 +289,11 @@ async fn test_replica_resynced_from_scratch() {
 
     let shared_da = builder.shared_da_for_replicas().await.unwrap();
 
+    // sov_test_utils::initialize_logging();
+
     // ACTUAL TEST BEGINS
     let test_rollups = builder
-        .launch_n_replicas(1, shared_da.clone())
+        .launch_n_replicas(1, shared_da.clone(), true)
         .await
         .unwrap();
     let mut test_rollups = test_rollups.into_iter();
@@ -299,12 +301,8 @@ async fn test_replica_resynced_from_scratch() {
     // Allow master to take over
     tokio::time::sleep(Duration::from_secs(1)).await;
 
-    let (mut master, replicas) = identify_master_and_replicas(
-        test_rollups.next().unwrap(),
-        test_rollups.map(Some).collect(),
-    )
-    .await
-    .unwrap();
+    let mut master = test_rollups.next().unwrap();
+    let replicas = test_rollups.map(Some).collect();
 
     let (master_with_state, state) = setup_test_rollup_with_initial_state(master, &admin).await;
     master = master_with_state;
@@ -318,8 +316,8 @@ async fn test_replica_resynced_from_scratch() {
     ];
     let (master, replicas, state) =
         test_actions_against_replicas(&admin, (master, replicas, state), actions).await;
-    println!("Basic actions succeeded. Now launching big DA block production...");
 
+    println!("\nTEST: running for 40 blocks\n");
     // Run for 40 more blocks
     let slots = vec![
         TestingAction::AcceptTx,
@@ -334,10 +332,10 @@ async fn test_replica_resynced_from_scratch() {
     let (master, mut replicas, state) =
         test_actions_against_replicas(&admin, (master, replicas, state), slots).await;
 
-    println!("Block production succeeded. Launching brand new replica...");
+    println!("\nTEST: launching new replica\n");
     // Launch brand new replica
     let extra_replica = builder
-        .launch_n_replicas(1, shared_da)
+        .launch_n_replicas(1, shared_da, false)
         .await
         .unwrap()
         .into_iter()
@@ -345,9 +343,10 @@ async fn test_replica_resynced_from_scratch() {
         .unwrap();
     replicas.push(Some(extra_replica));
     // Let it sync
+    println!("\nTEST: sleeping to sync replica...\n");
     tokio::time::sleep(Duration::from_secs(10)).await;
 
-    println!("Inserting extra test actions!");
+    println!("\nTEST: sleep done, creating two new transactions and a new DA slot\n");
     // Verify rollup can still accept transactions, and state is consistent across replicas
     let actions = vec![
         TestingAction::AcceptTx,
@@ -358,7 +357,7 @@ async fn test_replica_resynced_from_scratch() {
     let (master, replicas, _state) =
         test_actions_against_replicas(&admin, (master, replicas, state), actions).await;
 
-    println!("Shutting everything down.");
+    println!("\nTEST: shutting down\n");
     for replica in replicas {
         replica.unwrap().shutdown().await.unwrap();
     }

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
@@ -2,13 +2,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use sov_mock_da::BlockProducingConfig;
-use sov_modules_api::Runtime;
+use sov_modules_api::{Amount, Runtime, SafeVec};
 use sov_modules_stf_blueprint::GenesisParams;
-use sov_paymaster::PaymasterConfig;
+use sov_paymaster::{PayeePolicy, PayerGenesisConfig, PaymasterConfig, PaymasterPolicyInitializer};
+use sov_sequencer::SequencerKindConfig;
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
-use sov_test_utils::test_rollup::TestRollup;
+use sov_test_utils::test_rollup::{GenesisSource, RollupBuilder, TestRollup};
 use sov_test_utils::{
-    TestSpec, TestUser, TEST_BLOB_PROCESSING_TIMEOUT, TEST_FINALIZATION_BLOCKS, TEST_MAX_BATCH_SIZE,
+    RtAgnosticBlueprint, TestSpec, TestUser, TEST_BLOB_PROCESSING_TIMEOUT, TEST_DEFAULT_USER_BALANCE, TEST_FINALIZATION_BLOCKS, TEST_MAX_BATCH_SIZE
 };
 use sov_value_setter::ValueSetterConfig;
 
@@ -88,7 +89,7 @@ async fn test_actions_against_replicas(
         run_actions_against_test_rollup(actions, master, &admin.clone(), state).await;
 
     // Ensure replicas have processed the database changes
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    tokio::time::sleep(Duration::from_millis(3000)).await;
 
     // Verify state synchronization across all replicas
     for replica_opt in &mut replicas {
@@ -186,4 +187,146 @@ async fn seq_with_replicas() {
     }
     // Shut down master last, otherwise the postgres subscription will drop and replicas will error
     master.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_replica_resynced_from_scratch() {
+    // very ugly. currently copy-pastes code from create_test_rollups and new_test_rollup in order
+    // to access the launch_n_replicas interface. need to refactor
+    let mut genesis_config =
+        HighLevelOptimisticGenesisConfig::generate().add_accounts_with_default_balance(1);
+    let admin = genesis_config.additional_accounts()[0].clone();
+    let sequencer = genesis_config.initial_sequencer.clone();
+
+    let paymaster = TestUser::generate(
+        TEST_DEFAULT_USER_BALANCE
+            .checked_mul(Amount::new(10))
+            .unwrap(),
+    );
+    genesis_config
+        .additional_accounts_mut()
+        .push(paymaster.clone());
+
+    let users: Vec<TestUser<TestSpec>> = vec![TestUser::generate_with_default_balance(); 20];
+    genesis_config.additional_accounts_mut().extend(users);
+
+    let paymaster_config = PaymasterConfig {
+        payers: [PayerGenesisConfig {
+            payer_address: paymaster.address(),
+            policy: PaymasterPolicyInitializer {
+                default_payee_policy: PayeePolicy::Allow {
+                    max_fee: None,
+                    gas_limit: None,
+                    max_gas_price: None,
+                    transaction_limit: None,
+                },
+                payees: SafeVec::new(),
+                authorized_sequencers: sov_paymaster::AuthorizedSequencers::All,
+                authorized_updaters: [paymaster.address()].as_ref().try_into().unwrap(),
+            },
+            sequencers_to_register: [sequencer.da_address].as_ref().try_into().unwrap(),
+        }]
+                .as_ref()
+                    .try_into()
+                    .unwrap(),
+    };
+
+    let rt_genesis_config =
+        <TestRuntime<TestSpec> as Runtime<TestSpec>>::GenesisConfig::from_minimal_config(
+            genesis_config.into(),
+            ValueSetterConfig {
+                admin: admin.address(),
+            },
+            (),
+            paymaster_config,
+            (),
+        );
+
+    let genesis_params = GenesisParams {
+        runtime: rt_genesis_config.clone(),
+    };
+
+    let dir = tempdir_inside_codebase_dir();
+
+    let builder = RollupBuilder::<RtAgnosticBlueprint<TestSpec, TestRuntime<TestSpec>>>::new(
+        GenesisSource::CustomParams(genesis_params.clone()),
+        BlockProducingConfig::Manual,
+        0,
+    )
+    .set_config(|c| {
+        c.rollup_prover_config = None;
+        c.automatic_batch_production = true;
+        c.storage = dir;
+        c.max_batch_size_bytes = TEST_MAX_BATCH_SIZE;
+        c.blob_processing_timeout_secs = TEST_BLOB_PROCESSING_TIMEOUT;
+        c.stop_at_rollup_height = None;
+        if let SequencerKindConfig::Preferred(preferred_sequencer_config) = &mut c.sequencer_config
+        {
+            preferred_sequencer_config.batch_execution_time_limit_millis =
+                MAX_BATCH_EXECUTION_TIME_MILLIS;
+        }
+        c.max_concurrent_blobs = 16;
+    })
+    .set_da_config(|c| c.sender_address = genesis_params.runtime.sequencer_registry.sequencer_config.seq_da_address)
+    .with_preferred_seq_min_profit_per_tx(0)
+    .with_preferred_seq_recovery_strategy(sov_sequencer::preferred::RecoveryStrategy::TryToSave);
+
+    let builder = if num_cpus::get() != 96 {
+        builder.with_postgres_sequencer().await.unwrap()
+    } else {
+        tracing::warn!(
+            "Replica test cannot run, postgres is disabled due to detecting the dev server"
+        );
+        return;
+    };
+
+    let shared_da = builder.shared_da_for_replicas().await.unwrap();
+
+    let test_rollups = builder.launch_n_replicas(1, shared_da.clone()).await.unwrap();
+
+    let mut test_rollups = test_rollups.into_iter();
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Identify initial master and replicas
+    let (mut master, replicas) = identify_master_and_replicas(
+        test_rollups.next().unwrap(),
+        test_rollups.map(Some).collect(),
+    )
+    .await
+    .unwrap();
+
+    let (master_with_state, state) = setup_test_rollup_with_initial_state(master, &admin).await;
+    master = master_with_state;
+
+    let actions = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }];
+    let (master, replicas, state) =
+        test_actions_against_replicas(&admin, (master, replicas, state), actions).await;
+    println!("Basic actions succeeded. Now launching big DA block production...");
+
+    let slots = vec![TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }].into_iter().cycle().take(120).collect();
+    let (master, mut replicas, state) =
+        test_actions_against_replicas(&admin, (master, replicas, state), slots).await;
+
+    println!("Block production succeeded. Launching brand new replica...");
+    let extra_replica = builder.launch_n_replicas(1, shared_da).await.unwrap().into_iter().next().unwrap();
+    replicas.push(Some(extra_replica));
+
+    println!("Sleeping...");
+    tokio::time::sleep(Duration::from_secs(25)).await;
+
+    println!("Inserting actions!");
+    let actions = vec![TestingAction::AcceptTx, TestingAction::AcceptTx, TestingAction::NewDaSlot, TestingAction::Sleep { duration_ms: 100 }];
+    let (master, replicas, _state) =
+        test_actions_against_replicas(&admin, (master, replicas, state), actions).await;
+    println!("Basic actions succeeded. Now launching big DA block production...");
+
+    println!("Shutting everything down.");
+    for replica in replicas {
+        replica.unwrap().shutdown().await.unwrap();
+    }
+    master.shutdown().await.unwrap();
+
+    println!("Shut down everything except extra replica");
+
+    // extra_replica.shutdown().await.unwrap();
 }

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -592,7 +592,7 @@ where
         num_replicas: u64,
     ) -> anyhow::Result<Vec<TestRollup<R, Arc<tempfile::TempDir>>>> {
         let da = self.shared_da_for_replicas().await?;
-        self.launch_n_replicas(num_replicas, da).await
+        self.launch_n_replicas(num_replicas, da, true).await
     }
 
     fn shared_da_connection_string(&self) -> String {
@@ -621,6 +621,7 @@ where
         &self,
         num_replicas: u64,
         shared_da: Arc<RwLock<StorableMockDaLayer>>,
+        with_master: bool
     ) -> anyhow::Result<Vec<TestRollup<R, Arc<tempfile::TempDir>>>> {
         if num_replicas == 0 {
             anyhow::bail!("num_replicas must be at least 1 (master + replicas)");
@@ -672,7 +673,7 @@ where
             };
 
             // Set replica mode for non-master instances
-            if i > 0 {
+            if i > 0 || !with_master {
                 if let SequencerKindConfig::Preferred(ref mut preferred_config) =
                     instance_builder.config.sequencer_config
                 {

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -621,7 +621,7 @@ where
         &self,
         num_replicas: u64,
         shared_da: Arc<RwLock<StorableMockDaLayer>>,
-        with_master: bool
+        with_master: bool,
     ) -> anyhow::Result<Vec<TestRollup<R, Arc<tempfile::TempDir>>>> {
         if num_replicas == 0 {
             anyhow::bail!("num_replicas must be at least 1 (master + replicas)");

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -324,6 +324,11 @@ impl<R: FullNodeBlueprint<Native>, StoragePath: AsPath> RollupBuilder<R, Storage
                 .expect("storage folder should exist by this time");
         self
     }
+
+    /// A reference to the storage directory the rollup will run in
+    pub fn storage_path(&self) -> StoragePath {
+        self.config.storage.clone()
+    }
 }
 
 impl<R, StoragePath> RollupBuilder<R, StoragePath>
@@ -586,6 +591,37 @@ where
         self,
         num_replicas: u64,
     ) -> anyhow::Result<Vec<TestRollup<R, Arc<tempfile::TempDir>>>> {
+        let da = self.shared_da_for_replicas().await?;
+        self.launch_n_replicas(num_replicas, da).await
+    }
+
+    fn shared_da_connection_string(&self) -> String {
+        let base_path = self.config.storage.as_path();
+
+        format!(
+            "sqlite://{}?mode=rwc",
+            base_path.join("shared_mock_da.sqlite").to_string_lossy()
+        )
+    }
+
+    /// Create a mockda suitable for passing to launch_n_replicas().
+    /// Should be created once, then stored and cloned.
+    pub async fn shared_da_for_replicas(&self) -> anyhow::Result<Arc<RwLock<StorableMockDaLayer>>> {
+        Ok(Arc::new(RwLock::new(
+            StorableMockDaLayer::new_from_connection(
+                &self.shared_da_connection_string(),
+                self.da_config.finalization_blocks,
+            )
+            .await?,
+        )))
+    }
+
+    /// Create several replicas with the provided DA.
+    pub async fn launch_n_replicas(
+        &self,
+        num_replicas: u64,
+        shared_da: Arc<RwLock<StorableMockDaLayer>>
+    ) -> anyhow::Result<Vec<TestRollup<R, Arc<tempfile::TempDir>>>> {
         if num_replicas == 0 {
             anyhow::bail!("num_replicas must be at least 1 (master + replicas)");
         }
@@ -610,17 +646,7 @@ where
         })?;
 
         // Create shared MockDA sqlite file in base directory
-        let shared_da_connection = format!(
-            "sqlite://{}?mode=rwc",
-            base_path.join("shared_mock_da.sqlite").to_string_lossy()
-        );
-        let da_layer = Arc::new(RwLock::new(
-            StorableMockDaLayer::new_from_connection(
-                &shared_da_connection,
-                self.da_config.finalization_blocks,
-            )
-            .await?,
-        ));
+        let shared_da_connection = self.shared_da_connection_string();
 
         let mut rollups = Vec::new();
 
@@ -634,7 +660,7 @@ where
                 genesis: self.genesis.clone(),
                 da_config: MockDaConfig {
                     connection_string: shared_da_connection.clone(),
-                    da_layer: Some(da_layer.clone()),
+                    da_layer: Some(shared_da.clone()),
                     ..self.da_config.clone()
                 },
                 config: RollupBuilderConfig {

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -620,7 +620,7 @@ where
     pub async fn launch_n_replicas(
         &self,
         num_replicas: u64,
-        shared_da: Arc<RwLock<StorableMockDaLayer>>
+        shared_da: Arc<RwLock<StorableMockDaLayer>>,
     ) -> anyhow::Result<Vec<TestRollup<R, Arc<tempfile::TempDir>>>> {
         if num_replicas == 0 {
             anyhow::bail!("num_replicas must be at least 1 (master + replicas)");


### PR DESCRIPTION
# Description

This PR bundles three separate fixes:
 * Unrelated to replication: there was an edge case involving the transaction cache. During resync, `inner.process_wait_for_node_resync()` flushes the tx cache for every update_state. Once the sequencer is considered resynced, say at update state for slot `n`, the tx cache will have `next_tx_number` from slot `n`. When the next StateUpdateInfo for slot `n+1` comes in and goes into the replay_batches branch, the sequencer starts replaying pending batches starting with `n+2`. This means that transactions from slot `n+1` will not have been added to the tx cache - and it will error on when sanity checking for consecutive tx numbers.
     * This has been fixed by having `ReplaySoftConfirmationsOnTopOfNodeState` contain `is_startup_or_resync` rather than just `is_startup`, i.e. the first update_state after a successful resync will still have this as `true` (and then will set `inner.is_ready = Ok(())` so will be false henceforth). This is then special cased to flush the tx cache one again.
 * Replication: backfill used to run concurrently to the event pre-fetching futures. This was incorrect: it should run in order with `processed_events`. `create_backfill_future()` has been removed, and the backfill future has been replaced with one that resolves immediately; the actual backfill call has been moved to the ordered event processing loop. (This is backported from the failover PR, but was necessary to allow replicas to resync.)
 * Replication resync: replicas have access to the sequencer DB, but until their node is resynced, they cannot actually apply the pending batches because none of the events in the DB can be applied onto their executor's state. There was no proper functionality to wait for resync. This PR adds a notification channel from update_state which the replica_sync_task uses to a) avoid processing events until the executor is sufficiently caught up, and b) fast-forward event processing in case update_state actually fast-forwards the executor state beyond the current event cursor.
     * There is a known edge case remaining: if an event _starts_ being processed, but before it sends the message to `inner`, update_state finishes and replaces the executor with a future state - then there is no check for this, the past event will be re-applied to the state. This will cause the replica to crash with no other ill effects (`batch` events will cause a visible slot number mismatch, and `transaction` events will cause result in a duplicate transaction panic), and should be rare enough that restarting the replica should be sufficient mitigation for now.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] ~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
