### PR TITLE
EVM: `eth_getLogs` supprot for range queries

### DIFF
--- a/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
@@ -7,6 +7,7 @@ use crate::EthereumAuthenticator;
 use crate::FromVmAddress;
 use crate::HasKernel;
 use crate::Sequencer;
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use alloy_rpc_types::eth::Filter;
 use alloy_rpc_types::FilterBlockOption;
@@ -14,8 +15,10 @@ use alloy_rpc_types::Log;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::types::Params as JRpcParams;
 use jsonrpsee::Extensions;
+use sov_evm::PendingOrBlock;
 use sov_modules_api::ApiStateAccessor;
 use sov_modules_api::Spec;
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 #[derive(Default, Debug, Clone, Copy)]
@@ -128,4 +131,52 @@ where
     }
 
     Ok(rpc_logs)
+}
+
+fn logs_for_blocks_range<S>(
+    _filter: Filter,
+    from_block: Option<BlockNumberOrTag>,
+    to_block: Option<BlockNumberOrTag>,
+    state: &mut ApiStateAccessor<S>,
+) -> Result<Vec<Log>, ErrorObjectOwned>
+where
+    S: Spec,
+    S::Address: FromVmAddress<EthereumAddress>,
+{
+    let rpc_logs = Vec::new();
+    let evm = sov_evm::Evm::<S>::default();
+
+    let start = get_block_nr(from_block, &evm, state)?;
+    let end = get_block_nr(to_block, &evm, state)?;
+
+    let block_range = RangeInclusive::new(start, end);
+    for _height in block_range {
+        // TODO
+    }
+    Ok(rpc_logs)
+}
+
+fn get_block_nr<S>(
+    block_nr_or_tag: Option<BlockNumberOrTag>,
+    evm: &sov_evm::Evm<S>,
+    state: &mut ApiStateAccessor<S>,
+) -> Result<u64, ErrorObjectOwned>
+where
+    S: Spec,
+    S::Address: FromVmAddress<EthereumAddress>,
+{
+    let number = evm.str_to_block_nr(block_nr_or_tag.map(|b| b.to_string()), state);
+    match number {
+        PendingOrBlock::Pending => {
+            return Err(to_jsonrpsee_error_object(
+                "Pending blocks are not supported",
+                ETH_RPC_ERROR,
+            ))
+        }
+        PendingOrBlock::Invalid(err) => {
+            let msg = format!("Invalid block: {err}");
+            return Err(to_jsonrpsee_error_object(msg, ETH_RPC_ERROR));
+        }
+        PendingOrBlock::Number(number) => Ok(number),
+    }
 }

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
@@ -73,14 +73,9 @@ where
             logs_for_block_hash(filter, block_hash, state)
         }
         FilterBlockOption::Range {
-            from_block: _,
-            to_block: _,
-        } => {
-            return Err(to_jsonrpsee_error_object(
-                "FilterBlockOption::Range not supported",
-                ETH_RPC_ERROR,
-            ));
-        }
+            from_block,
+            to_block,
+        } => logs_for_blocks_range(filter, from_block, to_block, state),
     }
 }
 

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
@@ -101,6 +101,45 @@ where
         tracing::warn!(%msg);
         return Err(to_jsonrpsee_error_object(&msg, ETH_RPC_ERROR));
     };
