### PR TITLE
Added support for complex map keys to json_to_borsh, if they're serialized using nested json stringifications.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-08-14
+- #1501 Adds support to the universal wallet's `json_to_borsh` for deserializing nested-stringified JSON objects. In particular, this allows map types with complex object keys to be serialized by json-stringifying the keys, and they will be deserialized correctly for the borsh conversion.
+
 # 2025-08-12
 - #1491 **BREAKING CHANGE** Dedup endpoint (`/rollup/addresses/{address}/dedup`) now actually returns nonce and not generation number. 
   It is possible to pass query parameter `?select=nonce` or `?select=generation` to explicitly request required uniqueness identifier.

--- a/crates/universal-wallet/schema/src/json_to_borsh.rs
+++ b/crates/universal-wallet/schema/src/json_to_borsh.rs
@@ -226,12 +226,16 @@ impl<W: std::io::Write, L: LinkingScheme> TypeVisitor<L, ContainerSerdeMetadata>
         schema: &impl TypeResolver<LinkingScheme = L, Metadata = ContainerSerdeMetadata>,
         mut context: Context<L>,
     ) -> Self::ReturnType {
-        let mut json_fields = match context.value {
+        let mut value = context.value;
+        while let Value::String(s) = value {
+            value = serde_json::from_str(&s).map_err(|e| EncodeError::Json(e.to_string()))?;
+        }
+        let mut json_fields = match value {
             Value::Object(o) => o,
             _ => {
                 return Err(EncodeError::InvalidType {
                     schema_type: format!("{} struct", s.type_name),
-                    value: context.value.to_string(),
+                    value: value.to_string(),
                 })
             }
         };

--- a/crates/universal-wallet/schema/src/schema/tests.rs
+++ b/crates/universal-wallet/schema/src/schema/tests.rs
@@ -808,7 +808,7 @@ pub struct VecOfWrapper {
     memo: Vec<SchemalessStringWrapper>,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Hash, PartialOrd, Ord)]
 #[cfg_attr(test, derive(UniversalWallet, BorshSerialize, BorshDeserialize))]
 pub struct RegistrationLike {
     address: [u8; 32],
@@ -848,6 +848,66 @@ pub enum TestCallStructRec<T> {
 #[cfg_attr(test, derive(UniversalWallet, BorshSerialize))]
 pub struct ComplexRec<T> {
     unnested_enum: TestCallRec<T>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(test, derive(UniversalWallet, BorshSerialize))]
+pub struct ComplexMapKey {
+    object_map: HashMap<RegistrationLike, u8>,
+}
+
+impl Serialize for ComplexMapKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        struct Helper {
+            object_map: HashMap<String, u8>,
+        }
+
+        let mut stringified_map = HashMap::new();
+        for (k, v) in &self.object_map {
+            let key_json = serde_json::to_string(k).map_err(serde::ser::Error::custom)?;
+            stringified_map.insert(key_json, *v);
+        }
+
+        Helper {
+            object_map: stringified_map,
+        }
+        .serialize(serializer)
+    }
+}
+
+#[test]
+fn test_complex_map_key() {
+    let mut object_map: HashMap<RegistrationLike, u8> = HashMap::new();
+    object_map.insert(
+        RegistrationLike {
+            address: [23; 32],
+            some_bytes: vec![1, 2, 3, 4, 5],
+            extra_complexity: vec![AThirdComplexType {
+                address: [17; 32],
+                extra_bytes: vec![6, 7, 8, 9, 10],
+                role: Role::Attester,
+            }],
+        },
+        19,
+    );
+
+    let complex_map = ComplexMapKey { object_map };
+
+    encode_decode_tests!(ComplexMapKey, complex_map, "{ object_map: { { address: 0x1717171717171717171717171717171717171717171717171717171717171717, some_bytes: 0x0102030405, extra_complexity: [{ address: celestia1zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygsr0ealj, extra_bytes: [6, 7, 8, 9, 10], role: Attester }] }: 19 } }");
+
+    // let schema = Schema::of_single_type::<ComplexMapKey>().unwrap();
+    // let borsh_ser = borsh::to_vec(&complex_key).unwrap();
+    // let json = serde_json::to_string(&complex_key).unwrap();
+
+    // // The JSON should have the complex object as a stringified key
+    // assert!(json.contains(r#""address":[23,23,23"#));
+
+    // // Test that json_to_borsh can handle the nested JSON string
+    // assert_eq!(schema.json_to_borsh(0, &json).unwrap(), borsh_ser);
 }
 
 #[derive(Debug, PartialEq, Serialize, Eq, Clone)]
@@ -1137,7 +1197,7 @@ pub struct StructWithBase58 {
     role: Role,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Hash, PartialOrd, Ord)]
 #[cfg_attr(test, derive(UniversalWallet, BorshSerialize, BorshDeserialize))]
 pub struct AThirdComplexType {
     #[cfg_attr(test, sov_wallet(display(bech32(prefix = "PREFIX_CELESTIA"))))]


### PR DESCRIPTION
# Description

Rust maps types are typically serialized in JSON as objects, but JSON keys must be strings. This made it impossible to use maps with complex keys in call messages. This adds support for nested serialization of keys to stringify them.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
