### PR TITLE
EVM: cleanup + nonce test

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -31,14 +31,17 @@ where
         context: &Context<S>,
         state: &mut impl TxState<S>,
     ) -> anyhow::Result<()> {
-        // Check if the tx went through the EVM authenticator.
+        // The signature was checked before the call was dispatched,
+        // and the signer was recovered during the authentication process.
         let signer = *context
             .get_sender_credential::<Address>()
             .ok_or(anyhow::anyhow!(
                 "EVM transaction must be authenticated by the EVM authenticator"
             ))?;
 
-        let sov_nonce = self.get_sov_nonce(signer, state)?;
+        // Inside the EVM, we use nonces only for the CREATE operation.
+        // The uniqueness check was performed before the call was dispatched.
+        let account_nonce = self.get_account_nonce(signer, state)?;
 
         let evm_tx: TransactionSigned = convert_to_transaction_signed(message.rlp)?;
 
@@ -52,7 +55,8 @@ where
 
         let evm_db: EvmDb<_, S> = self.get_db(state);
 
-        let result = executor::execute_tx(sov_nonce, evm_db, &block_env, &evm_tx, signer, cfg_env);
+        let result =
+            executor::execute_tx(account_nonce, evm_db, &block_env, &evm_tx, signer, cfg_env);
 
         let previous_transaction = self.pending_transactions.last(state)?;
         let previous_transaction_cumulative_gas_used = previous_transaction
@@ -130,7 +134,11 @@ where
     // This means we must ensure a unique value is provided to satisfy the opcode.
     // Here, we use the nonce tracked by the EVM, but keep in mind that `eth_getTransactionCount`
     // will return the nonce tracked by the sov-uniqueness module.
-    fn get_sov_nonce(&self, address: Address, state: &mut impl TxState<S>) -> anyhow::Result<u64> {
+    fn get_account_nonce(
+        &self,
+        address: Address,
+        state: &mut impl TxState<S>,
+    ) -> anyhow::Result<u64> {
         Ok(self
             .accounts
             .get(&address, state)?

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -32,16 +32,13 @@ where
         state: &mut impl TxState<S>,
     ) -> anyhow::Result<()> {
         // Check if the tx went through the EVM authenticator.
-        // TODO: This may no longer be needed.
-        //
-        // If a sov-modules address is registered as a credential id,
-        // then it should be able to send EVM transactions - in that scenario, to give EVM an address, we could
-        // use the address of the EVM address that the sov-modules address is registered as a credential to.
         let signer = *context
             .get_sender_credential::<Address>()
             .ok_or(anyhow::anyhow!(
                 "EVM transaction must be authenticated by the EVM authenticator"
             ))?;
+
+        let sov_nonce = self.get_sov_nonce(signer, state)?;
 
         let evm_tx: TransactionSigned = convert_to_transaction_signed(message.rlp)?;
 
@@ -52,8 +49,6 @@ where
 
         let cfg = self.cfg(state)?.expect("Evm config must be set");
         let cfg_env = get_cfg_env(&block_env, cfg, None);
-
-        let sov_nonce = self.get_sov_nonce(signer, state)?;
 
         let evm_db: EvmDb<_, S> = self.get_db(state);
 

--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -26,7 +26,7 @@ impl From<SealedBlock> for BlockEnv {
     }
 }
 
-pub(crate) fn create_tx_env(sov_nonce: u64, tx: &TransactionSigned, signer: Address) -> TxEnv {
+pub(crate) fn create_tx_env(account_nonce: u64, tx: &TransactionSigned, signer: Address) -> TxEnv {
     TxEnv {
         tx_type: TransactionType::Eip1559.into(),
         caller: signer,
@@ -37,7 +37,7 @@ pub(crate) fn create_tx_env(sov_nonce: u64, tx: &TransactionSigned, signer: Addr
         value: tx.value(),
         data: tx.input().clone(),
         chain_id: tx.chain_id(),
-        nonce: sov_nonce,
+        nonce: account_nonce,
         ..Default::default()
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -44,7 +44,6 @@ pub fn execute_tx<DB: Database<Error = Infallible> + DatabaseCommit>(
         .with_block(block_env)
         .with_cfg(cfg);
     let mut evm = SovEvm::new(context, ());
-
     evm.transact_commit(tx_env)
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -31,14 +31,14 @@ pub(crate) fn get_cfg_env(
 
 /// Execute an Ethereum transaction and commit it to the database.
 pub fn execute_tx<DB: Database<Error = Infallible> + DatabaseCommit>(
-    sov_nonce: u64,
+    account_nonce: u64,
     db: DB,
     block_env: &BlockEnv,
     tx: &TransactionSigned,
     signer: Address,
     cfg: CfgEnv,
 ) -> Result<ExecutionResult, EVMError<Infallible>> {
-    let tx_env = create_tx_env(sov_nonce, tx, signer);
+    let tx_env = create_tx_env(account_nonce, tx, signer);
     let context = Context::mainnet()
         .with_db(db)
         .with_block(block_env)

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -218,7 +218,6 @@ where
             .unwrap_or_default();
 
         debug!(%address, nonce, "EVM module JSON-RPC request to `eth_getTransactionCount`");
-
         Ok(U64::from(nonce))
     }
 

--- a/crates/module-system/module-implementations/sov-evm/src/sov_evm/handler.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/sov_evm/handler.rs
@@ -1,6 +1,5 @@
 use revm::{
     context::{
-        self,
         result::{EVMError, HaltReason, InvalidTransaction},
         Transaction,
     },
@@ -49,6 +48,7 @@ where
 
         // Load caller's account.
         let caller_account = journal.load_account_code(tx.caller())?.data;
+        let old_balance = caller_account.info.balance;
 
         // Touch account so we know it is changed.
         caller_account.mark_touch();
@@ -57,6 +57,8 @@ where
             // Nonce is already checked
             caller_account.info.nonce = caller_account.info.nonce.saturating_add(1);
         }
+
+        journal.caller_accounting_journal_entry(tx.caller(), old_balance, tx.kind().is_call());
 
         Ok(())
     }

--- a/crates/module-system/module-implementations/sov-evm/src/sov_evm/handler.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/sov_evm/handler.rs
@@ -52,7 +52,6 @@ where
 
         // Touch account so we know it is changed.
         caller_account.mark_touch();
-        // Bump the nonce for calls. Nonce for CREATE will be bumped in `make_create_frame`.
         if tx.kind().is_call() {
             // Nonce is already checked
             caller_account.info.nonce = caller_account.info.nonce.saturating_add(1);

--- a/crates/module-system/module-implementations/sov-evm/src/sov_evm/handler.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/sov_evm/handler.rs
@@ -1,5 +1,9 @@
 use revm::{
-    context::result::{EVMError, HaltReason, InvalidTransaction},
+    context::{
+        self,
+        result::{EVMError, HaltReason, InvalidTransaction},
+        Transaction,
+    },
     context_interface::{ContextTr, JournalTr},
     handler::{
         evm::FrameTr, instructions::InstructionProvider, EvmTr, FrameResult, Handler,
@@ -38,8 +42,19 @@ where
 
     fn validate_against_state_and_deduct_caller(
         &self,
-        _evm: &mut Self::Evm,
+        evm: &mut Self::Evm,
     ) -> Result<(), Self::Error> {
+        let context = evm.ctx();
+        let (tx, journal) = context.tx_journal_mut();
+
+        // Load caller's account.
+        let caller_account = journal.load_account_code(tx.caller())?.data;
+        // Bump the nonce for calls. Nonce for CREATE will be bumped in `make_create_frame`.
+        if tx.kind().is_call() {
+            // Nonce is already checked
+            caller_account.info.nonce = caller_account.info.nonce.saturating_add(1);
+        }
+
         Ok(())
     }
 

--- a/crates/module-system/module-implementations/sov-evm/src/sov_evm/handler.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/sov_evm/handler.rs
@@ -49,6 +49,9 @@ where
 
         // Load caller's account.
         let caller_account = journal.load_account_code(tx.caller())?.data;
+
+        // Touch account so we know it is changed.
+        caller_account.mark_touch();
         // Bump the nonce for calls. Nonce for CREATE will be bumped in `make_create_frame`.
         if tx.kind().is_call() {
             // Nonce is already checked

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
@@ -93,7 +93,7 @@ pub(crate) fn create_transfer_tx(
         nonce,
         ..Default::default()
     };
-    create_evm_tx(from, tx)
+    create_tx(from, tx)
 }
 
 pub(crate) fn create_deploy_tx(
@@ -106,7 +106,7 @@ pub(crate) fn create_deploy_tx(
         nonce,
         ..Default::default()
     };
-    create_evm_tx(account, tx)
+    create_tx(account, tx)
 }
 
 pub(crate) fn create_set_arg_tx(
@@ -122,10 +122,10 @@ pub(crate) fn create_set_arg_tx(
         nonce,
         ..Default::default()
     };
-    create_evm_tx(account, tx)
+    create_tx(account, tx)
 }
 
-fn create_evm_tx(account: &EvmAccount, tx: TxEip1559) -> TransactionType<RT, S> {
+fn create_tx(account: &EvmAccount, tx: TxEip1559) -> TransactionType<RT, S> {
     let tx_with_defaults = TxEip1559 {
         gas_limit: 1_000_000,
         max_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128 * 2,

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
@@ -93,7 +93,7 @@ pub(crate) fn create_transfer_tx(
         nonce,
         ..Default::default()
     };
-    create_tx(from, tx)
+    create_evm_tx(from, tx)
 }
 
 pub(crate) fn create_deploy_tx(
@@ -106,7 +106,7 @@ pub(crate) fn create_deploy_tx(
         nonce,
         ..Default::default()
     };
-    create_tx(account, tx)
+    create_evm_tx(account, tx)
 }
 
 pub(crate) fn create_set_arg_tx(
@@ -122,10 +122,10 @@ pub(crate) fn create_set_arg_tx(
         nonce,
         ..Default::default()
     };
-    create_tx(account, tx)
+    create_evm_tx(account, tx)
 }
 
-fn create_tx(account: &EvmAccount, tx: TxEip1559) -> TransactionType<RT, S> {
+fn create_evm_tx(account: &EvmAccount, tx: TxEip1559) -> TransactionType<RT, S> {
     let tx_with_defaults = TxEip1559 {
         gas_limit: 1_000_000,
         max_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128 * 2,

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
@@ -11,11 +11,11 @@ fn simple_transfer() {
     let (mut runner, from, to) = setup();
 
     let value = 1;
-    let create_contract_tx = create_transfer_tx(0, &from, &to, value);
+    let transfer_tx = create_transfer_tx(0, &from, &to, value);
 
     let evm = Evm::<S>::default();
     runner.execute_transaction(TransactionTestCase {
-        input: create_contract_tx,
+        input: transfer_tx,
         assert: Box::new(move |ctx, state| {
             let mut db = evm.get_db(state);
             let from_acc = db.basic(from.address()).unwrap().unwrap();

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
@@ -7,7 +7,7 @@ use sov_test_utils::{BatchTestCase, SimpleStorageContract};
 use sov_test_utils::{TransactionTestCase, TEST_DEFAULT_USER_BALANCE};
 
 #[test]
-fn simple_transfer() {
+fn test_simple_transfer() {
     let (mut runner, from, to) = setup();
 
     let value = 1;
@@ -19,6 +19,7 @@ fn simple_transfer() {
         assert: Box::new(move |ctx, state| {
             let mut db = evm.get_db(state);
             let from_acc = db.basic(from.address()).unwrap().unwrap();
+
             let to_acc = db.basic(to.address()).unwrap().unwrap();
             // The only balance changes should be from the trasfer itself and not from gas as it's disabled in SovEvm
             assert_eq!(

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
@@ -101,3 +101,33 @@ fn test_failed_tx_doesnt_update_evm_module_state() {
         }),
     });
 }
+
+#[test]
+fn test_account_nonce() {
+    let (mut runner, from, to) = setup();
+
+    let from_addr = from.address();
+    let value = 1;
+    let transfer_tx = create_transfer_tx(0, &from, &to, value);
+
+    runner.execute_transaction(TransactionTestCase {
+        input: transfer_tx,
+        assert: Box::new(move |_ctx, state| {
+            let evm = Evm::<S>::default();
+            let mut db = evm.get_db(state);
+            let from_acc = db.basic(from_addr).unwrap().unwrap();
+            assert_eq!(from_acc.nonce, 1);
+        }),
+    });
+
+    let transfer_tx = create_transfer_tx(1, &from, &to, value);
+    runner.execute_transaction(TransactionTestCase {
+        input: transfer_tx,
+        assert: Box::new(move |_ctx, state| {
+            let evm = Evm::<S>::default();
+            let mut db = evm.get_db(state);
+            let from_acc = db.basic(from_addr).unwrap().unwrap();
+            assert_eq!(from_acc.nonce, 2);
+        }),
+    });
+}

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
@@ -19,7 +19,6 @@ fn test_simple_transfer() {
         assert: Box::new(move |ctx, state| {
             let mut db = evm.get_db(state);
             let from_acc = db.basic(from.address()).unwrap().unwrap();
-
             let to_acc = db.basic(to.address()).unwrap().unwrap();
             // The only balance changes should be from the trasfer itself and not from gas as it's disabled in SovEvm
             assert_eq!(

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
@@ -109,10 +109,10 @@ fn test_account_nonce() {
     let value = 1;
     let transfer_tx = create_transfer_tx(0, &from, &to, value);
 
+    let evm = Evm::<S>::default();
     runner.execute_transaction(TransactionTestCase {
         input: transfer_tx,
         assert: Box::new(move |_ctx, state| {
-            let evm = Evm::<S>::default();
             let mut db = evm.get_db(state);
             let from_acc = db.basic(from_addr).unwrap().unwrap();
             assert_eq!(from_acc.nonce, 1);
@@ -120,10 +120,11 @@ fn test_account_nonce() {
     });
 
     let transfer_tx = create_transfer_tx(1, &from, &to, value);
+
+    let evm = Evm::<S>::default();
     runner.execute_transaction(TransactionTestCase {
         input: transfer_tx,
         assert: Box::new(move |_ctx, state| {
-            let evm = Evm::<S>::default();
             let mut db = evm.get_db(state);
             let from_acc = db.basic(from_addr).unwrap().unwrap();
             assert_eq!(from_acc.nonce, 2);


### PR DESCRIPTION
# Description

This PR includes the following changes:
1. General cleanup and renaming
2. Updates `validate_against_state_and_deduct_caller` to handle nonce updates (based on the original revm implementation)
3.  Adds a nonce test

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
