### PR TITLE
Add support for transaction receipts from pending blocks

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -123,6 +123,35 @@ where
         self.pending_transactions
             .push(&pending_transaction, state)?;
 
+        #[cfg(feature = "native")]
+        {
+            let head = self.head.get(state)?.unwrap();
+            let first_tx_index = head.transactions.end;
+
+            let pending_len = self.pending_transactions.len(state)?;
+
+            let tx_index = first_tx_index + pending_len - 1;
+
+            self.transactions
+                .set(&tx_index, &pending_transaction.transaction, state)?;
+
+            self.receipts
+                .set(&tx_index, &pending_transaction.receipt, state)?;
+
+            let hash = pending_transaction.transaction.signed_transaction.hash();
+            self.transaction_hashes.set(hash, &tx_index, state)?;
+
+            /*
+            self.receipts
+                .push_accessory(&pending_transaction.receipt, state)?;
+            self.transactions
+                .push_accessory(&pending_transaction.transaction, state)?;
+            let hash = pending_transaction.transaction.signed_transaction.hash();
+            self.transaction_hashes
+                .set(hash, &current_tx_number, state)?;
+            */
+        }
+
         Ok(())
     }
 

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -1,10 +1,3 @@
-use alloy_primitives::Address;
-use reth_primitives::TransactionSigned;
-use revm::context::result::EVMError;
-use sov_address::{EthereumAddress, FromVmAddress};
-use sov_modules_api::macros::{serialize, UniversalWallet};
-use sov_modules_api::{Context, Spec, TxState};
-
 use crate::conversions::convert_to_transaction_signed;
 use crate::db::EvmDb;
 use crate::evm::executor::{self};
@@ -12,6 +5,14 @@ use crate::evm::primitive_types::{Receipt, TransactionSignedAndRecovered};
 use crate::evm::RlpEvmTransaction;
 use crate::executor::get_cfg_env;
 use crate::{Evm, PendingTransaction, SpecId};
+use alloy_primitives::Address;
+use reth_primitives::TransactionSigned;
+use revm::context::result::EVMError;
+use sov_address::{EthereumAddress, FromVmAddress};
+use sov_modules_api::macros::{serialize, UniversalWallet};
+#[cfg(feature = "native")]
+use sov_modules_api::prelude::UnwrapInfallible;
+use sov_modules_api::{Context, Spec, TxState};
 
 /// EVM call message.
 #[derive(Debug, PartialEq, Eq, Clone, schemars::JsonSchema, UniversalWallet)]
@@ -123,23 +124,34 @@ where
         self.pending_transactions
             .push(&pending_transaction, state)?;
 
+        // Fetch `head` and `pending_len` before the `native` code block.
+        // This ensures consistent gas charges between native and non-native execution.
+        #[allow(unused_variables)]
+        let head = self
+            .head
+            .get(state)?
+            .expect("Impossible happened: Head must be set.");
+
+        #[allow(unused_variables)]
+        let pending_len = self.pending_transactions.len(state)?;
+
         #[cfg(feature = "native")]
         {
-            let head = self.head.get(state)?.unwrap();
             let first_tx_index = head.transactions.end;
-
-            let pending_len = self.pending_transactions.len(state)?;
-
             let tx_index = first_tx_index + pending_len - 1;
 
             self.transactions
-                .set(&tx_index, &pending_transaction.transaction, state)?;
+                .set(&tx_index, &pending_transaction.transaction, state)
+                .unwrap_infallible();
 
             self.receipts
-                .set(&tx_index, &pending_transaction.receipt, state)?;
+                .set(&tx_index, &pending_transaction.receipt, state)
+                .unwrap_infallible();
 
             let hash = pending_transaction.transaction.signed_transaction.hash();
-            self.transaction_hashes.set(hash, &tx_index, state)?;
+            self.transaction_hashes
+                .set(hash, &tx_index, state)
+                .unwrap_infallible();
         }
 
         Ok(())

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -140,16 +140,6 @@ where
 
             let hash = pending_transaction.transaction.signed_transaction.hash();
             self.transaction_hashes.set(hash, &tx_index, state)?;
