### PR TITLE
Remove dependency on reth-rpc-eth-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,9 +106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8ff73a143281cb77c32006b04af9c047a6b8fe5860e85a88ad325328965355"
 dependencies = [
  "alloy-primitives",
- "alloy-rlp",
  "num_enum 0.7.4",
- "serde",
  "strum 0.27.2",
 ]
 
@@ -247,12 +245,26 @@ dependencies = [
  "alloy-eips",
  "alloy-hardforks",
  "alloy-primitives",
- "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
  "derive_more 2.0.1",
- "op-alloy-consensus",
- "op-revm",
+ "revm",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "alloy-evm"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b2845e4c4844e53dd08bf24d3af7b163ca7d1e3c68eb587e38c4e976659089"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "auto_impl",
+ "derive_more 2.0.1",
  "revm",
  "thiserror 2.0.16",
 ]
@@ -501,18 +513,6 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
-]
-
-[[package]]
-name = "alloy-rpc-types-admin"
-version = "1.0.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65acc9264342069decb617aa344847f55180ba3aeab1c8d1db062d0619881029"
-dependencies = [
- "alloy-genesis",
- "alloy-primitives",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -848,20 +848,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 dependencies = [
  "backtrace",
-]
-
-[[package]]
-name = "aquamarine"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
-dependencies = [
- "include_dir",
- "itertools 0.10.5",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -4099,23 +4085,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enr"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "851bd664a3d3a3c175cff92b2f0df02df3c541b4895d0ae307611827aae46152"
-dependencies = [
- "alloy-rlp",
- "base64 0.22.1",
- "bytes",
- "hex",
- "log",
- "rand 0.8.5",
- "secp256k1 0.30.0",
- "sha3",
- "zeroize",
-]
-
-[[package]]
 name = "enum-map"
 version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4487,7 +4456,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "const-hex",
- "enr 0.10.0",
+ "enr",
  "ethers-core",
  "futures-core",
  "futures-timer",
@@ -5878,25 +5847,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee796ad498c8d9a1d68e477df8f754ed784ef875de1414ebdaf169f70a6a784"
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6204,11 +6154,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fba77a59c4c644fd48732367624d1bcf6f409f9c9a286fbc71d2f1fc0b2ea16"
 dependencies = [
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.25.1",
+ "jsonrpsee-core",
  "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-types",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "tokio",
@@ -6226,7 +6176,7 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "http 1.3.1",
- "jsonrpsee-core 0.25.1",
+ "jsonrpsee-core",
  "pin-project",
  "rustls 0.23.31",
  "rustls-pki-types",
@@ -6253,7 +6203,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-types",
  "parking_lot",
  "pin-project",
  "rand 0.9.2",
@@ -6269,20 +6219,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-core"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
-dependencies = [
- "async-trait",
- "jsonrpsee-types 0.26.0",
- "serde",
- "serde_json",
- "thiserror 2.0.16",
- "tracing",
-]
-
-[[package]]
 name = "jsonrpsee-http-client"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6293,8 +6229,8 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-rustls 0.27.7",
  "hyper-util",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "rustls 0.23.31",
  "rustls-platform-verifier",
  "serde",
@@ -6330,8 +6266,8 @@ dependencies = [
  "http-body-util",
  "hyper 1.7.0",
  "hyper-util",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "pin-project",
  "route-recognizer",
  "serde",
@@ -6358,26 +6294,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-types"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
-dependencies = [
- "http 1.3.1",
- "serde",
- "serde_json",
- "thiserror 2.0.16",
-]
-
-[[package]]
 name = "jsonrpsee-wasm-client"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b67695cbcf4653f39f8f8738925547e0e23fd9fe315bccf951097b9f6a38781"
 dependencies = [
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "tower 0.5.2",
 ]
 
@@ -6389,8 +6313,8 @@ checksum = "2da2694c9ff271a9d3ebfe520f6b36820e85133a51be77a3cb549fd615095261"
 dependencies = [
  "http 1.3.1",
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.25.1",
- "jsonrpsee-types 0.25.1",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "tower 0.5.2",
  "url",
 ]
@@ -6982,28 +6906,6 @@ dependencies = [
  "log",
  "objc",
  "paste",
-]
-
-[[package]]
-name = "metrics"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
-dependencies = [
- "ahash",
- "portable-atomic",
-]
-
-[[package]]
-name = "metrics-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dbdd96ed57d565ec744cba02862d707acf373c5772d152abae6ec5c4e24f6c"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -7610,17 +7512,6 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror 2.0.16",
-]
-
-[[package]]
-name = "op-revm"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba21d705bbbfc947a423cba466d75e4af0c7d43ee89ba0a0f1cfa04963cede9"
-dependencies = [
- "auto_impl",
- "revm",
- "serde",
 ]
 
 [[package]]
@@ -9348,7 +9239,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.31",
- "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -9377,52 +9267,6 @@ dependencies = [
  "clap",
  "reqwest 0.12.23",
  "tokio",
-]
-
-[[package]]
-name = "reth-chain-state"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "derive_more 2.0.1",
- "metrics",
- "parking_lot",
- "pin-project",
- "reth-chainspec",
- "reth-errors",
- "reth-ethereum-primitives",
- "reth-execution-types",
- "reth-metrics",
- "reth-primitives-traits",
- "reth-storage-api",
- "reth-trie",
- "revm-database",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-chainspec"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "auto_impl",
- "derive_more 2.0.1",
- "reth-ethereum-forks",
- "reth-network-peers",
- "reth-primitives-traits",
- "serde_json",
 ]
 
 [[package]]
@@ -9468,16 +9312,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-db-models"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "reth-primitives-traits",
-]
-
-[[package]]
 name = "reth-errors"
 version = "1.7.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
@@ -9485,27 +9319,6 @@ dependencies = [
  "reth-consensus",
  "reth-execution-errors",
  "reth-storage-errors",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "reth-eth-wire-types"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-hardforks",
- "alloy-primitives",
- "alloy-rlp",
- "bytes",
- "derive_more 2.0.1",
- "reth-chainspec",
- "reth-codecs-derive",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "serde",
  "thiserror 2.0.16",
 ]
 
@@ -9542,32 +9355,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-evm"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-primitives",
- "auto_impl",
- "derive_more 2.0.1",
- "futures-util",
- "reth-execution-errors",
- "reth-execution-types",
- "reth-primitives-traits",
- "reth-storage-api",
- "reth-storage-errors",
- "reth-trie-common",
- "revm",
-]
-
-[[package]]
 name = "reth-execution-errors"
 version = "1.7.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.20.1",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
@@ -9582,113 +9374,13 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.20.1",
  "alloy-primitives",
  "derive_more 2.0.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "reth-trie-common",
  "revm",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-fs-util"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "reth-metrics"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "metrics",
