### PR TITLE
Gas limit based on gas and funds

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -5,7 +5,7 @@ use sov_address::{EthereumAddress, FromVmAddress};
 use sov_modules_api::macros::{serialize, UniversalWallet};
 #[cfg(feature = "native")]
 use sov_modules_api::prelude::UnwrapInfallible;
-use sov_modules_api::{Context, GasSpec, Spec, TxState};
+use sov_modules_api::{BasicGasState, Context, GasSpec, Spec, TxState};
 #[cfg(feature = "native")]
 use std::convert::Infallible;
 
@@ -51,10 +51,7 @@ where
         // Inside the EVM, we use nonces only for the CREATE operation.
         // The uniqueness check was performed before the call was dispatched.
         let account_nonce = self.get_account_nonce(signer, state)?;
-        let gas_limit = state
-            .try_as_basic_gas_state()
-            .expect("We should have a BasicGasMeter or it's derivative in tx context")
-            .gas_limit();
+        let gas_limit = self.gas_limit(state);
         let tx_env = create_tx_env(&tx, signer, account_nonce, gas_limit);
 
         let transaction = TransactionSignedAndRecovered {
@@ -114,6 +111,23 @@ where
             .unwrap_infallible();
 
         Ok(())
+    }
+
+    fn gas_limit(&self, state: &mut impl TxState<S>) -> u64 {
+        let BasicGasState { gas, funds, price } = state
+            .try_as_basic_gas_state()
+            .expect("We should have a BasicGasMeter or it's derivative in tx context");
+        let funds = funds.0;
+        let gas = gas.as_ref()[0];
+        let price = price.as_ref()[0].0;
+        match (funds, gas) {
+            (0, 0) => 0,
+            (_, 0) => u64::MAX,
+            (funds, gas) => {
+                let gas_from_funds = (funds / price).min(u64::MAX as u128) as u64;
+                gas.min(gas_from_funds)
+            }
+        }
     }
 
     fn get_receipt(

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -51,7 +51,10 @@ where
         // Inside the EVM, we use nonces only for the CREATE operation.
         // The uniqueness check was performed before the call was dispatched.
         let account_nonce = self.get_account_nonce(signer, state)?;
-        let gas_limit = state.remaining_gas()?.as_ref()[0];
+        let gas_limit = state
+            .try_as_basic_gas_state()
+            .expect("We should have a BasicGasMeter or it's derivative in tx context")
+            .gas_limit();
         let tx_env = create_tx_env(&tx, signer, account_nonce, gas_limit);
 
         let transaction = TransactionSignedAndRecovered {

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
@@ -6,6 +6,7 @@ use alloy_primitives::U256;
 use alloy_rpc_types::BlockTransactions;
 use revm::Database;
 use sov_evm::Evm;
+use sov_modules_api::GasArray;
 use sov_test_utils::TransactionType;
 use sov_test_utils::{BatchTestCase, SimpleStorageContract};
 use sov_test_utils::{TransactionTestCase, TEST_DEFAULT_USER_BALANCE};
@@ -32,6 +33,38 @@ fn test_simple_transfer() {
             assert_eq!(to_acc.balance, value);
         }),
     });
+}
+
+#[test]
+fn test_evm_gas_usage() {
+    std::env::set_var(
+        "SOV_TEST_CONST_OVERRIDE_DEFAULT_GAS_TO_CHARGE_PER_EVM_GAS",
+        "[1, 0]",
+    );
+    let gas_used_with_evm_metering = {
+        let (mut runner, from, to) = setup();
+        let transfer = create_transfer_tx(0, &from, &to, 0).tx;
+        let (receipt, _) = runner.execute(transfer);
+        receipt.last_batch_receipt().inner.gas_used.clone()
+    };
+    std::env::set_var(
+        "SOV_TEST_CONST_OVERRIDE_DEFAULT_GAS_TO_CHARGE_PER_EVM_GAS",
+        "[0, 0]",
+    );
+    let gas_used_without_evm_metering = {
+        let (mut runner, from, to) = setup();
+        let transfer = create_transfer_tx(0, &from, &to, 0).tx;
+        let (receipt, _) = runner.execute(transfer);
+        receipt.last_batch_receipt().inner.gas_used.clone()
+    };
+    const BASE_EVM_GAS: u64 = 21_000;
+    assert_eq!(
+        gas_used_with_evm_metering
+            .checked_sub(&gas_used_without_evm_metering)
+            .unwrap()
+            .as_ref(),
+        &[BASE_EVM_GAS, 0]
+    );
 }
 
 #[test]

