### PR TITLE
Make FullyBakedTx cheaply clonable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ borsh = { version = "1", features = ["derive"] }
 bincode = "1.3.3"
 bcs = "0.1.6"
 byteorder = { version = "1.5.0", default-features = false }
-bytes = { version = "1.7.1", default-features = false }
+bytes = { version = "1.10", default-features = false }
 convert_case = { version = "0.6", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["now"] }
 darling = "0.20"

--- a/crates/full-node/sov-db/src/schema/types.rs
+++ b/crates/full-node/sov-db/src/schema/types.rs
@@ -8,6 +8,7 @@ use sov_rollup_interface::node::ledger_api::{BatchResponse, TxResponse};
 use sov_rollup_interface::stf::{
     DiscardedBlob, StoredEvent, TransactionReceipt, TxReceiptContents,
 };
+use sov_rollup_interface::Bytes;
 
 /// A cheaply cloneable bytes abstraction for use within the trust boundary of the node
 /// (i.e. when interfacing with the database). Serializes and deserializes more efficiently,
@@ -131,17 +132,17 @@ impl StoredBatch {
 /// The on-disk format of a transaction. Includes the txhash, the serialized tx data,
 /// and identifies the events emitted by this transaction
 #[derive(Debug, PartialEq, BorshSerialize, BorshDeserialize, Clone)]
-#[cfg_attr(
-    feature = "arbitrary",
-    derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
-)]
+// #[cfg_attr(
+//     feature = "arbitrary",
+//     derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
+// )]
 pub struct StoredTransaction {
     /// The hash of the transaction.
     pub hash: DbHash,
     /// The range of event-numbers emitted by this transaction.
     pub events: std::ops::Range<EventNumber>,
     /// The serialized transaction data, if the rollup decides to store it.
-    pub body: Option<Vec<u8>>,
+    pub body: Option<Bytes>,
     /// A custom "receipt" for this transaction defined by the rollup.
     pub receipt: DbBytes,
     /// This transaction's parent batch number.

--- a/crates/full-node/sov-db/src/schema/types.rs
+++ b/crates/full-node/sov-db/src/schema/types.rs
@@ -132,10 +132,6 @@ impl StoredBatch {
 /// The on-disk format of a transaction. Includes the txhash, the serialized tx data,
 /// and identifies the events emitted by this transaction
 #[derive(Debug, PartialEq, BorshSerialize, BorshDeserialize, Clone)]
-// #[cfg_attr(
-//     feature = "arbitrary",
-//     derive(proptest_derive::Arbitrary, arbitrary::Arbitrary)
-// )]
 pub struct StoredTransaction {
     /// The hash of the transaction.
     pub hash: DbHash,

--- a/crates/full-node/sov-ledger-apis/src/lib.rs
+++ b/crates/full-node/sov-ledger-apis/src/lib.rs
@@ -32,6 +32,7 @@ use sov_rollup_interface::node::ledger_api::{
     SlotIdentifier, SlotResponse, TxIdAndOffset, TxIdentifier, TxResponse,
 };
 use sov_rollup_interface::stf::TxReceiptContents;
+use sov_rollup_interface::Bytes;
 use tokio::sync::watch;
 
 type PathMap = Path<HashMap<String, NumberOrHash>>;
@@ -940,7 +941,7 @@ struct Transaction<TxReceipt: TxReceiptContents, E> {
     pub hash: HexHash,
     pub event_range: Range<u64>,
     #[serde_as(as = "serde_with::base64::Base64")]
-    pub body: Vec<u8>,
+    pub body: Bytes,
     pub receipt: TxEffect<TxReceipt>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub events: Option<Vec<RuntimeEventResponse<E>>>,

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -243,7 +243,10 @@ impl PreferredSequencerDbBackend for PostgresBackend {
         let event_types = vec!["transaction"; txs.len()];
         let tx_indexes = (start..end).collect::<Vec<_>>();
         let hashes = txs.iter().map(|(_, hash)| hash.0).collect::<Vec<_>>();
-        let txs = txs.iter().map(|(tx, _)| &tx.data).collect::<Vec<_>>();
+        let txs = txs
+            .iter()
+            .map(|(tx, _)| tx.data.as_ref())
+            .collect::<Vec<_>>();
         run_with_retries!(
             &self.backoff_policy,
             sqlx::query::<Postgres>(
@@ -276,7 +279,7 @@ impl PreferredSequencerDbBackend for PostgresBackend {
             .bind(i64::try_from(sequence_number)?)
             .bind(i64::try_from(tx_index_within_batch)?)
             .bind::<&[u8]>(hash.as_ref())
-            .bind(&tx.data)
+            .bind(tx.data.as_ref())
             .execute(&self.pool),
             "postgres_db_backend_add_tx"
         )?;

--- a/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
@@ -317,9 +317,7 @@ mod tests {
         let mut txs = vec![];
         let mut tx_hashes = vec![];
         for i in 0..10 {
-            let tx = FullyBakedTx {
-                data: vec![i as u8; 200],
-            };
+            let tx = FullyBakedTx::new(vec![i as u8; 200]);
             let tx_hash = HexString([i as u8; 32]);
             txs.push(tx);
             tx_hashes.push(tx_hash);

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -96,9 +96,7 @@ mod tests {
             data.push(DbData::BatchStart(stored_batch.clone()));
 
             for i in 0..nb_of_txs {
-                data.push(DbData::Transaction(FullyBakedTx {
-                    data: vec![i as u8],
-                }));
+                data.push(DbData::Transaction(FullyBakedTx::new(vec![i as u8])));
             }
 
             data.push(DbData::BatchEnd(stored_batch));

--- a/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
@@ -248,7 +248,9 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
             return Ok(None);
         };
         Ok(Some(AcceptedTx {
-            tx: FullyBakedTx::new(tx.body.unwrap_or_default()),
+            tx: FullyBakedTx {
+                data: tx.body.unwrap_or_default(),
+            },
             tx_hash,
             confirmation: Confirmation {
                 events: tx

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -22,6 +22,7 @@ use sov_rest_utils::{
 };
 use sov_rollup_interface::da::{DaBlobHash, DaSpec};
 use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::Bytes;
 use sov_rollup_interface::TxHash;
 use tokio::sync::watch::Receiver;
 use tokio_stream::wrappers::BroadcastStream;
@@ -463,8 +464,8 @@ pub struct ApiAcceptedTx<Confirmation> {
     pub id: TxHash,
     /// The base64 encoded transaction body
     #[serde_as(as = "serde_with::base64::Base64")]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub tx: Vec<u8>,
+    #[serde(skip_serializing_if = "Bytes::is_empty")]
+    pub tx: Bytes,
     /// The confirmation data
     #[serde(flatten)]
     pub confirmation: Confirmation,

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -69,9 +69,7 @@ pub struct TestNode {
 impl TestNode {
     /// Creates a DA block containing a transaction blob, optionally including an aggregated proof.
     pub async fn send_transaction(&self) -> anyhow::Result<MockHash> {
-        let batch = vec![FullyBakedTx {
-            data: vec![1, 2, 3],
-        }];
+        let batch = vec![FullyBakedTx::new(vec![1, 2, 3])];
 
         let serialized_batch = borsh::to_vec(&batch)?;
         self.da
@@ -83,7 +81,7 @@ impl TestNode {
 
     /// Creates a DA block containing an empty transaction blob, optionally including an aggregated proof.
     pub async fn try_send_aggregated_proof(&self) -> anyhow::Result<MockHash> {
-        let batch = vec![FullyBakedTx { data: vec![] }];
+        let batch = vec![FullyBakedTx::new(vec![])];
         let serialized_batch = borsh::to_vec(&batch)?;
         self.da
             .send_transaction(&serialized_batch)

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -182,9 +182,7 @@ async fn test_runner_with_background_da_service(
     let seen_da_height_boundary = target_height + finality as u64 + 30;
 
     while synced_da_height <= target_height {
-        let batch = vec![FullyBakedTx {
-            data: vec![1, 2, 3],
-        }];
+        let batch = vec![FullyBakedTx::new(vec![1, 2, 3])];
 
         let serialized_batch = borsh::to_vec(&batch)?;
         let _ = da_service.send_transaction(&serialized_batch).await.await?;
@@ -420,8 +418,5 @@ fn get_result_from_blocks(
 }
 
 fn batch(serialized_tx: Vec<u8>) -> Vec<u8> {
-    borsh::to_vec(&vec![FullyBakedTx {
-        data: serialized_tx,
-    }])
-    .unwrap()
+    borsh::to_vec(&vec![FullyBakedTx::new(serialized_tx)]).unwrap()
 }

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/da_simulation.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/da_simulation.rs
@@ -89,9 +89,9 @@ pub fn simulate_da_with_bad_serialization(key: TestPrivateKey) -> Vec<FullyBaked
         ),
     );
 
-    let mut serialized = encode_with_auth(tx);
-    serialized.data[0] = serialized.data[0].wrapping_add(20);
-    vec![serialized]
+    let mut serialized = encode_with_auth(tx).data.to_vec();
+    serialized[0] = serialized[0].wrapping_add(20);
+    vec![FullyBakedTx::new(serialized.to_vec())]
 }
 
 fn encode_with_auth(tx: Transaction<IntegTestRuntime<S>, S>) -> FullyBakedTx {

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/stf_tests.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/stf_tests.rs
@@ -217,7 +217,7 @@ fn test_unregistered_sequencer_registration_is_limited_to_one_per_batch() {
     // We don't have an API for this because the `Batch` struct isn't allowed to contain direct registration transactions.
     let txs = txs
         .into_iter()
-        .map(|tx| FullyBakedTx::new(tx.data))
+        .map(|tx| FullyBakedTx { data: tx.data })
         .collect();
     let blob = new_test_blob_from_batch(txs, direct_sequencer_da_address.as_ref());
 

--- a/crates/module-system/module-implementations/sov-sequencer-registry/tests/integration/reward_mechanism.rs
+++ b/crates/module-system/module-implementations/sov-sequencer-registry/tests/integration/reward_mechanism.rs
@@ -235,7 +235,7 @@ fn produce_malformed_tx(
         )
         .to_serialized_authenticated_tx(&mut nonces);
 
-    tx.data.pop();
+    tx.data.truncate(tx.data.len() - 1);
     TransactionType::PreAuthenticated(tx)
 }
 

--- a/crates/module-system/sov-modules-api/src/batch.rs
+++ b/crates/module-system/sov-modules-api/src/batch.rs
@@ -8,6 +8,7 @@ use crate::{
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::Bytes;
 
 /// `FullyBakedTx` represents a serialized signed rollup transaction that has been encoded with
 /// authentication information and is ready to be placed on the DA layer.
@@ -24,7 +25,7 @@ use sov_rollup_interface::da::DaSpec;
 pub struct FullyBakedTx {
     /// Serialized transaction.
     #[as_ref(forward)]
-    pub data: Vec<u8>,
+    pub data: Bytes,
 }
 
 impl std::fmt::Debug for FullyBakedTx {
@@ -39,7 +40,9 @@ impl FullyBakedTx {
     /// Construct a `FullyBakedTx` containing the given data
     #[must_use]
     pub fn new(data: Vec<u8>) -> Self {
-        Self { data }
+        Self {
+            data: Bytes::from_owner(data),
+        }
     }
 }
 

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/common.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/common.rs
@@ -4,6 +4,7 @@ use sov_modules_api::{
     BatchSequencerReceipt, Context, DispatchCall, Error, IgnoredTransactionReceipt, Spec,
     StateProvider, TransactionReceipt, TxScratchpad, WorkingSet, *,
 };
+use sov_rollup_interface::Bytes;
 use sov_rollup_interface::TxHash;
 use tracing::{debug, info};
 
@@ -136,7 +137,7 @@ pub fn get_gas_used<S: Spec>(receipt: &TransactionReceipt<S>) -> S::Gas {
 pub(crate) fn create_tx_receipt<S: Spec>(
     skipped: SkippedTxContents<S>,
     raw_tx_hash: TxHash,
-    raw_tx_body: Vec<u8>,
+    raw_tx_body: Bytes,
 ) -> TransactionReceipt<S> {
     info!(
         error = %skipped.error,

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
@@ -28,7 +28,7 @@ type TxAndError = (TxProcessingError, FullyBakedTx);
 /// this method must return Ok(()) and handle any sequencer rewards internally.
 #[allow(clippy::result_large_err, clippy::too_many_arguments)]
 #[cfg_attr(feature = "native", tracing::instrument(skip_all, name = "StfBlueprint::process_tx", fields(context = ?execution_context)))]
-// #[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
+#[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
 pub fn process_tx_and_reward_prover<S, R, I, C>(
     runtime: &mut R,
     pre_exec_working_set: PreExecWorkingSet<S, I>,
@@ -323,7 +323,7 @@ where
     (Ok(apply_tx), scratchpad, pre_exec_gas_meter)
 }
 
-// #[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
+#[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
 #[cfg_attr(
     feature = "native",
     tracing::instrument(skip_all, name = "StfBlueprint::authenticate")
@@ -355,7 +355,7 @@ impl<S: Spec> IncrementalBatchReceipt<S> {
 
 #[tracing::instrument(skip_all, name = "StfBlueprint::apply_batch", fields(context = ?execution_context))]
 #[allow(clippy::too_many_arguments)]
-// #[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
+#[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
 pub(crate) fn apply_batch<S, RT, B>(
     runtime: &mut RT,
     mut checkpoint: StateCheckpoint<S>,
@@ -659,7 +659,7 @@ fn penalize_sequencer<S: Spec, RT: Runtime<S>, I: StateProvider<S>>(
 }
 
 /// Executes the authentication and processing of a transaction, and rewards/penalizes the sequencer
-// #[cfg_attr(feature = "bench", sov_modules_api::cycsle_tracker)]
+#[cfg_attr(feature = "bench", sov_modules_api::cycsle_tracker)]
 #[allow(clippy::too_many_arguments)]
 fn auth_and_process_tx_and_incentivize_sequencer<S, RT, I, C>(
     runtime: &mut RT,

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
@@ -659,7 +659,7 @@ fn penalize_sequencer<S: Spec, RT: Runtime<S>, I: StateProvider<S>>(
 }
 
 /// Executes the authentication and processing of a transaction, and rewards/penalizes the sequencer
-#[cfg_attr(feature = "bench", sov_modules_api::cycsle_tracker)]
+#[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
 #[allow(clippy::too_many_arguments)]
 fn auth_and_process_tx_and_incentivize_sequencer<S, RT, I, C>(
     runtime: &mut RT,

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
@@ -28,7 +28,7 @@ type TxAndError = (TxProcessingError, FullyBakedTx);
 /// this method must return Ok(()) and handle any sequencer rewards internally.
 #[allow(clippy::result_large_err, clippy::too_many_arguments)]
 #[cfg_attr(feature = "native", tracing::instrument(skip_all, name = "StfBlueprint::process_tx", fields(context = ?execution_context)))]
-#[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
+// #[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
 pub fn process_tx_and_reward_prover<S, R, I, C>(
     runtime: &mut R,
     pre_exec_working_set: PreExecWorkingSet<S, I>,
@@ -323,7 +323,7 @@ where
     (Ok(apply_tx), scratchpad, pre_exec_gas_meter)
 }
 
-#[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
+// #[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
 #[cfg_attr(
     feature = "native",
     tracing::instrument(skip_all, name = "StfBlueprint::authenticate")
@@ -355,7 +355,7 @@ impl<S: Spec> IncrementalBatchReceipt<S> {
 
 #[tracing::instrument(skip_all, name = "StfBlueprint::apply_batch", fields(context = ?execution_context))]
 #[allow(clippy::too_many_arguments)]
-#[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
+// #[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
 pub(crate) fn apply_batch<S, RT, B>(
     runtime: &mut RT,
     mut checkpoint: StateCheckpoint<S>,
@@ -433,6 +433,22 @@ where
 
     let mut clean_scratchpad = checkpoint.to_tx_scratchpad();
 
+    // Optimistically execute each transaction in the batch.
+    // We need...
+    // - A pool of threads that can "run ahead" of the main thread
+    // - To periodically update the checkpoint that the worker threads are using
+    // - For each worker...
+    //   - Grab the next tx from the queue
+    //   - Update state from the broadcast channel
+    //   - Run the tx
+    //   - Send the result back to the main thread.
+    //
+    // For the main thread:
+    //   - For each tx...
+    //     - Check if optimistic results are available
+    //     - If so, do a consistency check (each read needs to match the latest value)
+    //        - If the check passes, apply the tx to the state
+    //        - If the check fails, discard the result and execute the tx on the main thread
     for (idx, (raw_tx, mut injected_control_flow)) in batch_with_id.enumerate() {
         injected_control_flow.try_warm_up_cache(&mut clean_scratchpad);
 
@@ -643,7 +659,7 @@ fn penalize_sequencer<S: Spec, RT: Runtime<S>, I: StateProvider<S>>(
 }
 
 /// Executes the authentication and processing of a transaction, and rewards/penalizes the sequencer
-#[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
+// #[cfg_attr(feature = "bench", sov_modules_api::cycsle_tracker)]
 #[allow(clippy::too_many_arguments)]
 fn auth_and_process_tx_and_incentivize_sequencer<S, RT, I, C>(
     runtime: &mut RT,

--- a/crates/module-system/sov-test-utils/src/ledger_db.rs
+++ b/crates/module-system/sov-test-utils/src/ledger_db.rs
@@ -14,7 +14,7 @@ use sov_modules_api::da::Time;
 use sov_modules_api::{ModuleId, StoredEvent};
 use sov_rollup_interface::stf::{BatchReceipt, TransactionReceipt, TxEffect};
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
-use sov_rollup_interface::TxHash;
+use sov_rollup_interface::{Bytes, TxHash};
 use tempfile::{tempdir, TempDir};
 use tokio::sync::watch;
 
@@ -37,7 +37,7 @@ pub async fn materialize_simple_ledger_db_data(
 
     let tx_receipts = vec![TransactionReceipt {
         tx_hash: TxHash::new([1; 32]),
-        body_to_save: Some(b"tx-body".to_vec()),
+        body_to_save: Some(Bytes::from_static(b"tx-body")),
         events: events(0),
         receipt: TxEffect::Successful(0),
     }];
@@ -140,13 +140,13 @@ pub fn materialize_and_commit_complex_ledger_db_data(
             tx_receipts: vec![
                 TransactionReceipt::<TestTxReceiptContents> {
                     tx_hash: sha2::Sha256::digest(b"tx0").into(),
-                    body_to_save: Some(b"tx0 body".to_vec()),
+                    body_to_save: Some(Bytes::from_static(b"tx0 body")),
                     events: events(0),
                     receipt: TxEffect::Successful(0),
                 },
                 TransactionReceipt::<TestTxReceiptContents> {
                     tx_hash: sha2::Sha256::digest(b"tx1").into(),
-                    body_to_save: Some(b"tx1 body".to_vec()),
+                    body_to_save: Some(Bytes::from_static(b"tx1 body")),
                     events: events(1),
                     receipt: TxEffect::Successful(1),
                 },
@@ -159,13 +159,13 @@ pub fn materialize_and_commit_complex_ledger_db_data(
             tx_receipts: vec![
                 TransactionReceipt::<TestTxReceiptContents> {
                     tx_hash: sha2::Sha256::digest(b"tx2").into(),
-                    body_to_save: Some(b"tx2 body".to_vec()),
+                    body_to_save: Some(Bytes::from_static(b"tx2 body")),
                     events: events(2),
                     receipt: TxEffect::Successful(2),
                 },
                 TransactionReceipt::<TestTxReceiptContents> {
                     tx_hash: sha2::Sha256::digest(b"tx3").into(),
-                    body_to_save: Some(b"tx3 body".to_vec()),
+                    body_to_save: Some(Bytes::from_static(b"tx3 body")),
                     events: events(3),
                     receipt: TxEffect::Successful(3),
                 },
@@ -182,13 +182,13 @@ pub fn materialize_and_commit_complex_ledger_db_data(
             tx_receipts: vec![
                 TransactionReceipt::<TestTxReceiptContents> {
                     tx_hash: sha2::Sha256::digest(b"tx4").into(),
-                    body_to_save: Some(b"tx4 body".to_vec()),
+                    body_to_save: Some(Bytes::from_static(b"tx4 body")),
                     events: events(4),
                     receipt: TxEffect::Successful(4),
                 },
                 TransactionReceipt::<TestTxReceiptContents> {
                     tx_hash: sha2::Sha256::digest(b"tx5").into(),
-                    body_to_save: Some(b"tx5 body".to_vec()),
+                    body_to_save: Some(Bytes::from_static(b"tx5 body")),
                     events: events(5),
                     receipt: TxEffect::Successful(5),
                 },
@@ -238,7 +238,7 @@ fn batch3_tx_receipts() -> Vec<TransactionReceipt<TestTxReceiptContents>> {
     (0..260u64)
         .map(|i| TransactionReceipt::<TestTxReceiptContents> {
             tx_hash: ::sha2::Sha256::digest(format!("tx{}", 6 + i)).into(),
-            body_to_save: Some(format!("tx{} body", 6 + i).into_bytes()),
+            body_to_save: Some(Bytes::from_owner(format!("tx{} body", 6 + i).into_bytes())),
             events: events(6 + i),
             receipt: TxEffect::Skipped(0),
         })

--- a/crates/rollup-interface/src/node/ledger_api.rs
+++ b/crates/rollup-interface/src/node/ledger_api.rs
@@ -2,6 +2,7 @@
 //! via an RPC interface.
 use async_trait::async_trait;
 use borsh::{BorshDeserialize, BorshSerialize};
+use bytes::Bytes;
 use derive_more::derive::Display;
 use futures::stream::BoxStream;
 use serde::de::DeserializeOwned;
@@ -244,7 +245,7 @@ pub struct TxResponse<Tx: TxReceiptContents, E> {
     pub event_range: core::ops::Range<u64>,
     /// The transaction body, if stored by the rollup.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub body: Option<Vec<u8>>,
+    pub body: Option<Bytes>,
     /// The events emitted by this transaction, if the [`QueryMode`] of the request is not `Compact`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub events: Option<Vec<E>>,

--- a/crates/rollup-interface/src/state_machine/stf/fuzzing.rs
+++ b/crates/rollup-interface/src/state_machine/stf/fuzzing.rs
@@ -1,5 +1,6 @@
 //! Implements fuzzing strategies for structs in the stf module
 
+use bytes::Bytes;
 use digest::typenum::U32;
 use digest::Digest;
 use proptest::prelude::{any, Arbitrary};
@@ -139,7 +140,7 @@ where
                     };
                     Self {
                         tx_hash,
-                        body_to_save,
+                        body_to_save: body_to_save.map(Bytes::from_owner),
                         events,
                         receipt,
                     }

--- a/crates/rollup-interface/src/state_machine/stf/transaction.rs
+++ b/crates/rollup-interface/src/state_machine/stf/transaction.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use bytes::Bytes;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
@@ -28,7 +29,7 @@ pub struct TransactionReceipt<T: TxReceiptContents> {
     /// in the database.
     /// Skip serialization because it is unnecessary over the wire.
     #[serde(skip_serializing)]
-    pub body_to_save: Option<Vec<u8>>,
+    pub body_to_save: Option<Bytes>,
     /// The events output by this transaction
     pub events: Vec<StoredEvent>,
     /// Any additional structured data to be saved in the database and served over RPC

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -1191,9 +1191,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -1167,9 +1167,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
# Description

This small PR changes the inner type of `FullyBakedTx` and its children from `Vec<u8>` to `bytes::Bytes`. This makes the type cheaply clonable, which will be useful for optimistic execution.


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

