### PR TITLE
Introduce UnmeteredStorageAccessInspector to not double-charge for storage access

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -2,17 +2,21 @@ use alloy_primitives::Address;
 use reth_primitives::TransactionSigned;
 use reth_revm::db::DBErrorMarker;
 use revm::context::TxEnv;
+use revm::InspectEvm;
 use revm::{
     context::{
         result::{EVMError, ExecResultAndState, ExecutionResult},
         BlockEnv, CfgEnv, Context,
     },
-    Database, ExecuteEvm, MainContext,
+    Database, MainContext,
 };
 
 use crate::{
-    db::commit::FallibleDatabaseCommit, evm::conversions::create_tx_env, get_spec_id,
-    sov_evm::SovEvm, EvmRuntimeConfig,
+    db::commit::FallibleDatabaseCommit,
+    evm::conversions::create_tx_env,
+    get_spec_id,
+    sov_evm::{SovEvm, UnmeteredStorageAccessInspector},
+    EvmRuntimeConfig,
 };
 
 /// builds CfgEnv
@@ -44,6 +48,7 @@ pub fn transact_commit<
 ) -> Result<ExecutionResult, EVMError<E>> {
     let tx_env = create_tx_env(account_nonce, tx, signer);
     let ExecResultAndState { result, state } = transact(&mut db, block_env, tx_env, cfg)?;
+    // We don't use transact_commit as it does not support returning an error
     db.commit(state)?;
     Ok(result)
 }
@@ -68,11 +73,9 @@ fn transact<DB: Database<Error = E>, E: DBErrorMarker>(
         .with_db(db)
         .with_block(block_env)
         .with_cfg(cfg);
-    let mut evm = SovEvm::new(context, ());
-    // We don't use transact_commit as it does not support returning an error
-    let result = evm.transact_one(tx)?;
-    let state = evm.finalize();
-    Ok(ExecResultAndState::new(result, state))
+    let inspector = UnmeteredStorageAccessInspector::new();
+    let mut evm = SovEvm::new(context, inspector);
+    evm.inspect_tx(tx)
 }
 
 #[cfg(test)]

--- a/crates/module-system/module-implementations/sov-evm/src/sov_evm/inspector.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/sov_evm/inspector.rs
@@ -8,8 +8,8 @@ use revm::{
 /// An Inspector that erases the costs of storage access
 #[derive(Clone, Debug, Default)]
 pub struct UnmeteredStorageAccessInspector {
-    /// Keep track of the last opcode executed and the remaining gas
-    last_opcode_gas_remaining: Option<(OpCode, u64)>,
+    /// Keep track of the remaining gas before opcode execution
+    last_gas_remaining: Option<u64>,
 }
 
 impl UnmeteredStorageAccessInspector {
@@ -23,20 +23,20 @@ where
     CTX: ContextTr,
 {
     fn step(&mut self, interp: &mut Interpreter, _: &mut CTX) {
-        if let Some(opcode) = OpCode::new(interp.bytecode.opcode()) {
-            // keep track of the last opcode executed
-            self.last_opcode_gas_remaining = Some((opcode, interp.gas.remaining()));
-        }
+        self.last_gas_remaining = Some(interp.gas.remaining());
     }
 
     fn step_end(&mut self, interp: &mut Interpreter, _: &mut CTX) {
-        if let Some((opcode, gas_remaining)) = self.last_opcode_gas_remaining.take() {
-            // compute gas usage for the last opcode
+        let gas_remaining = self
+            .last_gas_remaining
+            .take()
+            .expect("step() is always called before step_end()");
+        // if storage access - revert gas changes
+        let opcode = OpCode::new(interp.bytecode.opcode());
+        if opcode == Some(OpCode::SSTORE) || opcode == Some(OpCode::SLOAD) {
+            // compute gas usage for the opcode
             let gas_cost = gas_remaining.saturating_sub(interp.gas.remaining());
-            // if storage access - revert gas changes
-            if opcode == OpCode::SSTORE || opcode == OpCode::SLOAD {
-                interp.gas.erase_cost(gas_cost);
-            }
+            interp.gas.erase_cost(gas_cost);
         }
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/sov_evm/inspector.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/sov_evm/inspector.rs
@@ -1,0 +1,42 @@
+use revm::{
+    bytecode::opcode::OpCode,
+    context::ContextTr,
+    interpreter::{interpreter_types::Jumps, Interpreter},
+    Inspector,
+};
+
+/// An Inspector that erases the costs of storage access
+#[derive(Clone, Debug, Default)]
+pub struct UnmeteredStorageAccessInspector {
+    /// Keep track of the last opcode executed and the remaining gas
+    last_opcode_gas_remaining: Option<(OpCode, u64)>,
+}
+
+impl UnmeteredStorageAccessInspector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<CTX> Inspector<CTX> for UnmeteredStorageAccessInspector
+where
+    CTX: ContextTr,
+{
+    fn step(&mut self, interp: &mut Interpreter, _: &mut CTX) {
+        if let Some(opcode) = OpCode::new(interp.bytecode.opcode()) {
+            // keep track of the last opcode executed
+            self.last_opcode_gas_remaining = Some((opcode, interp.gas.remaining()));
+        }
+    }
+
+    fn step_end(&mut self, interp: &mut Interpreter, _: &mut CTX) {
+        if let Some((opcode, gas_remaining)) = self.last_opcode_gas_remaining.take() {
+            // compute gas usage for the last opcode
+            let gas_cost = gas_remaining.saturating_sub(interp.gas.remaining());
+            // if storage access - revert gas changes
+            if opcode == OpCode::SSTORE || opcode == OpCode::SLOAD {
+                interp.gas.erase_cost(gas_cost);
+            }
+        }
+    }
+}

--- a/crates/module-system/module-implementations/sov-evm/src/sov_evm/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/sov_evm/mod.rs
@@ -3,5 +3,7 @@
 mod api;
 mod evm;
 mod handler;
+mod inspector;
 
 pub use evm::SovEvm;
+pub use inspector::UnmeteredStorageAccessInspector;


### PR DESCRIPTION
# Description

  This PR introduces a new REVM inspector that removes gas costs for storage access operations (SLOAD and
  SSTORE). This allows us to not double-charge for storage.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
