### PR TITLE
Add tx priority level

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+use std::collections::BTreeMap;
 use std::num::NonZero;
 use std::ops::Deref;
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
@@ -820,6 +821,24 @@ enum Message<S: Spec, Rt: Runtime<S>> {
     },
 }
 
+impl<S: Spec, Rt: Runtime<S>> Message<S, Rt> {
+    fn is_accept_tx(&self) -> bool {
+        matches!(self, Message::AcceptTx { .. })
+    }
+
+    fn priority(&self, runtime: &Rt) -> u64 {
+        // Computes the priority of the message. Note that the implementation of the queue assumes that transactions never have higher priority than internal
+        // sequencer messages - if we change this assumption, we'll need to update the implementation of sequencer state updater to handle this.
+        match self {
+            Message::AcceptTx { baked_tx, .. } => {
+                let priority = runtime.get_transaction_priority(baked_tx);
+                priority as u64
+            }
+            _ => u64::MAX,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) enum AcceptTxError<S: Spec> {
     SequencerOverloaded503,
@@ -907,6 +926,8 @@ where
             inner,
             channel_size: channel_size.clone(),
             message_receiver,
+            heap: BTreeMap::new(),
+            runtime: Default::default(),
         },
         SequencerStateUpdator {
             message_sender,
@@ -1200,6 +1221,30 @@ where
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Priority {
+    priority: u64,
+    index: u64,
+}
+
+impl PartialOrd for Priority {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Priority {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let priority_cmp = self.priority.cmp(&other.priority);
+        if priority_cmp == std::cmp::Ordering::Equal {
+            // If priority is equal, give higher priority to the message that is older
+            self.index.cmp(&other.index).reverse()
+        } else {
+            priority_cmp
+        }
+    }
+}
+
 pub(crate) struct SynchronizedSequencerState<S, Rt>
 where
     S: Spec,
@@ -1208,6 +1253,9 @@ where
     inner: Inner<S, Rt>,
     channel_size: Arc<AtomicU32>,
     message_receiver: mpsc::Receiver<Message<S, Rt>>,
+    // A heap of message, ordered from low to high priority.
+    heap: BTreeMap<Priority, Message<S, Rt>>,
+    runtime: Rt,
 }
 
 impl<S, Rt> SynchronizedSequencerState<S, Rt>
@@ -1215,25 +1263,92 @@ where
     S: Spec,
     Rt: Runtime<S>,
 {
+    const MAX_HEAP_SIZE: usize = 10_000;
+
     async fn send_response<T>(&mut self, resp: oneshot::Sender<T>, v: T, name: &'static str) {
         if resp.send(v).is_err() {
             tracing::debug!("SynchronizedSequencerState: Response channel closed - unable to send response to {}", name);
         }
     }
 
+    fn heap_is_full(&self) -> bool {
+        self.heap.len() >= Self::MAX_HEAP_SIZE
+    }
+
     pub(crate) async fn start(mut self) -> JoinHandle<()> {
         tokio::spawn(async move {
-            while let Some(msg) = self.message_receiver.recv().await {
-                if let Err(e) = self.handle_next_message(msg).await {
-                    match e {
-                        SequencerStateUpdatorError::Shutdown => {
-                            return;
-                        }
-                        SequencerStateUpdatorError::Unexpected => {
-                            self.inner.shutdown_sender.send(()).unwrap();
-                            panic!("The sequencer experienced an unexpected error and cannot accept transactions! See logs for more details.");
+            let mut index = 0;
+            loop {
+                // Start by trying to drain the channel of inbound messages.
+                while let Ok(msg) = self.message_receiver.try_recv() {
+                    self.heap.insert(
+                        Priority {
+                            priority: msg.priority(&self.runtime),
+                            index,
+                        },
+                        msg,
+                    );
+                    index += 1;
+
+                    // If the heap is full after adding the new message, try to clear some space by dropping old messages
+                    if self.heap_is_full() {
+                        tracing::warn!("SynchronizedSequencerState: The message heap is full, dropping the lowest priority message if possible.");
+                        let Some((priority, lowest_priority_msg)) = self.heap.pop_first() else {
+                            // This should be unreachable - we just checked that the heap was full
+                            unreachable!("A heap with len >= 10_000 return None for pop_first");
+                        };
+
+                        // If the lowest priority message is an accept_tx message, send a 503 and drop it. Now we can continue retrieving messages from the channel.
+                        // Here we rely on the guarantee that accept_tx messages always have lower priority than other message types. If this guarantee is removed later,
+                        // we'll need to update this logic.
+                        if let Message::AcceptTx { resp, .. } = lowest_priority_msg {
+                            self.send_response(
+                                resp,
+                                Err(AcceptTxError::SequencerOverloaded503),
+                                "accept_tx",
+                            )
+                            .await;
+                        } else {
+                            // Otherwise, the heap is completely full of undroppable messages. Stop reading from the channel and process one.
+                            self.heap.insert(priority, lowest_priority_msg);
+                            break;
                         }
                     }
+                }
+
+                // Process the highest priority message in the heap. This ensures that the heap will not be full at the start of the next iteration
+                if let Some((_priority, msg)) = self.heap.pop_last() {
+                    if let Err(e) = self.handle_next_message(msg).await {
+                        match e {
+                            SequencerStateUpdatorError::Shutdown => {
+                                return;
+                            }
+                            SequencerStateUpdatorError::Unexpected => {
+                                self.inner.shutdown_sender.send(()).unwrap();
+                                panic!("The sequencer experienced an unexpected error and cannot accept transactions! See logs for more details.");
+                            }
+                        }
+                    }
+                }
+
+                // If we don't have any more messages to process, yield until a message becomes available
+                if self.heap.is_empty() {
+                    let Some(msg) = self.message_receiver.recv().await else {
+                        break;
+                    };
+                    assert!(
+                        self.heap
+                            .insert(
+                                Priority {
+                                    priority: msg.priority(&self.runtime),
+                                    index
+                                },
+                                msg
+                            )
+                            .is_none(),
+                        "Duplicate priority for message. This is a bug, please report it"
+                    );
+                    index += 1;
                 }
             }
         })

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -12,6 +12,7 @@ use base64::Engine;
 use borsh::{BorshDeserialize, BorshSerialize};
 use full_node_configs::sequencer::default_ideal_lag_behind_finalized_slot;
 use futures::future;
+use serde_json::Number;
 use sov_api_spec::types::{
     self as api_types, SequencerListEventsPage, SequencerListEventsResponse, TxReceiptResult,
 };
@@ -60,6 +61,18 @@ generate_optimistic_runtime_with_kernel!(
             Self::Decodable::HooksCount(sov_test_modules::hooks_count::CallMessage::DelayedCallMsg) => DELAYED_TX_DELAY_MS,
             _ => 0,
         }
+    },
+    transaction_priority_wrapper: |call: &sov_modules_api::FullyBakedTx| {
+        use sov_modules_api::capabilities::TransactionAuthenticator;
+        let Ok(call) = Self::Auth::decode_serialized_tx(call) else {
+            return 0;
+        };
+        match call {
+            Self::Decodable::ValueSetter(sov_value_setter::CallMessage::SetValue { value, .. }) =>
+                value,
+            _ => 0,
+        }
+
     }
 );
 
@@ -145,6 +158,77 @@ impl DaLayerWithSubscription {
         for _ in 0..n {
             self.produce_and_wait_for_slot().await;
         }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_transaction_priority() {
+    let (test_rollup, admin) = create_test_rollup(
+        0,
+        TEST_MAX_BATCH_SIZE,
+        TEST_BLOB_PROCESSING_TIMEOUT,
+        MAX_BATCH_EXECUTION_TIME_MILLIS,
+    )
+    .await;
+
+    let Some(test_rollup) = test_rollup else {
+        return;
+    };
+
+    let nb_of_blocks = 5;
+    let mut da_layer = DaLayerWithSubscription::new(&test_rollup).await;
+    da_layer.produce_and_wait_for_n_slots(nb_of_blocks).await;
+    let mut event_subscription = test_rollup
+        .api_client()
+        .subscribe_to_events()
+        .await
+        .unwrap();
+
+    // Send a transaction which will block the sequencer for a while. This gives us time to send other txs with different priorities and ensure
+    // that the priority tiebreaker is working.
+    let client = test_rollup.api_client().clone();
+    let tx = tx_set_value_and_sleep(&admin.private_key, 0, 1000, 5000);
+    tokio::spawn(async move {
+        client
+            .accept_tx(&api_types::AcceptTxBody {
+                body: BASE64_STANDARD.encode(&tx),
+            })
+            .await
+            .unwrap();
+    });
+    // Sleep for a little while to ensure the tx has been received and is currently blocking the sequencer.
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
+    // Send transactions in from 1 to 10 concurrently.
+    for i in 1..10 {
+        let tx = tx_set_value(&admin.private_key, 0, i);
+        let client = test_rollup.api_client().clone();
+        tokio::spawn(async move {
+            client
+                .accept_tx(&api_types::AcceptTxBody {
+                    body: BASE64_STANDARD.encode(&tx),
+                })
+                .await
+                .unwrap();
+        });
+    }
+
+    fn assert_event_value(event: &sov_api_spec::types::LedgerEvent, expected_value: u32) {
+        assert_eq!(
+            event.value.get("new_value").unwrap(),
+            &serde_json::Value::Number(Number::from(expected_value)),
+            "Event value is not {expected_value}. {event:?}"
+        );
+    }
+
+    // Check that our initial tx arrived first and was processed - otherwise the priority numbers won't have had any effect.
+    let initial_event = event_subscription.next().await.unwrap().unwrap();
+    assert_event_value(&initial_event, 1000);
+
+    // No matter what order txs arrived in, events should always be received in reverse order because higher numbers get higher priority.
+    for i in (1..10).rev() {
+        let event = event_subscription.next().await.unwrap().unwrap();
+        assert_event_value(&event, i);
     }
 }
 

--- a/crates/full-node/sov-sequencer/tests/integration/setup_mode.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/setup_mode.rs
@@ -49,7 +49,7 @@ generate_optimistic_runtime_with_kernel!(
     modules: [value_setter: ValueSetter<S>],
     transaction_delay_ms_wrapper: |_: &Self::Decodable| {
         0
-    }
+    },
 );
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/module-system/sov-modules-api/src/runtime/mod.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/mod.rs
@@ -12,6 +12,8 @@ use serde::{Deserialize, Serialize};
 use crate::hooks::FinalizeHook;
 use crate::hooks::{BlockHooks, TxHooks};
 use crate::transaction::TransactionCallable;
+#[cfg(feature = "native")]
+use crate::FullyBakedTx;
 use crate::{DispatchCall, Genesis, RuntimeEventProcessor, Spec};
 
 /// Flag indicating what mode the rollup is operating in.
@@ -93,6 +95,15 @@ pub trait Runtime<S: Spec>:
     /// based on the transaction content. The delay will be applied before
     /// transaction processing begins.
     fn get_transaction_delay_ms(&self, _call: &Self::Decodable) -> u64 {
+        0
+    }
+
+    /// Gets the priority level of a transaction. Higher priority transactions are processed first in the sequencer when possible.
+    /// Messages with equal priority are processed in the order they are received. If messages have a delay configured in [`Runtime::get_transaction_delay_ms`],
+    /// they are considered to be "received" after the delay period has elapsed.
+    // Returns a u32 so that the sequencer can represent priority as a u64 and have some reserved values that are greater than the maximum priority level of any transaction.
+    #[cfg(feature = "native")]
+    fn get_transaction_priority(&self, _call: &FullyBakedTx) -> u32 {
         0
     }
 }

--- a/crates/module-system/sov-test-utils/src/runtime/macros.rs
+++ b/crates/module-system/sov-test-utils/src/runtime/macros.rs
@@ -15,6 +15,11 @@ macro_rules! generate_runtime_without_capabilities {
         // `fn(&Self, &::sov_modules_api::FullyBakedTx) -> u64`
         // If not provided, defaults to 0ms delay (via Runtime trait default).
         $(, transaction_delay_ms_wrapper: $transaction_delay_ms_wrapper_expr:expr)?
+        // Optional: A wrapper expression for custom transaction priority logic.
+        // Expected signature for the expression (e.g., a closure or function path):
+        // `fn(&Self, &::sov_modules_api::FullyBakedTx) -> u32`
+        // If not provided, defaults to 0 priority (via Runtime trait default).
+        $(, transaction_priority_wrapper: $transaction_priority_wrapper_expr:expr)?
         // optional final comma for the entire argument block
         $(,)?
     ) => {
@@ -184,6 +189,14 @@ macro_rules! generate_runtime_without_capabilities {
                     ($transaction_delay_ms_wrapper_expr)(call)
                 }
             )?
+
+            // Conditionally generate get_transaction_priority if the wrapper is provided.
+            // If not provided, the default from the Runtime trait (returning 0) will be used.
+            $(
+                fn get_transaction_priority(&self, call: &::sov_modules_api::FullyBakedTx) -> u32 {
+                    ($transaction_priority_wrapper_expr)(call)
+                }
+            )?
         }
 
 
@@ -273,6 +286,7 @@ macro_rules! generate_runtime {
         auth_type: $auth:ty,
         auth_call_wrapper: $auth_wrapper:expr
         $(, transaction_delay_ms_wrapper: $transaction_delay_ms_wrapper_expr:expr)?
+        $(, transaction_priority_wrapper: $transaction_priority_wrapper_expr:expr)?
         // optional final comma
         $(,)?
     ) => {
@@ -286,6 +300,7 @@ macro_rules! generate_runtime {
             auth_type: $auth,
             auth_call_wrapper: $auth_wrapper
             $(, transaction_delay_ms_wrapper: $transaction_delay_ms_wrapper_expr)?
+            $(, transaction_priority_wrapper: $transaction_priority_wrapper_expr)?
         }
 
         impl<S> ::sov_modules_api::capabilities::HasCapabilities<S> for $id<S>
@@ -338,7 +353,8 @@ macro_rules! generate_optimistic_runtime_with_kernel {
         $id:ident <=
         kernel_type: $kernel_ty:ty,
         modules: [$($module_name:ident : $module_ty:path),*],
-        $(transaction_delay_ms_wrapper: $transaction_delay_ms_wrapper_expr:expr)?
+        $(transaction_delay_ms_wrapper: $transaction_delay_ms_wrapper_expr:expr,)?
+        $(transaction_priority_wrapper: $transaction_priority_wrapper_expr:expr)?
         $(,)? // Optional trailing comma for the module list or wrapper
     ) => {
         $crate::generate_runtime! {
@@ -351,6 +367,7 @@ macro_rules! generate_optimistic_runtime_with_kernel {
             auth_type: sov_modules_api::capabilities::RollupAuthenticator<S, Self>,
             auth_call_wrapper: |auth_data| auth_data
             $(, transaction_delay_ms_wrapper: $transaction_delay_ms_wrapper_expr)?
+            $(, transaction_priority_wrapper: $transaction_priority_wrapper_expr)?
         }
     };
 }


### PR DESCRIPTION
# Description

This PR adds an optional get_transaction_priority method to the runtime trait. Under load, transactions with higher priority are always processed before lower priority txs, and priorities with equal priority are processed in FIFO order.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