-
-            /*
-            self.receipts
-                .push_accessory(&pending_transaction.receipt, state)?;
-            self.transactions
-                .push_accessory(&pending_transaction.transaction, state)?;
-            let hash = pending_transaction.transaction.signed_transaction.hash();
-            self.transaction_hashes
-                .set(hash, &current_tx_number, state)?;
-            */
         }
 
         Ok(())

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use std::ops::Range;
 
 use alloy_consensus::{

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::ops::Range;
 
 use alloy_consensus::{
@@ -139,6 +140,61 @@ impl<'de> serde::Deserialize<'de> for SealedBlock {
             header: Sealed::new_unchecked(header, seal),
             transactions,
         })
+    }
+}
+
+#[cfg(feature = "native")]
+pub(crate) enum MaybeSealedBlock {
+    Sealed(Box<SealedBlock>),
+    Pending {
+        block_number: u64,
+        first_tx_number: u64,
+        base_fee_per_gas: u64,
+    },
+}
+
+#[cfg(feature = "native")]
+impl MaybeSealedBlock {
+    pub fn hash(&self) -> Option<B256> {
+        match self {
+            Self::Sealed(block) => Some(block.header.hash()),
+            Self::Pending { .. } => None,
+        }
+    }
+
+    pub fn number(&self) -> u64 {
+        match self {
+            Self::Sealed(block) => block.header.number,
+            Self::Pending { block_number, .. } => *block_number,
+        }
+    }
+
+    pub fn transactions_start(&self) -> u64 {
+        match self {
+            Self::Sealed(block) => block.transactions.start,
+            Self::Pending {
+                first_tx_number, ..
+            } => *first_tx_number,
+        }
+    }
+
+    pub fn timestamp(&self) -> Option<u64> {
+        match self {
+            Self::Sealed(block) => Some(block.header.timestamp),
+            Self::Pending { .. } => None,
+        }
+    }
+
+    pub fn base_fee_per_gas(&self) -> u64 {
+        match self {
+            Self::Sealed(block) => block
+                .header
+                .base_fee_per_gas
+                .expect("Legacy blocks with no base fee are unsupported"),
+            Self::Pending {
+                base_fee_per_gas, ..
+            } => *base_fee_per_gas,
+        }
     }
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -153,6 +153,7 @@ impl<S: Spec> BlockHooks for Evm<S> {
                 .set(&block, &mut accessory_state)
                 .unwrap_infallible();
 
+            /*
             let mut tx_index = start_tx_index;
             for PendingTransaction {
                 transaction,
@@ -176,6 +177,7 @@ impl<S: Spec> BlockHooks for Evm<S> {
 
                 tx_index += 1;
             }
+            */
         }
 
         self.pending_transactions.clear(state).unwrap_infallible();

--- a/crates/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -152,32 +152,6 @@ impl<S: Spec> BlockHooks for Evm<S> {
             self.pending_head
                 .set(&block, &mut accessory_state)
                 .unwrap_infallible();
-
-            /*
-            let mut tx_index = start_tx_index;
-            for PendingTransaction {
-                transaction,
-                receipt,
-            } in &pending_transactions
-            {
-                self.transactions
-                    .set(&tx_index, transaction, &mut accessory_state)
-                    .unwrap_infallible();
-                self.receipts
-                    .set(&tx_index, receipt, &mut accessory_state)
-                    .unwrap_infallible();
-
-                self.transaction_hashes
-                    .set(
-                        transaction.signed_transaction.hash(),
-                        &tx_index,
-                        &mut accessory_state,
-                    )
-                    .unwrap_infallible();
-
-                tx_index += 1;
-            }
-            */
         }
 
         self.pending_transactions.clear(state).unwrap_infallible();

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_consensus::{Transaction as TransactionTrait, TxReceipt};
 use alloy_primitives::{Address, U64};
@@ -302,17 +303,28 @@ where
             "EVM module JSON-RPC request to `eth_getTransactionReceipt`"
         );
 
-        let tx_number = self.get_tx_index_by_hash(&hash, state);
+        //let tx_number = self.get_tx_index_by_hash(&hash, state);
 
+        /*
         let receipt = tx_number.map(|number| {
             let tx = self.transaction(number, state).unwrap();
             let block = self.block(tx.block_number, state);
             let receipt = self.receipt(tx_number.unwrap(), state).unwrap();
 
             build_rpc_receipt(block, tx, tx_number.unwrap(), receipt)
-        });
+        });*/
 
