### PR TITLE
Sequencer: Fix flaky test `upgradability::test_start_at`

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -55,7 +55,7 @@ impl PostgresBackend {
             .with_min_delay(Duration::from_millis(2))
             .with_max_delay(Duration::from_millis(500))
             .with_factor(2.0)
-            .with_max_times(8);
+            .with_max_times(10);
 
         let pool = run_with_retries!(
             &backoff_policy,

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -55,7 +55,7 @@ impl PostgresBackend {
             .with_min_delay(Duration::from_millis(2))
             .with_max_delay(Duration::from_millis(500))
             .with_factor(2.0)
-            .with_max_times(10);
+            .with_max_times(8);
 
         let pool = run_with_retries!(
             &backoff_policy,

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -67,9 +67,6 @@ async fn test_start_at_immediate_finality() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_start_at() {
-    sov_test_utils::logging::initialize_or_change_logging_with_filter(
-        "info,sov_metrics=error,integration=debug",
-    );
     check_start_at(TEST_FINALIZATION_BLOCKS - 1).await;
     check_start_at(TEST_FINALIZATION_BLOCKS).await;
     check_start_at(TEST_FINALIZATION_BLOCKS + 1).await;
@@ -299,6 +296,8 @@ async fn check_start_at(finalization_blocks: u32) {
         .restart_with_heights(Some(start_at), None)
         .await
         .unwrap();
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     let client = test_rollup.client.clone();
     let current_height = get_height(&client).await.unwrap();

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -67,6 +67,9 @@ async fn test_start_at_immediate_finality() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_start_at() {
+    sov_test_utils::logging::initialize_or_change_logging_with_filter(
+        "info,sov_metrics=error,integration=debug",
+    );
     check_start_at(TEST_FINALIZATION_BLOCKS - 1).await;
     check_start_at(TEST_FINALIZATION_BLOCKS).await;
     check_start_at(TEST_FINALIZATION_BLOCKS + 1).await;

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -297,8 +297,6 @@ async fn check_start_at(finalization_blocks: u32) {
         .await
         .unwrap();
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
-
     let client = test_rollup.client.clone();
     let current_height = get_height(&client).await.unwrap();
 
@@ -307,6 +305,7 @@ async fn check_start_at(finalization_blocks: u32) {
     // Verify that the last processed height was `stop_at_height`. Since we called `pause_update_state`,
     // we should see the final height before the shutdown.
     assert_eq!(current_height, stop_at_height);
+    test_rollup.shutdown().await.unwrap();
 }
 
 async fn assert_rollup_processes_only_finalized_blocks(client: &NodeClient) {


### PR DESCRIPTION
# Description


- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

