### PR TITLE
Refactor simulation endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12556,7 +12556,9 @@ dependencies = [
  "borsh",
  "derivative",
  "derive_more 1.0.0",
+ "hex",
  "openapiv3",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "serde_with",
@@ -12573,6 +12575,7 @@ dependencies = [
  "sov-uniqueness",
  "strum 0.26.3",
  "tempfile",
+ "thiserror 1.0.69",
  "tracing",
  "utoipa-swagger-ui",
 ]

--- a/crates/full-node/sov-api-spec/openapi-v3.yaml
+++ b/crates/full-node/sov-api-spec/openapi-v3.yaml
@@ -465,6 +465,32 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SimulateExecutionResponse"
+  /rollup/simulate-v2:
+    post:
+      summary: Simulate transaction execution (v2)
+      description: |-
+        Simulates transaction execution against the current blockchain state without committing changes.
+        This endpoint provides detailed gas estimation, event emission, and error handling.
+        Useful for estimating gas costs, testing transaction behavior, and debugging.
+      operationId: simulate_v2
+      tags:
+        - Rollup
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SimulateParametersV2"
+      responses:
+        "200":
+          description: Simulation completed successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimulateOutcomeV2"
+        "400":
+          $ref: "#/components/responses/ApiErrorResponse"
+        "500":
+          $ref: "#/components/responses/ApiErrorResponse"
   /rollup/sync-status:
     get:
       summary: Get the current sync status of the rollup
@@ -856,10 +882,15 @@ components:
           type: integer
         hyperlane_domain:
           type: integer
+        address_prefix:
+          type: string
+          description: The HRP used for addresses in this rollup (e.g., "sov"). Doesn't apply to solana/eth addressed apps.
+          example: "sov"
       required:
         - chain_name
         - chain_id
         - hyperlane_domain
+        - address_prefix
     Hash:
       type: string
       title: Hash
@@ -1142,3 +1173,137 @@ components:
                 - target_da_height
           required:
             - syncing
+    SimulateParametersV2:
+      type: object
+      description: Parameters for transaction simulation requests (v2)
+      properties:
+        sender:
+          type: string
+          description: The credential ID of the transaction sender
+          example: "sov1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq5k2jj4"
+        call:
+          type: object
+          description: The runtime call to simulate, provided as JSON
+          additionalProperties: true
+          example:
+            Bank:
+              Transfer:
+                to:
+                  user: "sov1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq5k2jj4"
+                coins:
+                  amount: "1000"
+                  token_id: "token_1234567890abcdef"
+        tx_details:
+          $ref: "#/components/schemas/TxDetailsParameterV2"
+        sequencer:
+          $ref: "#/components/schemas/SequencerParameterV2"
+        uniqueness:
+          type: object
+          description: Optional uniqueness data for the transaction
+          additionalProperties: true
+      required:
+        - sender
+        - call
+    TxDetailsParameterV2:
+      type: object
+      description: Optional transaction details for simulation requests
+      properties:
+        max_priority_fee_bips:
+          type: integer
+          description: Maximum priority fee in basis points
+          format: uint16
+          example: 100
+        max_fee:
+          type: string
+          description: Maximum fee the sender is willing to pay
+          example: "1000000"
+        gas_limit:
+          type: array
+          items:
+            type: integer
+            format: uint64
+          description: Gas limit for the transaction as an array of u64 values
+          example: [1000000, 0, 0, 0]
+    SequencerParameterV2:
+      type: object
+      description: Optional sequencer configuration for simulation requests
+      properties:
+        rollup_address:
+          type: string
+          description: Custom rollup address for the sequencer
+          example: "sov1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq5k2jj4"
+        da_address:
+          type: string
+          description: Custom data availability address for the sequencer
+          example: "celestia1234567890abcdef"
+    SimulateOutcomeV2:
+      type: object
+      description: The outcome of a transaction simulation
+      discriminator:
+        propertyName: outcome
+      oneOf:
+        - $ref: "#/components/schemas/SuccessOutcomeV2"
+        - $ref: "#/components/schemas/FailOutcomeV2"
+    SuccessOutcomeV2:
+      type: object
+      description: Successful simulation outcome
+      properties:
+        outcome:
+          type: string
+          enum: [success]
+        gas_used:
+          type: string
+          description: The amount of gas consumed by the transaction
+          example: "104000"
+        events:
+          type: array
+          items:
+            $ref: "#/components/schemas/SimulatedEventV2"
+          description: Events emitted during transaction execution
+      required:
+        - outcome
+        - gas_used
+        - events
+    FailOutcomeV2:
+      type: object
+      description: Failed simulation outcome
+      properties:
+        outcome:
+          type: string
+          enum: [reverted, skipped]
+        reason:
+          type: string
+          description: The reason why the transaction failed
+          example: "Insufficient balance"
+      required:
+        - outcome
+        - reason
+    SimulatedEventV2:
+      type: object
+      description: An event emitted during transaction simulation
+      properties:
+        value:
+          type: object
+          description: The event data
+          additionalProperties: true
+          example:
+            token_transferred:
+              coins:
+                amount: "1000"
+                token_id: "token_1234567890abcdef"
+              from:
+                user: "sov1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq5k2jj4"
+              to:
+                user: "sov1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq2k2jj4"
+        key:
+          type: string
+          description: The event key
+          example: "Bank/TokenTransferred"
+        module:
+          type: string
+          description: The module that emitted the event
+          example: "Bank"
+      required:
+        - value
+        - key
+        - module

--- a/crates/full-node/sov-api-spec/openapi.stainless.yml
+++ b/crates/full-node/sov-api-spec/openapi.stainless.yml
@@ -86,6 +86,17 @@ resources:
     methods:
       simulate: post /rollup/simulate
     subresources:
+      simulate_v2:
+        methods:
+          simulate: post /rollup/simulate-v2
+        models:
+          simulateOutcomeV2: SimulateOutcomeV2
+          simulateParametersV2: SimulateParametersV2
+          successOutcomeV2: SuccessOutcomeV2
+          failOutcomeV2: FailOutcomeV2
+          simulatedEventV2: SimulatedEventV2
+          txDetailsParameterV2: TxDetailsParameterV2
+          sequencerParameterV2: SequencerParameterV2
       base_fee_per_gas:
         methods:
           retrieve: get /rollup/base-fee-per-gas/latest

--- a/crates/full-node/sov-rollup-apis/Cargo.toml
+++ b/crates/full-node/sov-rollup-apis/Cargo.toml
@@ -19,6 +19,8 @@ axum = { workspace = true }
 borsh = { workspace = true }
 derive_more = { workspace = true }
 derivative = { workspace = true }
+thiserror = { workspace = true }
+hex = { workspace = true }
 serde = { workspace = true }
 utoipa-swagger-ui = { workspace = true, features = ["axum"] }
 openapiv3 = { workspace = true }
@@ -41,11 +43,10 @@ tempfile = { workspace = true }
 axum-server = { workspace = true }
 anyhow = { workspace = true }
 strum = { workspace = true }
+reqwest = { workspace = true }
 
 # Sovereign dependencies
 sov-bank = { workspace = true, features = ["native"] }
 sov-test-utils = { workspace = true }
 sov-kernels = { workspace = true, features = ["native"] }
 sov-state = { workspace = true, features = ["native"] }
-
-

--- a/crates/full-node/sov-rollup-apis/src/endpoints/constants.rs
+++ b/crates/full-node/sov-rollup-apis/src/endpoints/constants.rs
@@ -13,6 +13,7 @@ pub struct ConstantsResponse {
     chain_id: u64,
     chain_name: &'static str,
     hyperlane_domain: u32,
+    address_prefix: &'static str,
 }
 
 impl Default for ConstantsResponse {
@@ -21,6 +22,7 @@ impl Default for ConstantsResponse {
             chain_id: config_value!("CHAIN_ID"),
             chain_name: config_value!("CHAIN_NAME"),
             hyperlane_domain: config_value!("HYPERLANE_BRIDGE_DOMAIN"),
+            address_prefix: config_value!("ADDRESS_PREFIX"),
         }
     }
 }

