### PR TITLE
Speed up `seq_many_invalid_tx` by adjusting retry logic

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1723,10 +1723,7 @@ async fn flaky_seq_back_pressure() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn seq_many_invalid_txs() {
-    sov_test_utils::logging::initialize_or_change_logging_with_filter(
-        "warn,sov_metrics=error,sov=debug,integration=debug",
-    );
-    let txs = 100u64;
+    let txs = 1000u64;
     let (test_rollup, admin) = create_test_rollup(
         0,
         TEST_MAX_BATCH_SIZE,
@@ -1760,14 +1757,9 @@ async fn seq_many_invalid_txs() {
     let mut handles = Vec::with_capacity(txs as usize);
     for i in 0..txs {
         let client = client.clone();
-        let da_service = test_rollup.da_service.clone();
-
         // Generation is always below, so each tx is going to fail
         let tx = tx_set_value(&admin.private_key, 0, i);
         handles.push(tokio::spawn(async move {
-            let start_task = std::time::Instant::now();
-
-            // Use backon retry logic with exponential backoff
             let backoff = backon::ExponentialBuilder::default()
                 .with_factor(1.5)
                 .with_min_delay(Duration::from_millis(200))
@@ -1798,7 +1790,7 @@ async fn seq_many_invalid_txs() {
                             std::str::from_utf8(bytes.as_ref())
                                 .ok()
                                 .map(|s| {
-                                    // Try to parse status from response
+                                    // Try to parse status from the response
                                     s.contains("\"status\":5")
                                 })
                                 .unwrap_or(false)
@@ -1813,25 +1805,13 @@ async fn seq_many_invalid_txs() {
                     );
                 })
                 .await;
-
-            tracing::info!("Task {} i submit is done in {:?}", i, start_task.elapsed());
-            // Why each handle produces a block, when we produce 50 after the loop?
-            da_service.produce_block_now().await.unwrap();
-
-            // Panic on HTTP 200 success (as requested in TODO)
-            if let Ok(response) = &res {
-                panic!(
-                    "Task {i}: Transaction unexpectedly succeeded with HTTP 200. Response: {response:?}"
-                );
-            }
-
             assert!(res.is_err(), "Request has been accepted, when it shouldn't");
         }));
     }
 
     test_rollup
         .da_service
-        .produce_n_blocks_now(50)
+        .produce_n_blocks_now(txs as usize / 2)
         .await
         .unwrap();
 

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1825,7 +1825,10 @@ async fn seq_many_invalid_txs() {
         res.expect("Background sender task has panicked");
     }
 
-    let _ = test_rollup.shutdown().await.expect("Rollup shutdown properly");
+    let _ = test_rollup
+        .shutdown()
+        .await
+        .expect("Rollup shutdown properly");
 }
 
 /// Ensure that we use the correct visible slot number when replaying transactions after a call to `update_state` in the sequencer.

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -88,7 +88,7 @@ impl DaLayerWithSubscription {
             .da_service
             .block_producing(),
             BlockProducingConfig::Manual),
-            "Can't currently use DaLayerWithSubscription with a non-manual block producing config because notifications may be produced without our knowledge"
+                "Can't currently use DaLayerWithSubscription with a non-manual block producing config because notifications may be produced without our knowledge"
         );
         let da_layer = test_rollup.da_service.da_layer().clone();
         let state_update_subscription = test_rollup.subscribe_state_updates().await;
