### PR TITLE
fix: remove unused import

### DIFF
--- a/crates/adapters/mock-zkvm/src/crypto.rs
+++ b/crates/adapters/mock-zkvm/src/crypto.rs
@@ -1,5 +1,4 @@
 //! Cryptography for general purpose use
-use std::hash::Hash;
 #[cfg(feature = "native")]
 use std::str::FromStr;
 


### PR DESCRIPTION
use std::hash::Hash;
Import isn't needed for #[derive(Hash)] and it's not used anywhere