### PR TITLE
Use `TestRollup::shutdown` for proper shutdown in restart tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2025-08-01
 - #1460 Adds `chain_hash` to the `/rollup/schema` endpoint response, this requires passing the chain hash during endpoint initialization.
+- #1471 Reduces flakiness in demo-rollup restart tests.
 
 # 2025-07-30
 - #1444 Updates in `TestRollup`

--- a/crates/module-system/sov-test-utils/src/lib.rs
+++ b/crates/module-system/sov-test-utils/src/lib.rs
@@ -162,7 +162,7 @@ pub const TEST_DEFAULT_SEQUENCER_ADDRESS: &str =
     "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf";
 
 /// Default wait time value for different [`sov_mock_da::BlockProducingConfig`] value in tests.
-pub const TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS: u64 = 100;
+pub const TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS: u64 = 300;
 /// Default [`BlockProducingConfig`] for tests that need periodic block producing.
 pub const TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING: BlockProducingConfig =
     BlockProducingConfig::Periodic {

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -103,11 +103,6 @@ async fn start_stop_empty(
 
         tracing::info!("Triggering shutdown....");
         tokio::time::timeout(ROLLUP_SHUTDOWN_TIMEOUT, test_rollup.shutdown()).await??;
-        // By design, child tasks don't always report back to their parents when they finish shutting down. This is fine
-        // during normal operation, but it means that we can't "await" until every spawned task is shutdown for this test. That makes
-        // the test flaky, since we sometimes try to restart the rollup before we finish shutting it down, causing rocksdb locks to trigger.
-        // A small sleep prevents this.
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
 
     let known = [

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -63,9 +63,7 @@ async fn start_stop_empty(
     let collector = LogCollector::new(Level::WARN);
     let new_env_filter = EnvFilter::from_str("debug")?;
     let fmt_layer = fmt::layer().with_filter(new_env_filter);
-    let subscriber = registry()
-        .with(fmt_layer)
-        .with(collector.clone());
+    let subscriber = registry().with(fmt_layer).with(collector.clone());
     subscriber.init();
 
     let rollup_storage_dir = Arc::new(tempfile::tempdir()?);

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -99,20 +99,8 @@ async fn start_stop_empty(
         // Let rollup run for some time
         tokio::time::sleep(sleep_duration).await;
 
-        let TestRollup {
-            shutdown_sender,
-            rollup_task,
-            da_service,
-            ..
-        } = test_rollup;
-
-        drop(da_service);
         tracing::info!("Triggering shutdown....");
-        shutdown_sender.send(())?;
-        tokio::time::timeout(ROLLUP_SHUTDOWN_TIMEOUT, rollup_task)
-            .await
-            .context("Joining rollup task failed")???;
-
+        tokio::time::timeout(ROLLUP_SHUTDOWN_TIMEOUT, test_rollup.shutdown()).await??;
         // // By design, child tasks don't always report back to their parents when they finish shutting down. This is fine
         // // during normal operation, but it means that we can't "await" until every spawned task is shutdown for this test. That makes
         // // the test flaky, since we sometimes try to restart the rollup before we finish shutting it down, causing rocksdb locks to trigger.

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -61,7 +61,7 @@ async fn start_stop_empty(
     rollup_prover_config: RollupProverConfig<Risc0>,
 ) -> anyhow::Result<()> {
     let collector = LogCollector::new(Level::WARN);
-    let new_env_filter = EnvFilter::from_str("debug")?;
+    let new_env_filter = EnvFilter::from_str("debug,jmt=warn")?;
     let fmt_layer = fmt::layer().with_filter(new_env_filter);
     let subscriber = registry().with(fmt_layer).with(collector.clone());
     subscriber.init();

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -22,7 +22,7 @@ use sov_test_utils::test_rollup::{RollupBuilder, TestRollup};
 use sov_test_utils::TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING;
 use tracing::Level;
 use tracing_subscriber::prelude::*;
-use tracing_subscriber::{registry, EnvFilter, Layer};
+use tracing_subscriber::{fmt, registry, EnvFilter, Layer};
 
 use crate::test_helpers::test_genesis_source;
 
@@ -61,7 +61,11 @@ async fn start_stop_empty(
     rollup_prover_config: RollupProverConfig<Risc0>,
 ) -> anyhow::Result<()> {
     let collector = LogCollector::new(Level::WARN);
-    let subscriber = registry().with(collector.clone());
+    let new_env_filter = EnvFilter::from_str("debug")?;
+    let fmt_layer = fmt::layer().with_filter(new_env_filter);
+    let subscriber = registry()
+        .with(fmt_layer)
+        .with(collector.clone());
     subscriber.init();
 
     let rollup_storage_dir = Arc::new(tempfile::tempdir()?);
@@ -101,11 +105,11 @@ async fn start_stop_empty(
 
         tracing::info!("Triggering shutdown....");
         tokio::time::timeout(ROLLUP_SHUTDOWN_TIMEOUT, test_rollup.shutdown()).await??;
-        // // By design, child tasks don't always report back to their parents when they finish shutting down. This is fine
-        // // during normal operation, but it means that we can't "await" until every spawned task is shutdown for this test. That makes
-        // // the test flaky, since we sometimes try to restart the rollup before we finish shutting it down, causing rocksdb locks to trigger.
-        // // A small sleep prevents this.
-        // tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        // By design, child tasks don't always report back to their parents when they finish shutting down. This is fine
+        // during normal operation, but it means that we can't "await" until every spawned task is shutdown for this test. That makes
+        // the test flaky, since we sometimes try to restart the rollup before we finish shutting it down, causing rocksdb locks to trigger.
+        // A small sleep prevents this.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
 
     let known = [


### PR DESCRIPTION
# Description

Similar to https://github.com/Sovereign-Labs/sovereign-sdk/pull/1467 , because `TestRollup::shutdown` handles more logic.

* Adds logging to flaky restart tests
* Changes default block time for MockDa from 100ms to 300ms

- [x] Internal change ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Suppose to improve stability of the tests


## Docs
No updates
