### PR TITLE
Add `TxPriority` parameter to celestia adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2025-09-29
 - #1770 **Breaking change** introduces a required `buffer_raw_txs` field to `EthRpcConfig`. This change is only breaking for EVM rollups.
+- #1783 Adds `da.tx_priority` optional field for celestia adapter. Possible values are `Low`, `Medium` or `High`. It can be used to improve blob inclusion.
 
 # 2025-09-25
 - #1758 A new config value in rollup.toml: `runner.da_total_timeout_secs`. It should be larger than the total time da service attempts to fetch data. Default value is 10 minutes.

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -27,6 +27,8 @@ pub struct CelestiaConfig {
     /// Set it only to ensure that the target node runs with correct credentials.
     pub signer_address: Option<CelestiaAddress>,
 
+    /// Default is medium.
+    pub tx_priority: Option<TxPriority>,
     /// Minimal time to wait before reattempting to request to celestia node.
     /// See [`backon::ExponentialBuilder`] for more details
     #[serde(default = "default_min_delay_ms")]
@@ -43,6 +45,24 @@ pub struct CelestiaConfig {
     /// See [`backon::ExponentialBuilder`] for more details
     #[serde(default = "default_factor")]
     pub backoff_factor: f32,
+}
+
+/// Custom type matching [`celestia_rpc::TxPriority`] but with `JsonSchema` support.
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize, JsonSchema)]
+pub enum TxPriority {
+    Low,
+    Medium,
+    High,
+}
+
+impl From<TxPriority> for celestia_rpc::TxPriority {
+    fn from(value: TxPriority) -> Self {
+        match value {
+            TxPriority::Low => celestia_rpc::TxPriority::Low,
+            TxPriority::Medium => celestia_rpc::TxPriority::Medium,
+            TxPriority::High => celestia_rpc::TxPriority::High,
+        }
+    }
 }
 
 impl CelestiaConfig {
@@ -66,6 +86,7 @@ impl CelestiaConfig {
             celestia_rpc_timeout_seconds: NonZero::new(120).unwrap(),
             safe_lead_time_ms: 500,
             signer_address: None,
+            tx_priority: None,
             backoff_min_delay_ms: 50,
             backoff_max_delay_ms: 100,
             backoff_max_times: 3,

--- a/crates/adapters/celestia/src/da_service.rs
+++ b/crates/adapters/celestia/src/da_service.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use backon::ExponentialBuilder;
 use celestia_rpc::prelude::*;
+use celestia_rpc::TxPriority;
 use celestia_types::blob::Blob as JsonBlob;
 use celestia_types::nmt::Namespace;
 use celestia_types::state::Address;
@@ -48,6 +49,7 @@ pub struct CelestiaService {
     safe_lead_time: Duration,
     backoff_policy: ExponentialBuilder,
     request_timeout: Duration,
+    tx_priority: Option<TxPriority>,
 }
 
 impl CelestiaService {
@@ -59,6 +61,7 @@ impl CelestiaService {
         safe_lead_time: Duration,
         backoff_policy: ExponentialBuilder,
         request_timeout: Duration,
+        tx_priority: Option<TxPriority>,
     ) -> Self {
         Self {
             submit_client: Arc::new(Mutex::new(client.clone())),
@@ -69,6 +72,7 @@ impl CelestiaService {
             safe_lead_time,
             backoff_policy,
             request_timeout,
+            tx_priority,
         }
     }
 
@@ -105,7 +109,10 @@ impl CelestiaService {
             "Submitting a blob"
         );
 
-        let tx_config = celestia_rpc::TxConfig::default();
+        let mut tx_config = celestia_rpc::TxConfig::default();
+        if let Some(priority) = self.tx_priority.as_ref() {
+            tx_config = tx_config.with_priority(*priority);
+        }
         let start_lock = std::time::Instant::now();
         let submit_client = self.submit_client.lock().await;
         let lock_acquisition = start_lock.elapsed();
@@ -217,6 +224,7 @@ impl CelestiaService {
             Duration::from_millis(config.safe_lead_time_ms),
             backoff_policy,
             request_timeout,
+            config.tx_priority.map(Into::into),
         )
     }
 }

--- a/examples/demo-rollup/celestia_rollup_config.toml
+++ b/examples/demo-rollup/celestia_rollup_config.toml
@@ -9,6 +9,12 @@ max_celestia_response_body_size = 104_857_600
 # Default: 60 seconds
 # We set it to allow skipping 3 blocks on mocha testnet
 celestia_rpc_timeout_seconds = 18
+
+# Options are "Low", "Medium" and "High"
+# Defines a priority of rollup blob transactions. Set it to "High" for faster inclusion.
+# Default: Medium
+#tx_priority = "High"
+
 # Exponential backoff configuration for retrying failed requests to Celestia node
 # Minimal time to wait before reattempting to request to celestia node.
 # Default: 100 milliseconds
@@ -22,6 +28,7 @@ backoff_max_times = 10
 # Exponential factor for reattempting failed requests
 # Default: 2.0
 # backoff_factor = 2.0
+
 
 # WITH CURRENT UNCOMMENTED VALUES:
 # Timeout per request: 18 seconds


### PR DESCRIPTION
# Description

Allows to change TxPriority for blob submission. Currently default is Medium.

This change will allow customers to change this without recompilation of the rollup.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1630

## Testing
Manually tested with demo-rollup

## Docs
Added configuration description