-        Ok(receipt)
+        let Some(number) = self.get_tx_index_by_hash(&hash, state) else {
+            return Ok(None);
+        };
+
+        let tx = self.transaction(number, state).unwrap();
+        // The block may be `None` for a few seconds after the tx is processed
+        let block = self.get_maybe_sealed_block(&tx, state);
+        let receipt = self.receipt(number, state).unwrap();
+        let receipt = build_rpc_receipt2(block, tx, number, receipt);
+
+        Ok(Some(receipt))
     }
 
     /// Handler for: `eth_call`
@@ -498,10 +510,42 @@ where
     }
 }
 
+use crate::primitive_types::MaybeSealedBlock;
+
 impl<S: Spec> Evm<S>
 where
     S::Address: FromVmAddress<EthereumAddress>,
 {
+    fn get_maybe_sealed_block(
+        &self,
+        tx: &TransactionSignedAndRecovered,
+        state: &mut ApiStateAccessor<S>,
+    ) -> MaybeSealedBlock {
+        let block = self.blocks.get(&tx.block_number, state).unwrap_infallible();
+        if let Some(block) = block {
+            return MaybeSealedBlock::Sealed(block.into());
+        }
+        let current_block_env = self
+            .block_env
+            .get(state)
+            .unwrap_infallible()
+            .unwrap_or_default();
+        let block_num: u64 = current_block_env
+            .number
+            .try_into()
+            .expect("Block number is too large to fit in a u64. It's over!");
+        assert_eq!(block_num, tx.block_number, "Transaction is in a block that is not yet sealed, but that block is not yet pending! This is impossible!");
+
+        let head = self.head.get(state).unwrap_infallible().unwrap();
+        let first_tx_index = head.transactions.end;
+
+        MaybeSealedBlock::Pending {
+            block_number: tx.block_number,
+            first_tx_number: first_tx_index,
+            base_fee_per_gas: current_block_env.basefee,
+        }
+    }
+
     fn get_sealed_block_by_number(
         &self,
         block_number: Option<String>,
@@ -711,6 +755,69 @@ pub(crate) fn build_rpc_receipt(
         block_number,
         gas_used: receipt.gas_used,
         effective_gas_price: transaction.effective_gas_price(block.header.base_fee_per_gas),
+        blob_gas_used: None,
+        blob_gas_price: None,
+        from,
+        to,
+        contract_address,
+    }
+}
+
+pub(crate) fn build_rpc_receipt2(
+    block: MaybeSealedBlock,
+    tx: TransactionSignedAndRecovered,
+    tx_number: u64,
+    receipt: Receipt,
+) -> TransactionReceipt {
+    let transaction: Recovered<TransactionSigned> = tx.into();
+    let from = transaction.signer();
+
+    let block_hash = block.hash();
+    let block_number = Some(block.number());
+    let transaction_hash = Some(*transaction.hash());
+    // Safety: The transaction cannot have a lower number than the block start
+    let transaction_index = tx_number
+        .checked_sub(block.transactions_start())
+        .expect("Overflow while subtracting block start from tx number. This is a bug!");
+
+    let logs: Vec<Log> = receipt
+        .receipt
+        .logs
+        .iter()
+        .enumerate()
+        .map(|(tx_log_idx, log)| Log {
+            inner: log.clone(),
+            block_hash,
+            block_number,
+            block_timestamp: block.timestamp(),
+            transaction_hash,
+            transaction_index: Some(transaction_index),
+            log_index: Some(receipt.log_index_start + tx_log_idx as u64),
+            removed: false,
+        })
+        .collect();
+
+    let logs_bloom = receipt.receipt.bloom();
+
+    let rpc_receipt = alloy_rpc_types::Receipt {
+        status: receipt.receipt.success.into(),
+        cumulative_gas_used: receipt.receipt.cumulative_gas_used,
+        logs,
+    };
+
+    let (contract_address, to) = match transaction.kind() {
+        TxKind::Create => (Some(from.create(transaction.nonce())), None),
+        TxKind::Call(addr) => (None, Some(Address(*addr))),
+    };
+
+    TransactionReceipt {
+        inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom::new(rpc_receipt, logs_bloom)),
+        transaction_hash: *transaction.hash(),
+        transaction_index: Some(transaction_index),
+        block_hash,
+        block_number,
+        gas_used: receipt.gas_used,
+        effective_gas_price: transaction.effective_gas_price(Some(block.base_fee_per_gas())),
         blob_gas_used: None,
         blob_gas_price: None,
         from,

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_consensus::{Transaction as TransactionTrait, TxReceipt};
 use alloy_primitives::{Address, U64};
@@ -30,6 +29,7 @@ use crate::executor::get_cfg_env;
 use crate::helpers::{
     from_primitive_with_hash, from_recovered_with_block_context, prepare_call_env,
 };
+use crate::primitive_types::MaybeSealedBlock;
 use crate::{Evm, MIN_CREATE_GAS, MIN_TRANSACTION_GAS};
 
 pub(crate) mod error;
@@ -302,18 +302,6 @@ where
             %hash,
             "EVM module JSON-RPC request to `eth_getTransactionReceipt`"
         );
-
-        //let tx_number = self.get_tx_index_by_hash(&hash, state);
-
-        /*
-        let receipt = tx_number.map(|number| {
-            let tx = self.transaction(number, state).unwrap();
-            let block = self.block(tx.block_number, state);
-            let receipt = self.receipt(tx_number.unwrap(), state).unwrap();
-
-            build_rpc_receipt(block, tx, tx_number.unwrap(), receipt)
-        });*/
-
         let Some(number) = self.get_tx_index_by_hash(&hash, state) else {
             return Ok(None);
         };
@@ -322,7 +310,7 @@ where
         // The block may be `None` for a few seconds after the tx is processed
         let block = self.get_maybe_sealed_block(&tx, state);
         let receipt = self.receipt(number, state).unwrap();
-        let receipt = build_rpc_receipt2(block, tx, number, receipt);
+        let receipt = build_rpc_receipt(block, tx, number, receipt);
 
         Ok(Some(receipt))
     }
