### PR TITLE
Logging clean ups related to tx processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ total-clean:
     	echo "Running cargo clean in $$dir"; \
     	(cargo clean --manifest-path "$$dir/Cargo.toml"); \
     done;
-	rm -rf "examples/demo-rollup/tests/evm/uniswap/node_modules"
+	rm -rf "examples/demo-rollup/tests/evm/uniswap/node_modules";
+	rm -rf "soak_data/examples/demo-rollup/sov-soak-testing/soak_data"
 
 test:  ## Runs test suite using next test
 	@cargo nextest run --no-fail-fast --status-level skip --all-features

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
@@ -145,20 +145,24 @@ impl TestState {
         client: &sov_api_spec::Client,
         max_slots_to_wait: u64,
     ) -> anyhow::Result<Vec<(TxHash, TxStatus)>> {
+        let head_slot = client.get_latest_slot(None).await?;
         tracing::info!(
             txs_to_wait = self.txs_to_wait.len(),
+            head_slot_number = head_slot.number,
+            head_slot_hash = ?head_slot.hash,
             "Start gathering statuses"
         );
-        let head_slot = client.get_latest_slot(None).await?;
         let head_slot = head_slot.number;
+
         let wait_to = head_slot + config_deferred_slots_count() + 5;
         tracing::info!(current_head_slot = head_slot, wait_max_till_slot= %wait_to, "Start gathering all statuses");
         let mut last_tx_statuses: Vec<(HexHash, TxStatus)> =
             Vec::with_capacity(self.txs_to_wait.len());
 
         let mut slots = 0;
+        let mut last_inspected_slot_number = head_slot;
+        let mut empty_subs = 0;
         while !self.txs_to_wait.is_empty() {
-            slots += 1;
             if slots > max_slots_to_wait {
                 anyhow::bail!(
                     "Didn't receive status for all transactions in {} slots. Remaining txs: {:?}",
@@ -166,10 +170,26 @@ impl TestState {
                     self.txs_to_wait,
                 );
             }
-            let Some(next_slot) = self.slots_subscription.try_next().await? else {
-                continue;
+            if empty_subs >= 10 {
+                anyhow::bail!(
+                    "No data received via subscription in {} subscriptions",
+                    empty_subs
+                );
+            }
+            let next_slot = match self.slots_subscription.try_next().await? {
+                None => {
+                    tracing::warn!(%last_inspected_slot_number, "No slot received, problem with node");
+                    // Need to resubscribe from the last inspected slot,
+                    // but for now we just tolerate empty
+                    empty_subs += 1;
+                    continue;
+                }
+                Some(n) => n,
             };
-            tracing::info!(slot_number = next_slot.number, "Received slot");
+            empty_subs = 0;
+            slots += 1;
+            last_inspected_slot_number = next_slot.number;
+            tracing::info!(slot_number = next_slot.number, hash = ?next_slot.hash, "Received slot");
             if next_slot.number > wait_to {
                 break;
             }

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/common.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/common.rs
@@ -195,7 +195,7 @@ pub(crate) fn apply_batch_logs<'a, S: Spec>(
     for (i, tx_receipt) in batch_receipt.tx_receipts.iter().enumerate() {
         debug!(
             tx_idx = i,
-            tx_hash = hex::encode(tx_receipt.tx_hash),
+            tx_hash = %tx_receipt.tx_hash,
             receipt = ?tx_receipt.receipt,
             gas_used = %get_gas_used(tx_receipt),
             "Tx receipt"

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
@@ -329,7 +329,7 @@ where
     B: IncrementalBatch<S>,
 {
     let span = if let Some(id) = batch_with_id.id() {
-        tracing::info_span!("batch", batch_id = hex::encode(id)).entered()
+        tracing::info_span!("batch", batch_id = %HexHash::from(id)).entered()
     } else {
         tracing::info_span!("sequencer-batch").entered()
     };


### PR DESCRIPTION
# Description

as part of investigation `test_check_no_reorgs_longer` test, this PR have several changes:

* Replaces `hex::encode` with using display of `HexHash`, which is more consistent with the other usages, as it is 0x prefixed.
* Changes test part that gathers statuses. Now empty data from subscription is counted as slot. Instead it will tolerate up to 10 empty responses and fail, clearly indicating problem with WebSocket subcription

