### PR TITLE
Add to/from bytes trait bounds on crypto spec private key

### DIFF
--- a/crates/adapters/mock-zkvm/src/crypto.rs
+++ b/crates/adapters/mock-zkvm/src/crypto.rs
@@ -15,7 +15,7 @@ use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
 /// Defines private key types and operations
 #[cfg(feature = "native")]
 pub mod private_key {
-    use ed25519_dalek::{Signer, SigningKey};
+    use ed25519_dalek::{SignatureError, Signer, SigningKey};
     use rand::rngs::OsRng;
     #[cfg(feature = "arbitrary")]
     use sov_rollup_interface::crypto::PrivateKey;
@@ -27,6 +27,21 @@ pub mod private_key {
     #[derive(Clone, serde::Serialize, serde::Deserialize)]
     pub struct Ed25519PrivateKey {
         key_pair: SigningKey,
+    }
+
+    impl AsRef<[u8]> for Ed25519PrivateKey {
+        fn as_ref(&self) -> &[u8] {
+            self.key_pair.as_bytes()
+        }
+    }
+
+    impl TryFrom<Vec<u8>> for Ed25519PrivateKey {
+        type Error = SignatureError;
+
+        fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+            let key_pair = SigningKey::try_from(value.as_slice())?;
+            Ok(Self { key_pair })
+        }
     }
 
     impl core::fmt::Debug for Ed25519PrivateKey {

--- a/crates/adapters/risc0/src/crypto.rs
+++ b/crates/adapters/risc0/src/crypto.rs
@@ -15,7 +15,7 @@ use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
 #[cfg(feature = "native")]
 pub mod private_key {
 
-    use ed25519_dalek::{Signer, SigningKey};
+    use ed25519_dalek::{SignatureError, Signer, SigningKey};
     use rand::rngs::OsRng;
 
     use super::{Risc0PublicKey, Risc0Signature};
@@ -33,6 +33,21 @@ pub mod private_key {
                 .field("public_key", &self.key_pair.verifying_key())
                 .field("private_key", &"***REDACTED***")
                 .finish()
+        }
+    }
+
+    impl AsRef<[u8]> for Risc0PrivateKey {
+        fn as_ref(&self) -> &[u8] {
+            self.key_pair.as_bytes()
+        }
+    }
+
+    impl TryFrom<Vec<u8>> for Risc0PrivateKey {
+        type Error = SignatureError;
+
+        fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+            let key_pair = SigningKey::try_from(value.as_slice())?;
+            Ok(Self { key_pair })
         }
     }
 

--- a/crates/adapters/sp1/src/crypto.rs
+++ b/crates/adapters/sp1/src/crypto.rs
@@ -34,6 +34,21 @@ pub mod private_key {
         }
     }
 
