### PR TITLE
`Accounts`: Add `enable_custom_account_mappings` flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2025-08-26
+- #1562 **BREAKING CHANGE** The `account.json` genesis files now include a new field: `enable_custom_account_mappings`. If this field is set to false, the custom `CredentialId` => `Account` mapping is disabled. It should remain disabled for EVM rollups.
 # 2025-08-22
 - #1553 Enables ignored EVM tests. This is NOT a breaking change.
 - #1555 **BREAKING CHANGE** Refactors EVM configuration types to reduce duplication and improve clarity:

--- a/crates/fuzz/fuzz_targets/accounts_call.rs
+++ b/crates/fuzz/fuzz_targets/accounts_call.rs
@@ -60,7 +60,10 @@ fuzz_target!(
             })
             .collect();
 
-        let config = AccountConfig { accounts };
+        let config = AccountConfig {
+            accounts,
+            enable_custom_account_mappings: true,
+        };
 
         let mut accounts: Accounts<S> = Accounts::default();
         let mut genesis_state = state.to_genesis_state_accessor::<Accounts<S>>(&config);

--- a/crates/module-system/module-implementations/sov-accounts/src/call.rs
+++ b/crates/module-system/module-implementations/sov-accounts/src/call.rs
@@ -1,3 +1,4 @@
+use anyhow::bail;
 use anyhow::{anyhow, Result};
 use schemars::JsonSchema;
 use sov_modules_api::macros::{serialize, UniversalWallet};
@@ -25,6 +26,12 @@ impl<S: Spec> Accounts<S> {
         context: &Context<S>,
         state: &mut impl TxState<S>,
     ) -> Result<()> {
+        if !self.enable_custom_account_mappings.get(state)?.expect(
+            "`enable_custom_account_mappings` should not be None; it must be set at genesis.",
+        ) {
+            bail!("Custom account mappings are disabled");
+        }
+
         self.exit_if_credential_exists(&new_credential_id, state)?;
 
         // Insert the new credential id -> account mapping

--- a/crates/module-system/module-implementations/sov-accounts/src/fuzz.rs
+++ b/crates/module-system/module-implementations/sov-accounts/src/fuzz.rs
@@ -39,6 +39,7 @@ where
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {
             accounts: u.arbitrary_iter()?.collect::<Result<_, _>>()?,
+            enable_custom_account_mappings: u.arbitrary()?,
         })
     }
 }

