### PR TITLE
Add standard authentication to Eip712Authenticator

### DIFF
--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
@@ -141,12 +141,12 @@ pub fn sign_utx<S: Spec, RT: Runtime<S>>(
         .unwrap();
 
     let utx_bytes = borsh::to_vec(&utx).expect("Failed to serialize unsigned transaction");
-    let eip712_hash = schema
-        .eip712_signing_hash(transaction_type_index, &utx_bytes)
+    let eip712_signing_data = schema
+        .eip712_signing_digest(transaction_type_index, &utx_bytes)
         .expect("Failed to calculate EIP712 hash");
 
     let pk = signer.private_key();
-    let signature = pk.sign(&eip712_hash);
+    let signature = pk.sign(&eip712_signing_data);
     utx.to_signed_tx(pk.pub_key(), signature)
 }
 

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
@@ -1,5 +1,7 @@
 use sov_address::{EthereumAddress, EvmCryptoSpec};
 use sov_evm::Eip712Authenticator;
+use sov_evm::Eip712AuthenticatorInput;
+use sov_evm::Eip712AuthenticatorTrait;
 use sov_evm::SchemaProvider;
 use sov_mock_da::{MockBlob, MockDaSpec};
 use sov_mock_zkvm::MockZkvm;
@@ -91,6 +93,13 @@ generate_runtime! {
     auth_type: Eip712Authenticator<S, TestRuntime<S>, TestSchemaProvider>,
     auth_call_wrapper: |call| call,
 }
+
+impl Eip712AuthenticatorTrait<S> for TestRuntime<S> {
+    fn add_eip712_auth(tx: RawTx) -> <Self::Auth as TransactionAuthenticator<S>>::Input {
+        Eip712AuthenticatorInput::Eip712(tx)
+    }
+}
+
 type RT = TestRuntime<S>;
 
 fn setup() -> (TestRunner<RT, S>, TestUser<S>) {
@@ -157,9 +166,11 @@ pub fn encode_message<S: Spec, RT: Runtime<S> + EncodeCall<ValueSetter<S>>>() ->
     RT::to_decodable(msg)
 }
 
-pub fn encode<S: Spec, RT: Runtime<S>>(tx: Transaction<RT, S>) -> FullyBakedTx {
+pub fn encode<S: Spec, RT: Runtime<S> + Eip712AuthenticatorTrait<S>>(
+    tx: Transaction<RT, S>,
+) -> FullyBakedTx {
     let raw_tx = RawTx::new(borsh::to_vec(&tx).unwrap());
-    RT::Auth::encode_with_standard_auth(raw_tx)
+    <RT as Eip712AuthenticatorTrait<S>>::encode_with_eip712_auth(raw_tx)
 }
 
 fn execute_tx(

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -24,7 +24,9 @@ use sov_rollup_interface::TxHash;
 use sov_state::User;
 
 mod eip712;
-pub use eip712::{Eip712Authenticator, SchemaProvider};
+pub use eip712::{
+    Eip712Authenticator, Eip712AuthenticatorInput, Eip712AuthenticatorTrait, SchemaProvider,
+};
 
 use crate::conversions::RlpConversionError;
 use crate::TransactionSigned;

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
@@ -267,7 +267,7 @@ fn verify_eip712_signature<
         ))?;
 
     let eip712_hash = schema
