### PR TITLE
Refactor soak tests to use builder pattern rather than hardcoded TxType in the lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ to decrease the number of writes it will attempt at each slot.
 # 2025-10-01
 - #1796 Adds `EVM_GAS_METERING_MODE` configuration to switch between "Rollup" and "EVM" gas metering modes. Rollup mode (default) keeps existing behavior where EVM doesn't charge for storage access and initial cost. EVM mode enables mainnet-like gas costs useful for computing metrics like MGas/s.
 - #1791 Re-enable EVM gas estimation while bumping the margins.
+- #1790 Updates the `sov-soak-testing-lib` interface to introduce a `SoakTestRunner`, allowing for more flexible usage as more modules are integrated into the soak generator; the old functions `run_generator_task_for_xx()` have been removed. The soak test crate in the demo rollup has been updated accordingly. This is a *breaking change* for any custom soak testing setups.
 
 # 2025-09-29
 - #1770 **Breaking change** introduces a required `buffer_raw_txs` field to `EthRpcConfig`. This change is only breaking for EVM rollups.

--- a/crates/utils/sov-soak-testing-lib/src/lib.rs
+++ b/crates/utils/sov-soak-testing-lib/src/lib.rs
@@ -170,9 +170,8 @@ where
     where
         R: EncodeCall<StateConsistency<S>>,
     {
-        let state_consistency_harness = StateConsistencyHarness::new(
-            StateConsistencyMessageGenerator::default()
-        );
+        let state_consistency_harness =
+            StateConsistencyHarness::new(StateConsistencyMessageGenerator::default());
         self.modules.push(Arc::new(state_consistency_harness));
         self
     }

--- a/crates/utils/sov-soak-testing-lib/src/lib.rs
+++ b/crates/utils/sov-soak-testing-lib/src/lib.rs
@@ -61,16 +61,6 @@ pub fn plain_tx_with_default_details<R: Runtime<S>, S: Spec>(
 }
 
 #[derive(Clone, Copy, Debug, clap::ValueEnum)]
-pub enum TxType {
-    /// Only [`SyntheticLoad`] transactions - includes many heavy txs
-    SyntheticLoad,
-    /// Only [`Bank`] transactions
-    Bank,
-    /// Mixed [`SyntheticLoad`] and [`Bank`] transactions
-    Mixed,
-}
-
-#[derive(Clone, Copy, Debug, clap::ValueEnum)]
 pub enum ValidityProfile {
     /// Only valid transactions
     Clean,
@@ -101,6 +91,112 @@ impl ValidityProfile {
         }
     }
 }
