### PR TITLE
Remove empty `events` array from tx responses when events were not requested

### DIFF
--- a/crates/full-node/sov-ledger-apis/src/lib.rs
+++ b/crates/full-node/sov-ledger-apis/src/lib.rs
@@ -901,7 +901,8 @@ struct Transaction<TxReceipt: TxReceiptContents, E> {
     #[serde_as(as = "serde_with::base64::Base64")]
     pub body: Vec<u8>,
     pub receipt: TxEffect<TxReceipt>,
-    pub events: Vec<RuntimeEventResponse<E>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub events: Option<Vec<RuntimeEventResponse<E>>>,
     pub batch_number: u64,
 }
 
@@ -913,7 +914,7 @@ impl<TxReceipt: TxReceiptContents, E> Transaction<TxReceipt, E> {
             event_range: tx.event_range,
             body: tx.body.unwrap_or_default(),
             receipt: tx.receipt.into(),
-            events: tx.events.unwrap_or_default(),
+            events: tx.events,
             batch_number: tx.batch_number,
         }
     }


### PR DESCRIPTION
# Description

This PR fixes a surprising behavior of our ledger API where a transaction includes an empty events array when events were not requested with the `include_children` flag. Now, the empty array is included if and only if the user requested events to be included and the transaction did not emit any events

