### PR TITLE
Set default capacity for Maps and Vecs used as caches.

### DIFF
--- a/crates/module-system/sov-modules-api/src/state/accessors/internals.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/internals.rs
@@ -6,13 +6,13 @@ use crate::{Spec, StateCheckpoint, TxChangeSet};
 use sov_metrics::{StateAccessMetric, StateMetrics};
 use sov_rollup_interface::stf::ExecutionContext;
 pub(crate) use sov_state::AccessoryWrite;
-use sov_state::NodeLeafAndMaybeValue;
 #[cfg(feature = "native")]
 use sov_state::StateGetter;
 use sov_state::{
     namespaces, AccessSize, IsValueCached, Namespace, ProvableStorageCache, SlotKey, SlotValue,
     StateAccesses, Storage,
 };
+use sov_state::{NodeLeafAndMaybeValue, DEFAULT_CACHE_CAPACITY};
 
 #[cfg(feature = "native")]
 use super::checkpoints::ChangeSet;
@@ -64,14 +64,17 @@ impl<S: Storage> Delta<S> {
             uncomitted_changes: None,
             user_cache: Default::default(),
             kernel_cache: Default::default(),
-            accessory_writes: Default::default(),
+            accessory_writes: HashMap::with_capacity(DEFAULT_CACHE_CAPACITY),
         }
     }
 
     #[cfg(feature = "native")]
     pub(super) fn take_accessory_delta(&mut self) -> AccessoryDelta<S> {
         AccessoryDelta {
-            writes: std::mem::take(&mut self.accessory_writes),
+            writes: std::mem::replace(
+                &mut self.accessory_writes,
+                HashMap::with_capacity(DEFAULT_CACHE_CAPACITY),
+            ),
             #[cfg(feature = "native")]
             uncomitted_changes: self.uncomitted_changes.as_ref().map(|g| g.box_clone()),
             storage: self.inner.clone(),
@@ -474,7 +477,7 @@ impl<T> RevertableWriter<T> {
     pub(super) fn new(inner: T) -> Self {
         Self {
             inner,
-            writes: HashMap::default(),
+            writes: HashMap::with_capacity(DEFAULT_CACHE_CAPACITY),
             cache_writes: TempCache::new(),
         }
     }

--- a/crates/module-system/sov-state/src/cache.rs
+++ b/crates/module-system/sov-state/src/cache.rs
@@ -93,31 +93,29 @@ impl Access {
 pub(crate) mod internal {
     use std::collections::HashMap;
 
+    use crate::DEFAULT_CACHE_CAPACITY;
+
     use super::*;
+
     /// [`CacheLog`] keeps track of the original and current values of each key accessed.
     /// By tracking original values, we can detect and eliminate write patterns where a key is
     /// changed temporarily and then reset to its original value
     #[derive(Debug, Clone)]
     pub(crate) struct CacheLog {
-        revertable_log: std::collections::HashMap<SlotKey, Access>,
-        log: std::collections::HashMap<SlotKey, Access>,
+        revertable_log: HashMap<SlotKey, Access>,
+        log: HashMap<SlotKey, Access>,
     }
 
     impl Default for CacheLog {
         fn default() -> Self {
             Self {
-                revertable_log: HashMap::with_capacity(100),
-                log: HashMap::with_capacity(100),
+                revertable_log: HashMap::with_capacity(DEFAULT_CACHE_CAPACITY),
+                log: HashMap::with_capacity(DEFAULT_CACHE_CAPACITY),
             }
         }
     }
 
     impl CacheLog {
-        pub(crate) fn reserve(&mut self, additional_cap: usize) {
-            self.revertable_log.reserve(additional_cap);
-            self.log.reserve(additional_cap);
-        }
-
         // This method is used to get all the changeset from the cache. The `revertable_log`
         // shoule be either merged or discarded before calling this method.
         pub(crate) fn iter(&self) -> impl Iterator<Item = (&SlotKey, &Access)> {
@@ -316,7 +314,7 @@ impl<N: ProvableCompileTimeNamespace> ProvableStorageCache<N> {
     pub fn commit_revertable_storage_cache(&mut self) {
         let cap = self.revertable_ordered_reads.capacity();
         let revertable_ordered_reads =
-            mem::replace(&mut self.revertable_ordered_reads, Vec::with_capacity(cap)); //mem::take(&mut self.revertable_ordered_reads);
+            mem::replace(&mut self.revertable_ordered_reads, Vec::with_capacity(cap));
         self.ordered_db_reads.extend(
             revertable_ordered_reads
                 .into_iter()
@@ -613,14 +611,6 @@ impl<N: ProvableCompileTimeNamespace> ProvableStorageCache<N> {
         &mut self,
         reads: Vec<(SlotKey, Option<NodeLeafAndMaybeValue>)>,
     ) {
-        if reads.len()
-            > self.revertable_ordered_reads.capacity() - self.revertable_ordered_reads.len()
-        {
-            let s = reads.len() - self.revertable_ordered_reads.capacity();
-            self.revertable_ordered_reads.reserve(s);
-            self.cache.reserve(s);
-        }
-
         for (key, node) in reads {
             if self.cache.get(&key).is_some() {
                 continue;

--- a/crates/module-system/sov-state/src/cache.rs
+++ b/crates/module-system/sov-state/src/cache.rs
@@ -91,17 +91,33 @@ impl Access {
 }
 
 pub(crate) mod internal {
+    use std::collections::HashMap;
+
     use super::*;
     /// [`CacheLog`] keeps track of the original and current values of each key accessed.
     /// By tracking original values, we can detect and eliminate write patterns where a key is
     /// changed temporarily and then reset to its original value
-    #[derive(Default, Debug, Clone)]
+    #[derive(Debug, Clone)]
     pub(crate) struct CacheLog {
         revertable_log: std::collections::HashMap<SlotKey, Access>,
         log: std::collections::HashMap<SlotKey, Access>,
     }
 
+    impl Default for CacheLog {
+        fn default() -> Self {
+            Self {
+                revertable_log: HashMap::with_capacity(100),
+                log: HashMap::with_capacity(100),
+            }
+        }
+    }
+
     impl CacheLog {
+        pub(crate) fn reserve(&mut self, additional_cap: usize) {
+            self.revertable_log.reserve(additional_cap);
+            self.log.reserve(additional_cap);
+        }
+
         // This method is used to get all the changeset from the cache. The `revertable_log`
         // shoule be either merged or discarded before calling this method.
         pub(crate) fn iter(&self) -> impl Iterator<Item = (&SlotKey, &Access)> {
@@ -298,7 +314,9 @@ impl<N: ProvableCompileTimeNamespace> ProvableStorageCache<N> {
 
     /// Commit the revertable part of the `ProvableStorageCache`.
     pub fn commit_revertable_storage_cache(&mut self) {
-        let revertable_ordered_reads = mem::take(&mut self.revertable_ordered_reads);
+        let cap = self.revertable_ordered_reads.capacity();
+        let revertable_ordered_reads =
+            mem::replace(&mut self.revertable_ordered_reads, Vec::with_capacity(cap)); //mem::take(&mut self.revertable_ordered_reads);
         self.ordered_db_reads.extend(
             revertable_ordered_reads
                 .into_iter()
@@ -595,6 +613,14 @@ impl<N: ProvableCompileTimeNamespace> ProvableStorageCache<N> {
         &mut self,
         reads: Vec<(SlotKey, Option<NodeLeafAndMaybeValue>)>,
     ) {
+        if reads.len()
+            > self.revertable_ordered_reads.capacity() - self.revertable_ordered_reads.len()
+        {
+            let s = reads.len() - self.revertable_ordered_reads.capacity();
+            self.revertable_ordered_reads.reserve(s);
+            self.cache.reserve(s);
+        }
+
         for (key, node) in reads {
             if self.cache.get(&key).is_some() {
                 continue;

--- a/crates/module-system/sov-state/src/lib.rs
+++ b/crates/module-system/sov-state/src/lib.rs
@@ -39,6 +39,9 @@ pub use crate::namespaces::*;
 pub use crate::storage::*;
 pub use crate::witness::{ArrayWitness, Witness};
 
+/// The initial capacity set for the various caches.
+pub const DEFAULT_CACHE_CAPACITY: usize = 32;
+
 /// A trait specifying the hash function and format of the witness used in
 /// merkle proofs for storage access
 pub trait MerkleProofSpec: Send + Sync {

--- a/examples/demo-rollup/mock_rollup_config.toml
+++ b/examples/demo-rollup/mock_rollup_config.toml
@@ -41,7 +41,7 @@ bind_port = 12346
 # public_address = "http://rollup.sovereign.xyz"
 
 [monitoring]
-telegraf_address = "udp://127.0.0.1:8094"
+telegraf_address = "udp://127.0.0.1:9094"
 # Defines how many measurements a rollup node will accumulate before sending it to the Telegraf.
 # It is expected from the rollup node to produce metrics all the time,
 # so measurements are buffered by size and not sent by time.

--- a/examples/demo-rollup/mock_rollup_config.toml
+++ b/examples/demo-rollup/mock_rollup_config.toml
@@ -41,7 +41,7 @@ bind_port = 12346
 # public_address = "http://rollup.sovereign.xyz"
 
 [monitoring]
-telegraf_address = "udp://127.0.0.1:9094"
+telegraf_address = "udp://127.0.0.1:8094"
 # Defines how many measurements a rollup node will accumulate before sending it to the Telegraf.
 # It is expected from the rollup node to produce metrics all the time,
 # so measurements are buffered by size and not sent by time.


### PR DESCRIPTION
# Description


- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
