### PR TITLE
feat: add env var override for Postgres connection string

### DIFF
--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -166,6 +166,28 @@ impl Default for PreferredSequencerConfig {
     }
 }
 
+impl PreferredSequencerConfig {
+    /// Returns the Postgres connection string, resolving environment overrides.
+    ///
+    /// Precedence (first non-empty wins):
+    /// - `SOV_SEQUENCER_POSTGRES_URL`
+    /// - `DATABASE_URL`
+    /// - `self.postgres_connection_string`
+    pub fn resolved_postgres_connection_string(&self) -> Option<String> {
+        if let Ok(url) = std::env::var("SOV_SEQUENCER_POSTGRES_URL") {
+            if !url.is_empty() {
+                return Some(url);
+            }
+        }
+        if let Ok(url) = std::env::var("DATABASE_URL") {
+            if !url.is_empty() {
+                return Some(url);
+            }
+        }
+        self.postgres_connection_string.clone()
+    }
+}
+
 /// The ideal buffer of finalized slots that the sequencer should maintain. The larger this number,
 /// the longer forced transactions will take to be included but the more the sequencer is able to buffer
 /// instability on the DA layer.

--- a/crates/full-node/sov-sequencer/README.md
+++ b/crates/full-node/sov-sequencer/README.md
@@ -31,3 +31,19 @@ These tests can be skipped by setting the `SOV_TEST_SKIP_DOCKER` env var to `1` 
 ```bash
 SOV_TEST_SKIP_DOCKER=1 cargo nextest run
 ```
+
+### Postgres configuration via environment variables
+
+When running the preferred sequencer with Postgres, you can supply the connection string via environment variables without storing secrets in your config file.
+
+Precedence (first non-empty wins):
+
+1. `SOV_SEQUENCER_POSTGRES_URL`
+2. `DATABASE_URL`
+3. `sequencer.preferred.postgres_connection_string` in your TOML config
+
+Example:
+
+```bash
+SOV_SEQUENCER_POSTGRES_URL="postgres://user:pass@host:5432/db" cargo run -p sov-sequencer -- ...
+```

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -162,7 +162,9 @@ where
             shutdown_sender.clone(),
             config.sequencer_kind_config.is_replica,
             storage_path,
-            &config.sequencer_kind_config.postgres_connection_string,
+            &config
+                .sequencer_kind_config
+                .resolved_postgres_connection_string(),
         )
         .await?;
 


### PR DESCRIPTION
- Add resolved_postgres_connection_string() method to PreferredSequencerConfig
- Support SOV_SEQUENCER_POSTGRES_URL and DATABASE_URL env vars
- Update sequencer to use resolved connection string
- Add documentation with precedence and usage examples

Resolves #1490