### PR TITLE
EVM: enable CANCUN hardfork. 

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -154,7 +154,7 @@ where
                 set_accessory_state_time,
             };
             sov_metrics::track_metrics(|t| {
-                t.submit(dbg!(metrics));
+                t.submit(metrics);
             });
         }
 

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -74,6 +74,11 @@ where
     ) -> anyhow::Result<()> {
         start_timer!(total);
         let tx = convert_to_tx_signed(message.rlp)?;
+
+        if matches!(tx, alloy_consensus::EthereumTxEnvelope::Eip4844(_)) {
+            anyhow::bail!("Eip4844 not supported");
+        }
+
         start_timer!(fetch_state);
         let (cfg, block, tx_env, tx, pending_len) = self.fetch_state(context, state, tx)?;
         save_elapsed!(fetch_state_time SINCE fetch_state);

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -104,7 +104,7 @@ where
         #[cfg(feature = "native")]
         {
             sov_metrics::track_metrics(|t| {
-                t.submit(dbg!(db.metrics()));
+                t.submit(db.metrics());
             });
         }
 

--- a/crates/module-system/module-implementations/sov-evm/src/config.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/config.rs
@@ -36,7 +36,7 @@ impl Default for EvmChainSpec {
             limit_contract_code_size: None,
             coinbase: Address::ZERO,
             block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
-            hardforks: vec![(0, SpecId::SHANGHAI)],
+            hardforks: vec![(0, SpecId::CANCUN)],
         }
     }
 }
@@ -96,7 +96,7 @@ mod tests {
             }],
             chain_spec: crate::EvmChainSpec {
                 limit_contract_code_size: None,
-                hardforks: vec![(0, SpecId::SHANGHAI)],
+                hardforks: vec![(0, SpecId::CANCUN)],
                 ..Default::default()
             },
             ..Default::default()
@@ -117,7 +117,7 @@ mod tests {
                     "limit_contract_code_size":null,
                     "coinbase":"0x0000000000000000000000000000000000000000",
                     "block_gas_limit":30000000,
-                    "hardforks":[[0,"SHANGHAI"]]
+                    "hardforks":[[0,"CANCUN"]]
                 }
         }"#;
 

--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -2,7 +2,10 @@ use alloy_consensus::{transaction::Recovered, Transaction};
 use alloy_eips::eip2718::{Decodable2718, Eip2718Error};
 use alloy_primitives::{Address, Bytes, U256};
 use reth_primitives_traits::SignedTransaction;
-use revm::context::{BlockEnv, TransactionType, TxEnv};
+use revm::{
+    context::{BlockEnv, TransactionType, TxEnv},
+    context_interface::block::BlobExcessGasAndPrice,
+};
 use thiserror::Error;
 
 use super::primitive_types::SealedBlock;
@@ -20,8 +23,11 @@ impl From<SealedBlock> for BlockEnv {
             prevrandao: Some(block.header.mix_hash),
             basefee: 0,
             gas_limit: block.header.gas_limit,
-            // Not used fields:
-            blob_excess_gas_and_price: None,
+
+            blob_excess_gas_and_price: Some(BlobExcessGasAndPrice {
+                excess_blob_gas: 0,
+                blob_gasprice: 0,
+            }),
             difficulty: Default::default(),
         }
     }

--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -11,7 +11,9 @@ use thiserror::Error;
 use super::primitive_types::SealedBlock;
 #[cfg(feature = "native")]
 use crate::primitive_types::TxSignedAndRecovered;
-use crate::{evm::primitive_types::TransactionSigned, RlpEvmTransaction};
+use crate::{
+    evm::primitive_types::TransactionSigned, RlpEvmTransaction, BLOB_GAS_PRICE, EXCESS_BLOB_GAS,
+};
 
 // BlockEnv from SealedBlock
 impl From<SealedBlock> for BlockEnv {
@@ -25,8 +27,8 @@ impl From<SealedBlock> for BlockEnv {
             gas_limit: block.header.gas_limit,
 
             blob_excess_gas_and_price: Some(BlobExcessGasAndPrice {
-                excess_blob_gas: 0,
-                blob_gasprice: 0,
+                excess_blob_gas: EXCESS_BLOB_GAS,
+                blob_gasprice: BLOB_GAS_PRICE,
             }),
             difficulty: Default::default(),
         }

--- a/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -122,7 +122,7 @@ mod tests {
                 limit_contract_code_size: Some(100),
                 ..Default::default()
             },
-            hardforks: vec![(0, SpecId::SHANGHAI)],
+            hardforks: vec![(0, SpecId::CANCUN)],
         };
 
         let mut template_cfg_env = CfgEnv::default();
