### PR TITLE
Add fuzzing for universal wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13932,7 +13932,7 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-wallet-fuzz"
-version = "0.0.0"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "borsh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13936,6 +13936,7 @@ version = "0.3.0"
 dependencies = [
  "arbitrary",
  "borsh",
+ "hex",
  "libfuzzer-sys",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13931,6 +13931,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "universal-wallet-fuzz"
+version = "0.0.0"
+dependencies = [
+ "arbitrary",
+ "borsh",
+ "libfuzzer-sys",
+ "serde",
+ "serde_json",
+ "sov-modules-api",
+ "sov-rollup-interface",
+ "sov-universal-wallet",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ members = [
     "crates/universal-wallet/schema",
     "crates/universal-wallet/macros",
     "crates/universal-wallet/macro-helpers",
+    "crates/universal-wallet/fuzz",
     "crates/utils/sov-eth-client",
     "crates/utils/workspace-hack",
     # Hyperlane

--- a/crates/universal-wallet/fuzz/.gitignore
+++ b/crates/universal-wallet/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/crates/universal-wallet/fuzz/Cargo.toml
+++ b/crates/universal-wallet/fuzz/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "universal-wallet-fuzz"
-version = "0.0.0"
 publish = false
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/universal-wallet/fuzz/Cargo.toml
+++ b/crates/universal-wallet/fuzz/Cargo.toml
@@ -17,7 +17,7 @@ arbitrary = { workspace = true, features = ["derive"] }
 borsh = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true, features = ["alloc", "derive"] }
-serde_json = { workspace = true, features = ["arbitrary_precision"] }
+serde_json = { workspace = true }
 sov-universal-wallet = { workspace = true, package = "sov-universal-wallet", features = [
   "serde",
 ] }

--- a/crates/universal-wallet/fuzz/Cargo.toml
+++ b/crates/universal-wallet/fuzz/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "universal-wallet-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { workspace = true, features = ["derive"] }
+borsh = { workspace = true }
+serde = { workspace = true, features = ["alloc", "derive"] }
+serde_json = { workspace = true, features = ["arbitrary_precision"] }
+sov-universal-wallet = { workspace = true, package = "sov-universal-wallet", features = [
+  "serde",
+] }
+sov-modules-api = { workspace = true, features = ["arbitrary"] }
+sov-rollup-interface = { workspace = true, features = ["arbitrary"] }
+
+[lib]
+name = "universal_wallet_fuzz"
+path = "src/lib.rs"
+
+[[bin]]
+name = "fuzz_display"
+path = "fuzz_targets/fuzz_display.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_json_to_borsh"
+path = "fuzz_targets/fuzz_json_to_borsh.rs"
+test = false
+doc = false
+bench = false
+
+[features]
+default = []
+floats = []
+js-compat = []

--- a/crates/universal-wallet/fuzz/Cargo.toml
+++ b/crates/universal-wallet/fuzz/Cargo.toml
@@ -15,6 +15,7 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 arbitrary = { workspace = true, features = ["derive"] }
 borsh = { workspace = true }
+hex = { workspace = true }
 serde = { workspace = true, features = ["alloc", "derive"] }
 serde_json = { workspace = true, features = ["arbitrary_precision"] }
 sov-universal-wallet = { workspace = true, package = "sov-universal-wallet", features = [
@@ -43,5 +44,4 @@ bench = false
 
 [features]
 default = []
-floats = []
 js-compat = []

--- a/crates/universal-wallet/fuzz/README.md
+++ b/crates/universal-wallet/fuzz/README.md
@@ -1,0 +1,18 @@
+# Universal Wallet fuzzing
+
+A library that generates and runs fuzz testing on `universal-wallet`.
+
+Designed to be usable alongside implementations in other languages (such as JS) to perform differential tests & ensure implementation correctness.
+
+Run like so:
+
+```
+cargo fuzz run fuzz_json_to_borsh --fuzz-dir . --features js-compat
+```
+
+`fuzz-dir` is provided otherwise the fuzz runner tries to use `crates/fuzz` as the crate.
+
+### Features
+
+- `js-compat` serializes numbers in a way that is compatible with JS/JSON, big ints as strings, etc.
+- `floats` Uses f32/f64 in fuzz tests, when running JSON+borsh based tests this can cause failures due to precision loss.

--- a/crates/universal-wallet/fuzz/README.md
+++ b/crates/universal-wallet/fuzz/README.md
@@ -15,4 +15,3 @@ cargo fuzz run fuzz_json_to_borsh --fuzz-dir . --features js-compat
 ### Features
 
 - `js-compat` serializes numbers in a way that is compatible with JS/JSON, big ints as strings, etc.
-- `floats` Uses f32/f64 in fuzz tests, when running JSON+borsh based tests this can cause failures due to precision loss.

--- a/crates/universal-wallet/fuzz/fuzz_targets/fuzz_display.rs
+++ b/crates/universal-wallet/fuzz/fuzz_targets/fuzz_display.rs
@@ -1,0 +1,12 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use sov_universal_wallet::schema::Schema;
+use universal_wallet_fuzz::FuzzInput;
+
+fuzz_target!(|input: FuzzInput| {
+    let schema = Schema::of_single_type::<FuzzInput>().unwrap();
+    let bytes = borsh::to_vec(&input).unwrap();
+
+    assert!(schema.display(0, &bytes).is_ok());
+});

--- a/crates/universal-wallet/fuzz/fuzz_targets/fuzz_json_to_borsh.rs
+++ b/crates/universal-wallet/fuzz/fuzz_targets/fuzz_json_to_borsh.rs
@@ -7,9 +7,6 @@ use universal_wallet_fuzz::FuzzInput;
 #[cfg(not(feature = "js-compat"))]
 compile_error!("This fuzz test requires JS/JSON compatability otherwise big numbers/floats, etc aren't handled leading to failing tests");
 
-#[cfg(feature = "floats")]
-compile_error!("NaN & Infinity aren't handled in Schema::json_to_borsh which fails tests");
-
 fuzz_target!(|input: FuzzInput| {
     let schema = Schema::of_single_type::<FuzzInput>().unwrap();
     let data = serde_json::to_string(&input).unwrap();

--- a/crates/universal-wallet/fuzz/fuzz_targets/fuzz_json_to_borsh.rs
+++ b/crates/universal-wallet/fuzz/fuzz_targets/fuzz_json_to_borsh.rs
@@ -1,0 +1,20 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use sov_universal_wallet::schema::Schema;
+use universal_wallet_fuzz::FuzzInput;
+
+#[cfg(not(feature = "js-compat"))]
+compile_error!("This fuzz test requires JS/JSON compatability otherwise big numbers/floats, etc aren't handled leading to failing tests");
+
+#[cfg(feature = "floats")]
+compile_error!("NaN & Infinity aren't handled in Schema::json_to_borsh which fails tests");
+
+fuzz_target!(|input: FuzzInput| {
+    let schema = Schema::of_single_type::<FuzzInput>().unwrap();
+    let data = serde_json::to_string(&input).unwrap();
+    let json_serialized = schema.json_to_borsh(0, &data).unwrap();
+    let borsh = borsh::to_vec(&input).unwrap();
+
+    assert_eq!(json_serialized, borsh);
+});

--- a/crates/universal-wallet/fuzz/fuzz_targets/fuzz_json_to_borsh.rs
+++ b/crates/universal-wallet/fuzz/fuzz_targets/fuzz_json_to_borsh.rs
@@ -4,9 +4,6 @@ use libfuzzer_sys::fuzz_target;
 use sov_universal_wallet::schema::Schema;
 use universal_wallet_fuzz::FuzzInput;
 
-#[cfg(not(feature = "js-compat"))]
-compile_error!("This fuzz test requires JS/JSON compatability otherwise big numbers/floats, etc aren't handled leading to failing tests");
-
 fuzz_target!(|input: FuzzInput| {
     let schema = Schema::of_single_type::<FuzzInput>().unwrap();
     let data = serde_json::to_string(&input).unwrap();

--- a/crates/universal-wallet/fuzz/rust-toolchain.toml
+++ b/crates/universal-wallet/fuzz/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/crates/universal-wallet/fuzz/src/js_compat.rs
+++ b/crates/universal-wallet/fuzz/src/js_compat.rs
@@ -113,6 +113,67 @@ macro_rules! impl_js_safe_signed {
 impl_js_safe_signed!(JsI64, i64);
 impl_js_safe_signed!(JsI128, i128);
 
+// Serialize floats as hex encoded bytes to avoid precision loss when converting to/from JSON.
+// Implements arbitrary that avoids NaN as this is not supported by borsh.
+macro_rules! impl_js_safe_float {
+    ($wrapper:ident, $inner:ty, $byte_count:expr) => {
+        #[derive(Debug, BorshDeserialize, BorshSerialize, UniversalWallet)]
+        pub struct $wrapper(pub $inner);
+
+        impl Serialize for $wrapper {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                let bytes = self.0.to_le_bytes();
+                let hex_string = hex::encode(bytes);
+                serializer.serialize_str(&format!("0x{}", hex_string))
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $wrapper {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                use serde::de::Error;
+
+                let hex_string: String = Deserialize::deserialize(deserializer)?;
+                let hex_string = hex_string.strip_prefix("0x").expect("not prefixed with 0x");
+                let bytes = hex::decode(hex_string)
+                    .map_err(|e| D::Error::custom(format!("Invalid hex string: {}", e)))?;
+
+                if bytes.len() != $byte_count {
+                    return Err(D::Error::custom(format!(
+                        "Hex string must decode to exactly {} bytes for {}",
+                        $byte_count,
+                        stringify!($inner)
+                    )));
+                }
+
+                let byte_array: [u8; $byte_count] = bytes
+                    .try_into()
+                    .map_err(|_| D::Error::custom("Failed to convert bytes to array"))?;
+
+                Ok($wrapper(<$inner>::from_le_bytes(byte_array)))
+            }
+        }
+
+        impl Arbitrary<'_> for $wrapper {
+            fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+                let val: $inner = u.arbitrary()?;
+                // borsh doesnt allow NaN
+                let valid_val = if val.is_nan() { 0.0 } else { val };
+
+                Ok($wrapper(valid_val))
+            }
+        }
+    };
+}
+
+impl_js_safe_float!(JsF32, f32, 4);
+impl_js_safe_float!(JsF64, f64, 8);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/universal-wallet/fuzz/src/js_compat.rs
+++ b/crates/universal-wallet/fuzz/src/js_compat.rs
@@ -1,0 +1,179 @@
+use arbitrary::Arbitrary;
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
+use sov_modules_api::macros::UniversalWallet;
+
+const JS_MAX_SAFE_INTEGER: u128 = 9_007_199_254_740_991;
+const JS_MIN_SAFE_INTEGER: i128 = -9_007_199_254_740_991;
+
+macro_rules! impl_js_safe_unsigned {
+    ($wrapper:ident, $inner:ty) => {
+        #[derive(Debug, Arbitrary, BorshDeserialize, BorshSerialize, UniversalWallet)]
+        pub struct $wrapper(pub $inner);
+
+        impl Serialize for $wrapper {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                let val = self.0 as u128;
+                if val <= JS_MAX_SAFE_INTEGER {
+                    serializer.serialize_u64(val as u64)
+                } else {
+                    serializer.serialize_str(&self.0.to_string())
+                }
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $wrapper {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                use serde::de::Error;
+
+                let value: Value = Deserialize::deserialize(deserializer)?;
+                let num: u128 = match value {
+                    Value::Number(n) => n
+                        .as_u64()
+                        .ok_or_else(|| D::Error::custom("Invalid number"))?
+                        as u128,
+                    Value::String(s) => s.parse().map_err(D::Error::custom)?,
+                    _ => return Err(D::Error::custom("Expected number or string")),
+                };
+
+                if num > <$inner>::MAX as u128 {
+                    return Err(D::Error::custom(format!(
+                        "Value {} too large for {}",
+                        num,
+                        stringify!($inner)
+                    )));
+                }
+
+                Ok($wrapper(num as $inner))
+            }
+        }
+    };
+}
+
+impl_js_safe_unsigned!(JsU64, u64);
+impl_js_safe_unsigned!(JsU128, u128);
+
+macro_rules! impl_js_safe_signed {
+    ($wrapper:ident, $inner:ty) => {
+        #[derive(Debug, Arbitrary, BorshDeserialize, BorshSerialize, UniversalWallet)]
+        pub struct $wrapper(pub $inner);
+
+        impl Serialize for $wrapper {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                let val = self.0 as i128;
+                if val >= JS_MIN_SAFE_INTEGER && val <= JS_MAX_SAFE_INTEGER as i128 {
+                    serializer.serialize_i64(val as i64)
+                } else {
+                    serializer.serialize_str(&self.0.to_string())
+                }
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $wrapper {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                use serde::de::Error;
+
+                let value: Value = Deserialize::deserialize(deserializer)?;
+                let num: i128 = match value {
+                    Value::Number(n) => n
+                        .as_i64()
+                        .ok_or_else(|| D::Error::custom("Invalid number"))?
+                        as i128,
+                    Value::String(s) => s.parse().map_err(D::Error::custom)?,
+                    _ => return Err(D::Error::custom("Expected number or string")),
+                };
+
+                if num < <$inner>::MIN as i128 || num > <$inner>::MAX as i128 {
+                    return Err(D::Error::custom(format!(
+                        "Value {} out of range for {}",
+                        num,
+                        stringify!($inner)
+                    )));
+                }
+
+                Ok($wrapper(num as $inner))
+            }
+        }
+    };
+}
+
+impl_js_safe_signed!(JsI64, i64);
+impl_js_safe_signed!(JsI128, i128);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_i128() {
+        let large = JsI128(i128::MAX);
+        let smaller = JsI128(JS_MIN_SAFE_INTEGER);
+
+        assert_eq!(
+            &serde_json::to_string(&large).unwrap(),
+            "\"170141183460469231731687303715884105727\"" // string
+        );
+        assert_eq!(
+            &serde_json::to_string(&smaller).unwrap(),
+            "-9007199254740991" // int
+        );
+    }
+
+    #[test]
+    fn test_i64() {
+        let large = JsI64(i64::MAX);
+        let smaller = JsI64(-55i64);
+
+        assert_eq!(
+            &serde_json::to_string(&large).unwrap(),
+            "\"9223372036854775807\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&smaller).unwrap(),
+            "-55" // int
+        );
+    }
+
+    #[test]
+    fn test_u128() {
+        let large = JsU128(u128::MAX);
+        let smaller = JsU128(JS_MAX_SAFE_INTEGER);
+
+        assert_eq!(
+            &serde_json::to_string(&large).unwrap(),
+            "\"340282366920938463463374607431768211455\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&smaller).unwrap(),
+            "9007199254740991"
+        );
+    }
+
+    #[test]
+    fn test_u64() {
+        let large = JsU64(u64::MAX);
+        let smaller = JsU64(1234u64);
+
+        assert_eq!(
+            &serde_json::to_string(&large).unwrap(),
+            "\"18446744073709551615\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&smaller).unwrap(),
+            "1234" // int
+        );
+    }
+}

--- a/crates/universal-wallet/fuzz/src/js_compat.rs
+++ b/crates/universal-wallet/fuzz/src/js_compat.rs
@@ -139,7 +139,7 @@ macro_rules! impl_js_safe_float {
                 use serde::de::Error;
 
                 let hex_string: String = Deserialize::deserialize(deserializer)?;
-                let hex_string = hex_string.strip_prefix("0x").expect("not prefixed with 0x");
+                let hex_string = hex_string.strip_prefix("0x").unwrap_or(&hex_string);
                 let bytes = hex::decode(hex_string)
                     .map_err(|e| D::Error::custom(format!("Invalid hex string: {}", e)))?;
 

--- a/crates/universal-wallet/fuzz/src/lib.rs
+++ b/crates/universal-wallet/fuzz/src/lib.rs
@@ -1,0 +1,128 @@
+use arbitrary::{Arbitrary, Unstructured};
+use borsh::{BorshDeserialize, BorshSerialize};
+use sov_modules_api::macros::UniversalWallet;
+use sov_modules_api::prelude::serde::{Deserialize, Serialize};
+use sov_modules_api::SafeString;
+use sov_universal_wallet::schema::safe_string::DEFAULT_MAX_STRING_LENGTH;
+
+mod js_compat;
+
+#[cfg(feature = "js-compat")]
+pub mod types {
+    pub type I64 = crate::js_compat::JsI64;
+    pub type I128 = crate::js_compat::JsI128;
+    pub type U64 = crate::js_compat::JsU64;
+    pub type U128 = crate::js_compat::JsU128;
+}
+
+#[cfg(not(feature = "js-compat"))]
+pub mod types {
+    pub type I64 = i64;
+    pub type I128 = i128;
+    pub type U64 = u64;
+    pub type U128 = u128;
+}
+
+use types::{I128, I64, U128, U64};
+
+// arbitrary isn't implemented for safe string
+#[derive(Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize, UniversalWallet)]
+pub struct ArbitrarySafeString(SafeString);
+
+impl Arbitrary<'_> for ArbitrarySafeString {
+    fn arbitrary(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
+        let len = u.int_in_range(0..=DEFAULT_MAX_STRING_LENGTH)?;
+
+        let chars: Result<String, _> = (0..len)
+            .map(|_| {
+                let c = u.int_in_range(32u8..=126u8)? as char;
+                Ok(c)
+            })
+            .collect();
+
+        let s = chars?;
+        Ok(ArbitrarySafeString(s.try_into().unwrap()))
+    }
+}
+
+#[derive(
+    Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize, UniversalWallet, Arbitrary,
+)]
+pub enum ByteVecInput {
+    Hex(#[sov_wallet(display(hex))] Vec<u8>),
+    Base58(#[sov_wallet(display(base58))] Vec<u8>),
+    Decimal(#[sov_wallet(display(decimal))] Vec<u8>),
+}
+
+#[derive(
+    Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize, UniversalWallet, Arbitrary,
+)]
+pub enum ByteArrayInput {
+    Hex(#[sov_wallet(display(hex))] [u8; 32]),
+    Base58(#[sov_wallet(display(base58))] [u8; 32]),
+    Decimal(#[sov_wallet(display(decimal))] [u8; 32]),
+}
+
+#[derive(
+    Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize, UniversalWallet, Arbitrary,
+)]
+pub enum NumberInput {
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(U64),
+    U128(U128),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(I64),
+    I128(I128),
+    #[cfg(feature = "floats")]
+    F32(F32),
+    #[cfg(feature = "floats")]
+    F64(f64),
+}
+
+#[derive(
+    Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize, UniversalWallet, Arbitrary,
+)]
+pub struct ComplexStruct {
+    field_a: Vec<(Option<u8>, [i8; 32])>,
+    needs_more_vecs: Vec<Vec<Vec<Vec<U128>>>>,
+    never: (),
+    bulk_tuple: (i32, i32, u64, I128, ArbitrarySafeString, Option<bool>),
+}
+
+#[derive(
+    Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize, UniversalWallet, Arbitrary,
+)]
+pub struct SkippedField {
+    #[allow(dead_code)]
+    #[borsh(skip)]
+    #[serde(skip)]
+    #[sov_wallet(skip)]
+    skipper: u8,
+    not_skipped: u8,
+}
+
+#[derive(
+    Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize, UniversalWallet, Arbitrary,
+)]
+pub enum FuzzInput {
+    Bool(bool),
+    String(ArbitrarySafeString),
+    ByteVec(ByteVecInput),
+    Vec(Vec<(i8, u16)>),
+    ByteArray(ByteArrayInput),
+    Array([i16; 5]),
+    // TODO: Map
+    Number(NumberInput),
+    InlineStruct {
+        field: u32,
+        name: ArbitrarySafeString,
+    },
+    MultiTuple(i8, Option<u8>),
+    SkippedField(SkippedField),
+    Complex(ComplexStruct),
+    Null(()),
+}

