### PR TITLE
Refactor PostgreSQL container setup and integrate replication tasks in the sequencer.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13056,6 +13056,7 @@ dependencies = [
  "strum 0.26.3",
  "tempfile",
  "testcontainers",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.20",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13016,6 +13016,7 @@ dependencies = [
  "ethers",
  "hex",
  "jsonschema",
+ "num_cpus",
  "reqwest 0.12.23",
  "rockbound",
  "schemars 0.8.22",

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -16,6 +16,8 @@ mod update_state;
 
 use crate::preferred::block_executor::RollupBlockExecutorConfig;
 use crate::preferred::cache_warm_up_executor::CacheWarmUpExecutor;
+use crate::preferred::replica::event_handler::ReplicaEventProcessor;
+use crate::preferred::replica::replica_sync_task::ReplicaSyncTask;
 use async_trait::async_trait;
 use axum::http::StatusCode;
 use batch_size_tracker::BatchSizeTracker;
@@ -277,21 +279,25 @@ where
             _runtime: PhantomData,
             config: config.clone(),
             shutdown_receiver: shutdown_receiver.clone(),
-            shutdown_sender,
+            shutdown_sender: shutdown_sender.clone(),
             tx_queue_id,
             stop_at_rollup_height,
             test_only_state_update_notification_sender: broadcast::channel(100).0,
         });
 
