### PR TITLE
Refactor EVM RPC

### DIFF
--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -139,7 +139,6 @@ pub(crate) mod signer {
     use alloy_eips::Encodable2718;
     use alloy_primitives::Address;
     use alloy_rpc_types::TransactionRequest;
-    use sov_evm::eth_api_into_rpc_error;
     use sov_modules_api::macros::config_value;
     use sov_rpc_eth_types::EthApiError;
 
@@ -211,7 +210,7 @@ pub(crate) mod signer {
 
             let transaction = transaction_request
                 .build_typed_tx()
-                .map_err(|_| eth_api_into_rpc_error(EthApiError::TransactionConversionError))?;
+                .map_err(|_| EthApiError::TransactionConversionError)?;
 
             // sign transaction
             let signed_tx = ethereum

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/error.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/error.rs
@@ -52,11 +52,6 @@ impl<Ws: StateAccessor> From<crate::db::Error<Ws>> for EthApiError {
     }
 }
 
-/// Hack while reth is not upgraded for `jsonrpsee` 0.25
-pub fn eth_api_into_rpc_error(eth_error: EthApiError) -> ErrorObjectOwned {
-    ErrorObject::owned(500, format!("Eth Error: {eth_error:?}"), None::<()>)
-}
-
 /// Converts internal error into rpc error
 pub fn into_rpc_error(err: impl Error) -> ErrorObjectOwned {
     ErrorObject::owned(500, format!("{err}"), None::<()>)

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/error.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/error.rs
@@ -1,7 +1,11 @@
 //! Place where [`RlpConversionError`] is converted to [`EthApiError`]
 
+use std::error::Error;
+
 use alloy_primitives::Bytes;
-use revm::context::result::{ExecutionResult, HaltReason};
+use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
+use revm::context::result::{EVMError, ExecutionResult, HaltReason, InvalidHeader};
+use sov_modules_api::StateAccessor;
 use sov_rpc_eth_types::{EthApiError, EthResult, RevertError, RpcInvalidTransactionError};
 
 use crate::evm::conversions::RlpConversionError;
@@ -30,4 +34,30 @@ pub(crate) fn ensure_success(result: ExecutionResult<HaltReason>) -> EthResult<B
             Err(RpcInvalidTransactionError::halt(reason, gas_used).into())
         }
     }
+}
+
+pub fn eth_from_evm_error<Ws: StateAccessor>(err: EVMError<crate::db::Error<Ws>>) -> EthApiError {
+    match err {
+        EVMError::Transaction(err) => RpcInvalidTransactionError::from(err).into(),
+        EVMError::Header(InvalidHeader::PrevrandaoNotSet) => EthApiError::PrevrandaoNotSet,
+        EVMError::Header(InvalidHeader::ExcessBlobGasNotSet) => EthApiError::ExcessBlobGasNotSet,
+        EVMError::Database(db_err) => db_err.into(),
+        EVMError::Custom(data) => EthApiError::EvmCustom(data),
+    }
+}
+
+impl<Ws: StateAccessor> From<crate::db::Error<Ws>> for EthApiError {
+    fn from(err: crate::db::Error<Ws>) -> Self {
+        EthApiError::EvmCustom(format!("Database error: {err}"))
+    }
+}
+
+/// Hack while reth is not upgraded for `jsonrpsee` 0.25
+pub fn eth_api_into_rpc_error(eth_error: EthApiError) -> ErrorObjectOwned {
+    ErrorObject::owned(500, format!("Eth Error: {eth_error:?}"), None::<()>)
+}
+
+/// Converts internal error into rpc error
+pub fn into_rpc_error(err: impl Error) -> ErrorObjectOwned {
+    ErrorObject::owned(500, format!("{err}"), None::<()>)
 }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/error.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/error.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 
 use alloy_primitives::Bytes;
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
-use revm::context::result::{EVMError, ExecutionResult, HaltReason, InvalidHeader};
+use revm::context::result::{ExecutionResult, HaltReason};
 use sov_modules_api::StateAccessor;
 use sov_rpc_eth_types::{EthApiError, EthResult, RevertError, RpcInvalidTransactionError};
 
@@ -33,16 +33,6 @@ pub(crate) fn ensure_success(result: ExecutionResult<HaltReason>) -> EthResult<B
         ExecutionResult::Halt { reason, gas_used } => {
             Err(RpcInvalidTransactionError::halt(reason, gas_used).into())
         }