@@ -509,8 +497,6 @@ where
         Ok(U64::from(gas_limit))
     }
 }
-
-use crate::primitive_types::MaybeSealedBlock;
 
 impl<S: Spec> Evm<S>
 where
@@ -704,66 +690,6 @@ fn get_cfg_env_template() -> CfgEnv {
 
 // modified from: https://github.com/paradigmxyz/reth many times
 pub(crate) fn build_rpc_receipt(
-    block: SealedBlock,
-    tx: TransactionSignedAndRecovered,
-    tx_number: u64,
-    receipt: Receipt,
-) -> TransactionReceipt {
-    let transaction: Recovered<TransactionSigned> = tx.into();
-    let from = transaction.signer();
-
-    let block_hash = Some(block.header.seal());
-    let block_number = Some(block.header.number);
-    let transaction_hash = Some(*transaction.hash());
-    let transaction_index = tx_number - block.transactions.start;
-
-    let logs: Vec<Log> = receipt
-        .receipt
-        .logs
-        .iter()
-        .enumerate()
-        .map(|(tx_log_idx, log)| Log {
-            inner: log.clone(),
-            block_hash,
-            block_number,
-            block_timestamp: Some(block.header.timestamp),
-            transaction_hash,
-            transaction_index: Some(transaction_index),
-            log_index: Some(receipt.log_index_start + tx_log_idx as u64),
-            removed: false,
-        })
-        .collect();
-
-    let logs_bloom = receipt.receipt.bloom();
-
-    let rpc_receipt = alloy_rpc_types::Receipt {
-        status: receipt.receipt.success.into(),
-        cumulative_gas_used: receipt.receipt.cumulative_gas_used,
-        logs,
-    };
-
-    let (contract_address, to) = match transaction.kind() {
-        TxKind::Create => (Some(from.create(transaction.nonce())), None),
-        TxKind::Call(addr) => (None, Some(Address(*addr))),
-    };
-
-    TransactionReceipt {
-        inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom::new(rpc_receipt, logs_bloom)),
-        transaction_hash: *transaction.hash(),
-        transaction_index: Some(transaction_index),
-        block_hash,
-        block_number,
-        gas_used: receipt.gas_used,
-        effective_gas_price: transaction.effective_gas_price(block.header.base_fee_per_gas),
-        blob_gas_used: None,
-        blob_gas_price: None,
-        from,
-        to,
-        contract_address,
-    }
-}
-
-pub(crate) fn build_rpc_receipt2(
     block: MaybeSealedBlock,
     tx: TransactionSignedAndRecovered,
     tx_number: u64,


### PR DESCRIPTION
# Description

This is a port of #1596.

The main differences: 
1. Transactions & Receipts are kept in Maps rather than Vecs
2. No need for `LiveTxNumbers`

Tests are coming in the follow-up 

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