@@ -137,7 +137,7 @@ mod tests {
         expected_cfg_env.disable_balance_check = true;
         expected_cfg_env.disable_block_gas_limit = true;
         expected_cfg_env.limit_contract_code_size = Some(100);
-        expected_cfg_env.spec = SpecId::SHANGHAI;
+        expected_cfg_env.spec = SpecId::CANCUN;
 
         assert_eq!(expected_cfg_env, cfg_env);
     }

--- a/crates/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -94,6 +94,7 @@ fn init_block(config: &EvmGenesisConfig) -> Block {
         state_root: KECCAK_EMPTY,
         gas_limit: config.chain_spec.block_gas_limit,
         timestamp: config.genesis_timestamp,
+        excess_blob_gas: Some(0),
         ..Default::default()
     };
 
@@ -108,20 +109,13 @@ fn init_spec(config: &EvmGenesisConfig) -> anyhow::Result<Vec<(BlockNumber, Spec
         .chain_spec
         .hardforks
         .iter()
-        .map(|&(k, v)| {
-            // https://github.com/Sovereign-Labs/sovereign-sdk/issues/912
-            if v == SpecId::CANCUN {
-                panic!("Cancun is not supported");
-            }
-
-            (k, v)
-        })
+        .cloned()
         .collect::<Vec<_>>();
 
     spec.sort_by(|a, b| a.0.cmp(&b.0));
 
     if spec.is_empty() {
-        spec.push((0, SpecId::SHANGHAI));
+        spec.push((0, SpecId::CANCUN));
     } else if spec[0].0 != 0u64 {
         panic!("EVM spec must start from block 0");
     };

--- a/crates/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -8,7 +8,7 @@ use sov_modules_api::{GenesisState, Module, Spec};
 
 use crate::db::init::InitEvmDb;
 use crate::evm::primitive_types::Block;
-use crate::{Evm, EvmGenesisConfig, EvmRuntimeConfig};
+use crate::{Evm, EvmGenesisConfig, EvmRuntimeConfig, EXCESS_BLOB_GAS};
 #[cfg(feature = "native")]
 use std::ops::RangeInclusive;
 
@@ -94,7 +94,7 @@ fn init_block(config: &EvmGenesisConfig) -> Block {
         state_root: KECCAK_EMPTY,
         gas_limit: config.chain_spec.block_gas_limit,
         timestamp: config.genesis_timestamp,
-        excess_blob_gas: Some(0),
+        excess_blob_gas: Some(EXCESS_BLOB_GAS),
         ..Default::default()
     };
 

--- a/crates/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -105,12 +105,7 @@ fn init_block(config: &EvmGenesisConfig) -> Block {
 }
 
 fn init_spec(config: &EvmGenesisConfig) -> anyhow::Result<Vec<(BlockNumber, SpecId)>> {
-    let mut spec = config
-        .chain_spec
-        .hardforks
-        .iter()
-        .cloned()
-        .collect::<Vec<_>>();
+    let mut spec = config.chain_spec.hardforks.to_vec();
 
     spec.sort_by(|a, b| a.0.cmp(&b.0));
 

--- a/crates/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -4,6 +4,7 @@ use alloy_consensus::proofs::{calculate_receipt_root, calculate_transaction_root
 use alloy_consensus::TxReceipt;
 use alloy_primitives::Bloom;
 use alloy_primitives::{B256, U256};
+use revm::context_interface::block::BlobExcessGasAndPrice;
 #[cfg(feature = "native")]
 use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::UnwrapInfallible;
@@ -64,6 +65,10 @@ impl<S: Spec> BlockHooks for Evm<S> {
             // See: https://eips.ethereum.org/EIPS/eip-4399#tips-for-application-developers
             prevrandao: Some(B256::from(pre_state_user_root)),
             gas_limit: cfg.chain_spec.block_gas_limit,
+            blob_excess_gas_and_price: Some(BlobExcessGasAndPrice {
+                excess_blob_gas: 0,
+                blob_gasprice: 0,
+            }),
             ..Default::default()
         };
         self.block_env
@@ -135,6 +140,7 @@ impl<S: Spec> BlockHooks for Evm<S> {
             gas_limit: block_env.gas_limit,
             gas_used,
             mix_hash: block_env.prevrandao.map_or(B256::ZERO, B256::from),
+            excess_blob_gas: Some(0),
             ..Default::default()
         };
 

--- a/crates/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -1,5 +1,5 @@
 use crate::evm::primitive_types::{Block, TransactionSigned};
-use crate::{BlockEnv, Evm, PendingTransaction};
+use crate::{BlockEnv, Evm, PendingTransaction, BLOB_GAS_PRICE, EXCESS_BLOB_GAS};
 use alloy_consensus::proofs::{calculate_receipt_root, calculate_transaction_root};
 use alloy_consensus::TxReceipt;
 use alloy_primitives::Bloom;
@@ -66,8 +66,8 @@ impl<S: Spec> BlockHooks for Evm<S> {
             prevrandao: Some(B256::from(pre_state_user_root)),
             gas_limit: cfg.chain_spec.block_gas_limit,
             blob_excess_gas_and_price: Some(BlobExcessGasAndPrice {
-                excess_blob_gas: 0,
-                blob_gasprice: 0,
+                excess_blob_gas: EXCESS_BLOB_GAS,
+                blob_gasprice: BLOB_GAS_PRICE,
             }),
             ..Default::default()
         };
@@ -140,7 +140,9 @@ impl<S: Spec> BlockHooks for Evm<S> {
             gas_limit: block_env.gas_limit,
             gas_used,
             mix_hash: block_env.prevrandao.map_or(B256::ZERO, B256::from),
-            excess_blob_gas: Some(0),
+            excess_blob_gas: block_env
+                .blob_excess_gas_and_price
+                .map(|blob_gas| blob_gas.excess_blob_gas),
             ..Default::default()
         };
 

--- a/crates/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/lib.rs
@@ -62,6 +62,10 @@ pub use conversions::convert_to_tx_signed;
 pub use conversions::create_tx_env;
 use revm::state::Bytecode;
 
+/// These values are associated with EIP-4844, which we do not support, but they must be set to a value other than None for CANCUN.
+const EXCESS_BLOB_GAS: u64 = 0;
+const BLOB_GAS_PRICE: u128 = 0;
+
 /// The sov-evm module provides compatibility with the EVM.
 #[allow(dead_code)]
 #[derive(Clone, ModuleInfo)]

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -618,6 +618,7 @@ where
                 .timestamp
                 .try_into()
                 .expect("The impossible happened: timestamp overflow u64"),
+            excess_blob_gas: Some(0),
             ..Default::default()
         };
 

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -15,6 +15,7 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
 use revm::context::result::{EVMError, ExecutionResult, InvalidHeader};
 use revm::context::{BlockEnv, CfgEnv, TxEnv};
+use revm::context_interface::block::BlobExcessGasAndPrice;
 use revm::Database;
 use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 use sov_address::{EthereumAddress, FromVmAddress};
@@ -491,12 +492,17 @@ where
         block_number: Option<String>,
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<ExecutionResult> {
-        let block_env = self.resolve_block_env(block_number, state)?;
+        let mut block_env = self.resolve_block_env(block_number, state)?;
         let tx_env =
             prepare_call_env(&block_env, request.clone()).map_err(eth_api_into_rpc_error)?;
         let cfg = self.cfg_infallible(state);
         let cfg_env = get_cfg_env(&block_env, cfg, Some(get_cfg_env_template()));
         let evm_db: EvmDb<_, S> = self.get_db(state);
+
+        block_env.blob_excess_gas_and_price = Some(BlobExcessGasAndPrice {
+            excess_blob_gas: 0,
+            blob_gasprice: 0,
+        });
 
         executor::call(evm_db, &block_env, tx_env, cfg_env)
             .map_err(|err| eth_api_into_rpc_error(eth_from_evm_error(err)))

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -15,7 +15,6 @@ use jsonrpsee::core::RpcResult;
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
 use revm::context::result::{EVMError, ExecutionResult, InvalidHeader};
 use revm::context::{BlockEnv, CfgEnv, TxEnv};
-use revm::context_interface::block::BlobExcessGasAndPrice;
 use revm::Database;
 use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 use sov_address::{EthereumAddress, FromVmAddress};
@@ -492,17 +491,12 @@ where
         block_number: Option<String>,
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<ExecutionResult> {
-        let mut block_env = self.resolve_block_env(block_number, state)?;
+        let block_env = self.resolve_block_env(block_number, state)?;
         let tx_env =
             prepare_call_env(&block_env, request.clone()).map_err(eth_api_into_rpc_error)?;
         let cfg = self.cfg_infallible(state);
         let cfg_env = get_cfg_env(&block_env, cfg, Some(get_cfg_env_template()));
         let evm_db: EvmDb<_, S> = self.get_db(state);
-
-        block_env.blob_excess_gas_and_price = Some(BlobExcessGasAndPrice {
-            excess_blob_gas: 0,
-            blob_gasprice: 0,
-        });
 
         executor::call(evm_db, &block_env, tx_env, cfg_env)
             .map_err(|err| eth_api_into_rpc_error(eth_from_evm_error(err)))
@@ -624,7 +618,10 @@ where
                 .timestamp
                 .try_into()
                 .expect("The impossible happened: timestamp overflow u64"),
-            excess_blob_gas: Some(0),
+            excess_blob_gas: current_block_env
+                .blob_excess_gas_and_price
+                .map(|blob_gas| blob_gas.excess_blob_gas),
+
             ..Default::default()
         };
 

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/contracts.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/contracts.rs
@@ -48,7 +48,7 @@ fn test_invalid_contract_execution() {
         });
         let (signed_eth_tx, _) = account.sign(tx_request);
         let cfg_env =
-            CfgEnv::new_with_spec(SpecId::SHANGHAI).with_chain_id(config_value!("CHAIN_ID"));
+            CfgEnv::new_with_spec(SpecId::CANCUN).with_chain_id(config_value!("CHAIN_ID"));
         let tx = convert_to_tx_signed(signed_eth_tx).unwrap();
         let tx_env = create_tx_env(&tx, account.address(), 1, 1_000_000);
         let result =

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
@@ -91,6 +91,7 @@ fn test_genesis_block() {
             state_root: actual_block.header().state_root(),
             gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
             beneficiary,
+            excess_blob_gas: Some(0),
             ..Default::default()
         };
 

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
@@ -49,16 +49,16 @@ fn test_genesis_cfg() {
                     block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
                     coinbase: Address::from([3u8; 20]),
                     limit_contract_code_size: Some(5000),
-                    hardforks: vec![(0, SpecId::BERLIN), (1, SpecId::SHANGHAI)],
+                    hardforks: vec![(0, SpecId::BERLIN), (1, SpecId::CANCUN)],
                 },
-                hardforks: vec![(0, SpecId::BERLIN), (1, SpecId::SHANGHAI)],
+                hardforks: vec![(0, SpecId::BERLIN), (1, SpecId::CANCUN)],
             }
         );
     });
 }
 
 #[test]
