### PR TITLE
fix(stf-runner): avoid duplicate CORS headers by applying CORS only in RPC router

### DIFF
--- a/crates/full-node/sov-stf-runner/src/http.rs
+++ b/crates/full-node/sov-stf-runner/src/http.rs
@@ -32,9 +32,8 @@ pub(crate) async fn start_http_server(
     let handle = tokio::spawn(async move {
         tracing::info!(%rest_address, "Starting HTTP server");
         let mut router = router.layer(axum::middleware::from_fn(measure_time));
-        if let CorsConfiguration::Permissive = cors_configuration {
-            router = router.layer(CorsLayer::permissive());
-        }
+        // CORS is applied inside `rpc_module_to_router` for `/rpc` routes to avoid
+        // duplicate `Access-Control-*` headers and conflicting policies.
         let router = router.nest("/rpc", rpc_router);
         let router = NormalizePathLayer::trim_trailing_slash().layer(router);
 


### PR DESCRIPTION


Description
- Summary: Remove top-level CORS layer in start_http_server to prevent duplicate Access-Control-* headers.
- Rationale: CORS was applied both at the top router and inside rpc_module_to_router for /rpc, causing header duplication and potential preflight inconsistencies.
- Change: CORS is now applied only within rpc_module_to_router.
