### PR TITLE
Pre-mint tokens so that we don't need to mint them on every swap. Also add metrics on soak test

### DIFF
--- a/crates/utils/sov-evm-soak-testing/src/uniswap.rs
+++ b/crates/utils/sov-evm-soak-testing/src/uniswap.rs
@@ -3,12 +3,41 @@ use alloy_primitives::{utils::parse_ether, Address, U256};
 use anyhow::Result;
 use rand::Rng;
 use sov_test_utils::{Erc20, Router, Submit};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Default)]
+pub struct SwapMetrics {
+    pub total_swaps: usize,
+    pub total_time: Duration,
+    pub get_amounts_out_time: Duration,
+    pub swap_execution_time: Duration,
+}
+
+impl SwapMetrics {
+    pub fn print_summary(&self) {
+        if self.total_swaps == 0 {
+            return;
+        }
+
+        println!("\n📊 Swap Metrics Summary");
+        println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        println!("Total swaps:              {}", self.total_swaps);
+        println!("Total time:               {:?}", self.total_time);
+        println!("Average per swap:         {:?}", self.total_time / self.total_swaps as u32);
+        println!("Get amounts out (total):  {:?}", self.get_amounts_out_time);
+        println!("Get amounts out (avg):    {:?}", self.get_amounts_out_time / self.total_swaps as u32);
+        println!("Swap execution (total):   {:?}", self.swap_execution_time);
+        println!("Swap execution (avg):     {:?}", self.swap_execution_time / self.total_swaps as u32);
+        println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    }
+}
 
 pub struct UniSoakTest<P, N> {
     weth: Erc20::Erc20Instance<P, N>,
     usdc: Erc20::Erc20Instance<P, N>,
     router: Router::RouterInstance<P, N>,
     signer: Address,
+    metrics: SwapMetrics,
 }
 
 impl<P, N> UniSoakTest<P, N>
@@ -33,10 +62,11 @@ where
             weth,
             usdc,
             router,
+            metrics: SwapMetrics::default(),
         })
     }
 
-    pub async fn run(&self, count: usize) -> Result<()> {
+    pub async fn run(mut self, count: usize) -> Result<()> {
         // Larger pool for load testing - 10k WETH : 20k USDC
         println!("💧 Adding liquidity: 10,000 WETH + 20,000 USDC");
         let weth_liquidity = parse_ether("10000")?;
@@ -54,10 +84,11 @@ where
         self.execute_random_swaps(count).await?;
 
         println!("✅ Load test completed successfully!");
+        self.metrics.print_summary();
         Ok(())
     }
 
-    async fn execute_random_swaps(&self, count: usize) -> Result<()> {
+    async fn execute_random_swaps(&mut self, count: usize) -> Result<()> {
         let mut rng = rand::thread_rng();
 
         for i in 1..=count {
@@ -90,17 +121,30 @@ where
         Ok(())
     }
 
-    async fn execute_swap(&self, amount_in: U256, path: Vec<Address>) -> Result<()> {
+    async fn execute_swap(&mut self, amount_in: U256, path: Vec<Address>) -> Result<()> {
+        let swap_total = Instant::now();
+
+        let get_amounts_out = Instant::now();
         let expected_out = self
             .router
             .getAmountsOut(amount_in, path.clone())
             .call()
             .await?[1];
+        let get_amounts_out_time = get_amounts_out.elapsed();
 
+        let swap_execution = Instant::now();
         self.router
             .swapExactTokensForTokens(amount_in, expected_out, path, self.signer)
             .submit()
             .await?;
+        let swap_execution_time = swap_execution.elapsed();
+
+        let swap_total_time = swap_total.elapsed();
+
+        self.metrics.total_swaps += 1;
+        self.metrics.total_time += swap_total_time;
+        self.metrics.get_amounts_out_time += get_amounts_out_time;
+        self.metrics.swap_execution_time += swap_execution_time;
 
         Ok(())
     }

--- a/crates/utils/sov-evm-soak-testing/src/uniswap.rs
+++ b/crates/utils/sov-evm-soak-testing/src/uniswap.rs
@@ -44,6 +44,12 @@ where
         self.add_initial_liquidity(weth_liquidity, usdc_liquidity)
             .await?;
 
+        // Pre-mint large token balances and approve infinite allowance
+        println!("🪙 Pre-minting tokens and approving router...");
+        let large_amount = parse_ether("1000000000")?; // 1 billion tokens
+        self.mint_and_approve(&self.weth, large_amount).await?;
+        self.mint_and_approve(&self.usdc, large_amount).await?;
+
         println!("🔄 Starting load test: {count} random swaps...");
         self.execute_random_swaps(count).await?;
 
@@ -91,13 +97,6 @@ where
             .call()
             .await?[1];
 
-        let from_token = if path[0] == *self.usdc.address() {
-            &self.usdc
-        } else {
-            &self.weth
-        };
-
-        self.mint_and_approve(from_token, amount_in).await?;
         self.router
             .swapExactTokensForTokens(amount_in, expected_out, path, self.signer)
             .submit()

--- a/crates/utils/sov-evm-soak-testing/src/uniswap.rs
+++ b/crates/utils/sov-evm-soak-testing/src/uniswap.rs
@@ -23,11 +23,20 @@ impl SwapMetrics {
         println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
         println!("Total swaps:              {}", self.total_swaps);
         println!("Total time:               {:?}", self.total_time);
-        println!("Average per swap:         {:?}", self.total_time / self.total_swaps as u32);
+        println!(
+            "Average per swap:         {:?}",
+            self.total_time / self.total_swaps as u32
+        );
         println!("Get amounts out (total):  {:?}", self.get_amounts_out_time);
-        println!("Get amounts out (avg):    {:?}", self.get_amounts_out_time / self.total_swaps as u32);
+        println!(
+            "Get amounts out (avg):    {:?}",
+            self.get_amounts_out_time / self.total_swaps as u32
+        );
         println!("Swap execution (total):   {:?}", self.swap_execution_time);
-        println!("Swap execution (avg):     {:?}", self.swap_execution_time / self.total_swaps as u32);
+        println!(
+            "Swap execution (avg):     {:?}",
+            self.swap_execution_time / self.total_swaps as u32
+        );
         println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
     }
 }


### PR DESCRIPTION
# Description

This explains why I saw inconsistent number of storage accesses. (2/1, 2/2, 5/9). Now I only see 5/9.
We used to do in a cycle:
* mint
* approve
* swap

Now we do just swap and pre-mint a billion tokens.
This gets us down to 35s/1000 swaps.
28.2 TPS.
2.8M gas/s

```
📊 Completed 1000/1000 swaps
✅ Load test completed successfully!

📊 Swap Metrics Summary
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Total swaps:              1000
Total time:               35.395138406s
Average per swap:         35.395138ms
Get amounts out (total):  4.118942101s
Get amounts out (avg):    4.118942ms
Swap execution (total):   31.275937073s
Swap execution (avg):     31.275937ms
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

real    0m35.779s
user    0m0.718s
sys     0m0.396s
```

------
- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