+
+/// A runner for the soak tests, providing helpers for setting up modules to be used in the soak
+/// test.
+///
+/// Modules can be seleted dynamically but only if the Runtime includes them.
+///
+/// # Example
+/// ```ignore
+/// SoakTestBuilder::new()
+///     .with_bank()
+///     .with_state_consistency()
+///     .run(client, rx, worker_id, num_workers, validity).await?;
+/// ```
+#[derive(Default)]
+pub struct SoakTestRunner<R, S: Spec> {
+    modules: Vec<BasicModuleRef<S, R>>,
+}
+
+impl<R, S> SoakTestRunner<R, S>
+where
+    R: Runtime<S> + Clone,
+    S: Spec,
+{
+    /// Create a new builder with no modules.
+    pub fn new() -> Self {
+        Self {
+            modules: Vec::new(),
+        }
+    }
+
+    /// Add Bank module to the soak test.
+    ///
+    /// This method is only available if your Runtime implements `EncodeCall<Bank<S>>`.
+    pub fn with_bank(mut self) -> Self
+    where
+        R: EncodeCall<Bank<S>>,
+    {
+        let bank_harness = BankHarness::new(BankMessageGenerator::<S>::new(
+            Distribution::with_equiprobable_values(vec![Transfer]),
+            Percent::fifty(),
+        ));
+        self.modules.push(Arc::new(bank_harness));
+        self
+    }
+
+    /// Add SyntheticLoad module to the soak test.
+    ///
+    /// This method is only available if your Runtime implements `EncodeCall<SyntheticLoad<S>>`.
+    pub fn with_synthetic_load(mut self) -> Self
+    where
+        R: EncodeCall<SyntheticLoad<S>>,
+    {
+        let synthetic_load_admin = <<S as Spec>::CryptoSpec as CryptoSpec>::PrivateKey::generate();
+        let synthetic_load_harness = SyntheticLoadHarness::new(SyntheticLoadMessageGenerator::new(
+            Distribution::with_equiprobable_values(vec![
+                ReadAndSetManyIndividualValues,
+                ReadAndSetHeavyState,
+                RunCPUHeavyOperation,
+            ]),
+            sov_transaction_generator::generators::synthetic_load::SyntheticLoadGeneratorOptions {
+                maximum_vec_length: 10,
+                min_and_max_number_of_individual_state_operations: (1, 10000),
+                min_and_max_number_of_new_values_for_heavy_state: (100, 1000),
+                min_and_max_number_of_iterations_for_cpu_heavy_operation: (1000, 5000),
+                max_heavy_state_size: 1_000_000,
+            },
+            synthetic_load_admin,
+        ));
+        self.modules.push(Arc::new(synthetic_load_harness));
+        self
+    }
+
+    /// Add StateConsistency module to the soak test.
+    ///
+    /// This method is only available if your Runtime implements `EncodeCall<StateConsistency<S>>`.
+    pub fn with_state_consistency(mut self) -> Self
+    where
+        R: EncodeCall<StateConsistency<S>>,
+    {
+        let state_consistency_harness = StateConsistencyHarness::new(
+            StateConsistencyMessageGenerator::default()
+        );
+        self.modules.push(Arc::new(state_consistency_harness));
+        self
+    }
+
+    /// Run the soak test with the configured modules.
+    ///
+    /// # Parameters
+    /// - `client`: The API client for submitting transactions
+    /// - `rx`: Receiver to signal when to stop the test
+    /// - `worker_id`: Unique identifier for this worker
+    /// - `num_workers`: Total number of parallel workers
+    /// - `validity`: Distribution of valid vs invalid messages
+    pub async fn run(
+        self,
+        client: sov_api_spec::Client,
+        rx: Receiver<bool>,
+        worker_id: u128,
+        num_workers: u32,
+        validity: Distribution<MessageValidity>,
+    ) -> anyhow::Result<()> {
+        prepare_and_send_txs(self.modules, client, rx, worker_id, num_workers, validity).await
+    }
+}
+
 pub struct TestGenerator<R: Runtime<S>, S: Spec> {
     generator: BasicCallMessageFactory<S, R>,
     state: State<S, BasicTag>,
@@ -172,85 +268,6 @@ pub fn setup_harness<R: Runtime<S> + Clone, S: Spec>(rng_salt: u128) -> TestGene
         target_buffer_size: BUFFER_SIZE,
         salt: rng_salt,
     }
