### PR TITLE
Add `CacheWarmUpMetrics` to cache_warm_up_executor.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
@@ -85,6 +85,8 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
     }
 
     pub(crate) fn send_tx(&self, tx: FullyBakedTx) -> FullyBakedTxWithMaybeChangeSet {
+        // We need to update the `size` field before inserting the thx into tx_sender, otherwise the workers may see an outdated channel size.
+        let size = self.size.fetch_add(1, Ordering::Relaxed);
         let (sender, receiver) = oneshot::channel();
 
         // Skip update if consumer is too slow.
@@ -95,8 +97,6 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
 
         let maybe_receiver = match res {
             Ok(_) => {
-                let size = self.size.fetch_add(1, Ordering::Relaxed);
-
                 sov_metrics::track_metrics(|t| {
                     t.submit(CacheWarmUpMetrics {
                         tx_channel_size: size + 1,
@@ -106,11 +106,14 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
                 Some(receiver)
             }
             Err(flume::TrySendError::Full(_)) => {
-                let size = self.size.load(Ordering::Relaxed);
+                let size = self.size.fetch_sub(1, Ordering::Relaxed);
                 tracing::warn!(size, "The tx queue is full. You may want to increase the number of workers for cache warmup.");
                 None
             }
-            Err(flume::TrySendError::Disconnected(_)) => None,
+            Err(flume::TrySendError::Disconnected(_)) => {
+                self.size.fetch_sub(1, Ordering::Relaxed);
+                None
+            }
         };
 
         FullyBakedTxWithMaybeChangeSet {

--- a/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
@@ -4,13 +4,16 @@ use crate::preferred::RollupBlockExecutor;
 use crate::preferred::RollupBlockExecutorConfig;
 use crate::RollupHeight;
 use crate::SequencerConfig;
+use sov_metrics::Metric;
 use sov_modules_api::Spec;
 use sov_modules_api::StateCheckpoint;
 use sov_modules_api::StateUpdateInfo;
 use sov_modules_api::Storage;
 use sov_modules_api::{FullyBakedTx, Runtime};
 use std::collections::BTreeMap;
+use std::io::Write;
 use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio::task::JoinHandle;
 
@@ -60,10 +63,21 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
         let res = self.tx_sender.try_send(tx);
         match res {
             Ok(_) => {
-                self.size.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let size = self.size.fetch_add(1, Ordering::Relaxed);
+
+                sov_metrics::track_metrics(|t| {
+                    t.submit(CacheWarmUpMetrics {
+                        tx_channel_size: size + 1,
+                    });
+                });
             }
-            Err(flume::TrySendError::Full(_)) => todo!(),
-            Err(flume::TrySendError::Disconnected(_)) => todo!(),
+            Err(flume::TrySendError::Full(_)) => {
+                let size = self.size.load(Ordering::Relaxed);
+                tracing::warn!(size, "The tx queue is full. You may want to increase the number of workers for cache warmup.");
+            }
+            Err(flume::TrySendError::Disconnected(_)) => {
+                // Do nothing.
+            }
         }
     }
 
@@ -143,7 +157,7 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
                         let baked_tx = match tx {
                              Ok(tx) =>
                              {
-                                tx_receiver.size.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                                tx_receiver.size.fetch_sub(1, Ordering::Relaxed);
                                 tx
                              },
                              Err(flume::RecvError::Disconnected) => {
@@ -186,5 +200,25 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
                 notify.state_roots,
             )
             .await;
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CacheWarmUpMetrics {
+    tx_channel_size: u64,
+}
+
+impl Metric for CacheWarmUpMetrics {
+    fn measurement_name(&self) -> &'static str {
+        "sov_sequencer_cache_warmup_metrics"
+    }
+
+    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        write!(
+            buffer,
+            "{} tx_channel_size={}",
+            self.measurement_name(),
+            self.tx_channel_size,
+        )
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
@@ -10,6 +10,8 @@ use sov_modules_api::StateUpdateInfo;
 use sov_modules_api::Storage;
 use sov_modules_api::{FullyBakedTx, Runtime};
 use std::collections::BTreeMap;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 use tokio::task::JoinHandle;
 
 // We have several work-stealing executor workers for a single main worker, so we don't expect the channel to become full.
@@ -35,9 +37,16 @@ impl<S: Spec> Clone for StartBlockNotification<S> {
 }
 
 #[derive(Clone)]
+struct TxReceiver {
+    size: Arc<AtomicU64>,
+    receiver: flume::Receiver<FullyBakedTx>,
+}
+
+#[derive(Clone)]
 pub(crate) struct CacheWarmUpExecutor<S: Spec> {
     start_block_notification_sender: tokio::sync::watch::Sender<Option<StartBlockNotification<S>>>,
     tx_sender: flume::Sender<FullyBakedTx>,
+    size: Arc<AtomicU64>,
 }
 
 impl<S: Spec> CacheWarmUpExecutor<S> {
@@ -48,7 +57,14 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
 
     pub(crate) fn send_tx(&self, tx: FullyBakedTx) {
         // Skip update if consumer is too slow.
-        let _ = self.tx_sender.try_send(tx);
+        let res = self.tx_sender.try_send(tx);
+        match res {
+            Ok(_) => {
+                self.size.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+            Err(flume::TrySendError::Full(_)) => todo!(),
+            Err(flume::TrySendError::Disconnected(_)) => todo!(),
+        }
     }
 
     pub(crate) async fn spawn_execution_task<Rt: Runtime<S>>(
@@ -57,6 +73,11 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
         seq_config: SequencerConfig<S::Address, PreferredSequencerConfig>,
     ) -> (Self, Vec<JoinHandle<()>>) {
         let (tx_sender, tx_receiver) = flume::bounded(TX_CHANNEL_SIZE);
+        let size = Arc::new(AtomicU64::new(0));
+        let tx_receiver = TxReceiver {
+            size: size.clone(),
+            receiver: tx_receiver,
+        };
 
         // Option<StartBlockNotification<S>> is niche-optimized, so keeping it instead of using
         // StartBlockNotification directly in the channel does not introduce any overhead.
@@ -81,6 +102,7 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
             Self {
                 tx_sender,
                 start_block_notification_sender,
+                size,
             },
             handles,
         )
@@ -90,7 +112,7 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
         info: StateUpdateInfo<S::Storage>,
         exec_config: RollupBlockExecutorConfig<S>,
         seq_config: SequencerConfig<S::Address, PreferredSequencerConfig>,
-        tx_receiver: flume::Receiver<FullyBakedTx>,
+        tx_receiver: TxReceiver,
         mut start_block_notification_receiver: tokio::sync::watch::Receiver<
             Option<StartBlockNotification<S>>,
         >,
@@ -117,14 +139,19 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
                         }
                     }
 
-                    tx = tx_receiver.recv_async() => {
+                    tx = tx_receiver.receiver.recv_async() => {
                         let baked_tx = match tx {
-                             Ok(tx) => tx,
+                             Ok(tx) =>
+                             {
+                                tx_receiver.size.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                                tx
+                             },
                              Err(flume::RecvError::Disconnected) => {
                                 // Quit if channel closed.
                                 return
                             },
                         };
+
                         if is_started {
                             let res = executor.apply_tx_to_in_progress_batch(&baked_tx).await;
 


### PR DESCRIPTION
# Description

Adds metrics to the cache_warm_up_executor.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

