### PR TITLE
EVM: Fix for `block_timestamp` in pending block.

### DIFF
--- a/constants.testing.toml
+++ b/constants.testing.toml
@@ -10,7 +10,7 @@ freeze = [1, 1]
 CHAIN_ID = 4321
 CHAIN_NAME = "TestChain"
 # We will keep only this many blocks in the EVM module.
-EVM_BLOCK_PRUNING_THRESHOLD = 1000
+EVM_BLOCK_PRUNING_THRESHOLD = 10000
 # How many rollup blocks to wait before terminating setup mode. While setup mode is enabled,
 # the rollup does not charge gas. This is useful when initializing the rollup with a bridged gas token.
 SETUP_MODE_TERMINATION_HEIGHT = 0 # Disable setup mode entirely by default.

--- a/constants.toml
+++ b/constants.toml
@@ -11,7 +11,7 @@ freeze = [1, 1]
 CHAIN_ID = 4321
 CHAIN_NAME = "TestChain"
 # We will keep only this many blocks in the EVM module.
-EVM_BLOCK_PRUNING_THRESHOLD = 1000
+EVM_BLOCK_PRUNING_THRESHOLD = 10000
 # How many rollup blocks to wait before terminating setup mode. While setup mode is enabled,
 # the rollup does not charge gas. This is useful when initializing the rollup with a bridged gas token.
 SETUP_MODE_TERMINATION_HEIGHT = 0 # Disable setup mode entirely by default.

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -98,7 +98,7 @@ async fn stream_logs<S, Seq>(
                         inner: log,
                         block_hash: block.hash(),
                         block_number: Some(block.number()),
-                        block_timestamp: block.timestamp(),
+                        block_timestamp: Some(block.timestamp()),
                         transaction_hash: Some(receipt.transaction_hash),
                         transaction_index: Some(transaction_index),
                         log_index: Some(receipt.log_index_start + log_index_in_tx as u64),

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -83,10 +83,6 @@ async fn stream_logs<S, Seq>(
             continue;
         }
 
-        println!(
-            "prev_last_tx_index {} curr_last_tx_index {}",
-            prev_last_tx_index, curr_last_tx_index
-        );
         for index in prev_last_tx_index..curr_last_tx_index {
             let receipt = evm.receipt(index, state).unwrap();
 

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -121,10 +121,7 @@ async fn stream_logs<S, Seq>(
                         )
                     });
 
-                    println!("lll");
-
                     if let Err(err) = accepted_sink.send(msg).await {
-                        println!("panice");
                         tracing::info!(%err, "The subscription client disconnected from the server.");
                         return;
                     }

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -83,6 +83,10 @@ async fn stream_logs<S, Seq>(
             continue;
         }
 
+        println!(
+            "prev_last_tx_index {} curr_last_tx_index {}",
+            prev_last_tx_index, curr_last_tx_index
+        );
         for index in prev_last_tx_index..curr_last_tx_index {
             let receipt = evm.receipt(index, state).unwrap();
 
@@ -117,7 +121,10 @@ async fn stream_logs<S, Seq>(
                         )
                     });
 
