### PR TITLE
Fix flakyness `test_check_no_reorgs_longer` by notifying only about processed finalized transitions

### DIFF
--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -143,7 +143,7 @@ impl LedgerNotificationService {
     ) {
         tracing::trace!(
             %triggered_at_slot,
-            finalize_slot = %slot_number,
+            finalized_slot = %slot_number,
             "Registering finalized slot notification");
         self.finalized_slot_notifications
             .lock()
@@ -279,11 +279,11 @@ impl LedgerDb {
     ///
     /// To provide strong consistency across the REST API,
     /// we need to delay updating the inner reader of such ledger dbs until
-    /// the full execution has completed (including the seqeuncer).
+    /// the full execution has completed (including the sequencer).
     ///
     /// This solves an issue where `/ledger/slots/finalized` would return a slot_number
     /// then that slot number was used to query module state:
-    /// `/modules/mymodule/state/a?slot_number=slot_number` but would return an invalid
+    /// `/modules/my-module/state/a?slot_number=slot_number` but would return an invalid
     /// slot number error because state updates hadn't propagated to module-related
     /// state accessors.
     ///
@@ -438,10 +438,10 @@ impl LedgerDb {
             current_item_numbers.batch_number += 1;
         }
 
-        for discarded_blob in data_to_commit.discarded_blobs.into_iter() {
+        for discarded_blob_hash in data_to_commit.discarded_blobs.into_iter() {
             self.put_discarded_blob(
                 StoredDiscardedBlob {
-                    discarded_blob,
+                    hash: discarded_blob_hash.0,
                     slot_number,
                 },
                 &mut schema_batch,
@@ -470,23 +470,24 @@ impl LedgerDb {
         self.notification_service.send_notifications();
     }
 
-    /// Send all notifications for slots <= `slot_num`.
-    pub fn send_notifications_for_slot(&self, slot_num: SlotNumber) {
+    /// Send all notifications for slots <= `slot_number`.
+    pub fn send_notifications_for_slot(&self, slot_number: SlotNumber) {
         self.notification_service
-            .send_notifications_for_slot(slot_num);
+            .send_notifications_for_slot(slot_number);
     }
 
     /// Materializes the latest finalized slot and registers notification.
     pub fn materialize_latest_finalize_slot(
         &self,
-        current_slot_num: SlotNumber,
-        slot_num: SlotNumber,
+        current_slot_number: SlotNumber,
+        finalized_slot_number: SlotNumber,
     ) -> anyhow::Result<SchemaBatch> {
         let mut schema_batch = SchemaBatch::new();
-        schema_batch.put::<FinalizedSlots>(&LatestFinalizedSlotSingleton, &slot_num)?;
+        schema_batch
+            .put::<FinalizedSlots>(&LatestFinalizedSlotSingleton, &finalized_slot_number)?;
         // Register notification for the slot number that was finalized. It will get *sent* after the slot is finished committing.
         self.notification_service
-            .register_finalized_slot_notification(current_slot_num, slot_num);
+            .register_finalized_slot_notification(current_slot_number, finalized_slot_number);
         Ok(schema_batch)
     }
 
@@ -516,7 +517,7 @@ impl LedgerDb {
     /// Materializes aggregated zk proof
     pub fn materialize_aggregated_proof(
         &self,
-        current_slot_num: SlotNumber,
+        current_slot_number: SlotNumber,
         agg_proof: SerializedAggregatedProof,
     ) -> anyhow::Result<SchemaBatch> {
         let mut schema_batch = SchemaBatch::new();
@@ -525,7 +526,7 @@ impl LedgerDb {
 
         self.notification_service
             .register_aggregated_proof_notification(
-                current_slot_num,
+                current_slot_number,
                 AggregatedProofResponse { proof: agg_proof },
             );
         Ok(schema_batch)
@@ -535,10 +536,10 @@ impl LedgerDb {
     pub fn materialize_stf_info(
         &self,
         stf_info: &StoredStfInfo,
-        slot_num: SlotNumber,
+        slot_number: SlotNumber,
     ) -> anyhow::Result<SchemaBatch> {
         let mut schema_batch = SchemaBatch::new();
-        schema_batch.put::<StfInfoByNumber>(&slot_num, stf_info)?;
+        schema_batch.put::<StfInfoByNumber>(&slot_number, stf_info)?;
         Ok(schema_batch)
     }
 
@@ -551,10 +552,10 @@ impl LedgerDb {
     /// Materializes the latest height of the written STF info.
     pub fn materialize_stf_info_write_slot_number(
         &self,
-        stf_write_slot_num: SlotNumber,
+        stf_write_slot_number: SlotNumber,
     ) -> anyhow::Result<SchemaBatch> {
         let mut schema_batch = SchemaBatch::new();
-        schema_batch.put::<StfInfoMetadata>(&WRITE_ROLLUP_HEIGHT_ID, &stf_write_slot_num)?;
+        schema_batch.put::<StfInfoMetadata>(&WRITE_ROLLUP_HEIGHT_ID, &stf_write_slot_number)?;
         Ok(schema_batch)
     }
 
@@ -595,9 +596,9 @@ impl LedgerDb {
     }
 
     /// Delete STF info for the given slot number.
-    pub fn delete_stf_info(&self, slot_num: SlotNumber) -> anyhow::Result<SchemaBatch> {
+    pub fn delete_stf_info(&self, slot_number: SlotNumber) -> anyhow::Result<SchemaBatch> {
         let mut schema_batch = SchemaBatch::new();
-        schema_batch.delete::<StfInfoByNumber>(&slot_num)?;
+        schema_batch.delete::<StfInfoByNumber>(&slot_number)?;
         Ok(schema_batch)
     }
 

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -438,10 +438,10 @@ impl LedgerDb {
             current_item_numbers.batch_number += 1;
         }
 
-        for discarded_blob_hash in data_to_commit.discarded_blobs.into_iter() {
+        for discarded_blob in data_to_commit.discarded_blobs.into_iter() {
             self.put_discarded_blob(
                 StoredDiscardedBlob {
-                    hash: discarded_blob_hash.0,
+                    discarded_blob,
                     slot_number,
                 },
                 &mut schema_batch,

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -259,25 +259,28 @@ impl LedgerDb {
         }
     }
 
-    /// Initialize a new [`LedgerDb`] that shares the LedgerNotificationService
+    /// Initialize a new [`LedgerDb`] that shares the [`LedgerNotificationService`]
     /// of the provided ledger_db. It uses the other [`LedgerDb`]s inner reader
-    /// as the starting point.
+    /// as **the starting point**.
     ///
     /// This is used to create a [`LedgerDb`] used for serving API requests
     /// and publishing notifications produced by the "core" ledger instance.
     ///
-    /// In order to provide strong consistency across the REST API
+    /// To provide strong consistency across the REST API,
     /// we need to delay updating the inner reader of such ledger dbs until
     /// the full execution has completed (including the seqeuncer).
     ///
     /// This solves an issue where `/ledger/slots/finalized` would return a slot_number
     /// then that slot number was used to query module state:
-    /// `/modules/mymodule/state/a?slot_number=slot_number` but would return a invalid
-    /// slot number error because state updates haddn't progogated to module related
+    /// `/modules/mymodule/state/a?slot_number=slot_number` but would return an invalid
+    /// slot number error because state updates hadn't propagated to module-related
     /// state accessors.
+    ///
+    /// Important note: Produced instance of the [`LedgerDb`] will have a new independent `RwLock`,
+    /// so a call to `other.replace_reader()` won't propagate data to the newly created instance.
+    /// It is by design.
     pub fn with_shared_notifications(other: &LedgerDb) -> Self {
         Self {
-            // db: other.db.clone(),
             db: Arc::new(RwLock::new(other.clone_reader())),
             notification_service: other.notification_service.clone(),
         }

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -161,6 +161,7 @@ impl LedgerNotificationService {
     }
 
     pub(crate) fn send_notifications_for_slot(&self, slot: SlotNumber) {
+        tracing::trace!(slot_number = %slot, "Start sending notifications");
         {
             let mut slot_notifications = self
                 .slot_notifications
@@ -176,6 +177,7 @@ impl LedgerNotificationService {
                 }
             });
         }
+        tracing::trace!(slot_number = %slot, "Slot notifications are sent");
 
         {
             let mut finalized_slot_notifications = self
@@ -194,6 +196,7 @@ impl LedgerNotificationService {
                 }
             });
         }
+        tracing::trace!(slot_number = %slot, "Finalized slot notifications are sent");
 
         {
             let mut proof_notifications = self
@@ -212,6 +215,7 @@ impl LedgerNotificationService {
                 }
             });
         }
+        tracing::trace!(slot_number = %slot, "All notifications are sent");
     }
 
     pub(crate) fn send_notifications(&self) {
@@ -273,6 +277,7 @@ impl LedgerDb {
     /// state accessors.
     pub fn with_shared_notifications(other: &LedgerDb) -> Self {
         Self {
+            // db: other.db.clone(),
             db: Arc::new(RwLock::new(other.clone_reader())),
             notification_service: other.notification_service.clone(),
         }

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -123,6 +123,10 @@ impl LedgerNotificationService {
         triggered_at_slot: SlotNumber,
         slot_number: SlotNumber,
     ) {
+        tracing::trace!(
+            %triggered_at_slot,
+            finalize_slot = %slot_number,
+            "Registering processed slot notification");
         self.slot_notifications
             .lock()
             .expect("Slot notification lock is poisoned")
@@ -135,14 +139,18 @@ impl LedgerNotificationService {
     pub(crate) fn register_finalized_slot_notification(
         &self,
         triggered_at_slot: SlotNumber,
-        slot_num: SlotNumber,
+        slot_number: SlotNumber,
     ) {
+        tracing::trace!(
+            %triggered_at_slot,
+            finalize_slot = %slot_number,
+            "Registering finalized slot notification");
         self.finalized_slot_notifications
             .lock()
             .expect("Finalized slot notification lock is poisoned")
             .push(Notification {
                 triggered_at_slot,
-                notification: slot_num,
+                notification: slot_number,
             });
     }
 
@@ -151,6 +159,9 @@ impl LedgerNotificationService {
         triggered_at_slot: SlotNumber,
         aggregated_proof: AggregatedProofResponse,
     ) {
+        tracing::trace!(
+            %triggered_at_slot,
+            "Registering aggregated proof notification");
         self.proof_notifications
             .lock()
             .expect("Aggregated proof notification lock is poisoned")
@@ -465,7 +476,7 @@ impl LedgerDb {
             .send_notifications_for_slot(slot_num);
     }
 
-    /// Materializes latest finalized slot and registers notification.
+    /// Materializes the latest finalized slot and registers notification.
     pub fn materialize_latest_finalize_slot(
         &self,
         current_slot_num: SlotNumber,

--- a/crates/full-node/sov-ledger-apis/src/lib.rs
+++ b/crates/full-node/sov-ledger-apis/src/lib.rs
@@ -775,14 +775,14 @@ where
                                         err.to_string()
                                     )),
                                 };
-                                tracing::trace!(
-                                    from = %old_last,
-                                    up_to_inc = %incoming_slot_num,
-                                    "Collected websocket notification about finalized slots"
-                                );
+                                tracing::trace!(%slot_number, "Preparing slot result for sending to websocket");
                                 slots.push(slot_result);
                             }
-
+                            tracing::trace!(
+                                from = %old_last,
+                                up_to_inc = %incoming_slot_num,
+                                "Collected websocket notification about finalized slots"
+                            );
                             // Returning `Some(...)` yields items to the *downstream*;
                             // returning `None` would end the stream.
                             Some(futures::stream::iter(slots))

--- a/crates/full-node/sov-ledger-apis/src/lib.rs
+++ b/crates/full-node/sov-ledger-apis/src/lib.rs
@@ -737,6 +737,11 @@ where
                 .scan(
                     initial_slot,
                     move |last_notified_slot, incoming_slot_num| {
+                        tracing::trace!(
+                            %last_notified_slot,
+                            %incoming_slot_num,
+                            "Incoming finalized slot number in WebSocket handler"
+                        );
                         let old_last = *last_notified_slot;
                         // Not ideal, since slot results with an error won't get re-notified.
                         // An incoming slot is going to be included in the notification.
@@ -747,6 +752,11 @@ where
                             let capacity =
                                 incoming_slot_num.saturating_sub(old_last.get()).get() as usize;
                             let mut slots = Vec::with_capacity(capacity);
+                            tracing::trace!(
+                                from = %old_last,
+                                up_to_inc = %incoming_slot_num,
+                                "Going to notify about finalized slots"
+                            );
                             for slot_number in old_last.range_inclusive(incoming_slot_num) {
                                 let slot_result = match ledger
                                     .get_slot_by_number::<B, TxReceipt, RuntimeEventResponse<E>>(
@@ -765,7 +775,11 @@ where
                                         err.to_string()
                                     )),
                                 };
-
+                                tracing::trace!(
+                                    from = %old_last,
+                                    up_to_inc = %incoming_slot_num,
+                                    "Collected websocket notification about finalized slots"
+                                );
                                 slots.push(slot_result);
                             }
 

--- a/crates/full-node/sov-sequencer/src/common.rs
+++ b/crates/full-node/sov-sequencer/src/common.rs
@@ -415,7 +415,7 @@ pub async fn loop_send_tx_notifications<S: Spec, Rt: RuntimeEventProcessor>(
                     }
                 }
             }
-            *latest_processed_slot_number.lock().await =info.slot_number;
+            *latest_processed_slot_number.lock().await = info.slot_number;
 
             Ok(())
         }

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -676,6 +676,10 @@ where
             "Starting LedgerAPI storage update");
         self.api_ledger_db
             .replace_reader(info.ledger_reader.clone());
+        tracing::trace!(
+            slot_number = %info.slot_number,
+            latest_finalized_slot_number = %info.latest_finalized_slot_number,
+            "LedgerDb reader is replaced, sending notifications for the slot");
         self.api_ledger_db
             .send_notifications_for_slot(info.slot_number);
         tracing::trace!(

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -677,6 +677,7 @@ where
         self.api_ledger_db
             .replace_reader(info.ledger_reader.clone());
         tracing::trace!(
+            time = ?start.elapsed(),
             slot_number = %info.slot_number,
             latest_finalized_slot_number = %info.latest_finalized_slot_number,
             "LedgerDb reader is replaced, sending notifications for the slot");

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
@@ -55,6 +55,7 @@ type TestRollupBuilder = RollupBuilder<RollupBlueprint>;
 
 const TEST_RANDOMIZATION_SEED: HexHash = HexHash::new([10; 32]);
 const TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+const RUNNER_LOG_DEBUG: &str = "debug,sov_metrics=error,sov_sequencer::preferred=trace,sov_db=trace,sov_ledger_apis=trace,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info";
 
 fn setup_genesis(additional_accounts: usize) -> (HighLevelZkGenesisConfig<S>, GenesisConfig<S>) {
     let high_level_genesis_config = HighLevelZkGenesisConfig::generate()
@@ -382,7 +383,7 @@ async fn test_check_no_reorgs() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_check_no_reorgs_longer() -> anyhow::Result<()> {
-    sov_test_utils::logging::initialize_or_change_logging_with_filter("debug,sov_metrics=error,sov_sequencer::preferred=trace,sov_db=trace,sov_rollup_apis=trace,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info");
+    sov_test_utils::logging::initialize_or_change_logging_with_filter(RUNNER_LOG_DEBUG);
     tokio::time::timeout(
         TEST_TIMEOUT,
         test_stream_of_transactions(StreamOfTransactionsArgs {
@@ -399,13 +400,13 @@ async fn test_check_no_reorgs_longer() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_check_no_reorgs_longer_faster_finality() -> anyhow::Result<()> {
-    sov_test_utils::logging::initialize_or_change_logging_with_filter("debug,sov_metrics=error,sov_sequencer::preferred=trace,sov_db=trace,sov_rollup_apis=trace,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info");
+    sov_test_utils::logging::initialize_or_change_logging_with_filter(RUNNER_LOG_DEBUG);
     tokio::time::timeout(
         TEST_TIMEOUT,
         test_stream_of_transactions(StreamOfTransactionsArgs {
             block_time_ms: 500,
             finalization_blocks: 3,
-            da_slots: 60,
+            da_slots: 50,
             txs_per_da_slot: 10,
             additional_users: 20,
             randomization_config: None,
@@ -416,13 +417,13 @@ async fn test_check_no_reorgs_longer_faster_finality() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_check_no_reorgs_longer_longer_finality() -> anyhow::Result<()> {
-    sov_test_utils::logging::initialize_or_change_logging_with_filter("debug,sov_metrics=error,sov_sequencer::preferred=trace,sov_db=trace,sov_rollup_apis=trace,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info");
+    sov_test_utils::logging::initialize_or_change_logging_with_filter(RUNNER_LOG_DEBUG);
     tokio::time::timeout(
         TEST_TIMEOUT,
         test_stream_of_transactions(StreamOfTransactionsArgs {
             block_time_ms: 500,
             finalization_blocks: 30,
-            da_slots: 60,
+            da_slots: 50,
             txs_per_da_slot: 10,
             additional_users: 20,
             randomization_config: None,
@@ -433,13 +434,13 @@ async fn test_check_no_reorgs_longer_longer_finality() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_check_no_reorgs_longer_instant_finality() -> anyhow::Result<()> {
-    sov_test_utils::logging::initialize_or_change_logging_with_filter("debug,sov_metrics=error,sov_sequencer::preferred=trace,sov_db=trace,sov_rollup_apis=trace,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info");
+    sov_test_utils::logging::initialize_or_change_logging_with_filter(RUNNER_LOG_DEBUG);
     tokio::time::timeout(
         TEST_TIMEOUT,
         test_stream_of_transactions(StreamOfTransactionsArgs {
             block_time_ms: 500,
             finalization_blocks: 0,
-            da_slots: 60,
+            da_slots: 50,
             txs_per_da_slot: 10,
             additional_users: 20,
             randomization_config: None,

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
@@ -382,7 +382,7 @@ async fn test_check_no_reorgs() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_check_no_reorgs_longer() -> anyhow::Result<()> {
-    sov_test_utils::logging::initialize_or_change_logging_with_filter("debug,sov_metrics=error,sov_sequencer::preferred=trace,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info");
+    sov_test_utils::logging::initialize_or_change_logging_with_filter("debug,sov_metrics=error,sov_sequencer::preferred=trace,sov_db=trace,sov_rollup_apis=trace,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info");
     tokio::time::timeout(
         TEST_TIMEOUT,
         test_stream_of_transactions(StreamOfTransactionsArgs {

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
@@ -6,9 +6,7 @@ use std::sync::Arc;
 use futures::{Stream, StreamExt, TryStreamExt};
 use sov_api_spec::types::{Slot, TxStatus};
 use sov_blob_storage::config_deferred_slots_count;
-use sov_mock_da::{
-    BlockProducingConfig, MockDaConfig, RandomizationBehaviour, RandomizationConfig,
-};
+use sov_mock_da::{BlockProducingConfig, RandomizationBehaviour, RandomizationConfig};
 use sov_modules_api::prelude::arbitrary::Unstructured;
 use sov_modules_api::{Runtime, Spec};
 use sov_paymaster::{

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
@@ -250,11 +250,9 @@ async fn test_stream_of_transactions(
             ..Default::default()
         });
         config.rollup_prover_config = None;
-        config.automatic_batch_production = true;
+        config.max_concurrent_blobs = 128;
     })
     .set_da_config(|da_config| {
-        // We don't need to test restarts, so let's save disk accesses and file descriptors.
-        da_config.connection_string = MockDaConfig::sqlite_in_memory();
         da_config.sender_address = genesis_config
             .sequencer_registry
             .sequencer_config

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
@@ -397,6 +397,40 @@ async fn test_check_no_reorgs_longer() -> anyhow::Result<()> {
     .await?
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_check_no_reorgs_longer_faster_finality() -> anyhow::Result<()> {
+    sov_test_utils::logging::initialize_or_change_logging_with_filter("debug,sov_metrics=error,sov_sequencer::preferred=trace,sov_db=trace,sov_rollup_apis=trace,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info");
+    tokio::time::timeout(
+        TEST_TIMEOUT,
+        test_stream_of_transactions(StreamOfTransactionsArgs {
+            block_time_ms: 500,
+            finalization_blocks: 3,
+            da_slots: 60,
+            txs_per_da_slot: 10,
+            additional_users: 20,
+            randomization_config: None,
+        }),
+    )
+    .await?
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_check_no_reorgs_longer_instant_finality() -> anyhow::Result<()> {
+    sov_test_utils::logging::initialize_or_change_logging_with_filter("debug,sov_metrics=error,sov_sequencer::preferred=trace,sov_db=trace,sov_rollup_apis=trace,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info");
+    tokio::time::timeout(
+        TEST_TIMEOUT,
+        test_stream_of_transactions(StreamOfTransactionsArgs {
+            block_time_ms: 500,
+            finalization_blocks: 0,
+            da_slots: 60,
+            txs_per_da_slot: 10,
+            additional_users: 20,
+            randomization_config: None,
+        }),
+    )
+        .await?
+}
+
 struct StreamOfTransactionsArgs {
     /// StorableMockDa is started in PeriodicBatchProduction mode, so this
     /// parameter defines block time.

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_with_reorgs.rs
@@ -415,6 +415,23 @@ async fn test_check_no_reorgs_longer_faster_finality() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_check_no_reorgs_longer_longer_finality() -> anyhow::Result<()> {
+    sov_test_utils::logging::initialize_or_change_logging_with_filter("debug,sov_metrics=error,sov_sequencer::preferred=trace,sov_db=trace,sov_rollup_apis=trace,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info");
+    tokio::time::timeout(
+        TEST_TIMEOUT,
+        test_stream_of_transactions(StreamOfTransactionsArgs {
+            block_time_ms: 500,
+            finalization_blocks: 30,
+            da_slots: 60,
+            txs_per_da_slot: 10,
+            additional_users: 20,
+            randomization_config: None,
+        }),
+    )
+    .await?
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_check_no_reorgs_longer_instant_finality() -> anyhow::Result<()> {
     sov_test_utils::logging::initialize_or_change_logging_with_filter("debug,sov_metrics=error,sov_sequencer::preferred=trace,sov_db=trace,sov_rollup_apis=trace,integration=warn,jmt=info,hyper=info,request=info,tower=info,sqlx=warn,h2=info");
     tokio::time::timeout(
@@ -428,7 +445,7 @@ async fn test_check_no_reorgs_longer_instant_finality() -> anyhow::Result<()> {
             randomization_config: None,
         }),
     )
-        .await?
+    .await?
 }
 
 struct StreamOfTransactionsArgs {

--- a/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
@@ -316,8 +316,7 @@ where
         // ----
 
         let processing_finalized_transitions_start = std::time::Instant::now();
-        let (last_finalized_header, finalized_transitions) =
-            self.process_finalized_state_transitions(da_service).await?;
+        let finalized_transitions = self.process_finalized_state_transitions(da_service).await?;
         let processing_finalized_transitions_time =
             processing_finalized_transitions_start.elapsed();
         tracing::trace!(
@@ -332,25 +331,29 @@ where
             .materialize_slot(slot_commit, new_state_root.as_ref())?;
         tracing::trace!("Initial Ledger ChangeSet is materialized");
 
-        // TODO: Review this, does not look nice.
-        let last_finalized_slot_number = SlotNumber::new_dangerous(
-            last_finalized_header
-                .height()
-                .saturating_sub(da_height_at_genesis),
-        );
-        tracing::trace!(
-            ?last_finalized_slot_number,
-            "Going to materialize last finalized slot number"
-        );
-        let last_finalized_slot_update = self
-            .ledger_db
-            .materialize_latest_finalize_slot(slot_number, last_finalized_slot_number)?;
+        if let Some(finalized_transition) = finalized_transitions.iter().last() {
+            let last_processed_finalized_header = &finalized_transition.block_header;
+            let last_finalized_slot_number = SlotNumber::new_dangerous(
+                last_processed_finalized_header
+                    .height()
+                    .saturating_sub(da_height_at_genesis),
+            );
+            tracing::trace!(
+                ?last_finalized_slot_number,
+                current_slot_number = ?slot_number,
+                "Going to materialize last finalized slot number"
+            );
+            let last_finalized_slot_update = self
+                .ledger_db
+                .materialize_latest_finalize_slot(slot_number, last_finalized_slot_number)?;
 
-        ledger_change_set.merge(last_finalized_slot_update);
-        tracing::trace!(
-            ?last_finalized_slot_number,
-            "Last finalized slot is materialized into LedgerDb ChangeSet"
-        );
+            ledger_change_set.merge(last_finalized_slot_update);
+            tracing::trace!(
+                ?last_finalized_slot_number,
+                current_slot_number = ?slot_number,
+                "Last finalized slot is materialized into LedgerDb ChangeSet"
+            );
+        }
 
         if let Some(stf_info_sender) = &self.stf_info_sender {
             tracing::trace!("Going to materialize StateTransitionInfo");
@@ -791,14 +794,10 @@ where
 
     /// Returns all [`StateTransitionInfo`] which are below finalized height
     /// and relevant LedgerDb changes.
-    /// Also returns the latest finalized block header, so caller shouldn't do another call.
     async fn process_finalized_state_transitions(
         &mut self,
         da_service: &Da,
-    ) -> anyhow::Result<(
-        <Da::Spec as DaSpec>::BlockHeader,
-        Vec<StateOnBlock<Da::Spec, StateRoot>>,
-    )> {
+    ) -> anyhow::Result<Vec<StateOnBlock<Da::Spec, StateRoot>>> {
         // DaService call # 1
         let mut da_service_calls = 1;
         let last_finalized_header = da_service.get_last_finalized_block_header().await?;
@@ -866,20 +865,20 @@ where
 
                 {
                     self.seen_on_height.get_mut(&height)
-                            .expect("Continuity broken, inconsistent internal state")
-                            .retain(|block_hash| {
-                                if new_survivors.contains(block_hash) {
-                                    true
-                                } else {
-                                    tracing::trace!(
+                        .expect("Continuity broken, inconsistent internal state")
+                        .retain(|block_hash| {
+                            if new_survivors.contains(block_hash) {
+                                true
+                            } else {
+                                tracing::trace!(
                                 %block_hash,
                                 ?new_survivors,
                                 "Removing block header from seen_on_height, because it does not originate from last seen finalized header"
                             );
-                                    self.state_on_block.remove(block_hash);
-                                    false
-                                }
-                            });
+                                self.state_on_block.remove(block_hash);
+                                false
+                            }
+                        });
                 }
 
                 survivors = new_survivors;
@@ -941,7 +940,7 @@ where
             ?da_service_calls,
             "Completed check for finalized transitions"
         );
-        Ok((last_finalized_header, finalized_transitions))
+        Ok(finalized_transitions)
     }
 
     // Returns updating time

--- a/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
@@ -253,10 +253,10 @@ async fn test_reorg_happened_correct_block_returned() -> anyhow::Result<()> {
 
 /// This test checks that process_stf_changes goes normally,
 /// even when the finalized block progressed above the passed block header.
-/// Important invariant, that ledger db receives "true" last finalized height,
-/// not height of the last **seen** finalized transition.
+/// Important invariant, ledger db receives the last **processed finalized rollup transition**
+/// and not **the last seen  finalized DA height**
 /// Basically this test covers the case of "syncing node",
-/// and it is an important invariant that LedgerDb gets true finalized height
+/// and it is an important invariant that LedgerDb gets finalized height that it has processed
 #[tokio::test(flavor = "multi_thread")]
 async fn test_save_last_finalized_larger_than_seen_latest_seen_transition() -> anyhow::Result<()> {
     let tempdir = tempfile::tempdir()?;
@@ -303,8 +303,6 @@ async fn test_save_last_finalized_larger_than_seen_latest_seen_transition() -> a
         da_service.send_transaction(&[10; 10]).await.await??;
     }
 
-    let last_finalized_height = da_service.get_last_finalized_block_header().await?.height();
-
     let (change_set, transition_witness) = produce_synthetic_state_transition_witness(
         state_manager.get_state_root().to_owned(),
         prover_storage,
@@ -326,9 +324,10 @@ async fn test_save_last_finalized_larger_than_seen_latest_seen_transition() -> a
         .await?;
     check_internal_consistency(&state_manager, finality as usize);
 
-    // Last finalized height written to LedgerDb as it passed.
+    // The last finalized height is not written to LedgerDb directly,
+    // only the last processed finalized height.
     assert_eq!(
-        last_finalized_height,
+        chain_length,
         state_manager
             .ledger_db
             .get_latest_finalized_slot_number()

--- a/crates/utils/sov-rest-utils/src/lib.rs
+++ b/crates/utils/sov-rest-utils/src/lib.rs
@@ -230,7 +230,7 @@ pub async fn serve_generic_ws_subscription<S, M>(
             _ = shutdown_receiver.changed() => break,
         }
     }
-
+    tracing::trace!("Closing websocket subscription");
     socket.close().await.ok();
 }
 


### PR DESCRIPTION
# Description

StateManager register notification for the latest seen finalized DA height, not the latest processed. This means that slot might be not available for WebSocket subcription.

Essence of this PR is in 1611c30093b427b843372104d1c635e342c72f8e

Other changes:

* More trace logging in various places for easier debug
* More tests similar to `test_check_no_reorgs_longer` but with longer/shorter finality
* Consistency renaming in `LedgerDb`: we had mix of `slot_num` vs `slot_number`, I've converted everything to `slot_number`

- [x] Internal change ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
New tests are added and existing are passing

## Docs
Updated
