### PR TITLE
`PreferredBlobSender`: Make `BlobSender` optional

### DIFF
--- a/crates/full-node/sov-blob-sender/src/lib.rs
+++ b/crates/full-node/sov-blob-sender/src/lib.rs
@@ -112,6 +112,7 @@ where
         blob_processing_timeout: Duration,
         blob_sender_channel: Option<broadcast::Sender<BlobExecutionStatus<Da::Spec>>>,
         completed_blobs_to_send: Vec<(BlobToSend, BlobInternalId)>,
+        nb_of_concurrent_blob_submissions: Arc<AtomicUsize>,
     ) -> anyhow::Result<(Self, JoinHandle<()>)> {
         Self::new_with_task_intervals(
             da,
@@ -123,6 +124,7 @@ where
             blob_sender_channel,
             LEDGER_POLL_INTERVAL,
             completed_blobs_to_send,
+            nb_of_concurrent_blob_submissions,
         )
         .await
     }
@@ -137,6 +139,7 @@ where
         blob_sender_channel: Option<broadcast::Sender<BlobExecutionStatus<Da::Spec>>>,
         ledger_pool_interval: Duration,
         completed_blobs_to_send: Vec<(BlobToSend, BlobInternalId)>,
+        nb_of_concurrent_blob_submissions: Arc<AtomicUsize>,
     ) -> anyhow::Result<(Self, JoinHandle<()>)> {
         let shutdown_receiver = shutdown_sender.subscribe();
         let db = Arc::new(BlobSenderDb::new(storage_path).await?);
@@ -168,7 +171,7 @@ where
             shutdown_sender,
             da,
             finalization_manager,
-            nb_of_concurrent_blob_submissions: Arc::new(AtomicUsize::new(0)),
+            nb_of_concurrent_blob_submissions,
             blob_processing_timeout,
             blob_sender_channel,
             ledger_pool_interval,

--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -14,6 +14,7 @@ use sov_modules_api::HexHash;
 use sov_rollup_interface::da::BlobReaderTrait;
 use sov_rollup_interface::node::da::DaService;
 use sov_test_utils::logging::LogCollector;
+use std::sync::atomic::AtomicUsize;
 use tempfile::TempDir;
 use tokio::sync::{broadcast, watch, RwLock};
 use tokio::task::JoinHandle;
@@ -317,6 +318,7 @@ async fn create_blob_sender(
 
     let hooks = TestHooks {};
 
+    let nb_of_concurrent_blob_submissions = Arc::new(AtomicUsize::new(0));
     let (blob_sender, handle) = BlobSender::new_with_task_intervals(
         da,
         finalization_manager,
@@ -327,6 +329,7 @@ async fn create_blob_sender(
         blob_status_sender,
         Duration::from_millis(1000),
         Default::default(),
+        nb_of_concurrent_blob_submissions,
     )
     .await
     .unwrap();

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -181,23 +181,22 @@ where
 
         let mut handles = vec![];
 
-        let blob_sender = {
-            let (blob_sender, blob_sender_handle) = PreferredBlobSender::new(
-                da,
-                ledger_db.clone(),
-                &db_cache,
-                storage_path,
-                tx_status_manager.clone(),
-                shutdown_sender.clone(),
-                Duration::from_secs(config.blob_processing_timeout_secs),
-                blobs_sender_channel.clone(),
-                config.sequencer_kind_config.is_replica,
-            )
-            .await?;
+        let (blob_sender, blob_sender_handle) = PreferredBlobSender::new(
+            da,
+            ledger_db.clone(),
+            db_cache.all_completed_blobs().clone(),
+            storage_path.into(),
+            tx_status_manager.clone(),
+            shutdown_sender.clone(),
+            Duration::from_secs(config.blob_processing_timeout_secs),
+            blobs_sender_channel.clone(),
+            config.sequencer_kind_config.is_replica,
+        )
+        .await?;
 
+        if let Some(blob_sender_handle) = blob_sender_handle {
             handles.push(blob_sender_handle);
-            blob_sender
-        };
+        }
 
         let (state_root_compute_handle, state_root_compute_task) =
             StateRootBackgroundTaskState::create(

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -209,7 +209,7 @@ where
             .await?;
 
             handles.push(blob_sender_handle);
-            PreferredBlobSender::from((inner_blob_sender, config.sequencer_kind_config.is_replica))
+            PreferredBlobSender::new(inner_blob_sender, config.sequencer_kind_config.is_replica)
         };
 
         let (state_root_compute_handle, state_root_compute_task) =

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -230,7 +230,7 @@ where
 
         let (executor_events_sender, executor_events_receiver) =
             ExecutorEventsSender::new(shutdown_sender.clone(), db_cache);
-        let in_flight_blobs = blob_sender.nb_of_in_flight_blobs_handle();
+        let in_flight_blobs = blob_sender.nb_of_in_flight_blobs();
 
         // Here we need to mutliply by 1000 to convert from millis to micros.
         let batch_execution_time_limit_micros = config

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -38,7 +38,7 @@ use preferred_blob_sender::PreferredBlobSender;
 use replica_sync_task::spawn_replica_sync_task;
 use serde_with::serde_as;
 use side_effects::SideEffectsTask;
-use sov_blob_sender::{new_blob_id, BlobExecutionStatus, BlobSender};
+use sov_blob_sender::{new_blob_id, BlobExecutionStatus};
 use sov_blob_storage::{PreferredBatchData, SequenceNumber};
 use sov_db::ledger_db::LedgerDb;
 use sov_modules_api::capabilities::{BlobSelector, RollupHeight, TransactionAuthenticator};
@@ -64,13 +64,12 @@ use transaction_subscriptions::TransactionCache;
 use crate::common::{
     error_not_fully_synced, generic_accept_tx_error, loop_send_tx_notifications, poll_state_update,
     AcceptedTx, Sequencer, SequencerEventStream, StateUpdateError, StateUpdateNotification,
-    TxStatusBlobSenderHooks, WithCachedTxHashes,
+    WithCachedTxHashes,
 };
 use crate::metrics::{track_in_progress_batch_size, PreferredSequencerFetchBatchesToReplayMetrics};
 use crate::preferred::block_executor::{RollupBlockExecutor, RollupBlockExecutorError};
 use crate::preferred::db::DbEvent;
 use crate::preferred::executor_events::ExecutorEventsSender;
-use crate::preferred::preferred_blob_sender::create_blobs_to_send;
 use crate::preferred::transaction_subscriptions::TxResultWriter;
 use crate::rest_api::ApiAcceptedTx;
 use crate::{
@@ -171,6 +170,7 @@ where
             } else {
                 Box::new(RocksDbBackend::new(storage_path).await?)
             };
+
         let (db, latest_db_event_id, next_sequence_number, db_cache) =
             PreferredSequencerDb::<S, Rt>::new(
                 db_backend,
@@ -181,35 +181,22 @@ where
 
         let mut handles = vec![];
 
-        let completed_blobs = db_cache.all_completed_blobs();
-
         let blob_sender = {
-            let blobs_to_send = if config.sequencer_kind_config.is_replica {
-                Vec::new()
-            } else {
-                // It's possible that sov-blob-sender's DB might miss some blob data at
-                // node startup due to:
-                //  1. Disk failure (the sequencer can use Postgres so it's durable).
-                //  2. DB corruption.
-                //  3. Node crash at an inconvenient time.
-                // Let's restore all missing blob data to make sure they land on the DA.
-                create_blobs_to_send(completed_blobs)?
-            };
-
-            let (inner_blob_sender, blob_sender_handle) = BlobSender::new(
+            let (blob_sender, blob_sender_handle) = PreferredBlobSender::new(
                 da,
                 ledger_db.clone(),
+                &db_cache,
                 storage_path,
-                TxStatusBlobSenderHooks::new(tx_status_manager.clone()),
+                tx_status_manager.clone(),
                 shutdown_sender.clone(),
                 Duration::from_secs(config.blob_processing_timeout_secs),
-                Some(blobs_sender_channel.clone()),
-                blobs_to_send,
+                blobs_sender_channel.clone(),
+                config.sequencer_kind_config.is_replica,
             )
             .await?;
 
             handles.push(blob_sender_handle);
-            PreferredBlobSender::new(inner_blob_sender, config.sequencer_kind_config.is_replica)
+            blob_sender
         };
 
         let (state_root_compute_handle, state_root_compute_task) =

--- a/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
@@ -1,13 +1,13 @@
-use std::{
-    path::Path,
-    sync::{atomic::AtomicUsize, Arc},
-};
-
 use sov_blob_sender::BlobExecutionStatus;
 use sov_blob_sender::{BlobInternalId, BlobSender, BlobToSend};
 use sov_blob_storage::{PreferredBatchData, PreferredProofData};
 use sov_db::ledger_db::LedgerDb;
+use sov_modules_api::TxHash;
 use sov_rollup_interface::node::da::DaService;
+use std::{
+    path::Path,
+    sync::{atomic::AtomicUsize, Arc},
+};
 use tokio::sync::broadcast;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -15,30 +15,35 @@ use tokio::time::Duration;
 use tracing::debug;
 
 use super::db::{PreferredSequencerReadBatch, PreferredSequencerReadBlob};
-use crate::{
-    common::TxStatusBlobSenderHooks, preferred::db::PreferredSequencerCache, TxStatusManager,
-};
+use crate::{common::TxStatusBlobSenderHooks, TxStatusManager};
 
 /// Wrapper around [`BlobSender`] with preferred blob -specific logic.
 pub struct PreferredBlobSender<Da: DaService> {
-    inner: BlobSender<Da, TxStatusBlobSenderHooks<Da::Spec>, LedgerDb>,
-    is_replica: bool,
+    inner: Option<BlobSender<Da, TxStatusBlobSenderHooks<Da::Spec>, LedgerDb>>,
+    nb_of_concurrent_blob_submissions: Arc<AtomicUsize>,
 }
 
 impl<Da: DaService> PreferredBlobSender<Da> {
     pub(crate) async fn new(
         da: Da,
         ledger_db: LedgerDb,
-        db_cache: &PreferredSequencerCache,
-        storage_path: &Path,
+        all_completed_blobs: Vec<PreferredSequencerReadBlob>,
+        storage_path: Box<Path>,
         tx_status_manager: TxStatusManager<Da::Spec>,
         shutdown_sender: watch::Sender<()>,
         blob_processing_timeout: Duration,
         blobs_sender_channel: broadcast::Sender<BlobExecutionStatus<Da::Spec>>,
         is_replica: bool,
-    ) -> anyhow::Result<(Self, JoinHandle<()>)> {
-        let blobs_to_send = if is_replica {
-            Vec::new()
+    ) -> anyhow::Result<(Self, Option<JoinHandle<()>>)> {
+        let nb_of_concurrent_blob_submissions = Arc::new(AtomicUsize::new(0));
+        if is_replica {
+            Ok((
+                Self {
+                    inner: None,
+                    nb_of_concurrent_blob_submissions,
+                },
+                None,
+            ))
         } else {
             // It's possible that sov-blob-sender's DB might miss some blob data at
             // node startup due to:
@@ -46,22 +51,28 @@ impl<Da: DaService> PreferredBlobSender<Da> {
             //  2. DB corruption.
             //  3. Node crash at an inconvenient time.
             // Let's restore all missing blob data to make sure they land on the DA.
-            create_blobs_to_send(db_cache.all_completed_blobs())?
-        };
+            let blobs_to_send = create_blobs_to_send(all_completed_blobs)?;
+            let (inner, blob_sender_handle) = BlobSender::new(
+                da.clone(),
+                ledger_db,
+                storage_path.as_ref(),
+                TxStatusBlobSenderHooks::new(tx_status_manager.clone()),
+                shutdown_sender,
+                blob_processing_timeout,
+                Some(blobs_sender_channel),
+                blobs_to_send,
+                nb_of_concurrent_blob_submissions.clone(),
+            )
+            .await?;
 
-        let (inner, blob_sender_handle) = BlobSender::new(
-            da,
-            ledger_db,
-            storage_path,
-            TxStatusBlobSenderHooks::new(tx_status_manager),
-            shutdown_sender,
-            blob_processing_timeout,
-            Some(blobs_sender_channel),
-            blobs_to_send,
-        )
-        .await?;
-
-        Ok((Self { inner, is_replica }, blob_sender_handle))
+            Ok((
+                Self {
+                    inner: Some(inner),
+                    nb_of_concurrent_blob_submissions,
+                },
+                Some(blob_sender_handle),
+            ))
+        }
     }
 
     pub(crate) async fn publish_proof(
@@ -70,6 +81,10 @@ impl<Da: DaService> PreferredBlobSender<Da> {
         sequence_number: u64,
         blob_id: BlobInternalId,
     ) -> anyhow::Result<()> {
+        let Some(ref mut inner) = self.inner else {
+            return Ok(());
+        };
+
         let blob_bytes = proof_bytes(&proof_data, sequence_number)?;
 
         debug!(
@@ -77,7 +92,7 @@ impl<Da: DaService> PreferredBlobSender<Da> {
             blob_id, "Dispatching proof blob for publishing"
         );
 
-        self.inner.publish_proof_blob(blob_bytes, blob_id).await?;
+        inner.publish_proof_blob(blob_bytes, blob_id).await?;
 
         Ok(())
     }
@@ -86,22 +101,22 @@ impl<Da: DaService> PreferredBlobSender<Da> {
         &mut self,
         batch: PreferredSequencerReadBatch,
     ) -> anyhow::Result<()> {
+        let Some(ref mut inner) = self.inner else {
+            return Ok(());
+        };
+
         let blob_id = batch.blob_id;
         let data = batch_bytes(batch)?;
 
-        self.inner.publish_batch_blob(data, blob_id).await?;
+        inner.publish_batch_blob(data, blob_id).await?;
 
         Ok(())
     }
 
-    pub async fn publish_blobs(
+    pub async fn publish_blobs_for_recovery(
         &mut self,
         completed_blobs: Vec<PreferredSequencerReadBlob>,
     ) -> anyhow::Result<()> {
-        if self.is_replica {
-            return Ok(());
-        }
-
         for blob in completed_blobs {
             match blob {
                 PreferredSequencerReadBlob::Batch(batch) => {
@@ -120,11 +135,15 @@ impl<Da: DaService> PreferredBlobSender<Da> {
     }
 
     pub(crate) fn nb_of_in_flight_blobs(&self) -> Arc<AtomicUsize> {
-        self.inner.nb_of_in_flight_blobs_handle()
+        self.nb_of_concurrent_blob_submissions.clone()
     }
 
-    pub(crate) fn hooks(&self) -> &TxStatusBlobSenderHooks<Da::Spec> {
-        self.inner.hooks()
+    pub(crate) async fn add_txs(&self, blob_id: BlobInternalId, tx_hashes: Arc<Vec<TxHash>>) {
+        let Some(ref inner) = self.inner else {
+            return;
+        };
+
+        inner.hooks().add_txs(blob_id, tx_hashes).await;
     }
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
@@ -1,13 +1,23 @@
-use std::sync::{atomic::AtomicUsize, Arc};
+use std::{
+    path::Path,
+    sync::{atomic::AtomicUsize, Arc},
+};
 
+use sov_blob_sender::BlobExecutionStatus;
 use sov_blob_sender::{BlobInternalId, BlobSender, BlobToSend};
 use sov_blob_storage::{PreferredBatchData, PreferredProofData};
 use sov_db::ledger_db::LedgerDb;
 use sov_rollup_interface::node::da::DaService;
+use tokio::sync::broadcast;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tokio::time::Duration;
 use tracing::debug;
 
 use super::db::{PreferredSequencerReadBatch, PreferredSequencerReadBlob};
-use crate::common::TxStatusBlobSenderHooks;
+use crate::{
+    common::TxStatusBlobSenderHooks, preferred::db::PreferredSequencerCache, TxStatusManager,
+};
 
 /// Wrapper around [`BlobSender`] with preferred blob -specific logic.
 pub struct PreferredBlobSender<Da: DaService> {
@@ -16,11 +26,42 @@ pub struct PreferredBlobSender<Da: DaService> {
 }
 
 impl<Da: DaService> PreferredBlobSender<Da> {
-    pub(crate) fn new(
-        inner: BlobSender<Da, TxStatusBlobSenderHooks<Da::Spec>, LedgerDb>,
+    pub(crate) async fn new(
+        da: Da,
+        ledger_db: LedgerDb,
+        db_cache: &PreferredSequencerCache,
+        storage_path: &Path,
+        tx_status_manager: TxStatusManager<Da::Spec>,
+        shutdown_sender: watch::Sender<()>,
+        blob_processing_timeout: Duration,
+        blobs_sender_channel: broadcast::Sender<BlobExecutionStatus<Da::Spec>>,
         is_replica: bool,
-    ) -> Self {
-        Self { inner, is_replica }
+    ) -> anyhow::Result<(Self, JoinHandle<()>)> {
+        let blobs_to_send = if is_replica {
+            Vec::new()
+        } else {
+            // It's possible that sov-blob-sender's DB might miss some blob data at
+            // node startup due to:
+            //  1. Disk failure (the sequencer can use Postgres so it's durable).
+            //  2. DB corruption.
+            //  3. Node crash at an inconvenient time.
+            // Let's restore all missing blob data to make sure they land on the DA.
+            create_blobs_to_send(db_cache.all_completed_blobs())?
+        };
+
+        let (inner, blob_sender_handle) = BlobSender::new(
+            da,
+            ledger_db,
+            storage_path,
+            TxStatusBlobSenderHooks::new(tx_status_manager),
+            shutdown_sender,
+            blob_processing_timeout,
+            Some(blobs_sender_channel),
+            blobs_to_send,
+        )
+        .await?;
+
+        Ok((Self { inner, is_replica }, blob_sender_handle))
     }
 
     pub(crate) async fn publish_proof(

--- a/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{atomic::AtomicUsize, Arc};
 
 use sov_blob_sender::{BlobInternalId, BlobSender, BlobToSend};
 use sov_blob_storage::{PreferredBatchData, PreferredProofData};
@@ -10,10 +10,9 @@ use super::db::{PreferredSequencerReadBatch, PreferredSequencerReadBlob};
 use crate::common::TxStatusBlobSenderHooks;
 
 /// Wrapper around [`BlobSender`] with preferred blob -specific logic.
-#[derive(derive_more::Deref, derive_more::From)]
+#[derive(derive_more::From)]
 pub struct PreferredBlobSender<Da: DaService> {
     inner: BlobSender<Da, TxStatusBlobSenderHooks<Da::Spec>, LedgerDb>,
-    #[deref(ignore)]
     is_replica: bool,
 }
 
@@ -71,6 +70,14 @@ impl<Da: DaService> PreferredBlobSender<Da> {
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn nb_of_in_flight_blobs(&self) -> Arc<AtomicUsize> {
+        self.inner.nb_of_in_flight_blobs_handle()
+    }
+
+    pub(crate) fn hooks(&self) -> &TxStatusBlobSenderHooks<Da::Spec> {
+        self.inner.hooks()
     }
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
@@ -10,14 +10,20 @@ use super::db::{PreferredSequencerReadBatch, PreferredSequencerReadBlob};
 use crate::common::TxStatusBlobSenderHooks;
 
 /// Wrapper around [`BlobSender`] with preferred blob -specific logic.
-#[derive(derive_more::From)]
 pub struct PreferredBlobSender<Da: DaService> {
     inner: BlobSender<Da, TxStatusBlobSenderHooks<Da::Spec>, LedgerDb>,
     is_replica: bool,
 }
 
 impl<Da: DaService> PreferredBlobSender<Da> {
-    pub async fn publish_proof(
+    pub(crate) fn new(
+        inner: BlobSender<Da, TxStatusBlobSenderHooks<Da::Spec>, LedgerDb>,
+        is_replica: bool,
+    ) -> Self {
+        Self { inner, is_replica }
+    }
+
+    pub(crate) async fn publish_proof(
         &mut self,
         proof_data: Arc<[u8]>,
         sequence_number: u64,
@@ -35,7 +41,7 @@ impl<Da: DaService> PreferredBlobSender<Da> {
         Ok(())
     }
 
-    pub async fn publish_batch(
+    pub(crate) async fn publish_batch(
         &mut self,
         batch: PreferredSequencerReadBatch,
     ) -> anyhow::Result<()> {

--- a/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
@@ -65,7 +65,6 @@ where
 
         // Publish the batch.
         self.blob_sender
-            .hooks()
             .add_txs(batch.blob_id, batch.tx_hashes.clone())
             .await;
         self.blob_sender.publish_batch(batch).await?;
@@ -83,7 +82,9 @@ where
                 RecoveryStrategy::TryToSave => {
                     // Flush our batches to try to save them if we can
                     warn!(num_batches_to_replay = batches_to_flush.len(), "TryToSave recovery strategy has been configured. The currently pending soft confirmations will be flushed to the node. This may save some of the transactions, but if any are no longer valid, the sequencer will be penalised.");
-                    self.blob_sender.publish_blobs(batches_to_flush).await?;
+                    self.blob_sender
+                        .publish_blobs_for_recovery(batches_to_flush)
+                        .await?;
                 }
                 RecoveryStrategy::None => {
                     // Shut down

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -2,12 +2,6 @@
 
 mod mempool;
 
-use std::boxed::Box;
-use std::marker::PhantomData;
-use std::num::NonZero;
-use std::path::Path;
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use axum::http::StatusCode;
 pub use full_node_configs::sequencer::StdSequencerConfig;
@@ -22,6 +16,12 @@ use sov_modules_stf_blueprint::{process_tx_and_reward_prover, ApplyTxResult, Pre
 use sov_rest_utils::json_obj;
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::node::DaSyncState;
+use std::boxed::Box;
+use std::marker::PhantomData;
+use std::num::NonZero;
+use std::path::Path;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::{watch, Mutex};
 use tokio::task::JoinHandle;
@@ -126,6 +126,8 @@ where
             StateCheckpoint::new(latest_state_update.storage.clone(), &runtime.kernel());
 
         let da_address = da.get_signer().await;
+
+        let nb_of_concurrent_blob_submissions = Arc::new(AtomicUsize::new(0));
         let (blob_sender, blob_sender_handle) = BlobSender::new(
             da,
             ledger_db.clone(),
@@ -135,6 +137,7 @@ where
             Duration::from_secs(config.blob_processing_timeout_secs),
             None,
             Default::default(),
+            nb_of_concurrent_blob_submissions,
         )
         .await?;
 

--- a/crates/full-node/sov-sequencer/src/test_stateless.rs
+++ b/crates/full-node/sov-sequencer/src/test_stateless.rs
@@ -1,10 +1,6 @@
 #![allow(dead_code)]
 
 //! Sequencer without any validation or state.
-use std::marker::PhantomData;
-use std::path::Path;
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use sov_blob_sender::{new_blob_id, BlobSender};
 use sov_db::ledger_db::LedgerDb;
@@ -16,6 +12,10 @@ use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::node::DaSyncState;
 use sov_rollup_interface::{StateUpdateInfo, TxHash};
+use std::marker::PhantomData;
+use std::path::Path;
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
 use tokio::sync::{watch, Mutex};
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
@@ -73,6 +73,7 @@ where
         let (state_sender, _rec) = watch::channel(StateCheckpoint::new(storage, &runtime.kernel()));
         let tx_status_manager = TxStatusManager::default();
 
+        let nb_of_concurrent_blob_submissions = Arc::new(AtomicUsize::new(0));
         let seq = Arc::new(Self {
             inner: inner.into(),
             blob_sender: Arc::new(Mutex::new(
@@ -85,6 +86,7 @@ where
                     Duration::from_secs(config.blob_processing_timeout_secs),
                     None,
                     Default::default(),
+                    nb_of_concurrent_blob_submissions,
                 )
                 .await?
                 .0,


### PR DESCRIPTION
# Description

Replicas don’t send blobs to the DA, so the blob sender for them should be set to None. 

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

