### PR TITLE
Add binary WebSocket frame support to RPC server and client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-10-29
+- #1838 Add binary WebSocket frame support to RPC server and client.
+
 # 2025-10-28
 - #1987 Added `newHeads` subscription to `eth_subscribe`.
 
@@ -50,8 +53,6 @@ The purpose of this change is to enable rollups to accept transactions signed wi
 
 # 2025-10-10
 - #1840 DOn't panic on selfdestruct/blockhash. Return an error.
-# 2025-10-09
-- #1838 Add binary WebSocket frame support to RPC server and client for reduced overhead.
 
 # 2025-10-08
 - #1833 Adds a config option `pruner_max_batch_size` in the `storage` section of the rollup config. If the pruner appears to cause performance degradation, you can reduce the batch size here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ The purpose of this change is to enable rollups to accept transactions signed wi
 
 # 2025-10-10
 - #1840 DOn't panic on selfdestruct/blockhash. Return an error.
+# 2025-10-09
+- #1838 Add binary WebSocket frame support to RPC server and client for reduced overhead.
+
+# 2025-10-08
+- #1833 Adds a config option `pruner_max_batch_size` in the `storage` section of the rollup config. If the pruner appears to cause performance degradation, you can reduce the batch size here
+to decrease the number of writes it will attempt at each slot.
 
 # 2025-10-08
 - #1827 Implement eth_getBlockReceipts in EVM module.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11174,7 +11174,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "tokio",
- "tokio-tungstenite 0.23.1",
+ "tokio-tungstenite 0.28.0",
  "tracing",
 ]
 
@@ -12654,6 +12654,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite 0.28.0",
  "tower 0.5.2",
  "tower-http 0.5.2",
  "tower-layer",
