### PR TITLE
feat(sov-db): parameterize ForkDescription Arbitrary with ForkGenParams

### DIFF
--- a/crates/full-node/sov-db/src/storage_manager/tests/arbitrary.rs
+++ b/crates/full-node/sov-db/src/storage_manager/tests/arbitrary.rs
@@ -21,33 +21,39 @@ pub struct ForkDescription {
 }
 
 impl Arbitrary for ForkDescription {
-    type Parameters = ();
+    type Parameters = ForkGenParams;
 
-    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        let leaf = (1u64..=10u64, 5u8..=30).prop_map(|(start_height, length)| ForkDescription {
-            start_height,
-            length,
-            child_forks: Vec::new(),
-        });
+    fn arbitrary_with(params: Self::Parameters) -> Self::Strategy {
+        // lengths must be >= 1 to satisfy invariants in ForkMap materialization
+        debug_assert!(*params.leaf_length.start() >= 1);
+        debug_assert!(params.inner_length.start >= 1);
+
+        let leaf = (params.leaf_start_height.clone(), params.leaf_length.clone()).prop_map(
+            |(start_height, length)| ForkDescription {
+                start_height,
+                length,
+                child_forks: Vec::new(),
+            },
+        );
 
         leaf.prop_recursive(
-            8,   // 8 levels deep
-            256, // Shoot for maximum size of 256 nodes
-            10,  // Each collection can have up to 10 items
-            |inner| {
-                // TODO: Parametrize it
+            params.max_depth,
+            params.max_nodes,
+            params.max_items_per_collection,
+            move |inner| {
                 (
-                    1u64..=10u64,
-                    3u8..15,
-                    proptest::collection::vec(inner, 0..4),
+                    params.inner_start_height.clone(),
+                    params.inner_length.clone(),
+                    proptest::collection::vec(inner, params.inner_children.clone()),
                 )
                     .prop_map(|(start_height, length, child_forks)| {
                         let child_forks = child_forks
                             .into_iter()
                             .map(|mut child_fork| {
                                 // child should start before parent ends
+                                let max_child_start = length.saturating_sub(1) as u64;
                                 child_fork.start_height =
-                                    std::cmp::min((length - 1) as u64, child_fork.start_height);
+                                    std::cmp::min(max_child_start, child_fork.start_height);
                                 child_fork
                             })
                             .collect();
@@ -63,6 +69,36 @@ impl Arbitrary for ForkDescription {
     }
 
     type Strategy = BoxedStrategy<Self>;
+}
+
+#[derive(Clone, Debug)]
+pub struct ForkGenParams {
+    pub leaf_start_height: std::ops::RangeInclusive<u64>,
+    pub leaf_length: std::ops::RangeInclusive<u8>,
+    pub inner_start_height: std::ops::RangeInclusive<u64>,
+    // Use exclusive upper-bound to mirror the original 3u8..15
+    pub inner_length: std::ops::Range<u8>,
+    pub inner_children: std::ops::Range<usize>,
+    pub max_depth: u32,
+    pub max_nodes: u32,
+    pub max_items_per_collection: u32,
+}
+
+impl Default for ForkGenParams {
+    fn default() -> Self {
+        Self {
+            leaf_start_height: 1u64..=10u64,
+            leaf_length: 5u8..=30u8,
+            inner_start_height: 1u64..=10u64,
+            // 3..15 (exclusive) matches original behavior
+            inner_length: 3u8..15u8,
+            inner_children: 0..4,
+            // Matches original prop_recursive configuration
+            max_depth: 8,
+            max_nodes: 256,
+            max_items_per_collection: 10,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/full-node/sov-db/src/storage_manager/tests/arbitrary.rs
+++ b/crates/full-node/sov-db/src/storage_manager/tests/arbitrary.rs
@@ -25,8 +25,8 @@ impl Arbitrary for ForkDescription {
 
     fn arbitrary_with(params: Self::Parameters) -> Self::Strategy {
         // lengths must be >= 1 to satisfy invariants in ForkMap materialization
-        debug_assert!(*params.leaf_length.start() >= 1);
-        debug_assert!(params.inner_length.start >= 1);
+        assert!(*params.leaf_length.start() >= 1);
+        assert!(params.inner_length.start >= 1);
 
         let leaf = (params.leaf_start_height.clone(), params.leaf_length.clone()).prop_map(
             |(start_height, length)| ForkDescription {


### PR DESCRIPTION
- Introduce ForkGenParams to configure proptest ranges and recursion limits.
- Replace hardcoded ranges with parameterized values; provide Default matching previous behavior.
- Preserve invariants (min length >= 1); use saturating_sub for child start bounds and add debug asserts.