### PR TITLE
`BlobSelector`: Resubmit discarded blobs

### DIFF
--- a/crates/full-node/sov-blob-sender/src/lib.rs
+++ b/crates/full-node/sov-blob-sender/src/lib.rs
@@ -17,6 +17,7 @@ use sov_rollup_interface::common::HexHash;
 use sov_rollup_interface::node::da::{DaService, SubmitBlobReceipt};
 use sov_rollup_interface::node::ledger_api::{LedgerStateProvider, QueryMode};
 use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
+use sov_rollup_interface::stf::BlobDiscardReason;
 use tokio::sync::{broadcast, oneshot, watch, Mutex};
 use tokio::task::JoinHandle;
 use tokio::time::{interval, sleep};
@@ -55,15 +56,6 @@ pub trait BlobSenderHooks: Send + Sync + 'static {
 
     /// The blob was published and is now part of the DA's canonical chain.
     async fn on_published_blob(
-        &self,
-        _blob_id: BlobInternalId,
-        _blob_hash: [u8; 32],
-        _da_tx_id: <Self::Da as DaSpec>::TransactionId,
-    ) {
-    }
-
-    /// The blob was processed by the rollup node, but it may not be finalized yet.
-    async fn on_processed_blob(
         &self,
         _blob_id: BlobInternalId,
         _blob_hash: [u8; 32],
@@ -441,7 +433,10 @@ impl FinalizationManager for LedgerDb {
         {
             Some(batch) => (batch.slot_number, BlobSelectorStatus::Accepted),
             None => match self.get_discarded_blob_by_hash(blob_hash).await? {
-                Some(blob) => (blob.slot_number, BlobSelectorStatus::Discarded),
+                Some(blob) => (
+                    blob.slot_number,
+                    BlobSelectorStatus::Discarded(blob.discarded_blob.reason),
+                ),
                 None => return Ok(None),
             },
         };
@@ -690,14 +685,6 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                         return;
                     }
 
-                    self.hooks
-                        .on_processed_blob(
-                            blob_id,
-                            receipt.blob_hash.into(),
-                            receipt.da_transaction_id.clone(),
-                        )
-                        .await;
-
                     loop {
                         let finality_status = match self
                             .get_blob_finalized_or_discarded(
@@ -747,21 +734,41 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                     }
                 }
                 BlobSubmissionStatus::Finalized { receipt, .. } => {
-                    self.send_notification(blob_status.clone()).await;
-                    // Upon crashing, we'd rather call the hook twice rather than not
-                    // calling it at all. So, we call it *before* removing the blob from
-                    // the database.
-                    self.hooks
-                        .on_finalized_blob(
-                            blob_id,
-                            receipt.blob_hash.into(),
-                            &receipt.da_transaction_id,
-                        )
-                        .await;
+                    match blob_status.blob_selector_status {
+                        Some(BlobSelectorStatus::Accepted)
+                        | Some(BlobSelectorStatus::Discarded(
+                            BlobDiscardReason::SequenceNumberTooLow,
+                        )) => {
+                            self.send_notification(blob_status.clone()).await;
+                            // Upon crashing, we'd rather call the hook twice rather than not
+                            // calling it at all. So, we call it *before* removing the blob from
+                            // the database.
+                            self.hooks
+                                .on_finalized_blob(
+                                    blob_id,
+                                    receipt.blob_hash.into(),
+                                    &receipt.da_transaction_id,
+                                )
+                                .await;
 
-                    // We won't shut down the rollup in case of this error, but we will log the error.
-                    let _ = self.remove_blob_or_err(blob_id).await;
-                    break;
+                            // We won't shut down the rollup in case of this error, but we will log the error.
+                            let _ = self.remove_blob_or_err(blob_id).await;
+                            break;
+                        }
+                        // Resubmit if discarded for any reason except `SequenceNumberTooLow`
+                        Some(BlobSelectorStatus::Discarded(reason)) => {
+                            blob_status = BlobExecutionStatus {
+                                blob_submission_status: BlobSubmissionStatus::MustSubmit,
+                                blob_selector_status: None,
+                            };
+
+                            error!(?reason, "BlobSelector discarded the blob; resubmitting.");
+                            continue;
+                        }
+                        None => {
+                            unreachable!("The impossible happened: blob_selector_status is None.")
+                        }
+                    }
                 }
             }
         }
