### PR TITLE
Add `/sequencer/ready` to OpenAPI spec and unflaky some more sequencer tests

### DIFF
--- a/crates/full-node/sov-api-spec/openapi-v3.yaml
+++ b/crates/full-node/sov-api-spec/openapi-v3.yaml
@@ -291,6 +291,18 @@ paths:
           "$ref": "#/components/responses/ApiErrorResponse"
         "503":
           "$ref": "#/components/responses/ApiErrorResponse"
+  /sequencer/ready:
+    get:
+      summary: Check whether the sequencer is ready to receive transactions
+      description: Returns an empty response when ready, or a 503 error with details when not ready
+      operationId: is_ready
+      tags:
+        - Sequencer
+      responses:
+        "200":
+          description: Sequencer is ready
+        "503":
+          "$ref": "#/components/responses/ApiErrorResponse"
   /sequencer/txs/{txHash}/status:
     get:
       summary: Get a transaction status by hash

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -569,7 +569,7 @@ async fn sequencer_filled_up_block() {
 const SEQUENCER_RECOVERY_ERROR: &str = "The preferred sequencer is recovering from downtime and cannot provide soft-confirmations at this time";
 
 #[tokio::test(flavor = "multi_thread")]
-async fn flaky_seq_behind_deferred_slots_count_simple_lagging() {
+async fn seq_behind_deferred_slots_count_simple_lagging() {
     std::env::set_var("SOV_TEST_CONST_OVERRIDE_DEFERRED_SLOTS_COUNT", "40");
     let (test_rollup, admin) = create_test_rollup(
         0,
@@ -624,18 +624,17 @@ async fn flaky_seq_behind_deferred_slots_count_simple_lagging() {
     for _ in 0..30 {
         let _ = da_layer.produce_block().await; // Don't wait for state updates since we've just paused them
     }
-    tokio::time::sleep(Duration::from_millis(1500)).await; // Sleep to give time for at least some of these to be processed.
+    // Make sure the DA has synced everything
+    test_rollup.wait_for_node_synced().await.unwrap();
 
     tracing::info!("Resuming preferred sequencer batch production.");
     test_rollup.resume_preferred_batches().await;
-    // Produce two blocks that will trigger update_state() and cause the sequencer to go into
-    // recovery
     // A single block is usually enough but was very rarely flaky. Producing two blocks fixes that
     // and doesn't hurt
-    for _ in 0..2 {
-        let _ = da_layer.produce_block().await; // Now updates are not working because we're in recovery mode.
-        sleep(Duration::from_millis(100)).await; // Sleep to give time for the sequencer to go into recovery.
-    }
+    // Now on the next state update, the sequencer should always enter recovery
+    test_rollup.da_service.produce_block_now().await.unwrap();
+    sleep(Duration::from_millis(50)).await;
+    assert!(!test_rollup.is_sequencer_ready().await);
 
     // Create transaction that should fail: sequencer should not accept transactions while in
     // recovery.
@@ -657,7 +656,7 @@ async fn flaky_seq_behind_deferred_slots_count_simple_lagging() {
 
     // Give time for the sequencer to catch up its visible state number
     tracing::info!("Producing DA blocks to let the sequencer resync.");
-    for _ in 0..10 {
+    while !test_rollup.is_sequencer_ready().await {
         let _ = da_layer.produce_block().await;
         sleep(Duration::from_millis(50)).await; // Notifications don't work during recovery.
     }
@@ -779,14 +778,12 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     let test_rollup = builder.start().await.unwrap();
     let client = test_rollup.api_client().clone();
 
-    // Give the rollup time to process the backlog and enter recovery mode
-    tokio::time::sleep(Duration::from_millis(1000)).await;
-
-    // Produce a few more blocks to trigger recovery detection
-    for _ in 0..3 {
-        test_rollup.da_service.produce_block_now().await.unwrap();
-        sleep(Duration::from_millis(1000)).await;
-    }
+    // First we sync the node to the new DA blocks
+    test_rollup.wait_for_node_synced().await.unwrap();
+    // Now on the next state update, the sequencer should always enter recovery
+    test_rollup.da_service.produce_block_now().await.unwrap();
+    sleep(Duration::from_millis(50)).await;
+    assert!(!test_rollup.is_sequencer_ready().await);
 
     // Create transaction that should fail: sequencer should not accept transactions while in recovery
     const UPDATE_VEC_VALUE: u8 = 12;
@@ -805,12 +802,10 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
 
     // Give time for the sequencer to catch up its visible state number
     tracing::info!("Producing DA blocks to let the sequencer resync.");
-    for _ in 0..20 {
+    while !test_rollup.is_sequencer_ready().await {
         test_rollup.da_service.produce_block_now().await.unwrap();
         sleep(Duration::from_millis(50)).await;
     }
-    tokio::time::sleep(Duration::from_millis(100)).await;
-    test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer
     client

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -629,12 +629,13 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
 
     tracing::info!("Resuming preferred sequencer batch production.");
     test_rollup.resume_preferred_batches().await;
-    // A single block is usually enough but was very rarely flaky. Producing two blocks fixes that
-    // and doesn't hurt
-    // Now on the next state update, the sequencer should always enter recovery
+    // Normally on the next state update, the sequencer should always enter recovery.
+    // However for some reason this was flaky.
     test_rollup.da_service.produce_block_now().await.unwrap();
-    sleep(Duration::from_millis(50)).await;
-    assert!(!test_rollup.is_sequencer_ready().await);
+    while test_rollup.is_sequencer_ready().await {
+        let _ = da_layer.produce_block().await;
+        sleep(Duration::from_millis(50)).await;
+    }
 
     // Create transaction that should fail: sequencer should not accept transactions while in
     // recovery.

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -809,16 +809,17 @@ where
     }
 
     /// Generic helper for waiting on a condition with timeout and polling.
+    ///  * condition_string: inserted into "Timeout waiting for {condition_string}", format accordingly
     async fn wait_for_condition<F, Fut>(
         &self,
         mut condition_check: F,
-        condition_name: &str,
-        timeout_secs: u64,
+        condition_string: &str,
     ) -> anyhow::Result<()>
     where
         F: FnMut() -> Fut,
         Fut: std::future::Future<Output = anyhow::Result<bool>>,
     {
+        const TIMEOUT_SECS: u64 = 20;
         let wait_loop = async {
             loop {
                 match condition_check().await {
@@ -829,13 +830,10 @@ where
             }
         };
 
-        timeout(Duration::from_secs(timeout_secs), wait_loop)
+        timeout(Duration::from_secs(TIMEOUT_SECS), wait_loop)
             .await
             .with_context(|| {
-                format!(
-                    "Timeout waiting for {} after {} seconds",
-                    condition_name, timeout_secs
-                )
+                format!("Timeout waiting for {condition_string} after {TIMEOUT_SECS} seconds")
             })?
     }
 
@@ -849,7 +847,6 @@ where
         self.wait_for_condition(
             || async { Ok(self.is_sequencer_ready().await == wait_for_ready) },
             condition_name,
-            20,
         )
         .await
     }
@@ -865,7 +862,6 @@ where
                 ))
             },
             "node to sync",
-            20,
         )
         .await
     }

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -791,24 +791,83 @@ where
             .await
     }
 
+    /// Checks if the sequencer is ready without waiting.
+    pub async fn is_sequencer_ready(&self) -> bool {
+        self.client.client.is_ready().await.is_ok()
+    }
+
+    /// Polls the sequencer until is_ready() returns Err(). Useful when you expect the sequencer to
+    /// go into resync/recovery/startup mode, to avoid wait_for_sequencer_ready() from resolving
+    /// _before_ the sequencer becomes unready.
+    pub async fn wait_for_sequencer_not_ready(&self) -> anyhow::Result<()> {
+        self.wait_for_sequencer_state(false).await
+    }
+
     /// Polls the sequencer until is_ready() returns Ok(()).
     pub async fn wait_for_sequencer_ready(&self) -> anyhow::Result<()> {
+        self.wait_for_sequencer_state(true).await
+    }
+
+    /// Generic helper for waiting on a condition with timeout and polling.
+    async fn wait_for_condition<F, Fut>(
+        &self,
+        mut condition_check: F,
+        condition_name: &str,
+        timeout_secs: u64,
+    ) -> anyhow::Result<()>
+    where
+        F: FnMut() -> Fut,
+        Fut: std::future::Future<Output = anyhow::Result<bool>>,
+    {
         let wait_loop = async {
             loop {
-                match self.client.http_get("/sequencer/ready").await {
-                    Ok(_) => {
-                        return Ok(());
-                    }
-                    Err(_) => {
-                        tokio::time::sleep(Duration::from_millis(100)).await;
-                    }
+                match condition_check().await {
+                    Ok(true) => return Ok(()),
+                    Ok(false) => tokio::time::sleep(Duration::from_millis(100)).await,
+                    Err(e) => return Err(e),
                 }
             }
         };
 
-        timeout(Duration::from_secs(20), wait_loop)
+        timeout(Duration::from_secs(timeout_secs), wait_loop)
             .await
-            .context("Timeout waiting for sequencer to be ready after 10 seconds")?
+            .with_context(|| {
+                format!(
+                    "Timeout waiting for {} after {} seconds",
+                    condition_name, timeout_secs
+                )
+            })?
+    }
+
+    /// Helper that waits for the sequencer to reach either a ready or un-ready state.
+    async fn wait_for_sequencer_state(&self, wait_for_ready: bool) -> anyhow::Result<()> {
+        let condition_name = if wait_for_ready {
+            "sequencer to be ready"
+        } else {
+            "sequencer to be not-ready"
+        };
+        self.wait_for_condition(
+            || async { Ok(self.is_sequencer_ready().await == wait_for_ready) },
+            condition_name,
+            20,
+        )
+        .await
+    }
+
+    /// Waits for the node to finish syncing with the DA layer.
+    pub async fn wait_for_node_synced(&self) -> anyhow::Result<()> {
+        self.wait_for_condition(
+            || async {
+                let response = self.client.client.get_sync_status().await?;
+                Ok(matches!(
+                    response.into_inner(),
+                    sov_api_spec::types::SyncStatus::Synced { .. }
+                ))
+            },
+            "node to sync",
+            20,
+        )
+        .await
     }
 
     /// Restarts the rollup.

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -706,6 +706,9 @@ where
     R::Spec: Spec<Da = MockDaSpec>,
     StoragePath: AsPath,
 {
+    /// Default timeout for polling operations in seconds.
+    pub const POLLING_TIMEOUT: u64 = 20;
+
     /// Pauses batch production for the preferred sequencer.
     ///
     /// Transactions accepted by the preferred sequencer after this call (and
@@ -799,11 +802,15 @@ where
     /// Polls the sequencer until is_ready() returns Err(). Useful when you expect the sequencer to
     /// go into resync/recovery/startup mode, to avoid wait_for_sequencer_ready() from resolving
     /// _before_ the sequencer becomes unready.
+    ///
+    /// Times out after TestRollup::POLLING_TIMEOUT seconds.
     pub async fn wait_for_sequencer_not_ready(&self) -> anyhow::Result<()> {
         self.wait_for_sequencer_state(false).await
     }
 
     /// Polls the sequencer until is_ready() returns Ok(()).
+    ///
+    /// Times out after TestRollup::POLLING_TIMEOUT seconds.
     pub async fn wait_for_sequencer_ready(&self) -> anyhow::Result<()> {
         self.wait_for_sequencer_state(true).await
     }
@@ -819,7 +826,6 @@ where
         F: FnMut() -> Fut,
         Fut: std::future::Future<Output = anyhow::Result<bool>>,
     {
-        const TIMEOUT_SECS: u64 = 20;
         let wait_loop = async {
             loop {
                 match condition_check().await {
@@ -830,10 +836,13 @@ where
             }
         };
 
-        timeout(Duration::from_secs(TIMEOUT_SECS), wait_loop)
+        timeout(Duration::from_secs(Self::POLLING_TIMEOUT), wait_loop)
             .await
             .with_context(|| {
-                format!("Timeout waiting for {condition_string} after {TIMEOUT_SECS} seconds")
+                format!(
+                    "Timeout waiting for {condition_string} after {} seconds",
+                    Self::POLLING_TIMEOUT
+                )
             })?
     }
 
@@ -852,6 +861,8 @@ where
     }
 
     /// Waits for the node to finish syncing with the DA layer.
+    ///
+    /// Times out after TestRollup::POLLING_TIMEOUT seconds.
     pub async fn wait_for_node_synced(&self) -> anyhow::Result<()> {
         self.wait_for_condition(
             || async {

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -888,7 +888,6 @@ where
             c.stop_at_rollup_height = stop_at_height;
         });
         let rollup = builder.start().await?;
-        rollup.wait_for_sequencer_ready().await?;
         Ok(rollup)
     }
 


### PR DESCRIPTION
# Description
Adds more utilities to `TestRollup`. This should help unflaky both recovery tests (I was able to `cargo stress` both for 200+ runs without failure) and should allow the utilities to be used to going forward to reduce reliance on sleeps in tests that rely on the node syncing or the sequencer being ready/unready.

I also tried adding `wait_for_sequencer_ready()` to `TestRollup::start()` but this fails - I think we need to generate some DA blocks first before the sequencer can become ready. This can be explored in a follow-up PR if more related flakiness is observed.

- [ ] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] ~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
