### PR TITLE
Suppress any logs emitted while running in the `SequencerWarmUp` execution context.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -806,10 +806,13 @@ where
         executor_context,
     } = ctx;
 
-    let _span = tracing::trace_span!(
-        "preferred_seq_bg_task",
-        checkpoint_height = %checkpoint.rollup_height_to_access(),
-    )
+    let _span = match executor_context {
+        ExecutionContext::Sequencer => tracing::trace_span!(ExecutionContext::SEQUENCER),
+        ExecutionContext::SequencerWarmUp => {
+            tracing::trace_span!(ExecutionContext::SEQUENCER_WARM_UP)
+        }
+        ExecutionContext::Node => tracing::trace_span!(ExecutionContext::NODE),
+    }
     .entered();
 
     let stf = StfBlueprint::<S, Rt>::new();

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
@@ -21,10 +21,8 @@ where
 {
     fn enabled(&self, _meta: &tracing::Metadata<'_>, ctx: &Context<'_, S>) -> bool {
         if let Some(current) = ctx.lookup_current() {
-            if let Some(current) = ctx.lookup_current() {
-                if current.name() == self.0 {
-                    return false;
-                }
+            if current.name() == self.0 {
+                return false;
             }
         }
         true

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
@@ -21,9 +21,8 @@ where
 {
     fn enabled(&self, _meta: &tracing::Metadata<'_>, ctx: &Context<'_, S>) -> bool {
         if let Some(current) = ctx.lookup_current() {
-            // iterate current span and all its ancestors (root → leaf order)
-            for span in current.scope().from_root() {
-                if span.name() == self.0 {
+            if let Some(current) = ctx.lookup_current() {
+                if current.name() == self.0 {
                     return false;
                 }
             }

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
@@ -5,10 +5,32 @@ use std::str::FromStr;
 
 pub use crate::native_only::telemetry::{should_init_open_telemetry_exporter, OtelGuard};
 use crate::GIT_COMMIT_HASH;
+use sov_modules_api::ExecutionContext;
 use tracing::info;
 use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::layer::{Context, Filter};
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{fmt, EnvFilter, Layer};
+
+#[derive(Clone, Copy)]
+struct IgnoreSpan(&'static str);
+
+impl<S> Filter<S> for IgnoreSpan
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fn enabled(&self, _meta: &tracing::Metadata<'_>, ctx: &Context<'_, S>) -> bool {
+        if let Some(current) = ctx.lookup_current() {
+            // iterate current span and all its ancestors (root → leaf order)
+            for span in current.scope().from_root() {
+                if span.name() == self.0 {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
 
 /// Default [`tracing`] initialization for the rollup node.
 /// Returns optional [`OtelGuard`] which should be held through the lifetime of the caller,
@@ -23,7 +45,11 @@ pub fn initialize_logging() -> Option<OtelGuard> {
     };
 
     let get_env_filter = || EnvFilter::from_str(&env_filter).unwrap();
-    let mut layers = fmt::layer().with_filter(get_env_filter()).boxed();
+
+    let mut layers = fmt::layer()
+        .with_filter(get_env_filter())
+        .with_filter(IgnoreSpan(ExecutionContext::SEQUENCER_WARM_UP))
+        .boxed();
 
     if cfg!(tokio_unstable) {
         layers = layers

--- a/crates/rollup-interface/Cargo.toml
+++ b/crates/rollup-interface/Cargo.toml
@@ -63,7 +63,7 @@ native = [
     "sov-rollup-interface/native",
     "tracing",
     "tokio",
-    "rockbound"
+    "rockbound",
 ]
 arbitrary = [
 	"dep:arbitrary",

--- a/crates/rollup-interface/src/state_machine/stf/mod.rs
+++ b/crates/rollup-interface/src/state_machine/stf/mod.rs
@@ -112,6 +112,17 @@ pub enum ExecutionContext {
 }
 
 impl ExecutionContext {
+    // This string representation is used inside tracing::spans. The macro that creates
+    // spans only accepts const &'static str, and strum generates only &'static str.
+    // Therefore, we had to define these constants manually.
+
+    /// String representation of the SequencerWarmUp variant.
+    pub const SEQUENCER_WARM_UP: &'static str = "SequencerWarmUp";
+    /// String representation of the Sequencer variant.
+    pub const SEQUENCER: &'static str = "Sequencer";
+    /// String representation of the NODE variant.
+    pub const NODE: &'static str = "Node";
+
     /// Returns true if and only if `self` matches [`ExecutionContext::Sequencer`].
     pub fn is_sequencer(&self) -> bool {
         match self {


### PR DESCRIPTION
# Description

Executors running in the SequencerWarmUp context are used solely for cache warm-up, and their logs are suppressed to avoid noise.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1743 
