### PR TITLE
Replica: Enable backfilling logic. 

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -205,8 +205,8 @@ impl EventReceiver {
         listener: &mut PgListener,
     ) -> Result<EventsNotificationPayload, EventReceiverError> {
         let mut last_notification = None;
-        // We are only interested in the last notification form the ebd because the backfill logic
-        // allows skipping some notifications.
+        // We only care about the latest notification from the DB,
+        // since the backfill logic allows us to skip earlier ones.
         while let Some(p) = listener.next_buffered() {
             last_notification = Some(p);
         }
@@ -256,6 +256,10 @@ impl EventReceiver {
             current_event_id, target_event_id
         );
 
+        // Currently, we fetch data in a loop. One possible (but not yet necessary) optimization would be to issue
+        // multiple parallel queries to the DB for different `event_id`` ranges.
+        // After analyzing real-world workloads, we can revisit this optimization. Implementing it would only affect
+        // the contents of this method and would not require significant refactoring.
         while current_event_id <= target_event_id {
             let page_end = std::cmp::min(current_event_id + PAGE_SIZE as u64, target_event_id);
 

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -85,9 +85,9 @@ impl EventsNotificationPayload {
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum EventReceiverError {
     #[error("Error while querying for  db data: {0}")]
-    ListenerError(#[from] sqlx::Error),
+    DbError(#[from] sqlx::Error),
 
-    #[error("Error while paring the db notification: {0}")]
+    #[error("Error while parsing the db notification: {0}")]
     ParsingError(#[from] anyhow::Error),
 }
 
@@ -173,7 +173,7 @@ impl EventReceiver {
                             exit_rollup(&shutdown_sender).await;
                         }
 
-                        EventReceiverError::ListenerError(e) => {
+                        EventReceiverError::DbError(e) => {
                             error!("Failed to receive notifications from database: {e:?}. Shutting down replica.");
 
                             if shutdown_receiver.has_changed().unwrap_or(true) {

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -1,15 +1,24 @@
+use crate::preferred::db::StoredBlob;
 use crate::preferred::exit_rollup;
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
+use sov_modules_api::FullyBakedTx;
 use sqlx::postgres::{PgListener, PgPoolOptions};
 use sqlx::PgPool;
+use sqlx::Row;
 use std::str::FromStr;
 use tokio::sync::watch;
-use tracing::error;
+use tracing::{debug, error, trace};
+
+const MAX_DB_ERRORS_ALLOWED: u32 = 10;
+
+// Process events in pages to avoid excessive memory consumption
+const PAGE_SIZE: i64 = 2000;
 
 /// Event type enum for type-safe parsing
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, sqlx::Type)]
 #[serde(rename_all = "snake_case")]
+#[sqlx(type_name = "event_type", rename_all = "snake_case")]
 pub(crate) enum EventType {
     Transaction,
     BatchStart,
@@ -75,63 +84,265 @@ impl EventsNotificationPayload {
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum EventReceiverError {
-    #[error("Error while listening for events: {0}")]
+    #[error("Error while querying for  db data: {0}")]
     ListenerError(#[from] sqlx::Error),
 
-    #[error("Error while querying for events: {0}")]
+    #[error("Error while paring the db notification: {0}")]
     ParsingError(#[from] anyhow::Error),
 }
 
 pub(crate) struct EventReceiver {
-    listener: PgListener,
-    query_pool: PgPool,
+    connection_string: String,
+    db_data_sender: tokio::sync::mpsc::Sender<DbData>,
+    db_data_receiver: tokio::sync::mpsc::Receiver<DbData>,
+    shutdown_sender: watch::Sender<()>,
+    start_event_id: u64,
 }
 
 impl EventReceiver {
     pub(crate) async fn new(
-        connection_string: &str,
-        shutdown_sender: &watch::Sender<()>,
-    ) -> anyhow::Result<Self> {
+        connection_string: String,
+        shutdown_sender: watch::Sender<()>,
+        start_event_id: u64,
+    ) -> Self {
+        let (db_data_sender, db_data_receiver) = tokio::sync::mpsc::channel(PAGE_SIZE as usize);
+        Self {
+            connection_string,
+            db_data_sender,
+            db_data_receiver,
+            shutdown_sender,
+            start_event_id,
+        }
+    }
+
+    pub(crate) async fn spawn_db_data_fetcher(&mut self) {
         // Create a separate persistent connection pool for querying transaction data
         let query_pool = match PgPoolOptions::default()
             .max_connections(5) // Small pool since we're just doing simple queries
-            .connect(connection_string)
+            .connect(&self.connection_string)
             .await
         {
             Ok(pool) => pool,
             Err(e) => {
                 error!("Failed to connect to PostgreSQL: {e:?}. Replica shutting down.");
-                exit_rollup(shutdown_sender).await;
+                exit_rollup(&self.shutdown_sender).await;
                 unreachable!("EventReceiver: impossible happened rollup didn't exit");
             }
         };
 
         // Create a dedicated listener for PostgreSQL LISTEN/NOTIFY
-        let mut listener = match PgListener::connect(connection_string).await {
+        let mut listener = match PgListener::connect(&self.connection_string).await {
             Ok(listener) => listener,
             Err(e) => {
                 error!("Failed to create PostgreSQL listener: {e:?}. Replica shutting down.");
-                exit_rollup(shutdown_sender).await;
+                exit_rollup(&self.shutdown_sender).await;
                 unreachable!("EventReceiver: impossible happened rollup didn't exit");
             }
         };
 
         if let Err(e) = listener.listen("events_changes").await {
             error!("Failed to listen on events_changes channel: {e:?}. Replica shutting down.");
-            exit_rollup(shutdown_sender).await;
+            exit_rollup(&self.shutdown_sender).await;
             unreachable!("EventReceiver: impossible happened rollup didn't exit");
         }
 
-        Ok(Self {
-            listener,
-            query_pool,
-        })
+        let mut nb_of_consecutive_db_errors = 0;
+        let shutdown_sender = self.shutdown_sender.clone();
+        let shutdown_receiver = self.shutdown_sender.subscribe();
+
+        let mut db_data_sender = self.db_data_sender.clone();
+        let start_event_id = self.start_event_id;
+        tokio::spawn(async move {
+            loop {
+                if shutdown_receiver.has_changed().unwrap_or(true) {
+                    break;
+                }
+
+                if let Err(e) = Self::fetch_data(
+                    start_event_id,
+                    &query_pool,
+                    &mut listener,
+                    &mut db_data_sender,
+                )
+                .await
+                {
+                    match e {
+                        EventReceiverError::ParsingError(e) => {
+                            // This should never happen, so we shut down the replica immediately
+                            error!("Failed to parse notification: {e:?}. Shutting down replica.");
+                            exit_rollup(&shutdown_sender).await;
+                        }
+
+                        EventReceiverError::ListenerError(e) => {
+                            error!("Failed to receive notifications from database: {e:?}. Shutting down replica.");
+
+                            if shutdown_receiver.has_changed().unwrap_or(true) {
+                                break;
+                            }
+
+                            // Since network errors can occur, we will retry receiving a few times before initiating replica shutdown.
+                            if nb_of_consecutive_db_errors >= MAX_DB_ERRORS_ALLOWED {
+                                error!("Failed to connect to the database after {nb_of_consecutive_db_errors} attempts. Shutting down replica.");
+                                exit_rollup(&shutdown_sender).await;
+                            }
+
+                            nb_of_consecutive_db_errors += 1;
+                            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                            continue;
+                        }
+                    }
+                }
+                nb_of_consecutive_db_errors = 0;
+            }
+        });
     }
 
-    pub(crate) async fn recv(&mut self) -> Result<EventsNotificationPayload, EventReceiverError> {
-        let notification = self.listener.recv().await?;
-        let payload = notification.payload();
+    pub(crate) async fn recv(&mut self) -> Option<DbData> {
+        self.db_data_receiver.recv().await
+    }
+
+    async fn recv_notifications(
+        listener: &mut PgListener,
+    ) -> Result<EventsNotificationPayload, EventReceiverError> {
+        let mut last_notification = None;
+        // We are only interested in the last notification form the ebd because the backfill logic
+        // allows skipping some notifications.
+        while let Some(p) = listener.next_buffered() {
+            last_notification = Some(p);
+        }
+
+        let pg_notification = match last_notification {
+            Some(notification) => notification,
+            None => listener.recv().await?,
+        };
+
+        let payload = pg_notification.payload();
         let parsed_notification = EventsNotificationPayload::parse_csv(payload)?;
         Ok(parsed_notification)
+    }
+
+    async fn fetch_data(
+        start_event_id: u64,
+        query_pool: &PgPool,
+        listener: &mut PgListener,
+        db_data_sender: &mut tokio::sync::mpsc::Sender<DbData>,
+    ) -> Result<(), EventReceiverError> {
+        let notification = Self::recv_notifications(listener).await?;
+
+        Self::backfill_to_event_id(
+            query_pool,
+            start_event_id,
+            notification.event_id,
+            db_data_sender,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn backfill_to_event_id(
+        query_pool: &PgPool,
+        mut current_event_id: u64,
+        target_event_id: u64,
+        db_data_sender: &mut tokio::sync::mpsc::Sender<DbData>,
+    ) -> Result<(), EventReceiverError> {
+        // If we're already caught up, nothing to do
+        if current_event_id > target_event_id {
+            return Ok(());
+        }
+
+        debug!(
+            "Backfilling events from {} to {}",
+            current_event_id, target_event_id
+        );
+
+        while current_event_id <= target_event_id {
+            let page_end = std::cmp::min(current_event_id + PAGE_SIZE as u64, target_event_id);
+
+            trace!(
+                "Processing backfill page: events {} to {}",
+                current_event_id,
+                page_end
+            );
+
+            // Query and process events for this page
+            let events = sqlx::query(
+                "SELECT event_id, sequence_number, index_in_batch, event_type, hash, data FROM events 
+                 WHERE event_id >= $1 AND event_id <= $2
+                 ORDER BY event_id ASC",
+            )
+            .bind(current_event_id as i64)
+            .bind(page_end as i64)
+            .fetch_all(query_pool)
+            .await?;
+
+            for row in events {
+                let event_type: EventType = row.get("event_type");
+                let sequence_number = row.get::<i64, _>("sequence_number") as u64;
+
+                match event_type {
+                    EventType::Transaction => {
+                        let tx_data: Vec<u8> = row.get("data");
+
+                        let baked_tx = FullyBakedTx::new(tx_data);
+                        let _ = db_data_sender.send(DbData::Transaction(baked_tx)).await;
+                    }
+                    EventType::BatchStart => {
+                        let batch_data: Vec<u8> = row.get("data");
+                        let batch_metadata = parse_serialized_batch(batch_data, sequence_number)?;
+                        let _ = db_data_sender
+                            .send(DbData::BatchStart(batch_metadata))
+                            .await;
+                    }
+                    EventType::BatchEnd => {
+                        let _ = db_data_sender.send(DbData::BatchEnd).await;
+                    }
+                    EventType::NewProof => {
+                        let _ = db_data_sender.send(DbData::NewProof).await;
+                    }
+                }
+            }
+
+            current_event_id = page_end + 1;
+        }
+
+        Ok(())
+    }
+}
+
+/// Structure representing batch metadata stored by the master sequencer
+#[derive(Debug)]
+pub(crate) struct BatchMetadata {
+    pub(crate) visible_slot_number_after_increase: VisibleSlotNumber,
+    pub(crate) visible_slots_to_advance: NonZero<u8>,
+}
+
+use sov_modules_api::VisibleSlotNumber;
+use std::num::NonZero;
+
+#[derive(Debug)]
+pub(crate) enum DbData {
+    BatchStart(BatchMetadata),
+    Transaction(FullyBakedTx),
+    BatchEnd,
+    NewProof,
+}
+
+fn parse_serialized_batch(data: Vec<u8>, sequence_number: u64) -> anyhow::Result<BatchMetadata> {
+    let stored_blob: StoredBlob = borsh::from_slice(&data)?;
+
+    match stored_blob {
+        StoredBlob::Batch {
+            visible_slot_number_after_increase,
+            visible_slots_to_advance,
+            ..
+        } => Ok(BatchMetadata {
+            visible_slot_number_after_increase,
+            visible_slots_to_advance,
+        }),
+        StoredBlob::Proof { .. } => Err(anyhow::anyhow!(
+            "Expected batch blob but found proof blob for sequence_number {}",
+            sequence_number
+        )),
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -1,13 +1,9 @@
-use crate::preferred::exit_rollup;
-use crate::preferred::replica::event_receiver::EventReceiverError;
-use crate::preferred::replica::event_receiver::{EventReceiver, EventsNotificationPayload};
+use crate::preferred::replica::event_receiver::DbData;
+use crate::preferred::replica::event_receiver::EventReceiver;
 use tokio::sync::watch;
-use tracing::error;
-
-const MAX_DB_ERRORS_ALLOWED: u32 = 10;
 
 pub(crate) trait ReplicaEventHandler {
-    async fn on_notification(&self, notification: EventsNotificationPayload);
+    async fn on_da_event(&self, batch: DbData);
 }
 
 pub(crate) struct ReplicaSyncTask<R: ReplicaEventHandler> {
@@ -18,12 +14,17 @@ pub(crate) struct ReplicaSyncTask<R: ReplicaEventHandler> {
 
 impl<R: ReplicaEventHandler> ReplicaSyncTask<R> {
     pub(crate) async fn new(
-        postgres_connection_string: &str,
+        postgres_connection_string: String,
         handler: R,
         shutdown_sender: watch::Sender<()>,
+        start_event_id: u64,
     ) -> anyhow::Result<Self> {
-        let event_receiver =
-            EventReceiver::new(postgres_connection_string, &shutdown_sender).await?;
+        let event_receiver = EventReceiver::new(
+            postgres_connection_string,
+            shutdown_sender.clone(),
+            start_event_id,
+        )
+        .await;
         Ok(Self {
             event_receiver,
             handler,
@@ -32,41 +33,16 @@ impl<R: ReplicaEventHandler> ReplicaSyncTask<R> {
     }
 
     pub(crate) async fn start(&mut self) {
+        self.event_receiver.spawn_db_data_fetcher().await;
         let shutdown_receiver = self.shutdown_sender.subscribe();
-        let mut nb_of_consecutive_db_errors = 0;
 
         loop {
-            tokio::select! {
-                notification_result = self.event_receiver.recv() => {
-                    match notification_result {
-                        Ok(notification) => {
-                            nb_of_consecutive_db_errors = 0;
-                            self.handler.on_notification(notification).await;
-                        }
+            if shutdown_receiver.has_changed().unwrap_or(true) {
+                break;
+            }
 
-                        Err(EventReceiverError::ParsingError(e)) => {
-                            // This should never happen, so we shut down the replica immediately
-                            error!("Failed to parse notification: {e:?}. Shutting down replica.");
-                            exit_rollup(&self.shutdown_sender).await;
-                        }
-                        Err(EventReceiverError::ListenerError(e)) => {
-                            error!("Failed to receive notifications from database: {e:?}. Shutting down replica.");
-
-                            if shutdown_receiver.has_changed().unwrap_or(true) {
-                                break;
-                            }
-
-                            // Since network errors can occur, we will retry receiving a few times before initiating replica shutdown.
-                            if nb_of_consecutive_db_errors >= MAX_DB_ERRORS_ALLOWED {
-                                error!("Failed to connect to the database after {nb_of_consecutive_db_errors} attempts. Shutting down replica.");
-                                exit_rollup(&self.shutdown_sender).await;
-                            }
-
-                            nb_of_consecutive_db_errors += 1;
-                            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                        }
-                    }
-                }
+            if let Some(data) = self.event_receiver.recv().await {
+                self.handler.on_da_event(data).await;
             }
         }
     }
@@ -76,7 +52,11 @@ impl<R: ReplicaEventHandler> ReplicaSyncTask<R> {
 mod tests {
     use super::*;
     use crate::preferred::db::postgres::PostgresBackend;
+    use crate::preferred::db::BatchToStore;
     use crate::preferred::db::PreferredSequencerDbBackend;
+    use sov_modules_api::FullyBakedTx;
+    use sov_modules_api::TxHash;
+    use sov_modules_api::VisibleSlotNumber;
     use sov_test_utils::postgres::connection_string_from_postgres_container;
     use sov_test_utils::postgres::create_postgres_container;
     use std::num::NonZero;
@@ -84,19 +64,19 @@ mod tests {
 
     #[derive(Clone)]
     struct TestHandler {
-        send: mpsc::Sender<EventsNotificationPayload>,
+        send: mpsc::Sender<DbData>,
     }
 
     impl TestHandler {
-        pub fn new() -> (Self, mpsc::Receiver<EventsNotificationPayload>) {
+        pub fn new() -> (Self, mpsc::Receiver<DbData>) {
             let (send, recv) = mpsc::channel(1);
             (Self { send }, recv)
         }
     }
 
     impl ReplicaEventHandler for TestHandler {
-        async fn on_notification(&self, notification: EventsNotificationPayload) {
-            self.send.send(notification).await.unwrap();
+        async fn on_da_event(&self, data: DbData) {
+            self.send.send(data).await.unwrap();
         }
     }
 
@@ -113,15 +93,43 @@ mod tests {
 
         let (sync_task_ready_snd, mut sync_task_ready_rcv) = mpsc::channel(1);
 
+        let sequence_number = 10;
+        let blob_id = 99;
+        let visible_slot_number_after_increase = VisibleSlotNumber::new_dangerous(11);
+        let visible_slots_to_advance = NonZero::new(1).unwrap();
         // Insert `postgres_db_backend_begin_rollup_block` into the db.
         {
             let conn_str = postgres_connection_string.clone();
             tokio::spawn(async move {
                 let mut db = PostgresBackend::connect(&conn_str).await.unwrap();
                 sync_task_ready_rcv.recv().await.unwrap();
-                db.begin_rollup_block(99, 11, Default::default(), NonZero::new(1).unwrap())
-                    .await
-                    .unwrap();
+
+                db.begin_rollup_block(
+                    sequence_number,
+                    blob_id,
+                    visible_slot_number_after_increase,
+                    visible_slots_to_advance,
+                )
+                .await
+                .unwrap();
+
+                db.add_tx(
+                    sequence_number,
+                    0,
+                    FullyBakedTx::new(vec![1, 2, 3]),
+                    TxHash::new([11; 32]),
+                )
+                .await
+                .unwrap();
+
+                db.end_rollup_block(BatchToStore {
+                    blob_id,
+                    sequence_number,
+                    visible_slot_number_after_increase,
+                    visible_slots_to_advance,
+                })
+                .await
+                .unwrap();
             });
         }
 
@@ -134,7 +142,7 @@ mod tests {
             let test_handler = test_handler.clone();
             let shutdown_snd = shutdown_snd.clone();
             tokio::spawn(async move {
-                let mut sync_task = ReplicaSyncTask::new(&conn_str, test_handler, shutdown_snd)
+                let mut sync_task = ReplicaSyncTask::new(conn_str, test_handler, shutdown_snd, 0)
                     .await
                     .unwrap();
                 sync_task_ready_snd.send(()).await.unwrap();
@@ -142,8 +150,9 @@ mod tests {
             });
         }
 
-        let event = recv.recv().await.unwrap();
-        assert_eq!(event.sequence_number, 99);
+        let _event = recv.recv().await.unwrap();
+        let _event = recv.recv().await.unwrap();
+        let _event = recv.recv().await.unwrap();
 
         shutdown_snd.send(()).unwrap();
     }


### PR DESCRIPTION
# Description

This PR introduces the following changes:
1. `EventReceiver` spawns a Tokio task to listen for the latest PG notifications.
2. Upon receiving a notification, it fetches the relevant data from PG.
3. Forwards the fetched data to `ReplicaSyncTask`.

Additional tests will be included in the next PR.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1524
