### PR TITLE
EVM: `eth_subscribe` emits logs only after receiving notifications from the sequencer.

### DIFF
--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -14,7 +14,6 @@ use sov_modules_api::capabilities::HasKernel;
 use sov_modules_api::Spec;
 use sov_sequencer::Sequencer;
 use std::sync::Arc;
-use std::time::Duration;
 
 use crate::handlers::ETH_RPC_ERROR;
 

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -64,7 +64,7 @@ async fn stream_logs<S, Seq>(
     Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
 {
     let evm = Evm::<S>::default();
-    let state = &mut ethereum.sequencer.api_state().default_api_state_accessor();
+    let state = &mut ethereum.api_state_accessor();
 
     let pending_block = evm.pending_block(state);
     let mut prev_last_tx_index = pending_block.transactions.end;
@@ -72,13 +72,15 @@ async fn stream_logs<S, Seq>(
     // Fetch the initial block. If it’s stale, it will be replaced below.
     let mut block = evm.get_maybe_sealed_block(pending_block.header.number - 1, state);
 
-    loop {
-        let state = &mut ethereum.sequencer.api_state().default_api_state_accessor();
+    let state_updates = &mut ethereum.sequencer.api_state().checkpoint_receiver();
+
+    while state_updates.changed().await.is_ok() {
+        let state = &mut ethereum.api_state_accessor();
+
         let pending_block = evm.pending_block(state);
         let curr_last_tx_index = pending_block.transactions.end;
 
         if curr_last_tx_index <= prev_last_tx_index {
-            tokio::time::sleep(Duration::from_millis(10)).await;
             continue;
         }
 

--- a/crates/full-node/sov-ethereum/src/lib.rs
+++ b/crates/full-node/sov-ethereum/src/lib.rs
@@ -113,7 +113,7 @@ where
         self.sequencer
             .api_state()
             .build_api_state_accessor(None)
-            .unwrap()
+            .expect("Failed to build api state accessor")
     }
 }
 

--- a/crates/full-node/sov-ethereum/src/lib.rs
+++ b/crates/full-node/sov-ethereum/src/lib.rs
@@ -12,7 +12,7 @@ pub use sov_eth_dev_signer::Signers;
 pub use sov_evm::EthereumAuthenticator;
 use sov_evm::{convert_to_transaction_signed, RlpEvmTransaction};
 use sov_modules_api::capabilities::HasKernel;
-use sov_modules_api::Spec;
+use sov_modules_api::{ApiStateAccessor, Spec};
 use sov_sequencer::Sequencer;
 use std::future::ready;
 
@@ -107,6 +107,13 @@ where
         let message = borsh::to_vec(&raw_tx).expect("Failed to serialize raw tx");
 
         Ok((*tx_hash, message))
+    }
+
+    fn api_state_accessor(&self) -> ApiStateAccessor<S> {
+        self.sequencer
+            .api_state()
+            .build_api_state_accessor(None)
+            .unwrap()
     }
 }
 

--- a/crates/module-system/sov-modules-api/src/rest/mod.rs
+++ b/crates/module-system/sov-modules-api/src/rest/mod.rs
@@ -284,6 +284,11 @@ impl<S: Spec, T> ApiState<S, T> {
 
         Ok(state)
     }
+
+    /// TOOD
+    pub fn checkpoint_receiver(&self) -> watch::Receiver<StateCheckpoint<S>> {
+        self.checkpoint_receiver.clone()
+    }
 }
 
 /// The height parameter for REST API requests. This can be a rollup height or a slot number.

--- a/crates/module-system/sov-modules-api/src/rest/mod.rs
+++ b/crates/module-system/sov-modules-api/src/rest/mod.rs
@@ -285,7 +285,7 @@ impl<S: Spec, T> ApiState<S, T> {
         Ok(state)
     }
 
-    /// TOOD
+    /// Retunr the checkpoint receiver.
     pub fn checkpoint_receiver(&self) -> watch::Receiver<StateCheckpoint<S>> {
         self.checkpoint_receiver.clone()
     }

--- a/crates/module-system/sov-modules-api/src/rest/mod.rs
+++ b/crates/module-system/sov-modules-api/src/rest/mod.rs
@@ -285,7 +285,7 @@ impl<S: Spec, T> ApiState<S, T> {
         Ok(state)
     }
 
-    /// Retunr the checkpoint receiver.
+    /// Returns the checkpoint receiver.
     pub fn checkpoint_receiver(&self) -> watch::Receiver<StateCheckpoint<S>> {
         self.checkpoint_receiver.clone()
     }


### PR DESCRIPTION
# Description

Rather than polling for new EVM logs in a loop, we trigger log checks only when the sequencer sends a notification.

- [x]  ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