- "metrics-derive",
-]
-
-[[package]]
-name = "reth-net-banlist"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-primitives",
-]
-
-[[package]]
-name = "reth-network-api"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "alloy-rpc-types-admin",
- "alloy-rpc-types-eth",
- "auto_impl",
- "derive_more 2.0.1",
- "enr 0.13.0",
- "futures",
- "reth-eth-wire-types",
- "reth-ethereum-forks",
- "reth-network-p2p",
- "reth-network-peers",
- "reth-network-types",
- "reth-tokio-util",
- "thiserror 2.0.16",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "reth-network-p2p"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "auto_impl",
- "derive_more 2.0.1",
- "futures",
- "reth-consensus",
- "reth-eth-wire-types",
- "reth-ethereum-primitives",
- "reth-network-peers",
- "reth-network-types",
- "reth-primitives-traits",
- "reth-storage-errors",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "reth-network-peers"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "secp256k1 0.30.0",
- "serde_with",
- "thiserror 2.0.16",
- "url",
-]
-
-[[package]]
-name = "reth-network-types"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-eip2124",
- "reth-net-banlist",
- "reth-network-peers",
- "serde_json",
- "tracing",
 ]
 
 [[package]]
@@ -9744,111 +9436,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229
 dependencies = [
  "alloy-primitives",
  "derive_more 2.0.1",
- "serde",
  "thiserror 2.0.16",
-]
-
-[[package]]
-name = "reth-revm"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-primitives",
- "reth-primitives-traits",
- "reth-storage-api",
- "reth-storage-errors",
- "revm",
-]
-
-[[package]]
-name = "reth-rpc-convert"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-consensus",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-signer",
- "jsonrpsee-types 0.26.0",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-primitives-traits",
- "revm-context",
- "thiserror 2.0.16",
-]
-
-[[package]]
-name = "reth-rpc-eth-types"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-network",
- "alloy-primitives",
- "alloy-rpc-client",
- "alloy-rpc-types-eth",
- "alloy-sol-types",
- "alloy-transport",
- "derive_more 2.0.1",
- "futures",
- "itertools 0.14.0",
- "jsonrpsee-core 0.26.0",
- "jsonrpsee-types 0.26.0",
- "metrics",
- "rand 0.9.2",
- "reqwest 0.12.23",
- "reth-chain-state",
- "reth-chainspec",
- "reth-errors",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-execution-types",
- "reth-metrics",
- "reth-primitives-traits",
- "reth-revm",
- "reth-rpc-convert",
- "reth-rpc-server-types",
- "reth-storage-api",
- "reth-tasks",
- "reth-transaction-pool",
- "reth-trie",
- "revm",
- "revm-inspectors",
- "schnellru",
- "serde",
- "thiserror 2.0.16",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-rpc-server-types"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "jsonrpsee-core 0.26.0",
- "jsonrpsee-types 0.26.0",
- "reth-errors",
- "reth-network-api",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-stages-types"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-primitives",
- "reth-trie-common",
 ]
 
 [[package]]
@@ -9860,28 +9448,6 @@ dependencies = [
  "derive_more 2.0.1",
  "serde",
  "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-storage-api"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "auto_impl",
- "reth-chainspec",
- "reth-db-models",
- "reth-ethereum-primitives",
- "reth-execution-types",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
- "revm-database",
 ]
 
 [[package]]
@@ -9901,93 +9467,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-tasks"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "auto_impl",
- "dyn-clone",
- "futures-util",
- "metrics",
- "reth-metrics",
- "thiserror 2.0.16",
- "tokio",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "reth-tokio-util"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-transaction-pool"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "aquamarine",
- "auto_impl",
- "bitflags 2.9.4",
- "futures-util",
- "metrics",
- "parking_lot",
- "pin-project",
- "reth-chain-state",
- "reth-chainspec",
- "reth-eth-wire-types",
- "reth-ethereum-primitives",
- "reth-execution-types",
- "reth-fs-util",
- "reth-metrics",
- "reth-primitives-traits",
- "reth-storage-api",
- "reth-tasks",
- "revm-interpreter",
- "revm-primitives",
- "rustc-hash 2.1.1",
- "schnellru",
- "serde",
- "serde_json",
- "smallvec",
- "thiserror 2.0.16",
- "tokio",
- "tokio-stream",
- "tracing",
-]
-
-[[package]]
-name = "reth-trie"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "auto_impl",
- "itertools 0.14.0",
- "reth-execution-errors",
- "reth-primitives-traits",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
- "reth-trie-sparse",
- "revm-database",
- "tracing",
-]
-
-[[package]]
 name = "reth-trie-common"
 version = "1.7.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
@@ -9995,34 +9474,12 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
  "alloy-trie",
- "bytes",
  "derive_more 2.0.1",
  "itertools 0.14.0",
  "nybbles",
- "rayon",
  "reth-primitives-traits",
  "revm-database",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-trie-sparse"
-version = "1.7.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.7.0#9d56da53ec0ad60e229456a0c70b338501d923a5"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "auto_impl",
- "reth-execution-errors",
- "reth-primitives-traits",
- "reth-trie-common",
- "smallvec",
- "tracing",
 ]
 
 [[package]]
@@ -10171,10 +9628,8 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-sol-types",
- "anstyle",
  "colorchoice",
  "revm",
- "serde",
  "serde_json",
  "thiserror 2.0.16",
 ]
