### PR TITLE
fix: pkg handling for names with spaces and special characters

### DIFF
--- a/scripts/validate_packages_to_publish_yml.sh
+++ b/scripts/validate_packages_to_publish_yml.sh
@@ -27,30 +27,30 @@ echo ""
 echo "Validating packages_to_publish.yml..."
 
 status=0
-while read -r pkg; do
-    if yq -e "[\"$pkg\"] - . | length == 1" packages_to_publish.yml > /dev/null 2>&1; then
+while IFS= read -r pkg; do
+    if yq -e --arg pkg "$pkg" '[ $pkg ] - . | length == 1' packages_to_publish.yml > /dev/null 2>&1; then
         printf "%40s | ERR is releasable but NOT found in packages_to_publish.yml\n" "$pkg"
-		status=1
-	fi
+        status=1
+    fi
 done <<< "$releasable_packages"
 
 echo ""
 echo "Validating the presence of package metadata for all packages_to_publish.yml entries..."
 
-while read -r pkg; do
-	# Capture both stdout and stderr.
-	output=$(cargo package --allow-dirty -p $pkg --list 2>&1)
+while IFS= read -r pkg; do
+    # Capture both stdout and stderr.
+    output=$(cargo package --allow-dirty -p "$pkg" --list 2>&1)
     if echo "$output" | grep -q "warning:"; then
         printf "%40s | ERR warnings found:\n" "$pkg"
-		echo "$output" | grep "warning:"
-		status=1
-	fi
+        echo "$output" | grep "warning:"
+        status=1
+    fi
 done < <(yq '.[]' packages_to_publish.yml)
 
 echo ""
 if [ $status -eq 1 ]; then
-	echo "Validation failed."
-	exit 1
+    echo "Validation failed."
+    exit 1
 fi
 
 echo "Validation successful, everything okay."


### PR DESCRIPTION
# Description

some packages weren’t handled correctly when their names had spaces or special characters.  

this update:  
- uses `IFS=` in the `read` loop to preserve spaces and tabs.  
- passes package names safely to `yq`.  
- quotes `$pkg` in `cargo package` to avoid errors.  

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing

## Docs