### PR TITLE
Fix universal wallet display attrs not serialized correctly

### DIFF
--- a/crates/universal-wallet/fuzz/src/lib.rs
+++ b/crates/universal-wallet/fuzz/src/lib.rs
@@ -55,7 +55,10 @@ impl Arbitrary<'_> for ArbitrarySafeString {
 )]
 pub enum ByteVecInput {
     Hex(#[sov_wallet(display(hex))] Vec<u8>),
-    Base58(#[sov_wallet(display(base58))] Vec<u8>),
+    Base58 {
+        #[sov_wallet(display(base58))]
+        address: Vec<u8>,
+    },
     Decimal(#[sov_wallet(display(decimal))] Vec<u8>),
 }
 

--- a/crates/universal-wallet/fuzz/src/lib.rs
+++ b/crates/universal-wallet/fuzz/src/lib.rs
@@ -50,6 +50,10 @@ impl Arbitrary<'_> for ArbitrarySafeString {
     }
 }
 
+fn bech_prefix() -> &'static str {
+    "test"
+}
+
 #[derive(
     Debug, BorshSerialize, BorshDeserialize, Serialize, Deserialize, UniversalWallet, Arbitrary,
 )]
@@ -60,6 +64,7 @@ pub enum ByteVecInput {
         address: Vec<u8>,
     },
     Decimal(#[sov_wallet(display(decimal))] Vec<u8>),
+    Bechm(#[sov_wallet(display(bech32m(prefix = "bech_prefix()")))] Vec<u8>),
 }
 
 #[derive(
@@ -69,6 +74,7 @@ pub enum ByteArrayInput {
     Hex(#[sov_wallet(display(hex))] [u8; 32]),
     Base58(#[sov_wallet(display(base58))] [u8; 32]),
     Decimal(#[sov_wallet(display(decimal))] [u8; 32]),
+    Bech(#[sov_wallet(display(bech32(prefix = "bech_prefix()")))] [u8; 32]),
 }
 
 #[derive(

--- a/crates/universal-wallet/macro-helpers/src/schema.rs
+++ b/crates/universal-wallet/macro-helpers/src/schema.rs
@@ -773,10 +773,22 @@ fn build_virtual_struct(
                 Some(ty) => quote!{#[sov_wallet(template_override_ty = #ty)]},
                 None => quote!{}
             };
+            let display_attribute = match &field.display {
+                Some(display_type) => {
+                    match display_type {
+                        ByteDisplayType::Hex => quote! {#[sov_wallet(display(hex))]},
+                        ByteDisplayType::Decimal => quote! {#[sov_wallet(display(decimal))]},
+                        ByteDisplayType::Base58 => quote! {#[sov_wallet(display(base58))]},
+                        ByteDisplayType::Bech32 { prefix } => quote! {#[sov_wallet(display(bech32(prefix = #prefix)))]},
+                        ByteDisplayType::Bech32m { prefix } => quote! {#[sov_wallet(display(bech32m(prefix = #prefix)))]},
+                    }
+                },
+                None => quote!{}
+            };
             // TODO: propagate `#[serde(rename)]` attributes to each field here if support for it
             // is required
             quote! {
-                #template_attribute #template_override_attribute #bounds_attribute #name: #field_type
+                #template_attribute #template_override_attribute #bounds_attribute #display_attribute #name: #field_type
             }
         })
         .collect::<Vec<_>>();
@@ -846,8 +858,20 @@ fn build_virtual_tuple(
                 Some(ty) => quote! {#[sov_wallet(template_override_ty = #ty)]},
                 None => quote! {},
             };
+            let display_attribute = match &field.display {
+                Some(display_type) => {
+                    match display_type {
+                        ByteDisplayType::Hex => quote! {#[sov_wallet(display(hex))]},
+                        ByteDisplayType::Decimal => quote! {#[sov_wallet(display(decimal))]},
+                        ByteDisplayType::Base58 => quote! {#[sov_wallet(display(base58))]},
+                        ByteDisplayType::Bech32 { prefix } => quote! {#[sov_wallet(display(bech32(prefix = #prefix)))]},
+                        ByteDisplayType::Bech32m { prefix } => quote! {#[sov_wallet(display(bech32m(prefix = #prefix)))]},
+                    }
+                },
+                None => quote!{}
+            };
             quote! {
-                #template_attribute #template_override_attribute #bounds_attribute #field_type
+                #template_attribute #template_override_attribute #bounds_attribute #display_attribute #field_type
             }
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
# Description

When serializing universal wallet schema to JSON display attributes like `Base58` were getting dropped causing `Hex` to be used always. The display attribute is now propagated

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
