### PR TITLE
Simplify EVM executor

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -56,7 +56,7 @@ where
         let evm_db: EvmDb<_, S> = self.get_db(state);
 
         let result =
-            executor::execute_tx(account_nonce, evm_db, &block_env, &evm_tx, signer, cfg_env);
+            executor::transact_commit(account_nonce, evm_db, &block_env, &evm_tx, signer, cfg_env);
 
         let previous_transaction = self.pending_transactions.last(state)?;
         let previous_transaction_cumulative_gas_used = previous_transaction

--- a/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -1,14 +1,12 @@
 use alloy_primitives::Address;
 use reth_primitives::TransactionSigned;
 use reth_revm::db::DBErrorMarker;
-#[cfg(feature = "native")]
-use revm::context::{result::ResultAndState, TxEnv};
+use revm::context::TxEnv;
 use revm::{
     context::{
-        result::{EVMError, ExecutionResult},
-        BlockEnv, CfgEnv, Context, ContextTr,
+        result::{EVMError, ExecResultAndState, ExecutionResult},
+        BlockEnv, CfgEnv, Context,
     },
-    handler::EvmTr,
     Database, ExecuteEvm, MainContext,
 };
 
@@ -33,46 +31,48 @@ pub(crate) fn get_cfg_env(
 }
 
 /// Execute an Ethereum transaction and commit it to the database.
