### PR TITLE
Do not serialize `TransactionReceip.body_to_save`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 2025-09-12
 - #1672 Fixes some minor bugs related to pruning in the sequencer DB which could cause duplicate blob submission on restart.
+- #1682 Removes `body_to_save` from TransactionReceipt. Please use original transaction bytes which have been sent.
+
 # 2025-09-11
 - #1669 Account for sequencer gas in EVM transaction receipts. EVM transaction receipts now properly reflect the sequencer gas consumed during execution.
 

--- a/crates/rollup-interface/src/state_machine/stf/transaction.rs
+++ b/crates/rollup-interface/src/state_machine/stf/transaction.rs
@@ -15,9 +15,10 @@ pub struct IgnoredTransactionReceipt<T: TxReceiptContents> {
 }
 
 /// A receipt for a single transaction. These receipts are stored in the rollup's database
-/// and may be queried via RPC. Receipts are generic over a type `R` which the rollup can use to
+/// and may be queried via RPC. Receipts are generic over a type `T` which the rollup can use to
 /// store additional data, such as the status code of the transaction or the amount of gas used.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+// Note: Debug is manually implemented, please adjust it if this structure is changes
+#[derive(Clone, Serialize, Deserialize)]
 /// A receipt showing the result of a transaction
 #[serde(bound = "T: TxReceiptContents")]
 pub struct TransactionReceipt<T: TxReceiptContents> {
@@ -33,6 +34,17 @@ pub struct TransactionReceipt<T: TxReceiptContents> {
     /// Any additional structured data to be saved in the database and served over RPC
     /// For example, this might contain a status code.
     pub receipt: TxEffect<T>,
+}
+
+impl<T: TxReceiptContents> core::fmt::Debug for TransactionReceipt<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TransactionReceipt")
+            .field("tx_hash", &self.tx_hash)
+            .field("body_to_save", &"<removed>")
+            .field("events", &self.events)
+            .field("receipt", &self.receipt)
+            .finish()
+    }
 }
 
 /// The outcome of a transaction.

--- a/crates/rollup-interface/src/state_machine/stf/transaction.rs
+++ b/crates/rollup-interface/src/state_machine/stf/transaction.rs
@@ -24,7 +24,9 @@ pub struct TransactionReceipt<T: TxReceiptContents> {
     /// The canonical hash of this transaction
     pub tx_hash: TxHash,
     /// The canonically serialized body of the transaction, if it should be persisted
-    /// in the database
+    /// in the database.
+    /// Skip serialization because it is unnecessary over the wire.
+    #[serde(skip_serializing)]
     pub body_to_save: Option<Vec<u8>>,
     /// The events output by this transaction
     pub events: Vec<StoredEvent>,


### PR DESCRIPTION
# Description

Sending fully serialized transaction back to the client seems unnecessary, considering that client should have this exact data.

Also it removes it from Debug output, so logs have managed size. Any dev who needs to inspect this value, can explicitly access it.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes #1534 

## Testing
All existing tests are passing

## Docs
Added comment about why it is skipped