### PR TITLE
Update utoipa to v5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8494,30 +8494,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12150,7 +12126,7 @@ dependencies = [
  "tracing-test",
  "trybuild",
  "unwrap-infallible",
- "utoipa 4.2.3",
+ "utoipa 5.4.0",
  "utoipa-swagger-ui",
 ]
 
@@ -15338,18 +15314,6 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
-dependencies = [
- "indexmap 2.11.1",
- "serde",
- "serde_json",
- "utoipa-gen 4.3.1",
-]
-
-[[package]]
-name = "utoipa"
 version = "5.0.0-beta.0"
 source = "git+https://github.com/juhaku/utoipa.git?rev=a985d8c1340f80ab69b2b0e5de799df98d567732#a985d8c1340f80ab69b2b0e5de799df98d567732"
 dependencies = [
@@ -15360,12 +15324,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "utoipa-gen"
-version = "4.3.1"
+name = "utoipa"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "proc-macro-error",
+ "indexmap 2.11.1",
+ "serde",
+ "serde_json",
+ "utoipa-gen 5.4.0",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.0.0-beta.0"
+source = "git+https://github.com/juhaku/utoipa.git?rev=a985d8c1340f80ab69b2b0e5de799df98d567732#a985d8c1340f80ab69b2b0e5de799df98d567732"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -15373,8 +15347,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.0.0-beta.0"
-source = "git+https://github.com/juhaku/utoipa.git?rev=a985d8c1340f80ab69b2b0e5de799df98d567732#a985d8c1340f80ab69b2b0e5de799df98d567732"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,7 +251,7 @@ tracing-subscriber = { version = "0.3.18" } # There's hardly any reason to disab
 tracing-test = { version = "0.2.5", features = [
     "no-env-filter",
 ] } # https://docs.rs/tracing-test/latest/tracing_test/#per-crate-filtering
-utoipa = "4.2"
+utoipa = "5"
 utoipa-swagger-ui = { git = "https://github.com/juhaku/utoipa.git", rev = "a985d8c1340f80ab69b2b0e5de799df98d567732", features = ["axum", "debug-embed"] }
 unwrap-infallible = "0.1.5"
 bech32 = { version = "0.11" }

--- a/crates/module-system/hyperlane/src/merkle/openapi-v3.yaml
+++ b/crates/module-system/hyperlane/src/merkle/openapi-v3.yaml
@@ -1,5 +1,5 @@
 # Specification for custom bank REST API endpoints
-openapi: "3.0.2"
+openapi: 3.0.2
 info:
   title: sov-hyperlane-integration merkle-tree-hook custom endpoints
   version: 0.1.0

--- a/crates/module-system/hyperlane/src/merkle/openapi-v3.yaml
+++ b/crates/module-system/hyperlane/src/merkle/openapi-v3.yaml
@@ -1,5 +1,5 @@
 # Specification for custom bank REST API endpoints
-openapi: 3.0.2
+openapi: 3.1.0
 info:
   title: sov-hyperlane-integration merkle-tree-hook custom endpoints
   version: 0.1.0

--- a/crates/module-system/hyperlane/src/openapi-v3.yaml
+++ b/crates/module-system/hyperlane/src/openapi-v3.yaml
@@ -1,5 +1,5 @@
 # Specification for custom bank REST API endpoints
-openapi: 3.0.2
+openapi: 3.1.0
 info:
   title: sov-hyperlane-integration custom endpoints
   version: 0.1.0

--- a/crates/module-system/hyperlane/src/openapi-v3.yaml
+++ b/crates/module-system/hyperlane/src/openapi-v3.yaml
@@ -1,5 +1,5 @@
 # Specification for custom bank REST API endpoints
-openapi: "3.0.2"
+openapi: 3.0.2
 info:
   title: sov-hyperlane-integration custom endpoints
   version: 0.1.0

--- a/crates/module-system/hyperlane/src/warp/openapi-v3.yaml
+++ b/crates/module-system/hyperlane/src/warp/openapi-v3.yaml
@@ -1,5 +1,5 @@
 # Specification for custom bank REST API endpoints
-openapi: 3.0.2
+openapi: 3.1.0
 info:
   title: warp route custom endpoints
   version: 0.1.0

--- a/crates/module-system/hyperlane/src/warp/openapi-v3.yaml
+++ b/crates/module-system/hyperlane/src/warp/openapi-v3.yaml
@@ -1,5 +1,5 @@
 # Specification for custom bank REST API endpoints
-openapi: "3.0.2"
+openapi: 3.0.2
 info:
   title: warp route custom endpoints
   version: 0.1.0

--- a/crates/module-system/module-implementations/sov-bank/openapi-v3.yaml
+++ b/crates/module-system/module-implementations/sov-bank/openapi-v3.yaml
@@ -1,5 +1,5 @@
 # Specification for custom bank REST API endpoints
-openapi: "3.0.2"
+openapi: 3.1.0
 info:
   title: Sov-bank custom endpoints
   version: 0.1.0

--- a/crates/module-system/sov-modules-api/src/rest/__private/openapi-templates/runtime-base.yaml
+++ b/crates/module-system/sov-modules-api/src/rest/__private/openapi-templates/runtime-base.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.2"
+openapi: 3.1.0
 info:
   title: Sovereign SDK Runtime API
   version: 0.1.0

--- a/crates/module-system/sov-modules-api/src/rest/__private/openapi.rs
+++ b/crates/module-system/sov-modules-api/src/rest/__private/openapi.rs
@@ -146,7 +146,7 @@ impl<N, T, Codec> CustomStateItemPath
     for StateItemOpenApiSpecImpl<NamespacedStateValue<N, T, Codec>>
 where
     N: CompileTimeNamespace,
-    T: for<'a> ToSchema<'a> + Serialize + Send + Sync + 'static,
+    T: ToSchema + Serialize + Send + Sync + 'static,
     Codec: StateCodec,
     Codec::ValueCodec: StateItemCodec<T>,
 {
@@ -156,7 +156,7 @@ where
         module_name: &str,
         field_name: &str,
     ) -> Option<(OpenApiPaths, String, Response)> {
-        let (name, _) = <T as ToSchema<'_>>::schema();
+        let name = <T as ToSchema>::name();
         let custom_element_response = format!("{name}StateItemResponse");
 
         Some((
@@ -176,7 +176,7 @@ impl<N, K, V, Codec> CustomStateItemPath
 where
     N: CompileTimeNamespace,
     K: Serialize + DeserializeOwned + FromStr + Display + Clone + Send + Sync + 'static,
-    V: for<'a> ToSchema<'a> + Serialize + Clone + Send + Sync + 'static,
+    V: ToSchema + Serialize + Clone + Send + Sync + 'static,
     Codec: StateCodec,
     Codec::KeyCodec: StateItemCodec<K>,
     Codec::ValueCodec: StateItemCodec<V>,
@@ -187,7 +187,7 @@ where
         module_name: &str,
         field_name: &str,
     ) -> Option<(OpenApiPaths, String, Response)> {
-        let (name, _) = <V as ToSchema<'_>>::schema();
+        let name = <V as ToSchema>::name();
         let custom_element_response = format!("{name}StateMapElementResponse");
 
         Some((
@@ -213,7 +213,7 @@ where
 impl<N, T, Codec> CustomStateItemPath for StateItemOpenApiSpecImpl<NamespacedStateVec<N, T, Codec>>
 where
     N: CompileTimeNamespace,
-    T: Serialize + Send + Sync + 'static + for<'a> ToSchema<'a>,
+    T: Serialize + Send + Sync + 'static + ToSchema,
     Codec: StateCodec,
     Codec::ValueCodec: StateItemCodec<T> + StateItemCodec<u64>,
     Codec::KeyCodec: StateItemCodec<u64>,
@@ -224,7 +224,7 @@ where
         module_name: &str,
         field_name: &str,
     ) -> Option<(OpenApiPaths, String, Response)> {
-        let (name, _) = <T as ToSchema<'_>>::schema();
+        let name = <T as ToSchema>::name();
         let custom_element_response = format!("{name}StateVecElementResponse");
 
         Some((
@@ -237,7 +237,7 @@ where
 
 impl<V, Codec> CustomStateItemPath for StateItemOpenApiSpecImpl<VersionedStateValue<V, Codec>>
 where
-    V: Serialize + Clone + Send + Sync + 'static + for<'a> ToSchema<'a>,
+    V: Serialize + Clone + Send + Sync + 'static + ToSchema,
     Codec: StateCodec,
     Codec::ValueCodec: StateItemCodec<V>,
     Codec::KeyCodec: StateItemCodec<SlotNumber>,
@@ -248,7 +248,7 @@ where
         module_name: &str,
         field_name: &str,
     ) -> Option<(OpenApiPaths, String, Response)> {
-        let (name, _) = <V as ToSchema<'_>>::schema();
+        let name = <V as ToSchema>::name();
         let custom_element_response = format!("{name}StateItemResponse");
 
         Some((
@@ -466,20 +466,20 @@ pub fn state_vec_paths_with_response(
 }
 
 /// Add a simple custom response to the OpenAPI spec
-fn make_simple_custom_response<'a, 'resp, T: ToSchema<'a>>(description: &str) -> Response {
+fn make_simple_custom_response<'resp, T: ToSchema>(description: &str) -> Response {
     // Create a simple response with a basic schema
     let response = utoipa::openapi::ResponseBuilder::new()
         .description(description)
         .content(
             "application/json",
             utoipa::openapi::ContentBuilder::new()
-                .schema(utoipa::openapi::RefOr::T(utoipa::openapi::Schema::Object(
+                .schema(Some(utoipa::openapi::RefOr::T(utoipa::openapi::Schema::Object(
                     utoipa::openapi::ObjectBuilder::new()
                         .description(Some(description.to_string()))
-                        .property("value", T::schema().1)
+                        .property("value", T::schema())
                         .required("value")
                         .build(),
-                )))
+                ))))
                 .build(),
         )
         .build();
@@ -488,26 +488,26 @@ fn make_simple_custom_response<'a, 'resp, T: ToSchema<'a>>(description: &str) ->
 }
 
 /// Add a simple custom response to the OpenAPI spec
-fn make_custom_response_map<'a, 'resp, T: ToSchema<'a>>(description: &str) -> Response {
+fn make_custom_response_map<'resp, T: ToSchema>(description: &str) -> Response {
+    use utoipa::PartialSchema;
     // Create a simple response with a basic schema
     let response = utoipa::openapi::ResponseBuilder::new()
         .description(description)
         .content(
             "application/json",
             utoipa::openapi::ContentBuilder::new()
-                .schema(utoipa::openapi::RefOr::T(utoipa::openapi::Schema::Object(
+                .schema(Some(utoipa::openapi::RefOr::T(utoipa::openapi::Schema::Object(
                     utoipa::openapi::ObjectBuilder::new()
                         .description(Some(description.to_string()))
                         .property(
                             "key",
-                            utoipa::openapi::ObjectBuilder::new()
-                                .schema_type(utoipa::openapi::SchemaType::String),
+                            String::schema(),
                         )
                         .required("key")
-                        .property("value", T::schema().1)
+                        .property("value", T::schema())
                         .required("value")
                         .build(),
-                )))
+                ))))
                 .build(),
         )
         .build();
@@ -516,26 +516,26 @@ fn make_custom_response_map<'a, 'resp, T: ToSchema<'a>>(description: &str) -> Re
 }
 
 /// Add a simple custom response to the OpenAPI spec
-fn make_custom_response_vec<'a, 'resp, T: ToSchema<'a>>(description: &str) -> Response {
+fn make_custom_response_vec<'resp, T: ToSchema>(description: &str) -> Response {
+    use utoipa::PartialSchema;
     // Create a simple response with a basic schema
     let response = utoipa::openapi::ResponseBuilder::new()
         .description(description)
         .content(
             "application/json",
             utoipa::openapi::ContentBuilder::new()
-                .schema(utoipa::openapi::RefOr::T(utoipa::openapi::Schema::Object(
+                .schema(Some(utoipa::openapi::RefOr::T(utoipa::openapi::Schema::Object(
                     utoipa::openapi::ObjectBuilder::new()
                         .description(Some(description.to_string()))
                         .property(
                             "index",
-                            utoipa::openapi::ObjectBuilder::new()
-                                .schema_type(utoipa::openapi::SchemaType::Integer),
+                            u64::schema(),
                         )
                         .required("index")
-                        .property("value", T::schema().1)
+                        .property("value", T::schema())
                         .required("value")
                         .build(),
-                )))
+                ))))
                 .build(),
         )
         .build();

--- a/crates/module-system/sov-modules-api/src/rest/__private/openapi.rs
+++ b/crates/module-system/sov-modules-api/src/rest/__private/openapi.rs
@@ -466,81 +466,75 @@ pub fn state_vec_paths_with_response(
 }
 
 /// Add a simple custom response to the OpenAPI spec
-fn make_simple_custom_response<'resp, T: ToSchema>(description: &str) -> Response {
+fn make_simple_custom_response<T: ToSchema>(description: &str) -> Response {
     // Create a simple response with a basic schema
-    let response = utoipa::openapi::ResponseBuilder::new()
+    utoipa::openapi::ResponseBuilder::new()
         .description(description)
         .content(
             "application/json",
             utoipa::openapi::ContentBuilder::new()
-                .schema(Some(utoipa::openapi::RefOr::T(utoipa::openapi::Schema::Object(
-                    utoipa::openapi::ObjectBuilder::new()
-                        .description(Some(description.to_string()))
-                        .property("value", T::schema())
-                        .required("value")
-                        .build(),
-                ))))
+                .schema(Some(utoipa::openapi::RefOr::T(
+                    utoipa::openapi::Schema::Object(
+                        utoipa::openapi::ObjectBuilder::new()
+                            .description(Some(description.to_string()))
+                            .property("value", T::schema())
+                            .required("value")
+                            .build(),
+                    ),
+                )))
                 .build(),
         )
-        .build();
-
-    response
+        .build()
 }
 
 /// Add a simple custom response to the OpenAPI spec
-fn make_custom_response_map<'resp, T: ToSchema>(description: &str) -> Response {
+fn make_custom_response_map<T: ToSchema>(description: &str) -> Response {
     use utoipa::PartialSchema;
     // Create a simple response with a basic schema
-    let response = utoipa::openapi::ResponseBuilder::new()
+    utoipa::openapi::ResponseBuilder::new()
         .description(description)
         .content(
             "application/json",
             utoipa::openapi::ContentBuilder::new()
-                .schema(Some(utoipa::openapi::RefOr::T(utoipa::openapi::Schema::Object(
-                    utoipa::openapi::ObjectBuilder::new()
-                        .description(Some(description.to_string()))
-                        .property(
-                            "key",
-                            String::schema(),
-                        )
-                        .required("key")
-                        .property("value", T::schema())
-                        .required("value")
-                        .build(),
-                ))))
+                .schema(Some(utoipa::openapi::RefOr::T(
+                    utoipa::openapi::Schema::Object(
+                        utoipa::openapi::ObjectBuilder::new()
+                            .description(Some(description.to_string()))
+                            .property("key", String::schema())
+                            .required("key")
+                            .property("value", T::schema())
+                            .required("value")
+                            .build(),
+                    ),
+                )))
                 .build(),
         )
-        .build();
-
-    response
+        .build()
 }
 
 /// Add a simple custom response to the OpenAPI spec
-fn make_custom_response_vec<'resp, T: ToSchema>(description: &str) -> Response {
+fn make_custom_response_vec<T: ToSchema>(description: &str) -> Response {
     use utoipa::PartialSchema;
     // Create a simple response with a basic schema
-    let response = utoipa::openapi::ResponseBuilder::new()
+    utoipa::openapi::ResponseBuilder::new()
         .description(description)
         .content(
             "application/json",
             utoipa::openapi::ContentBuilder::new()
-                .schema(Some(utoipa::openapi::RefOr::T(utoipa::openapi::Schema::Object(
-                    utoipa::openapi::ObjectBuilder::new()
-                        .description(Some(description.to_string()))
-                        .property(
-                            "index",
-                            u64::schema(),
-                        )
-                        .required("index")
-                        .property("value", T::schema())
-                        .required("value")
-                        .build(),
-                ))))
+                .schema(Some(utoipa::openapi::RefOr::T(
+                    utoipa::openapi::Schema::Object(
+                        utoipa::openapi::ObjectBuilder::new()
+                            .description(Some(description.to_string()))
+                            .property("index", u64::schema())
+                            .required("index")
+                            .property("value", T::schema())
+                            .required("value")
+                            .build(),
+                    ),
+                )))
                 .build(),
         )
-        .build();
-
-    response
+        .build()
 }
 
 pub fn add_simple_custom_response(spec: &mut OpenApi, response_name: &str, response: Response) {

--- a/crates/module-system/sov-modules-api/tests/integration/rest_api.rs
+++ b/crates/module-system/sov-modules-api/tests/integration/rest_api.rs
@@ -13,7 +13,6 @@ use sov_modules_api::{
 };
 use sov_test_utils::TestSpec;
 use utoipa::openapi::path::ParameterIn;
-use utoipa::openapi::PathItemType;
 
 #[derive(Debug, Clone, borsh::BorshSerialize, borsh::BorshDeserialize)]
 pub struct Foo {
@@ -183,7 +182,7 @@ async fn rest_api_routes() {
     println!("spec.paths.paths: {:#?}", spec.paths.paths);
     assert_eq!(expected_paths_count, spec.paths.paths.len());
     for (path, item) in spec.paths.paths {
-        let get_operation = match item.operations.get(&PathItemType::Get) {
+        let get_operation = match item.get {
             None => {
                 continue;
             }


### PR DESCRIPTION
# Description

This PR updates our utoipa version to 5.0. Unfortunately, v5.0 requires OpenAPI spec version 3.1, which is incompatible with progenitor. Luckily for us, though, we currently only use progenitor for our ledger API client, which uses handwritten specs. So, this PR leaves the handwritten ledger spec at v3.0 and upgrades everything else to 3.1. 

## Linked Issues
- Related to https://github.com/oxidecomputer/progenitor/issues/762