-        // Launch replica sync task only for replicas
-        // This will block until the currently stored batches in the DB are replayed onto the
-        // state, then yield when it switches to processing postgres events live.
-        // This is necessary to prevent conflicts with the update_state task.
+        // Launch replica sync task only for replicas.
         if config.sequencer_kind_config.is_replica {
-            //handles.push(
-            //    spawn_replica_sync_task(seq.clone(), shutdown_receiver.clone(), latest_db_event_id)
-            //        .await,
-            //);
+            if let Some(postgres_connection_string) =
+                &config.sequencer_kind_config.postgres_connection_string
+            {
+                let mut replica_task = ReplicaSyncTask::new(
+                    postgres_connection_string.clone(),
+                    shutdown_sender.clone(),
+                )
+                .await?;
+
+                handles.push(replica_task.start(ReplicaEventProcessor {}).await);
+            }
         }
         handles.push(tokio::spawn({
             update_state_task(

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
@@ -1,0 +1,10 @@
+use crate::preferred::replica::event_receiver::DbData;
+use crate::preferred::replica::replica_sync_task::ReplicaEventHandler;
+use async_trait::async_trait;
+
+pub struct ReplicaEventProcessor {}
+
+#[async_trait]
+impl ReplicaEventHandler for ReplicaEventProcessor {
+    async fn on_da_event(&self, _data: DbData) {}
+}

--- a/crates/full-node/sov-sequencer/src/preferred/replica/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/mod.rs
@@ -1,3 +1,4 @@
 #![allow(dead_code)]
+pub(crate) mod event_handler;
 pub(crate) mod event_receiver;
 pub(crate) mod replica_sync_task;

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -58,8 +58,10 @@ mod tests {
     use sov_modules_api::FullyBakedTx;
     use sov_modules_api::TxHash;
     use sov_modules_api::VisibleSlotNumber;
-    use sov_test_utils::postgres::connection_string_from_postgres_container;
-    use sov_test_utils::postgres::create_postgres_container;
+    use sov_test_utils::postgres::{
+        connection_string_from_postgres_container, create_postgres_container,
+    };
+
     use std::num::NonZero;
     use tokio::sync::mpsc;
 
@@ -127,10 +129,12 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_notifications() {
         let dir = tempfile::tempdir().unwrap();
-        let postgres = create_postgres_container(&dir.path().join("postgres_data"))
-            .await
-            .unwrap();
+        let Some(postgres) = create_postgres_container(&dir.path().join("postgres_data")).await
+        else {
+            return;
+        };
 
+        let postgres = postgres.unwrap();
         let postgres_connection_string = connection_string_from_postgres_container(&postgres)
             .await
             .unwrap();

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -2,6 +2,7 @@ use crate::preferred::replica::event_receiver::DbData;
 use crate::preferred::replica::event_receiver::EventReceiver;
 use async_trait::async_trait;
 use tokio::sync::watch;
+use tokio::task::JoinHandle;
 
 #[async_trait]
 pub(crate) trait ReplicaEventHandler: Send + Sync + 'static {
@@ -16,7 +17,6 @@ pub(crate) struct ReplicaSyncTask {
 impl ReplicaSyncTask {
     pub(crate) async fn new(
         postgres_connection_string: String,
-
         shutdown_sender: watch::Sender<()>,
     ) -> anyhow::Result<Self> {
         Ok(Self {
@@ -25,7 +25,7 @@ impl ReplicaSyncTask {
         })
     }
 
-    pub(crate) async fn start<R: ReplicaEventHandler>(&mut self, handler: R) {
+    pub(crate) async fn start<R: ReplicaEventHandler>(&mut self, handler: R) -> JoinHandle<()> {
         let mut event_receiver = EventReceiver::new(
             self.postgres_connection_string.clone(),
             self.shutdown_sender.clone(),
@@ -45,7 +45,7 @@ impl ReplicaSyncTask {
                     handler.on_da_event(data).await;
                 }
             }
-        });
+        })
     }
 }
 
@@ -59,7 +59,7 @@ mod tests {
     use sov_modules_api::TxHash;
     use sov_modules_api::VisibleSlotNumber;
     use sov_test_utils::postgres::{
-        connection_string_from_postgres_container, create_postgres_container,
+        connection_string_from_postgres_container, create_postgres_container, CreatePostgresError,
     };
 
     use std::num::NonZero;
@@ -129,12 +129,16 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_notifications() {
         let dir = tempfile::tempdir().unwrap();
-        let Some(postgres) = create_postgres_container(&dir.path().join("postgres_data")).await
-        else {
-            return;
+
+        let postgres = create_postgres_container(&dir.path().join("postgres_data")).await;
+        let postgres = match postgres {
+            Ok(pg) => pg,
+            Err(CreatePostgresError::DockerNotSupported) => return,
+            Err(CreatePostgresError::DockerError(e)) => {
+                panic!("Failed to create Postgres container: {e}");
+            }
         };
 
-        let postgres = postgres.unwrap();
         let postgres_connection_string = connection_string_from_postgres_container(&postgres)
             .await
             .unwrap();

--- a/crates/module-system/sov-test-utils/Cargo.toml
+++ b/crates/module-system/sov-test-utils/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+thiserror = { workspace = true }
 async-trait = { workspace = true }
 axum-server = { workspace = true }
 borsh = { workspace = true }

--- a/crates/module-system/sov-test-utils/Cargo.toml
+++ b/crates/module-system/sov-test-utils/Cargo.toml
@@ -28,6 +28,8 @@ serde_json = { workspace = true }
 testcontainers = { workspace = true }
 tracing = { workspace = true }
 hex = { workspace = true }
+num_cpus = { workspace = true }
+
 
 ethereum-types = { workspace = true }
 ethers = { workspace = true }

--- a/crates/module-system/sov-test-utils/src/postgres.rs
+++ b/crates/module-system/sov-test-utils/src/postgres.rs
@@ -38,30 +38,41 @@ impl Image for PostgresImage {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+/// Error indicating problems when creating a Postgres container.
+pub enum CreatePostgresError {
+    #[error("Docker is not supported on this platform")]
+    /// Docker is not supported on this platform
+    DockerNotSupported,
+
+    #[error("Failed to create a Docker container: {0}")]
+    /// Failed to create a Docker container, maybe the Docker daemon is not running.
+    DockerError(#[from] anyhow::Error),
+}
+
 /// Creates a container with a PostgreSQL database.
 pub async fn create_postgres_container(
     dir: &Path,
-) -> Option<anyhow::Result<ContainerAsync<PostgresImage>>> {
+) -> Result<ContainerAsync<PostgresImage>, CreatePostgresError> {
     if should_skip_postgres() {
-        return None;
+        return Err(CreatePostgresError::DockerNotSupported);
     }
 
     let postgres_data_dir = dir.join("postgres_data");
     debug!(?postgres_data_dir, "Using Postgres data directory");
 
-    let res = async {
-        std::fs::create_dir_all(&postgres_data_dir)?;
-        let img = PostgresImage
-            .with_mount(Mount::bind_mount(
-                postgres_data_dir.to_string_lossy(),
-                "/var/lib/postgresql/data",
-            ))
-            .start()
-            .await?;
-        Ok(img)
-    };
+    std::fs::create_dir_all(&postgres_data_dir)
+        .map_err(|e| CreatePostgresError::DockerError(e.into()))?;
 
-    Some(res.await)
+    let img = PostgresImage
+        .with_mount(Mount::bind_mount(
+            postgres_data_dir.to_string_lossy(),
+            "/var/lib/postgresql/data",
+        ))
+        .start()
+        .await
+        .map_err(|e| CreatePostgresError::DockerError(e.into()))?;
+    Ok(img)
 }
 
 fn should_skip_postgres() -> bool {

--- a/crates/module-system/sov-test-utils/src/postgres.rs
+++ b/crates/module-system/sov-test-utils/src/postgres.rs
@@ -41,18 +41,46 @@ impl Image for PostgresImage {
 /// Creates a container with a PostgreSQL database.
 pub async fn create_postgres_container(
     dir: &Path,
-) -> anyhow::Result<ContainerAsync<PostgresImage>> {
+) -> Option<anyhow::Result<ContainerAsync<PostgresImage>>> {
+    if should_skip_postgres() {
+        return None;
+    }
+
     let postgres_data_dir = dir.join("postgres_data");
     debug!(?postgres_data_dir, "Using Postgres data directory");
-    std::fs::create_dir_all(&postgres_data_dir)?;
 
-    Ok(PostgresImage
-        .with_mount(Mount::bind_mount(
-            postgres_data_dir.to_string_lossy(),
-            "/var/lib/postgresql/data",
-        ))
-        .start()
-        .await?)
+    let res = async {
+        std::fs::create_dir_all(&postgres_data_dir)?;
+        let img = PostgresImage
+            .with_mount(Mount::bind_mount(
+                postgres_data_dir.to_string_lossy(),
+                "/var/lib/postgresql/data",
+            ))
+            .start()
+            .await?;
+        Ok(img)
+    };
+
+    Some(res.await)
+}
+
+fn should_skip_postgres() -> bool {
+    // We skip all docker (i.e. postgres) tests on our dev server due to firewall false positives
+    // bricking the machine.
+    // The dev machine has 96 threads, which we detect to disable postgres. Currently no dev or CI
+    // setup uses a machine of exactly this size, though if this ever changes this will cause
+    // false positives.
+    const DEV_SERVER_CPUS: usize = 96;
+
+    if num_cpus::get() == DEV_SERVER_CPUS {
+        return true;
+    }
+
+    if std::env::var("SOV_TEST_SKIP_DOCKER") == Ok("1".to_string()) {
+        return true;
+    }
+
+    false
 }
 
 /// Returns the connection string for the PostgreSQL.

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use crate::postgres::create_postgres_container;
+use crate::postgres::CreatePostgresError;
 use crate::postgres::PostgresImage;
 use crate::{
     TEST_DEFAULT_PROVER_ADDRESS, TEST_DEFAULT_SEQUENCER_ADDRESS, TEST_MAX_BATCH_SIZE,
@@ -49,6 +50,7 @@ pub use sov_stf_runner::processes::RollupProverConfig;
 use sov_stf_runner::{
     HttpServerConfig, MonitoringConfig, ProofManagerConfig, RollupConfig, RunnerConfig,
 };
+use tempfile::TempDir;
 use testcontainers::ContainerAsync;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -118,32 +120,11 @@ pub struct RollupBuilder<R: FullNodeBlueprint<Native>> {
     genesis: GenesisSource<R::Spec, R::Runtime>,
     da_config: <<R as FullNodeBlueprint<sov_modules_api::execution_mode::Native>>::DaService as DaService>::Config,
     config: RollupBuilderConfig<R::Spec>,
-    postgres_container_opt: Option<Arc<ContainerAsync<PostgresImage>>>,
+    postgres_container_opt: Option<Arc<PostgresData>>,
     with_secondary_sequencer: Option<MockAddress>,
 }
 
 impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
-    /// Uses the preferred sequencer with Postgres as a database.
-    pub async fn with_postgres_sequencer(mut self) -> Option<Self> {
-        let postgres = create_postgres_container(&self.config.storage.path().join("postgres_data"))
-            .await?
-            .unwrap();
-
-        let postgres_connection_string = connection_string_from_postgres_container(&postgres)
-            .await
-            .expect("Failed to get postgres_connection_string");
-
-        match &mut self.config.sequencer_config {
-            SequencerKindConfig::Preferred(ref mut config) => {
-                config.postgres_connection_string = Some(postgres_connection_string);
-                self.postgres_container_opt = Some(Arc::new(postgres));
-            }
-            _ => panic!("Can't use Postgres with a non-preferred sequencer"),
-        }
-
-        Some(self)
-    }
-
     /// See [`PreferredSequencerConfig::minimum_profit_per_tx`].
     pub fn with_preferred_seq_min_profit_per_tx(mut self, minimum_profit_per_tx: u128) -> Self {
         if let SequencerKindConfig::Preferred(ref mut config) = &mut self.config.sequencer_config {
@@ -373,6 +354,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
         finalization_blocks: u32,
         storage_path: StoragePath,
         is_replica: bool,
+        postgres_connection_string: Option<String>,
     ) -> RollupBuilderConfig<R::Spec> {
         RollupBuilderConfig {
             max_allowed_node_distance_behind: 10,
@@ -383,6 +365,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
             automatic_batch_production: true,
             sequencer_config: SequencerKindConfig::Preferred(PreferredSequencerConfig {
                 is_replica,
+                postgres_connection_string,
                 ..Default::default()
             }),
             prover_address: TEST_DEFAULT_PROVER_ADDRESS.to_string(),
@@ -404,22 +387,45 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
     }
 }
 
+pub struct PostgresData {
+    storage_path: TempDir,
+    postgres: ContainerAsync<PostgresImage>,
+    connection_string: String,
+}
+
+impl PostgresData {
+    pub async fn create_postgres() -> Result<Arc<PostgresData>, CreatePostgresError> {
+        let dir = tempfile::tempdir().unwrap();
+        let pg = create_postgres_container(&dir.path().join("postgres_data")).await?;
+
+        Ok(Arc::new(PostgresData {
+            storage_path: dir,
+            connection_string: connection_string_from_postgres_container(&pg).await?,
+            postgres: pg,
+        }))
+    }
+}
+
 impl<R> RollupBuilder<R>
 where
     R: FullNodeBlueprint<Native, DaService = StorableMockDaClient> + Default + 'static,
 {
-    pub fn new_with_external_da(
+    pub async fn new_with_external_da(
         is_replica: bool,
         genesis: GenesisSource<R::Spec, R::Runtime>,
         da_config: MockDaClientConfig,
+        postgres_container_opt: Option<Arc<PostgresData>>,
     ) -> Self {
         let storage_path = StoragePath::Tmp(Arc::new(tempfile::tempdir().unwrap()));
+        let post_str = postgres_container_opt
+            .as_ref()
+            .map(|p| p.connection_string.clone());
 
         Self {
             genesis,
             da_config,
-            config: Self::default_config(0, storage_path, is_replica),
-            postgres_container_opt: None,
+            config: Self::default_config(0, storage_path, is_replica, post_str),
+            postgres_container_opt,
             with_secondary_sequencer: None,
         }
     }
@@ -477,7 +483,7 @@ where
             genesis,
             da_config,
             postgres_container_opt: None,
-            config: Self::default_config(finalization_blocks, storage_path, false),
+            config: Self::default_config(finalization_blocks, storage_path, false, None),
             with_secondary_sequencer: None,
         }
     }

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -124,13 +124,14 @@ pub struct RollupBuilder<R: FullNodeBlueprint<Native>> {
 
 impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
     /// Uses the preferred sequencer with Postgres as a database.
-    async fn with_postgres_sequencer(mut self) -> anyhow::Result<Self> {
-        let postgres =
-            create_postgres_container(&self.config.storage.path().join("postgres_data")).await
-            .with_context(|| "Failed to start Postgres container. This is most likely because (1) the Docker daemon is not running or (2) Docker Desktop doesn't have file sharing permissions to the repository directory")?;
+    pub async fn with_postgres_sequencer(mut self) -> Option<Self> {
+        let postgres = create_postgres_container(&self.config.storage.path().join("postgres_data"))
+            .await?
+            .unwrap();
 
-        let postgres_connection_string =
-            connection_string_from_postgres_container(&postgres).await?;
+        let postgres_connection_string = connection_string_from_postgres_container(&postgres)
+            .await
+            .expect("Failed to get postgres_connection_string");
 
         match &mut self.config.sequencer_config {
             SequencerKindConfig::Preferred(ref mut config) => {
@@ -140,7 +141,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
             _ => panic!("Can't use Postgres with a non-preferred sequencer"),
         }
 
-        Ok(self)
+        Some(self)
     }
 
     /// See [`PreferredSequencerConfig::minimum_profit_per_tx`].

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -49,6 +49,9 @@ async fn start_rollup(
             url: format!("http://{addr}"),
         },
     )
+    .with_postgres_sequencer()
+    .await
+    .unwrap()
     .start_test_rollup()
     .await
     .unwrap()

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -13,10 +13,13 @@ use sov_modules_api::PrivateKey;
 use sov_modules_api::PublicKey;
 use sov_modules_api::Spec;
 use sov_modules_rollup_blueprint::RollupBlueprint;
+use sov_test_utils::postgres::CreatePostgresError;
 use sov_test_utils::test_rollup::read_private_key;
+use sov_test_utils::test_rollup::PostgresData;
 use sov_test_utils::test_rollup::RollupBuilder;
 use sov_test_utils::test_rollup::TestRollup;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tokio::sync::watch;
 
 type S = <ExternalMockDemoRollup<Native> as RollupBlueprint<Native>>::Spec;
@@ -40,6 +43,7 @@ async fn create_da_service() -> (StorableMockDaService, watch::Sender<()>, Socke
 async fn start_rollup(
     is_replica: bool,
     addr: SocketAddr,
+    postgres: Option<Arc<PostgresData>>,
 ) -> TestRollup<ExternalMockDemoRollup<Native>> {
     let genesis = test_genesis_source(OperatingMode::Operator);
     RollupBuilder::new_with_external_da(
@@ -48,10 +52,9 @@ async fn start_rollup(
         MockDaClientConfig {
             url: format!("http://{addr}"),
         },
+        postgres,
     )
-    .with_postgres_sequencer()
     .await
-    .unwrap()
     .start_test_rollup()
     .await
     .unwrap()
@@ -62,8 +65,63 @@ async fn test_replica_receives_txs_from_da() {
     let (_, shutdown_sender, addr) = create_da_service().await;
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
 
-    let test_rollup = start_rollup(false, addr).await;
-    let replica_test_rollup = start_rollup(true, addr).await;
+    let test_rollup = start_rollup(false, addr, None).await;
+    let replica_test_rollup = start_rollup(true, addr, None).await;
+
+    let token_id = config_gas_token_id();
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
+
+    let receiver_addr = random_address();
+
+    let tx = build_transfer_token_tx::<S>(
+        &key_and_address.private_key,
+        token_id,
+        receiver_addr,
+        100,
+        0,
+    );
+
+    let height_before_tx = test_rollup.height().await;
+
+    test_rollup
+        .client
+        .client
+        .send_txs_to_sequencer(&[tx])
+        .await
+        .unwrap();
+
+    test_rollup
+        .wait_for_height(height_before_tx.get() + 5)
+        .await;
+
+    let receiver_balance = replica_test_rollup
+        .client
+        .get_balance::<S>(&receiver_addr, &token_id, None)
+        .await
+        .unwrap();
+
+    assert_eq!(receiver_balance.0, 100);
+    let _ = test_rollup.shutdown().await;
+    let _ = shutdown_sender.send(());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_replica_receives_txs_from_postgres() {
+    let postgres = PostgresData::create_postgres().await;
+
+    let postgres = match postgres {
+        Ok(pg) => Some(pg),
+        Err(CreatePostgresError::DockerNotSupported) => return,
+        Err(CreatePostgresError::DockerError(e)) => {
+            panic!("Failed to create Postgres container: {e}");
+        }
+    };
+
+    let (_, shutdown_sender, addr) = create_da_service().await;
+    let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
+
+    let test_rollup = start_rollup(false, addr, postgres.clone()).await;
+    let replica_test_rollup = start_rollup(true, addr, postgres).await;
 
     let token_id = config_gas_token_id();
     test_rollup.wait_for_sequencer_ready().await.unwrap();


### PR DESCRIPTION
# Description
This PR includes the following changes:

1. Refactors and simplifies the logic for initializing `PostgreSQL` containers.
2. Integrates the replication task into the sequencer. Currently, this task only receives updates from the master sequencer; the core logic will be implemented in the next PR.
3. Adds a test to verify that both `PostgreSQL` and its replicas can be successfully instantiated.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
