### PR TITLE
Add support for realtime_sendRawTransaction

### DIFF
--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use alloy_primitives::{Bytes, B256};
 
+use alloy_rpc_types::TransactionReceipt;
 use jsonrpsee::types::{ErrorObjectOwned, Params};
 use jsonrpsee::Extensions;
 use sov_address::{EthereumAddress, FromVmAddress};
@@ -155,4 +156,37 @@ where
     })?;
 
     Ok(tx_hash)
+}
+
+pub async fn realtime_send_raw_transaction<S, Seq>(
+    parameters: Params<'static>,
+    ethereum: Arc<Ethereum<S, Seq>>,
+    _: Extensions,
+) -> Result<Option<TransactionReceipt>, ErrorObjectOwned>
+where
+    S: Spec,
+    Seq: Sequencer<Spec = S>,
+    S::Address: FromVmAddress<EthereumAddress>,
+    Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
+{
+    let data: Bytes = parameters.one().unwrap();
+
+    let raw_evm_tx = RlpEvmTransaction { rlp: data.to_vec() };
+
+    let (tx_hash, raw_message) = ethereum
+        .make_raw_tx(raw_evm_tx)
+        .map_err(|e| to_jsonrpsee_error_object(e, ETH_RPC_ERROR))?;
+
+    let tx = Seq::Rt::encode_with_ethereum_auth(RawTx::new(raw_message));
+
+    ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
+        to_jsonrpsee_error_object(
+            format!("{} - '{}' ({:?})", e.status, e.message, e.details),
+            ETH_RPC_ERROR,
+        )
+    })?;
+
+    let evm = sov_evm::Evm::<S>::default();
+    let receipt = evm.get_transaction_receipt(tx_hash, &mut ethereum.sequencer.api_state().default_api_state_accessor())?;
+    Ok::<_, ErrorObjectOwned>(receipt)
 }

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -187,6 +187,9 @@ where
     })?;
 
     let evm = sov_evm::Evm::<S>::default();
-    let receipt = evm.get_transaction_receipt(tx_hash, &mut ethereum.sequencer.api_state().default_api_state_accessor())?;
+    let receipt = evm.get_transaction_receipt(
+        tx_hash,
+        &mut ethereum.sequencer.api_state().default_api_state_accessor(),
+    )?;
     Ok::<_, ErrorObjectOwned>(receipt)
 }

--- a/crates/full-node/sov-ethereum/src/lib.rs
+++ b/crates/full-node/sov-ethereum/src/lib.rs
@@ -62,6 +62,10 @@ where
         ready(Ok::<_, Infallible>(U256::ZERO))
     })?;
     rpc.register_async_method("eth_sendRawTransaction", handlers::eth_send_raw_transaction)?;
+    rpc.register_async_method(
+        "realtime_sendRawTransaction",
+        handlers::realtime_send_raw_transaction,
+    )?;
 
     #[cfg(feature = "local")]
     {


### PR DESCRIPTION
# Description

This PR adds support for the `realtime_sendRawTransaction` API, which returns the receipt when the tx is created.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