--- a/crates/module-system/sov-modules-api/src/gas/mod.rs
+++ b/crates/module-system/sov-modules-api/src/gas/mod.rs
@@ -20,11 +20,4 @@ pub struct UnlimitedGasMeter<S>(PhantomData<S>);
 
 impl<S: Spec> GasMeter for UnlimitedGasMeter<S> {
     type Spec = S;
-
-    fn remaining_gas(
-        &mut self,
-    ) -> anyhow::Result<<Self::Spec as Spec>::Gas, GasMeteringError<<Self::Spec as Spec>::Gas>>
-    {
-        Ok(<S as Spec>::Gas::MAX)
-    }
 }

--- a/crates/module-system/sov-modules-api/src/gas/traits.rs
+++ b/crates/module-system/sov-modules-api/src/gas/traits.rs
@@ -906,7 +906,6 @@ impl<S: Spec> GasMeter for BasicGasMeter<S> {
             gas: self.remaining_gas.clone(),
             funds: self
                 .remaining_funds
-                .clone()
                 .expect("This method is used in TX context where amount is set"),
             price: self.gas_price.clone(),
         })

--- a/crates/module-system/sov-modules-api/src/gas/traits.rs
+++ b/crates/module-system/sov-modules-api/src/gas/traits.rs
@@ -570,13 +570,9 @@ pub trait GasMeter {
         Ok(())
     }
 
