### PR TITLE
Increase hyperlane-cli timeout

### DIFF
--- a/crates/module-system/hyperlane/tests/integration/with_agent/helpers/evm.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/helpers/evm.rs
@@ -13,7 +13,7 @@ use testcontainers::{ContainerAsync, ImageExt};
 use testcontainers_modules::anvil::AnvilNode;
 
 pub const ANVIL_PORT: u16 = 8545;
-const TAG: &str = "v1.1.0";
+const TAG: &str = "v1.3.6";
 
 pub struct AnvilRunner {
     container: ContainerAsync<AnvilNode>,
@@ -27,7 +27,8 @@ impl AnvilRunner {
         // Hard code tag, so we don't accidental breakages
         let container = AnvilNode::default()
             .with_tag(TAG)
-            .with_cmd(["--port", &ANVIL_PORT.to_string()])
+            // Single string is on purpose, otherwise arguments go to `sh -c` and not into anvil
+            .with_cmd([format!("anvil --port {ANVIL_PORT} --block-time 5")])
             .start()
             .await
             .expect("failed to start anvil");

--- a/crates/module-system/hyperlane/tests/integration/with_agent/helpers/evm.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/helpers/evm.rs
@@ -28,7 +28,7 @@ impl AnvilRunner {
         let container = AnvilNode::default()
             .with_tag(TAG)
             // Single string is on purpose, otherwise arguments go to `sh -c` and not into anvil
-            .with_cmd([format!("anvil --port {ANVIL_PORT} --block-time 5")])
+            .with_cmd([format!("--port {ANVIL_PORT} --block-time 5")])
             .start()
             .await
             .expect("failed to start anvil");

--- a/crates/module-system/hyperlane/tests/integration/with_agent/helpers/evm.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/helpers/evm.rs
@@ -27,8 +27,6 @@ impl AnvilRunner {
         // Hard code tag, so we don't accidental breakages
         let container = AnvilNode::default()
             .with_tag(TAG)
-            // Single string is on purpose, otherwise arguments go to `sh -c` and not into anvil
-            .with_cmd([format!("--port {ANVIL_PORT} --block-time 5")])
             .start()
             .await
             .expect("failed to start anvil");

--- a/crates/module-system/hyperlane/tests/integration/with_agent/helpers/hyperlane_cli.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/helpers/hyperlane_cli.rs
@@ -11,7 +11,6 @@ use testcontainers::{ContainerRequest, GenericImage, ImageExt};
 
 const IMAGE: &str = "ghcr.io/sovereign-labs/hyperlane-cli";
 const TAG: &str = "sov-integration-3";
-const REGISTRY_REPO: &str = "https://github.com/citizen-stig/hyperlane-registry";
 
 pub struct HyperlaneCliRunner {
     data: tempfile::TempDir,
@@ -64,9 +63,8 @@ impl HyperlaneCliRunner {
             "core",
             "deploy",
             "--registry",
-            REGISTRY_REPO,
-            "--registry",
             "/root/.hyperlane",
+            "--disableProxy",
             "--config",
             "/root/configs/core-config.yaml",
             "--chain",
@@ -109,9 +107,8 @@ impl HyperlaneCliRunner {
             "warp",
             "deploy",
             "--registry",
-            REGISTRY_REPO,
-            "--registry",
             "/root/.hyperlane",
+            "--disableProxy",
             "--config",
             "/root/configs/warp-route-deployment.yaml",
             "--yes",

--- a/crates/module-system/hyperlane/tests/integration/with_agent/helpers/hyperlane_cli.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/helpers/hyperlane_cli.rs
@@ -179,7 +179,8 @@ async fn wait_till_container_exit(hyperlane_cli_image: ContainerRequest<GenericI
         .is_running()
         .await
         .expect("failed to get running status");
-    for _ in 0..300 {
+    // 600 * 100ms = 60_000ms = 60s
+    for _ in 0..600 {
         is_running = container.is_running().await.unwrap();
         if !is_running {
             break;

--- a/crates/module-system/hyperlane/tests/integration/with_agent/helpers/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/helpers/mod.rs
@@ -195,9 +195,9 @@ impl HyperlaneBuilder {
         let docker_image = env::var("CUSTOM_HLP_DOCKER_IMAGE");
         let has_custom_image = !matches!(docker_image, Err(env::VarError::NotPresent));
 
-        // Current image is based on https://github.com/Sovereign-Labs/hyperlane-monorepo/tree/integration-2025-08-27-rebase branch
+        // Current image is based on https://github.com/Sovereign-Labs/hyperlane-monorepo/tree/integration-2025-09-17-rebase branch
         let docker_image = docker_image
-            .unwrap_or_else(|_| "ghcr.io/sovereign-labs/hyperlane-agent:integration-2".into());
+            .unwrap_or_else(|_| "ghcr.io/sovereign-labs/hyperlane-agent:integration-5".into());
         let (name, tag) = docker_image
             .split_once(':')
             .unwrap_or((&docker_image, "latest"));

--- a/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
@@ -1,7 +1,7 @@
 //! End-to-end tests for hyperlane implementation that utilize real relayer, validators and evm devnet.
 //!
 //! The docker setup uses several containers:
-//! 1. Hyperlane agents are built from official [Dockerfile](https://github.com/Sovereign-Labs/hyperlane-monorepo/blob/integration-2025-08-27-rebase/rust/Dockerfile)
+//! 1. Hyperlane agents are built from official [Dockerfile](https://github.com/Sovereign-Labs/hyperlane-monorepo/blob/integration-2025-09-17-rebase/rust/Dockerfile)
 //! 2. Hyperlane CLI is built from [docker/hyperlane/hyperlane-cli.Dockerfile](https://github.com/Sovereign-Labs/sovereign-sdk/blob/39e6ee0e94b7a8a5d1e23c346efdab856814c62a/docker/hyperlane/hyperlane-cli.Dockerfile)j
 //! 3. EVM uses official anvil image: `ghcr.io/foundry-rs/foundry`
 //!
@@ -367,7 +367,8 @@ async fn test_dispatch_message_to_evm_counterparty() {
                 .unwrap();
 
             // Find the dispatched message on counterparty
-            // TODO: How to do it more reliably?
+            // TODO: How to do it more reliably? Check relayer metrics repeatedly, including error
+            // If error metrics increases, fail early and print logs.
             tracing::info!("Waiting for relayer to submit transaction to EVM...");
             sleep(Duration::from_secs(20)).await; // give relayer extra time to relay
 


### PR DESCRIPTION
# Description

This PR attempts to improve stability of hyperlane tests. This includes:

* Bumping wait time for hyperlane cli to 60 seconds instead of 30 seconds
* Upgrading anvil version
* Disable proxy calls in hyperlane cli
* Upgrading hyperlane agents to the latest with all the fixes.

What is not included in this PR:

* Checking relayer metrics instead of sleeping
* Testing outbound transfers with non test ISM

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
All existing tests are passing

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
