### PR TITLE
`Sequencer` Fix tx-cache logic during resync

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -1344,6 +1344,12 @@ where
                 !inner.has_finished_startup,
             )
         };
+
+        let is_resync = matches!(
+            inner.is_ready,
+            Err(SequencerNotReadyDetails::Syncing { .. })
+        );
+
         let time_spent_fetching_batches = fetch_batches_to_replay_metrics.duration;
         sov_metrics::track_metrics(|t| {
             t.submit(fetch_batches_to_replay_metrics);
@@ -1410,7 +1416,7 @@ where
             }
             (false, false, false, _) => {
                 PreferredSeqOperation::ReplaySoftConfirmationsOnTopOfNodeState(
-                    is_startup,
+                    is_startup || is_resync,
                     time_spent_fetching_batches,
                 )
             }

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -707,7 +707,7 @@ enum Message<S: Spec, Rt: Runtime<S>> {
     PruneSequencerDb {
         reason: &'static str,
     },
-    FlushTxCache {
+    ForceOverwriteState {
         api_ledger_db: LedgerDb,
         transaction_cache_write_handle: TxResultWriter<S, Rt>,
         info: StateUpdateInfo<S::Storage>,
@@ -981,7 +981,7 @@ where
         self.send(Message::PruneSequencerDb { reason }).await;
     }
 
-    pub(crate) async fn flush_tx_cache_msg(
+    pub(crate) async fn force_overite_state_msg(
         &self,
         api_ledger_db: LedgerDb,
         transaction_cache_write_handle: TxResultWriter<S, Rt>,
@@ -989,7 +989,7 @@ where
         rollup_exec_config: RollupBlockExecutorConfig<S, Rt>,
         reason: &'static str,
     ) {
-        self.send(Message::FlushTxCache {
+        self.send(Message::ForceOverwriteState {
             api_ledger_db,
             transaction_cache_write_handle,
             info,
@@ -1217,14 +1217,14 @@ where
                     Message::PruneSequencerDb { reason } => {
                         self.process_prune_sequencer_db(reason).await;
                     }
-                    Message::FlushTxCache {
+                    Message::ForceOverwriteState {
                         api_ledger_db,
                         transaction_cache_write_handle,
                         info,
                         rollup_exec_config,
                         reason,
                     } => {
-                        self.process_flush_tx_cache(
+                        self.process_force_overwrite_state(
                             api_ledger_db,
                             transaction_cache_write_handle,
                             info,
@@ -1352,7 +1352,7 @@ where
 
         let is_recover = matches!(
             inner.is_ready,
-            Err(SequencerNotReadyDetails::PreferredSequencerRecovering { .. })
+            Err(SequencerNotReadyDetails::PreferredSequencerRecovering)
         );
 
         let time_spent_fetching_batches = fetch_batches_to_replay_metrics.duration;
@@ -1420,8 +1420,17 @@ where
                 PreferredSeqOperation::RecoverAndCatchUp
             }
             (false, false, false, _) => {
+                let should_flush_tx_cache = is_startup || is_resync || is_recover;
+
+                if should_flush_tx_cache {
+                    inner
+                        .executor_events_sender
+                        .flush_transactions_cache(info.next_tx_number)
+                        .await;
+                }
+
                 PreferredSeqOperation::ReplaySoftConfirmationsOnTopOfNodeState(
-                    is_startup || is_resync || is_recover,
+                    should_flush_tx_cache,
                     time_spent_fetching_batches,
                 )
             }
@@ -1640,7 +1649,7 @@ where
         });
     }
 
-    async fn process_flush_tx_cache(
+    async fn process_force_overwrite_state(
         &mut self,
         api_ledger_db: LedgerDb,
         transaction_cache_write_handle: TxResultWriter<S, Rt>,
@@ -1649,11 +1658,6 @@ where
         reason: &'static str,
     ) {
         let mut inner = self.get_inner_with_timing(reason).await;
-        inner
-            .executor_events_sender
-            .flush_transactions_cache(info.next_tx_number)
-            .await;
-
         let executor_from_info = RollupBlockExecutor::<_, Rt>::new(&info, rollup_exec_config);
 
         inner
@@ -1708,15 +1712,6 @@ where
         if node_sequence_number > our_sequence_number {
             inner
                 .overwrite_next_sequence_number_for_recovery(node_sequence_number)
-                .await;
-            inner
-                .executor_events_sender
-                .flush_transactions_cache(info.next_tx_number)
-                .await;
-        } else if !inner.has_finished_startup {
-            inner
-                .executor_events_sender
-                .flush_transactions_cache(info.next_tx_number)
                 .await;
         }
 

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -1350,6 +1350,11 @@ where
             Err(SequencerNotReadyDetails::Syncing { .. })
         );
 
+        let is_recover = matches!(
+            inner.is_ready,
+            Err(SequencerNotReadyDetails::PreferredSequencerRecovering { .. })
+        );
+
         let time_spent_fetching_batches = fetch_batches_to_replay_metrics.duration;
         sov_metrics::track_metrics(|t| {
             t.submit(fetch_batches_to_replay_metrics);
@@ -1416,7 +1421,7 @@ where
             }
             (false, false, false, _) => {
                 PreferredSeqOperation::ReplaySoftConfirmationsOnTopOfNodeState(
-                    is_startup || is_resync,
+                    is_startup || is_resync || is_recover,
                     time_spent_fetching_batches,
                 )
             }

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -464,7 +464,7 @@ where
 
                 let rollup_exec_config = self.create_bloc_exec_config_for_recovery();
                 self.synchronized_state_updator
-                    .flush_tx_cache_msg(
+                    .force_overite_state_msg(
                         self.api_ledger_db.clone(),
                         self.transaction_cache.write_handle(),
                         info.clone(),

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -746,13 +746,13 @@ where
         }
 
         PreferredSeqOperation::ReplaySoftConfirmationsOnTopOfNodeState(
-            is_startup,
+            is_startup_or_resync,
             time_spent_fetching_batches,
         ) => {
             seq.replay_soft_confirmations_on_top_of_node_state(
                 info,
                 timer_start,
-                is_startup,
+                is_startup_or_resync,
                 time_spent_fetching_batches,
             )
             .await?;

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -746,13 +746,13 @@ where
         }
 
         PreferredSeqOperation::ReplaySoftConfirmationsOnTopOfNodeState(
-            is_startup_or_resync,
+            should_clean_tx_cache,
             time_spent_fetching_batches,
         ) => {
             seq.replay_soft_confirmations_on_top_of_node_state(
                 info,
                 timer_start,
-                is_startup_or_resync,
+                should_clean_tx_cache,
                 time_spent_fetching_batches,
             )
             .await?;

--- a/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
@@ -146,6 +146,17 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
         }
     }
 
+    pub async fn clean_and_overwrite_next_tx_number(&self, tx_number: u64) {
+        tracing::debug!(
+            "Cleaning and overwriting transaction cache up to {}",
+            tx_number
+        );
+        let mut transaction_cache = self.inner.write().await;
+        transaction_cache.next_tx_number = tx_number;
+        transaction_cache.cache.clear();
+        transaction_cache.tx_hash_index.clear();
+    }
+
     pub async fn list_events(
         &self,
         event_numbers: std::ops::Range<u64>,

--- a/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
@@ -146,17 +146,6 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
         }
     }
 
-    pub async fn clean_and_overwrite_next_tx_number(&self, tx_number: u64) {
-        tracing::debug!(
-            "Cleaning and overwriting transaction cache up to {}",
-            tx_number
-        );
-        let mut transaction_cache = self.inner.write().await;
-        transaction_cache.next_tx_number = tx_number;
-        transaction_cache.cache.clear();
-        transaction_cache.tx_hash_index.clear();
-    }
-
     pub async fn list_events(
         &self,
         event_numbers: std::ops::Range<u64>,

--- a/crates/full-node/sov-sequencer/src/preferred/update_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/update_state.rs
@@ -33,7 +33,7 @@ where
         &self,
         info: StateUpdateInfo<S::Storage>,
         timer_start: Instant,
-        is_startup: bool,
+        is_startup_or_resync: bool,
         mut time_spent_fetching_batches: std::time::Duration, // The time already spent fetching batches to replay
     ) -> anyhow::Result<()> {
         // On shutdown exit early. This prevents duplicate subscriptions to the DB events channel, which would cause spurious warnings.
@@ -53,7 +53,7 @@ where
 
         // During startup, we need to repopulate the transaction cache with any transactions from the soft-confirmed batches
         // Outside of this edge case, we don't want replay to affect the transaction cache, so we don't pass a writer.
-        let startup_transaction_cache_writer = if is_startup {
+        let startup_transaction_cache_writer = if is_startup_or_resync {
             Some(self.transaction_cache.write_handle())
         } else {
             None
@@ -74,6 +74,12 @@ where
 
         let node_state_root = tracing::trace_span!("root_hash")
             .in_scope(|| info.storage.get_root_hash(info.slot_number))?;
+
+        if is_startup_or_resync {
+            self.transaction_cache
+                .clean_and_overwrite_next_tx_number(info.next_tx_number)
+                .await;
+        }
 
         // Repeatedly fetch all completed batches from the database that haven't yet been played on this sequencer and replay them
         let (in_progress_batch, mut db_event_subscription) = loop {

--- a/crates/full-node/sov-sequencer/src/preferred/update_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/update_state.rs
@@ -33,7 +33,7 @@ where
         &self,
         info: StateUpdateInfo<S::Storage>,
         timer_start: Instant,
-        is_startup_or_resync: bool,
+        should_clean_tx_cache: bool,
         mut time_spent_fetching_batches: std::time::Duration, // The time already spent fetching batches to replay
     ) -> anyhow::Result<()> {
         // On shutdown exit early. This prevents duplicate subscriptions to the DB events channel, which would cause spurious warnings.
@@ -51,9 +51,7 @@ where
         // Total time to update the state for `replay_soft_confirmations_on_top_of_node_stat`e, including time spent in the `Message` channel.
         let mut total_message_processing_duration = std::time::Duration::ZERO;
 
-        // During startup, we need to repopulate the transaction cache with any transactions from the soft-confirmed batches
-        // Outside of this edge case, we don't want replay to affect the transaction cache, so we don't pass a writer.
-        let startup_transaction_cache_writer = if is_startup_or_resync {
+        let startup_transaction_cache_writer = if should_clean_tx_cache {
             let tx_cache_writer = self.transaction_cache.write_handle();
             tx_cache_writer
                 .clean_and_overwrite_next_tx_number(info.next_tx_number)

--- a/crates/full-node/sov-sequencer/src/preferred/update_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/update_state.rs
@@ -54,7 +54,11 @@ where
         // During startup, we need to repopulate the transaction cache with any transactions from the soft-confirmed batches
         // Outside of this edge case, we don't want replay to affect the transaction cache, so we don't pass a writer.
         let startup_transaction_cache_writer = if is_startup_or_resync {
-            Some(self.transaction_cache.write_handle())
+            let tx_cache_writer = self.transaction_cache.write_handle();
+            tx_cache_writer
+                .clean_and_overwrite_next_tx_number(info.next_tx_number)
+                .await;
+            Some(tx_cache_writer)
         } else {
             None
         };
@@ -74,12 +78,6 @@ where
 
         let node_state_root = tracing::trace_span!("root_hash")
             .in_scope(|| info.storage.get_root_hash(info.slot_number))?;
-
-        if is_startup_or_resync {
-            self.transaction_cache
-                .clean_and_overwrite_next_tx_number(info.next_tx_number)
-                .await;
-        }
 
         // Repeatedly fetch all completed batches from the database that haven't yet been played on this sequencer and replay them
         let (in_progress_batch, mut db_event_subscription) = loop {

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1897,6 +1897,73 @@ async fn events_are_returned_in_tx_response() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_no_crashes_on_resync_with_transactions() {
+    let (test_rollup, admin) = create_test_rollup(
+        0,
+        TEST_MAX_BATCH_SIZE,
+        TEST_BLOB_PROCESSING_TIMEOUT,
+        MAX_BATCH_EXECUTION_TIME_MILLIS,
+    )
+    .await;
+
+    let Some(test_rollup) = test_rollup else {
+        return;
+    };
+
+    let (test_rollup, state) = setup_test_rollup_with_initial_state(test_rollup, &admin).await;
+
+    let actions = vec![
+        TestingAction::AcceptTx,
+        TestingAction::AcceptTx,
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+    ];
+    let (test_rollup, state) =
+        run_actions_against_test_rollup(actions, test_rollup, &admin.clone(), state).await;
+
+    let actions = vec![
+        TestingAction::AcceptTx,
+        TestingAction::AcceptTx,
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+    ]
+    .into_iter()
+    .cycle()
+    .take(160)
+    .collect(); // repeat for 40 blocks
+    let (test_rollup, state) =
+        run_actions_against_test_rollup(actions, test_rollup, &admin.clone(), state).await;
+
+    let builder = test_rollup.shutdown().await.unwrap();
+
+    let rollup_storage_path = builder.storage_path();
+    // Next, delete everything except the preferred sequencer DB. Resync again to verify that this
+    // doesn't interfere
+    for path in ["state", "accessory", "ledger", "blob_sender"] {
+        std::fs::remove_dir_all(rollup_storage_path.path().join(path)).unwrap();
+    }
+
+    let test_rollup = builder.start().await.unwrap();
+
+    // Let it resync
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Verify accepting actions works
+    let actions = vec![
+        TestingAction::AcceptTx,
+        TestingAction::AcceptTx,
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+        TestingAction::QuerySetValue,
+    ];
+
+    let (test_rollup, _state) =
+        run_actions_against_test_rollup(actions, test_rollup, &admin.clone(), state).await;
+
+    test_rollup.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn delayed_tx_is_processed_after_delay() {
     let (test_rollup, admin) = create_test_rollup(
         0,

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -324,6 +324,11 @@ impl<R: FullNodeBlueprint<Native>, StoragePath: AsPath> RollupBuilder<R, Storage
                 .expect("storage folder should exist by this time");
         self
     }
+
+    /// A reference to the storage directory the rollup will run in
+    pub fn storage_path(&self) -> StoragePath {
+        self.config.storage.clone()
+    }
 }
 
 impl<R, StoragePath> RollupBuilder<R, StoragePath>


### PR DESCRIPTION
# Description

This is the first fix extracted from: 
https://github.com/Sovereign-Labs/sovereign-sdk/pull/1447

```
    Unrelated to replication: there was an edge case involving the transaction cache. During resync, inner.process_wait_for_node_resync() flushes the tx cache for every update_state. 
    Once the sequencer is considered resynced, say at update state for slot n, the tx cache will have next_tx_number from slot n. 
    When the next StateUpdateInfo for slot n+1 comes in and goes into the replay_batches branch, 
    the sequencer starts replaying pending batches starting with n+2. 
    This means that transactions from slot n+1 will not have been added to the tx cache - and it will error on when sanity checking for consecutive tx numbers.
    This has been fixed by having ReplaySoftConfirmationsOnTopOfNodeState contain is_startup_or_resync rather than just is_startup, i.e. 
    the first update_state after a successful resync will still have this as true (and then will set inner.is_ready = Ok(()) so will be false henceforth). 
    This is then special cased to flush the tx cache one again.
```

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
