### PR TITLE
Parallelize uniswap test

### DIFF
--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -1,3 +1,4 @@
+use alloy::hex;
 use alloy_primitives::Address;
 use anyhow::Result;
 use clap::Parser;
@@ -37,6 +38,9 @@ enum TestType {
         /// Number of iterations
         #[arg(short, long, default_value = "100")]
         count: usize,
+
+        #[arg(short, long, default_value = "1")]
+        num_workers: usize,
     },
     /// Run SimpleStorage soak test
     SimpleStorage,
@@ -47,11 +51,42 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     match args.test {
-        TestType::Uniswap { count } => {
-            let client = RpcClient::new(&args.private_key, args.rpc_addr).await;
-            let signer = Address::from_slice(client.address().as_bytes());
-            let test = UniSoakTest::new(client.alloy_client, signer).await?;
-            test.run(count).await?;
+        TestType::Uniswap { count, num_workers } => {
+            if num_workers > 255 {
+                return Err(anyhow::anyhow!("num_workers must be less than 256 because of our private key tweaking. This is an easy fix, but we haven't done it yet."));
+            }
+            let mut handles: Vec<tokio::task::JoinHandle<anyhow::Result<()>>> =
+                Vec::with_capacity(num_workers);
+            for i in 0..num_workers {
+                // Tweak the private key to avoid conflicts between workers
+                let key = {
+                    let mut key_bytes: [u8; 32] =
+                        hex::decode(&args.private_key).unwrap().try_into().unwrap();
+                    key_bytes[0] = key_bytes[0].wrapping_add(i as u8);
+                    hex::encode(key_bytes)
+                };
+                let addr: SocketAddr = args.rpc_addr.clone(); // Clone the RPC address to avoid lifetime issues
+                                                              // Spawn a new task for each worker
+                handles.push(tokio::spawn(async move {
+                    let client = RpcClient::new(&key, addr).await;
+                    let signer = Address::from_slice(&client.address().0);
+                    match UniSoakTest::new(client.alloy_client, signer).await {
+                        Ok(test) => {
+                            if let Err(e) = test.run(count).await {
+                                println!("Worker {i} error during run: {e:?}");
+                            }
+                        }
+                        Err(e) => {
+                            println!("Worker {i} failed to deploy contracts: {e:?}");
+                        }
+                    }
+                    Ok(())
+                }));
+            }
+
+            for handle in handles {
+                handle.await??;
+            }
         }
         TestType::SimpleStorage => {
             let contract = SimpleStorage::default();

--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -65,10 +65,9 @@ async fn main() -> Result<()> {
                     key_bytes[0] = key_bytes[0].wrapping_add(i as u8);
                     hex::encode(key_bytes)
                 };
-                let addr: SocketAddr = args.rpc_addr.clone(); // Clone the RPC address to avoid lifetime issues
-                                                              // Spawn a new task for each worker
+                // Spawn a new task for each worker
                 handles.push(tokio::spawn(async move {
-                    let client = RpcClient::new(&key, addr).await;
+                    let client = RpcClient::new(&key, args.rpc_addr).await;
                     let signer = Address::from_slice(&client.address().0);
                     match UniSoakTest::new(client.alloy_client, signer).await {
                         Ok(test) => {

--- a/crates/utils/sov-evm-soak-testing/src/uniswap.rs
+++ b/crates/utils/sov-evm-soak-testing/src/uniswap.rs
@@ -98,9 +98,17 @@ where
     }
 
     async fn execute_random_swaps(&mut self, count: usize) -> Result<()> {
-        let mut rng = rand::thread_rng();
-
-        for i in 1..=count {
+        // Random amount between 0.1% and 5% of pool reserves
+        let min_percent = 0.001; // 0.1%
+        let max_percent = 0.05; // 5%
+        let percents = {
+            let mut y_rng = rand::thread_rng();
+            (1..=count)
+                .map(|_| y_rng.gen_range(min_percent..=max_percent))
+                .collect::<Vec<_>>()
+        };
+        for (idx, percent) in percents.iter().enumerate() {
+            let i = idx + 1;
             // Alternate between USDC→WETH and WETH→USDC to keep pool balanced
             let is_usdc_to_weth = i % 2 == 1;
 
@@ -110,14 +118,9 @@ where
                 (vec![*self.weth.address(), *self.usdc.address()], "10000") // Max 10k WETH
             };
 
-            // Random amount between 0.1% and 5% of pool reserves
-            let min_percent = 0.001; // 0.1%
-            let max_percent = 0.05; // 5%
-            let random_percent = rng.gen_range(min_percent..=max_percent);
-
             let base_value = base_amount.parse::<f64>()?;
             #[allow(clippy::float_arithmetic)] // This is a soak test and not guest code
-            let scaled_amount = format!("{:.6}", random_percent * base_value);
+            let scaled_amount = format!("{:.6}", percent * base_value);
             let amount = parse_ether(&scaled_amount)?;
 
             self.execute_swap(amount, path).await?;


### PR DESCRIPTION
# Description

This PR adds a `num-workers` argument to the uniswap soak test, allowing many generators to run in parallel.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