@@ -11163,17 +10618,6 @@ dependencies = [
  "quote",
  "serde_derive_internals",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "schnellru"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
-dependencies = [
- "ahash",
- "cfg-if",
- "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -12388,7 +11832,6 @@ dependencies = [
  "jsonrpsee",
  "proptest",
  "reth-primitives",
- "reth-rpc-eth-types",
  "serde",
  "sov-accounts",
  "sov-address",
@@ -12399,6 +11842,7 @@ dependencies = [
  "sov-kernels",
  "sov-mock-da",
  "sov-modules-api",
+ "sov-rpc-eth-types",
  "sov-sequencer",
  "sov-state",
  "sov-stf-runner",
@@ -12436,7 +11880,6 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives",
  "reth-primitives-traits",
- "reth-rpc-eth-types",
  "revm",
  "revm-database-interface",
  "revm-inspectors",
@@ -12453,6 +11896,7 @@ dependencies = [
  "sov-mock-da",
  "sov-modules-api",
  "sov-rollup-interface",
+ "sov-rpc-eth-types",
  "sov-state",
  "sov-test-utils",
  "sov-uniqueness",
@@ -13028,6 +12472,24 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "sov-rpc-eth-types"
+version = "0.3.0"
+dependencies = [
+ "alloy-eips",
+ "alloy-evm 0.21.0",
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-sol-types",
+ "alloy-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "reth-errors",
+ "reth-primitives-traits",
+ "revm",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/utils/sov-zkvm-utils",
     "crates/utils/sov-build",
     "crates/utils/sov-eip-712",
+    "crates/utils/sov-rpc-eth-types",
     # Module System
     "crates/module-system/sov-cli",
     "crates/module-system/sov-modules-stf-blueprint",
@@ -162,6 +163,7 @@ sov-modules-rollup-blueprint = { path = "crates/module-system/sov-modules-rollup
 sov-modules-macros = { path = "crates/module-system/sov-modules-macros", default-features = false, version = "0.3" }
 sov-modules-stf-blueprint = { path = "crates/module-system/sov-modules-stf-blueprint", default-features = false, version = "0.3" }
 sov-test-utils = { path = "crates/module-system/sov-test-utils", default-features = false, version = "0.3" }
+sov-rpc-eth-types = { path = "crates/utils/sov-rpc-eth-types", default-features = false, version = "0.3" }
 sov-db = { path = "crates/full-node/sov-db", default-features = false, version = "0.3" }
 rest-api-load-testing = { path = "crates/utils/rest-api-load-testing" }
 sov-universal-wallet = { path = "crates/universal-wallet/schema" }
@@ -255,6 +257,8 @@ derive_more = { version = "1.0", default-features = false, features = ["std"] }
 clap = { version = "4.5.16", features = ["derive"] }
 toml = { version = "0.8.19", features = ["parse"] }
 jsonrpsee = { version = "0.25.1" }
+jsonrpsee-types = { version = "0.25.1" }
+jsonrpsee-core = { version = "0.25.1" }
 schemars = { version = "0.8.21", features = ["derive"] }
 tempfile = "3.20.0"
 testcontainers = "0.25.0"
@@ -279,17 +283,19 @@ alloy-chains = { version = "0.2.9", default-features = false }
 alloy-primitives = { version = "1.3.1", default-features = false }
 alloy-sol-types = { version = "1.3.1", default-features = false }
 alloy-eips = { version = "1.0.25", default-features = false }
+alloy-evm = { version = "0.21.0", default-features = false }
 alloy-consensus = { version = "1.0.30", default-features = false }
+alloy-transport = { version = "1.0.30", default-features = false }
 alloy-rpc-types = { version = "1.0.30", features = [
     "eth",
 ], default-features = false }
 
 alloy-provider = { version = "1.0.30", features = ["ws"] }
 alloy-rpc-types-trace = { version = "1.0.30" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.7.0", default-features = false }
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.7.0", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.7.0", default-features = false }
 reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.7.0", default-features = false }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.7.0", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.7.0", default-features = false }
 revm = { version = "29.0.0", features = ["serde"], default-features = false }
 revm-database-interface = { version = "7.0.5", default-features = false }
 revm-context = { version = "9.0.2", default-features = false }

--- a/crates/full-node/sov-ethereum/Cargo.toml
+++ b/crates/full-node/sov-ethereum/Cargo.toml
@@ -30,7 +30,7 @@ alloy-primitives = { workspace = true }
 alloy-rpc-types = { workspace = true }
 alloy-eips = { workspace = true }
 reth-primitives = { workspace = true }
-reth-rpc-eth-types = { workspace = true }
+sov-rpc-eth-types = { workspace = true }
 
 tokio = { workspace = true, features = ["sync"] }
 

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -28,9 +28,9 @@ pub(crate) mod signer {
     use alloy_eips::Encodable2718;
     use alloy_primitives::Address;
     use alloy_rpc_types::TransactionRequest;
-    use reth_rpc_eth_types::EthApiError;
     use sov_evm::eth_api_into_rpc_error;
     use sov_modules_api::macros::config_value;
+    use sov_rpc_eth_types::EthApiError;
 
     pub async fn eth_accounts<S, Seq>(
         _: JRpcParams<'static>,

--- a/crates/full-node/sov-ethereum/src/signer.rs
+++ b/crates/full-node/sov-ethereum/src/signer.rs
@@ -1,12 +1,12 @@
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::RpcModule;
 use reth_primitives::{TxKind, U256};
-use reth_rpc_eth_types::EthApiError;
 use sov_address::{EthereumAddress, FromVmAddress};
 use sov_evm::{eth_api_into_rpc_error, EthereumAuthenticator, Evm, RlpEvmTransaction};
 use sov_modules_api::capabilities::HasKernel;
 use sov_modules_api::macros::config_value;
 use sov_modules_api::{ApiStateAccessor, RawTx, Spec};
+use sov_rpc_eth_types::EthApiError;
 use sov_sequencer::Sequencer;
 
 use crate::{to_jsonrpsee_error_object, Ethereum, ETH_RPC_ERROR};

--- a/crates/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-evm/Cargo.toml
@@ -71,11 +71,12 @@ reth-ethereum-primitives = { workspace = true, features = [
 reth-primitives = { workspace = true }
 reth-primitives-traits = { workspace = true }
 revm-inspectors = { workspace = true, default-features = false, optional = true }
-reth-rpc-eth-types = { workspace = true, optional = true }
+sov-rpc-eth-types = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
+alloy-primitives = { workspace = true, features = ["getrandom"] }
 alloy-consensus = { workspace = true, features = ["secp256k1"] }
 sov-evm = { path = ".", features = ["native"] }
 strum = { workspace = true }
@@ -125,7 +126,7 @@ native = [
 	"alloy-primitives/std",
 	"reth-primitives/std",
 	"reth-ethereum-primitives/std",
-	"dep:reth-rpc-eth-types",
+	"dep:sov-rpc-eth-types",
 	# Optional for speed up in native mode
 	# "revm/asm-keccak"
 	"sov-evm/native",

--- a/crates/module-system/module-implementations/sov-evm/src/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/helpers.rs
@@ -3,8 +3,8 @@ use alloy_primitives::TxKind;
 use alloy_primitives::{BlockNumber, Sealed};
 use alloy_primitives::{B256, U256};
 use alloy_rpc_types::{Header, TransactionRequest};
-use reth_rpc_eth_types::EthResult;
 use revm::context::{BlockEnv, TransactionType, TxEnv};
+use sov_rpc_eth_types::EthResult;
 
 use alloy_consensus::TxEip4844;
 

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/error.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/error.rs
@@ -1,8 +1,8 @@
 //! Place where [`RlpConversionError`] is converted to [`EthApiError`]
 
 use alloy_primitives::Bytes;
-use reth_rpc_eth_types::{EthApiError, EthResult, RevertError, RpcInvalidTransactionError};
 use revm::context::result::{ExecutionResult, HaltReason};
+use sov_rpc_eth_types::{EthApiError, EthResult, RevertError, RpcInvalidTransactionError};
 
 use crate::evm::conversions::RlpConversionError;
 

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -13,7 +13,6 @@ use alloy_rpc_types_trace::geth::{GethDebugBuiltInTracerType, GethDebugTracerTyp
 use error::ensure_success;
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
-use reth_rpc_eth_types::{EthApiError, RpcInvalidTransactionError};
 use revm::context::result::{EVMError, ExecutionResult, InvalidHeader};
 use revm::context::{BlockEnv, CfgEnv, TxEnv};
 use revm::Database;
@@ -23,6 +22,7 @@ use sov_modules_api::macros::{config_value, rpc_gen};
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::{ApiStateAccessor, GasMeter, GasSpec, Spec, StateAccessor};
 use sov_rollup_interface::common::RollupHeight;
+use sov_rpc_eth_types::{EthApiError, RpcInvalidTransactionError};
 use tracing::debug;
 
 use crate::conversions::replay_tx_env;

--- a/crates/utils/sov-rpc-eth-types/Cargo.toml
+++ b/crates/utils/sov-rpc-eth-types/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "sov-rpc-eth-types"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+publish.workspace = true
+repository.workspace = true
+
+[dependencies]
+alloy-primitives = { workspace = true }
+alloy-rpc-types = { workspace = true }
+jsonrpsee-types = { workspace = true }
+jsonrpsee-core = { workspace = true }
+thiserror = { workspace = true }
+revm = { workspace = true }
+alloy-eips = { workspace = true }
+alloy-evm = { workspace = true }
+alloy-sol-types = { workspace = true }
+alloy-transport = { workspace = true }
+reth-errors = { workspace = true }
+reth-primitives-traits = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/utils/sov-rpc-eth-types/src/lib.rs
+++ b/crates/utils/sov-rpc-eth-types/src/lib.rs
@@ -1,0 +1,771 @@
+use alloy_eips::BlockId;
+use alloy_primitives::{Address, Bytes, B256, U256};
+use alloy_rpc_types::error::EthRpcErrorCode;
+use alloy_rpc_types::request::TransactionInputError;
+use alloy_sol_types::{ContractError, RevertReason};
+use alloy_transport::{RpcError, TransportErrorKind};
+use core::time::Duration;
+use reth_errors::RethError;
+use reth_primitives_traits::transaction::error::InvalidTransactionError;
+use reth_primitives_traits::transaction::signed::RecoveryError;
+use revm::context::result::{HaltReason, InvalidTransaction, OutOfGasError};
+use revm::context_interface::result::{EVMError, InvalidHeader};
+use std::convert::Infallible;
+
+/// An error due to invalid transaction.
+///
+/// The only reason this exists is to maintain compatibility with other clients de-facto standard
+/// error messages.
+///
+/// These error variants can be thrown when the transaction is checked prior to execution.
+///
+/// These variants also cover all errors that can be thrown by revm.
+///
+/// ## Nomenclature
+///
+/// This type is explicitly modeled after geth's error variants and uses
+///   `fee cap` for `max_fee_per_gas`
+///   `tip` for `max_priority_fee_per_gas`
+#[derive(thiserror::Error, Debug)]
+pub enum RpcInvalidTransactionError {
+    /// returned if the nonce of a transaction is lower than the one present in the local chain.
+    #[error("nonce too low: next nonce {state}, tx nonce {tx}")]
+    NonceTooLow {
+        /// The nonce of the transaction.
+        tx: u64,
+        /// The current state of the nonce in the local chain.
+        state: u64,
+    },
+    /// returned if the nonce of a transaction is higher than the next one expected based on the
+    /// local chain.
+    #[error("nonce too high")]
+    NonceTooHigh,
+    /// Returned if the nonce of a transaction is too high
+    /// Incrementing the nonce would lead to invalid state (overflow)
+    #[error("nonce has max value")]
+    NonceMaxValue,
+    /// thrown if the transaction sender doesn't have enough funds for a transfer
+    #[error("insufficient funds for transfer")]
+    InsufficientFundsForTransfer,
+    /// thrown if creation transaction provides the init code bigger than init code size limit.
+    #[error("max initcode size exceeded")]
+    MaxInitCodeSizeExceeded,
+    /// Represents the inability to cover max fee + value (account balance too low).
+    #[error("insufficient funds for gas * price + value: have {balance} want {cost}")]
+    InsufficientFunds {
+        /// Transaction cost.
+        cost: U256,
+        /// Current balance of transaction sender.
+        balance: U256,
+    },
+    /// This is similar to [`Self::InsufficientFunds`] but with a different error message and
+    /// exists for compatibility reasons.
+    ///
+    /// This error is used in `eth_estimateCall` when the highest available gas limit, capped with
+    /// the allowance of the caller is too low: [`Self::GasTooLow`].
+    #[error("gas required exceeds allowance ({gas_limit})")]
+    GasRequiredExceedsAllowance {
+        /// The gas limit the transaction was executed with.
+        gas_limit: u64,
+    },
+    /// Thrown when calculating gas usage
+    #[error("gas uint64 overflow")]
+    GasUintOverflow,
+    /// Thrown if the transaction is specified to use less gas than required to start the
+    /// invocation.
+    #[error("intrinsic gas too low")]
+    GasTooLow,
+    /// Thrown if the transaction gas exceeds the limit
+    #[error("intrinsic gas too high")]
+    GasTooHigh,
+    /// Thrown if the transaction gas limit exceeds the maximum
+    #[error("gas limit too high")]
+    GasLimitTooHigh,
+    /// Thrown if a transaction is not supported in the current network configuration.
+    #[error("transaction type not supported")]
+    TxTypeNotSupported,
+    /// Thrown to ensure no one is able to specify a transaction with a tip higher than the total
+    /// fee cap.
+    #[error("max priority fee per gas higher than max fee per gas")]
+    TipAboveFeeCap,
+    /// A sanity error to avoid huge numbers specified in the tip field.
+    #[error("max priority fee per gas higher than 2^256-1")]
+    TipVeryHigh,
+    /// A sanity error to avoid huge numbers specified in the fee cap field.
+    #[error("max fee per gas higher than 2^256-1")]
+    FeeCapVeryHigh,
+    /// Thrown post London if the transaction's fee is less than the base fee of the block
+    #[error("max fee per gas less than block base fee")]
+    FeeCapTooLow,
+    /// Thrown if the sender of a transaction is a contract.
+    #[error("sender is not an EOA")]
+    SenderNoEOA,
+    /// Gas limit was exceeded during execution.
+    /// Contains the gas limit.
+    #[error("out of gas: gas required exceeds: {0}")]
+    BasicOutOfGas(u64),
+    /// Gas limit was exceeded during memory expansion.
+    /// Contains the gas limit.
+    #[error("out of gas: gas exhausted during memory expansion: {0}")]
+    MemoryOutOfGas(u64),
+    /// Gas limit was exceeded during precompile execution.
+    /// Contains the gas limit.
+    #[error("out of gas: gas exhausted during precompiled contract execution: {0}")]
+    PrecompileOutOfGas(u64),
+    /// An operand to an opcode was invalid or out of range.
+    /// Contains the gas limit.
+    #[error("out of gas: invalid operand to an opcode: {0}")]
+    InvalidOperandOutOfGas(u64),
+    /// Thrown if executing a transaction failed during estimate/call
+    #[error(transparent)]
+    Revert(RevertError),
+    /// Unspecific EVM halt error.
+    #[error("EVM error: {0:?}")]
+    EvmHalt(HaltReason),
+    /// Invalid chain id set for the transaction.
+    #[error("invalid chain ID")]
+    InvalidChainId,
+    /// The transaction is before Spurious Dragon and has a chain ID
+    #[error("transactions before Spurious Dragon should not have a chain ID")]
+    OldLegacyChainId,
+    /// The transitions is before Berlin and has access list
+    #[error("transactions before Berlin should not have access list")]
+    AccessListNotSupported,
+    /// `max_fee_per_blob_gas` is not supported for blocks before the Cancun hardfork.
+    #[error("max_fee_per_blob_gas is not supported for blocks before the Cancun hardfork")]
+    MaxFeePerBlobGasNotSupported,
+    /// `blob_hashes`/`blob_versioned_hashes` is not supported for blocks before the Cancun
+    /// hardfork.
+    #[error("blob_versioned_hashes is not supported for blocks before the Cancun hardfork")]
+    BlobVersionedHashesNotSupported,
+    /// Block `blob_base_fee` is greater than tx-specified `max_fee_per_blob_gas` after Cancun.
+    #[error("max fee per blob gas less than block blob gas fee")]
+    BlobFeeCapTooLow,
+    /// Blob transaction has a versioned hash with an invalid blob
+    #[error("blob hash version mismatch")]
+    BlobHashVersionMismatch,
+    /// Blob transaction has no versioned hashes
+    #[error("blob transaction missing blob hashes")]
+    BlobTransactionMissingBlobHashes,
+    /// Blob transaction has too many blobs
+    #[error("blob transaction exceeds max blobs per block; got {have}")]
+    TooManyBlobs {
+        /// The number of blobs in the transaction.
+        have: usize,
+    },
+    /// Blob transaction is a create transaction
+    #[error("blob transaction is a create transaction")]
+    BlobTransactionIsCreate,
+    /// EIP-7702 is not enabled.
+    #[error("EIP-7702 authorization list not supported")]
+    AuthorizationListNotSupported,
+    /// EIP-7702 transaction has invalid fields set.
+    #[error("EIP-7702 authorization list has invalid fields")]
+    AuthorizationListInvalidFields,
+    /// Transaction priority fee is below the minimum required priority fee.
+    #[error("transaction priority fee below minimum required priority fee {minimum_priority_fee}")]
+    PriorityFeeBelowMinimum {
+        /// Minimum required priority fee.
+        minimum_priority_fee: u128,
+    },
+    /// Any other error
+    #[error("{0}")]
+    Other(Box<dyn ToRpcError>),
+}
+
+impl RpcInvalidTransactionError {
+    /// crates a new [`RpcInvalidTransactionError::Other`] variant.
+    pub fn other<E: ToRpcError>(err: E) -> Self {
+        Self::Other(Box::new(err))
+    }
+
+    /// Returns the rpc error code for this error.
+    pub const fn error_code(&self) -> i32 {
+        match self {
+            Self::InvalidChainId
+            | Self::GasTooLow
+            | Self::GasTooHigh
+            | Self::GasRequiredExceedsAllowance { .. }
+            | Self::NonceTooLow { .. }
+            | Self::NonceTooHigh { .. }
+            | Self::FeeCapTooLow
+            | Self::FeeCapVeryHigh => EthRpcErrorCode::InvalidInput.code(),
+            Self::Revert(_) => EthRpcErrorCode::ExecutionError.code(),
+            _ => EthRpcErrorCode::TransactionRejected.code(),
+        }
+    }
+
+    /// Converts the halt error
+    ///
+    /// Takes the configured gas limit of the transaction which is attached to the error
+    pub const fn halt(reason: HaltReason, gas_limit: u64) -> Self {
+        match reason {
+            HaltReason::OutOfGas(err) => Self::out_of_gas(err, gas_limit),
+            HaltReason::NonceOverflow => Self::NonceMaxValue,
+            err => Self::EvmHalt(err),
+        }
+    }
+
+    /// Converts the out of gas error
+    pub const fn out_of_gas(reason: OutOfGasError, gas_limit: u64) -> Self {
+        match reason {
+            OutOfGasError::Basic | OutOfGasError::ReentrancySentry => {
+                Self::BasicOutOfGas(gas_limit)
+            }
+            OutOfGasError::Memory | OutOfGasError::MemoryLimit => Self::MemoryOutOfGas(gas_limit),
+            OutOfGasError::Precompile => Self::PrecompileOutOfGas(gas_limit),
+            OutOfGasError::InvalidOperand => Self::InvalidOperandOutOfGas(gas_limit),
+        }
+    }
+
+    /// Converts this error into the rpc error object.
+    pub fn into_rpc_err(self) -> jsonrpsee_types::error::ErrorObject<'static> {
+        self.into()
+    }
+}
+
+impl From<RpcInvalidTransactionError> for jsonrpsee_types::error::ErrorObject<'static> {
+    fn from(err: RpcInvalidTransactionError) -> Self {
+        match err {
+            RpcInvalidTransactionError::Revert(revert) => {
+                // include out data if some
+                rpc_err(
+                    revert.error_code(),
+                    revert.to_string(),
+                    revert.output.as_ref().map(|out| out.as_ref()),
+                )
+            }
+            RpcInvalidTransactionError::Other(err) => err.to_rpc_error(),
+            err => rpc_err(err.error_code(), err.to_string(), None),
+        }
+    }
+}
+
+impl From<InvalidTransaction> for RpcInvalidTransactionError {
+    fn from(err: InvalidTransaction) -> Self {
+        match err {
+            InvalidTransaction::InvalidChainId | InvalidTransaction::MissingChainId => {
+                Self::InvalidChainId
+            }
+            InvalidTransaction::PriorityFeeGreaterThanMaxFee => Self::TipAboveFeeCap,
+            InvalidTransaction::GasPriceLessThanBasefee => Self::FeeCapTooLow,
+            InvalidTransaction::CallerGasLimitMoreThanBlock
+            | InvalidTransaction::TxGasLimitGreaterThanCap { .. } => {
+                // tx.gas > block.gas_limit
+                Self::GasTooHigh
+            }
+            InvalidTransaction::CallGasCostMoreThanGasLimit { .. } => {
+                // tx.gas < cost
+                Self::GasTooLow
+            }
+            InvalidTransaction::GasFloorMoreThanGasLimit { .. } => {
+                // Post prague EIP-7623 tx floor calldata gas cost > tx.gas_limit
+                // where floor gas is the minimum amount of gas that will be spent
+                // In other words, the tx's gas limit is lower that the minimum gas requirements of
+                // the tx's calldata
+                Self::GasTooLow
+            }
+            InvalidTransaction::RejectCallerWithCode => Self::SenderNoEOA,
+            InvalidTransaction::LackOfFundForMaxFee { fee, balance } => Self::InsufficientFunds {
+                cost: *fee,
+                balance: *balance,
+            },
+            InvalidTransaction::OverflowPaymentInTransaction => Self::GasUintOverflow,
+            InvalidTransaction::NonceOverflowInTransaction => Self::NonceMaxValue,
+            InvalidTransaction::CreateInitCodeSizeLimit => Self::MaxInitCodeSizeExceeded,
+            InvalidTransaction::NonceTooHigh { .. } => Self::NonceTooHigh,
+            InvalidTransaction::NonceTooLow { tx, state } => Self::NonceTooLow { tx, state },
+            InvalidTransaction::AccessListNotSupported => Self::AccessListNotSupported,
+            InvalidTransaction::MaxFeePerBlobGasNotSupported => Self::MaxFeePerBlobGasNotSupported,
+            InvalidTransaction::BlobVersionedHashesNotSupported => {
+                Self::BlobVersionedHashesNotSupported
+            }
+            InvalidTransaction::BlobGasPriceGreaterThanMax => Self::BlobFeeCapTooLow,
+            InvalidTransaction::EmptyBlobs => Self::BlobTransactionMissingBlobHashes,
+            InvalidTransaction::BlobVersionNotSupported => Self::BlobHashVersionMismatch,
+            InvalidTransaction::TooManyBlobs { have, .. } => Self::TooManyBlobs { have },
+            InvalidTransaction::BlobCreateTransaction => Self::BlobTransactionIsCreate,
+            InvalidTransaction::AuthorizationListNotSupported => {
+                Self::AuthorizationListNotSupported
+            }
+            InvalidTransaction::AuthorizationListInvalidFields
+            | InvalidTransaction::EmptyAuthorizationList => Self::AuthorizationListInvalidFields,
+            InvalidTransaction::Eip2930NotSupported
+            | InvalidTransaction::Eip1559NotSupported
+            | InvalidTransaction::Eip4844NotSupported
+            | InvalidTransaction::Eip7702NotSupported
+            | InvalidTransaction::Eip7873NotSupported => Self::TxTypeNotSupported,
+            InvalidTransaction::Eip7873MissingTarget => {
+                Self::other(internal_rpc_err(err.to_string()))
+            }
+        }
+    }
+}
+
+impl From<InvalidTransactionError> for RpcInvalidTransactionError {
+    fn from(err: InvalidTransactionError) -> Self {
+        use InvalidTransactionError;
+        // This conversion is used to convert any transaction errors that could occur inside the
+        // txpool (e.g. `eth_sendRawTransaction`) to their corresponding RPC
+        match err {
+            InvalidTransactionError::InsufficientFunds(res) => Self::InsufficientFunds {
+                cost: res.expected,
+                balance: res.got,
+            },
+            InvalidTransactionError::NonceNotConsistent { tx, state } => {
+                Self::NonceTooLow { tx, state }
+            }
+            InvalidTransactionError::OldLegacyChainId => {
+                // Note: this should be unreachable since Spurious Dragon now enabled
+                Self::OldLegacyChainId
+            }
+            InvalidTransactionError::ChainIdMismatch => Self::InvalidChainId,
+            InvalidTransactionError::Eip2930Disabled
+            | InvalidTransactionError::Eip1559Disabled
+            | InvalidTransactionError::Eip4844Disabled
+            | InvalidTransactionError::Eip7702Disabled
+            | InvalidTransactionError::TxTypeNotSupported => Self::TxTypeNotSupported,
+            InvalidTransactionError::GasUintOverflow => Self::GasUintOverflow,
+            InvalidTransactionError::GasTooLow => Self::GasTooLow,
+            InvalidTransactionError::GasTooHigh => Self::GasTooHigh,
+            InvalidTransactionError::TipAboveFeeCap => Self::TipAboveFeeCap,
+            InvalidTransactionError::FeeCapTooLow => Self::FeeCapTooLow,
+            InvalidTransactionError::SignerAccountHasBytecode => Self::SenderNoEOA,
+            InvalidTransactionError::GasLimitTooHigh => Self::GasLimitTooHigh,
+        }
+    }
+}
+
+/// Represents a reverted transaction and its output data.
+///
+/// Displays "execution reverted(: reason)?" if the reason is a string.
+#[derive(Debug, Clone, thiserror::Error)]
+pub struct RevertError {
+    /// The transaction output data
+    ///
+    /// Note: this is `None` if output was empty
+    output: Option<Bytes>,
+}
+
+// === impl RevertError ==
+
+impl RevertError {
+    /// Wraps the output bytes
+    ///
+    /// Note: this is intended to wrap an revm output
+    pub fn new(output: Bytes) -> Self {
+        if output.is_empty() {
+            Self { output: None }
+        } else {
+            Self {
+                output: Some(output),
+            }
+        }
+    }
+
+    /// Returns error code to return for this error.
+    pub const fn error_code(&self) -> i32 {
+        EthRpcErrorCode::ExecutionError.code()
+    }
+}
+
+impl std::fmt::Display for RevertError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("execution reverted")?;
+        if let Some(reason) = self
+            .output
+            .as_ref()
+            .and_then(|out| RevertReason::decode(out))
+        {
+            let error = reason.to_string();
+            let mut error = error.as_str();
+            if matches!(
+                reason,
+                RevertReason::ContractError(ContractError::Revert(_))
+            ) {
+                // we strip redundant `revert: ` prefix from the revert reason
+                error = error.trim_start_matches("revert: ");
+            }
+            write!(f, ": {error}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Constructs a JSON-RPC error, consisting of `code`, `message` and optional `data`.
+pub fn rpc_err(
+    code: i32,
+    msg: impl Into<String>,
+    data: Option<&[u8]>,
+) -> jsonrpsee_types::error::ErrorObject<'static> {
+    jsonrpsee_types::error::ErrorObject::owned(
+        code,
+        msg.into(),
+        data.map(|data| {
+            jsonrpsee_core::to_json_raw_value(&alloy_primitives::hex::encode_prefixed(data))
+                .expect("serializing String can't fail")
+        }),
+    )
+}
+
+/// Constructs an internal JSON-RPC error.
+pub fn internal_rpc_err(msg: impl Into<String>) -> jsonrpsee_types::error::ErrorObject<'static> {
+    rpc_err(jsonrpsee_types::error::INTERNAL_ERROR_CODE, msg, None)
+}
+
+/// A trait to convert an error to an RPC error.
+pub trait ToRpcError: core::error::Error + Send + Sync + 'static {
+    /// Converts the error to a JSON-RPC error object.
+    fn to_rpc_error(&self) -> jsonrpsee_types::ErrorObject<'static>;
+}
+
+impl ToRpcError for jsonrpsee_types::ErrorObject<'static> {
+    fn to_rpc_error(&self) -> jsonrpsee_types::ErrorObject<'static> {
+        self.clone()
+    }
+}
+
+impl ToRpcError for RpcError<TransportErrorKind> {
+    fn to_rpc_error(&self) -> jsonrpsee_types::ErrorObject<'static> {
+        match self {
+            Self::ErrorResp(payload) => jsonrpsee_types::error::ErrorObject::owned(
+                payload.code as i32,
+                payload.message.clone(),
+                payload.data.clone(),
+            ),
+            err => internal_rpc_err(err.to_string()),
+        }
+    }
+}
+
+/// Result alias
+pub type EthResult<T> = Result<T, EthApiError>;
+
+/// Errors that can occur when interacting with the `eth_` namespace
+#[derive(Debug, thiserror::Error)]
+pub enum EthApiError {
+    /// When a raw transaction is empty
+    #[error("empty transaction data")]
+    EmptyRawTransactionData,
+    /// When decoding a signed transaction fails
+    #[error("failed to decode signed transaction")]
+    FailedToDecodeSignedTransaction,
+    /// When the transaction signature is invalid
+    #[error("invalid transaction signature")]
+    InvalidTransactionSignature,
+    // /// Errors related to the transaction pool
+    // #[error(transparent)]
+    // PoolError(RpcPoolError),
+    /// Header not found for block hash/number/tag
+    #[error("header not found")]
+    HeaderNotFound(BlockId),
+    /// Header range not found for start block hash/number/tag to end block hash/number/tag
+    #[error("header range not found, start block {0:?}, end block {1:?}")]
+    HeaderRangeNotFound(BlockId, BlockId),
+    /// Thrown when historical data is not available because it has been pruned
+    ///
+    /// This error is intended for use as a standard response when historical data is
+    /// requested that has been pruned according to the node's data retention policy.
+    ///
+    /// See also <https://eips.ethereum.org/EIPS/eip-4444>
+    #[error("pruned history unavailable")]
+    PrunedHistoryUnavailable,
+    /// Receipts not found for block hash/number/tag
+    #[error("receipts not found")]
+    ReceiptsNotFound(BlockId),
+    /// Thrown when an unknown block or transaction index is encountered
+    #[error("unknown block or tx index")]
+    UnknownBlockOrTxIndex,
+    /// When an invalid block range is provided
+    #[error("invalid block range")]
+    InvalidBlockRange,
+    /// Thrown when the target block for proof computation exceeds the maximum configured window.
+    #[error("distance to target block exceeds maximum proof window")]
+    ExceedsMaxProofWindow,
+    /// An internal error where prevrandao is not set in the evm's environment
+    #[error("prevrandao not in the EVM's environment after merge")]
+    PrevrandaoNotSet,
+    /// `excess_blob_gas` is not set for Cancun and above
+    #[error("excess blob gas missing in the EVM's environment after Cancun")]
+    ExcessBlobGasNotSet,
+    /// Thrown when a call or transaction request (`eth_call`, `eth_estimateGas`,
+    /// `eth_sendTransaction`) contains conflicting fields (legacy, EIP-1559)
+    #[error("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")]
+    ConflictingFeeFieldsInRequest,
+    /// Errors related to invalid transactions
+    #[error(transparent)]
+    InvalidTransaction(#[from] RpcInvalidTransactionError),
+    // /// Thrown when constructing an RPC block from primitive block data fails
+    // #[error(transparent)]
+    // InvalidBlockData(#[from] BlockError),
+    /// Thrown when an `AccountOverride` contains conflicting `state` and `stateDiff` fields
+    #[error("account {0:?} has both 'state' and 'stateDiff'")]
+    BothStateAndStateDiffInOverride(Address),
+    /// Other internal error
+    #[error(transparent)]
+    Internal(RethError),
+    // /// Error related to signing
+    // #[error(transparent)]
+    // Signing(#[from] SignError),
+    /// Thrown when a requested transaction is not found
+    #[error("transaction not found")]
+    TransactionNotFound,
+    /// Some feature is unsupported
+    #[error("unsupported")]
+    Unsupported(&'static str),
+    /// General purpose error for invalid params
+    #[error("{0}")]
+    InvalidParams(String),
+    /// When the tracer config does not match the tracer
+    #[error("invalid tracer config")]
+    InvalidTracerConfig,
+    /// When the percentile array is invalid
+    #[error("invalid reward percentiles")]
+    InvalidRewardPercentiles,
+    /// Error thrown when a spawned blocking task failed to deliver an anticipated response.
+    ///
+    /// This only happens if the blocking task panics and is aborted before it can return a
+    /// response back to the request handler.
+    #[error("internal blocking task error")]
+    InternalBlockingTaskError,
+    /// Error thrown when a spawned blocking task failed to deliver an anticipated response
+    #[error("internal eth error")]
+    InternalEthError,
+    /// Error thrown when a (tracing) call exceeds the configured timeout
+    #[error("execution aborted (timeout = {0:?})")]
+    ExecutionTimedOut(Duration),
+    /// Internal Error thrown by the javascript tracer
+    #[error("{0}")]
+    InternalJsTracerError(String),
+    #[error(transparent)]
+    /// Call Input error when both `data` and `input` fields are set and not equal.
+    TransactionInputError(#[from] TransactionInputError),
+    /// Evm generic purpose error.
+    #[error("Revm error: {0}")]
+    EvmCustom(String),
+    /// Bytecode override is invalid.
+    ///
+    /// This can happen if bytecode provided in an
+    /// [`AccountOverride`](alloy_rpc_types_eth::state::AccountOverride) is malformed, e.g. invalid
+    /// 7702 bytecode.
+    // #[error("Invalid bytecode: {0}")]
+    // InvalidBytecode(String),
+    /// Error encountered when converting a transaction type
+    #[error("Transaction conversion error")]
+    TransactionConversionError,
+    // /// Error thrown when tracing with a muxTracer fails
+    // #[error(transparent)]
+    // MuxTracerError(#[from] MuxError),
+    /// Error thrown when waiting for transaction confirmation times out
+    #[error(
+        "Transaction {hash} was added to the mempool but wasn't confirmed within {duration:?}."
+    )]
+    TransactionConfirmationTimeout {
+        /// Hash of the transaction that timed out
+        hash: B256,
+        /// Duration that was waited before timing out
+        duration: Duration,
+    },
+    // /// Error thrown when batch tx response channel fails
+    // #[error(transparent)]
+    // BatchTxRecvError(#[from] RecvError),
+    /// Error thrown when batch tx send channel fails
+    #[error("Batch transaction sender channel closed")]
+    BatchTxSendError,
+    /// Any other error
+    #[error("{0}")]
+    Other(Box<dyn ToRpcError>),
+}
+
+impl EthApiError {
+    /// crates a new [`EthApiError::Other`] variant.
+    pub fn other<E: ToRpcError>(err: E) -> Self {
+        Self::Other(Box::new(err))
+    }
+
+    /// Returns `true` if error is [`RpcInvalidTransactionError::GasTooHigh`]
+    pub const fn is_gas_too_high(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidTransaction(
+                RpcInvalidTransactionError::GasTooHigh
+                    | RpcInvalidTransactionError::GasLimitTooHigh
+            )
+        )
+    }
+
+    /// Returns `true` if error is [`RpcInvalidTransactionError::GasTooLow`]
+    pub const fn is_gas_too_low(&self) -> bool {
+        matches!(
+            self,
+            Self::InvalidTransaction(RpcInvalidTransactionError::GasTooLow)
+        )
+    }
+
+    /// Returns the [`RpcInvalidTransactionError`] if this is a [`EthApiError::InvalidTransaction`]
+    pub const fn as_invalid_transaction(&self) -> Option<&RpcInvalidTransactionError> {
+        match self {
+            Self::InvalidTransaction(e) => Some(e),
+            _ => None,
+        }
+    }
+
+    /// Converts this error into the rpc error object.
+    pub fn into_rpc_err(self) -> jsonrpsee_types::error::ErrorObject<'static> {
+        self.into()
+    }
+}
+
+impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
+    fn from(error: EthApiError) -> Self {
+        match error {
+            EthApiError::FailedToDecodeSignedTransaction
+            | EthApiError::InvalidTransactionSignature
+            | EthApiError::EmptyRawTransactionData
+            | EthApiError::InvalidBlockRange
+            | EthApiError::ExceedsMaxProofWindow
+            | EthApiError::ConflictingFeeFieldsInRequest
+            | EthApiError::BothStateAndStateDiffInOverride(_)
+            | EthApiError::InvalidTracerConfig
+            | EthApiError::TransactionConversionError
+            | EthApiError::InvalidRewardPercentiles => invalid_params_rpc_err(error.to_string()),
+            EthApiError::InvalidTransaction(err) => err.into(),
+            EthApiError::PrevrandaoNotSet
+            | EthApiError::ExcessBlobGasNotSet
+            | EthApiError::Internal(_)
+            | EthApiError::EvmCustom(_) => internal_rpc_err(error.to_string()),
+            EthApiError::UnknownBlockOrTxIndex | EthApiError::TransactionNotFound => {
+                rpc_error_with_code(EthRpcErrorCode::ResourceNotFound.code(), error.to_string())
+            }
+            // TODO(onbjerg): We rewrite the error message here because op-node does string matching
+            // on the error message.
+            //
+            // Until https://github.com/ethereum-optimism/optimism/pull/11759 is released, this must be kept around.
+            EthApiError::HeaderNotFound(id) => rpc_error_with_code(
+                EthRpcErrorCode::ResourceNotFound.code(),
+                format!("block not found: {}", block_id_to_str(id)),
+            ),
+            EthApiError::ReceiptsNotFound(id) => rpc_error_with_code(
+                EthRpcErrorCode::ResourceNotFound.code(),
+                format!("{error}: {}", block_id_to_str(id)),
+            ),
+            EthApiError::HeaderRangeNotFound(start_id, end_id) => rpc_error_with_code(
+                EthRpcErrorCode::ResourceNotFound.code(),
+                format!(
+                    "{error}: start block: {}, end block: {}",
+                    block_id_to_str(start_id),
+                    block_id_to_str(end_id),
+                ),
+            ),
+            err @ EthApiError::TransactionConfirmationTimeout { .. } => rpc_error_with_code(
+                EthRpcErrorCode::TransactionConfirmationTimeout.code(),
+                err.to_string(),
+            ),
+            EthApiError::Unsupported(msg) => internal_rpc_err(msg),
+            EthApiError::InternalJsTracerError(msg) => internal_rpc_err(msg),
+            EthApiError::InvalidParams(msg) => invalid_params_rpc_err(msg),
+            err @ EthApiError::ExecutionTimedOut(_) => rpc_error_with_code(
+                jsonrpsee_types::error::CALL_EXECUTION_FAILED_CODE,
+                err.to_string(),
+            ),
+            err @ (EthApiError::InternalBlockingTaskError | EthApiError::InternalEthError) => {
+                internal_rpc_err(err.to_string())
+            }
+            err @ EthApiError::TransactionInputError(_) => invalid_params_rpc_err(err.to_string()),
+            EthApiError::PrunedHistoryUnavailable => rpc_error_with_code(4444, error.to_string()),
+            EthApiError::Other(err) => err.to_rpc_error(),
+            EthApiError::BatchTxSendError => {
+                internal_rpc_err("Batch transaction sender channel closed".to_string())
+            }
+        }
+    }
+}
+
+#[cfg(feature = "js-tracer")]
+impl From<revm_inspectors::tracing::js::JsInspectorError> for EthApiError {
+    fn from(error: revm_inspectors::tracing::js::JsInspectorError) -> Self {
+        match error {
+            err @ revm_inspectors::tracing::js::JsInspectorError::JsError(_) => {
+                Self::InternalJsTracerError(err.to_string())
+            }
+            err => Self::InvalidParams(err.to_string()),
+        }
+    }
+}
+
+impl From<InvalidHeader> for EthApiError {
+    fn from(value: InvalidHeader) -> Self {
+        match value {
+            InvalidHeader::ExcessBlobGasNotSet => Self::ExcessBlobGasNotSet,
+            InvalidHeader::PrevrandaoNotSet => Self::PrevrandaoNotSet,
+        }
+    }
+}
+
+impl<T> From<EVMError<T, InvalidTransaction>> for EthApiError
+where
+    T: Into<Self>,
+{
+    fn from(err: EVMError<T, InvalidTransaction>) -> Self {
+        match err {
+            EVMError::Transaction(invalid_tx) => match invalid_tx {
+                InvalidTransaction::NonceTooLow { tx, state } => {
+                    Self::InvalidTransaction(RpcInvalidTransactionError::NonceTooLow { tx, state })
+                }
+                _ => RpcInvalidTransactionError::from(invalid_tx).into(),
+            },
+            EVMError::Header(err) => err.into(),
+            EVMError::Database(err) => err.into(),
+            EVMError::Custom(err) => Self::EvmCustom(err),
+        }
+    }
+}
+
+impl From<RecoveryError> for EthApiError {
+    fn from(_: RecoveryError) -> Self {
+        Self::InvalidTransactionSignature
+    }
+}
+
+impl From<Infallible> for EthApiError {
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
+}
+
+/// Constructs an invalid params JSON-RPC error.
+pub fn invalid_params_rpc_err(
+    msg: impl Into<String>,
+) -> jsonrpsee_types::error::ErrorObject<'static> {
+    rpc_err(jsonrpsee_types::error::INVALID_PARAMS_CODE, msg, None)
+}
+
+/// Constructs an internal JSON-RPC error with data
+pub fn internal_rpc_err_with_data(
+    msg: impl Into<String>,
+    data: &[u8],
+) -> jsonrpsee_types::error::ErrorObject<'static> {
+    rpc_err(jsonrpsee_types::error::INTERNAL_ERROR_CODE, msg, Some(data))
+}
+
+/// Constructs an internal JSON-RPC error with code and message
+pub fn rpc_error_with_code(
+    code: i32,
+    msg: impl Into<String>,
+) -> jsonrpsee_types::error::ErrorObject<'static> {
+    rpc_err(code, msg, None)
+}
+
+/// Formats a [`BlockId`] into an error message.
+pub fn block_id_to_str(id: BlockId) -> String {
+    match id {
+        BlockId::Hash(h) => {
+            if h.require_canonical == Some(true) {
+                format!("canonical hash {}", h.block_hash)
+            } else {
+                format!("hash {}", h.block_hash)
+            }
+        }
+        BlockId::Number(n) => format!("{n}"),
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,11 @@ license-files = [{ path = "COPYING", hash = 0x106164e0 }]
 
 # Sovereign SDK packages use a custom community license
 [[licenses.clarify]]
+name = "sov-rpc-eth-types"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
 name = "sov-blob-sender"
 expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
 license-files = []


### PR DESCRIPTION
# Description

Removes dependency on `reth-rpc-eth-types` which pulls in a ton of dependencies we don't use.
Copies the parts we do use into `sov-rpc-eth-types` (771 lines). It's in the separate crate so it does not get recompiled when we work on `sov-evm`.

If you go to Cargo.lock and search all `reth-*` deps - their number dropped from 39 to 15. And those we still have are much simpler like primitives.

The total amount of compilation units dropped: `1922 -> 1852`

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
