### PR TITLE
`Sequencer`: Backfill runs together with `processed_events` in `replica_sync_task`

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -101,7 +101,6 @@ pub trait PreferredSequencerDbBackend: Send + Sync + 'static {
 pub struct DbSnapshotData {
     pub completed_blobs: Vec<PreferredSequencerReadBlob>,
     pub in_progress_batch: Option<InProgressBatch>,
-    pub latest_event_id: Option<u64>,
 }
 
 /// See [`PreferredSequencerReadBlob::Batch`].
@@ -397,11 +396,10 @@ where
         backend: Box<dyn PreferredSequencerDbBackend>,
         shutdown_sender: watch::Sender<()>,
         is_replica: bool,
-    ) -> anyhow::Result<(Self, Option<u64>, SequenceNumber, PreferredSequencerCache)> {
+    ) -> anyhow::Result<(Self, SequenceNumber, PreferredSequencerCache)> {
         let DbSnapshotData {
             completed_blobs,
             in_progress_batch,
-            latest_event_id,
         } = backend.current_data().await?;
         let completed_blobs = VecDeque::from(completed_blobs);
 
@@ -422,7 +420,6 @@ where
                 shutdown_sender: shutdown_sender.clone(),
                 phantom_runtime: PhantomData,
             },
-            latest_event_id,
             sequence_number_of_next_blob,
             PreferredSequencerCache::new(completed_blobs, in_progress_batch, shutdown_sender),
         ))

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -173,12 +173,6 @@ impl PostgresBackend {
     async fn current_data_transaction(&self) -> anyhow::Result<DbSnapshotData> {
         let mut tx = self.pool.begin().await?;
 
-        let latest_event_id: Option<u64> =
-            sqlx::query_scalar::<_, Option<i64>>("SELECT MAX(event_id) FROM events")
-                .fetch_one(&mut *tx)
-                .await?
-                .map(|id| id as u64);
-
         let completed_blobs_metadata: Vec<(i64, Vec<u8>)> =
             sqlx::query_as::<Postgres, _>(
                 "SELECT sequence_number, data FROM events WHERE event_type = 'batch_end' ORDER BY sequence_number",
@@ -206,7 +200,6 @@ impl PostgresBackend {
         Ok(DbSnapshotData {
             completed_blobs,
             in_progress_batch,
-            latest_event_id,
         })
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
@@ -154,7 +154,6 @@ impl PreferredSequencerDbBackend for RocksDbBackend {
         Ok(DbSnapshotData {
             completed_blobs,
             in_progress_batch,
-            latest_event_id: None,
         })
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -83,6 +83,10 @@ where
     metrics: Vec<PreferredSequencerChannelMetrics>,
     // Shared between sequencer and Inner.
     tx_queue_id: Arc<AtomicU64>,
+    /// Channel that sends a notification every time the executor is replaced after batch replay
+
+    /// finishes (at the end of update_state).
+    replay_notifier: watch::Sender<Option<SequenceNumber>>,
     stop_at_rollup_height: Option<RollupHeight>,
 }
 
@@ -300,7 +304,7 @@ where
                     target_visible_slot_number = %visible_slot_number_after_increase,
                     "Cannot calculate visible slots to advance for replica: target is not greater than current"
                 );
-                anyhow!("Invalid visible slot number progression for replica".to_string())
+                anyhow!(format!("Invalid visible slot number progression for replica: target is not greater than current. visible_slot_number_after_increase: {visible_slot_number_after_increase}, current_visible_slot_number: {current_visible_slot_number}"))
             })?;
 
         assert_eq!(
@@ -777,6 +781,7 @@ pub(crate) fn create<S, Rt>(
     executor_events_sender: ExecutorEventsSender<S, Rt>,
     sequence_number_of_next_blob: SequenceNumber,
     in_flight_blobs: Arc<AtomicUsize>,
+    replay_notifier: watch::Sender<Option<SequenceNumber>>,
     stop_at_rollup_height: Option<RollupHeight>,
 ) -> (
     SynchronizedSequencerState<S, Rt>,
@@ -809,6 +814,7 @@ where
         has_finished_startup: false,
         metrics: Vec::with_capacity(128),
         is_ready,
+        replay_notifier,
         stop_at_rollup_height,
     };
 
@@ -1590,6 +1596,11 @@ where
         inner.executor.replace_state(*executor).await;
         inner.is_ready = Ok(());
         inner.has_finished_startup = true;
+        let last_replayed_sequence_number = inner.sequence_number_of_next_blob.checked_sub(1);
+        inner
+            .replay_notifier
+            .send_replace(last_replayed_sequence_number);
+
         inner.latest_info = info;
         let checkpoint = inner
             .executor

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -311,14 +311,7 @@ where
         // state, then yield when it switches to processing postgres events live.
         // This is necessary to prevent conflicts with the update_state task.
         if config.sequencer_kind_config.is_replica {
-            handles.push(
-                spawn_replica_sync_task(
-                    seq.clone(),
-                    shutdown_receiver.clone(),
-                    latest_state_update.clone(),
-                )
-                .await,
-            );
+            handles.push(spawn_replica_sync_task(seq.clone(), shutdown_receiver.clone()).await);
         }
         handles.push(tokio::spawn({
             update_state_task(

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -157,6 +157,7 @@ where
             "Attempting to use preferred sequencer with an incompatible rollup. Set your sequencer config to `standard` in your rollup's config.toml file or change your kernel to be compatible with soft confirmations."
         );
 
+        let (replica_sync_notifer, replica_sync_receiver) = watch::channel(None);
         let (checkpoint_sender, checkpoint_receiver) = watch::channel(StateCheckpoint::new(
             latest_state_update.storage.clone(),
             &runtime.kernel(),
@@ -269,6 +270,7 @@ where
             executor_events_sender,
             next_sequence_number,
             in_flight_blobs,
+            replica_sync_notifer,
             stop_at_rollup_height,
         );
 
@@ -311,7 +313,14 @@ where
         // state, then yield when it switches to processing postgres events live.
         // This is necessary to prevent conflicts with the update_state task.
         if config.sequencer_kind_config.is_replica {
-            handles.push(spawn_replica_sync_task(seq.clone(), shutdown_receiver.clone()).await);
+            handles.push(
+                spawn_replica_sync_task(
+                    seq.clone(),
+                    shutdown_receiver.clone(),
+                    replica_sync_receiver,
+                )
+                .await,
+            );
         }
         handles.push(tokio::spawn({
             update_state_task(

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -181,13 +181,12 @@ where
             } else {
                 Box::new(RocksDbBackend::new(storage_path).await?)
             };
-        let (db, latest_db_event_id, next_sequence_number, db_cache) =
-            PreferredSequencerDb::<S, Rt>::new(
-                db_backend,
-                shutdown_sender.clone(),
-                config.sequencer_kind_config.is_replica,
-            )
-            .await?;
+        let (db, next_sequence_number, db_cache) = PreferredSequencerDb::<S, Rt>::new(
+            db_backend,
+            shutdown_sender.clone(),
+            config.sequencer_kind_config.is_replica,
+        )
+        .await?;
 
         let mut handles = vec![];
 
@@ -317,7 +316,6 @@ where
                     seq.clone(),
                     shutdown_receiver.clone(),
                     latest_state_update.clone(),
-                    latest_db_event_id,
                 )
                 .await,
             );

--- a/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
@@ -119,21 +119,6 @@ where
     Rt: Runtime<S>,
     Da: DaService<Spec = S::Da>,
 {
-    if let Err(e) = sequencer
-        .replay_soft_confirmations_on_top_of_node_state(
-            latest_state_update,
-            std::time::Instant::now(),
-            true,
-            std::time::Duration::from_secs(0),
-        )
-        .await
-    {
-        error!(
-            "Replica failed to replay existing soft confirmation on startup: {e:?}. Shutting down."
-        );
-        exit_rollup(&sequencer.shutdown_sender).await;
-        unreachable!()
-    }
     tokio::spawn(replica_sync_task_inner(sequencer, shutdown_receiver))
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
@@ -8,7 +8,7 @@ use anyhow::anyhow;
 use futures::stream::FuturesOrdered;
 use futures::{Future, StreamExt};
 use serde::{Deserialize, Serialize};
-use sov_modules_api::{FullyBakedTx, Runtime, Spec, StateUpdateInfo, TxHash, VisibleSlotNumber};
+use sov_modules_api::{FullyBakedTx, Runtime, Spec, TxHash, VisibleSlotNumber};
 use sov_rollup_interface::node::da::DaService;
 use sqlx::postgres::{PgListener, PgPoolOptions};
 use sqlx::{PgPool, Row};
@@ -112,7 +112,6 @@ enum CompletedEvent {
 pub async fn spawn_replica_sync_task<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     shutdown_receiver: watch::Receiver<()>,
-    latest_state_update: StateUpdateInfo<S::Storage>,
 ) -> JoinHandle<()>
 where
     S: Spec,

--- a/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
@@ -21,8 +21,9 @@ use crate::preferred::{exit_rollup, DbEvent, PreferredSequencer};
 use crate::ProofBlobSender;
 
 /// Event type enum for type-safe parsing
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, sqlx::Type)]
 #[serde(rename_all = "snake_case")]
+#[sqlx(type_name = "event_type", rename_all = "snake_case")]
 enum EventType {
     Transaction,
     BatchStart,
@@ -100,7 +101,10 @@ type PendingEventFuture = Pin<Box<dyn Future<Output = anyhow::Result<CompletedEv
 #[derive(Debug)]
 enum CompletedEvent {
     Event(DbEvent),
-    Backfill,
+    Backfill {
+        current_latest: Option<u64>,
+        target: u64,
+    },
 }
 
 /// Background task for replica sequencers to sync state from the master sequencer's database.
@@ -109,7 +113,6 @@ pub async fn spawn_replica_sync_task<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     shutdown_receiver: watch::Receiver<()>,
     latest_state_update: StateUpdateInfo<S::Storage>,
-    latest_loaded_event_id: Option<u64>,
 ) -> JoinHandle<()>
 where
     S: Spec,
@@ -131,17 +134,12 @@ where
         exit_rollup(&sequencer.shutdown_sender).await;
         unreachable!()
     }
-    tokio::spawn(replica_sync_task_inner(
-        sequencer,
-        shutdown_receiver,
-        latest_loaded_event_id,
-    ))
+    tokio::spawn(replica_sync_task_inner(sequencer, shutdown_receiver))
 }
 
 async fn replica_sync_task_inner<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     mut shutdown_receiver: watch::Receiver<()>,
-    latest_loaded_event_id: Option<u64>,
 ) where
     S: Spec,
     Rt: Runtime<S>,
@@ -179,8 +177,6 @@ async fn replica_sync_task_inner<S, Rt, Da>(
         }
     };
 
-    let mut latest_received_event_id = latest_loaded_event_id;
-
     // Create a dedicated listener for PostgreSQL LISTEN/NOTIFY
     let mut listener = match PgListener::connect(connection_string).await {
         Ok(listener) => listener,
@@ -204,7 +200,6 @@ async fn replica_sync_task_inner<S, Rt, Da>(
         sequencer.clone(),
         &mut listener,
         &query_pool,
-        &mut latest_received_event_id,
         &mut shutdown_receiver,
     )
     .await
@@ -219,7 +214,6 @@ async fn concurrent_event_processing_loop<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     listener: &mut PgListener,
     query_pool: &PgPool,
-    latest_received_event_id: &mut Option<u64>,
     shutdown_receiver: &mut watch::Receiver<()>,
 ) -> anyhow::Result<()>
 where
@@ -239,6 +233,7 @@ where
     const MAX_CONCURRENT: usize = 1000;
     let mut pending_events: FuturesOrdered<PendingEventFuture> = FuturesOrdered::new();
 
+    let mut latest_received_event_id: Option<u64> = None;
     loop {
         tokio::select! {
             // Only poll listener if we have capacity
@@ -252,17 +247,21 @@ where
                             .map_err(|e| anyhow!("Failed to parse CSV notification payload: {e}"))?;
 
                         // Check for gaps and add backfill if needed
-                        if detect_gap(*latest_received_event_id, parsed_notification.event_id).is_some() {
-                            let backfill_future = create_backfill_future(
-                                sequencer.clone(),
-                                query_pool,
-                                *latest_received_event_id,
-                                parsed_notification.event_id,
-                            );
+                        if detect_gap(latest_received_event_id, parsed_notification.event_id).is_some() {
+
+                            let backfill_future: PendingEventFuture = Box::pin(async move {
+                                Ok(CompletedEvent::Backfill {
+                                    current_latest: latest_received_event_id,
+                                    target: parsed_notification.event_id,
+                                })
+                            });
+
                             pending_events.push_back(backfill_future);
+                        } else if latest_received_event_id.map(|latest_id| parsed_notification.event_id <= latest_id).unwrap_or(false) {
+                            continue;
                         }
 
-                        *latest_received_event_id = Some(parsed_notification.event_id);
+                        latest_received_event_id = Some(parsed_notification.event_id);
 
                         // Create future for current notification
                         let event_future = create_event_future(parsed_notification, query_pool);
@@ -282,8 +281,11 @@ where
                     CompletedEvent::Event(db_event) => {
                         process_db_event(sequencer.clone(), db_event, query_pool).await?;
                     }
-                    CompletedEvent::Backfill => {
-                        trace!("Backfill completed up to event_id");
+                    CompletedEvent::Backfill {
+                        current_latest,
+                        target,
+                    }  => {
+                        backfill_to_event_id(sequencer.clone(), query_pool, current_latest, target).await?;
                     }
                 }
             },
@@ -358,27 +360,6 @@ fn create_event_future(
             })
         }
     }
-}
-
-/// Creates a future for backfilling a gap in events using existing backfill logic
-fn create_backfill_future<S, Rt, Da>(
-    sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
-    query_pool: &PgPool,
-    current_latest: Option<u64>,
-    target_event_id: u64,
-) -> PendingEventFuture
-where
-    S: Spec,
-    Rt: Runtime<S>,
-    Da: DaService<Spec = S::Da>,
-{
-    let sequencer = sequencer.clone();
-    let pool = query_pool.clone();
-
-    Box::pin(async move {
-        backfill_to_event_id(sequencer.clone(), &pool, current_latest, target_event_id).await?;
-        Ok(CompletedEvent::Backfill)
-    })
 }
 
 /// Processes a completed DB event
