### PR TITLE
fix: incorrect block number in eth_subscribe missing-block error log

### DIFF
--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -98,7 +98,10 @@ async fn stream_logs<S, Seq>(
                 match evm.get_maybe_sealed_block(receipt.block_number, state) {
                     Some(b) => block = b,
                     None => {
-                        tracing::error!(start_block, "Block does not exist");
+                        tracing::error!(
+                            block_number = receipt.block_number,
+                            "Block does not exist"
+                        );
                         return;
                     }
                 }


### PR DESCRIPTION
Correct the error log when a block lookup by receipt.block_number fails: previously it logged start_block, which is unrelated and misleading. Using the actual receipt.block_number makes diagnostics accurate and aligns with logging practices elsewhere (e.g., get_logs handler). This prevents confusion when debugging pruned or missing state.