### PR TITLE
EVM: Add stub for `eth_subscribe`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "alloy"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ecf116474faea3e30ecb03cb14548598ca8243d5316ce50f820e67b3e848473"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-pubsub",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-transport-ipc",
+ "alloy-transport-ws",
+]
+
+[[package]]
 name = "alloy-chains"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +167,42 @@ dependencies = [
  "alloy-serde",
  "arbitrary",
  "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28074a21cd4f7c3a7ab218c4f38fae6be73944e1feae3b670c68b60bf85ca40"
+dependencies = [
+ "alloy-consensus",
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-pubsub",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "futures",
+ "futures-util",
+ "serde_json",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "alloy-core"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe6c56d58fbfa9f0f6299376e8ce33091fc6494239466814c3f54b55743cb09"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
 ]
 
 [[package]]
@@ -370,6 +431,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-provider"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59879a772ebdcde9dc4eb38b2535d32e8503d3175687cc09e763a625c5fcf32"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-pubsub",
+ "alloy-rpc-client",
+ "alloy-rpc-types-anvil",
+ "alloy-rpc-types-debug",
+ "alloy-rpc-types-eth",
+ "alloy-rpc-types-trace",
+ "alloy-rpc-types-txpool",
+ "alloy-signer",
+ "alloy-sol-types",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-transport-ipc",
+ "alloy-transport-ws",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap 6.1.0",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "http 1.1.0",
+ "lru 0.13.0",
+ "parking_lot",
+ "pin-project",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-pubsub"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a682f14e10c3f4489c57b64ed457801b3e7ffc5091b6a35883d0e5960b9b894"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "auto_impl",
+ "bimap",
+ "futures",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,14 +522,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rpc-client"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194ff51cd1d2e65c66b98425e0ca7eb559ca1a579725834c986d84faf8e224c0"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-pubsub",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-transport-ipc",
+ "alloy-transport-ws",
+ "futures",
+ "pin-project",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
 name = "alloy-rpc-types"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d4fe522f6fc749c8afce721bdc8f73b715d317c3c02fcb9b51f7a143e4401dd"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types-anvil",
+ "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
+ "alloy-rpc-types-trace",
+ "alloy-rpc-types-txpool",
  "alloy-serde",
  "serde",
 ]
@@ -417,6 +577,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rpc-types-anvil"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6af88d9714b499675164cac2fa2baadb3554579ab3ea8bc0d7b0c0de4f9d692"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
 name = "alloy-rpc-types-any"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +597,18 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-debug"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2fe118e6c152d54cb4549b9835fb87d38b12754bb121375183ee3ec84bd0849"
+dependencies = [
+ "alloy-primitives",
+ "derive_more 2.0.1",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -469,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9a2184493c374ca1dbba9569d37215c23e489970f8c3994f731cb3ed6b0b7d"
+checksum = "719e5eb9c15e21dab3dee2cac53505500e5e701f25d556734279c5f02154022a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -479,6 +663,18 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.11",
+]
+
+[[package]]
+name = "alloy-rpc-types-txpool"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c751233a6067ccc8a4cbd469e0fd34e0d9475fd118959dbc777ae3af31bba7"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
 ]
 
 [[package]]
