### PR TITLE
`Bank`: Add support for querying DerivedHolder balance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2025-08-25
+- #1558 Enables querying the `DerivedHolder/Module` balance. Previously, the balance route only worked for user addresses at `/tokens/{}/balances/{}`. This has been updated: the endpoint now attempts to convert the provided string into a `TokenHolder::User/Module/Bank` before processing.
 # 2025-08-22
 - #1553 Enables ignored EVM tests. This is NOT a breaking change.
 

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/stf_tests.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/stf_tests.rs
@@ -59,13 +59,8 @@ fn test_demo_values_in_db() -> Result<(), Infallible> {
         let runtime = IntegTestRuntime::<TestSpec>::default();
         let resp = runtime
             .bank
-            .supply_of(None, get_default_token_id::<S>(&admin_address), state);
-        assert_eq!(
-            resp.unwrap(),
-            sov_bank::TotalSupplyResponse {
-                amount: Some(Amount::new(1000))
-            }
-        );
+            .get_total_supply_of(&get_default_token_id::<S>(&admin_address), state);
+        assert_eq!(resp.unwrap(), Some(Amount::new(1000)));
 
         assert_eq!(
             runtime.value_setter.value.get(state).unwrap_infallible(),
@@ -113,13 +108,8 @@ fn test_demo_values_in_cache() -> Result<(), Infallible> {
 
         let resp = runtime
             .bank
-            .supply_of(None, get_default_token_id::<S>(&admin_address), state);
-        assert_eq!(
-            resp.unwrap(),
-            sov_bank::TotalSupplyResponse {
-                amount: Some(Amount::new(1000))
-            }
-        );
+            .get_total_supply_of(&get_default_token_id::<S>(&admin_address), state);
+        assert_eq!(resp.unwrap(), Some(Amount::new(1000)));
 
         assert_eq!(
             runtime.value_setter.value.get(state).unwrap_infallible(),

--- a/crates/module-system/module-implementations/sov-bank/src/query.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/query.rs
@@ -105,11 +105,11 @@ impl<S: Spec> HasCustomRestApi for Bank<S> {
         axum::Router::new()
             .route("/tokens/gas_token", get(Self::route_gas_token))
             .route(
-                "/tokens/gas_token/balances/:address",
+                "/tokens/gas_token/balances/:holderStr",
                 get(Self::route_gas_token_balance),
             )
             .route(
-                "/tokens/:tokenId/balances/:address",
+                "/tokens/:tokenId/balances/:holderStr",
                 get(Self::route_balance),
             )
             .route(

--- a/crates/module-system/module-implementations/sov-bank/src/query.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/query.rs
@@ -57,7 +57,7 @@ impl<S: Spec> Bank<S> {
                 Ok(Coins { amount, token_id }.into())
             }
             Err(err) => Err(errors::bad_request_400(
-                &format!("The given holder {holder_str} is not convertible to a TokenHolder"),
+                &format!("The given parameter {holder_str} is not a valid address or token holder"),
                 err.to_string(),
             )),
         }

--- a/crates/module-system/module-implementations/sov-bank/src/query.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/query.rs
@@ -1,15 +1,15 @@
 //! Defines REST queries exposed by the bank module, along with the relevant types.
 
+use crate::TokenHolder;
+use crate::{config_gas_token_id, get_token_id, Amount, Bank, Coins, TokenId};
 use axum::routing::get;
 use axum::Json;
-use sov_modules_api::capabilities::RollupHeight;
+use derive_more::FromStr;
 use sov_modules_api::prelude::utoipa::openapi::OpenApi;
 use sov_modules_api::prelude::{axum, serde_yaml, UnwrapInfallible};
 use sov_modules_api::rest::utils::{errors, ApiResult, Path, Query};
 use sov_modules_api::rest::{ApiState, HasCustomRestApi};
 use sov_modules_api::{ApiStateAccessor, Spec};
-
-use crate::{config_gas_token_id, get_token_id, Amount, Bank, Coins, TokenId};
 
 /// Structure returned by the `balance_of` method.
 #[derive(Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize, Clone)]
@@ -36,7 +36,7 @@ impl<S: Spec> Bank<S> {
     async fn route_gas_token_balance(
         state: ApiState<S, Self>,
         accessor: ApiStateAccessor<S>,
-        Path(user_address): Path<S::Address>,
+        Path(user_address): Path<String>,
     ) -> ApiResult<Coins> {
         Self::route_balance(state, accessor, Path((config_gas_token_id(), user_address))).await
     }
@@ -44,14 +44,19 @@ impl<S: Spec> Bank<S> {
     async fn route_balance(
         state: ApiState<S, Self>,
         mut accessor: ApiStateAccessor<S>,
-        Path((token_id, user_address)): Path<(TokenId, S::Address)>,
+        Path((token_id, holder_str)): Path<(TokenId, String)>,
     ) -> ApiResult<Coins> {
-        let amount = state
-            .get_balance_of(&user_address, token_id, &mut accessor)
-            .unwrap_infallible()
-            .ok_or_else(|| errors::not_found_404("Balance", user_address))?;
+        if let Ok(holder) = TokenHolder::from_str(&holder_str) {
+            let amount = state
+                .balances
+                .get(&(holder.clone(), &token_id), &mut accessor)
+                .unwrap_infallible()
+                .ok_or_else(|| errors::not_found_404("Balance", holder))?;
 
-        Ok(Coins { amount, token_id }.into())
+            return Ok(Coins { amount, token_id }.into());
+        }
+
+        todo!()
     }
 
     async fn route_total_supply(

--- a/crates/module-system/module-implementations/sov-bank/src/query.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/query.rs
@@ -46,17 +46,21 @@ impl<S: Spec> Bank<S> {
         mut accessor: ApiStateAccessor<S>,
         Path((token_id, holder_str)): Path<(TokenId, String)>,
     ) -> ApiResult<Coins> {
-        if let Ok(holder) = TokenHolder::from_str(&holder_str) {
-            let amount = state
-                .balances
-                .get(&(holder.clone(), &token_id), &mut accessor)
-                .unwrap_infallible()
-                .ok_or_else(|| errors::not_found_404("Balance", holder))?;
+        match TokenHolder::from_str(&holder_str) {
+            Ok(holder) => {
+                let amount = state
+                    .balances
+                    .get(&(holder.clone(), &token_id), &mut accessor)
+                    .unwrap_infallible()
+                    .ok_or_else(|| errors::not_found_404("Balance", holder))?;
 
-            return Ok(Coins { amount, token_id }.into());
+                Ok(Coins { amount, token_id }.into())
+            }
+            Err(err) => Err(errors::bad_request_400(
+                &format!("The given holder {holder_str} is not convertible to a TokenHolder"),
+                err.to_string(),
+            )),
         }
-
-        todo!()
     }
 
     async fn route_total_supply(

--- a/crates/module-system/module-implementations/sov-bank/src/query.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/query.rs
@@ -25,44 +25,6 @@ pub struct TotalSupplyResponse {
     pub amount: Option<Amount>,
 }
 
-impl<S: Spec> Bank<S> {
-    /// Method that returns the balance of the user at the address `user_address` for the token
-    /// stored at the address `token_id`.
-    pub fn balance_of(
-        &self,
-        version: Option<RollupHeight>,
-        user_address: S::Address,
-        token_id: TokenId,
-        state: &mut ApiStateAccessor<S>,
-    ) -> Result<BalanceResponse, anyhow::Error> {
-        let amount = if let Some(v) = version {
-            let state = &mut state.get_archival_state(v).map_err(|e| anyhow::anyhow!("Impossible to retrieve the state at the provided height. Please ensure you're querying a valid state. Error: {e}"))?;
-            self.get_balance_of(&user_address, token_id, state)
-        } else {
-            self.get_balance_of(&user_address, token_id, state)
-        }
-        .unwrap_infallible();
-        Ok(BalanceResponse { amount })
-    }
-
-    /// Method that returns the supply of a token stored at the address `token_id`.
-    pub fn supply_of(
-        &self,
-        version: Option<RollupHeight>,
-        token_id: TokenId,
-        state: &mut ApiStateAccessor<S>,
-    ) -> Result<TotalSupplyResponse, anyhow::Error> {
-        let amount = if let Some(v) = version {
-            let mut state = state.get_archival_state(v).map_err(|e| anyhow::anyhow!("Impossible to retrieve the state at the provided height. Please ensure you're querying a valid state. Error: {e}"))?;
-            self.get_total_supply_of(&token_id, &mut state)
-        } else {
-            self.get_total_supply_of(&token_id, state)
-        }
-        .unwrap_infallible();
-        Ok(TotalSupplyResponse { amount })
-    }
-}
-
 /// Axum routes.
 impl<S: Spec> Bank<S> {
     async fn route_gas_token() -> axum::Json<types::TokenIdResponse> {

--- a/crates/utils/sov-node-client/src/lib.rs
+++ b/crates/utils/sov-node-client/src/lib.rs
@@ -202,7 +202,7 @@ impl NodeClient {
         Ok(amount)
     }
 
-    /// Get balance of the hoder.
+    /// Get balance of the holder.
     pub async fn get_balance_for_holder<S: sov_modules_api::Spec>(
         &self,
         holder: &str,

--- a/crates/utils/sov-node-client/src/lib.rs
+++ b/crates/utils/sov-node-client/src/lib.rs
@@ -202,6 +202,32 @@ impl NodeClient {
         Ok(amount)
     }
 
+    /// Get balance of the user.
+    pub async fn get_balance_for_holder<S: sov_modules_api::Spec>(
+        &self,
+        holder: &str,
+        token_id: &TokenId,
+        rollup_height: Option<u64>,
+    ) -> anyhow::Result<Amount> {
+        let height_param: String = rollup_height
+            .map(|h| format!("?rollup_height={h}"))
+            .unwrap_or_default();
+        let balance_url = format!(
+            "{}/modules/bank/tokens/{}/balances/{}{}",
+            self.base_url, token_id, holder, height_param
+        );
+        let amount = self.query_amount(&balance_url).await?;
+
+        tracing::debug!(
+            holder = %holder,
+            url = balance_url,
+            %amount,
+            "Queried balance",
+        );
+
+        Ok(amount)
+    }
+
     /// Send transactions to the sequencer.
     /// Accepts vector of borsh serialized [`sov_modules_api::transaction::Transaction`].
     /// Returns batch submission receipt and hashes of transactions provided to this method.

--- a/crates/utils/sov-node-client/src/lib.rs
+++ b/crates/utils/sov-node-client/src/lib.rs
@@ -202,7 +202,7 @@ impl NodeClient {
         Ok(amount)
     }
 
-    /// Get balance of the user.
+    /// Get balance of the hoder.
     pub async fn get_balance_for_holder<S: sov_modules_api::Spec>(
         &self,
         holder: &str,

--- a/crates/utils/sov-node-client/src/lib.rs
+++ b/crates/utils/sov-node-client/src/lib.rs
@@ -207,14 +207,10 @@ impl NodeClient {
         &self,
         holder: &str,
         token_id: &TokenId,
-        rollup_height: Option<u64>,
     ) -> anyhow::Result<Amount> {
-        let height_param: String = rollup_height
-            .map(|h| format!("?rollup_height={h}"))
-            .unwrap_or_default();
         let balance_url = format!(
-            "{}/modules/bank/tokens/{}/balances/{}{}",
-            self.base_url, token_id, holder, height_param
+            "{}/modules/bank/tokens/{}/balances/{}",
+            self.base_url, token_id, holder
         );
         let amount = self.query_amount(&balance_url).await?;
 

--- a/examples/demo-rollup/tests/bank/operator_rollup/bank_periodic_da_tests.rs
+++ b/examples/demo-rollup/tests/bank/operator_rollup/bank_periodic_da_tests.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 
 use serde::Deserialize;
 use sov_address::MultiAddress;
-use sov_bank::config_gas_token_id;
+use sov_bank::derived_holder::DerivedHolder;
+use sov_bank::{config_gas_token_id, Amount};
 use sov_cli::NodeClient;
 use sov_demo_rollup::{mock_da_risc0_host_args, MockDemoRollup};
 use sov_mock_da::storable::service::StorableMockDaService;
@@ -115,6 +116,16 @@ async fn send_test_bank_txs(
             .unwrap();
         assert!(reward_amount > 0);
     }
+
+    // Check the derive holder api
+    let derived_holder_str = DerivedHolder::from([22; 32]).to_string();
+    let derived_holder_balance_err = client
+        .get_balance_for_holder::<TestSpec>(&derived_holder_str, &token_id, None)
+        .await
+        .unwrap_err()
+        .to_string();
+
+    assert!(derived_holder_balance_err.contains("404 Not Found"));
 
     Ok(())
 }

--- a/examples/demo-rollup/tests/bank/operator_rollup/bank_periodic_da_tests.rs
+++ b/examples/demo-rollup/tests/bank/operator_rollup/bank_periodic_da_tests.rs
@@ -120,7 +120,7 @@ async fn send_test_bank_txs(
     // Check the derive holder api
     let derived_holder_str = DerivedHolder::from([22; 32]).to_string();
     let derived_holder_balance_err = client
-        .get_balance_for_holder::<TestSpec>(&derived_holder_str, &token_id, None)
+        .get_balance_for_holder::<TestSpec>(&derived_holder_str, &token_id)
         .await
         .unwrap_err()
         .to_string();


### PR DESCRIPTION
# Description

This PR introduces the following changes:
1. Removes unused methods from `Bank`
2. Extends `route_balance` to allow querying `User/Module/DerivedHolder` balances
3. Extends a unit test to check if we can pass `DerivedHolder` to the balance endpoint.

Note: The `Bank::Transfer` call message currently only accepts user addresses, which limits testing and the bank functionality. We’ll revisit this on the daily call to decide whether to extend `Bank::Transfer` to support any token holder.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