--- a/crates/module-system/module-implementations/sov-accounts/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-accounts/src/genesis.rs
@@ -24,7 +24,12 @@ pub struct AccountConfig<S: Spec> {
     /// Accounts to initialize the rollup.
     pub accounts: Vec<AccountData<S::Address>>,
     /// Enable custom `CredentailId` => `Account` mapping.
+    #[serde(default = "default_true")]
     pub enable_custom_account_mappings: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl<S: Spec> Accounts<S> {

--- a/crates/module-system/module-implementations/sov-accounts/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-accounts/src/genesis.rs
@@ -23,6 +23,8 @@ pub struct AccountData<Address> {
 pub struct AccountConfig<S: Spec> {
     /// Accounts to initialize the rollup.
     pub accounts: Vec<AccountData<S::Address>>,
+    /// Enable custom `CredentailId` => `Account` mapping.
+    pub enable_custom_account_mappings: bool,
 }
 
 impl<S: Spec> Accounts<S> {
@@ -31,6 +33,16 @@ impl<S: Spec> Accounts<S> {
         config: &<Self as sov_modules_api::Module>::Config,
         state: &mut impl GenesisState<S>,
     ) -> Result<()> {
+        self.enable_custom_account_mappings
+            .set(&config.enable_custom_account_mappings, state)?;
+
+        if !config.enable_custom_account_mappings {
+            if !config.accounts.is_empty() {
+                bail!("Custom account mapping is disabled, but accounts are provided")
+            }
+            return Ok(());
+        }
+
         for acc in &config.accounts {
             if self.accounts.get(&acc.credential_id, state)?.is_some() {
                 bail!("Account already exists")
@@ -70,11 +82,13 @@ mod tests {
                 credential_id,
                 address: credential_id.into(),
             }],
+            enable_custom_account_mappings: false,
         };
 
         let data = r#"
         {
-            "accounts":[{"credential_id":"0x1cd4e2d9d5943e6f3d12589d31feee6bb6c11e7b8cd996a393623e207da72cbf","address":"sov1rn2w9kw4jslx70gjtzwnrlhwdwmvz8nm3nvedgunvglzqp593hk"}]
+            "accounts":[{"credential_id":"0x1cd4e2d9d5943e6f3d12589d31feee6bb6c11e7b8cd996a393623e207da72cbf","address":"sov1rn2w9kw4jslx70gjtzwnrlhwdwmvz8nm3nvedgunvglzqp593hk"}],
+            "enable_custom_account_mappings":false
         }"#;
 
         let parsed_config: AccountConfig<TestSpec> = serde_json::from_str(data).unwrap();

--- a/crates/module-system/module-implementations/sov-accounts/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-accounts/src/lib.rs
@@ -46,7 +46,7 @@ pub struct Accounts<S: Spec> {
     #[state]
     pub(crate) accounts: StateMap<CredentialId, Account<S>>,
 
-    /// If this field is false, `CallMessage::InsertCredentialId`` messages will be rejected.
+    /// If this field is false, `CallMessage::InsertCredentialId` messages will be rejected.
     #[state]
     enable_custom_account_mappings: StateValue<bool>,
 }

--- a/crates/module-system/module-implementations/sov-accounts/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-accounts/src/lib.rs
@@ -15,7 +15,7 @@ mod tests;
 pub use call::CallMessage;
 use sov_modules_api::{
     Context, CredentialId, DaSpec, GenesisState, Module, ModuleId, ModuleInfo, ModuleRestApi, Spec,
-    StateMap, TxState,
+    StateMap, StateValue, TxState,
 };
 
 /// An account on the rollup.
@@ -45,6 +45,10 @@ pub struct Accounts<S: Spec> {
     /// Mapping from a credential to its corresponding account.
     #[state]
     pub(crate) accounts: StateMap<CredentialId, Account<S>>,
+
+    /// If this field is false, `CallMessage::InsertCredentialId`` messages will be rejected.
+    #[state]
+    enable_custom_account_mappings: StateValue<bool>,
 }
 
 impl<S: Spec> Module for Accounts<S> {

--- a/crates/module-system/module-implementations/sov-accounts/tests/integration/main.rs
+++ b/crates/module-system/module-implementations/sov-accounts/tests/integration/main.rs
@@ -44,6 +44,19 @@ fn setup() -> (TestData<S>, TestRunner<RT, S>) {
     )
 }
 
+fn setup_with_disable_custom_account_mappings() -> (TestUser<S>, TestRunner<RT, S>) {
+    let mut genesis_config = HighLevelOptimisticGenesisConfig::generate();
+    let user = TestUser::generate_with_default_balance();
+    genesis_config = genesis_config.add_accounts(vec![user.clone()]);
+
+    let mut genesis = GenesisConfig::from_minimal_config(genesis_config.into());
+    genesis.accounts.enable_custom_account_mappings = false;
+    (
+        user,
+        TestRunner::new_with_genesis(genesis.into_genesis_params(), RT::default()),
+    )
+}
+
 #[test]
 fn test_config_account() {
     let (
@@ -298,5 +311,25 @@ fn test_resolve_with_different_default_address() {
                 .unwrap(),
             account_1.address()
         );
+    });
+}
+
+#[test]
+fn test_disable_custom_account_mappings() {
+    let (user, mut runner) = setup_with_disable_custom_account_mappings();
+
+    let new_credential = TestPrivateKey::generate().pub_key().credential_id();
+
+    runner.execute_transaction(TransactionTestCase {
+        input: user.create_plain_message::<RT, Accounts<S>>(CallMessage::InsertCredentialId(
+            new_credential,
+        )),
+        assert: Box::new(move |result, _state| match result.tx_receipt {
+            TxEffect::Reverted(contents) => {
+                let Error::ModuleError(err) = contents.reason;
+                assert_eq!(err.to_string(), "Custom account mappings are disabled");
+            }
+            _ => panic!("Expected reverted transaction"),
+        }),
     });
 }

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
@@ -69,7 +69,9 @@ pub(crate) fn setup() -> (TestRunner<RT, S>, TestUser<S>, EvmAccount, EvmAccount
     // SHANGHAI instead of LATEST
     // https://github.com/Sovereign-Labs/sovereign-sdk/issues/912
     evm_config.chain_spec.hardforks = vec![(0, SpecId::SHANGHAI)];
+
     let genesis = GenesisConfig::from_minimal_config(genesis_config.into(), evm_config);
+
     let runner =
         TestRunner::new_with_genesis(genesis.into_genesis_params(), TestRuntime::default());
 

--- a/crates/module-system/module-schemas/genesis-schemas/sov-accounts.json
+++ b/crates/module-system/module-schemas/genesis-schemas/sov-accounts.json
@@ -4,7 +4,8 @@
   "description": "Initial configuration for sov-accounts module.",
   "type": "object",
   "required": [
-    "accounts"
+    "accounts",
+    "enable_custom_account_mappings"
   ],
   "properties": {
     "accounts": {
@@ -13,6 +14,10 @@
       "items": {
         "$ref": "#/definitions/AccountData_for_Address"
       }
+    },
+    "enable_custom_account_mappings": {
+      "description": "TODO",
+      "type": "boolean"
     }
   },
   "definitions": {

--- a/crates/module-system/sov-test-utils/src/runtime/genesis/operator/mod.rs
+++ b/crates/module-system/sov-test-utils/src/runtime/genesis/operator/mod.rs
@@ -173,6 +173,7 @@ impl<S: Spec> MinimalOperatorGenesisConfig<S> {
                             })
                             .collect()
                     },
+                    enable_custom_account_mappings: true,
                 },
                 uniqueness: (),
                 blob_storage: (),

--- a/crates/module-system/sov-test-utils/src/runtime/genesis/optimistic/config.rs
+++ b/crates/module-system/sov-test-utils/src/runtime/genesis/optimistic/config.rs
@@ -276,6 +276,7 @@ impl<S: Spec> MinimalOptimisticGenesisConfig<S> {
                             })
                             .collect()
                     },
+                    enable_custom_account_mappings: true,
                 },
                 uniqueness: (),
                 blob_storage: (),

