### PR TITLE
Fix sequence number calculation used to prune sequencer DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-09-12
+- #1672 Fixes some minor bugs related to pruning in the sequencer DB which could cause duplicate blob submission on restart.
+
 # 2025-09-09
 - #1646 Implements `eth_estimateGas` RPC method for the EVM module. This allows clients to estimate the gas required for transaction execution before submitting them to the network.
 - #1650 Adds an optional `state_cache_size` param to the `storage` section of the rollup config.toml file. 

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -576,8 +576,8 @@ where
 {
     let mut checkpoint = StateCheckpoint::new(latest_state_info.storage.clone(), &runtime.kernel());
     let mut state = KernelStateAccessor::from_checkpoint(&runtime.kernel(), &mut checkpoint);
+    state.read_from_storage_at_slot_number(latest_state_info.latest_finalized_slot_number);
 
-    state.update_true_slot_number(latest_state_info.latest_finalized_slot_number);
     runtime
         .kernel()
         .next_sequence_number(&mut state)

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -379,13 +379,7 @@ where
 
         match latest_finalized_sequence_number(latest_state_info, &mut runtime) {
             Some(num) => {
-                // TODO(@neysofu): somehow, if we prune too close to the latest
-                // finalized sequence number, we get panics due to missing blobs
-                // and inconsistent state. There is clearly something wrong with
-                // the pruning height calculation height.
-                if let Some(num) = num.checked_sub(100) {
-                    self.executor_events_sender.prune(num).await;
-                }
+                self.executor_events_sender.prune(num).await;
             }
             None => {
                 // Nothing to prune because there's no sequence number history.
@@ -1362,6 +1356,16 @@ where
         let condition_nodes_sequence_number_is_fresher =
             next_sequence_number_according_to_node > next_sequence_number;
 
+        // There's an edge case on restart where the node hasn't synced to the chain tip yet but doesn't know it. We can check for it by seeing
+        // if the first batch to replay has a sequencer number that's more than 1 greater than the node's sequence number (because sequence numbers are contiguous, and
+        // we only prune a blob from the sequencer DB after it's been finalized on DA - so that blob must already exist on DA and the node just doesn't know that it isn't synced).
+        let oldest_unfinalized_sequence_number = batches_to_replay
+            .first()
+            .map(|b: &PreferredBatchToReplay| b.batch.inner.sequence_number);
+        let condition_node_is_unsynced_and_doesnt_know_it = (next_sequence_number_according_to_node
+            .saturating_add(1))
+            < oldest_unfinalized_sequence_number.unwrap_or(0);
+
         // Once we're this close to `deferred_slots_count`, we risk crossing the
         // `deferred_slots_count` threshold before the next call to
         // `update_state`. That's no good.
@@ -1388,9 +1392,10 @@ where
             condition_too_close_to_deferred_slots_count_for_comfort,
             condition_node_is_lagging,
             condition_are_there_batches_to_replay,
+            condition_node_is_unsynced_and_doesnt_know_it,
         ) {
-            (true, _, _, true) => PreferredSeqOperation::Unreachable,
-            (true, _, false, false) => {
+            (true, _, _, true, _) => PreferredSeqOperation::Unreachable,
+            (true, _, false, false, _) => {
                 warn!("The node has a higher sequence number than the sequencer, but we're very close to the chain tip, i.e. we don't expect to be simply syncing. This could mean there is another preferred sequencer running (which is not supported and will likely lead to issues), or you very recently restarted the node and there's still some in-flight blobs. Resyncing to the chain tip.");
                 inner.is_ready = Err(SequencerNotReadyDetails::Syncing {
                     target_da_height: sync_status.target_da_height(),
@@ -1398,7 +1403,7 @@ where
                 });
                 PreferredSeqOperation::WaitForNodeResyncToTip
             }
-            (_, _, true, _) => {
+            (_, _, true, _, _) => {
                 warn!(?distance, "The sequencer must pause because the node has lagged behind the DA blockchain. This might lead to a brief downtime for users.");
                 inner.is_ready = Err(SequencerNotReadyDetails::Syncing {
                     target_da_height: sync_status.target_da_height(),
@@ -1406,13 +1411,24 @@ where
                 });
                 PreferredSeqOperation::WaitForNodeResyncWithAllowedSlack
             }
-            (false, true, false, _) => {
+            (false, true, false, _, _) => {
                 error!(slot_number_according_to_node=%info.slot_number, %current_visible_slot_number, "Sequencer has detected that it is past, or very close to, having the visible_slot_number lag behind the deferred_slots_count threshold. Normal operation will be suspended until this can be remedied.");
                 inner.trigger_recovery(info).await;
 
                 PreferredSeqOperation::RecoverAndCatchUp
             }
-            (false, false, false, _) => {
+            // Node is out of sync and doesn't know it. This is a rare edge case after a DB wipe.
+            (_, _, _, _, true) => {
+                // Check for this condition after all of the normal "out-of-sync" conditions have been checked, because it may be possible for other unsynced conditions to trip this check
+                // and we'd rather report the real root cause if there's a different one.
+                warn!("The node is unsynced and doesn't know it. This probably means that you wiped the node DB and are resyncing.");
+                inner.is_ready = Err(SequencerNotReadyDetails::Syncing {
+                    target_da_height: sync_status.target_da_height(),
+                    synced_da_height: sync_status.synced_da_height(),
+                });
+                PreferredSeqOperation::WaitForNodeResyncToTip
+            }
+            (false, false, false, _, _) => {
                 let should_flush_tx_cache = is_startup || is_resync || is_recover;
 
                 // We only need to replay the transactions in the edge cases where the event/tx cache needs repopulating.

--- a/crates/module-system/sov-modules-api/src/state/accessors/kernel.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/kernel.rs
@@ -66,7 +66,7 @@ pub struct KernelStateAccessor<'a, S: Spec> {
     /// The inner working set
     pub checkpoint: &'a mut StateCheckpoint<S>,
     pub(crate) true_slot_num: SlotNumber,
-    /// Whether to read directly with `read_direct_from_storage` override enabled. This is a bug in the sequencer. Please report it. instead of using the checkpoint
+    /// Whether to read directly from storage instead of using the checkpoint
     #[cfg(feature = "native")]
     read_direct_from_storage: bool,
 }
@@ -184,10 +184,10 @@ impl<S: Spec> UniversalStateAccessor for KernelStateAccessor<'_, S> {
             use sov_state::namespaces::{Kernel as KernelNamespace, User};
             use sov_state::NativeStorage;
             match namespace {
-                Namespace::User => self.checkpoint.delta.inner.get_historical::<User>(key, Some(self.true_slot_num), &Default::default()).expect("Failed to read user value with `read_direct_from_storage` override enabled. This is a bug in the sequencer. Please report it."),
-                Namespace::Kernel => self.checkpoint.delta.inner.get_historical::<KernelNamespace>(key, Some(self.true_slot_num), &Default::default()).expect("Failed to read kernel value with `read_direct_from_storage` override enabled. This is a bug in the sequencer. Please report it."),
-                Namespace::Accessory => self.checkpoint.delta.inner.get_accessory_historical(key, Some(self.true_slot_num)).expect("Failed to read accessory value with `read_direct_from_storage` override enabled. This is a bug in the sequencer. Please report it."),
-            }
+                Namespace::User => self.checkpoint.delta.inner.get_historical::<User>(key, Some(self.true_slot_num), &Default::default()),
+                Namespace::Kernel => self.checkpoint.delta.inner.get_historical::<KernelNamespace>(key, Some(self.true_slot_num), &Default::default()),
+                Namespace::Accessory => self.checkpoint.delta.inner.get_accessory_historical(key, Some(self.true_slot_num)),
+            }.unwrap_or_else(|e| panic!("Failed to read value from key `{key}` in namespace `{namespace:?}` with `read_direct_from_storage` override enabled. This is a bug in the sequencer. Please report it. Error: {e}"))
         } else {
             self.checkpoint.get_value(namespace, key, metric)
         }

--- a/crates/module-system/sov-modules-api/src/state/accessors/kernel.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/kernel.rs
@@ -66,6 +66,9 @@ pub struct KernelStateAccessor<'a, S: Spec> {
     /// The inner working set
     pub checkpoint: &'a mut StateCheckpoint<S>,
     pub(crate) true_slot_num: SlotNumber,
+    /// Whether to read directly with `read_direct_from_storage` override enabled. This is a bug in the sequencer. Please report it. instead of using the checkpoint
+    #[cfg(feature = "native")]
+    read_direct_from_storage: bool,
 }
 
 impl<S: Spec> GasMeter for KernelStateAccessor<'_, S> {
@@ -115,8 +118,15 @@ impl<'a, S: Spec> KernelStateAccessor<'a, S> {
 
         Self {
             checkpoint,
+            read_direct_from_storage: false,
             true_slot_num,
         }
+    }
+    /// Configures the accessor to read directly from storage at the given slot number, bypassing the state checkpoint.
+    #[cfg(feature = "native")]
+    pub fn read_from_storage_at_slot_number(&mut self, height: SlotNumber) {
+        self.read_direct_from_storage = true;
+        self.true_slot_num = height;
     }
 }
 
@@ -142,6 +152,56 @@ impl<S: Spec> KernelStateAccessor<'_, S> {
     }
 }
 
+#[cfg(feature = "native")]
+impl<S: Spec> UniversalStateAccessor for KernelStateAccessor<'_, S> {
+    fn get_size(
+        &mut self,
+        namespace: Namespace,
+        key: &SlotKey,
+        metric: &mut StateAccessMetric,
+    ) -> Option<u32> {
+        use sov_state::NativeStorage;
+        if self.read_direct_from_storage {
+            use sov_state::namespaces::{Kernel as KernelNamespace, User};
+            match namespace {
+                Namespace::User => self.checkpoint.delta.inner.get_leaf_historical::<User>(key, Some(self.true_slot_num), &Default::default()).expect("Failed to read user value with `read_direct_from_storage` override enabled. This is a bug in the sequencer. Please report it.").map(|l| l.size()),
+                Namespace::Kernel => self.checkpoint.delta.inner.get_leaf_historical::<KernelNamespace>(key, Some(self.true_slot_num), &Default::default()).expect("Failed to read kernel value with `read_direct_from_storage` override enabled. This is a bug in the sequencer. Please report it.").map(|l| l.size()),
+                Namespace::Accessory => self.checkpoint.delta.inner.get_accessory_historical(key, Some(self.true_slot_num)).expect("Failed to read accessory value with `read_direct_from_storage` override enabled. This is a bug in the sequencer. Please report it.").map(|l| l.size()),
+            }
+        } else {
+            self.checkpoint.get_size(namespace, key, metric)
+        }
+    }
+
+    fn get_value(
+        &mut self,
+        namespace: Namespace,
+        key: &SlotKey,
+        metric: &mut StateAccessMetric,
+    ) -> Option<SlotValue> {
+        if self.read_direct_from_storage {
+            use sov_state::namespaces::{Kernel as KernelNamespace, User};
+            use sov_state::NativeStorage;
+            match namespace {
+                Namespace::User => self.checkpoint.delta.inner.get_historical::<User>(key, Some(self.true_slot_num), &Default::default()).expect("Failed to read user value with `read_direct_from_storage` override enabled. This is a bug in the sequencer. Please report it."),
+                Namespace::Kernel => self.checkpoint.delta.inner.get_historical::<KernelNamespace>(key, Some(self.true_slot_num), &Default::default()).expect("Failed to read kernel value with `read_direct_from_storage` override enabled. This is a bug in the sequencer. Please report it."),
+                Namespace::Accessory => self.checkpoint.delta.inner.get_accessory_historical(key, Some(self.true_slot_num)).expect("Failed to read accessory value with `read_direct_from_storage` override enabled. This is a bug in the sequencer. Please report it."),
+            }
+        } else {
+            self.checkpoint.get_value(namespace, key, metric)
+        }
+    }
+
+    fn set_value(&mut self, namespace: Namespace, key: &SlotKey, value: SlotValue) {
+        self.checkpoint.set_value(namespace, key, value);
+    }
+
+    fn delete_value(&mut self, namespace: Namespace, key: &SlotKey) {
+        self.checkpoint.delete_value(namespace, key);
+    }
+}
+
+#[cfg(not(feature = "native"))]
 impl<S: Spec> UniversalStateAccessor for KernelStateAccessor<'_, S> {
     fn get_size(
         &mut self,

--- a/crates/module-system/sov-modules-api/src/state/accessors/kernel.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/kernel.rs
@@ -118,8 +118,9 @@ impl<'a, S: Spec> KernelStateAccessor<'a, S> {
 
         Self {
             checkpoint,
-            read_direct_from_storage: false,
             true_slot_num,
+            #[cfg(feature = "native")]
+            read_direct_from_storage: false,
         }
     }
     /// Configures the accessor to read directly from storage at the given slot number, bypassing the state checkpoint.

--- a/crates/module-system/sov-state/src/storage.rs
+++ b/crates/module-system/sov-state/src/storage.rs
@@ -293,6 +293,13 @@ pub struct NodeLeafAndMaybeValue {
     pub(crate) value: ReadType,
 }
 
+impl NodeLeafAndMaybeValue {
+    /// Get the size of the value.
+    pub fn size(&self) -> u32 {
+        self.leaf.size
+    }
+}
+
 /// Size and hash of a value saved in the state.
 #[derive(
     Clone,

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -121,6 +121,7 @@ async fn start_stop_empty(
             "The sequencer must pause because the node has lagged behind the DA blockchain. This might lead to a brief downtime for users.".to_string()
         ),
         (Level::WARN, "Skipping pruning of sequence number because it's already been pruned".to_string()),
+        (Level::WARN, "The node is unsynced and doesn't know it. This probably means that you wiped the node DB and are resyncing.".to_string()),
     ];
 
     let mut recorded_errors_warnings =

