### PR TITLE
More celestia metrics

### DIFF
--- a/crates/adapters/celestia/src/da_service.rs
+++ b/crates/adapters/celestia/src/da_service.rs
@@ -134,7 +134,6 @@ impl CelestiaService {
             tendermint::Hash::from_str(&tx_response.txhash)
                 .expect("Failed to decode hash from `TxResponse`"),
         );
-        // TODO: On error too!
         info!(
             da_height = tx_response.height,
             tx_hash = %tx_hash,
@@ -350,10 +349,6 @@ impl CelestiaService {
         &self,
         aggregated_proof: &[u8],
     ) -> Result<SubmitBlobReceipt<TmHash>, MaybeRetryable<anyhow::Error>> {
-        debug!(
-            proof_size = aggregated_proof.len(),
-            "Submitting aggregated proof to Celestia"
-        );
         self.submit_blob_to_namespace(aggregated_proof, self.rollup_proof_namespace)
             .await
             .map_err(into_transient_with_context)
@@ -499,6 +494,7 @@ impl DaService for CelestiaService {
             "send_proof",
         )
         .await;
+        // UNWRAP: Not possible, because receiver is in the scope still
         tx.send(res).unwrap();
         rx
     }

--- a/crates/adapters/celestia/src/da_service.rs
+++ b/crates/adapters/celestia/src/da_service.rs
@@ -134,6 +134,7 @@ impl CelestiaService {
             tendermint::Hash::from_str(&tx_response.txhash)
                 .expect("Failed to decode hash from `TxResponse`"),
         );
+        // TODO: On error too!
         info!(
             da_height = tx_response.height,
             tx_hash = %tx_hash,
@@ -231,17 +232,20 @@ impl CelestiaService {
     ) -> Result<CelestiaHeader, MaybeRetryable<anyhow::Error>> {
         let start = std::time::Instant::now();
         let client = &self.read_client;
-        let extended_header =
-            tokio::time::timeout(self.request_timeout, client.header_get_by_height(height))
-                .await
-                .map_err(|_| MaybeRetryable::Transient(anyhow::anyhow!("Request timeout")))?
-                .map_err(into_transient_with_context)?;
+        let result =
+            tokio::time::timeout(self.request_timeout, client.header_get_by_height(height)).await;
+        let is_success = matches!(result, Ok(Ok(_)));
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(GetBlockHeaderMeasurement {
                 height,
                 fetch_header_time: start.elapsed(),
+                is_success,
             });
         });
+
+        let extended_header = result
+            .map_err(|_| MaybeRetryable::Transient(anyhow::anyhow!("Request timeout")))?
+            .map_err(into_transient_with_context)?;
 
         Ok(extended_header.into())
     }
@@ -313,16 +317,20 @@ impl CelestiaService {
         &self,
     ) -> Result<CelestiaHeader, MaybeRetryable<anyhow::Error>> {
         let start = std::time::Instant::now();
-        let header = self
-            .read_client
-            .header_network_head()
-            .await
-            .map_err(into_transient_with_context)?;
+        let result =
+            tokio::time::timeout(self.request_timeout, self.read_client.header_network_head())
+                .await;
+        let is_success = matches!(result, Ok(Ok(_)));
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(GetChainHeadMeasurement {
                 fetch_header_time: start.elapsed(),
+                is_success,
             });
         });
+        let header = result
+            .map_err(|_| MaybeRetryable::Transient(anyhow::anyhow!("Request timeout")))?
+            .map_err(into_transient_with_context)?;
+
         Ok(CelestiaHeader::from(header))
     }
 
@@ -342,7 +350,10 @@ impl CelestiaService {
         &self,
         aggregated_proof: &[u8],
     ) -> Result<SubmitBlobReceipt<TmHash>, MaybeRetryable<anyhow::Error>> {
-        debug!(proof_size = aggregated_proof.len(), "Submitting aggregated proof to Celestia");
+        debug!(
+            proof_size = aggregated_proof.len(),
+            "Submitting aggregated proof to Celestia"
+        );
         self.submit_blob_to_namespace(aggregated_proof, self.rollup_proof_namespace)
             .await
             .map_err(into_transient_with_context)

--- a/crates/adapters/celestia/src/da_service.rs
+++ b/crates/adapters/celestia/src/da_service.rs
@@ -22,7 +22,8 @@ use tracing::{debug, info, instrument, trace};
 
 pub use crate::config::CelestiaConfig;
 use crate::metrics::{
-    BlobSubmitMeasurement, GetBlockMeasurement, NamespaceDataMetrics, RollupNamespace,
+    BlobSubmitMeasurement, GetBlockHeaderMeasurement, GetBlockMeasurement, GetChainHeadMeasurement,
+    NamespaceDataMetrics, RollupNamespace,
 };
 use crate::types::{
     BlobWithSender, FilteredCelestiaBlock, NamespaceBoundaryProof, NamespaceRelevantData, TmHash,
@@ -228,12 +229,19 @@ impl CelestiaService {
         &self,
         height: u64,
     ) -> Result<CelestiaHeader, MaybeRetryable<anyhow::Error>> {
+        let start = std::time::Instant::now();
         let client = &self.read_client;
         let extended_header =
             tokio::time::timeout(self.request_timeout, client.header_get_by_height(height))
                 .await
                 .map_err(|_| MaybeRetryable::Transient(anyhow::anyhow!("Request timeout")))?
                 .map_err(into_transient_with_context)?;
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit(GetBlockHeaderMeasurement {
+                height,
+                fetch_header_time: start.elapsed(),
+            });
+        });
 
         Ok(extended_header.into())
     }
