### PR TITLE
docs(celestia/verifier): Update prevalidate_blobs doc to reference PreValidationOutput::EarlyReturn

### DIFF
--- a/crates/adapters/celestia/src/verifier/mod.rs
+++ b/crates/adapters/celestia/src/verifier/mod.rs
@@ -260,7 +260,7 @@ impl PreValidationOutput {
 /// 1. Checks that blobs quantity matches inclusion proofs quantity.
 /// 2. Checks that row roots are non-empty for non-empty blobs slice.
 /// 3. Handles the case of an empty blobs slice and verifies absence proof.
-///    In this case returns `Ok(None)` and the caller can exit early.
+///    In this case returns `PreValidationOutput::EarlyReturn` and the caller can exit early.
 fn prevalidate_blobs(
     namespace_row_roots: &[&NamespacedHash],
     blobs: &[BlobWithSender],


### PR DESCRIPTION
- Replace outdated “returns Ok(None)” with “PreValidationOutput::EarlyReturn”
- Aligns documentation with current return type and usage