### PR TITLE
Set blockenv at genesis.

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -1,6 +1,6 @@
 use alloy_consensus::{transaction::Recovered, Transaction};
 use alloy_eips::eip2718::{Decodable2718, Eip2718Error};
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, Bytes, B256, U256};
 use reth_primitives_traits::SignedTransaction;
 use revm::{
     context::{BlockEnv, TransactionType, TxEnv},
@@ -18,19 +18,14 @@ use crate::{
 // BlockEnv from SealedBlock
 impl From<SealedBlock> for BlockEnv {
     fn from(block: SealedBlock) -> Self {
-        Self {
-            number: U256::from(block.header.number),
-            beneficiary: block.header.beneficiary,
-            timestamp: U256::from(block.header.timestamp),
-            prevrandao: Some(block.header.mix_hash),
-            gas_limit: block.header.gas_limit,
-            blob_excess_gas_and_price: Some(BlobExcessGasAndPrice {
-                excess_blob_gas: EXCESS_BLOB_GAS,
-                blob_gasprice: BLOB_GAS_PRICE,
-            }),
-            basefee: block.base_fee(),
-            difficulty: Default::default(),
-        }
+        create_block_env(
+            block.base_fee(),
+            block.header.gas_limit,
+            block.header.timestamp,
+            block.header.beneficiary,
+            block.header.number,
+            None,
+        )
     }
 }
 
@@ -105,6 +100,29 @@ impl TryFrom<RlpEvmTransaction> for Recovered<TransactionSigned> {
             .map_err(|_| RlpConversionError::InvalidSignature)?;
 
         Ok(tx)
+    }
+}
+
+pub(crate) fn create_block_env(
+    base_fee: u64,
+    gas_limit: u64,
+    timestamp: u64,
+    beneficiary: Address,
+    number: u64,
+    prevrandao: Option<B256>,
+) -> BlockEnv {
+    BlockEnv {
+        number: U256::from(number),
+        beneficiary,
+        timestamp: U256::from(timestamp),
+        prevrandao,
+        gas_limit: gas_limit,
+        basefee: base_fee,
+        blob_excess_gas_and_price: Some(BlobExcessGasAndPrice {
+            excess_blob_gas: EXCESS_BLOB_GAS,
+            blob_gasprice: BLOB_GAS_PRICE,
+        }),
+        ..Default::default()
     }
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -116,7 +116,7 @@ pub(crate) fn create_block_env(
         beneficiary,
         timestamp: U256::from(timestamp),
         prevrandao,
-        gas_limit: gas_limit,
+        gas_limit,
         basefee: base_fee,
         blob_excess_gas_and_price: Some(BlobExcessGasAndPrice {
             excess_blob_gas: EXCESS_BLOB_GAS,

--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -24,7 +24,7 @@ impl From<SealedBlock> for BlockEnv {
             block.header.timestamp,
             block.header.beneficiary,
             block.header.number,
-            None,
+            Some(block.header.mix_hash),
         )
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -1,6 +1,8 @@
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_primitives::{Address, B256, U256};
 use alloy_primitives::{BlockNumber, Bytes};
+use revm::context::BlockEnv;
+use revm::context_interface::block::BlobExcessGasAndPrice;
 use revm::primitives::hardfork::SpecId;
 use revm::state::AccountInfo;
 use sov_address::{EthereumAddress, FromVmAddress};
@@ -8,7 +10,7 @@ use sov_modules_api::{GenesisState, Module, Spec};
 
 use crate::db::init::InitEvmDb;
 use crate::evm::primitive_types::Block;
-use crate::{Evm, EvmGenesisConfig, EvmRuntimeConfig, EXCESS_BLOB_GAS};
+use crate::{Evm, EvmGenesisConfig, EvmRuntimeConfig, BLOB_GAS_PRICE, EXCESS_BLOB_GAS};
 #[cfg(feature = "native")]
 use std::ops::RangeInclusive;
 
@@ -55,6 +57,10 @@ where
 
         self.cfg.set(&chain_cfg, state)?;
         self.head.set(&block, state)?;
+
+        let block_env = self.env_from_block(&block);
+        self.block_env.set(&block_env, state)?;
+
         #[cfg(feature = "native")]
         {
             self.block_numbers.set(&RangeInclusive::new(0, 0), state)?;
@@ -85,6 +91,23 @@ where
         };
 
         Ok(())
+    }
+
+    fn env_from_block(&self, block: &Block) -> BlockEnv {
+        BlockEnv {
+            number: U256::from(block.header.number),
+            beneficiary: block.header.beneficiary,
+            timestamp: U256::from(block.header.timestamp),
+            prevrandao: None,
+            gas_limit: block.header.gas_limit,
+            blob_excess_gas_and_price: Some(BlobExcessGasAndPrice {
+                excess_blob_gas: EXCESS_BLOB_GAS,
+                blob_gasprice: BLOB_GAS_PRICE,
+            }),
+
+            basefee: self.base_fee(),
+            ..Default::default()
+        }
     }
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -93,6 +93,7 @@ where
         Ok(())
     }
 
+    // `BlockEnv`` will be overridden in begin_rollup_block_hook.
     fn env_from_block(&self, block: &Block) -> BlockEnv {
         BlockEnv {
             number: U256::from(block.header.number),

--- a/crates/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -1,16 +1,15 @@
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_primitives::{Address, B256, U256};
 use alloy_primitives::{BlockNumber, Bytes};
-use revm::context::BlockEnv;
-use revm::context_interface::block::BlobExcessGasAndPrice;
 use revm::primitives::hardfork::SpecId;
 use revm::state::AccountInfo;
 use sov_address::{EthereumAddress, FromVmAddress};
 use sov_modules_api::{GenesisState, Module, Spec};
 
+use crate::conversions::create_block_env;
 use crate::db::init::InitEvmDb;
 use crate::evm::primitive_types::Block;
-use crate::{Evm, EvmGenesisConfig, EvmRuntimeConfig, BLOB_GAS_PRICE, EXCESS_BLOB_GAS};
+use crate::{Evm, EvmGenesisConfig, EvmRuntimeConfig, EXCESS_BLOB_GAS};
 #[cfg(feature = "native")]
 use std::ops::RangeInclusive;
 
@@ -58,7 +57,14 @@ where
         self.cfg.set(&chain_cfg, state)?;
         self.head.set(&block, state)?;
 
-        let block_env = self.env_from_block(&block);
+        let block_env = create_block_env(
+            self.base_fee(),
+            block.header.gas_limit,
+            block.header.timestamp,
+            block.header.beneficiary,
+            block.header.number,
+            None,
+        );
         self.block_env.set(&block_env, state)?;
 
         #[cfg(feature = "native")]
@@ -91,24 +97,6 @@ where
         };
 
         Ok(())
-    }
-
-    // `BlockEnv`` will be overridden in begin_rollup_block_hook.
-    fn env_from_block(&self, block: &Block) -> BlockEnv {
-        BlockEnv {
-            number: U256::from(block.header.number),
-            beneficiary: block.header.beneficiary,
-            timestamp: U256::from(block.header.timestamp),
-            prevrandao: None,
-            gas_limit: block.header.gas_limit,
-            blob_excess_gas_and_price: Some(BlobExcessGasAndPrice {
-                excess_blob_gas: EXCESS_BLOB_GAS,
-                blob_gasprice: BLOB_GAS_PRICE,
-            }),
-
-            basefee: self.base_fee(),
-            ..Default::default()
-        }
     }
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -1,10 +1,10 @@
+use crate::conversions::create_block_env;
 use crate::evm::primitive_types::{Block, TransactionSigned};
-use crate::{BlockEnv, Evm, PendingTransaction, BLOB_GAS_PRICE, EXCESS_BLOB_GAS};
+use crate::{Evm, PendingTransaction};
 use alloy_consensus::proofs::{calculate_receipt_root, calculate_transaction_root};
 use alloy_consensus::TxReceipt;
 use alloy_primitives::Bloom;
-use alloy_primitives::{B256, U256};
-use revm::context_interface::block::BlobExcessGasAndPrice;
+use alloy_primitives::B256;
 #[cfg(feature = "native")]
 use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::UnwrapInfallible;
@@ -56,23 +56,15 @@ impl<S: Spec> BlockHooks for Evm<S> {
             .unwrap_infallible()
             .as_millis() as u64;
 
-        let new_pending_env = BlockEnv {
-            number: U256::from(new_block_number),
-            beneficiary: cfg.chain_spec.coinbase,
-            timestamp: U256::from(new_timestamp),
-            // WARNING: `prevrandao`` value is predictable up to [`DEFERRED_SLOTS_COUNT`] in advance,
-            // Users should follow the same best practice that they would on Ethereum and use future randomness.
-            // See: https://eips.ethereum.org/EIPS/eip-4399#tips-for-application-developers
-            prevrandao: Some(B256::from(pre_state_user_root)),
-            gas_limit: cfg.chain_spec.block_gas_limit,
-            blob_excess_gas_and_price: Some(BlobExcessGasAndPrice {
-                excess_blob_gas: EXCESS_BLOB_GAS,
-                blob_gasprice: BLOB_GAS_PRICE,
-            }),
+        let new_pending_env = create_block_env(
+            self.base_fee(),
+            cfg.chain_spec.block_gas_limit,
+            new_timestamp,
+            cfg.chain_spec.coinbase,
+            new_block_number,
+            Some(B256::from(pre_state_user_root)),
+        );
 
-            basefee: self.base_fee(),
-            ..Default::default()
-        };
         self.block_env
             .set(&new_pending_env, state)
             .unwrap_infallible();


### PR DESCRIPTION
# Description

Before the first `block_env` was set by  `begin_rollup_block_hook`. 

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
