### PR TITLE
Buffer evm txs with future nonces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-09-29
+- #1770 **Breaking change** introduces a required `buffer_raw_txs` field to `EthRpcConfig`. This change is only breaking for EVM rollups.
+
 # 2025-09-25
 - #1758 A new config value in rollup.toml: `runner.da_total_timeout_secs`. It should be larger than the total time da service attempts to fetch data. Default value is 10 minutes.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11860,6 +11860,7 @@ dependencies = [
  "sov-state",
  "sov-stf-runner",
  "sov-test-utils",
+ "sov-uniqueness",
  "strum 0.26.3",
  "test-strategy",
  "tokio",

--- a/crates/full-node/sov-ethereum/Cargo.toml
+++ b/crates/full-node/sov-ethereum/Cargo.toml
@@ -19,6 +19,7 @@ jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 sov-address = { workspace = true, features = ["evm"] }
 
 sov-evm = { workspace = true, features = ["native"] }
+sov-uniqueness = { workspace = true, features = ["native"] }
 sov-modules-api = { workspace = true, features = ["native"] }
 sov-sequencer = { workspace = true }
 sov-eth-dev-signer = { workspace = true }

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -114,10 +114,10 @@ where
             }
         }
         // tokio::time::sleep can have unreliable timing under load, so if the total time we've been retrying is too large we'll break the loop early.
-        if start.elapsed().as_millis() > MAX_RETRY_DURATION_MS {
+        if start.elapsed().as_millis() > MAX_BUFFER_DURATION_MS {
             break;
         }
-        tokio::time::sleep(std::time::Duration::from_millis(MAX_BUFFER_DURATION_MS)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(SLEEP_DURATION_MS)).await;
         state = ethereum.sequencer.api_state().default_api_state_accessor();
     }
 

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -70,9 +70,13 @@ where
         ..
     } = auth_data;
     drop(auth_data); // Drop the authorization data because it's not `Send`, so we can't hold it across retries.
+    let retries = if ethereum.buffer_raw_txs {
+        MAX_RETRIES
+    } else {
+        0
+    };
     let start = std::time::Instant::now();
