### PR TITLE
Increase default MockDa block time from 300 to 450 ms

### DIFF
--- a/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
@@ -369,7 +369,7 @@ async fn test_dispatch_message_to_evm_counterparty() {
             // Find the dispatched message on counterparty
             // TODO: How to do it more reliably?
             tracing::info!("Waiting for relayer to submit transaction to EVM...");
-            sleep(Duration::from_secs(30)).await; // give relayer extra time to relay
+            sleep(Duration::from_secs(20)).await; // give relayer extra time to relay
 
             // Check if relayer is healthy before checking for events
             tracing::info!("Checking for events on EVM counterparty...");

--- a/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
@@ -369,7 +369,7 @@ async fn test_dispatch_message_to_evm_counterparty() {
             // Find the dispatched message on counterparty
             // TODO: How to do it more reliably?
             tracing::info!("Waiting for relayer to submit transaction to EVM...");
-            sleep(Duration::from_secs(10)).await; // give relayer extra time to relay
+            sleep(Duration::from_secs(30)).await; // give relayer extra time to relay
 
             // Check if relayer is healthy before checking for events
             tracing::info!("Checking for events on EVM counterparty...");

--- a/crates/module-system/sov-test-utils/src/lib.rs
+++ b/crates/module-system/sov-test-utils/src/lib.rs
@@ -169,8 +169,9 @@ pub const TEST_DEFAULT_SEQUENCER_ADDRESS: &str =
     "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf";
 
 /// Default wait time value for different [`sov_mock_da::BlockProducingConfig`] value in tests.
-pub const TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS: u64 = 300;
+pub const TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS: u64 = 450;
 /// Default [`BlockProducingConfig`] for tests that need periodic block producing.
+/// uses [`TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS`]
 pub const TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING: BlockProducingConfig =
     BlockProducingConfig::Periodic {
         block_time_ms: TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS,


### PR DESCRIPTION
# Description

To reduce load on sequencer and node and make tests a little bit more stable