### PR TITLE
EVM: Set the correct timestamp for the EVM block.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12443,6 +12443,7 @@ dependencies = [
  "sha2 0.10.9",
  "sov-address",
  "sov-bank",
+ "sov-chain-state",
  "sov-eth-dev-signer",
  "sov-evm",
  "sov-kernels",

--- a/crates/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-evm/Cargo.toml
@@ -22,6 +22,7 @@ sov-state = { workspace = true }
 sov-address = { workspace = true, features = ["evm"] }
 sov-bank = { workspace = true }
 sov-uniqueness = { workspace = true }
+sov-chain-state = { workspace = true }
 
 anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
@@ -139,4 +140,6 @@ native = [
 	"sov-kernels/native",
 	"sov-bank/native",
 	"sov-uniqueness/native",
+	"sov-chain-state/native",
+	
 ]

--- a/crates/module-system/module-implementations/sov-evm/src/config.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/config.rs
@@ -1,5 +1,4 @@
 use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
-use alloy_eips::merge::SLOT_DURATION;
 use alloy_primitives::Address;
 use revm::primitives::hardfork::SpecId;
 
@@ -14,8 +13,6 @@ pub struct EvmChainSpec {
     pub coinbase: Address,
     /// Maximum gas allowed per block
     pub block_gas_limit: u64,
-    /// Seconds to add to parent block timestamp
-    pub block_timestamp_delta: u64,
     /// Hard fork activation schedule (block number -> fork ID)
     pub hardforks: Vec<(u64, SpecId)>,
 }
@@ -39,7 +36,6 @@ impl Default for EvmChainSpec {
             limit_contract_code_size: None,
             coinbase: Address::ZERO,
             block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
-            block_timestamp_delta: SLOT_DURATION.as_secs(),
             hardforks: vec![(0, SpecId::SHANGHAI)],
         }
     }
@@ -100,7 +96,6 @@ mod tests {
             }],
             chain_spec: crate::EvmChainSpec {
                 limit_contract_code_size: None,
-                block_timestamp_delta: 1u64,
                 hardforks: vec![(0, SpecId::SHANGHAI)],
                 ..Default::default()
             },
@@ -122,7 +117,6 @@ mod tests {
                     "limit_contract_code_size":null,
                     "coinbase":"0x0000000000000000000000000000000000000000",
                     "block_gas_limit":30000000,
-                    "block_timestamp_delta":1,
                     "hardforks":[[0,"SHANGHAI"]]
                 }
         }"#;

