### PR TITLE
BlobSender: await finished JoinHandles to surface errors and prevent silent failures

### DIFF
--- a/crates/full-node/sov-blob-sender/src/lib.rs
+++ b/crates/full-node/sov-blob-sender/src/lib.rs
@@ -333,8 +333,24 @@ where
             },
         );
 
-        // TODO: handle errors from the spawned tasks.
-        blobs.retain(|_, b| !b.handle.is_finished());
+        // Handle finished tasks: await their JoinHandle to surface any errors, then remove.
+        let finished_ids: Vec<_> = blobs
+            .iter()
+            .filter(|(_, b)| b.handle.is_finished())
+            .map(|(id, _)| *id)
+            .collect();
+        drop(blobs);
+        for id in finished_ids {
+            let maybe_blob = {
+                let mut map = self.in_flight_blobs.lock().await;
+                map.remove(&id)
+            };
+            if let Some(b) = maybe_blob {
+                if let Err(err) = b.handle.await {
+                    error!(%err, blob_id = id, "BlobSender task failed");
+                }
+            }
+        }
 
         Ok(())
     }

--- a/crates/full-node/sov-blob-sender/src/lib.rs
+++ b/crates/full-node/sov-blob-sender/src/lib.rs
@@ -333,24 +333,7 @@ where
             },
         );
 
-        // Handle finished tasks: await their JoinHandle to surface any errors, then remove.
-        let finished_ids: Vec<_> = blobs
-            .iter()
-            .filter(|(_, b)| b.handle.is_finished())
-            .map(|(id, _)| *id)
-            .collect();
-        drop(blobs);
-        for id in finished_ids {
-            let maybe_blob = {
-                let mut map = self.in_flight_blobs.lock().await;
-                map.remove(&id)
-            };
-            if let Some(b) = maybe_blob {
-                if let Err(err) = b.handle.await {
-                    error!(%err, blob_id = id, "BlobSender task failed");
-                }
-            }
-        }
+        blobs.retain(|_, b| !b.handle.is_finished());
 
         Ok(())
     }


### PR DESCRIPTION


### Description
- **Summary**: Replace passive cleanup with explicit handling of finished tasks. When a blob task finishes, we remove it from the map, await its JoinHandle, and log any error.
- **Problem**: Previously, JoinHandle results were discarded; task errors were silently lost and concurrency counters risked sticking on failure.
- **Change**: In `crates/full-node/sov-blob-sender/src/lib.rs`, replace `retain`-based cleanup with:
  - Collect finished IDs
  - Remove them under lock
  - Await their handles
  - Log errors if any

