### PR TITLE
Add `wait_for_sequencer_ready()` to TestRollup to reduce flakiness

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -659,8 +659,9 @@ async fn flaky_seq_behind_deferred_slots_count_simple_lagging() {
     tracing::info!("Producing DA blocks to let the sequencer resync.");
     for _ in 0..10 {
         let _ = da_layer.produce_block().await;
-        sleep(Duration::from_millis(100)).await; // Notifications don't work during recovery.
+        sleep(Duration::from_millis(50)).await; // Notifications don't work during recovery.
     }
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer
     // This transaction will be soft-confirmed. The assertion should pass at this stage.
@@ -807,6 +808,7 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
         test_rollup.da_service.produce_block_now().await.unwrap();
         sleep(Duration::from_millis(50)).await;
     }
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer
     client

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -806,7 +806,7 @@ where
             }
         };
 
-        timeout(Duration::from_secs(10), wait_loop)
+        timeout(Duration::from_secs(20), wait_loop)
             .await
             .context("Timeout waiting for sequencer to be ready after 10 seconds")?
     }

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -791,6 +791,26 @@ where
             .await
     }
 
+    /// Polls the sequencer until is_ready() returns Ok(()).
+    pub async fn wait_for_sequencer_ready(&self) -> anyhow::Result<()> {
+        let wait_loop = async {
+            loop {
+                match self.client.http_get("/sequencer/ready").await {
+                    Ok(_) => {
+                        return Ok(());
+                    }
+                    Err(_) => {
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    }
+                }
+            }
+        };
+
+        timeout(Duration::from_secs(10), wait_loop)
+            .await
+            .context("Timeout waiting for sequencer to be ready after 10 seconds")?
+    }
+
     /// Restarts the rollup.
     pub async fn restart(self) -> anyhow::Result<Self> {
         self.restart_with_heights(None, None).await
@@ -812,7 +832,9 @@ where
             c.start_at_rollup_height = start_at_height;
             c.stop_at_rollup_height = stop_at_height;
         });
-        builder.start().await
+        let rollup = builder.start().await?;
+        rollup.wait_for_sequencer_ready().await?;
+        Ok(rollup)
     }
 
     /// Wait until sequencer reaches a specific height.

--- a/examples/demo-rollup/tests/bank/op_rollup/bank_periodic_da_tests.rs
+++ b/examples/demo-rollup/tests/bank/op_rollup/bank_periodic_da_tests.rs
@@ -49,6 +49,8 @@ async fn bank_tx_periodic_da_tests() -> anyhow::Result<()> {
         .await
         .unwrap();
 
+    test_rollup.wait_for_sequencer_ready().await?;
+
     // If the rollup throws an error, return it and stop trying to send the transaction
     tokio::select! {
         err = test_rollup.rollup_task => err?,


### PR DESCRIPTION
# Description

And experimentally adds it to TestRollup::restart(), to see how it affects CI and whether it hopefully reduces flakiness.

- [ ] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] ~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
