### PR TITLE
Allow using MultiAddress with Hyperlane

### DIFF
--- a/crates/module-system/hyperlane/src/lib.rs
+++ b/crates/module-system/hyperlane/src/lib.rs
@@ -36,9 +36,9 @@ pub use igp::{
 };
 pub use ism::Ism;
 pub use merkle::{Event as MerkleTreeEvent, MerkleTreeHook};
+pub use sov_modules_api::hyperlane::HyperlaneAddress;
 pub use types::{EthAddress, Message, StorageLocation, ValidatorSignature};
 pub use warp::{CallMessage as WarpCallMessage, Event as WarpEvent, Warp};
-pub use sov_modules_api::hyperlane::HyperlaneAddress;
 
 /// A fixed assumed address of mailbox contract on sovereign rollup.
 ///
@@ -192,7 +192,6 @@ impl<S: Spec, R: Recipient<S>> Mailbox<S, R> {
         }
     }
 }
-
 
 /// A module that can receive messages via the hyperlane protocol.
 ///

--- a/crates/module-system/hyperlane/src/lib.rs
+++ b/crates/module-system/hyperlane/src/lib.rs
@@ -38,6 +38,7 @@ pub use ism::Ism;
 pub use merkle::{Event as MerkleTreeEvent, MerkleTreeHook};
 pub use types::{EthAddress, Message, StorageLocation, ValidatorSignature};
 pub use warp::{CallMessage as WarpCallMessage, Event as WarpEvent, Warp};
+pub use sov_modules_api::hyperlane::HyperlaneAddress;
 
 /// A fixed assumed address of mailbox contract on sovereign rollup.
 ///
@@ -192,79 +193,6 @@ impl<S: Spec, R: Recipient<S>> Mailbox<S, R> {
     }
 }
 
-/// An address which is compatible with the hyperlane protocol.
-///
-/// Implementers of this trait must ensure that their addresses can be unambiguously represented in 32 bytes.
-/// For example, if the address type is an enum where at least one variant is 32 bytes long, the impelementation
-/// must pick one variant and always deserialize into that type (since there's no room to encode the discriminant).
-pub trait HyperlaneAddress: Sized {
-    /// Convert the address to a Hyperlane sender address.
-    fn to_sender(&self) -> HexHash;
-    /// Convert a Hyperlane sender address back to the original..
-    fn from_sender(recipient: HexHash) -> anyhow::Result<Self>;
-}
-
-impl HyperlaneAddress for sov_modules_api::Address {
-    fn to_sender(&self) -> HexHash {
-        const START_INDEX: usize = 32 - sov_modules_api::Address::LENGTH;
-        // Pad the address with leading zeros to 32 bytes. This is the hyperlane convention
-        let mut bytes = [0u8; 32];
-        bytes[START_INDEX..].copy_from_slice(self.as_ref());
-        bytes.into()
-    }
-
-    fn from_sender(recipient: HexHash) -> anyhow::Result<Self> {
-        const START_INDEX: usize = 32 - sov_modules_api::Address::LENGTH;
-        // Check that the address is padded with leading zeros to match the hyperlane convention.
-        let (padding, address) = recipient.0.split_at(START_INDEX);
-
-        // Ensure padding is all zeros:
-        anyhow::ensure!(
-            padding.iter().all(|&byte| byte == 0),
-            "Invalid address - not enough leading zeros"
-        );
-
-        Ok(Self::new(address.try_into().expect(
-            "Infallible conversion failed; this is a bug, please report it",
-        )))
-    }
-}
-
-impl HyperlaneAddress for Base58Address {
-    /// Convert the address to a Hyperlane sender address.
-    fn to_sender(&self) -> HexHash {
-        HexString(self.0)
-    }
-    /// Convert a Hyperlane sender address back to the original..
-    fn from_sender(recipient: HexHash) -> anyhow::Result<Self> {
-        Ok(Self(recipient.0))
-    }
-}
-
-#[cfg(feature = "evm")]
-impl HyperlaneAddress for sov_address::EthereumAddress {
-    fn to_sender(&self) -> HexHash {
-        const START_INDEX: usize = 32 - 20; // EthereumAddress is 20 bytes
-                                            // Pad the address with leading zeros to 32 bytes. This is the hyperlane convention
-        let mut bytes = [0u8; 32];
-        bytes[START_INDEX..].copy_from_slice(self.as_ref());
-        bytes.into()
-    }
-
-    fn from_sender(recipient: HexHash) -> anyhow::Result<Self> {
-        const START_INDEX: usize = 32 - 20;
-        // Check that the address is padded with leading zeros to match the hyperlane convention.
-        let (padding, address) = recipient.0.split_at(START_INDEX);
-
-        // Ensure padding is all zeros:
-        anyhow::ensure!(
-            padding.iter().all(|&byte| byte == 0),
-            "Invalid address - not enough leading zeros"
-        );
-
-        Self::try_from(address)
-    }
-}
 
 /// A module that can receive messages via the hyperlane protocol.
 ///

