### PR TITLE
Generalizing sov-benchmarks to support NOMT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2025-09-21
 - #1729 Adds optional `num_cache_warmup_workers` to `xxx_rollup_config.toml`. This field specifies the number of workers responsible for warming up the executor cache in the preferred sequencer.
+- #1752 Changes in benchmark for sov-demo-rollup
 
 # 2025-09-19
 - #1723 **Breaking change** Introduced an optional `[sequencer.extension]` section in the rollup config, this section is required for `EVM` rollups.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11449,6 +11449,7 @@ dependencies = [
  "sov-risc0-adapter",
  "sov-rollup-interface",
  "sov-sp1-adapter",
+ "sov-state",
  "sov-test-modules",
  "sov-test-utils",
  "sov-transaction-generator",

--- a/examples/demo-rollup/sov-benchmarks/Cargo.toml
+++ b/examples/demo-rollup/sov-benchmarks/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 sov-rollup-interface = { workspace = true, features = ["arbitrary"] }
 sov-modules-api = { workspace = true, features = ["arbitrary", "bench", "native"] }
 sov-capabilities = { workspace = true }
+sov-state = { workspace = true }
 
 sov-test-modules = { workspace = true, features = ["native"] }
 sov-test-utils = { workspace = true, features = ["arbitrary"] }

--- a/examples/demo-rollup/sov-benchmarks/src/lib.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/lib.rs
@@ -22,7 +22,7 @@ use sov_test_utils::runtime::sov_paymaster::{
     self, PayeePolicy, PayerGenesisConfig, PaymasterPolicyInitializer, SafeVec,
 };
 use sov_test_utils::runtime::TestRunner;
-use sov_test_utils::storage::{ForklessStorageManager, SimpleStorageManager};
+use sov_test_utils::storage::ForklessStorageManager;
 use sov_test_utils::{MockDaSpec, MockZkvm, TestPreferredSequencer, TestProver, TestUser};
 
 pub const DEFAULT_BLOCK_TIME_MS: u64 = 150;
@@ -66,8 +66,6 @@ pub type NomtBenchSpec = ConfigurableSpec<
 >;
 
 type RT<S> = Runtime<S>;
-
-type Runner<S> = TestRunner<RT<S>, S>;
 
 /// Benchmark user roles
 pub struct Roles<S: Spec> {
@@ -161,17 +159,26 @@ where
 }
 
 /// Setups benchmarks and returns the [`TestRunner`] along with benchmark roles
-pub fn setup_with_runner<Vm: Zkvm>(
+pub fn setup_with_runner<S, Vm, Sm>(
     num_senders: u64,
     inner_code_commitment: <Vm::Verifier as ZkVerifier>::CodeCommitment,
-) -> (Runner<BenchSpec<Vm>>, Roles<BenchSpec<Vm>>)
+) -> (TestRunner<RT<S>, S, Sm>, Roles<S>)
 where
+    Vm: Zkvm,
+    S: Spec<
+        InnerZkvm = Vm,
+        OuterZkvm = MockZkvm,
+        Da = MockDaSpec,
+        Address = MultiAddressEvm,
+        Storage = Sm::Storage,
+    >,
     <Vm::Verifier as ZkVerifier>::CryptoSpec: CryptoSpecExt,