--- a/crates/full-node/sov-rollup-apis/src/endpoints/mod.rs
+++ b/crates/full-node/sov-rollup-apis/src/endpoints/mod.rs
@@ -4,3 +4,5 @@ pub mod constants;
 pub mod dedup;
 /// Provides functionality for the `/rollup/schema` endpoint.
 pub mod schema;
+/// Provides functionality for the `/rollup/simulate` endpoint.
+pub mod simulate;

--- a/crates/full-node/sov-rollup-apis/src/endpoints/simulate.rs
+++ b/crates/full-node/sov-rollup-apis/src/endpoints/simulate.rs
@@ -432,7 +432,7 @@ impl<S: Spec, R: Runtime<S> + HasCapabilities<S> + RuntimeEventProcessor> Simula
             )
             .map_err(SimulateError::ContextResolution)?;
 
-        let ws_gas_meter = auth_tx_data.gas_meter(&gas_price, &<S::Gas>::MAX);
+        let ws_gas_meter = auth_tx_data.gas_meter(gas_price, <S::Gas>::MAX);
         let working_set = WorkingSet::create_working_set(scratchpad, &auth_tx_data, ws_gas_meter);
 
         let schema = get_runtime_schema::<S, R>().map_err(SimulateError::SchemaConstruction)?;

