### PR TITLE
Limit Memory Consumption of StateDB Pruning Task

### DIFF
--- a/crates/full-node/sov-db/benches/pruner_bench.rs
+++ b/crates/full-node/sov-db/benches/pruner_bench.rs
@@ -64,10 +64,10 @@ fn bench_pruner(c: &mut Criterion) {
             },
             |(_tempdir, rocksdb)| {
                 let pruner = Pruner::new(rocksdb.clone());
-                let pruning_batch = pruner
+                let output = pruner
                     .collect_pruning_batch_for_module_accessory_state(100)
                     .unwrap();
-                rocksdb.write_schemas(pruning_batch).unwrap();
+                rocksdb.write_schemas(output.pruning_batch).unwrap();
             },
         );
     });

--- a/crates/full-node/sov-db/src/pruner.rs
+++ b/crates/full-node/sov-db/src/pruner.rs
@@ -4,6 +4,7 @@ use rockbound::schema::{KeyCodec, Schema};
 use rockbound::{SchemaBatch, SchemaIterator, SchemaKey, SeekKeyEncoder, DB};
 use sov_rollup_interface::common::SlotNumber;
 
+use crate::storage_manager::{PrunerJobOutput, MAX_INDIVIDUAL_PRUNING_BATCH_SIZE};
 use crate::metrics::nomt::PrunerMetric;
 use crate::schema::tables::ModuleAccessoryState;
 
@@ -21,7 +22,7 @@ impl Pruner {
     }
 
     /// Gathers all delete operations that can prune older versions.
-    pub fn collect_pruning_batch<T>(&self, keep_versions: u64) -> anyhow::Result<SchemaBatch>
+    pub fn collect_pruning_batch<T>(&self, keep_versions: u64) -> anyhow::Result<PrunerJobOutput>
     where
         T: Schema<Key = VersionedSchemaKey>,
         VersionedSchemaKey: SeekKeyEncoder<T> + KeyCodec<T>,
@@ -30,6 +31,7 @@ impl Pruner {
         let mut keys_inspected = 0;
         let mut keys_to_prune = 0;
         let mut pruning_batch = SchemaBatch::new();
+        let mut hit_size_limit = false;
         if keep_versions == 0 {
             return Err(anyhow::anyhow!("keep_versions must be at least 1"));
         }
@@ -49,6 +51,10 @@ impl Pruner {
                     &(base_key, last_prunable_version),
                 )?;
             }
+            if keys_to_prune >= MAX_INDIVIDUAL_PRUNING_BATCH_SIZE {
+                hit_size_limit = true;
+                break;
+            }
         }
         let pruning_time = start.elapsed();
         sov_metrics::track_metrics(|tracker| {
@@ -60,7 +66,10 @@ impl Pruner {
             });
         });
 
-        Ok(pruning_batch)
+        Ok(PrunerJobOutput {
+            pruning_batch,
+            hit_size_limit,
+        })
     }
 
     /// Can be pruned up to a returned version (included).
@@ -106,7 +115,7 @@ impl Pruner {
     pub fn collect_pruning_batch_for_module_accessory_state(
         &self,
         keep_versions: u64,
-    ) -> anyhow::Result<SchemaBatch> {
+    ) -> anyhow::Result<PrunerJobOutput> {
         self.collect_pruning_batch::<ModuleAccessoryState>(keep_versions)
     }
 }

