### PR TITLE
Celestia metrics: consisten field names.

### DIFF
--- a/crates/adapters/celestia/src/metrics.rs
+++ b/crates/adapters/celestia/src/metrics.rs
@@ -146,7 +146,7 @@ impl Metric for BlobSubmitMeasurement {
         if let Some(success_metrics) = &self.success_metrics {
             write!(
                 buffer,
-                ",status_code={},da_height={},gas_used={}",
+                ",status_code={},height={},gas_used={}",
                 success_metrics.response_code, success_metrics.da_height, success_metrics.gas_used,
             )?;
         }

--- a/crates/full-node/sov-blob-sender/src/lib.rs
+++ b/crates/full-node/sov-blob-sender/src/lib.rs
@@ -531,7 +531,6 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
             tracing::error!(
                 %blob_hash,
                 ?da_tx_id,
-                timer = ?start_time,
                 blob_processing_timeout = ?self.blob_processing_timeout,
                 ?elapsed,
                 "BlobSender: elapsed time for blob submission exceeded the resubmit interval.",

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -1708,7 +1708,7 @@ where
     ) {
         let mut inner = self.get_inner_with_timing(reason).await;
 
-        // Creates a new executor  for recovery. This must *not* be called to create executors
+        // Creates a new executor for recovery. This must *not* be called to create executors
         // under other circumstances, since it causes side effects on the transaction cache.
         let transaction_cache_write_handle = inner.tx_cache_writer.clone();
         let recovery_executor = RollupBlockExecutor::<_, Rt>::new_with_tx_cache_writer(

--- a/crates/module-system/hyperlane/src/ism.rs
+++ b/crates/module-system/hyperlane/src/ism.rs
@@ -204,8 +204,8 @@ impl MessageIdMultisigIsmMetadata {
 
         // Sanity check that the number of signatures is correct. We already checked the length at the top of this function,
         // so a failure here indicates a bug.
-        assert!(
-            signatures.len() == num_signatures,
+        assert_eq!(
+            signatures.len(), num_signatures,
             "Invalid number of signatures: expected {}, got {}",
             num_signatures,
             signatures.len()

--- a/crates/module-system/hyperlane/src/ism.rs
+++ b/crates/module-system/hyperlane/src/ism.rs
@@ -205,7 +205,8 @@ impl MessageIdMultisigIsmMetadata {
         // Sanity check that the number of signatures is correct. We already checked the length at the top of this function,
         // so a failure here indicates a bug.
         assert_eq!(
-            signatures.len(), num_signatures,
+            signatures.len(),
+            num_signatures,
             "Invalid number of signatures: expected {}, got {}",
             num_signatures,
             signatures.len()

--- a/crates/module-system/module-implementations/sov-blob-storage/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-blob-storage/src/capabilities.rs
@@ -130,8 +130,8 @@ impl<S: Spec> BlobStorage<S> {
     }
 
     // Selects blobs from the DA layer in the order they appear, subject to the given size limit. Note that this method
-    // mutatates the `blobs_with_total_size_limit` argument rather than returning a new value - this makes it easy to share
-    // beween the preferred and non-preferred paths.
+    // mutates the `blobs_with_total_size_limit` argument rather than returning a new value - this makes it easy to share
+    // between the preferred and non-preferred paths.
     fn select_blobs_da_ordering_helper<'a>(
         &mut self,
         blob_iter: impl Iterator<Item = BlobOrigin<'a, <S::Da as DaSpec>::BlobTransaction>>,
@@ -716,7 +716,8 @@ impl<S: Spec> BlobStorage<S> {
                     continue;
                 }
             }
-            // If we reach this point, neither the list of new blobs nor the list of stored blobs has the next sequence number. We're stuck. break and returne the old sequence number
+            // If we reach this point, neither the list of new blobs nor the list of stored blobs has the next sequence number.
+            // We're stuck. break and return the old sequence number
             break sequence_tracker.next_sequence_number;
         };
 
@@ -956,8 +957,8 @@ impl<S: Spec> BlobStorage<S> {
         )
     }
 
-    /// Takes the next run of blobs and extracts the list  of blobs that should be processed this slot, if any. Saves
-    /// any new preferred blobs that aren't going to be used immediately into storage.
+    /// Takes the next run of blobs and extracts the list of blobs that should be processed this slot, if any.
+    /// Saves any new preferred blobs that aren't going to be used immediately into storage.
     fn get_blobs_to_process_from_run(
         &mut self,
         next_run_of_blobs: Vec<BlobArrival>,
@@ -1088,7 +1089,7 @@ impl<S: Spec> BlobStorage<S> {
 impl<S: Spec> BlobStorage<S> {
     #[allow(clippy::type_complexity)]
     /// This implementation returns three categories of blobs:
-    /// 1. Any blobs sent by the preferred sequencer ("prority blobs")
+    /// 1. Any blobs sent by the preferred sequencer ("priority blobs")
     /// 2. Any non-priority blobs which were sent `DEFERRED_SLOTS_COUNT` slots ago ("expiring deferred blobs")
     /// 3. Some additional deferred blobs needed to fill the total requested by the sequencer, if applicable. ("bonus blobs")
     pub fn get_blobs_for_this_slot<CF: InjectedControlFlow<S> + Clone>(
@@ -1140,7 +1141,7 @@ impl<S: Spec> BlobStorage<S> {
         }
 
         // Otherwise, we're configured for a preferred sequencer but one doesn't exist. This usually means that the preferred sequencer was slashed.
-        // Entery recovery mode.
+        // Enter recovery mode.
         let selection =
             self.select_blobs_in_recovery_mode(current_blobs, &mut discarded_blobs, state);
 

--- a/crates/module-system/module-implementations/sov-blob-storage/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-blob-storage/src/lib.rs
@@ -78,7 +78,7 @@ impl<S: Spec> ValidatedBlob<S, BatchWithId<S>> {
         size += 1; // for the blob enum discriminant
         size += sender.as_ref().len();
         size += 33; // For the option discriminant and derived holder size
-        size += 12; // Account for serializing the blob length, the length of the sender field, and the length of the seqeuncer address if it's a proof
+        size += 12; // Account for serializing the blob length, the length of the sender field, and the length of the sequencer address if it's a proof
         size
     }
 }

--- a/crates/module-system/module-implementations/sov-blob-storage/src/max_size_checker.rs
+++ b/crates/module-system/module-implementations/sov-blob-storage/src/max_size_checker.rs
@@ -96,7 +96,7 @@ impl<S: Spec> BlobsAccumulatorWithSizeLimit<S> {
     fn new_with_size(max_total_size: u32) -> Self {
         let max_preferred_blob_size = max_total_size
             .checked_div(sov_modules_api::PREFERRED_DATA_FRACTION.denominator)
-            .expect("Can't devide by 0")
+            .expect("Can't divide by 0")
             .checked_mul(sov_modules_api::PREFERRED_DATA_FRACTION.numerator)
             // This cannot overflow because the PREFERRED_DATA_FRACTION must be less than 1.
             .unwrap();

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -173,7 +173,7 @@ pub struct ApiStateAccessor<S: Spec> {
     // Unfortunately, we need to run one query using the accessor in order to determine the correct visible slot number,
     // so we can't make this field non-optional.
     visible_slot_number: Option<VisibleSlotNumber>,
-    // The true slot number to use for user/accessory queries. This need not correspond exactly the the accessor's
+    // The true slot number to use for user/accessory queries. This need not correspond exactly the accessor's
     // rollup height (if present) but it must be older than the N+1th rollup height.
     //
     // Suppose we have the following rollup heights:
@@ -351,7 +351,7 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
     }
 
     /// A specialized constructor for use in sov-test-utils. This constructor matches the unusual semantic of our testing framework, which expects to see
-    /// the *next* visible slot number with the *current* rollup height in the accessor as soon as the a slot finishes executing.
+    /// the *next* visible slot number with the *current* rollup height in the accessor as soon as the slot finishes executing.
     ///
     /// In actual execution, this semantic is not needed because the time between the end of slot N and the start of slot N+1 is neglible. Unfortunately,
     /// our tests are written assuming that all assertions will execute during this miniscule instant of time, so we have to accommodate it for now.

--- a/crates/module-system/sov-test-utils/src/runtime/mod.rs
+++ b/crates/module-system/sov-test-utils/src/runtime/mod.rs
@@ -311,7 +311,7 @@ where
             .unwrap_infallible()
     }
 
-    /// A simple helper function to get the the staked balance of a sequencer.
+    /// A simple helper function to get the staked balance of a sequencer.
     pub fn get_sequencer_staking_balance(
         sequencer: &<S::Da as DaSpec>::Address,
         state: &mut ApiStateAccessor<S>,

--- a/crates/rollup-interface/src/state_machine/da.rs
+++ b/crates/rollup-interface/src/state_machine/da.rs
@@ -90,7 +90,7 @@ pub struct CountedBufReader<B: bytes::Buf> {
 }
 
 impl<B: bytes::Buf> CountedBufReader<B> {
-    /// Creates a new buffer reader with counter from an objet that implements the buffer trait
+    /// Creates a new buffer reader with counter from an object that implements the buffer trait
     pub fn new(inner: B) -> Self {
         let buf_size = inner.remaining();
         CountedBufReader {

--- a/crates/rollup-interface/src/state_machine/stf/mod.rs
+++ b/crates/rollup-interface/src/state_machine/stf/mod.rs
@@ -204,7 +204,7 @@ pub struct DiscardedBlob {
 
 /// The result of applying a slot to current state. We define a helpful alias [`ApplySlotOutput`]
 /// to make the type signature of [`StateTransitionFunction::apply_slot`] more readable. Unfortunately,
-/// since this type both depends on and appears in the defintion of the [`StateTransitionFunction`] trait,
+/// since this type both depends on and appears in the definition of the [`StateTransitionFunction`] trait,
 /// we have to use a type alias to avoid introducing an unneeded [`Sized`] bound.
 pub struct ApplySlotOutputInner<Root, ChangeSet, BR, PR, Witness> {
     /// Final state root after all blobs were applied


### PR DESCRIPTION
# Description

use `height` instead of `da_height` as in fetch block metrics.

Also contains some minor typos and clean ups in logging

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existing tests are passing

## Docs
No updates