@@ -794,7 +801,7 @@ struct BlobSubmissionRequest<Da: DaSpec> {
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum BlobSelectorStatus {
-    Discarded,
+    Discarded(BlobDiscardReason),
     Accepted,
 }
 

--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -13,6 +13,7 @@ use sov_modules_api::da::BlockHeaderTrait;
 use sov_modules_api::HexHash;
 use sov_rollup_interface::da::BlobReaderTrait;
 use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::stf::BlobDiscardReason;
 use sov_test_utils::logging::LogCollector;
 use std::sync::atomic::AtomicUsize;
 use tempfile::TempDir;
@@ -34,6 +35,7 @@ impl BlobSenderHooks for TestHooks {
 struct TestFinalizationManager<Da: DaService> {
     da: Da,
     start_da_height: u64,
+    blob_selector_status: BlobSelectorStatus,
 }
 
 impl<Da: DaService> TestFinalizationManager<Da> {
@@ -81,7 +83,7 @@ where
             }
         };
 
-        Ok(finalized.map(|f| (f, BlobSelectorStatus::Accepted)))
+        Ok(finalized.map(|f| (f, self.blob_selector_status.clone())))
     }
 }
 
@@ -97,6 +99,7 @@ async fn blob_sender_posts_data_to_da() -> anyhow::Result<()> {
         da.clone(),
         shutdown_sender,
         None,
+        BlobSelectorStatus::Accepted,
     )
     .await;
 
@@ -154,6 +157,7 @@ async fn blob_sender_shutdown_task() -> anyhow::Result<()> {
         da.clone(),
         shutdown_sender.clone(),
         Some(status_sender),
+        BlobSelectorStatus::Accepted,
     )
     .await;
 
@@ -195,6 +199,7 @@ async fn blob_sender_resubmits_blobs_in_progress_after_restart() -> anyhow::Resu
             da.clone(),
             shutdown_sender.clone(),
             None,
+            BlobSelectorStatus::Accepted,
         )
         .await;
 
@@ -218,6 +223,7 @@ async fn blob_sender_resubmits_blobs_in_progress_after_restart() -> anyhow::Resu
             da.clone(),
             shutdown_sender.clone(),
             None,
+            BlobSelectorStatus::Accepted,
         )
         .await;
 
@@ -261,6 +267,7 @@ async fn blob_sender_exit_if_blob_not_processed() -> anyhow::Result<()> {
         da.clone(),
         shutdown_sender.clone(),
         None,
+        BlobSelectorStatus::Accepted,
     )
     .await;
 