+    Sm: ForklessStorageManager,
 {
-    let (genesis_config, roles) = setup(num_senders, inner_code_commitment);
+    let (genesis_config, roles) = setup::<S, Vm>(num_senders, inner_code_commitment);
 
     (
-        TestRunner::<_, _, SimpleStorageManager<_>>::new_with_genesis(
+        TestRunner::<_, _, Sm>::new_with_genesis(
             genesis_config.into_genesis_params(),
             Default::default(),
         ),

--- a/examples/demo-rollup/sov-benchmarks/src/lib.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/lib.rs
@@ -3,6 +3,7 @@
 use core::time::Duration;
 use std::sync::Arc;
 
+use crate::sov_paymaster::PaymasterConfig;
 use demo_stf::genesis_config::EvmGenesisConfig;
 use demo_stf::runtime::{GenesisConfig, Runtime};
 use sov_address::MultiAddressEvm;
@@ -11,20 +12,18 @@ use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::Native;
 use sov_modules_api::{Amount, CryptoSpecExt, Spec, ZkVerifier, Zkvm};
 use sov_risc0_adapter::Risc0;
-use sov_rollup_interface::zk::ZkvmHost;
+use sov_rollup_interface::da::DaSpec;
 use sov_sp1_adapter::SP1;
+use sov_state::nomt::prover_storage::NomtProverStorage;
+use sov_state::DefaultStorageSpec;
 use sov_test_modules::access_pattern::AccessPatternGenesisConfig;
 use sov_test_utils::runtime::genesis::zk::config::HighLevelZkGenesisConfig;
 use sov_test_utils::runtime::sov_paymaster::{
     self, PayeePolicy, PayerGenesisConfig, PaymasterPolicyInitializer, SafeVec,
 };
 use sov_test_utils::runtime::TestRunner;
-use sov_test_utils::test_rollup::{GenesisSource, RollupBuilder, TestRollup};
-use sov_test_utils::{
-    MockDaSpec, MockZkvm, RtAgnosticBlueprint, TestPreferredSequencer, TestProver, TestUser,
-};
-
-use crate::sov_paymaster::PaymasterConfig;
+use sov_test_utils::storage::{ForklessStorageManager, SimpleStorageManager};
+use sov_test_utils::{MockDaSpec, MockZkvm, TestPreferredSequencer, TestProver, TestUser};
 
 pub const DEFAULT_BLOCK_TIME_MS: u64 = 150;
 pub const DEFAULT_BLOCK_PRODUCING_CONFIG: BlockProducingConfig = BlockProducingConfig::Periodic {
@@ -50,11 +49,25 @@ pub type BenchRisc0Spec = BenchSpec<Risc0>;
 /// [`ConfigurableSpec`] with [`MockDaSpec`] and a [`SP1`] inner vm
 pub type BenchSP1Spec = BenchSpec<SP1>;
 
+/// [`ConfigurableSpec`] with [`MockDaSpec`] and a custom inner vm
+pub type NomtBenchSpec = ConfigurableSpec<
+    MockDaSpec,
+    MockZkvm,
+    MockZkvm,
+    MultiAddressEvm,
+    Native,
+    <<MockZkvm as Zkvm>::Verifier as ZkVerifier>::CryptoSpec,
+    NomtProverStorage<
+        DefaultStorageSpec<
+            <<<MockZkvm as Zkvm>::Verifier as ZkVerifier>::CryptoSpec as sov_rollup_interface::zk::CryptoSpec>::Hasher,
+        >,
+        <MockDaSpec as DaSpec>::SlotHash,
+    >,
+>;
+
 type RT<S> = Runtime<S>;
 
 type Runner<S> = TestRunner<RT<S>, S>;
-
-type RollupBlueprint<S> = RtAgnosticBlueprint<S, RT<S>>;
 
 /// Benchmark user roles
 pub struct Roles<S: Spec> {
@@ -71,11 +84,13 @@ pub struct Roles<S: Spec> {
 }
 
 /// Setups benchmarks and returns the genesis config along with benchmark roles
-pub fn setup<Vm: Zkvm>(
+pub fn setup<S, Vm>(
     num_senders: u64,
     inner_code_commitment: <Vm::Verifier as ZkVerifier>::CodeCommitment,
-) -> (GenesisConfig<BenchSpec<Vm>>, Roles<BenchSpec<Vm>>)
+) -> (GenesisConfig<S>, Roles<S>)
 where
+    S: Spec<InnerZkvm = Vm, OuterZkvm = MockZkvm, Da = MockDaSpec, Address = MultiAddressEvm>,
+    Vm: Zkvm,
     <Vm::Verifier as ZkVerifier>::CryptoSpec: CryptoSpecExt,
 {
     let mut genesis_config =
@@ -145,7 +160,7 @@ where
     )
 }
 
-/// Setups benchmarks and returns the a [`TestRunner`] along with benchmark roles
+/// Setups benchmarks and returns the [`TestRunner`] along with benchmark roles
 pub fn setup_with_runner<Vm: Zkvm>(
     num_senders: u64,
     inner_code_commitment: <Vm::Verifier as ZkVerifier>::CodeCommitment,
@@ -156,7 +171,7 @@ where
     let (genesis_config, roles) = setup(num_senders, inner_code_commitment);
 
     (
-        TestRunner::<_, _>::new_with_genesis(
+        TestRunner::<_, _, SimpleStorageManager<_>>::new_with_genesis(
             genesis_config.into_genesis_params(),
             Default::default(),
         ),
@@ -164,39 +179,31 @@ where
     )
 }
 
-/// Setups benchmarks and returns the a [`TestRollup`] along with benchmark roles
-pub async fn setup_with_rollup<Vm: Zkvm>(
+pub fn setup_with_runner_and_spec<Vm, Sm, S>(
     num_senders: u64,
-    host_args: Arc<<Vm::Host as ZkvmHost>::HostArgs>,
     inner_code_commitment: <Vm::Verifier as ZkVerifier>::CodeCommitment,
-) -> (
-    TestRollup<RollupBlueprint<BenchSpec<Vm>>>,
-    Roles<BenchSpec<Vm>>,
-)
+) -> (TestRunner<RT<S>, S, Sm>, Roles<S>)
 where
+    Vm: Zkvm,
     <Vm::Verifier as ZkVerifier>::CryptoSpec: CryptoSpecExt,
+    Sm: ForklessStorageManager,
+    S: Spec<
+        InnerZkvm = Vm,
+        OuterZkvm = MockZkvm,
+        Da = MockDaSpec,
+        Address = MultiAddressEvm,
+        Storage = Sm::Storage,
+    >,
 {
-    let (genesis_config, roles) = setup(num_senders, inner_code_commitment);
+    let (genesis_config, roles) = setup::<S, Vm>(num_senders, inner_code_commitment);
 
-    let rollup_builder = RollupBuilder::new(
-        GenesisSource::CustomParams(genesis_config.into_genesis_params()),
-        DEFAULT_BLOCK_PRODUCING_CONFIG,
-        DEFAULT_FINALIZATION_BLOCKS,
+    (
+        TestRunner::<RT<S>, S, Sm>::new_with_genesis(
+            genesis_config.into_genesis_params(),
+            Default::default(),
+        ),
+        roles,
     )
-    .with_zkvm_host_args(host_args)
-    .set_config(|config| {
-        config.prover_address = roles.prover.user_info.address().to_string();
-    })
-    .set_da_config(|da_config| {
-        da_config.sender_address = roles.preferred_sequencer.sequencer_info.da_address;
-    });
-
-    let rollup = rollup_builder
-        .start()
-        .await
-        .expect("Impossible to start rollup");
-
-    (rollup, roles)
 }
 
 /// Returns the risc0 host arguments for a rollup with mock da. This is the code that is zk-proven by the rollup

--- a/examples/demo-rollup/sov-benchmarks/src/node/Makefile
+++ b/examples/demo-rollup/sov-benchmarks/src/node/Makefile
@@ -17,6 +17,12 @@ basic:
 	@echo "Output: Standard"
 	@cd ../.. && cargo bench --bench=rollup_coarse_measure
 
+basic-nomt:
+	@echo "Running basic benchmark with $(SOV_BENCH_BLOCKS) blocks and $(SOV_BENCH_TXNS_PER_BLOCKS) transactions per block and NOMT"
+	@echo "Method: Coarse Timers"
+	@echo "Output: Standard"
+	@cd ../.. && SOV_BENCH=nomt cargo bench --bench=rollup_coarse_measure
+
 flamegraph:
 	@echo "Running basic benchmark with $(SOV_BENCH_BLOCKS) blocks and $(SOV_BENCH_TXNS_PER_BLOCKS) transactions per block"
 	@echo "Method: Coarse Timers"

--- a/examples/demo-rollup/sov-benchmarks/src/node/mod.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/node/mod.rs
@@ -1,17 +1,15 @@
-use std::collections::HashMap;
-
-use sov_mock_da::MockBlob;
+use crate::{Roles, RT};
+use sov_address::{EthereumAddress, MultiAddress, MultiAddressEvm};
+use sov_mock_da::{MockBlob, MockDaSpec};
 use sov_modules_api::{Amount, BatchSequencerReceipt, CryptoSpec, PublicKey, Spec};
 use sov_rollup_interface::crypto::PrivateKey;
 use sov_rollup_interface::da::RelevantBlobs;
 use sov_test_utils::runtime::{sov_bank, Bank, Coins, TestRunner, TokenId};
+use sov_test_utils::storage::ForklessStorageManager;
 use sov_test_utils::{
     AsUser, MockZkvm, TestPrivateKey, TestUser, TransactionType, TxReceiptContents,
 };
-
-use crate::{BenchSpec, Roles, RT};
-
-type S = BenchSpec<MockZkvm>;
+use std::collections::HashMap;
 
 type BatchReceipt<S> =
     sov_rollup_interface::stf::BatchReceipt<BatchSequencerReceipt<S>, TxReceiptContents<S>>;
@@ -19,7 +17,10 @@ type BatchReceipt<S> =
 type BenchmarkMessages = Vec<RelevantBlobs<MockBlob>>;
 
 /// Builds a simple transfer transaction
-pub fn build_send_tx(sender: &TestUser<S>, token_id: TokenId) -> TransactionType<RT<S>, S> {
+pub fn build_send_tx<S>(sender: &TestUser<S>, token_id: TokenId) -> TransactionType<RT<S>, S>
+where
+    S: Spec<Address = MultiAddress<EthereumAddress>>,
+{
     let priv_key = TestPrivateKey::generate();
     let to_address: <S as Spec>::Address = priv_key.pub_key().credential_id().into();
 
@@ -47,10 +48,19 @@ pub fn assert_batch_receipts<S: Spec>(batch_receipts: &[BatchReceipt<S>]) {
     }
 }
 
-fn generate_initial_slots(
+fn generate_initial_slots<Sm, S>(
     roles: &Roles<S>,
-    nonces: &mut HashMap<<<S as Spec>::CryptoSpec as CryptoSpec>::PublicKey, u64>,
-) -> (TokenId, BenchmarkMessages) {
+    nonces: &mut HashMap<<S::CryptoSpec as CryptoSpec>::PublicKey, u64>,
+) -> (TokenId, BenchmarkMessages)
+where
+    Sm: ForklessStorageManager,
+    S: Spec<
+        OuterZkvm = MockZkvm,
+        Da = MockDaSpec,
+        Address = MultiAddressEvm,
+        Storage = Sm::Storage,
+    >,
+{
     let token_name = "sov-bench-token";
     let token_id = sov_bank::get_token_id::<S>(token_name, None, &roles.bank_admin.address());
 
@@ -89,7 +99,7 @@ fn generate_initial_slots(
             .into_iter()
             .map(|batch| {
                 let preferred_batch = roles.preferred_sequencer.build_preferred_batch(batch);
-                TestRunner::<RT<S>, S>::soft_confirmation_batches_to_blobs(
+                TestRunner::<RT<S>, S, Sm>::soft_confirmation_batches_to_blobs(
                     vec![preferred_batch],
                     nonces,
                 )
@@ -99,12 +109,21 @@ fn generate_initial_slots(
 }
 
 /// Generate benchmark transactions for the node
-pub fn generate_transfers(
+pub fn generate_transfers<S, Sm>(
     slots_to_process: u64,
     token_id: TokenId,
     roles: &Roles<S>,
-    runner: &mut TestRunner<RT<S>, S>,
-) -> BenchmarkMessages {
+    runner: &mut TestRunner<RT<S>, S, Sm>,
+) -> BenchmarkMessages
+where
+    Sm: ForklessStorageManager,
+    S: Spec<
+        OuterZkvm = MockZkvm,
+        Da = MockDaSpec,
+        Address = MultiAddressEvm,
+        Storage = Sm::Storage,
+    >,
+{
     let send_messages = (0..slots_to_process)
         .map(|_| {
             roles
@@ -118,8 +137,10 @@ pub fn generate_transfers(
     let benchmark_messages = send_messages
         .into_iter()
         .map(|batch| {
-            let preferred_batch = roles.preferred_sequencer.build_preferred_batch(batch);
-            TestRunner::<RT<S>, S>::soft_confirmation_batches_to_blobs(
+            let preferred_batch = roles
+                .preferred_sequencer
+                .build_preferred_batch::<RT<S>>(batch);
+            TestRunner::<RT<S>, S, Sm>::soft_confirmation_batches_to_blobs(
                 vec![preferred_batch],
                 runner.nonces_mut(),
             )
@@ -130,8 +151,17 @@ pub fn generate_transfers(
 }
 
 /// Prefills the state with benchmark transactions
-pub fn prefill_state(roles: &Roles<S>, runner: &mut TestRunner<RT<S>, S>) -> TokenId {
-    let (token_id, slots) = generate_initial_slots(roles, runner.nonces_mut());
+pub fn prefill_state<Sm, S>(roles: &Roles<S>, runner: &mut TestRunner<RT<S>, S, Sm>) -> TokenId
+where
+    Sm: ForklessStorageManager,
+    S: Spec<
+        OuterZkvm = MockZkvm,
+        Da = MockDaSpec,
+        Address = MultiAddressEvm,
+        Storage = Sm::Storage,
+    >,
+{
+    let (token_id, slots) = generate_initial_slots::<Sm, S>(roles, runner.nonces_mut());
     for blobs in slots {
         let apply_slot_output = runner.execute(blobs);
 

--- a/examples/demo-rollup/sov-benchmarks/src/node/rollup_bench.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/node/rollup_bench.rs
@@ -5,6 +5,7 @@ use std::env;
 use criterion::{criterion_group, criterion_main, Criterion};
 use sov_benchmarks::node::{assert_batch_receipts, generate_transfers, prefill_state};
 use sov_benchmarks::setup_with_runner;
+use sov_test_utils::MockZkvm;
 
 fn stf_apply_slot_bench(c: &mut Criterion) {
     let bench_after_blocks: u64 = env::var("SOV_BENCH_BLOCKS")
@@ -26,7 +27,7 @@ fn stf_apply_slot_bench(c: &mut Criterion) {
         bench_after_blocks * senders_count
     );
 
-    let (mut runner, roles) = setup_with_runner(senders_count, Default::default());
+    let (mut runner, roles) = setup_with_runner::<MockZkvm>(senders_count, Default::default());
 
     let token_id = prefill_state(&roles, &mut runner);
     let bench_messages = generate_transfers(bench_after_blocks, token_id, &roles, &mut runner);

--- a/examples/demo-rollup/sov-benchmarks/src/node/rollup_bench.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/node/rollup_bench.rs
@@ -3,9 +3,48 @@
 use std::env;
 
 use criterion::{criterion_group, criterion_main, Criterion};
+use sov_address::MultiAddressEvm;
 use sov_benchmarks::node::{assert_batch_receipts, generate_transfers, prefill_state};
-use sov_benchmarks::setup_with_runner;
+use sov_benchmarks::{setup_with_runner, BenchSpec, NomtBenchSpec};
+use sov_mock_da::MockDaSpec;
+use sov_modules_api::Spec;
+use sov_test_utils::storage::{
+    ForklessStorageManager, SimpleNomtStorageManager, SimpleStorageManager,
+};
 use sov_test_utils::MockZkvm;
+
+fn run_spec<S, Sm>(c: &mut Criterion, name: &str, senders_count: u64, bench_after_blocks: u64)
+where
+    Sm: ForklessStorageManager,
+    S: Spec<
+        InnerZkvm = MockZkvm,
+        OuterZkvm = MockZkvm,
+        Da = MockDaSpec,
+        Address = MultiAddressEvm,
+        Storage = Sm::Storage,
+    >,
+{
+    let (mut runner, roles) =
+        setup_with_runner::<S, MockZkvm, Sm>(senders_count, Default::default());
+
+    let token_id = prefill_state(&roles, &mut runner);
+    let bench_messages = generate_transfers(bench_after_blocks, token_id, &roles, &mut runner);
+
+    for message in bench_messages {
+        let apply_slot_output = runner.execute(message);
+        assert_batch_receipts(&apply_slot_output.0.batch_receipts);
+    }
+
+    c.bench_function(&format!("rollup main stf loop: {name}"), |b| {
+        b.iter(|| {
+            let bench_messages = generate_transfers(1, token_id, &roles, &mut runner)
+                .pop()
+                .unwrap();
+            let apply_slot_output = runner.execute(bench_messages);
+            assert_batch_receipts(&apply_slot_output.0.batch_receipts);
+        });
+    });
+}
 
 fn stf_apply_slot_bench(c: &mut Criterion) {
     let bench_after_blocks: u64 = env::var("SOV_BENCH_BLOCKS")
@@ -27,25 +66,18 @@ fn stf_apply_slot_bench(c: &mut Criterion) {
         bench_after_blocks * senders_count
     );
 
-    let (mut runner, roles) = setup_with_runner::<MockZkvm>(senders_count, Default::default());
-
-    let token_id = prefill_state(&roles, &mut runner);
-    let bench_messages = generate_transfers(bench_after_blocks, token_id, &roles, &mut runner);
-
-    for message in bench_messages {
-        let apply_slot_output = runner.execute(message);
-        assert_batch_receipts(&apply_slot_output.0.batch_receipts);
-    }
-
-    c.bench_function("rollup main stf loop", |b| {
-        b.iter(|| {
-            let bench_messages = generate_transfers(1, token_id, &roles, &mut runner)
-                .pop()
-                .unwrap();
-            let apply_slot_output = runner.execute(bench_messages);
-            assert_batch_receipts(&apply_slot_output.0.batch_receipts);
-        });
-    });
+    run_spec::<BenchSpec<MockZkvm>, SimpleStorageManager<_>>(
+        c,
+        "jmt",
+        senders_count,
+        bench_after_blocks,
+    );
+    run_spec::<NomtBenchSpec, SimpleNomtStorageManager<_>>(
+        c,
+        "nomt",
+        senders_count,
+        bench_after_blocks,
+    );
 }
 
 fn configure_criterion() -> Criterion {

--- a/examples/demo-rollup/sov-benchmarks/src/node/rollup_bench.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/node/rollup_bench.rs
@@ -6,7 +6,6 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use sov_benchmarks::node::{assert_batch_receipts, generate_transfers, prefill_state};
 use sov_benchmarks::setup_with_runner;
 
-
 fn stf_apply_slot_bench(c: &mut Criterion) {
     let bench_after_blocks: u64 = env::var("SOV_BENCH_BLOCKS")
         .unwrap_or("100".to_string())

--- a/examples/demo-rollup/sov-benchmarks/src/node/rollup_bench.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/node/rollup_bench.rs
@@ -6,6 +6,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use sov_benchmarks::node::{assert_batch_receipts, generate_transfers, prefill_state};
 use sov_benchmarks::setup_with_runner;
 
+
 fn stf_apply_slot_bench(c: &mut Criterion) {
     let bench_after_blocks: u64 = env::var("SOV_BENCH_BLOCKS")
         .unwrap_or("100".to_string())

--- a/examples/demo-rollup/sov-benchmarks/src/node/rollup_coarse_measure.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/node/rollup_coarse_measure.rs
@@ -151,7 +151,7 @@ where
         "Not enough successful transactions, something is broken"
     );
     if params.timer_output {
-        println!("Spec: {}", std::any::type_name::<S::Storage>());
+        println!("Storage: {}", std::any::type_name::<S::Storage>());
         print_times(
             total,
             apply_block_time,

--- a/examples/demo-rollup/sov-benchmarks/src/node/rollup_coarse_measure.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/node/rollup_coarse_measure.rs
@@ -6,11 +6,18 @@ use std::time::{Duration, Instant};
 
 use humantime::format_duration;
 use prettytable::{row, Table};
+use sov_address::MultiAddressEvm;
 use sov_benchmarks::node::{generate_transfers, prefill_state};
-use sov_benchmarks::setup_with_runner;
+use sov_benchmarks::{setup_with_runner_and_spec, BenchSpec, NomtBenchSpec};
+use sov_mock_da::MockDaSpec;
 use sov_modules_api::prelude::anyhow;
+use sov_modules_api::Spec;
+use sov_test_utils::storage::{
+    ForklessStorageManager, SimpleNomtStorageManager, SimpleStorageManager,
+};
+use sov_test_utils::MockZkvm;
 
-// Minimum TPS below which it is considered an issue
+// Minimum TPS, below which it is considered an issue
 const MIN_TPS: f64 = 1000.0;
 // Number to check that rollup actually executed some transactions
 const MAX_TPS: f64 = 30_000.0;
@@ -94,14 +101,26 @@ impl BenchParams {
     }
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn run_with_spec<S, Sm>() -> anyhow::Result<()>
+where
+    Sm: ForklessStorageManager,
+    S: Spec<
+        InnerZkvm = MockZkvm,
+        OuterZkvm = MockZkvm,
+        Da = MockDaSpec,
+        Address = MultiAddressEvm,
+        Storage = Sm::Storage,
+    >,
+{
     let params = BenchParams::new();
     let mut num_success_txns: u64 = 0;
 
-    let (mut runner, roles) = setup_with_runner(params.transactions_per_block, Default::default());
+    let (mut runner, roles) = setup_with_runner_and_spec::<MockZkvm, Sm, S>(
+        params.transactions_per_block,
+        Default::default(),
+    );
     let token_id = prefill_state(&roles, &mut runner);
-    let blocks = generate_transfers(params.blocks, token_id, &roles, &mut runner);
+    let blocks = generate_transfers::<S, Sm>(params.blocks, token_id, &roles, &mut runner);
 
     let expected_num_txs: u64 = params.blocks * params.transactions_per_block;
 
@@ -132,6 +151,7 @@ async fn main() -> anyhow::Result<()> {
         "Not enough successful transactions, something is broken"
     );
     if params.timer_output {
+        println!("Spec: {}", std::any::type_name::<S::Storage>());
         print_times(
             total,
             apply_block_time,
@@ -141,4 +161,18 @@ async fn main() -> anyhow::Result<()> {
         );
     }
     Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    match env::var("SOV_BENCH") {
+        Ok(s) => {
+            if &s == "nomt" {
+                run_with_spec::<NomtBenchSpec, SimpleNomtStorageManager<_>>().await
+            } else {
+                run_with_spec::<BenchSpec<MockZkvm>, SimpleStorageManager<_>>().await
+            }
+        }
+        Err(_) => run_with_spec::<BenchSpec<MockZkvm>, SimpleStorageManager<_>>().await,
+    }
 }

--- a/scripts/ci_rollup_count_check.sh
+++ b/scripts/ci_rollup_count_check.sh
@@ -3,7 +3,7 @@ export SOV_BENCH_BLOCKS=10
 export SOV_BENCH_TXNS_PER_BLOCKS=10000
 export TPS=1000
 (cd examples/demo-rollup/sov-benchmarks/src/node && make basic 2>&1) | tee output.log
-(cd examples/demo-rollup/sov-benchmarks/src/node && make basic 2>&1) | tee nomt_output.log
+(cd examples/demo-rollup/sov-benchmarks/src/node && make basic-nomt 2>&1) | tee nomt_output.log
 
 check_tps() {
     local output_file=$1

--- a/scripts/ci_rollup_count_check.sh
+++ b/scripts/ci_rollup_count_check.sh
@@ -3,23 +3,32 @@ export SOV_BENCH_BLOCKS=10
 export SOV_BENCH_TXNS_PER_BLOCKS=10000
 export TPS=1000
 (cd examples/demo-rollup/sov-benchmarks/src/node && make basic 2>&1) | tee output.log
+(cd examples/demo-rollup/sov-benchmarks/src/node && make basic 2>&1) | tee nomt_output.log
 
-output_file="output.log"
-
-tps_line=$(grep -w "Transactions per sec (TPS)" $output_file)
-
-if [ -z "$tps_line" ]; then
-    echo "The line containing 'TPS' was not found."
-    exit 1
-else
-    tps_count=$(echo "$tps_line" | awk -F '|' '{print $3}' | sed 's/,//g')
-    result=$(awk -v val="$tps_count" -v threshold="$TPS" 'BEGIN {print (val < threshold) ? "FAIL" : "PASS"}')
-    if [ "$result" = "FAIL" ]; then
-        echo "The value for TPS is less than $TPS. Failing the check. Value: $tps_count"
-        exit 1
+check_tps() {
+    local output_file=$1
+    
+    echo "Checking TPS for $output_file..."
+    
+    tps_line=$(grep -w "Transactions per sec (TPS)" $output_file)
+    
+    if [ -z "$tps_line" ]; then
+        echo "The line containing 'TPS' was not found in $output_file."
+        return 1
     else
-        echo "The value for TPS is greater than $TPS. Passing the check. Value: $tps_count"
-        exit 0
+        tps_count=$(echo "$tps_line" | awk -F '|' '{print $3}' | sed 's/,//g')
+        result=$(awk -v val="$tps_count" -v threshold="$TPS" 'BEGIN {print (val < threshold) ? "FAIL" : "PASS"}')
+        if [ "$result" = "FAIL" ]; then
+            echo "The value for TPS in $output_file is less than $TPS. Failing the check. Value: $tps_count"
+            return 1
+        else
+            echo "The value for TPS in $output_file is greater than $TPS. Passing the check. Value: $tps_count"
+            return 0
+        fi
     fi
-fi
-exit 1
+}
+
+check_tps "output.log" || exit 1
+check_tps "nomt_output.log" || exit 1
+
+exit 0


### PR DESCRIPTION
# Description

Porting changes from https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/2968

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
`rollup_tps_validation` now shows both storages

## Docs
No updates