--- a/crates/universal-wallet/fuzz/src/lib.rs
+++ b/crates/universal-wallet/fuzz/src/lib.rs
@@ -13,6 +13,8 @@ pub mod types {
     pub type I128 = crate::js_compat::JsI128;
     pub type U64 = crate::js_compat::JsU64;
     pub type U128 = crate::js_compat::JsU128;
+    pub type F32 = crate::js_compat::JsF32;
+    pub type F64 = crate::js_compat::JsF64;
 }
 
 #[cfg(not(feature = "js-compat"))]
@@ -21,9 +23,11 @@ pub mod types {
     pub type I128 = i128;
     pub type U64 = u64;
     pub type U128 = u128;
+    pub type F32 = f32;
+    pub type F64 = f64;
 }
 
-use types::{I128, I64, U128, U64};
+use types::{F32, F64, I128, I64, U128, U64};
 
 // arbitrary isn't implemented for safe string
 #[derive(Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize, UniversalWallet)]
@@ -77,10 +81,8 @@ pub enum NumberInput {
     I32(i32),
     I64(I64),
     I128(I128),
-    #[cfg(feature = "floats")]
-    F32(f32),
-    #[cfg(feature = "floats")]
-    F64(f64),
+    F32(F32),
+    F64(F64),
 }
 
 #[derive(