-}
-
-/// The passed client is responsible for handling timeouts (otherwise calls can block).
-pub async fn run_generator_task_for_bank_and_synthetic_load<
-    R: Runtime<S> + EncodeCall<Bank<S>> + EncodeCall<SyntheticLoad<S>> + Clone,
-    S: Spec,
->(
-    client: sov_api_spec::Client,
-    rx: Receiver<bool>,
-    worker_id: u128,
-    num_workers: u32,
-    validity: Distribution<MessageValidity>,
-    tx_type: TxType,
-) -> anyhow::Result<()> {
-    let bank_harness = BankHarness::new(BankMessageGenerator::<S>::new(
-        Distribution::with_equiprobable_values(vec![Transfer]),
-        Percent::fifty(),
-    ));
-    let synthetic_load_admin = <<S as Spec>::CryptoSpec as CryptoSpec>::PrivateKey::generate();
-    let synthetic_load_harness = SyntheticLoadHarness::new(SyntheticLoadMessageGenerator::new(
-        Distribution::with_equiprobable_values(vec![
-            ReadAndSetManyIndividualValues,
-            ReadAndSetHeavyState,
-            RunCPUHeavyOperation,
-        ]),
-        sov_transaction_generator::generators::synthetic_load::SyntheticLoadGeneratorOptions {
-            maximum_vec_length: 10,
-            min_and_max_number_of_individual_state_operations: (1, 10000),
-            min_and_max_number_of_new_values_for_heavy_state: (100, 1000),
-            min_and_max_number_of_iterations_for_cpu_heavy_operation: (1000, 5000),
-            max_heavy_state_size: 1_000_000,
-        },
-        synthetic_load_admin,
-    ));
-    let modules: Vec<BasicModuleRef<S, R>> = match tx_type {
-        TxType::SyntheticLoad => vec![Arc::new(synthetic_load_harness.clone())],
-        TxType::Bank => vec![Arc::new(bank_harness.clone())],
-        TxType::Mixed => vec![
-            Arc::new(bank_harness.clone()),
-            Arc::new(synthetic_load_harness.clone()),
-        ],
-    };
-
-    prepare_and_send_txs(modules, client, rx, worker_id, num_workers, validity).await
-}
-
-/// The passed client is responsible for handling timeouts (otherwise calls can block).
-pub async fn run_generator_task_for_bank<R: Runtime<S> + EncodeCall<Bank<S>> + Clone, S: Spec>(
-    client: sov_api_spec::Client,
-    rx: Receiver<bool>,
-    worker_id: u128,
-    num_workers: u32,
-    validity: Distribution<MessageValidity>,
-) -> anyhow::Result<()> {
-    let bank_harness = BankHarness::new(BankMessageGenerator::<S>::new(
-        Distribution::with_equiprobable_values(vec![Transfer]),
-        Percent::fifty(),
-    ));
-
-    let modules: Vec<BasicModuleRef<S, R>> = vec![Arc::new(bank_harness.clone())];
-    prepare_and_send_txs(modules, client, rx, worker_id, num_workers, validity).await
-}
-
-/// The passed client is responsible for handling timeouts (otherwise calls can block).
-pub async fn run_generator_task_for_state_consistency<
-    R: Runtime<S> + EncodeCall<StateConsistency<S>> + Clone,
-    S: Spec,
->(
-    client: sov_api_spec::Client,
-    rx: Receiver<bool>,
-    worker_id: u128,
-    num_workers: u32,
-    validity: Distribution<MessageValidity>,
-) -> anyhow::Result<()> {
-    let state_consistency_harness =
-        StateConsistencyHarness::new(StateConsistencyMessageGenerator::default());
-
-    let modules: Vec<BasicModuleRef<S, R>> = vec![Arc::new(state_consistency_harness.clone())];
-    prepare_and_send_txs(modules, client, rx, worker_id, num_workers, validity).await
 }
 
 async fn prepare_and_send_txs<R: Runtime<S> + Clone, S: Spec>(

--- a/crates/utils/transaction-generator/src/generators/state_consistency/mod.rs
+++ b/crates/utils/transaction-generator/src/generators/state_consistency/mod.rs
@@ -33,6 +33,13 @@ impl<S: Spec, T> From<&AccountState<S, T>> for StateConsistencyAccount<S> {
         StateConsistencyAccount {
             private_key: value.private_key.clone(),
             current_value: value.consistency_value,
+            // The generator normally uses only one singleton account. The tag is applied once, the
+            // first time the account is generated. To avoid a bit of extra overhead in the
+            // generator, we can skip the TagAction::Add except the first time we generate the
+            // account.
+            // So by default, on every normal account load, this will be true. When we do not find
+            // an account with the tag and generated a new one for the first time, then we
+            // explicitly set it to false.
             already_tagged: true,
         }
     }

--- a/examples/demo-rollup/sov-soak-testing/src/bin/generator.rs
+++ b/examples/demo-rollup/sov-soak-testing/src/bin/generator.rs
@@ -165,7 +165,7 @@ async fn main() -> Result<(), anyhow::Error> {
             args.num_workers,
             args.runtime,
             args.validity_profile,
-            args.tx_type.clone(),
+            args.tx_type,
         ));
     }
 

--- a/examples/demo-rollup/sov-soak-testing/src/bin/generator.rs
+++ b/examples/demo-rollup/sov-soak-testing/src/bin/generator.rs
@@ -1,12 +1,17 @@
 use std::time::Duration;
 
 use clap::Parser;
+use sov_bank::Bank;
 use sov_modules_api::prelude::tracing;
