### PR TITLE
Fix gas_charging allocation hotspot

### DIFF
--- a/crates/module-system/sov-modules-api/src/gas/traits.rs
+++ b/crates/module-system/sov-modules-api/src/gas/traits.rs
@@ -870,12 +870,13 @@ impl<S: Spec> GasMeter for BasicGasMeter<S> {
         amount: &S::Gas,
         parameter: u32,
     ) -> Result<(), GasMeteringError<<S as Spec>::Gas>> {
-        let total_amount =
-            amount
-                .checked_scalar_product(parameter as u64)
-                .ok_or(GasMeteringError::Overflow(format!(
+        let total_amount = amount
+            .checked_scalar_product(parameter as u64)
+            .ok_or_else(|| {
+                GasMeteringError::Overflow(format!(
                     "Unable to charge gas. The product of {amount} to {parameter} is overflowing"
-                )))?;
+                ))
+            })?;
         tracing::trace!(%total_amount, parameter, gas_before = %self.remaining_gas, funds_before = ?self.remaining_funds, "Charging linear gas");
         self.charge_gas_inner(&total_amount)?;
 


### PR DESCRIPTION
# Description

This tiny PR removes a significant allocation hotspot. Previously, we incorrectly used the eager `ok_or` combinator for a very rare error that allocated, rather than the lazy `ok_or_else`. This resulted in a useless allocation on each gas charging operation. According to some very rough stats I pulled together, this accounted for almost 15% of all allocations in the SDK under load. 

## Testing
After this PR, I've verified that `charge_linear_gas` no longer shows up as an allocation hotspot.