-        .eip712_signing_hash(transaction_type_index, &unsigned_tx_bytes)
+        .eip712_signing_digest(transaction_type_index, &unsigned_tx_bytes)
         .map_err(|e| {
             AuthenticationError::FatalError(
                 FatalError::SigVerificationFailed(format!("Failed to calculate EIP712 hash: {e}")),

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate/eip712.rs
@@ -1,6 +1,7 @@
 use std::marker::PhantomData;
 use std::sync::OnceLock;
 
+use borsh::{BorshDeserialize, BorshSerialize};
 use sov_address::EvmCryptoSpec;
 use sov_modules_api::capabilities::{
     self, calculate_hash_metered, extract_authorization_data, verify_chain_id, AuthenticationError,
@@ -13,7 +14,7 @@ use sov_modules_api::transaction::{
 };
 use sov_modules_api::{
     DispatchCall, FullyBakedTx, GasMeter, MeteredBorshDeserialize, MeteredBorshDeserializeError,
-    ProvableStateReader, RawTx, Spec, TxHash,
+    ProvableStateReader, RawTx, Runtime, Spec, TxHash,
 };
 use sov_state::User;
 
@@ -36,26 +37,56 @@ pub trait SchemaProvider {
     }
 }
 
+/// Indicates that a runtime supports the Eip712 transaction authenticator
+/// and provides suitable methods for encoding and decoding EIP712-signed transactions.
+pub trait Eip712AuthenticatorTrait<S: Spec>: Runtime<S> {
+    /// Add the Solana offchain discriminant to a transaction the runtime.
+    fn add_eip712_auth(tx: RawTx) -> <Self::Auth as TransactionAuthenticator<S>>::Input;
+
+    /// Encode a transaction with the Solana offchain discriminant for the runtime.
+    fn encode_with_eip712_auth(tx: RawTx) -> FullyBakedTx {
+        <Self::Auth as TransactionAuthenticator<S>>::encode_authenticator_input(
+            &Self::add_eip712_auth(tx),
+        )
+    }
+}
+
 /// EIP-712-compatible transaction authenticator. See [`TransactionAuthenticator`].
 pub struct Eip712Authenticator<S, D, SP>(PhantomData<(S, D, SP)>);
 
-impl<S, D, SP> TransactionAuthenticator<S> for Eip712Authenticator<S, D, SP>
+/// See [`TransactionAuthenticator::Input`].
+#[derive(std::fmt::Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub enum Eip712AuthenticatorInput {
+    /// Authenticate using EIP712 an signature.
+    Eip712(RawTx),
+    /// Authenticate using the standard `sov-module` authenticator.
+    Standard(RawTx),
+}
+
+impl<S, Rt, SP> TransactionAuthenticator<S> for Eip712Authenticator<S, Rt, SP>
 where
     S: Spec<CryptoSpec = EvmCryptoSpec>,
-    D: DispatchCall<Spec = S>,
+    Rt: Runtime<S> + DispatchCall<Spec = S>,
     SP: SchemaProvider,
 {
-    type Decodable = D::Decodable;
-    type Input = RawTx;
+    type Decodable = Rt::Decodable;
+    type Input = Eip712AuthenticatorInput;
 
     #[cfg(feature = "native")]
     fn decode_serialized_tx(
         tx: &FullyBakedTx,
     ) -> Result<Self::Decodable, sov_modules_api::capabilities::FatalError> {
-        let tx: RawTx = borsh::from_slice(&tx.data)
-            .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
+        let auth_variant: Eip712AuthenticatorInput = borsh::from_slice(&tx.data).map_err(|e| {
+            sov_modules_api::capabilities::FatalError::DeserializationFailed(e.to_string())
+        })?;
 
-        capabilities::decode_sov_tx::<S, D>(&tx.data)
+        match auth_variant {
+            Eip712AuthenticatorInput::Standard(raw_tx)
+            | Eip712AuthenticatorInput::Eip712(raw_tx) => {
+                let call = sov_modules_api::capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)?;
+                Ok(call)
+            }
+        }
     }
 
     fn authenticate<Accessor: ProvableStateReader<User, Spec = S>>(
@@ -65,21 +96,35 @@ where
         capabilities::AuthenticationOutput<S, Self::Decodable>,
         capabilities::AuthenticationError,
     > {
-        let tx: RawTx = borsh::from_slice(&tx.data).map_err(|e| {
-            capabilities::fatal_deserialization_error::<_, S, _>(&tx.data, e, state)
+        let input: Eip712AuthenticatorInput = borsh::from_slice(&tx.data).map_err(|e| {
+            sov_modules_api::capabilities::fatal_deserialization_error::<_, S, _>(
+                &tx.data, e, state,
+            )
         })?;
 
-        authenticate::<_, S, D, SP>(&tx.data, state)
+        match input {
+            Eip712AuthenticatorInput::Eip712(tx) => authenticate::<_, S, Rt, SP>(&tx.data, state),
+            Eip712AuthenticatorInput::Standard(tx) => {
+                sov_modules_api::capabilities::authenticate::<_, S, Rt>(
+                    &tx.data,
+                    &Rt::CHAIN_HASH,
+                    state,
+                )
+            }
+        }
     }
 
     #[cfg(feature = "native")]
     fn compute_tx_hash(
         tx: &sov_modules_api::FullyBakedTx,
     ) -> anyhow::Result<sov_modules_api::TxHash> {
-        use sov_modules_api::capabilities::calculate_hash;
+        let input: Eip712AuthenticatorInput = borsh::from_slice(&tx.data)?;
 
-        let tx: RawTx = borsh::from_slice(&tx.data)?;
-        Ok(calculate_hash::<S>(&tx.data))
+        match input {
+            Eip712AuthenticatorInput::Eip712(tx) | Eip712AuthenticatorInput::Standard(tx) => {
+                Ok(sov_modules_api::capabilities::calculate_hash::<S>(&tx.data))
+            }
+        }
     }
 
     fn authenticate_unregistered<Accessor: ProvableStateReader<User, Spec = S>>(
@@ -89,14 +134,41 @@ where
         capabilities::AuthenticationOutput<S, Self::Decodable>,
         capabilities::UnregisteredAuthenticationError,
     > {
-        let tx: RawTx = borsh::from_slice(&batch.tx.data)
-            .map_err(|_| UnregisteredAuthenticationError::InvalidAuthenticationDiscriminant)?;
+        let Self::Input::Standard(input) = borsh::from_slice(&batch.tx.data)
+            .map_err(|_| UnregisteredAuthenticationError::InvalidAuthenticationDiscriminant)?
+        else {
+            return Err(UnregisteredAuthenticationError::InvalidAuthenticationDiscriminant);
+        };
 
-        Ok(authenticate::<_, S, D, SP>(&tx.data, state)?)
+        let (tx_and_raw_hash, auth_data, runtime_call) =
+            sov_modules_api::capabilities::authenticate::<_, S, Rt>(
+                &input.data,
+                &Rt::CHAIN_HASH,
+                state,
+            )
+            .map_err(|e| match e {
+                AuthenticationError::FatalError(err, hash) => {
+                    UnregisteredAuthenticationError::FatalError(err, hash)
+                }
+                AuthenticationError::OutOfGas(err) => {
+                    UnregisteredAuthenticationError::OutOfGas(err)
+                }
+            })?;
+
+        if Rt::allow_unregistered_tx(&runtime_call) {
+            Ok((tx_and_raw_hash, auth_data, runtime_call))
+        } else {
+            Err(UnregisteredAuthenticationError::FatalError(
+                FatalError::Other(
+                    "The runtime call included in the transaction was invalid.".to_string(),
+                ),
+                tx_and_raw_hash.raw_tx_hash,
+            ))?
+        }
     }
 
     fn add_standard_auth(tx: RawTx) -> Self::Input {
-        tx
+        Eip712AuthenticatorInput::Standard(tx)
     }
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/lib.rs
@@ -33,8 +33,9 @@ mod helpers;
 use alloy_primitives::U256;
 use alloy_primitives::{Address, B256};
 pub use authenticate::{
-    authenticate, decode_evm_tx, Eip712Authenticator, EthereumAuthenticator, EvmAuthenticator,
-    EvmAuthenticatorInput, SchemaProvider,
+    authenticate, decode_evm_tx, Eip712Authenticator, Eip712AuthenticatorInput,
+    Eip712AuthenticatorTrait, EthereumAuthenticator, EvmAuthenticator, EvmAuthenticatorInput,
+    SchemaProvider,
 };
 pub use revm::primitives::hardfork::SpecId;
 use sov_address::{EthereumAddress, FromVmAddress};

--- a/crates/universal-wallet/schema/src/schema/mod.rs
+++ b/crates/universal-wallet/schema/src/schema/mod.rs
@@ -362,6 +362,8 @@ impl Schema {
         Ok(output)
     }
 
+    /// EIP712-compatible JSON encoding of an object, which can be used directly as a parameter
+    /// for `eth_signTypedData_v4` RPCs.
     #[cfg(feature = "eip712")]
     pub fn eip712_json(&self, type_index: usize, input: &[u8]) -> Result<String, SchemaError> {
         let Some(typed_data) = self.eip712_get_typed_data_inner(type_index, input)? else {
@@ -370,6 +372,8 @@ impl Schema {
         Ok(serde_json::to_string(&typed_data)?)
     }
 
+    /// The EIP712 signing hash of an object, corresponding to its `eip712_json` encoding.
+    /// This hash should be signed directly with a secp256k1 key to obtain the EIP712 signature.
     #[cfg(feature = "eip712")]
     pub fn eip712_signing_hash(
         &self,
@@ -380,6 +384,28 @@ impl Schema {
             return Ok(Default::default());
         };
         Ok(typed_data.eip712_signing_hash()?.into())
+    }
+
+    /// The unashed EIP712 signing digest of an object, corresponding to its `eip712_json` encoding.
+    /// This value needs to be keccak256 hashed then secp256k1 signed to obtain the EIP712 signature.
+    #[cfg(feature = "eip712")]
+    pub fn eip712_signing_digest(
+        &self,
+        type_index: usize,
+        input: &[u8],
+    ) -> Result<[u8; 66], SchemaError> {
+        let Some(typed_data) = self.eip712_get_typed_data_inner(type_index, input)? else {
+            return Ok([0; 66]);
+        };
+        // References:
+        // - https://eips.ethereum.org/EIPS/eip-712#specification-of-the-eth_signtypeddata-json-rpc
+        // - https://github.com/alloy-rs/core/blob/main/crates/dyn-abi/src/eip712/typed_data.rs#L212
+        let mut buf = [0u8; 66];
+        buf[0] = 0x19;
+        buf[1] = 0x01;
+        buf[2..34].copy_from_slice(typed_data.domain.separator().as_slice());
+        buf[34..].copy_from_slice(typed_data.hash_struct()?.as_slice());
+        Ok(buf)
     }
 
     #[cfg(feature = "eip712")]


### PR DESCRIPTION
# Description

Extends the EIP712 authenticator to accept an enum of transaction types and adds support for standard sov transactions, similarly to the EVM and Solana authenticators.

Also fixes a double-hashing bug in the authenticator, by exposing a method to get the raw (unhashed) EIP712 digest from the schema. See #1755.

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [ ] ~~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