-    }
-}
-
-pub fn eth_from_evm_error<Ws: StateAccessor>(err: EVMError<crate::db::Error<Ws>>) -> EthApiError {
-    match err {
-        EVMError::Transaction(err) => RpcInvalidTransactionError::from(err).into(),
-        EVMError::Header(InvalidHeader::PrevrandaoNotSet) => EthApiError::PrevrandaoNotSet,
-        EVMError::Header(InvalidHeader::ExcessBlobGasNotSet) => EthApiError::ExcessBlobGasNotSet,
-        EVMError::Database(db_err) => db_err.into(),
-        EVMError::Custom(data) => EthApiError::EvmCustom(data),
     }
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -1,0 +1,357 @@
+use crate::db::commit::FallibleDatabaseCommit;
+use crate::error::{eth_api_into_rpc_error, into_rpc_error};
+use crate::rpc::error::ensure_success;
+use crate::rpc::eth_from_evm_error;
+use alloy_primitives::{Address, U64};
+use alloy_primitives::{Bytes, B256, U256};
+use alloy_rpc_types::{
+    state::StateOverride, Block, BlockOverrides, FeeHistory, Transaction, TransactionReceipt,
+    TransactionRequest,
+};
+use alloy_rpc_types_trace::geth::GethDebugTracingOptions;
+use alloy_rpc_types_trace::geth::GethTrace;
+use jsonrpsee::core::RpcResult;
+use revm::context::result::ResultAndState;
+use revm::Database;
+use sov_address::{EthereumAddress, FromVmAddress};
+use sov_modules_api::macros::{config_value, rpc_gen};
+use sov_modules_api::prelude::UnwrapInfallible;
+use sov_modules_api::{ApiStateAccessor, GasMeter, GasSpec, Spec};
+use sov_rollup_interface::common::RollupHeight;
+use sov_rpc_eth_types::EthApiError;
+use tracing::debug;
+
+use crate::conversions::replay_tx_env;
+use crate::executor::{get_cfg_env, transact_commit};
+use crate::{apply_margins, Evm};
+use std::ops::DerefMut;
+
+const EMPTY_FEE_HISTORY: FeeHistory = FeeHistory {
+    base_fee_per_gas: vec![],
+    gas_used_ratio: vec![],
+    oldest_block: 0,
+    reward: None,
+    blob_gas_used_ratio: vec![],
+    // EIP-4844 related
+    base_fee_per_blob_gas: vec![],
+};
+
+#[rpc_gen(client, server)]
+impl<S: Spec> Evm<S>
+where
+    S::Address: FromVmAddress<EthereumAddress>,
+{
+    /// Handler for `net_version`
+    #[rpc_method(name = "net_version")]
+    pub fn net_version(&self, _state: &mut ApiStateAccessor<S>) -> RpcResult<String> {
+        debug!("EVM module JSON-RPC request to `net_version`");
+
+        // Network ID is the same as chain ID for most networks
+        let chain_id = config_value!("CHAIN_ID");
+        Ok(chain_id.to_string())
+    }
+
+    /// Handler for: `eth_chainId`
+    #[rpc_method(name = "eth_chainId")]
+    pub fn chain_id(&self, _state: &mut ApiStateAccessor<S>) -> RpcResult<Option<U64>> {
+        let chain_id = config_value!("CHAIN_ID");
+        debug!(
+            chain_id = chain_id,
+            "EVM module JSON-RPC request to `eth_chainId`"
+        );
+        Ok(Some(U64::from(chain_id)))
+    }
+
+    /// Handler for `eth_getBlockByHash`
+    #[rpc_method(name = "eth_getBlockByHash")]
+    pub fn get_block_by_hash(
+        &self,
+        block_hash: B256,
+        details: Option<bool>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> RpcResult<Option<Block>> {
+        debug!(
+            ?block_hash,
+            "EVM module JSON-RPC request to `eth_getBlockByHash`"
+        );
+
+        let block_number_hex = self
+            .block_hashes
+            .get(&block_hash, state)
+            .unwrap_infallible()
+            .map(|number| hex::encode(number.to_be_bytes()));
+
+        Ok(match block_number_hex {
+            Some(block_number_hex) => self.get_block(Some(block_number_hex), details, state),
+            None => None,
+        })
+    }
+
+    /// Handler for: `eth_getBlockByNumber`
+    #[rpc_method(name = "eth_getBlockByNumber")]
+    pub fn get_block_by_number(
+        &self,
+        block_number: Option<String>,
+        details: Option<bool>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> RpcResult<Option<Block>> {
+        debug!(
+            block_number,
+            "EVM module JSON-RPC request to `eth_getBlockByNumber`"
+        );
+        Ok(self.get_block(block_number, details, state))
+    }
+
+    /// Handler for: `eth_getBalance`
+    #[rpc_method(name = "eth_getBalance")]
+    pub fn get_balance(
+        &self,
+        address: Address,
+        block_number: Option<String>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> RpcResult<U256> {
+        let mut state = self.resolve_state(block_number, state)?;
+        let balance = self
+            .get_db(state.deref_mut())
+            .basic(address)
+            .map_err(|e| eth_api_into_rpc_error(EthApiError::from(e)))?
+            .map(|account| account.balance)
+            .unwrap_or_default();
+
+        debug!(
+            %address,
+            %balance,
+            "EVM module JSON-RPC request to `eth_getBalance`"
+        );
+
+        Ok(balance)
+    }
+
+    /// Handler for: `eth_getStorageAt`
+    #[rpc_method(name = "eth_getStorageAt")]
+    pub fn get_storage_at(
+        &self,
+        address: Address,
+        index: U256,
+        block_number: Option<String>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> RpcResult<U256> {
+        debug!("EVM module JSON-RPC request to `eth_getStorageAt`");
+
+        let mut state = self.resolve_state(block_number, state)?;
+        let storage_slot = self
+            .account_storage
+            .get(&(&address, &index), state.deref_mut())
+            .unwrap_infallible()
+            .unwrap_or_default();
+
+        Ok(storage_slot)
+    }
+
+    /// Handler for: `eth_getTransactionCount`
+    #[rpc_method(name = "eth_getTransactionCount")]
+    pub fn get_transaction_count(
+        &self,
+        address: Address,
+        block_number: Option<String>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> RpcResult<U64> {
+        let mut state = self.resolve_state(block_number, state)?;
+
+        let ethereum_address: EthereumAddress = address.into();
+        let credential_id = ethereum_address.as_credential_id();
+
+        let nonce = self
+            .uniqueness_module
+            .next_nonce(&credential_id, state.deref_mut())
+            .unwrap_or_default();
+
+        debug!(%address, nonce, "EVM module JSON-RPC request to `eth_getTransactionCount`");
+        Ok(U64::from(nonce))
+    }
+
+    /// Handler for: `eth_getCode`
+    #[rpc_method(name = "eth_getCode")]
+    pub fn get_code(
+        &self,
+        address: Address,
+        block_number: Option<String>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> RpcResult<Bytes> {
+        debug!("EVM module JSON-RPC request to `eth_getCode`");
+        let state = self.resolve_state(block_number, state)?;
+        Ok(self.get_contract_code(address, state).unwrap_or_default())
+    }
+
+    /// Handler for: `eth_feeHistory`
+    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
+    #[rpc_method(name = "eth_feeHistory")]
+    pub fn fee_history(&self) -> RpcResult<FeeHistory> {
+        debug!("EVM module JSON-RPC request to `eth_feeHistory`");
+        Ok(EMPTY_FEE_HISTORY)
+    }
+
+    /// Handler for: `eth_getTransactionByHash`
+    #[rpc_method(name = "eth_getTransactionByHash")]
+    pub fn get_transaction_by_hash(
+        &self,
+        hash: B256,
+        state: &mut ApiStateAccessor<S>,
+    ) -> RpcResult<Option<Transaction>> {
+        let transaction = self.get_transaction(hash, state);
+        debug!(
+            %hash,
+            ?transaction,
+            "EVM module JSON-RPC request to `eth_getTransactionByHash`"
+        );
+        Ok(transaction)
+    }
+
+    /// Handler for: `eth_getBlockReceipts`
+    #[rpc_method(name = "eth_getBlockReceipts")]
+    pub fn get_block_receipts(
+        &self,
+        block_number: Option<String>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> RpcResult<Option<Vec<TransactionReceipt>>> {
+        debug!(
+            block_number,
+            "EVM module JSON-RPC request to `eth_getBlockReceipts`"
+        );
+        Ok(self.get_receipts(block_number, state))
+    }
+
+    /// Handler for: `eth_getTransactionReceipt`
+    #[rpc_method(name = "eth_getTransactionReceipt")]
+    pub fn get_transaction_receipt(
+        &self,
+        hash: B256,
+        state: &mut ApiStateAccessor<S>,
+    ) -> RpcResult<Option<TransactionReceipt>> {
+        debug!(
+            %hash,
+            "EVM module JSON-RPC request to `eth_getTransactionReceipt`"
+        );
+        Ok(self.get_receipt_by_hash(hash, state))
+    }
+
+    /// Handler for: `eth_call`
+    //https://github.com/paradigmxyz/reth/blob/f577e147807a783438a3f16aad968b4396274483/crates/rpc/rpc/src/eth/api/transactions.rs#L502
+    #[rpc_method(name = "eth_call")]
+    pub fn eth_call(
+        &self,
+        request: TransactionRequest,
+        block_number: Option<String>,
+        _state_overrides: Option<StateOverride>,
+        _block_overrides: Option<Box<BlockOverrides>>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> RpcResult<Bytes> {
+        debug!("EVM module JSON-RPC request to `eth_call`");
+        let result = self.call(request, block_number, state)?.result;
+        ensure_success(result).map_err(eth_api_into_rpc_error)
+    }
+
+    /// Handler for: `eth_blockNumber`
+    #[rpc_method(name = "eth_blockNumber")]
+    pub fn block_number(&self, state: &mut ApiStateAccessor<S>) -> RpcResult<U256> {
+        debug!("EVM module JSON-RPC request to `eth_blockNumber`");
+        let block_number_range = self
+            .block_numbers
+            .get(state)
+            .unwrap_infallible()
+            // Justified, we set it at genesis and later only override it.
+            .expect("The impossible happened: block_numbers was not set.");
+
+        Ok(U256::from(*block_number_range.end()))
+    }
+
+    /// Handler for: `eth_estimateGas`
+    // https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/api/call.rs#L172
+    #[rpc_method(name = "eth_estimateGas")]
+    pub fn eth_estimate_gas(
+        &self,
+        request: TransactionRequest,
+        block_number: Option<String>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> RpcResult<U64> {
+        debug!("EVM module JSON-RPC request to `eth_estimateGas`");
+        let ResultAndState {
+            result,
+            state: changes,
+        } = self.call(request, block_number, state)?;
+        self.get_db(state)
+            .commit(changes)
+            .expect("Impossible as gas meter is initialized with INF");
+        let gas_used = result.gas_used();
+        let gas_meter = state.try_as_basic_gas_meter().unwrap();
+        gas_meter
+            .charge_linear_gas(<S as GasSpec>::gas_to_charge_per_evm_gas(), gas_used as u32)
+            .expect("No underflow is possible here as we init EVM gas with gas meter gas");
+        let total_gas_used =
+            gas_meter.initial_gas.as_ref()[0] - gas_meter.remaining_gas.as_ref()[0];
+        Ok(U64::from(apply_margins(total_gas_used)?))
+    }
+
+    /// Handler for: `debug_traceTransaction`
+    #[rpc_method(name = "debug_traceTransaction")]
+    pub fn debug_trace_transaction(
+        &self,
+        tx_hash: B256,
+        opts: Option<GethDebugTracingOptions>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> RpcResult<GethTrace> {
+        debug!("EVM module JSON-RPC request to `debug_traceTransaction`");
+        // Get transaction and block data
+        let index = self
+            .get_tx_index_by_hash(&tx_hash, state)
+            .ok_or_else(|| eth_api_into_rpc_error(EthApiError::PrunedHistoryUnavailable))?;
+
+        let traced_tx = self
+            .transaction(index, state)
+            .ok_or_else(|| eth_api_into_rpc_error(EthApiError::PrunedHistoryUnavailable))?;
+
+        let block = self
+            .blocks
+            .get(&traced_tx.block_number, state)?
+            .expect("Transaction block not available");
+
+        // Get archival state and environment
+        let mut archival_state = state
+            .get_archival_state(RollupHeight::new(traced_tx.block_number - 1))
+            .map_err(into_rpc_error)?;
+
+        let block_env = self
+            .block_env(&mut archival_state)?
+            .ok_or_else(|| eth_api_into_rpc_error(EthApiError::PrunedHistoryUnavailable))?;
+
+        let cfg = self.cfg(&mut archival_state).map_err(into_rpc_error)?;
+        let cfg_env = get_cfg_env(&block_env, cfg, None);
+
+        // Replay previous transactions in the block
+        let mut evm_db = self.get_db(&mut archival_state);
+
+        for tx_idx in block.transactions {
+            let tx = self
+                .transaction(tx_idx, state)
+                .ok_or_else(|| eth_api_into_rpc_error(EthApiError::PrunedHistoryUnavailable))?;
+
+            // Skip the transaction we're tracing
+            if *tx.signed_transaction.hash() == tx_hash {
+                break;
+            }
+
+            transact_commit(&mut evm_db, &block_env, replay_tx_env(&tx), cfg_env.clone())
+                .map_err(|e| eth_api_into_rpc_error(eth_from_evm_error(e)))?;
+        }
+
+        // Trace the target transaction
+        self.trace_transaction(
+            block_env,
+            replay_tx_env(&traced_tx),
+            cfg_env,
+            evm_db,
+            &opts.unwrap_or_default(),
+        )
+        .map_err(eth_api_into_rpc_error)
+    }
+}

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -1,7 +1,6 @@
 use crate::db::commit::FallibleDatabaseCommit;
 use crate::error::into_rpc_error;
 use crate::rpc::error::ensure_success;
-use crate::rpc::eth_from_evm_error;
 use alloy_primitives::{Address, U64};
 use alloy_primitives::{Bytes, B256, U256};
 use alloy_rpc_types::{
@@ -341,7 +340,7 @@ where
             }
 
             transact_commit(&mut evm_db, &block_env, replay_tx_env(&tx), cfg_env.clone())
-                .map_err(eth_from_evm_error)?;
+                .map_err(EthApiError::from)?;
         }
 
         // Trace the target transaction

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -1,5 +1,5 @@
 use crate::db::commit::FallibleDatabaseCommit;
-use crate::error::{eth_api_into_rpc_error, into_rpc_error};
+use crate::error::into_rpc_error;
 use crate::rpc::error::ensure_success;
 use crate::rpc::eth_from_evm_error;
 use alloy_primitives::{Address, U64};
@@ -114,7 +114,7 @@ where
         let balance = self
             .get_db(state.deref_mut())
             .basic(address)
-            .map_err(|e| eth_api_into_rpc_error(EthApiError::from(e)))?
+            .map_err(|e| EthApiError::from(e))?
             .map(|account| account.balance)
             .unwrap_or_default();
 
@@ -248,7 +248,7 @@ where
     ) -> RpcResult<Bytes> {
         debug!("EVM module JSON-RPC request to `eth_call`");
         let result = self.call(request, block_number, state)?.result;
-        ensure_success(result).map_err(eth_api_into_rpc_error)
+        Ok(ensure_success(result)?)
     }
 
     /// Handler for: `eth_blockNumber`
@@ -304,11 +304,11 @@ where
         // Get transaction and block data
         let index = self
             .get_tx_index_by_hash(&tx_hash, state)
-            .ok_or_else(|| eth_api_into_rpc_error(EthApiError::PrunedHistoryUnavailable))?;
+            .ok_or_else(|| EthApiError::PrunedHistoryUnavailable)?;
 
         let traced_tx = self
             .transaction(index, state)
-            .ok_or_else(|| eth_api_into_rpc_error(EthApiError::PrunedHistoryUnavailable))?;
+            .ok_or_else(|| EthApiError::PrunedHistoryUnavailable)?;
 
         let block = self
             .blocks
@@ -322,7 +322,7 @@ where
 
         let block_env = self
             .block_env(&mut archival_state)?
-            .ok_or_else(|| eth_api_into_rpc_error(EthApiError::PrunedHistoryUnavailable))?;
+            .ok_or_else(|| EthApiError::PrunedHistoryUnavailable)?;
 
         let cfg = self.cfg(&mut archival_state).map_err(into_rpc_error)?;
         let cfg_env = get_cfg_env(&block_env, cfg, None);
@@ -333,7 +333,7 @@ where
         for tx_idx in block.transactions {
             let tx = self
                 .transaction(tx_idx, state)
-                .ok_or_else(|| eth_api_into_rpc_error(EthApiError::PrunedHistoryUnavailable))?;
+                .ok_or_else(|| EthApiError::PrunedHistoryUnavailable)?;
 
             // Skip the transaction we're tracing
             if *tx.signed_transaction.hash() == tx_hash {
@@ -341,17 +341,16 @@ where
             }
 
             transact_commit(&mut evm_db, &block_env, replay_tx_env(&tx), cfg_env.clone())
-                .map_err(|e| eth_api_into_rpc_error(eth_from_evm_error(e)))?;
+                .map_err(|e| eth_from_evm_error(e))?;
         }
 
         // Trace the target transaction
-        self.trace_transaction(
+        Ok(self.trace_transaction(
             block_env,
             replay_tx_env(&traced_tx),
             cfg_env,
             evm_db,
             &opts.unwrap_or_default(),
-        )
-        .map_err(eth_api_into_rpc_error)
+        )?)
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -114,7 +114,7 @@ where
         let balance = self
             .get_db(state.deref_mut())
             .basic(address)
-            .map_err(|e| EthApiError::from(e))?
+            .map_err(EthApiError::from)?
             .map(|account| account.balance)
             .unwrap_or_default();
 
@@ -341,7 +341,7 @@ where
             }
 
             transact_commit(&mut evm_db, &block_env, replay_tx_env(&tx), cfg_env.clone())
-                .map_err(|e| eth_from_evm_error(e))?;
+                .map_err(eth_from_evm_error)?;
         }
 
         // Trace the target transaction

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -1,36 +1,29 @@
-use std::error::Error;
-
-use crate::db::commit::FallibleDatabaseCommit;
 use alloy_consensus::{transaction::Recovered, Transaction as TransactionTrait, TxReceipt};
-use alloy_primitives::{Address, BlockHash, U64};
+use alloy_primitives::{Address, BlockHash};
 use alloy_primitives::{Bytes, TxKind, B256, U256};
 use alloy_rpc_types::{
-    state::StateOverride, Block, BlockOverrides, BlockTransactions, FeeHistory, Log,
-    ReceiptEnvelope, ReceiptWithBloom, Transaction, TransactionReceipt, TransactionRequest,
+    Block, BlockTransactions, Log, ReceiptEnvelope, ReceiptWithBloom, Transaction,
+    TransactionReceipt, TransactionRequest,
 };
 use alloy_rpc_types_trace::geth::GethDebugTracingOptions;
 use alloy_rpc_types_trace::geth::GethTrace;
 use alloy_rpc_types_trace::geth::{GethDebugBuiltInTracerType, GethDebugTracerType};
-use error::ensure_success;
 use jsonrpsee::core::RpcResult;
-use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
-use revm::context::result::{EVMError, InvalidHeader, ResultAndState};
+use revm::context::result::ResultAndState;
 use revm::context::{BlockEnv, CfgEnv, TxEnv};
-use revm::Database;
 use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 use sov_address::{EthereumAddress, FromVmAddress};
-use sov_modules_api::macros::{config_value, rpc_gen};
+use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::UnwrapInfallible;
-use sov_modules_api::{ApiStateAccessor, GasMeter, GasSpec, Spec, StateAccessor};
+use sov_modules_api::{ApiStateAccessor, Spec};
 use sov_rollup_interface::common::RollupHeight;
 use sov_rpc_eth_types::{EthApiError, RpcInvalidTransactionError};
-use tracing::debug;
 
-use crate::conversions::replay_tx_env;
 use crate::db::EvmDb;
+use crate::error::{eth_api_into_rpc_error, eth_from_evm_error, into_rpc_error};
 use crate::evm::executor;
 use crate::evm::primitive_types::{Receipt, TransactionSigned, TxSignedAndRecovered};
-use crate::executor::{get_cfg_env, inspect, transact_commit};
+use crate::executor::{get_cfg_env, inspect};
 use crate::helpers::{
     from_primitive_with_hash, from_recovered_with_block_context, prepare_call_env,
 };
@@ -38,336 +31,7 @@ pub use crate::primitive_types::MaybeSealedBlock;
 use crate::Evm;
 
 pub(crate) mod error;
-
-const EMPTY_FEE_HISTORY: FeeHistory = FeeHistory {
-    base_fee_per_gas: vec![],
-    gas_used_ratio: vec![],
-    oldest_block: 0,
-    reward: None,
-    blob_gas_used_ratio: vec![],
-    // EIP-4844 related
-    base_fee_per_blob_gas: vec![],
-};
-
-#[rpc_gen(client, server)]
-impl<S: Spec> Evm<S>
-where
-    S::Address: FromVmAddress<EthereumAddress>,
-{
-    /// Handler for `net_version`
-    #[rpc_method(name = "net_version")]
-    pub fn net_version(&self, _state: &mut ApiStateAccessor<S>) -> RpcResult<String> {
-        debug!("EVM module JSON-RPC request to `net_version`");
-
-        // Network ID is the same as chain ID for most networks
-        let chain_id = config_value!("CHAIN_ID");
-        Ok(chain_id.to_string())
-    }
-
-    /// Handler for: `eth_chainId`
-    #[rpc_method(name = "eth_chainId")]
-    pub fn chain_id(&self, _state: &mut ApiStateAccessor<S>) -> RpcResult<Option<U64>> {
-        let chain_id = config_value!("CHAIN_ID");
-        debug!(
-            chain_id = chain_id,
-            "EVM module JSON-RPC request to `eth_chainId`"
-        );
-        Ok(Some(U64::from(chain_id)))
-    }
-
-    /// Handler for `eth_getBlockByHash`
-    #[rpc_method(name = "eth_getBlockByHash")]
-    pub fn get_block_by_hash(
-        &self,
-        block_hash: B256,
-        details: Option<bool>,
-        state: &mut ApiStateAccessor<S>,
-    ) -> RpcResult<Option<Block>> {
-        debug!(
-            ?block_hash,
-            "EVM module JSON-RPC request to `eth_getBlockByHash`"
-        );
-
-        let block_number_hex = self
-            .block_hashes
-            .get(&block_hash, state)
-            .unwrap_infallible()
-            .map(|number| hex::encode(number.to_be_bytes()));
-
-        Ok(match block_number_hex {
-            Some(block_number_hex) => self.get_block(Some(block_number_hex), details, state),
-            None => None,
-        })
-    }
-
-    /// Handler for: `eth_getBlockByNumber`
-    #[rpc_method(name = "eth_getBlockByNumber")]
-    pub fn get_block_by_number(
-        &self,
-        block_number: Option<String>,
-        details: Option<bool>,
-        state: &mut ApiStateAccessor<S>,
-    ) -> RpcResult<Option<Block>> {
-        debug!(
-            block_number,
-            "EVM module JSON-RPC request to `eth_getBlockByNumber`"
-        );
-        Ok(self.get_block(block_number, details, state))
-    }
-
-    /// Handler for: `eth_getBalance`
-    #[rpc_method(name = "eth_getBalance")]
-    pub fn get_balance(
-        &self,
-        address: Address,
-        block_number: Option<String>,
-        state: &mut ApiStateAccessor<S>,
-    ) -> RpcResult<U256> {
-        let mut state = self.resolve_state(block_number, state)?;
-        let balance = self
-            .get_db(state.deref_mut())
-            .basic(address)
-            .map_err(|e| eth_api_into_rpc_error(EthApiError::from(e)))?
-            .map(|account| account.balance)
-            .unwrap_or_default();
-
-        debug!(
-            %address,
-            %balance,
-            "EVM module JSON-RPC request to `eth_getBalance`"
-        );
-
-        Ok(balance)
-    }
-
-    /// Handler for: `eth_getStorageAt`
-    #[rpc_method(name = "eth_getStorageAt")]
-    pub fn get_storage_at(
-        &self,
-        address: Address,
-        index: U256,
-        block_number: Option<String>,
-        state: &mut ApiStateAccessor<S>,
-    ) -> RpcResult<U256> {
-        debug!("EVM module JSON-RPC request to `eth_getStorageAt`");
-
-        let mut state = self.resolve_state(block_number, state)?;
-        let storage_slot = self
-            .account_storage
-            .get(&(&address, &index), state.deref_mut())
-            .unwrap_infallible()
-            .unwrap_or_default();
-
-        Ok(storage_slot)
-    }
-
-    /// Handler for: `eth_getTransactionCount`
-    #[rpc_method(name = "eth_getTransactionCount")]
-    pub fn get_transaction_count(
-        &self,
-        address: Address,
-        block_number: Option<String>,
-        state: &mut ApiStateAccessor<S>,
-    ) -> RpcResult<U64> {
-        let mut state = self.resolve_state(block_number, state)?;
-
-        let ethereum_address: EthereumAddress = address.into();
-        let credential_id = ethereum_address.as_credential_id();
-
-        let nonce = self
-            .uniqueness_module
-            .next_nonce(&credential_id, state.deref_mut())
-            .unwrap_or_default();
-
-        debug!(%address, nonce, "EVM module JSON-RPC request to `eth_getTransactionCount`");
-        Ok(U64::from(nonce))
-    }
-
-    /// Handler for: `eth_getCode`
-    #[rpc_method(name = "eth_getCode")]
-    pub fn get_code(
-        &self,
-        address: Address,
-        block_number: Option<String>,
-        state: &mut ApiStateAccessor<S>,
-    ) -> RpcResult<Bytes> {
-        debug!("EVM module JSON-RPC request to `eth_getCode`");
-        let state = self.resolve_state(block_number, state)?;
-        Ok(self.get_contract_code(address, state).unwrap_or_default())
-    }
-
-    /// Handler for: `eth_feeHistory`
-    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
-    #[rpc_method(name = "eth_feeHistory")]
-    pub fn fee_history(&self) -> RpcResult<FeeHistory> {
-        debug!("EVM module JSON-RPC request to `eth_feeHistory`");
-        Ok(EMPTY_FEE_HISTORY)
-    }
-
-    /// Handler for: `eth_getTransactionByHash`
-    #[rpc_method(name = "eth_getTransactionByHash")]
-    pub fn get_transaction_by_hash(
-        &self,
-        hash: B256,
-        state: &mut ApiStateAccessor<S>,
-    ) -> RpcResult<Option<Transaction>> {
-        let transaction = self.get_transaction(hash, state);
-        debug!(
-            %hash,
-            ?transaction,
-            "EVM module JSON-RPC request to `eth_getTransactionByHash`"
-        );
-        Ok(transaction)
-    }
-
-    /// Handler for: `eth_getBlockReceipts`
-    #[rpc_method(name = "eth_getBlockReceipts")]
-    pub fn get_block_receipts(
-        &self,
-        block_number: Option<String>,
-        state: &mut ApiStateAccessor<S>,
-    ) -> RpcResult<Option<Vec<TransactionReceipt>>> {
-        debug!(
-            block_number,
-            "EVM module JSON-RPC request to `eth_getBlockReceipts`"
-        );
-        Ok(self.get_receipts(block_number, state))
-    }
-
-    /// Handler for: `eth_getTransactionReceipt`
-    #[rpc_method(name = "eth_getTransactionReceipt")]
-    pub fn get_transaction_receipt(
-        &self,
-        hash: B256,
-        state: &mut ApiStateAccessor<S>,
-    ) -> RpcResult<Option<TransactionReceipt>> {
-        debug!(
-            %hash,
-            "EVM module JSON-RPC request to `eth_getTransactionReceipt`"
-        );
-        Ok(self.get_receipt_by_hash(hash, state))
-    }
-
-    /// Handler for: `eth_call`
-    //https://github.com/paradigmxyz/reth/blob/f577e147807a783438a3f16aad968b4396274483/crates/rpc/rpc/src/eth/api/transactions.rs#L502
-    #[rpc_method(name = "eth_call")]
-    pub fn eth_call(
-        &self,
-        request: TransactionRequest,
-        block_number: Option<String>,
-        _state_overrides: Option<StateOverride>,
-        _block_overrides: Option<Box<BlockOverrides>>,
-        state: &mut ApiStateAccessor<S>,
-    ) -> RpcResult<Bytes> {
-        debug!("EVM module JSON-RPC request to `eth_call`");
-        let result = self.call(request, block_number, state)?.result;
-        ensure_success(result).map_err(eth_api_into_rpc_error)
-    }
-
-    /// Handler for: `eth_blockNumber`
-    #[rpc_method(name = "eth_blockNumber")]
-    pub fn block_number(&self, state: &mut ApiStateAccessor<S>) -> RpcResult<U256> {
-        debug!("EVM module JSON-RPC request to `eth_blockNumber`");
-        let block_number_range = self
-            .block_numbers
-            .get(state)
-            .unwrap_infallible()
-            // Justified, we set it at genesis and later only override it.
-            .expect("The impossible happened: block_numbers was not set.");
-
-        Ok(U256::from(*block_number_range.end()))
-    }
-
-    /// Handler for: `eth_estimateGas`
-    // https://github.com/paradigmxyz/reth/blob/main/crates/rpc/rpc/src/eth/api/call.rs#L172
-    #[rpc_method(name = "eth_estimateGas")]
-    pub fn eth_estimate_gas(
-        &self,
-        request: TransactionRequest,
-        block_number: Option<String>,
-        state: &mut ApiStateAccessor<S>,
-    ) -> RpcResult<U64> {
-        debug!("EVM module JSON-RPC request to `eth_estimateGas`");
-        let ResultAndState {
-            result,
-            state: changes,
-        } = self.call(request, block_number, state)?;
-        self.get_db(state)
-            .commit(changes)
-            .expect("Impossible as gas meter is initialized with INF");
-        let gas_used = result.gas_used();
-        let gas_meter = state.try_as_basic_gas_meter().unwrap();
-        gas_meter
-            .charge_linear_gas(<S as GasSpec>::gas_to_charge_per_evm_gas(), gas_used as u32)
-            .expect("No underflow is possible here as we init EVM gas with gas meter gas");
-        let total_gas_used =
-            gas_meter.initial_gas.as_ref()[0] - gas_meter.remaining_gas.as_ref()[0];
-        Ok(U64::from(apply_margins(total_gas_used)?))
-    }
-
-    /// Handler for: `debug_traceTransaction`
-    #[rpc_method(name = "debug_traceTransaction")]
-    pub fn debug_trace_transaction(
-        &self,
-        tx_hash: B256,
-        opts: Option<GethDebugTracingOptions>,
-        state: &mut ApiStateAccessor<S>,
-    ) -> RpcResult<GethTrace> {
-        debug!("EVM module JSON-RPC request to `debug_traceTransaction`");
-        // Get transaction and block data
-        let index = self
-            .get_tx_index_by_hash(&tx_hash, state)
-            .ok_or_else(|| eth_api_into_rpc_error(EthApiError::PrunedHistoryUnavailable))?;
-
-        let traced_tx = self
-            .transaction(index, state)
-            .ok_or_else(|| eth_api_into_rpc_error(EthApiError::PrunedHistoryUnavailable))?;
-
-        let block = self
-            .blocks
-            .get(&traced_tx.block_number, state)?
-            .expect("Transaction block not available");
-
-        // Get archival state and environment
-        let mut archival_state = state
-            .get_archival_state(RollupHeight::new(traced_tx.block_number - 1))
-            .map_err(into_rpc_error)?;
-
-        let block_env = self
-            .block_env(&mut archival_state)?
-            .ok_or_else(|| eth_api_into_rpc_error(EthApiError::PrunedHistoryUnavailable))?;
-
-        let cfg = self.cfg(&mut archival_state).map_err(into_rpc_error)?;
-        let cfg_env = get_cfg_env(&block_env, cfg, None);
-
-        // Replay previous transactions in the block
-        let mut evm_db = self.get_db(&mut archival_state);
-
-        for tx_idx in block.transactions {
-            let tx = self
-                .transaction(tx_idx, state)
-                .ok_or_else(|| eth_api_into_rpc_error(EthApiError::PrunedHistoryUnavailable))?;
-
-            // Skip the transaction we're tracing
-            if *tx.signed_transaction.hash() == tx_hash {
-                break;
-            }
-
-            transact_commit(&mut evm_db, &block_env, replay_tx_env(&tx), cfg_env.clone())
-                .map_err(|e| eth_api_into_rpc_error(eth_from_evm_error(e)))?;
-        }
-
-        // Trace the target transaction
-        self.trace_transaction(
-            block_env,
-            replay_tx_env(&traced_tx),
-            cfg_env,
-            evm_db,
-            &opts.unwrap_or_default(),
-        )
-        .map_err(eth_api_into_rpc_error)
-    }
-}
+pub(crate) mod handlers;
 
 /// Result of String => BlockNr conversion
 #[derive(Debug)]
@@ -380,10 +44,9 @@ pub enum PendingOrBlock {
     Invalid(String),
 }
 
-// HACK: This should be much lower but because gas estimation doesn't work now - we temporarily set it to a large value.
 const ABSOLUTE_MARGIN: u64 = 100_000;
 /// gas * 1.5 + 100_000
-fn apply_margins(gas: u64) -> Result<u64, RpcInvalidTransactionError> {
+pub(crate) fn apply_margins(gas: u64) -> Result<u64, RpcInvalidTransactionError> {
     (gas / 2)
         .checked_mul(3)
         .and_then(|with_relative_margin| with_relative_margin.checked_add(ABSOLUTE_MARGIN))
@@ -831,35 +494,4 @@ pub(crate) fn build_rpc_receipt(
         to,
         contract_address,
     }
-}
-
-fn eth_from_evm_error<Ws: StateAccessor>(err: EVMError<crate::db::Error<Ws>>) -> EthApiError {
-    match err {
-        EVMError::Transaction(err) => RpcInvalidTransactionError::from(err).into(),
-        EVMError::Header(InvalidHeader::PrevrandaoNotSet) => EthApiError::PrevrandaoNotSet,
-        EVMError::Header(InvalidHeader::ExcessBlobGasNotSet) => EthApiError::ExcessBlobGasNotSet,
-        EVMError::Database(db_err) => db_err.into(),
-        EVMError::Custom(data) => EthApiError::EvmCustom(data),
-    }
-}
-
-impl<Ws: StateAccessor> From<crate::db::Error<Ws>> for EthApiError {
-    fn from(err: crate::db::Error<Ws>) -> Self {
-        EthApiError::EvmCustom(format!("Database error: {err}"))
-    }
-}
-
-/// Hack while reth is not upgraded for `jsonrpsee` 0.25
-pub fn eth_api_into_rpc_error(eth_error: EthApiError) -> ErrorObjectOwned {
-    ErrorObject::owned(500, format!("Eth Error: {eth_error:?}"), None::<()>)
-}
-
-/// Hack while reth is not upgraded for `jsonrpsee` 0.25
-pub fn invalid_tx_into_rpc_error(rpc: RpcInvalidTransactionError) -> ErrorObjectOwned {
-    eth_api_into_rpc_error(rpc.into())
-}
-
-/// Converts internal error into rpc error
-pub fn into_rpc_error(err: impl Error) -> ErrorObjectOwned {
-    ErrorObject::owned(500, format!("{err}"), None::<()>)
 }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -20,7 +20,7 @@ use sov_rollup_interface::common::RollupHeight;
 use sov_rpc_eth_types::{EthApiError, RpcInvalidTransactionError};
 
 use crate::db::EvmDb;
-use crate::error::{eth_from_evm_error, into_rpc_error};
+use crate::error::into_rpc_error;
 use crate::evm::executor;
 use crate::evm::primitive_types::{Receipt, TransactionSigned, TxSignedAndRecovered};
 use crate::executor::{get_cfg_env, inspect};
@@ -205,14 +205,14 @@ where
         request: TransactionRequest,
         block_number: Option<String>,
         state: &mut ApiStateAccessor<S>,
-    ) -> RpcResult<ResultAndState> {
+    ) -> Result<ResultAndState, EthApiError> {
         let block_env = self.resolve_block_env(block_number, state)?;
         let tx_env = prepare_call_env(&block_env, request.clone())?;
         let cfg = self.cfg_infallible(state);
         let cfg_env = get_cfg_env(&block_env, cfg, Some(get_cfg_env_template()));
         let evm_db: EvmDb<_, S> = self.get_db(state);
 
-        Ok(executor::transact(evm_db, &block_env, tx_env, cfg_env).map_err(eth_from_evm_error)?)
+        Ok(executor::transact(evm_db, &block_env, tx_env, cfg_env)?)
     }
 
     /// Retrieves a sealed block generated from an existing or pending block.

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -20,7 +20,7 @@ use sov_rollup_interface::common::RollupHeight;
 use sov_rpc_eth_types::{EthApiError, RpcInvalidTransactionError};
 
 use crate::db::EvmDb;
-use crate::error::{eth_api_into_rpc_error, eth_from_evm_error, into_rpc_error};
+use crate::error::{eth_from_evm_error, into_rpc_error};
 use crate::evm::executor;
 use crate::evm::primitive_types::{Receipt, TransactionSigned, TxSignedAndRecovered};
 use crate::executor::{get_cfg_env, inspect};
@@ -207,14 +207,13 @@ where
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<ResultAndState> {
         let block_env = self.resolve_block_env(block_number, state)?;
-        let tx_env =
-            prepare_call_env(&block_env, request.clone()).map_err(eth_api_into_rpc_error)?;
+        let tx_env = prepare_call_env(&block_env, request.clone())?;
         let cfg = self.cfg_infallible(state);
         let cfg_env = get_cfg_env(&block_env, cfg, Some(get_cfg_env_template()));
         let evm_db: EvmDb<_, S> = self.get_db(state);
 
-        executor::transact(evm_db, &block_env, tx_env, cfg_env)
-            .map_err(|err| eth_api_into_rpc_error(eth_from_evm_error(err)))
+        Ok(executor::transact(evm_db, &block_env, tx_env, cfg_env)
+            .map_err(|err| eth_from_evm_error(err))?)
     }
 
     /// Retrieves a sealed block generated from an existing or pending block.

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -212,8 +212,7 @@ where
         let cfg_env = get_cfg_env(&block_env, cfg, Some(get_cfg_env_template()));
         let evm_db: EvmDb<_, S> = self.get_db(state);
 
-        Ok(executor::transact(evm_db, &block_env, tx_env, cfg_env)
-            .map_err(|err| eth_from_evm_error(err))?)
+        Ok(executor::transact(evm_db, &block_env, tx_env, cfg_env).map_err(eth_from_evm_error)?)
     }
 
     /// Retrieves a sealed block generated from an existing or pending block.


### PR DESCRIPTION
# Description

Splits RPC module into handlers and actual logic.
Now that error code didn't live in handlers - I was able to spot that we don't need to manually convert ETH errors to RPC errors any more. (second commit).
First commit contains no logic changes. Just moving around

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
