### PR TITLE
Remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13212,14 +13212,10 @@ dependencies = [
  "libfuzzer-sys",
  "rand 0.8.5",
  "serde_json",
- "sha2 0.10.9",
  "sov-accounts",
  "sov-bank",
- "sov-celestia-adapter",
  "sov-modules-api",
- "sov-rollup-interface",
  "sov-test-utils",
- "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12933,7 +12933,6 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "toml 0.8.23",
  "tower 0.5.2",
  "tower-http 0.5.2",
  "tower-layer",

--- a/crates/full-node/sov-stf-runner/Cargo.toml
+++ b/crates/full-node/sov-stf-runner/Cargo.toml
@@ -24,7 +24,6 @@ thiserror = { workspace = true }
 borsh = { workspace = true }
 serde = { workspace = true }
 strum = { workspace = true }
-toml = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 full-node-configs = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client", "server"] }

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -11,16 +11,12 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 serde_json = { workspace = true }
-tempfile = { workspace = true }
 rand = { workspace = true }
-sha2 = { workspace = true }
 
 # Sovereign-maintained dependencies.
-sov-celestia-adapter = { workspace = true, features = ["native", "arbitrary"] }
 sov-modules-api = { workspace = true, features = ["arbitrary", "native"] }
 sov-accounts = { workspace = true, features = ["arbitrary", "native"] }
 sov-bank = { workspace = true, features = ["native"] }
-sov-rollup-interface = { workspace = true }
 sov-test-utils = { workspace = true, features = ["arbitrary"] }
 
 [[bin]]


### PR DESCRIPTION
# Description

Remove 5 unused dependencies:
- fuzz: `sha2`, `tempfile`, `sov-celestia-adapter`, `sov-rollup-interface`
- sov-stf-runner: `toml`

-----

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
