### PR TITLE
Remove workspace-hack dependency from sov-hyperlane-integration

### DIFF
--- a/crates/module-system/hyperlane/Cargo.toml
+++ b/crates/module-system/hyperlane/Cargo.toml
@@ -38,7 +38,6 @@ testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true, features = ["anvil"] }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
-workspace-hack = { workspace = true } # required for feature unification with arbitrary
 
 [dependencies]
 sov-address = { workspace = true, optional = true }

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -1616,7 +1616,6 @@ dependencies = [
  "borsh",
  "schemars 0.8.22",
  "serde",
- "serde_json",
  "sov-accounts",
  "sov-address",
  "sov-attester-incentives",

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -1440,7 +1440,6 @@ dependencies = [
  "borsh",
  "schemars 0.8.22",
  "serde",
- "serde_json",
  "sov-accounts",
  "sov-address",
  "sov-attester-incentives",

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -1959,7 +1959,6 @@ dependencies = [
  "borsh",
  "schemars 0.8.21",
  "serde",
- "serde_json",
  "sov-accounts",
  "sov-address",
  "sov-attester-incentives",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -1803,7 +1803,6 @@ dependencies = [
  "borsh",
  "schemars 0.8.21",
  "serde",
- "serde_json",
  "sov-accounts",
  "sov-address",
  "sov-attester-incentives",


### PR DESCRIPTION
# Description

It was causing issues with dependency resolution in the starter. I'm not sure why it was initially added but CI passes with it gone so it seems like it's no longer necessary.

- [ ] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] ~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
