### PR TITLE
Fix unused patches of sha=0.10.8 in zkvm guests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,7 +242,8 @@ serde_arrays = "0.1"
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_yaml = { version = "0.9", default-features = false }
 serde_with = { version = "3.12", features = ["schemars_0_8"] }
-sha2 = { version = "0.10.8", default-features = false }
+# Pinned version because zkvm-guests rely on patches. Upgrade `examples/demo-rollup/provers/* to use same patch as this one.
+sha2 = { version = "=0.10.9", default-features = false }
 sha3 = { version = "0.10.8", default-features = false }
 strum = { version = "0.26.3", features = ["derive"] }
 syn = { version = "2.0" }

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -4321,8 +4321,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.9.9-risczero.0#c2b5d71c687cbccf9235069732c050486a01b1b2"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -4334,8 +4334,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.10.9-risczero.0#8631fabdea7bdffa97b11868e04e73491d8e5bcf"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5871,8 +5870,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "sha2"
-version = "0.10.8"
-source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.10.8-risczero.0#244dc3b08788f7a4ccce14c66896ae3b4f24c166"

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.toml
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.toml
@@ -24,7 +24,8 @@ sov-kernels = { path = "../../../../../crates/module-system/sov-kernels" }
 sov-metrics = { path = "../../../../../crates/full-node/sov-metrics", optional = true }
 
 [patch.crates-io]
-sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
+sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", package = "sha2", tag = "sha2-v0.10.9-risczero.0" }
+sha2-v0-9-9 = { git = "https://github.com/risc0/RustCrypto-hashes", package = "sha2", tag = "sha2-v0.9.9-risczero.0" }
 # Corresponding release: <https://github.com/risc0/curve25519-dalek/releases/tag/curve25519-4.1.2-risczero.0>
 ed25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", rev = "3dccc5b71b806f500e73829e2a5cbfe288cce2a0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -3877,8 +3877,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.9.9-risczero.0#c2b5d71c687cbccf9235069732c050486a01b1b2"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
@@ -3890,8 +3889,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.10.9-risczero.0#8631fabdea7bdffa97b11868e04e73491d8e5bcf"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5463,8 +5461,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "sha2"
-version = "0.10.8"
-source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.10.8-risczero.0#244dc3b08788f7a4ccce14c66896ae3b4f24c166"

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.toml
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.toml
@@ -22,7 +22,9 @@ sov-kernels = { path = "../../../../../crates/module-system/sov-kernels" }
 sov-metrics = { path = "../../../../../crates/full-node/sov-metrics", optional = true }
 
 [patch.crates-io]
-sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", tag = "sha2-v0.10.8-risczero.0" }
+sha2 = { git = "https://github.com/risc0/RustCrypto-hashes", package = "sha2", tag = "sha2-v0.10.9-risczero.0" }
+sha2-v0-9-9 = { git = "https://github.com/risc0/RustCrypto-hashes", package = "sha2", tag = "sha2-v0.9.9-risczero.0" }
+
 # Corresponding release: <https://github.com/risc0/curve25519-dalek/releases/tag/curve25519-4.1.2-risczero.0>
 ed25519-dalek = { git = "https://github.com/risc0/curve25519-dalek", rev = "3dccc5b71b806f500e73829e2a5cbfe288cce2a0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -5733,7 +5733,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.9.9"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?rev=32cd33136ff22cc977ea6a95dd5a322a1de7283c#32cd33136ff22cc977ea6a95dd5a322a1de7283c"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=sha2-v0.9.9#e942f6f13a820a58716587f508fa50b6582cf34f"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
@@ -5745,8 +5745,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=sha2-v0.10.9#82c36a428f8d6f05f3bfccdedb243e9d1f85359d"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -8187,8 +8186,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "sha2"
-version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?rev=1f224388fdede7cef649bce0d63876d1a9e3f515#1f224388fdede7cef649bce0d63876d1a9e3f515"

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.toml
@@ -25,11 +25,8 @@ sov-metrics = { path = "../../../../../crates/full-node/sov-metrics", optional =
 ] }
 
 [patch.crates-io]
-# Commented out branches, but below there are exact revision, this helps with preventing accidental breakages
-#sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-v0.9.9" }
-sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", rev = "32cd33136ff22cc977ea6a95dd5a322a1de7283c" }
-#sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-v0.10.8" }
-sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", rev = "1f224388fdede7cef649bce0d63876d1a9e3f515" }
+sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "sha2-v0.9.9" }
+sha2-v0-10-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "sha2-v0.10.9" }
 #curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", branch = "patch-curve25519-v4.1.3" }
 curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", rev = "1d73fd95f1a76bee8f46643cf78bbccc1fb06ede" }
 # This is not needed, as it is patched via curve25519-dalek already

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -5347,8 +5347,7 @@ dependencies = [
 [[package]]
 name = "sha2"
 version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=sha2-v0.10.9#82c36a428f8d6f05f3bfccdedb243e9d1f85359d"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -7703,8 +7702,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "sha2"
-version = "0.10.8"
-source = "git+https://github.com/sp1-patches/RustCrypto-hashes?rev=1f224388fdede7cef649bce0d63876d1a9e3f515#1f224388fdede7cef649bce0d63876d1a9e3f515"

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.toml
@@ -25,10 +25,8 @@ sov-metrics = { path = "../../../../../crates/full-node/sov-metrics", optional =
 
 [patch.crates-io]
 # Commented out branches, but below there are exact revision, this helps with preventing accidental breakages
-#sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-v0.9.9" }
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", rev = "32cd33136ff22cc977ea6a95dd5a322a1de7283c" }
-#sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-v0.10.8" }
-sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", rev = "1f224388fdede7cef649bce0d63876d1a9e3f515" }
+sha2-v0-10-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "sha2-v0.10.9" }
 #curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", branch = "patch-curve25519-v4.1.3" }
 curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", rev = "1d73fd95f1a76bee8f46643cf78bbccc1fb06ede" }
 # This is not needed, as it is patched via curve25519-dalek already


### PR DESCRIPTION
# Description

sha2 patch version has been accidentally upgraded, leaving zkvm patches behind.

**Should be propagated to starter**

This PR fixes this.

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] ~~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~~