+                    println!("lll");
+
                     if let Err(err) = accepted_sink.send(msg).await {
+                        println!("panice");
                         tracing::info!(%err, "The subscription client disconnected from the server.");
                         return;
                     }

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -156,15 +156,15 @@ impl<'de> serde::Deserialize<'de> for SealedBlock {
 /// Sealed or pending block.
 pub enum MaybeSealedBlock {
     Sealed(Box<SealedBlock>),
-    Pending {
-        timestamp: u64,
-        block_number: u64,
-        first_tx_number: u64,
-    },
+    Pending(crate::Block),
 }
 
 #[cfg(feature = "native")]
 impl MaybeSealedBlock {
+    pub fn new_sealed(block: SealedBlock) -> Self {
+        MaybeSealedBlock::Sealed(Box::new(block))
+    }
+
     pub fn hash(&self) -> Option<B256> {
         match self {
             Self::Sealed(block) => Some(block.header.hash()),
@@ -175,23 +175,21 @@ impl MaybeSealedBlock {
     pub fn number(&self) -> u64 {
         match self {
             Self::Sealed(block) => block.header.number,
-            Self::Pending { block_number, .. } => *block_number,
+            Self::Pending(pending) => pending.header.number,
         }
     }
 
     pub fn transactions_start(&self) -> u64 {
         match self {
             Self::Sealed(block) => block.transactions.start,
-            Self::Pending {
-                first_tx_number, ..
-            } => *first_tx_number,
+            Self::Pending(pending) => pending.transactions.start,
         }
     }
 
     pub fn timestamp(&self) -> u64 {
         match self {
             Self::Sealed(block) => block.header.timestamp,
-            Self::Pending { timestamp, .. } => *timestamp,
+            Self::Pending(pending) => pending.header.timestamp,
         }
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -155,14 +155,14 @@ impl<'de> serde::Deserialize<'de> for SealedBlock {
 #[cfg(feature = "native")]
 /// Sealed or pending block.
 pub enum MaybeSealedBlock {
-    Sealed(Box<SealedBlock>),
+    Sealed(SealedBlock),
     Pending(crate::Block),
 }
 
 #[cfg(feature = "native")]
 impl MaybeSealedBlock {
     pub fn new_sealed(block: SealedBlock) -> Self {
-        MaybeSealedBlock::Sealed(Box::new(block))
+        MaybeSealedBlock::Sealed(block)
     }
 
     pub fn hash(&self) -> Option<B256> {

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -161,10 +161,6 @@ pub enum MaybeSealedBlock {
 
 #[cfg(feature = "native")]
 impl MaybeSealedBlock {
-    pub fn new_sealed(block: SealedBlock) -> Self {
-        MaybeSealedBlock::Sealed(block)
-    }
-
     pub fn hash(&self) -> Option<B256> {
         match self {
             Self::Sealed(block) => Some(block.header.hash()),

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -157,6 +157,7 @@ impl<'de> serde::Deserialize<'de> for SealedBlock {
 pub enum MaybeSealedBlock {
     Sealed(Box<SealedBlock>),
     Pending {
+        timestamp: u64,
         block_number: u64,
         first_tx_number: u64,
     },
@@ -187,10 +188,10 @@ impl MaybeSealedBlock {
         }
     }
 
-    pub fn timestamp(&self) -> Option<u64> {
+    pub fn timestamp(&self) -> u64 {
         match self {
-            Self::Sealed(block) => Some(block.header.timestamp),
-            Self::Pending { .. } => None,
+            Self::Sealed(block) => block.header.timestamp,
+            Self::Pending { timestamp, .. } => *timestamp,
         }
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -395,29 +395,9 @@ where
         if let Some(block) = block {
             return MaybeSealedBlock::Sealed(block.into());
         }
-        let current_block_env = self
-            .block_env
-            .get(state)
-            .unwrap_infallible()
-            .unwrap_or_default();
-        let env_block_num: u64 = current_block_env.number.try_into().expect(
-            "The impossible happened: block number is too large to fit in a u64. It's over!",
-        );
-        assert_eq!(env_block_num, block_number, "Transaction is in a block that is not yet sealed, but that block is not yet pending! This is impossible!");
 
-        let head = self
-            .head
-            .get(state)
-            .unwrap_infallible()
-            // Justified, the head is initialized at genesis and modified only later through overrides.
-            .expect("The impossible happened: head was not set.");
-        let first_tx_index = head.transactions.end;
-
-        MaybeSealedBlock::Pending {
-            timestamp: current_block_env.timestamp.try_into().unwrap(),
-            block_number,
-            first_tx_number: first_tx_index,
-        }
+        let pending = self.pending_block(state);
+        MaybeSealedBlock::Pending(pending)
     }
 
     /// Retrieves a sealed block by number.

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -492,7 +492,10 @@ where
         let header = alloy_consensus::Header {
             parent_hash: head_block.header.seal(),
             number: pending_block_number,
-            timestamp: current_block_env.timestamp.try_into().unwrap(),
+            timestamp: current_block_env
+                .timestamp
+                .try_into()
+                .expect("The impossible happened: timestamp overflow u64"),
             ..Default::default()
         };
 

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -393,7 +393,7 @@ where
     ) -> MaybeSealedBlock {
         let block = self.blocks.get(&block_number, state).unwrap_infallible();
         if let Some(block) = block {
-            return MaybeSealedBlock::Sealed(block.into());
+            return MaybeSealedBlock::Sealed(block);
         }
 
         let pending = self.pending_block(state);

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -414,6 +414,7 @@ where
         let first_tx_index = head.transactions.end;
 
         MaybeSealedBlock::Pending {
+            timestamp: current_block_env.timestamp.try_into().unwrap(),
             block_number,
             first_tx_number: first_tx_index,
         }
@@ -493,6 +494,12 @@ where
             // This is justified, as we just fetched `block_numbers`.
             .expect("The impossible happened: parent_block was not set.");
 
+        let current_block_env = self
+            .block_env
+            .get(state)
+            .unwrap_infallible()
+            .unwrap_or_default();
+
         assert_eq!(&head_block.header.number, block_numbers.end());
 
         let pending_transactions_len = self.pending_transactions.len(state).unwrap_infallible();
@@ -505,6 +512,7 @@ where
         let header = alloy_consensus::Header {
             parent_hash: head_block.header.seal(),
             number: pending_block_number,
+            timestamp: current_block_env.timestamp.try_into().unwrap(),
             ..Default::default()
         };
 
@@ -572,7 +580,7 @@ pub(crate) fn build_rpc_receipt(
             inner: log,
             block_hash,
             block_number,
-            block_timestamp: block.timestamp(),
+            block_timestamp: Some(block.timestamp()),
             transaction_hash: Some(transaction_hash),
             transaction_index: Some(transaction_index),
             log_index: Some(receipt.log_index_start + tx_log_idx as u64),

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -36,7 +36,7 @@ async fn evm_test_log_subscription() {
         send_txs_and_pause(10..15, contract_address, &evm_client, &test_rollup).await;
 
     // Log listening started.
-    log_collector.spawn_log_watcher(sub).await;
+    log_collector.spawn_log_watcher(sub, None).await;
 
     // Logs from this txs will shouw up in the subscription.
     let mut tx_hashes_2 =
@@ -83,12 +83,13 @@ async fn evm_test_log_subscription_with_pending_blcok() {
     test_rollup.wait_for_next_blocks(1).await;
     test_rollup.pause_preferred_batches().await;
 
-    let nb_of_txs = 2;
+    let nb_of_txs = 100;
 
     let sub = evm_client.alloy_subscribe_logs(&Filter::new()).await;
-    let sub_id = sub.local_id().clone();
 
-    log_collector.spawn_log_watcher(sub).await;
+    log_collector
+        .spawn_log_watcher(sub, Some(nb_of_txs as usize))
+        .await;
 
     let mut tx_hashes = Vec::new();
 
@@ -97,8 +98,6 @@ async fn evm_test_log_subscription_with_pending_blcok() {
         tx_hashes.push(hash);
     }
 
-    // Kill subscription.
-    evm_client.alloy_unsubscribe(sub_id);
     log_collector.wait().await;
 
     let logs_from_subscription = log_collector.logs().await;
@@ -113,7 +112,6 @@ async fn evm_test_log_subscription_with_pending_blcok() {
 
     // Verify conditions for logs in the pending block.
     for log in logs_from_subscription {
-        println!("log {:?}", block_nr);
         assert!(log.block_hash.is_none());
         assert_eq!(log.block_number.unwrap(), block_nr);
         assert!(log.block_timestamp.unwrap() > 0);
@@ -245,12 +243,22 @@ impl LogCollector {
     async fn spawn_log_watcher(
         &mut self,
         mut sub: alloy_pubsub::Subscription<alloy_rpc_types_eth::Log>,
+        expected_nr_of_logs: Option<usize>,
     ) {
         let logs_from_subscription = self.logs_from_subscription.clone();
         let snd = self.snd.clone();
 
         tokio::spawn(async move {
             loop {
+                if let Some(expected_nr_of_logs) = expected_nr_of_logs {
+                    let len = logs_from_subscription.lock().await.len();
+
+                    if len >= expected_nr_of_logs {
+                        snd.send(()).unwrap();
+                        return;
+                    }
+                }
+
                 match sub.recv().await {
                     Ok(log) => {
                         logs_from_subscription.lock().await.push(log);
@@ -258,12 +266,11 @@ impl LogCollector {
                     Err(e) => match e {
                         broadcast::error::RecvError::Closed => {
                             snd.send(()).unwrap();
-
                             break;
                         }
-                        broadcast::error::RecvError::Lagged(_) => {
-                            println!("======Lagged");
-                        } //panic!("Lagged"),
+                        broadcast::error::RecvError::Lagged(err) => {
+                            panic!("Log watcher error: {:?}", err)
+                        }
                     },
                 }
             }
@@ -327,7 +334,7 @@ async fn get_filtered_logs(
     let sub = evm_client.alloy_subscribe_logs(&filter).await;
     let sub_id = sub.local_id().clone();
 
-    log_collector.spawn_log_watcher(sub).await;
+    log_collector.spawn_log_watcher(sub, None).await;
 
     for i in 0..number_of_txs {
         let _ = evm_client

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -73,6 +73,53 @@ async fn evm_test_log_subscription() {
     assert!(block_nr > 0);
 }
 
+// Tests for logs from pending block.
+#[tokio::test(flavor = "multi_thread")]
+async fn evm_test_log_subscription_with_pending_blcok() {
+    let (test_rollup, evm_client, _) = setup(0).await;
+    let mut log_collector = LogCollector::new();
+
+    let contract_address = evm_client.alloy_deploy_contract().await;
+    test_rollup.wait_for_next_blocks(1).await;
+    test_rollup.pause_preferred_batches().await;
+
+    let nb_of_txs = 2;
+
+    let sub = evm_client.alloy_subscribe_logs(&Filter::new()).await;
+    let sub_id = sub.local_id().clone();
+
+    log_collector.spawn_log_watcher(sub).await;
+
+    let mut tx_hashes = Vec::new();
+
+    for i in 0..nb_of_txs {
+        let hash = evm_client.alloy_set_value(contract_address, i).await;
+        tx_hashes.push(hash);
+    }
+
+    // Kill subscription.
+    evm_client.alloy_unsubscribe(sub_id);
+    log_collector.wait().await;
+
+    let logs_from_subscription = log_collector.logs().await;
+    assert_eq!(logs_from_subscription.len(), nb_of_txs as usize);
+
+    let block_nr = evm_client
+        .eth_get_block_by_number(Some("pending".to_string()))
+        .await
+        .number
+        .unwrap()
+        .as_u64();
+
+    // Verify conditions for logs in the pending block.
+    for log in logs_from_subscription {
+        println!("log {:?}", block_nr);
+        assert!(log.block_hash.is_none());
+        assert_eq!(log.block_number.unwrap(), block_nr);
+        assert!(log.block_timestamp.unwrap() > 0);
+    }
+}
+
 // Subscription test with filtering.
 // `SimpleStorageContract::set_value` emits logs where topic2 matches the function argument,
 // and topic3 ranges from 0 to nb_of_logs_per_tx.

--- a/examples/demo-rollup/tests/evm/evm_soft_conf.rs
+++ b/examples/demo-rollup/tests/evm/evm_soft_conf.rs
@@ -62,7 +62,6 @@ async fn evm_test_soft_confirmations() -> anyhow::Result<()> {
             assert_eq!(pending_blokck.number.unwrap().as_u64(), expected_block_nr);
             assert_eq!(pending_blokck.transactions, vec![tx_hash]);
             let block_timestamp: u64 = pending_blokck.timestamp.try_into().unwrap();
-            println!("block_timestamp {:?}", block_timestamp);
             assert!(block_timestamp > 0);
         }
 

--- a/examples/demo-rollup/tests/evm/evm_soft_conf.rs
+++ b/examples/demo-rollup/tests/evm/evm_soft_conf.rs
@@ -26,7 +26,6 @@ async fn evm_test_soft_confirmations() -> anyhow::Result<()> {
                 .eth_get_block_by_number(Some("pending".to_string()))
                 .await;
 
-            println!("P HASH {:?}", pending_block.hash.unwrap());
             assert_eq!(pending_block.parent_hash, latest_block.hash.unwrap());
             assert_eq!(
                 pending_block.number.unwrap(),

--- a/examples/demo-rollup/tests/evm/evm_soft_conf.rs
+++ b/examples/demo-rollup/tests/evm/evm_soft_conf.rs
@@ -26,6 +26,7 @@ async fn evm_test_soft_confirmations() -> anyhow::Result<()> {
                 .eth_get_block_by_number(Some("pending".to_string()))
                 .await;
 
+            println!("P HASH {:?}", pending_block.hash.unwrap());
             assert_eq!(pending_block.parent_hash, latest_block.hash.unwrap());
             assert_eq!(
                 pending_block.number.unwrap(),
@@ -61,6 +62,9 @@ async fn evm_test_soft_confirmations() -> anyhow::Result<()> {
 
             assert_eq!(pending_blokck.number.unwrap().as_u64(), expected_block_nr);
             assert_eq!(pending_blokck.transactions, vec![tx_hash]);
+            let block_timestamp: u64 = pending_blokck.timestamp.try_into().unwrap();
+            println!("block_timestamp {:?}", block_timestamp);
+            assert!(block_timestamp > 0);
         }
 
         // Now we created a block and the block hash becomes available.


### PR DESCRIPTION
# Description

This PR fixes a bug where `block_timestamp` was not being populated for pending blocks.
Although the hash of the pending block is unknown, we do have access to both the `block_number` and `block_timestamp`, which are now check in tests.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