--- a/crates/module-system/hyperlane/src/lib.rs
+++ b/crates/module-system/hyperlane/src/lib.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "native")]
 use sov_modules_api::rest::HasRestApi;
 use sov_modules_api::{
-    Context, DaSpec, GenesisState, HexHash, HexString, Module, ModuleId, ModuleInfo,
-    ModuleRestApi, Spec, StateMap, StateReader, StateValue, TxState,
+    Context, DaSpec, GenesisState, HexHash, HexString, Module, ModuleId, ModuleInfo, ModuleRestApi,
+    Spec, StateMap, StateReader, StateValue, TxState,
 };
 use sov_state::User;
 #[cfg(feature = "native")]

--- a/crates/module-system/hyperlane/src/lib.rs
+++ b/crates/module-system/hyperlane/src/lib.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "native")]
 use sov_modules_api::rest::HasRestApi;
 use sov_modules_api::{
-    Base58Address, Context, DaSpec, GenesisState, HexHash, HexString, Module, ModuleId, ModuleInfo,
+    Context, DaSpec, GenesisState, HexHash, HexString, Module, ModuleId, ModuleInfo,
     ModuleRestApi, Spec, StateMap, StateReader, StateValue, TxState,
 };
 use sov_state::User;

--- a/crates/module-system/sov-address/src/evm/address.rs
+++ b/crates/module-system/sov-address/src/evm/address.rs
@@ -3,9 +3,12 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use serde::{Deserialize, Serialize};
 use sov_modules_api::macros::UniversalWallet;
+#[cfg(feature = "evm")]
+use sov_modules_api::HexHash;
 use sov_rollup_interface::common::HexString;
 use sov_rollup_interface::crypto::CredentialId;
 use sov_rollup_interface::BasicAddress;
+use sov_modules_api::hyperlane::{HyperlaneAddress};
 
 use crate::evm::public_key::EthereumPublicKey;
 use crate::{MultiAddress, Not28Bytes};
@@ -128,6 +131,31 @@ impl schemars::JsonSchema for EthereumAddress {
             "description": "20 bytes in hexadecimal format, with `0x` prefix.",
         }))
         .unwrap()
+    }
+}
+
+
+impl HyperlaneAddress for EthereumAddress {
+    fn to_sender(&self) -> HexHash {
+        const START_INDEX: usize = 32 - 20; // EthereumAddress is 20 bytes
+                                            // Pad the address with leading zeros to 32 bytes. This is the hyperlane convention
+        let mut bytes = [0u8; 32];
+        bytes[START_INDEX..].copy_from_slice(self.as_ref());
+        bytes.into()
+    }
+
+    fn from_sender(recipient: HexHash) -> anyhow::Result<Self> {
+        const START_INDEX: usize = 32 - 20;
+        // Check that the address is padded with leading zeros to match the hyperlane convention.
+        let (padding, address) = recipient.0.split_at(START_INDEX);
+
+        // Ensure padding is all zeros:
+        anyhow::ensure!(
+            padding.iter().all(|&byte| byte == 0),
+            "Invalid address - not enough leading zeros"
+        );
+
+        Self::try_from(address)
     }
 }
 

--- a/crates/module-system/sov-address/src/evm/address.rs
+++ b/crates/module-system/sov-address/src/evm/address.rs
@@ -2,13 +2,13 @@ use alloy_primitives::{Address, AddressError};
 use borsh::{BorshDeserialize, BorshSerialize};
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use serde::{Deserialize, Serialize};
+use sov_modules_api::hyperlane::HyperlaneAddress;
 use sov_modules_api::macros::UniversalWallet;
 #[cfg(feature = "evm")]
 use sov_modules_api::HexHash;
 use sov_rollup_interface::common::HexString;
 use sov_rollup_interface::crypto::CredentialId;
 use sov_rollup_interface::BasicAddress;
-use sov_modules_api::hyperlane::{HyperlaneAddress};
 
 use crate::evm::public_key::EthereumPublicKey;
 use crate::{MultiAddress, Not28Bytes};
@@ -133,7 +133,6 @@ impl schemars::JsonSchema for EthereumAddress {
         .unwrap()
     }
 }
