### PR TITLE
EVM: Remove chain_id from genesis.

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -45,22 +45,24 @@ fn recover_evm_signer(
 }
 
 /// Creates the transaction details and tx hash for an EVM transaction.
-fn create_evm_tx_details_and_hash<S: Spec>(
+fn create_auth_tx_and_hash<S: Spec>(
     tx: &TransactionSigned,
-) -> Result<(TxDetails<S>, TxHash), AuthenticationError> {
+) -> Result<AuthenticatedTransactionAndRawHash<S>, AuthenticationError> {
     let tx_hash = TxHash::new(**tx.hash());
     let tx_chain_id = validate_chain_id(tx.chain_id(), tx_hash)?;
     let gas_limit = tx.gas_limit();
 
-    Ok((
-        TxDetails {
-            chain_id: tx_chain_id,
-            max_priority_fee_bips: PriorityFeeBips::ZERO,
-            max_fee: Amount::new(100_000_000_000),
-            gas_limit: Some([gas_limit, gas_limit].into()),
-        },
-        tx_hash,
-    ))
+    let tx_details = TxDetails {
+        chain_id: tx_chain_id,
+        max_priority_fee_bips: PriorityFeeBips::ZERO,
+        max_fee: Amount::new(100_000_000_000),
+        gas_limit: Some([gas_limit, gas_limit].into()),
+    };
+
+    Ok(AuthenticatedTransactionAndRawHash {
+        raw_tx_hash: tx_hash,
+        authenticated_tx: tx_details.into(),
+    })
 }
 
 fn validate_chain_id(
@@ -68,9 +70,10 @@ fn validate_chain_id(
     tx_hash: TxHash,
 ) -> Result<u64, AuthenticationError> {
     let rollup_chain_id = config_value!("CHAIN_ID");
-    let tx_chain_id = tx_chain_id.ok_or_else(|| {
-        AuthenticationError::FatalError(FatalError::MissingChainId(rollup_chain_id), tx_hash)
-    })?;
+    let tx_chain_id = tx_chain_id.ok_or(AuthenticationError::FatalError(
+        FatalError::MissingChainId(rollup_chain_id),
+        tx_hash,
+    ))?;
 
     if tx_chain_id != rollup_chain_id {
         return Err(AuthenticationError::FatalError(
@@ -123,17 +126,12 @@ where
     let (rlp, tx) = decode_evm_tx(raw_tx)
         .map_err(|e| fatal_deserialization_error::<Accessor, S, _>(raw_tx, e, state))?;
 
-    let (tx_details, hash) = create_evm_tx_details_and_hash(&tx)?;
+    let tx_and_raw_hash = create_auth_tx_and_hash(&tx)?;
 
-    let signer = recover_evm_signer(&tx, hash)?;
-
-    let tx_and_raw_hash = AuthenticatedTransactionAndRawHash {
-        raw_tx_hash: hash,
-        authenticated_tx: tx_details.into(),
-    };
+    let signer = recover_evm_signer(&tx, tx_and_raw_hash.raw_tx_hash)?;
 
     let nonce = tx.nonce();
-    let auth_data = extract_evm_authorization_data::<S>(signer, hash, nonce);
+    let auth_data = extract_evm_authorization_data::<S>(signer, tx_and_raw_hash.raw_tx_hash, nonce);
 
     let call = CallMessage { rlp };
 

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -44,30 +44,17 @@ fn recover_evm_signer(
     })
 }
 
-/// Creates the transaction details for an EVM transaction.
-fn create_evm_tx_details<S: Spec>(
+/// Creates the transaction details and tx hash for an EVM transaction.
+fn create_evm_tx_details_and_hash<S: Spec>(
     tx: &TransactionSigned,
 ) -> Result<(TxDetails<S>, TxHash), AuthenticationError> {
     let tx_hash = TxHash::new(**tx.hash());
+    let tx_chain_id = validate_chain_id(tx.chain_id(), tx_hash)?;
     let gas_limit = tx.gas_limit();
-    let rollup_chain_id = config_value!("CHAIN_ID");
-    let chain_id = tx.chain_id().ok_or_else(|| {
-        AuthenticationError::FatalError(FatalError::MissingChainId(rollup_chain_id), tx_hash)
-    })?;
-
-    if chain_id != rollup_chain_id {
-        return Err(AuthenticationError::FatalError(
-            FatalError::InvalidChainId {
-                expected: rollup_chain_id,
-                got: chain_id,
-            },
-            tx_hash,
-        ));
-    }
 
     Ok((
         TxDetails {
-            chain_id,
+            chain_id: tx_chain_id,
             max_priority_fee_bips: PriorityFeeBips::ZERO,
             max_fee: Amount::new(100_000_000_000),
             gas_limit: Some([gas_limit, gas_limit].into()),
@@ -76,6 +63,27 @@ fn create_evm_tx_details<S: Spec>(
     ))
 }
 
+fn validate_chain_id(
+    tx_chain_id: Option<u64>,
+    tx_hash: TxHash,
+) -> Result<u64, AuthenticationError> {
+    let rollup_chain_id = config_value!("CHAIN_ID");
+    let tx_chain_id = tx_chain_id.ok_or_else(|| {
+        AuthenticationError::FatalError(FatalError::MissingChainId(rollup_chain_id), tx_hash)
+    })?;
+
+    if tx_chain_id != rollup_chain_id {
+        return Err(AuthenticationError::FatalError(
+            FatalError::InvalidChainId {
+                expected: rollup_chain_id,
+                got: tx_chain_id,
+            },
+            tx_hash,
+        ));
+    }
+
+    Ok(tx_chain_id)
+}
 /// Extracts EVM authorization data from a verified transaction.
 fn extract_evm_authorization_data<S: Spec>(
     signer: Address,
@@ -115,7 +123,7 @@ where
     let (rlp, tx) = decode_evm_tx(raw_tx)
         .map_err(|e| fatal_deserialization_error::<Accessor, S, _>(raw_tx, e, state))?;
 
-    let (tx_details, hash) = create_evm_tx_details(&tx)?;
+    let (tx_details, hash) = create_evm_tx_details_and_hash(&tx)?;
 
     let signer = recover_evm_signer(&tx, hash)?;
 

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -47,8 +47,8 @@ fn recover_evm_signer(
 /// Creates the transaction details for an EVM transaction.
 fn create_evm_tx_details<S: Spec>(
     tx: &TransactionSigned,
-    tx_hash: TxHash,
-) -> Result<TxDetails<S>, AuthenticationError> {
+) -> Result<(TxDetails<S>, TxHash), AuthenticationError> {
+    let tx_hash = TxHash::new(**tx.hash());
     let gas_limit = tx.gas_limit();
     let rollup_chain_id = config_value!("CHAIN_ID");
     let chain_id = tx.chain_id().ok_or_else(|| {
@@ -65,13 +65,16 @@ fn create_evm_tx_details<S: Spec>(
         ));
     }
 
-    Ok(TxDetails {
-        // If the tx `chain_id` is not set we assume the rollup `chain_id``.
-        chain_id,
-        max_priority_fee_bips: PriorityFeeBips::ZERO,
-        max_fee: Amount::new(100_000_000_000),
-        gas_limit: Some([gas_limit, gas_limit].into()),
-    })
+    Ok((
+        TxDetails {
+            // If the tx `chain_id` is not set we assume the rollup `chain_id``.
+            chain_id,
+            max_priority_fee_bips: PriorityFeeBips::ZERO,
+            max_fee: Amount::new(100_000_000_000),
+            gas_limit: Some([gas_limit, gas_limit].into()),
+        },
+        tx_hash,
+    ))
 }
 
 /// Extracts EVM authorization data from a verified transaction.
@@ -112,13 +115,15 @@ where
 
     let (rlp, tx) = decode_evm_tx(raw_tx)
         .map_err(|e| fatal_deserialization_error::<Accessor, S, _>(raw_tx, e, state))?;
-    let hash = TxHash::new(**tx.hash());
+
+    let (tx_details, hash) = create_evm_tx_details(&tx)?;
+    //let hash = TxHash::new(**tx.hash());
 
     let signer = recover_evm_signer(&tx, hash)?;
 
     let tx_and_raw_hash = AuthenticatedTransactionAndRawHash {
         raw_tx_hash: hash,
-        authenticated_tx: create_evm_tx_details(&tx, hash)?.into(),
+        authenticated_tx: tx_details.into(),
     };
 
     let nonce = tx.nonce();

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -117,7 +117,6 @@ where
         .map_err(|e| fatal_deserialization_error::<Accessor, S, _>(raw_tx, e, state))?;
 
     let (tx_details, hash) = create_evm_tx_details(&tx)?;
-    //let hash = TxHash::new(**tx.hash());
 
     let signer = recover_evm_signer(&tx, hash)?;
 

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -67,7 +67,6 @@ fn create_evm_tx_details<S: Spec>(
 
     Ok((
         TxDetails {
-            // If the tx `chain_id` is not set we assume the rollup `chain_id``.
             chain_id,
             max_priority_fee_bips: PriorityFeeBips::ZERO,
             max_fee: Amount::new(100_000_000_000),

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -45,14 +45,33 @@ fn recover_evm_signer(
 }
 
 /// Creates the transaction details for an EVM transaction.
-fn create_evm_tx_details<S: Spec>(tx: &TransactionSigned) -> TxDetails<S> {
+fn create_evm_tx_details<S: Spec>(
+    tx: &TransactionSigned,
+    tx_hash: TxHash,
+) -> Result<TxDetails<S>, AuthenticationError> {
     let gas_limit = tx.gas_limit();
-    TxDetails {
-        chain_id: config_value!("CHAIN_ID"),
+    let rollup_chain_id = config_value!("CHAIN_ID");
+    let chain_id = tx.chain_id().ok_or_else(|| {
+        AuthenticationError::FatalError(FatalError::MissingChainId(rollup_chain_id), tx_hash)
+    })?;
+
+    if chain_id != rollup_chain_id {
+        return Err(AuthenticationError::FatalError(
+            FatalError::InvalidChainId {
+                expected: rollup_chain_id,
+                got: chain_id,
+            },
+            tx_hash,
+        ));
+    }
+
+    Ok(TxDetails {
+        // If the tx `chain_id` is not set we assume the rollup `chain_id``.
+        chain_id,
         max_priority_fee_bips: PriorityFeeBips::ZERO,
         max_fee: Amount::new(100_000_000_000),
         gas_limit: Some([gas_limit, gas_limit].into()),
-    }
+    })
 }
 
 /// Extracts EVM authorization data from a verified transaction.
@@ -99,7 +118,7 @@ where
 
     let tx_and_raw_hash = AuthenticatedTransactionAndRawHash {
         raw_tx_hash: hash,
-        authenticated_tx: create_evm_tx_details(&tx).into(),
+        authenticated_tx: create_evm_tx_details(&tx, hash)?.into(),
     };
 
     let nonce = tx.nonce();

--- a/crates/module-system/module-implementations/sov-evm/src/config.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/config.rs
@@ -99,7 +99,6 @@ mod tests {
                 code: Bytes::default(),
             }],
             chain_spec: crate::EvmChainSpec {
-                chain_id: 4321, // Use a hard-coded value instead of config_value!("CHAIN_ID") since the string below is hard-coded
                 limit_contract_code_size: None,
                 block_timestamp_delta: 1u64,
                 hardforks: vec![(0, SpecId::SHANGHAI)],
@@ -120,7 +119,6 @@ mod tests {
                 "initial_base_fee":7,
                 "genesis_timestamp":0,
                 "chain_spec":{
-                    "chain_id":4321,
                     "limit_contract_code_size":null,
                     "coinbase":"0x0000000000000000000000000000000000000000",
                     "block_gas_limit":30000000,

--- a/crates/module-system/module-implementations/sov-evm/src/config.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/config.rs
@@ -2,15 +2,12 @@ use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
 use alloy_eips::merge::SLOT_DURATION;
 use alloy_primitives::Address;
 use revm::primitives::hardfork::SpecId;
-use sov_modules_api::macros::config_value;
 
 use crate::AccountData;
 
 /// Core EVM chain parameters shared between genesis and runtime
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
 pub struct EvmChainSpec {
-    /// Unique chain identifier
-    pub chain_id: u64,
     /// Maximum contract code size (None = unlimited)
     pub limit_contract_code_size: Option<usize>,
     /// Address where transaction fees are collected
@@ -39,7 +36,6 @@ pub struct EvmGenesisConfig {
 impl Default for EvmChainSpec {
     fn default() -> Self {
         Self {
-            chain_id: config_value!("CHAIN_ID"),
             limit_contract_code_size: None,
             coinbase: Address::ZERO,
             block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,

--- a/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -1,3 +1,9 @@
+use crate::{
+    db::commit::FallibleDatabaseCommit,
+    get_spec_id,
+    sov_evm::{SovEvm, UnmeteredStorageAccessInspector},
+    EvmRuntimeConfig,
+};
 use reth_revm::db::DBErrorMarker;
 use revm::context::TxEnv;
 use revm::InspectEvm;
@@ -8,13 +14,7 @@ use revm::{
     },
     Database, MainContext,
 };
-
-use crate::{
-    db::commit::FallibleDatabaseCommit,
-    get_spec_id,
-    sov_evm::{SovEvm, UnmeteredStorageAccessInspector},
-    EvmRuntimeConfig,
-};
+use sov_modules_api::macros::config_value;
 
 /// builds CfgEnv
 /// Returns correct config depending on spec for given block number
@@ -25,7 +25,7 @@ pub(crate) fn get_cfg_env(
     template_cfg: Option<CfgEnv>,
 ) -> CfgEnv {
     let mut cfg_env = template_cfg.unwrap_or_default();
-    cfg_env.chain_id = cfg.chain_spec.chain_id;
+    cfg_env.chain_id = config_value!("CHAIN_ID");
     cfg_env.limit_contract_code_size = cfg.chain_spec.limit_contract_code_size;
     cfg_env.disable_block_gas_limit = true;
     cfg_env.disable_balance_check = true;

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -38,18 +38,18 @@ where
 {
     /// Handler for `net_version`
     #[rpc_method(name = "net_version")]
-    pub fn net_version(&self, state: &mut ApiStateAccessor<S>) -> RpcResult<String> {
+    pub fn net_version(&self, _state: &mut ApiStateAccessor<S>) -> RpcResult<String> {
         debug!("EVM module JSON-RPC request to `net_version`");
 
         // Network ID is the same as chain ID for most networks
-        let chain_id = self.cfg_infallible(state).chain_spec.chain_id;
+        let chain_id = config_value!("CHAIN_ID");
         Ok(chain_id.to_string())
     }
 
     /// Handler for: `eth_chainId`
     #[rpc_method(name = "eth_chainId")]
-    pub fn chain_id(&self, state: &mut ApiStateAccessor<S>) -> RpcResult<Option<U64>> {
-        let chain_id = self.cfg_infallible(state).chain_spec.chain_id;
+    pub fn chain_id(&self, _state: &mut ApiStateAccessor<S>) -> RpcResult<Option<U64>> {
+        let chain_id = config_value!("CHAIN_ID");
         debug!(
             chain_id = chain_id,
             "EVM module JSON-RPC request to `eth_chainId`"

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
@@ -46,7 +46,6 @@ fn test_genesis_cfg() {
             evm.cfg_infallible(state),
             EvmRuntimeConfig {
                 chain_spec: sov_evm::EvmChainSpec {
-                    chain_id: 1000,
                     block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
                     block_timestamp_delta: 2,
                     coinbase: Address::from([3u8; 20]),
@@ -122,7 +121,6 @@ fn default_config() -> EvmGenesisConfig {
         initial_base_fee: 70,
         genesis_timestamp: 50,
         chain_spec: sov_evm::EvmChainSpec {
-            chain_id: 1000,
             block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
             block_timestamp_delta: 2,
             coinbase: Address::from([3u8; 20]),

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -626,6 +626,15 @@
           "format": "uint",
           "minimum": 0.0
         },
+        "state_cache_size": {
+          "description": "The size of the cache which holds hot key-value pairs in the flat state database. Default is 1GB. A larger cache size can improve execution speed at the cost of more memory usage.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
         "user_commit_concurrency": {
           "description": "Number of concurrent commit workers for the user state. More details at [`Options::commit_concurrency`]",
           "type": [

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -181,6 +181,9 @@ pub enum FatalError {
     /// Signature verification failed.
     #[error("Signature verification failed: {0}")]
     SigVerificationFailed(String),
+    /// Missing chain id
+    #[error("Missing chain id: expected {0}")]
+    MissingChainId(u64),
     /// The chain id was invalid
     #[error("Invalid chain id: expected {expected}, got {got}")]
     InvalidChainId {

--- a/examples/test-data/genesis/demo/celestia/evm.json
+++ b/examples/test-data/genesis/demo/celestia/evm.json
@@ -24,7 +24,6 @@
   "initial_base_fee": 7,
   "genesis_timestamp": 0,
   "chain_spec": {
-    "chain_id": 4321,
     "limit_contract_code_size": null,
     "coinbase": "0x0000000000000000000000000000000000000000",
     "block_gas_limit": 30000000,

--- a/examples/test-data/genesis/demo/mock/evm.json
+++ b/examples/test-data/genesis/demo/mock/evm.json
@@ -24,7 +24,6 @@
   "initial_base_fee": 7,
   "genesis_timestamp": 0,
   "chain_spec": {
-    "chain_id": 4321,
     "limit_contract_code_size": null,
     "coinbase": "0x0000000000000000000000000000000000000000",
     "block_gas_limit": 30000000,

--- a/examples/test-data/genesis/integration-tests/evm.json
+++ b/examples/test-data/genesis/integration-tests/evm.json
@@ -24,7 +24,6 @@
   "initial_base_fee": 7,
   "genesis_timestamp": 0,
   "chain_spec": {
-    "chain_id": 4321,
     "limit_contract_code_size": null,
     "coinbase": "0x0000000000000000000000000000000000000000",
     "block_gas_limit": 30000000,


### PR DESCRIPTION
# Description

Removes chain_id from evm genesis.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