@@ -292,6 +299,98 @@ async fn blob_sender_exit_if_blob_not_processed() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn blobs_with_seq_nr_too_low_are_not_resubmitted() -> anyhow::Result<()> {
+    let da_dir = tempfile::tempdir().unwrap();
+    let (shutdown_sender, _shutdown_receiver) = watch::channel(());
+    let da = create_da(&da_dir).await;
+    let storage_dir = tempfile::tempdir().unwrap();
+    let (mut blob_sender, _) = create_blob_sender(
+        Duration::from_secs(20),
+        &storage_dir,
+        da.clone(),
+        shutdown_sender,
+        None,
+        BlobSelectorStatus::Discarded(BlobDiscardReason::SequenceNumberTooLow),
+    )
+    .await;
+
+    let data_1 = {
+        let blob_id = 11u8;
+        let data = Arc::new([blob_id, 2, 3, 4, 5]);
+        blob_sender
+            .publish_batch_blob(data.clone(), blob_id as BlobInternalId)
+            .await?;
+        data
+    };
+
+    sleep(Duration::from_secs(1)).await;
+    let submissions = blob_sender.nb_of_concurrent_blob_submissions();
+    assert_eq!(submissions, 1);
+
+    {
+        da.produce_block_now().await?;
+        sleep(Duration::from_secs(1)).await;
+        assert_data_at(&da, data_1.as_slice(), 1).await;
+
+        let submissions = blob_sender.nb_of_concurrent_blob_submissions();
+        assert_eq!(submissions, 0);
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn discarded_blobs_are_resubmitted() -> anyhow::Result<()> {
+    let collector = LogCollector::new(Level::ERROR);
+    let subscriber = registry().with(collector.clone());
+    subscriber.init();
+
+    let da_dir = tempfile::tempdir().unwrap();
+    let (shutdown_sender, _shutdown_receiver) = watch::channel(());
+    let da = create_da(&da_dir).await;
+    let storage_dir = tempfile::tempdir().unwrap();
+    let (mut blob_sender, _) = create_blob_sender(
+        Duration::from_secs(20),
+        &storage_dir,
+        da.clone(),
+        shutdown_sender,
+        None,
+        // If a blob is discarded for a reason other than BlobDiscardReason::SequenceNumberTooLow, it will be resubmitted.
+        BlobSelectorStatus::Discarded(BlobDiscardReason::SenderInsufficientStake),
+    )
+    .await;
+
+    let data_1 = {
+        let blob_id = 11u8;
+        let data = Arc::new([blob_id, 2, 3, 4, 5]);
+        blob_sender
+            .publish_batch_blob(data.clone(), blob_id as BlobInternalId)
+            .await?;
+        data
+    };
+
+    sleep(Duration::from_secs(1)).await;
+    let submissions = blob_sender.nb_of_concurrent_blob_submissions();
+    assert_eq!(submissions, 1);
+
+    {
+        da.produce_block_now().await?;
+        sleep(Duration::from_secs(1)).await;
+        assert_data_at(&da, data_1.as_slice(), 1).await;
+
+        let submissions = blob_sender.nb_of_concurrent_blob_submissions();
+        assert_eq!(submissions, 1);
+    }
+
+    let mut records = collector.records();
+    let (_, log) = records.pop().unwrap();
+
+    assert!(log.contains("BlobSelector discarded the blob; resubmitting."));
+
+    Ok(())
+}
+
 async fn create_da(da_dir: &TempDir) -> StorableMockDaService {
     let da_layer = Arc::new(RwLock::new(
         StorableMockDaLayer::new_in_path(da_dir.path(), 0)
@@ -307,6 +406,7 @@ async fn create_blob_sender(
     da: StorableMockDaService,
     shutdown_sender: watch::Sender<()>,
     blob_status_sender: Option<broadcast::Sender<BlobExecutionStatus<MockDaSpec>>>,
+    blob_selector_status: BlobSelectorStatus,
 ) -> (
     BlobSender<StorableMockDaService, TestHooks, TestFinalizationManager<StorableMockDaService>>,
     JoinHandle<()>,
@@ -314,6 +414,7 @@ async fn create_blob_sender(
     let finalization_manager = TestFinalizationManager {
         da: da.clone(),
         start_da_height: 0,
+        blob_selector_status,
     };
 
     let hooks = TestHooks {};

--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -133,25 +133,18 @@ async fn blob_sender_posts_data_to_da() -> anyhow::Result<()> {
     Ok(())
 }
 
-/*
 #[tokio::test(flavor = "multi_thread")]
 async fn blob_sender_shutdown_task() -> anyhow::Result<()> {
     let collector = LogCollector::new(Level::INFO);
     let subscriber = registry().with(collector.clone());
     subscriber.init();
 
-    let da_dir = tempfile::tempdir().unwrap();
-    let (shutdown_sender, _shutdown_receiver) = watch::channel(());
-    let da = create_da(&da_dir).await;
-    let storage_dir = tempfile::tempdir().unwrap();
-
+    let deps = create_deps().await;
     let (status_sender, mut status_reciever) = broadcast::channel(100);
 
     let (mut blob_sender, handle) = create_blob_sender(
         Duration::from_secs(20),
-        &storage_dir,
-        da.clone(),
-        shutdown_sender.clone(),
+        &deps,
         Some(status_sender),
         BlobSelectorStatus::Accepted,
     )
@@ -168,7 +161,7 @@ async fn blob_sender_shutdown_task() -> anyhow::Result<()> {
 
     // Wait for the blob task to start.
     status_reciever.recv().await.unwrap();
-    shutdown_sender.send(()).unwrap();
+    deps.shutdown_sender.send(()).unwrap();
     handle.await.unwrap();
 
     let mut records = collector.records();
@@ -182,18 +175,13 @@ async fn blob_sender_shutdown_task() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn blob_sender_resubmits_blobs_in_progress_after_restart() -> anyhow::Result<()> {
-    let da_dir = tempfile::tempdir().unwrap();
-    let (shutdown_sender, _shutdown_receiver) = watch::channel(());
-    let da = create_da(&da_dir).await;
-    let storage_dir = tempfile::tempdir().unwrap();
+    let deps = create_deps().await;
 
     // Send blob to the DA and shutdown blob sender.
     {
         let (mut blob_sender, handle) = create_blob_sender(
             Duration::from_secs(20),
-            &storage_dir,
-            da.clone(),
-            shutdown_sender.clone(),
+            &deps,
             None,
             BlobSelectorStatus::Accepted,
         )
@@ -207,7 +195,7 @@ async fn blob_sender_resubmits_blobs_in_progress_after_restart() -> anyhow::Resu
                 .await?;
             data
         };
-        shutdown_sender.send(()).unwrap();
+        deps.shutdown_sender.send(()).unwrap();
         handle.await.unwrap();
     }
 
@@ -215,9 +203,7 @@ async fn blob_sender_resubmits_blobs_in_progress_after_restart() -> anyhow::Resu
     {
         let (mut blob_sender, _) = create_blob_sender(
             Duration::from_secs(20),
-            &storage_dir,
-            da.clone(),
-            shutdown_sender.clone(),
+            &deps,
             None,
             BlobSelectorStatus::Accepted,
         )
@@ -235,7 +221,7 @@ async fn blob_sender_resubmits_blobs_in_progress_after_restart() -> anyhow::Resu
         assert_eq!(submissions, 2);
 
         sleep(Duration::from_secs(1)).await;
-        da.produce_block_now().await?;
+        deps.da.produce_block_now().await?;
         // We have to wait a littele bit for the async task in blob sender.
         sleep(Duration::from_secs(1)).await;
 
@@ -252,16 +238,11 @@ async fn blob_sender_exit_if_blob_not_processed() -> anyhow::Result<()> {
     let subscriber = registry().with(collector.clone());
     subscriber.init();
 
-    let da_dir = tempfile::tempdir().unwrap();
-    let (shutdown_sender, _shutdown_receiver) = watch::channel(());
-    let da = create_da(&da_dir).await;
-    let storage_dir = tempfile::tempdir().unwrap();
+    let deps = create_deps().await;
 
     let (mut blob_sender, blob_sender_handle) = create_blob_sender(
         Duration::from_secs(1),
-        &storage_dir,
-        da.clone(),
-        shutdown_sender.clone(),
+        &deps,
         None,
         BlobSelectorStatus::Accepted,
     )
@@ -297,15 +278,10 @@ async fn blob_sender_exit_if_blob_not_processed() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn blobs_with_seq_nr_too_low_are_not_resubmitted() -> anyhow::Result<()> {
-    let da_dir = tempfile::tempdir().unwrap();
-    let (shutdown_sender, _shutdown_receiver) = watch::channel(());
-    let da = create_da(&da_dir).await;
-    let storage_dir = tempfile::tempdir().unwrap();
+    let deps = create_deps().await;
     let (mut blob_sender, _) = create_blob_sender(
         Duration::from_secs(20),
-        &storage_dir,
-        da.clone(),
-        shutdown_sender,
+        &deps,
         None,
         BlobSelectorStatus::Discarded(BlobDiscardReason::SequenceNumberTooLow),
     )
@@ -325,9 +301,9 @@ async fn blobs_with_seq_nr_too_low_are_not_resubmitted() -> anyhow::Result<()> {
     assert_eq!(submissions, 1);
 
     {
-        da.produce_block_now().await?;
+        deps.da.produce_block_now().await?;
         sleep(Duration::from_secs(1)).await;
-        assert_data_at(&da, data_1.as_slice(), 1).await;
+        assert_data_at(&deps.da, data_1.as_slice(), 1).await;
 
         let submissions = blob_sender.nb_of_concurrent_blob_submissions();
         assert_eq!(submissions, 0);
@@ -342,15 +318,10 @@ async fn discarded_blobs_are_resubmitted() -> anyhow::Result<()> {
     let subscriber = registry().with(collector.clone());
     subscriber.init();
 
-    let da_dir = tempfile::tempdir().unwrap();
-    let (shutdown_sender, _shutdown_receiver) = watch::channel(());
-    let da = create_da(&da_dir).await;
-    let storage_dir = tempfile::tempdir().unwrap();
+    let deps = create_deps().await;
     let (mut blob_sender, _) = create_blob_sender(
         Duration::from_secs(20),
-        &storage_dir,
-        da.clone(),
-        shutdown_sender,
+        &deps,
         None,
         // If a blob is discarded for a reason other than BlobDiscardReason::SequenceNumberTooLow, it will be resubmitted.
         BlobSelectorStatus::Discarded(BlobDiscardReason::SenderInsufficientStake),
@@ -371,9 +342,9 @@ async fn discarded_blobs_are_resubmitted() -> anyhow::Result<()> {
     assert_eq!(submissions, 1);
 
     {
-        da.produce_block_now().await?;
+        deps.da.produce_block_now().await?;
         sleep(Duration::from_secs(1)).await;
-        assert_data_at(&da, data_1.as_slice(), 1).await;
+        assert_data_at(&deps.da, data_1.as_slice(), 1).await;
 
         let submissions = blob_sender.nb_of_concurrent_blob_submissions();
         assert_eq!(submissions, 1);
@@ -386,8 +357,6 @@ async fn discarded_blobs_are_resubmitted() -> anyhow::Result<()> {
 
     Ok(())
 }
-
-*/
 
 struct Deps {
     _da_dir: TempDir,

--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -89,15 +89,10 @@ where
 
 #[tokio::test(flavor = "multi_thread")]
 async fn blob_sender_posts_data_to_da() -> anyhow::Result<()> {
-    let da_dir = tempfile::tempdir().unwrap();
-    let (shutdown_sender, _shutdown_receiver) = watch::channel(());
-    let da = create_da(&da_dir).await;
-    let storage_dir = tempfile::tempdir().unwrap();
+    let deps = create_deps().await;
     let (mut blob_sender, _) = create_blob_sender(
         Duration::from_secs(20),
-        &storage_dir,
-        da.clone(),
-        shutdown_sender,
+        &deps,
         None,
         BlobSelectorStatus::Accepted,
     )
@@ -126,10 +121,10 @@ async fn blob_sender_posts_data_to_da() -> anyhow::Result<()> {
     assert_eq!(submissions, 2);
 
     {
-        da.produce_block_now().await?;
+        deps.da.produce_block_now().await?;
         sleep(Duration::from_secs(1)).await;
-        assert_data_at(&da, data_1.as_slice(), 1).await;
-        assert_data_at(&da, data_2.as_slice(), 1).await;
+        assert_data_at(&deps.da, data_1.as_slice(), 1).await;
+        assert_data_at(&deps.da, data_2.as_slice(), 1).await;
 
         let submissions = blob_sender.nb_of_concurrent_blob_submissions();
         assert_eq!(submissions, 0);
@@ -138,6 +133,7 @@ async fn blob_sender_posts_data_to_da() -> anyhow::Result<()> {
     Ok(())
 }
 
+/*
 #[tokio::test(flavor = "multi_thread")]
 async fn blob_sender_shutdown_task() -> anyhow::Result<()> {
     let collector = LogCollector::new(Level::INFO);
@@ -391,6 +387,31 @@ async fn discarded_blobs_are_resubmitted() -> anyhow::Result<()> {
     Ok(())
 }
 
+*/
+
+struct Deps {
+    _da_dir: TempDir,
+    shutdown_sender: watch::Sender<()>,
+    _shutdown_receiver: watch::Receiver<()>,
+    da: StorableMockDaService,
+    storage_dir: TempDir,
+}
+
+async fn create_deps() -> Deps {
+    let da_dir = tempfile::tempdir().unwrap();
+    let (shutdown_sender, shutdown_receiver) = watch::channel(());
+    let da = create_da(&da_dir).await;
+    let storage_dir = tempfile::tempdir().unwrap();
+
+    Deps {
+        _da_dir: da_dir,
+        shutdown_sender,
+        _shutdown_receiver: shutdown_receiver,
+        da,
+        storage_dir,
+    }
+}
+
 async fn create_da(da_dir: &TempDir) -> StorableMockDaService {
     let da_layer = Arc::new(RwLock::new(
         StorableMockDaLayer::new_in_path(da_dir.path(), 0)
@@ -402,9 +423,7 @@ async fn create_da(da_dir: &TempDir) -> StorableMockDaService {
 
 async fn create_blob_sender(
     blob_processing_timeout: Duration,
-    storage_dir: &TempDir,
-    da: StorableMockDaService,
-    shutdown_sender: watch::Sender<()>,
+    deps: &Deps,
     blob_status_sender: Option<broadcast::Sender<BlobExecutionStatus<MockDaSpec>>>,
     blob_selector_status: BlobSelectorStatus,
 ) -> (
@@ -412,7 +431,7 @@ async fn create_blob_sender(
     JoinHandle<()>,
 ) {
     let finalization_manager = TestFinalizationManager {
-        da: da.clone(),
+        da: deps.da.clone(),
         start_da_height: 0,
         blob_selector_status,
     };
@@ -421,11 +440,11 @@ async fn create_blob_sender(
 
     let nb_of_concurrent_blob_submissions = Arc::new(AtomicUsize::new(0));
     let (blob_sender, handle) = BlobSender::new_with_task_intervals(
-        da,
+        deps.da.clone(),
         finalization_manager,
-        storage_dir.path(),
+        deps.storage_dir.path(),
         hooks,
-        shutdown_sender,
+        deps.shutdown_sender.clone(),
         blob_processing_timeout,
         blob_status_sender,
         Duration::from_millis(1000),

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
@@ -9,6 +9,7 @@ use sov_modules_api::prelude::*;
 use sov_modules_api::{DispatchCall, RawTx, Runtime};
 use sov_modules_stf_blueprint::GenesisParams;
 use sov_paymaster::PaymasterConfig;
+use sov_rollup_interface::stf::BlobDiscardReason;
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
 use sov_test_utils::test_rollup::TestRollup;
 use sov_test_utils::{
@@ -97,7 +98,7 @@ async fn test_discard_oversized_blobs() {
 
     tokio::time::timeout(tokio::time::Duration::from_secs(15), async {
         while let Some(blob_status) = sub.next().await {
-            if let Some(BlobSelectorStatus::Discarded(_)) =
+            if let Some(BlobSelectorStatus::Discarded(BlobDiscardReason::OutOfCapacity)) =
                 blob_status.as_ref().unwrap().blob_selector_status
             {
                 break;

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
@@ -97,7 +97,7 @@ async fn test_discard_oversized_blobs() {
 
     tokio::time::timeout(tokio::time::Duration::from_secs(15), async {
         while let Some(blob_status) = sub.next().await {
-            if let Some(BlobSelectorStatus::Discarded) =
+            if let Some(BlobSelectorStatus::Discarded(_)) =
                 blob_status.as_ref().unwrap().blob_selector_status
             {
                 break;

--- a/crates/module-system/module-implementations/sov-blob-storage/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-blob-storage/src/capabilities.rs
@@ -836,7 +836,10 @@ impl<S: Spec> BlobStorage<S> {
 
             if !blobs_to_select.can_accept_blob(SequencerType::Preferred, blob_with_id.blob_size())
             {
-                tracing::error!(blob_id = hex::encode(blob_id), "TODO");
+                tracing::error!(
+                    blob_id = hex::encode(blob_id),
+                    "The blob is discarded because it exceeds the size limit."
+                );
                 Self::discard(
                     discarded_blobs,
                     preferred_sender,

--- a/crates/module-system/module-implementations/sov-blob-storage/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-blob-storage/src/capabilities.rs
@@ -834,11 +834,23 @@ impl<S: Spec> BlobStorage<S> {
                 .get_sender_balance(preferred_sender, state)
                 .unwrap_or(Amount::ZERO);
 
+            if !blobs_to_select.can_accept_blob(SequencerType::Preferred, blob_with_id.blob_size())
+            {
+                tracing::error!(blob_id = hex::encode(blob_id), "TODO");
+                Self::discard(
+                    discarded_blobs,
+                    preferred_sender,
+                    blob_id,
+                    BlobDiscardReason::OutOfCapacity,
+                );
+
+                continue;
+            }
+
             let Some(validated_blob) = self.validate_preferred_blob(
                 blob_with_id,
                 preferred_sender.clone(),
                 available_balance,
-                blobs_to_select,
                 visible_height_increase,
                 state,
             ) else {

--- a/crates/module-system/module-implementations/sov-blob-storage/src/validation.rs
+++ b/crates/module-system/module-implementations/sov-blob-storage/src/validation.rs
@@ -7,8 +7,7 @@ use sov_modules_api::{
     GasSpec, KernelStateAccessor, ModuleInfo, PrivilegedKernelAccessor, Spec,
 };
 
-use crate::max_size_checker::BlobsAccumulatorWithSizeLimit;
-use crate::{BlobStorage, Escrow, SequencerType, ValidatedBlob};
+use crate::{BlobStorage, Escrow, ValidatedBlob};
 
 const CONSERVATIVE_KEY_SIZE: u32 = 256;
 
@@ -114,13 +113,9 @@ impl<S: Spec> BlobStorage<S> {
         blob: BlobDataWithId<S, BatchWithId<S>>,
         sender: <<S as Spec>::Da as DaSpec>::Address,
         available_balance: Amount,
-        selected_blobs: &BlobsAccumulatorWithSizeLimit<S>,
         visible_height_increase: u64,
         state: &mut KernelStateAccessor<'_, S>,
     ) -> Option<ValidatedBlob<S, BatchWithId<S>>> {
-        if !selected_blobs.can_accept_blob(SequencerType::Preferred, blob.blob_size()) {
-            return None;
-        }
         let best_gas_price_estimate = self.get_new_gas_price(visible_height_increase, state);
 
         let gas_needed_for_pre_exec_checks = <S as GasSpec>::max_tx_check_costs();

--- a/crates/module-system/module-schemas/genesis-schemas/sov-bank.json
+++ b/crates/module-system/module-schemas/genesis-schemas/sov-bank.json
@@ -4,15 +4,18 @@
   "description": "Initial configuration for sov-bank module.",
   "type": "object",
   "required": [
-    "gas_token_config",
     "tokens"
   ],
   "properties": {
     "gas_token_config": {
       "description": "Configuration for the gas token",
-      "allOf": [
+      "default": null,
+      "anyOf": [
         {
           "$ref": "#/definitions/GasTokenConfig"
+        },
+        {
+          "type": "null"
         }
       ]
     },

--- a/crates/rollup-interface/src/state_machine/stf/mod.rs
+++ b/crates/rollup-interface/src/state_machine/stf/mod.rs
@@ -165,7 +165,16 @@ type ProofReceipts<Address, Da, StateRoot, StorageProof> =
     Vec<ProofReceipt<Address, Da, StateRoot, StorageProof>>;
 
 /// The reason that a blob was discarded
-#[derive(Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    BorshDeserialize,
+    BorshSerialize,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum BlobDiscardReason {
     /// The sequencer sent a blob with an old sequencer number that we've already processed.
     SequenceNumberTooLow,


### PR DESCRIPTION
# Description

This PR introduces the following changes to `BlobSende`r:
1. If a blob is discarded by` BlobSelector` for a reason other than `SequenceNumberTooLow`, `BlobSender` resubmits it.
2. If a blob is discarded with the reason `SequenceNumberTooLow`,` BlobSender` removes it from memory.
3. Fixed a bug in `BlobSelector` where blobs were rejected for the `InsufficientFunds` reason instead of `OutOfCapacity`.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
