### PR TITLE
Airtight evm metrics

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -82,9 +82,7 @@ where
         start_timer!(fetch_state);
         let (cfg, block, tx_env, tx, pending_len) = self.fetch_state(context, state, tx)?;
         save_elapsed!(fetch_state_time SINCE fetch_state);
-        start_timer!(get_db);
         let db = self.get_db(state);
-        save_elapsed!(get_db_time SINCE get_db);
         let mut db = MetricsDb::new(db);
 
         start_timer!(execution);
@@ -105,13 +103,8 @@ where
         if !result.is_success() {
             return on_revert(*tx.signed_transaction.hash(), result);
         }
-
-        #[cfg(feature = "native")]
-        {
-            sov_metrics::track_metrics(|t| {
-                t.submit(db.metrics());
-            });
-        }
+        let db_metrics = db.metrics();
+        drop(db); // To release the state
 
         let gas_used = result.gas_used();
         start_timer!(receipt_t);
@@ -127,6 +120,7 @@ where
         self.pending_transactions.push(&pending_tx, state)?;
         save_elapsed!(set_state_time SINCE set_state);
 
+        start_timer!(get_head_t);
         // Fetch `head` and `pending_len` before the `native` code block.
         // This ensures consistent gas charges between native and non-native execution.
         #[allow(unused_variables)]
@@ -135,6 +129,7 @@ where
             .get(state)?
             // Justified, we set it at `genesis` and leter only override it.
             .expect("Impossible happened: Head must be set.");
+        save_elapsed!(get_head_time SINCE get_head_t);
 
         #[cfg(feature = "native")]
         let set_accessory_state_time = {
@@ -151,15 +146,18 @@ where
             let metrics = EvmTxMetrics {
                 total_time,
                 fetch_state_time,
-                get_db_time,
                 execution_time,
                 state_commit_time,
                 receipt_time,
                 set_state_time,
+                get_head_time,
                 set_accessory_state_time,
             };
             sov_metrics::track_metrics(|t| {
                 t.submit(metrics);
+            });
+            sov_metrics::track_metrics(|t| {
+                t.submit(db_metrics);
             });
         }
 

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -103,6 +103,7 @@ where
         if !result.is_success() {
             return on_revert(*tx.signed_transaction.hash(), result);
         }
+        #[cfg(feature = "native")]
         let db_metrics = db.metrics();
         drop(db); // To release the state
 

--- a/crates/module-system/module-implementations/sov-evm/src/metrics.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/metrics.rs
@@ -5,12 +5,12 @@ use std::{io::Write, time::Duration};
 pub(crate) struct EvmTxMetrics {
     pub total_time: Duration,
     pub fetch_state_time: Duration,
-    pub get_db_time: Duration,
     pub execution_time: Duration,
     pub state_commit_time: Duration,
     pub receipt_time: Duration,
-    pub set_accessory_state_time: Duration,
     pub set_state_time: Duration,
+    pub get_head_time: Duration,
+    pub set_accessory_state_time: Duration,
 }
 
 impl Metric for EvmTxMetrics {
@@ -22,11 +22,11 @@ impl Metric for EvmTxMetrics {
         let fields: &[(&str, Duration)] = &[
             ("total_time", self.total_time),
             ("fetch_prestate_time", self.fetch_state_time),
-            ("get_db_time", self.get_db_time),
             ("execution_time", self.execution_time),
             ("state_commit_time", self.state_commit_time),
             ("receipt_time", self.receipt_time),
             ("set_state_time", self.set_state_time),
+            ("get_head_time", self.get_head_time),
             ("set_accessory_state_time", self.set_accessory_state_time),
         ];
         write!(buffer, "{}", self.measurement_name())?;

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -441,8 +441,8 @@ pub enum PendingOrBlock {
 }
 
 // HACK: This should be much lower but because gas estimation doesn't work now - we temporarily set it to a large value.
-const ABSOLUTE_MARGIN: u64 = 1_000_000;
-/// gas * 1.5 + 1_000_000
+const ABSOLUTE_MARGIN: u64 = 10_000_000;
+/// gas * 1.5 + 10_000_000
 fn apply_margins(gas: u64) -> Result<u64, RpcInvalidTransactionError> {
     (gas / 2)
         .checked_mul(3)

--- a/examples/demo-rollup/tests/evm/evm_gas_estimation.rs
+++ b/examples/demo-rollup/tests/evm/evm_gas_estimation.rs
@@ -8,7 +8,7 @@ async fn simple_transfer() -> anyhow::Result<()> {
 
     let simple_transfer = test_client.make_tx(Some(Address::zero()), None);
     let gas_estimation = test_client.eth_estimate_gas(simple_transfer).await;
-    assert_eq!(gas_estimation, 1_000_000); // Simple transfer consumes 0 EVM gas so we only see the ABSOLUTE_MARGIN
+    assert_eq!(gas_estimation, 10_000_000); // Simple transfer consumes 0 EVM gas so we only see the ABSOLUTE_MARGIN
     Ok(())
 }
 
@@ -18,6 +18,6 @@ async fn contract_deploy() -> anyhow::Result<()> {
 
     let deploy_tx = test_client.make_tx(None, Some(test_client.contract.byte_code()));
     let gas_estimation = test_client.eth_estimate_gas(deploy_tx).await;
-    assert_eq!(gas_estimation, (206_448 / 2) * 3 + 1_000_000);
+    assert_eq!(gas_estimation, (206_448 / 2) * 3 + 10_000_000);
     Ok(())
 }


### PR DESCRIPTION
# Description
```
total_time:                  497.056 µs   (100.0%)
  fetch_state_time:            56.699 µs    (11.4%)
  execution_time:             265.387 µs    (53.4%)
    ├─ account db lookups:      85.048 µs    (17.1%)
    ├─ storage db lookups:      67.139 µs    (13.5%)
    └─ other EVM work:         113.200 µs    (22.8%)
  state_commit_time:          105.190 µs    (21.2%)
  receipt_time:                39.180 µs     (7.9%)
  set_state_time:              16.710 µs     (3.4%)
  get_head_time:                8.530 µs     (1.7%)
  set_accessory_state_time:     3.860 µs     (0.8%)


Totals

Accounted = 495.556 µs
Measured Total = 497.056 µs
Unaccounted = 1.500 µs (0.3%)
```

EVM metrics now cover 99.7% of total time.
Also increased the absolute margin on gas estimation as I hit it again. This should be solved but not now.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