--- a/crates/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -49,12 +49,11 @@ impl<S: Spec> BlockHooks for Evm<S> {
             // This is justified. We will never have so many blocks.
             .expect("The impossible happened: Block number overflow");
 
-        // TODO EVM: #1510. This is wrong we should take the sov timestamp.
-        let new_timestamp = parent_block
-            .header
-            .timestamp
-            .checked_add(cfg.chain_spec.block_timestamp_delta)
-            .expect("The impossible happened: Timestamp overflow");
+        let new_timestamp = self
+            .chain_state_module
+            .get_time(state)
+            .unwrap_infallible()
+            .as_millis() as u64;
 
         let new_pending_env = BlockEnv {
             number: U256::from(new_block_number),
@@ -122,6 +121,7 @@ impl<S: Spec> BlockHooks for Evm<S> {
         let transactions_root = calculate_transaction_root(transactions.as_slice());
 
         let header = alloy_consensus::Header {
+            timestamp: block_env.timestamp.to::<u64>(),
             parent_hash: parent_block.header.seal(),
             number: block_env.number.to::<u64>(),
             beneficiary: parent_block.header.beneficiary,

--- a/crates/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/lib.rs
@@ -139,6 +139,10 @@ pub struct Evm<S: Spec> {
     #[module]
     pub(crate) uniqueness_module: sov_uniqueness::Uniqueness<S>,
 
+    /// A reference to the ChainState module.
+    #[module]
+    pub(crate) chain_state_module: sov_chain_state::ChainState<S>,
+
     #[phantom]
     phantom: core::marker::PhantomData<S>,
 }

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
@@ -47,7 +47,6 @@ fn test_genesis_cfg() {
             EvmRuntimeConfig {
                 chain_spec: sov_evm::EvmChainSpec {
                     block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
-                    block_timestamp_delta: 2,
                     coinbase: Address::from([3u8; 20]),
                     limit_contract_code_size: Some(5000),
                     hardforks: vec![(0, SpecId::BERLIN), (1, SpecId::SHANGHAI)],
@@ -122,7 +121,6 @@ fn default_config() -> EvmGenesisConfig {
         genesis_timestamp: 50,
         chain_spec: sov_evm::EvmChainSpec {
             block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
-            block_timestamp_delta: 2,
             coinbase: Address::from([3u8; 20]),
             limit_contract_code_size: Some(5000),
             hardforks: vec![(0, SpecId::BERLIN), (1, SpecId::SHANGHAI)],

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -63,7 +63,7 @@ async fn evm_test_log_subscription() {
         if block_nr_from_log > block_nr {
             let block_timestamp_from_log = log.block_timestamp.unwrap();
             assert!(block_timestamp_from_log > time_stamp);
-            time_stamp = block_nr_from_log;
+            time_stamp = block_timestamp_from_log;
             block_nr = block_timestamp_from_log;
         }
 

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -53,10 +53,24 @@ async fn evm_test_log_subscription() {
 
     assert_eq!(logs_from_subscription.len(), logs_fetched.len());
 
+    let mut block_nr = 0;
+    let mut time_stamp = 0;
     for (i, log) in logs_fetched.iter().enumerate() {
         let sub_log = &logs_from_subscription[i];
+        let block_nr_from_log = log.block_number.unwrap();
+
+        // Verify that the block timestamp increases along with the block number.
+        if block_nr_from_log > block_nr {
+            let block_timestamp_from_log = log.block_timestamp.unwrap();
+            assert!(block_timestamp_from_log > time_stamp);
+            time_stamp = block_nr_from_log;
+            block_nr = block_timestamp_from_log;
+        }
+
         assert_logs(log, sub_log);
     }
+
+    assert!(block_nr > 0);
 }
 
 // Subscription test with filtering.

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -64,7 +64,7 @@ async fn evm_test_log_subscription() {
             let block_timestamp_from_log = log.block_timestamp.unwrap();
             assert!(block_timestamp_from_log > time_stamp);
             time_stamp = block_timestamp_from_log;
-            block_nr = block_timestamp_from_log;
+            block_nr = block_nr_from_log;
         }
 
         assert_logs(log, sub_log);

--- a/examples/test-data/genesis/demo/celestia/evm.json
+++ b/examples/test-data/genesis/demo/celestia/evm.json
@@ -27,7 +27,6 @@
     "limit_contract_code_size": null,
     "coinbase": "0x0000000000000000000000000000000000000000",
     "block_gas_limit": 30000000,
-    "block_timestamp_delta": 1,
     "base_fee_params": {
       "max_change_denominator": 8,
       "elasticity_multiplier": 2

--- a/examples/test-data/genesis/demo/mock/evm.json
+++ b/examples/test-data/genesis/demo/mock/evm.json
@@ -27,7 +27,6 @@
     "limit_contract_code_size": null,
     "coinbase": "0x0000000000000000000000000000000000000000",
     "block_gas_limit": 30000000,
-    "block_timestamp_delta": 1,
     "base_fee_params": {
       "max_change_denominator": 8,
       "elasticity_multiplier": 2

--- a/examples/test-data/genesis/integration-tests/evm.json
+++ b/examples/test-data/genesis/integration-tests/evm.json
@@ -27,7 +27,6 @@
     "limit_contract_code_size": null,
     "coinbase": "0x0000000000000000000000000000000000000000",
     "block_gas_limit": 30000000,
-    "block_timestamp_delta": 1,
     "base_fee_params": {
       "max_change_denominator": 8,
       "elasticity_multiplier": 2


### PR DESCRIPTION
# Description

This PR derives the EVM block timestamp from the `ChainState` module.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)