### PR TITLE
EVM: Decouple `evm` and `sov` nonce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11336,6 +11336,7 @@ dependencies = [
  "sov-rollup-interface",
  "sov-state",
  "sov-test-utils",
+ "sov-uniqueness",
  "strum 0.26.3",
  "tempfile",
  "thiserror 1.0.64",

--- a/crates/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-evm/Cargo.toml
@@ -21,6 +21,7 @@ sov-kernels = { workspace = true }
 sov-state = { workspace = true }
 sov-address = { workspace = true, features = ["evm"] }
 sov-bank = { workspace = true }
+sov-uniqueness = { workspace = true }
 
 anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
@@ -104,6 +105,7 @@ arbitrary = [
 	"sov-state/arbitrary",
 	"sov-test-utils/arbitrary",
 	"sov-bank/arbitrary",
+	"sov-uniqueness/arbitrary",
 	"alloy-consensus/arbitrary",
 	"reth-primitives-traits/arbitrary",
 	"reth-ethereum-primitives/arbitrary"
@@ -128,4 +130,5 @@ native = [
 	"sov-rollup-interface/native",
 	"sov-kernels/native",
 	"sov-bank/native",
+	"sov-uniqueness/native"
 ]

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -63,9 +63,9 @@ fn extract_evm_authorization_data<S: Spec>(
 where
     S::Address: FromVmAddress<EthereumAddress>,
 {
-    let credentials = Credentials::new(signer);
-    let credential_id = signer.into_word().0.into();
     let ethereum_address: EthereumAddress = signer.into();
+    let credentials = Credentials::new(signer);
+    let credential_id = ethereum_address.as_credential_id();
 
     AuthorizationData {
         uniqueness: UniquenessData::Nonce(nonce),

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -53,8 +53,12 @@ where
         let cfg = self.cfg(state)?.expect("Evm config must be set");
         let cfg_env = get_cfg_env(&block_env, cfg, None);
 
+        let nonce_to_use = self.get_nonce_to_use(signer, state)?;
+
         let evm_db: EvmDb<_, S> = self.get_db(state);
-        let result = executor::execute_tx(evm_db, &block_env, &evm_tx, signer, cfg_env);
+
+        let result =
+            executor::execute_tx(nonce_to_use, evm_db, &block_env, &evm_tx, signer, cfg_env);
 
         let previous_transaction = self.pending_transactions.last(state)?;
         let previous_transaction_cumulative_gas_used = previous_transaction
@@ -122,6 +126,26 @@ where
             .push(&pending_transaction, state)?;
 
         Ok(())
+    }
+
+    // The nonce check is already performed by the stf-blueprint during transaction preprocessing,
+    // so the EVM does not need to perform any additional nonce validation.
+    //
+    // However, the account nonce is still used by the EVM in the `CREATE` opcode when generating
+    // a contract address: `new_address = keccak256(sender, nonce)`.
+    // This means we must ensure a unique value is provided to satisfy the opcode.
+    // Here, we use the nonce tracked by the EVM, but keep in mind that `eth_getTransactionCount`
+    // will return the nonce tracked by the sov-uniqueness module.
+    fn get_nonce_to_use(
+        &self,
+        address: Address,
+        state: &mut impl TxState<S>,
+    ) -> anyhow::Result<u64> {
+        Ok(self
+            .accounts
+            .get(&address, state)?
+            .map(|acc| acc.info.nonce)
+            .unwrap_or_default())
     }
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -53,12 +53,11 @@ where
         let cfg = self.cfg(state)?.expect("Evm config must be set");
         let cfg_env = get_cfg_env(&block_env, cfg, None);
 
-        let nonce_to_use = self.get_nonce_to_use(signer, state)?;
+        let sov_nonce = self.get_sov_nonce(signer, state)?;
 
         let evm_db: EvmDb<_, S> = self.get_db(state);
 
-        let result =
-            executor::execute_tx(nonce_to_use, evm_db, &block_env, &evm_tx, signer, cfg_env);
+        let result = executor::execute_tx(sov_nonce, evm_db, &block_env, &evm_tx, signer, cfg_env);
 
         let previous_transaction = self.pending_transactions.last(state)?;
         let previous_transaction_cumulative_gas_used = previous_transaction
@@ -136,11 +135,7 @@ where
     // This means we must ensure a unique value is provided to satisfy the opcode.
     // Here, we use the nonce tracked by the EVM, but keep in mind that `eth_getTransactionCount`
     // will return the nonce tracked by the sov-uniqueness module.
-    fn get_nonce_to_use(
-        &self,
-        address: Address,
-        state: &mut impl TxState<S>,
-    ) -> anyhow::Result<u64> {
+    fn get_sov_nonce(&self, address: Address, state: &mut impl TxState<S>) -> anyhow::Result<u64> {
         Ok(self
             .accounts
             .get(&address, state)?

--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -26,7 +26,7 @@ impl From<SealedBlock> for BlockEnv {
     }
 }
 
-pub(crate) fn create_tx_env(tx: &TransactionSigned, signer: Address) -> TxEnv {
+pub(crate) fn create_tx_env(nonce_to_use: u64, tx: &TransactionSigned, signer: Address) -> TxEnv {
     TxEnv {
         tx_type: TransactionType::Eip1559.into(),
         caller: signer,
@@ -37,7 +37,7 @@ pub(crate) fn create_tx_env(tx: &TransactionSigned, signer: Address) -> TxEnv {
         value: tx.value(),
         data: tx.input().clone(),
         chain_id: tx.chain_id(),
-        nonce: tx.nonce(),
+        nonce: nonce_to_use,
         ..Default::default()
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -26,7 +26,7 @@ impl From<SealedBlock> for BlockEnv {
     }
 }
 
-pub(crate) fn create_tx_env(nonce_to_use: u64, tx: &TransactionSigned, signer: Address) -> TxEnv {
+pub(crate) fn create_tx_env(sov_nonce: u64, tx: &TransactionSigned, signer: Address) -> TxEnv {
     TxEnv {
         tx_type: TransactionType::Eip1559.into(),
         caller: signer,
@@ -37,7 +37,7 @@ pub(crate) fn create_tx_env(nonce_to_use: u64, tx: &TransactionSigned, signer: A
         value: tx.value(),
         data: tx.input().clone(),
         chain_id: tx.chain_id(),
-        nonce: nonce_to_use,
+        nonce: sov_nonce,
         ..Default::default()
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -31,13 +31,14 @@ pub(crate) fn get_cfg_env(
 
 /// Execute an Ethereum transaction and commit it to the database.
 pub fn execute_tx<DB: Database<Error = Infallible> + DatabaseCommit>(
+    nonce_to_use: u64,
     db: DB,
     block_env: &BlockEnv,
     tx: &TransactionSigned,
     signer: Address,
     cfg: CfgEnv,
 ) -> Result<ExecutionResult, EVMError<Infallible>> {
-    let tx_env = create_tx_env(tx, signer);
+    let tx_env = create_tx_env(nonce_to_use, tx, signer);
     let context = Context::mainnet()
         .with_db(db)
         .with_block(block_env)

--- a/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -31,14 +31,14 @@ pub(crate) fn get_cfg_env(
 
 /// Execute an Ethereum transaction and commit it to the database.
 pub fn execute_tx<DB: Database<Error = Infallible> + DatabaseCommit>(
-    nonce_to_use: u64,
+    sov_nonce: u64,
     db: DB,
     block_env: &BlockEnv,
     tx: &TransactionSigned,
     signer: Address,
     cfg: CfgEnv,
 ) -> Result<ExecutionResult, EVMError<Infallible>> {
-    let tx_env = create_tx_env(nonce_to_use, tx, signer);
+    let tx_env = create_tx_env(sov_nonce, tx, signer);
     let context = Context::mainnet()
         .with_db(db)
         .with_block(block_env)

--- a/crates/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/lib.rs
@@ -123,13 +123,17 @@ pub struct Evm<S: Spec> {
     #[state]
     pub(crate) transaction_hashes: AccessoryStateMap<B256, u64, BcsCodec>,
 
+    /// Used only by the RPC: Receipts.
+    #[state]
+    pub(crate) receipts: AccessoryStateVec<Receipt, BcsCodec>,
+
     /// A reference to the Bank module.
     #[module]
     pub(crate) bank_module: sov_bank::Bank<S>,
 
-    /// Used only by the RPC: Receipts.
-    #[state]
-    pub(crate) receipts: AccessoryStateVec<Receipt, BcsCodec>,
+    /// A reference to the Uniqueness module.
+    #[module]
+    pub(crate) uniqueness_module: sov_uniqueness::Uniqueness<S>,
 
     #[phantom]
     phantom: core::marker::PhantomData<S>,

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -209,11 +209,12 @@ where
         // TODO: Implement block_number once we have archival state #882
         // https://github.com/Sovereign-Labs/sovereign-sdk/issues/882
 
+        let ethereum_address: EthereumAddress = address.into();
+        let credential_id = ethereum_address.as_credential_id();
+
         let nonce = self
-            .get_db(state)
-            .basic(address)
-            .unwrap_infallible()
-            .map(|account| account.nonce)
+            .uniqueness_module
+            .next_nonce(&credential_id, state)
             .unwrap_or_default();
 
         debug!(%address, nonce, "EVM module JSON-RPC request to `eth_getTransactionCount`");

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/contracts.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/contracts.rs
@@ -56,6 +56,7 @@ fn test_invalid_contract_execution() {
         let cfg_env =
             CfgEnv::new_with_spec(SpecId::SHANGHAI).with_chain_id(config_value!("CHAIN_ID"));
         let result = executor::execute_tx(
+            1,
             &mut evm_db,
             &BlockEnv::default(),
             &convert_to_transaction_signed(signed_eth_tx).unwrap(),

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
@@ -1,50 +1,23 @@
+use crate::helpers::setup;
+use crate::helpers::EvmAccount;
+use crate::runtime::{RT, S};
 use alloy_consensus::{TxEip1559, TypedTransaction};
 use alloy_eips::eip1559::MIN_PROTOCOL_BASE_FEE;
+use alloy_primitives::Address;
 use alloy_primitives::{Bytes, TxKind, U256};
 use sov_evm::{EthereumAuthenticator, Evm};
 use sov_modules_api::macros::config_value;
 use sov_modules_api::RawTx;
 use sov_test_utils::{BatchTestCase, SimpleStorageContract, TransactionType};
 
-use crate::helpers::setup;
-use crate::runtime::{RT, S};
-
 #[test]
 fn test_executing_eth_transaction() {
     let (mut runner, _, account, _) = setup();
     let contract = SimpleStorageContract::default();
     let contract_addr = account.address().create(0);
-    let create_contract_tx_request = TypedTransaction::Eip1559(TxEip1559 {
-        chain_id: config_value!("CHAIN_ID"),
-        nonce: 0,
-        max_priority_fee_per_gas: Default::default(),
-        max_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128 * 2,
-        gas_limit: 1_000_000,
-        to: TxKind::Create,
-        value: Default::default(),
-        input: Bytes::from(contract.byte_code().to_vec()),
-        access_list: Default::default(),
-    });
-    let (signed_eth_tx, _) = account.sign(create_contract_tx_request);
-    let create_contract_tx = RawTx {
-        data: borsh::to_vec(&signed_eth_tx).unwrap(),
-    };
+    let create_contract_tx = create_contract_tx(0, &contract, &account);
 
-    let set_arg_eth_tx = TypedTransaction::Eip1559(TxEip1559 {
-        chain_id: config_value!("CHAIN_ID"),
-        nonce: 1,
-        max_priority_fee_per_gas: Default::default(),
-        max_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128 * 2,
-        gas_limit: 1_000_000,
-        to: TxKind::Call(contract_addr),
-        value: Default::default(),
-        input: Bytes::from(hex::decode(hex::encode(contract.set_call_data(5))).unwrap()),
-        access_list: Default::default(),
-    });
-    let (signed_eth_tx, _) = account.sign(set_arg_eth_tx);
-    let set_value_tx = RawTx {
-        data: borsh::to_vec(&signed_eth_tx).unwrap(),
-    };
+    let set_value_tx = create_set_arg_tx(5, 1, &contract, contract_addr, &account);
 
     runner.execute_batch(BatchTestCase {
         input: vec![
@@ -72,57 +45,33 @@ fn test_executing_eth_transaction() {
         }),
     });
 
-    let set_arg_eth_tx = TypedTransaction::Eip1559(TxEip1559 {
-        chain_id: config_value!("CHAIN_ID"),
-        nonce: 2,
-        max_priority_fee_per_gas: Default::default(),
-        max_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128 * 2,
-        gas_limit: 1_000_000,
-        to: TxKind::Call(contract_addr),
-        value: Default::default(),
-        input: Bytes::from(hex::decode(hex::encode(contract.set_call_data(92))).unwrap()),
-        access_list: Default::default(),
-    });
-    let (signed_eth_tx, _) = account.sign(set_arg_eth_tx);
-    let set_value_tx = RawTx {
-        data: borsh::to_vec(&signed_eth_tx).unwrap(),
-    };
+    for n in 2..10 {
+        let set_value_tx =
+            create_set_arg_tx((n + 90) as u32, n, &contract, contract_addr, &account);
 
-    runner.execute_batch(BatchTestCase {
-        input: vec![TransactionType::<RT, S>::PreAuthenticated(
-            RT::encode_with_ethereum_auth(set_value_tx),
-        )]
-        .into(),
-        assert: Box::new(move |_result, state| {
-            let evm = Evm::<S>::default();
-            let storage_value = evm
-                .get_storage(&contract_addr, &U256::ZERO, state)
-                .unwrap()
-                .unwrap();
-            assert_eq!(U256::from(92), storage_value);
-        }),
-    });
+        runner.execute_batch(BatchTestCase {
+            input: vec![TransactionType::<RT, S>::PreAuthenticated(
+                RT::encode_with_ethereum_auth(set_value_tx),
+            )]
+            .into(),
+            assert: Box::new(move |_result, state| {
+                let evm = Evm::<S>::default();
+                let storage_value = evm
+                    .get_storage(&contract_addr, &U256::ZERO, state)
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(U256::from(n + 90), storage_value);
+            }),
+        });
+    }
 }
 
 #[test]
 fn test_failed_tx_doesnt_update_evm_module_state() {
     let (mut runner, _, _, no_balance_account) = setup();
     let contract = SimpleStorageContract::default();
-    let create_contract_tx_request = TypedTransaction::Eip1559(TxEip1559 {
-        chain_id: config_value!("CHAIN_ID"),
-        nonce: 0,
-        max_priority_fee_per_gas: Default::default(),
-        max_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128 * 2,
-        gas_limit: 1_000_000,
-        to: TxKind::Create,
-        value: Default::default(),
-        input: Bytes::from(contract.byte_code().to_vec()),
-        access_list: Default::default(),
-    });
-    let (signed_eth_tx, _) = no_balance_account.sign(create_contract_tx_request);
-    let create_contract_tx = RawTx {
-        data: borsh::to_vec(&signed_eth_tx).unwrap(),
-    };
+    let create_contract_tx = create_contract_tx(0, &contract, &no_balance_account);
+
     runner.execute_batch(BatchTestCase {
         input: vec![TransactionType::<RT, S>::PreAuthenticated(
             RT::encode_with_ethereum_auth(create_contract_tx),
@@ -135,4 +84,47 @@ fn test_failed_tx_doesnt_update_evm_module_state() {
             assert!(evm.pending_transactions(state).is_empty());
         }),
     });
+}
+
+fn create_contract_tx(nonce: u64, contract: &SimpleStorageContract, account: &EvmAccount) -> RawTx {
+    let create_contract_tx_request = TypedTransaction::Eip1559(TxEip1559 {
+        chain_id: config_value!("CHAIN_ID"),
+        nonce,
+        max_priority_fee_per_gas: Default::default(),
+        max_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128 * 2,
+        gas_limit: 1_000_000,
+        to: TxKind::Create,
+        value: Default::default(),
+        input: Bytes::from(contract.byte_code().to_vec()),
+        access_list: Default::default(),
+    });
+    let (signed_eth_tx, _) = account.sign(create_contract_tx_request);
+    RawTx {
+        data: borsh::to_vec(&signed_eth_tx).unwrap(),
+    }
+}
+
+fn create_set_arg_tx(
+    set_arg: u32,
+    nonce: u64,
+    contract: &SimpleStorageContract,
+    contract_addr: Address,
+    account: &EvmAccount,
+) -> RawTx {
+    let set_arg_eth_tx = TypedTransaction::Eip1559(TxEip1559 {
+        chain_id: config_value!("CHAIN_ID"),
+        nonce,
+        max_priority_fee_per_gas: Default::default(),
+        max_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128 * 2,
+        gas_limit: 1_000_000,
+        to: TxKind::Call(contract_addr),
+        value: Default::default(),
+        input: Bytes::from(hex::decode(hex::encode(contract.set_call_data(set_arg))).unwrap()),
+        access_list: Default::default(),
+    });
+
+    let (signed_eth_tx, _) = account.sign(set_arg_eth_tx);
+    RawTx {
+        data: borsh::to_vec(&signed_eth_tx).unwrap(),
+    }
 }

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
@@ -46,6 +46,7 @@ fn test_executing_eth_transaction() {
     });
 
     for n in 2..10 {
+        let address = account.address();
         let set_value_tx =
             create_set_arg_tx((n + 90) as u32, n, &contract, contract_addr, &account);
 
@@ -56,6 +57,12 @@ fn test_executing_eth_transaction() {
             .into(),
             assert: Box::new(move |_result, state| {
                 let evm = Evm::<S>::default();
+                let nonce_from_module = evm
+                    .get_transaction_count(address, None, state)
+                    .unwrap()
+                    .to::<u64>();
+                assert_eq!(n + 1, nonce_from_module);
+
                 let storage_value = evm
                     .get_storage(&contract_addr, &U256::ZERO, state)
                     .unwrap()

--- a/crates/module-system/sov-address/src/evm/address.rs
+++ b/crates/module-system/sov-address/src/evm/address.rs
@@ -33,6 +33,12 @@ use crate::{MultiAddress, Not28Bytes};
 /// A standard 20-byte Ethereum address with checksum.
 pub struct EthereumAddress(#[sov_wallet(as_ty = "[u8;20]", display = "hex")] pub Address);
 
+impl EthereumAddress {
+    pub fn as_credential_id(&self) -> CredentialId {
+        CredentialId::from_bytes(self.0.into_word().into())
+    }
+}
+
 impl From<CredentialId> for EthereumAddress {
     fn from(credential_id: CredentialId) -> Self {
         credential_id.0.into()

--- a/crates/module-system/sov-address/src/evm/public_key.rs
+++ b/crates/module-system/sov-address/src/evm/public_key.rs
@@ -1,6 +1,5 @@
-use alloy_primitives::keccak256;
+use crate::EthereumAddress;
 use borsh::{BorshDeserialize, BorshSerialize};
-use k256::elliptic_curve::sec1::ToEncodedPoint;
 use k256::EncodedPoint;
 use schemars::JsonSchema;
 use sov_modules_api::macros::UniversalWallet;
@@ -98,12 +97,8 @@ impl std::hash::Hash for EthereumPublicKey {
 
 impl sov_rollup_interface::crypto::PublicKey for EthereumPublicKey {
     fn credential_id(&self) -> sov_rollup_interface::crypto::CredentialId {
-        // Use the same method as EthereumAddress::from(&EthereumPublicKey)
-        // Get the uncompressed public key bytes (without the prefix byte)
-        let uncompressed = self.pub_key.to_encoded_point(false);
-        let hash: [u8; 32] = keccak256(&uncompressed.as_bytes()[1..]).into();
-
-        sov_rollup_interface::crypto::CredentialId(hash.into())
+        let eth_address = EthereumAddress::from(self);
+        eth_address.as_credential_id()
     }
 }
 
@@ -332,7 +327,7 @@ mod tests {
         // Get the ethereum address from the public key turned into credential id turned into address
         let credential_id = public_key.credential_id();
         assert_eq!(
-            "0x4efbae02ded675eac115583671334bf1710d12c9f689cc819476fa589f08c64c",
+            "0x00000000000000000000000071334bf1710d12c9f689cc819476fa589f08c64c",
             credential_id.to_string()
         );
         let address_from_credential_id: EthereumAddress = credential_id.into();

--- a/crates/rollup-interface/src/state_machine/crypto/mod.rs
+++ b/crates/rollup-interface/src/state_machine/crypto/mod.rs
@@ -34,6 +34,13 @@ use crate::common::HexHash;
 )]
 pub struct CredentialId(pub HexHash);
 
+impl CredentialId {
+    /// Make new `CredentialId`
+    pub fn from_bytes(value: [u8; 32]) -> Self {
+        Self(HexHash::new(value))
+    }
+}
+
 impl schemars::JsonSchema for CredentialId {
     fn schema_name() -> String {
         "CredentialId".to_string()


### PR DESCRIPTION
# Description

This PR includes the following updates:
1. Adds a new` EthereumAddress::as_credential_id` method.
2. Refactors `fn extract_evm_authorization_data and fn get_transaction_count` to use the new method.
3. Introduces  `Uniqueness` module to the EVM. With this change, the `SOV` nonce and the `EVM` nonce are decoupled. The EVM nonce is now maintained solely for supporting the `CRATE` opcode.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

