### PR TITLE
Remove `DaSyncState` from the sequencer.

### DIFF
--- a/crates/full-node/sov-rollup-apis/Cargo.toml
+++ b/crates/full-node/sov-rollup-apis/Cargo.toml
@@ -47,3 +47,4 @@ sov-test-utils = { workspace = true }
 sov-kernels = { workspace = true, features = ["native"] }
 sov-state = { workspace = true, features = ["native"] }
 
+

--- a/crates/full-node/sov-rollup-apis/tests/integration/main.rs
+++ b/crates/full-node/sov-rollup-apis/tests/integration/main.rs
@@ -13,7 +13,6 @@ use sov_modules_api::prelude::*;
 use sov_modules_api::{Spec, SyncStatus};
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
 use sov_test_utils::runtime::TestRunner;
-
 type S = sov_test_utils::TestSpec;
 
 generate_optimistic_runtime!(TestRuntime <= );
@@ -64,6 +63,11 @@ impl TestData {
 
         let mut ledger = SimpleLedgerStorageManager::new_any_path();
 
+        let (sync_sender, sync_receiver) = watch::channel(SyncStatus::Syncing {
+            synced_da_height: 0,
+            target_da_height: 0,
+        });
+
         let state_update_info = StateUpdateInfo {
             storage,
             ledger_reader: ledger.create_ledger_storage(),
@@ -71,13 +75,12 @@ impl TestData {
             next_tx_number: 0,
             slot_number: SlotNumber::GENESIS,
             latest_finalized_slot_number: SlotNumber::GENESIS,
+            sync_status: SyncStatus::Synced {
+                synced_da_height: 22,
+            },
         };
 
         let (state_update_sender, state_update_receiver) = watch::channel(state_update_info);
-        let (sync_sender, sync_receiver) = watch::channel(SyncStatus::Syncing {
-            synced_da_height: 0,
-            target_da_height: 0,
-        });
 
         let axum_router: axum::Router<()> =
             RollupTxRouter::<Arc<DefaultRollupStateProvider<S, RT>>>::axum_router(
@@ -128,6 +131,9 @@ impl TestData {
             next_tx_number: 0,
             slot_number: SlotNumber::GENESIS,
             latest_finalized_slot_number: SlotNumber::GENESIS,
+            sync_status: SyncStatus::Synced {
+                synced_da_height: 99,
+            },
         };
         self.storage_sender.send_replace(state_update_info);
     }

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -10,7 +10,7 @@ use sov_blob_sender::BlobInternalId;
 use sov_blob_storage::SequenceNumber;
 use sov_modules_api::capabilities::RollupHeight;
 use sov_modules_api::{
-    DaSyncState, FullyBakedTx, GasArray, GasSpec, Runtime, Spec, StateCheckpoint, StateUpdateInfo,
+    FullyBakedTx, GasArray, GasSpec, Runtime, Spec, StateCheckpoint, StateUpdateInfo,
     VersionReader, VisibleSlotNumber,
 };
 use sov_state::{NativeStorage, Storage};
@@ -701,7 +701,6 @@ enum Message<S: Spec, Rt: Runtime<S>> {
     SequencerConditions {
         resp: oneshot::Sender<PreferredSeqOperation<S, Rt>>,
         info: StateUpdateInfo<S::Storage>,
-        da_sync_state: Arc<DaSyncState>,
         next_sequence_number_according_to_node: u64,
         reason: &'static str,
     },
@@ -752,7 +751,6 @@ enum Message<S: Spec, Rt: Runtime<S>> {
     },
     WaitNodeResync {
         info: StateUpdateInfo<S::Storage>,
-        da_sync_state: Arc<DaSyncState>,
         reason: &'static str,
     },
     #[cfg(feature = "test-utils")]
@@ -908,7 +906,6 @@ where
     pub(crate) async fn sequencer_conditions_msg(
         &self,
         info: &StateUpdateInfo<S::Storage>,
-        da_sync_state: Arc<DaSyncState>,
         next_sequence_number_according_to_node: u64,
         reason: &'static str,
     ) -> PreferredSeqOperation<S, Rt> {
@@ -916,7 +913,6 @@ where
         self.send(Message::SequencerConditions {
             resp,
             info: info.clone(),
-            da_sync_state,
             next_sequence_number_according_to_node,
             reason,
         })
@@ -1039,15 +1035,9 @@ where
     pub(crate) async fn wait_for_node_resync_msg(
         &self,
         info: StateUpdateInfo<S::Storage>,
-        da_sync_state: Arc<DaSyncState>,
         reason: &'static str,
     ) {
-        self.send(Message::WaitNodeResync {
-            info,
-            da_sync_state,
-            reason,
-        })
-        .await;
+        self.send(Message::WaitNodeResync { info, reason }).await;
     }
 
     /// Closes the current batch
@@ -1145,14 +1135,12 @@ where
                     Message::SequencerConditions {
                         resp,
                         info,
-                        da_sync_state,
                         next_sequence_number_according_to_node,
                         reason,
                     } => {
                         let ret = self
                             .process_sequencer_conditions(
                                 &info,
-                                da_sync_state,
                                 next_sequence_number_according_to_node,
                                 reason,
                             )
@@ -1241,13 +1229,8 @@ where
                     } => {
                         self.process_do_new_tx(tx_hash, baked_tx, reason).await;
                     }
-                    Message::WaitNodeResync {
-                        info,
-                        da_sync_state,
-                        reason,
-                    } => {
-                        self.process_wait_for_node_resync(info, da_sync_state, reason)
-                            .await;
+                    Message::WaitNodeResync { info, reason } => {
+                        self.process_wait_for_node_resync(info, reason).await;
                     }
                     #[cfg(feature = "test-utils")]
                     Message::ForceCloseCurrentBatch { reason: _reason } => {
@@ -1324,10 +1307,11 @@ where
     async fn process_sequencer_conditions(
         &mut self,
         info: &StateUpdateInfo<S::Storage>,
-        da_sync_state: Arc<DaSyncState>,
         next_sequence_number_according_to_node: u64,
         reason: &'static str,
     ) -> PreferredSeqOperation<S, Rt> {
+        let sync_status = &info.sync_status;
+
         debug!(?info, "Processing state update info from update_state");
         let mut inner = self.get_inner_with_timing(reason).await;
         let next_sequence_number = inner.sequence_number_of_next_blob;
@@ -1353,7 +1337,7 @@ where
             t.submit(fetch_batches_to_replay_metrics);
         });
 
-        let distance = da_sync_state.status().distance();
+        let distance = sync_status.distance();
 
         let condition_nodes_sequence_number_is_fresher =
             next_sequence_number_according_to_node > next_sequence_number;
@@ -1389,16 +1373,16 @@ where
             (true, _, false, false) => {
                 warn!("The node has a higher sequence number than the sequencer, but we're very close to the chain tip, i.e. we don't expect to be simply syncing. This could mean there is another preferred sequencer running (which is not supported and will likely lead to issues), or you very recently restarted the node and there's still some in-flight blobs. Resyncing to the chain tip.");
                 inner.is_ready = Err(SequencerNotReadyDetails::Syncing {
-                    target_da_height: da_sync_state.target_da_height.load(Ordering::Relaxed),
-                    synced_da_height: da_sync_state.synced_da_height.load(Ordering::Relaxed),
+                    target_da_height: sync_status.target_da_height(),
+                    synced_da_height: sync_status.synced_da_height(),
                 });
                 PreferredSeqOperation::WaitForNodeResyncToTip
             }
             (_, _, true, _) => {
                 warn!(?distance, "The sequencer must pause because the node has lagged behind the DA blockchain. This might lead to a brief downtime for users.");
                 inner.is_ready = Err(SequencerNotReadyDetails::Syncing {
-                    target_da_height: da_sync_state.target_da_height.load(Ordering::Relaxed),
-                    synced_da_height: da_sync_state.synced_da_height.load(Ordering::Relaxed),
+                    target_da_height: sync_status.target_da_height(),
+                    synced_da_height: sync_status.synced_da_height(),
                 });
                 PreferredSeqOperation::WaitForNodeResyncWithAllowedSlack
             }
@@ -1706,14 +1690,13 @@ where
     async fn process_wait_for_node_resync(
         &mut self,
         info: StateUpdateInfo<S::Storage>,
-        da_sync_state: Arc<DaSyncState>,
         reason: &'static str,
     ) {
         let mut inner = self.get_inner_with_timing(reason).await;
         let mut rt = Rt::default();
         inner.is_ready = Err(SequencerNotReadyDetails::Syncing {
-            target_da_height: da_sync_state.target_da_height.load(Ordering::Relaxed),
-            synced_da_height: da_sync_state.synced_da_height.load(Ordering::Relaxed),
+            target_da_height: info.sync_status.target_da_height(),
+            synced_da_height: info.sync_status.synced_da_height(),
         });
 
         let node_sequence_number = get_next_sequence_number_according_to_node(&info, &mut rt);

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -52,7 +52,6 @@ use sov_modules_api::{
 use sov_rest_utils::errors::{database_error_500, sequencer_overloaded_503};
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::node::da::DaService;
-use sov_rollup_interface::node::DaSyncState;
 use sov_rollup_interface::TxHash;
 use state_root_compute::StateRootBackgroundTaskState;
 use tokio::sync::mpsc::{self};
@@ -94,7 +93,6 @@ where
     tx_status_manager: TxStatusManager<S::Da>,
     blobs_sender_channel: broadcast::Sender<BlobExecutionStatus<Da::Spec>>,
     api_state: ApiState<S>,
-    da_sync_state: Arc<DaSyncState>,
     _runtime: PhantomData<(Rt, Da)>,
     config: SequencerConfig<S::Address, PreferredSequencerConfig>,
 
@@ -125,7 +123,6 @@ where
     pub async fn create(
         da: Da,
         state_update_receiver: StateUpdateReceiver<S::Storage>,
-        da_sync_state: Arc<DaSyncState>,
         storage_path: &Path,
         config: &SequencerConfig<S::Address, PreferredSequencerConfig>,
         ledger_db: LedgerDb,
@@ -285,7 +282,6 @@ where
             tx_status_manager: tx_status_manager.clone(),
             transaction_cache: cached_txs,
             blobs_sender_channel,
-            da_sync_state,
             api_state,
             _runtime: PhantomData,
             config: config.clone(),
@@ -379,14 +375,20 @@ where
             // 1. Dump our catchup batches once every DA block to fast-forward the
             //    visible_slot_number
             for i in 1..=max_batches_to_send {
-                let start_height = self.da_sync_state.target_da_height.load(Ordering::Relaxed);
+                let start_height = info.sync_status.target_da_height();
                 loop {
-                    let new_height = self.da_sync_state.target_da_height.load(Ordering::Relaxed);
+                    let new_height = info.sync_status.target_da_height();
                     if new_height > start_height {
                         break;
                     } else {
                         tokio::time::sleep(Duration::from_millis(100)).await;
                     }
+                    info = poll_state_update::<S>(
+                        state_update_receiver,
+                        shutdown_receiver,
+                        "update_state_task",
+                    )
+                    .await?;
                 }
                 if i % 10 == 0 {
                     tracing::info!(number = %i, min = %min_batches_to_send, max = %max_batches_to_send, "Sending catchup batch");
@@ -473,10 +475,10 @@ where
         let mut info = current_info;
 
         loop {
-            let is_synced = self.da_sync_state.status().distance() <= distance_to_tip;
+            let is_synced = info.sync_status.distance() <= distance_to_tip;
 
             self.synchronized_state_updator
-                .wait_for_node_resync_msg(info, self.da_sync_state.clone(), "wait_for_node_resync")
+                .wait_for_node_resync_msg(info, "wait_for_node_resync")
                 .await;
 
             // Exit after processing if we're synced
@@ -642,7 +644,6 @@ where
         .synchronized_state_updator
         .sequencer_conditions_msg(
             &info,
-            seq.da_sync_state.clone(),
             next_sequence_number_according_to_node,
             "update_state::fetch_initial_batches_to_replay",
         )

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -9,6 +9,7 @@ use jsonrpsee::RpcModule;
 use sov_db::ledger_db::{LedgerDb, SlotCommit};
 use sov_db::schema::{DeltaReader, SchemaBatch};
 use sov_metrics::{MonitoringConfig, RunnerMetrics};
+
 use sov_rollup_interface::common::{RollupHeight, SlotNumber};
 use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait, DaSpec};
 use sov_rollup_interface::node::da::{DaService, SlotData};
@@ -151,12 +152,12 @@ where
         storage_manager: Sm,
         state_update_channel: watch::Sender<StateUpdateInfo<Sm::StfState>>,
         prev_state_root: Stf::StateRoot,
-        sync_status_sender: watch::Sender<SyncStatus>,
         state_height_tracker: Box<dyn ProvableHeightTracker>,
         shutdown_receiver: watch::Receiver<()>,
         monitoring_config: MonitoringConfig,
         start_at_rollup_height: Option<RollupHeight>,
         stop_at_rollup_height: Option<RollupHeight>,
+        sync_state: Arc<DaSyncState>,
     ) -> anyhow::Result<Self> {
         error_if_tokio_runtime_is_not_multi_threaded()?;
 
@@ -165,15 +166,12 @@ where
         let listen_address_http =
             SocketAddr::new(axum_config.bind_host.parse()?, axum_config.bind_port);
 
-        let next_item_numbers = ledger_db.get_next_items_numbers()?;
-        let last_slot_processed_before_shutdown = next_item_numbers.slot_number.saturating_sub(1);
+        let first_unprocessed_height_at_startup = sync_state
+            .synced_da_height
+            .load(std::sync::atomic::Ordering::Acquire)
+            + 1;
 
-        let da_height_processed =
-            runner_config.genesis_height + last_slot_processed_before_shutdown.get();
-
-        let first_unprocessed_height_at_startup = da_height_processed + 1;
         debug!(
-            %last_slot_processed_before_shutdown,
             %runner_config.genesis_height,
             %first_unprocessed_height_at_startup,
             proof_manager_config = ?pm_config,
@@ -191,16 +189,6 @@ where
         } else {
             (None, None)
         };
-
-        let target_da_height = Self::get_target_block(&da_service, &stop_at_rollup_height)
-            .await?
-            .height();
-
-        let sync_state = Arc::new(DaSyncState {
-            synced_da_height: da_height_processed.into(),
-            target_da_height: AtomicU64::new(target_da_height),
-            sync_status_sender,
-        });
 
         let da_polling_interval = Duration::from_millis(runner_config.da_polling_interval_ms);
 
@@ -250,18 +238,6 @@ where
             stop_at_rollup_height,
             save_tx_bodies: runner_config.save_tx_bodies,
         })
-    }
-
-    async fn get_target_block(
-        da_service: &Da,
-        stop_at_rollup_height: &Option<RollupHeight>,
-    ) -> anyhow::Result<<Da::Spec as DaSpec>::BlockHeader> {
-        // If we've entered the upgrade procedure, the rollup processes only finalized blocks.
-        if stop_at_rollup_height.is_some() {
-            da_service.get_last_finalized_block_header().await
-        } else {
-            da_service.get_head_block_header().await
-        }
     }
 
     /// Subscribes to this runner's [`StateUpdateInfo`] channel, if enabled.
@@ -321,7 +297,7 @@ where
 
             loop {
                 match future_or_shutdown(
-                    Self::get_target_block(&da_service, &stop_at_rollup_height),
+                    get_target_block(da_service.as_ref(), &stop_at_rollup_height),
                     &shutdown_receiver,
                 )
                 .await
@@ -734,6 +710,7 @@ where
 pub async fn query_state_update_info<S>(
     ledger_db: &LedgerDb,
     storage: S,
+    da_sync_state: &DaSyncState,
 ) -> anyhow::Result<StateUpdateInfo<S>> {
     let slot_number = ledger_db.get_head_slot_number().await?;
     let next_event_number = ledger_db
@@ -754,6 +731,7 @@ pub async fn query_state_update_info<S>(
         next_tx_number,
         slot_number,
         latest_finalized_slot_number,
+        sync_status: da_sync_state.status(),
     })
 }
 
@@ -764,4 +742,44 @@ fn error_if_tokio_runtime_is_not_multi_threaded() -> anyhow::Result<()> {
             RuntimeFlavor::CurrentThread => Err(anyhow::anyhow!("A multi-threaded Tokio runtime is required to run the rollup node. Check your Tokio configuration. If you're testing node functionality, make sure your test uses `#[tokio::test(flavor = \"multi_thread\")]` or an equivalent configuration. Aborting.")),
             _ => Ok(())
         }
+}
+
+/// Creats a new `DaSyncState`
+pub async fn make_da_sync_state<Da: DaService<Error = anyhow::Error>>(
+    runner_config: &RunnerConfig,
+    stop_at_rollup_height: Option<RollupHeight>,
+    ledger_db: &LedgerDb,
+    da_service: &Da,
+    sync_status_sender: watch::Sender<SyncStatus>,
+) -> anyhow::Result<Arc<DaSyncState>> {
+    let next_item_numbers = ledger_db.get_next_items_numbers()?;
+    let last_slot_processed_before_shutdown = next_item_numbers.slot_number.saturating_sub(1);
+
+    debug!(%last_slot_processed_before_shutdown);
+    let da_height_processed =
+        runner_config.genesis_height + last_slot_processed_before_shutdown.get();
+
+    let target_da_height = get_target_block(da_service, &stop_at_rollup_height)
+        .await?
+        .height();
+
+    let sync_state = Arc::new(DaSyncState {
+        synced_da_height: da_height_processed.into(),
+        target_da_height: AtomicU64::new(target_da_height),
+        sync_status_sender,
+    });
+
+    Ok(sync_state)
+}
+
+async fn get_target_block<Da: DaService<Error = anyhow::Error>>(
+    da_service: &Da,
+    stop_at_rollup_height: &Option<RollupHeight>,
+) -> anyhow::Result<<Da::Spec as DaSpec>::BlockHeader> {
+    // If we've entered the upgrade procedure, the rollup processes only finalized blocks.
+    if stop_at_rollup_height.is_some() {
+        da_service.get_last_finalized_block_header().await
+    } else {
+        da_service.get_head_block_header().await
+    }
 }

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -169,7 +169,8 @@ where
         let first_unprocessed_height_at_startup = sync_state
             .synced_da_height
             .load(std::sync::atomic::Ordering::Acquire)
-            + 1;
+            .checked_add(1)
+            .expect("The impossible happened  first_unprocessed_height_at_startup overflowed");
 
         debug!(
             %runner_config.genesis_height,

--- a/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
@@ -449,7 +449,9 @@ where
         ledger_state: DeltaReader,
     ) -> anyhow::Result<()> {
         self.ledger_db.replace_reader(ledger_state);
-        let state_update_info = query_state_update_info(&self.ledger_db, stf_state).await?;
+        let state_update_info =
+            query_state_update_info(&self.ledger_db, stf_state, self.da_sync_state.as_ref())
+                .await?;
 
         // `send_replace` is superior to `send` for our use case. It never fails
         // because it doesn't need to notify all receivers, unlike `send`, which

--- a/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
@@ -1024,10 +1024,6 @@ where
     let genesis_header = MockBlockHeader::from_height(0);
     let (stf_state, ledger_state) = storage_manager.create_state_after(&genesis_header)?;
     let ledger_db = LedgerDb::with_reader(ledger_state)?;
-    let update_info = query_state_update_info(&ledger_db, stf_state).await?;
-
-    // Update channel, receiver does not need to be alive
-    let (state_update_sender, _state_update_recv) = watch::channel(update_info);
 
     let (sync_status_sender, _rec) = tokio::sync::watch::channel(SyncStatus::START);
 
@@ -1036,6 +1032,10 @@ where
         target_da_height: AtomicU64::new(u64::MAX),
         sync_status_sender,
     });
+
+    let update_info = query_state_update_info(&ledger_db, stf_state, sync_state.as_ref()).await?;
+    // Update channel, receiver does not need to be alive
+    let (state_update_sender, _state_update_recv) = watch::channel(update_info);
 
     let mut state_manager = StateManager::new(
         storage_manager,

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -18,7 +18,7 @@ use sov_mock_da::{
 use sov_mock_zkvm::{MockZkvm, MockZkvmHost};
 use sov_modules_api::provable_height_tracker::InfiniteHeight;
 use sov_modules_api::{
-    FullyBakedTx, ProofSender, StateTransitionFunction, StateUpdateInfo, SyncStatus,
+    DaSyncState, FullyBakedTx, ProofSender, StateTransitionFunction, StateUpdateInfo, SyncStatus,
 };
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::DaSpec;
@@ -30,6 +30,7 @@ use sov_rollup_interface::zk::Zkvm;
 use sov_sequencer::standard::StdSequencerConfig;
 use sov_sequencer::{react_to_state_updates, SequencerConfig, SequencerKindConfig};
 use sov_state::{DefaultStorageSpec, NativeStorage, ProverStorage};
+use sov_stf_runner::make_da_sync_state;
 use sov_stf_runner::processes::{
     start_zk_workflow_in_background, ParallelProverService, RollupProverConfigDiscriminants,
 };
@@ -151,12 +152,13 @@ impl ProofSender for MockProofSender {
 // Returns genesis state root, prev state root for given init variant and initial value for state update info.
 pub async fn bootstrap_state_update_info(
     storage_manager: &mut StorageManager,
+    da_sync_state: &DaSyncState,
 ) -> anyhow::Result<StateUpdateInfo<ProverStorage<S>>> {
     let genesis_block_header = MockBlockHeader::from_height(0);
     let (stf_storage, ledger_state) = storage_manager.create_state_after(&genesis_block_header)?;
     let ledger_db = LedgerDb::with_reader(ledger_state)?;
 
-    query_state_update_info(&ledger_db, stf_storage).await
+    query_state_update_info(&ledger_db, stf_storage, da_sync_state).await
 }
 
 pub async fn initialize_runner(
@@ -172,15 +174,31 @@ pub async fn initialize_runner(
     let verifier = MockDaVerifier::default();
 
     let rollup_config = rollup_config(&da_service, path, aggregated_proof_block_jump);
+
     let mut storage_manager: StorageManager = NativeStorageManager::new(path).unwrap();
 
+    let finalized_header = da_service.get_last_finalized_block_header().await.unwrap();
+    let (_, ledger_state) = storage_manager
+        .create_state_after(&finalized_header)
+        .unwrap();
+    let ledger_db = LedgerDb::with_reader(ledger_state).unwrap();
+    let (sync_sender, _sync_status_receiver) = watch::channel(SyncStatus::START);
+
+    let da_sync_state = make_da_sync_state(
+        &rollup_config.runner,
+        None,
+        &ledger_db,
+        da_service.as_ref(),
+        sync_sender,
+    )
+    .await
+    .unwrap();
     let (state_update_sender, state_update_recv) = watch::channel(
-        bootstrap_state_update_info(&mut storage_manager)
+        bootstrap_state_update_info(&mut storage_manager, da_sync_state.as_ref())
             .await
             .unwrap(),
     );
 
-    let (sync_sender, _sync_status_receiver) = watch::channel(SyncStatus::START);
     let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
     shutdown_receiver.mark_unchanged();
 
@@ -188,12 +206,6 @@ pub async fn initialize_runner(
         .initialize(&stf, &mut storage_manager)
         .await
         .unwrap();
-
-    let finalized_header = da_service.get_last_finalized_block_header().await.unwrap();
-    let (_, ledger_state) = storage_manager
-        .create_state_after(&finalized_header)
-        .unwrap();
-    let ledger_db = LedgerDb::with_reader(ledger_state).unwrap();
 
     let mut tasks = JoinSet::new();
 
@@ -227,12 +239,12 @@ pub async fn initialize_runner(
         storage_manager,
         state_update_sender,
         prev_state_root,
-        sync_sender,
         Box::new(InfiniteHeight),
         shutdown_receiver.clone(),
         rollup_config.monitoring.clone(),
         None,
         None,
+        da_sync_state,
     )
     .await
     .unwrap();

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -18,6 +18,7 @@ use sov_rollup_interface::node::SyncStatus;
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_state::storage::NativeStorage;
 use sov_state::{ArrayWitness, ProverStorage, Storage, StorageRoot};
+use sov_stf_runner::make_da_sync_state;
 use sov_stf_runner::StateTransitionRunner;
 use sov_test_utils::storage::SimpleStorageManager;
 use tempfile::TempDir;
@@ -120,14 +121,30 @@ async fn test_runner_with_background_da_service(
     let mut storage_manager: crate::helpers::runner_init::StorageManager =
         NativeStorageManager::new(tempdir.path())?;
 
-    let (state_update_sender, _state_update_recv) =
-        watch::channel(bootstrap_state_update_info(&mut storage_manager).await?);
+    let block = da_service.get_block_at(0).await?;
+    let genesis_header = block.header().clone();
+    let (_, ledger_state) = storage_manager.create_state_after(&genesis_header).unwrap();
+
     let (sync_sender, mut sync_status_receiver) = watch::channel(SyncStatus::START);
+    let ledger_db = LedgerDb::with_reader(ledger_state).unwrap();
+    let da_sync_state = make_da_sync_state(
+        &rollup_config.runner,
+        None,
+        &ledger_db,
+        da_service.as_ref(),
+        sync_sender,
+    )
+    .await
+    .unwrap();
+
+    let (state_update_sender, _state_update_recv) = watch::channel(
+        bootstrap_state_update_info(&mut storage_manager, da_sync_state.as_ref()).await?,
+    );
+
     sync_status_receiver.mark_unchanged();
 
     let genesis_params = vec![1, 2, 3, 4, 5];
-    let block = da_service.get_block_at(0).await?;
-    let genesis_header = block.header().clone();
+
     let init_variant: MockInitVariant = InitVariant::Genesis {
         block,
         genesis_params,
@@ -135,8 +152,6 @@ async fn test_runner_with_background_da_service(
     let (prev_state_root, _genesis_state_root) =
         init_variant.initialize(&stf, &mut storage_manager).await?;
 
-    let (_, ledger_state) = storage_manager.create_state_after(&genesis_header).unwrap();
-    let ledger_db = LedgerDb::with_reader(ledger_state).unwrap();
     let mut runner: HashStfRunner<StorableMockDaService> = StateTransitionRunner::new(
         rollup_config.runner.clone(),
         None,
@@ -146,12 +161,12 @@ async fn test_runner_with_background_da_service(
         storage_manager,
         state_update_sender,
         prev_state_root,
-        sync_sender,
         Box::new(InfiniteHeight),
         shutdown_receiver.clone(),
         rollup_config.monitoring.clone(),
         None,
         None,
+        da_sync_state,
     )
     .await?;
 

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -30,6 +30,7 @@ use sov_sequencer::standard::StdSequencer;
 use sov_sequencer::{ProofBlobSender, Sequencer, SequencerApis, SequencerKindConfig};
 use sov_state::storage::NativeStorage;
 use sov_state::Storage;
+use sov_stf_runner::make_da_sync_state;
 use sov_stf_runner::processes::{
     start_op_workflow_in_background, start_operator_workflow_in_background,
     start_zk_workflow_in_background, ProverService, RollupProverConfig,
@@ -234,7 +235,6 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     PreferredSequencer::<Self::Spec, Self::Runtime, Self::DaService>::create(
                         da_service.clone(),
                         state_update_receiver.clone(),
-                        da_sync_state,
                         &rollup_config.storage.path,
                         &rollup_config.sequencer.with_seq_config(seq_config.clone()),
                         ledger_db.clone(),
@@ -373,7 +373,21 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             }
         };
 
-        let state_update_info = query_state_update_info(&ledger_db, prover_storage.clone()).await?;
+        let (sync_status_sender, sync_status_receiver) =
+            tokio::sync::watch::channel(SyncStatus::START);
+
+        let da_sync_state = make_da_sync_state(
+            &rollup_config.runner,
+            stop_at_rollup_height,
+            &ledger_db,
+            da_service.as_ref(),
+            sync_status_sender,
+        )
+        .await?;
+
+        let state_update_info =
+            query_state_update_info(&ledger_db, prover_storage.clone(), da_sync_state.as_ref())
+                .await?;
 
         let mut rt = Self::Runtime::default();
         let checkpoint = StateCheckpoint::new(prover_storage, &rt.kernel());
@@ -404,9 +418,6 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             MaximumProvableHeight::new(state_update_sender.subscribe(), Self::Runtime::default()),
         );
 
-        let (sync_status_sender, sync_status_receiver) =
-            tokio::sync::watch::channel(SyncStatus::START);
-
         let mut runner = StateTransitionRunner::new(
             rollup_config.runner.clone(),
             if prover_config.is_some() {
@@ -420,19 +431,19 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             storage_manager,
             state_update_sender,
             prev_state_root,
-            sync_status_sender,
             visible_state_height_tracker,
             main_shutdown_receiver.clone(),
             rollup_config.monitoring.clone(),
             start_at_rollup_height,
             stop_at_rollup_height,
+            da_sync_state.clone(),
         )
         .await?;
 
         let sequencer = self
             .create_sequencer(
                 state_update_receiver.clone(),
-                runner.da_sync_state(),
+                da_sync_state,
                 &rollup_config,
                 &ledger_db,
                 &api_ledger_db,

--- a/crates/module-system/sov-test-utils/src/sequencer.rs
+++ b/crates/module-system/sov-test-utils/src/sequencer.rs
@@ -138,7 +138,8 @@ impl<Rt: Runtime<TestSpec>> TestSequencerSetup<Rt> {
             vec![]
         };
 
-        let state_update_info = query_state_update_info(&ledger_db, stf_state).await?;
+        let state_update_info =
+            query_state_update_info(&ledger_db, stf_state, da_sync_state.as_ref()).await?;
 
         let (state_update_sender, state_update_receiver) = watch::channel(state_update_info);
         let (shutdown_sender, mut shutdown_receiver) = watch::channel(());

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -535,6 +535,7 @@ where
             next_tx_number: 0,
             slot_number: SlotNumber::ONE,
             latest_finalized_slot_number: SlotNumber::ONE,
+            sync_status: da_sync_state.status(),
         };
 
         let (sender, state_update_receiver) = watch::channel(state_update_info);

--- a/crates/rollup-interface/src/node/da_sync_state.rs
+++ b/crates/rollup-interface/src/node/da_sync_state.rs
@@ -33,6 +33,26 @@ pub enum SyncStatus {
 }
 
 impl SyncStatus {
+    /// The current height through which we've synced
+    pub fn synced_da_height(&self) -> u64 {
+        match self {
+            SyncStatus::Syncing {
+                synced_da_height, ..
+            }
+            | SyncStatus::Synced { synced_da_height } => *synced_da_height,
+        }
+    }
+
+    /// The height to which we're syncing.
+    pub fn target_da_height(&self) -> u64 {
+        match self {
+            SyncStatus::Synced { synced_da_height } => *synced_da_height,
+            SyncStatus::Syncing {
+                target_da_height, ..
+            } => *target_da_height,
+        }
+    }
+
     /// Where a node starts syncing from.
     pub const START: Self = SyncStatus::Syncing {
         synced_da_height: 0,

--- a/crates/rollup-interface/src/state_machine/mod.rs
+++ b/crates/rollup-interface/src/state_machine/mod.rs
@@ -164,4 +164,6 @@ pub struct StateUpdateInfo<StfState> {
     pub slot_number: SlotNumber,
     /// The latest slot number that was finalized.
     pub latest_finalized_slot_number: SlotNumber,
+    ///  The node's sync status at the time this `StateUpdateInfo` was created.
+    pub sync_status: crate::node::SyncStatus,
 }


### PR DESCRIPTION
# Description

This PR makes the sequencer more deterministic by removing `DaSyncStatus` from it. Previously, `DaSyncStatus` fetched DA information directly from the node and mutated its internal state, creating an implicit dependency between the node and the sequencer. In the new design, the sync information is provided through `StateUpdateInfo` and is immutable, eliminating that hidden coupling.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

