### PR TITLE
Sequencer: add slot number metrics

### DIFF
--- a/crates/full-node/sov-sequencer/src/metrics.rs
+++ b/crates/full-node/sov-sequencer/src/metrics.rs
@@ -28,6 +28,8 @@ pub struct PreferredSequencerUpdateStateMetrics {
     pub transactions_count: u64,
     pub in_progress_batch: bool,
     pub time_spent_fetching_batches: std::time::Duration,
+    pub true_slot: u64,
+    pub visible_slot: u64,
 }
 
 impl Metric for PreferredSequencerUpdateStateMetrics {
@@ -38,14 +40,16 @@ impl Metric for PreferredSequencerUpdateStateMetrics {
     fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
         write!(
             buffer,
-            "{} duration_ms={},total_message_processing_duration_ms={},fetch_batches_duration_us={},batches_count={},transactions_count={},in_progress_batch={}",
+            "{} duration_ms={},total_message_processing_duration_ms={},fetch_batches_duration_us={},batches_count={},transactions_count={},in_progress_batch={},true_slot={},visible_slot={}",
             self.measurement_name(),
             self.duration.as_millis(),
             self.total_message_processing_duration.as_millis(),
             self.time_spent_fetching_batches.as_micros(),
             self.batches_count,
             self.transactions_count,
-            self.in_progress_batch
+            self.in_progress_batch,
+            self.true_slot,
+            self.visible_slot
         )
     }
 }

--- a/crates/full-node/sov-sequencer/src/metrics.rs
+++ b/crates/full-node/sov-sequencer/src/metrics.rs
@@ -28,8 +28,6 @@ pub struct PreferredSequencerUpdateStateMetrics {
     pub transactions_count: u64,
     pub in_progress_batch: bool,
     pub time_spent_fetching_batches: std::time::Duration,
-    pub true_slot: u64,
-    pub visible_slot: u64,
 }
 
 impl Metric for PreferredSequencerUpdateStateMetrics {
@@ -40,16 +38,14 @@ impl Metric for PreferredSequencerUpdateStateMetrics {
     fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
         write!(
             buffer,
-            "{} duration_ms={},total_message_processing_duration_ms={},fetch_batches_duration_us={},batches_count={},transactions_count={},in_progress_batch={},true_slot={},visible_slot={}",
+            "{} duration_ms={},total_message_processing_duration_ms={},fetch_batches_duration_us={},batches_count={},transactions_count={},in_progress_batch={}",
             self.measurement_name(),
             self.duration.as_millis(),
             self.total_message_processing_duration.as_millis(),
             self.time_spent_fetching_batches.as_micros(),
             self.batches_count,
             self.transactions_count,
-            self.in_progress_batch,
-            self.true_slot,
-            self.visible_slot
+            self.in_progress_batch
         )
     }
 }
