### PR TITLE
Fix Handling of Uncomitted State in Accessory Delta

### DIFF
--- a/constants.toml
+++ b/constants.toml
@@ -29,7 +29,7 @@ DEFERRED_SLOTS_COUNT = 120
 MAX_VISIBLE_HEIGHT_INCREASE_PER_SLOT = 10
 # How many *rollup blocks* we wait before making a state root visible to the rollup.
 # This value should always be set to at least 1
-STATE_ROOT_DELAY_BLOCKS = 1
+STATE_ROOT_DELAY_BLOCKS = 3
 # How many blobs from unregistered sequencers we will accept per slot
 # We can't slash misbehaving senders because they aren't a registered sequencer with a stake so
 # this serves as protection against spam.

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -670,8 +670,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
                 next_visible_rollup_height,
                 HexString(next_visible_root.namespace_root(sov_state::ProvableNamespace::User))
             );
-            self.state_roots
-                .insert(received_height, next_visible_root);
+            self.state_roots.insert(received_height, next_visible_root);
         }
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -671,7 +671,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
                 HexString(next_visible_root.namespace_root(sov_state::ProvableNamespace::User))
             );
             self.state_roots
-                .insert(next_visible_rollup_height, next_visible_root);
+                .insert(received_height, next_visible_root);
         }
     }
 

--- a/crates/module-system/sov-modules-api/src/state/accessors/internals.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/internals.rs
@@ -91,7 +91,7 @@ impl<S: Storage> Delta<S> {
             accessory_writes,
             witness,
             #[cfg(feature = "native")]
-                uncomitted_changes,
+            uncomitted_changes,
         } = self;
 
         (
@@ -362,7 +362,6 @@ impl<S: Storage> AccessoryDelta<S> {
 }
 
 impl<S: Storage> UniversalStateAccessor for AccessoryDelta<S> {
-
     #[cfg(not(feature = "native"))]
     fn get_size(
         &mut self,

--- a/crates/module-system/sov-modules-api/src/state/accessors/internals.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/internals.rs
@@ -71,6 +71,8 @@ impl<S: Storage> Delta<S> {
     pub(super) fn take_accessory_delta(&mut self) -> AccessoryDelta<S> {
         AccessoryDelta {
             writes: std::mem::take(&mut self.accessory_writes),
+            #[cfg(feature = "native")]
+            uncomitted_changes: self.uncomitted_changes.as_ref().map(|g| g.box_clone()),
             storage: self.inner.clone(),
             metrics: StateMetrics::default(),
         }
@@ -89,7 +91,7 @@ impl<S: Storage> Delta<S> {
             accessory_writes,
             witness,
             #[cfg(feature = "native")]
-                uncomitted_changes: _,
+                uncomitted_changes,
         } = self;
 
         (
@@ -100,6 +102,8 @@ impl<S: Storage> Delta<S> {
             AccessoryDelta {
                 writes: accessory_writes,
                 storage: inner.clone(),
+                #[cfg(feature = "native")]
+                uncomitted_changes,
                 metrics: StateMetrics::default(),
             },
             witness,
@@ -338,6 +342,8 @@ impl<S: Storage> fmt::Debug for Delta<S> {
 /// A delta containing *only* the accessory state.
 pub struct AccessoryDelta<S: Storage> {
     writes: HashMap<SlotKey, AccessoryWrite>,
+    #[cfg(feature = "native")]
+    uncomitted_changes: Option<Box<dyn StateGetter>>,
     storage: S,
     metrics: StateMetrics,
 }
@@ -356,6 +362,8 @@ impl<S: Storage> AccessoryDelta<S> {
 }
 
 impl<S: Storage> UniversalStateAccessor for AccessoryDelta<S> {
+
+    #[cfg(not(feature = "native"))]
     fn get_size(
         &mut self,
         _namespace: Namespace,
@@ -371,6 +379,7 @@ impl<S: Storage> UniversalStateAccessor for AccessoryDelta<S> {
         val.map(|v| v.size())
     }
 
+    #[cfg(not(feature = "native"))]
     fn get_value(
         &mut self,
         _namespace: Namespace,
@@ -382,6 +391,51 @@ impl<S: Storage> UniversalStateAccessor for AccessoryDelta<S> {
         }
 
         let val = self.storage.get_accessory(key);
+        metric.storage_read_size = Some(val.as_ref().map(|v| v.size()).unwrap_or(0)); // For the metric, use "Some" to indicate that we hit storage even if the value is None
+        val
+    }
+
+    #[cfg(feature = "native")]
+    fn get_size(
+        &mut self,
+        namespace: Namespace,
+        key: &SlotKey,
+        metric: &mut StateAccessMetric,
+    ) -> Option<u32> {
+        if let Some(write) = self.writes.get(key) {
+            return write.value.as_ref().map(|v| v.size());
+        }
+
+        let val = if let Some(uncomitted_changes) = self.uncomitted_changes.as_ref() {
+            uncomitted_changes
+                .get(namespace, key)
+                .or_else(|| self.storage.get_accessory(key))
+        } else {
+            self.storage.get_accessory(key)
+        };
+
+        metric.storage_read_size = Some(val.as_ref().map(|v| v.size()).unwrap_or(0)); // For the metric, use "Some" to indicate that we hit storage even if the value is None
+        val.map(|v| v.size())
+    }
+
+    #[cfg(feature = "native")]
+    fn get_value(
+        &mut self,
+        namespace: Namespace,
+        key: &SlotKey,
+        metric: &mut StateAccessMetric,
+    ) -> Option<SlotValue> {
+        if let Some(write) = self.writes.get(key) {
+            return write.value.clone();
+        }
+
+        let val = if let Some(uncomitted_changes) = self.uncomitted_changes.as_ref() {
+            uncomitted_changes
+                .get(namespace, key)
+                .or_else(|| self.storage.get_accessory(key))
+        } else {
+            self.storage.get_accessory(key)
+        };
         metric.storage_read_size = Some(val.as_ref().map(|v| v.size()).unwrap_or(0)); // For the metric, use "Some" to indicate that we hit storage even if the value is None
         val
     }


### PR DESCRIPTION
# Description

This PR fixes an issue where the Accessory Delta did not properly read from uncomitted state. This was discovered during manual soak testing, but is trivially reproducible by setting `STATE_ROOT_DELAY` to a value greater than `1`. I've done so in this PR.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