--- a/crates/module-system/sov-test-utils/src/runtime/genesis/optimistic/tests.rs
+++ b/crates/module-system/sov-test-utils/src/runtime/genesis/optimistic/tests.rs
@@ -201,7 +201,10 @@ fn create_test_rt_genesis_config<S: Spec>(
             admin: None,
         },
 
-        accounts: AccountConfig { accounts: vec![] },
+        accounts: AccountConfig {
+            accounts: vec![],
+            enable_custom_account_mappings: true,
+        },
 
         uniqueness: (),
     }

--- a/crates/module-system/sov-test-utils/src/runtime/genesis/zk/config.rs
+++ b/crates/module-system/sov-test-utils/src/runtime/genesis/zk/config.rs
@@ -189,7 +189,10 @@ impl<S: Spec> MinimalZkGenesisConfig<S> {
                     gas_token_name,
                     placeholder,
                 ),
-                accounts: AccountConfig { accounts: vec![] },
+                accounts: AccountConfig {
+                    accounts: vec![],
+                    enable_custom_account_mappings: true,
+                },
                 uniqueness: (),
                 blob_storage: (),
                 chain_state: BasicGenesisConfig::chain_state(

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -4996,6 +4996,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
+ "sov-uniqueness",
  "thiserror 1.0.65",
  "tracing",
 ]

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -5874,6 +5874,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
+ "sov-uniqueness",
  "thiserror 1.0.64",
  "tracing",
 ]

--- a/examples/demo-rollup/tests/evm/evm_account_abstraction.rs
+++ b/examples/demo-rollup/tests/evm/evm_account_abstraction.rs
@@ -14,6 +14,7 @@ use sov_test_utils::{TEST_DEFAULT_MAX_FEE, TEST_DEFAULT_MAX_PRIORITY_FEE};
 type TestSpec = DemoRollupSpec;
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "Account abstraction for the EVM is disabled"]
 async fn test_evm_account_abstraction() {
     let chain_id = config_value!("CHAIN_ID");
     let finalization_blocks = 0;

--- a/examples/test-data/genesis/demo/celestia/accounts.json
+++ b/examples/test-data/genesis/demo/celestia/accounts.json
@@ -1,5 +1,6 @@
 
 {
     "accounts": [
-    ]
+    ],
+    "enable_custom_account_mappings":false
 }

--- a/examples/test-data/genesis/demo/mock/accounts.json
+++ b/examples/test-data/genesis/demo/mock/accounts.json
@@ -1,5 +1,6 @@
 
 {
     "accounts": [
-    ]
+    ],
+    "enable_custom_account_mappings":false
 }

--- a/examples/test-data/genesis/integration-tests/accounts.json
+++ b/examples/test-data/genesis/integration-tests/accounts.json
@@ -1,4 +1,5 @@
 {
     "accounts": [
-    ]
+    ],
+    "enable_custom_account_mappings":false
 }


### PR DESCRIPTION
# Description

This PR introduces the `enable_custom_account_mappings` flag in the `Accounts` module. When set to false, the module will reject` CallMessage::InsertCredentialId` messages, preventing the creation of custom mappings.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