@@ -304,11 +312,17 @@ impl CelestiaService {
     async fn get_head_block_header_inner(
         &self,
     ) -> Result<CelestiaHeader, MaybeRetryable<anyhow::Error>> {
+        let start = std::time::Instant::now();
         let header = self
             .read_client
             .header_network_head()
             .await
             .map_err(into_transient_with_context)?;
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit(GetChainHeadMeasurement {
+                fetch_header_time: start.elapsed(),
+            });
+        });
         Ok(CelestiaHeader::from(header))
     }
 
@@ -328,7 +342,7 @@ impl CelestiaService {
         &self,
         aggregated_proof: &[u8],
     ) -> Result<SubmitBlobReceipt<TmHash>, MaybeRetryable<anyhow::Error>> {
-        debug!("Submitting aggregated proof to Celestia");
+        debug!(proof_size = aggregated_proof.len(), "Submitting aggregated proof to Celestia");
         self.submit_blob_to_namespace(aggregated_proof, self.rollup_proof_namespace)
             .await
             .map_err(into_transient_with_context)

--- a/crates/adapters/celestia/src/metrics.rs
+++ b/crates/adapters/celestia/src/metrics.rs
@@ -155,6 +155,7 @@ impl Metric for BlobSubmitMeasurement {
 pub(crate) struct GetBlockHeaderMeasurement {
     pub height: u64,
     pub fetch_header_time: std::time::Duration,
+    pub is_success: bool,
 }
 
 impl Metric for GetBlockHeaderMeasurement {
@@ -165,9 +166,10 @@ impl Metric for GetBlockHeaderMeasurement {
     fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
         write!(
             buffer,
-            "{},height={} total_time_us={}",
+            "{},height={},is_success={} total_time_us={}",
             self.measurement_name(),
             self.height,
+            self.is_success as u8,
             self.fetch_header_time.as_micros(),
         )
     }
@@ -176,6 +178,7 @@ impl Metric for GetBlockHeaderMeasurement {
 #[derive(Debug)]
 pub(crate) struct GetChainHeadMeasurement {
     pub fetch_header_time: std::time::Duration,
+    pub is_success: bool,
 }
 
 impl Metric for GetChainHeadMeasurement {
@@ -186,8 +189,9 @@ impl Metric for GetChainHeadMeasurement {
     fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
         write!(
             buffer,
-            "{} total_time_us={}",
+            "{},is_success={} total_time_us={}",
             self.measurement_name(),
+            self.is_success as u8,
             self.fetch_header_time.as_micros(),
         )
     }

--- a/crates/adapters/celestia/src/metrics.rs
+++ b/crates/adapters/celestia/src/metrics.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use celestia_types::row_namespace_data::NamespaceData;
 use celestia_types::state::RawTxResponse;
 use sov_metrics::Metric;
@@ -37,8 +35,6 @@ impl NamespaceDataMetrics {
         let shares = data.rows.iter().map(|r| r.shares.len()).sum();
         Self { rows, shares }
     }
-
-    fn serialize_for_telegraf(&self) {}
 }
 
 #[derive(Debug)]
@@ -152,5 +148,47 @@ impl Metric for BlobSubmitMeasurement {
         }
 
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct GetBlockHeaderMeasurement {
+    pub height: u64,
+    pub fetch_header_time: std::time::Duration,
+}
+
+impl Metric for GetBlockHeaderMeasurement {
+    fn measurement_name(&self) -> &'static str {
+        "sov_celestia_adapter_get_header_at"
+    }
+
+    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        write!(
+            buffer,
+            "{},height={} total_time_us={}",
+            self.measurement_name(),
+            self.height,
+            self.fetch_header_time.as_micros(),
+        )
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct GetChainHeadMeasurement {
+    pub fetch_header_time: std::time::Duration,
+}
+
+impl Metric for GetChainHeadMeasurement {
+    fn measurement_name(&self) -> &'static str {
+        "sov_celestia_adapter_get_head_block"
+    }
+
+    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        write!(
+            buffer,
+            "{} total_time_us={}",
+            self.measurement_name(),
+            self.fetch_header_time.as_micros(),
+        )
     }
 }


### PR DESCRIPTION
# Description

Tracking how much time it took to get block header or head of the chain. It contributes to sync performance

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1630


## Testing
Manually checked the metrics

## Docs
No updates
