### PR TITLE
sov-db: NOMT blocking commit on release

### DIFF
--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -15,7 +15,9 @@ const KERNEL: &str = "kernel_state";
 const USER: &str = "user_state";
 const BOTH: &str = "user_and_kernel_state";
 
+#[cfg(debug_assertions)]
 const COMMIT_START_DELAY: std::time::Duration = std::time::Duration::from_millis(1);
+#[cfg(debug_assertions)]
 const COMMIT_RETRY_ATTEMPTS: usize = 26;
 
 /// Contains all the most recent rollup data.
@@ -443,6 +445,7 @@ where
 /// due to contention.
 /// This is necessary because another thread might be holding a lock on the NOMT.
 /// The function will attempt to commit a total of [`COMMIT_RETRY_ATTEMPTS`] times before giving up and returning an error.
+#[cfg(debug_assertions)]
 fn try_commit_overlay_with_backoff<H>(
     nomt: &Nomt<BinaryHasher<H>>,
     mut overlay: Overlay,

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -99,8 +99,7 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
         let start_kernel = std::time::Instant::now();
         let write_attempts_kernel = {
             let _span = tracing::debug_span!("namespace_commit", namespace = "kernel").entered();
-            try_commit_overlay_with_backoff(&self.kernel, kernel)
-                .context("kernel namespace commit")?
+            commit_nomt(&self.kernel, kernel).context("kernel namespace commit")?
         };
         let write_kernel = start_kernel.elapsed();
 
@@ -144,7 +143,7 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
         let start_user = std::time::Instant::now();
         let write_attempts_user = {
             let _span = tracing::debug_span!("namespace_commit", namespace = "user").entered();
-            try_commit_overlay_with_backoff(&self.user, user).context("user namespace commit")?
+            commit_nomt(&self.user, user).context("user namespace commit")?
         };
         let write_user = start_user.elapsed();
 
@@ -490,6 +489,23 @@ where
         "Failed to commit overlay after {} attempts",
         COMMIT_RETRY_ATTEMPTS
     );
+}
+
+/// Commits an overlay to NOMT, using blocking commit in release mode and
+/// non-blocking with backoff in debug mode.
+fn commit_nomt<H>(nomt: &Nomt<BinaryHasher<H>>, overlay: Overlay) -> anyhow::Result<usize>
+where
+    H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync,
+{
+    #[cfg(not(debug_assertions))]
+    {
+        overlay.commit(nomt)?;
+        Ok(1)
+    }
+    #[cfg(debug_assertions)]
+    {
+        try_commit_overlay_with_backoff(nomt, overlay)
+    }
 }
 
 /// Begin a new user and kernel session with only data that has been written to disk


### PR DESCRIPTION
# Description

Due to issues during original integration of NOMT, we've decided to implement exponential backoff for NOMT commit.

But this means that there will be some time, when commit code sleeps before next attempt, but NOMT is already ready to commit.

We've observed that when added metric on number of attempts during commit:
<img width="3806" height="1598" alt="Screenshot 2025-10-16 at 19 51 59" src="https://github.com/user-attachments/assets/86e99768-2eac-483f-920e-373de6b53bd1" />



This PR changes behaviour, in release mode NOMT will use blocking commit, which won't waste any time sleeping.

Previous behaviuor is kept, so our test could fail without infinite blocking.

Changes during soak test (~2k TPS on celestia mocha):

<img width="3816" height="1712" alt="Screenshot 2025-10-16 at 19 46 53" src="https://github.com/user-attachments/assets/bbf914bd-27dd-47f5-a27e-983ed9bd7f24" />

It clearly improves long tail, but not that much with median:

<img width="3824" height="1720" alt="Screenshot 2025-10-16 at 19 47 20" src="https://github.com/user-attachments/assets/76000f9e-cc88-4b51-927d-0dfca94bc321" />

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existing tests are passing


