### PR TITLE
refactor: replace format!("{}", x) with x.to_string() in test

### DIFF
--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/mod.rs
@@ -193,7 +193,7 @@ mod tests {
     #[test]
     fn prover_config_debug_and_display_are_the_same() {
         let config = RollupProverConfigDiscriminants::Skip;
-        assert_eq!(format!("{config:?}"), format!("{}", config));
+        assert_eq!(format!("{config:?}"), config.to_string());
     }
 
     #[test]


### PR DESCRIPTION
# Description
Replace inefficient format!("{}", config) with config.to_string() in test.

This change eliminates an unnecessary string formatting operation while maintaining identical functionality. Using to_string() is more idiomatic and slightly more efficient than format!("{}", x) for simple Display conversions.
