### PR TITLE
Fix messed up NOMT commit metrics

### DIFF
--- a/crates/full-node/sov-db/src/metrics/nomt.rs
+++ b/crates/full-node/sov-db/src/metrics/nomt.rs
@@ -158,15 +158,38 @@ impl Metric for PrunerMetric {
 #[derive(Debug)]
 pub struct MerklizedCommitMetric {
     pub flag_prepare: std::time::Duration,
-    pub write_attempts_kernel: usize,
-    // How much time in total it took to write overlay
-    pub write_kernel: std::time::Duration,
     pub flag_mid: std::time::Duration,
+    pub flag_finish: std::time::Duration,
+    // How much time in total it took to write overlay
+    pub write_user: std::time::Duration,
+    pub write_kernel: std::time::Duration,
     // How many attempts it took to write
     pub write_attempts_user: usize,
-    pub write_user: std::time::Duration,
-    pub flag_finish: std::time::Duration,
+    pub write_attempts_kernel: usize,
     pub total: std::time::Duration,
+}
+
+impl MerklizedCommitMetric {
+    fn serialize_values_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        // Flag
+        let flag_prepare_us = self.flag_prepare.as_micros();
+        let flag_mid_us = self.flag_mid.as_micros();
+        let flag_finish_us = self.flag_finish.as_micros();
+        write!(buffer,
+               "merklized_flag_prepare_us={flag_prepare_us},merklized_flag_mid_us={flag_mid_us},merklized_flag_finish={flag_finish_us}")?;
+        // Times
+        let write_user_us = self.write_user.as_micros();
+        let write_kernel_us = self.write_kernel.as_micros();
+        let total_us = self.total.as_micros();
+        write!(buffer,
+               ",merklized_write_user_us={write_user_us},merklized_write_kernel_us={write_kernel_us},merklized_total_us={total_us}")?;
+
+        // Attempts
+        let write_attempts_user = self.write_attempts_user;
+        let write_attempts_kernel = self.write_attempts_kernel;
+        write!(buffer,
+               ",merklized_attempts_write_user={write_attempts_user},merklized_write_attempts_kernel={write_attempts_kernel}")
+    }
 }
 
 #[derive(Debug)]
@@ -190,23 +213,14 @@ impl Metric for CommitDetailedMetric {
     }
 
     fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
-        write!(
-            buffer,
-            "{} merklized_flag_prepare_us={},write_attempts_kernel={},write_kernel_us={},write_attempts_user={},write_user_us={},flag_mid_us={},flag_finish_us={},merklized_total_us={},merklized_from_caller_us={},flat_prepare_us={},flat_write_us={},accessory_commit_us={},ledger_commit_us={}",
-            self.measurement_name(),
-            self.merklized_commit_from_caller.as_micros(),
-            self.merklized_commit.flag_prepare.as_micros(),
-            self.merklized_commit.write_attempts_kernel,
-            self.merklized_commit.write_kernel.as_micros(),
-            self.merklized_commit.write_attempts_user,
-            self.merklized_commit.write_user.as_micros(),
-            self.merklized_commit.flag_mid.as_micros(),
-            self.merklized_commit.flag_finish.as_micros(),
-            self.merklized_commit.total.as_micros(),
-            self.flat.prepare.as_micros(),
-            self.flat.write.as_micros(),
-            self.accessory_commit.as_micros(),
-            self.ledger_commit.as_micros(),
-        )
+        write!(buffer, "{} ", self.measurement_name())?;
+        self.merklized_commit
+            .serialize_values_for_telegraf(buffer)?;
+        let merklized_commit_from_caller_us = self.merklized_commit_from_caller.as_micros();
+        let flat_prepare_us = self.flat.prepare.as_micros();
+        let flat_write_us = self.flat.write.as_micros();
+        let accessory_commit_us = self.accessory_commit.as_micros();
+        let ledger_commit_us = self.ledger_commit.as_micros();
+        write!(buffer, ",merklized_from_caller_us={merklized_commit_from_caller_us},flat_prepare_us={flat_prepare_us},flat_write_us={flat_write_us},accessory_commit_us={accessory_commit_us},ledger_commit_us={ledger_commit_us}")
     }
 }


### PR DESCRIPTION
# Description

NOMT commit metrics added in https://github.com/Sovereign-Labs/sovereign-sdk/pull/1841 have been accidentally shuffled. This PR fixes  that.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

