### PR TITLE
Warm up the main executor cache with `TxChangeset` from the worker executors.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
@@ -5,7 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::preferred::cache_warm_up_executor::FullyBakedTxWithMaybeChangeSet;
 use sov_modules_api::state::TxScratchpad;
 use sov_modules_api::{
-    ChangeSet, Context, DispatchCall, FullyBakedTx, GasArray, IncrementalBatch,
+    ChangeSet, Context, DispatchCall, ExecutionContext, FullyBakedTx, GasArray, IncrementalBatch,
     InjectedControlFlow, IterableBatchWithId, MaybeExecuted, NoOpControlFlow,
     ProvisionalSequencerOutcome, Runtime, SlotGasMeter, TransactionReceipt, TxChangeSet,
     TxControlFlow,
@@ -84,9 +84,11 @@ impl<S: Spec> InjectedControlFlow<S> for MaybeAsyncBatchControlFlow<S> {
                 maybe_tx_change_set,
             } => {
                 if let Some(mut rec) = maybe_tx_change_set.take() {
-                    if let Ok(_change_set) = rec.try_recv() {}
-                    // TODO
-                    scratchpad.apply_change_set();
+                    // If the worker executor provides cache values in time, we apply them to the main executor.
+                    // Otherwise, we proceed without waiting and let the main executor continue.
+                    if let Ok(change_set) = rec.try_recv() {
+                        scratchpad.apply_change_set(change_set);
+                    }
                 }
             }
             MaybeAsyncBatchControlFlow::Sync => {}
@@ -99,6 +101,7 @@ impl<S: Spec> InjectedControlFlow<S> for MaybeAsyncBatchControlFlow<S> {
         dirty_scratchpad: TxScratchpad<S, StateCheckpoint<S>>,
         slot_gas_meter_before_tx: &SlotGasMeter<S>,
         gas_used: &<S as Spec>::Gas,
+        execution_context: ExecutionContext,
     ) -> (StateCheckpoint<S>, TxControlFlow<TransactionReceipt<S>>) {
         match self {
             Self::Async {
@@ -109,6 +112,7 @@ impl<S: Spec> InjectedControlFlow<S> for MaybeAsyncBatchControlFlow<S> {
                 dirty_scratchpad,
                 slot_gas_meter_before_tx,
                 gas_used,
+                execution_context,
             ),
             Self::Sync => <NoOpControlFlow as sov_modules_api::InjectedControlFlow<S>>::post_tx(
                 &NoOpControlFlow,
@@ -116,6 +120,7 @@ impl<S: Spec> InjectedControlFlow<S> for MaybeAsyncBatchControlFlow<S> {
                 dirty_scratchpad,
                 slot_gas_meter_before_tx,
                 gas_used,
+                execution_context,
             ),
         }
     }
@@ -212,6 +217,7 @@ impl<S: Spec> AsyncBatchResponder<S> {
         dirty_scratchpad: TxScratchpad<S, StateCheckpoint<S>>,
         slot_gas_meter_before_tx: &SlotGasMeter<S>,
         gas_used: &<S as Spec>::Gas,
+        execution_context: ExecutionContext,
     ) -> (StateCheckpoint<S>, TxControlFlow<TransactionReceipt<S>>) {
         let end_time: u64 = SystemTime::now().duration_since(UNIX_EPOCH).expect("SystemTime::now() returned something earlier than the UNIX epoch. This should be unreachable.").as_micros().try_into().expect("Unix time in micros overflowed u64. This should be unreachable for the next 300,000 years");
         let execution_time = end_time - self.unix_timestamp_micros.load(Ordering::SeqCst);
@@ -228,7 +234,7 @@ impl<S: Spec> AsyncBatchResponder<S> {
         if !receipt.receipt.is_successful() {
             let response = ExecutedTxResponse {
                 receipt: receipt.clone(),
-                tx_changes: dirty_scratchpad.tx_changes(),
+                tx_changes: dirty_scratchpad.tx_changes(execution_context),
                 remaining_slot_gas: slot_gas_meter_before_tx
                     .remaining_preferred_slot_gas()
                     .clone(), // Since we ignore this tx, the remaining gas limit is unchanged
@@ -256,7 +262,7 @@ impl<S: Spec> AsyncBatchResponder<S> {
 
         let response = ExecutedTxResponse {
             receipt: receipt.clone(),
-            tx_changes: dirty_scratchpad.tx_changes(),
+            tx_changes: dirty_scratchpad.tx_changes(execution_context),
             remaining_slot_gas,
             execution_time_micros: execution_time,
         };

--- a/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
@@ -77,13 +77,17 @@ pub enum MaybeAsyncBatchControlFlow<S: Spec> {
 }
 
 impl<S: Spec> InjectedControlFlow<S> for MaybeAsyncBatchControlFlow<S> {
-    fn try_warm_up_cache(&mut self, _scratchpad: &mut TxScratchpad<S, StateCheckpoint<S>>) {
+    fn try_warm_up_cache(&mut self, scratchpad: &mut TxScratchpad<S, StateCheckpoint<S>>) {
         match self {
             MaybeAsyncBatchControlFlow::Async {
                 responder: _,
                 maybe_tx_change_set,
             } => {
-                let _maybe_tx_change_set = maybe_tx_change_set.take();
+                if let Some(mut rec) = maybe_tx_change_set.take() {
+                    if let Ok(_change_set) = rec.try_recv() {}
+                    // TODO
+                    scratchpad.apply_change_set();
+                }
             }
             MaybeAsyncBatchControlFlow::Sync => {}
         }

--- a/crates/module-system/sov-modules-api/src/batch.rs
+++ b/crates/module-system/sov-modules-api/src/batch.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::ExecutionContext;
 use crate::{
     Amount, Context, DispatchCall, Gas, Runtime, SlotGasMeter, Spec, StateCheckpoint,
     TransactionReceipt, TxScratchpad,
@@ -346,6 +347,7 @@ pub trait InjectedControlFlow<S: Spec> {
         dirty_scratchpad: TxScratchpad<S, StateCheckpoint<S>>,
         slot_gas_meter_before_tx: &SlotGasMeter<S>,
         gas_used: &<S as Spec>::Gas,
+        exec_context: ExecutionContext,
     ) -> (StateCheckpoint<S>, TxControlFlow<TransactionReceipt<S>>);
 }
 
@@ -384,6 +386,7 @@ impl<S: Spec> InjectedControlFlow<S> for NoOpControlFlow {
         dirty_scratchpad: TxScratchpad<S, StateCheckpoint<S>>,
         _slot_gas_meter_before_tx: &SlotGasMeter<S>,
         _gas_used: &<S as Spec>::Gas,
+        _execution_context: ExecutionContext,
     ) -> (StateCheckpoint<S>, TxControlFlow<TransactionReceipt<S>>) {
         match provisional_outcome.execution_status {
             MaybeExecuted::Executed(receipt) => (

--- a/crates/module-system/sov-modules-api/src/state/accessors/checkpoints.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/checkpoints.rs
@@ -256,6 +256,11 @@ impl<S: Spec> StateCheckpoint<S> {
         self.delta.changes()
     }
 
+    /// Warms up the cache with reads whose keys are not already present.
+    pub fn add_read_if_not_present(&mut self, reads: FirstTimeReads) {
+        self.delta.add_read_if_not_present(reads);
+    }
+
     /// Directly apply a set of changes to the state checkpoint. This method should generally *not* be used
     /// during normal execution, since changes should happen through `StateValue` types which
     /// use the UniversalStateAccessor API. It is primarily intended for use in the sequencer, which has to manage

--- a/crates/module-system/sov-modules-api/src/state/accessors/internals.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/internals.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 use crate::state::accessors::StateMetricsProvider;
 use crate::{Spec, StateCheckpoint, TxChangeSet};
 use sov_metrics::{StateAccessMetric, StateMetrics};
+use sov_rollup_interface::stf::ExecutionContext;
 pub(crate) use sov_state::AccessoryWrite;
+use sov_state::NodeLeafAndMaybeValue;
 #[cfg(feature = "native")]
 use sov_state::StateGetter;
 use sov_state::{
@@ -17,7 +19,6 @@ use super::checkpoints::ChangeSet;
 use super::temp_cache::{CacheLookup, TempCache};
 use super::UniversalStateAccessor;
 use crate::state::traits::PerBlockCache;
-use sov_state::NodeLeaf;
 
 /// A [`Delta`] is a diff over an underlying [`Storage`] instance. When queried, it first checks
 /// whether the value is in its local cache and, if so, returns it. Otherwise, it queries the
@@ -133,16 +134,16 @@ impl<S: Storage> Delta<S> {
 #[derive(Debug, Clone, Default)]
 pub struct FirstTimeReads {
     /// User space reads.
-    pub user_reads: Vec<(SlotKey, Option<NodeLeaf>)>,
+    pub user: Vec<(SlotKey, Option<NodeLeafAndMaybeValue>)>,
     /// Kernel space reads.
-    pub kernel_reads: Vec<(SlotKey, Option<NodeLeaf>)>,
+    pub kernel: Vec<(SlotKey, Option<NodeLeafAndMaybeValue>)>,
 }
 
 impl<S: Storage> Delta<S> {
     pub fn first_reads(&self) -> FirstTimeReads {
         FirstTimeReads {
-            user_reads: self.user_cache.revertable_ordered_reads().clone(),
-            kernel_reads: self.kernel_cache.revertable_ordered_reads().clone(),
+            user: self.user_cache.revertable_ordered_reads().clone(),
+            kernel: self.kernel_cache.revertable_ordered_reads().clone(),
         }
     }
 
@@ -327,6 +328,12 @@ impl<S: Storage> Delta<S> {
             }
         }
     }
+
+    pub fn add_read_if_not_present(&mut self, reads: FirstTimeReads) {
+        self.user_cache.add_read_if_not_present_in_cache(reads.user);
+        self.kernel_cache
+            .add_read_if_not_present_in_cache(reads.kernel);
+    }
 }
 
 impl<S: Storage> fmt::Debug for Delta<S> {
@@ -398,7 +405,7 @@ impl<S: Storage> UniversalStateAccessor for AccessoryDelta<S> {
 
 pub(super) struct RevertableWriter<T> {
     pub(super) inner: T,
-    writes: HashMap<(SlotKey, Namespace), Option<SlotValue>>,
+    pub(crate) writes: HashMap<(SlotKey, Namespace), Option<SlotValue>>,
     pub(crate) cache_writes: TempCache,
 }
 
@@ -450,14 +457,21 @@ impl<T> RevertableWriter<T> {
 
 impl<S: Spec> RevertableWriter<StateCheckpoint<S>> {
     /// Change set resulting from transaction execution.
-    pub fn changes(&self) -> TxChangeSet {
+    pub fn changes(&self, execution_context: ExecutionContext) -> TxChangeSet {
+        // Only the WarmUp executors warm up the reads.
+        let reads = if matches!(execution_context, ExecutionContext::SequencerWarmUp) {
+            Some(self.inner.first_reads().clone())
+        } else {
+            None
+        };
+
         TxChangeSet {
             writes: self
                 .writes
                 .iter()
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect(),
-            reads: self.inner.first_reads().clone(),
+            reads,
         }
     }
 }

--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad.rs
@@ -1010,7 +1010,7 @@ mod tests {
     }
 
     fn create_srcratchpad<S: Spec>(storage: S::Storage) -> TxScratchpad<S, StateCheckpoint<S>> {
-        let checkpoint = StateCheckpoint::new(stotage, &MockKernel::new(4, 1));
+        let checkpoint = StateCheckpoint::new(storage, &MockKernel::new(4, 1));
         checkpoint.to_tx_scratchpad()
     }
 

--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad.rs
@@ -929,7 +929,7 @@ mod tests {
         let storage_manager = SimpleStorageManager::new();
         let storage = storage_manager.create_storage();
 
-        let mut worker_scratchpad = create_srtatchpad::<TestSpec>(storage.clone());
+        let mut worker_scratchpad = create_srcratchpad::<TestSpec>(storage.clone());
 
         // Key and values.
         let init_reads = vec![(10, 1), (11, 2), (12, 3)];
@@ -951,7 +951,7 @@ mod tests {
 
         // Retrieve the changeset from the worker, then apply it to the main scratchpad.
         let changeset_from_worker = worker_scratchpad.tx_changes(ExecutionContext::SequencerWarmUp);
-        let mut main_scratchpad = create_srtatchpad::<TestSpec>(storage.clone());
+        let mut main_scratchpad = create_srcratchpad::<TestSpec>(storage.clone());
 
         // After receiving the changeset from the worker, the main scratchpad can see all its values.
         {
@@ -970,8 +970,8 @@ mod tests {
         let storage_manager = SimpleStorageManager::new();
         let storage = storage_manager.create_storage();
 
-        let mut worker_scratchpad = create_srtatchpad::<TestSpec>(storage.clone());
-        let mut main_scratchpad = create_srtatchpad::<TestSpec>(storage.clone());
+        let mut worker_scratchpad = create_srcratchpad::<TestSpec>(storage.clone());
+        let mut main_scratchpad = create_srcratchpad::<TestSpec>(storage.clone());
 
         // Initialize the main_scratchpad cache with reads
         let main_reads = vec![(10, 1), (11, 2), (12, 3)];

--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad.rs
@@ -22,10 +22,13 @@ use crate::{
     AccessoryStateWriter, Amount, BasicGasMeter, Gas, GasInfo, GasMeter, GasMeteringError,
     GetGasPrice, ProvableStateReader, ProvableStateWriter, TxState, VersionReader,
 };
+
 use sov_metrics::{StateAccessMetric, StateMetrics};
 use sov_rollup_interface::common::{SlotNumber, VisibleSlotNumber};
+use sov_rollup_interface::stf::ExecutionContext;
 use sov_state::{
-    EventContainer, Kernel as KernelType, Namespace, SlotKey, SlotValue, TypeErasedEvent, User,
+    EventContainer, Kernel as KernelType, Namespace, NodeLeafAndMaybeValue, SlotKey, SlotValue,
+    TypeErasedEvent, User,
 };
 
 /// A state diff over the storage that contains all the changes related to transaction execution.
@@ -273,7 +276,7 @@ pub struct TxChangeSet {
     /// The transaction writes.
     pub writes: Vec<((SlotKey, sov_state::Namespace), Option<SlotValue>)>,
     /// The transaction reads.
-    pub reads: FirstTimeReads,
+    pub reads: Option<FirstTimeReads>,
 }
 
 impl<S: Spec, I: StateProvider<S>> TxScratchpad<S, I> {
@@ -342,12 +345,28 @@ impl<S: Spec, I: StateProvider<S>> PerBlockCache for TxScratchpad<S, I> {
 
 impl<S: Spec> TxScratchpad<S, StateCheckpoint<S>> {
     /// Change set resulting from transaction execution.
-    pub fn tx_changes(&self) -> TxChangeSet {
-        self.inner.changes()
+    pub fn tx_changes(&self, execution_context: ExecutionContext) -> TxChangeSet {
+        self.inner.changes(execution_context)
     }
 
-    /// TODO
-    pub fn apply_change_set(&mut self) {}
+    /// Applies changes to the TxScratchpad to warm up its cache.
+    pub fn apply_change_set(&mut self, changes: TxChangeSet) {
+        let mut reads = changes.reads.unwrap();
+
+        // If a write overrides a read, ignore the read.
+        self.filter_out_writes(&mut reads.user, Namespace::User);
+        self.filter_out_writes(&mut reads.kernel, Namespace::Kernel);
+
+        self.inner.inner.add_read_if_not_present(reads);
+    }
+
+    fn filter_out_writes(
+        &self,
+        reads: &mut Vec<(SlotKey, Option<NodeLeafAndMaybeValue>)>,
+        namespace: Namespace,
+    ) {
+        reads.retain(|(k, _)| !self.inner.writes.contains_key(&(k.clone(), namespace)));
+    }
 }
 
 /// A working set that can be used to charge gas for pre transaction execution checks.
@@ -765,19 +784,25 @@ impl<S: Spec, I: StateProvider<S>> PerBlockCache for WorkingSet<S, I> {
 
 #[cfg(test)]
 mod tests {
+    use sov_metrics::StateAccessMetric;
     use sov_rollup_interface::common::HexString;
+    use sov_rollup_interface::stf::ExecutionContext;
     use sov_state::codec::BcsCodec;
     use sov_state::namespaces::User;
-    use sov_state::{Kernel, SlotKey, SlotValue};
+    use sov_state::Namespace;
+    use sov_state::{Kernel, NodeLeafAndMaybeValue, SlotKey, SlotValue};
     use sov_test_utils::storage::SimpleStorageManager;
+    use sov_test_utils::TestHasher;
     use sov_test_utils::{MockDaSpec, MockZkvm};
 
     use crate::capabilities::mocks::MockKernel;
     use crate::capabilities::Kernel as _;
     use crate::execution_mode::Native;
+    use crate::state::accessors::internals::FirstTimeReads;
+    use crate::state::accessors::seal::UniversalStateAccessor;
     use crate::{
         BasicGasMeter, GasArray, Spec, StateAccessor, StateCheckpoint, StateProvider, StateReader,
-        StateWriter, WorkingSet,
+        StateWriter, TxChangeSet, TxScratchpad, WorkingSet,
     };
 
     type TestSpec = crate::default_spec::DefaultSpec<MockDaSpec, MockZkvm, MockZkvm, Native>;
@@ -892,5 +917,145 @@ mod tests {
             StateReader::<User>::get(&mut new_scratchpad, &storage_key_3)
                 .expect("This should be unfaillible")
         );
+    }
+
+    #[test]
+    fn test_cache_warmup_changeset() {
+        test_cache_warmup_changeset_with_namespace(Namespace::User);
+        test_cache_warmup_changeset_with_namespace(Namespace::Kernel);
+    }
+
+    fn test_cache_warmup_changeset_with_namespace(namespace: Namespace) {
+        let storage_manager = SimpleStorageManager::new();
+        let storage = storage_manager.create_storage();
+
+        let mut worker_scratchpad = create_srtatchpad::<TestSpec>(storage.clone());
+
+        // Key and values.
+        let init_reads = vec![(10, 1), (11, 2), (12, 3)];
+
+        // Simulate a worker reading some values and filling its cache.
+        {
+            worker_scratchpad.apply_change_set(changeset(init_reads.clone(), namespace));
+            assert_scratchpad_contains_data(&init_reads, &mut worker_scratchpad, namespace);
+        }
+
+        // Only `ExecutionContext::SequencerWarmUp` is responsible for placing the reads into `TxChangeSet``.
+        {
+            let ch = worker_scratchpad.tx_changes(ExecutionContext::Sequencer);
+            assert!(ch.reads.is_none());
+
+            let ch = worker_scratchpad.tx_changes(ExecutionContext::Node);
+            assert!(ch.reads.is_none());
+        }
+
+        // Retrieve the changeset from the worker, then apply it to the main scratchpad.
+        let changeset_from_worker = worker_scratchpad.tx_changes(ExecutionContext::SequencerWarmUp);
+        let mut main_scratchpad = create_srtatchpad::<TestSpec>(storage.clone());
+
+        // After receiving the changeset from the worker, the main scratchpad can see all its values.
+        {
+            main_scratchpad.apply_change_set(changeset_from_worker.clone());
+            assert_scratchpad_contains_data(&init_reads, &mut main_scratchpad, namespace);
+        }
+    }
+
+    #[test]
+    fn test_cache_warmup_overrides() {
+        test_cache_warmup_overrides_with_namespace(Namespace::User);
+        test_cache_warmup_overrides_with_namespace(Namespace::Kernel);
+    }
+
+    fn test_cache_warmup_overrides_with_namespace(namespace: Namespace) {
+        let storage_manager = SimpleStorageManager::new();
+        let storage = storage_manager.create_storage();
+
+        let mut worker_scratchpad = create_srtatchpad::<TestSpec>(storage.clone());
+        let mut main_scratchpad = create_srtatchpad::<TestSpec>(storage.clone());
+
+        // Initialize the main_scratchpad cache with reads
+        let main_reads = vec![(10, 1), (11, 2), (12, 3)];
+        main_scratchpad.apply_change_set(changeset(main_reads.clone(), namespace));
+
+        // Initialize the main_scratchpad cache with writes.
+        let main_writes = vec![(20, 11), (21, 12), (22, 13)];
+        for (k, v) in main_writes.clone() {
+            main_scratchpad.set_value(namespace, &key(k), value(v));
+        }
+
+        let changeset_from_worker = {
+            let worker_reads = vec![
+                // These keys are the same as the read/write keys observed by the main scratchpad above, but they hold different values.
+                (10, 0),
+                (11, 0),
+                (12, 0),
+                (20, 0),
+                (21, 0),
+                (22, 0),
+                // These key–value pairs are extra and not present in the main scratchpad.
+                (101, 111),
+                (102, 112),
+            ];
+
+            worker_scratchpad.apply_change_set(changeset(worker_reads, namespace));
+            worker_scratchpad.tx_changes(ExecutionContext::SequencerWarmUp)
+        };
+        main_scratchpad.apply_change_set(changeset_from_worker);
+
+        // The main_reads and main_writes were not overridden by the changes from the worker_scratchpad.
+        assert_scratchpad_contains_data(&main_reads, &mut main_scratchpad, namespace);
+        assert_scratchpad_contains_data(&main_writes, &mut main_scratchpad, namespace);
+        // The extra key–value pairs are inserted into the main_scratchpad.
+        assert_scratchpad_contains_data(&[(101, 111), (102, 112)], &mut main_scratchpad, namespace);
+    }
+
+    fn create_srtatchpad<S: Spec>(stotage: S::Storage) -> TxScratchpad<S, StateCheckpoint<S>> {
+        let checkpoint = StateCheckpoint::new(stotage, &MockKernel::new(4, 1));
+        checkpoint.to_tx_scratchpad()
+    }
+
+    fn key(k: u8) -> SlotKey {
+        SlotKey::from(vec![k])
+    }
+
+    fn value(v: u8) -> SlotValue {
+        SlotValue::new(&vec![v], &BcsCodec {})
+    }
+
+    fn changeset(reads: Vec<(u8, u8)>, namespace: Namespace) -> TxChangeSet {
+        let reads = reads
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    key(k),
+                    Some(NodeLeafAndMaybeValue::new_read::<TestHasher>(value(v))),
+                )
+            })
+            .collect();
+
+        let (user, kernel) = match namespace {
+            Namespace::User => (reads, vec![]),
+            Namespace::Kernel => (vec![], reads),
+            Namespace::Accessory => unimplemented!(),
+        };
+
+        TxChangeSet {
+            writes: vec![],
+            reads: Some(FirstTimeReads { user, kernel }),
+        }
+    }
+
+    fn assert_scratchpad_contains_data(
+        data: &[(u8, u8)],
+        scratchpad: &mut TxScratchpad<TestSpec, StateCheckpoint<TestSpec>>,
+        namespace: Namespace,
+    ) {
+        let mut metric = StateAccessMetric::placeholder();
+        for (k, v) in data {
+            let get_value = scratchpad
+                .get_value(namespace, &key(*k), &mut metric)
+                .unwrap();
+            assert_eq!(value(*v), get_value);
+        }
     }
 }

--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad.rs
@@ -1009,7 +1009,7 @@ mod tests {
         assert_scratchpad_contains_data(&[(101, 111), (102, 112)], &mut main_scratchpad, namespace);
     }
 
-    fn create_srtatchpad<S: Spec>(stotage: S::Storage) -> TxScratchpad<S, StateCheckpoint<S>> {
+    fn create_srcratchpad<S: Spec>(storage: S::Storage) -> TxScratchpad<S, StateCheckpoint<S>> {
         let checkpoint = StateCheckpoint::new(stotage, &MockKernel::new(4, 1));
         checkpoint.to_tx_scratchpad()
     }

--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad.rs
@@ -345,6 +345,9 @@ impl<S: Spec> TxScratchpad<S, StateCheckpoint<S>> {
     pub fn tx_changes(&self) -> TxChangeSet {
         self.inner.changes()
     }
+
+    /// TODO
+    pub fn apply_change_set(&mut self) {}
 }
 
 /// A working set that can be used to charge gas for pre transaction execution checks.

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
@@ -505,6 +505,7 @@ where
             dirty_scratchpad,
             slot_gas_meter,
             &gas_used,
+            execution_context,
         );
         match outcome {
             TxControlFlow::ContinueProcessing(receipt) => {

--- a/crates/module-system/sov-state/src/cache.rs
+++ b/crates/module-system/sov-state/src/cache.rs
@@ -214,14 +214,13 @@ pub(crate) mod internal {
 use internal::CacheLog;
 
 /// Caches reads and writes for a (key, value) pair. On the first read the value is fetched
-/// from an external source represented by the `ValueReader` trait. On following reads,
-/// the cache checks if the value we read was inserted before.
+/// from an external. On following reads, the cache checks if the value we read was inserted before.
 #[derive(Default, Debug)]
 pub struct ProvableStorageCache<N> {
     // Transaction cache.
     pub(crate) cache: CacheLog,
     // Reads that were retrieved from storage for the first time but can still be reverted.
-    revertable_ordered_reads: Vec<(SlotKey, Option<NodeLeaf>)>,
+    revertable_ordered_reads: Vec<(SlotKey, Option<NodeLeafAndMaybeValue>)>,
     // Ordered reads and writes.
     ordered_db_reads: Vec<(SlotKey, Option<NodeLeaf>)>,
     phantom: core::marker::PhantomData<N>,
@@ -293,14 +292,18 @@ impl<N: ProvableCompileTimeNamespace> ProvableStorageCache<N> {
 // value, but in ZK execution, arbitrary large values cannot be stored as hints in the witness.
 impl<N: ProvableCompileTimeNamespace> ProvableStorageCache<N> {
     /// Returns `revertable_ordered_reads`
-    pub fn revertable_ordered_reads(&self) -> &Vec<(SlotKey, Option<NodeLeaf>)> {
+    pub fn revertable_ordered_reads(&self) -> &Vec<(SlotKey, Option<NodeLeafAndMaybeValue>)> {
         &self.revertable_ordered_reads
     }
 
     /// Commit the revertable part of the `ProvableStorageCache`.
     pub fn commit_revertable_storage_cache(&mut self) {
         let revertable_ordered_reads = mem::take(&mut self.revertable_ordered_reads);
-        self.ordered_db_reads.extend(revertable_ordered_reads);
+        self.ordered_db_reads.extend(
+            revertable_ordered_reads
+                .into_iter()
+                .map(|(key, node)| (key, node.map(|n| n.leaf))),
+        );
         self.cache.commit_revertable_log();
     }
 
@@ -488,7 +491,7 @@ impl<N: ProvableCompileTimeNamespace> ProvableStorageCache<N> {
 
     fn get_or_fetch_with_fn<S: Storage, F, Args, E>(
         cache: &mut CacheLog,
-        revertable_ordered_reads: &mut Vec<(SlotKey, Option<NodeLeaf>)>,
+        revertable_ordered_reads: &mut Vec<(SlotKey, Option<NodeLeafAndMaybeValue>)>,
         key: &SlotKey,
         storage: &S,
         witness: &S::Witness,
@@ -579,12 +582,31 @@ impl<N: ProvableCompileTimeNamespace> ProvableStorageCache<N> {
     fn add_read(
         key: SlotKey,
         node: Option<NodeLeafAndMaybeValue>,
-        revertable_ordered_reads: &mut Vec<(SlotKey, Option<NodeLeaf>)>,
+        revertable_ordered_reads: &mut Vec<(SlotKey, Option<NodeLeafAndMaybeValue>)>,
         cache: &mut CacheLog,
     ) {
-        revertable_ordered_reads.push((key.clone(), node.as_ref().map(|n| n.leaf)));
+        revertable_ordered_reads.push((key.clone(), node.clone()));
 
         cache.add_read(key, node);
+    }
+
+    /// Adds only the reads whose keys are not already in the cache.
+    pub fn add_read_if_not_present_in_cache(
+        &mut self,
+        reads: Vec<(SlotKey, Option<NodeLeafAndMaybeValue>)>,
+    ) {
+        for (key, node) in reads {
+            if self.cache.get(&key).is_some() {
+                continue;
+            }
+
+            Self::add_read(
+                key,
+                node,
+                &mut self.revertable_ordered_reads,
+                &mut self.cache,
+            );
+        }
     }
 }
 

--- a/crates/module-system/sov-state/src/sequencer_state.rs
+++ b/crates/module-system/sov-state/src/sequencer_state.rs
@@ -235,6 +235,11 @@ pub enum MaybePresentValue<T = SlotValue> {
 }
 
 impl<T> MaybePresentValue<T> {
+    /// Check if the enum variant is `MaybePresentValue::Present`
+    pub fn is_present(&self) -> bool {
+        matches!(self, MaybePresentValue::Present(_))
+    }
+
     /// Map the value if it is present.
     pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> MaybePresentValue<U> {
         match self {

--- a/crates/module-system/sov-state/src/storage.rs
+++ b/crates/module-system/sov-state/src/storage.rs
@@ -302,6 +302,14 @@ impl NodeLeafAndMaybeValue {
     pub fn size(&self) -> u32 {
         self.leaf.size
     }
+
+    /// Create a new NodeLeafAndMaybeValue withReadType::Read.
+    pub fn new_read<H: Digest<OutputSize = typenum::U32>>(value: SlotValue) -> Self {
+        Self {
+            leaf: NodeLeaf::make_leaf::<H>(&value),
+            value: ReadType::Read(value),
+        }
+    }
 }
 
 /// Size and hash of a value saved in the state.
@@ -319,9 +327,9 @@ impl NodeLeafAndMaybeValue {
 )]
 pub struct NodeLeaf {
     /// The size of the value.
-    pub(crate) size: u32,
+    pub size: u32,
     /// The hash of the value.
-    pub(crate) val_hash: [u8; 32],
+    pub val_hash: [u8; 32],
 }
 
 impl NodeLeaf {

--- a/crates/module-system/sov-test-utils/src/runtime/mod.rs
+++ b/crates/module-system/sov-test-utils/src/runtime/mod.rs
@@ -1022,6 +1022,7 @@ impl<S: Spec> InjectedControlFlow<S> for SeqControlFlow {
         dirty_scratchpad: TxScratchpad<S, StateCheckpoint<S>>,
         _slot_gas_meter_before_tx: &SlotGasMeter<S>,
         _gas_used: &<S as Spec>::Gas,
+        execution_context: ExecutionContext,
     ) -> (StateCheckpoint<S>, TxControlFlow<TransactionReceipt<S>>) {
         let ProvisionalSequencerOutcome {
             execution_status, ..
@@ -1031,7 +1032,7 @@ impl<S: Spec> InjectedControlFlow<S> for SeqControlFlow {
         };
 
         if !receipt.receipt.is_successful() {
-            let _ = dirty_scratchpad.tx_changes();
+            let _ = dirty_scratchpad.tx_changes(execution_context);
             return (dirty_scratchpad.revert(), TxControlFlow::IgnoreTx);
         }
 


### PR DESCRIPTION
# Description
This PR introduces the following changes:
1. Only the `ExecutionContext::SequencerWarmUp` executor populates reads in `TxChangeSet`. These reads are used to warm up the main executor’s cache.

2. Adds the necessary plumbing to populate the main executor’s cache. The primary entry point is `TxScratchpad::apply_change_set`.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