--- a/crates/universal-wallet/fuzz/src/lib.rs
+++ b/crates/universal-wallet/fuzz/src/lib.rs
@@ -78,7 +78,7 @@ pub enum NumberInput {
     I64(I64),
     I128(I128),
     #[cfg(feature = "floats")]
-    F32(F32),
+    F32(f32),
     #[cfg(feature = "floats")]
     F64(f64),
 }

--- a/crates/universal-wallet/fuzz/src/lib.rs
+++ b/crates/universal-wallet/fuzz/src/lib.rs
@@ -5,6 +5,7 @@ use sov_modules_api::prelude::serde::{Deserialize, Serialize};
 use sov_modules_api::SafeString;
 use sov_universal_wallet::schema::safe_string::DEFAULT_MAX_STRING_LENGTH;
 
+#[cfg(feature = "js-compat")]
 mod js_compat;
 
 #[cfg(feature = "js-compat")]

--- a/crates/universal-wallet/schema/src/json_to_borsh.rs
+++ b/crates/universal-wallet/schema/src/json_to_borsh.rs
@@ -120,6 +120,43 @@ macro_rules! serialize_primitive {
     }};
 }
 
+// We allow serializing floats as bytes from `0x` prefixed hex strings.
+// This is to avoid precision loss when working with floats in JSON.
+macro_rules! serialize_float {
+    ($self:ident, $val:expr, $as_fn:ident, $expected_type:ty) => {{
+        let value = $val
+            .$as_fn()
+            .and_then(|v| {
+                #[allow(clippy::unnecessary_cast)]
+                let f = v as $expected_type;
+                if f.is_nan() {
+                    None
+                } else {
+                    Some(f)
+                }
+            })
+            .or_else(|| {
+                $val.as_str().and_then(|str_val| {
+                    if str_val.starts_with("0x") {
+                        <$expected_type as FromHex>::from_hex(
+                            str_val
+                                .strip_prefix("0x")
+                                .expect("impossible, we checked prefix"),
+                        )
+                    } else {
+                        <$expected_type as FromStr>::from_str(str_val).ok()
+                    }
+                })
+            })
+            .ok_or(EncodeError::InvalidType {
+                schema_type: stringify!($expected_type).to_string(),
+                value: $val.to_string(),
+            })?;
+        borsh::to_writer(&mut $self.out, &value)?;
+        Ok(()) as Self::ReturnType
+    }};
+}
+
 impl<W: std::io::Write, L: LinkingScheme> TypeVisitor<L, ContainerSerdeMetadata>
     for EncodeVisitor<'_, W>
 {
@@ -290,17 +327,8 @@ impl<W: std::io::Write, L: LinkingScheme> TypeVisitor<L, ContainerSerdeMetadata>
         context: Context<L>,
     ) -> Self::ReturnType {
         match p {
-            Primitive::Float32 => {
-                serialize_primitive!(self, context.value, as_f64, f32, |f| {
-                    let f = f as f32;
-                    if f.is_finite() {
-                        Some(f)
-                    } else {
-                        None
-                    }
-                })
-            }
-            Primitive::Float64 => serialize_primitive!(self, context.value, as_f64, f64),
+            Primitive::Float32 => serialize_float!(self, context.value, as_f64, f32),
+            Primitive::Float64 => serialize_float!(self, context.value, as_f64, f64),
             Primitive::Boolean => serialize_primitive!(self, context.value, as_bool, bool),
             Primitive::Integer(int, _) => match int {
                 IntegerType::i8 => serialize_primitive!(self, context.value, as_i64, i8),
@@ -458,5 +486,35 @@ impl<W: std::io::Write, L: LinkingScheme> TypeVisitor<L, ContainerSerdeMetadata>
             value_type.visit(schema, self, Context::from_val(val.1.clone(), value))?;
         }
         Ok(())
+    }
+}
+
+trait FromHex {
+    fn from_hex(hex_str: &str) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+impl FromHex for f32 {
+    fn from_hex(hex_str: &str) -> Option<Self> {
+        let bytes = hex::decode(hex_str).ok()?;
+        if bytes.len() == 4 {
+            let byte_array: [u8; 4] = bytes.try_into().ok()?;
+            Some(f32::from_le_bytes(byte_array))
+        } else {
+            None
+        }
+    }
+}
+
+impl FromHex for f64 {
+    fn from_hex(hex_str: &str) -> Option<Self> {
+        let bytes = hex::decode(hex_str).ok()?;
+        if bytes.len() == 8 {
+            let byte_array: [u8; 8] = bytes.try_into().ok()?;
+            Some(f64::from_le_bytes(byte_array))
+        } else {
+            None
+        }
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -17,7 +17,7 @@ allow = [
   "Apache-2.0 WITH LLVM-exception",
   "LicenseRef-Sovereign-Permissionless-Commercial-License",
   "Zlib",
-  "BSL-1.0",                                              # Relevant discussion: <https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/985#issuecomment-2242712349>.
+  "BSL-1.0",                                                # Relevant discussion: <https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/985#issuecomment-2242712349>.
 ]
 
 [[licenses.clarify]]
@@ -372,6 +372,11 @@ license-files = []
 
 [[licenses.clarify]]
 name = "sov-build"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
+name = "universal-wallet-fuzz"
 expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
 license-files = []
 


### PR DESCRIPTION
# Description

Implements some basic fuzzing for universal wallet, mostly interested in testing serialization so we can compare with JS impl.

Allows passing floats as hex strings in JSON to avoid precision loss that occurs when passing as numbers.

Closes #1451 

**Ross TODO:** update universal wallet version in WASM to get float updates

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
