### PR TITLE
Improve `exit_rollup` and add logging to `blobs_are_send_after_rollup_resync`

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -131,6 +131,7 @@ where
         let shutdown_receiver = shutdown_sender.subscribe();
         let latest_state_update = state_update_receiver.borrow().clone();
         let da_address = da.get_signer().await;
+
         debug!(
             ?latest_state_update,
             %da_address,
@@ -1089,15 +1090,28 @@ fn err_cant_fit_tx(current_batch_size: usize, max_batch_size: usize, tx_len: usi
     }
 }
 
-pub(crate) async fn exit_rollup(shutdown_sender: &watch::Sender<()>) {
+#[track_caller]
+pub(crate) fn exit_rollup(
+    shutdown_sender: &watch::Sender<()>,
+) -> impl std::future::Future<Output = ()> {
+    let location = std::panic::Location::caller();
+    exit_rollup_inner(shutdown_sender.clone(), location)
+}
+
+async fn exit_rollup_inner(
+    shutdown_sender: watch::Sender<()>,
+    location: &'static std::panic::Location<'static>,
+) {
     // In the Kubernetes environment, logs are sometimes lost during shutdown.
     // This delay ensures logs have time to be flushed before the application exits.
     tracing::info!("Shutting down the rollup");
     if shutdown_sender.send(()).is_err() {
-        tracing::error!("Failed to send shutdown signal");
+        tracing::error!("Failed to send shutdown signal: {location}");
     }
     sleep(Duration::from_secs(5)).await;
-    tracing::info!("Calling std::process::exit(1).");
+    let msg = format!("Calling std::process::exit(1): {location}");
+    tracing::error!(msg);
+    println!("{msg}");
     std::process::exit(1);
 }
 

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
@@ -111,6 +111,7 @@ async fn test_discard_oversized_blobs() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_blobs_are_send_after_rollup_resync() {
+    sov_test_utils::initialize_logging();
     let (test_rollup, _) = create_test_rollup().await;
     let da = test_rollup.da_service.clone();
     let mut header_subscrition = da.subscribe_finalized_header().await.unwrap();


### PR DESCRIPTION
# Description

The `test_blobs_are_send_after_rollup_resync` test is flaky.
This PR introduces the following changes to help debug the issue:
1. The exit_rollup method now reports the caller's location.
2. Added additional logging to the tests.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
