### PR TITLE
Re-enable gas estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-10-01
+- #1791 Re-enable EVM gas estimation while bumping the margins.
+
 # 2025-09-29
 - #1770 **Breaking change** introduces a required `buffer_raw_txs` field to `EthRpcConfig`. This change is only breaking for EVM rollups.
 - #1783 Adds `da.tx_priority` optional field for celestia adapter. Possible values are `Low`, `Medium` or `High`. It can be used to improve blob inclusion.

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -441,8 +441,8 @@ pub enum PendingOrBlock {
 }
 
 // HACK: This should be much lower but because gas estimation doesn't work now - we temporarily set it to a large value.
-const ABSOLUTE_MARGIN: u64 = 100_000_000;
-/// gas * 1.5 + 100_000_000
+const ABSOLUTE_MARGIN: u64 = 1_000_000;
+/// gas * 1.5 + 1_000_000
 fn apply_margins(gas: u64) -> Result<u64, RpcInvalidTransactionError> {
     (gas / 2)
         .checked_mul(3)

--- a/examples/demo-rollup/tests/evm/evm_gas_estimation.rs
+++ b/examples/demo-rollup/tests/evm/evm_gas_estimation.rs
@@ -8,7 +8,7 @@ async fn simple_transfer() -> anyhow::Result<()> {
 
     let simple_transfer = test_client.make_tx(Some(Address::zero()), None);
     let gas_estimation = test_client.eth_estimate_gas(simple_transfer).await;
-    assert_eq!(gas_estimation, 100_000_000); // Simple transfer consumes 0 EVM gas so we only see the ABSOLUTE_MARGIN
+    assert_eq!(gas_estimation, 1_000_000); // Simple transfer consumes 0 EVM gas so we only see the ABSOLUTE_MARGIN
     Ok(())
 }
 
@@ -18,6 +18,6 @@ async fn contract_deploy() -> anyhow::Result<()> {
 
     let deploy_tx = test_client.make_tx(None, Some(test_client.contract.byte_code()));
     let gas_estimation = test_client.eth_estimate_gas(deploy_tx).await;
-    assert_eq!(gas_estimation, (206_448 / 2) * 3 + 100_000_000);
+    assert_eq!(gas_estimation, (206_448 / 2) * 3 + 1_000_000);
     Ok(())
 }


### PR DESCRIPTION
# Description

After investigation I wasn't able to reproduce the behavior when charging gas on gas meter no-oped. The issue currently was that the gas charged by sequencer during actual execution and during simulation differed when the contract was being deployed by another contract. For now I increased the absolute margin so that it passes but still to a reasonable amount.

Unfortunately debugging this thing is painful as demo-rollup rebuilds 1m+ even for the simplest changes.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
