### PR TITLE
Fix using primitive u64 in JS fuzz test

### DIFF
--- a/crates/universal-wallet/fuzz/Cargo.toml
+++ b/crates/universal-wallet/fuzz/Cargo.toml
@@ -48,5 +48,5 @@ doc = false
 bench = false
 
 [features]
-default = []
+default = ["js-compat"]
 js-compat = []

--- a/crates/universal-wallet/fuzz/README.md
+++ b/crates/universal-wallet/fuzz/README.md
@@ -29,6 +29,9 @@ SOV_UNIVERSAL_WALLET_FUZZ_JS_DIR="../../../../sovereign-sdk-web3-js/packages/ser
 
 Where `SOV_UNIVERSAL_WALLET_FUZZ_JS_DIR` is the path to the `serializers` package in the [web3 js repo](https://github.com/Sovereign-Labs/sovereign-sdk-web3-js/tree/master).
 
+**NOTE:** If updating `FuzzInput` you should _not_ use `u64`, `i64`, `u128`, `i128` types directly as this will cause testing to fail against the JS implementations
+due to precision loss. Use the wrapper `U64`, `I64`, etc types for JS compatibility.
+
 ### Features
 
 - `js-compat` serializes numbers in a way that is compatible with JS/JSON, big ints as strings, etc.

--- a/crates/universal-wallet/fuzz/src/lib.rs
+++ b/crates/universal-wallet/fuzz/src/lib.rs
@@ -93,7 +93,7 @@ pub struct ComplexStruct {
     field_a: Vec<(Option<u8>, [i8; 32])>,
     needs_more_vecs: Vec<Vec<Vec<Vec<U128>>>>,
     never: (),
-    bulk_tuple: (i32, i32, u64, I128, ArbitrarySafeString, Option<bool>),
+    bulk_tuple: (i32, i32, U64, I128, ArbitrarySafeString, Option<bool>),
 }
 
 #[derive(


### PR DESCRIPTION
# Description

Precision loss was causing tests to fail for big u64s

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