@@ -146,6 +142,32 @@ impl Metric for PreferredSequencerFetchBatchesToReplayMetrics {
             self.duration.as_micros(),
             self.num_batches,
             self.num_transactions,
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct PreferredSequencerSlotNumberMetrics {
+    pub true_slot_number: u64,
+    pub latest_finalized_slot_number: u64,
+    pub node_visible_slot_number: u64,
+    pub seq_visible_slot_number: u64,
+}
+
+impl Metric for PreferredSequencerSlotNumberMetrics {
+    fn measurement_name(&self) -> &'static str {
+        "sov_rollup_preferred_sequencer_slot_numbers"
+    }
+
+    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        write!(
+            buffer,
+            "{} true_slot={},last_finalized_slot={},node_visible_slot={},seq_visible_slot={}",
+            self.measurement_name(),
+            self.true_slot_number,
+            self.latest_finalized_slot_number,
+            self.node_visible_slot_number,
+            self.seq_visible_slot_number,
         )
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use super::batch_size_tracker::BatchSizeTracker;
 use crate::metrics::{
     track_sequence_number, PreferredSequencerChannelMetrics, PreferredSequencerChannelMetricsBatch,
-    PreferredSequencerPruneMetrics,
+    PreferredSequencerPruneMetrics, PreferredSequencerSlotNumberMetrics,
 };
 use crate::preferred::block_executor::StartBlockData;
 use crate::preferred::block_executor::{
@@ -1563,6 +1563,10 @@ where
         reason: &'static str,
     ) -> PreferredSeqOperation<S, Rt> {
         let sync_status = &info.sync_status;
+        let true_slot_number = info.slot_number.get();
+        let latest_finalized_slot_number = info.latest_finalized_slot_number.get();
+        let node_visible_slot_number =
+            current_visible_slot_number_according_to_node::<S, Rt>(info).get();
 
         debug!(?info, "Processing state update info from update_state");
         let mut inner = self.get_inner_with_timing(reason).await;
@@ -1572,6 +1576,14 @@ where
                 inner.completed_batches_to_replay(next_sequence_number_according_to_node, true),
                 !inner.has_finished_startup,
             )
+        };
+
+        let seq_visible_slot_number = match batches_to_replay.iter().last() {
+            None => node_visible_slot_number,
+            Some(b) => {
+                let _visible_slots_advance = b.batch.inner.visible_slots_to_advance.get();
+                b.visible_slot_number_after_increase.get()
+            }
         };
 
         let is_resync = matches!(
@@ -1587,6 +1599,12 @@ where
         let time_spent_fetching_batches = fetch_batches_to_replay_metrics.duration;
         sov_metrics::track_metrics(|t| {
             t.submit(fetch_batches_to_replay_metrics);
+            t.submit(PreferredSequencerSlotNumberMetrics {
+                true_slot_number,
+                latest_finalized_slot_number,
+                node_visible_slot_number,
+                seq_visible_slot_number,
+            });
         });
 
         let distance = sync_status.distance();

--- a/crates/full-node/sov-sequencer/src/preferred/update_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/update_state.rs
@@ -6,9 +6,9 @@ use sov_state::{NativeStorage, Storage};
 
 use crate::metrics::PreferredSequencerUpdateStateMetrics;
 use crate::preferred::{
-    get_next_sequence_number_according_to_node, DbEvent, FetchBatches, Flow,
-    PreferredBatchToReplay, PreferredSequencer, ProcessFinalCatchupData, RollupBlockExecutor,
-    StateUpdateInfo,
+    current_visible_slot_number_according_to_node, get_next_sequence_number_according_to_node,
+    DbEvent, FetchBatches, Flow, PreferredBatchToReplay, PreferredSequencer,
+    ProcessFinalCatchupData, RollupBlockExecutor, StateUpdateInfo,
 };
 
 impl<S, Rt, Da> PreferredSequencer<S, Rt, Da>
@@ -157,6 +157,11 @@ where
             .await?;
         }
 
+        // Extract slot numbers before moving info
+
+        let true_slot = info.slot_number.get();
+        let visible_slot = current_visible_slot_number_according_to_node::<S, Rt>(&info).get();
+
         let (maybe_data, message_processing_duration) = self
             .synchronized_state_updator
             .final_catchup_msg(
@@ -188,6 +193,8 @@ where
                 .expect("transactions in a single batch cannot possibly exceed u64::MAX"),
             in_progress_batch: data.batch_is_in_progress,
             time_spent_fetching_batches,
+            true_slot,
+            visible_slot,
         };
 
         sov_metrics::track_metrics(|t| {

--- a/crates/full-node/sov-sequencer/src/preferred/update_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/update_state.rs
@@ -6,9 +6,9 @@ use sov_state::{NativeStorage, Storage};
 
 use crate::metrics::PreferredSequencerUpdateStateMetrics;
 use crate::preferred::{
-    current_visible_slot_number_according_to_node, get_next_sequence_number_according_to_node,
-    DbEvent, FetchBatches, Flow, PreferredBatchToReplay, PreferredSequencer,
-    ProcessFinalCatchupData, RollupBlockExecutor, StateUpdateInfo,
+    get_next_sequence_number_according_to_node, DbEvent, FetchBatches, Flow,
+    PreferredBatchToReplay, PreferredSequencer, ProcessFinalCatchupData, RollupBlockExecutor,
+    StateUpdateInfo,
 };
 
 impl<S, Rt, Da> PreferredSequencer<S, Rt, Da>
@@ -157,11 +157,6 @@ where
             .await?;
         }
 
-        // Extract slot numbers before moving info
-
-        let true_slot = info.slot_number.get();
-        let visible_slot = current_visible_slot_number_according_to_node::<S, Rt>(&info).get();
-
         let (maybe_data, message_processing_duration) = self
             .synchronized_state_updator
             .final_catchup_msg(
@@ -193,8 +188,6 @@ where
                 .expect("transactions in a single batch cannot possibly exceed u64::MAX"),
             in_progress_batch: data.batch_is_in_progress,
             time_spent_fetching_batches,
-            true_slot,
-            visible_slot,
         };
 
         sov_metrics::track_metrics(|t| {


### PR DESCRIPTION
# Description

Adds counting of slot numbers in sequencer. Data is counted as is, differences are calculated on influx. Dashboard is updated:

<img width="1897" height="801" alt="Screenshot 2025-10-14 at 11 56 05" src="https://github.com/user-attachments/assets/2eeba25e-30e1-4b24-9ce2-cf3da6fe6c3c" />


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes #1774 

## Testing
Existing tests are passing, no new tests have been addedd

## Docs
No updates