### PR TITLE
fix: bring back `axum.default-features = false`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ async-trait = "0.1.81"
 arrayvec = { version = "0.7.6", features = ["serde", "borsh"] }
 console-subscriber = "0.4"
 
-axum = { version = "0.7.9" }
+axum = { version = "0.7.9", default-features = false }
 axum-server = { version = "0.6", features = ["tls-rustls"] }
 arbitrary = { version = "1.3.2", features = ["derive"] }
 backon = { version = "1.5.1", default-features = false, features = ["tokio-sleep"] }
@@ -276,7 +276,7 @@ ruint = { version = "1", default-features = false }
 risc0-zkvm = { version = "2.1", default-features = false }
 risc0-zkvm-platform = "2.0"
 risc0-build = "2.1"
-flume = { version = "0.11.1", features = ["async"]}
+flume = { version = "0.11.1", features = ["async"] }
 
 # EVM dependencies
 ethereum-types = "0.14.1"

--- a/crates/adapters/mock-da/Cargo.toml
+++ b/crates/adapters/mock-da/Cargo.toml
@@ -47,7 +47,7 @@ rand = { workspace = true, optional = true, features = ["small_rng"] }
 rand_chacha = { workspace = true, optional = true }
 
 # For HTTP server and client
-axum = { workspace = true, optional = true }
+axum = { workspace = true, optional = true, default-features = true }
 reqwest = { workspace = true, features = ["json"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
# Description

Fixes warning:

```
cd examples/demo-rollup && cargo run
warning: /Users/nikolai/workspace/sovereign/sovereign-sdk-public/examples/demo-rollup/Cargo.toml: `default-features` is ignored for axum, since `default-features` was not specified for `workspace.dependencies.axum`, this could become a hard error in the future
```

- [x] Internal change ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Existing tests are passing

## Docs
No updates
