### PR TITLE
Increase timeout for 10k_batches semi-bench test

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
@@ -306,12 +306,12 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn flaky_test_sequencer_rocksdb_db_performance_can_run_1k_batches_in_90_seconds() {
-        let handle = tokio::task::spawn(run_rocksdb_test(10000));
+    async fn flaky_test_sequencer_rocksdb_db_performance_can_run_10k_batches_in_2_minutes() {
+        let handle = tokio::task::spawn(run_rocksdb_test(10_000));
 
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(90), handle)
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(120), handle)
             .await
-            .expect("Creating 10000 batches should take less than 90 seconds; you may need to check your filesystem performance!");
+            .expect("Creating 10_000 batches should take less than 2 minutes; you may need to check your filesystem performance!");
     }
 
     async fn run_rocksdb_test(iters: u64) {


### PR DESCRIPTION
# Description

Increase time to 2 minutes, as 2 minutes is still acceptable in will detect performance degradation.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Existing tests are passing

## Docs
No updates
