### PR TITLE
Prevent metrics loss on shutdown & blob sender logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2025-09-25
 - #1758 A new config value in rollup.toml: `runner.da_total_timeout_secs`. It should be larger than the total time da service attempts to fetch data. Default value is 10 minutes.
+- #1771 Added new logging warning about metrics, which triggers demo-rollup test.
 
 # 2025-09-21
 - #1729 Adds optional `num_cache_warmup_workers` to `xxx_rollup_config.toml`. This field specifies the number of workers responsible for warming up the executor cache in the preferred sequencer.

--- a/crates/full-node/sov-blob-sender/src/lib.rs
+++ b/crates/full-node/sov-blob-sender/src/lib.rs
@@ -481,7 +481,10 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
         let res = self.db.set_state(blob_id, state).await;
         if let Err(err) = &res {
             tracing::error!(
-                "BlobSender: unable to save blob state: {state:?}, error: {err}, blob_id: {blob_id}. Shutting down."
+                blob_id,
+                error = ?err,
+                ?state,
+                "BlobSender: unable to save blob state. Shutting down."
             );
         }
         res
@@ -500,7 +503,11 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
 
         if let Err(err) = &is_finalized {
             tracing::error!(
-                "BlobSender: unable to check if blob is finalized: {state:?}, error: {err}, blob_id: {blob_id}. Shutting down."
+                blob_id,
+                %blob_hash,
+                error = ?err,
+                ?state,
+                "BlobSender: unable to check if blob is finalized. Shutting down."
             );
         }
 
@@ -533,7 +540,7 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                 ?da_tx_id,
                 blob_processing_timeout = ?self.blob_processing_timeout,
                 ?elapsed,
-                "BlobSender: elapsed time for blob submission exceeded the resubmit interval.",
+                "BlobSender: elapsed time for blob processing exceeded the timeout.",
             );
             return true;
         }
@@ -629,13 +636,18 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                                     MAX_NB_OF_BLOB_SUBMISSION_RETRIES,
                                     ?da_tx_id,
                                     %blob_hash,
-                                    "Shutting down the rollup. Blob submission failed."
+                                    "Shutting down the rollup. Blob processing wasn't completed on time."
                                 );
                                 let _ = self.shutdown_sender.send(());
                                 return;
                             }
 
