### PR TITLE
Set explicit HTTP client timeouts in NodeClient

### DIFF
--- a/crates/utils/sov-node-client/src/lib.rs
+++ b/crates/utils/sov-node-client/src/lib.rs
@@ -64,7 +64,13 @@ impl NodeClient {
     /// the required functionality.
     pub fn new_unchecked(api_url: &str) -> Self {
         let base_url = api_url.to_string();
-        let http_client = reqwest::Client::new();
+        // Configure HTTP client with explicit timeouts to avoid indefinite hangs and improve resiliency.
+        let http_client = reqwest::ClientBuilder::new()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(30))
+            .pool_idle_timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         let client = sov_api_spec::Client::new(api_url);
 
         NodeClient {


### PR DESCRIPTION


### Description
- **What**: Configure `reqwest::Client` in `NodeClient::new_unchecked` with explicit timeouts.
- **Why**: Prevents indefinite hangs during network issues, improves CLI responsiveness and test stability.
- **How**: Use `ClientBuilder` with `connect_timeout(5s)`, `timeout(30s)`, `pool_idle_timeout(30s)`; safe fallback to default client on build error.