+use sov_modules_api::{EncodeCall, Runtime, Spec};
 use sov_soak_testing::{
-    run_generator_task_for_bank_and_synthetic_load, CelestiaRollupSpec, DemoCelestiaRT, DemoMockRT,
-    MockDemoRollupSpec, TestRT, TxType, ValidityProfile,
+    CelestiaRollupSpec, DemoCelestiaRT, DemoMockRT, MockDemoRollupSpec, SoakTestRunner, TestRT,
+    ValidityProfile,
 };
+use sov_synthetic_load::SyntheticLoad;
 use sov_test_utils::TestSpec;
+use sov_transaction_generator::interface::MessageValidity;
+use sov_transaction_generator::Distribution;
 use tokio::signal::unix::SignalKind;
 use tokio::sync::watch::Receiver;
 use tokio::task::JoinSet;
@@ -48,6 +53,43 @@ struct Args {
     tx_type: TxType,
 }
 
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+pub enum TxType {
+    /// Only [`SyntheticLoad`] transactions - includes many heavy txs
+    SyntheticLoad,
+    /// Only [`Bank`] transactions
+    Bank,
+    /// Mixed [`SyntheticLoad`] and [`Bank`] transactions
+    Mixed,
+}
+
+/// Helper to create the Runner for any demo runtime.
+/// All the demo rollup runtimes only support Bank and SyntheticLoad.
+async fn run_soak_test_with_demo_runtime<R, S>(
+    client: sov_api_spec::Client,
+    rx: Receiver<bool>,
+    worker_id: u128,
+    num_workers: u32,
+    validity: Distribution<MessageValidity>,
+    tx_type: TxType,
+) -> anyhow::Result<()>
+where
+    R: Runtime<S> + EncodeCall<Bank<S>> + EncodeCall<SyntheticLoad<S>> + Clone,
+    S: Spec,
+{
+    let mut runner = SoakTestRunner::<R, S>::new();
+
+    runner = match tx_type {
+        TxType::Bank => runner.with_bank(),
+        TxType::SyntheticLoad => runner.with_synthetic_load(),
+        TxType::Mixed => runner.with_bank().with_synthetic_load(),
+    };
+
+    runner
+        .run(client, rx, worker_id, num_workers, validity)
+        .await
+}
+
 async fn worker_task(
     client: sov_api_spec::Client,
     rx: Receiver<bool>,
@@ -61,7 +103,7 @@ async fn worker_task(
 
     let result = match runtime {
         SelectedRuntime::Test => {
-            run_generator_task_for_bank_and_synthetic_load::<TestRT, TestSpec>(
+            run_soak_test_with_demo_runtime::<TestRT, TestSpec>(
                 client,
                 rx,
                 worker_id,
@@ -72,7 +114,7 @@ async fn worker_task(
             .await
         }
         SelectedRuntime::DemoCelestia => {
-            run_generator_task_for_bank_and_synthetic_load::<DemoCelestiaRT, CelestiaRollupSpec>(
+            run_soak_test_with_demo_runtime::<DemoCelestiaRT, CelestiaRollupSpec>(
                 client,
                 rx,
                 worker_id,
@@ -83,7 +125,7 @@ async fn worker_task(
             .await
         }
         SelectedRuntime::DemoMock => {
-            run_generator_task_for_bank_and_synthetic_load::<DemoMockRT, MockDemoRollupSpec>(
+            run_soak_test_with_demo_runtime::<DemoMockRT, MockDemoRollupSpec>(
                 client,
                 rx,
                 worker_id,
@@ -123,7 +165,7 @@ async fn main() -> Result<(), anyhow::Error> {
             args.num_workers,
             args.runtime,
             args.validity_profile,
-            args.tx_type,
+            args.tx_type.clone(),
         ));
     }
 


### PR DESCRIPTION
# Description

The `sov-soak-testing-lib` had functions `run_generator_with_bank()` and `run_generator_with_bank_and_synthetic_load()`, which was fine for two modules, but with additional modules being integrated into soak testing this would result in a combinatorial amount of functions and `TxType` variants.
Instead this refactors the lib to use a `SoakTestRunner` with helper functions to enable individual modules, bounded by the `EncodeCall<>` trait for that specific module, which makes any combination of modules selectable if the Runtime under test supports it.

Since the demo-rollup only supports the same two modules as before, `TxType` is moved there as its main purpose is CLAP parsing of cli args.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
