### PR TITLE
Two gas metering mods. Canonical EVM and Rollup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 2025-10-01
+- #1796 Adds `EVM_GAS_METERING_MODE` configuration to switch between "Rollup" and "EVM" gas metering modes. Rollup mode (default) keeps existing behavior where EVM doesn't charge for storage access and initial cost. EVM mode enables mainnet-like gas costs useful for computing metrics like MGas/s.
 - #1791 Re-enable EVM gas estimation while bumping the margins.
 
 # 2025-09-29

--- a/constants.testing.toml
+++ b/constants.testing.toml
@@ -11,6 +11,8 @@ CHAIN_ID = 4321
 CHAIN_NAME = "TestChain"
 # We will keep only this many blocks in the EVM module.
 EVM_BLOCK_PRUNING_THRESHOLD = 10000
+# Rollup for production and EVM for benchmarks
+EVM_GAS_METERING_MODE = "Rollup"
 # How many rollup blocks to wait before terminating setup mode. While setup mode is enabled,
 # the rollup does not charge gas. This is useful when initializing the rollup with a bridged gas token.
 SETUP_MODE_TERMINATION_HEIGHT = 0 # Disable setup mode entirely by default.

--- a/constants.toml
+++ b/constants.toml
@@ -12,6 +12,7 @@ CHAIN_ID = 4321
 CHAIN_NAME = "TestChain"
 # We will keep only this many blocks in the EVM module.
 EVM_BLOCK_PRUNING_THRESHOLD = 10000
+EVM_GAS_METERING_MODE = "Rollup"
 # How many rollup blocks to wait before terminating setup mode. While setup mode is enabled,
 # the rollup does not charge gas. This is useful when initializing the rollup with a bridged gas token.
 SETUP_MODE_TERMINATION_HEIGHT = 0 # Disable setup mode entirely by default.

--- a/constants.toml
+++ b/constants.toml
@@ -12,6 +12,7 @@ CHAIN_ID = 4321
 CHAIN_NAME = "TestChain"
 # We will keep only this many blocks in the EVM module.
 EVM_BLOCK_PRUNING_THRESHOLD = 10000
+# Rollup for production and EVM for benchmarks
 EVM_GAS_METERING_MODE = "Rollup"
 # How many rollup blocks to wait before terminating setup mode. While setup mode is enabled,
 # the rollup does not charge gas. This is useful when initializing the rollup with a bridged gas token.

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -221,7 +221,7 @@ where
         let gas_used = result.gas_used()
             + match gas_metering_mode() {
                 GasMeteringMode::Rollup => self.sequencer_gas_used(state),
-                GasMeteringMode::EVM => 0,
+                GasMeteringMode::Evm => 0,
             };
         let logs = result.into_logs();
         let transaction_hash = *tx.signed_transaction.hash();

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -19,7 +19,7 @@ use crate::evm::RlpEvmTransaction;
 use crate::executor::{get_cfg_env, transact};
 #[cfg(feature = "native")]
 use crate::metrics::EvmTxMetrics;
-use crate::{Evm, PendingTransaction};
+use crate::{gas_metering_mode, Evm, GasMeteringMode, PendingTransaction};
 use anyhow::Context as _;
 
 /// EVM call message.
@@ -187,6 +187,17 @@ where
         }
     }
 
+    fn sequencer_gas_used(&self, state: &mut impl TxState<S>) -> u64 {
+        let gas_meter = state.try_as_basic_gas_meter().unwrap();
+        let sequencer_gas_used =
+            gas_meter.initial_gas.as_ref()[0] - gas_meter.remaining_gas.as_ref()[0];
+        let evm_gas_to_sequencer_gas_ratio =
+            <S as GasSpec>::gas_to_charge_per_evm_gas().as_ref()[0];
+        sequencer_gas_used
+            .checked_div(evm_gas_to_sequencer_gas_ratio)
+            .expect("gas_to_charge_per_evm_gas() is zero")
+    }
+
     fn get_receipt(
         &self,
         tx: &TxSignedAndRecovered,
@@ -207,15 +218,11 @@ where
                 .expect("Impossible happened: Log index overflow.")
         });
         let is_success = result.is_success();