-pub fn execute_tx<DB: Database<Error = E> + FallibleDatabaseCommit<Error = E>, E: DBErrorMarker>(
+pub fn transact_commit<
+    DB: Database<Error = E> + FallibleDatabaseCommit<Error = E>,
+    E: DBErrorMarker,
+>(
     account_nonce: u64,
-    db: DB,
+    mut db: DB,
     block_env: &BlockEnv,
     tx: &TransactionSigned,
     signer: Address,
     cfg: CfgEnv,
 ) -> Result<ExecutionResult, EVMError<E>> {
     let tx_env = create_tx_env(account_nonce, tx, signer);
+    let ExecResultAndState { result, state } = transact(&mut db, block_env, tx_env, cfg)?;
+    db.commit(state)?;
+    Ok(result)
+}
+
+#[cfg(feature = "native")]
+pub(crate) fn call<DB: Database<Error = E>, E: DBErrorMarker>(
+    mut db: DB,
+    block_env: &BlockEnv,
+    tx: TxEnv,
+    cfg: CfgEnv,
+) -> Result<ExecutionResult, EVMError<E>> {
+    Ok(transact(&mut db, block_env, tx, cfg)?.result)
+}
+
+fn transact<DB: Database<Error = E>, E: DBErrorMarker>(
+    db: &mut DB,
+    block_env: &BlockEnv,
+    tx: TxEnv,
+    cfg: CfgEnv,
+) -> Result<ExecResultAndState<ExecutionResult>, EVMError<E>> {
     let context = Context::mainnet()
         .with_db(db)
         .with_block(block_env)
         .with_cfg(cfg);
     let mut evm = SovEvm::new(context, ());
     // We don't use transact_commit as it does not support returning an error
-    let result = evm.transact_one(tx_env)?;
-    let changes = evm.finalize();
-    evm.ctx().db_mut().commit(changes)?;
-    Ok(result)
-}
-
-#[cfg(feature = "native")]
-pub(crate) fn inspect<DB: Database<Error = E>, E>(
-    db: DB,
-    block_env: &BlockEnv,
-    tx: TxEnv,
-    cfg: CfgEnv,
-) -> Result<ResultAndState, EVMError<E>> {
-    use revm::InspectEvm;
-
-    let config = revm_inspectors::tracing::TracingInspectorConfig::all();
-    let inspector = revm_inspectors::tracing::TracingInspector::new(config);
-
-    let context = Context::mainnet()
-        .with_db(db)
-        .with_block(block_env)
-        .with_cfg(cfg);
-    let mut evm = SovEvm::new(context, inspector);
-
-    evm.inspect_tx(tx)
+    let result = evm.transact_one(tx)?;
+    let state = evm.finalize();
+    Ok(ExecResultAndState::new(result, state))
 }
 
 #[cfg(test)]

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -337,8 +337,8 @@ where
 
         let evm_db: EvmDb<_, S> = self.get_db(state);
 
-        let result = match executor::inspect(evm_db, &block_env, tx_env, cfg_env) {
-            Ok(result) => result.result,
+        let result = match executor::call(evm_db, &block_env, tx_env, cfg_env) {
+            Ok(result) => result,
             Err(err) => return Err(eth_api_into_rpc_error(eth_from_evm_error(err))),
         };
 
@@ -435,7 +435,7 @@ where
         let evm_db = self.get_db(state);
 
         // execute the call without writing to db
-        let result = executor::inspect(evm_db, &block_env, tx_env.clone(), cfg_env.clone());
+        let result = executor::call(evm_db, &block_env, tx_env.clone(), cfg_env.clone());
 
         // Exceptional case: init used too much gas, we need to increase the gas limit and try
         // again
@@ -452,8 +452,8 @@ where
         }
 
         let result = match result {
-            Ok(result) => match result.result {
-                ExecutionResult::Success { .. } => result.result,
+            Ok(result) => match result {
+                ExecutionResult::Success { .. } => result,
                 ExecutionResult::Halt { reason, gas_used } => {
                     return Err(invalid_tx_into_rpc_error(RpcInvalidTransactionError::halt(
                         reason, gas_used,
@@ -582,7 +582,7 @@ where
             tx_env.gas_limit = mid_gas_limit;
 
             let evm_db = self.get_db(state);
-            let result = executor::inspect(evm_db, block_env, tx_env.clone(), cfg_env.clone());
+            let result = executor::call(evm_db, block_env, tx_env.clone(), cfg_env.clone());
 
             // Exceptional case: init used too much gas, we need to increase the gas limit and try
             // again
@@ -598,7 +598,7 @@ where
             }
 
             match result {
-                Ok(result) => match result.result {
+                Ok(result) => match result {
                     ExecutionResult::Success { .. } => {
                         // cap the highest gas limit with succeeding gas limit
                         highest_gas_limit = mid_gas_limit;
@@ -719,8 +719,8 @@ where
 {
     let req_gas_limit = tx_env.gas_limit;
     tx_env.gas_limit = block_env.gas_limit;
-    let res = executor::inspect(db, &block_env, tx_env, cfg_env).unwrap();
-    match res.result {
+    let res = executor::call(db, &block_env, tx_env, cfg_env).unwrap();
+    match res {
         ExecutionResult::Success { .. } => {
             // a transaction succeeded by manually increasing the gas limit to
             // highest, which means the caller lacks funds to pay for the tx

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/contracts.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/contracts.rs
@@ -55,7 +55,7 @@ fn test_invalid_contract_execution() {
         let (signed_eth_tx, _) = account.sign(tx_request);
         let cfg_env =
             CfgEnv::new_with_spec(SpecId::SHANGHAI).with_chain_id(config_value!("CHAIN_ID"));
-        let result = executor::execute_tx(
+        let result = executor::transact_commit(
             1,
             evm_db,
             &BlockEnv::default(),


### PR DESCRIPTION
# Description

So we used to have two functions. `inspect_tx` and `transact`.
`inspect_tx` was used in RPC to simulate execution without recording state changes. For whatever reason it also created inspectors and ignored them later.
`transact` was comiting the changes.
Also both functions created EVM and Context.

This PR simplifies it. We now have two public functions (transact_commit and call) that use common helper under the hood.
One discards the state and another one commits it.

This is in preparation for the SLOAD/SSTORE PR that will introduce the inspector that will refund the gas spent in those opcodes.

----

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