@@ -507,7 +488,7 @@ async fn backfill_to_event_id<S: Spec, Rt: Runtime<S>, Da: DaService<Spec = S::D
 
         // Query and process events for this page
         let events = sqlx::query(
-            "SELECT sequence_number, index_in_batch, event_type, hash, data FROM events 
+            "SELECT event_id, sequence_number, index_in_batch, event_type, hash, data FROM events 
              WHERE event_id >= $1 AND event_id < $2
              ORDER BY event_id ASC",
         )
@@ -517,12 +498,8 @@ async fn backfill_to_event_id<S: Spec, Rt: Runtime<S>, Da: DaService<Spec = S::D
         .await?;
 
         for row in events {
-            let event_type_str: String = row.get("event_type");
+            let event_type: EventType = row.get("event_type");
             let sequence_number = row.get::<i64, _>("sequence_number") as u64;
-
-            let event_type: EventType = event_type_str
-                .parse()
-                .map_err(|e| anyhow::anyhow!("Invalid event type '{}': {}", event_type_str, e))?;
 
             match event_type {
                 EventType::Transaction => {

--- a/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica_sync_task.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::preferred::SequenceNumber;
 use anyhow::anyhow;
 use futures::stream::FuturesOrdered;
 use futures::{Future, StreamExt};
@@ -112,18 +113,24 @@ enum CompletedEvent {
 pub async fn spawn_replica_sync_task<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     shutdown_receiver: watch::Receiver<()>,
+    replay_receiver: watch::Receiver<Option<SequenceNumber>>,
 ) -> JoinHandle<()>
 where
     S: Spec,
     Rt: Runtime<S>,
     Da: DaService<Spec = S::Da>,
 {
-    tokio::spawn(replica_sync_task_inner(sequencer, shutdown_receiver))
+    tokio::spawn(replica_sync_task_inner(
+        sequencer,
+        shutdown_receiver,
+        replay_receiver,
+    ))
 }
 
 async fn replica_sync_task_inner<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     mut shutdown_receiver: watch::Receiver<()>,
+    mut replay_receiver: watch::Receiver<Option<SequenceNumber>>,
 ) where
     S: Spec,
     Rt: Runtime<S>,
@@ -185,6 +192,7 @@ async fn replica_sync_task_inner<S, Rt, Da>(
         &mut listener,
         &query_pool,
         &mut shutdown_receiver,
+        &mut replay_receiver,
     )
     .await
     {
@@ -199,6 +207,7 @@ async fn concurrent_event_processing_loop<S, Rt, Da>(
     listener: &mut PgListener,
     query_pool: &PgPool,
     shutdown_receiver: &mut watch::Receiver<()>,
+    replay_receiver: &mut watch::Receiver<Option<SequenceNumber>>,
 ) -> anyhow::Result<()>
 where
     S: Spec,
@@ -218,6 +227,7 @@ where
     let mut pending_events: FuturesOrdered<PendingEventFuture> = FuturesOrdered::new();
 
     let mut latest_received_event_id: Option<u64> = None;
+    let mut last_fully_processed_batch: Option<SequenceNumber> = None;
     loop {
         tokio::select! {
             // Only poll listener if we have capacity
@@ -229,6 +239,34 @@ where
                         let payload = notification.payload();
                         let parsed_notification = EventsNotificationPayload::parse_csv(payload)
                             .map_err(|e| anyhow!("Failed to parse CSV notification payload: {e}"))?;
+
+
+                            let replayed_sequence_number = *replay_receiver.borrow();
+                            match replayed_sequence_number {
+                                // Node is not synced yet - ignore all incoming events
+                                None => {
+                                    trace!("Replica receiving event but node is not synced yet, ignoring. Event: {payload}");
+                                    continue;
+                                }
+
+                                // We are indeed synced. Is the last replayed batch ahead of our event
+                                // stream?
+                                Some(last_replayed_sequence_number) => {
+                                    if last_fully_processed_batch.is_none_or(|seq| seq < last_replayed_sequence_number) {
+                                        // Query the batch_close event with this sequence number to find the event_id
+                                        // Set our latest_received_event_id to that event's id so we continue from there
+                                        let new_latest_event_id = query_event_id_for_batch_close(query_pool, last_replayed_sequence_number).await?;
+                                        if latest_received_event_id.is_some_and(|latest| latest >= new_latest_event_id) {
+                                            // Return an error rather than using assert! - this way the
+                                            // sequencer will call exit_rollup() cleanly
+                                            anyhow::bail!("Sanity check failed - update_state fast-forwarded our sequence number, but this would not have fast-forwarded our event ID");
+                                        }
+                                        latest_received_event_id = Some(new_latest_event_id);
+                                        last_fully_processed_batch = Some(last_replayed_sequence_number);
+                                        debug!("Replica event processing fast-forwarding to sequence_number {}, event_id {}, due to update_state running ahead", last_replayed_sequence_number, new_latest_event_id);
+                                    }
+                                }
+                            }
 
                         // Check for gaps and add backfill if needed
                         if detect_gap(latest_received_event_id, parsed_notification.event_id).is_some() {
@@ -263,7 +301,7 @@ where
             Some(completed_result) = pending_events.next() => {
                 match completed_result? {
                     CompletedEvent::Event(db_event) => {
-                        process_db_event(sequencer.clone(), db_event, query_pool).await?;
+                        process_db_event(sequencer.clone(), db_event, query_pool, &mut last_fully_processed_batch).await?;
                     }
                     CompletedEvent::Backfill {
                         current_latest,
@@ -351,6 +389,7 @@ async fn process_db_event<S, Rt, Da>(
     sequencer: Arc<PreferredSequencer<S, Rt, Da>>,
     db_event: DbEvent,
     query_pool: &PgPool,
+    last_fully_processed_batch: &mut Option<u64>,
 ) -> anyhow::Result<()>
 where
     S: Spec,
@@ -366,6 +405,7 @@ where
             Ok(())
         }
         DbEvent::BatchClosed(_) => {
+            *last_fully_processed_batch = Some(last_fully_processed_batch.map_or(0, |n| n + 1));
             sequencer
                 .synchronized_state_updator
                 .close_current_batch_msg("replica_sync_task:close_current_batch")
@@ -609,4 +649,21 @@ async fn query_proof_blob_from_db(
             sequence_number
         )),
     }
+}
+
+async fn query_event_id_for_batch_close(
+    query_pool: &PgPool,
+
+    sequence_number: u64,
+) -> anyhow::Result<u64> {
+    let row = sqlx::query(
+        "SELECT event_id FROM events WHERE sequence_number = $1 AND event_type = 'batch_end'",
+    )
+    .bind(i64::try_from(sequence_number)?)
+    .fetch_one(query_pool)
+    .await?;
+
+    let event_id: i64 = row.get("event_id");
+
+    Ok(event_id as u64)
 }

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
@@ -98,7 +98,7 @@ async fn test_actions_against_replicas(
         run_actions_against_test_rollup(actions, master, &admin.clone(), state).await;
 
     // Ensure replicas have processed the database changes
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    tokio::time::sleep(Duration::from_millis(3000)).await;
 
     // Verify state synchronization across all replicas
     for replica_opt in &mut replicas {
@@ -136,6 +136,9 @@ async fn restart_replica(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn seq_with_replicas() {
+    sov_test_utils::logging::initialize_or_change_logging_with_filter(
+        "debug,sov_metrics=error,sov_sequencer::preferred=debug",
+    );
     let (test_rollups, _tempdir, admin) = create_test_rollups(4).await;
     let Some(test_rollups) = test_rollups else {
         return;

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
@@ -2,13 +2,23 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use sov_mock_da::BlockProducingConfig;
+use sov_modules_api::Amount;
 use sov_modules_api::Runtime;
+use sov_modules_api::SafeVec;
 use sov_modules_stf_blueprint::GenesisParams;
+use sov_paymaster::PayeePolicy;
+use sov_paymaster::PayerGenesisConfig;
 use sov_paymaster::PaymasterConfig;
+use sov_paymaster::PaymasterPolicyInitializer;
+use sov_sequencer::SequencerKindConfig;
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
+use sov_test_utils::test_rollup::GenesisSource;
+use sov_test_utils::test_rollup::RollupBuilder;
 use sov_test_utils::test_rollup::TestRollup;
+use sov_test_utils::RtAgnosticBlueprint;
 use sov_test_utils::{
-    TestSpec, TestUser, TEST_BLOB_PROCESSING_TIMEOUT, TEST_FINALIZATION_BLOCKS, TEST_MAX_BATCH_SIZE,
+    TestSpec, TestUser, TEST_BLOB_PROCESSING_TIMEOUT, TEST_DEFAULT_USER_BALANCE,
+    TEST_FINALIZATION_BLOCKS, TEST_MAX_BATCH_SIZE,
 };
 use sov_value_setter::ValueSetterConfig;
 
@@ -185,5 +195,174 @@ async fn seq_with_replicas() {
         replica.unwrap().shutdown().await.unwrap();
     }
     // Shut down master last, otherwise the postgres subscription will drop and replicas will error
+    master.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_replica_resynced_from_scratch() {
+    // Ugly: currently copy-pastes code from create_test_rollups and new_test_rollup in order
+    // to access the launch_n_replicas interface. Should probably be refactored
+    let mut genesis_config =
+        HighLevelOptimisticGenesisConfig::generate().add_accounts_with_default_balance(1);
+    let admin = genesis_config.additional_accounts()[0].clone();
+    let sequencer = genesis_config.initial_sequencer.clone();
+
+    let paymaster = TestUser::generate(
+        TEST_DEFAULT_USER_BALANCE
+            .checked_mul(Amount::new(10))
+            .unwrap(),
+    );
+    genesis_config
+        .additional_accounts_mut()
+        .push(paymaster.clone());
+
+    let users: Vec<TestUser<TestSpec>> = vec![TestUser::generate_with_default_balance(); 20];
+    genesis_config.additional_accounts_mut().extend(users);
+
+    let paymaster_config = PaymasterConfig {
+        payers: [PayerGenesisConfig {
+            payer_address: paymaster.address(),
+            policy: PaymasterPolicyInitializer {
+                default_payee_policy: PayeePolicy::Allow {
+                    max_fee: None,
+                    gas_limit: None,
+                    max_gas_price: None,
+                    transaction_limit: None,
+                },
+                payees: SafeVec::new(),
+                authorized_sequencers: sov_paymaster::AuthorizedSequencers::All,
+                authorized_updaters: [paymaster.address()].as_ref().try_into().unwrap(),
+            },
+            sequencers_to_register: [sequencer.da_address].as_ref().try_into().unwrap(),
+        }]
+        .as_ref()
+        .try_into()
+        .unwrap(),
+    };
+
+    let rt_genesis_config =
+        <TestRuntime<TestSpec> as Runtime<TestSpec>>::GenesisConfig::from_minimal_config(
+            genesis_config.into(),
+            ValueSetterConfig {
+                admin: admin.address(),
+            },
+            (),
+            paymaster_config,
+            (),
+        );
+
+    let genesis_params = GenesisParams {
+        runtime: rt_genesis_config.clone(),
+    };
+
+    let dir = tempdir_inside_codebase_dir();
+
+    let builder = RollupBuilder::<RtAgnosticBlueprint<TestSpec, TestRuntime<TestSpec>>>::new(
+        GenesisSource::CustomParams(genesis_params.clone()),
+        BlockProducingConfig::Manual,
+        0,
+    )
+    .set_config(|c| {
+        c.rollup_prover_config = None;
+        c.automatic_batch_production = true;
+        c.storage = dir;
+        c.max_batch_size_bytes = TEST_MAX_BATCH_SIZE;
+        c.blob_processing_timeout_secs = TEST_BLOB_PROCESSING_TIMEOUT;
+        c.stop_at_rollup_height = None;
+        if let SequencerKindConfig::Preferred(preferred_sequencer_config) = &mut c.sequencer_config
+        {
+            preferred_sequencer_config.batch_execution_time_limit_millis =
+                MAX_BATCH_EXECUTION_TIME_MILLIS;
+        }
+        c.max_concurrent_blobs = 16;
+    })
+    .set_da_config(|c| {
+        c.sender_address = genesis_params
+            .runtime
+            .sequencer_registry
+            .sequencer_config
+            .seq_da_address;
+    })
+    .with_preferred_seq_min_profit_per_tx(0)
+    .with_preferred_seq_recovery_strategy(sov_sequencer::preferred::RecoveryStrategy::TryToSave);
+
+    let builder = if num_cpus::get() != 96 {
+        builder.with_postgres_sequencer().await.unwrap()
+    } else {
+        tracing::warn!(
+            "Replica test cannot run, postgres is disabled due to detecting the dev server"
+        );
+        return;
+    };
+
+    let shared_da = builder.shared_da_for_replicas().await.unwrap();
+
+    // sov_test_utils::initialize_logging();
+
+    // ACTUAL TEST BEGINS
+    let test_rollups = builder
+        .launch_n_replicas(1, shared_da.clone(), true)
+        .await
+        .unwrap();
+    let mut test_rollups = test_rollups.into_iter();
+
+    // Allow master to take over
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let mut master = test_rollups.next().unwrap();
+    let replicas = test_rollups.map(Some).collect();
+
+    let (master_with_state, state) = setup_test_rollup_with_initial_state(master, &admin).await;
+    master = master_with_state;
+
+    // Sanity check once
+    let actions = vec![
+        TestingAction::AcceptTx,
+        TestingAction::AcceptTx,
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+    ];
+    let (master, replicas, state) =
+        test_actions_against_replicas(&admin, (master, replicas, state), actions).await;
+
+    // Run for 40 more blocks
+    let slots = vec![
+        TestingAction::AcceptTx,
+        TestingAction::AcceptTx,
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+    ]
+    .into_iter()
+    .cycle()
+    .take(160)
+    .collect();
+    let (master, mut replicas, state) =
+        test_actions_against_replicas(&admin, (master, replicas, state), slots).await;
+
+    // Launch brand new replica
+    let extra_replica = builder
+        .launch_n_replicas(1, shared_da, false)
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+    replicas.push(Some(extra_replica));
+    // Let it sync
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Verify rollup can still accept transactions, and state is consistent across replicas
+    let actions = vec![
+        TestingAction::AcceptTx,
+        TestingAction::AcceptTx,
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+    ];
+    let (master, replicas, _state) =
+        test_actions_against_replicas(&admin, (master, replicas, state), actions).await;
+
+    for replica in replicas {
+        replica.unwrap().shutdown().await.unwrap();
+    }
     master.shutdown().await.unwrap();
 }

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_replicas.rs
@@ -156,6 +156,14 @@ async fn seq_with_replicas() {
     let actions = vec![
         TestingAction::NewDaSlot,
         TestingAction::Sleep { duration_ms: 100 },
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
+        TestingAction::NewDaSlot,
+        TestingAction::Sleep { duration_ms: 100 },
     ];
     let (master, replicas, mut state) =
         test_actions_against_replicas(&admin, (master, replicas, state), actions).await;

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -441,6 +441,7 @@ where
         Ok(TestRollup {
             builder: self,
             rollup_task,
+            api_client: sov_api_spec::client::Client::new(&client.base_url),
             http_addr: rest_addr,
             rollup_config,
             client,
@@ -590,6 +591,38 @@ where
         self,
         num_replicas: u64,
     ) -> anyhow::Result<Vec<TestRollup<R, Arc<tempfile::TempDir>>>> {
+        let da = self.shared_da_for_replicas().await?;
+        self.launch_n_replicas(num_replicas, da, true).await
+    }
+
+    fn shared_da_connection_string(&self) -> String {
+        let base_path = self.config.storage.as_path();
+
+        format!(
+            "sqlite://{}?mode=rwc",
+            base_path.join("shared_mock_da.sqlite").to_string_lossy()
+        )
+    }
+
+    /// Create a mockda suitable for passing to launch_n_replicas().
+    /// Should be created once, then stored and cloned.
+    pub async fn shared_da_for_replicas(&self) -> anyhow::Result<Arc<RwLock<StorableMockDaLayer>>> {
+        Ok(Arc::new(RwLock::new(
+            StorableMockDaLayer::new_from_connection(
+                &self.shared_da_connection_string(),
+                self.da_config.finalization_blocks,
+            )
+            .await?,
+        )))
+    }
+
+    /// Create several replicas with the provided DA.
+    pub async fn launch_n_replicas(
+        &self,
+        num_replicas: u64,
+        shared_da: Arc<RwLock<StorableMockDaLayer>>,
+        with_master: bool,
+    ) -> anyhow::Result<Vec<TestRollup<R, Arc<tempfile::TempDir>>>> {
         if num_replicas == 0 {
             anyhow::bail!("num_replicas must be at least 1 (master + replicas)");
         }
@@ -614,17 +647,7 @@ where
         })?;
 
         // Create shared MockDA sqlite file in base directory
-        let shared_da_connection = format!(
-            "sqlite://{}?mode=rwc",
-            base_path.join("shared_mock_da.sqlite").to_string_lossy()
-        );
-        let da_layer = Arc::new(RwLock::new(
-            StorableMockDaLayer::new_from_connection(
-                &shared_da_connection,
-                self.da_config.finalization_blocks,
-            )
-            .await?,
-        ));
+        let shared_da_connection = self.shared_da_connection_string();
 
         let mut rollups = Vec::new();
 
@@ -638,7 +661,7 @@ where
                 genesis: self.genesis.clone(),
                 da_config: MockDaConfig {
                     connection_string: shared_da_connection.clone(),
-                    da_layer: Some(da_layer.clone()),
+                    da_layer: Some(shared_da.clone()),
                     ..self.da_config.clone()
                 },
                 config: RollupBuilderConfig {
@@ -650,7 +673,7 @@ where
             };
 
             // Set replica mode for non-master instances
-            if i > 0 {
+            if i > 0 || !with_master {
                 if let SequencerKindConfig::Preferred(ref mut preferred_config) =
                     instance_builder.config.sequencer_config
                 {
@@ -674,6 +697,8 @@ pub struct TestRollup<R: FullNodeBlueprint<Native>, StoragePath = Arc<tempfile::
     /// A wallet client that can be used to interact with the node and submit
     /// txs to the sequencer.
     pub client: NodeClient,
+    /// Auto-generated API client for the rollup.
+    pub api_client: sov_api_spec::client::Client,
     /// Address of the HTTP server.
     pub http_addr: SocketAddr,
     /// The rollup config used to run the rollup.
@@ -708,6 +733,11 @@ where
     R::Spec: Spec<Da = MockDaSpec>,
     StoragePath: AsPath,
 {
+    /// Helper to get api_client
+    pub fn api_client(&self) -> &sov_api_spec::client::Client {
+        &self.client.client
+    }
+
     /// Pauses batch production for the preferred sequencer.
     ///
     /// Transactions accepted by the preferred sequencer after this call (and
@@ -715,11 +745,6 @@ where
     /// same batch.
     pub async fn pause_preferred_batches(&self) {
         std::env::set_var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE", "1");
-    }
-
-    /// Helper to get api_client
-    pub fn api_client(&self) -> &sov_api_spec::client::Client {
-        &self.client.client
     }
 
     /// Resumes batch production after [`TestRollup::pause_preferred_batches`].


### PR DESCRIPTION
# Description

This is the first fix extracted from:
https://github.com/Sovereign-Labs/sovereign-sdk/pull/1447

```
Replication: backfill used to run concurrently to the event pre-fetching futures. 
This was incorrect: it should run in order with processed_events. create_backfill_future() 
has been removed, and the backfill future has been replaced with one that resolves immediately; 
the actual backfill call has been moved to the ordered event processing loop. 
(This is backported from the failover PR, but was necessary to allow replicas to resync.)
```

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