-        let gas_meter = state.try_as_basic_gas_meter().unwrap();
-        let sequencer_gas_used =
-            gas_meter.initial_gas.as_ref()[0] - gas_meter.remaining_gas.as_ref()[0];
-        let evm_gas_to_sequencer_gas_ratio =
-            <S as GasSpec>::gas_to_charge_per_evm_gas().as_ref()[0];
-        let scaled_sequencer_gas_used = sequencer_gas_used
-            .checked_div(evm_gas_to_sequencer_gas_ratio)
-            .expect("gas_to_charge_per_evm_gas() is zero");
-        let gas_used = scaled_sequencer_gas_used + result.gas_used();
+        let gas_used = result.gas_used()
+            + match gas_metering_mode() {
+                GasMeteringMode::Rollup => self.sequencer_gas_used(state),
+                GasMeteringMode::EVM => 0,
+            };
         let logs = result.into_logs();
         let transaction_hash = *tx.signed_transaction.hash();
         tracing::debug!(

--- a/crates/module-system/module-implementations/sov-evm/src/config.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/config.rs
@@ -85,14 +85,14 @@ pub(crate) enum GasMeteringMode {
     Rollup,
     /// EVM gas costs are resembling those on the mainnet.
     /// Useful to compute metrics like MGas/s.
-    EVM,
+    Evm,
 }
 
 impl From<&str> for GasMeteringMode {
     fn from(s: &str) -> Self {
         match s {
             "Rollup" => GasMeteringMode::Rollup,
-            "EVM" => GasMeteringMode::EVM,
+            "EVM" => GasMeteringMode::Evm,
             _ => panic!("Invalid EVM_GAS_METERING_MODE"),
         }
     }

--- a/crates/module-system/module-implementations/sov-evm/src/config.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/config.rs
@@ -1,6 +1,7 @@
 use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
 use alloy_primitives::Address;
 use revm::primitives::hardfork::SpecId;
+use sov_modules_api::macros::config_value;
 
 use crate::AccountData;
 
@@ -73,6 +74,32 @@ impl Default for EvmRuntimeConfig {
             hardforks,
         }
     }
+}
+
+#[derive(Debug, Copy, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub(crate) enum GasMeteringMode {
+    /// EVM doesn't charge for storage access and initial cost.
+    /// Sequencer charges the initial cost and state access.
+    /// Later adds to the receipt amount.
+    #[default]
+    Rollup,
+    /// EVM gas costs are resembling those on the mainnet.
+    /// Useful to compute metrics like MGas/s.
+    EVM,
+}
+
+impl From<&str> for GasMeteringMode {
+    fn from(s: &str) -> Self {
+        match s {
+            "Rollup" => GasMeteringMode::Rollup,
+            "EVM" => GasMeteringMode::EVM,
+            _ => panic!("Invalid EVM_GAS_METERING_MODE"),
+        }
+    }
+}
+
+pub(crate) fn gas_metering_mode() -> GasMeteringMode {
+    config_value!("EVM_GAS_METERING_MODE").into()
 }
 
 #[cfg(test)]

--- a/crates/module-system/module-implementations/sov-evm/src/config.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/config.rs
@@ -76,7 +76,7 @@ impl Default for EvmRuntimeConfig {
     }
 }
 
-#[derive(Debug, Copy, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Copy, Clone, Default, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
 pub(crate) enum GasMeteringMode {
     /// EVM doesn't charge for storage access and initial cost.
     /// Sequencer charges the initial cost and state access.

--- a/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -1,7 +1,7 @@
 use crate::{
     db::commit::FallibleDatabaseCommit,
     get_spec_id,
-    sov_evm::{SovEvm, UnmeteredStorageAccessInspector},
+    sov_evm::{SovEvm, StorageAccessInspector},
     EvmRuntimeConfig,
 };
 use revm::context::TxEnv;
@@ -81,8 +81,8 @@ where
     I: Inspector<Context<&'a BlockEnv, TxEnv, CfgEnv, DB>, EthInterpreter>,
 {
     let context = context(db, block_env, cfg);
-    let unmetered_storage_inspector = UnmeteredStorageAccessInspector::new();
-    let mut evm = SovEvm::new(context, (inspector, unmetered_storage_inspector));
+    let storage_inspector = StorageAccessInspector::new();
+    let mut evm = SovEvm::new(context, (inspector, storage_inspector));
     evm.inspect_tx(tx)
 }
 
@@ -94,7 +94,7 @@ pub fn transact<DB: Database<Error = E>, E: DBErrorMarker>(
     cfg: CfgEnv,
 ) -> Result<ExecResultAndState<ExecutionResult>, EVMError<E>> {
     let context = context(db, block_env, cfg);
-    let mut evm = SovEvm::new(context, UnmeteredStorageAccessInspector::new());
+    let mut evm = SovEvm::new(context, StorageAccessInspector::new());
     evm.inspect_tx(tx)
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/sov_evm/handler.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/sov_evm/handler.rs
@@ -49,7 +49,7 @@ where
         self.validate_env(evm)?;
         match gas_metering_mode() {
             GasMeteringMode::Rollup => Ok(InitialAndFloorGas::new(0, 0)), // We disable charging initial gas
-            GasMeteringMode::EVM => self.validate_initial_tx_gas(evm),
+            GasMeteringMode::Evm => self.validate_initial_tx_gas(evm),
         }
     }
 

--- a/crates/module-system/module-implementations/sov-evm/src/sov_evm/handler.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/sov_evm/handler.rs
@@ -17,6 +17,8 @@ use revm::{
     Database,
 };
 
+use crate::{gas_metering_mode, GasMeteringMode};
+
 #[derive(Debug)]
 pub struct SovHandler<EVM>(core::marker::PhantomData<EVM>);
 
@@ -45,8 +47,10 @@ where
     #[inline]
     fn validate(&self, evm: &mut Self::Evm) -> Result<InitialAndFloorGas, Self::Error> {
         self.validate_env(evm)?;
-        // We disable charging initial gas
-        Ok(InitialAndFloorGas::new(0, 0))
+        match gas_metering_mode() {
+            GasMeteringMode::Rollup => Ok(InitialAndFloorGas::new(0, 0)), // We disable charging initial gas
+            GasMeteringMode::EVM => self.validate_initial_tx_gas(evm),
+        }
     }
 
     fn validate_against_state_and_deduct_caller(

--- a/crates/module-system/module-implementations/sov-evm/src/sov_evm/inspector.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/sov_evm/inspector.rs
@@ -29,7 +29,7 @@ where
             GasMeteringMode::Rollup => {
                 self.last_gas_remaining = Some(interp.gas.remaining());
             }
-            GasMeteringMode::EVM => (),
+            GasMeteringMode::Evm => (),
         }
     }
 
