### PR TITLE
Add logging to `update_api_ledger`

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -658,8 +658,18 @@ pub(crate) async fn update_api_ledger<S: Spec, Rt: Runtime<S>>(
     transaction_cache: TxResultWriter<S, Rt>,
     info: &StateUpdateInfo<S::Storage>,
 ) {
+    let start = std::time::Instant::now();
+    tracing::trace!(
+        slot_number = %info.slot_number,
+        latest_finalized_slot_number = %info.latest_finalized_slot_number,
+        "Starting LedgerAPI storage update");
     api_ledger_db.replace_reader(info.ledger_reader.clone());
     api_ledger_db.send_notifications_for_slot(info.slot_number);
+    tracing::trace!(
+        time = ?start.elapsed(),
+        slot_number = %info.slot_number,
+        latest_finalized_slot_number = %info.latest_finalized_slot_number,
+        "LedgerAPI storage updated, notification has been sent");
     prune_transactions_cache(info.next_tx_number, transaction_cache).await;
 }
 

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
@@ -382,8 +382,7 @@ async fn test_check_no_reorgs() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_check_no_reorgs_longer() -> anyhow::Result<()> {
-    // sov_test_utils::logging::initialize_or_change_logging_with_filter("info,sov_metrics=error,integration=debug");
-    sov_test_utils::logging::initialize_or_change_logging_with_filter("debug,sov_metrics=error,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info");
+    sov_test_utils::logging::initialize_or_change_logging_with_filter("debug,sov_metrics=error,sov_sequencer::preferred=trace,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info");
     tokio::time::timeout(
         TEST_TIMEOUT,
         test_stream_of_transactions(StreamOfTransactionsArgs {


### PR DESCRIPTION
For better visibility on websocket storage issue

Also enable sov_sequencer tracing logging for problematic test