### PR TITLE
BlobSender: Don't resend completed batches.

### DIFF
--- a/crates/full-node/sov-blob-sender/src/lib.rs
+++ b/crates/full-node/sov-blob-sender/src/lib.rs
@@ -578,6 +578,7 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
 
                     match receipt_fut.await {
                         Ok(Ok(receipt)) => {
+                            trace!(%blob_id, %receipt, "Blob status set from MustSubmit to Published.");
                             blob_status = BlobExecutionStatus {
                                 blob_submission_status: BlobSubmissionStatus::Published { receipt },
                                 blob_selector_status: None,
@@ -634,6 +635,7 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                                 return;
                             }
 
+                            debug!(%blob_id, %receipt, "Timeout: Blob status set from Published to MustSubmit.");
                             blob_status = BlobExecutionStatus {
                                 blob_submission_status: BlobSubmissionStatus::MustSubmit,
                                 blob_selector_status: None,
@@ -658,6 +660,8 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                             Some((_, blob_selector_status)) => {
                                 // Never skip directly to `Finalized` state, or
                                 // we won't send out the notification.
+
+                                trace!(%blob_id, %receipt, "Blob status set from Published to Processed.");
                                 blob_status = BlobExecutionStatus {
                                     blob_submission_status: BlobSubmissionStatus::Processed {
                                         receipt: receipt.clone(),
@@ -668,6 +672,7 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                                 break;
                             }
                             None => {
+                                trace!(%blob_id, %receipt, "Waiting for blob to be published");
                                 sleep(Duration::from_secs(1)).await;
                             }
                         }
@@ -703,11 +708,13 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                         };
 
                         match finality_status {
-                            Some((false, _)) => {
+                            Some((false, blob_selector_status)) => {
+                                trace!(%blob_id, %receipt, ?blob_selector_status, "Waiting for blob finalization.");
                                 sleep(self.ledger_pool_interval).await;
                                 continue;
                             }
                             Some((true, blob_selector_status)) => {
+                                trace!(%blob_id, %receipt, "Blob status set from Processed to Finalized.");
                                 blob_status = BlobExecutionStatus {
                                     blob_submission_status: BlobSubmissionStatus::Finalized {
                                         receipt: receipt.clone(),
@@ -724,6 +731,7 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                                     "Re-org detected; resubmitting blob"
                                 );
 
+                                trace!(%blob_id, %receipt, "Blob status set from Processed to MustSubmit.");
                                 blob_status = BlobExecutionStatus {
                                     blob_submission_status: BlobSubmissionStatus::MustSubmit,
                                     blob_selector_status: None,
@@ -739,6 +747,8 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                         | Some(BlobSelectorStatus::Discarded(
                             BlobDiscardReason::SequenceNumberTooLow,
                         )) => {
+                            trace!(%blob_id, %receipt, ?blob_status, "Blob was discarded. Removing it form the blob sender");
+
                             self.send_notification(blob_status.clone()).await;
                             // Upon crashing, we'd rather call the hook twice rather than not
                             // calling it at all. So, we call it *before* removing the blob from
@@ -752,11 +762,13 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                                 .await;
 
                             // We won't shut down the rollup in case of this error, but we will log the error.
+
                             let _ = self.remove_blob_or_err(blob_id).await;
                             break;
                         }
                         // Resubmit if discarded for any reason except `SequenceNumberTooLow`
                         Some(BlobSelectorStatus::Discarded(reason)) => {
+                            trace!(%blob_id, %receipt, ?reason, "Blob was discarded. Setting status to MustSubmit.");
                             blob_status = BlobExecutionStatus {
                                 blob_submission_status: BlobSubmissionStatus::MustSubmit,
                                 blob_selector_status: None,
@@ -793,6 +805,8 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
     }
 }
 
+#[derive(derive_more::Debug)]
+#[debug(bounds())]
 struct BlobSubmissionRequest<Da: DaSpec> {
     blob: BlobToSend,
     blob_id: BlobInternalId,

--- a/crates/full-node/sov-blob-sender/src/lib.rs
+++ b/crates/full-node/sov-blob-sender/src/lib.rs
@@ -103,7 +103,6 @@ where
         shutdown_sender: watch::Sender<()>,
         blob_processing_timeout: Duration,
         blob_sender_channel: Option<broadcast::Sender<BlobExecutionStatus<Da::Spec>>>,
-        completed_blobs_to_send: Vec<(BlobToSend, BlobInternalId)>,
         nb_of_concurrent_blob_submissions: Arc<AtomicUsize>,
     ) -> anyhow::Result<(Self, JoinHandle<()>)> {
         Self::new_with_task_intervals(
@@ -115,7 +114,6 @@ where
             blob_processing_timeout,
             blob_sender_channel,
             LEDGER_POLL_INTERVAL,
-            completed_blobs_to_send,
             nb_of_concurrent_blob_submissions,
         )
         .await
@@ -130,30 +128,15 @@ where
         blob_processing_timeout: Duration,
         blob_sender_channel: Option<broadcast::Sender<BlobExecutionStatus<Da::Spec>>>,
         ledger_pool_interval: Duration,
-        completed_blobs_to_send: Vec<(BlobToSend, BlobInternalId)>,
         nb_of_concurrent_blob_submissions: Arc<AtomicUsize>,
     ) -> anyhow::Result<(Self, JoinHandle<()>)> {
         let shutdown_receiver = shutdown_sender.subscribe();
         let db = Arc::new(BlobSenderDb::new(storage_path).await?);
 
-        let mut all_blobs = db.get_all::<Da::Spec>().await?;
+        let blobs_to_send_after_retart = db.get_all::<Da::Spec>().await?;
 
         let hooks = Arc::new(hooks);
         let in_flight_blobs: Arc<Mutex<_>> = Default::default();
-
-        let completed_blobs_to_send =
-            completed_blobs_to_send
-                .into_iter()
-                .map(|(blob, blob_id)| BlobSubmissionRequest {
-                    blob,
-                    blob_id,
-                    latest_known_processing_state: BlobExecutionStatus {
-                        blob_submission_status: BlobSubmissionStatus::MustSubmit,
-                        blob_selector_status: None,
-                    },
-                });
-
-        all_blobs.extend(completed_blobs_to_send);
 
         let sender = Self {
             db,
@@ -167,7 +150,7 @@ where
             blob_processing_timeout,
             blob_sender_channel,
             ledger_pool_interval,
-            blobs_to_send_after_retart: Some(all_blobs),
+            blobs_to_send_after_retart: Some(blobs_to_send_after_retart),
         };
 
         let handle = Self::main_task(in_flight_blobs, shutdown_receiver).await;

--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -417,7 +417,6 @@ async fn create_blob_sender(
         blob_processing_timeout,
         blob_status_sender,
         Duration::from_millis(1000),
-        Default::default(),
         nb_of_concurrent_blob_submissions,
     )
     .await

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -195,10 +195,6 @@ impl PreferredSequencerCache {
         self.in_progress_batch.as_ref()
     }
 
-    pub fn all_completed_blobs(&self) -> Vec<PreferredSequencerReadBlob> {
-        self.completed_blobs.clone().into()
-    }
-
     pub fn all_completed_blobs_greater_than_or_equal_to(
         &self,
         sequence_number: SequenceNumber,

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -173,7 +173,6 @@ where
         let (blob_sender, blob_sender_handle) = PreferredBlobSender::new(
             da,
             ledger_db.clone(),
-            db_cache.all_completed_blobs().clone(),
             storage_path.into(),
             tx_status_manager.clone(),
             shutdown_sender.clone(),

--- a/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
@@ -1,5 +1,5 @@
 use sov_blob_sender::BlobExecutionStatus;
-use sov_blob_sender::{BlobInternalId, BlobSender, BlobToSend};
+use sov_blob_sender::{BlobInternalId, BlobSender};
 use sov_blob_storage::{PreferredBatchData, PreferredProofData};
 use sov_db::ledger_db::LedgerDb;
 use sov_modules_api::TxHash;
@@ -27,7 +27,6 @@ impl<Da: DaService> PreferredBlobSender<Da> {
     pub(crate) async fn new(
         da: Da,
         ledger_db: LedgerDb,
-        all_completed_blobs: Vec<PreferredSequencerReadBlob>,
         storage_path: Box<Path>,
         tx_status_manager: TxStatusManager<Da::Spec>,
         shutdown_sender: watch::Sender<()>,
@@ -45,13 +44,6 @@ impl<Da: DaService> PreferredBlobSender<Da> {
                 None,
             ))
         } else {
-            // It's possible that sov-blob-sender's DB might miss some blob data at
-            // node startup due to:
-            //  1. Disk failure (the sequencer can use Postgres so it's durable).
-            //  2. DB corruption.
-            //  3. Node crash at an inconvenient time.
-            // Let's restore all missing blob data to make sure they land on the DA.
-            let blobs_to_send = create_blobs_to_send(all_completed_blobs)?;
             let (inner, blob_sender_handle) = BlobSender::new(
                 da.clone(),
                 ledger_db,
@@ -60,7 +52,6 @@ impl<Da: DaService> PreferredBlobSender<Da> {
                 shutdown_sender,
                 blob_processing_timeout,
                 Some(blobs_sender_channel),
-                blobs_to_send,
                 nb_of_concurrent_blob_submissions.clone(),
             )
             .await?;
@@ -145,37 +136,6 @@ impl<Da: DaService> PreferredBlobSender<Da> {
 
         inner.hooks().add_txs(blob_id, tx_hashes).await;
     }
-}
-
-pub fn create_blobs_to_send(
-    completed_blobs: Vec<PreferredSequencerReadBlob>,
-) -> anyhow::Result<Vec<(BlobToSend, BlobInternalId)>> {
-    let mut blobs_to_send = Vec::new();
-
-    for blob in completed_blobs {
-        match blob {
-            PreferredSequencerReadBlob::Batch(batch) => {
-                let blob_id = batch.blob_id;
-                let data = batch_bytes(batch)?;
-                blobs_to_send.push((BlobToSend::Batch { data }, blob_id));
-            }
-            PreferredSequencerReadBlob::Proof {
-                data,
-                sequence_number,
-                blob_id,
-            } => {
-                let data = proof_bytes(&data, sequence_number)?;
-                debug!(
-                    sequence_number,
-                    blob_id, "Dispatching proof blob for publishing"
-                );
-
-                blobs_to_send.push((BlobToSend::Proof { data }, blob_id));
-            }
-        }
-    }
-
-    Ok(blobs_to_send)
 }
 
 fn proof_bytes(proof_data: &[u8], sequence_number: u64) -> anyhow::Result<Arc<[u8]>> {

--- a/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
@@ -60,14 +60,14 @@ where
         batch: PreferredSequencerReadBatch,
         info_to_store: BatchToStore,
     ) -> anyhow::Result<()> {
-        self.db.terminate_batch(info_to_store).await?;
-        self.update_api_state(checkpoint);
-
         // Publish the batch.
         self.blob_sender
             .add_txs(batch.blob_id, batch.tx_hashes.clone())
             .await;
         self.blob_sender.publish_batch(batch).await?;
+
+        self.db.terminate_batch(info_to_store).await?;
+        self.update_api_state(checkpoint);
 
         Ok(())
     }

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -136,7 +136,6 @@ where
             TxStatusBlobSenderHooks::new(txsm.clone()),
             shutdown_sender,
             Duration::from_secs(config.blob_processing_timeout_secs),
-            None,
             Default::default(),
             nb_of_concurrent_blob_submissions,
         )

--- a/crates/full-node/sov-sequencer/src/test_stateless.rs
+++ b/crates/full-node/sov-sequencer/src/test_stateless.rs
@@ -84,7 +84,6 @@ where
                     TxStatusBlobSenderHooks::new(tx_status_manager.clone()),
                     shutdown_sender,
                     Duration::from_secs(config.blob_processing_timeout_secs),
-                    None,
                     Default::default(),
                     nb_of_concurrent_blob_submissions,
                 )


### PR DESCRIPTION
# Description
The `BlobSender` was attempting to send all batches that were completed and not pruned. However, due to a bug here https://github.com/Sovereign-Labs/sovereign-sdk/blob/nightly/crates/full-node/sov-sequencer/src/preferred/inner.rs#L382 It ended up sending too many batches. As we are not pruning everything we have to.


This PR refactors the `BlobSender` to prevent it from re-sending completed batches.  We will discuss on the daily what to do about the original bug.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
