### PR TITLE
feat(hexstring): enforce even-length hex in JSON Schema patterns

### DIFF
--- a/crates/rollup-interface/src/common/hex_string.rs
+++ b/crates/rollup-interface/src/common/hex_string.rs
@@ -34,8 +34,8 @@ impl schemars::JsonSchema for HexString {
     fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
         serde_json::from_value(serde_json::json!({
             "type": "string",
-            "pattern": "^0x[a-fA-F0-9]+$",
-            "description": "A `0x`-prefixed hexadecimal string (uppercase or lowercase) of variable length.",
+            "pattern": "^0x(?:[a-fA-F0-9]{2})+$",
+            "description": "A `0x`-prefixed hexadecimal string (uppercase or lowercase) of variable length, with an even number of hex digits.",
         }))
         .unwrap()
     }
@@ -65,7 +65,7 @@ impl<const N: usize> schemars::JsonSchema for HexString<SafeVec<u8, N>> {
     fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
         serde_json::from_value(serde_json::json!({
             "type": "string",
-            "pattern": format!("^0x[a-fA-F0-9]{{0,{}}}$", N * 2),
+            "pattern": format!("^0x(?:[a-fA-F0-9]{{2}}){{0,{}}}$", N),
             "description": format!("At most {} bytes in hexadecimal format, with `0x` prefix.", N),
         }))
         .unwrap()


### PR DESCRIPTION
- Update HexString schema pattern to ^0x(?:[a-fA-F0-9]{2})+$ to ensure even-length hex strings.
- Update HexString<SafeVec<u8, N>> schema pattern to ^0x(?:[a-fA-F0-9]{2}){0,N}$ to cap at N bytes and enforce even-length.