### PR TITLE
Minor pruning fixes

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -1578,41 +1578,42 @@ where
     }
 
     async fn process_new_storage(&mut self, info: StateUpdateInfo<S::Storage>) {
+        let mut inner = self.get_inner_with_timing("update_state::fast_path").await;
         // Atomically swap in the new storage and prune the old one.
         let new_rollup_height = StateCheckpoint::new(info.storage.clone(), &Rt::default().kernel())
             .rollup_height_to_access();
         // Notify the executor that the storage has been replaced so it can drop any writes that have now been persisted.
-        self.inner
+        inner
             .executor
             .state_update_notifier
             .send_replace(new_rollup_height);
-        self.inner
+        inner
             .executor
             .checkpoint
             .replace_storage_and_prune(info.storage.clone(), &Rt::default().kernel());
         tracing::info!("Storage has been replaced");
         // Update the `inner`'s state to reflect the new storage.
         // These steps should match `process_final_catchup` except for the need to drop the db_event_subscription.
-        self.inner.is_ready = Ok(());
-        self.inner.has_finished_startup = true;
-        self.inner.latest_info = info;
-        let checkpoint = self
-            .inner
+        inner.is_ready = Ok(());
+        inner.has_finished_startup = true;
+        inner.latest_info = info;
+        let checkpoint =
+            inner
             .executor
             .checkpoint
             .clone_with_empty_witness_dropping_temp_cache();
-        self.inner
+        inner
             .executor_events_sender
             .force_update_api_state(checkpoint)
             .await;
 
-        self.inner
+        inner
             .executor
             .state_roots
             .retain(|height, _| *height > new_rollup_height);
 
-        let info = &self.inner.latest_info;
-        self.inner.update_api_ledger(info).await;
+        let info = &inner.latest_info;
+        inner.update_api_ledger(info).await;
     }
 
     async fn process_final_catchup(

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -1597,8 +1597,7 @@ where
         inner.is_ready = Ok(());
         inner.has_finished_startup = true;
         inner.latest_info = info;
-        let checkpoint =
-            inner
+        let checkpoint = inner
             .executor
             .checkpoint
             .clone_with_empty_witness_dropping_temp_cache();

--- a/crates/module-system/sov-modules-api/src/state/accessors/checkpoints.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/checkpoints.rs
@@ -105,6 +105,8 @@ impl<S: Spec> StateCheckpoint<S> {
         let new_rollup_height = new_checkpoint.rollup_height;
         self.delta
             .replace_storage_and_prune(storage, new_rollup_height.get());
+        // Prune the temp cache
+        std::mem::take(&mut self.cache);
     }
 
     /// Creates a new [`StateCheckpoint`] instance without any changes, backed

--- a/crates/module-system/sov-modules-api/src/state/accessors/internals.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/internals.rs
@@ -78,6 +78,7 @@ impl<S: Storage> Delta<S> {
             .prune_writes_up_to_and_all_reads(rollup_height);
         self.accessory_writes
             .retain(|_, write| write.at_rollup_height > rollup_height);
+        self.witness = Default::default(); // Prune the witness
     }
 
     pub(super) fn with_witness(inner: S, witness: S::Witness) -> Self {


### PR DESCRIPTION
# Description

This tiny PR adds some additional pruning on the state checkpoint to ensure that no memory is leaked. Neither optimization is likely to matter in practice, but we add them for correctness just in case. This PR also fixes a minor bug in the fast path for update_state where we referenced `self.inner` directly in the `SynchronizedSequencerState` rather than using `self.get_inner_with_timing`. This caused the `channel_size` metric to be misreported.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