@@ -1722,6 +1722,11 @@ async fn flaky_seq_back_pressure() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn seq_many_invalid_txs() {
+    sov_test_utils::logging::initialize_or_change_logging_with_filter(
+        "warn,sov_metrics=error,sov=debug,integration=debug",
+    );
+    let start_test = std::time::Instant::now();
+    let txs = 100u64;
     let (test_rollup, admin) = create_test_rollup(
         0,
         TEST_MAX_BATCH_SIZE,
@@ -1745,36 +1750,51 @@ async fn seq_many_invalid_txs() {
     }
 
     let client = test_rollup.api_client().clone();
-    let tx = tx_set_value(&admin.private_key, 100, 0);
+    let tx = tx_set_value(&admin.private_key, txs, 1_000_000);
 
     client
         .send_raw_tx_to_sequencer_with_retry(&tx)
         .await
         .unwrap();
 
-    let mut handles = Vec::default();
-    for i in 0..100 {
+    tracing::info!("Preparation is done: {:?}", start_test.elapsed());
+
+    let start_loop = std::time::Instant::now();
+
+    let mut handles = Vec::with_capacity(txs as usize);
+    for i in 0..txs {
         let client = client.clone();
         let da_service = test_rollup.da_service.clone();
 
+        // Generation is always below, so each tx is going to fail
         let tx = tx_set_value(&admin.private_key, 0, i);
         handles.push(tokio::spawn(async move {
-            let res = client.send_raw_tx_to_sequencer_with_retry(&tx).await;
+            let start_task = std::time::Instant::now();
+            // TODO: rewrite to use backon retry here, and retry only if communication error or HTTP 5XX happens.
+            // Panic if HTTP 200
+            let res = client.send_raw_tx_to_sequencer(&tx).await;
+            tracing::info!("Task {} i submit is done in {:?}", i, start_task.elapsed());
+            // Why each handle produces block, when we produce 50 after the loop
             da_service.produce_block_now().await.unwrap();
+            tracing::info!("Task {} i fully completed in {:?}", i, start_task.elapsed());
             res
         }));
     }
+    tracing::info!("LOOP IS COMPLETED IN {:?}", start_loop.elapsed());
 
+    let final_start = std::time::Instant::now();
     test_rollup
         .da_service
         .produce_n_blocks_now(50)
         .await
         .unwrap();
+    tracing::info!("Producing 50 blocks is done in {:?}", final_start.elapsed());
 
     let results = future::join_all(handles).await;
     for res in results {
         assert!(res.unwrap().is_err());
     }
+    tracing::info!("JOINGING THREADS DONE IN {:?}", final_start.elapsed());
 }
 
 /// Ensure that we use the correct visible slot number when replaying transactions after a call to `update_state` in the sequencer.

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1807,7 +1807,9 @@ async fn seq_many_invalid_txs() {
                 })
                 .await;
             // Producing block to add more work for the sequencer
-            da_service.produce_block_now().await.unwrap();
+            if i % 5 == 0 {
+                da_service.produce_block_now().await.unwrap();
+            }
             assert!(res.is_err(), "Request has been accepted, when it shouldn't");
         }));
     }
@@ -1822,6 +1824,8 @@ async fn seq_many_invalid_txs() {
     for res in results {
         res.expect("Background sender task has panicked");
     }
+
+    let _ = test_rollup.shutdown().await.expect("Rollup shutdown properly");
 }
 
 /// Ensure that we use the correct visible slot number when replaying transactions after a call to `update_state` in the sequencer.

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1,6 +1,7 @@
 //! Integration tests for the preferred sequencer that use [`RollupBuilder`] and
 //! thus test sequencer + node interactions.
 
