### PR TITLE
Allow pushing to accessory state vecs during tx execution

### DIFF
--- a/crates/module-system/sov-modules-api/src/containers/vec.rs
+++ b/crates/module-system/sov-modules-api/src/containers/vec.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use sov_state::codec::BorshCodec;
 use sov_state::namespaces::{Accessory, CompileTimeNamespace, Kernel, User};
-use sov_state::{EncodeLike, Prefix, StateCodec, StateItemCodec};
+use sov_state::{EncodeLike, Prefix, StateCodec, StateItemCodec, StateItemDecoder};
 use thiserror::Error;
 use unwrap_infallible::UnwrapInfallible;
 
@@ -320,6 +320,25 @@ where
     }
 }
 
+impl< V, Codec> NamespacedStateVec<Accessory, V, Codec>
+where
+    Codec: StateCodec,
+    Codec::ValueCodec: StateItemCodec<V> + StateItemCodec<u64>,
+    Codec::KeyCodec: StateItemCodec<u64>,
+{
+    /// Pushes a value to the end of the vector without requiring read access to the length.
+    pub fn push_accessory<Vq, W>(&mut self, value: &Vq, state: &mut W) -> Result<(), <W as StateWriter<Accessory>>::Error> 
+    where W: StateWriter<Accessory>, Vq: ?Sized, Codec::ValueCodec: EncodeLike<Vq, V>{
+        let len_key = self.len_value.slot_key();
+        let index = if let Some(len_bytes)= state.get_value(Accessory::NAMESPACE, &len_key) {
+          self.len_value.codec().value_codec().decode_unwrap(len_bytes.value())
+        } else {
+            0
+        };
+        self.len_value.set(&index.saturating_add(1), state)?;
+        self.elems.set(&index, value, state)
+    }
+}
 /// An [`Iterator`] over a state vector.
 ///
 /// See [`NamespacedStateVec::iter`] for more details.

--- a/crates/module-system/sov-modules-api/src/containers/vec.rs
+++ b/crates/module-system/sov-modules-api/src/containers/vec.rs
@@ -320,18 +320,29 @@ where
     }
 }
 
-impl< V, Codec> NamespacedStateVec<Accessory, V, Codec>
+impl<V, Codec> NamespacedStateVec<Accessory, V, Codec>
 where
     Codec: StateCodec,
     Codec::ValueCodec: StateItemCodec<V> + StateItemCodec<u64>,
     Codec::KeyCodec: StateItemCodec<u64>,
 {
     /// Pushes a value to the end of the vector without requiring read access to the length.
-    pub fn push_accessory<Vq, W>(&mut self, value: &Vq, state: &mut W) -> Result<(), <W as StateWriter<Accessory>>::Error> 
-    where W: StateWriter<Accessory>, Vq: ?Sized, Codec::ValueCodec: EncodeLike<Vq, V>{
+    pub fn push_accessory<Vq, W>(
+        &mut self,
+        value: &Vq,
+        state: &mut W,
+    ) -> Result<(), <W as StateWriter<Accessory>>::Error>
+    where
+        W: StateWriter<Accessory>,
+        Vq: ?Sized,
+        Codec::ValueCodec: EncodeLike<Vq, V>,
+    {
         let len_key = self.len_value.slot_key();
-        let index = if let Some(len_bytes)= state.get_value(Accessory::NAMESPACE, &len_key) {
-          self.len_value.codec().value_codec().decode_unwrap(len_bytes.value())
+        let index = if let Some(len_bytes) = state.get_value(Accessory::NAMESPACE, &len_key) {
+            self.len_value
+                .codec()
+                .value_codec()
+                .decode_unwrap(len_bytes.value())
         } else {
             0
         };

--- a/crates/module-system/sov-modules-api/src/containers/vec.rs
+++ b/crates/module-system/sov-modules-api/src/containers/vec.rs
@@ -176,7 +176,7 @@ where
         let len = self.len(state)?;
 
         self.elems_mut().set(&len, value, state)?;
-        self.set_len(len + 1, state)?;
+        self.set_len(len.checked_add(1).expect("Overflowed u64 while pushing to a state vec. This should be impossible in the lifetime of the universe."), state)?;
 
         Ok(())
     }
@@ -219,7 +219,8 @@ where
             };
 
             for i in index..new_len {
-                let next_elem = self.elems().remove(&(i + 1), state)?;
+                let next_idx = i.checked_add(1).expect("Overflowed u64 while removing from a state vec. This should be impossible in the lifetime of the universe.");
+                let next_elem = self.elems().remove(&next_idx, state)?;
                 if let Some(next_elem) = next_elem {
                     self.elems_mut().set(&i, &next_elem, state)?;
                 }
@@ -346,7 +347,7 @@ where
         } else {
             0
         };
-        self.len_value.set(&index.saturating_add(1), state)?;
+        self.len_value.set(&index.checked_add(1).expect("Overflowed u64 while pushing to a state vec. This should be impossible in the lifetime of the universe."), state)?;
         self.elems.set(&index, value, state)
     }
 }


### PR DESCRIPTION
# Description

This PR allows users to push to accessory state vecs without requiring read permissions. This is sound, since users are not allowed to view the contents of the vec (including the length) by the signature of the method. This is required to allow real-time soft confirmations for EVM chains

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
