### PR TITLE
fix: correct "cargo version" to "rustc version" in error message

### DIFF
--- a/crates/utils/sov-zkvm-utils/src/lib.rs
+++ b/crates/utils/sov-zkvm-utils/src/lib.rs
@@ -46,7 +46,7 @@ pub fn does_rustc_match(zk_vm: &str) -> anyhow::Result<RustComparisonResult> {
         .map_err(|e| anyhow::anyhow!("{e:?}"))?;
     if !native_version_cmd.status.success() {
         anyhow::bail!(
-            "Failed to get native cargo version: {:?}",
+            "Failed to get native rustc version: {:?}",
             native_version_cmd
         );
     }


### PR DESCRIPTION
# Description

- Fix typo in does_rustc_match function error message
- Function works with rustc, not cargo, so error message should be accurate
- Improves clarity when debugging toolchain version mismatches
