### PR TITLE
fix: cap sleep duration in set_value_and_sleep to prevent DoS

### DIFF
--- a/crates/module-system/module-implementations/sov-value-setter/src/call.rs
+++ b/crates/module-system/module-implementations/sov-value-setter/src/call.rs
@@ -99,7 +99,10 @@ impl<S: Spec> ValueSetter<S> {
         state: &mut impl TxState<S>,
     ) -> Result<()> {
         self.set_value(new_value, None, context, state)?;
-        std::thread::sleep(std::time::Duration::from_millis(sleep_millis));
+        // Cap sleep to avoid blocking the executor for excessive time (DoS risk).
+        let max_ms: u64 = 100;
+        let bounded = std::cmp::min(sleep_millis, max_ms);
+        std::thread::sleep(std::time::Duration::from_millis(bounded));
         Ok(())
     }
 


### PR DESCRIPTION

### Problem
The `set_value_and_sleep` method in `sov-value-setter` allows unrestricted user input for sleep duration, potentially causing:
- **DoS vulnerability**: attackers can block execution threads with excessive sleep times
- **Performance degradation**: blocking sleep in transaction execution path
- **Poor maintainability**: unclear dependency on user input for execution timing

### Solution
- Added 100ms upper bound for sleep duration using `std::cmp::min`
- Added explanatory comment about DoS risk mitigation
- Preserves original functionality while preventing abuse

