### PR TITLE
Add sequencer replica tests for PostgreSQL notifications.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -33,13 +33,7 @@ use crate::preferred::{exit_rollup, track_in_progress_batch_size};
 
 #[async_trait]
 pub trait PreferredSequencerDbBackend: Send + Sync + 'static {
-    async fn begin_rollup_block(
-        &mut self,
-        sequence_number: SequenceNumber,
-        blob_id: BlobInternalId,
-        visible_slot_number_after_increase: VisibleSlotNumber,
-        visibile_slots_to_advance: NonZero<u8>,
-    ) -> anyhow::Result<()>;
+    async fn begin_rollup_block(&mut self, stored_batch: BatchToStore) -> anyhow::Result<()>;
 
     /// Calls to this method MUST be "sandwiched" between
     /// [`PreferredSequencerDbBackend::begin_rollup_block`] and
@@ -101,7 +95,6 @@ pub trait PreferredSequencerDbBackend: Send + Sync + 'static {
 pub struct DbSnapshotData {
     pub completed_blobs: Vec<PreferredSequencerReadBlob>,
     pub in_progress_batch: Option<InProgressBatch>,
-    //pub latest_event_id: Option<u64>,
 }
 
 /// See [`PreferredSequencerReadBlob::Batch`].
@@ -410,13 +403,12 @@ impl PreferredSequencerDb {
     }
 
     pub(crate) async fn initial_data(
-        &mut self,
+        &self,
     ) -> anyhow::Result<(SequenceNumber, PreferredSequencerCache)> {
-        if let Some(backend) = &mut self.backend {
+        if let Some(backend) = &self.backend {
             let DbSnapshotData {
                 completed_blobs,
                 in_progress_batch,
-                //latest_event_id,
             } = backend.current_data().await?;
 
             let completed_blobs = VecDeque::from(completed_blobs);
@@ -431,7 +423,6 @@ impl PreferredSequencerDb {
             };
 
             Ok((
-                //latest_event_id,
                 sequence_number_of_next_blob,
                 PreferredSequencerCache::new(
                     completed_blobs,
@@ -491,14 +482,13 @@ impl PreferredSequencerDb {
                 "Storing new rollup block"
             );
 
-            backend
-                .begin_rollup_block(
-                    sequence_number,
-                    blob_id,
-                    visible_slot_number_after_increase,
-                    visible_slots_to_advance,
-                )
-                .await?;
+            let batch_to_store = BatchToStore {
+                sequence_number,
+                blob_id,
+                visible_slot_number_after_increase,
+                visible_slots_to_advance,
+            };
+            backend.begin_rollup_block(batch_to_store).await?;
         }
 
         Ok(sequence_number)

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -101,7 +101,7 @@ pub trait PreferredSequencerDbBackend: Send + Sync + 'static {
 pub struct DbSnapshotData {
     pub completed_blobs: Vec<PreferredSequencerReadBlob>,
     pub in_progress_batch: Option<InProgressBatch>,
-    pub latest_event_id: Option<u64>,
+    //pub latest_event_id: Option<u64>,
 }
 
 /// See [`PreferredSequencerReadBlob::Batch`].
@@ -411,12 +411,12 @@ impl PreferredSequencerDb {
 
     pub(crate) async fn initial_data(
         &mut self,
-    ) -> anyhow::Result<(Option<u64>, SequenceNumber, PreferredSequencerCache)> {
+    ) -> anyhow::Result<(SequenceNumber, PreferredSequencerCache)> {
         if let Some(backend) = &mut self.backend {
             let DbSnapshotData {
                 completed_blobs,
                 in_progress_batch,
-                latest_event_id,
+                //latest_event_id,
             } = backend.current_data().await?;
 
             let completed_blobs = VecDeque::from(completed_blobs);
@@ -431,7 +431,7 @@ impl PreferredSequencerDb {
             };
 
             Ok((
-                latest_event_id,
+                //latest_event_id,
                 sequence_number_of_next_blob,
                 PreferredSequencerCache::new(
                     completed_blobs,
@@ -441,7 +441,6 @@ impl PreferredSequencerDb {
             ))
         } else {
             Ok((
-                None,
                 0, // TODO this will be revisited when we enable the replica sync task.
                 PreferredSequencerCache::new(
                     VecDeque::default(),

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -1,4 +1,3 @@
-use std::num::NonZero;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -200,24 +199,17 @@ impl PostgresBackend {
         Ok(DbSnapshotData {
             completed_blobs,
             in_progress_batch,
-            //latest_event_id,
         })
     }
 }
 
 #[async_trait]
 impl PreferredSequencerDbBackend for PostgresBackend {
-    async fn begin_rollup_block(
-        &mut self,
-        sequence_number: SequenceNumber,
-        blob_id: BlobInternalId,
-        visible_slot_number_after_increase: sov_modules_api::VisibleSlotNumber,
-        visible_slots_to_advance: NonZero<u8>,
-    ) -> anyhow::Result<()> {
+    async fn begin_rollup_block(&mut self, batch_to_store: BatchToStore) -> anyhow::Result<()> {
         let blob_data = borsh::to_vec(&StoredBlob::Batch {
-            blob_id,
-            visible_slot_number_after_increase,
-            visible_slots_to_advance,
+            blob_id: batch_to_store.blob_id,
+            visible_slot_number_after_increase: batch_to_store.visible_slot_number_after_increase,
+            visible_slots_to_advance: batch_to_store.visible_slots_to_advance,
         })?;
 
         // Compound CTE statement to avoid multiple roundtrips
@@ -230,7 +222,7 @@ impl PreferredSequencerDbBackend for PostgresBackend {
              INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data) 
              SELECT $1, 'batch_start', NULL, NULL, $2",
             )
-            .bind(i64::try_from(sequence_number)?)
+            .bind(i64::try_from(batch_to_store.sequence_number)?)
             .bind::<&[u8]>(blob_data.as_ref())
             .execute(&self.pool),
             "postgres_db_backend_begin_rollup_block"

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -173,12 +173,6 @@ impl PostgresBackend {
     async fn current_data_transaction(&self) -> anyhow::Result<DbSnapshotData> {
         let mut tx = self.pool.begin().await?;
 
-        let latest_event_id: Option<u64> =
-            sqlx::query_scalar::<_, Option<i64>>("SELECT MAX(event_id) FROM events")
-                .fetch_one(&mut *tx)
-                .await?
-                .map(|id| id as u64);
-
         let completed_blobs_metadata: Vec<(i64, Vec<u8>)> =
             sqlx::query_as::<Postgres, _>(
                 "SELECT sequence_number, data FROM events WHERE event_type = 'batch_end' ORDER BY sequence_number",
@@ -206,7 +200,7 @@ impl PostgresBackend {
         Ok(DbSnapshotData {
             completed_blobs,
             in_progress_batch,
-            latest_event_id,
+            //latest_event_id,
         })
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
@@ -154,7 +154,7 @@ impl PreferredSequencerDbBackend for RocksDbBackend {
         Ok(DbSnapshotData {
             completed_blobs,
             in_progress_batch,
-            latest_event_id: None,
+            //latest_event_id: None,
         })
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
@@ -148,7 +148,6 @@ impl PreferredSequencerDbBackend for RocksDbBackend {
         Ok(DbSnapshotData {
             completed_blobs,
             in_progress_batch,
-            //latest_event_id: None,
         })
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
@@ -1,4 +1,3 @@
-use std::num::NonZero;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -6,7 +5,7 @@ use axum::async_trait;
 use rockbound::{gen_rocksdb_options, SchemaBatch};
 use sov_blob_sender::BlobInternalId;
 use sov_blob_storage::SequenceNumber;
-use sov_modules_api::{FullyBakedTx, TxHash, VisibleSlotNumber};
+use sov_modules_api::{FullyBakedTx, TxHash};
 
 use super::{DbSnapshotData, PreferredSequencerDbBackend, PreferredSequencerReadBlob, StoredBlob};
 use crate::preferred::db::{BatchToStore, InProgressBatch};
@@ -40,22 +39,17 @@ impl PreferredSequencerDbBackend for RocksDbBackend {
     }
 
     #[tracing::instrument(skip_all, level = "trace")]
-    async fn begin_rollup_block(
-        &mut self,
-        sequence_number: SequenceNumber,
-        blob_id: BlobInternalId,
-        visible_slot_number_after_increase: VisibleSlotNumber,
-        visible_slots_to_advance: NonZero<u8>,
-    ) -> anyhow::Result<()> {
+    async fn begin_rollup_block(&mut self, batch_to_store: BatchToStore) -> anyhow::Result<()> {
         self.db
             .put_async::<tables::InProgressBatch>(
                 &(),
                 &(
-                    sequence_number,
+                    batch_to_store.sequence_number,
                     StoredBlob::Batch {
-                        visible_slot_number_after_increase,
-                        visible_slots_to_advance,
-                        blob_id,
+                        visible_slot_number_after_increase: batch_to_store
+                            .visible_slot_number_after_increase,
+                        visible_slots_to_advance: batch_to_store.visible_slots_to_advance,
+                        blob_id: batch_to_store.blob_id,
                     },
                 ),
             )
@@ -295,10 +289,11 @@ mod tables {
 
 #[cfg(test)]
 mod tests {
-    use sov_modules_api::HexString;
-    use tempfile::TempDir;
-
     use super::*;
+    use sov_modules_api::HexString;
+    use sov_modules_api::VisibleSlotNumber;
+    use std::num::NonZero;
+    use tempfile::TempDir;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_overlapping_range_deletion_pathology() {
@@ -332,26 +327,21 @@ mod tests {
 
         // Trigger `iters` batches of 10 txs. Ensure that performance stays reasonable
         for batch in 0u64..iters {
-            db.begin_rollup_block(
-                SequenceNumber::from(batch),
-                BlobInternalId::from(batch),
-                VisibleSlotNumber::new_dangerous(batch),
-                NonZero::new(1).unwrap(),
-            )
-            .await
-            .unwrap();
-
-            for (i, (tx, tx_hash)) in txs.iter().zip(tx_hashes.iter()).enumerate() {
-                db.add_tx(SequenceNumber::from(batch), i as u64, tx.clone(), *tx_hash)
-                    .await
-                    .unwrap();
-            }
             let batch_to_store = BatchToStore {
                 sequence_number: SequenceNumber::from(batch),
                 visible_slot_number_after_increase: VisibleSlotNumber::new_dangerous(batch),
                 visible_slots_to_advance: NonZero::new(1).unwrap(),
                 blob_id: BlobInternalId::from(batch),
             };
+
+            db.begin_rollup_block(batch_to_store.clone()).await.unwrap();
+
+            for (i, (tx, tx_hash)) in txs.iter().zip(tx_hashes.iter()).enumerate() {
+                db.add_tx(SequenceNumber::from(batch), i as u64, tx.clone(), *tx_hash)
+                    .await
+                    .unwrap();
+            }
+
             db.end_rollup_block(batch_to_store).await.unwrap();
 
             if batch > 1 {

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -166,7 +166,7 @@ where
         )
         .await?;
 
-        let (_latest_db_event_id, next_sequence_number, db_cache) = db.initial_data().await?;
+        let (next_sequence_number, db_cache) = db.initial_data().await?;
 
         let mut handles = vec![];
 

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -158,7 +158,7 @@ where
         let (blobs_sender_channel, _) =
             broadcast::channel(config.sequencer_kind_config.events_channel_size);
 
-        let mut db = PreferredSequencerDb::new(
+        let db = PreferredSequencerDb::new(
             shutdown_sender.clone(),
             config.sequencer_kind_config.is_replica,
             storage_path,

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -1,4 +1,4 @@
-use crate::preferred::db::StoredBlob;
+use crate::preferred::db::{BatchToStore, StoredBlob};
 use crate::preferred::exit_rollup;
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
@@ -169,11 +169,12 @@ impl EventReceiver {
                 )
                 .await
                 {
-                    Ok(n) => {
-                        start_event_id = Some(n + 1);
+                    Ok(next_event_id) => {
+                        nb_of_consecutive_db_errors = 0;
+                        start_event_id = Some(next_event_id + 1);
                     }
-                    Err(e) => {
-                        match e {
+                    Err(err) => {
+                        match err {
                             EventReceiverError::ParsingError(e) => {
                                 // This should never happen, so we shut down the replica immediately
                                 error!(
@@ -202,8 +203,6 @@ impl EventReceiver {
                         }
                     }
                 }
-
-                nb_of_consecutive_db_errors = 0;
             }
         });
     }
@@ -258,7 +257,7 @@ impl EventReceiver {
         target_event_id: u64,
         db_data_sender: &mut tokio::sync::mpsc::Sender<DbData>,
     ) -> Result<(), EventReceiverError> {
-        let mut current_event_id = current_event_id.unwrap_or(0);
+        let mut current_event_id = current_event_id.unwrap_or(1);
 
         // If we're already caught up, nothing to do
         if current_event_id > target_event_id {
@@ -299,21 +298,26 @@ impl EventReceiver {
                 let sequence_number = row.get::<i64, _>("sequence_number") as u64;
 
                 match event_type {
+                    EventType::BatchStart => {
+                        let batch_data: Vec<u8> = row.get("data");
+                        let batch_to_store = parse_serialized_batch(batch_data, sequence_number)?;
+
+                        let _ = db_data_sender
+                            .send(DbData::BatchStart(batch_to_store))
+                            .await;
+                    }
                     EventType::Transaction => {
                         let tx_data: Vec<u8> = row.get("data");
 
                         let baked_tx = FullyBakedTx::new(tx_data);
                         let _ = db_data_sender.send(DbData::Transaction(baked_tx)).await;
                     }
-                    EventType::BatchStart => {
-                        let batch_data: Vec<u8> = row.get("data");
-                        let batch_metadata = parse_serialized_batch(batch_data, sequence_number)?;
-                        let _ = db_data_sender
-                            .send(DbData::BatchStart(batch_metadata))
-                            .await;
-                    }
+
                     EventType::BatchEnd => {
-                        let _ = db_data_sender.send(DbData::BatchEnd).await;
+                        let batch_data: Vec<u8> = row.get("data");
+                        let batch_to_store = parse_serialized_batch(batch_data, sequence_number)?;
+
+                        let _ = db_data_sender.send(DbData::BatchEnd(batch_to_store)).await;
                     }
                     EventType::NewProof => {
                         let _ = db_data_sender.send(DbData::NewProof).await;
@@ -328,35 +332,27 @@ impl EventReceiver {
     }
 }
 
-/// Structure representing batch metadata stored by the master sequencer
-#[derive(Debug)]
-pub(crate) struct BatchMetadata {
-    pub(crate) visible_slot_number_after_increase: VisibleSlotNumber,
-    pub(crate) visible_slots_to_advance: NonZero<u8>,
-}
-
-use sov_modules_api::VisibleSlotNumber;
-use std::num::NonZero;
-
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DbData {
-    BatchStart(BatchMetadata),
+    BatchStart(BatchToStore),
     Transaction(FullyBakedTx),
-    BatchEnd,
+    BatchEnd(BatchToStore),
     NewProof,
 }
 
-fn parse_serialized_batch(data: Vec<u8>, sequence_number: u64) -> anyhow::Result<BatchMetadata> {
+fn parse_serialized_batch(data: Vec<u8>, sequence_number: u64) -> anyhow::Result<BatchToStore> {
     let stored_blob: StoredBlob = borsh::from_slice(&data)?;
 
     match stored_blob {
         StoredBlob::Batch {
             visible_slot_number_after_increase,
             visible_slots_to_advance,
-            ..
-        } => Ok(BatchMetadata {
+            blob_id,
+        } => Ok(BatchToStore {
             visible_slot_number_after_increase,
             visible_slots_to_advance,
+            blob_id,
+            sequence_number,
         }),
         StoredBlob::Proof { .. } => Err(anyhow::anyhow!(
             "Expected batch blob but found proof blob for sequence_number {}",
@@ -368,7 +364,7 @@ fn parse_serialized_batch(data: Vec<u8>, sequence_number: u64) -> anyhow::Result
 async fn latest_event_id(query_pool: &PgPool) -> Result<Option<u64>, sqlx::Error> {
     Ok(
         sqlx::query_scalar::<_, Option<i64>>("SELECT MAX(event_id) FROM events")
-            .fetch_one(&*query_pool)
+            .fetch_one(query_pool)
             .await?
             .map(|id| id as u64),
     )

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -96,22 +96,16 @@ pub(crate) struct EventReceiver {
     db_data_sender: tokio::sync::mpsc::Sender<DbData>,
     db_data_receiver: tokio::sync::mpsc::Receiver<DbData>,
     shutdown_sender: watch::Sender<()>,
-    start_event_id: u64,
 }
 
 impl EventReceiver {
-    pub(crate) async fn new(
-        connection_string: String,
-        shutdown_sender: watch::Sender<()>,
-        start_event_id: u64,
-    ) -> Self {
+    pub(crate) async fn new(connection_string: String, shutdown_sender: watch::Sender<()>) -> Self {
         let (db_data_sender, db_data_receiver) = tokio::sync::mpsc::channel(PAGE_SIZE as usize);
         Self {
             connection_string,
             db_data_sender,
             db_data_receiver,
             shutdown_sender,
-            start_event_id,
         }
     }
 
@@ -125,6 +119,15 @@ impl EventReceiver {
             Ok(pool) => pool,
             Err(e) => {
                 error!("Failed to connect to PostgreSQL: {e:?}. Replica shutting down.");
+                exit_rollup(&self.shutdown_sender).await;
+                unreachable!("EventReceiver: impossible happened rollup didn't exit");
+            }
+        };
+
+        let mut start_event_id = match latest_event_id(&query_pool).await {
+            Ok(latest_event_id) => latest_event_id,
+            Err(e) => {
+                error!("Failed to get latest event id: {e:?}. Replica shutting down.");
                 exit_rollup(&self.shutdown_sender).await;
                 unreachable!("EventReceiver: impossible happened rollup didn't exit");
             }
@@ -151,14 +154,14 @@ impl EventReceiver {
         let shutdown_receiver = self.shutdown_sender.subscribe();
 
         let mut db_data_sender = self.db_data_sender.clone();
-        let start_event_id = self.start_event_id;
+
         tokio::spawn(async move {
             loop {
                 if shutdown_receiver.has_changed().unwrap_or(true) {
                     break;
                 }
 
-                if let Err(e) = Self::fetch_data(
+                match Self::fetch_data(
                     start_event_id,
                     &query_pool,
                     &mut listener,
@@ -166,32 +169,40 @@ impl EventReceiver {
                 )
                 .await
                 {
-                    match e {
-                        EventReceiverError::ParsingError(e) => {
-                            // This should never happen, so we shut down the replica immediately
-                            error!("Failed to parse notification: {e:?}. Shutting down replica.");
-                            exit_rollup(&shutdown_sender).await;
-                        }
-
-                        EventReceiverError::DbError(e) => {
-                            error!("Failed to receive notifications from database: {e:?}. Shutting down replica.");
-
-                            if shutdown_receiver.has_changed().unwrap_or(true) {
-                                break;
-                            }
-
-                            // Since network errors can occur, we will retry receiving a few times before initiating replica shutdown.
-                            if nb_of_consecutive_db_errors >= MAX_DB_ERRORS_ALLOWED {
-                                error!("Failed to connect to the database after {nb_of_consecutive_db_errors} attempts. Shutting down replica.");
+                    Ok(n) => {
+                        start_event_id = Some(n + 1);
+                    }
+                    Err(e) => {
+                        match e {
+                            EventReceiverError::ParsingError(e) => {
+                                // This should never happen, so we shut down the replica immediately
+                                error!(
+                                    "Failed to parse notification: {e:?}. Shutting down replica."
+                                );
                                 exit_rollup(&shutdown_sender).await;
                             }
 
-                            nb_of_consecutive_db_errors += 1;
-                            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                            continue;
+                            EventReceiverError::DbError(e) => {
+                                error!("Failed to receive notifications from database: {e:?}. Shutting down replica.");
+
+                                if shutdown_receiver.has_changed().unwrap_or(true) {
+                                    break;
+                                }
+
+                                // Since network errors can occur, we will retry receiving a few times before initiating replica shutdown.
+                                if nb_of_consecutive_db_errors >= MAX_DB_ERRORS_ALLOWED {
+                                    error!("Failed to connect to the database after {nb_of_consecutive_db_errors} attempts. Shutting down replica.");
+                                    exit_rollup(&shutdown_sender).await;
+                                }
+
+                                nb_of_consecutive_db_errors += 1;
+                                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                                continue;
+                            }
                         }
                     }
                 }
+
                 nb_of_consecutive_db_errors = 0;
             }
         });
@@ -205,6 +216,7 @@ impl EventReceiver {
         listener: &mut PgListener,
     ) -> Result<EventsNotificationPayload, EventReceiverError> {
         let mut last_notification = None;
+
         // We only care about the latest notification from the DB,
         // since the backfill logic allows us to skip earlier ones.
         while let Some(p) = listener.next_buffered() {
@@ -222,11 +234,11 @@ impl EventReceiver {
     }
 
     async fn fetch_data(
-        start_event_id: u64,
+        start_event_id: Option<u64>,
         query_pool: &PgPool,
         listener: &mut PgListener,
         db_data_sender: &mut tokio::sync::mpsc::Sender<DbData>,
-    ) -> Result<(), EventReceiverError> {
+    ) -> Result<u64, EventReceiverError> {
         let notification = Self::recv_notifications(listener).await?;
 
         Self::backfill_to_event_id(
@@ -237,15 +249,17 @@ impl EventReceiver {
         )
         .await?;
 
-        Ok(())
+        Ok(notification.event_id)
     }
 
     async fn backfill_to_event_id(
         query_pool: &PgPool,
-        mut current_event_id: u64,
+        current_event_id: Option<u64>,
         target_event_id: u64,
         db_data_sender: &mut tokio::sync::mpsc::Sender<DbData>,
     ) -> Result<(), EventReceiverError> {
+        let mut current_event_id = current_event_id.unwrap_or(0);
+
         // If we're already caught up, nothing to do
         if current_event_id > target_event_id {
             return Ok(());
@@ -349,4 +363,13 @@ fn parse_serialized_batch(data: Vec<u8>, sequence_number: u64) -> anyhow::Result
             sequence_number
         )),
     }
+}
+
+async fn latest_event_id(query_pool: &PgPool) -> Result<Option<u64>, sqlx::Error> {
+    Ok(
+        sqlx::query_scalar::<_, Option<i64>>("SELECT MAX(event_id) FROM events")
+            .fetch_one(&*query_pool)
+            .await?
+            .map(|id| id as u64),
+    )
 }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -82,6 +82,50 @@ mod tests {
         }
     }
 
+    fn create_test_data(test_case: Vec<usize>) -> Vec<DbData> {
+        let mut data = Vec::new();
+
+        for (seq_nr, nb_of_txs) in test_case.into_iter().enumerate() {
+            let stored_batch = BatchToStore {
+                sequence_number: (seq_nr as u64),
+                blob_id: (seq_nr + 99) as u128,
+                visible_slot_number_after_increase: VisibleSlotNumber::new_dangerous(1),
+                visible_slots_to_advance: NonZero::new(1).unwrap(),
+            };
+
+            data.push(DbData::BatchStart(stored_batch.clone()));
+
+            for i in 0..nb_of_txs {
+                data.push(DbData::Transaction(FullyBakedTx {
+                    data: vec![i as u8],
+                }));
+            }
+
+            data.push(DbData::BatchEnd(stored_batch));
+        }
+
+        data
+    }
+
+    async fn execute(mut db: PostgresBackend, data: Vec<DbData>) {
+        for db_data in data {
+            match db_data {
+                DbData::BatchStart(stored_batch) => {
+                    db.begin_rollup_block(stored_batch).await.unwrap();
+                }
+                DbData::Transaction(tx) => {
+                    db.add_tx(1, 0, tx, TxHash::new([1; 32])).await.unwrap();
+                }
+                DbData::BatchEnd(stored_batch) => {
+                    db.end_rollup_block(stored_batch).await.unwrap();
+                }
+                DbData::NewProof => {
+                    unimplemented!()
+                }
+            }
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_notifications() {
         let dir = tempfile::tempdir().unwrap();
@@ -93,54 +137,22 @@ mod tests {
             .await
             .unwrap();
 
-        let mut db = PostgresBackend::connect(&postgres_connection_string)
+        let db = PostgresBackend::connect(&postgres_connection_string)
             .await
             .unwrap();
 
         let (sync_task_ready_snd, mut sync_task_ready_rcv) = mpsc::channel(1);
 
-        let sequence_number = 10;
-        let blob_id = 99;
-        let visible_slot_number_after_increase = VisibleSlotNumber::new_dangerous(11);
-        let visible_slots_to_advance = NonZero::new(1).unwrap();
-
-        // Insert `postgres_db_backend_begin_rollup_block` into the db.
+        let test_data = create_test_data(vec![1, 0, 1000, 2]);
         {
+            let test_data = test_data.clone();
             tokio::spawn(async move {
                 sync_task_ready_rcv.recv().await.unwrap();
-
-                db.begin_rollup_block(
-                    sequence_number,
-                    blob_id,
-                    visible_slot_number_after_increase,
-                    visible_slots_to_advance,
-                )
-                .await
-                .unwrap();
-
-                db.add_tx(
-                    sequence_number,
-                    0,
-                    FullyBakedTx::new(vec![1, 2, 3]),
-                    TxHash::new([11; 32]),
-                )
-                .await
-                .unwrap();
-
-                db.end_rollup_block(BatchToStore {
-                    blob_id,
-                    sequence_number,
-                    visible_slot_number_after_increase,
-                    visible_slots_to_advance,
-                })
-                .await
-                .unwrap();
+                execute(db, test_data).await;
             });
         }
 
-        // Check if replica sync task received the notification.
         let (shutdown_snd, _shutdown_rcv) = watch::channel(());
-
         let (test_handler, mut recv) = TestHandler::new();
         {
             let conn_str = postgres_connection_string.clone();
@@ -148,15 +160,16 @@ mod tests {
             let shutdown_snd = shutdown_snd.clone();
             tokio::spawn(async move {
                 let mut sync_task = ReplicaSyncTask::new(conn_str, shutdown_snd).await.unwrap();
-
                 sync_task.start(test_handler).await;
                 sync_task_ready_snd.send(()).await.unwrap();
             });
         }
 
-        let _event = recv.recv().await.unwrap();
-        let _event = recv.recv().await.unwrap();
-        let _event = recv.recv().await.unwrap();
+        // Check if replica sync task received the notification.
+        for data in test_data {
+            let recv_data = recv.recv().await.unwrap();
+            assert_eq!(recv_data, data);
+        }
 
         shutdown_snd.send(()).unwrap();
     }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -1,50 +1,51 @@
 use crate::preferred::replica::event_receiver::DbData;
 use crate::preferred::replica::event_receiver::EventReceiver;
+use async_trait::async_trait;
 use tokio::sync::watch;
 
-pub(crate) trait ReplicaEventHandler {
+#[async_trait]
+pub(crate) trait ReplicaEventHandler: Send + Sync + 'static {
     async fn on_da_event(&self, batch: DbData);
 }
 
-pub(crate) struct ReplicaSyncTask<R: ReplicaEventHandler> {
-    event_receiver: EventReceiver,
-    handler: R,
+pub(crate) struct ReplicaSyncTask {
     shutdown_sender: watch::Sender<()>,
+    postgres_connection_string: String,
 }
 
-impl<R: ReplicaEventHandler> ReplicaSyncTask<R> {
+impl ReplicaSyncTask {
     pub(crate) async fn new(
         postgres_connection_string: String,
-        handler: R,
+
         shutdown_sender: watch::Sender<()>,
-        start_event_id: u64,
     ) -> anyhow::Result<Self> {
-        let event_receiver = EventReceiver::new(
-            postgres_connection_string,
-            shutdown_sender.clone(),
-            start_event_id,
-        )
-        .await;
         Ok(Self {
-            event_receiver,
-            handler,
+            postgres_connection_string,
             shutdown_sender,
         })
     }
 
-    pub(crate) async fn start(&mut self) {
-        self.event_receiver.spawn_db_data_fetcher().await;
+    pub(crate) async fn start<R: ReplicaEventHandler>(&mut self, handler: R) {
+        let mut event_receiver = EventReceiver::new(
+            self.postgres_connection_string.clone(),
+            self.shutdown_sender.clone(),
+        )
+        .await;
+
+        event_receiver.spawn_db_data_fetcher().await;
         let shutdown_receiver = self.shutdown_sender.subscribe();
 
-        loop {
-            if shutdown_receiver.has_changed().unwrap_or(true) {
-                break;
-            }
+        tokio::spawn(async move {
+            loop {
+                if shutdown_receiver.has_changed().unwrap_or(true) {
+                    break;
+                }
 
-            if let Some(data) = self.event_receiver.recv().await {
-                self.handler.on_da_event(data).await;
+                if let Some(data) = event_receiver.recv().await {
+                    handler.on_da_event(data).await;
+                }
             }
-        }
+        });
     }
 }
 
@@ -74,6 +75,7 @@ mod tests {
         }
     }
 
+    #[async_trait]
     impl ReplicaEventHandler for TestHandler {
         async fn on_da_event(&self, data: DbData) {
             self.send.send(data).await.unwrap();
@@ -91,17 +93,20 @@ mod tests {
             .await
             .unwrap();
 
+        let mut db = PostgresBackend::connect(&postgres_connection_string)
+            .await
+            .unwrap();
+
         let (sync_task_ready_snd, mut sync_task_ready_rcv) = mpsc::channel(1);
 
         let sequence_number = 10;
         let blob_id = 99;
         let visible_slot_number_after_increase = VisibleSlotNumber::new_dangerous(11);
         let visible_slots_to_advance = NonZero::new(1).unwrap();
+
         // Insert `postgres_db_backend_begin_rollup_block` into the db.
         {
-            let conn_str = postgres_connection_string.clone();
             tokio::spawn(async move {
-                let mut db = PostgresBackend::connect(&conn_str).await.unwrap();
                 sync_task_ready_rcv.recv().await.unwrap();
 
                 db.begin_rollup_block(
@@ -142,11 +147,10 @@ mod tests {
             let test_handler = test_handler.clone();
             let shutdown_snd = shutdown_snd.clone();
             tokio::spawn(async move {
-                let mut sync_task = ReplicaSyncTask::new(conn_str, test_handler, shutdown_snd, 0)
-                    .await
-                    .unwrap();
+                let mut sync_task = ReplicaSyncTask::new(conn_str, shutdown_snd).await.unwrap();
+
+                sync_task.start(test_handler).await;
                 sync_task_ready_snd.send(()).await.unwrap();
-                sync_task.start().await;
             });
         }
 


### PR DESCRIPTION
# Description

This PR cleans up the replica task code and introduces improved testing infrastructure for PostgreSQL notifications.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1524