--- a/crates/full-node/sov-rollup-apis/src/endpoints/simulate.rs
+++ b/crates/full-node/sov-rollup-apis/src/endpoints/simulate.rs
@@ -1,0 +1,459 @@
+//! Transaction simulation endpoints for the Sovereign rollup.
+//!
+//! This module provides REST API endpoints for simulating transaction execution
+//! without actually committing them to the blockchain. This is useful for:
+//! - Estimating gas costs before submitting transactions
+//! - Testing transaction behavior and outcomes
+//! - Debugging transaction failures
+//! - Frontend applications showing transaction previews
+use axum::http::StatusCode;
+use axum::{extract::State, response::IntoResponse, routing::post, Json, Router};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use sov_modules_api::capabilities::{
+    AuthorizationData, ChainState, HasCapabilities, TransactionAuthorizer, UniquenessData,
+};
+use sov_modules_api::common::Amount;
+use sov_modules_api::macros::config_value;
+use sov_modules_api::prelude::anyhow;
+use sov_modules_api::rest::StateUpdateReceiver;
+use sov_modules_api::sov_universal_wallet::schema::{RollupRoots, SchemaError};
+use sov_modules_api::transaction::{Credentials, PriorityFeeBips, TxDetails};
+use sov_modules_api::{
+    get_runtime_schema, AuthenticatedTransactionData, CredentialId, DaSpec, EventModuleName,
+    FullyBakedTx, Gas, GasArray, HexHash, HexString, Runtime, RuntimeEventProcessor, Spec,
+    StateCheckpoint, StateProvider as _, WorkingSet,
+};
+use sov_modules_stf_blueprint::{apply_tx, get_gas_used, ApplyTxResult};
+use sov_rest_utils::{json_obj, preconfigured_router_layers, ErrorObject};
+use sov_rollup_interface::stf::TxEffect;
+use sov_uniqueness::Uniqueness;
+use std::str::FromStr;
+
+/// Trait for transaction simulation endpoints.
+///
+/// Implementations of this trait provide transaction simulation functionality
+/// through a REST API. The simulation executes transactions against the current
+/// blockchain state without committing the changes.
+pub trait SimulateEndpoint: Send + Sync + 'static {
+    /// The state used by the simulation router.
+    type State: Clone + Send + Sync;
+
+    /// The input parameters for the simulation request.
+    type Parameters: DeserializeOwned + Clone + Send;
+
+    /// The response type returned by successful simulations.
+    type Response: Serialize;
+
+    /// The error type for simulation failures.
+    type Error: Into<ErrorObject>;
+
+    /// Handles a simulation request.
+    ///
+    /// This method processes the simulation parameters and returns either
+    /// a successful simulation result or an error describing what went wrong.
+    ///
+    /// # Arguments
+    /// * `params` - The simulation parameters including transaction details
+    ///
+    /// # Returns
+    /// * `Ok(Response)` - Successful simulation with gas usage and events
+    /// * `Err(Error)` - Simulation failed due to invalid input or execution error
+    fn handler(state: Self::State, params: Self::Parameters)
+        -> Result<Self::Response, Self::Error>;
+
+    /// Returns a configured axum router for the endpoint.
+    ///
+    /// Creates an axum router with the `/rollup/simulate-v2` endpoint that accepts POST requests.
+    /// The router calls the implemented [`Self::handler`] and returns the result as JSON.
+    /// If [`Self::handler`] returns an error, it will be converted to an [`ErrorObject`] and
+    /// returned with the appropriate HTTP status code.
+    ///
+    /// # Warning
+    ///
+    /// If you override this method, you should ensure you provide the standard `/rollup/simulate-v2` path.
+    /// If the path is different, then external tooling like web3 SDKs won't be able to consume the
+    /// functionality and will fail to work.
+    ///
+    /// # Returns
+    /// An axum [`Router`] configured with the simulation endpoint.
+    fn axum_router(state: Self::State) -> Router<()> {
+        preconfigured_router_layers(
+            Router::new()
+                .route(
+                    "/rollup/simulate-v2",
+                    post(
+                        |State(state): State<Self::State>, Json(body): Json<Self::Parameters>| async move {
+                            match Self::handler(state, body) {
+                                Ok(data) => Json(data).into_response(),
+                                Err(err) => err.into().into_response(),
+                            }
+                        },
+                    ),
+                )
+                .with_state(state.clone()),
+        )
+    }
+}
+
+/// Errors that can occur during transaction simulation.
+#[derive(thiserror::Error, Debug)]
+pub enum SimulateError {
+    /// Invalid input parameters were provided.
+    #[error("Invalid input")]
+    InvalidInput(String),
+
+    /// Failed to retrieve the current gas price from the chain state.
+    #[error("Failed to retrieve gas price")]
+    GasPriceRetrieval,
+
+    /// Failed to resolve the transaction context for execution.
+    #[error("Failed to resolve tx context")]
+    ContextResolution(#[source] anyhow::Error),
+
+    /// Failed to create the runtime schema needed for call deserialization.
+    #[error("Failed to create schema for rollup")]
+    SchemaConstruction(#[source] anyhow::Error),
+
+    /// Failed to serialize the call message from JSON to bytes.
+    #[error("Failed to serialize call message")]
+    CallSerialization(#[from] SchemaError),
+
+    /// Failed to decode the call bytes into a runtime call.
+    #[error("Failed to decode call message into a runtime call")]
+    CallDecoding(#[from] std::io::Error),
+}
+
+impl From<SimulateError> for ErrorObject {
+    fn from(value: SimulateError) -> Self {
+        let (status, error) = match &value {
+            SimulateError::InvalidInput(message) => (StatusCode::BAD_REQUEST, message.clone()),
+            SimulateError::GasPriceRetrieval => (StatusCode::INTERNAL_SERVER_ERROR, "".to_string()),
+            SimulateError::ContextResolution(error) | SimulateError::SchemaConstruction(error) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
+            }
+            SimulateError::CallSerialization(error) => (StatusCode::BAD_REQUEST, error.to_string()),
+            SimulateError::CallDecoding(error) => {
+                // Internal server error because if JSON to bytes serialization works
+                // then bytes to RuntimeCall should also work.
+                (StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
+            }
+        };
+
+        Self {
+            status,
+            message: value.to_string(),
+            details: json_obj!({"error":error}),
+        }
+    }
+}
+
+const NULL_TX_HASH: HexHash = HexString([0; 32]);
+
+/// Sequencer configuration for transaction simulation.
+///
+/// Contains the addresses needed to simulate transactions in the context
+/// of a specific sequencer.
+#[derive(Clone)]
+pub struct SequencerSimulate<S: Spec> {
+    rollup_address: S::Address,
+    da_address: <S::Da as DaSpec>::Address,
+}
+
+/// Main implementation of the simulation endpoint for Sovereign rollups.
+///
+/// This struct provides transaction simulation functionality by executing
+/// transactions against the current state without committing changes.
+/// It supports gas estimation, event emission, and error handling.
+#[derive(Clone)]
+pub struct SovereignSimulate<S: Spec, R> {
+    state_receiver: StateUpdateReceiver<S::Storage>,
+    default_sequencer: SequencerSimulate<S>,
+    _phantom: std::marker::PhantomData<R>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SimulatedEvent<E> {
+    value: E,
+    key: String,
+    module: String,
+}
+
+/// Successful simulation outcome containing gas usage and events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SuccessOutcome<E> {
+    /// The amount of gas consumed by the transaction.
+    gas_used: Amount,
+    /// Events emitted during transaction execution.
+    events: Vec<SimulatedEvent<E>>,
+}
+
+/// Failed simulation outcome with error reason.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailOutcome {
+    /// The reason why the transaction failed.
+    pub reason: String,
+}
+
+/// The outcome of a transaction simulation.
+///
+/// This enum represents the three possible outcomes when simulating a transaction:
+/// successful execution, transaction revert, or transaction skipped due to errors.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum SimulateOutcome<E> {
+    /// The transaction executed successfully.
+    Success(SuccessOutcome<E>),
+    /// The transaction was reverted during execution.
+    Reverted(FailOutcome),
+    /// The transaction was skipped due to pre-execution errors.
+    Skipped(FailOutcome),
+}
+
+impl<S: Spec, R: Runtime<S> + HasCapabilities<S> + RuntimeEventProcessor> SovereignSimulate<S, R> {
+    /// Creates a new simulation endpoint instance.
+    ///
+    /// # Arguments
+    /// * `receiver` - State update receiver for accessing current blockchain state
+    /// * `sequencer_rollup_address` - Default rollup address for the sequencer
+    /// * `sequencer_da_address` - Default data availability address for the sequencer
+    ///
+    /// # Returns
+    /// A new `SovereignSimulate` instance ready to handle simulation requests.
+    pub fn new(
+        receiver: StateUpdateReceiver<S::Storage>,
+        sequencer_rollup_address: S::Address,
+        sequencer_da_address: <S::Da as DaSpec>::Address,
+    ) -> Self {
+        Self {
+            state_receiver: receiver,
+            default_sequencer: SequencerSimulate {
+                rollup_address: sequencer_rollup_address,
+                da_address: sequencer_da_address,
+            },
+            _phantom: Default::default(),
+        }
+    }
+
+    /// Converts this simulation endpoint into an axum router.
+    ///
+    /// This is a convenience method that wraps the endpoint in an `Arc` and
+    /// creates the router using the `SimulateEndpoint` trait implementation.
+    /// The resulting router can be merged with other routers or used directly
+    /// to serve the simulation endpoint.
+    ///
+    /// # Returns
+    /// An axum [`Router`] configured with the `/rollup/simulate-v2` endpoint.
+    pub fn into_router(self) -> Router<()> {
+        Self::axum_router(std::sync::Arc::new(self))
+    }
+
+    fn tx_details(&self, partial: TxDetailsParameter) -> Result<TxDetails<S>, SimulateError> {
+        let gas_limit = partial
+            .gas_limit
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(|e| SimulateError::InvalidInput(format!("{e:?}")))?;
+        Ok(TxDetails {
+            chain_id: config_value!("CHAIN_ID"),
+            max_priority_fee_bips: partial
+                .max_priority_fee_bips
+                .unwrap_or(PriorityFeeBips::ZERO),
+            max_fee: partial.max_fee.unwrap_or(Amount::MAX),
+            gas_limit,
+        })
+    }
+
+    fn sequencer(
+        &self,
+        partial: SequencerParameter,
+    ) -> Result<SequencerSimulate<S>, SimulateError> {
+        let rollup_address: S::Address = if let Some(input) = partial.rollup_address {
+            S::Address::from_str(&input).map_err(|_| {
+                SimulateError::InvalidInput("failed to parse sequencer rollup address".to_owned())
+            })?
+        } else {
+            self.default_sequencer.rollup_address.clone()
+        };
+        let da_address = if let Some(input) = partial.da_address {
+            <S::Da as DaSpec>::Address::from_str(&input).map_err(|_| {
+                SimulateError::InvalidInput("failed to parse sequencer da address".to_owned())
+            })?
+        } else {
+            self.default_sequencer.da_address.clone()
+        };
+        Ok({
+            SequencerSimulate {
+                rollup_address,
+                da_address,
+            }
+        })
+    }
+
+    fn authorization_data(
+        &self,
+        params: &SimulateParameters,
+        state: &mut StateCheckpoint<S>,
+    ) -> AuthorizationData<S> {
+        let credential_id = CredentialId::from_str(&params.sender).unwrap();
+        let uniqueness = params.uniqueness.unwrap_or_else(|| {
+            let generation = Uniqueness::<S>::default()
+                .next_generation(&credential_id, state)
+                .unwrap();
+            UniquenessData::Generation(generation)
+        });
+
+        AuthorizationData {
+            tx_hash: NULL_TX_HASH,
+            uniqueness,
+            credential_id,
+            default_address: credential_id.into(),
+            credentials: Credentials::new(credential_id),
+        }
+    }
+
+    fn outcome(&self, result: ApplyTxResult<S>) -> SimulateOutcome<R::RuntimeEvent> {
+        let gas_price = result.transaction_consumption.gas_price();
+        let gas_used = get_gas_used(&result.receipt);
+        let events = result
+            .receipt
+            .events
+            .iter()
+            .map(|stored_event| {
+                // This should be infailable, a transaction execution should never
+                // produce events that aren't (de)serializable by the runtime
+                let value: R::RuntimeEvent = borsh::de::BorshDeserialize::try_from_slice(
+                    stored_event.value().inner().as_slice(),
+                )
+                .unwrap();
+                let key = String::from_utf8(stored_event.key().inner().clone())
+                    .unwrap_or_else(|_| hex::encode(stored_event.key().inner()));
+                let module = value.module_name().to_string();
+                SimulatedEvent { value, key, module }
+            })
+            .collect::<Vec<_>>();
+
+        match result.receipt.receipt {
+            TxEffect::Skipped(e) => SimulateOutcome::Skipped(FailOutcome {
+                reason: e.error.to_string(),
+            }),
+            TxEffect::Reverted(e) => SimulateOutcome::Reverted(FailOutcome {
+                reason: e.reason.to_string(),
+            }),
+            TxEffect::Successful(_) => SimulateOutcome::Success(SuccessOutcome {
+                gas_used: gas_used.value(gas_price),
+                events,
+            }),
+        }
+    }
+}
+
+/// Optional transaction details for simulation requests.
+///
+/// These parameters allow customizing the transaction execution environment
+/// for simulation purposes.
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct TxDetailsParameter {
+    /// Maximum priority fee in basis points.
+    pub max_priority_fee_bips: Option<PriorityFeeBips>,
+    /// Maximum fee the sender is willing to pay.
+    pub max_fee: Option<Amount>,
+    /// Gas limit for the transaction as an array of u64 values.
+    pub gas_limit: Option<Vec<u64>>,
+}
+
+/// Optional sequencer configuration for simulation requests.
+///
+/// Allows overriding the default sequencer addresses for simulation purposes.
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct SequencerParameter {
+    /// Custom rollup address for the sequencer.
+    pub rollup_address: Option<String>,
+    /// Custom data availability address for the sequencer.
+    pub da_address: Option<String>,
+}
+
+/// Parameters for transaction simulation requests.
+///
+/// This struct contains all the information needed to simulate a transaction
+/// including the sender, the call to execute, and optional configuration.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct SimulateParameters {
+    /// The credential ID of the transaction sender as a string.
+    pub sender: String,
+    /// The runtime call to simulate, provided as JSON.
+    pub call: serde_json::Value,
+    /// Optional transaction details like gas limits and fees.
+    pub tx_details: Option<TxDetailsParameter>,
+    /// Optional sequencer configuration overrides.
+    pub sequencer: Option<SequencerParameter>,
+    /// Optional uniqueness data for the transaction.
+    /// If not provided a valid uniqueness will be used.
+    pub uniqueness: Option<UniquenessData>,
+}
+
+impl<S: Spec, R: Runtime<S> + HasCapabilities<S> + RuntimeEventProcessor> SimulateEndpoint
+    for SovereignSimulate<S, R>
+{
+    type State = std::sync::Arc<Self>;
+
+    type Parameters = SimulateParameters;
+
+    type Response = SimulateOutcome<R::RuntimeEvent>;
+
+    type Error = SimulateError;
+
+    fn handler(
+        state: Self::State,
+        params: Self::Parameters,
+    ) -> Result<Self::Response, Self::Error> {
+        let mut runtime = R::default();
+        let mut accessor = StateCheckpoint::new(
+            state.state_receiver.borrow().storage.clone(),
+            &runtime.kernel(),
+        );
+        let gas_price = runtime
+            .chain_state()
+            .base_fee_per_gas(&mut accessor)
+            .ok_or(SimulateError::GasPriceRetrieval)?;
+        let auth_data = state.authorization_data(&params, &mut accessor);
+        let sequencer = state.sequencer(params.sequencer.unwrap_or_default())?;
+        let auth_tx_data =
+            AuthenticatedTransactionData(state.tx_details(params.tx_details.unwrap_or_default())?);
+
+        let mut scratchpad = accessor.to_tx_scratchpad();
+        let context = runtime
+            .transaction_authorizer()
+            .resolve_context(
+                &auth_data,
+                &sequencer.da_address,
+                sequencer.rollup_address,
+                &mut scratchpad,
+            )
+            .map_err(SimulateError::ContextResolution)?;
+
+        let ws_gas_meter = auth_tx_data.gas_meter(&gas_price, &<S::Gas>::MAX);
+        let working_set = WorkingSet::create_working_set(scratchpad, &auth_tx_data, ws_gas_meter);
+
+        let schema = get_runtime_schema::<S, R>().map_err(SimulateError::SchemaConstruction)?;
+        let call_bytes = schema.json_to_borsh(
+            schema.rollup_expected_index(RollupRoots::RuntimeCall)?,
+            &params.call.to_string(),
+        )?;
+        let runtime_call = R::decode_call(&call_bytes)?;
+
+        let (result, _) = apply_tx(
+            &mut runtime,
+            &context,
+            &auth_tx_data,
+            // We don't have a way to get the raw transaction hash because it depends on the signature.
+            NULL_TX_HASH,
+            // We use an empty tx body because we can't build an actual one without the signature. We could make something *more* accurate here, but it might be confusing to the user.
+            FullyBakedTx::new(vec![]),
+            runtime_call,
+            working_set,
+        );
+
+        Ok(state.outcome(result))
+    }
+}

--- a/crates/full-node/sov-rollup-apis/tests/integration/main.rs
+++ b/crates/full-node/sov-rollup-apis/tests/integration/main.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use sov_api_spec::Client;
 use sov_modules_api::prelude::tokio::sync::watch;
+use sov_rollup_apis::endpoints::simulate::{SimulateEndpoint, SovereignSimulate};
 use sov_rollup_apis::{DefaultRollupStateProvider, RollupTxRouter};
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::StateUpdateInfo;
@@ -27,7 +28,7 @@ struct TestData {
 
     user: TestUser<S>,
 
-    axum_addr: SocketAddr,
+    pub axum_addr: SocketAddr,
     axum_server: axum_server::Handle,
 
     sync_sender: watch::Sender<SyncStatus>,
@@ -82,13 +83,19 @@ impl TestData {
 
         let (state_update_sender, state_update_receiver) = watch::channel(state_update_info);
 
+        let simulate_v2 = SovereignSimulate::<S, RT>::new(
+            state_update_receiver.clone(),
+            sequencer_rollup_address,
+            sequencer_da_address,
+        );
         let axum_router: axum::Router<()> =
             RollupTxRouter::<Arc<DefaultRollupStateProvider<S, RT>>>::axum_router(
                 state_update_receiver,
                 sequencer_da_address,
                 sequencer_rollup_address,
                 sync_receiver,
-            );
+            )
+            .merge(simulate_v2.into_router());
 
         let (axum_addr, axum_server) = {
             let handle = axum_server::Handle::new();

--- a/crates/full-node/sov-rollup-apis/tests/integration/main.rs
+++ b/crates/full-node/sov-rollup-apis/tests/integration/main.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use sov_api_spec::Client;
 use sov_modules_api::prelude::tokio::sync::watch;
-use sov_rollup_apis::endpoints::simulate::{SimulateEndpoint, SovereignSimulate};
+use sov_rollup_apis::endpoints::simulate::SovereignSimulate;
 use sov_rollup_apis::{DefaultRollupStateProvider, RollupTxRouter};
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::StateUpdateInfo;

--- a/crates/full-node/sov-rollup-apis/tests/integration/rest_api.rs
+++ b/crates/full-node/sov-rollup-apis/tests/integration/rest_api.rs
@@ -4,8 +4,9 @@ use sov_modules_api::capabilities::config_chain_id;
 use sov_modules_api::prelude::tokio::{self};
 use sov_modules_api::transaction::{PriorityFeeBips, TxDetails};
 use sov_modules_api::{Amount, Gas, GasArray, GasSpec, PrivateKey, Spec, SyncStatus, TxEffect};
+use sov_rest_utils::json_obj;
 use sov_rollup_apis::{PartialTransaction, SimulateExecutionContainer};
-use sov_test_utils::{AsUser, EncodeCall, TransactionTestCase, TEST_DEFAULT_MAX_FEE};
+use sov_test_utils::{AsUser, EncodeCall, TestUser, TransactionTestCase, TEST_DEFAULT_MAX_FEE};
 
 use crate::{TestData, RT, S};
 
@@ -191,6 +192,102 @@ async fn test_simulation() {
         "The queries receipt isn't successful. Instead, the receipt is {:?}",
         query_apply_tx_receipt.receipt
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulation_v2_success() {
+    let data = TestData::setup().await;
+
+    let sender = data.user.credential_id().to_string();
+    let receiver = TestUser::<S>::generate_with_default_balance().address();
+    let call = sov_bank::CallMessage::<S>::Transfer {
+        to: receiver,
+        coins: sov_bank::Coins {
+            amount: Amount::new(1000),
+            token_id: config_gas_token_id(),
+        },
+    };
+    let params = json_obj!({
+        "sender": sender,
+        "call": {
+            "bank": call,
+        },
+    });
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!("http://{}/rollup/simulate-v2", data.axum_addr))
+        .json(&params)
+        .send()
+        .await
+        .unwrap();
+    let actual = response.json::<serde_json::Value>().await.unwrap();
+    // Test raw JSON to ensure it's acutally usable
+    let expected = serde_json::json!({
+        "outcome": "success",
+        "gas_used": "104000",
+        "events": [
+            {
+                "key": "Bank/TokenTransferred",
+                "module": "Bank",
+                "value": {
+                    "token_transferred": {
+                        "from": {
+                            "user": data.user.address()
+                        },
+                        "to": {
+                            "user": receiver
+                        },
+                        "coins": {
+                            "amount": "1000",
+                            "token_id": "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"
+                        }
+                    }
+                }
+            }
+        ]
+    });
+
+    assert_eq!(actual, expected);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulation_v2_fail() {
+    let data = TestData::setup().await;
+
+    let sender = TestUser::<S>::generate_with_default_balance();
+    let receiver = TestUser::<S>::generate_with_default_balance().address();
+    let call = sov_bank::CallMessage::<S>::Transfer {
+        to: receiver,
+        coins: sov_bank::Coins {
+            amount: Amount::new(1000),
+            token_id: config_gas_token_id(),
+        },
+    };
+    let params = json_obj!({
+        "sender": sender.credential_id().to_string(),
+        "call": {
+            "bank": call,
+        },
+    });
+    let client = reqwest::Client::new();
+
+    let response = client
+        .post(format!("http://{}/rollup/simulate-v2", data.axum_addr))
+        .json(&params)
+        .send()
+        .await
+        .unwrap();
+    let actual = response.json::<serde_json::Value>().await.unwrap();
+    // Test raw JSON to ensure it's acutally usable
+    let expected = serde_json::json!({
+        "outcome": "reverted",
+        // we lose the context because of how module errors are currently implemented
+        // the actual reason for the failure is the sender doesnt have enough balance
+        "reason": "Failed to transfer token_id=token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"
+    });
+
+    assert_eq!(actual, expected);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/full-node/sov-rollup-apis/tests/integration/rest_api.rs
+++ b/crates/full-node/sov-rollup-apis/tests/integration/rest_api.rs
@@ -222,33 +222,30 @@ async fn test_simulation_v2_success() {
         .await
         .unwrap();
     let actual = response.json::<serde_json::Value>().await.unwrap();
-    // Test raw JSON to ensure it's acutally usable
-    let expected = serde_json::json!({
-        "outcome": "success",
-        "gas_used": "104000",
-        "events": [
-            {
-                "key": "Bank/TokenTransferred",
-                "module": "Bank",
-                "value": {
-                    "token_transferred": {
-                        "from": {
-                            "user": data.user.address()
-                        },
-                        "to": {
-                            "user": receiver
-                        },
-                        "coins": {
-                            "amount": "1000",
-                            "token_id": "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"
-                        }
+
+    assert_eq!(actual["outcome"], "success");
+    assert!(actual.get("gas_used").is_some());
+    assert_eq!(
+        actual["events"][0],
+        serde_json::json!({
+            "key": "Bank/TokenTransferred",
+            "module": "Bank",
+            "value": {
+                "token_transferred": {
+                    "from": {
+                        "user": data.user.address()
+                    },
+                    "to": {
+                        "user": receiver
+                    },
+                    "coins": {
+                        "amount": "1000",
+                        "token_id": "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"
                     }
                 }
             }
-        ]
-    });
-
-    assert_eq!(actual, expected);
+        })
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/endpoints.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/endpoints.rs
@@ -9,6 +9,7 @@ use sov_modules_api::{
     BatchSequencerReceipt, NodeEndpoints, RuntimeEventProcessor, Spec, SyncStatus, *,
 };
 use sov_modules_stf_blueprint::Runtime as RuntimeTrait;
+use sov_rollup_apis::endpoints::simulate::SovereignSimulate;
 use sov_rollup_apis::{DefaultRollupStateProvider, RollupTxRouter};
 use sov_stf_runner::{RollupConfig, RunnerConfig};
 
@@ -63,6 +64,12 @@ where
             .merge(ledger_axum_router.with_state(ledger_state));
     }
 
+    let simulate_v2 = SovereignSimulate::<B::Spec, B::Runtime>::new(
+        state_update_receiver.clone(),
+        config.sequencer.rollup_address.clone(),
+        sequencer.da_address.clone(),
+    );
+    endpoints.axum_router = endpoints.axum_router.merge(simulate_v2.into_router());
     // Rollup endpoint
     {
         let rollup_router = RollupTxRouter::<


### PR DESCRIPTION
# Description

Refactors simulation endpoints inputs & outputs to make it easier to use.

Inputs can simply be a `sender` in the form of a credential id and the json for a runtime call (no need to serialize). With more advanced simulation parameters optional.

Outputs include the gas used, events as JSON (previously base64 binary), and a string representation of the error that occurred (if any). The error loses important context about what actually caused the revert due to the way errors are currently implemented and returned in modules, I have a dream to fix this one day with https://github.com/Sovereign-Labs/sovereign-sdk/pull/1419 but for now it's not ideal.

The old endpoint will be removed once it's confirmed it's not used by zeta.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- closes #1537
- https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/1753