-                            debug!(%blob_id, %receipt, "Timeout: Blob status set from Published to MustSubmit.");
+                            info!(
+                                %blob_id,
+                                %receipt,
+                                attempted = nb_of_retries_attempted,
+                                max_attempts = MAX_NB_OF_BLOB_SUBMISSION_RETRIES,
+                                "Processing timeout: Blob status set from Published to MustSubmit.");
                             blob_status = BlobExecutionStatus {
                                 blob_submission_status: BlobSubmissionStatus::MustSubmit,
                                 blob_selector_status: None,
@@ -649,6 +661,7 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                             .await
                         {
                             Ok(finality_status) => finality_status,
+                            // Error is logged inside the method
                             Err(_) => {
                                 // If we can't check the finality status, we shut down.
                                 let _ = self.shutdown_sender.send(());

--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -270,7 +270,13 @@ async fn blob_sender_exit_if_blob_not_processed() -> anyhow::Result<()> {
     }
 
     let (_, log) = records.remove(0);
-    assert!(log.contains("Shutting down the rollup. Blob submission failed."));
+    let pattern = "Shutting down the rollup. Blob processing wasn't completed on time.";
+    assert!(
+        log.contains(&pattern),
+        "Pattern '{}' not found in '{}'",
+        pattern,
+        log
+    );
     Ok(())
 }
 

--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -272,10 +272,8 @@ async fn blob_sender_exit_if_blob_not_processed() -> anyhow::Result<()> {
     let (_, log) = records.remove(0);
     let pattern = "Shutting down the rollup. Blob processing wasn't completed on time.";
     assert!(
-        log.contains(&pattern),
-        "Pattern '{}' not found in '{}'",
-        pattern,
-        log
+        log.contains(pattern),
+        "Pattern '{pattern}' not found in '{log}'"
     );
     Ok(())
 }

--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -266,9 +266,7 @@ async fn blob_sender_exit_if_blob_not_processed() -> anyhow::Result<()> {
 
     for _ in 0..sov_blob_sender::MAX_NB_OF_BLOB_SUBMISSION_RETRIES {
         let (_, log) = records.remove(0);
-        assert!(log.contains(
-            "BlobSender: elapsed time for blob submission exceeded the resubmit interval."
-        ));
+        assert!(log.contains("BlobSender: elapsed time for blob processing exceeded the timeout."));
     }
 
     let (_, log) = records.remove(0);

--- a/crates/full-node/sov-metrics/src/influxdb/mod.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/mod.rs
@@ -85,15 +85,15 @@ pub fn safe_telegraf_string(string: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
-    use std::str::FromStr;
-
     use super::*;
     use crate::influxdb::config::TelegrafSocketConfig;
     use crate::influxdb::publisher::{
         metrics_publisher_task, receive_with_timeout, spawn_metrics_udp_receiver,
     };
     use crate::influxdb::tracker::timestamp;
+    use std::io::Write;
+    use std::str::FromStr;
+    use tokio::sync::watch;
 
     /// Starts publisher tasks and checks that tracker pushes all required metrics
     #[tokio::test(flavor = "multi_thread")]
@@ -107,11 +107,13 @@ mod tests {
         };
 
         let (metrics_back_sender, mut metrics_back_receiver) = tokio::sync::mpsc::channel(100);
+        let (_shutdown_sender, mut shutdown_receiver) = watch::channel(());
+        shutdown_receiver.mark_unchanged();
         spawn_metrics_udp_receiver(socket, metrics_back_sender.clone());
 
         let (sender, receiver) = tokio::sync::mpsc::channel(10);
         let _task_handle = tokio::spawn(async move {
-            metrics_publisher_task(receiver, &monitoring_config).await;
+            metrics_publisher_task(receiver, &monitoring_config, shutdown_receiver).await;
         });
 
         let tracker = MetricsTracker { sender };
@@ -167,6 +169,8 @@ mod tests {
         Ok(())
     }
 
+    // TODO: test for check of the shutdown submission.
+
     #[derive(Debug)]
     struct MyCustomMetric {
         value: u64,
@@ -201,10 +205,12 @@ mod tests {
 
         let (metrics_back_sender, mut metrics_back_receiver) = tokio::sync::mpsc::channel(100);
         spawn_metrics_udp_receiver(socket, metrics_back_sender.clone());
+        let (_shutdown_sender, mut shutdown_receiver) = watch::channel(());
+        shutdown_receiver.mark_unchanged();
 
         let (sender, receiver) = tokio::sync::mpsc::channel(10);
         let _task_handle = tokio::spawn(async move {
-            metrics_publisher_task(receiver, &monitoring_config).await;
+            metrics_publisher_task(receiver, &monitoring_config, shutdown_receiver).await;
         });
 
         let tracker = MetricsTracker { sender };

--- a/crates/full-node/sov-metrics/src/influxdb/mod.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/mod.rs
@@ -169,8 +169,6 @@ mod tests {
         Ok(())
     }
 
-    // TODO: test for check of the shutdown submission.
-
     #[derive(Debug)]
     struct MyCustomMetric {
         value: u64,

--- a/crates/full-node/sov-metrics/src/influxdb/publisher.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/publisher.rs
@@ -204,9 +204,10 @@ async fn process_measurement(
             ?measurement,
             "Failed to format measurement, skipping"
         );
+    } else {
+        // We know that telegraf format is string-based, so for debugging we can print strings:
+        tracing::trace!(buffer = ?String::from_utf8_lossy(buffer), "Serialized measurement into buffer");
     };
-    // We know that telegraf format is string-based, so for debugging we can print strings:
-    tracing::trace!(buffer = ?String::from_utf8_lossy(buffer), "Serialized measurement into buffer");
     // Exceed max size, need to submit the packet first.
     if buffer.len() > max_buffer_size {
         if let Err(error) = publisher.publish(buffer).await {
@@ -261,7 +262,7 @@ mod tests {
         let first_chunk = 2;
         let second_chunk = 3;
         let max_udp_size = sample_metric.0.len() * (first_chunk + second_chunk);
-        let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
+        let (_shutdown_sender, mut shutdown_receiver) = watch::channel(());
         shutdown_receiver.mark_unchanged();
 
         let total_send = first_chunk + second_chunk;
@@ -304,8 +305,6 @@ mod tests {
         assert!(receive_with_timeout(&mut metrics_back_receiver)
             .await
             .is_none());
-
-        shutdown_sender.send(())?;
 
         Ok(())
     }
@@ -366,7 +365,7 @@ mod tests {
             max_pending_metrics: None,
         };
 
-        let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
+        let (_shutdown_sender, mut shutdown_receiver) = watch::channel(());
         shutdown_receiver.mark_unchanged();
         let (metrics_back_sender, mut metrics_back_receiver) = tokio::sync::mpsc::channel(1);
         spawn_metrics_udp_receiver(socket, metrics_back_sender.clone());
@@ -381,8 +380,6 @@ mod tests {
         assert!(receive_with_timeout(&mut metrics_back_receiver)
             .await
             .is_some());
-
-        shutdown_sender.send(())?;
 
         Ok(())
     }

--- a/crates/full-node/sov-metrics/src/influxdb/publisher.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/publisher.rs
@@ -2,11 +2,14 @@
 
 use std::net::SocketAddr;
 
+use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
 use tokio::io::AsyncWriteExt;
 
 use crate::influxdb::config::{MonitoringConfig, Transport};
 use crate::influxdb::SerializableMetric;
 use crate::TelegrafSocketConfig;
+
+const SHUTDOWN_DRAINING_LIMIT: std::time::Duration = std::time::Duration::from_secs(1);
 
 enum PublisherTransport {
     Tcp(tokio::net::TcpStream),
@@ -77,8 +80,9 @@ impl MetricsPublisher {
 }
 
 pub(crate) async fn metrics_publisher_task(
-    mut receiver: tokio::sync::mpsc::Receiver<SerializableMetric>,
+    mut metrics_receiver: tokio::sync::mpsc::Receiver<SerializableMetric>,
     config: &MonitoringConfig,
+    shutdown_receiver: tokio::sync::watch::Receiver<()>,
 ) {
     tracing::trace!(?config, "Starting metrics publisher task");
     let max_buffer_size = config.get_max_datagram_size() as usize;
@@ -113,33 +117,52 @@ pub(crate) async fn metrics_publisher_task(
         }
     };
 
-    while let Some(measurement) = receiver.recv().await {
-        #[cfg(feature = "gas-constant-estimation")]
-        if let Err(err) = measurement.write_to_csv(csv_writers) {
-            tracing::warn!(?err, "Failed to write metrics to CSV file");
-        }
-        tracing::trace!(?measurement, "Received measurement");
-        if !buffer.is_empty() {
-            buffer.push(b'\n');
-        }
-        if let Err(error) = measurement.serialize_for_telegraf(&mut buffer) {
-            tracing::warn!(?error, "Failed to format measurement, skipping");
-        };
-        // We know that telegraf format is string based, so for debugging we can print strings:
-        tracing::trace!(buffer = ?String::from_utf8_lossy(&buffer), "Serialized measurement into buffer");
-
-        // Exceed max size, need to submit the packet first.
-        if buffer.len() > max_buffer_size {
-            if let Err(e) = publisher.publish(&buffer).await {
-                tracing::warn!(?e, "Failed to publish metrics");
+    loop {
+        match future_or_shutdown(metrics_receiver.recv(), &shutdown_receiver).await {
+            FutureOrShutdownOutput::Output(Some(measurement)) => {
+                #[cfg(feature = "gas-constant-estimation")]
+                if let Err(err) = measurement.write_to_csv(csv_writers) {
+                    tracing::warn!(?err, "Failed to write metrics to CSV file");
+                }
+                tracing::trace!(?measurement, "Received measurement");
+                process_measurement(&mut buffer, measurement, &mut publisher, max_buffer_size)
+                    .await;
             }
+            FutureOrShutdownOutput::Shutdown | FutureOrShutdownOutput::Output(None) => {
+                // Drain all remaining measurements from the channel
+                let mut drained_count = 0;
+                let start = std::time::Instant::now();
+                while let Ok(remaining) = metrics_receiver.try_recv() {
+                    drained_count += 1;
+                    process_measurement(&mut buffer, remaining, &mut publisher, max_buffer_size)
+                        .await;
+                    if start.elapsed() > SHUTDOWN_DRAINING_LIMIT {
+                        break;
+                    }
+                }
 
-            // Clearing even in case of error, otherwise the packet can grow too much.
-            buffer.clear();
+                if drained_count > 0 {
+                    tracing::info!(
+                        drained_metrics = drained_count,
+                        "Drained remaining metrics from channel during shutdown"
+                    );
+                }
+                tracing::info!(
+                    remaining_buffer_size = buffer.len(),
+                    "Metrics task is going to shutdown, send remaining metrics"
+                );
+                if !buffer.is_empty() {
+                    tracing::trace!("Some metrics remain in the buffer, publish before exit");
+                    if let Err(e) = publisher.publish(&buffer).await {
+                        tracing::warn!(?e, "Failed to publish metrics during shutdown");
+                    }
+                    buffer.clear();
+                }
+                break;
+            }
         }
     }
-
-    tracing::debug!("Metrics publishing task has been completed");
+    tracing::info!("Metrics publishing task has been completed");
 }
 
 /// Listens on UDP port and converts all received metrics to strings and sends back to a channel.
@@ -166,6 +189,38 @@ pub(crate) fn spawn_metrics_udp_receiver(
     });
 }
 
+async fn process_measurement(
+    buffer: &mut Vec<u8>,
+    measurement: SerializableMetric,
+    publisher: &mut MetricsPublisher,
+    max_buffer_size: usize,
+) {
+    if !buffer.is_empty() {
+        buffer.push(b'\n');
+    }
+    if let Err(error) = measurement.serialize_for_telegraf(buffer) {
+        tracing::warn!(
+            ?error,
+            ?measurement,
+            "Failed to format measurement, skipping"
+        );
+    };
+    // We know that telegraf format is string-based, so for debugging we can print strings:
+    tracing::trace!(buffer = ?String::from_utf8_lossy(buffer), "Serialized measurement into buffer");
+    // Exceed max size, need to submit the packet first.
+    if buffer.len() > max_buffer_size {
+        if let Err(error) = publisher.publish(buffer).await {
+            tracing::warn!(
+                ?error,
+                dropped_metrics = %String::from_utf8_lossy(buffer),
+                "Failed to publish metrics");
+        }
+
+        // Clearing even in case of error, otherwise the packet can grow too much.
+        buffer.clear();
+    }
+}
+
 #[cfg(test)]
 pub(crate) async fn receive_with_timeout(
     receiver: &mut tokio::sync::mpsc::Receiver<String>,
@@ -178,11 +233,11 @@ pub(crate) async fn receive_with_timeout(
 
 #[cfg(test)]
 mod tests {
-    use tokio::io::AsyncReadExt;
-
     use super::*;
     use crate::influxdb::config::TelegrafSocketConfig;
     use crate::influxdb::Metric;
+    use tokio::io::AsyncReadExt;
+    use tokio::sync::watch;
 
     #[derive(Clone, Debug)]
     struct SampleMetric(Vec<u8>);
@@ -206,6 +261,8 @@ mod tests {
         let first_chunk = 2;
         let second_chunk = 3;
         let max_udp_size = sample_metric.0.len() * (first_chunk + second_chunk);
+        let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
+        shutdown_receiver.mark_unchanged();
 
         let total_send = first_chunk + second_chunk;
 
@@ -218,7 +275,7 @@ mod tests {
 
         let (sender, receiver) = tokio::sync::mpsc::channel(10);
         let _task_handle = tokio::spawn(async move {
-            metrics_publisher_task(receiver, &monitoring_config).await;
+            metrics_publisher_task(receiver, &monitoring_config, shutdown_receiver).await;
         });
 
         for _ in 0..first_chunk {
@@ -247,6 +304,8 @@ mod tests {
         assert!(receive_with_timeout(&mut metrics_back_receiver)
             .await
             .is_none());
+
+        shutdown_sender.send(())?;
 
         Ok(())
     }
@@ -307,12 +366,14 @@ mod tests {
             max_pending_metrics: None,
         };
 
+        let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
+        shutdown_receiver.mark_unchanged();
         let (metrics_back_sender, mut metrics_back_receiver) = tokio::sync::mpsc::channel(1);
         spawn_metrics_udp_receiver(socket, metrics_back_sender.clone());
 
         let (sender, receiver) = tokio::sync::mpsc::channel(10);
         let _task_handle = tokio::spawn(async move {
-            metrics_publisher_task(receiver, &monitoring_config).await;
+            metrics_publisher_task(receiver, &monitoring_config, shutdown_receiver).await;
         });
 
         sender.send(Box::new(sample_metric)).await?;
@@ -320,6 +381,8 @@ mod tests {
         assert!(receive_with_timeout(&mut metrics_back_receiver)
             .await
             .is_some());
+
+        shutdown_sender.send(())?;
 
         Ok(())
     }

--- a/crates/full-node/sov-metrics/src/influxdb/tracker.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/tracker.rs
@@ -15,17 +15,23 @@ pub(crate) static METRICS_TRACKER: OnceLock<MetricsTracker> = OnceLock::new();
 pub(crate) type Timestamp = u128;
 
 /// Spawns task that published metrics in the background.
-pub fn init_metrics_tracker(config: &MonitoringConfig) {
+pub fn init_metrics_tracker(
+    config: &MonitoringConfig,
+    shutdown_receiver: tokio::sync::watch::Receiver<()>,
+) -> Option<tokio::task::JoinHandle<()>> {
     if METRICS_TRACKER.get().is_none() {
         let (sender, receiver) =
             tokio::sync::mpsc::channel(config.get_max_pending_metrics() as usize);
-        let config = config.clone();
-        let _handle = tokio::spawn(async move {
-            publisher::metrics_publisher_task(receiver, &config).await;
+        let config_for_task = config.clone();
+        let handle = tokio::spawn(async move {
+            publisher::metrics_publisher_task(receiver, &config_for_task, shutdown_receiver).await;
         });
-        tracing::trace!("Metrics tracker initialized");
+        tracing::debug!(?config, "Metrics tracker initialized");
         OnceLock::set(&METRICS_TRACKER, MetricsTracker { sender })
             .expect("Metrics tracker failed to set metrics");
+        Some(handle)
+    } else {
+        None
     }
 }
 

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -161,6 +161,25 @@ where
         sync_state: Arc<DaSyncState>,
     ) -> anyhow::Result<Self> {
         error_if_tokio_runtime_is_not_multi_threaded()?;
+        let mut background_handles = Vec::new();
+
+        // This sender is not used immediately,
+        // But when REST and RPC handlers start, sender is used to get another subscription.
+        let (secondary_shutdown_sender, mut secondary_shutdown_receiver) = watch::channel(());
+        secondary_shutdown_receiver.mark_unchanged();
+        let receiver_for_metrics = secondary_shutdown_receiver.clone();
+        let metrics_handle = tokio::spawn(async move {
+            if let Some(handle) =
+                sov_metrics::init_metrics_tracker(&monitoring_config, receiver_for_metrics)
+            {
+                handle.await?;
+            } else {
+                tracing::warn!("Metics have been initialized outside of runner, some measurements can be lost on shutdown");
+            };
+
+            Ok(())
+        });
+        background_handles.push(metrics_handle);
 
         let axum_config = &runner_config.http_config;
 
@@ -214,15 +233,7 @@ where
             shutdown_receiver.clone(),
         )
         .await?;
-
-        // This sender is not used immediately,
-        // But when REST and RPC handlers start, sender is used to get another subscription.
-        let (secondary_shutdown_sender, mut secondary_shutdown_receiver) = watch::channel(());
-        secondary_shutdown_receiver.mark_unchanged();
-
-        tokio::spawn(async move {
-            sov_metrics::init_metrics_tracker(&monitoring_config);
-        });
+        background_handles.push(fetcher_background_handle);
 
         Ok(Self {
             first_unprocessed_height_at_startup,
@@ -238,7 +249,7 @@ where
             sync_fetcher,
             shutdown_receiver,
             secondary_shutdown_sender,
-            background_handles: vec![fetcher_background_handle],
+            background_handles,
             start_at_rollup_height,
             stop_at_rollup_height,
             save_tx_bodies: runner_config.save_tx_bodies,
@@ -410,7 +421,7 @@ where
         info!("Runner main loop is completed, keep shutting down...");
         if let Err(e) = self.secondary_shutdown_sender.send(()) {
             tracing::warn!(
-                ?e,
+                error = ?e,
                 "Failed to send secondary shutdown signal. Happens if no HTTP handlers are running"
             );
         }
@@ -423,7 +434,6 @@ where
         for handle in background_handles {
             let _ = handle.await?;
         }
-
         Ok(())
     }
 
@@ -456,7 +466,6 @@ where
         Ok(false)
     }
 
-    #[tracing::instrument(skip(self))]
     async fn process_next_slot(
         &mut self,
         mut next_da_height: NextDaHeightToProcess,
@@ -465,6 +474,14 @@ where
     ) -> anyhow::Result<Option<NextDaHeightToProcess>> {
         let loop_start = std::time::Instant::now();
         let prev_state_root = self.get_state_root().clone();
+        let span = tracing::info_span!("process_next_slot", next_da_height = next_da_height);
+
+        if let Some(h) = start_at_rollup_height {
+            span.record("start_at_rollup_height", tracing::field::display(h));
+        }
+        if let Some(h) = stop_at_rollup_height {
+            span.record("stop_at_rollup_height", tracing::field::display(h));
+        }
         debug!("Requesting DA block");
 
         let mut transaction_count = 0;
@@ -621,7 +638,7 @@ where
 
         // Updating counters and metrics
         self.sync_state.update_synced(next_da_height);
-        debug!(
+        info!(
             time = ?loop_start.elapsed(),
             "Block execution complete"
         );

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -434,6 +434,7 @@ where
         for handle in background_handles {
             let _ = handle.await?;
         }
+
         Ok(())
     }
 
@@ -638,7 +639,7 @@ where
 
         // Updating counters and metrics
         self.sync_state.update_synced(next_da_height);
-        info!(
+        debug!(
             time = ?loop_start.elapsed(),
             "Block execution complete"
         );

--- a/crates/module-system/sov-modules-macros/tests/integration/metrics.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/metrics.rs
@@ -2,6 +2,7 @@ use sov_metrics::{init_metrics_tracker, MonitoringConfig, TelegrafSocketConfig};
 use sov_modules_api::{Gas, GasMeter};
 use sov_modules_macros::track_gas_constants_usage;
 use tokio::net::UdpSocket;
+use tokio::sync::watch;
 use tokio::time::timeout;
 
 type S = sov_test_utils::TestSpec;
@@ -37,11 +38,17 @@ async fn test_metrics_macro() {
         .await
         .expect("Impossible to bind to port");
 
-    init_metrics_tracker(&MonitoringConfig {
-        telegraf_address: TelegrafSocketConfig::udp(channel.local_addr().unwrap()),
-        max_datagram_size: Some(1),
-        max_pending_metrics: None,
-    });
+    let (_shutdown_sender, mut shutdown_receiver) = watch::channel(());
+    shutdown_receiver.mark_unchanged();
+
+    init_metrics_tracker(
+        &MonitoringConfig {
+            telegraf_address: TelegrafSocketConfig::udp(channel.local_addr().unwrap()),
+            max_datagram_size: Some(1),
+            max_pending_metrics: None,
+        },
+        shutdown_receiver,
+    );
 
     let input = &mut 10;
 
@@ -93,11 +100,17 @@ async fn test_metrics_macro_without_input() {
         .await
         .expect("Impossible to bind to port");
 
-    init_metrics_tracker(&MonitoringConfig {
-        telegraf_address: TelegrafSocketConfig::udp(channel.local_addr().unwrap()),
-        max_datagram_size: Some(1),
-        max_pending_metrics: None,
-    });
+    let (_shutdown_sender, mut shutdown_receiver) = watch::channel(());
+    shutdown_receiver.mark_unchanged();
+
+    init_metrics_tracker(
+        &MonitoringConfig {
+            telegraf_address: TelegrafSocketConfig::udp(channel.local_addr().unwrap()),
+            max_datagram_size: Some(1),
+            max_pending_metrics: None,
+        },
+        shutdown_receiver,
+    );
 
     test_metrics_without_input();
 

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
@@ -54,7 +54,7 @@ pub fn default_rust_log_value() -> String {
     [
         "debug", // Default logging level.
         // Info-only:
-        "sov-paymaster=info", // We rarely need to debug why exactly transactions aren't covered
+        "sov_paymaster=info", // We rarely need to debug why exactly transactions aren't covered
         "h2=info",
         "tower=info",
         "tower_http=info",

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -122,7 +122,7 @@ async fn start_stop_empty(
         ),
         (Level::WARN, "Skipping pruning of sequence number because it's already been pruned".to_string()),
         (Level::WARN, "The node is unsynced and doesn't know it. This probably means that you wiped the node DB and are resyncing.".to_string()),
-        (Level::WARN, "Metics have been initialized outside of runner, some measurements can be lost on shutdown.".to_string()),
+        (Level::WARN, "Metics have been initialized outside of runner, some measurements can be lost on shutdown".to_string()),
     ];
 
     let mut recorded_errors_warnings =

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -122,6 +122,7 @@ async fn start_stop_empty(
         ),
         (Level::WARN, "Skipping pruning of sequence number because it's already been pruned".to_string()),
         (Level::WARN, "The node is unsynced and doesn't know it. This probably means that you wiped the node DB and are resyncing.".to_string()),
+        (Level::WARN, "Metics have been initialized outside of runner, some measurements can be lost on shutdown.".to_string()),
     ];
 
     let mut recorded_errors_warnings =

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -311,6 +311,10 @@ async fn test_start_prover_manual() -> anyhow::Result<()> {
             Level::WARN,
             "Received error updating target height, stopping background task".to_string(),
         ),
+        (
+            Level::WARN,
+            "Metics have been initialized outside of runner, some measurements can be lost on shutdown".to_string(),
+        ),
     ];
     recorded_errors_warnings.retain(|e| !known.contains(e));
     // We could've checked `.is_empty`, but in case of failure, we will see errors immediately.

--- a/examples/demo-rollup/tests/resync/mod.rs
+++ b/examples/demo-rollup/tests/resync/mod.rs
@@ -309,6 +309,7 @@ async fn test_rollup_resync() -> anyhow::Result<()> {
         // oddity that might be worth investigating.
         (Level::WARN, "State Transition Info is not consumed fast enough, cannot prune older entries. Please check that consumer works.".to_string()),
         (Level::WARN, "The node is unsynced and doesn't know it. This probably means that you wiped the node DB and are resyncing.".to_string()),
+        (Level::WARN, "Metics have been initialized outside of runner, some measurements can be lost on shutdown".to_string()),
     ];
 
     let mut recorded_errors_warnings =


### PR DESCRIPTION
# Description

Metrics publishing task is now handled in the regular shutdown process, this prevents loss of the metrics that were in the buffer at the time of shutdown:
 * Publishing task receives shutdown receiver and can stop when rollup stops
 * It fetches all metrics from the channel and submits all remaining buffered metrics, so nothing is dropped during shutdown

Various changes in logging:

* Blob sender uses proper wording when timeout for processing is exceeded
* Use structured logging instead of string interpolation. Should help for customers who uses dedicated logging facility
* Runner uses custom span and adds start/stop heights only when they are initialized


- [x] Internal change~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Manually tested. It is tricky to test metrics shutdown, as it relies on OnceLock per process.

## Docs
No updates