@@ -14298,18 +14299,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.23.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
@@ -14334,6 +14323,18 @@ dependencies = [
  "tokio-rustls 0.26.2",
  "tungstenite 0.26.2",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -14781,24 +14782,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.3.1",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
@@ -14829,6 +14812,23 @@ dependencies = [
  "rand 0.9.2",
  "rustls 0.23.31",
  "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.16",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.9.2",
  "sha1",
  "thiserror 2.0.16",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,6 +275,7 @@ testcontainers-modules = "0.13.0"
 test-strategy = "0.4.0"
 tokio = { version = "1.42.2", default-features = false }
 tokio-stream = { version = "0.1", features = ["sync"] }
+tokio-tungstenite = { version = "0.28.0", default-features = false }
 uuid = { version = "1.10", default-features = false } # v1.9 is important because it guarantees monotic UUIDv7 generation: https://github.com/uuid-rs/uuid/releases/tag/1.9.0.
 lazy_static = "1.5.0"
 num_cpus = "1.16"

--- a/crates/full-node/sov-api-spec/Cargo.toml
+++ b/crates/full-node/sov-api-spec/Cargo.toml
@@ -34,7 +34,7 @@ borsh = { workspace = true }
 backon = { workspace = true }
 sov-rollup-interface = { workspace = true, features = ["native"] }
 tokio = { workspace = true }
-tokio-tungstenite = "0.23"
+tokio-tungstenite = { workspace = true, features = ["connect"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/full-node/sov-api-spec/src/client.rs
+++ b/crates/full-node/sov-api-spec/src/client.rs
@@ -194,12 +194,21 @@ impl Client {
                             err
                         ))),
                     },
-                    Ok(Message::Binary(msg)) => {
-                        tracing::warn!(
-                            ?msg,
-                            "Received unsupported binary message from WebSocket connection"
-                        );
-                        None
+                    Ok(Message::Binary(data)) => {
+                        // Parse binary frame as UTF-8 JSON
+                        match std::str::from_utf8(&data) {
+                            Ok(text) => match serde_json::from_str(text) {
+                                Ok(tx_status) => Some(Ok(tx_status)),
+                                Err(err) => Some(Err(anyhow::anyhow!(
+                                    "failed to deserialize JSON from binary frame: {}",
+                                    err
+                                ))),
+                            },
+                            Err(err) => Some(Err(anyhow::anyhow!(
+                                "invalid UTF-8 in binary WebSocket frame: {}",
+                                err
+                            ))),
+                        }
                     }
                     // All other kinds of messages are ignored because
                     // `tokio-tungstenite` ought to handle all

--- a/crates/full-node/sov-stf-runner/Cargo.toml
+++ b/crates/full-node/sov-stf-runner/Cargo.toml
@@ -50,6 +50,7 @@ proptest = { workspace = true }
 jsonrpsee = { workspace = true, features = ["client", "ws-client"] }
 rand = { workspace = true, features = ["small_rng"] }
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
+tokio-tungstenite = { workspace = true }
 
 sov-sequencer = { workspace = true }
 sov-state = { workspace = true, features = ["native"] }

--- a/crates/full-node/sov-stf-runner/src/http.rs
+++ b/crates/full-node/sov-stf-runner/src/http.rs
@@ -409,7 +409,9 @@ mod tests {
         // Send a JSON-RPC request as binary frame
         let request = r#"{"jsonrpc":"2.0","method":"test_hello","params":[],"id":1}"#;
         write
-            .send(TungsteniteMessage::Binary(request.as_bytes().to_vec().into()))
+            .send(TungsteniteMessage::Binary(
+                request.as_bytes().to_vec().into(),
+            ))
             .await?;
 
         // Read binary response

--- a/crates/full-node/sov-stf-runner/src/http.rs
+++ b/crates/full-node/sov-stf-runner/src/http.rs
@@ -421,7 +421,7 @@ mod tests {
                 let response_text = std::str::from_utf8(&data)?;
                 assert!(response_text.contains("\"result\":\"hi\""));
             }
-            _ => panic!("Expected binary response, got: {:?}", response),
+            _ => panic!("Expected binary response, got: {response:?}"),
         }
 
         shutdown_sender.send(())?;

--- a/crates/full-node/sov-stf-runner/src/http.rs
+++ b/crates/full-node/sov-stf-runner/src/http.rs
@@ -165,6 +165,52 @@ async fn handle_socket(socket: WebSocket, rpc_methods: RpcModule<()>) {
     tokio::spawn(handle_socket_read(receiver, socket_requests, rpc_methods));
 }
 
+async fn handle_rpc_message(
+    text: &str,
+    socket_responses: &tokio::sync::mpsc::Sender<Message>,
+    rpc_methods: &RpcModule<()>,
+    use_binary: bool,
+) {
+    // Buffer size picked up from `jsonrpsee` crate examples
+    match rpc_methods.raw_json_request(text, 1).await {
+        Ok((rpc_response, mut receiver)) => {
+            tracing::trace!("RPC request processed successfully: {}", rpc_response);
+            let response_message = if use_binary {
+                Message::Binary(rpc_response.to_string().into_bytes())
+            } else {
+                Message::Text(rpc_response.to_string())
+            };
+
+            if socket_responses.send(response_message).await.is_err() {
+                tracing::error!("Websocket sender has been closed, aborting websocket");
+                return;
+            }
+
+            if !receiver.is_closed() {
+                let subscription_responses = socket_responses.clone();
+                tokio::task::spawn(async move {
+                    tracing::trace!("Spawning subscription responses loop");
+                    while let Some(message) = receiver.recv().await {
+                        tracing::trace!("Subscription message received: {}", message);
+                        let sub_message = if use_binary {
+                            Message::Binary(message.to_string().into_bytes())
+                        } else {
+                            Message::Text(message.to_string())
+                        };
+                        if let Err(error) = subscription_responses.send(sub_message).await {
+                            tracing::error!(%error, "Error while sending RPC response");
+                        }
+                    }
+                    tracing::trace!("Subscription channel closed");
+                });
+            }
+        }
+        Err(error) => {
+            tracing::error!(%error, "Error while processing RPC request");
+        }
+    }
+}
+
 async fn handle_socket_read(
     mut socket_requests: futures_util::stream::SplitStream<WebSocket>,
     socket_responses: tokio::sync::mpsc::Sender<Message>,
@@ -174,44 +220,18 @@ async fn handle_socket_read(
         tracing::trace!(message = ?msg, "Message received from websocket");
         match msg {
             Message::Text(text) => {
-                // Buffer size picked up from `jsonrpsee` crate examples
-                match rpc_methods.raw_json_request(&text, 1).await {
-                    Ok((rpc_response, mut receiver)) => {
-                        tracing::trace!("RPC request processed successfully: {}", rpc_response);
-                        if socket_responses
-                            .send(Message::Text(rpc_response.to_string()))
-                            .await
-                            .is_err()
-                        {
-                            tracing::error!("Websocket sender has been closed, aborting websocket");
-                            break;
-                        }
-
-                        if !receiver.is_closed() {
-                            let subscription_responses = socket_responses.clone();
-                            tokio::task::spawn(async move {
-                                tracing::trace!("Spawning subscription responses loop");
-                                while let Some(message) = receiver.recv().await {
-                                    tracing::trace!("Subscription message received: {}", message);
-                                    if let Err(error) = subscription_responses
-                                        .send(Message::Text(message.to_string()))
-                                        .await
-                                    {
-                                        tracing::error!(%error, "Error while sending RPC response");
-                                    }
-                                }
-                                tracing::trace!("Subscription channel closed");
-                            });
-                        }
+                handle_rpc_message(&text, &socket_responses, &rpc_methods, false).await;
+            }
+            Message::Binary(data) => {
+                // Parse binary frame as UTF-8 JSON-RPC request
+                match std::str::from_utf8(&data) {
+                    Ok(text) => {
+                        handle_rpc_message(text, &socket_responses, &rpc_methods, true).await;
                     }
                     Err(error) => {
-                        tracing::error!(%error, "Error while processing RPC request");
+                        tracing::error!(%error, "Invalid UTF-8 in binary WebSocket frame");
                     }
                 }
-            }
-            // NOTE: No support for binary formats.
-            Message::Binary(_) => {
-                tracing::warn!("Binary JSON RPC messages are not supported");
             }
             Message::Pong(_) => {}
             Message::Ping(ping) => {
@@ -242,9 +262,13 @@ async fn handle_socket_write(
 
 #[cfg(test)]
 mod tests {
+    use futures_util::sink::SinkExt;
+    use futures_util::stream::StreamExt;
     use jsonrpsee::core::client::{ClientT, SubscriptionClientT};
     use jsonrpsee::core::JsonRawValue;
     use jsonrpsee::ws_client::WsClientBuilder;
+    use tokio_tungstenite::connect_async;
+    use tokio_tungstenite::tungstenite::Message as TungsteniteMessage;
 
     use super::*;
 
@@ -367,6 +391,36 @@ mod tests {
         .await?;
         subscription.unsubscribe().await?;
         assert_eq!(numbers, (0..10).collect::<Vec<u64>>());
+
+        shutdown_sender.send(())?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_binary_frames() -> anyhow::Result<()> {
+        let (addr, shutdown_sender) = build_and_start_test_server().await;
+
+        // Connect using raw tungstenite client to send binary frames
+        let (ws_stream, _) = connect_async(format!("ws://{addr}/rpc"))
+            .await
+            .expect("Failed to connect");
+        let (mut write, mut read) = ws_stream.split();
+
+        // Send a JSON-RPC request as binary frame
+        let request = r#"{"jsonrpc":"2.0","method":"test_hello","params":[],"id":1}"#;
+        write
+            .send(TungsteniteMessage::Binary(request.as_bytes().to_vec().into()))
+            .await?;
+
+        // Read binary response
+        let response = read.next().await.expect("No response")?;
+        match response {
+            TungsteniteMessage::Binary(data) => {
+                let response_text = std::str::from_utf8(&data)?;
+                assert!(response_text.contains("\"result\":\"hi\""));
+            }
+            _ => panic!("Expected binary response, got: {:?}", response),
+        }
 
         shutdown_sender.send(())?;
         Ok(())


### PR DESCRIPTION
Enable binary frame support for WebSocket connections to reduce overhead compared to text frames. JSON-RPC messages can now be sent as binary data over WebSocket, with responses matching the request frame type.

Server changes:
- Extract RPC message handling into handle_rpc_message() helper
- Parse binary frames as UTF-8 JSON-RPC requests
- Return binary responses for binary requests, text for text requests
- Add unit test for binary frame handling

Client changes:
- Update WebSocket subscription handler to accept binary frames
- Parse and deserialize binary frames as UTF-8 JSON
- Enable tokio-tungstenite 'connect' feature for client usage

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