@@ -48,7 +48,7 @@ where
                     interp.gas.erase_cost(gas_cost);
                 }
             }
-            GasMeteringMode::EVM => (),
+            GasMeteringMode::Evm => (),
         }
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/sov_evm/inspector.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/sov_evm/inspector.rs
@@ -5,38 +5,50 @@ use revm::{
     Inspector,
 };
 
+use crate::{gas_metering_mode, GasMeteringMode};
+
 /// An Inspector that erases the costs of storage access
 #[derive(Clone, Debug, Default)]
-pub struct UnmeteredStorageAccessInspector {
+pub struct StorageAccessInspector {
     /// Keep track of the remaining gas before opcode execution
     last_gas_remaining: Option<u64>,
 }
 
-impl UnmeteredStorageAccessInspector {
+impl StorageAccessInspector {
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl<CTX> Inspector<CTX> for UnmeteredStorageAccessInspector
+impl<CTX> Inspector<CTX> for StorageAccessInspector
 where
     CTX: ContextTr,
 {
     fn step(&mut self, interp: &mut Interpreter, _: &mut CTX) {
-        self.last_gas_remaining = Some(interp.gas.remaining());
+        match gas_metering_mode() {
+            GasMeteringMode::Rollup => {
+                self.last_gas_remaining = Some(interp.gas.remaining());
+            }
+            GasMeteringMode::EVM => (),
+        }
     }
 
     fn step_end(&mut self, interp: &mut Interpreter, _: &mut CTX) {
-        let gas_remaining = self
-            .last_gas_remaining
-            .take()
-            .expect("step() is always called before step_end()");
-        // if storage access - revert gas changes
-        let opcode = OpCode::new(interp.bytecode.opcode());
-        if opcode == Some(OpCode::SSTORE) || opcode == Some(OpCode::SLOAD) {
-            // compute gas usage for the opcode
-            let gas_cost = gas_remaining.saturating_sub(interp.gas.remaining());
-            interp.gas.erase_cost(gas_cost);
+        match gas_metering_mode() {
+            GasMeteringMode::Rollup => {
+                let gas_remaining = self
+                    .last_gas_remaining
+                    .take()
+                    .expect("step() is always called before step_end()");
+                // if storage access - revert gas changes
+                let opcode = OpCode::new(interp.bytecode.opcode());
+                if opcode == Some(OpCode::SSTORE) || opcode == Some(OpCode::SLOAD) {
+                    // compute gas usage for the opcode
+                    let gas_cost = gas_remaining.saturating_sub(interp.gas.remaining());
+                    interp.gas.erase_cost(gas_cost);
+                }
+            }
+            GasMeteringMode::EVM => (),
         }
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/sov_evm/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/sov_evm/mod.rs
@@ -6,4 +6,4 @@ mod handler;
 mod inspector;
 
 pub use evm::SovEvm;
-pub use inspector::UnmeteredStorageAccessInspector;
+pub use inspector::StorageAccessInspector;


### PR DESCRIPTION
# Description

Sometimes we want to compare apples to apples and see how well our EVM performs in terms of MGas/s.
Because we measure gas differently than EVM - it was impossible.
This PR adds a config value with gas metering mode allowing us to enable canonical EVM gas numbers for profiling.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
