### PR TITLE
Add the chain name to the SolanaOffchainUnsognedTransaction struct so that it's displayed to the user

### DIFF
--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -198,6 +198,15 @@ pub enum FatalError {
         /// The actual chain id
         got: String,
     },
+    /// The chain name was invalid. Not every type of transaction will be able to throw this (some
+    /// will just implicitly fail signature checks).
+    #[error("Invalid chain name: expected {expected}, got {got}")]
+    InvalidChainName {
+        /// The expected chain id
+        expected: String,
+        /// The actual chain id
+        got: String,
+    },
     /// Transaction decoding failed.
     #[error("Transaction decoding error: {0}")]
     MessageDecodingFailed(String),

--- a/crates/module-system/sov-modules-macros/src/common.rs
+++ b/crates/module-system/sov-modules-macros/src/common.rs
@@ -237,6 +237,54 @@ pub(crate) fn get_generics_type_param(
     Ok(generic_param.clone())
 }
 
+/// Builds a string that adds a `Spec` bound to the first generic, and
+/// `serde::Serialize + serde::Deserialize` bounds to every other.
+/// This is useful because the Spec trait includes a built-in bound on Deserialize, which causes
+/// issues when serde auto-generates `S: Deserialize` bounds by default. So we have to override
+/// this for S only, while ensuring we keep the normal Serialize + Deserialize bounds on every
+/// other generic.
+pub(crate) fn get_serde_bounds_str(
+    generics: &syn::Generics,
+    unique_lifetime_name: &str,
+) -> syn::Result<String> {
+    let mut params = generics.params.iter();
+
+    // First parameter is assumed to be the Spec
+    let spec_ident = match params.next() {
+        Some(syn::GenericParam::Type(type_param)) => type_param.ident.clone(),
+        Some(syn::GenericParam::Lifetime(lf)) => {
+            return Err(syn::Error::new_spanned(
+                lf,
+                "Expected type parameter, found lifetime parameter",
+            ));
+        }
+        Some(syn::GenericParam::Const(cnst)) => {
+            return Err(syn::Error::new_spanned(
+                cnst,
+                "Expected type parameter, found const parameter",
+            ));
+        }
+        None => {
+            return Err(syn::Error::new_spanned(
+                generics,
+                "No generic parameters found",
+            ));
+        }
+    };
+    let mut all_bounds = vec![format!("{}: sov_modules_api::module::Spec", spec_ident)];
+
+    // Collect other type parameters that need serde bounds
+    let other_bounds: Vec<String> = params.filter_map(|generic| match generic {
+        syn::GenericParam::Type(type_param) => {
+            Some(format!("{}: serde::Serialize + for<'{unique_lifetime_name}> serde::Deserialize<'{unique_lifetime_name}>", type_param.ident))
+        },
+        syn::GenericParam::Lifetime(_) | syn::GenericParam::Const(_) => None,
+    }).collect();
+
+    all_bounds.extend(other_bounds);
+    Ok(all_bounds.join(", "))
+}
+
 pub(crate) fn get_derived_enum_attrs(
     ident: &str,
     input: &syn::DeriveInput,

--- a/crates/module-system/sov-modules-macros/src/dispatch/dispatch_call.rs
+++ b/crates/module-system/sov-modules-macros/src/dispatch/dispatch_call.rs
@@ -2,8 +2,8 @@ use proc_macro2::Span;
 use syn::DeriveInput;
 
 use crate::common::{
-    get_derived_enum_attrs, get_generics_type_param, pascal_case_ident, StructDef,
-    StructFieldExtractor, CALL,
+    get_derived_enum_attrs, get_generics_type_param, get_serde_bounds_str, pascal_case_ident,
+    StructDef, StructFieldExtractor, CALL,
 };
 
 impl StructDef<'_> {
@@ -127,6 +127,7 @@ impl DispatchCallMacro {
         &self,
         input: DeriveInput,
     ) -> syn::Result<proc_macro::TokenStream> {
+        let serde_bounds_str = get_serde_bounds_str(&input.generics, "_dispatch_call_de")?;
         let default_attrs = vec![
             quote::quote! {
                 #[
@@ -153,7 +154,7 @@ impl DispatchCallMacro {
                 #[sov_wallet(template_inherit)]
             },
             quote::quote! {
-                #[serde(bound = "", rename_all = "snake_case")]
+                #[serde(bound = #serde_bounds_str, rename_all = "snake_case")]
             },
             quote::quote! {
                 #[strum_discriminants(derive(
@@ -167,6 +168,7 @@ impl DispatchCallMacro {
         ];
 
         let enum_attributes = get_derived_enum_attrs("dispatch_call", &input, default_attrs)?;
+
         let DeriveInput {
             data,
             ident,

--- a/crates/module-system/sov-modules-macros/src/dispatch/genesis.rs
+++ b/crates/module-system/sov-modules-macros/src/dispatch/genesis.rs
@@ -2,7 +2,8 @@ use proc_macro2::Span;
 use syn::{DeriveInput, ImplGenerics, TypeGenerics, WhereClause};
 
 use crate::common::{
-    get_derived_enum_attrs, get_generics_type_param, StructFieldExtractor, StructNamedField,
+    get_derived_enum_attrs, get_generics_type_param, get_serde_bounds_str, StructFieldExtractor,
+    StructNamedField,
 };
 
 pub(crate) struct GenesisMacro {
@@ -20,12 +21,13 @@ impl GenesisMacro {
         &self,
         input: DeriveInput,
     ) -> syn::Result<proc_macro::TokenStream> {
+        let serde_bounds_str = get_serde_bounds_str(&input.generics, "_genesis_de")?;
         let default_attrs = vec![
             quote::quote! {
                 #[derive(Clone, ::serde::Deserialize, ::serde::Serialize)]
             },
             quote::quote! {
-                #[serde(bound = "")]
+                #[serde(bound = #serde_bounds_str)]
             },
         ];
         let config_attributes = get_derived_enum_attrs("genesis", &input, default_attrs)?;

--- a/crates/module-system/sov-modules-macros/tests/integration/dispatch.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/dispatch.rs
@@ -159,8 +159,6 @@ pub mod third_test_module {
     pub trait ModuleThreeStorable:
         borsh::BorshSerialize
         + borsh::BorshDeserialize
-        + serde::Serialize
-        + for<'a> serde::Deserialize<'a>
         + UniversalWallet
         + schemars::JsonSchema
         + core::fmt::Debug

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -13,7 +13,7 @@ use sov_modules_api::transaction::{
 };
 use sov_modules_api::{
     charge_gas_to_deserialize_json, CryptoSpec, DispatchCall, GasMeter, MeteredSignature,
-    ProvableStateReader, Spec, TxHash,
+    ProvableStateReader, Spec, TxHash, SafeString,
 };
 
 /// The application domain for Solana offchain messages (placeholder for now)
@@ -34,6 +34,8 @@ pub struct SolanaOffchainUnsignedTransaction<R: TransactionCallable, S: Spec> {
     pub uniqueness: UniquenessData,
     /// Data related to fees and gas handling.
     pub details: TxDetails<S>,
+    /// The chain name, to aid with user safety.
+    pub chain_name: SafeString,
     /// The chain hash the transaction data was signed with. Because we're not actually using the
     /// schema to display the transaction, we have to include and validate the hash explicitly.
     #[serde_as(as = "serde_with::hex::Hex")]
@@ -247,6 +249,7 @@ where
 pub fn authenticate<Accessor, S, D>(
     raw_tx: &[u8],
     runtime_chain_hash: &[u8; 32],
+    runtime_chain_name: &'static str,
     state: &mut Accessor,
 ) -> Result<AuthenticationOutput<S, D::Decodable>, AuthenticationError>
 where
@@ -278,6 +281,8 @@ where
     })?;
 
     let provided_chain_hash = solana_unsigned_tx.chain_hash;
+    let provided_chain_name = solana_unsigned_tx.chain_name.to_string();
+
     let unsigned_tx = solana_unsigned_tx.into_unsigned_tx();
     // This is useful to be able to reuse some of the standard authenticator's logic
     let reconstructed_tx_v0 = transaction::Version0 {
@@ -293,6 +298,16 @@ where
             FatalError::InvalidChainHash {
                 expected: hex::encode(runtime_chain_hash),
                 got: hex::encode(provided_chain_hash),
+            },
+            raw_tx_hash,
+        ));
+    }
+
+    if provided_chain_name != runtime_chain_name {
+        return Err(AuthenticationError::FatalError(
+            FatalError::InvalidChainName {
+                expected: runtime_chain_name.to_string(),
+                got: provided_chain_name,
             },
             raw_tx_hash,
         ));

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -99,9 +99,9 @@ impl RawSolanaOffchainMessagePreamble {
     /// Validates a Solana offchain message preamble
     fn validate(&self, actual_message_length: usize) -> Result<(), FatalError> {
         if self.signing_domain != *b"\xffsolana offchain" {
-            return Err(FatalError::DeserializationFailed(format!(
-                "Invalid Solana signing domain in preamble"
-            )));
+            return Err(FatalError::DeserializationFailed(
+                "Invalid Solana signing domain in preamble".to_string(),
+            ));
         }
         // 0 is the only supported header version
         if self.header_version != 0 {
@@ -258,14 +258,14 @@ where
     let unpacked_message = unpack_solana_message::<S>(raw_tx)
         .map_err(|e| AuthenticationError::FatalError(e, raw_tx_hash))?;
 
-    let mut json_slice = unpacked_message.json_bytes();
+    let json_slice = unpacked_message.json_bytes();
     charge_gas_to_deserialize_json(json_slice, state).map_err(|e| {
         AuthenticationError::OutOfGas(format!(
             "Transaction deserialization run out of gas: {e}, tx hash {raw_tx_hash}"
         ))
     })?;
     let solana_unsigned_tx = SolanaOffchainUnsignedTransaction::<D, S>::unmetered_deserialize(
-        &mut json_slice,
+        json_slice,
     )
     .map_err(|e| {
         AuthenticationError::FatalError(

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -13,7 +13,7 @@ use sov_modules_api::transaction::{
 };
 use sov_modules_api::{
     charge_gas_to_deserialize_json, CryptoSpec, DispatchCall, GasMeter, MeteredSignature,
-    ProvableStateReader, Spec, TxHash, SafeString,
+    ProvableStateReader, SafeString, Spec, TxHash,
 };
 
 /// The payload for a solana offchain message.
@@ -73,6 +73,7 @@ pub struct SolanaOffchainSpecCompliantMessage<S: Spec> {
 pub struct SolanaOffchainSimpleMessage<S: Spec> {
     /// The message is a JSON-serialized SolanaOffchainUnsignedTransaction, unaltered.
     pub signed_message: Vec<u8>,
+    pub chain_hash: [u8; 32],
     pub pubkey: <S::CryptoSpec as CryptoSpec>::PublicKey,
     pub signature: <S::CryptoSpec as CryptoSpec>::Signature,
 }
@@ -96,7 +97,7 @@ pub struct RawSolanaOffchainMessagePreamble {
 
 impl RawSolanaOffchainMessagePreamble {
     /// Validates a Solana offchain message preamble
-    fn validate(&self, chain_hash: &[u8; 32], actual_message_length: usize) -> Result<(), FatalError> {
+    fn validate(&self, actual_message_length: usize) -> Result<(), FatalError> {
         if self.signing_domain != *b"\xffsolana offchain" {
             return Err(FatalError::DeserializationFailed(format!(
                 "Invalid Solana signing domain in preamble"
@@ -106,11 +107,6 @@ impl RawSolanaOffchainMessagePreamble {
         if self.header_version != 0 {
             return Err(FatalError::DeserializationFailed(format!(
                     "Invalid header version in preamble: only version 0 is supported, but version {} was provided", self.header_version
-        )));
-        }
-        if self.application_domain != chain_hash {
-            return Err(FatalError::DeserializationFailed(format!(
-                    "Invalid application domain in preamble: supported domain is {}, provided domain was {}", hex::encode(chain_hash), hex::encode(self.application_domain)
         )));
         }
         // Format 0 is the ASCII, hw-wallet compatible format
@@ -138,6 +134,7 @@ impl RawSolanaOffchainMessagePreamble {
 struct UnpackedSolanaMessage<S: Spec> {
     pub_key: <S::CryptoSpec as CryptoSpec>::PublicKey,
     signature: <S::CryptoSpec as CryptoSpec>::Signature,
+    chain_hash: [u8; 32],
     signed_bytes: Vec<u8>,
     json_start: usize,
 }
@@ -173,10 +170,7 @@ fn verify_solana_signature<S: Spec>(
         })
 }
 
-fn unpack_solana_message<S: Spec>(
-    raw_tx: &[u8],
-    chain_hash: &[u8; 32],
-) -> Result<UnpackedSolanaMessage<S>, FatalError> {
+fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage<S>, FatalError> {
     // First 4 bytes are the length of the Vec<u8> as u32 (borsh encoding)
     if raw_tx.len() < 5 {
         return Err(FatalError::DeserializationFailed(
@@ -205,7 +199,7 @@ fn unpack_solana_message<S: Spec>(
         let actual_message_length = envelope.signed_message_with_preamble.len() - PREAMBLE_LEN;
 
         // Validate the preamble
-        preamble.validate(chain_hash, actual_message_length)?;
+        preamble.validate(actual_message_length)?;
 
         let signer: <S::CryptoSpec as CryptoSpec>::PublicKey = borsh::from_slice(&preamble.signer)
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
@@ -213,6 +207,7 @@ fn unpack_solana_message<S: Spec>(
         Ok(UnpackedSolanaMessage {
             pub_key: signer,
             signature: envelope.signature,
+            chain_hash: preamble.application_domain,
             signed_bytes: envelope.signed_message_with_preamble,
             json_start: PREAMBLE_LEN,
         })
@@ -224,6 +219,7 @@ fn unpack_solana_message<S: Spec>(
         Ok(UnpackedSolanaMessage {
             pub_key: raw_message.pubkey,
             signature: raw_message.signature,
+            chain_hash: raw_message.chain_hash,
             signed_bytes: raw_message.signed_message,
             json_start: 0,
         })
@@ -231,16 +227,13 @@ fn unpack_solana_message<S: Spec>(
 }
 
 /// Decode bytes as a Sovereign SDK transaction, returning the message and tx info.
-pub fn decode_solana_json_tx<S, D>(
-    raw_tx: &[u8],
-    chain_hash: &[u8; 32],
-) -> Result<D::Decodable, FatalError>
+pub fn decode_solana_json_tx<S, D>(raw_tx: &[u8]) -> Result<D::Decodable, FatalError>
 where
     S: Spec,
     D: DispatchCall<Spec = S>,
     <D as DispatchCall>::Decodable: Serialize + DeserializeOwned,
 {
-    let unpacked_message = unpack_solana_message::<S>(raw_tx, chain_hash)?;
+    let unpacked_message = unpack_solana_message::<S>(raw_tx)?;
     let solana_unsigned_tx: SolanaOffchainUnsignedTransaction<D, S> =
         serde_json::from_slice(unpacked_message.json_bytes())
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
@@ -262,7 +255,7 @@ where
     let raw_tx_hash = calculate_hash_metered::<Accessor, S>(raw_tx, state)
         .map_err(|e| AuthenticationError::OutOfGas(e.to_string()))?;
 
-    let unpacked_message = unpack_solana_message::<S>(raw_tx, runtime_chain_hash)
+    let unpacked_message = unpack_solana_message::<S>(raw_tx)
         .map_err(|e| AuthenticationError::FatalError(e, raw_tx_hash))?;
 
     let mut json_slice = unpacked_message.json_bytes();
@@ -283,8 +276,8 @@ where
 
     let provided_chain_name = solana_unsigned_tx.chain_name.to_string();
 
-    let unsigned_tx = solana_unsigned_tx.into_unsigned_tx();
     // This is useful to be able to reuse some of the standard authenticator's logic
+    let unsigned_tx = solana_unsigned_tx.into_unsigned_tx();
     let reconstructed_tx_v0 = transaction::Version0 {
         runtime_call: unsigned_tx.runtime_call,
         uniqueness: unsigned_tx.uniqueness,
@@ -292,6 +285,16 @@ where
         signature: unpacked_message.signature,
         pub_key: unpacked_message.pub_key,
     };
+
+    if unpacked_message.chain_hash != *runtime_chain_hash {
+        return Err(AuthenticationError::FatalError(
+            FatalError::InvalidChainHash {
+                expected: hex::encode(runtime_chain_hash),
+                got: hex::encode(unpacked_message.chain_hash),
+            },
+            raw_tx_hash,
+        ));
+    }
 
     if provided_chain_name != runtime_chain_name {
         return Err(AuthenticationError::FatalError(
@@ -362,12 +365,13 @@ pub mod test {
 
         let serialized = borsh::to_vec(&envelope).unwrap();
 
-        let result = unpack_solana_message::<TestSpec>(&serialized, &TEST_CHAIN_HASH);
+        let result = unpack_solana_message::<TestSpec>(&serialized);
         assert!(result.is_ok());
 
         let unpacked = result.unwrap();
         assert_eq!(unpacked.pub_key, pubkey);
         assert_eq!(unpacked.signature, signature);
+        assert_eq!(unpacked.chain_hash, TEST_CHAIN_HASH);
         assert_eq!(unpacked.json_bytes(), message);
         assert_eq!(unpacked.signed_bytes, signed_message);
     }
@@ -382,18 +386,20 @@ pub mod test {
 
         let raw_message = SolanaOffchainSimpleMessage::<TestSpec> {
             signed_message: message.to_vec(),
+            chain_hash: TEST_CHAIN_HASH,
             pubkey: pubkey.clone(),
             signature: signature.clone(),
         };
 
         let serialized = borsh::to_vec(&raw_message).unwrap();
 
-        let result = unpack_solana_message::<TestSpec>(&serialized, &TEST_CHAIN_HASH);
+        let result = unpack_solana_message::<TestSpec>(&serialized);
         assert!(result.is_ok());
 
         let unpacked = result.unwrap();
         assert_eq!(unpacked.pub_key, pubkey);
         assert_eq!(unpacked.signature, signature);
+        assert_eq!(unpacked.chain_hash, TEST_CHAIN_HASH);
         assert_eq!(unpacked.json_bytes(), message);
         assert_eq!(unpacked.signed_bytes, message);
     }
@@ -427,7 +433,7 @@ pub mod test {
         let serialized = borsh::to_vec(&envelope).unwrap();
 
         // Should fail validation
-        let result = unpack_solana_message::<TestSpec>(&serialized, &TEST_CHAIN_HASH);
+        let result = unpack_solana_message::<TestSpec>(&serialized);
         assert!(result.is_err());
         assert!(matches!(result, Err(FatalError::DeserializationFailed(_))));
     }

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -16,9 +16,6 @@ use sov_modules_api::{
     ProvableStateReader, Spec, TxHash, SafeString,
 };
 
-/// The application domain for Solana offchain messages (placeholder for now)
-pub const APPLICATION_DOMAIN: [u8; 32] = [0u8; 32];
-
 /// The payload for a solana offchain message.
 /// Essentially a wrapper around `sov_modules_api::transaction::UnsignedTransaction` that also
 /// includes the chain_hash, in order to ensure the hash gets signed as part of the message.
@@ -34,12 +31,10 @@ pub struct SolanaOffchainUnsignedTransaction<R: TransactionCallable, S: Spec> {
     pub uniqueness: UniquenessData,
     /// Data related to fees and gas handling.
     pub details: TxDetails<S>,
-    /// The chain name, to aid with user safety.
+    /// The chain name, so that users can verify the destination chain and avoid replay attacks
+    /// from malicious chains (if the chain name matches some other chain the use but didn't expect
+    /// to be signing for right now).
     pub chain_name: SafeString,
-    /// The chain hash the transaction data was signed with. Because we're not actually using the
-    /// schema to display the transaction, we have to include and validate the hash explicitly.
-    #[serde_as(as = "serde_with::hex::Hex")]
-    pub chain_hash: [u8; 32],
 }
 
 impl<R, S> SolanaOffchainUnsignedTransaction<R, S>
@@ -101,7 +96,7 @@ pub struct RawSolanaOffchainMessagePreamble {
 
 impl RawSolanaOffchainMessagePreamble {
     /// Validates a Solana offchain message preamble
-    fn validate(&self, actual_message_length: usize) -> Result<(), FatalError> {
+    fn validate(&self, chain_hash: &[u8; 32], actual_message_length: usize) -> Result<(), FatalError> {
         if self.signing_domain != *b"\xffsolana offchain" {
             return Err(FatalError::DeserializationFailed(format!(
                 "Invalid Solana signing domain in preamble"
@@ -113,9 +108,9 @@ impl RawSolanaOffchainMessagePreamble {
                     "Invalid header version in preamble: only version 0 is supported, but version {} was provided", self.header_version
         )));
         }
-        if self.application_domain != APPLICATION_DOMAIN {
+        if self.application_domain != chain_hash {
             return Err(FatalError::DeserializationFailed(format!(
-                    "Invalid application domain in preamble: supported domain is {}, provided domain was {}", hex::encode(APPLICATION_DOMAIN), hex::encode(self.application_domain)
+                    "Invalid application domain in preamble: supported domain is {}, provided domain was {}", hex::encode(chain_hash), hex::encode(self.application_domain)
         )));
         }
         // Format 0 is the ASCII, hw-wallet compatible format
@@ -178,7 +173,10 @@ fn verify_solana_signature<S: Spec>(
         })
 }
 
-fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage<S>, FatalError> {
+fn unpack_solana_message<S: Spec>(
+    raw_tx: &[u8],
+    chain_hash: &[u8; 32],
+) -> Result<UnpackedSolanaMessage<S>, FatalError> {
     // First 4 bytes are the length of the Vec<u8> as u32 (borsh encoding)
     if raw_tx.len() < 5 {
         return Err(FatalError::DeserializationFailed(
@@ -207,7 +205,7 @@ fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage
         let actual_message_length = envelope.signed_message_with_preamble.len() - PREAMBLE_LEN;
 
         // Validate the preamble
-        preamble.validate(actual_message_length)?;
+        preamble.validate(chain_hash, actual_message_length)?;
 
         let signer: <S::CryptoSpec as CryptoSpec>::PublicKey = borsh::from_slice(&preamble.signer)
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
@@ -233,13 +231,16 @@ fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage
 }
 
 /// Decode bytes as a Sovereign SDK transaction, returning the message and tx info.
-pub fn decode_solana_json_tx<S, D>(raw_tx: &[u8]) -> Result<D::Decodable, FatalError>
+pub fn decode_solana_json_tx<S, D>(
+    raw_tx: &[u8],
+    chain_hash: &[u8; 32],
+) -> Result<D::Decodable, FatalError>
 where
     S: Spec,
     D: DispatchCall<Spec = S>,
     <D as DispatchCall>::Decodable: Serialize + DeserializeOwned,
 {
-    let unpacked_message = unpack_solana_message::<S>(raw_tx)?;
+    let unpacked_message = unpack_solana_message::<S>(raw_tx, chain_hash)?;
     let solana_unsigned_tx: SolanaOffchainUnsignedTransaction<D, S> =
         serde_json::from_slice(unpacked_message.json_bytes())
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
@@ -261,7 +262,7 @@ where
     let raw_tx_hash = calculate_hash_metered::<Accessor, S>(raw_tx, state)
         .map_err(|e| AuthenticationError::OutOfGas(e.to_string()))?;
 
-    let unpacked_message = unpack_solana_message::<S>(raw_tx)
+    let unpacked_message = unpack_solana_message::<S>(raw_tx, runtime_chain_hash)
         .map_err(|e| AuthenticationError::FatalError(e, raw_tx_hash))?;
 
     let mut json_slice = unpacked_message.json_bytes();
@@ -280,7 +281,6 @@ where
         )
     })?;
 
-    let provided_chain_hash = solana_unsigned_tx.chain_hash;
     let provided_chain_name = solana_unsigned_tx.chain_name.to_string();
 
     let unsigned_tx = solana_unsigned_tx.into_unsigned_tx();
@@ -292,16 +292,6 @@ where
         signature: unpacked_message.signature,
         pub_key: unpacked_message.pub_key,
     };
-
-    if provided_chain_hash != *runtime_chain_hash {
-        return Err(AuthenticationError::FatalError(
-            FatalError::InvalidChainHash {
-                expected: hex::encode(runtime_chain_hash),
-                got: hex::encode(provided_chain_hash),
-            },
-            raw_tx_hash,
-        ));
-    }
 
     if provided_chain_name != runtime_chain_name {
         return Err(AuthenticationError::FatalError(
@@ -348,6 +338,8 @@ pub mod test {
     use super::*;
     use crate::utils::make_preamble_for_message;
 
+    const TEST_CHAIN_HASH: [u8; 32] = [0u8; 32];
+
     #[test]
     fn test_unpack_with_preamble() {
         let message = b"{\"test\":\"abcd\"}";
@@ -357,7 +349,7 @@ pub mod test {
         let pubkey = Ed25519PrivateKey::generate().pub_key();
         let signature: Ed25519Signature = [4u8; 64].as_slice().try_into().unwrap();
 
-        let preamble = make_preamble_for_message(pubkey.bytes(), message_len);
+        let preamble = make_preamble_for_message(pubkey.bytes(), &TEST_CHAIN_HASH, message_len);
 
         let mut signed_message = Vec::new();
         signed_message.extend_from_slice(&preamble);
@@ -370,7 +362,7 @@ pub mod test {
 
         let serialized = borsh::to_vec(&envelope).unwrap();
 
-        let result = unpack_solana_message::<TestSpec>(&serialized);
+        let result = unpack_solana_message::<TestSpec>(&serialized, &TEST_CHAIN_HASH);
         assert!(result.is_ok());
 
         let unpacked = result.unwrap();
@@ -396,7 +388,7 @@ pub mod test {
 
         let serialized = borsh::to_vec(&raw_message).unwrap();
 
-        let result = unpack_solana_message::<TestSpec>(&serialized);
+        let result = unpack_solana_message::<TestSpec>(&serialized, &TEST_CHAIN_HASH);
         assert!(result.is_ok());
 
         let unpacked = result.unwrap();
@@ -417,7 +409,7 @@ pub mod test {
         let mut header = Vec::<u8>::new();
         header.extend(b"\xffsolanaXoffchain"); // Wrong domain
         header.push(0);
-        header.extend(APPLICATION_DOMAIN);
+        header.extend(TEST_CHAIN_HASH);
         header.push(0);
         header.push(1);
         header.extend(pubkey.bytes());
@@ -435,7 +427,7 @@ pub mod test {
         let serialized = borsh::to_vec(&envelope).unwrap();
 
         // Should fail validation
-        let result = unpack_solana_message::<TestSpec>(&serialized);
+        let result = unpack_solana_message::<TestSpec>(&serialized, &TEST_CHAIN_HASH);
         assert!(result.is_err());
         assert!(matches!(result, Err(FatalError::DeserializationFailed(_))));
     }

--- a/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
@@ -66,7 +66,7 @@ where
                 Ok(call)
             }
             SolanaOffchainAuthenticatorInput::SolanaOffchain(raw_tx) => {
-                let call = decode_solana_json_tx::<S, Rt>(&raw_tx.data, &Rt::CHAIN_HASH)?;
+                let call = decode_solana_json_tx::<S, Rt>(&raw_tx.data)?;
                 Ok(call)
             }
         }

--- a/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
@@ -66,7 +66,7 @@ where
                 Ok(call)
             }
             SolanaOffchainAuthenticatorInput::SolanaOffchain(raw_tx) => {
-                let call = decode_solana_json_tx::<S, Rt>(&raw_tx.data)?;
+                let call = decode_solana_json_tx::<S, Rt>(&raw_tx.data, &Rt::CHAIN_HASH)?;
                 Ok(call)
             }
         }

--- a/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
@@ -7,6 +7,7 @@ use sov_modules_api::capabilities::{
     AuthenticationError, BatchFromUnregisteredSequencer, FatalError, TransactionAuthenticator,
     UnregisteredAuthenticationError,
 };
+use sov_modules_api::macros::config_value;
 use sov_modules_api::{DispatchCall, FullyBakedTx, ProvableStateReader, RawTx, Runtime, Spec};
 
 /// Indicates that a runtime supports the `SolanaOffchain` transaction authenticator
@@ -90,6 +91,7 @@ where
                     crate::authentication::authenticate::<Accessor, S, Rt>(
                         &tx.data,
                         &Rt::CHAIN_HASH,
+                        config_value!("CHAIN_NAME"),
                         state,
                     )?;
 

--- a/crates/module-system/sov-solana-offchain-auth/src/utils.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/utils.rs
@@ -1,13 +1,17 @@
-use crate::authentication::APPLICATION_DOMAIN;
-
-pub fn make_preamble_for_message(pubkey: &[u8; 32], message_length: u16) -> [u8; 85] {
+/// Generate the header that needs to be pre-pended to the message when serializing according to
+/// the Ledger-compatible spec.
+pub fn make_preamble_for_message(
+    pubkey: &[u8; 32],
+    chain_hash: &[u8; 32],
+    message_length: u16,
+) -> [u8; 85] {
     let mut header = Vec::<u8>::new();
     // Signing domain (pre-defined constant)
     header.extend(b"\xffsolana offchain");
     // Header version (only 0 is valid)
     header.push(0);
     // Application domain
-    header.extend(APPLICATION_DOMAIN);
+    header.extend(chain_hash);
     // Message format - 0 is for ASCII, hardware wallet compatible
     header.push(0);
     // Signer count

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
@@ -192,6 +192,7 @@ fn create_transfer_tx_json(amount: Amount, recipient: &str) -> String {
         runtime_call: unsigned_tx.runtime_call,
         uniqueness: unsigned_tx.uniqueness,
         details: unsigned_tx.details,
+        chain_name: config_value!("CHAIN_NAME").to_string().try_into().unwrap(),
         chain_hash: RT::CHAIN_HASH,
     };
 
@@ -281,7 +282,7 @@ async fn test_submit_ledger_signed_transaction() {
     // updated.)
     assert_eq!(
         transfer_json_tx,
-        r#"{"runtime_call":{"bank":{"transfer":{"to":"4zdwHNaEa5npHtRtaZ3RL1m6rptuQZ6RBLHG6cAyVHjL","coins":{"amount":"5000","token_id":"token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"}}}},"uniqueness":{"generation":0},"details":{"max_priority_fee_bips":0,"max_fee":"100000000000","gas_limit":[1000000000,1000000000],"chain_id":4321},"chain_hash":"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"}"#
+        r#"{"runtime_call":{"bank":{"transfer":{"to":"4zdwHNaEa5npHtRtaZ3RL1m6rptuQZ6RBLHG6cAyVHjL","coins":{"amount":"5000","token_id":"token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"}}}},"uniqueness":{"generation":0},"details":{"max_priority_fee_bips":0,"max_fee":"100000000000","gas_limit":[1000000000,1000000000],"chain_id":4321},"chain_name":"TestChain","chain_hash":"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"}"#
     );
     let encoded_tx = transfer_json_tx.as_bytes().to_vec();
     let pubkey: [u8; 32] = bs58::decode(LEDGER_ADDRESS)
@@ -290,7 +291,7 @@ async fn test_submit_ledger_signed_transaction() {
         .try_into()
         .unwrap();
     let signature: Ed25519Signature = bs58::decode(
-        "5K7i3PTJM1DDACVEuke2jXrkSutGEKb5ByyiNwBXQXiERZi8hFxnFARdnH21qr4yGgdmZygY9SyJQc6SPbJbZCrX",
+        "2UjL4oVWN8d1Ejiztegjb4a5qGCLMM8GEdAsyzPa8eVUxrrStB4yaMry58SQ4Pn7jtXYK59HGuWqQ5RhDTtoBZfN",
     )
     .into_vec()
     .unwrap()

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
@@ -262,6 +262,7 @@ async fn test_submit_ledger_signed_transaction() {
 
         let message = SolanaOffchainSimpleMessage::<S> {
             signed_message: encoded_tx,
+            chain_hash: RT::CHAIN_HASH,
             pubkey,
             signature,
         };
@@ -348,6 +349,7 @@ async fn test_submit_raw_signed_message_transaction() {
 
     let message = SolanaOffchainSimpleMessage::<S> {
         signed_message: encoded_tx,
+        chain_hash: RT::CHAIN_HASH,
         pubkey,
         signature,
     };
@@ -383,6 +385,7 @@ async fn test_submit_invalid_raw_signed_message_transaction() {
 
     let message = SolanaOffchainSimpleMessage::<S> {
         signed_message: encoded_tx,
+        chain_hash: RT::CHAIN_HASH,
         pubkey,
         signature,
     };

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
@@ -193,7 +193,6 @@ fn create_transfer_tx_json(amount: Amount, recipient: &str) -> String {
         uniqueness: unsigned_tx.uniqueness,
         details: unsigned_tx.details,
         chain_name: config_value!("CHAIN_NAME").to_string().try_into().unwrap(),
-        chain_hash: RT::CHAIN_HASH,
     };
 
     serde_json::to_string(&solana_unsigned_tx).unwrap()
@@ -282,7 +281,7 @@ async fn test_submit_ledger_signed_transaction() {
     // updated.)
     assert_eq!(
         transfer_json_tx,
-        r#"{"runtime_call":{"bank":{"transfer":{"to":"4zdwHNaEa5npHtRtaZ3RL1m6rptuQZ6RBLHG6cAyVHjL","coins":{"amount":"5000","token_id":"token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"}}}},"uniqueness":{"generation":0},"details":{"max_priority_fee_bips":0,"max_fee":"100000000000","gas_limit":[1000000000,1000000000],"chain_id":4321},"chain_name":"TestChain","chain_hash":"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"}"#
+        r#"{"runtime_call":{"bank":{"transfer":{"to":"4zdwHNaEa5npHtRtaZ3RL1m6rptuQZ6RBLHG6cAyVHjL","coins":{"amount":"5000","token_id":"token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"}}}},"uniqueness":{"generation":0},"details":{"max_priority_fee_bips":0,"max_fee":"100000000000","gas_limit":[1000000000,1000000000],"chain_id":4321},"chain_name":"TestChain"}"#
     );
     let encoded_tx = transfer_json_tx.as_bytes().to_vec();
     let pubkey: [u8; 32] = bs58::decode(LEDGER_ADDRESS)
@@ -291,7 +290,7 @@ async fn test_submit_ledger_signed_transaction() {
         .try_into()
         .unwrap();
     let signature: Ed25519Signature = bs58::decode(
-        "2UjL4oVWN8d1Ejiztegjb4a5qGCLMM8GEdAsyzPa8eVUxrrStB4yaMry58SQ4Pn7jtXYK59HGuWqQ5RhDTtoBZfN",
+        "3GBYQrmcKtUiXAQLz2bUR55Kh7YfgUy2g199ePXYSUHbRHLAsdjcTctSrt98oiA79nZVQU79AbBpiKU23Z2UTstQ",
     )
     .into_vec()
     .unwrap()
@@ -300,7 +299,7 @@ async fn test_submit_ledger_signed_transaction() {
     .unwrap();
 
     let mut signed_message_with_preamble =
-        make_preamble_for_message(&pubkey, encoded_tx.len() as u16).to_vec();
+        make_preamble_for_message(&pubkey, &RT::CHAIN_HASH, encoded_tx.len() as u16).to_vec();
     signed_message_with_preamble.extend_from_slice(&encoded_tx);
 
     let message = SolanaOffchainSpecCompliantMessage::<S> {


### PR DESCRIPTION
# Description

Follow-up to #1522

This may be more readable than the chain hash, and it's very unlikely that two legitimate non-malicious chains will have the same chain name, thus protecting against replay attacks on another chain (as long as the user pays attention not to sign transactions for malicious chains).

As a follow-up, it may even be possible to hide the chain hash from users to make the display nicer.

- [ ] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~ This is an immediate follow-up to the authenticator PR, so nobody should be using it when this is merged. Therefore it's non-breaking.
- [x] ~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to #1520 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