-
-    for _ in 0..MAX_RETRIES {
+    for _ in 0..retries {
         match uniqueness {
             UniquenessData::Nonce(nonce) => {
                 let expected_nonce = sov_uniqueness::Uniqueness::<S>::default()

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -33,7 +33,7 @@ const SLEEP_DURATION_MS: u64 = 10;
 /// The maximum number of times to fetch the nonce and retry.
 const MAX_RETRIES: u32 = 10;
 /// The maximum amount of time to buffer a tx with a future nonce. Provides an upper bound in case retry attempts are taking too long.
-const MAX_BUFFER_DURATION_MS: u64 = 200;
+const MAX_BUFFER_DURATION_MS: u128 = 200;
 
 async fn process_raw_transaction<S, Seq, T, F>(
     data: Bytes,
@@ -61,7 +61,7 @@ where
         .to_provable_reader();
     let (_decoded_tx, auth_data, _call) =
         <Seq::Rt as Runtime<S>>::Auth::authenticate(&tx, &mut state).map_err(|e| {
-            to_jsonrpsee_error_object(format!("Authentication failed: {}", e), ETH_RPC_ERROR)
+            to_jsonrpsee_error_object(format!("Authentication failed: {e}"), ETH_RPC_ERROR)
         })?;
     let mut state = state.api_state_accessor;
     let AuthorizationData {
@@ -93,14 +93,13 @@ where
                     return on_success(tx_hash, ethereum);
                 } else if nonce < expected_nonce {
                     return Err(to_jsonrpsee_error_object(
-                        format!("Nonce error: nonce {} has already been used", nonce),
+                        format!("Nonce error: nonce {nonce} has already been used"),
                         ETH_RPC_ERROR,
                     ));
                 } else if nonce > (expected_nonce + FUTURE_NONCE_THRESHOLD) {
                     return Err(to_jsonrpsee_error_object(
                         format!(
-                            "Nonce error: Provided nonce {} is in the future. Expected nonce is {}",
-                            nonce, expected_nonce
+                            "Nonce error: Provided nonce {nonce} is in the future. Expected nonce is {expected_nonce}",
                         ),
                         ETH_RPC_ERROR,
                     ));

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -7,7 +7,11 @@ use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::types::Params as JRpcParams;
 use jsonrpsee::Extensions;
 use sov_address::{EthereumAddress, FromVmAddress};
+use sov_modules_api::Runtime;
 pub use sov_evm::EthereumAuthenticator;
+use sov_modules_api::capabilities::TransactionAuthenticator;
+use sov_modules_api::capabilities::UniquenessData;
+use sov_modules_api::capabilities::AuthorizationData;
 #[cfg(feature = "local")]
 use sov_evm::Evm;
 use sov_evm::RlpEvmTransaction;
@@ -147,17 +151,47 @@ where
     let (tx_hash, raw_message) = ethereum
         .make_raw_tx(raw_evm_tx)
         .map_err(|e| to_jsonrpsee_error_object(e, ETH_RPC_ERROR))?;
-
     let tx = Seq::Rt::encode_with_ethereum_auth(RawTx::new(raw_message));
+    let mut state = ethereum.sequencer.api_state().default_api_state_accessor().to_provable_reader();
+    let (_decoded_tx, auth_data, _call) = <Seq::Rt as Runtime<S>>::Auth::authenticate(&tx, &mut state).map_err(|e| to_jsonrpsee_error_object(format!("Authentication failed: {}", e), ETH_RPC_ERROR))?;
+    let mut state = state.api_state_accessor;
+    let AuthorizationData { credential_id, uniqueness, .. } = auth_data;
+    drop(auth_data); // Drop auth_data to avoid holding it across the `await` point. This is required because it contains an `rc` which isn't thread safe.
+    for _ in 0..20 {
+        match uniqueness {
+            UniquenessData::Nonce(nonce) => {
+                let expected_nonce = sov_uniqueness::Uniqueness::<S>::default().nonce(&credential_id, &mut state)?.unwrap_or_default();
+                if nonce == expected_nonce {
+                    ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
+                        to_jsonrpsee_error_object(
+                            format!("{} - '{}' ({:?})", e.status, e.message, e.details),
+                            ETH_RPC_ERROR,
+                        )
+                    })?;
+                    return Ok(tx_hash);
+                } else if nonce < expected_nonce {
+                    return Err(to_jsonrpsee_error_object(format!("Nonce error: nonce {} has already been used", nonce), ETH_RPC_ERROR));
+                }
+            }
+            _ => {
+                // This should be unreachable
+                return Err(to_jsonrpsee_error_object("Invalid uniqueness data", ETH_RPC_ERROR));
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        state = ethereum.sequencer.api_state().default_api_state_accessor();
+    }
 
+    // Fallback to trying the tx anyway in case of shenanigans.
     ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
         to_jsonrpsee_error_object(
             format!("{} - '{}' ({:?})", e.status, e.message, e.details),
             ETH_RPC_ERROR,
         )
     })?;
+    return Ok(tx_hash);
 
-    Ok(tx_hash)
+
 }
 
 pub async fn realtime_send_raw_transaction<S, Seq>(
@@ -180,6 +214,45 @@ where
         .map_err(|e| to_jsonrpsee_error_object(e, ETH_RPC_ERROR))?;
 
     let tx = Seq::Rt::encode_with_ethereum_auth(RawTx::new(raw_message));
+    let mut state = ethereum.sequencer.api_state().default_api_state_accessor().to_provable_reader();
+    let (_decoded_tx, auth_data, _call) = <Seq::Rt as Runtime<S>>::Auth::authenticate(&tx, &mut state).map_err(|e| to_jsonrpsee_error_object(format!("Authentication failed: {}", e), ETH_RPC_ERROR))?;
+    let mut state = state.api_state_accessor;
+    let AuthorizationData { credential_id, uniqueness, .. } = auth_data;
+    drop(auth_data); // Drop auth_data to avoid holding it across the `await` point. This is required because it contains an `rc` which isn't thread safe.
+    for _ in 0..20 {
+        match uniqueness {
+            UniquenessData::Nonce(nonce) => {
+                let expected_nonce = sov_uniqueness::Uniqueness::<S>::default().nonce(&credential_id, &mut state)?.unwrap_or_default();
+                if nonce == expected_nonce {
+                    ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
+                        to_jsonrpsee_error_object(
+                            format!("{} - '{}' ({:?})", e.status, e.message, e.details),
+                            ETH_RPC_ERROR,
+                        )
+                    })?;
+                    
+                    let evm = sov_evm::Evm::<S>::default();
+                    let receipt = evm.get_transaction_receipt(
+                        tx_hash,
+                        &mut ethereum.sequencer.api_state().default_api_state_accessor(),
+                    )?;
+
+
+                    return Ok::<_, ErrorObjectOwned>(receipt)
+                } else if nonce < expected_nonce {
+                    return Err(to_jsonrpsee_error_object(format!("Nonce error: nonce {} has already been used", nonce), ETH_RPC_ERROR));
+                }
+            }
+            _ => {
+                // This should be unreachable
+                return Err(to_jsonrpsee_error_object("Invalid uniqueness data", ETH_RPC_ERROR));
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        state = ethereum.sequencer.api_state().default_api_state_accessor();
+    }
+
+    // Fallback to trying the tx anyway in case of shenanigans.
 
     ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
         to_jsonrpsee_error_object(
@@ -193,5 +266,7 @@ where
         tx_hash,
         &mut ethereum.sequencer.api_state().default_api_state_accessor(),
     )?;
+
+
     Ok::<_, ErrorObjectOwned>(receipt)
 }

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -7,15 +7,15 @@ use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::types::Params as JRpcParams;
 use jsonrpsee::Extensions;
 use sov_address::{EthereumAddress, FromVmAddress};
-use sov_modules_api::Runtime;
 pub use sov_evm::EthereumAuthenticator;
-use sov_modules_api::capabilities::TransactionAuthenticator;
-use sov_modules_api::capabilities::UniquenessData;
-use sov_modules_api::capabilities::AuthorizationData;
 #[cfg(feature = "local")]
 use sov_evm::Evm;
 use sov_evm::RlpEvmTransaction;
+use sov_modules_api::capabilities::AuthorizationData;
 use sov_modules_api::capabilities::HasKernel;
+use sov_modules_api::capabilities::TransactionAuthenticator;
+use sov_modules_api::capabilities::UniquenessData;
+use sov_modules_api::Runtime;
 use sov_modules_api::{RawTx, Spec};
 use sov_sequencer::Sequencer;
 use std::sync::Arc;
@@ -25,6 +25,110 @@ use crate::to_jsonrpsee_error_object;
 use crate::Ethereum;
 
 const ETH_RPC_ERROR: &str = "ETH_RPC_ERROR";
+/// Txs with nonce in the future of more than this threshold are rejected immediately. If the nonce is in the future but below the threshold, we'll buffer it
+/// for a little while.
+const FUTURE_NONCE_THRESHOLD: u64 = 100;
+/// How long to wait between retries.
+const SLEEP_DURATION_MS: u64 = 10;
+/// The maximum number of times to fetch the nonce and retry.
+const MAX_RETRIES: u32 = 10;
+/// The maximum amount of time to buffer a tx with a future nonce. Provides an upper bound in case retry attempts are taking too long.
+const MAX_BUFFER_DURATION_MS: u64 = 200;
+
+async fn process_raw_transaction<S, Seq, T, F>(
+    data: Bytes,
+    ethereum: Arc<Ethereum<S, Seq>>,
+    on_success: F,
+) -> Result<T, ErrorObjectOwned>
+where
+    S: Spec,
+    Seq: Sequencer<Spec = S>,
+    S::Address: FromVmAddress<EthereumAddress>,
+    Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
+    F: Fn(B256, Arc<Ethereum<S, Seq>>) -> Result<T, ErrorObjectOwned>,
+{
+    let raw_evm_tx = RlpEvmTransaction { rlp: data.to_vec() };
+    let (tx_hash, raw_message) = ethereum
+        .make_raw_tx(raw_evm_tx)
+        .map_err(|e| to_jsonrpsee_error_object(e, ETH_RPC_ERROR))?;
+
+    // Authenticate the transaction so that we can get the credential ID and nonce.
+    let tx = Seq::Rt::encode_with_ethereum_auth(RawTx::new(raw_message));
+    let mut state = ethereum
+        .sequencer
+        .api_state()
+        .default_api_state_accessor()
+        .to_provable_reader();
+    let (_decoded_tx, auth_data, _call) =
+        <Seq::Rt as Runtime<S>>::Auth::authenticate(&tx, &mut state).map_err(|e| {
+            to_jsonrpsee_error_object(format!("Authentication failed: {}", e), ETH_RPC_ERROR)
+        })?;
+    let mut state = state.api_state_accessor;
+    let AuthorizationData {
+        credential_id,
+        uniqueness,
+        ..
+    } = auth_data;
+    drop(auth_data); // Drop the authorization data because it's not `Send`, so we can't hold it across retries.
+    let start = std::time::Instant::now();
+
+    for _ in 0..MAX_RETRIES {
+        match uniqueness {
+            UniquenessData::Nonce(nonce) => {
+                let expected_nonce = sov_uniqueness::Uniqueness::<S>::default()
+                    .nonce(&credential_id, &mut state)?
+                    .unwrap_or_default();
+                if nonce == expected_nonce {
+                    ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
+                        to_jsonrpsee_error_object(
+                            format!("{} - '{}' ({:?})", e.status, e.message, e.details),
+                            ETH_RPC_ERROR,
+                        )
+                    })?;
+
+                    return on_success(tx_hash, ethereum);
+                } else if nonce < expected_nonce {
+                    return Err(to_jsonrpsee_error_object(
+                        format!("Nonce error: nonce {} has already been used", nonce),
+                        ETH_RPC_ERROR,
+                    ));
+                } else if nonce > (expected_nonce + FUTURE_NONCE_THRESHOLD) {
+                    return Err(to_jsonrpsee_error_object(
+                        format!(
+                            "Nonce error: Provided nonce {} is in the future. Expected nonce is {}",
+                            nonce, expected_nonce
+                        ),
+                        ETH_RPC_ERROR,
+                    ));
+                }
+            }
+            _ => {
+                return Err(to_jsonrpsee_error_object(
+                    "Invalid uniqueness data",
+                    ETH_RPC_ERROR,
+                ));
+            }
+        }
+        // tokio::time::sleep can have unreliable timing under load, so if the total time we've been retrying is too large we'll break the loop early.
+        if start.elapsed().as_millis() > MAX_RETRY_DURATION_MS {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(MAX_BUFFER_DURATION_MS)).await;
+        state = ethereum.sequencer.api_state().default_api_state_accessor();
+    }
+
+    // Once we've exhausted all retries, make one "regular" attempt to accept the transaction.
+    // This ensures that every tx is attempted at least once even if MAX_RETRIES is set to zero
+    // and provides some protection against spuriously rejecting txs in case our view of the state was stale.
+    ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
+        to_jsonrpsee_error_object(
+            format!("{} - '{}' ({:?})", e.status, e.message, e.details),
+            ETH_RPC_ERROR,
+        )
+    })?;
+
+    on_success(tx_hash, ethereum)
+}
 
 #[cfg(feature = "local")]
 pub(crate) mod signer {
@@ -146,52 +250,7 @@ where
 {
     let data: Bytes = parameters.one()?;
 
-    let raw_evm_tx = RlpEvmTransaction { rlp: data.to_vec() };
-
-    let (tx_hash, raw_message) = ethereum
-        .make_raw_tx(raw_evm_tx)
-        .map_err(|e| to_jsonrpsee_error_object(e, ETH_RPC_ERROR))?;
-    let tx = Seq::Rt::encode_with_ethereum_auth(RawTx::new(raw_message));
-    let mut state = ethereum.sequencer.api_state().default_api_state_accessor().to_provable_reader();
-    let (_decoded_tx, auth_data, _call) = <Seq::Rt as Runtime<S>>::Auth::authenticate(&tx, &mut state).map_err(|e| to_jsonrpsee_error_object(format!("Authentication failed: {}", e), ETH_RPC_ERROR))?;
-    let mut state = state.api_state_accessor;
-    let AuthorizationData { credential_id, uniqueness, .. } = auth_data;
-    drop(auth_data); // Drop auth_data to avoid holding it across the `await` point. This is required because it contains an `rc` which isn't thread safe.
-    for _ in 0..20 {
-        match uniqueness {
-            UniquenessData::Nonce(nonce) => {
-                let expected_nonce = sov_uniqueness::Uniqueness::<S>::default().nonce(&credential_id, &mut state)?.unwrap_or_default();
-                if nonce == expected_nonce {
-                    ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
-                        to_jsonrpsee_error_object(
-                            format!("{} - '{}' ({:?})", e.status, e.message, e.details),
-                            ETH_RPC_ERROR,
-                        )
-                    })?;
-                    return Ok(tx_hash);
-                } else if nonce < expected_nonce {
-                    return Err(to_jsonrpsee_error_object(format!("Nonce error: nonce {} has already been used", nonce), ETH_RPC_ERROR));
-                }
-            }
-            _ => {
-                // This should be unreachable
-                return Err(to_jsonrpsee_error_object("Invalid uniqueness data", ETH_RPC_ERROR));
-            }
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        state = ethereum.sequencer.api_state().default_api_state_accessor();
-    }
-
-    // Fallback to trying the tx anyway in case of shenanigans.
-    ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
-        to_jsonrpsee_error_object(
-            format!("{} - '{}' ({:?})", e.status, e.message, e.details),
-            ETH_RPC_ERROR,
-        )
-    })?;
-    return Ok(tx_hash);
-
-
+    process_raw_transaction(data, ethereum, |tx_hash, _| Ok(tx_hash)).await
 }
 
 pub async fn realtime_send_raw_transaction<S, Seq>(
@@ -207,66 +266,12 @@ where
 {
     let data: Bytes = parameters.one()?;
 
-    let raw_evm_tx = RlpEvmTransaction { rlp: data.to_vec() };
-
-    let (tx_hash, raw_message) = ethereum
-        .make_raw_tx(raw_evm_tx)
-        .map_err(|e| to_jsonrpsee_error_object(e, ETH_RPC_ERROR))?;
-
-    let tx = Seq::Rt::encode_with_ethereum_auth(RawTx::new(raw_message));
-    let mut state = ethereum.sequencer.api_state().default_api_state_accessor().to_provable_reader();
-    let (_decoded_tx, auth_data, _call) = <Seq::Rt as Runtime<S>>::Auth::authenticate(&tx, &mut state).map_err(|e| to_jsonrpsee_error_object(format!("Authentication failed: {}", e), ETH_RPC_ERROR))?;
-    let mut state = state.api_state_accessor;
-    let AuthorizationData { credential_id, uniqueness, .. } = auth_data;
-    drop(auth_data); // Drop auth_data to avoid holding it across the `await` point. This is required because it contains an `rc` which isn't thread safe.
-    for _ in 0..20 {
-        match uniqueness {
-            UniquenessData::Nonce(nonce) => {
-                let expected_nonce = sov_uniqueness::Uniqueness::<S>::default().nonce(&credential_id, &mut state)?.unwrap_or_default();
-                if nonce == expected_nonce {
-                    ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
-                        to_jsonrpsee_error_object(
-                            format!("{} - '{}' ({:?})", e.status, e.message, e.details),
-                            ETH_RPC_ERROR,
-                        )
-                    })?;
-                    
-                    let evm = sov_evm::Evm::<S>::default();
-                    let receipt = evm.get_transaction_receipt(
-                        tx_hash,
-                        &mut ethereum.sequencer.api_state().default_api_state_accessor(),
-                    )?;
-
-
-                    return Ok::<_, ErrorObjectOwned>(receipt)
-                } else if nonce < expected_nonce {
-                    return Err(to_jsonrpsee_error_object(format!("Nonce error: nonce {} has already been used", nonce), ETH_RPC_ERROR));
-                }
-            }
-            _ => {
-                // This should be unreachable
-                return Err(to_jsonrpsee_error_object("Invalid uniqueness data", ETH_RPC_ERROR));
-            }
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        state = ethereum.sequencer.api_state().default_api_state_accessor();
-    }
-
-    // Fallback to trying the tx anyway in case of shenanigans.
-
-    ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
-        to_jsonrpsee_error_object(
-            format!("{} - '{}' ({:?})", e.status, e.message, e.details),
-            ETH_RPC_ERROR,
+    process_raw_transaction(data, ethereum, |tx_hash, ethereum| {
+        let evm = sov_evm::Evm::<S>::default();
+        evm.get_transaction_receipt(
+            tx_hash,
+            &mut ethereum.sequencer.api_state().default_api_state_accessor(),
         )
-    })?;
-
-    let evm = sov_evm::Evm::<S>::default();
-    let receipt = evm.get_transaction_receipt(
-        tx_hash,
-        &mut ethereum.sequencer.api_state().default_api_state_accessor(),
-    )?;
-
-
-    Ok::<_, ErrorObjectOwned>(receipt)
+    })
+    .await
 }

