### PR TITLE
EVM: Remove nonce form the evm genesis.

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/README.md
+++ b/crates/module-system/module-implementations/sov-evm/README.md
@@ -18,10 +18,8 @@ For example, parts of `evm.json`:
   "data": [
     {
       "address": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-      "balance": "0xffffffffffffffff",
       "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
       "code": "0x",
-      "nonce": 0
     }
   ]
 }

--- a/crates/module-system/module-implementations/sov-evm/src/config.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/config.rs
@@ -104,7 +104,6 @@ mod tests {
                 address,
                 code_hash: AccountData::empty_code(),
                 code: Bytes::default(),
-                nonce: 0,
             }],
             chain_spec: crate::EvmChainSpec {
                 chain_id: 4321, // Use a hard-coded value instead of config_value!("CHAIN_ID") since the string below is hard-coded

--- a/crates/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -21,8 +21,6 @@ pub struct AccountData {
     pub code_hash: B256,
     /// Smart contract code.
     pub code: Bytes,
-    /// Account nonce.
-    pub nonce: u64,
 }
 
 impl AccountData {
@@ -69,7 +67,7 @@ where
             AccountInfo {
                 balance: U256::ZERO,
                 code_hash: acc.code_hash,
-                nonce: acc.nonce,
+                nonce: 0,
                 code: None,
             },
         );

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
@@ -26,7 +26,7 @@ fn test_genesis_data() {
             &AccountInfo {
                 balance: U256::ZERO,
                 code_hash: account.code_hash,
-                nonce: account.nonce,
+                nonce: 0,
                 code: None,
             }
         );
@@ -119,7 +119,6 @@ fn default_config() -> EvmGenesisConfig {
             address: Address::from([1u8; 20]),
             code_hash: KECCAK_EMPTY,
             code: Bytes::default(),
-            nonce: 0,
         }],
         initial_base_fee: 70,
         genesis_timestamp: 50,

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
@@ -51,13 +51,11 @@ pub(crate) fn setup() -> (TestRunner<RT, S>, EvmAccount, EvmAccount) {
                 address: evm_account.address(),
                 code_hash: KECCAK_EMPTY,
                 code: Default::default(),
-                nonce: 0,
             },
             AccountData {
                 address: no_balance_account.address(),
                 code_hash: KECCAK_EMPTY,
                 code: Default::default(),
-                nonce: 0,
             },
         ],
         ..Default::default()

--- a/crates/module-system/module-implementations/sov-uniqueness/tests/integration/utils.rs
+++ b/crates/module-system/module-implementations/sov-uniqueness/tests/integration/utils.rs
@@ -129,7 +129,6 @@ pub(crate) fn setup() -> (TestUser<S>, TestRunner<TestNonceRuntime<S>, S>, EvmAc
             address: evm_account.address(),
             code_hash: KECCAK_EMPTY,
             code: Default::default(),
-            nonce: 0,
         }],
         chain_spec: EvmChainSpec {
             // SHANGHAI instead of LATEST

--- a/crates/module-system/module-schemas/genesis-schemas/sov-bank.json
+++ b/crates/module-system/module-schemas/genesis-schemas/sov-bank.json
@@ -73,7 +73,7 @@
           }
         },
         "supply_cap": {
-          "description": "The supply cap of the token, if any.",
+          "description": "Supply cap of the token. If None, the value falls back to Amount::MAX.",
           "anyOf": [
             {
               "$ref": "#/definitions/Amount"
@@ -133,7 +133,7 @@
           }
         },
         "supply_cap": {
-          "description": "The supply cap of the token, if any.",
+          "description": "Supply cap of the token. If None, the value falls back to Amount::MAX.",
           "anyOf": [
             {
               "$ref": "#/definitions/Amount"

--- a/examples/test-data/genesis/demo/celestia/evm.json
+++ b/examples/test-data/genesis/demo/celestia/evm.json
@@ -3,26 +3,22 @@
     {
       "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-      "code": "0x",
-      "nonce": 0
+      "code": "0x"
     },
     {
       "address": "0x3FE0233e6cf3c9753fcB7449987EC49C88aDDE71",
       "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-      "code": "0x",
-      "nonce": 0
+      "code": "0x"
     },
     {
       "address": "0x4Fa6c577eE74B4F3C5309Af1b6313dd6D525e694",
       "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-      "code": "0x",
-      "nonce": 0
+      "code": "0x"
     },
     {
       "address": "0xa80749aD39A047603cbc5D0f46a03A1c6B2Db6c9",
       "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-      "code": "0x",
-      "nonce": 0
+      "code": "0x"
     }
   ],
   "initial_base_fee": 7,

--- a/examples/test-data/genesis/demo/mock/evm.json
+++ b/examples/test-data/genesis/demo/mock/evm.json
@@ -3,26 +3,22 @@
     {
       "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-      "code": "0x",
-      "nonce": 0
+      "code": "0x"
     },
     {
       "address": "0x3FE0233e6cf3c9753fcB7449987EC49C88aDDE71",
       "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-      "code": "0x",
-      "nonce": 0
+      "code": "0x"
     },
     {
       "address": "0x4Fa6c577eE74B4F3C5309Af1b6313dd6D525e694",
       "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-      "code": "0x",
-      "nonce": 0
+      "code": "0x"
     },
     {
       "address": "0xa80749aD39A047603cbc5D0f46a03A1c6B2Db6c9",
       "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-      "code": "0x",
-      "nonce": 0
+      "code": "0x"
     }
   ],
   "initial_base_fee": 7,

--- a/examples/test-data/genesis/integration-tests/evm.json
+++ b/examples/test-data/genesis/integration-tests/evm.json
@@ -3,26 +3,22 @@
     {
       "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-      "code": "0x",
-      "nonce": 0
+      "code": "0x"
     },
     {
       "address": "0x3FE0233e6cf3c9753fcB7449987EC49C88aDDE71",
       "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-      "code": "0x",
-      "nonce": 0
+      "code": "0x"
     },
     {
       "address": "0x4Fa6c577eE74B4F3C5309Af1b6313dd6D525e694",
       "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-      "code": "0x",
-      "nonce": 0
+      "code": "0x"
     },
     {
       "address": "0xa80749aD39A047603cbc5D0f46a03A1c6B2Db6c9",
       "code_hash": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-      "code": "0x",
-      "nonce": 0
+      "code": "0x"
     }
   ],
   "initial_base_fee": 7,


### PR DESCRIPTION
# Description

The nonces are managed by `sov-uniqueness` module, so we should not include them in the EVM genesis.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