-
 
 impl HyperlaneAddress for EthereumAddress {
     fn to_sender(&self) -> HexHash {

--- a/crates/module-system/sov-address/src/lib.rs
+++ b/crates/module-system/sov-address/src/lib.rs
@@ -8,8 +8,10 @@ use borsh::{BorshDeserialize, BorshSerialize};
 pub use evm::{EthereumAddress, EvmCryptoSpec, MultiAddressEvm};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use sov_modules_api::hyperlane::HyperlaneAddress;
 use sov_modules_api::macros::UniversalWallet;
 use sov_modules_api::{address_prefix, Address, BasicAddress, CredentialId};
+use sov_rollup_interface::common::HexHash;
 
 /// A generic VM-compatible address enum, enabling supporting for both Sov SDK standard SHA-256 derived addresses and VM-specific addresses.
 #[derive(
@@ -163,6 +165,22 @@ impl<VmAddress> FromVmAddress<VmAddress> for MultiAddress<VmAddress> {
 impl<VmAddress> From<Address> for MultiAddress<VmAddress> {
     fn from(value: Address) -> Self {
         Self::Standard(value)
+    }
+}
+
+impl<VmAddress: HyperlaneAddress> HyperlaneAddress for MultiAddress<VmAddress> {
+    fn to_sender(&self) -> HexHash {
+        match self {
+            Self::Standard(addr) => addr.to_sender(),
+            Self::Vm(addr) => addr.to_sender(),
+        }
+    }
+
+    fn from_sender(recipient: HexHash) -> anyhow::Result<Self> {
+        match Address::try_from(recipient.as_ref()) {
+            Ok(addr) => Ok(Self::Standard(addr)),
+            Err(e) => Err(anyhow::anyhow!("Failed to convert recipient to MultiAddress. Only standard addresses are supported: {}", e)),
+        }
     }
 }
 pub trait Not28Bytes {}

--- a/crates/module-system/sov-modules-api/src/hyperlane.rs
+++ b/crates/module-system/sov-modules-api/src/hyperlane.rs
@@ -2,8 +2,6 @@ use sov_rollup_interface::common::{HexHash, HexString};
 
 use crate::{Address, Base58Address};
 
-
-
 /// An address which is compatible with the hyperlane protocol.
 ///
 /// Implementers of this trait must ensure that their addresses can be unambiguously represented in 32 bytes.

--- a/crates/module-system/sov-modules-api/src/hyperlane.rs
+++ b/crates/module-system/sov-modules-api/src/hyperlane.rs
@@ -1,0 +1,54 @@
+use sov_rollup_interface::common::{HexHash, HexString};
+
+use crate::{Address, Base58Address};
+
+
+
+/// An address which is compatible with the hyperlane protocol.
+///
+/// Implementers of this trait must ensure that their addresses can be unambiguously represented in 32 bytes.
+/// For example, if the address type is an enum where at least one variant is 32 bytes long, the impelementation
+/// must pick one variant and always deserialize into that type (since there's no room to encode the discriminant).
+pub trait HyperlaneAddress: Sized {
+    /// Convert the address to a Hyperlane sender address.
+    fn to_sender(&self) -> HexHash;
+    /// Convert a Hyperlane sender address back to the original..
+    fn from_sender(recipient: HexHash) -> anyhow::Result<Self>;
+}
+
+impl HyperlaneAddress for Address {
+    fn to_sender(&self) -> HexHash {
+        const START_INDEX: usize = 32 - Address::LENGTH;
+        // Pad the address with leading zeros to 32 bytes. This is the hyperlane convention
+        let mut bytes = [0u8; 32];
+        bytes[START_INDEX..].copy_from_slice(self.as_ref());
+        bytes.into()
+    }
+
+    fn from_sender(recipient: HexHash) -> anyhow::Result<Self> {
+        const START_INDEX: usize = 32 - Address::LENGTH;
+        // Check that the address is padded with leading zeros to match the hyperlane convention.
+        let (padding, address) = recipient.0.split_at(START_INDEX);
+
+        // Ensure padding is all zeros:
+        anyhow::ensure!(
+            padding.iter().all(|&byte| byte == 0),
+            "Invalid address - not enough leading zeros"
+        );
+
+        Ok(Self::new(address.try_into().expect(
+            "Infallible conversion failed; this is a bug, please report it",
+        )))
+    }
+}
+
+impl HyperlaneAddress for Base58Address {
+    /// Convert the address to a Hyperlane sender address.
+    fn to_sender(&self) -> HexHash {
+        HexString(self.0)
+    }
+    /// Convert a Hyperlane sender address back to the original..
+    fn from_sender(recipient: HexHash) -> anyhow::Result<Self> {
+        Ok(Self(recipient.0))
+    }
+}

--- a/crates/module-system/sov-modules-api/src/hyperlane.rs
+++ b/crates/module-system/sov-modules-api/src/hyperlane.rs
@@ -10,7 +10,7 @@ use crate::{Address, Base58Address};
 pub trait HyperlaneAddress: Sized {
     /// Convert the address to a Hyperlane sender address.
     fn to_sender(&self) -> HexHash;
-    /// Convert a Hyperlane sender address back to the original..
+    /// Convert a Hyperlane sender address back to the original.
     fn from_sender(recipient: HexHash) -> anyhow::Result<Self>;
 }
 

--- a/crates/module-system/sov-modules-api/src/lib.rs
+++ b/crates/module-system/sov-modules-api/src/lib.rs
@@ -59,6 +59,9 @@ pub mod state;
 /// Defines the metadata that is used to generate execution proofs.
 pub mod proof_metadata;
 
+/// Defines traits used by the hyperlane protocol.
+pub mod hyperlane;
+
 mod reexport_macros;
 
 #[cfg(test)]


### PR DESCRIPTION
# Description
This PR moves the hyperlane address trait to sov-modules-api so that it can be implemented without a dependency on the hyperlane module. It also implements the trait for MultiAddress when the VM address is hyperlane compatible.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