-fn test_empty_spec_defaults_to_shanghai() {
+fn test_empty_spec_defaults_to_cancun() {
     let mut cfg = default_config();
     cfg.chain_spec.hardforks.clear();
     let runner = basic_setup(cfg);
@@ -66,7 +66,7 @@ fn test_empty_spec_defaults_to_shanghai() {
     runner.query_visible_state(move |state| {
         let evm = Evm::<S>::default();
         let evm_cfg = evm.cfg_infallible(state);
-        assert_eq!(evm_cfg.hardforks, vec![(0, SpecId::SHANGHAI)]);
+        assert_eq!(evm_cfg.hardforks, vec![(0, SpecId::CANCUN)]);
     });
 }
 
@@ -75,14 +75,6 @@ fn test_empty_spec_defaults_to_shanghai() {
 fn test_cfg_missing_specs() {
     let mut cfg = EvmGenesisConfig::default();
     cfg.chain_spec.hardforks = vec![(5, SpecId::BERLIN)];
-    let _ = basic_setup(cfg);
-}
-
-#[test]
-#[should_panic(expected = "Cancun is not supported")]
-fn test_cancun_is_unsupported() {
-    let mut cfg = EvmGenesisConfig::default();
-    cfg.chain_spec.hardforks = vec![(0, SpecId::CANCUN)];
     let _ = basic_setup(cfg);
 }
 
@@ -123,7 +115,7 @@ fn default_config() -> EvmGenesisConfig {
             block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
             coinbase: Address::from([3u8; 20]),
             limit_contract_code_size: Some(5000),
-            hardforks: vec![(0, SpecId::BERLIN), (1, SpecId::SHANGHAI)],
+            hardforks: vec![(0, SpecId::BERLIN), (1, SpecId::CANCUN)],
         },
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
@@ -65,9 +65,8 @@ pub(crate) fn setup() -> (TestRunner<RT, S>, EvmAccount, EvmAccount) {
         ],
         ..Default::default()
     };
-    // SHANGHAI instead of LATEST
-    // https://github.com/Sovereign-Labs/sovereign-sdk/issues/912
-    evm_config.chain_spec.hardforks = vec![(0, SpecId::SHANGHAI)];
+
+    evm_config.chain_spec.hardforks = vec![(0, SpecId::CANCUN)];
 
     let mut genesis = GenesisConfig::from_minimal_config(genesis_config.into(), evm_config);
 

--- a/crates/module-system/module-implementations/sov-uniqueness/tests/integration/utils.rs
+++ b/crates/module-system/module-implementations/sov-uniqueness/tests/integration/utils.rs
@@ -131,9 +131,9 @@ pub(crate) fn setup() -> (TestUser<S>, TestRunner<TestNonceRuntime<S>, S>, EvmAc
             code: Default::default(),
         }],
         chain_spec: EvmChainSpec {
-            // SHANGHAI instead of LATEST
+            // CANCUN instead of LATEST
             // https://github.com/Sovereign-Labs/sovereign-sdk/issues/912
-            hardforks: vec![(0, SpecId::SHANGHAI)].into_iter().collect(),
+            hardforks: vec![(0, SpecId::CANCUN)].into_iter().collect(),
             ..Default::default()
         },
         ..Default::default()

--- a/examples/test-data/genesis/demo/celestia/evm.json
+++ b/examples/test-data/genesis/demo/celestia/evm.json
@@ -31,6 +31,6 @@
       "max_change_denominator": 8,
       "elasticity_multiplier": 2
     },
-    "hardforks": [[0, "SHANGHAI"]]
+    "hardforks": [[0, "CANCUN"]]
   }
 }

--- a/examples/test-data/genesis/demo/mock/evm.json
+++ b/examples/test-data/genesis/demo/mock/evm.json
@@ -31,6 +31,6 @@
       "max_change_denominator": 8,
       "elasticity_multiplier": 2
     },
-    "hardforks": [[0, "SHANGHAI"]]
+    "hardforks": [[0, "CANCUN"]]
   }
 }

--- a/examples/test-data/genesis/integration-tests/evm.json
+++ b/examples/test-data/genesis/integration-tests/evm.json
@@ -31,6 +31,6 @@
       "max_change_denominator": 8,
       "elasticity_multiplier": 2
     },
-    "hardforks": [[0, "SHANGHAI"]]
+    "hardforks": [[0, "CANCUN"]]
   }
 }


### PR DESCRIPTION
# Description

Cancun requires `excess_blob_gas` and `blob_gasprice` to be set. These fields are related to` EIP-4844`, which we don't support, so we set them to 0.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)