### PR TITLE
Make pruner batch size configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # 2025-10-08
+- #1833 Adds a config option `pruner_max_batch_size` in the `storage` section of the rollup config. If the pruner appears to cause performance degradation, you can reduce the batch size here
+to decrease the number of writes it will attempt at each slot.
+
+# 2025-10-08
 - #1827 Implement eth_getBlockReceipts in EVM module.
 
 # 2025-10-07

--- a/crates/full-node/full-node-configs/src/snapshots/full_node_configs__runner__tests__correct_config.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/full_node_configs__runner__tests__correct_config.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/full-node/full-node-configs/src/runner.rs
+assertion_line: 222
 expression: config
 ---
 {
@@ -17,7 +18,8 @@ expression: config
     "kernel_page_cache_size": null,
     "kernel_leaf_cache_size": null,
     "pruner_block_interval": null,
-    "pruner_versions_to_keep": null
+    "pruner_versions_to_keep": null,
+    "pruner_max_batch_size": null
   },
   "runner": {
     "genesis_height": 31337,

--- a/crates/full-node/sov-db/benches/pruner_bench.rs
+++ b/crates/full-node/sov-db/benches/pruner_bench.rs
@@ -63,7 +63,7 @@ fn bench_pruner(c: &mut Criterion) {
                 (tempdir, rocksdb)
             },
             |(_tempdir, rocksdb)| {
-                let pruner = Pruner::new(rocksdb.clone());
+                let pruner = Pruner::new(rocksdb.clone(), None);
                 let output = pruner
                     .collect_pruning_batch_for_module_accessory_state(100)
                     .unwrap();

--- a/crates/full-node/sov-db/src/config.rs
+++ b/crates/full-node/sov-db/src/config.rs
@@ -1,6 +1,8 @@
 use nomt::Options;
 use schemars::JsonSchema;
 
+use crate::storage_manager::DEFAULT_MAX_PRUNING_BATCH_SIZE;
+
 /// Configuration for Sovereign Rollup node database.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
 pub struct RollupDbConfig {
@@ -50,6 +52,8 @@ pub struct RollupDbConfig {
     pub pruner_block_interval: Option<u64>,
     /// These many versions will be available for historical querying.
     pub pruner_versions_to_keep: Option<usize>,
+    /// Maximum number of keys to prune in a single batch.
+    pub pruner_max_batch_size: Option<usize>,
 }
 
 impl RollupDbConfig {
@@ -83,6 +87,7 @@ impl RollupDbConfig {
             kernel_leaf_cache_size: None,
             pruner_block_interval: Some(100),
             pruner_versions_to_keep: Some(20),
+            pruner_max_batch_size: None,
         }
     }
 
@@ -152,6 +157,11 @@ impl RollupDbConfig {
     pub(crate) fn get_pruner_versions_to_keep(&self) -> usize {
         self.pruner_versions_to_keep
             .expect("`pruner_versions_to_keep` must be set")
+    }
+
+    pub(crate) fn get_pruner_max_batch_size(&self) -> usize {
+        self.pruner_max_batch_size
+            .unwrap_or(DEFAULT_MAX_PRUNING_BATCH_SIZE)
     }
 }
 

--- a/crates/full-node/sov-db/src/pruner.rs
+++ b/crates/full-node/sov-db/src/pruner.rs
@@ -6,19 +6,20 @@ use sov_rollup_interface::common::SlotNumber;
 
 use crate::metrics::nomt::PrunerMetric;
 use crate::schema::tables::ModuleAccessoryState;
-use crate::storage_manager::{PrunerJobOutput, MAX_INDIVIDUAL_PRUNING_BATCH_SIZE};
+use crate::storage_manager::{PrunerJobOutput, DEFAULT_MAX_PRUNING_BATCH_SIZE};
 
 type VersionedSchemaKey = (SchemaKey, SlotNumber);
 
 /// Allows pruning old versions of keys.
 pub struct Pruner {
     db: Arc<DB>,
+    max_batch_size: Option<usize>,
 }
 
 impl Pruner {
     /// Creates a new pruner instance with the given database.
-    pub fn new(db: Arc<DB>) -> Self {
-        Self { db }
+    pub fn new(db: Arc<DB>, max_batch_size: Option<usize>) -> Self {
+        Self { db, max_batch_size }
     }
 
     /// Gathers all delete operations that can prune older versions.
@@ -51,7 +52,11 @@ impl Pruner {
                     &(base_key, last_prunable_version),
                 )?;
             }
-            if keys_to_prune >= MAX_INDIVIDUAL_PRUNING_BATCH_SIZE {
+            if keys_to_prune
+                >= self
+                    .max_batch_size
+                    .unwrap_or(DEFAULT_MAX_PRUNING_BATCH_SIZE)
+            {
                 hit_size_limit = true;
                 break;
             }
@@ -314,7 +319,7 @@ mod tests {
         .unwrap();
         rocksdb.write_schemas(data_9).unwrap();
 
-        let pruner = Pruner::new(rocksdb.clone());
+        let pruner = Pruner::new(rocksdb.clone(), None);
 
         let keys_to_prune = pruner
             .collect_pruning_batch::<ModuleAccessoryState>(3)

--- a/crates/full-node/sov-db/src/storage_manager/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/mod.rs
@@ -5,7 +5,7 @@ mod nomt_based;
 pub mod tests;
 
 pub use delta_reader_based::*;
-pub(crate) use nomt_based::MAX_INDIVIDUAL_PRUNING_BATCH_SIZE;
+pub(crate) use nomt_based::DEFAULT_MAX_PRUNING_BATCH_SIZE;
 pub use nomt_based::{
     FlatStateDb, InitializableNativeNomtStorage, NomtChangeSet, NomtStorageManager,
     PrunerJobOutput, StateFinishedSession,

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -28,7 +28,7 @@ const GIGABYTE: usize = 1024 * 1024 * 1024;
 
 // 300 thousand keys * 32 bytes is about 10 MB. This should be a large enough batch size to keep up with state growth,
 // without consuming excessive memory.
-pub(crate) const MAX_INDIVIDUAL_PRUNING_BATCH_SIZE: usize = 300_000;
+pub(crate) const DEFAULT_MAX_PRUNING_BATCH_SIZE: usize = 300_000;
 
 pub(crate) struct DbGroup<H, K> {
     merklized_state: Arc<NomtStateDb<H>>,
@@ -167,11 +167,11 @@ where
         update_ledger_finalized_height(self.ledger.clone())
     }
 
-    pub(crate) fn start_pruner(&self, versions_to_keep: usize) -> PrunerJob {
+    pub(crate) fn start_pruner(&self, versions_to_keep: usize, max_batch_size: usize) -> PrunerJob {
         tracing::info!(versions_to_keep, "Starting pruner task iteration");
         let user = self.flat_state.get_user_db().clone();
         let kernel = self.flat_state.get_kernel_db().clone();
-        let accessory_pruner = Pruner::new(self.accessory.clone());
+        let accessory_pruner = Pruner::new(self.accessory.clone(), Some(max_batch_size));
 
         // Spawn historical state pruner thread
         let historical_state: JoinHandle<Result<PrunerJobOutput, anyhow::Error>> =
@@ -212,7 +212,7 @@ where
                             batch.delete::<NomtHistoricalState<UserNamespace>>(&key)?;
                             keys_to_prune += 1;
                         }
-                        if keys_to_prune >= MAX_INDIVIDUAL_PRUNING_BATCH_SIZE {
+                        if keys_to_prune >= max_batch_size {
                             hit_size_limit = true;
                             break;
                         }
@@ -227,7 +227,7 @@ where
                 {
                     let prunable_keys = kernel
                         .iter_pruning_keys_up_to_version(kernel_version)?
-                        .take(MAX_INDIVIDUAL_PRUNING_BATCH_SIZE);
+                        .take(max_batch_size);
                     for key in prunable_keys {
                         // Prune the pruning table.
                         let key = key?;
@@ -247,7 +247,7 @@ where
                             batch.delete::<NomtHistoricalState<KernelNamespace>>(&key)?;
                             keys_to_prune += 1;
                         }
-                        if keys_to_prune >= MAX_INDIVIDUAL_PRUNING_BATCH_SIZE {
+                        if keys_to_prune >= max_batch_size {
                             hit_size_limit = true;
                             break;
                         }

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -22,7 +22,7 @@ use crate::metrics::nomt::StorageManagerFinalizationMetric;
 use crate::state_db_nomt::{NomtSessionBuilder, StateOverlay};
 use crate::storage_manager::nomt_based::groups::{CommitGroup, DbGroup, PrunerJob, SnapshotGroup};
 pub use groups::PrunerJobOutput;
-pub(crate) use groups::MAX_INDIVIDUAL_PRUNING_BATCH_SIZE;
+pub(crate) use groups::DEFAULT_MAX_PRUNING_BATCH_SIZE;
 
 #[allow(missing_docs)]
 pub struct StateFinishedSession {
@@ -110,6 +110,7 @@ pub struct NomtStorageManager<Da: DaSpec, H, S: InitializableNativeNomtStorage<H
     last_pruner_finish_at_height: Option<u64>,
     pruner_block_interval: Option<u64>,
     pruner_versions_to_keep: usize,
+    pruner_max_batch_size: usize,
 
     _phantom_s: PhantomData<S>,
 }
@@ -124,6 +125,7 @@ where
     pub fn new(config: RollupDbConfig) -> anyhow::Result<Self> {
         let pruner_block_interval = config.get_pruner_interval();
         let pruner_versions_to_keep = config.get_pruner_versions_to_keep();
+        let pruner_max_batch_size = config.get_pruner_max_batch_size();
         assert!(
             pruner_versions_to_keep >= 1,
             "Pruner versions to keep should be at least 1, got {pruner_versions_to_keep}",
@@ -143,6 +145,7 @@ where
             last_pruner_finish_at_height: None,
             pruner_block_interval,
             pruner_versions_to_keep,
+            pruner_max_batch_size,
             _phantom_s: Default::default(),
         })
     }
@@ -479,7 +482,9 @@ where
                     })
                     .unwrap_or(true);
             if should_run_pruner {
-                let pruner = self.db_group.start_pruner(self.pruner_versions_to_keep);
+                let pruner = self
+                    .db_group
+                    .start_pruner(self.pruner_versions_to_keep, self.pruner_max_batch_size);
                 self.pruner = Some(pruner);
             }
         }

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -624,6 +624,15 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "pruner_max_batch_size": {
+          "description": "Maximum number of keys to prune in a single batch.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
         "pruner_versions_to_keep": {
           "description": "These many versions will be available for historical querying.",
           "type": [

--- a/examples/demo-rollup/mock_rollup_config.toml
+++ b/examples/demo-rollup/mock_rollup_config.toml
@@ -25,6 +25,7 @@ block_time_ms = 1_000
 # The path to the rollup's data directory. Paths that do not begin with `/` are interpreted as relative paths.
 path = "demo_data"
 state_cache_size = 4294967296 # 4GB. Default is 1GB.
+# pruner_max_batch_size = 300000 # The maximum number of key/value pairs to prune in a single batch. Each key is about 70 bytes, so your prunery memory requirements will be about 21MB by default.
 
 # We define the rollup's genesis to occur at block number `genesis_height`. The rollup will ignore
 # any blocks before this height, and any blobs at this height will not be processed


### PR DESCRIPTION
# Description

This PR adds a `pruner_max_batch_size` config to `rollup.toml` to limit the amount of pruning per block. 

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

