### PR TITLE
Add basic error handling in `replica_sync_task`

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -1,8 +1,10 @@
+use crate::preferred::exit_rollup;
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::{PgListener, PgPoolOptions};
 use sqlx::PgPool;
 use std::str::FromStr;
+use tokio::sync::watch;
 use tracing::error;
 
 /// Event type enum for type-safe parsing
@@ -71,13 +73,25 @@ impl EventsNotificationPayload {
     }
 }
 
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum EventReceiverError {
+    #[error("Error while listening for events: {0}")]
+    ListenerError(#[from] sqlx::Error),
+
+    #[error("Error while querying for events: {0}")]
+    ParsingError(#[from] anyhow::Error),
+}
+
 pub(crate) struct EventReceiver {
     listener: PgListener,
     query_pool: PgPool,
 }
 
 impl EventReceiver {
-    pub(crate) async fn new(connection_string: &str) -> anyhow::Result<Self> {
+    pub(crate) async fn new(
+        connection_string: &str,
+        shutdown_sender: &watch::Sender<()>,
+    ) -> anyhow::Result<Self> {
         // Create a separate persistent connection pool for querying transaction data
         let query_pool = match PgPoolOptions::default()
             .max_connections(5) // Small pool since we're just doing simple queries
@@ -87,8 +101,8 @@ impl EventReceiver {
             Ok(pool) => pool,
             Err(e) => {
                 error!("Failed to connect to PostgreSQL: {e:?}. Replica shutting down.");
-                //exit_rollup(&sequencer.shutdown_sender).await;
-                todo!("Error handling")
+                exit_rollup(shutdown_sender).await;
+                unreachable!("EventReceiver: impossible happened rollup didn't exit");
             }
         };
 
@@ -97,15 +111,15 @@ impl EventReceiver {
             Ok(listener) => listener,
             Err(e) => {
                 error!("Failed to create PostgreSQL listener: {e:?}. Replica shutting down.");
-                //exit_rollup(&sequencer.shutdown_sender).await;
-                todo!("Error handling")
+                exit_rollup(shutdown_sender).await;
+                unreachable!("EventReceiver: impossible happened rollup didn't exit");
             }
         };
 
         if let Err(e) = listener.listen("events_changes").await {
             error!("Failed to listen on events_changes channel: {e:?}. Replica shutting down.");
-            //exit_rollup(&sequencer.shutdown_sender).await;
-            todo!("Error handling")
+            exit_rollup(shutdown_sender).await;
+            unreachable!("EventReceiver: impossible happened rollup didn't exit");
         }
 
         Ok(Self {
@@ -114,15 +128,10 @@ impl EventReceiver {
         })
     }
 
-    pub(crate) async fn recv(
-        &mut self,
-    ) -> anyhow::Result<anyhow::Result<EventsNotificationPayload>> {
-        Ok(self.listener.recv().await.map(|notification| {
-            let payload = notification.payload();
-            let parsed_notification = EventsNotificationPayload::parse_csv(payload)
-                .map_err(|e| anyhow!("Failed to parse CSV notification payload: {e}"));
-
-            parsed_notification
-        })?)
+    pub(crate) async fn recv(&mut self) -> Result<EventsNotificationPayload, EventReceiverError> {
+        let notification = self.listener.recv().await?;
+        let payload = notification.payload();
+        let parsed_notification = EventsNotificationPayload::parse_csv(payload)?;
+        Ok(parsed_notification)
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -1,5 +1,10 @@
+use crate::preferred::exit_rollup;
+use crate::preferred::replica::event_receiver::EventReceiverError;
 use crate::preferred::replica::event_receiver::{EventReceiver, EventsNotificationPayload};
+use tokio::sync::watch;
 use tracing::error;
+
+const MAX_DB_ERRORS_ALLOWED: u32 = 10;
 
 pub(crate) trait ReplicaEventHandler {
     async fn on_notification(&self, notification: EventsNotificationPayload);
@@ -8,27 +13,57 @@ pub(crate) trait ReplicaEventHandler {
 pub(crate) struct ReplicaSyncTask<R: ReplicaEventHandler> {
     event_receiver: EventReceiver,
     handler: R,
+    shutdown_sender: watch::Sender<()>,
 }
 
 impl<R: ReplicaEventHandler> ReplicaSyncTask<R> {
-    pub(crate) async fn new(postgres_connection_string: &str, handler: R) -> anyhow::Result<Self> {
-        let event_receiver = EventReceiver::new(postgres_connection_string).await?;
+    pub(crate) async fn new(
+        postgres_connection_string: &str,
+        handler: R,
+        shutdown_sender: watch::Sender<()>,
+    ) -> anyhow::Result<Self> {
+        let event_receiver =
+            EventReceiver::new(postgres_connection_string, &shutdown_sender).await?;
         Ok(Self {
             event_receiver,
             handler,
+            shutdown_sender,
         })
     }
 
     pub(crate) async fn start(&mut self) {
+        let shutdown_receiver = self.shutdown_sender.subscribe();
+        let mut nb_of_consecutive_db_errors = 0;
+
         loop {
             tokio::select! {
                 notification_result = self.event_receiver.recv() => {
                     match notification_result {
                         Ok(notification) => {
-                            self.handler.on_notification(notification.unwrap()).await;
+                            nb_of_consecutive_db_errors = 0;
+                            self.handler.on_notification(notification).await;
                         }
-                        Err(e) => {
-                            error!("Error receiving notifications: {e:?}");
+
+                        Err(EventReceiverError::ParsingError(e)) => {
+                            // This should never happen, so we shut down the replica immediately
+                            error!("Failed to parse notification: {e:?}. Shutting down replica.");
+                            exit_rollup(&self.shutdown_sender).await;
+                        }
+                        Err(EventReceiverError::ListenerError(e)) => {
+                            error!("Failed to receive notifications from database: {e:?}. Shutting down replica.");
+
+                            if shutdown_receiver.has_changed().unwrap_or(true) {
+                                break;
+                            }
+
+                            // Since network errors can occur, we will retry receiving a few times before initiating replica shutdown.
+                            if nb_of_consecutive_db_errors >= MAX_DB_ERRORS_ALLOWED {
+                                error!("Failed to connect to the database after {nb_of_consecutive_db_errors} attempts. Shutting down replica.");
+                                exit_rollup(&self.shutdown_sender).await;
+                            }
+
+                            nb_of_consecutive_db_errors += 1;
+                            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                         }
                     }
                 }
@@ -91,12 +126,17 @@ mod tests {
         }
 
         // Check if replica sync task received the notification.
+        let (shutdown_snd, _shutdown_rcv) = watch::channel(());
+
         let (test_handler, mut recv) = TestHandler::new();
         {
             let conn_str = postgres_connection_string.clone();
             let test_handler = test_handler.clone();
+            let shutdown_snd = shutdown_snd.clone();
             tokio::spawn(async move {
-                let mut sync_task = ReplicaSyncTask::new(&conn_str, test_handler).await.unwrap();
+                let mut sync_task = ReplicaSyncTask::new(&conn_str, test_handler, shutdown_snd)
+                    .await
+                    .unwrap();
                 sync_task_ready_snd.send(()).await.unwrap();
                 sync_task.start().await;
             });
@@ -104,5 +144,7 @@ mod tests {
 
         let event = recv.recv().await.unwrap();
         assert_eq!(event.sequence_number, 99);
+
+        shutdown_snd.send(()).unwrap();
     }
 }


### PR DESCRIPTION
# Description

This PR adds basic error handling in `replica_sync_task `

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to  #1524
