### PR TITLE
Use `tokio::task::block_in_place` where LedgerDb lock is touched

### DIFF
--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -419,10 +419,10 @@ impl LedgerDb {
             current_item_numbers.batch_number += 1;
         }
 
-        for dicarded_blob_hash in data_to_commit.discarded_blobs.into_iter() {
+        for discarded_blob_hash in data_to_commit.discarded_blobs.into_iter() {
             self.put_discarded_blob(
                 StoredDiscardedBlob {
-                    hash: dicarded_blob_hash.0,
+                    hash: discarded_blob_hash.0,
                     slot_number,
                 },
                 &mut schema_batch,

--- a/crates/full-node/sov-db/src/ledger_db/rpc.rs
+++ b/crates/full-node/sov-db/src/ledger_db/rpc.rs
@@ -556,16 +556,16 @@ impl LedgerStateProvider for LedgerDb {
     type Error = anyhow::Error;
 
     async fn get_head_slot_number(&self) -> Result<SlotNumber, Self::Error> {
-        self.get_rpc_reader()
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader
             .get_head_slot_number()
             .await
             .map(Option::unwrap_or_default)
     }
 
     async fn get_latest_finalized_slot_number(&self) -> Result<SlotNumber, Self::Error> {
-        self.get_rpc_reader()
-            .get_latest_finalized_slot_number()
-            .await
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader.get_latest_finalized_slot_number().await
     }
 
     async fn get_slots<B, T, E>(
@@ -578,7 +578,8 @@ impl LedgerStateProvider for LedgerDb {
         T: TxReceiptContents,
         E: for<'a> TryFrom<(u64, &'a StoredEvent), Error = anyhow::Error> + Send + Sync,
     {
-        self.get_rpc_reader().get_slots(slot_ids, query_mode).await
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader.get_slots(slot_ids, query_mode).await
     }
 
     async fn get_batches<B, T, E>(
@@ -597,9 +598,8 @@ impl LedgerStateProvider for LedgerDb {
             batch_ids.len(),
             MAX_BATCHES_PER_REQUEST
         );
-        self.get_rpc_reader()
-            .get_batches(batch_ids, query_mode)
-            .await
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader.get_batches(batch_ids, query_mode).await
     }
 
     async fn get_transactions<T, E>(
@@ -617,9 +617,8 @@ impl LedgerStateProvider for LedgerDb {
             tx_ids.len(),
             MAX_TRANSACTIONS_PER_REQUEST
         );
-        self.get_rpc_reader()
-            .get_transactions(tx_ids, query_mode)
-            .await
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader.get_transactions(tx_ids, query_mode).await
     }
 
     async fn get_events<E>(
@@ -635,7 +634,8 @@ impl LedgerStateProvider for LedgerDb {
             event_ids.len(),
             MAX_EVENTS_PER_REQUEST
         );
-        self.get_rpc_reader().get_events(event_ids).await
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader.get_events(event_ids).await
     }
 
     async fn get_filtered_slot_events<B, T, E>(
@@ -734,7 +734,8 @@ impl LedgerStateProvider for LedgerDb {
     }
 
     async fn get_tx_numbers_by_hash(&self, hash: &[u8; 32]) -> Result<Vec<u64>, Self::Error> {
-        self.get_rpc_reader().get_tx_numbers_by_hash(hash).await
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader.get_tx_numbers_by_hash(hash).await
     }
 
     // Get X by number
@@ -778,23 +779,24 @@ impl LedgerStateProvider for LedgerDb {
     }
 
     async fn get_latest_event_number(&self) -> Result<Option<u64>, Self::Error> {
-        self.get_rpc_reader().get_latest_event_number().await
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader.get_latest_event_number().await
     }
 
     async fn get_events_by_txn_hash<E>(&self, txn_hash: &[u8; 32]) -> anyhow::Result<Vec<E>>
     where
         E: for<'a> TryFrom<(u64, &'a StoredEvent), Error = anyhow::Error> + Send + Sync,
     {
-        self.get_rpc_reader().get_events_by_txn_hash(txn_hash).await
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader.get_events_by_txn_hash(txn_hash).await
     }
 
     async fn get_events_by_txn_number<E>(&self, txn_num: u64) -> anyhow::Result<Vec<E>>
     where
         E: for<'a> TryFrom<(u64, &'a StoredEvent), Error = anyhow::Error> + Send + Sync,
     {
-        self.get_rpc_reader()
-            .get_events_by_txn_number(txn_num)
-            .await
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader.get_events_by_txn_number(txn_num).await
     }
 
     async fn get_slots_range<B, T, E>(
@@ -865,32 +867,32 @@ impl LedgerStateProvider for LedgerDb {
         &self,
         slot_id: &SlotIdentifier,
     ) -> Result<Option<SlotNumber>, Self::Error> {
-        self.get_rpc_reader().resolve_slot_identifier(slot_id).await
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader.resolve_slot_identifier(slot_id).await
     }
 
     async fn resolve_batch_identifier(
         &self,
         batch_id: &BatchIdentifier,
     ) -> Result<Option<u64>, Self::Error> {
-        self.get_rpc_reader()
-            .resolve_batch_identifier(batch_id)
-            .await
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader.resolve_batch_identifier(batch_id).await
     }
 
     async fn resolve_tx_identifier(
         &self,
         tx_id: &TxIdentifier,
     ) -> Result<Option<u64>, Self::Error> {
-        self.get_rpc_reader().resolve_tx_identifier(tx_id).await
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader.resolve_tx_identifier(tx_id).await
     }
 
     async fn resolve_event_identifier(
         &self,
         event_id: &EventIdentifier,
     ) -> Result<Option<u64>, Self::Error> {
-        self.get_rpc_reader()
-            .resolve_event_identifier(event_id)
-            .await
+        let rpc_reader = tokio::task::block_in_place(|| self.get_rpc_reader());
+        rpc_reader.resolve_event_identifier(event_id).await
     }
 
     async fn get_latest_aggregated_proof(&self) -> anyhow::Result<Option<AggregatedProofResponse>> {
@@ -936,6 +938,7 @@ impl LedgerStateProvider for LedgerDb {
 }
 
 impl LedgerDb {
+    // This method is blocking via std::sync::RwLock
     pub(crate) fn get_rpc_reader(&self) -> LedgerRpcReader {
         LedgerRpcReader {
             db: self.clone_reader(),

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -658,7 +658,7 @@ pub(crate) async fn update_api_ledger<S: Spec, Rt: Runtime<S>>(
     transaction_cache: TxResultWriter<S, Rt>,
     info: &StateUpdateInfo<S::Storage>,
 ) {
-    api_ledger_db.replace_reader(info.ledger_reader.clone());
+    tokio::task::block_in_place(|| api_ledger_db.replace_reader(info.ledger_reader.clone()));
     api_ledger_db.send_notifications_for_slot(info.slot_number);
     prune_transactions_cache(info.next_tx_number, transaction_cache).await;
 }

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -550,7 +550,7 @@ where
             inner.checkpoint = Some(checkpoint);
         }
 
-        self.api_ledger_db.replace_reader(ledger_reader.clone());
+        tokio::task::block_in_place(|| self.api_ledger_db.replace_reader(ledger_reader.clone()));
         self.api_ledger_db.send_notifications_for_slot(*slot_number);
 
         if self.config.automatic_batch_production {

--- a/crates/full-node/sov-sequencer/src/test_stateless.rs
+++ b/crates/full-node/sov-sequencer/src/test_stateless.rs
@@ -213,8 +213,10 @@ where
         let mut inner = self.inner.lock().await;
         inner.storage = update_info.storage;
 
-        self.api_ledger_db
-            .replace_reader(update_info.ledger_reader.clone());
+        tokio::task::block_in_place(|| {
+            self.api_ledger_db
+                .replace_reader(update_info.ledger_reader.clone());
+        });
         self.api_ledger_db
             .send_notifications_for_slot(update_info.slot_number);
 

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -165,7 +165,7 @@ where
         let listen_address_http =
             SocketAddr::new(axum_config.bind_host.parse()?, axum_config.bind_port);
 
-        let next_item_numbers = ledger_db.get_next_items_numbers()?;
+        let next_item_numbers = tokio::task::block_in_place(|| ledger_db.get_next_items_numbers())?;
         let last_slot_processed_before_shutdown = next_item_numbers.slot_number.saturating_sub(1);
 
         let da_height_processed =
@@ -741,15 +741,18 @@ pub async fn query_state_update_info<S>(
         .await?
         .map(|x| x + 1)
         .unwrap_or_default();
-    let next_tx_number = ledger_db.get_next_items_numbers()?.tx_number;
+    let next_tx_number =
+        tokio::task::block_in_place(|| ledger_db.get_next_items_numbers())?.tx_number;
     let latest_finalized_slot_number = ledger_db
         .get_latest_finalized_slot_number()
         .await?
         .min(slot_number);
 
+    let ledger_reader = tokio::task::block_in_place(|| ledger_db.clone_reader());
+
     Ok(StateUpdateInfo {
         storage,
-        ledger_reader: ledger_db.clone_reader(),
+        ledger_reader,
         next_event_number,
         next_tx_number,
         slot_number,

--- a/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
@@ -327,10 +327,11 @@ where
         );
 
         let ledger_materialization_start = std::time::Instant::now();
-        let mut ledger_change_set = self
-            .ledger_db
-            .materialize_slot(slot_commit, new_state_root.as_ref())?;
-        tracing::trace!("Initial Ledger ChangeSet is materialized");
+        let mut ledger_change_set = tokio::task::block_in_place(|| {
+            self.ledger_db
+                .materialize_slot(slot_commit, new_state_root.as_ref())
+        })?;
+        tracing::trace!(time = ?ledger_materialization_start.elapsed(), "Initial Ledger ChangeSet is materialized");
 
         // TODO: Review this, does not look nice.
         let last_finalized_slot_number = SlotNumber::new_dangerous(
@@ -448,7 +449,7 @@ where
         stf_state: Sm::StfState,
         ledger_state: DeltaReader,
     ) -> anyhow::Result<()> {
-        self.ledger_db.replace_reader(ledger_state);
+        tokio::task::block_in_place(|| self.ledger_db.replace_reader(ledger_state));
         let state_update_info = query_state_update_info(&self.ledger_db, stf_state).await?;
 
         // `send_replace` is superior to `send` for our use case. It never fails


### PR DESCRIPTION
# Description

To avoid tokio starvation

From Documentation: 

> Runs the provided blocking function on the current thread without blocking the executor.
In general, issuing a blocking call or performing a lot of compute in a future without yielding is problematic, as it may prevent the executor from driving other tasks forward. Calling this function informs the executor that the currently executing task is about to block the thread, so the executor is able to hand off any other tasks it has to a new worker thread before that happens. See the CPU-bound tasks and blocking code section for more information.
Be aware that although this function avoids starving other independently spawned tasks, any other code running concurrently in the same task will be suspended during the call to block_in_place. This can happen e.g. when using the join! macro. To avoid this issue, use spawn_blocking instead of block_in_place.
Note that this function cannot be used within a current_thread runtime because in this case there are no other worker threads to hand off tasks to. On the other hand, calling the function outside a runtime is allowed. In this case, block_in_place just calls the provided closure normally.
Code running behind block_in_place cannot be cancelled. When you shut down the executor, it will wait indefinitely for all blocking operations to finish. You can use shutdown_timeout to stop waiting for them after a certain timeout. Be aware that this will still not cancel the tasks — they are simply allowed to keep running after the method returns.

This is another iteration of https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/3295 

If we notice performance degradataion, we can switch to `spawn_blocking`

- [x] Internal change ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/1000

## Testing
All existing tests are passing

## Docs
No updates
