### PR TITLE
Remove `workspace-hack` from sov-hyperlane-integration, this time properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12504,7 +12504,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "workspace-hack",
 ]
 
 [[package]]

--- a/crates/module-system/hyperlane/Cargo.toml
+++ b/crates/module-system/hyperlane/Cargo.toml
@@ -22,7 +22,7 @@ sov-mock-da = { workspace = true }
 sov-modules-api = { workspace = true, features = ["native"] }
 sov-sequencer = { workspace = true }
 sov-state = { workspace = true, features = ["native"] }
-sov-test-utils = { workspace = true }
+sov-test-utils = { workspace = true, features = ["arbitrary"] }
 sov-value-setter = { workspace = true, features = ["native"] }
 secp256k1 = { workspace = true, features = ["rand"] }
 

--- a/crates/module-system/hyperlane/Cargo.toml
+++ b/crates/module-system/hyperlane/Cargo.toml
@@ -58,7 +58,6 @@ sha3 = { workspace = true }
 ruint = { workspace = true }
 strum = { workspace = true }
 tracing = { workspace = true }
-workspace-hack = { workspace = true }
 
 [features]
 default = []


### PR DESCRIPTION
# Description

Somehow I failed to notice that the dependency was duplicated and I had only deteted it in dev-dependencies, not in the actual dependencies. Whoops.

Turns out actually removing it *did* cause some issues, but I was able to isolate the fix to adding the feature to `sov-test-utils` in the dev dependencies.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
