### PR TITLE
Ignore hyperlane tests.

### DIFF
--- a/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
@@ -235,7 +235,7 @@ async fn test_multisig_ism() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore(reason = "Ignore hyperlane tests")]
+#[ignore("Ignore hyperlane tests")]
 async fn test_process_message_from_evm_counterparty() {
     let dir = tempfile::tempdir().unwrap();
     let builder = HyperlaneBuilder::setup_image().await;
@@ -321,7 +321,7 @@ async fn test_process_message_from_evm_counterparty() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore(reason = "Ignore hyperlane tests")]
+#[ignore("Ignore hyperlane tests")]
 async fn test_dispatch_message_to_evm_counterparty() {
     let dir = tempfile::tempdir().unwrap();
     let builder = HyperlaneBuilder::setup_image().await;
@@ -611,7 +611,7 @@ async fn test_warp_transfer_back_and_forth_with_evm_counterparty(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore(reason = "Ignore hyperlane tests")]
+#[ignore("Ignore hyperlane tests")]
 async fn test_warp_transfer_back_and_forth_with_evm_without_scaling() {
     test_warp_transfer_back_and_forth_with_evm_counterparty(
         18,
@@ -624,7 +624,7 @@ async fn test_warp_transfer_back_and_forth_with_evm_without_scaling() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore(reason = "Ignore hyperlane tests")]
+#[ignore("Ignore hyperlane tests")]
 async fn test_warp_transfer_back_and_forth_with_evm_scaled_down() {
     test_warp_transfer_back_and_forth_with_evm_counterparty(
         16,
@@ -637,7 +637,7 @@ async fn test_warp_transfer_back_and_forth_with_evm_scaled_down() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore(reason = "Ignore hyperlane tests")]
+#[ignore("Ignore hyperlane tests")]
 async fn test_warp_transfer_back_and_forth_with_evm_scaled_up() {
     test_warp_transfer_back_and_forth_with_evm_counterparty(
         20,

--- a/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
@@ -235,7 +235,7 @@ async fn test_multisig_ism() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore("Ignore hyperlane tests")]
+#[ignore = "Ignore hyperlane tests"]
 async fn test_process_message_from_evm_counterparty() {
     let dir = tempfile::tempdir().unwrap();
     let builder = HyperlaneBuilder::setup_image().await;
@@ -321,7 +321,7 @@ async fn test_process_message_from_evm_counterparty() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore("Ignore hyperlane tests")]
+#[ignore = "Ignore hyperlane tests"]
 async fn test_dispatch_message_to_evm_counterparty() {
     let dir = tempfile::tempdir().unwrap();
     let builder = HyperlaneBuilder::setup_image().await;
@@ -611,7 +611,7 @@ async fn test_warp_transfer_back_and_forth_with_evm_counterparty(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore("Ignore hyperlane tests")]
+#[ignore = "Ignore hyperlane tests"]
 async fn test_warp_transfer_back_and_forth_with_evm_without_scaling() {
     test_warp_transfer_back_and_forth_with_evm_counterparty(
         18,
@@ -624,7 +624,7 @@ async fn test_warp_transfer_back_and_forth_with_evm_without_scaling() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore("Ignore hyperlane tests")]
+#[ignore = "Ignore hyperlane tests"]
 async fn test_warp_transfer_back_and_forth_with_evm_scaled_down() {
     test_warp_transfer_back_and_forth_with_evm_counterparty(
         16,
@@ -637,7 +637,7 @@ async fn test_warp_transfer_back_and_forth_with_evm_scaled_down() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore("Ignore hyperlane tests")]
+#[ignore = "Ignore hyperlane tests"]
 async fn test_warp_transfer_back_and_forth_with_evm_scaled_up() {
     test_warp_transfer_back_and_forth_with_evm_counterparty(
         20,

--- a/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
@@ -235,6 +235,7 @@ async fn test_multisig_ism() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore(reason = "Ignore hyperlane tests")]
 async fn test_process_message_from_evm_counterparty() {
     let dir = tempfile::tempdir().unwrap();
     let builder = HyperlaneBuilder::setup_image().await;
@@ -320,6 +321,7 @@ async fn test_process_message_from_evm_counterparty() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore(reason = "Ignore hyperlane tests")]
 async fn test_dispatch_message_to_evm_counterparty() {
     let dir = tempfile::tempdir().unwrap();
     let builder = HyperlaneBuilder::setup_image().await;
@@ -609,6 +611,7 @@ async fn test_warp_transfer_back_and_forth_with_evm_counterparty(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore(reason = "Ignore hyperlane tests")]
 async fn test_warp_transfer_back_and_forth_with_evm_without_scaling() {
     test_warp_transfer_back_and_forth_with_evm_counterparty(
         18,
@@ -621,6 +624,7 @@ async fn test_warp_transfer_back_and_forth_with_evm_without_scaling() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore(reason = "Ignore hyperlane tests")]
 async fn test_warp_transfer_back_and_forth_with_evm_scaled_down() {
     test_warp_transfer_back_and_forth_with_evm_counterparty(
         16,
@@ -633,6 +637,7 @@ async fn test_warp_transfer_back_and_forth_with_evm_scaled_down() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore(reason = "Ignore hyperlane tests")]
 async fn test_warp_transfer_back_and_forth_with_evm_scaled_up() {
     test_warp_transfer_back_and_forth_with_evm_counterparty(
         20,


### PR DESCRIPTION
# Description

The hyperlane tests started failing with:
```
   ZodError: [
      {
        "received": "radix",
        "code": "invalid_enum_value",
        "options": [
          "ethereum",
          "sealevel",
          "cosmos",
          "cosmosnative",
          "starknet"
        ],
        "path": [
          "protocol"
        ],
        "message": "Invalid enum value. Expected 'ethereum' | 'sealevel' | 'cosmos' | 'cosmosnative' | 'starknet', received 'radix'"
      }
```
As of 26/08/2025, we have temporarily disabled it.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
