### PR TITLE
Reduce pruning batch size

### DIFF
--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -26,9 +26,9 @@ use crate::storage_manager::{update_ledger_finalized_height, InitializableNative
 
 const GIGABYTE: usize = 1024 * 1024 * 1024;
 
-// 3 million keys * 32 bytes is about 100 MB. This should be a large enough batch size to keep up with state growth,
+// 300 thousand keys * 32 bytes is about 10 MB. This should be a large enough batch size to keep up with state growth,
 // without consuming excessive memory.
-pub(crate) const MAX_INDIVIDUAL_PRUNING_BATCH_SIZE: usize = 3_000_000;
+pub(crate) const MAX_INDIVIDUAL_PRUNING_BATCH_SIZE: usize = 300_000;
 
 pub(crate) struct DbGroup<H, K> {
     merklized_state: Arc<NomtStateDb<H>>,


### PR DESCRIPTION
# Description

This PR mitigates the pruning issues reported by Zeta by reducing the batch size even further. This makes end-block latencies more predictable on systems with limited IOPS.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
