### PR TITLE
Add schema EIP712 generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12378,6 +12378,7 @@ name = "sov-universal-wallet"
 version = "0.1.0"
 dependencies = [
  "alloy-dyn-abi",
+ "alloy-primitives",
  "arrayvec",
  "bech32 0.11.0",
  "borsh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-dyn-abi"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f56873f3cac7a2c63d8e98a4314b8311aa96adb1a0f82ae923eb2119809d2c"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "derive_more 2.0.1",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow 0.7.12",
+]
+
+[[package]]
 name = "alloy-eip2124"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12360,6 +12377,7 @@ dependencies = [
 name = "sov-universal-wallet"
 version = "0.1.0"
 dependencies = [
+ "alloy-dyn-abi",
  "arrayvec",
  "bech32 0.11.0",
  "borsh",

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -661,6 +661,7 @@ async fn flaky_seq_behind_deferred_slots_count_simple_lagging() {
         let _ = da_layer.produce_block().await;
         sleep(Duration::from_millis(50)).await; // Notifications don't work during recovery.
     }
+    sleep(Duration::from_millis(100)).await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer
@@ -804,10 +805,11 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
 
     // Give time for the sequencer to catch up its visible state number
     tracing::info!("Producing DA blocks to let the sequencer resync.");
-    for _ in 0..10 {
+    for _ in 0..20 {
         test_rollup.da_service.produce_block_now().await.unwrap();
         sleep(Duration::from_millis(50)).await;
     }
+    tokio::time::sleep(Duration::from_millis(100)).await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer

--- a/crates/universal-wallet/schema/Cargo.toml
+++ b/crates/universal-wallet/schema/Cargo.toml
@@ -21,6 +21,8 @@ nmt-rs = { workspace = true }
 # Schema ser/de traits, and json_to_borsh functionality
 serde_json = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
+# EIP712 functionality
+alloy-dyn-abi = { version = "1.3.1", features = ["eip712"], optional = true }
 # Re-exporting the macro
 sov-universal-wallet-macros = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }                    # for SafeString
@@ -28,7 +30,7 @@ schemars = { workspace = true, optional = true }                    # for SafeSt
 [dev-dependencies]
 borsh = { workspace = true }
 sov-universal-wallet-macros = { workspace = true }
-sov-universal-wallet = { path = ".", features = ["serde", "macros"] }
+sov-universal-wallet = { path = ".", features = ["serde", "eip712", "macros"] }
 sov-rollup-interface = { workspace = true }
 serde_arrays = { workspace = true }
 serde_with = { workspace = true }
@@ -45,4 +47,8 @@ serde = [
   "nmt-rs/serde",
   "arrayvec?/serde",
   "hex/serde",
+]
+eip712 = [
+  "serde",
+  "dep:alloy-dyn-abi",
 ]

--- a/crates/universal-wallet/schema/Cargo.toml
+++ b/crates/universal-wallet/schema/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 # EIP712 functionality
 alloy-dyn-abi = { version = "1.3.1", features = ["eip712"], optional = true }
+alloy-primitives = { workspace = true, optional = true }
 # Re-exporting the macro
 sov-universal-wallet-macros = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }                    # for SafeString
@@ -51,4 +52,5 @@ serde = [
 eip712 = [
   "serde",
   "dep:alloy-dyn-abi",
+  "dep:alloy-primitives",
 ]

--- a/crates/universal-wallet/schema/Cargo.toml
+++ b/crates/universal-wallet/schema/Cargo.toml
@@ -41,13 +41,14 @@ serde = { workspace = true }
 test-vectors = []
 macros = ["sov-universal-wallet-macros"]
 serde = [
-  "dep:serde",
-  "schemars",
-  "serde_json",
-  "sov-universal-wallet/serde",
-  "nmt-rs/serde",
-  "arrayvec?/serde",
-  "hex/serde",
+	"dep:serde",
+	"schemars",
+	"serde_json",
+	"sov-universal-wallet/serde",
+	"nmt-rs/serde",
+	"arrayvec?/serde",
+	"hex/serde",
+	"alloy-primitives?/serde"
 ]
 eip712 = [
   "serde",

--- a/crates/universal-wallet/schema/src/schema/mod.rs
+++ b/crates/universal-wallet/schema/src/schema/mod.rs
@@ -284,6 +284,16 @@ impl Schema {
         Ok(output)
     }
 
+    #[cfg(feature = "eip712")]
+    pub fn eip712_json(&self, type_index: usize, input: &[u8]) -> Result<String, SchemaError> {
+        todo!();
+    }
+
+    #[cfg(feature = "eip712")]
+    pub fn eip712_signing_hash(&self, type_index: usize, input: &[u8]) -> Result<[u8; 32], SchemaError> {
+        todo!();
+    }
+
     /// Use the schema to convert a serde-compatible JSON string of the given type into its borsh
     /// encoding
     #[cfg(feature = "serde")]

--- a/crates/universal-wallet/schema/src/schema/mod.rs
+++ b/crates/universal-wallet/schema/src/schema/mod.rs
@@ -25,6 +25,10 @@ use crate::display::{Context as DisplayContext, DisplayVisitor, FormatError};
 use crate::json_to_borsh::{Context as EncodeContext, EncodeError, EncodeVisitor};
 use crate::ty::byte_display::ByteParseError;
 use crate::ty::{ContainerSerdeMetadata, LinkingScheme, Ty};
+#[cfg(feature = "eip712")]
+use crate::visitors::eip712::{Context as Eip712Context, Eip712Error, Eip712Visitor};
+#[cfg(feature = "eip712")]
+use alloy_dyn_abi::{Eip712Types, Error as AlloyEip712Error, TypedData};
 
 #[derive(Debug, Error)]
 pub enum SchemaError {
@@ -35,6 +39,15 @@ pub enum SchemaError {
     #[cfg(feature = "serde")]
     #[error(transparent)]
     EncodeError(#[from] EncodeError),
+    #[cfg(feature = "serde")]
+    #[error(transparent)]
+    JsonError(#[from] serde_json::Error),
+    #[cfg(feature = "eip712")]
+    #[error(transparent)]
+    Eip712Error(#[from] Eip712Error),
+    #[cfg(feature = "eip712")]
+    #[error(transparent)]
+    AlloyEip712Error(#[from] AlloyEip712Error),
     #[error(transparent)]
     Bech32Error(#[from] ByteParseError),
     #[error("Rollup type {0:?} was missing from schema")]
@@ -285,13 +298,60 @@ impl Schema {
     }
 
     #[cfg(feature = "eip712")]
-    pub fn eip712_json(&self, type_index: usize, input: &[u8]) -> Result<String, SchemaError> {
-        todo!();
+    pub fn eip712_json(&mut self, type_index: usize, input: &[u8]) -> Result<String, SchemaError> {
+        let Some(typed_data) = self.eip712_get_typed_data_inner(type_index, input)? else {
+            return Ok(String::default());
+        };
+        Ok(serde_json::to_string(&typed_data)?)
     }
 
     #[cfg(feature = "eip712")]
-    pub fn eip712_signing_hash(&self, type_index: usize, input: &[u8]) -> Result<[u8; 32], SchemaError> {
-        todo!();
+    pub fn eip712_signing_hash(
+        &mut self,
+        type_index: usize,
+        input: &[u8],
+    ) -> Result<[u8; 32], SchemaError> {
+        let Some(typed_data) = self.eip712_get_typed_data_inner(type_index, input)? else {
+            return Ok(Default::default());
+        };
+        Ok(typed_data.eip712_signing_hash()?.into())
+    }
+
+    #[cfg(feature = "eip712")]
+    fn eip712_get_typed_data_inner(
+        &mut self,
+        type_index: usize,
+        input: &[u8],
+    ) -> Result<Option<TypedData>, SchemaError> {
+        let mut out_types = Eip712Types::default();
+        let input = &mut &input[..];
+        let mut visitor = Eip712Visitor::new(input, &mut out_types);
+        let root_type = self
+            .types()
+            .get(type_index)
+            .ok_or(SchemaError::InvalidIndex(type_index))?;
+        let Some(visitor_return) = root_type.visit(self, &mut visitor, Eip712Context::default())?
+        else {
+            return Ok(None);
+        };
+        if !visitor.has_displayed_whole_input() {
+            return Err(FormatError::UnusedInput.into());
+        }
+
+        Ok(Some(TypedData {
+            domain: alloy_dyn_abi::Eip712Domain {
+                name: Some(self.chain_data.chain_name.clone().into()),
+                version: None,
+                chain_id: Some(alloy_primitives::U256::from(self.chain_data.chain_id)),
+                // Our chain hash is 32 bytes. We could truncate it to fit in the 20-byte ethereum
+                // Address, but by putting it in the salt we retain the full entropy and security.
+                verifying_contract: None,
+                salt: Some(self.chain_hash()?.into()),
+            },
+            resolver: out_types.into(),
+            primary_type: visitor_return.unique_type_name,
+            message: visitor_return.json_value,
+        }))
     }
 
     /// Use the schema to convert a serde-compatible JSON string of the given type into its borsh

--- a/crates/universal-wallet/schema/src/ty/byte_display.rs
+++ b/crates/universal-wallet/schema/src/ty/byte_display.rs
@@ -7,8 +7,6 @@ use hex::FromHexError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::display::FormatError;
-
 #[derive(Debug, Error, PartialEq)]
 pub enum ByteParseError {
     #[error("The input could not be decoded as bech32: {0}")]
@@ -29,6 +27,14 @@ pub enum ByteParseError {
         encoding: String,
         actual: usize,
     },
+}
+
+#[derive(Debug, Error, Clone)]
+pub enum ByteFormatError {
+    #[error("Core error: {0}")]
+    Core(#[from] core::fmt::Error),
+    #[error("The input could not be displayed as bech32: {0}")]
+    InvalidBech32(#[from] bech32::EncodeError),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, BorshDeserialize, BorshSerialize)]
@@ -97,7 +103,7 @@ mod hrp_serde {
     }
 }
 impl ByteDisplay {
-    pub fn format(&self, input: &[u8], f: &mut impl core::fmt::Write) -> Result<(), FormatError> {
+    pub fn format(&self, input: &[u8], f: &mut impl core::fmt::Write) -> Result<(), ByteFormatError> {
         match self {
             ByteDisplay::Hex => {
                 f.write_str("0x")?;

--- a/crates/universal-wallet/schema/src/ty/byte_display.rs
+++ b/crates/universal-wallet/schema/src/ty/byte_display.rs
@@ -103,7 +103,11 @@ mod hrp_serde {
     }
 }
 impl ByteDisplay {
-    pub fn format(&self, input: &[u8], f: &mut impl core::fmt::Write) -> Result<(), ByteFormatError> {
+    pub fn format(
+        &self,
+        input: &[u8],
+        f: &mut impl core::fmt::Write,
+    ) -> Result<(), ByteFormatError> {
         match self {
             ByteDisplay::Hex => {
                 f.write_str("0x")?;

--- a/crates/universal-wallet/schema/src/visitors/display.rs
+++ b/crates/universal-wallet/schema/src/visitors/display.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use crate::schema::Primitive;
 use crate::ty::visitor::{ResolutionError, TypeResolver, TypeVisitor};
 use crate::ty::{
-    ByteDisplay, Enum, FixedPointDisplay, IntegerDisplay, IntegerType, LinkingScheme, Struct, Tuple,
+    byte_display, ByteDisplay, Enum, FixedPointDisplay, IntegerDisplay, IntegerType, LinkingScheme, Struct, Tuple
 };
 
 type Delimiters = (&'static str, &'static str);
@@ -20,8 +20,8 @@ pub const MAX_INPUT_CHUNK: usize = 65;
 pub enum FormatError {
     #[error("Core error: {0}")]
     Core(#[from] core::fmt::Error),
-    #[error("The input could not be displayed as bech32: {0}")]
-    InvalidBech32(#[from] bech32::EncodeError),
+    #[error("The byte sequence could not be formatted for display: {0}")]
+    InvalidBytes(#[from] byte_display::ByteFormatError),
     #[error("The input is not a valid utf-8 string: {0}")]
     InvalidString(#[from] core::str::Utf8Error),
     #[error("Invalid discriminant `{discriminant}` for {type_name}")]
@@ -105,7 +105,6 @@ impl<W: core::fmt::Write> core::fmt::Write for Output<'_, W> {
     }
 }
 
-#[allow(unused)]
 pub struct Input<'a> {
     buf: &'a mut &'a [u8],
     peeking: bool,
@@ -135,7 +134,7 @@ impl<'a> Input<'a> {
         self.buf.len()
     }
 
-    fn check_remaining_bytes(&self, mut len: usize) -> Result<(), FormatError> {
+    pub(crate) fn check_remaining_bytes(&self, mut len: usize) -> Result<(), FormatError> {
         if self.peeking {
             len += self.peek_cursor;
         }

--- a/crates/universal-wallet/schema/src/visitors/display.rs
+++ b/crates/universal-wallet/schema/src/visitors/display.rs
@@ -6,7 +6,8 @@ use thiserror::Error;
 use crate::schema::Primitive;
 use crate::ty::visitor::{ResolutionError, TypeResolver, TypeVisitor};
 use crate::ty::{
-    byte_display, ByteDisplay, Enum, FixedPointDisplay, IntegerDisplay, IntegerType, LinkingScheme, Struct, Tuple
+    byte_display, ByteDisplay, Enum, FixedPointDisplay, IntegerDisplay, IntegerType, LinkingScheme,
+    Struct, Tuple,
 };
 
 type Delimiters = (&'static str, &'static str);

--- a/crates/universal-wallet/schema/src/visitors/eip712.rs
+++ b/crates/universal-wallet/schema/src/visitors/eip712.rs
@@ -257,23 +257,6 @@ pub enum IsVirtual {
     No,
 }
 
-// /// An enum should display its tags
-// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-// pub enum IsHideTag {
-//     Yes,
-//     No,
-// }
-
-// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-// pub enum ParentType {
-//     None,
-//     Struct(IsVirtual),
-//     Tuple(IsVirtual, IsTrivial),
-//     Enum(IsHideTag),
-//     Vec,
-//     Map,
-// }
-
 // TODO: this would be nicer for devex if it were a function. The `<$t>::from_le_bytes` is what
 // makes it non-trivial to convert though
 macro_rules! display_int {

--- a/crates/universal-wallet/schema/src/visitors/eip712.rs
+++ b/crates/universal-wallet/schema/src/visitors/eip712.rs
@@ -1,0 +1,585 @@
+#[allow(dead_code)]
+
+use std::collections::HashMap;
+use std::fmt::Write;
+
+use alloy_dyn_abi::{Eip712Types, PropertyDef};
+use serde_json::Map;
+use thiserror::Error;
+
+use crate::schema::Primitive;
+use crate::ty::visitor::{ResolutionError, TypeResolver, TypeVisitor};
+use crate::ty::{
+    byte_display, ByteDisplay, Enum, IntegerDisplay, IntegerType, LinkingScheme, Struct, Tuple
+};
+
+pub type Result<T, E = FormatError> = core::result::Result<T, E>;
+
+#[derive(Debug, Error, Clone)]
+pub enum FormatError {
+    #[error("Core error: {0}")]
+    Core(#[from] core::fmt::Error),
+    #[error("EIP712 ABI error: {0}")]
+    Eip712Abi(#[from] alloy_dyn_abi::Error),
+    #[error("The byte sequence could not be formatted for display: {0}")]
+    InvalidBytes(#[from] byte_display::ByteFormatError),
+    #[error("The input is not a valid utf-8 string: {0}")]
+    InvalidString(#[from] core::str::Utf8Error),
+    #[error("Invalid discriminant `{discriminant}` for {type_name}")]
+    InvalidDiscriminant { type_name: String, discriminant: u8 },
+    #[error(transparent)]
+    UnresolvedType(#[from] ResolutionError),
+    #[error("A discriminant is required for items of type `{type_name}` but the input ended without providing one.")]
+    MissingDiscriminant { type_name: String },
+    #[error("The input claimed to provide an integer {claimed_size} bytes wide, but only provided {bytes_available} additional bytes of input.")]
+    MissingIntegerInput {
+        claimed_size: u8,
+        bytes_available: u8,
+    },
+    #[error("The input claimed to provide a byte array {claimed_size} bytes wide, but only provided {bytes_available} additional bytes of input.")]
+    MissingBytesInput {
+        claimed_size: usize,
+        bytes_available: usize,
+    },
+    #[error("The input should have contained a vector but did not provide one.")]
+    MissingVecLength,
+    #[error("The input should have contained a string but did not provide one.")]
+    MissingStringLength,
+    #[error("Map field keys must map to a string to allow for valid EIP712 encoding. Field {0} contained an invalid key.")]
+    InvalidMapKey(String),
+    #[error("The provided input had leftover bytes that weren't displayed.")]
+    UnusedInput,
+}
+
+/// The same Rust type in the schema can generate several solidity types. The simplest example of
+/// this is an enum type with values from several variants (each one would be its own solidity
+/// struct), but also e.g. optional values which are None are ommitted from the solidity struct so
+/// even rust `struct`s can generate different solidity types.
+/// We need to generate a unique type name if the field types are different, but without
+/// duplicating types which are genuinely identical. We do this by appending a numbered suffix if
+/// the Rust type name was already used for a different solidity type.
+#[derive(Default)]
+struct TypeVariants {
+    /// Maps from solidity field definitions to the unique generated name for this variant
+    variants: HashMap<Vec<PropertyDef>, String>,
+    /// The next suffix number to use (0 means no suffix, 1 means "_1", etc.)
+    next_suffix: usize,
+}
+
+pub struct Output<'t> {
+    types: &'t mut Eip712Types,
+    /// For each base (Rust) type name, tracks all its solidity variants that have already been
+    /// generated (see `TypeVariants`).
+    visited_types: HashMap<String, TypeVariants>,
+}
+
+impl<'t> Output<'t> {
+    pub fn new(types: &'t mut Eip712Types) -> Self {
+        Self {
+            types,
+            visited_types: Default::default(),
+        }
+    }
+    
+    /// Get or create a unique type name for the given field definitions.
+    /// If this exact field definition already exists for this base type, returns the existing name.
+    /// Otherwise, creates a new unique name with appropriate suffix.
+    pub fn insert_types_and_get_or_create_name(&mut self, base_name: &str, fields: Vec<PropertyDef>) -> String {
+        let type_info = self.visited_types.entry(base_name.to_string()).or_default();
+        
+        // Check if we've seen this exact field configuration for this base type before
+        if let Some(existing_name) = type_info.variants.get(&fields) {
+            return existing_name.clone();
+        }
+        
+        // Generate a unique name for this variant
+        let unique_name = if type_info.next_suffix == 0 {
+            base_name.to_string()
+        } else {
+            format!("{}{}", base_name, type_info.next_suffix)
+        };
+        type_info.next_suffix += 1;
+        type_info.variants.insert(fields.clone(), unique_name.clone());
+        
+        // Add to EIP712 types
+        self.types.insert(unique_name.clone(), fields);
+        
+        unique_name
+    }
+}
+
+pub struct Input<'a> {
+    buf: &'a mut &'a [u8],
+}
+
+impl<'a> Input<'a> {
+    pub fn new(buf: &'a mut &'a [u8]) -> Self {
+        Self {
+            buf,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buf.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.buf.len()
+    }
+
+    pub(crate) fn check_remaining_bytes(&self, len: usize) -> Result<(), FormatError> {
+        if self.buf.len() < len {
+            return Err(FormatError::MissingBytesInput {
+                claimed_size: len,
+                bytes_available: self.buf.len(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Splits the first `len` bytes from the input, returning them as a slice and updating the input buffer.
+    /// Returns an error if there are not enough bytes remaining to fulfill the request.
+    pub fn advance(&mut self, len: usize) -> Result<&[u8], FormatError> {
+        self.check_remaining_bytes(len)?;
+        let (leading, rest) = self.buf.split_at(len);
+        *self.buf = rest;
+        Ok(leading)
+    }
+}
+
+pub struct Eip712Visitor<'a, 't> {
+    input: Input<'a>,
+    output: Output<'t>,
+}
+
+impl<'a, 't> Eip712Visitor<'a, 't> {
+    pub fn new(input: &'a mut &'a [u8], out_types: &'t mut Eip712Types) -> Self {
+        Self {
+            input: Input::new(input),
+            output: Output::new(out_types),
+        }
+    }
+}
+
+impl Eip712Visitor<'_, '_> {
+    pub fn has_displayed_whole_input(&self) -> bool {
+        self.input.is_empty()
+    }
+
+    pub fn read_usize_borsh(&mut self) -> Result<usize, FormatError> {
+        if self.input.len() < 4 {
+            return Err(FormatError::MissingIntegerInput {
+                claimed_size: 4,
+                bytes_available: self.input.len() as u8,
+            });
+        }
+        let len = u32::from_le_bytes(
+            self.input
+                .advance(4)?
+                .try_into()
+                .expect("Converting [u8;4] to u32 is infallible"),
+        ) as usize;
+        Ok(len)
+    }
+
+    pub fn display_byte_sequence(
+        &mut self,
+        len: usize,
+        display: ByteDisplay,
+        _context: Context,
+    ) -> Result<Option<InnerReturnType>, FormatError> {
+        self.input.check_remaining_bytes(len)?;
+        let mut str = String::new();
+        display.format(self.input.advance(len)?, &mut str)?;
+        Ok(Some(InnerReturnType {
+            json_value: serde_json::Value::String(str),
+            unique_type_name: "string".to_string()
+        }))
+    }
+
+    /// Helper function for processing arrays and vectors, which share the same logic
+    /// except for how they determine their length.
+    fn process_sequence<L: LinkingScheme>(
+        &mut self,
+        len: usize,
+        value: &L::TypeLink,
+        schema: &impl TypeResolver<LinkingScheme = L>,
+        context: Context,
+    ) -> Result<Option<InnerReturnType>, FormatError> {
+        let inner = schema.resolve_or_err(value)?;
+        let base_name = &context.parent_name;
+
+        let mut json_values = Map::new();
+        let mut inner_types = Vec::new();
+        
+        for i in 0..len {
+            let Some(eip712_value) = inner.visit(schema, self, Context { is_virtual: IsVirtual::No, parent_name: format!("{base_name}_{i}") })? else {
+                continue
+            };
+            json_values.insert(i.to_string(), eip712_value.json_value);
+            let property_def = PropertyDef::new(eip712_value.unique_type_name, i.to_string())?;
+            inner_types.push(property_def);
+        }
+
+        let eip712_name = self.output.insert_types_and_get_or_create_name(&base_name, inner_types);
+        let json_value = serde_json::Value::Object(json_values);
+        Ok(Some(InnerReturnType { json_value, unique_type_name: eip712_name }))
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Context {
+    is_virtual: IsVirtual,
+    /// For virtual structs or tuples, the parent name (which will be the enum variant name)
+    /// replaces the type name. For non-virtual tuples, the parent name will be the field name and
+    /// is the only type name we have.
+    parent_name: String,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum IsVirtual {
+    Yes,
+    #[default]
+    No,
+}
+
+/// Tuple wrapping a single value
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IsTrivial {
+    Yes,
+    No,
+}
+
+// /// An enum should display its tags
+// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// pub enum IsHideTag {
+//     Yes,
+//     No,
+// }
+
+// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// pub enum ParentType {
+//     None,
+//     Struct(IsVirtual),
+//     Tuple(IsVirtual, IsTrivial),
+//     Enum(IsHideTag),
+//     Vec,
+//     Map,
+// }
+
+// TODO: this would be nicer for devex if it were a function. The `<$t>::from_le_bytes` is what
+// makes it non-trivial to convert though
+macro_rules! display_int {
+    ($t:ident, $input:expr, $disp:expr, $solint: expr) => {{
+        let size = IntegerType::$t.size();
+        if $input.len() < size {
+            return Err(FormatError::MissingIntegerInput {
+                claimed_size: size as u8,
+                bytes_available: $input.len() as u8,
+            });
+        }
+        let buf = $input.advance(size)?;
+        let value = <$t>::from_le_bytes(buf.try_into().unwrap()).to_string();
+        match $disp {
+            IntegerDisplay::Hex => {
+                Ok(Some(
+                        InnerReturnType {
+                            json_value: serde_json::Value::String(hex::encode(value)),
+                            unique_type_name: "string".to_string()
+                        }
+                ))
+            }
+            // EIP-712 doesn't have support for fixed point decimals.
+            IntegerDisplay::Decimal | IntegerDisplay::FixedPoint(_) => {
+                Ok(Some(
+                        InnerReturnType {
+                            json_value: serde_json::Value::String(value),
+                            unique_type_name: $solint.to_string()
+                        }
+                ))
+            }
+        }
+    }};
+}
+
+struct InnerReturnType {
+    json_value: serde_json::Value,
+    unique_type_name: String,
+}
+
+impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
+    type Arg = Context;
+    type ReturnType = Result<Option<InnerReturnType>, FormatError>;
+    fn visit_enum(
+        &mut self,
+        e: &Enum<L>,
+        schema: &impl TypeResolver<LinkingScheme = L>,
+        mut context: Context,
+    ) -> Self::ReturnType {
+        if self.input.is_empty() && !e.variants.is_empty() {
+            return Err(FormatError::MissingDiscriminant {
+                type_name: e.type_name.clone(),
+            });
+        }
+
+        let discriminant = self.input.advance(1)?[0];
+        let mut variants_by_discriminant =
+            e.variants.iter().filter(|v| v.discriminant == discriminant);
+        let variant = variants_by_discriminant
+            .next()
+            .ok_or(FormatError::InvalidDiscriminant {
+                type_name: e.type_name.clone(),
+                discriminant,
+            })?;
+        assert!(variants_by_discriminant.next().is_none(), "Found two enum variants with the same discriminant - the schema is malformed, cannot proceed!");
+        // TODO: start Value of a struct
+        if let Some(maybe_resolved) = &variant.value {
+            let inner = schema.resolve_or_err(maybe_resolved)?;
+            inner.visit(schema, self, context)?;
+            // TODO: populate from the inner fields
+            todo!();
+        } else {
+            // TODO: insert single struct with type bool
+            todo!()
+        }
+        Ok(())
+    }
+
+    fn visit_struct(
+        &mut self,
+        s: &Struct<L>,
+        schema: &impl TypeResolver<LinkingScheme = L>,
+        context: Context,
+    ) -> Self::ReturnType {
+        // 1. Get the type names and JSON values for every child field
+        // 2. Determine the type name, uniquely based on the subtypes
+        // 3. Construct type array and insert into output types with the provided name
+        // 4. Construct inner json: start an object and insert the child value JSONs
+        let base_name = if context.is_virtual == IsVirtual::Yes {
+            &context.parent_name
+        } else {
+            &s.type_name
+        };
+
+        let mut field_values = Map::new();
+        let mut field_types = Vec::new();
+
+        for field in &s.fields {
+            let inner_ty = schema.resolve_or_err(&field.value)?;
+            let Some(eip712_field) = inner_ty.visit(schema, self, Context { is_virtual: IsVirtual::No, parent_name: field.display_name.clone() })? else {
+                continue;
+            };
+            if !field.silent && !inner_ty.is_skip() {
+                field_values.insert(field.display_name.clone(), eip712_field.json_value);
+                let property_def = PropertyDef::new(eip712_field.unique_type_name, field.display_name.clone())?;
+                field_types.push(property_def);
+            }
+        }
+        let eip712_name = self.output.insert_types_and_get_or_create_name(&base_name, field_types);
+        let json_value = serde_json::Value::Object(field_values);
+        Ok(Some(InnerReturnType { json_value, unique_type_name: eip712_name }))
+    }
+
+    fn visit_tuple(
+        &mut self,
+        t: &Tuple<L>,
+        schema: &impl TypeResolver<LinkingScheme = L>,
+        context: Context,
+    ) -> Self::ReturnType {
+        // Trivial tuple (single field) - make it transparent
+        if t.fields.len() == 1 {
+            let field = &t.fields[0];
+            let inner_ty = schema.resolve_or_err(&field.value)?;
+            // Pass through the parent context since the tuple is transparent
+            return inner_ty.visit(schema, self, context);
+        }
+
+        // Non-trivial tuple - treat like a struct with numeric field names
+        let base_name = if context.is_virtual == IsVirtual::Yes {
+            &context.parent_name
+        } else {
+            &context.parent_name  // For tuples, parent_name is the field name
+        };
+
+        let mut field_values = Map::new();
+        let mut field_types = Vec::new();
+
+        for (i, field) in t.fields.iter().enumerate() {
+            let inner_ty = schema.resolve_or_err(&field.value)?;
+            let field_name = i.to_string();
+            let Some(eip712_field) = inner_ty.visit(schema, self, Context { 
+                is_virtual: IsVirtual::No, 
+                parent_name: format!("{base_name}_{field_name}")
+            })? else {
+                continue;
+            };
+            
+            if !field.silent && !inner_ty.is_skip() {
+                field_values.insert(field_name.clone(), eip712_field.json_value);
+                let property_def = PropertyDef::new(eip712_field.unique_type_name, field_name)?;
+                field_types.push(property_def);
+            }
+        }
+
+        let eip712_name = self.output.insert_types_and_get_or_create_name(&base_name, field_types);
+        let json_value = serde_json::Value::Object(field_values);
+        Ok(Some(InnerReturnType { json_value, unique_type_name: eip712_name }))
+    }
+
+    fn visit_option(
+        &mut self,
+        value: &L::TypeLink,
+        schema: &impl TypeResolver<LinkingScheme = L>,
+        context: Self::Arg,
+    ) -> Self::ReturnType {
+        let discriminant = self.input.advance(1)?[0];
+
+        match discriminant {
+            0 => Ok(None),
+            1 => {
+                schema.resolve_or_err(value)?.visit(schema, self, context)
+            }
+            _ => Err(FormatError::InvalidDiscriminant {
+                type_name: "Option".to_string(),
+                discriminant,
+            })
+        }
+    }
+
+    fn visit_primitive(
+        &mut self,
+        p: crate::schema::Primitive,
+        _schema: &impl TypeResolver<LinkingScheme = L>,
+        context: Context,
+    ) -> Self::ReturnType {
+        match p {
+            Primitive::Float32 => {
+                let value = self.input.advance(4)?;
+                let value = f32::from_le_bytes(value.try_into().unwrap()).to_string();
+                let json_value = serde_json::Value::String(value);
+                Ok(Some(InnerReturnType {
+                    json_value,
+                    unique_type_name: "string".to_string()
+                }))
+            }
+            Primitive::Float64 => {
+                let value = self.input.advance(8)?;
+                let value = f64::from_le_bytes(value.try_into().unwrap()).to_string();
+                let json_value = serde_json::Value::String(value);
+                Ok(Some(InnerReturnType {
+                    json_value,
+                    unique_type_name: "string".to_string()
+                }))
+            }
+            Primitive::Boolean => {
+                let value = self.input.advance(1)?;
+                let json_value = match value[0] {
+                    0 => serde_json::Value::Bool(false),
+                    1 => serde_json::Value::Bool(true),
+                    _ => {
+                        return Err(FormatError::InvalidDiscriminant {
+                            type_name: "bool".to_string(),
+                            discriminant: value[0],
+                        });
+                    }
+                };
+                Ok(Some(InnerReturnType {
+                    json_value,
+                    unique_type_name: "bool".to_string()
+                }))
+            }
+            Primitive::Integer(int, display) => match int {
+                IntegerType::i8 => display_int!(i8, self.input, display, "int8"),
+                IntegerType::i16 => display_int!(i16, self.input, display, "int16"),
+                IntegerType::i32 => display_int!(i32, self.input, display, "int32"),
+                IntegerType::i64 => display_int!(i64, self.input, display, "int64"),
+                IntegerType::i128 => display_int!(i128, self.input, display, "int128"),
+                IntegerType::u8 => display_int!(u8, self.input, display, "uint8"),
+                IntegerType::u16 => display_int!(u16, self.input, display, "uint16"),
+                IntegerType::u32 => display_int!(u32, self.input, display, "uint32"),
+                IntegerType::u64 => display_int!(u64, self.input, display, "uint64"),
+                IntegerType::u128 => display_int!(u128, self.input, display, "uint128"),
+            },
+            Primitive::ByteArray { len, display } => {
+                self.display_byte_sequence(len, display, context)
+            }
+            Primitive::ByteVec { display } => {
+                let len = self
+                    .read_usize_borsh()
+                    .or(Err(FormatError::MissingVecLength))?;
+                self.display_byte_sequence(len, display, context)
+            }
+            Primitive::String => {
+                let len = self
+                    .read_usize_borsh()
+                    .or(Err(FormatError::MissingStringLength))?;
+                let content = self.input.advance(len)?;
+                let content = std::str::from_utf8(content)?.to_string();
+                Ok(Some(InnerReturnType { json_value: serde_json::Value::String(content), unique_type_name: "string".to_string() }))
+            }
+            Primitive::Skip { len } => {
+                self.input.advance(len)?;
+                Ok(None)
+            }
+        }
+    }
+
+    fn visit_array(
+        &mut self,
+        len: &usize,
+        value: &L::TypeLink,
+        schema: &impl TypeResolver<LinkingScheme = L>,
+        context: Context,
+    ) -> Self::ReturnType {
+        self.process_sequence(*len, value, schema, context)
+    }
+
+    fn visit_vec(
+        &mut self,
+        value: &L::TypeLink,
+        schema: &impl TypeResolver<LinkingScheme = L>,
+        context: Context,
+    ) -> Self::ReturnType {
+        let len = self.read_usize_borsh()?;
+        self.process_sequence(len, value, schema, context)
+    }
+
+    fn visit_map(
+        &mut self,
+        key: &L::TypeLink,
+        value: &L::TypeLink,
+        schema: &impl TypeResolver<LinkingScheme = L>,
+        context: Context,
+    ) -> Self::ReturnType {
+        let len = self.read_usize_borsh()?;
+        let key = schema.resolve_or_err(key)?;
+        let value = schema.resolve_or_err(value)?;
+
+        let base_name = &context.parent_name;
+
+        let mut json_values = Map::new();
+        let mut inner_types = Vec::new();
+
+        for i in 0..len {
+            let Some(eip712_key) = key.visit(schema, self, Context { is_virtual: IsVirtual::No, parent_name: format!("{base_name}_{i}") })? else {
+                return Err(FormatError::InvalidMapKey(base_name.clone()))
+            };
+            let key_name = match eip712_key.json_value {
+                serde_json::Value::String(s) => s,
+                _ => return Err(FormatError::InvalidMapKey(base_name.clone()))
+            };
+
+            let Some(eip712_value) = value.visit(schema, self, context.clone())? else {
+                continue
+            };
+
+            json_values.insert(key_name.clone(), eip712_value.json_value);
+            let property_def = PropertyDef::new(eip712_value.unique_type_name, key_name)?;
+            inner_types.push(property_def);
+        }
+
+        let eip712_name = self.output.insert_types_and_get_or_create_name(&base_name, inner_types);
+        let json_value = serde_json::Value::Object(json_values);
+        Ok(Some(InnerReturnType { json_value, unique_type_name: eip712_name }))
+    }
+}

--- a/crates/universal-wallet/schema/src/visitors/eip712.rs
+++ b/crates/universal-wallet/schema/src/visitors/eip712.rs
@@ -232,7 +232,7 @@ impl Eip712Visitor<'_, '_> {
 
         let eip712_name = self
             .output
-            .insert_types_and_get_or_create_name(&base_name, inner_types);
+            .insert_types_and_get_or_create_name(base_name, inner_types);
         let json_value = serde_json::Value::Object(json_values);
         Ok(Some(InnerReturnType {
             json_value,
@@ -420,7 +420,7 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
         }
         let eip712_name = self
             .output
-            .insert_types_and_get_or_create_name(&base_name, field_types);
+            .insert_types_and_get_or_create_name(base_name, field_types);
         let json_value = serde_json::Value::Object(field_values);
         Ok(Some(InnerReturnType {
             json_value,
@@ -444,11 +444,7 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
         }
 
         // Non-trivial tuple - treat like a struct with numeric field names
-        let base_name = if context.is_virtual == IsVirtual::Yes {
-            &context.parent_name
-        } else {
-            &context.parent_name // For tuples, parent_name is the field name
-        };
+        let base_name = &context.parent_name;
 
         let mut field_values = Map::new();
         let mut field_types = Vec::new();
@@ -477,7 +473,7 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
 
         let eip712_name = self
             .output
-            .insert_types_and_get_or_create_name(&base_name, field_types);
+            .insert_types_and_get_or_create_name(base_name, field_types);
         let json_value = serde_json::Value::Object(field_values);
         Ok(Some(InnerReturnType {
             json_value,
@@ -648,7 +644,7 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
 
         let eip712_name = self
             .output
-            .insert_types_and_get_or_create_name(&base_name, inner_types);
+            .insert_types_and_get_or_create_name(base_name, inner_types);
         let json_value = serde_json::Value::Object(json_values);
         Ok(Some(InnerReturnType {
             json_value,

--- a/crates/universal-wallet/schema/src/visitors/eip712.rs
+++ b/crates/universal-wallet/schema/src/visitors/eip712.rs
@@ -1,7 +1,4 @@
-#[allow(dead_code)]
-
 use std::collections::HashMap;
-use std::fmt::Write;
 
 use alloy_dyn_abi::{Eip712Types, PropertyDef};
 use serde_json::Map;
@@ -10,13 +7,13 @@ use thiserror::Error;
 use crate::schema::Primitive;
 use crate::ty::visitor::{ResolutionError, TypeResolver, TypeVisitor};
 use crate::ty::{
-    byte_display, ByteDisplay, Enum, IntegerDisplay, IntegerType, LinkingScheme, Struct, Tuple
+    byte_display, ByteDisplay, Enum, IntegerDisplay, IntegerType, LinkingScheme, Struct, Tuple,
 };
 
-pub type Result<T, E = FormatError> = core::result::Result<T, E>;
+pub type Result<T, E = Eip712Error> = core::result::Result<T, E>;
 
 #[derive(Debug, Error, Clone)]
-pub enum FormatError {
+pub enum Eip712Error {
     #[error("Core error: {0}")]
     Core(#[from] core::fmt::Error),
     #[error("EIP712 ABI error: {0}")]
@@ -80,18 +77,22 @@ impl<'t> Output<'t> {
             visited_types: Default::default(),
         }
     }
-    
+
     /// Get or create a unique type name for the given field definitions.
     /// If this exact field definition already exists for this base type, returns the existing name.
     /// Otherwise, creates a new unique name with appropriate suffix.
-    pub fn insert_types_and_get_or_create_name(&mut self, base_name: &str, fields: Vec<PropertyDef>) -> String {
+    pub fn insert_types_and_get_or_create_name(
+        &mut self,
+        base_name: &str,
+        fields: Vec<PropertyDef>,
+    ) -> String {
         let type_info = self.visited_types.entry(base_name.to_string()).or_default();
-        
+
         // Check if we've seen this exact field configuration for this base type before
         if let Some(existing_name) = type_info.variants.get(&fields) {
             return existing_name.clone();
         }
-        
+
         // Generate a unique name for this variant
         let unique_name = if type_info.next_suffix == 0 {
             base_name.to_string()
@@ -99,11 +100,13 @@ impl<'t> Output<'t> {
             format!("{}{}", base_name, type_info.next_suffix)
         };
         type_info.next_suffix += 1;
-        type_info.variants.insert(fields.clone(), unique_name.clone());
-        
+        type_info
+            .variants
+            .insert(fields.clone(), unique_name.clone());
+
         // Add to EIP712 types
         self.types.insert(unique_name.clone(), fields);
-        
+
         unique_name
     }
 }
@@ -114,9 +117,7 @@ pub struct Input<'a> {
 
 impl<'a> Input<'a> {
     pub fn new(buf: &'a mut &'a [u8]) -> Self {
-        Self {
-            buf,
-        }
+        Self { buf }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -127,9 +128,9 @@ impl<'a> Input<'a> {
         self.buf.len()
     }
 
-    pub(crate) fn check_remaining_bytes(&self, len: usize) -> Result<(), FormatError> {
+    pub(crate) fn check_remaining_bytes(&self, len: usize) -> Result<(), Eip712Error> {
         if self.buf.len() < len {
-            return Err(FormatError::MissingBytesInput {
+            return Err(Eip712Error::MissingBytesInput {
                 claimed_size: len,
                 bytes_available: self.buf.len(),
             });
@@ -139,7 +140,7 @@ impl<'a> Input<'a> {
 
     /// Splits the first `len` bytes from the input, returning them as a slice and updating the input buffer.
     /// Returns an error if there are not enough bytes remaining to fulfill the request.
-    pub fn advance(&mut self, len: usize) -> Result<&[u8], FormatError> {
+    pub fn advance(&mut self, len: usize) -> Result<&[u8], Eip712Error> {
         self.check_remaining_bytes(len)?;
         let (leading, rest) = self.buf.split_at(len);
         *self.buf = rest;
@@ -166,9 +167,9 @@ impl Eip712Visitor<'_, '_> {
         self.input.is_empty()
     }
 
-    pub fn read_usize_borsh(&mut self) -> Result<usize, FormatError> {
+    pub fn read_usize_borsh(&mut self) -> Result<usize, Eip712Error> {
         if self.input.len() < 4 {
-            return Err(FormatError::MissingIntegerInput {
+            return Err(Eip712Error::MissingIntegerInput {
                 claimed_size: 4,
                 bytes_available: self.input.len() as u8,
             });
@@ -182,18 +183,18 @@ impl Eip712Visitor<'_, '_> {
         Ok(len)
     }
 
-    pub fn display_byte_sequence(
+    fn display_byte_sequence(
         &mut self,
         len: usize,
         display: ByteDisplay,
         _context: Context,
-    ) -> Result<Option<InnerReturnType>, FormatError> {
+    ) -> Result<Option<InnerReturnType>, Eip712Error> {
         self.input.check_remaining_bytes(len)?;
         let mut str = String::new();
         display.format(self.input.advance(len)?, &mut str)?;
         Ok(Some(InnerReturnType {
             json_value: serde_json::Value::String(str),
-            unique_type_name: "string".to_string()
+            unique_type_name: "string".to_string(),
         }))
     }
 
@@ -205,25 +206,38 @@ impl Eip712Visitor<'_, '_> {
         value: &L::TypeLink,
         schema: &impl TypeResolver<LinkingScheme = L>,
         context: Context,
-    ) -> Result<Option<InnerReturnType>, FormatError> {
+    ) -> Result<Option<InnerReturnType>, Eip712Error> {
         let inner = schema.resolve_or_err(value)?;
         let base_name = &context.parent_name;
 
         let mut json_values = Map::new();
         let mut inner_types = Vec::new();
-        
+
         for i in 0..len {
-            let Some(eip712_value) = inner.visit(schema, self, Context { is_virtual: IsVirtual::No, parent_name: format!("{base_name}_{i}") })? else {
-                continue
+            let Some(eip712_value) = inner.visit(
+                schema,
+                self,
+                Context {
+                    is_virtual: IsVirtual::No,
+                    parent_name: format!("{base_name}_{i}"),
+                },
+            )?
+            else {
+                continue;
             };
             json_values.insert(i.to_string(), eip712_value.json_value);
             let property_def = PropertyDef::new(eip712_value.unique_type_name, i.to_string())?;
             inner_types.push(property_def);
         }
 
-        let eip712_name = self.output.insert_types_and_get_or_create_name(&base_name, inner_types);
+        let eip712_name = self
+            .output
+            .insert_types_and_get_or_create_name(&base_name, inner_types);
         let json_value = serde_json::Value::Object(json_values);
-        Ok(Some(InnerReturnType { json_value, unique_type_name: eip712_name }))
+        Ok(Some(InnerReturnType {
+            json_value,
+            unique_type_name: eip712_name,
+        }))
     }
 }
 
@@ -240,13 +254,6 @@ pub struct Context {
 pub enum IsVirtual {
     Yes,
     #[default]
-    No,
-}
-
-/// Tuple wrapping a single value
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum IsTrivial {
-    Yes,
     No,
 }
 
@@ -273,7 +280,7 @@ macro_rules! display_int {
     ($t:ident, $input:expr, $disp:expr, $solint: expr) => {{
         let size = IntegerType::$t.size();
         if $input.len() < size {
-            return Err(FormatError::MissingIntegerInput {
+            return Err(Eip712Error::MissingIntegerInput {
                 claimed_size: size as u8,
                 bytes_available: $input.len() as u8,
             });
@@ -281,43 +288,35 @@ macro_rules! display_int {
         let buf = $input.advance(size)?;
         let value = <$t>::from_le_bytes(buf.try_into().unwrap()).to_string();
         match $disp {
-            IntegerDisplay::Hex => {
-                Ok(Some(
-                        InnerReturnType {
-                            json_value: serde_json::Value::String(hex::encode(value)),
-                            unique_type_name: "string".to_string()
-                        }
-                ))
-            }
+            IntegerDisplay::Hex => Ok(Some(InnerReturnType {
+                json_value: serde_json::Value::String(hex::encode(value)),
+                unique_type_name: "string".to_string(),
+            })),
             // EIP-712 doesn't have support for fixed point decimals.
-            IntegerDisplay::Decimal | IntegerDisplay::FixedPoint(_) => {
-                Ok(Some(
-                        InnerReturnType {
-                            json_value: serde_json::Value::String(value),
-                            unique_type_name: $solint.to_string()
-                        }
-                ))
-            }
+            IntegerDisplay::Decimal | IntegerDisplay::FixedPoint(_) => Ok(Some(InnerReturnType {
+                json_value: serde_json::Value::String(value),
+                unique_type_name: $solint.to_string(),
+            })),
         }
     }};
 }
 
-struct InnerReturnType {
-    json_value: serde_json::Value,
-    unique_type_name: String,
+pub struct InnerReturnType {
+    pub json_value: serde_json::Value,
+    pub unique_type_name: String,
 }
 
 impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
     type Arg = Context;
-    type ReturnType = Result<Option<InnerReturnType>, FormatError>;
+    type ReturnType = Result<Option<InnerReturnType>, Eip712Error>;
     fn visit_enum(
         &mut self,
         e: &Enum<L>,
         schema: &impl TypeResolver<LinkingScheme = L>,
-        mut context: Context,
+        context: Context,
     ) -> Self::ReturnType {
         if self.input.is_empty() && !e.variants.is_empty() {
-            return Err(FormatError::MissingDiscriminant {
+            return Err(Eip712Error::MissingDiscriminant {
                 type_name: e.type_name.clone(),
             });
         }
@@ -327,22 +326,57 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
             e.variants.iter().filter(|v| v.discriminant == discriminant);
         let variant = variants_by_discriminant
             .next()
-            .ok_or(FormatError::InvalidDiscriminant {
+            .ok_or(Eip712Error::InvalidDiscriminant {
                 type_name: e.type_name.clone(),
                 discriminant,
             })?;
         assert!(variants_by_discriminant.next().is_none(), "Found two enum variants with the same discriminant - the schema is malformed, cannot proceed!");
-        // TODO: start Value of a struct
-        if let Some(maybe_resolved) = &variant.value {
-            let inner = schema.resolve_or_err(maybe_resolved)?;
-            inner.visit(schema, self, context)?;
-            // TODO: populate from the inner fields
-            todo!();
+
+        // The enum type name comes from context (for nested) or from the enum itself
+        let enum_type_name = if context.is_virtual == IsVirtual::Yes {
+            &context.parent_name
         } else {
-            // TODO: insert single struct with type bool
-            todo!()
-        }
-        Ok(())
+            &e.type_name
+        };
+
+        // Create the single-field struct for the enum
+        let mut field_values = Map::new();
+        let mut field_types = Vec::new();
+
+        let (field_value, field_type_name) = if let Some(maybe_resolved) = &variant.value {
+            // Visit the variant's content with virtual context
+            let inner = schema.resolve_or_err(maybe_resolved)?;
+            let variant_context = Context {
+                is_virtual: IsVirtual::Yes,
+                parent_name: variant.name.clone(),
+            };
+
+            if let Some(result) = inner.visit(schema, self, variant_context)? {
+                (result.json_value, result.unique_type_name)
+            } else {
+                // Skip field if the inner type returns None
+                return Ok(None);
+            }
+        } else {
+            // Empty variant - use bool type with value true
+            (serde_json::Value::Bool(true), "bool".to_string())
+        };
+
+        // Add the variant as a field in the enum struct
+        field_values.insert(variant.name.clone(), field_value);
+        let property_def = PropertyDef::new(field_type_name, variant.name.clone())?;
+        field_types.push(property_def);
+
+        // Register this enum variant configuration and get its unique name
+        let eip712_name = self
+            .output
+            .insert_types_and_get_or_create_name(enum_type_name, field_types);
+        let json_value = serde_json::Value::Object(field_values);
+
+        Ok(Some(InnerReturnType {
+            json_value,
+            unique_type_name: eip712_name,
+        }))
     }
 
     fn visit_struct(
@@ -366,18 +400,32 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
 
         for field in &s.fields {
             let inner_ty = schema.resolve_or_err(&field.value)?;
-            let Some(eip712_field) = inner_ty.visit(schema, self, Context { is_virtual: IsVirtual::No, parent_name: field.display_name.clone() })? else {
+            let Some(eip712_field) = inner_ty.visit(
+                schema,
+                self,
+                Context {
+                    is_virtual: IsVirtual::No,
+                    parent_name: field.display_name.clone(),
+                },
+            )?
+            else {
                 continue;
             };
             if !field.silent && !inner_ty.is_skip() {
                 field_values.insert(field.display_name.clone(), eip712_field.json_value);
-                let property_def = PropertyDef::new(eip712_field.unique_type_name, field.display_name.clone())?;
+                let property_def =
+                    PropertyDef::new(eip712_field.unique_type_name, field.display_name.clone())?;
                 field_types.push(property_def);
             }
         }
-        let eip712_name = self.output.insert_types_and_get_or_create_name(&base_name, field_types);
+        let eip712_name = self
+            .output
+            .insert_types_and_get_or_create_name(&base_name, field_types);
         let json_value = serde_json::Value::Object(field_values);
-        Ok(Some(InnerReturnType { json_value, unique_type_name: eip712_name }))
+        Ok(Some(InnerReturnType {
+            json_value,
+            unique_type_name: eip712_name,
+        }))
     }
 
     fn visit_tuple(
@@ -386,11 +434,12 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
         schema: &impl TypeResolver<LinkingScheme = L>,
         context: Context,
     ) -> Self::ReturnType {
-        // Trivial tuple (single field) - make it transparent
+        // Trivial tuple (single field) - always transparent
+        // The magic happens in visit_enum when it sees a virtual context
         if t.fields.len() == 1 {
             let field = &t.fields[0];
             let inner_ty = schema.resolve_or_err(&field.value)?;
-            // Pass through the parent context since the tuple is transparent
+            // Pass through the context - if we're virtual, the inner enum will use parent_name as its type
             return inner_ty.visit(schema, self, context);
         }
 
@@ -398,7 +447,7 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
         let base_name = if context.is_virtual == IsVirtual::Yes {
             &context.parent_name
         } else {
-            &context.parent_name  // For tuples, parent_name is the field name
+            &context.parent_name // For tuples, parent_name is the field name
         };
 
         let mut field_values = Map::new();
@@ -407,13 +456,18 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
         for (i, field) in t.fields.iter().enumerate() {
             let inner_ty = schema.resolve_or_err(&field.value)?;
             let field_name = i.to_string();
-            let Some(eip712_field) = inner_ty.visit(schema, self, Context { 
-                is_virtual: IsVirtual::No, 
-                parent_name: format!("{base_name}_{field_name}")
-            })? else {
+            let Some(eip712_field) = inner_ty.visit(
+                schema,
+                self,
+                Context {
+                    is_virtual: IsVirtual::No,
+                    parent_name: format!("{base_name}_{field_name}"),
+                },
+            )?
+            else {
                 continue;
             };
-            
+
             if !field.silent && !inner_ty.is_skip() {
                 field_values.insert(field_name.clone(), eip712_field.json_value);
                 let property_def = PropertyDef::new(eip712_field.unique_type_name, field_name)?;
@@ -421,9 +475,14 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
             }
         }
 
-        let eip712_name = self.output.insert_types_and_get_or_create_name(&base_name, field_types);
+        let eip712_name = self
+            .output
+            .insert_types_and_get_or_create_name(&base_name, field_types);
         let json_value = serde_json::Value::Object(field_values);
-        Ok(Some(InnerReturnType { json_value, unique_type_name: eip712_name }))
+        Ok(Some(InnerReturnType {
+            json_value,
+            unique_type_name: eip712_name,
+        }))
     }
 
     fn visit_option(
@@ -436,13 +495,11 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
 
         match discriminant {
             0 => Ok(None),
-            1 => {
-                schema.resolve_or_err(value)?.visit(schema, self, context)
-            }
-            _ => Err(FormatError::InvalidDiscriminant {
+            1 => schema.resolve_or_err(value)?.visit(schema, self, context),
+            _ => Err(Eip712Error::InvalidDiscriminant {
                 type_name: "Option".to_string(),
                 discriminant,
-            })
+            }),
         }
     }
 
@@ -459,7 +516,7 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
                 let json_value = serde_json::Value::String(value);
                 Ok(Some(InnerReturnType {
                     json_value,
-                    unique_type_name: "string".to_string()
+                    unique_type_name: "string".to_string(),
                 }))
             }
             Primitive::Float64 => {
@@ -468,7 +525,7 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
                 let json_value = serde_json::Value::String(value);
                 Ok(Some(InnerReturnType {
                     json_value,
-                    unique_type_name: "string".to_string()
+                    unique_type_name: "string".to_string(),
                 }))
             }
             Primitive::Boolean => {
@@ -477,7 +534,7 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
                     0 => serde_json::Value::Bool(false),
                     1 => serde_json::Value::Bool(true),
                     _ => {
-                        return Err(FormatError::InvalidDiscriminant {
+                        return Err(Eip712Error::InvalidDiscriminant {
                             type_name: "bool".to_string(),
                             discriminant: value[0],
                         });
@@ -485,7 +542,7 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
                 };
                 Ok(Some(InnerReturnType {
                     json_value,
-                    unique_type_name: "bool".to_string()
+                    unique_type_name: "bool".to_string(),
                 }))
             }
             Primitive::Integer(int, display) => match int {
@@ -506,16 +563,19 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
             Primitive::ByteVec { display } => {
                 let len = self
                     .read_usize_borsh()
-                    .or(Err(FormatError::MissingVecLength))?;
+                    .or(Err(Eip712Error::MissingVecLength))?;
                 self.display_byte_sequence(len, display, context)
             }
             Primitive::String => {
                 let len = self
                     .read_usize_borsh()
-                    .or(Err(FormatError::MissingStringLength))?;
+                    .or(Err(Eip712Error::MissingStringLength))?;
                 let content = self.input.advance(len)?;
                 let content = std::str::from_utf8(content)?.to_string();
-                Ok(Some(InnerReturnType { json_value: serde_json::Value::String(content), unique_type_name: "string".to_string() }))
+                Ok(Some(InnerReturnType {
+                    json_value: serde_json::Value::String(content),
+                    unique_type_name: "string".to_string(),
+                }))
             }
             Primitive::Skip { len } => {
                 self.input.advance(len)?;
@@ -561,16 +621,24 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
         let mut inner_types = Vec::new();
 
         for i in 0..len {
-            let Some(eip712_key) = key.visit(schema, self, Context { is_virtual: IsVirtual::No, parent_name: format!("{base_name}_{i}") })? else {
-                return Err(FormatError::InvalidMapKey(base_name.clone()))
+            let Some(eip712_key) = key.visit(
+                schema,
+                self,
+                Context {
+                    is_virtual: IsVirtual::No,
+                    parent_name: format!("{base_name}_{i}"),
+                },
+            )?
+            else {
+                return Err(Eip712Error::InvalidMapKey(base_name.clone()));
             };
             let key_name = match eip712_key.json_value {
                 serde_json::Value::String(s) => s,
-                _ => return Err(FormatError::InvalidMapKey(base_name.clone()))
+                _ => return Err(Eip712Error::InvalidMapKey(base_name.clone())),
             };
 
             let Some(eip712_value) = value.visit(schema, self, context.clone())? else {
-                continue
+                continue;
             };
 
             json_values.insert(key_name.clone(), eip712_value.json_value);
@@ -578,8 +646,13 @@ impl<L: LinkingScheme, M> TypeVisitor<L, M> for Eip712Visitor<'_, '_> {
             inner_types.push(property_def);
         }
 
-        let eip712_name = self.output.insert_types_and_get_or_create_name(&base_name, inner_types);
+        let eip712_name = self
+            .output
+            .insert_types_and_get_or_create_name(&base_name, inner_types);
         let json_value = serde_json::Value::Object(json_values);
-        Ok(Some(InnerReturnType { json_value, unique_type_name: eip712_name }))
+        Ok(Some(InnerReturnType {
+            json_value,
+            unique_type_name: eip712_name,
+        }))
     }
 }

--- a/crates/universal-wallet/schema/src/visitors/mod.rs
+++ b/crates/universal-wallet/schema/src/visitors/mod.rs
@@ -1,4 +1,5 @@
 pub mod display;
+#[cfg(feature = "eip712")]
 pub mod eip712;
 #[cfg(feature = "serde")]
 pub mod json_to_borsh;

--- a/crates/universal-wallet/schema/src/visitors/mod.rs
+++ b/crates/universal-wallet/schema/src/visitors/mod.rs
@@ -1,3 +1,4 @@
 pub mod display;
+pub mod eip712;
 #[cfg(feature = "serde")]
 pub mod json_to_borsh;

--- a/crates/universal-wallet/schema/tests/integration/eip712.rs
+++ b/crates/universal-wallet/schema/tests/integration/eip712.rs
@@ -517,7 +517,168 @@ fn test_various_types() {
     eip712_tests!(
         MsgVariousTypes,
         msg,
-        false,
-        r#"{"domain":{"name":"","chainId":"0x0","salt":"0x387d7c4b3c3e545f6e6d1cad1b606ee46250d3acd1dfa80226d0e05551f20527"},"types":{"MsgVariousTypes":[{"type":"uint8","name":"u8"},{"type":"uint16","name":"u16"},{"type":"uint32","name":"u32"},{"type":"uint64","name":"u64"},{"type":"uint128","name":"u128"},{"type":"int8","name":"i8"},{"type":"int16","name":"i16"},{"type":"int32","name":"i32"},{"type":"int64","name":"i64"},{"type":"int128","name":"i128"},{"type":"bool","name":"bool"},{"type":"string","name":"f32"},{"type":"string","name":"f64"},{"type":"string","name":"string"},{"type":"string","name":"byte_vec"},{"type":"string","name":"byte_array"},{"type":"array","name":"array"},{"type":"vec","name":"vec"},{"type":"map","name":"map"}],"array":[{"type":"bool","name":"0"},{"type":"bool","name":"1"},{"type":"bool","name":"2"}],"map":[{"type":"bool","name":"1"},{"type":"bool","name":"2"},{"type":"bool","name":"3"}],"vec":[{"type":"bool","name":"0"},{"type":"bool","name":"1"},{"type":"bool","name":"2"}]},"primaryType":"MsgVariousTypes","message":{"array":{"0":false,"1":false,"2":true},"bool":true,"byte_array":"0x03050709","byte_vec":"0x060708","f32":"45.59","f64":"9716235.31632546","i128":"-180446744073709551615","i16":"-392","i32":"-15472432","i64":"-340542814143","i8":"-92","map":{"1":true,"2":false,"3":true},"string":"Hello","u128":"180446744073709551615","u16":"392","u32":"15472432","u64":"340542814143","u8":"92","vec":{"0":true,"1":false,"2":true}}}"#
+        r#"{
+  "domain": {
+    "chainId": "0x0",
+    "name": "",
+    "salt": "0x387d7c4b3c3e545f6e6d1cad1b606ee46250d3acd1dfa80226d0e05551f20527"
+  },
+  "message": {
+    "array": {
+      "0": false,
+      "1": false,
+      "2": true
+    },
+    "bool": true,
+    "byte_array": "0x03050709",
+    "byte_vec": "0x060708",
+    "f32": "45.59",
+    "f64": "9716235.31632546",
+    "i128": "-180446744073709551615",
+    "i16": "-392",
+    "i32": "-15472432",
+    "i64": "-340542814143",
+    "i8": "-92",
+    "map": {
+      "1": true,
+      "2": false,
+      "3": true
+    },
+    "string": "Hello",
+    "u128": "180446744073709551615",
+    "u16": "392",
+    "u32": "15472432",
+    "u64": "340542814143",
+    "u8": "92",
+    "vec": {
+      "0": true,
+      "1": false,
+      "2": true
+    }
+  },
+  "primaryType": "MsgVariousTypes",
+  "types": {
+    "MsgVariousTypes": [
+      {
+        "name": "u8",
+        "type": "uint8"
+      },
+      {
+        "name": "u16",
+        "type": "uint16"
+      },
+      {
+        "name": "u32",
+        "type": "uint32"
+      },
+      {
+        "name": "u64",
+        "type": "uint64"
+      },
+      {
+        "name": "u128",
+        "type": "uint128"
+      },
+      {
+        "name": "i8",
+        "type": "int8"
+      },
+      {
+        "name": "i16",
+        "type": "int16"
+      },
+      {
+        "name": "i32",
+        "type": "int32"
+      },
+      {
+        "name": "i64",
+        "type": "int64"
+      },
+      {
+        "name": "i128",
+        "type": "int128"
+      },
+      {
+        "name": "bool",
+        "type": "bool"
+      },
+      {
+        "name": "f32",
+        "type": "string"
+      },
+      {
+        "name": "f64",
+        "type": "string"
+      },
+      {
+        "name": "string",
+        "type": "string"
+      },
+      {
+        "name": "byte_vec",
+        "type": "string"
+      },
+      {
+        "name": "byte_array",
+        "type": "string"
+      },
+      {
+        "name": "array",
+        "type": "array"
+      },
+      {
+        "name": "vec",
+        "type": "vec"
+      },
+      {
+        "name": "map",
+        "type": "map"
+      }
+    ],
+    "array": [
+      {
+        "name": "0",
+        "type": "bool"
+      },
+      {
+        "name": "1",
+        "type": "bool"
+      },
+      {
+        "name": "2",
+        "type": "bool"
+      }
+    ],
+    "map": [
+      {
+        "name": "1",
+        "type": "bool"
+      },
+      {
+        "name": "2",
+        "type": "bool"
+      },
+      {
+        "name": "3",
+        "type": "bool"
+      }
+    ],
+    "vec": [
+      {
+        "name": "0",
+        "type": "bool"
+      },
+      {
+        "name": "1",
+        "type": "bool"
+      },
+      {
+        "name": "2",
+        "type": "bool"
+      }
+    ]
+  }
+}"#
     );
 }

--- a/crates/universal-wallet/schema/tests/integration/eip712.rs
+++ b/crates/universal-wallet/schema/tests/integration/eip712.rs
@@ -1,0 +1,523 @@
+use std::collections::BTreeMap;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use sov_rollup_interface::common::SafeString;
+use sov_universal_wallet::schema::Schema;
+use sov_universal_wallet::UniversalWallet;
+
+#[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]
+struct Address([u8; 32]);
+#[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]
+struct TokenId([u8; 32]);
+
+macro_rules! eip712_tests {
+    // Default to comparing pretty-printed JSON
+    ($schema_type:ty, $item:ident, $expected_display:literal) => {
+        eip712_tests!($schema_type, $item, true, $expected_display);
+    };
+    ($schema_type:ty, $item:ident, $pretty_print:literal, $expected_display:literal) => {
+        let mut schema = Schema::of_single_type::<$schema_type>().unwrap();
+        let borsh_ser = borsh::to_vec(&$item).unwrap();
+        let eip712_json = schema.eip712_json(0, &borsh_ser).unwrap();
+
+        let eip712_json = if $pretty_print {
+            // This allows passing $expected_display as a human-readable string, making the test
+            // code easier to parse for humans
+            let parsed: serde_json::Value = serde_json::from_str(&eip712_json).unwrap();
+            serde_json::to_string_pretty(&parsed).unwrap()
+        } else {
+            eip712_json
+        };
+        // println!("{}", eip712_json); // Uncomment for debugging tests
+        assert_eq!(eip712_json, $expected_display);
+
+        // Assert hash can be calculated with no errors
+        let _ = schema.eip712_signing_hash(0, &borsh_ser).unwrap();
+    };
+}
+
+#[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]
+enum TestCallMessage {
+    Transfer { amount: u128, to: Address },
+    Mint { token: TokenId, amount: u128 },
+}
+
+#[test]
+fn test_call_message() {
+    let message = TestCallMessage::Transfer {
+        amount: 56,
+        to: Address([2u8; 32]),
+    };
+
+    eip712_tests!(
+        TestCallMessage,
+        message,
+        r#"{
+  "domain": {
+    "chainId": "0x0",
+    "name": "",
+    "salt": "0x7eb69c66ea4b5b2240aade5bbb135fccc00e4bce2fc20862222309ae97c542cc"
+  },
+  "message": {
+    "Transfer": {
+      "amount": "56",
+      "to": "0x0202020202020202020202020202020202020202020202020202020202020202"
+    }
+  },
+  "primaryType": "TestCallMessage",
+  "types": {
+    "TestCallMessage": [
+      {
+        "name": "Transfer",
+        "type": "Transfer"
+      }
+    ],
+    "Transfer": [
+      {
+        "name": "amount",
+        "type": "uint128"
+      },
+      {
+        "name": "to",
+        "type": "string"
+      }
+    ]
+  }
+}"#
+    );
+}
+
+#[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]
+enum Role {
+    Attester,
+    Prover { address: Address },
+}
+
+#[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]
+struct Msg {
+    m: SafeString,
+    role: Role,
+}
+
+#[test]
+fn test_unit_enums() {
+    let msg = Msg {
+        m: "one".to_string().try_into().unwrap(),
+        role: Role::Attester,
+    };
+
+    eip712_tests!(
+        Msg,
+        msg,
+        r#"{
+  "domain": {
+    "chainId": "0x0",
+    "name": "",
+    "salt": "0x07b104a215fcba925e78c1ced02d15c3577b1fbce2b58daa5c5406beb6f99fcd"
+  },
+  "message": {
+    "m": "one",
+    "role": {
+      "Attester": true
+    }
+  },
+  "primaryType": "Msg",
+  "types": {
+    "Msg": [
+      {
+        "name": "m",
+        "type": "string"
+      },
+      {
+        "name": "role",
+        "type": "Role"
+      }
+    ],
+    "Role": [
+      {
+        "name": "Attester",
+        "type": "bool"
+      }
+    ]
+  }
+}"#
+    );
+}
+
+#[test]
+fn test_enums_2() {
+    let msg = Msg {
+        m: "two".to_string().try_into().unwrap(),
+        role: Role::Prover {
+            address: Address([3u8; 32]),
+        },
+    };
+
+    eip712_tests!(
+        Msg,
+        msg,
+        r#"{
+  "domain": {
+    "chainId": "0x0",
+    "name": "",
+    "salt": "0x07b104a215fcba925e78c1ced02d15c3577b1fbce2b58daa5c5406beb6f99fcd"
+  },
+  "message": {
+    "m": "two",
+    "role": {
+      "Prover": {
+        "address": "0x0303030303030303030303030303030303030303030303030303030303030303"
+      }
+    }
+  },
+  "primaryType": "Msg",
+  "types": {
+    "Msg": [
+      {
+        "name": "m",
+        "type": "string"
+      },
+      {
+        "name": "role",
+        "type": "Role"
+      }
+    ],
+    "Prover": [
+      {
+        "name": "address",
+        "type": "string"
+      }
+    ],
+    "Role": [
+      {
+        "name": "Prover",
+        "type": "Prover"
+      }
+    ]
+  }
+}"#
+    );
+}
+
+#[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]
+enum RoleNested {
+    Attester(u64),
+    Prover(ProverType),
+}
+
+#[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]
+enum ProverType {
+    Onchain { address: u64 },
+    Offchain(u64),
+}
+
+#[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]
+struct MsgNested {
+    m: SafeString,
+    role: RoleNested,
+}
+
+#[test]
+fn test_nested_enums() {
+    let msg = MsgNested {
+        m: "one".to_string().try_into().unwrap(),
+        role: RoleNested::Attester(48),
+    };
+
+    eip712_tests!(
+        MsgNested,
+        msg,
+        r#"{
+  "domain": {
+    "chainId": "0x0",
+    "name": "",
+    "salt": "0x07170be56d0d940836231cdae295585cd451c2cf74284bb07bd41317246f9be8"
+  },
+  "message": {
+    "m": "one",
+    "role": {
+      "Attester": "48"
+    }
+  },
+  "primaryType": "MsgNested",
+  "types": {
+    "MsgNested": [
+      {
+        "name": "m",
+        "type": "string"
+      },
+      {
+        "name": "role",
+        "type": "RoleNested"
+      }
+    ],
+    "RoleNested": [
+      {
+        "name": "Attester",
+        "type": "uint64"
+      }
+    ]
+  }
+}"#
+    );
+}
+
+#[test]
+fn test_nested_enums_2() {
+    let msg = MsgNested {
+        m: "two".to_string().try_into().unwrap(),
+        role: RoleNested::Prover(ProverType::Onchain { address: 65 }),
+    };
+
+    eip712_tests!(
+        MsgNested,
+        msg,
+        r#"{
+  "domain": {
+    "chainId": "0x0",
+    "name": "",
+    "salt": "0x07170be56d0d940836231cdae295585cd451c2cf74284bb07bd41317246f9be8"
+  },
+  "message": {
+    "m": "two",
+    "role": {
+      "Prover": {
+        "Onchain": {
+          "address": "65"
+        }
+      }
+    }
+  },
+  "primaryType": "MsgNested",
+  "types": {
+    "MsgNested": [
+      {
+        "name": "m",
+        "type": "string"
+      },
+      {
+        "name": "role",
+        "type": "RoleNested"
+      }
+    ],
+    "Onchain": [
+      {
+        "name": "address",
+        "type": "uint64"
+      }
+    ],
+    "Prover": [
+      {
+        "name": "Onchain",
+        "type": "Onchain"
+      }
+    ],
+    "RoleNested": [
+      {
+        "name": "Prover",
+        "type": "Prover"
+      }
+    ]
+  }
+}"#
+    );
+}
+
+#[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]
+enum RoleMultiElement {
+    Attester(u64, u128),
+    Prover(ProverType, u128),
+}
+
+#[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]
+struct MsgMultiElement {
+    m: SafeString,
+    role: RoleMultiElement,
+}
+
+#[test]
+fn test_multielement_enums_1() {
+    let msg = MsgMultiElement {
+        m: "one".to_string().try_into().unwrap(),
+        role: RoleMultiElement::Attester(765, 9876),
+    };
+
+    eip712_tests!(
+        MsgMultiElement,
+        msg,
+        r#"{
+  "domain": {
+    "chainId": "0x0",
+    "name": "",
+    "salt": "0xa0a9f6d015a69364793d27147f6a3ccec18bd99eff57689706804dbb944c7192"
+  },
+  "message": {
+    "m": "one",
+    "role": {
+      "Attester": {
+        "0": "765",
+        "1": "9876"
+      }
+    }
+  },
+  "primaryType": "MsgMultiElement",
+  "types": {
+    "Attester": [
+      {
+        "name": "0",
+        "type": "uint64"
+      },
+      {
+        "name": "1",
+        "type": "uint128"
+      }
+    ],
+    "MsgMultiElement": [
+      {
+        "name": "m",
+        "type": "string"
+      },
+      {
+        "name": "role",
+        "type": "RoleMultiElement"
+      }
+    ],
+    "RoleMultiElement": [
+      {
+        "name": "Attester",
+        "type": "Attester"
+      }
+    ]
+  }
+}"#
+    );
+}
+
+#[test]
+fn test_multielement_enums_2() {
+    let msg = MsgMultiElement {
+        m: "two".to_string().try_into().unwrap(),
+        role: RoleMultiElement::Prover(ProverType::Onchain { address: 123456 }, 9876),
+    };
+
+    eip712_tests!(
+        MsgMultiElement,
+        msg,
+        r#"{
+  "domain": {
+    "chainId": "0x0",
+    "name": "",
+    "salt": "0xa0a9f6d015a69364793d27147f6a3ccec18bd99eff57689706804dbb944c7192"
+  },
+  "message": {
+    "m": "two",
+    "role": {
+      "Prover": {
+        "0": {
+          "Onchain": {
+            "address": "123456"
+          }
+        },
+        "1": "9876"
+      }
+    }
+  },
+  "primaryType": "MsgMultiElement",
+  "types": {
+    "MsgMultiElement": [
+      {
+        "name": "m",
+        "type": "string"
+      },
+      {
+        "name": "role",
+        "type": "RoleMultiElement"
+      }
+    ],
+    "Onchain": [
+      {
+        "name": "address",
+        "type": "uint64"
+      }
+    ],
+    "Prover": [
+      {
+        "name": "0",
+        "type": "ProverType"
+      },
+      {
+        "name": "1",
+        "type": "uint128"
+      }
+    ],
+    "ProverType": [
+      {
+        "name": "Onchain",
+        "type": "Onchain"
+      }
+    ],
+    "RoleMultiElement": [
+      {
+        "name": "Prover",
+        "type": "Prover"
+      }
+    ]
+  }
+}"#
+    );
+}
+
+#[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]
+struct MsgVariousTypes {
+    u8: u8,
+    u16: u16,
+    u32: u32,
+    u64: u64,
+    u128: u128,
+    i8: i8,
+    i16: i16,
+    i32: i32,
+    i64: i64,
+    i128: i128,
+    bool: bool,
+    f32: f32,
+    f64: f64,
+    string: SafeString,
+    byte_vec: Vec<u8>,
+    byte_array: [u8; 4],
+    array: [bool; 3],
+    vec: Vec<bool>,
+    map: BTreeMap<u8, bool>,
+}
+
+#[test]
+fn test_various_types() {
+    let msg = MsgVariousTypes {
+        u8: 92,
+        u16: 392,
+        u32: 15_472_432,
+        u64: 340_542_814_143,
+        u128: 180_446_744_073_709_551_615,
+        i8: -92,
+        i16: -392,
+        i32: -15_472_432,
+        i64: -340_542_814_143,
+        i128: -180_446_744_073_709_551_615,
+        bool: true,
+        f32: 45.59,
+        f64: 9716235.31632546,
+        string: "Hello".to_string().try_into().unwrap(),
+        byte_vec: vec![6, 7, 8],
+        byte_array: [3, 5, 7, 9],
+        vec: vec![true, false, true],
+        array: [false, false, true],
+        map: BTreeMap::from([(1, true), (2, false), (3, true)]),
+    };
+
+    eip712_tests!(
+        MsgVariousTypes,
+        msg,
+        false,
+        r#"{"domain":{"name":"","chainId":"0x0","salt":"0x387d7c4b3c3e545f6e6d1cad1b606ee46250d3acd1dfa80226d0e05551f20527"},"types":{"MsgVariousTypes":[{"type":"uint8","name":"u8"},{"type":"uint16","name":"u16"},{"type":"uint32","name":"u32"},{"type":"uint64","name":"u64"},{"type":"uint128","name":"u128"},{"type":"int8","name":"i8"},{"type":"int16","name":"i16"},{"type":"int32","name":"i32"},{"type":"int64","name":"i64"},{"type":"int128","name":"i128"},{"type":"bool","name":"bool"},{"type":"string","name":"f32"},{"type":"string","name":"f64"},{"type":"string","name":"string"},{"type":"string","name":"byte_vec"},{"type":"string","name":"byte_array"},{"type":"array","name":"array"},{"type":"vec","name":"vec"},{"type":"map","name":"map"}],"array":[{"type":"bool","name":"0"},{"type":"bool","name":"1"},{"type":"bool","name":"2"}],"map":[{"type":"bool","name":"1"},{"type":"bool","name":"2"},{"type":"bool","name":"3"}],"vec":[{"type":"bool","name":"0"},{"type":"bool","name":"1"},{"type":"bool","name":"2"}]},"primaryType":"MsgVariousTypes","message":{"array":{"0":false,"1":false,"2":true},"bool":true,"byte_array":"0x03050709","byte_vec":"0x060708","f32":"45.59","f64":"9716235.31632546","i128":"-180446744073709551615","i16":"-392","i32":"-15472432","i64":"-340542814143","i8":"-92","map":{"1":true,"2":false,"3":true},"string":"Hello","u128":"180446744073709551615","u16":"392","u32":"15472432","u64":"340542814143","u8":"92","vec":{"0":true,"1":false,"2":true}}}"#
+    );
+}

--- a/crates/universal-wallet/schema/tests/integration/main.rs
+++ b/crates/universal-wallet/schema/tests/integration/main.rs
@@ -1,1 +1,9 @@
+mod eip712;
 mod schema;
+
+// Hack - because the macro is configured to be re-exported from sov_rollup_interface;
+// but _we_ are a dependency of sov_rollup_interface so we can't import it without causing a cycle
+// This should not be an issue anywhere else except inside this crate's tests right here
+mod sov_rollup_interface {
+    pub use sov_universal_wallet;
+}

--- a/crates/universal-wallet/schema/tests/integration/schema.rs
+++ b/crates/universal-wallet/schema/tests/integration/schema.rs
@@ -12,12 +12,8 @@ use sov_universal_wallet::schema::{
 };
 use sov_universal_wallet::UniversalWallet;
 
-// Hack - because the macro is configured to be re-exported from sov_rollup_interface;
-// but _we_ are a dependency of sov_rollup_interface so we can't import it without causing a cycle
-// This should not be an issue anywhere else except inside this crate's tests right here
-mod sov_rollup_interface {
-    pub use sov_universal_wallet;
-}
+// The fake sov_rollup_interface for fixing macro namespacing
+use crate::sov_rollup_interface;
 
 #[derive(Debug, Serialize)]
 struct TestVector {

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -1622,17 +1622,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-new"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "derive-where"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4988,11 +4977,9 @@ dependencies = [
  "anyhow",
  "borsh",
  "bytes",
- "derive-new",
  "derive_more 1.0.0",
  "digest 0.10.7",
  "hex",
- "itertools 0.14.0",
  "reth-ethereum-primitives",
  "reth-primitives",
  "reth-primitives-traits",

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -1622,6 +1622,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "derive-where"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4977,9 +4988,11 @@ dependencies = [
  "anyhow",
  "borsh",
  "bytes",
+ "derive-new",
  "derive_more 1.0.0",
  "digest 0.10.7",
  "hex",
+ "itertools 0.14.0",
  "reth-ethereum-primitives",
  "reth-primitives",
  "reth-primitives-traits",
@@ -5290,6 +5303,7 @@ dependencies = [
 name = "sov-universal-wallet"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "arrayvec",
  "bech32",
  "borsh",

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -1426,17 +1426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-new"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "derive-where"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4353,11 +4342,9 @@ dependencies = [
  "anyhow",
  "borsh",
  "bytes",
- "derive-new",
  "derive_more 1.0.0",
  "digest 0.10.7",
  "hex",
- "itertools 0.14.0",
  "reth-ethereum-primitives",
  "reth-primitives",
  "reth-primitives-traits",

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -1426,6 +1426,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "derive-where"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4342,9 +4353,11 @@ dependencies = [
  "anyhow",
  "borsh",
  "bytes",
+ "derive-new",
  "derive_more 1.0.0",
  "digest 0.10.7",
  "hex",
+ "itertools 0.14.0",
  "reth-ethereum-primitives",
  "reth-primitives",
  "reth-primitives-traits",
@@ -4673,6 +4686,7 @@ dependencies = [
 name = "sov-universal-wallet"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "arrayvec",
  "bech32",
  "borsh",

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -1960,6 +1960,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "derive-where"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6268,9 +6279,11 @@ dependencies = [
  "anyhow",
  "borsh",
  "bytes",
+ "derive-new",
  "derive_more 1.0.0",
  "digest 0.10.7",
  "hex",
+ "itertools 0.14.0",
  "reth-ethereum-primitives",
  "reth-primitives",
  "reth-primitives-traits",
@@ -6575,6 +6588,7 @@ dependencies = [
 name = "sov-universal-wallet"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "arrayvec",
  "bech32",
  "borsh",

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -1960,17 +1960,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-new"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "derive-where"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6279,11 +6268,9 @@ dependencies = [
  "anyhow",
  "borsh",
  "bytes",
- "derive-new",
  "derive_more 1.0.0",
  "digest 0.10.7",
  "hex",
- "itertools 0.14.0",
  "reth-ethereum-primitives",
  "reth-primitives",
  "reth-primitives-traits",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -1804,6 +1804,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "derive-where"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5855,9 +5866,11 @@ dependencies = [
  "anyhow",
  "borsh",
  "bytes",
+ "derive-new",
  "derive_more 1.0.0",
  "digest 0.10.7",
  "hex",
+ "itertools 0.14.0",
  "reth-ethereum-primitives",
  "reth-primitives",
  "reth-primitives-traits",
@@ -6180,6 +6193,7 @@ dependencies = [
 name = "sov-universal-wallet"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "arrayvec",
  "bech32",
  "borsh",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -1804,17 +1804,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-new"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "derive-where"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5866,11 +5855,9 @@ dependencies = [
  "anyhow",
  "borsh",
  "bytes",
- "derive-new",
  "derive_more 1.0.0",
  "digest 0.10.7",
  "hex",
- "itertools 0.14.0",
  "reth-ethereum-primitives",
  "reth-primitives",
  "reth-primitives-traits",


### PR DESCRIPTION
# Description

Adds EIP712 encoding functionality to the UniversalWallet schema, allowing any root type in the schema to both be encoded as an EIP712 compatible JSON and to calculate the EIP712 signing hash.

The main functionality to review is crates/universal-wallet/schema/src/visitors/eip712.rs (about 650 lines), and the bulk of the rest of the changelog is the new test file - which should be trivial to review but demonstrates how the generated JSONs appear.

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
