### PR TITLE
EIP 712 authenticator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4876,6 +4876,7 @@ dependencies = [
  "sov-attester-incentives",
  "sov-bank",
  "sov-chain-state",
+ "sov-evm",
  "sov-kernels",
  "sov-mock-da",
  "sov-mock-zkvm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4860,6 +4860,8 @@ dependencies = [
 name = "integration-tests"
 version = "0.3.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
  "anyhow",
  "borsh",
  "derive_more 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11080,6 +11080,8 @@ dependencies = [
 name = "sov-modules-api"
 version = "0.3.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
  "anyhow",
  "arbitrary",
  "async-trait",

--- a/crates/module-system/module-implementations/integration-tests/Cargo.toml
+++ b/crates/module-system/module-implementations/integration-tests/Cargo.toml
@@ -41,6 +41,7 @@ sov-modules-stf-blueprint = { workspace = true, features = [
 	"native",
 	"test-utils",
 ] }
+sov-evm = { workspace = true, features = ["native"] }
 sov-kernels = { workspace = true, features = ["native"] }
 
 sov-attester-incentives = { workspace = true, features = ["native"] }

--- a/crates/module-system/module-implementations/integration-tests/Cargo.toml
+++ b/crates/module-system/module-implementations/integration-tests/Cargo.toml
@@ -15,6 +15,8 @@ workspace = true
 
 [dev-dependencies]
 anyhow = { workspace = true }
+alloy-primitives = { workspace = true }
+alloy-sol-types = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 strum = { workspace = true }
 derive_more = { workspace = true }

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
@@ -13,13 +13,22 @@ use sov_rollup_interface::da::RelevantBlobs;
 use sov_rollup_interface::stf::{TxEffect, TxReceiptContents};
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
 use sov_test_utils::runtime::{TestRunner, ValueSetter};
-use sov_test_utils::{generate_optimistic_runtime, EncodeCall, TestUser, TEST_DEFAULT_MAX_FEE};
+use sov_test_utils::{generate_runtime, EncodeCall, TestUser, TEST_DEFAULT_MAX_FEE};
 use sov_value_setter::CallMessage;
 
 type TestSpec =
     ConfigurableSpec<MockDaSpec, MockZkvm, MockZkvm, EthereumAddress, Native, EvmCryptoSpec>;
 type S = TestSpec;
-generate_optimistic_runtime!(TestRuntime <= value_setter: ValueSetter<S>);
+generate_runtime! {
+    name: TestRuntime,
+    modules: [value_setter: ValueSetter<S>],
+    operating_mode: sov_modules_api::OperatingMode::Optimistic,
+    minimal_genesis_config_type: sov_test_utils::runtime::genesis::optimistic::MinimalOptimisticGenesisConfig<S>,
+    runtime_trait_impl_bounds: [],
+    kernel_type: sov_kernels::basic::BasicKernel<'a, S>,
+    auth_type: sov_modules_api::capabilities::RollupAuthenticator<S, TestRuntime<S>>,
+    auth_call_wrapper: |call| call,
+}
 type RT = TestRuntime<S>;
 
 fn setup() -> (TestRunner<RT, S>, TestUser<S>) {

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
@@ -1,3 +1,5 @@
+use alloy_primitives::address;
+use alloy_sol_types::{eip712_domain, sol, Eip712Domain, SolStruct};
 use sov_address::{EthereumAddress, EvmCryptoSpec};
 use sov_mock_da::{MockBlob, MockDaSpec};
 use sov_mock_zkvm::MockZkvm;
@@ -6,8 +8,9 @@ use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::Native;
 use sov_modules_api::macros::config_value;
 use sov_modules_api::transaction::{PriorityFeeBips, Transaction, UnsignedTransaction};
-use sov_modules_api::{DispatchCall, FullyBakedTx, RawTx, Runtime, Spec};
+use sov_modules_api::{FullyBakedTx, PrivateKey, RawTx, Runtime, Spec};
 use sov_rollup_interface::da::RelevantBlobs;
+use sov_rollup_interface::stf::{TxEffect, TxReceiptContents};
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
 use sov_test_utils::runtime::{TestRunner, ValueSetter};
 use sov_test_utils::{generate_optimistic_runtime, EncodeCall, TestUser, TEST_DEFAULT_MAX_FEE};
@@ -35,7 +38,21 @@ fn setup() -> (TestRunner<RT, S>, TestUser<S>) {
     (runner, admin)
 }
 
-pub fn create_tx_valid<S: Spec, RT: Runtime<S>>(
+const DOMAIN: Eip712Domain = eip712_domain! {
+    name: "CallMessage",
+    version: "1",
+    chain_id: 4321,
+    verifying_contract: address!("0000000000000000000000000000000000000000"),
+};
+
+sol! {
+    #[derive(Debug)]
+    struct TxDetails {
+        uint64 chain_id;
+    }
+}
+
+pub fn create_tx<S: Spec, RT: Runtime<S>>(
     nonce: u64,
     max_priority_fee_bips: PriorityFeeBips,
     signer: &TestUser<S>,
@@ -51,35 +68,34 @@ pub fn create_tx_valid<S: Spec, RT: Runtime<S>>(
         None,
     );
 
-    Transaction::<RT, S>::new_signed_tx(signer.private_key(), &RT::CHAIN_HASH, utx)
+    let tx_details = TxDetails { chain_id };
+    let hash = tx_details.eip712_signing_hash(&DOMAIN);
+    let pk = signer.private_key();
+
+    let signature = pk.sign(hash.as_slice());
+    let signed_tx = utx.to_signed_tx(pk.pub_key(), signature);
+    signed_tx
 }
 
-pub fn encode_message<S: Spec, RT: Runtime<S> + EncodeCall<ValueSetter<S>>>(
-) -> <RT as DispatchCall>::Decodable {
-    <RT as EncodeCall<ValueSetter<S>>>::to_decodable(CallMessage::SetValue {
-        value: 8,
+pub fn encode_message<S: Spec, RT: Runtime<S> + EncodeCall<ValueSetter<S>>>() -> RT::Decodable {
+    let msg = CallMessage::SetValue {
+        value: 0,
         gas: None,
-    })
+    };
+    RT::to_decodable(msg)
 }
 
 pub fn encode<S: Spec, RT: Runtime<S>>(tx: Transaction<RT, S>) -> FullyBakedTx {
-    <RT as Runtime<S>>::Auth::encode_with_standard_auth(RawTx::new(borsh::to_vec(&tx).unwrap()))
+    let raw_tx = RawTx::new(borsh::to_vec(&tx).unwrap());
+    RT::Auth::encode_with_standard_auth(raw_tx)
 }
 
-#[test]
-fn test_eip712() {
-    let (mut runner, admin) = setup();
-
-    let tx = create_tx_valid::<_, RT>(
-        0,
-        PriorityFeeBips::ZERO,
-        &admin,
-        config_value!("CHAIN_ID"),
-        encode_message::<_, RT>(),
-    );
+fn execute_tx(
+    mut runner: TestRunner<RT, S>,
+    tx: Transaction<RT, S>,
+) -> TxEffect<impl TxReceiptContents> {
     let serialized_tx = encode(tx);
     let txs: Vec<FullyBakedTx> = vec![serialized_tx];
-
     let blob = borsh::to_vec(&txs).unwrap();
     let blob = MockBlob::new_with_hash(blob, runner.config.sequencer_da_address);
 
@@ -88,5 +104,22 @@ fn test_eip712() {
         batch_blobs: vec![blob],
     };
 
-    let _ = runner.execute(blobs);
+    let (receipts, _) = runner.execute(blobs);
+    let receipt = receipts.last_tx_receipt().receipt.clone();
+    receipt
+}
+
+#[test]
+fn test_eip712() {
+    let (runner, admin) = setup();
+    let tx = create_tx::<_, RT>(
+        0,
+        PriorityFeeBips::ZERO,
+        &admin,
+        config_value!("CHAIN_ID"),
+        encode_message::<_, RT>(),
+    );
+
+    let receipt = execute_tx(runner, tx);
+    dbg!(receipt);
 }

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::address;
 use alloy_sol_types::{eip712_domain, sol, Eip712Domain, SolStruct};
 use sov_address::{EthereumAddress, EvmCryptoSpec};
+use sov_evm::Eip712Authenticator;
 use sov_mock_da::{MockBlob, MockDaSpec};
 use sov_mock_zkvm::MockZkvm;
 use sov_modules_api::capabilities::TransactionAuthenticator;
@@ -24,9 +25,9 @@ generate_runtime! {
     modules: [value_setter: ValueSetter<S>],
     operating_mode: sov_modules_api::OperatingMode::Optimistic,
     minimal_genesis_config_type: sov_test_utils::runtime::genesis::optimistic::MinimalOptimisticGenesisConfig<S>,
-    runtime_trait_impl_bounds: [],
+    runtime_trait_impl_bounds: [S: ::sov_modules_api::Spec<CryptoSpec = EvmCryptoSpec>],
     kernel_type: sov_kernels::basic::BasicKernel<'a, S>,
-    auth_type: sov_modules_api::capabilities::RollupAuthenticator<S, TestRuntime<S>>,
+    auth_type: Eip712Authenticator<S, TestRuntime<S>>,
     auth_call_wrapper: |call| call,
 }
 type RT = TestRuntime<S>;

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
@@ -9,7 +9,7 @@ use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::Native;
 use sov_modules_api::macros::config_value;
 use sov_modules_api::transaction::{PriorityFeeBips, Transaction, UnsignedTransaction};
-use sov_modules_api::{FullyBakedTx, PrivateKey, RawTx, Runtime, Spec};
+use sov_modules_api::{FullyBakedTx, PrivateKey, RawTx, Runtime, Spec, SuccessfulTxContents};
 use sov_rollup_interface::da::RelevantBlobs;
 use sov_rollup_interface::stf::{TxEffect, TxReceiptContents};
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
@@ -103,7 +103,7 @@ pub fn encode<S: Spec, RT: Runtime<S>>(tx: Transaction<RT, S>) -> FullyBakedTx {
 fn execute_tx(
     mut runner: TestRunner<RT, S>,
     tx: Transaction<RT, S>,
-) -> TxEffect<impl TxReceiptContents> {
+) -> TxEffect<impl TxReceiptContents<Successful = SuccessfulTxContents<S>>> {
     let serialized_tx = encode(tx);
     let txs: Vec<FullyBakedTx> = vec![serialized_tx];
     let blob = borsh::to_vec(&txs).unwrap();
@@ -131,5 +131,7 @@ fn test_eip712() {
     );
 
     let receipt = execute_tx(runner, tx);
-    dbg!(receipt);
+    let TxEffect::Successful(SuccessfulTxContents { .. }) = receipt else {
+        panic!("Expected transaction to succeed, got: {:?}", receipt);
+    };
 }

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
@@ -49,7 +49,7 @@ fn setup() -> (TestRunner<RT, S>, TestUser<S>) {
 }
 
 const DOMAIN: Eip712Domain = eip712_domain! {
-    name: "CallMessage",
+    name: "Transaction",
     version: "1",
     chain_id: 4321,
     verifying_contract: address!("0000000000000000000000000000000000000000"),

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::address;
-use alloy_sol_types::{eip712_domain, sol, Eip712Domain, SolStruct};
+use alloy_sol_types::{eip712_domain, Eip712Domain, SolStruct};
 use sov_address::{EthereumAddress, EvmCryptoSpec};
 use sov_evm::Eip712Authenticator;
 use sov_mock_da::{MockBlob, MockDaSpec};
@@ -8,6 +8,7 @@ use sov_modules_api::capabilities::TransactionAuthenticator;
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::Native;
 use sov_modules_api::macros::config_value;
+use sov_modules_api::transaction::TxDetails;
 use sov_modules_api::transaction::{PriorityFeeBips, Transaction, UnsignedTransaction};
 use sov_modules_api::{FullyBakedTx, PrivateKey, RawTx, Runtime, Spec, SuccessfulTxContents};
 use sov_rollup_interface::da::RelevantBlobs;
@@ -20,6 +21,7 @@ use sov_value_setter::CallMessage;
 type TestSpec =
     ConfigurableSpec<MockDaSpec, MockZkvm, MockZkvm, EthereumAddress, Native, EvmCryptoSpec>;
 type S = TestSpec;
+
 generate_runtime! {
     name: TestRuntime,
     modules: [value_setter: ValueSetter<S>],
@@ -55,36 +57,43 @@ const DOMAIN: Eip712Domain = eip712_domain! {
     verifying_contract: address!("0000000000000000000000000000000000000000"),
 };
 
-sol! {
-    #[derive(Debug)]
-    struct TxDetails {
-        uint64 chain_id;
+pub mod sol_struct {
+    use alloy_sol_types::sol;
+
+    sol! {
+        #[derive(Debug)]
+        struct TxDetails {
+            uint64 chain_id;
+        }
     }
 }
 
-pub fn create_tx<S: Spec, RT: Runtime<S>>(
-    nonce: u64,
-    max_priority_fee_bips: PriorityFeeBips,
+pub fn create_utx<S: Spec, RT: Runtime<S>>(message: RT::Decodable) -> UnsignedTransaction<RT, S> {
+    let details = TxDetails {
+        max_priority_fee_bips: PriorityFeeBips::ZERO,
+        max_fee: TEST_DEFAULT_MAX_FEE,
+        gas_limit: None,
+        chain_id: config_value!("CHAIN_ID"),
+    };
+    UnsignedTransaction::new_with_details(message, 0, details)
+}
+
+pub fn sign_utx<S: Spec, RT: Runtime<S>>(
+    utx: UnsignedTransaction<RT, S>,
     signer: &TestUser<S>,
-    chain_id: u64,
-    message: RT::Decodable,
 ) -> Transaction<RT, S> {
-    let utx = UnsignedTransaction::new(
-        message,
-        chain_id,
-        max_priority_fee_bips,
-        TEST_DEFAULT_MAX_FEE,
-        nonce,
-        None,
-    );
-
-    let tx_details = TxDetails { chain_id };
-    let hash = tx_details.eip712_signing_hash(&DOMAIN);
+    let hash = utx.details.as_sol_struct().eip712_signing_hash(&DOMAIN);
     let pk = signer.private_key();
-
     let signature = pk.sign(hash.as_slice());
-    let signed_tx = utx.to_signed_tx(pk.pub_key(), signature);
-    signed_tx
+    utx.to_signed_tx(pk.pub_key(), signature)
+}
+
+pub fn create_tx<S: Spec, RT: Runtime<S>>(
+    message: RT::Decodable,
+    signer: &TestUser<S>,
+) -> Transaction<RT, S> {
+    let utx = create_utx::<S, RT>(message);
+    sign_utx::<S, RT>(utx, signer)
 }
 
 pub fn encode_message<S: Spec, RT: Runtime<S> + EncodeCall<ValueSetter<S>>>() -> RT::Decodable {
@@ -120,18 +129,13 @@ fn execute_tx(
 }
 
 #[test]
-fn test_eip712() {
+fn correct_signature_is_accepted() {
     let (runner, admin) = setup();
-    let tx = create_tx::<_, RT>(
-        0,
-        PriorityFeeBips::ZERO,
-        &admin,
-        config_value!("CHAIN_ID"),
-        encode_message::<_, RT>(),
-    );
+    let call = encode_message::<_, RT>();
+    let tx = create_tx::<_, RT>(call, &admin);
 
     let receipt = execute_tx(runner, tx);
     let TxEffect::Successful(SuccessfulTxContents { .. }) = receipt else {
-        panic!("Expected transaction to succeed, got: {:?}", receipt);
+        panic!("Expected transaction to succeed, got: {receipt:?}");
     };
 }

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -19,6 +19,9 @@ use sov_modules_api::{
 use sov_rollup_interface::TxHash;
 use sov_state::User;
 
+mod eip712;
+pub use eip712::Eip712Authenticator;
+
 use crate::conversions::RlpConversionError;
 use crate::{call, CallMessage, RlpEvmTransaction};
 

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
@@ -2,11 +2,17 @@ use std::marker::PhantomData;
 
 use sov_address::EvmCryptoSpec;
 use sov_modules_api::capabilities::{
-    self, BatchFromUnregisteredSequencer, FatalError, TransactionAuthenticator,
+    self, calculate_hash_metered, AuthenticationError, AuthenticationOutput,
+    BatchFromUnregisteredSequencer, FatalError, TransactionAuthenticator,
+    UnregisteredAuthenticationError,
 };
+use sov_modules_api::transaction::Transaction;
 #[cfg(feature = "native")]
 use sov_modules_api::FullyBakedTx;
-use sov_modules_api::{DispatchCall, ProvableStateReader, RawTx, Runtime, Spec};
+use sov_modules_api::{
+    DispatchCall, MeteredBorshDeserialize, MeteredBorshDeserializeError, ProvableStateReader,
+    RawTx, Runtime, Spec,
+};
 use sov_state::User;
 
 /// EIP-712-compatible transaction authenticator. See [`TransactionAuthenticator`].
@@ -31,13 +37,17 @@ where
     }
 
     fn authenticate<Accessor: ProvableStateReader<User, Spec = S>>(
-        _tx: &FullyBakedTx,
-        _state: &mut Accessor,
+        tx: &FullyBakedTx,
+        state: &mut Accessor,
     ) -> Result<
         capabilities::AuthenticationOutput<S, Self::Decodable>,
         capabilities::AuthenticationError,
     > {
-        unimplemented!("authenticate");
+        let tx: RawTx = borsh::from_slice(&tx.data).map_err(|e| {
+            capabilities::fatal_deserialization_error::<_, S, _>(&tx.data, e, state)
+        })?;
+
+        authenticate::<_, S, Rt>(&tx.data, &Rt::CHAIN_HASH, state)
     }
 
     #[cfg(feature = "native")]
@@ -51,16 +61,57 @@ where
     }
 
     fn authenticate_unregistered<Accessor: ProvableStateReader<User, Spec = S>>(
-        _batch: &BatchFromUnregisteredSequencer,
-        _state: &mut Accessor,
+        batch: &BatchFromUnregisteredSequencer,
+        state: &mut Accessor,
     ) -> Result<
         capabilities::AuthenticationOutput<S, Self::Decodable>,
         capabilities::UnregisteredAuthenticationError,
     > {
-        unimplemented!("authenticate_unregistered");
+        let tx: RawTx = borsh::from_slice(&batch.tx.data)
+            .map_err(|_| UnregisteredAuthenticationError::InvalidAuthenticationDiscriminant)?;
+
+        Ok(authenticate::<_, S, Rt>(&tx.data, &Rt::CHAIN_HASH, state)?)
     }
 
     fn add_standard_auth(tx: RawTx) -> Self::Input {
         tx
     }
+}
+
+/// Authenticate raw sov-transaction signed as EIP712 typed data.
+///
+/// # Errors
+/// Returns an error if gas runs out at any point, if deserialization or hashing fails, or if the
+/// signature cannot be verified.
+pub fn authenticate<
+    Accessor: ProvableStateReader<User, Spec = S>,
+    S: Spec,
+    D: DispatchCall<Spec = S>,
+>(
+    mut raw_tx: &[u8],
+    chain_hash: &[u8; 32],
+    state: &mut Accessor,
+) -> Result<AuthenticationOutput<S, D::Decodable>, AuthenticationError> {
+    let raw_tx_hash = calculate_hash_metered::<Accessor, S>(raw_tx, state)
+        .map_err(|e| AuthenticationError::OutOfGas(e.to_string()))?;
+
+    let tx =
+        match <Transaction<D, S> as MeteredBorshDeserialize<S>>::deserialize(&mut raw_tx, state) {
+            Ok(ok) => ok,
+
+            Err(MeteredBorshDeserializeError::GasError(e)) => {
+                return Err(AuthenticationError::OutOfGas(format!(
+                    "Transaction deserialization run out of gas {e}, tx hash {raw_tx_hash}"
+                )))
+            }
+            Err(MeteredBorshDeserializeError::IOError(e)) => {
+                return Err(AuthenticationError::FatalError(
+                    FatalError::DeserializationFailed(e.to_string()),
+                    raw_tx_hash,
+                ));
+            }
+        };
+
+    unimplemented!("verify_and_decode_tx");
+    // verify_and_decode_tx::<S, D>(raw_tx_hash, tx, chain_hash, state)
 }

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use sov_address::EvmCryptoSpec;
 use sov_modules_api::capabilities::{
-    self, BatchFromUnregisteredSequencer, TransactionAuthenticator,
+    self, BatchFromUnregisteredSequencer, FatalError, TransactionAuthenticator,
 };
 #[cfg(feature = "native")]
 use sov_modules_api::FullyBakedTx;
@@ -22,9 +22,12 @@ where
 
     #[cfg(feature = "native")]
     fn decode_serialized_tx(
-        _tx: &FullyBakedTx,
+        tx: &FullyBakedTx,
     ) -> Result<Self::Decodable, sov_modules_api::capabilities::FatalError> {
-        todo!();
+        let tx: RawTx = borsh::from_slice(&tx.data)
+            .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
+
+        capabilities::decode_sov_tx::<S, Rt>(&tx.data)
     }
 
     fn authenticate<Accessor: ProvableStateReader<User, Spec = S>>(
@@ -34,14 +37,17 @@ where
         capabilities::AuthenticationOutput<S, Self::Decodable>,
         capabilities::AuthenticationError,
     > {
-        todo!();
+        unimplemented!("authenticate");
     }
 
     #[cfg(feature = "native")]
     fn compute_tx_hash(
-        _tx: &sov_modules_api::FullyBakedTx,
+        tx: &sov_modules_api::FullyBakedTx,
     ) -> anyhow::Result<sov_modules_api::TxHash> {
-        todo!();
+        use sov_modules_api::capabilities::calculate_hash;
+
+        let tx: RawTx = borsh::from_slice(&tx.data)?;
+        Ok(calculate_hash::<S>(&tx.data))
     }
 
     fn authenticate_unregistered<Accessor: ProvableStateReader<User, Spec = S>>(
@@ -51,7 +57,7 @@ where
         capabilities::AuthenticationOutput<S, Self::Decodable>,
         capabilities::UnregisteredAuthenticationError,
     > {
-        todo!();
+        unimplemented!("authenticate_unregistered");
     }
 
     fn add_standard_auth(tx: RawTx) -> Self::Input {

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
@@ -1,0 +1,60 @@
+use std::marker::PhantomData;
+
+use sov_address::EvmCryptoSpec;
+use sov_modules_api::capabilities::{
+    self, BatchFromUnregisteredSequencer, TransactionAuthenticator,
+};
+#[cfg(feature = "native")]
+use sov_modules_api::FullyBakedTx;
+use sov_modules_api::{DispatchCall, ProvableStateReader, RawTx, Runtime, Spec};
+use sov_state::User;
+
+/// EIP-712-compatible transaction authenticator. See [`TransactionAuthenticator`].
+pub struct Eip712Authenticator<S, Rt>(PhantomData<(S, Rt)>);
+
+impl<S, Rt> TransactionAuthenticator<S> for Eip712Authenticator<S, Rt>
+where
+    S: Spec<CryptoSpec = EvmCryptoSpec>,
+    Rt: Runtime<S> + DispatchCall<Spec = S>,
+{
+    type Decodable = Rt::Decodable;
+    type Input = RawTx;
+
+    #[cfg(feature = "native")]
+    fn decode_serialized_tx(
+        _tx: &FullyBakedTx,
+    ) -> Result<Self::Decodable, sov_modules_api::capabilities::FatalError> {
+        todo!();
+    }
+
+    fn authenticate<Accessor: ProvableStateReader<User, Spec = S>>(
+        _tx: &FullyBakedTx,
+        _state: &mut Accessor,
+    ) -> Result<
+        capabilities::AuthenticationOutput<S, Self::Decodable>,
+        capabilities::AuthenticationError,
+    > {
+        todo!();
+    }
+
+    #[cfg(feature = "native")]
+    fn compute_tx_hash(
+        _tx: &sov_modules_api::FullyBakedTx,
+    ) -> anyhow::Result<sov_modules_api::TxHash> {
+        todo!();
+    }
+
+    fn authenticate_unregistered<Accessor: ProvableStateReader<User, Spec = S>>(
+        _batch: &BatchFromUnregisteredSequencer,
+        _state: &mut Accessor,
+    ) -> Result<
+        capabilities::AuthenticationOutput<S, Self::Decodable>,
+        capabilities::UnregisteredAuthenticationError,
+    > {
+        todo!();
+    }
+
+    fn add_standard_auth(tx: RawTx) -> Self::Input {
+        tx
+    }
+}

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
@@ -9,10 +9,8 @@ use sov_modules_api::capabilities::{
 use sov_modules_api::transaction::{
     AuthenticatedTransactionAndRawHash, Transaction, TransactionVerificationError, VersionedTx,
 };
-#[cfg(feature = "native")]
-use sov_modules_api::FullyBakedTx;
 use sov_modules_api::{
-    DispatchCall, GasMeter, MeteredBorshDeserialize, MeteredBorshDeserializeError,
+    DispatchCall, FullyBakedTx, GasMeter, MeteredBorshDeserialize, MeteredBorshDeserializeError,
     ProvableStateReader, RawTx, Runtime, Spec, TxHash,
 };
 use sov_state::User;

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
@@ -2,16 +2,16 @@ use std::marker::PhantomData;
 
 use sov_address::EvmCryptoSpec;
 use sov_modules_api::capabilities::{
-    self, calculate_hash_metered, AuthenticationError, AuthenticationOutput,
-    BatchFromUnregisteredSequencer, FatalError, TransactionAuthenticator,
+    self, calculate_hash_metered, extract_authorization_data, verify_chain_id, AuthenticationError,
+    AuthenticationOutput, BatchFromUnregisteredSequencer, FatalError, TransactionAuthenticator,
     UnregisteredAuthenticationError,
 };
-use sov_modules_api::transaction::Transaction;
+use sov_modules_api::transaction::{AuthenticatedTransactionAndRawHash, Transaction, VersionedTx};
 #[cfg(feature = "native")]
 use sov_modules_api::FullyBakedTx;
 use sov_modules_api::{
-    DispatchCall, MeteredBorshDeserialize, MeteredBorshDeserializeError, ProvableStateReader,
-    RawTx, Runtime, Spec,
+    DispatchCall, GasMeter, MeteredBorshDeserialize, MeteredBorshDeserializeError,
+    ProvableStateReader, RawTx, Runtime, Spec, TxHash,
 };
 use sov_state::User;
 
@@ -111,7 +111,28 @@ pub fn authenticate<
                 ));
             }
         };
+    verify_and_decode_tx::<S, D>(raw_tx_hash, tx, chain_hash, state)
+}
 
-    unimplemented!("verify_and_decode_tx");
-    // verify_and_decode_tx::<S, D>(raw_tx_hash, tx, chain_hash, state)
+fn verify_and_decode_tx<S: Spec, D: DispatchCall<Spec = S>>(
+    raw_tx_hash: TxHash,
+    tx: Transaction<D, S>,
+    chain_hash: &[u8; 32],
+    meter: &mut impl GasMeter<Spec = S>,
+) -> Result<AuthenticationOutput<S, D::Decodable>, AuthenticationError> {
+    match &tx.versioned_tx {
+        VersionedTx::V0(tx_v0) => {
+            verify_chain_id(tx_v0, raw_tx_hash)?;
+            // verify_signature(&tx, chain_hash, raw_tx_hash, meter)?;
+            let authorization_data = extract_authorization_data::<S, D>(tx_v0, raw_tx_hash, meter)?;
+
+            let runtime_call = tx_v0.runtime_call.clone();
+            let tx_and_raw_hash = AuthenticatedTransactionAndRawHash {
+                raw_tx_hash,
+                authenticated_tx: tx_v0.details.clone().into(),
+            };
+
+            Ok((tx_and_raw_hash, authorization_data, runtime_call))
+        }
+    }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
@@ -1,5 +1,7 @@
 use std::marker::PhantomData;
 
+use alloy_primitives::address;
+use alloy_sol_types::{eip712_domain, Eip712Domain, SolStruct};
 use sov_address::EvmCryptoSpec;
 use sov_modules_api::capabilities::{
     self, calculate_hash_metered, extract_authorization_data, verify_chain_id, AuthenticationError,
@@ -47,7 +49,7 @@ where
             capabilities::fatal_deserialization_error::<_, S, _>(&tx.data, e, state)
         })?;
 
-        authenticate::<_, S, Rt>(&tx.data, &Rt::CHAIN_HASH, state)
+        authenticate::<_, S, Rt>(&tx.data, state)
     }
 
     #[cfg(feature = "native")]
@@ -70,7 +72,7 @@ where
         let tx: RawTx = borsh::from_slice(&batch.tx.data)
             .map_err(|_| UnregisteredAuthenticationError::InvalidAuthenticationDiscriminant)?;
 
-        Ok(authenticate::<_, S, Rt>(&tx.data, &Rt::CHAIN_HASH, state)?)
+        Ok(authenticate::<_, S, Rt>(&tx.data, state)?)
     }
 
     fn add_standard_auth(tx: RawTx) -> Self::Input {
@@ -85,11 +87,10 @@ where
 /// signature cannot be verified.
 pub fn authenticate<
     Accessor: ProvableStateReader<User, Spec = S>,
-    S: Spec,
+    S: Spec<CryptoSpec = EvmCryptoSpec>,
     D: DispatchCall<Spec = S>,
 >(
     mut raw_tx: &[u8],
-    chain_hash: &[u8; 32],
     state: &mut Accessor,
 ) -> Result<AuthenticationOutput<S, D::Decodable>, AuthenticationError> {
     let raw_tx_hash = calculate_hash_metered::<Accessor, S>(raw_tx, state)
@@ -111,19 +112,18 @@ pub fn authenticate<
                 ));
             }
         };
-    verify_and_decode_tx::<S, D>(raw_tx_hash, tx, chain_hash, state)
+    verify_and_decode_tx::<S, D>(raw_tx_hash, tx, state)
 }
 
-fn verify_and_decode_tx<S: Spec, D: DispatchCall<Spec = S>>(
+fn verify_and_decode_tx<S: Spec<CryptoSpec = EvmCryptoSpec>, D: DispatchCall<Spec = S>>(
     raw_tx_hash: TxHash,
     tx: Transaction<D, S>,
-    chain_hash: &[u8; 32],
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<AuthenticationOutput<S, D::Decodable>, AuthenticationError> {
     match &tx.versioned_tx {
         VersionedTx::V0(tx_v0) => {
             verify_chain_id(tx_v0, raw_tx_hash)?;
-            verify_eip712_signature(&tx, chain_hash, raw_tx_hash, meter)?;
+            verify_eip712_signature(&tx, raw_tx_hash, meter)?;
             let authorization_data = extract_authorization_data::<S, D>(tx_v0, raw_tx_hash, meter)?;
 
             let runtime_call = tx_v0.runtime_call.clone();
@@ -137,18 +137,30 @@ fn verify_and_decode_tx<S: Spec, D: DispatchCall<Spec = S>>(
     }
 }
 
-/// Verifies the EIP712 transaction signature.
-fn verify_eip712_signature<S: Spec, D: DispatchCall<Spec = S>>(
+fn verify_eip712_signature<S: Spec<CryptoSpec = EvmCryptoSpec>, D: DispatchCall<Spec = S>>(
     tx: &Transaction<D, S>,
-    chain_hash: &[u8; 32],
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<(), AuthenticationError> {
-    tx.verify_eip712(chain_hash, meter).map_err(|e| match e {
-        TransactionVerificationError::GasError(_) => AuthenticationError::OutOfGas(e.to_string()),
-        _ => AuthenticationError::FatalError(
-            FatalError::SigVerificationFailed(e.to_string()),
-            raw_tx_hash,
-        ),
-    })
+    let unsigned = tx.to_unsigned_transaction();
+    let tx_details = unsigned.details.as_sol_struct();
+
+    pub const DOMAIN: Eip712Domain = eip712_domain! {
+        name: "Transaction",
+        version: "1",
+        chain_id: 4321,
+        verifying_contract: address!("0000000000000000000000000000000000000000"),
+    };
+    let eip712_hash = tx_details.eip712_signing_hash(&DOMAIN);
+
+    tx.verify_signature(eip712_hash.as_slice(), meter)
+        .map_err(|e| match e {
+            TransactionVerificationError::GasError(_) => {
+                AuthenticationError::OutOfGas(e.to_string())
+            }
+            _ => AuthenticationError::FatalError(
+                FatalError::SigVerificationFailed(e.to_string()),
+                raw_tx_hash,
+            ),
+        })
 }

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
@@ -6,7 +6,9 @@ use sov_modules_api::capabilities::{
     AuthenticationOutput, BatchFromUnregisteredSequencer, FatalError, TransactionAuthenticator,
     UnregisteredAuthenticationError,
 };
-use sov_modules_api::transaction::{AuthenticatedTransactionAndRawHash, Transaction, VersionedTx};
+use sov_modules_api::transaction::{
+    AuthenticatedTransactionAndRawHash, Transaction, TransactionVerificationError, VersionedTx,
+};
 #[cfg(feature = "native")]
 use sov_modules_api::FullyBakedTx;
 use sov_modules_api::{
@@ -123,7 +125,7 @@ fn verify_and_decode_tx<S: Spec, D: DispatchCall<Spec = S>>(
     match &tx.versioned_tx {
         VersionedTx::V0(tx_v0) => {
             verify_chain_id(tx_v0, raw_tx_hash)?;
-            // verify_signature(&tx, chain_hash, raw_tx_hash, meter)?;
+            verify_eip712_signature(&tx, chain_hash, raw_tx_hash, meter)?;
             let authorization_data = extract_authorization_data::<S, D>(tx_v0, raw_tx_hash, meter)?;
 
             let runtime_call = tx_v0.runtime_call.clone();
@@ -135,4 +137,20 @@ fn verify_and_decode_tx<S: Spec, D: DispatchCall<Spec = S>>(
             Ok((tx_and_raw_hash, authorization_data, runtime_call))
         }
     }
+}
+
+/// Verifies the EIP712 transaction signature.
+fn verify_eip712_signature<S: Spec, D: DispatchCall<Spec = S>>(
+    tx: &Transaction<D, S>,
+    chain_hash: &[u8; 32],
+    raw_tx_hash: TxHash,
+    meter: &mut impl GasMeter<Spec = S>,
+) -> Result<(), AuthenticationError> {
+    tx.verify_eip712(chain_hash, meter).map_err(|e| match e {
+        TransactionVerificationError::GasError(_) => AuthenticationError::OutOfGas(e.to_string()),
+        _ => AuthenticationError::FatalError(
+            FatalError::SigVerificationFailed(e.to_string()),
+            raw_tx_hash,
+        ),
+    })
 }

--- a/crates/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/lib.rs
@@ -27,7 +27,8 @@ mod event;
 mod helpers;
 
 pub use authenticate::{
-    authenticate, decode_evm_tx, EthereumAuthenticator, EvmAuthenticator, EvmAuthenticatorInput,
+    authenticate, decode_evm_tx, Eip712Authenticator, EthereumAuthenticator, EvmAuthenticator,
+    EvmAuthenticatorInput,
 };
 pub use reth_primitives::revm_primitives::SpecId;
 use reth_primitives::revm_primitives::{Address, BlockEnv, B256};

--- a/crates/module-system/sov-modules-api/Cargo.toml
+++ b/crates/module-system/sov-modules-api/Cargo.toml
@@ -22,6 +22,8 @@ anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }
+alloy-sol-types = { workspace = true }
+alloy-primitives = { workspace = true }
 derive_more = { workspace = true, default-features = true, features = [
     "deref",
     "debug",

--- a/crates/module-system/sov-modules-api/Cargo.toml
+++ b/crates/module-system/sov-modules-api/Cargo.toml
@@ -96,7 +96,9 @@ arbitrary = [
 	"sov-test-utils/arbitrary",
 	"sov-mock-da/arbitrary",
 	"sov-bank/arbitrary",
-	"sov-modules-macros/arbitrary"
+	"sov-modules-macros/arbitrary",
+	"alloy-primitives/arbitrary",
+	"alloy-sol-types/arbitrary"
 ]
 bench = [
     "sov-metrics",

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -132,7 +132,6 @@ where
         capabilities::AuthenticationOutput<S, Self::Decodable>,
         capabilities::AuthenticationError,
     > {
-        println!("== AUTH ==");
         let AuthenticatorInput::Standard(input) = borsh::from_slice(&tx.data).map_err(|e| {
             capabilities::fatal_deserialization_error::<_, S, _>(&tx.data, e, pre_exec_ws)
         })?;

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -131,6 +131,7 @@ where
         capabilities::AuthenticationOutput<S, Self::Decodable>,
         capabilities::AuthenticationError,
     > {
+        println!("== AUTH ==");
         let AuthenticatorInput::Standard(input) = borsh::from_slice(&tx.data).map_err(|e| {
             capabilities::fatal_deserialization_error::<_, S, _>(&tx.data, e, pre_exec_ws)
         })?;

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -1,5 +1,6 @@
 //! This module defines abstractions and workflows around authenticating and authorizing
 //! transactions within a rollup.
+
 use std::marker::PhantomData;
 
 use borsh::{BorshDeserialize, BorshSerialize};

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -242,7 +242,7 @@ impl From<AuthenticationError> for UnregisteredAuthenticationError {
 }
 
 /// Verifies that the transaction has the correct chain ID.
-fn verify_chain_id<S: Spec, Call>(
+pub fn verify_chain_id<S: Spec, Call>(
     tx_v0: &crate::transaction::Version0<Call, S>,
     raw_tx_hash: TxHash,
 ) -> Result<(), AuthenticationError> {
@@ -275,7 +275,7 @@ fn verify_signature<S: Spec, D: DispatchCall<Spec = S>>(
 }
 
 /// Extracts authorization data from a verified transaction.
-fn extract_authorization_data<S: Spec, D: DispatchCall<Spec = S>>(
+pub fn extract_authorization_data<S: Spec, D: DispatchCall<Spec = S>>(
     tx_v0: &crate::transaction::Version0<D::Decodable, S>,
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,

--- a/crates/module-system/sov-modules-api/src/transaction/data.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/data.rs
@@ -111,6 +111,27 @@ pub struct TxDetails<S: Spec> {
     pub chain_id: u64,
 }
 
+pub mod sol_struct {
+    use alloy_sol_types::sol;
+
+    sol! {
+        #[derive(Debug)]
+        struct TxDetails {
+            uint64 chain_id;
+        }
+    }
+}
+
+impl<S: Spec> TxDetails<S> {
+    /// Converts the `TxDetails` to a SolStruct representation.
+    /// This is useful for EIP-712 signing.
+    pub fn as_sol_struct(&self) -> sol_struct::TxDetails {
+        sol_struct::TxDetails {
+            chain_id: self.chain_id,
+        }
+    }
+}
+
 /// Holds the original credentials to authenticate the transaction.
 /// For example, this could be a public key of the sender of the transaction.
 #[derive(Clone, Debug, Default)]

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -231,14 +231,7 @@ impl<R: TransactionCallable, S: Spec> Transaction<R, S> {
         })?;
         serialized_tx.extend_from_slice(chain_hash);
 
-        match &self.versioned_tx {
-            VersionedTx::V0(inner) => {
-                MeteredSignature::new::<S>(inner.signature.clone())
-                    .verify(&inner.pub_key, &serialized_tx, meter)
-                    .map_err(TransactionVerificationError::from)?;
-            }
-        }
-        Ok(())
+        self.verify_inner(&serialized_tx, meter)
     }
 
     /// Check whether the transaction has been signed correctly using EIP712.
@@ -264,14 +257,7 @@ impl<R: TransactionCallable, S: Spec> Transaction<R, S> {
         };
         let eip712_hash = tx_details.eip712_signing_hash(&DOMAIN);
 
-        match &self.versioned_tx {
-            VersionedTx::V0(inner) => {
-                MeteredSignature::new::<S>(inner.signature.clone())
-                    .verify(&inner.pub_key, eip712_hash.as_slice(), meter)
-                    .map_err(TransactionVerificationError::from)?;
-            }
-        }
-        Ok(())
+        self.verify_inner(eip712_hash.as_slice(), meter)
     }
 
     /// Creates a new transaction with the provided metadata.
@@ -298,6 +284,21 @@ impl<R: TransactionCallable, S: Spec> Transaction<R, S> {
         match self.versioned_tx {
             VersionedTx::V0(inner) => inner.runtime_call.clone(),
         }
+    }
+
+    fn verify_inner(
+        &self,
+        msg: &[u8],
+        meter: &mut impl GasMeter<Spec = S>,
+    ) -> Result<(), TransactionVerificationError<S::Gas>> {
+        match &self.versioned_tx {
+            VersionedTx::V0(inner) => {
+                MeteredSignature::new::<S>(inner.signature.clone())
+                    .verify(&inner.pub_key, msg, meter)
+                    .map_err(TransactionVerificationError::from)?;
+            }
+        }
+        Ok(())
     }
 
     fn to_unsigned_transaction(&self) -> UnsignedTransaction<R, S> {

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -336,12 +336,12 @@ impl<R: TransactionCallable, S: Spec> Transaction<R, S> {
     derive_more::Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, UniversalWallet,
 )]
 pub struct UnsignedTransaction<R: TransactionCallable, S: Spec> {
-    // The runtime call
-    runtime_call: R::Call,
-    // The generation number
-    generation: u64,
-    // Data related to fees and gas handling.
-    details: TxDetails<S>,
+    /// The runtime call
+    pub runtime_call: R::Call,
+    /// The generation number
+    pub generation: u64,
+    /// Data related to fees and gas handling.
+    pub details: TxDetails<S>,
 }
 // Manually implemented to ensure correct trait bounds for the same reason as for `Transaction`
 // above

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -3,6 +3,8 @@ mod rewards;
 use std::fmt::Debug;
 use std::io;
 
+use alloy_primitives::address;
+use alloy_sol_types::{eip712_domain, Eip712Domain, SolStruct};
 use borsh::{BorshDeserialize, BorshSerialize};
 pub use data::{AuthenticatedTransactionData, Credentials, PriorityFeeBips, TxDetails};
 pub(crate) use rewards::transaction_consumption_helper;
@@ -233,6 +235,39 @@ impl<R: TransactionCallable, S: Spec> Transaction<R, S> {
             VersionedTx::V0(inner) => {
                 MeteredSignature::new::<S>(inner.signature.clone())
                     .verify(&inner.pub_key, &serialized_tx, meter)
+                    .map_err(TransactionVerificationError::from)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Check whether the transaction has been signed correctly using EIP712.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    ///  * The signature is wrong
+    ///  * Serializing or hashing the transaction fails
+    ///  * Any operation runs out of gas
+    pub fn verify_eip712(
+        &self,
+        _chain_hash: &[u8; 32],
+        meter: &mut impl GasMeter<Spec = S>,
+    ) -> Result<(), TransactionVerificationError<S::Gas>> {
+        let unsigned = self.to_unsigned_transaction();
+        let tx_details = unsigned.details.as_sol_struct();
+
+        pub const DOMAIN: Eip712Domain = eip712_domain! {
+            name: "Transaction",
+            version: "1",
+            chain_id: 4321,
+            verifying_contract: address!("0000000000000000000000000000000000000000"),
+        };
+        let eip712_hash = tx_details.eip712_signing_hash(&DOMAIN);
+
+        match &self.versioned_tx {
+            VersionedTx::V0(inner) => {
+                MeteredSignature::new::<S>(inner.signature.clone())
+                    .verify(&inner.pub_key, eip712_hash.as_slice(), meter)
                     .map_err(TransactionVerificationError::from)?;
             }
         }

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -3,8 +3,6 @@ mod rewards;
 use std::fmt::Debug;
 use std::io;
 
-use alloy_primitives::address;
-use alloy_sol_types::{eip712_domain, Eip712Domain, SolStruct};
 use borsh::{BorshDeserialize, BorshSerialize};
 pub use data::{AuthenticatedTransactionData, Credentials, PriorityFeeBips, TxDetails};
 pub(crate) use rewards::transaction_consumption_helper;
@@ -231,33 +229,7 @@ impl<R: TransactionCallable, S: Spec> Transaction<R, S> {
         })?;
         serialized_tx.extend_from_slice(chain_hash);
 
-        self.verify_inner(&serialized_tx, meter)
-    }
-
-    /// Check whether the transaction has been signed correctly using EIP712.
-    ///
-    /// # Errors
-    /// Returns an error if:
-    ///  * The signature is wrong
-    ///  * Serializing or hashing the transaction fails
-    ///  * Any operation runs out of gas
-    pub fn verify_eip712(
-        &self,
-        _chain_hash: &[u8; 32],
-        meter: &mut impl GasMeter<Spec = S>,
-    ) -> Result<(), TransactionVerificationError<S::Gas>> {
-        let unsigned = self.to_unsigned_transaction();
-        let tx_details = unsigned.details.as_sol_struct();
-
-        pub const DOMAIN: Eip712Domain = eip712_domain! {
-            name: "Transaction",
-            version: "1",
-            chain_id: 4321,
-            verifying_contract: address!("0000000000000000000000000000000000000000"),
-        };
-        let eip712_hash = tx_details.eip712_signing_hash(&DOMAIN);
-
-        self.verify_inner(eip712_hash.as_slice(), meter)
+        self.verify_signature(&serialized_tx, meter)
     }
 
     /// Creates a new transaction with the provided metadata.
@@ -286,7 +258,8 @@ impl<R: TransactionCallable, S: Spec> Transaction<R, S> {
         }
     }
 
-    fn verify_inner(
+    /// Verify the transaction signature against the provided message.
+    pub fn verify_signature(
         &self,
         msg: &[u8],
         meter: &mut impl GasMeter<Spec = S>,
@@ -301,7 +274,8 @@ impl<R: TransactionCallable, S: Spec> Transaction<R, S> {
         Ok(())
     }
 
-    fn to_unsigned_transaction(&self) -> UnsignedTransaction<R, S> {
+    /// Converts the transaction to an unsigned transaction.
+    pub fn to_unsigned_transaction(&self) -> UnsignedTransaction<R, S> {
         match &self.versioned_tx {
             VersionedTx::V0(inner) => UnsignedTransaction::new_with_details(
                 inner.runtime_call.clone(),

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -4154,6 +4154,8 @@ dependencies = [
 name = "sov-modules-api"
 version = "0.3.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
  "anyhow",
  "bech32",
  "borsh",

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -3485,6 +3485,8 @@ dependencies = [
 name = "sov-modules-api"
 version = "0.3.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
  "anyhow",
  "bech32",
  "borsh",

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -5387,6 +5387,8 @@ dependencies = [
 name = "sov-modules-api"
 version = "0.3.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
  "anyhow",
  "bech32",
  "borsh",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -4992,6 +4992,8 @@ dependencies = [
 name = "sov-modules-api"
 version = "0.3.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
  "anyhow",
  "bech32",
  "borsh",


### PR DESCRIPTION
# Description

This PR implements EIP712 authenticator. It's similar to the canonical one ans reuses some logic but verifies the EIP712 signatures.
It relies on the fact that Transaction can verify it's signature as EIP712.
This relies on Transaction implementing `SolValue`.
For now - I manually convert the TxDetails to a type that implements SolValue. So that we have something to sign. This is obviously unfinished and insecure as we only sign one field.
Future plans:
* Run cargo expand on UniversalWallet on some simple type and see what it produces
* Ammend the macro so that it also generates sol! definitions
* Implement a conversion from `impl UniversalWallet` to `impl SolValue`

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
There is a success test. Failure test coming next

## Docs
No docs yet

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