+    logs_from_block(&mut rpc_logs, height, &filter, &evm, state)?;
+
+    Ok(rpc_logs)
+}
+
+fn logs_for_blocks_range<S>(
+    filter: Filter,
+    from_block: Option<BlockNumberOrTag>,
+    to_block: Option<BlockNumberOrTag>,
+    state: &mut ApiStateAccessor<S>,
+) -> Result<Vec<Log>, ErrorObjectOwned>
+where
+    S: Spec,
+    S::Address: FromVmAddress<EthereumAddress>,
+{
+    let mut rpc_logs = Vec::new();
+    let evm = sov_evm::Evm::<S>::default();
+
+    let start = get_block_nr(from_block, &evm, state)?;
+    let end = get_block_nr(to_block, &evm, state)?;
+
+    let block_range = RangeInclusive::new(start, end);
+    for height in block_range {
+        logs_from_block(&mut rpc_logs, height, &filter, &evm, state)?;
+    }
+    Ok(rpc_logs)
+}
+
+fn logs_from_block<S>(
+    rpc_logs: &mut Vec<Log>,
+    height: u64,
+    filter: &Filter,
+    evm: &sov_evm::Evm<S>,
+    state: &mut ApiStateAccessor<S>,
+) -> Result<(), ErrorObjectOwned>
+where
+    S: Spec,
+    S::Address: FromVmAddress<EthereumAddress>,
+{
     let block = evm.get_maybe_sealed_block(height, state);
 
     for index in block.transactions_start()..block.transactions_end() {
@@ -117,7 +156,7 @@ where
             if filter.matches(&log) {
                 let rpc_log = Log {
                     inner: log,
-                    block_hash: Some(block_hash),
+                    block_hash: block.hash(),
                     block_number: Some(receipt.block_number),
                     block_timestamp: Some(block.timestamp()),
                     transaction_hash: Some(receipt.transaction_hash),
@@ -130,30 +169,7 @@ where
         }
     }
 
-    Ok(rpc_logs)
-}
-
-fn logs_for_blocks_range<S>(
-    _filter: Filter,
-    from_block: Option<BlockNumberOrTag>,
-    to_block: Option<BlockNumberOrTag>,
-    state: &mut ApiStateAccessor<S>,
-) -> Result<Vec<Log>, ErrorObjectOwned>
-where
-    S: Spec,
-    S::Address: FromVmAddress<EthereumAddress>,
-{
-    let rpc_logs = Vec::new();
-    let evm = sov_evm::Evm::<S>::default();
-
-    let start = get_block_nr(from_block, &evm, state)?;
-    let end = get_block_nr(to_block, &evm, state)?;
-
-    let block_range = RangeInclusive::new(start, end);
-    for _height in block_range {
-        // TODO
-    }
-    Ok(rpc_logs)
+    Ok(())
 }
 
 fn get_block_nr<S>(

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
@@ -116,7 +116,7 @@ where
     let start = get_block_nr(from_block, &evm, state)?;
     let end = get_block_nr(to_block, &evm, state)?;
 
-    // TODO bool filters
+    // TODO bloom filters
     let block_range = RangeInclusive::new(start, end);
     for height in block_range {
         logs_from_block(&mut rpc_logs, height, &filter, &evm, state)?;

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
@@ -122,6 +122,7 @@ where
     let start = get_block_nr(from_block, &evm, state)?;
     let end = get_block_nr(to_block, &evm, state)?;
 
+    // TODO bool filters
     let block_range = RangeInclusive::new(start, end);
     for height in block_range {
         logs_from_block(&mut rpc_logs, height, &filter, &evm, state)?;

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use crate::handlers::ETH_RPC_ERROR;
 use crate::to_jsonrpsee_error_object;
 use crate::Ethereum;

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use crate::handlers::ETH_RPC_ERROR;
 use crate::to_jsonrpsee_error_object;
 use crate::Ethereum;

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -438,6 +438,16 @@ where
     }
 }
 
+/// Result of String => BlockNr conversion
+pub enum PendingOrBlock {
+    /// Pending blcock.
+    Pending,
+    /// Block number.
+    Number(u64),
+    /// Invalid block number.
+    Invalid(String),
+}
+
 impl<S: Spec> Evm<S>
 where
     S::Address: FromVmAddress<EthereumAddress>,
@@ -517,61 +527,62 @@ where
         MaybeSealedBlock::Pending(pending)
     }
 
+    /// Convert string to block nr.
+    pub fn str_to_block_nr(
+        &self,
+        block_number: Option<String>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> PendingOrBlock {
+        let block_number_str = block_number.unwrap_or_else(|| "latest".into());
+
+        match block_number_str.as_str() {
+            "earliest" => {
+                let block_numbers = self
+                    .block_numbers
+                    .get(state)
+                    .unwrap_infallible()
+                    // This is justified, as block numbers are set at genesis and only overridden later.
+                    .expect("The impossible happened: block_numbers was not set.");
+
+                PendingOrBlock::Number(*block_numbers.start())
+            }
+            "latest" => {
+                let block_numbers = self
+                    .block_numbers
+                    .get(state)
+                    .unwrap_infallible()
+                    // This is justified, as block numbers are set at genesis and only overridden later.
+                    .expect("The impossible happened: block_numbers was not set.");
+
+                PendingOrBlock::Number(*block_numbers.end())
+            }
+
+            "pending" => PendingOrBlock::Pending,
+            number => match u64::from_str_radix(number.trim_start_matches("0x"), 16) {
+                Ok(nr) => PendingOrBlock::Number(nr),
+                Err(_) => PendingOrBlock::Invalid(block_number_str),
+            },
+        }
+    }
+
     /// Retrieves a sealed block by number.
     pub fn get_sealed_block_by_number(
         &self,
         block_number: Option<String>,
         state: &mut ApiStateAccessor<S>,
     ) -> Option<SealedBlock> {
-        // safe, finalized, and pending are not supported
-        match block_number {
-            Some(ref block_number) if block_number == "earliest" => {
-                let block_numbers = self
-                    .block_numbers
-                    .get(state)
-                    .unwrap_infallible()
-                    // This is justified, as block numbers are set at genesis and only overridden later.
-                    .expect("The impossible happened: block_numbers was not set.");
-                let first_block_number = block_numbers.start();
+        let pending_or_block_nr = self.str_to_block_nr(block_number, state);
 
-                self.blocks
-                    .get(first_block_number, state)
-                    .unwrap_infallible()
-            }
-            Some(ref block_number) if block_number == "latest" => {
-                let block_numbers = self
-                    .block_numbers
-                    .get(state)
-                    .unwrap_infallible()
-                    // This is justified, as block numbers are set at genesis and only overridden later.
-                    .expect("The impossible happened: block_numbers was not set.");
-
-                let last_block_number = block_numbers.end();
-
-                self.blocks
-                    .get(last_block_number, state)
-                    .unwrap_infallible()
-            }
-            Some(ref block_number) if block_number == "pending" => {
+        match pending_or_block_nr {
+            PendingOrBlock::Number(nr) => self.blocks.get(&nr, state).unwrap_infallible(),
+            PendingOrBlock::Pending => {
                 let pending_block = self.pending_block(state);
                 Some(pending_block.seal())
             }
-            Some(ref block_number) => {
-                // hex representation may have 0x prefix
-                let Ok(block_number) =
-                    u64::from_str_radix(block_number.trim_start_matches("0x"), 16)
-                else {
-                    tracing::error!(
-                        block_number,
-                        "get_sealed_block_by_number: Block number must be a valid hex number, with or without 0x prefix"
-                    );
-
-                    return None;
-                };
-
-                self.blocks.get(&block_number, state).unwrap_infallible()
+            PendingOrBlock::Invalid(invalid) => {
+                tracing::error!(invalid, "Invalid block number");
+                None
             }
-            None => self.get_sealed_block_by_number(Some("latest".into()), state),
         }
     }
 

--- a/crates/utils/sov-eth-client/src/lib.rs
+++ b/crates/utils/sov-eth-client/src/lib.rs
@@ -480,6 +480,16 @@ impl TestClient {
         alloy_primitives::TxHash::from_slice(&tx_hash.0)
     }
 
+    pub async fn alloy_get_block_by_number(
+        &self,
+        block_number: Option<String>,
+    ) -> alloy_rpc_types::Block<alloy_primitives::TxHash> {
+        self.rpc
+            .request("eth_getBlockByNumber", rpc_params![block_number, false])
+            .await
+            .unwrap()
+    }
+
     pub async fn get_logs(&self, filter: &Filter) -> Vec<Log> {
         self.pub_sub.get_logs(filter).await.unwrap()
     }

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -1,4 +1,4 @@
-use alloy_rpc_types_eth::Filter;
+use alloy_rpc_types_eth::{BlockNumberOrTag, Filter, Log};
 
 use crate::evm::evm_test_helper::setup;
 
@@ -42,5 +42,48 @@ async fn evm_test_get_logs() {
             log.transaction_index.unwrap(),
             (index / nb_of_logs_per_tx as u64)
         );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn evm_test_get_logs_range() {
+    let (test_rollup, evm_client, _) = setup(0).await;
+    let contract_address = evm_client.alloy_deploy_contract().await;
+    test_rollup.wait_for_next_blocks(1).await;
+
+    let nb_of_txs = 10;
+    let nb_of_logs_per_tx = 5;
+
+    let start_block = evm_client
+        .alloy_get_block_by_number(Some(BlockNumberOrTag::Latest.to_string()))
+        .await
+        .number();
+
+    let mut tx_hashes = Vec::new();
+    for i in 0..nb_of_txs {
+        let hash = evm_client
+            .alloy_emit_logs(contract_address, i, nb_of_logs_per_tx)
+            .await;
+        tx_hashes.push(hash);
+        if i % 3 == 0 {
+            test_rollup.wait_for_next_blocks(1).await;
+        }
+    }
+    test_rollup.wait_for_next_blocks(1).await;
+
+    let end_block = evm_client
+        .alloy_get_block_by_number(Some(BlockNumberOrTag::Latest.to_string()))
+        .await
+        .number();
+
+    let filter = Filter::new()
+        .from_block(start_block)
+        .to_block(BlockNumberOrTag::Latest);
+
+    let logs = evm_client.get_logs(&filter).await;
+    assert_eq!(logs.len() as u32, nb_of_txs * nb_of_logs_per_tx);
+
+    for (index, log) in logs.into_iter().enumerate() {
+        assert!(filter.matches(log.inner.as_ref()));
     }
 }

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -1,4 +1,4 @@
-use alloy_rpc_types_eth::{BlockNumberOrTag, Filter, Log};
+use alloy_rpc_types_eth::{BlockNumberOrTag, Filter};
 
 use crate::evm::evm_test_helper::setup;
 
@@ -71,11 +71,6 @@ async fn evm_test_get_logs_range() {
     }
     test_rollup.wait_for_next_blocks(1).await;
 
-    let end_block = evm_client
-        .alloy_get_block_by_number(Some(BlockNumberOrTag::Latest.to_string()))
-        .await
-        .number();
-
     let filter = Filter::new()
         .from_block(start_block)
         .to_block(BlockNumberOrTag::Latest);
@@ -83,7 +78,7 @@ async fn evm_test_get_logs_range() {
     let logs = evm_client.get_logs(&filter).await;
     assert_eq!(logs.len() as u32, nb_of_txs * nb_of_logs_per_tx);
 
-    for (index, log) in logs.into_iter().enumerate() {
+    for log in logs {
         assert!(filter.matches(log.inner.as_ref()));
     }
 }


### PR DESCRIPTION
# Description

This PR adds support for range queries. More tests and support bloom filters will be added in the following pr.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
