### PR TITLE
fix: use JRpcParams and fallible parsing in realtime_sendRawTransaction

### DIFF
--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -3,8 +3,8 @@ mod subscribe;
 use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types::TransactionReceipt;
 pub use get_logs::eth_get_logs;
+use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::types::Params as JRpcParams;
-use jsonrpsee::types::{ErrorObjectOwned, Params};
 use jsonrpsee::Extensions;
 use sov_address::{EthereumAddress, FromVmAddress};
 pub use sov_evm::EthereumAuthenticator;
@@ -161,7 +161,7 @@ where
 }
 
 pub async fn realtime_send_raw_transaction<S, Seq>(
-    parameters: Params<'static>,
+    parameters: JRpcParams<'static>,
     ethereum: Arc<Ethereum<S, Seq>>,
     _: Extensions,
 ) -> Result<Option<TransactionReceipt>, ErrorObjectOwned>
@@ -171,7 +171,7 @@ where
     S::Address: FromVmAddress<EthereumAddress>,
     Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
 {
-    let data: Bytes = parameters.one().unwrap();
+    let data: Bytes = parameters.one()?;
 
     let raw_evm_tx = RlpEvmTransaction { rlp: data.to_vec() };
 


### PR DESCRIPTION
- Switch realtime_send_raw_transaction to JRpcParams<'static> and replace unwrap() with parameters.one()? to avoid panics on invalid/missing params.
- Align error handling with other ETH handlers which already use JRpcParams and fallible parsing (returning JSON-RPC Invalid params).
- This unsafe parsing was only present in realtime_send_raw_transaction; all other handlers already used the correct pattern.