+    impl AsRef<[u8]> for SP1PrivateKey {
+        fn as_ref(&self) -> &[u8] {
+            self.key_pair.as_bytes()
+        }
+    }
+
+    impl TryFrom<Vec<u8>> for SP1PrivateKey {
+        type Error = ed25519_consensus::Error;
+
+        fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+            let key_pair = SigningKey::try_from(value.as_slice())?;
+            Ok(Self { key_pair })
+        }
+    }
+
     impl sov_rollup_interface::crypto::PrivateKey for SP1PrivateKey {
         type PublicKey = SP1PublicKey;
 

--- a/crates/module-system/sov-address/src/evm/private_key.rs
+++ b/crates/module-system/sov-address/src/evm/private_key.rs
@@ -1,6 +1,6 @@
 /// Defines private key types and operations
 use alloy_primitives::keccak256;
-use k256::ecdsa::{Signature, SigningKey};
+use k256::ecdsa::{Error, Signature, SigningKey};
 use k256::PublicKey;
 use rand::rngs::OsRng;
 use sov_rollup_interface::crypto::PrivateKey;
@@ -13,6 +13,7 @@ use crate::evm::signature::EthereumSignature;
 #[derive(Clone)]
 pub struct EthereumPrivateKey {
     signing_key: SigningKey,
+    key_bytes: Vec<u8>,
 }
 
 impl core::fmt::Debug for EthereumPrivateKey {
@@ -24,6 +25,21 @@ impl core::fmt::Debug for EthereumPrivateKey {
     }
 }
 
+impl AsRef<[u8]> for EthereumPrivateKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.key_bytes
+    }
+}
+
+impl TryFrom<Vec<u8>> for EthereumPrivateKey {
+    type Error = Error;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        let signing_key = SigningKey::try_from(value.as_slice())?;
+        Ok(Self::new(signing_key))
+    }
+}
+
 impl PrivateKey for EthereumPrivateKey {
     type PublicKey = EthereumPublicKey;
 
@@ -32,9 +48,7 @@ impl PrivateKey for EthereumPrivateKey {
     fn generate() -> Self {
         let mut csprng = OsRng;
 
-        Self {
-            signing_key: SigningKey::random(&mut csprng),
-        }
+        Self::new(SigningKey::random(&mut csprng))
     }
 
     fn pub_key(&self) -> Self::PublicKey {
@@ -52,6 +66,14 @@ impl PrivateKey for EthereumPrivateKey {
 }
 
 impl EthereumPrivateKey {
+    pub fn new(signing_key: SigningKey) -> Self {
+        let key_bytes = signing_key.to_bytes().to_vec();
+        Self {
+            signing_key,
+            key_bytes,
+        }
+    }
+
     /// Returns the private key as a hex string.
     /// TODO: Should it be 0x prefixed??
     pub fn as_hex(&self) -> String {
@@ -95,14 +117,14 @@ impl<'de> serde::Deserialize<'de> for EthereumPrivateKey {
                 .map_err(|_| serde::de::Error::custom("Invalid private key length"))?;
             let signing_key =
                 SigningKey::from_bytes(&bytes.into()).map_err(serde::de::Error::custom)?;
-            Ok(Self { signing_key })
+            Ok(Self::new(signing_key))
         } else {
             // For binary formats, deserialize as fixed 32-byte array
             // This matches secp256k1's binary deserialization format
             let bytes = <[u8; 32]>::deserialize(deserializer)?;
             let signing_key =
                 SigningKey::from_bytes(&bytes.into()).map_err(serde::de::Error::custom)?;
-            Ok(Self { signing_key })
+            Ok(Self::new(signing_key))
         }
     }
 }
@@ -125,7 +147,7 @@ mod arbitrary_impls {
             let rng = &mut StdRng::from_seed(seed);
             let signing_key = SigningKey::random(rng);
 
-            Ok(Self { signing_key })
+            Ok(Self::new(signing_key))
         }
     }
 
@@ -151,9 +173,7 @@ mod arbitrary_impls {
 
         fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
             any::<[u8; 32]>()
-                .prop_map(|seed| Self {
-                    signing_key: SigningKey::random(&mut StdRng::from_seed(seed)),
-                })
+                .prop_map(|seed| Self::new(SigningKey::random(&mut StdRng::from_seed(seed))))
                 .boxed()
         }
     }

--- a/crates/rollup-interface/src/state_machine/crypto/signatures.rs
+++ b/crates/rollup-interface/src/state_machine/crypto/signatures.rs
@@ -58,7 +58,14 @@ pub trait PublicKey:
 /// A private key for generating digital signatures.
 #[cfg(feature = "native")]
 pub trait PrivateKey:
-    Debug + Send + Sync + Serialize + Clone + serde::de::DeserializeOwned
+    Debug
+    + Send
+    + Sync
+    + Serialize
+    + Clone
+    + serde::de::DeserializeOwned
+    + TryFrom<Vec<u8>>
+    + AsRef<[u8]>
 {
     /// The public key type associated with this signature scheme.
     type PublicKey: PublicKey;


### PR DESCRIPTION
# Description

Adds trait bounds to `CryptoSpec::PrivateKey` that allows creating it from bytes and converting to bytes.

This allows more flexibility for the private key when not coming from directly within the sovereign sdk ecosystem, it allows a byob private key approach which is nice for the rust "web3" crate we're working on.

PrivateKey currently has serde bounds but this is not sufficient because there's no way to know how the key will be actually (de)serialized so you can't create a PrivateKey externally, unlike to/from bytes traits.

As further work `PublicKey` & `Signature` should have similar trait bounds so we can serialize them as hex strings in the transaction structures, so the `pub_key` and `signature` fields are a predictable shape. Currently they can be either inlined hex string `signature: "0x..."` or a object like `signature: {msg_sig: "0x...."}` depending on which impls are used which means there's no way to reliably create these types externally, this has required ugly workarounds for external libraries like the TypeScript web3 SDK

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