--- a/examples/demo-rollup/tests/resync/mod.rs
+++ b/examples/demo-rollup/tests/resync/mod.rs
@@ -307,7 +307,8 @@ async fn test_rollup_resync() -> anyhow::Result<()> {
         (Level::WARN, "Skipping pruning of sequence number because it's already been pruned".to_string()),
         // This shows up occasionally, but especially often on hetzner. There may be some timing
         // oddity that might be worth investigating.
-        (Level::WARN, "State Transition Info is not consumed fast enough, cannot prune older entries. Please check that consumer works.".to_string())
+        (Level::WARN, "State Transition Info is not consumed fast enough, cannot prune older entries. Please check that consumer works.".to_string()),
+        (Level::WARN, "The node is unsynced and doesn't know it. This probably means that you wiped the node DB and are resyncing.".to_string()),
     ];
 
     let mut recorded_errors_warnings =


### PR DESCRIPTION
# Description

This PR fixes the bug in sequencer DB pruning. Previously, we tried to fetch the latest *finalized*  sequence number from the node just by manually overriding the `true_slot_number` stored in a fresh kernel state accessor to the latest *finalized* slot number. This was incorrect. Since `next_sequencer_number` is a regular kernel state value (not a versioned value) the `true_slot_number` of the accessor has no effect on the returned value. 

I've fixed the logic by adding a new override to `KernelStateAccessor` which bypasses the state checkpoint and reads directly from the `HistoricalValues` table to fetch the value as of the requested slot number.