-    /// Returns the amount of gas remaining. Used to set the EVM gas limit
-    fn remaining_gas(
-        &mut self,
-    ) -> Result<<Self::Spec as Spec>::Gas, GasMeteringError<<Self::Spec as Spec>::Gas>> {
-        unreachable!(
-            "Default implementation should not be called. Override in the respective gas meter"
-        )
+    /// Returns the basic gas state if it's a BasicGasMeter or contains a BasicGasMeter. Used to set the EVM gas limit
+    fn try_as_basic_gas_state(&mut self) -> Option<BasicGasState<Self::Spec>> {
+        None
     }
 
     /// Tracks the removal of gas consumption pattern.
@@ -905,10 +901,15 @@ impl<S: Spec> GasMeter for BasicGasMeter<S> {
         Ok(())
     }
 
-    fn remaining_gas(
-        &mut self,
-    ) -> Result<<Self::Spec as Spec>::Gas, GasMeteringError<<Self::Spec as Spec>::Gas>> {
-        Ok(self.remaining_gas.clone())
+    fn try_as_basic_gas_state(&mut self) -> Option<BasicGasState<Self::Spec>> {
+        Some(BasicGasState {
+            gas: self.remaining_gas.clone(),
+            funds: self
+                .remaining_funds
+                .clone()
+                .expect("This method is used in TX context where amount is set"),
+            price: self.gas_price.clone(),
+        })
     }
 
     #[cfg(all(feature = "gas-constant-estimation", feature = "native"))]
@@ -941,6 +942,23 @@ impl<S: Spec> GetGasPrice for BasicGasMeter<S> {
     type Spec = S;
     fn gas_price(&self) -> &<<Self::Spec as Spec>::Gas as Gas>::Price {
         &self.gas_price
+    }
+}
+
+/// A subset of BasicGasMeter used to compute EVM gas limit
+pub struct BasicGasState<S: Spec> {
+    gas: S::Gas,
+    funds: Amount,
+    price: <<S as Spec>::Gas as Gas>::Price,
+}
+
+impl<S: Spec> BasicGasState<S> {
+    /// Computes gas limit as a min from gas and funds divided by gas price
+    pub fn gas_limit(&self) -> u64 {
+        min(
+            self.gas.as_ref()[0],
+            (self.funds.0 / self.price.as_ref()[0].0) as u64,
+        )
     }
 }
 

--- a/crates/module-system/sov-modules-api/src/gas/traits.rs
+++ b/crates/module-system/sov-modules-api/src/gas/traits.rs
@@ -946,19 +946,12 @@ impl<S: Spec> GetGasPrice for BasicGasMeter<S> {
 
 /// A subset of BasicGasMeter used to compute EVM gas limit
 pub struct BasicGasState<S: Spec> {
-    gas: S::Gas,
-    funds: Amount,
-    price: <<S as Spec>::Gas as Gas>::Price,
-}
-
-impl<S: Spec> BasicGasState<S> {
-    /// Computes gas limit as a min from gas and funds divided by gas price
-    pub fn gas_limit(&self) -> u64 {
-        min(
-            self.gas.as_ref()[0],
-            (self.funds.0 / self.price.as_ref()[0].0) as u64,
-        )
-    }
+    /// Amount of gas available
+    pub gas: S::Gas,
+    /// Amount of funds available
+    pub funds: Amount,
+    /// Gas price
+    pub price: <<S as Spec>::Gas as Gas>::Price,
 }
 
 #[cfg(test)]

--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad.rs
@@ -18,8 +18,9 @@ use crate::transaction::{
 #[cfg(feature = "test-utils")]
 use crate::{AccessoryStateReader, GasArray};
 use crate::{
-    AccessoryStateWriter, Amount, BasicGasMeter, Gas, GasInfo, GasMeter, GasMeteringError,
-    GetGasPrice, ProvableStateReader, ProvableStateWriter, TxState, VersionReader,
+    AccessoryStateWriter, Amount, BasicGasMeter, BasicGasState, Gas, GasInfo, GasMeter,
+    GasMeteringError, GetGasPrice, ProvableStateReader, ProvableStateWriter, TxState,
+    VersionReader,
 };
 use sov_metrics::{StateAccessMetric, StateMetrics};
 use sov_rollup_interface::common::{SlotNumber, VisibleSlotNumber};
@@ -161,11 +162,8 @@ impl<S: Spec, I: TxState<S>> GasMeter for RevertableTxState<'_, S, I> {
     fn charge_gas(&mut self, amount: &S::Gas) -> Result<(), GasMeteringError<S::Gas>> {
         self.inner.charge_gas(amount)
     }
-    fn remaining_gas(
-        &mut self,
-    ) -> anyhow::Result<<Self::Spec as Spec>::Gas, GasMeteringError<<Self::Spec as Spec>::Gas>>
-    {
-        self.inner.remaining_gas()
+    fn try_as_basic_gas_state(&mut self) -> Option<BasicGasState<Self::Spec>> {
+        self.inner.try_as_basic_gas_state()
     }
 
     fn charge_linear_gas(
@@ -376,11 +374,8 @@ impl<S: Spec, I: StateProvider<S>> GasMeter for PreExecWorkingSet<S, I> {
     fn charge_gas(&mut self, amount: &S::Gas) -> anyhow::Result<(), GasMeteringError<S::Gas>> {
         self.gas_meter.charge_gas(amount)
     }
-    fn remaining_gas(
-        &mut self,
-    ) -> anyhow::Result<<Self::Spec as Spec>::Gas, GasMeteringError<<Self::Spec as Spec>::Gas>>
-    {
-        self.gas_meter.remaining_gas()
+    fn try_as_basic_gas_state(&mut self) -> Option<BasicGasState<Self::Spec>> {
+        self.gas_meter.try_as_basic_gas_state()
     }
     fn charge_linear_gas(
         &mut self,
@@ -653,11 +648,8 @@ impl<S: Spec, I: StateProvider<S>> GasMeter for WorkingSet<S, I> {
         self.gas_meter.charge_gas(gas)
     }
 
-    fn remaining_gas(
-        &mut self,
-    ) -> anyhow::Result<<Self::Spec as Spec>::Gas, GasMeteringError<<Self::Spec as Spec>::Gas>>
-    {
-        self.gas_meter.remaining_gas()
+    fn try_as_basic_gas_state(&mut self) -> Option<BasicGasState<Self::Spec>> {
+        self.gas_meter.try_as_basic_gas_state()
     }
 
     fn charge_linear_gas(


### PR DESCRIPTION
# Description

  This PR implements gas computation based on the transaction's gas price and available funds, ensuring
  proper gas metering for EVM transactions.

Also adds a test that demonstrates that EVM gas affects only one gas dimension

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