--- a/crates/full-node/sov-db/src/pruner.rs
+++ b/crates/full-node/sov-db/src/pruner.rs
@@ -319,7 +319,7 @@ mod tests {
         let keys_to_prune = pruner
             .collect_pruning_batch::<ModuleAccessoryState>(3)
             .unwrap();
-        rocksdb.write_schemas(keys_to_prune).unwrap();
+        rocksdb.write_schemas(keys_to_prune.pruning_batch).unwrap();
 
         // Assert that keys are deleted
         // Key A: has versions [6,7,8,9] -> keep [7,8,9], prune [6]

--- a/crates/full-node/sov-db/src/pruner.rs
+++ b/crates/full-node/sov-db/src/pruner.rs
@@ -4,9 +4,9 @@ use rockbound::schema::{KeyCodec, Schema};
 use rockbound::{SchemaBatch, SchemaIterator, SchemaKey, SeekKeyEncoder, DB};
 use sov_rollup_interface::common::SlotNumber;
 
-use crate::storage_manager::{PrunerJobOutput, MAX_INDIVIDUAL_PRUNING_BATCH_SIZE};
 use crate::metrics::nomt::PrunerMetric;
 use crate::schema::tables::ModuleAccessoryState;
+use crate::storage_manager::{PrunerJobOutput, MAX_INDIVIDUAL_PRUNING_BATCH_SIZE};
 
 type VersionedSchemaKey = (SchemaKey, SlotNumber);
 

--- a/crates/full-node/sov-db/src/storage_manager/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/mod.rs
@@ -7,8 +7,9 @@ pub mod tests;
 pub use delta_reader_based::*;
 pub use nomt_based::{
     FlatStateDb, InitializableNativeNomtStorage, NomtChangeSet, NomtStorageManager,
-    StateFinishedSession,
+    StateFinishedSession, PrunerJobOutput
 };
+pub(crate) use nomt_based::MAX_INDIVIDUAL_PRUNING_BATCH_SIZE;
 use rockbound::cache::delta_reader::DeltaReader;
 
 use crate::ledger_db::LedgerDb;

--- a/crates/full-node/sov-db/src/storage_manager/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/mod.rs
@@ -5,11 +5,11 @@ mod nomt_based;
 pub mod tests;
 
 pub use delta_reader_based::*;
+pub(crate) use nomt_based::MAX_INDIVIDUAL_PRUNING_BATCH_SIZE;
 pub use nomt_based::{
     FlatStateDb, InitializableNativeNomtStorage, NomtChangeSet, NomtStorageManager,
-    StateFinishedSession, PrunerJobOutput
+    PrunerJobOutput, StateFinishedSession,
 };
-pub(crate) use nomt_based::MAX_INDIVIDUAL_PRUNING_BATCH_SIZE;
 use rockbound::cache::delta_reader::DeltaReader;
 
 use crate::ledger_db::LedgerDb;

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -26,6 +26,10 @@ use crate::storage_manager::{update_ledger_finalized_height, InitializableNative
 
 const GIGABYTE: usize = 1024 * 1024 * 1024;
 
+// 3 million keys * 32 bytes is about 100 MB. This should be a large enough batch size to keep up with state growth,
+// without consuming excessive memory.
+pub(crate) const MAX_INDIVIDUAL_PRUNING_BATCH_SIZE: usize = 3_000_000;
+
 pub(crate) struct DbGroup<H, K> {
     merklized_state: Arc<NomtStateDb<H>>,
     flat_state: FlatStateDb,
@@ -87,8 +91,8 @@ where
     pub(crate) fn commit_pruning(&mut self, group: PruneGroup) -> anyhow::Result<()> {
         self.flat_state
             .other
-            .write_schemas(group.historical_state)?;
-        self.accessory.write_schemas(group.accessory)?;
+            .write_schemas(group.historical_state.pruning_batch)?;
+        self.accessory.write_schemas(group.accessory.pruning_batch)?;
         Ok(())
     }
 
@@ -163,13 +167,13 @@ where
     }
 
     pub(crate) fn start_pruner(&self, versions_to_keep: usize) -> PrunerJob {
-        tracing::info!(versions_to_keep, "Starting pruner task");
+        tracing::info!(versions_to_keep, "Starting pruner task iteration");
         let user = self.flat_state.get_user_db().clone();
         let kernel = self.flat_state.get_kernel_db().clone();
         let accessory_pruner = Pruner::new(self.accessory.clone());
 
         // Spawn historical state pruner thread
-        let historical_state = std::thread::spawn(move || -> anyhow::Result<SchemaBatch> {
+        let historical_state: JoinHandle<Result<PrunerJobOutput, anyhow::Error>> = std::thread::spawn(move || -> anyhow::Result<PrunerJobOutput> {
             let pruning_time = std::time::Instant::now();
             let current_user_version = user.get_committed_version()?;
             let current_kernel_version = kernel.get_committed_version()?;
@@ -177,6 +181,7 @@ where
             let mut batch = SchemaBatch::new();
             let mut keys_to_prune = 0;
             let mut keys_inspected = 0;
+            let mut hit_size_limit = false;
 
             if let Some(user_version) =
                 current_user_version.and_then(|v| v.checked_sub(versions_to_keep as u64))
@@ -205,6 +210,10 @@ where
                         batch.delete::<NomtHistoricalState<UserNamespace>>(&key)?;
                         keys_to_prune += 1;
                     }
+                    if keys_to_prune >= MAX_INDIVIDUAL_PRUNING_BATCH_SIZE {
+                        hit_size_limit = true;
+                        break;
+                    }
                 }
                 batch.put::<NomtCommittedVersion<UserNamespace>>(
                     &VersionedTableMetadataKey::PrunedVersion,
@@ -214,7 +223,7 @@ where
             if let Some(kernel_version) =
                 current_kernel_version.and_then(|v| v.checked_sub(versions_to_keep as u64))
             {
-                let prunable_keys = kernel.iter_pruning_keys_up_to_version(kernel_version)?;
+                let prunable_keys = kernel.iter_pruning_keys_up_to_version(kernel_version)?.take(MAX_INDIVIDUAL_PRUNING_BATCH_SIZE);
                 for key in prunable_keys {
                     // Prune the pruning table.
                     let key = key?;
@@ -234,6 +243,10 @@ where
                         batch.delete::<NomtHistoricalState<KernelNamespace>>(&key)?;
                         keys_to_prune += 1;
                     }
+                    if keys_to_prune >= MAX_INDIVIDUAL_PRUNING_BATCH_SIZE {
+                        hit_size_limit = true;
+                        break;
+                    }
                 }
                 batch.put::<NomtCommittedVersion<KernelNamespace>>(
                     &VersionedTableMetadataKey::PrunedVersion,
@@ -250,14 +263,16 @@ where
                     time: pruning_time,
                 });
             });
-            Ok(batch)
+            Ok(PrunerJobOutput {
+                pruning_batch: batch,
+                hit_size_limit,
+            })
         });
 
         // Spawn accessory pruner thread
-        let accessory_state = std::thread::spawn(move || -> anyhow::Result<SchemaBatch> {
+        let accessory_state = std::thread::spawn(move || -> anyhow::Result<PrunerJobOutput> {
             accessory_pruner
-                .collect_pruning_batch::<ModuleAccessoryState>(versions_to_keep as u64)?;
-            Ok(SchemaBatch::new())
+                .collect_pruning_batch::<ModuleAccessoryState>(versions_to_keep as u64)
         });
 
         PrunerJob {
@@ -329,8 +344,14 @@ pub(crate) struct SnapshotGroup {
 }
 
 pub(crate) struct PruneGroup {
-    historical_state: SchemaBatch,
-    accessory: SchemaBatch,
+    historical_state: PrunerJobOutput,
+    accessory: PrunerJobOutput,
+}
+
+impl PruneGroup {
+    pub(crate) fn hit_size_limit(&self) -> bool {
+        self.historical_state.hit_size_limit || self.accessory.hit_size_limit
+    }
 }
 
 pub(crate) struct CommitGroup {
@@ -342,8 +363,16 @@ pub(crate) struct CommitGroup {
 
 // Collection of 2 handles to pruner threads for each database.
 pub(crate) struct PrunerJob {
-    historical_state: JoinHandle<anyhow::Result<SchemaBatch>>,
-    accessory_state: JoinHandle<anyhow::Result<SchemaBatch>>,
+    historical_state: JoinHandle<anyhow::Result<PrunerJobOutput>>,
+    accessory_state: JoinHandle<anyhow::Result<PrunerJobOutput>>,
+}
+
+/// The output of a pruner job
+pub struct PrunerJobOutput {
+    /// The batch of keys to delete from the database.
+    pub pruning_batch: SchemaBatch,
+    /// Whether the pruner hit the batch size limit. If this is true, the pruner should be spawned again when possible to continue its work.
+    pub hit_size_limit: bool,
 }
 
 impl PrunerJob {
@@ -355,15 +384,15 @@ impl PrunerJob {
         let historical_state = self
             .historical_state
             .join()
-            .map_err(|e| anyhow::anyhow!("Historical state pruner panicked: {:?}", e))?;
+            .map_err(|e| anyhow::anyhow!("Historical state pruner panicked: {:?}", e))?.context("historical state")?;
         let accessory_state = self
             .accessory_state
             .join()
-            .map_err(|e| anyhow::anyhow!("Accessory state pruner panicked: {:?}", e))?;
-        tracing::info!("Pruner task has completed");
+            .map_err(|e| anyhow::anyhow!("Accessory state pruner panicked: {:?}", e))?.context("accessory state")?;
+        tracing::info!(%historical_state.hit_size_limit, %accessory_state.hit_size_limit, "Pruner task has completed");
         Ok(PruneGroup {
-            historical_state: historical_state.context("historical state")?,
-            accessory: accessory_state.context("accessory state")?,
+            historical_state: historical_state,
+            accessory: accessory_state,
         })
     }
 }

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -396,7 +396,7 @@ impl PrunerJob {
             .context("accessory state")?;
         tracing::info!(%historical_state.hit_size_limit, %accessory_state.hit_size_limit, "Pruner task has completed");
         Ok(PruneGroup {
-            historical_state: historical_state,
+            historical_state,
             accessory: accessory_state,
         })
     }

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -92,7 +92,8 @@ where
         self.flat_state
             .other
             .write_schemas(group.historical_state.pruning_batch)?;
-        self.accessory.write_schemas(group.accessory.pruning_batch)?;
+        self.accessory
+            .write_schemas(group.accessory.pruning_batch)?;
         Ok(())
     }
 
@@ -173,106 +174,108 @@ where
         let accessory_pruner = Pruner::new(self.accessory.clone());
 
         // Spawn historical state pruner thread
-        let historical_state: JoinHandle<Result<PrunerJobOutput, anyhow::Error>> = std::thread::spawn(move || -> anyhow::Result<PrunerJobOutput> {
-            let pruning_time = std::time::Instant::now();
-            let current_user_version = user.get_committed_version()?;
-            let current_kernel_version = kernel.get_committed_version()?;
+        let historical_state: JoinHandle<Result<PrunerJobOutput, anyhow::Error>> =
+            std::thread::spawn(move || -> anyhow::Result<PrunerJobOutput> {
+                let pruning_time = std::time::Instant::now();
+                let current_user_version = user.get_committed_version()?;
+                let current_kernel_version = kernel.get_committed_version()?;
 
-            let mut batch = SchemaBatch::new();
-            let mut keys_to_prune = 0;
-            let mut keys_inspected = 0;
-            let mut hit_size_limit = false;
+                let mut batch = SchemaBatch::new();
+                let mut keys_to_prune = 0;
+                let mut keys_inspected = 0;
+                let mut hit_size_limit = false;
 
-            if let Some(user_version) =
-                current_user_version.and_then(|v| v.checked_sub(versions_to_keep as u64))
-            {
-                let prunable_keys = user.iter_pruning_keys_up_to_version(user_version)?;
-                for key in prunable_keys {
-                    // Prune the pruning table.
-                    let key = key?;
-                    batch.delete::<NomtPruningState<UserNamespace>>(&key)?;
-                    keys_to_prune += 1;
-                    keys_inspected += 1;
-                    // Prune the historical state table. This is the main table that we want to prune.
-                    // We want to make sure that the the newest version of the key is accessible. The pruning table
-                    // records that we wrote key K at time T, so delete key K at time T-1. Recursively, this will ensure
-                    // that no keys are pruned that are still live, and all old keys are pruned as soon as possible.
-                    let mut key = key.into_versioned_key();
-                    let Some(previous_version) = key.1.checked_sub(1) else {
-                        continue;
-                    };
-                    let prev_written_version =
-                        user.get_version_for_key(&key.0, previous_version)?;
-
-                    keys_inspected += 1;
-                    if let Some(previous_version) = prev_written_version {
-                        key.1 = previous_version;
-                        batch.delete::<NomtHistoricalState<UserNamespace>>(&key)?;
+                if let Some(user_version) =
+                    current_user_version.and_then(|v| v.checked_sub(versions_to_keep as u64))
+                {
+                    let prunable_keys = user.iter_pruning_keys_up_to_version(user_version)?;
+                    for key in prunable_keys {
+                        // Prune the pruning table.
+                        let key = key?;
+                        batch.delete::<NomtPruningState<UserNamespace>>(&key)?;
                         keys_to_prune += 1;
-                    }
-                    if keys_to_prune >= MAX_INDIVIDUAL_PRUNING_BATCH_SIZE {
-                        hit_size_limit = true;
-                        break;
-                    }
-                }
-                batch.put::<NomtCommittedVersion<UserNamespace>>(
-                    &VersionedTableMetadataKey::PrunedVersion,
-                    &user_version,
-                )?;
-            }
-            if let Some(kernel_version) =
-                current_kernel_version.and_then(|v| v.checked_sub(versions_to_keep as u64))
-            {
-                let prunable_keys = kernel.iter_pruning_keys_up_to_version(kernel_version)?.take(MAX_INDIVIDUAL_PRUNING_BATCH_SIZE);
-                for key in prunable_keys {
-                    // Prune the pruning table.
-                    let key = key?;
-                    batch.delete::<NomtPruningState<KernelNamespace>>(&key)?;
-                    keys_to_prune += 1;
-                    keys_inspected += 1;
-                    // Prune the historical state table.
-                    let mut key = key.into_versioned_key();
-                    let Some(previous_version) = key.1.checked_sub(1) else {
-                        continue;
-                    };
-                    let prev_written_version =
-                        kernel.get_version_for_key(&key.0, previous_version)?;
-                    keys_inspected += 1;
-                    if let Some(previous_version) = prev_written_version {
-                        key.1 = previous_version;
-                        batch.delete::<NomtHistoricalState<KernelNamespace>>(&key)?;
-                        keys_to_prune += 1;
-                    }
-                    if keys_to_prune >= MAX_INDIVIDUAL_PRUNING_BATCH_SIZE {
-                        hit_size_limit = true;
-                        break;
-                    }
-                }
-                batch.put::<NomtCommittedVersion<KernelNamespace>>(
-                    &VersionedTableMetadataKey::PrunedVersion,
-                    &kernel_version,
-                )?;
-            }
+                        keys_inspected += 1;
+                        // Prune the historical state table. This is the main table that we want to prune.
+                        // We want to make sure that the the newest version of the key is accessible. The pruning table
+                        // records that we wrote key K at time T, so delete key K at time T-1. Recursively, this will ensure
+                        // that no keys are pruned that are still live, and all old keys are pruned as soon as possible.
+                        let mut key = key.into_versioned_key();
+                        let Some(previous_version) = key.1.checked_sub(1) else {
+                            continue;
+                        };
+                        let prev_written_version =
+                            user.get_version_for_key(&key.0, previous_version)?;
 
-            let pruning_time = pruning_time.elapsed();
-            sov_metrics::track_metrics(|tracker| {
-                tracker.submit(PrunerMetric {
-                    db: "versioned_dbs",
-                    keys_inspected,
-                    keys_to_prune,
-                    time: pruning_time,
+                        keys_inspected += 1;
+                        if let Some(previous_version) = prev_written_version {
+                            key.1 = previous_version;
+                            batch.delete::<NomtHistoricalState<UserNamespace>>(&key)?;
+                            keys_to_prune += 1;
+                        }
+                        if keys_to_prune >= MAX_INDIVIDUAL_PRUNING_BATCH_SIZE {
+                            hit_size_limit = true;
+                            break;
+                        }
+                    }
+                    batch.put::<NomtCommittedVersion<UserNamespace>>(
+                        &VersionedTableMetadataKey::PrunedVersion,
+                        &user_version,
+                    )?;
+                }
+                if let Some(kernel_version) =
+                    current_kernel_version.and_then(|v| v.checked_sub(versions_to_keep as u64))
+                {
+                    let prunable_keys = kernel
+                        .iter_pruning_keys_up_to_version(kernel_version)?
+                        .take(MAX_INDIVIDUAL_PRUNING_BATCH_SIZE);
+                    for key in prunable_keys {
+                        // Prune the pruning table.
+                        let key = key?;
+                        batch.delete::<NomtPruningState<KernelNamespace>>(&key)?;
+                        keys_to_prune += 1;
+                        keys_inspected += 1;
+                        // Prune the historical state table.
+                        let mut key = key.into_versioned_key();
+                        let Some(previous_version) = key.1.checked_sub(1) else {
+                            continue;
+                        };
+                        let prev_written_version =
+                            kernel.get_version_for_key(&key.0, previous_version)?;
+                        keys_inspected += 1;
+                        if let Some(previous_version) = prev_written_version {
+                            key.1 = previous_version;
+                            batch.delete::<NomtHistoricalState<KernelNamespace>>(&key)?;
+                            keys_to_prune += 1;
+                        }
+                        if keys_to_prune >= MAX_INDIVIDUAL_PRUNING_BATCH_SIZE {
+                            hit_size_limit = true;
+                            break;
+                        }
+                    }
+                    batch.put::<NomtCommittedVersion<KernelNamespace>>(
+                        &VersionedTableMetadataKey::PrunedVersion,
+                        &kernel_version,
+                    )?;
+                }
+
+                let pruning_time = pruning_time.elapsed();
+                sov_metrics::track_metrics(|tracker| {
+                    tracker.submit(PrunerMetric {
+                        db: "versioned_dbs",
+                        keys_inspected,
+                        keys_to_prune,
+                        time: pruning_time,
+                    });
                 });
+                Ok(PrunerJobOutput {
+                    pruning_batch: batch,
+                    hit_size_limit,
+                })
             });
-            Ok(PrunerJobOutput {
-                pruning_batch: batch,
-                hit_size_limit,
-            })
-        });
 
         // Spawn accessory pruner thread
         let accessory_state = std::thread::spawn(move || -> anyhow::Result<PrunerJobOutput> {
-            accessory_pruner
-                .collect_pruning_batch::<ModuleAccessoryState>(versions_to_keep as u64)
+            accessory_pruner.collect_pruning_batch::<ModuleAccessoryState>(versions_to_keep as u64)
         });
 
         PrunerJob {
@@ -384,11 +387,13 @@ impl PrunerJob {
         let historical_state = self
             .historical_state
             .join()
-            .map_err(|e| anyhow::anyhow!("Historical state pruner panicked: {:?}", e))?.context("historical state")?;
+            .map_err(|e| anyhow::anyhow!("Historical state pruner panicked: {:?}", e))?
+            .context("historical state")?;
         let accessory_state = self
             .accessory_state
             .join()
-            .map_err(|e| anyhow::anyhow!("Accessory state pruner panicked: {:?}", e))?.context("accessory state")?;
+            .map_err(|e| anyhow::anyhow!("Accessory state pruner panicked: {:?}", e))?
+            .context("accessory state")?;
         tracing::info!(%historical_state.hit_size_limit, %accessory_state.hit_size_limit, "Pruner task has completed");
         Ok(PruneGroup {
             historical_state: historical_state,

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -21,6 +21,8 @@ use crate::historical_state::{HistoricalStateReader, StateChanges};
 use crate::metrics::nomt::StorageManagerFinalizationMetric;
 use crate::state_db_nomt::{NomtSessionBuilder, StateOverlay};
 use crate::storage_manager::nomt_based::groups::{CommitGroup, DbGroup, PrunerJob, SnapshotGroup};
+pub use groups::PrunerJobOutput;
+pub(crate) use groups::MAX_INDIVIDUAL_PRUNING_BATCH_SIZE;
 
 #[allow(missing_docs)]
 pub struct StateFinishedSession {
@@ -105,7 +107,7 @@ pub struct NomtStorageManager<Da: DaSpec, H, S: InitializableNativeNomtStorage<H
 
     // If pruner is running.
     pruner: Option<PrunerJob>,
-    last_pruner_run_at_height: Option<u64>,
+    last_pruner_finish_at_height: Option<u64>,
     pruner_block_interval: u64,
     pruner_versions_to_keep: usize,
 
@@ -138,7 +140,7 @@ where
             nomt_snapshots: Arc::new(Default::default()),
             db_group,
             pruner: None,
-            last_pruner_run_at_height: None,
+            last_pruner_finish_at_height: None,
             pruner_block_interval,
             pruner_versions_to_keep,
             _phantom_s: Default::default(),
@@ -451,19 +453,25 @@ where
             .map(|p| p.is_finished())
             .unwrap_or(false);
         let mut pruning_commit_time = None;
+
         if is_pruner_ready {
             // UNWRAP: Checked above.
             let pruner = std::mem::take(&mut self.pruner).unwrap();
             let prune_group = pruner.join()?;
             let start = std::time::Instant::now();
+            let hit_size_limit = prune_group.hit_size_limit();
             self.db_group.commit_pruning(prune_group)?;
             pruning_commit_time = Some(start.elapsed());
-            self.last_pruner_run_at_height = Some(block_header.height());
+            // If the pruner didn't hit the size limit, we're done. Mark that the pruner finished at the current height. 
+            // Otherwise, we don't mark the run as finished, so the pruner will spawn another iteration.
+            if !hit_size_limit {
+                self.last_pruner_finish_at_height = Some(block_header.height());
+            }
         }
 
         let should_run_pruner = self.pruner.is_none()
             && self
-                .last_pruner_run_at_height
+                .last_pruner_finish_at_height
                 .map(|last_run_at_height| {
                     block_header.height().saturating_sub(last_run_at_height)
                         > self.pruner_block_interval

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -462,7 +462,7 @@ where
             let hit_size_limit = prune_group.hit_size_limit();
             self.db_group.commit_pruning(prune_group)?;
             pruning_commit_time = Some(start.elapsed());
-            // If the pruner didn't hit the size limit, we're done. Mark that the pruner finished at the current height. 
+            // If the pruner didn't hit the size limit, we're done. Mark that the pruner finished at the current height.
             // Otherwise, we don't mark the run as finished, so the pruner will spawn another iteration.
             if !hit_size_limit {
                 self.last_pruner_finish_at_height = Some(block_header.height());


### PR DESCRIPTION
# Description

This PR caps the memory usage of the `StateDB` Pruning task at a few hundred MB. Previously, pruning would try to handle the entire backlog in a single massive batch, causing slow/unpredictable progress and OOM issues. This PR prevents this by capping the size of the pruning batch and adding a flag to inform the caller whether the pruning task returned because it was actually finished, or whether its simply hit the size limit and should be re-run immediately. 


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

