### PR TITLE
Initial pass at EVM soak testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11911,6 +11911,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sov-evm-soak-testing"
+version = "0.3.0"
+dependencies = [
+ "alloy-primitives",
+ "anyhow",
+ "ethers",
+ "sov-eth-client",
+ "sov-node-client",
+ "sov-test-utils",
+ "tokio",
+]
+
+[[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/utils/sov-build",
     "crates/utils/sov-eip-712",
     "crates/utils/sov-rpc-eth-types",
+    "crates/utils/sov-evm-soak-testing",
     # Module System
     "crates/module-system/sov-cli",
     "crates/module-system/sov-modules-stf-blueprint",

--- a/crates/utils/sov-eth-client/src/lib.rs
+++ b/crates/utils/sov-eth-client/src/lib.rs
@@ -13,7 +13,6 @@ use ethers::core::k256::ecdsa::SigningKey;
 use ethers::core::types::transaction::eip2718::TypedTransaction;
 use ethers::core::types::{Block, Eip1559TransactionRequest, TxHash};
 use ethers::core::types::{Transaction, TransactionReceipt};
-use ethers::middleware::signer::SignerMiddlewareError;
 use ethers::middleware::SignerMiddleware;
 use ethers::providers::{Http, Middleware, PendingTransaction, Provider};
 use ethers::signers::Wallet;
@@ -40,7 +39,7 @@ pub struct TestClient {
     pub client: SignerMiddleware<Provider<Http>, Wallet<SigningKey>>,
     node_client: NodeClient,
     rpc: WsClient,
-    nonce: Arc<AtomicU64>,
+    pub nonce: Arc<AtomicU64>,
 }
 
 async fn pubsub(conn_str: &str) -> RootProvider {
@@ -114,7 +113,7 @@ impl TestClient {
         data: Option<ethers::core::types::Bytes>,
     ) -> TypedTransaction {
         // Get next nonce atomically
-        let nonce = self.nonce.fetch_add(1, Ordering::SeqCst);
+        let nonce = self.nonce.load(Ordering::SeqCst);
         let mut req = self.default_request().nonce(nonce);
 
         if let Some(data) = data {
@@ -132,10 +131,7 @@ impl TestClient {
         &self,
     ) -> Result<PendingTransaction<'_, Http>, Box<dyn std::error::Error>> {
         let typed_transaction = self.make_eip1559_tx(None, Some(self.contract.byte_code()));
-        let receipt_req = self
-            .client
-            .send_transaction(typed_transaction, None)
-            .await?;
+        let receipt_req = self.eth_send_transaction(typed_transaction).await?;
 
         Ok(receipt_req)
     }
@@ -157,7 +153,7 @@ impl TestClient {
             Some(self.contract.set_call_data(set_arg)),
         );
 
-        self.eth_send_transaction(typed_transaction).await
+        self.eth_send_transaction(typed_transaction).await.unwrap()
     }
 
     pub async fn set_values(
@@ -173,12 +169,7 @@ impl TestClient {
                 Some(self.contract.set_call_data(set_arg)),
             );
 
-            requests.push(
-                self.client
-                    .send_transaction(typed_transaction, None)
-                    .await
-                    .unwrap(),
-            );
+            requests.push(self.eth_send_transaction(typed_transaction).await.unwrap());
         }
         requests
     }
@@ -193,10 +184,7 @@ impl TestClient {
             Some(self.contract.set_call_data(set_arg)),
         );
 
-        self.client
-            .send_transaction(typed_transaction, None)
-            .await
-            .unwrap()
+        self.eth_send_transaction(typed_transaction).await.unwrap()
     }
 
     pub async fn set_value_call_and_estimate_gas(
@@ -232,14 +220,11 @@ impl TestClient {
     pub async fn always_reverts(
         &self,
         contract_address: H160,
-    ) -> Result<
-        PendingTransaction<'_, Http>,
-        SignerMiddlewareError<Provider<Http>, Wallet<SigningKey>>,
-    > {
+    ) -> Result<PendingTransaction<'_, Http>, Box<dyn std::error::Error>> {
         let typed_transaction =
             self.make_eip1559_tx(Some(contract_address), Some(self.contract.always_revert()));
 
-        self.client.send_transaction(typed_transaction, None).await
+        self.eth_send_transaction(typed_transaction).await
     }
 
     pub async fn query_contract(
@@ -260,12 +245,13 @@ impl TestClient {
         self.client.get_accounts().await.unwrap()
     }
 
-    pub async fn eth_send_transaction(&self, tx: TypedTransaction) -> PendingTransaction<'_, Http> {
-        self.client
-            .provider()
-            .send_transaction(tx, None)
-            .await
-            .unwrap()
+    pub async fn eth_send_transaction(
+        &self,
+        tx: TypedTransaction,
+    ) -> Result<PendingTransaction<'_, Http>, Box<dyn std::error::Error>> {
+        // Increment nonce
+        let _ = self.nonce.fetch_add(1, Ordering::SeqCst);
+        Ok(self.client.send_transaction(tx, None).await?)
     }
 
     pub async fn eth_chain_id(&self) -> u64 {
@@ -345,10 +331,7 @@ impl TestClient {
         // Set the value for ETH transfer
         typed_transaction.set_value(eth_value);
 
-        self.client
-            .send_transaction(typed_transaction, None)
-            .await
-            .unwrap()
+        self.eth_send_transaction(typed_transaction).await.unwrap()
     }
 
     pub async fn receipt(&self, hash: TxHash) -> Option<TransactionReceipt> {
@@ -364,8 +347,7 @@ impl TestClient {
     pub async fn alloy_deploy_contract(&self) -> alloy_primitives::Address {
         let typed_transaction = self.make_eip1559_tx(None, Some(self.contract.byte_code()));
         let addr = self
-            .client
-            .send_transaction(typed_transaction, None)
+            .eth_send_transaction(typed_transaction)
             .await
             .unwrap()
             .await
@@ -412,8 +394,7 @@ impl TestClient {
         );
 
         let tx_hash = self
-            .client
-            .send_transaction(typed_transaction, None)
+            .eth_send_transaction(typed_transaction)
             .await
             .unwrap()
             .tx_hash();
@@ -435,8 +416,7 @@ impl TestClient {
         );
 
         let tx_hash = self
-            .client
-            .send_transaction(typed_transaction, None)
+            .eth_send_transaction(typed_transaction)
             .await
             .unwrap()
             .tx_hash();

--- a/crates/utils/sov-eth-client/src/lib.rs
+++ b/crates/utils/sov-eth-client/src/lib.rs
@@ -11,7 +11,7 @@ use ethereum_types::H160;
 use ethers::core::abi::Address;
 use ethers::core::k256::ecdsa::SigningKey;
 use ethers::core::types::transaction::eip2718::TypedTransaction;
-use ethers::core::types::{Block, Eip1559TransactionRequest, TransactionRequest, TxHash};
+use ethers::core::types::{Block, Eip1559TransactionRequest, TxHash};
 use ethers::core::types::{Transaction, TransactionReceipt};
 use ethers::middleware::signer::SignerMiddlewareError;
 use ethers::middleware::SignerMiddleware;
@@ -205,25 +205,19 @@ impl TestClient {
     ) -> Result<Bytes, Box<dyn std::error::Error>> {
         let nonce = self.eth_get_transaction_count(self.from_addr).await;
 
-        // Any type of transaction can be used for eth_call
-        let req = TransactionRequest::new()
-            .from(self.from_addr)
-            .to(contract_address)
-            .chain_id(self.chain_id)
-            .nonce(nonce)
-            .data(self.contract.set_call_data(set_arg))
-            .gas_price(10u64);
-
-        let typed_transaction = TypedTransaction::Legacy(req.clone());
-
-        // Estimate gas on RPC
-        let gas = self.eth_estimate_gas(typed_transaction).await;
-
-        // Call with the estimated gas
-        let req = req.gas(gas);
-        let typed_transaction = TypedTransaction::Legacy(req);
-
-        let response = self.eth_call(typed_transaction).await?;
+        let typed_transaction = self.make_eip1559_tx(
+            nonce,
+            Some(contract_address),
+            Some(self.contract.set_call_data(set_arg)),
+        );
+        let gas = self.eth_estimate_gas(typed_transaction.clone()).await;
+        
+        let mut typed_transaction_with_gas = typed_transaction;
+        if let TypedTransaction::Eip1559(ref mut req) = typed_transaction_with_gas {
+            *req = req.clone().gas(gas);
+        }
+        
+        let response = self.eth_call(typed_transaction_with_gas).await?;
 
         Ok(response)
     }
@@ -367,13 +361,12 @@ impl TestClient {
         let nonce = self.eth_get_transaction_count(self.from_addr).await;
         tracing::info!(from = %self.from_addr, nonce, "SmartContract::set_value");
 
-        let req = self
-            .default_request()
-            .nonce(nonce)
-            .to(reciever)
-            .value(eth_value);
-
-        let typed_transaction = TypedTransaction::Eip1559(req);
+        let mut typed_transaction = self.make_eip1559_tx(nonce, Some(reciever), None);
+        
+        // Set the value for ETH transfer
+        if let TypedTransaction::Eip1559(ref mut req) = typed_transaction {
+            *req = req.clone().value(eth_value);
+        }
 
         self.client
             .send_transaction(typed_transaction, None)
@@ -392,7 +385,8 @@ impl TestClient {
 
 impl TestClient {
     pub async fn alloy_deploy_contract(&self) -> alloy_primitives::Address {
-        let typed_transaction = self.make_eip1559_tx(0, None, Some(self.contract.byte_code()));
+        let nonce = self.eth_get_transaction_count(self.from_addr).await;
+        let typed_transaction = self.make_eip1559_tx(nonce, None, Some(self.contract.byte_code()));
         let addr = self
             .client
             .send_transaction(typed_transaction, None)

--- a/crates/utils/sov-eth-client/src/lib.rs
+++ b/crates/utils/sov-eth-client/src/lib.rs
@@ -25,6 +25,8 @@ use jsonrpsee::ws_client::{WsClient, WsClientBuilder};
 use sov_cli::NodeClient;
 use sov_modules_api::{Runtime, Spec};
 use sov_test_utils::SimpleStorageContract;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 const GAS: u64 = 9000000u64;
 const MAX_FEE_PER_GAS: u64 = 100;
@@ -38,6 +40,7 @@ pub struct TestClient {
     pub client: SignerMiddleware<Provider<Http>, Wallet<SigningKey>>,
     node_client: NodeClient,
     rpc: WsClient,
+    nonce: Arc<AtomicU64>,
 }
 
 async fn pubsub(conn_str: &str) -> RootProvider {
@@ -75,14 +78,20 @@ impl TestClient {
             .await
             .unwrap();
 
+        // Fetch initial nonce from the network
+        let from_addr = client.address();
+        let initial_nonce = client.get_transaction_count(from_addr, None).await.unwrap().as_u64();
+        let nonce = Arc::new(AtomicU64::new(initial_nonce));
+
         Self {
             chain_id,
-            from_addr: client.address(),
+            from_addr,
             contract,
             pub_sub,
             client,
             node_client,
             rpc,
+            nonce,
         }
     }
 
@@ -97,10 +106,11 @@ impl TestClient {
 
     fn make_eip1559_tx(
         &self,
-        nonce: u64,
         to_address: Option<Address>,
         data: Option<ethers::core::types::Bytes>,
     ) -> TypedTransaction {
+        // Get next nonce atomically
+        let nonce = self.nonce.fetch_add(1, Ordering::SeqCst);
         let mut req = self.default_request().nonce(nonce);
 
         if let Some(data) = data {
@@ -117,8 +127,7 @@ impl TestClient {
     pub async fn deploy_contract(
         &self,
     ) -> Result<PendingTransaction<'_, Http>, Box<dyn std::error::Error>> {
-        let nonce = self.eth_get_transaction_count(self.from_addr).await;
-        let typed_transaction = self.make_eip1559_tx(nonce, None, Some(self.contract.byte_code()));
+        let typed_transaction = self.make_eip1559_tx(None, Some(self.contract.byte_code()));
         let receipt_req = self
             .client
             .send_transaction(typed_transaction, None)
@@ -128,8 +137,7 @@ impl TestClient {
     }
 
     pub async fn deploy_contract_call(&self) -> Result<Bytes, Box<dyn std::error::Error>> {
-        let nonce = self.eth_get_transaction_count(self.from_addr).await;
-        let typed_transaction = self.make_eip1559_tx(nonce, None, Some(self.contract.byte_code()));
+        let typed_transaction = self.make_eip1559_tx(None, Some(self.contract.byte_code()));
         let receipt_req = self.eth_call(typed_transaction).await?;
 
         Ok(receipt_req)
@@ -140,12 +148,7 @@ impl TestClient {
         contract_address: H160,
         set_arg: u32,
     ) -> PendingTransaction<'_, Http> {
-        // TODO: Re-evaluate if it's still needed after we migrate from ethers
-        let nonce = self.eth_get_transaction_count(self.from_addr).await;
-        tracing::info!(from = %self.from_addr, nonce, "SmartContract::set_value");
-
         let typed_transaction = self.make_eip1559_tx(
-            nonce,
             Some(contract_address),
             Some(self.contract.set_call_data(set_arg)),
         );
@@ -159,11 +162,9 @@ impl TestClient {
         set_args: Vec<u32>,
     ) -> Vec<PendingTransaction<'_, Http>> {
         let mut requests: Vec<_> = Vec::with_capacity(set_args.len());
-        let nonce = self.eth_get_transaction_count(self.from_addr).await;
 
-        for (i, set_arg) in set_args.into_iter().enumerate() {
+        for set_arg in set_args.into_iter() {
             let typed_transaction = self.make_eip1559_tx(
-                nonce + (i as u64),
                 Some(contract_address),
                 Some(self.contract.set_call_data(set_arg)),
             );
@@ -183,11 +184,7 @@ impl TestClient {
         contract_address: H160,
         set_arg: u32,
     ) -> PendingTransaction<'_, Http> {
-        let nonce = self.eth_get_transaction_count(self.from_addr).await;
-        tracing::info!(from = %self.from_addr, nonce, "SmartContract::set_value");
-
         let typed_transaction = self.make_eip1559_tx(
-            nonce,
             Some(contract_address),
             Some(self.contract.set_call_data(set_arg)),
         );
@@ -203,10 +200,7 @@ impl TestClient {
         contract_address: H160,
         set_arg: u32,
     ) -> Result<Bytes, Box<dyn std::error::Error>> {
-        let nonce = self.eth_get_transaction_count(self.from_addr).await;
-
         let typed_transaction = self.make_eip1559_tx(
-            nonce,
             Some(contract_address),
             Some(self.contract.set_call_data(set_arg)),
         );
@@ -226,10 +220,7 @@ impl TestClient {
         &self,
         contract_address: H160,
     ) -> Result<Bytes, Box<dyn std::error::Error>> {
-        let nonce = self.eth_get_transaction_count(self.from_addr).await;
-
         let typed_transaction = self.make_eip1559_tx(
-            nonce,
             Some(contract_address),
             Some(self.contract.failing_function_call_data()),
         );
@@ -244,10 +235,7 @@ impl TestClient {
         PendingTransaction<'_, Http>,
         SignerMiddlewareError<Provider<Http>, Wallet<SigningKey>>,
     > {
-        let nonce = self.eth_get_transaction_count(self.from_addr).await;
-
         let typed_transaction = self.make_eip1559_tx(
-            nonce,
             Some(contract_address),
             Some(self.contract.always_revert()),
         );
@@ -259,10 +247,7 @@ impl TestClient {
         &self,
         contract_address: H160,
     ) -> Result<ethereum_types::U256, Box<dyn std::error::Error>> {
-        let nonce = self.eth_get_transaction_count(self.from_addr).await;
-
         let typed_transaction = self.make_eip1559_tx(
-            nonce,
             Some(contract_address),
             Some(self.contract.get_call_data()),
         );
@@ -358,10 +343,7 @@ impl TestClient {
     }
 
     pub async fn send_eth(&self, reciever: H160, eth_value: u128) -> PendingTransaction<'_, Http> {
-        let nonce = self.eth_get_transaction_count(self.from_addr).await;
-        tracing::info!(from = %self.from_addr, nonce, "SmartContract::set_value");
-
-        let mut typed_transaction = self.make_eip1559_tx(nonce, Some(reciever), None);
+        let mut typed_transaction = self.make_eip1559_tx(Some(reciever), None);
         
         // Set the value for ETH transfer
         if let TypedTransaction::Eip1559(ref mut req) = typed_transaction {
@@ -385,8 +367,7 @@ impl TestClient {
 
 impl TestClient {
     pub async fn alloy_deploy_contract(&self) -> alloy_primitives::Address {
-        let nonce = self.eth_get_transaction_count(self.from_addr).await;
-        let typed_transaction = self.make_eip1559_tx(nonce, None, Some(self.contract.byte_code()));
+        let typed_transaction = self.make_eip1559_tx(None, Some(self.contract.byte_code()));
         let addr = self
             .client
             .send_transaction(typed_transaction, None)
@@ -428,11 +409,7 @@ impl TestClient {
         contract_address: alloy_primitives::Address,
         set_arg: u32,
     ) -> alloy_primitives::TxHash {
-        let nonce = self.eth_get_transaction_count(self.from_addr).await;
-        tracing::info!(from = %self.from_addr, nonce, "SmartContract::set_value");
-
         let typed_transaction = self.make_eip1559_tx(
-            nonce,
             Some(ethers::core::abi::Address::from_slice(
                 contract_address.as_slice(),
             )),
@@ -455,11 +432,7 @@ impl TestClient {
         topic: u32,
         nb_of_logs: u32,
     ) -> alloy_primitives::TxHash {
-        let nonce = self.eth_get_transaction_count(self.from_addr).await;
-        tracing::info!(from = %self.from_addr, nonce, "SmartContract::set_value");
-
         let typed_transaction = self.make_eip1559_tx(
-            nonce,
             Some(ethers::core::abi::Address::from_slice(
                 contract_address.as_slice(),
             )),

--- a/crates/utils/sov-eth-client/src/lib.rs
+++ b/crates/utils/sov-eth-client/src/lib.rs
@@ -204,7 +204,7 @@ impl TestClient {
         contract_address: H160,
         set_arg: u32,
     ) -> Result<Bytes, Box<dyn std::error::Error>> {
-        let typed_transaction = self.make_eip1559_tx(
+        let mut typed_transaction = self.make_eip1559_tx(
             Some(contract_address),
             Some(self.contract.set_call_data(set_arg)),
         );
@@ -212,7 +212,7 @@ impl TestClient {
 
         typed_transaction.set_gas(gas);
 
-        let response = self.eth_call(typed_transaction_with_gas).await?;
+        let response = self.eth_call(typed_transaction).await?;
 
         Ok(response)
     }

--- a/crates/utils/sov-eth-client/src/lib.rs
+++ b/crates/utils/sov-eth-client/src/lib.rs
@@ -117,7 +117,8 @@ impl TestClient {
     pub async fn deploy_contract(
         &self,
     ) -> Result<PendingTransaction<'_, Http>, Box<dyn std::error::Error>> {
-        let typed_transaction = self.make_eip1559_tx(0, None, Some(self.contract.byte_code()));
+        let nonce = self.eth_get_transaction_count(self.from_addr).await;
+        let typed_transaction = self.make_eip1559_tx(nonce, None, Some(self.contract.byte_code()));
         let receipt_req = self
             .client
             .send_transaction(typed_transaction, None)
@@ -127,7 +128,8 @@ impl TestClient {
     }
 
     pub async fn deploy_contract_call(&self) -> Result<Bytes, Box<dyn std::error::Error>> {
-        let typed_transaction = self.make_eip1559_tx(0, None, Some(self.contract.byte_code()));
+        let nonce = self.eth_get_transaction_count(self.from_addr).await;
+        let typed_transaction = self.make_eip1559_tx(nonce, None, Some(self.contract.byte_code()));
         let receipt_req = self.eth_call(typed_transaction).await?;
 
         Ok(receipt_req)

--- a/crates/utils/sov-eth-client/src/lib.rs
+++ b/crates/utils/sov-eth-client/src/lib.rs
@@ -80,7 +80,11 @@ impl TestClient {
 
         // Fetch initial nonce from the network
         let from_addr = client.address();
-        let initial_nonce = client.get_transaction_count(from_addr, None).await.unwrap().as_u64();
+        let initial_nonce = client
+            .get_transaction_count(from_addr, None)
+            .await
+            .unwrap()
+            .as_u64();
         let nonce = Arc::new(AtomicU64::new(initial_nonce));
 
         Self {
@@ -205,12 +209,9 @@ impl TestClient {
             Some(self.contract.set_call_data(set_arg)),
         );
         let gas = self.eth_estimate_gas(typed_transaction.clone()).await;
-        
-        let mut typed_transaction_with_gas = typed_transaction;
-        if let TypedTransaction::Eip1559(ref mut req) = typed_transaction_with_gas {
-            *req = req.clone().gas(gas);
-        }
-        
+
+        typed_transaction.set_gas(gas);
+
         let response = self.eth_call(typed_transaction_with_gas).await?;
 
         Ok(response)
@@ -235,10 +236,8 @@ impl TestClient {
         PendingTransaction<'_, Http>,
         SignerMiddlewareError<Provider<Http>, Wallet<SigningKey>>,
     > {
-        let typed_transaction = self.make_eip1559_tx(
-            Some(contract_address),
-            Some(self.contract.always_revert()),
-        );
+        let typed_transaction =
+            self.make_eip1559_tx(Some(contract_address), Some(self.contract.always_revert()));
 
         self.client.send_transaction(typed_transaction, None).await
     }
@@ -247,10 +246,8 @@ impl TestClient {
         &self,
         contract_address: H160,
     ) -> Result<ethereum_types::U256, Box<dyn std::error::Error>> {
-        let typed_transaction = self.make_eip1559_tx(
-            Some(contract_address),
-            Some(self.contract.get_call_data()),
-        );
+        let typed_transaction =
+            self.make_eip1559_tx(Some(contract_address), Some(self.contract.get_call_data()));
 
         let response = self.client.call(&typed_transaction, None).await?;
 
@@ -344,11 +341,9 @@ impl TestClient {
 
     pub async fn send_eth(&self, reciever: H160, eth_value: u128) -> PendingTransaction<'_, Http> {
         let mut typed_transaction = self.make_eip1559_tx(Some(reciever), None);
-        
+
         // Set the value for ETH transfer
-        if let TypedTransaction::Eip1559(ref mut req) = typed_transaction {
-            *req = req.clone().value(eth_value);
-        }
+        typed_transaction.set_value(eth_value);
 
         self.client
             .send_transaction(typed_transaction, None)

--- a/crates/utils/sov-evm-soak-testing/Cargo.toml
+++ b/crates/utils/sov-evm-soak-testing/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "sov-evm-soak-testing"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+publish.workspace = true
+repository.workspace = true
+
+[dependencies]
+sov-node-client = { workspace = true }
+sov-eth-client = { workspace = true }
+tokio = { workspace = true }
+anyhow = { workspace = true }
+ethers = { workspace = true }
+alloy-primitives = { workspace = true }
+sov-test-utils = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -1,0 +1,64 @@
+use anyhow::Result;
+use ethers::types::TransactionReceipt;
+use sov_eth_client::TestClient;
+use sov_test_utils::SimpleStorageContract;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::time::{sleep, Duration};
+
+async fn await_and_print_receipt<E>(
+    tx_id: u32,
+    pending_tx: impl std::future::Future<Output = Result<Option<TransactionReceipt>, E>>,
+) where
+    E: std::fmt::Debug,
+{
+    match pending_tx.await {
+        Ok(Some(receipt)) => println!(
+            "TX {}: Gas: {:?} Block: {:?}",
+            tx_id,
+            receipt.gas_used.unwrap(),
+            receipt.block_number.unwrap()
+        ),
+        Ok(None) => println!("TX {}: No receipt received", tx_id),
+        Err(e) => println!("TX {}: Error - {:?}", tx_id, e),
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let rpc_addr: SocketAddr = "127.0.0.1:12346".parse()?;
+    let chain_id = 4321;
+    let private_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    let contract = SimpleStorageContract::default();
+    let test_client = Arc::new(TestClient::new(chain_id, private_key, contract, rpc_addr).await);
+
+    let deploy_receipt = test_client
+        .deploy_contract()
+        .await
+        .map_err(|e| anyhow::anyhow!("Deploy contract failed: {:?}", e))?
+        .await?
+        .unwrap();
+    let contract_address = deploy_receipt.contract_address.unwrap();
+
+    println!("Contract deployed at: {:?}", contract_address);
+
+    let mut handles = Vec::new();
+    for i in 1..=10 {
+        let client = Arc::clone(&test_client);
+        let handle = tokio::spawn(async move {
+            let pending_tx = client.set_value(contract_address, i).await;
+            await_and_print_receipt(i, pending_tx).await;
+        });
+        handles.push(handle);
+        // Small delay between sending transactions to avoid overwhelming
+        sleep(Duration::from_millis(10)).await;
+        if i % 10 == 0 {
+            println!("Sent {} transactions...", i);
+        }
+    }
+    println!("All transactions sent, waiting for receipts...");
+    for handle in handles {
+        let _ = handle.await;
+    }
+    Ok(())
+}

--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -1,10 +1,7 @@
 use anyhow::Result;
-use ethers::types::TransactionReceipt;
 use sov_eth_client::TestClient;
 use sov_test_utils::SimpleStorageContract;
 use std::net::SocketAddr;
-use std::sync::Arc;
-use tokio::time::{sleep, Duration};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -12,7 +9,7 @@ async fn main() -> Result<()> {
     let chain_id = 4321;
     let private_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
     let contract = SimpleStorageContract::default();
-    let client = Arc::new(TestClient::new(chain_id, private_key, contract, rpc_addr).await);
+    let client = TestClient::new(chain_id, private_key, contract, rpc_addr).await;
 
     let deploy_receipt = client
         .deploy_contract()

--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -6,33 +6,15 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::time::{sleep, Duration};
 
-async fn await_and_print_receipt<E>(
-    tx_id: u32,
-    pending_tx: impl std::future::Future<Output = Result<Option<TransactionReceipt>, E>>,
-) where
-    E: std::fmt::Debug,
-{
-    match pending_tx.await {
-        Ok(Some(receipt)) => println!(
-            "TX {}: Gas: {:?} Block: {:?}",
-            tx_id,
-            receipt.gas_used.unwrap(),
-            receipt.block_number.unwrap()
-        ),
-        Ok(None) => println!("TX {}: No receipt received", tx_id),
-        Err(e) => println!("TX {}: Error - {:?}", tx_id, e),
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     let rpc_addr: SocketAddr = "127.0.0.1:12346".parse()?;
     let chain_id = 4321;
     let private_key = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
     let contract = SimpleStorageContract::default();
-    let test_client = Arc::new(TestClient::new(chain_id, private_key, contract, rpc_addr).await);
+    let client = Arc::new(TestClient::new(chain_id, private_key, contract, rpc_addr).await);
 
-    let deploy_receipt = test_client
+    let deploy_receipt = client
         .deploy_contract()
         .await
         .map_err(|e| anyhow::anyhow!("Deploy contract failed: {:?}", e))?
@@ -42,23 +24,18 @@ async fn main() -> Result<()> {
 
     println!("Contract deployed at: {:?}", contract_address);
 
-    let mut handles = Vec::new();
-    for i in 1..=10 {
-        let client = Arc::clone(&test_client);
-        let handle = tokio::spawn(async move {
-            let pending_tx = client.set_value(contract_address, i).await;
-            await_and_print_receipt(i, pending_tx).await;
-        });
-        handles.push(handle);
-        // Small delay between sending transactions to avoid overwhelming
-        sleep(Duration::from_millis(10)).await;
-        if i % 10 == 0 {
-            println!("Sent {} transactions...", i);
+    for i in 1..=1000 {
+        let pending_tx = client.set_value(contract_address, i).await;
+        match pending_tx.await {
+            Ok(Some(receipt)) => println!(
+                "TX {}: Gas: {:?} Block: {:?}",
+                i,
+                receipt.gas_used.unwrap(),
+                receipt.block_number.unwrap()
+            ),
+            Ok(None) => println!("TX {}: No receipt received", i),
+            Err(e) => println!("TX {}: Error - {:?}", i, e),
         }
-    }
-    println!("All transactions sent, waiting for receipts...");
-    for handle in handles {
-        let _ = handle.await;
     }
     Ok(())
 }

--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,11 @@ license-files = [{ path = "COPYING", hash = 0x106164e0 }]
 
 # Sovereign SDK packages use a custom community license
 [[licenses.clarify]]
+name = "sov-evm-soak-testing"
+expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
+license-files = []
+
+[[licenses.clarify]]
 name = "sov-rpc-eth-types"
 expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
 license-files = []


### PR DESCRIPTION
# Description

So the goal here is to generate some synthetic load on the EVM module to later profile - which parts consume how much time.

This first iteration:
* Deploys the test contract
* Calls set_value 1000 times

I've tried to do it without awaiting receipts and got nonce issues as I was sending transactions faster than the sequencer was processing them.
Now I do await receipts but it's too slow as I guess ethers waits for at least one confirmation so I can only send 1 transaction in a block.
Will figure out a way to speed it up in the next PR.
Will also generate more complex usage patterns.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
