### PR TITLE
Add tx generator to eth dev signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10805,10 +10805,13 @@ dependencies = [
 name = "sov-eth-dev-signer"
 version = "0.3.0"
 dependencies = [
+ "arbitrary",
+ "rand_chacha 0.3.1",
  "reth-primitives",
  "reth-rpc-types",
  "revm 12.1.0",
  "secp256k1",
+ "sha2 0.10.8",
  "thiserror 1.0.64",
 ]
 

--- a/crates/full-node/sov-eth-dev-signer/Cargo.toml
+++ b/crates/full-node/sov-eth-dev-signer/Cargo.toml
@@ -22,3 +22,6 @@ revm = { workspace = true, features = [
 reth-primitives = { workspace = true, features = ["secp256k1"] }
 reth-rpc-types = { workspace = true }
 secp256k1 = { workspace = true }
+sha2 = { workspace = true }
+rand_chacha = { workspace = true }
+arbitrary = { workspace = true }

--- a/crates/full-node/sov-eth-dev-signer/src/lib.rs
+++ b/crates/full-node/sov-eth-dev-signer/src/lib.rs
@@ -3,12 +3,16 @@
 
 use std::collections::HashMap;
 
+use arbitrary::Arbitrary;
 use reth_primitives::{
-    sign_message, Transaction, TransactionSigned, TxEip1559, TxEip2930, TxEip4844, TxLegacy,
+    sign_message, Bytes, Transaction, TransactionSigned, TxEip1559, TxEip2930, TxEip4844, TxKind, TxLegacy, U256
 };
-use reth_rpc_types::TypedTransactionRequest;
+use reth_rpc_types::{transaction::EIP1559TransactionRequest, AccessList, TypedTransactionRequest};
 use revm::primitives::{Address, B256};
-use secp256k1::{PublicKey, SecretKey};
+use secp256k1::{rand::{RngCore, SeedableRng}, PublicKey};
+pub use secp256k1::{SecretKey};
+use sha2::Digest;
+
 
 /// Ethereum transaction signer.
 #[derive(Clone)]
@@ -74,6 +78,127 @@ impl DevSigner {
     /// List of signers.
     pub fn signers(&self) -> Vec<Address> {
         self.signers.keys().copied().collect()
+    }
+
+
+}
+
+/// Transfer generator.
+pub struct TransferGenerator {
+    key: SecretKey,
+    randomness: Vec<u8>,
+    remaining_randomness: usize,
+    target_buffer_size: usize,
+    salt: u128,
+}
+
+
+/// Get a Vec of `num` bytes, seeded by `num` and  a salt value
+pub fn get_random_bytes(num: usize, salt: u128) -> Vec<u8> {
+    let mut output = vec![0; num];
+    randomize_buffer(&mut output, salt);
+    output
+}
+
+/// Randomize the given buffer. The rng is seeded from the buffer's length and the salt
+pub fn randomize_buffer(buffer: &mut [u8], salt: u128) {
+    // First, use the hash of a sha256 string to get a high quality rng. (Seeding yourself is hard because you need a high hamming weight!)
+    let input = format!("{}|{}", buffer.len(), salt);
+    let salt_hashed = sha2::Sha256::digest(input);
+    let mut rng = rand_chacha::ChaChaRng::from_seed(salt_hashed.into());
+    rng.fill_bytes(buffer);
+}
+
+/// Setup generation with the given params
+pub fn setup_harness(rng_salt: u128, key: SecretKey) -> TransferGenerator {
+    let random_bytes: Vec<u8> = get_random_bytes(100_000, rng_salt);
+    let u = &mut arbitrary::Unstructured::new(&random_bytes[..]);
+    let remaining_randomness = u.len();
+    TransferGenerator {
+        randomness: random_bytes,
+        remaining_randomness,
+        key,
+        target_buffer_size: 100_000,
+        salt: rng_salt,
+    }
+}
+
+impl TransferGenerator {
+    /// Set up a new transfer generator
+    pub fn new(key: SecretKey, salt: u128) -> Self {
+        setup_harness(salt, key)
+    }
+
+
+    /// Generate a transfer transaction.
+    pub fn generate(
+        &mut self,
+        nonce: u64,
+    ) -> TransactionSigned {
+        for _ in 0..20 {
+            if self.has_enough_randomness() {
+                let u =
+                    &mut arbitrary::Unstructured::new(&self.randomness[self.randomness_offset()..]);
+
+                if let Ok(output) = self.generate_min_transfer(nonce, u) {
+                    self.remaining_randomness = u.len();
+                    return output;
+                } else {
+                    self.target_buffer_size *= 2;
+                }
+            }
+            self.re_randomize();
+        }
+        unreachable!("Could not get enough randomness to generate a transaction");
+    }
+
+    fn re_randomize(&mut self) {
+        if self.randomness.len() < self.target_buffer_size {
+            self.randomness = vec![0; self.target_buffer_size];
+        }
+        randomize_buffer(&mut self.randomness[..], self.salt);
+        self.remaining_randomness = self.randomness.len();
+        self.salt += 1;
+    }
+
+    fn randomness_offset(&self) -> usize {
+        self.randomness.len() - self.remaining_randomness
+    }
+
+    fn has_enough_randomness(&self) -> bool {
+        self.remaining_randomness > std::cmp::min(1000, self.target_buffer_size / 10)
+    }
+
+    /// Generate a transfer transaction.
+    fn generate_min_transfer(&self, nonce: u64, u: &mut arbitrary::Unstructured<'_>) -> Result<TransactionSigned, arbitrary::Error> {
+
+        let to: [u8;20] = Arbitrary::arbitrary(u)?;
+        let value = 1;
+        let request = TypedTransactionRequest::EIP1559(EIP1559TransactionRequest {
+            chain_id: 4321,
+            nonce,
+            value: U256::from_limbs([value, 0, 0, 0]),
+            input: Bytes::new(),
+            max_priority_fee_per_gas: U256::ZERO,
+            max_fee_per_gas: U256::from_limbs([1000, 0, 0, 0]),
+            gas_limit: U256::from_limbs([u64::MAX, 0, 0, 0]),
+            kind: TxKind::Call(Address::from_slice(&to)),
+            access_list: AccessList::default(),
+        });
+
+        let transaction =
+            to_primitive_transaction(request).expect("Invalid transaction request");
+        let tx_signature_hash = transaction.signature_hash();
+        let signer = self.key;
+
+        let signature = sign_message(B256::from_slice(signer.as_ref()), tx_signature_hash)
+            .expect("Could not sign");
+
+        Ok(TransactionSigned::from_transaction_and_signature(
+            transaction,
+            signature,
+        ))
+
     }
 }
 

--- a/crates/full-node/sov-eth-dev-signer/src/lib.rs
+++ b/crates/full-node/sov-eth-dev-signer/src/lib.rs
@@ -5,14 +5,17 @@ use std::collections::HashMap;
 
 use arbitrary::Arbitrary;
 use reth_primitives::{
-    sign_message, Bytes, Transaction, TransactionSigned, TxEip1559, TxEip2930, TxEip4844, TxKind, TxLegacy, U256
+    sign_message, Bytes, Transaction, TransactionSigned, TxEip1559, TxEip2930, TxEip4844, TxKind,
+    TxLegacy, U256,
 };
 use reth_rpc_types::{transaction::EIP1559TransactionRequest, AccessList, TypedTransactionRequest};
 use revm::primitives::{Address, B256};
-use secp256k1::{rand::{RngCore, SeedableRng}, PublicKey};
-pub use secp256k1::{SecretKey};
+pub use secp256k1::SecretKey;
+use secp256k1::{
+    rand::{RngCore, SeedableRng},
+    PublicKey,
+};
 use sha2::Digest;
-
 
 /// Ethereum transaction signer.
 #[derive(Clone)]
@@ -79,8 +82,6 @@ impl DevSigner {
     pub fn signers(&self) -> Vec<Address> {
         self.signers.keys().copied().collect()
     }
-
-
 }
 
 /// Transfer generator.
@@ -91,7 +92,6 @@ pub struct TransferGenerator {
     target_buffer_size: usize,
     salt: u128,
 }
-
 
 /// Get a Vec of `num` bytes, seeded by `num` and  a salt value
 pub fn get_random_bytes(num: usize, salt: u128) -> Vec<u8> {
@@ -129,12 +129,8 @@ impl TransferGenerator {
         setup_harness(salt, key)
     }
 
-
     /// Generate a transfer transaction.
-    pub fn generate(
-        &mut self,
-        nonce: u64,
-    ) -> TransactionSigned {
+    pub fn generate(&mut self, nonce: u64) -> TransactionSigned {
         for _ in 0..20 {
             if self.has_enough_randomness() {
                 let u =
@@ -170,9 +166,12 @@ impl TransferGenerator {
     }
 
     /// Generate a transfer transaction.
-    fn generate_min_transfer(&self, nonce: u64, u: &mut arbitrary::Unstructured<'_>) -> Result<TransactionSigned, arbitrary::Error> {
-
-        let to: [u8;20] = Arbitrary::arbitrary(u)?;
+    fn generate_min_transfer(
+        &self,
+        nonce: u64,
+        u: &mut arbitrary::Unstructured<'_>,
+    ) -> Result<TransactionSigned, arbitrary::Error> {
+        let to: [u8; 20] = Arbitrary::arbitrary(u)?;
         let value = 1;
         let request = TypedTransactionRequest::EIP1559(EIP1559TransactionRequest {
             chain_id: 4321,
@@ -186,8 +185,7 @@ impl TransferGenerator {
             access_list: AccessList::default(),
         });
 
-        let transaction =
-            to_primitive_transaction(request).expect("Invalid transaction request");
+        let transaction = to_primitive_transaction(request).expect("Invalid transaction request");
         let tx_signature_hash = transaction.signature_hash();
         let signer = self.key;
 
@@ -198,7 +196,6 @@ impl TransferGenerator {
             transaction,
             signature,
         ))
-
     }
 }
 


### PR DESCRIPTION
# Description

This PR adds a very primitive tx generator the sov-eth-dev-signer package. This generator can create simple transfers. Future PRs will likely extend it with the capability to invoke smart contracts (especially ERC-20)

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