@@ -509,6 +705,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-signer-local"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad7094c39cd41b03ed642145b0bd37251e31a9cf2ed19e1ce761f089867356a6"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand 0.8.5",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "alloy-sol-macro"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +740,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74e91b0b553c115d14bd0ed41898309356dc85d0e3d4b9014c4e7715e48c8ad"
 dependencies = [
+ "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
@@ -546,12 +759,14 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84194d31220803f5f62d0a00f583fd3a062b36382e2bea446f1af96727754565"
 dependencies = [
+ "alloy-json-abi",
  "const-hex",
  "dunce",
  "heck 0.5.0",
  "macro-string",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn 2.0.98",
  "syn-solidity",
 ]
@@ -576,6 +791,83 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
  "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b7f8b6c540b55e858f958d3a92223494cf83c4fb43ff9b26491edbeb3a3b71"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "auto_impl",
+ "base64 0.22.1",
+ "derive_more 2.0.1",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+ "tokio",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260e9584dfd7998760d7dfe1856c6f8f346462b9e7837287d7eddfb3922ef275"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "reqwest 0.12.9",
+ "serde_json",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-ipc"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9491a1d81e97ae9d919da49e1c63dec4729c994e2715933968b8f780aa18793e"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-pubsub",
+ "alloy-transport",
+ "bytes",
+ "futures",
+ "interprocess",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-transport-ws"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d056ef079553e1f18834d6ef4c2793e4d51ac742021b2be5039dd623fe1354f0"
+dependencies = [
+ "alloy-pubsub",
+ "alloy-transport",
+ "futures",
+ "http 1.1.0",
+ "rustls 0.23.28",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "tracing",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -1449,6 +1741,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,9 +2131,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
@@ -3214,6 +3512,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "doctest-file"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
 
 [[package]]
 name = "dotenvy"
@@ -5361,6 +5665,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "interprocess"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
+dependencies = [
+ "doctest-file",
+ "futures-core",
+ "libc",
+ "recvmsg",
+ "tokio",
+ "widestring",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6076,6 +6395,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "lumina-utils"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6556,7 +6884,7 @@ dependencies = [
  "io-uring",
  "libc",
  "loom",
- "lru",
+ "lru 0.12.5",
  "nomt-core",
  "parking_lot",
  "rand 0.8.5",
@@ -8409,6 +8737,12 @@ checksum = "3f87cc11a0140b4b0da0ffc889885760c61b13672d80a908920b2c0df078fa14"
 dependencies = [
  "rayon",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -11555,6 +11889,7 @@ dependencies = [
 name = "sov-eth-client"
 version = "0.3.0"
 dependencies = [
+ "alloy",
  "alloy-primitives",
  "anyhow",
  "ethereum-types",
@@ -13002,7 +13337,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "hex",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "num-bigint 0.4.6",
  "p3-baby-bear",
  "p3-bn254-fr",
@@ -14221,6 +14556,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.28",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tungstenite 0.26.2",
+ "webpki-roots 0.26.3",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14662,6 +15013,25 @@ dependencies = [
  "rand 0.8.5",
  "sha1",
  "thiserror 1.0.64",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.9.1",
+ "rustls 0.23.28",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.11",
  "utf-8",
 ]
 
@@ -15240,6 +15610,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15301,6 +15685,12 @@ dependencies = [
  "redox_syscall 0.4.1",
  "wasite",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,31 +91,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
-name = "alloy"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecf116474faea3e30ecb03cb14548598ca8243d5316ce50f820e67b3e848473"
-dependencies = [
- "alloy-consensus",
- "alloy-contract",
- "alloy-core",
- "alloy-eips",
- "alloy-genesis",
- "alloy-network",
- "alloy-provider",
- "alloy-pubsub",
- "alloy-rpc-client",
- "alloy-rpc-types",
- "alloy-serde",
- "alloy-signer",
- "alloy-signer-local",
- "alloy-transport",
- "alloy-transport-http",
- "alloy-transport-ipc",
- "alloy-transport-ws",
-]
-
-[[package]]
 name = "alloy-chains"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,42 +142,6 @@ dependencies = [
  "alloy-serde",
  "arbitrary",
  "serde",
-]
-
-[[package]]
-name = "alloy-contract"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28074a21cd4f7c3a7ab218c4f38fae6be73944e1feae3b670c68b60bf85ca40"
-dependencies = [
- "alloy-consensus",
- "alloy-dyn-abi",
- "alloy-json-abi",
- "alloy-network",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-provider",
- "alloy-pubsub",
- "alloy-rpc-types-eth",
- "alloy-sol-types",
- "alloy-transport",
- "futures",
- "futures-util",
- "serde_json",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "alloy-core"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe6c56d58fbfa9f0f6299376e8ce33091fc6494239466814c3f54b55743cb09"
-dependencies = [
- "alloy-dyn-abi",
- "alloy-json-abi",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-sol-types",
 ]
 
 [[package]]
@@ -445,16 +384,11 @@ dependencies = [
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
- "alloy-rpc-types-anvil",
- "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "alloy-rpc-types-txpool",
  "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-stream",
  "async-trait",
@@ -532,7 +466,6 @@ dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
- "alloy-transport-ipc",
  "alloy-transport-ws",
  "futures",
  "pin-project",
@@ -554,12 +487,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d4fe522f6fc749c8afce721bdc8f73b715d317c3c02fcb9b51f7a143e4401dd"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-anvil",
- "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-rpc-types-trace",
- "alloy-rpc-types-txpool",
  "alloy-serde",
  "serde",
 ]
@@ -577,18 +506,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-anvil"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6af88d9714b499675164cac2fa2baadb3554579ab3ea8bc0d7b0c0de4f9d692"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
 name = "alloy-rpc-types-any"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,18 +514,6 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-debug"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2fe118e6c152d54cb4549b9835fb87d38b12754bb121375183ee3ec84bd0849"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.0.1",
- "serde",
- "serde_with",
 ]
 
 [[package]]
@@ -666,18 +571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-txpool"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c751233a6067ccc8a4cbd469e0fd34e0d9475fd118959dbc777ae3af31bba7"
-dependencies = [
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
 name = "alloy-serde"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,22 +598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-signer-local"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7094c39cd41b03ed642145b0bd37251e31a9cf2ed19e1ce761f089867356a6"
-dependencies = [
- "alloy-consensus",
- "alloy-network",
- "alloy-primitives",
- "alloy-signer",
- "async-trait",
- "k256",
- "rand 0.8.5",
- "thiserror 2.0.11",
-]
-
-[[package]]
 name = "alloy-sol-macro"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,7 +617,6 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74e91b0b553c115d14bd0ed41898309356dc85d0e3d4b9014c4e7715e48c8ad"
 dependencies = [
- "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
@@ -759,14 +635,12 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84194d31220803f5f62d0a00f583fd3a062b36382e2bea446f1af96727754565"
 dependencies = [
- "alloy-json-abi",
  "const-hex",
  "dunce",
  "heck 0.5.0",
  "macro-string",
  "proc-macro2",
  "quote",
- "serde_json",
  "syn 2.0.98",
  "syn-solidity",
 ]
@@ -830,26 +704,6 @@ dependencies = [
  "tower 0.5.2",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "alloy-transport-ipc"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9491a1d81e97ae9d919da49e1c63dec4729c994e2715933968b8f780aa18793e"
-dependencies = [
- "alloy-json-rpc",
- "alloy-pubsub",
- "alloy-transport",
- "bytes",
- "futures",
- "interprocess",
- "pin-project",
- "serde",
- "serde_json",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -3514,12 +3368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doctest-file"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5662,21 +5510,6 @@ dependencies = [
  "strum 0.26.3",
  "tempfile",
  "tracing",
-]
-
-[[package]]
-name = "interprocess"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d941b405bd2322993887859a8ee6ac9134945a24ec5ec763a8a962fc64dfec2d"
-dependencies = [
- "doctest-file",
- "futures-core",
- "libc",
- "recvmsg",
- "tokio",
- "widestring",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8737,12 +8570,6 @@ checksum = "3f87cc11a0140b4b0da0ffc889885760c61b13672d80a908920b2c0df078fa14"
 dependencies = [
  "rayon",
 ]
-
-[[package]]
-name = "recvmsg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -11889,8 +11716,10 @@ dependencies = [
 name = "sov-eth-client"
 version = "0.3.0"
 dependencies = [
- "alloy",
  "alloy-primitives",
+ "alloy-provider",
+ "alloy-pubsub",
+ "alloy-rpc-types",
  "anyhow",
  "ethereum-types",
  "ethers",
@@ -15685,12 +15514,6 @@ dependencies = [
  "redox_syscall 0.4.1",
  "wasite",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,7 +273,6 @@ risc0-build = "2.1"
 ethereum-types = "0.14.1"
 ethers = { version = "=2.0.14" }
 
-
 alloy-serde = { version = "1.0.24" }
 alloy-chains = { version = "0.2.0", default-features = false }
 alloy-primitives = { version = "1.3.1", default-features = false }
@@ -283,7 +282,10 @@ alloy-consensus = { version = "1.0.25", default-features = false }
 alloy-rpc-types = { version = "1.0.25", features = [
     "eth",
 ], default-features = false }
+
+alloy-provider = { version = "1.0", features = ["ws"] }
 alloy-rpc-types-trace = { version = "1.0.25" }
+
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d8451e54e7267f9f1634118d6d279b2216f7e2bb", default-features = false }
 reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d8451e54e7267f9f1634118d6d279b2216f7e2bb", default-features = false }
 reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "d8451e54e7267f9f1634118d6d279b2216f7e2bb", default-features = false }

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -1,11 +1,12 @@
-use std::sync::Arc;
-
+use alloy_primitives::Address;
 use alloy_primitives::{Bytes, B256};
-
+use alloy_rpc_types::Log;
 use jsonrpsee::types::{ErrorObjectOwned, Params};
 use jsonrpsee::Extensions;
+use jsonrpsee::PendingSubscriptionSink;
+use jsonrpsee::SubscriptionMessage;
+use reth_primitives::LogData;
 use sov_address::{EthereumAddress, FromVmAddress};
-
 pub use sov_evm::EthereumAuthenticator;
 #[cfg(feature = "local")]
 use sov_evm::Evm;
@@ -13,6 +14,8 @@ use sov_evm::RlpEvmTransaction;
 use sov_modules_api::capabilities::HasKernel;
 use sov_modules_api::{RawTx, Spec};
 use sov_sequencer::Sequencer;
+use std::sync::Arc;
+use std::time::Duration;
 
 use crate::to_jsonrpsee_error_object;
 use crate::Ethereum;
@@ -155,4 +158,51 @@ where
     })?;
 
     Ok(tx_hash)
+}
+
+pub async fn eth_subscribe<S, Seq>(
+    _params: Params<'static>,
+    pending: PendingSubscriptionSink,
+    _ethereum: Arc<Ethereum<S, Seq>>,
+    _: Extensions,
+) -> jsonrpsee::core::SubscriptionResult
+where
+    S: Spec,
+    Seq: Sequencer<Spec = S>,
+    S::Address: FromVmAddress<EthereumAddress>,
+    Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
+{
+    let sink = pending.accept().await?;
+
+    let _task = tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+
+            let log = Log {
+                inner: alloy_primitives::Log {
+                    address: Address::parse_checksummed(
+                        "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+                        None,
+                    )
+                    .unwrap(),
+
+                    data: LogData::new_unchecked(vec![], Default::default()),
+                },
+                block_hash: None,
+                block_number: None,
+                block_timestamp: None,
+                transaction_hash: None,
+                transaction_index: None,
+                log_index: None,
+                removed: false,
+            };
+
+            let msg =
+                SubscriptionMessage::new(sink.method_name(), sink.subscription_id(), &log).unwrap();
+
+            sink.send(msg).await.unwrap();
+        }
+    });
+
+    Ok(())
 }

--- a/crates/full-node/sov-ethereum/src/lib.rs
+++ b/crates/full-node/sov-ethereum/src/lib.rs
@@ -62,6 +62,12 @@ where
         ready(Ok::<_, Infallible>(U256::ZERO))
     })?;
     rpc.register_async_method("eth_sendRawTransaction", handlers::eth_send_raw_transaction)?;
+    rpc.register_subscription(
+        "_eth_subscribe",
+        "_eth_subscription",
+        "_eth_unsubscribe",
+        handlers::eth_subscribe,
+    )?;
 
     #[cfg(feature = "local")]
     {

--- a/crates/utils/sov-eth-client/Cargo.toml
+++ b/crates/utils/sov-eth-client/Cargo.toml
@@ -12,9 +12,11 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 alloy-primitives = { workspace = true }
+alloy-rpc-types  = { workspace = true }
+alloy-provider = { workspace = true }
+alloy-pubsub = "1.0"
 ethereum-types = { workspace = true }
 ethers = { workspace = true }
-alloy = { version = "1.0", features = ["full"] }
 futures = { workspace = true }
 jsonrpsee = { workspace = true }
 reth-primitives = { workspace = true }

--- a/crates/utils/sov-eth-client/Cargo.toml
+++ b/crates/utils/sov-eth-client/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = { workspace = true }
 alloy-primitives = { workspace = true }
 ethereum-types = { workspace = true }
 ethers = { workspace = true }
+alloy = { version = "1.0", features = ["full"] }
 futures = { workspace = true }
 jsonrpsee = { workspace = true }
 reth-primitives = { workspace = true }

--- a/crates/utils/sov-eth-client/src/lib.rs
+++ b/crates/utils/sov-eth-client/src/lib.rs
@@ -1,5 +1,11 @@
 #![allow(missing_docs)]
 
+use alloy::providers::Provider as _;
+use alloy::providers::ProviderBuilder;
+use alloy::providers::RootProvider;
+use alloy::pubsub::Subscription;
+use alloy::rpc::types::Filter;
+use alloy::rpc::types::Log;
 use alloy_primitives::Bytes;
 use ethereum_types::H160;
 use ethers::core::abi::Address;
@@ -11,6 +17,7 @@ use ethers::middleware::signer::SignerMiddlewareError;
 use ethers::middleware::SignerMiddleware;
 use ethers::providers::{Http, Middleware, PendingTransaction, Provider};
 use ethers::signers::Wallet;
+use ethers::signers::{LocalWallet, Signer};
 use futures::StreamExt;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::rpc_params;
@@ -27,29 +34,42 @@ pub struct TestClient {
     pub chain_id: u64,
     pub from_addr: Address,
     contract: SimpleStorageContract,
+    pub_sub: RootProvider,
     pub client: SignerMiddleware<Provider<Http>, Wallet<SigningKey>>,
     node_client: NodeClient,
     rpc: WsClient,
 }
 
+async fn pubsub(conn_str: &str) -> RootProvider {
+    ProviderBuilder::default().connect(conn_str).await.unwrap()
+}
+
 impl TestClient {
     pub async fn new(
         chain_id: u64,
-        key: Wallet<SigningKey>,
-        from_addr: Address,
+        private_key: &str,
         contract: SimpleStorageContract,
         http_addr: std::net::SocketAddr,
     ) -> Self {
-        let provider =
-            Provider::try_from(&format!("http://127.0.0.1:{}/rpc", http_addr.port())).unwrap();
-        let client = SignerMiddleware::new_with_provider_chain(provider, key)
-            .await
-            .unwrap();
+        let ws_conn_str = &format!("ws://127.0.0.1:{}/rpc", http_addr.port());
+        let http_conn_str = &format!("http://127.0.0.1:{}/rpc", http_addr.port());
 
-        let rpc = WsClientBuilder::default()
-            .build(&format!("ws://127.0.0.1:{}/rpc", http_addr.port()))
-            .await
-            .unwrap();
+        let pub_sub = pubsub(ws_conn_str).await;
+
+        let client = {
+            let key = private_key
+                .parse::<LocalWallet>()
+                .unwrap()
+                .with_chain_id(chain_id);
+
+            let provider = Provider::try_from(http_conn_str).unwrap();
+
+            SignerMiddleware::new_with_provider_chain(provider, key.clone())
+                .await
+                .unwrap()
+        };
+
+        let rpc = WsClientBuilder::default().build(ws_conn_str).await.unwrap();
 
         let node_client = NodeClient::new_at_localhost(http_addr.port())
             .await
@@ -57,8 +77,9 @@ impl TestClient {
 
         Self {
             chain_id,
-            from_addr,
+            from_addr: client.address(),
             contract,
+            pub_sub,
             client,
             node_client,
             rpc,
@@ -388,5 +409,10 @@ impl TestClient {
 
     pub async fn block_number(&self) -> u64 {
         self.client.get_block_number().await.unwrap().as_u64()
+    }
+
+    pub async fn subscribe_logs(&self) -> Subscription<Log> {
+        let filter = Filter::new();
+        self.pub_sub.subscribe_logs(&filter).await.unwrap()
     }
 }

--- a/crates/utils/sov-eth-client/src/lib.rs
+++ b/crates/utils/sov-eth-client/src/lib.rs
@@ -1,12 +1,12 @@
 #![allow(missing_docs)]
 
-use alloy::providers::Provider as _;
-use alloy::providers::ProviderBuilder;
-use alloy::providers::RootProvider;
-use alloy::pubsub::Subscription;
-use alloy::rpc::types::Filter;
-use alloy::rpc::types::Log;
 use alloy_primitives::Bytes;
+use alloy_provider::Provider as _;
+use alloy_provider::ProviderBuilder;
+use alloy_provider::RootProvider;
+use alloy_pubsub::Subscription;
+use alloy_rpc_types::Filter;
+use alloy_rpc_types::Log;
 use ethereum_types::H160;
 use ethers::core::abi::Address;
 use ethers::core::k256::ecdsa::SigningKey;

--- a/examples/demo-rollup/tests/evm/evm_account_abstraction.rs
+++ b/examples/demo-rollup/tests/evm/evm_account_abstraction.rs
@@ -1,7 +1,7 @@
 use crate::evm::evm_test_helper::{self};
 use crate::test_helpers::{DemoRollupSpec, CHAIN_HASH};
 use demo_stf::runtime::{Runtime, RuntimeCall};
-use ethers::core::abi::Address;
+use ethereum_types::Address;
 use sov_eth_client::TestClient;
 use sov_modules_api::capabilities::UniquenessData;
 use sov_modules_api::transaction::{Transaction, UnsignedTransaction};
@@ -14,10 +14,10 @@ use crate::evm::evm_test_helper::setup;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "Account abstraction for the EVM is disabled"]
 async fn test_evm_account_abstraction() {
-    let (test_rollup, test_client, from_addr, chain_id) = setup(0).await;
+    let (test_rollup, test_client, chain_id) = setup(0).await;
 
     // Before executing the evm checks we need to insert the credentials in the `Accounts`.
-    send_insert_credentials(&test_client, from_addr, chain_id).await;
+    send_insert_credentials(&test_client, test_client.from_addr, chain_id).await;
     // Execute the evm tests.
     execute_evm_tests(&test_client).await.unwrap();
 

--- a/examples/demo-rollup/tests/evm/evm_balances.rs
+++ b/examples/demo-rollup/tests/evm/evm_balances.rs
@@ -12,7 +12,8 @@ const RECIEVER_ADDR_STR: &str = "0x3FE0233e6cf3c9753fcB7449987EC49C88aDDE71";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn evm_test_balances() -> anyhow::Result<()> {
-    let (test_rollup, evm_client, sender_address, _) = setup(0).await;
+    let (test_rollup, evm_client, _) = setup(0).await;
+    let sender_address = evm_client.from_addr;
 
     let reciever_address = Address::from_str(RECIEVER_ADDR_STR).unwrap();
 

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -15,7 +15,8 @@ struct SimpleLog {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn evm_test_logs() {
-    let (test_rollup, evm_client, _, _) = setup(0).await;
+    let (test_rollup, evm_client, _) = setup(0).await;
+
     let contract_address = evm_test_helper::deploy_contract_check(&evm_client)
         .await
         .unwrap();
@@ -36,4 +37,8 @@ async fn evm_test_logs() {
     assert_eq!(contract_log.original.address, contract_address);
 
     assert_eq!(contract_log.paresed.value, set_arg.into());
+
+    //let mut sub = evm_client.subscribe_logs().await;
+    //let log = sub.recv().await.unwrap();
+    //println!("{:?}", log);
 }

--- a/examples/demo-rollup/tests/evm/evm_soft_conf.rs
+++ b/examples/demo-rollup/tests/evm/evm_soft_conf.rs
@@ -3,7 +3,7 @@ use crate::evm::evm_test_helper::setup;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn evm_test_soft_confirmations() -> anyhow::Result<()> {
-    let (test_rollup, evm_client, _, _) = setup(0).await;
+    let (test_rollup, evm_client, _) = setup(0).await;
 
     let contract_address = evm_test_helper::deploy_contract_check(&evm_client)
         .await

--- a/examples/demo-rollup/tests/evm/evm_test_helper.rs
+++ b/examples/demo-rollup/tests/evm/evm_test_helper.rs
@@ -3,8 +3,6 @@ use std::net::SocketAddr;
 use crate::test_helpers::test_genesis_source;
 
 use ethers::core::abi::Address;
-use ethers::providers::ProviderError;
-use ethers::signers::{LocalWallet, Signer};
 use futures::future::join_all;
 use sov_demo_rollup::MockRollupSpec;
 use sov_demo_rollup::{mock_da_risc0_host_args, MockDemoRollup};
@@ -51,21 +49,15 @@ pub(crate) async fn create_test_client(
     rest_port: SocketAddr,
     chain_id: u64,
     private_key: &str,
-) -> (TestClient, Address) {
-    let key = private_key
-        .parse::<LocalWallet>()
-        .unwrap()
-        .with_chain_id(chain_id);
-
+) -> TestClient {
     let contract = SimpleStorageContract::default();
-    let from_addr = key.address();
 
-    let test_client = TestClient::new(chain_id, key, from_addr, contract, rest_port).await;
+    let test_client = TestClient::new(chain_id, private_key, contract, rest_port).await;
 
     let eth_chain_id = test_client.eth_chain_id().await;
     assert_eq!(chain_id, eth_chain_id);
 
-    (test_client, from_addr)
+    test_client
 }
 
 /// Deploys a test contract on the test rollup.
@@ -137,7 +129,7 @@ pub(crate) async fn set_multiple_values_check(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let requests = client.set_values(contract_address, values).await;
 
-    let receipts: Vec<Result<Option<_>, ProviderError>> = join_all(requests).await;
+    let receipts: Vec<Result<Option<_>, _>> = join_all(requests).await;
     assert!(receipts
         .into_iter()
         .all(|x| x.is_ok() && x.unwrap().is_some()));
@@ -153,7 +145,7 @@ pub(crate) async fn set_multiple_values_check(
 
 pub async fn setup(
     finalization_blocks: u32,
-) -> (TestRollup<MockDemoRollup<Native>>, TestClient, Address, u64) {
+) -> (TestRollup<MockDemoRollup<Native>>, TestClient, u64) {
     let rollup_prover_config =
         get_appropriate_rollup_prover_config::<MockRollupSpec<Native>>(mock_da_risc0_host_args());
 
@@ -161,12 +153,11 @@ pub async fn setup(
     let test_rollup: TestRollup<MockDemoRollup<Native>> =
         start_node(rollup_prover_config, finalization_blocks).await;
 
-    let (evm_client, addr) =
-        create_test_client(test_rollup.http_addr, chain_id, SENDER_PRIV_KEY).await;
+    let evm_client = create_test_client(test_rollup.http_addr, chain_id, SENDER_PRIV_KEY).await;
 
     test_rollup.wait_for_next_blocks(10).await;
 
-    (test_rollup, evm_client, addr, chain_id)
+    (test_rollup, evm_client, chain_id)
 }
 
 // TODO: reenable this check by figuring out a way to get finer grained control over preferred batch production.

--- a/examples/demo-rollup/tests/evm/evm_tx.rs
+++ b/examples/demo-rollup/tests/evm/evm_tx.rs
@@ -18,7 +18,7 @@ async fn evm_tx_tests_non_instant_finality() -> anyhow::Result<()> {
 }
 
 async fn evm_tx_test(finalization_blocks: u32) -> anyhow::Result<()> {
-    let (test_rollup, test_client, _, _) = setup(finalization_blocks).await;
+    let (test_rollup, test_client, _) = setup(finalization_blocks).await;
 
     sanity_checks(&test_client).await;
     execute_evm_tests(&test_client, &test_rollup.da_service)


### PR DESCRIPTION
# Description
This PR introduces the following changes:

1. Adds `pub_sub: alloy::RootProvider` to the EVM test client, allowing us to subscribe to logs using `eth_subscribe`.
2. Adds a stub implementation for` eth_subscribe`. The full implementation will be included in the next PR.

The `eth_subscribe` implementation in ethers is buggy, so I switched to `alloy`, which works correctly.
Unfortunately, this means we now have two separate clients:

`alloy::RootProvider` for subscriptions
`ethers::SignerMiddleware` for the rest of the functionality

The goal is to fully migrate from `ethers` to `alloy`, but attempting to do this in one step proved too time-consuming.
I propose a gradual migration approach:

First, make the EVM test client’s public interface independent of `ethers`. This means all public methods should only accept and return standard Rust types.

Once that refactor is complete, switching completely to` alloy` will be straightforward.

I've already started this refactoring, but there are still many methods left to migrate.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