+use backon::Retryable;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -1725,7 +1726,6 @@ async fn seq_many_invalid_txs() {
     sov_test_utils::logging::initialize_or_change_logging_with_filter(
         "warn,sov_metrics=error,sov=debug,integration=debug",
     );
-    let start_test = std::time::Instant::now();
     let txs = 100u64;
     let (test_rollup, admin) = create_test_rollup(
         0,
@@ -1757,10 +1757,6 @@ async fn seq_many_invalid_txs() {
         .await
         .unwrap();
 
-    tracing::info!("Preparation is done: {:?}", start_test.elapsed());
-
-    let start_loop = std::time::Instant::now();
-
     let mut handles = Vec::with_capacity(txs as usize);
     for i in 0..txs {
         let client = client.clone();
@@ -1770,31 +1766,79 @@ async fn seq_many_invalid_txs() {
         let tx = tx_set_value(&admin.private_key, 0, i);
         handles.push(tokio::spawn(async move {
             let start_task = std::time::Instant::now();
-            // TODO: rewrite to use backon retry here, and retry only if communication error or HTTP 5XX happens.
-            // Panic if HTTP 200
-            let res = client.send_raw_tx_to_sequencer(&tx).await;
+
+            // Use backon retry logic with exponential backoff
+            let backoff = backon::ExponentialBuilder::default()
+                .with_factor(1.5)
+                .with_min_delay(Duration::from_millis(200))
+                .with_max_times(10)
+                .with_max_delay(Duration::from_secs(5));
+
+            let client_for_retry = client.clone();
+            let tx_for_retry = tx.clone();
+            let fut = move || {
+                let client = client_for_retry.clone();
+                let tx = tx_for_retry.clone();
+                async move { client.send_raw_tx_to_sequencer(&tx).await }
+            };
+
+            let res = fut
+                .retry(backoff)
+                .when(|err| {
+                    // Only retry on communication errors or HTTP 5XX
+                    match err {
+                        sov_api_spec::Error::CommunicationError(_) => true,
+                        sov_api_spec::Error::ErrorResponse(response_value) => {
+                            // Check if it's a 5XX error
+                            let status = response_value.status().as_u16();
+                            (500..600).contains(&status)
+                        }
+                        sov_api_spec::Error::InvalidResponsePayload(bytes, _) => {
+                            // Check if response contains 5XX status
+                            std::str::from_utf8(bytes.as_ref())
+                                .ok()
+                                .map(|s| {
+                                    // Try to parse status from response
+                                    s.contains("\"status\":5")
+                                })
+                                .unwrap_or(false)
+                        }
+                        _ => false,
+                    }
+                })
+                .notify(|err, dur| {
+                    tracing::warn!(
+                        "Task {} failed to submit transaction, retrying... Error: {:?}, Duration: {:?}",
+                        i, err, dur
+                    );
+                })
+                .await;
+
             tracing::info!("Task {} i submit is done in {:?}", i, start_task.elapsed());
-            // Why each handle produces block, when we produce 50 after the loop
+            // Why each handle produces a block, when we produce 50 after the loop?
             da_service.produce_block_now().await.unwrap();
-            tracing::info!("Task {} i fully completed in {:?}", i, start_task.elapsed());
-            res
+
+            // Panic on HTTP 200 success (as requested in TODO)
+            if let Ok(response) = &res {
+                panic!(
+                    "Task {i}: Transaction unexpectedly succeeded with HTTP 200. Response: {response:?}"
+                );
+            }
+
+            assert!(res.is_err(), "Request has been accepted, when it shouldn't");
         }));
     }
-    tracing::info!("LOOP IS COMPLETED IN {:?}", start_loop.elapsed());
 
-    let final_start = std::time::Instant::now();
     test_rollup
         .da_service
         .produce_n_blocks_now(50)
         .await
         .unwrap();
-    tracing::info!("Producing 50 blocks is done in {:?}", final_start.elapsed());
 
     let results = future::join_all(handles).await;
     for res in results {
-        assert!(res.unwrap().is_err());
+        res.expect("Background sender task has panicked");
     }
-    tracing::info!("JOINGING THREADS DONE IN {:?}", final_start.elapsed());
 }
 
 /// Ensure that we use the correct visible slot number when replaying transactions after a call to `update_state` in the sequencer.

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1757,6 +1757,7 @@ async fn seq_many_invalid_txs() {
     let mut handles = Vec::with_capacity(txs as usize);
     for i in 0..txs {
         let client = client.clone();
+        let da_service = test_rollup.da_service.clone();
         // Generation is always below, so each tx is going to fail
         let tx = tx_set_value(&admin.private_key, 0, i);
         handles.push(tokio::spawn(async move {
@@ -1805,6 +1806,8 @@ async fn seq_many_invalid_txs() {
                     );
                 })
                 .await;
+            // Producing block to add more work for the sequencer
+            da_service.produce_block_now().await.unwrap();
             assert!(res.is_err(), "Request has been accepted, when it shouldn't");
         }));
     }


### PR DESCRIPTION
# Description

Test `seq_many_invalid_tx` uses submit method with retry, which leads to very long test time, because default exponential backoff total waiting time is going to be a little bit more than 5 minutes. 

This PR changes that, and in order to keep closer to original intention:

* It will retry on most of the errors, except bad request
* It increases number of txs 10x to increase load on the sequencer.
* It removes creating block inside a task, so there's less between tasks, which on my machine lead 10x speed up in the test.

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues

## Testing
Test is passing

## Docs
No updates
