### PR TITLE
Enable nightly dev promotion to nightly

### DIFF
--- a/.github/workflows/acceptance_test_promote.yml
+++ b/.github/workflows/acceptance_test_promote.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           ref: ${{ github.event.client_payload.commit_sha }}
           fetch-depth: 0
+          ssh-key: ${{ secrets.ACCEPTANCE_TEST_DEPLOY_KEY }}
 
       - name: Verify commit exists
         run: |

--- a/.github/workflows/acceptance_test_promote.yml
+++ b/.github/workflows/acceptance_test_promote.yml
@@ -6,11 +6,9 @@ on:
 
 permissions:
   contents: write
-  issues: write
 
 env:
-  # Use test branch for now, will change to dev/nightly later
-  NIGHTLY_BRANCH: 'theodore/acceptance-nightly-testing'
+  NIGHTLY_BRANCH: 'nightly'
 
 jobs:
   promote:
@@ -92,3 +90,5 @@ jobs:
           echo "$ERROR_DETAILS"
           echo ""
           echo "TODO: Send Slack notification to configured channel"
+
+          exit 1

--- a/.github/workflows/acceptance_test_trigger.yml
+++ b/.github/workflows/acceptance_test_trigger.yml
@@ -1,25 +1,20 @@
 name: Trigger Acceptance Tests
 
 on:
-  # schedule:
-  #   # Nightly at 5am UTC
-  #   - cron: "0 5 * * *"
-  # Allow manual triggering for testing
+  schedule:
+    # Nightly at 5am UTC
+    - cron: "0 5 * * *"
+  # Can be triggered manually
   workflow_dispatch:
     inputs:
       dev_branch:
-        description: 'Dev branch to test'
+        description: 'Branch under test - the HEAD commit will be taken from this and fast-forwarded into nightly on success'
         required: false
-        default: 'theodore/acceptance-dev-testing'
-      nightly_branch:
-        description: 'Nightly branch to merge into'
-        required: false
-        default: 'theodore/acceptance-nightly-testing'
+        default: 'dev'
 
 env:
-  # Use test branches for now, will change to dev/nightly later
-  DEV_BRANCH: ${{ github.event.inputs.dev_branch || 'theodore/acceptance-dev-testing' }}
-  NIGHTLY_BRANCH: ${{ github.event.inputs.nightly_branch || 'theodore/acceptance-nightly-testing' }}
+  DEV_BRANCH: ${{ github.event.inputs.dev_branch || 'dev' }}
+  NIGHTLY_BRANCH: 'nightly'
 
 jobs:
   trigger:


### PR DESCRIPTION
# Description

Enables the cron CI that runs acceptance tests on `dev` every night and promotes the latest commit to `nightly` on success.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