--- a/crates/full-node/sov-ethereum/src/lib.rs
+++ b/crates/full-node/sov-ethereum/src/lib.rs
@@ -21,6 +21,8 @@ pub struct EthRpcConfig {
     #[cfg(feature = "local")]
     pub eth_signer: Signers,
     pub extension: SeqConfigExtension,
+    /// Whether to buffer raw transactions with a future nonce. If true, we'll retry the transaction a few times to see if the missing intermediate nonce was consumed.
+    pub buffer_raw_txs: bool,
 }
 
 pub fn get_ethereum_rpc<S, Seq>(eth_rpc_config: EthRpcConfig, sequencer: Arc<Seq>) -> RpcModule<()>
@@ -35,6 +37,7 @@ where
         #[cfg(feature = "local")]
         eth_signer,
         extension,
+        buffer_raw_txs,
     } = eth_rpc_config;
 
     let mut rpc = RpcModule::new(Ethereum {
@@ -42,6 +45,7 @@ where
         #[cfg(feature = "local")]
         eth_signer,
         extension,
+        buffer_raw_txs,
     });
 
     register_rpc_methods::<S, Seq>(&mut rpc).expect("Failed to register sequencer RPC methods");
@@ -95,6 +99,7 @@ struct Ethereum<S: Spec, Seq: Sequencer<Spec = S>> {
     #[cfg(feature = "local")]
     eth_signer: Signers,
     extension: SeqConfigExtension,
+    buffer_raw_txs: bool,
 }
 
 impl<S, Seq> Ethereum<S, Seq>

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -44,7 +44,7 @@ pub struct BatchFromUnregisteredSequencer {
 /// Typically, the authentication will require checking the signature of the transaction.
 pub trait TransactionAuthenticator<S: Spec> {
     /// The "message" that is extracted from the transaction and passed to the runtime for execution.
-    type Decodable;
+    type Decodable: Send;
 
     /// The input to the authenticator
     type Input: BorshDeserialize + BorshSerialize + Clone + std::fmt::Debug + Send + Sync + 'static;

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::GasMeteringError;
 use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
 use sov_metrics::{StateAccessMetric, StateMetrics};
 use sov_rollup_interface::common::{SlotNumber, VisibleSlotNumber};
@@ -10,7 +11,6 @@ use sov_state::{
     namespaces, CompileTimeNamespace, EventContainer, Namespace, NativeStorage,
     ProvableStorageCache, SlotKey, SlotValue, Storage, TypeErasedEvent,
 };
-use crate::GasMeteringError;
 
 use super::temp_cache::{CacheLookup, TempCache};
 use super::{BorshSerializedSize, StateCheckpoint, UniversalStateAccessor};
@@ -18,7 +18,9 @@ use crate::capabilities::{KernelWithSlotMapping, RollupHeight};
 use crate::gas::GasArray;
 use crate::state::accessors::internals::AccessoryWrite;
 use crate::state::traits::PerBlockCache;
-use crate::{Amount, BasicGasMeter, Gas, GasMeter, GetGasPrice, ProvableStateReader, Spec, VersionReader};
+use crate::{
+    Amount, BasicGasMeter, Gas, GasMeter, GetGasPrice, ProvableStateReader, Spec, VersionReader,
+};
 
 fn get_slot_number(visible_slot_number: Option<VisibleSlotNumber>) -> Option<SlotNumber> {
     // This TODO is not a security risk.
@@ -746,7 +748,6 @@ impl<S: Spec> VersionReader for ApiStateAccessor<S> {
     }
 }
 
-
 /// A wrapper around [`ApiStateAccessor`] that implements ProvableStateReader for both namespaces.
 pub struct MeteredApiStateAccessor<S: Spec> {
     pub api_state_accessor: ApiStateAccessor<S>,
@@ -760,26 +761,33 @@ impl<S: Spec> GasMeter for MeteredApiStateAccessor<S> {
 }
 
 impl<S: Spec> UniversalStateAccessor for MeteredApiStateAccessor<S> {
-    fn get_size(&mut self, namespace: Namespace, key: &SlotKey, metric: &mut StateAccessMetric) -> Option<u32> {
+    fn get_size(
+        &mut self,
+        namespace: Namespace,
+        key: &SlotKey,
+        metric: &mut StateAccessMetric,
+    ) -> Option<u32> {
         self.api_state_accessor.get_size(namespace, key, metric)
     }
-    fn get_value(&mut self, namespace: Namespace, key: &SlotKey, metric: &mut StateAccessMetric) -> Option<SlotValue> {
+    fn get_value(
+        &mut self,
+        namespace: Namespace,
+        key: &SlotKey,
+        metric: &mut StateAccessMetric,
+    ) -> Option<SlotValue> {
         self.api_state_accessor.get_value(namespace, key, metric)
     }
     fn set_value(&mut self, namespace: Namespace, key: &SlotKey, value: SlotValue) {
-        self.api_state_accessor.set_value(namespace, key, value)
+        self.api_state_accessor.set_value(namespace, key, value);
     }
     fn delete_value(&mut self, namespace: Namespace, key: &SlotKey) {
-        self.api_state_accessor.delete_value(namespace, key)
+        self.api_state_accessor.delete_value(namespace, key);
     }
 }
 
-impl<S: Spec> ProvableStateReader<namespaces::User> for MeteredApiStateAccessor<S> {
-   
-}
+impl<S: Spec> ProvableStateReader<namespaces::User> for MeteredApiStateAccessor<S> {}
 
-impl<S: Spec> ProvableStateReader<namespaces::Kernel> for MeteredApiStateAccessor<S> {
-}
+impl<S: Spec> ProvableStateReader<namespaces::Kernel> for MeteredApiStateAccessor<S> {}
 
 impl<S: Spec> GetGasPrice for MeteredApiStateAccessor<S> {
     type Spec = S;

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -10,6 +10,7 @@ use sov_state::{
     namespaces, CompileTimeNamespace, EventContainer, Namespace, NativeStorage,
     ProvableStorageCache, SlotKey, SlotValue, Storage, TypeErasedEvent,
 };
+use crate::GasMeteringError;
 
 use super::temp_cache::{CacheLookup, TempCache};
 use super::{BorshSerializedSize, StateCheckpoint, UniversalStateAccessor};
@@ -17,7 +18,7 @@ use crate::capabilities::{KernelWithSlotMapping, RollupHeight};
 use crate::gas::GasArray;
 use crate::state::accessors::internals::AccessoryWrite;
 use crate::state::traits::PerBlockCache;
-use crate::{Amount, BasicGasMeter, Gas, GasMeter, GetGasPrice, Spec, VersionReader};
+use crate::{Amount, BasicGasMeter, Gas, GasMeter, GetGasPrice, ProvableStateReader, Spec, VersionReader};
 
 fn get_slot_number(visible_slot_number: Option<VisibleSlotNumber>) -> Option<SlotNumber> {
     // This TODO is not a security risk.
@@ -458,6 +459,13 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
         )
     }
 
+    /// Converts this [`ApiStateAccessor`] into a [`MeteredApiStateAccessor`], allowing it to be used in authenticator methods.
+    pub fn to_provable_reader(self) -> MeteredApiStateAccessor<S> {
+        MeteredApiStateAccessor {
+            api_state_accessor: self,
+        }
+    }
+
     /// A specialized constructor for use in sov-test-utils. This constructor matches the unusual semantic of our testing framework, which expects to see
     /// the *next* visible slot number with the *current* rollup height in the accessor as soon as the slot finishes executing.
     ///
@@ -735,5 +743,47 @@ impl<S: Spec> VersionReader for ApiStateAccessor<S> {
                 panic!("Rollup height not cached for slot number {slot_number}, but that slot exists in storage. This is a bug in ApiStateAccessor initialization. Please report it.");
             }
         }
+    }
+}
+
+
+/// A wrapper around [`ApiStateAccessor`] that implements ProvableStateReader for both namespaces.
+pub struct MeteredApiStateAccessor<S: Spec> {
+    pub api_state_accessor: ApiStateAccessor<S>,
+}
+
+impl<S: Spec> GasMeter for MeteredApiStateAccessor<S> {
+    type Spec = S;
+    fn charge_gas(&mut self, amount: &S::Gas) -> Result<(), GasMeteringError<S::Gas>> {
+        self.api_state_accessor.gas_meter.charge_gas(amount)
+    }
+}
+
+impl<S: Spec> UniversalStateAccessor for MeteredApiStateAccessor<S> {
+    fn get_size(&mut self, namespace: Namespace, key: &SlotKey, metric: &mut StateAccessMetric) -> Option<u32> {
+        self.api_state_accessor.get_size(namespace, key, metric)
+    }
+    fn get_value(&mut self, namespace: Namespace, key: &SlotKey, metric: &mut StateAccessMetric) -> Option<SlotValue> {
+        self.api_state_accessor.get_value(namespace, key, metric)
+    }
+    fn set_value(&mut self, namespace: Namespace, key: &SlotKey, value: SlotValue) {
+        self.api_state_accessor.set_value(namespace, key, value)
+    }
+    fn delete_value(&mut self, namespace: Namespace, key: &SlotKey) {
+        self.api_state_accessor.delete_value(namespace, key)
+    }
+}
+
+impl<S: Spec> ProvableStateReader<namespaces::User> for MeteredApiStateAccessor<S> {
+   
+}
+
+impl<S: Spec> ProvableStateReader<namespaces::Kernel> for MeteredApiStateAccessor<S> {
+}
+
+impl<S: Spec> GetGasPrice for MeteredApiStateAccessor<S> {
+    type Spec = S;
+    fn gas_price(&self) -> &<S::Gas as Gas>::Price {
+        &self.api_state_accessor.gas_meter.gas_price
     }
 }

--- a/examples/demo-rollup/src/celestia_nomt_rollup.rs
+++ b/examples/demo-rollup/src/celestia_nomt_rollup.rs
@@ -141,6 +141,7 @@ impl FullNodeBlueprint<Native> for CelestiaNomtDemoRollup<Native> {
         let eth_rpc_config = EthRpcConfig {
             eth_signer,
             extension: rollup_config.extension_or_panic(),
+            buffer_raw_txs: true,
         };
 
         Ok(NodeEndpoints {

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -127,6 +127,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
         let eth_rpc_config = EthRpcConfig {
             eth_signer,
             extension: rollup_config.extension_or_panic(),
+            buffer_raw_txs: true,
         };
 
         Ok(NodeEndpoints {

--- a/examples/demo-rollup/src/mock_nomt_rollup.rs
+++ b/examples/demo-rollup/src/mock_nomt_rollup.rs
@@ -123,6 +123,7 @@ impl FullNodeBlueprint<Native> for MockNomtDemoRollup<Native> {
         let eth_rpc_config = EthRpcConfig {
             eth_signer,
             extension: rollup_config.extension_or_panic(),
+            buffer_raw_txs: true,
         };
 
         Ok(NodeEndpoints {

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -109,6 +109,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
         let eth_rpc_config = EthRpcConfig {
             eth_signer,
             extension: rollup_config.extension_or_panic(),
+            buffer_raw_txs: true,
         };
 
         Ok(NodeEndpoints {


### PR DESCRIPTION
# Description

This PR adds a simple retry strategy for EVM txs which have future nonces; we check the signature once to recover the account, and then (if the nonce was a near future nonce) poll to see whether the nonce has become current for up to 100ms. 

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
