### PR TITLE
Replica: Refactor `inner.rs` to allow the replica sequencer to share code with the master sequencer

### DIFF
--- a/crates/adapters/mock-da/src/storable/local_service.rs
+++ b/crates/adapters/mock-da/src/storable/local_service.rs
@@ -229,6 +229,23 @@ impl StorableMockDaService {
     }
 
     /// Creates new [`StorableMockDaService`] with a given address.
+    /// Manual block production.
+    pub async fn new_in_memory_manual(sequencer_da_address: MockAddress) -> Self {
+        let da_layer = StorableMockDaLayer::new_in_memory(0)
+            .await
+            .expect("Failed to initialize StorableMockDaLayer");
+        let producing = BlockProducingConfig::OnBatchSubmit {
+            block_wait_timeout_ms: None,
+        };
+        Self::new(
+            sequencer_da_address,
+            Arc::new(RwLock::new(da_layer)),
+            producing,
+        )
+        .await
+    }
+
+    /// Creates new [`StorableMockDaService`] with a given address.
     /// - Periodic block production.
     /// - Data is stored only in memory.
     pub async fn new_in_memory_periodic(

--- a/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
@@ -72,25 +72,37 @@ struct TxReceiver {
 }
 
 #[derive(Clone)]
-pub(crate) struct CacheWarmUpExecutor<S: Spec> {
+pub(crate) struct CacheWarmUpExecutorInner<S: Spec> {
     start_block_notification_sender: tokio::sync::watch::Sender<Option<StartBlockNotification<S>>>,
     tx_sender: flume::Sender<FullyBakedTxWithTxChangeSetSender>,
     size: Arc<AtomicU64>,
 }
 
+#[derive(Clone)]
+pub(crate) struct CacheWarmUpExecutor<S: Spec> {
+    inner: Option<CacheWarmUpExecutorInner<S>>,
+}
+
 impl<S: Spec> CacheWarmUpExecutor<S> {
     pub(crate) fn send_batch_start_notification(&self, data: StartBlockNotification<S>) {
+        let Some(inner) = &self.inner else {
+            return;
+        };
         // This `send` does not block.
-        let _ = self.start_block_notification_sender.send(Some(data));
+        let _ = inner.start_block_notification_sender.send(Some(data));
     }
 
     pub(crate) fn send_tx(&self, tx: FullyBakedTx) -> FullyBakedTxWithMaybeChangeSet {
+        let Some(inner) = &self.inner else {
+            return FullyBakedTxWithMaybeChangeSet { tx, receiver: None };
+        };
+
         // We need to update the `size` field before inserting the thx into tx_sender, otherwise the workers may see an outdated channel size.
-        let size = self.size.fetch_add(1, Ordering::Relaxed);
+        let size = inner.size.fetch_add(1, Ordering::Relaxed);
         let (sender, receiver) = oneshot::channel();
 
         // Skip update if consumer is too slow.
-        let res = self.tx_sender.try_send(FullyBakedTxWithTxChangeSetSender {
+        let res = inner.tx_sender.try_send(FullyBakedTxWithTxChangeSetSender {
             tx: tx.clone(),
             sender,
         });
@@ -106,12 +118,12 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
                 Some(receiver)
             }
             Err(flume::TrySendError::Full(_)) => {
-                let size = self.size.fetch_sub(1, Ordering::Relaxed);
+                let size = inner.size.fetch_sub(1, Ordering::Relaxed);
                 tracing::warn!(size, "The tx queue is full. You may want to increase the number of workers for cache warmup.");
                 None
             }
             Err(flume::TrySendError::Disconnected(_)) => {
-                self.size.fetch_sub(1, Ordering::Relaxed);
+                inner.size.fetch_sub(1, Ordering::Relaxed);
                 None
             }
         };
@@ -127,6 +139,10 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
         exec_config: RollupBlockExecutorConfig<S>,
         seq_config: SequencerConfig<S::Address, PreferredSequencerConfig>,
     ) -> (Self, Vec<JoinHandle<()>>) {
+        if seq_config.sequencer_kind_config.is_replica {
+            return (Self { inner: None }, vec![]);
+        }
+
         let (tx_sender, tx_receiver) = flume::bounded(TX_CHANNEL_SIZE);
         let size = Arc::new(AtomicU64::new(0));
         let tx_receiver = TxReceiver {
@@ -155,9 +171,11 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
 
         (
             Self {
-                tx_sender,
-                start_block_notification_sender,
-                size,
+                inner: Some(CacheWarmUpExecutorInner {
+                    tx_sender,
+                    start_block_notification_sender,
+                    size,
+                }),
             },
             handles,
         )

--- a/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
@@ -3,9 +3,7 @@ use std::sync::Arc;
 
 use sov_blob_sender::BlobInternalId;
 use sov_blob_storage::SequenceNumber;
-use sov_modules_api::{
-    FullyBakedTx, Runtime, Spec, StateCheckpoint, TxChangeSet, TxHash, VisibleSlotNumber,
-};
+use sov_modules_api::{Runtime, Spec, StateCheckpoint, TxChangeSet, VisibleSlotNumber};
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{mpsc, oneshot, watch};
 
@@ -221,14 +219,6 @@ impl<S: Spec, Rt: Runtime<S>> ExecutorEventsSender<S, Rt> {
             batch_to_close,
         })
         .await;
-    }
-
-    pub(crate) async fn insert_tx_without_confirmation(
-        &mut self,
-        tx: FullyBakedTx,
-        tx_hash: TxHash,
-    ) {
-        self.cache.insert_tx(tx, tx_hash).await;
     }
 
     pub(crate) async fn update_state_for_recovery(&mut self, checkpoint: StateCheckpoint<S>) {

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -29,7 +29,6 @@ use crate::preferred::{
     PreferredSequencerReadBatch, TxResultWriter,
 };
 use crate::{SequencerConfig, SequencerNotReadyDetails, SlotNumber, TxHash};
-use anyhow::anyhow;
 use sov_blob_sender::BlobInternalId;
 use sov_blob_storage::SequenceNumber;
 use sov_modules_api::capabilities::RollupHeight;
@@ -210,168 +209,6 @@ where
 
     fn current_height(&self) -> RollupHeight {
         self.executor.checkpoint.rollup_height_to_access()
-    }
-
-    /// Create a new batch, if possible. Errors here are expected, because it's not always possible to create a new batch due to transient DA issues.
-    /// We can only create a new batch if we have a finalized slot available to use as our `visible_slot_number_after_increase`.
-    #[tracing::instrument(skip_all, level = "trace")]
-    async fn try_to_create_and_start_batch_if_none_in_progress(
-        &mut self,
-        leave_space_for_next_batch: bool,
-    ) -> Result<(), BatchCreationError> {
-        if self.executor.has_in_progress_batch() {
-            return Ok(());
-        }
-
-        if let Some(height_to_stop_at) = self.stop_at_rollup_height {
-            let current_height = self.current_height();
-            if current_height >= height_to_stop_at {
-                debug!(%current_height, %height_to_stop_at,"The sequencer is at stop height and tried to create a batch (aborted due to stop height).");
-                return Err(BatchCreationError::PreferredSequencerAtStopHeight {
-                    current_height,
-                    height_to_stop_at,
-                });
-            }
-        }
-
-        if self.blob_sender_busy().is_some() {
-            warn!("The blob sender is busy, no batch could be started at this time.");
-            return Err(BatchCreationError::BlobSenderBusy);
-        }
-
-        let visible_increase = match next_visible_slot_number_increase(
-            &self.executor.checkpoint,
-            &self.latest_info,
-            leave_space_for_next_batch,
-            self.seq_config
-                .sequencer_kind_config
-                .ideal_lag_behind_finalized_slot,
-        ) {
-            Ok(visible_increase) => visible_increase,
-            Err(e) => {
-                warn!(
-                    "A batch was requested but the sequencer is not ready to produce one: {:?}",
-                    e
-                );
-                return Err(BatchCreationError::NoFinalizedSlotAvailable);
-            }
-        };
-
-        debug!(visible_increase, "No in-progress batch, starting a new one");
-        let node_state_root = self
-            .node_root_hash()
-            .map_err(BatchCreationError::DatabaseError)?;
-        let visible_slot_number_after_increase = self
-            .executor
-            .checkpoint
-            .current_visible_slot_number()
-            .advance(visible_increase.get().into());
-
-        // DB operations handled by replica-aware db implementation
-        let sequence_number = self.get_and_inc_next_sequence_number();
-        let min_profit_per_tx = self.seq_config.sequencer_kind_config.minimum_profit_per_tx;
-
-        let start_block_data = StartBlockData {
-            sanity_check_visible_slot_number_after_increase: visible_slot_number_after_increase,
-            visible_increase,
-            node_state_root: node_state_root.clone(),
-            minimum_profit_per_tx: min_profit_per_tx,
-        };
-
-        let old_checkpoint = self
-            .executor
-            .checkpoint
-            .clone_with_empty_witness_dropping_temp_cache();
-
-        self.executor
-            .start_rollup_block(start_block_data.clone())
-            .await;
-
-        let state_roots = self.executor.state_roots.clone();
-
-        if state_roots.len() > 50 {
-            tracing::warn!("Executor: The computed state roots map is large, and cloning it can be costly in terms of time. state_roots len: {}", state_roots.len());
-        }
-
-        let notification = StartBlockNotification {
-            state_roots,
-            data: start_block_data,
-            checkpoint: old_checkpoint,
-        };
-
-        self.cache_warm_up_executor
-            .send_batch_start_notification(notification);
-
-        self.executor_events_sender
-            .start_batch(
-                visible_slot_number_after_increase,
-                visible_increase,
-                sequence_number,
-                self.executor
-                    .checkpoint
-                    .clone_with_empty_witness_dropping_temp_cache(),
-            )
-            .await;
-
-        Ok(())
-    }
-
-    /// Creates and starts a batch for replicas using the exact visible slot parameters from the master
-    #[tracing::instrument(skip_all, level = "trace")]
-    async fn try_start_batch_with_parameters_from_master(
-        &mut self,
-        visible_slot_number_after_increase: VisibleSlotNumber,
-        visible_slots_to_advance: NonZero<u8>,
-    ) -> anyhow::Result<()> {
-        if self.executor.has_in_progress_batch() {
-            return Ok(());
-        }
-
-        // Calculate the correct visible_slots_to_advance for this replica based on its current state
-        let current_visible_slot_number = self.executor.checkpoint.current_visible_slot_number();
-        let replica_visible_slots_to_advance = visible_slot_number_after_increase.as_true()
-            .checked_sub(current_visible_slot_number.as_true().get())
-            .and_then(|diff| NonZero::new(diff.get().try_into().unwrap()))
-            .ok_or_else(|| {
-                error!(
-                    current_visible_slot_number = %current_visible_slot_number,
-                    target_visible_slot_number = %visible_slot_number_after_increase,
-                    "Cannot calculate visible slots to advance for replica: target is not greater than current"
-                );
-                anyhow!("Invalid visible slot number progression for replica".to_string())
-            })?;
-
-        assert_eq!(
-            visible_slots_to_advance,
-            replica_visible_slots_to_advance,
-            "Sanity check failed: replica visible_slots_to_advance calculation different from master."
-        );
-
-        let node_state_root = self.node_root_hash()?;
-        let sequence_number = self.get_and_inc_next_sequence_number();
-        let min_profit_per_tx = self.seq_config.sequencer_kind_config.minimum_profit_per_tx;
-
-        let start_block_data = StartBlockData {
-            sanity_check_visible_slot_number_after_increase: visible_slot_number_after_increase,
-            visible_increase: replica_visible_slots_to_advance,
-            node_state_root: node_state_root.clone(),
-            minimum_profit_per_tx: min_profit_per_tx,
-        };
-
-        self.executor.start_rollup_block(start_block_data).await;
-
-        self.executor_events_sender
-            .start_batch(
-                visible_slot_number_after_increase,
-                visible_slots_to_advance,
-                sequence_number,
-                self.executor
-                    .checkpoint
-                    .clone_with_empty_witness_dropping_temp_cache(),
-            )
-            .await;
-
-        Ok(())
     }
 
     fn current_sequence_number(&self) -> SequenceNumber {
@@ -680,37 +517,6 @@ where
         self.seq_config.sequencer_kind_config.is_replica
     }
 
-    async fn inner_do_batch_start(
-        &mut self,
-        visible_slot_number_after_increase: VisibleSlotNumber,
-        visible_slots_to_advance: NonZero<u8>,
-    ) -> anyhow::Result<()> {
-        if self.executor.has_in_progress_batch() {
-            return Err(anyhow!(
-                "Received open batch notification, but replica already has an open batch"
-            ));
-        }
-
-        // Query the master's batch metadata to get the exact visible slot parameters used
-        // let batch_metadata =
-        //     query_batch_metadata_from_db(query_pool, sequence_number).await?;
-        self.try_start_batch_with_parameters_from_master(
-            visible_slot_number_after_increase,
-            visible_slots_to_advance,
-        )
-        .await?;
-
-        // Ensure the batch was successfully started
-        if !self.executor.has_in_progress_batch() {
-            panic!(
-                "Replica: no batch in progress, and no batch could be started. This should not be possible under any circumstances as the master was able to create a batch at this point. Please report this bug. {:?} {:?}",
-                &self.executor.checkpoint, self.latest_info
-            );
-        }
-
-        Ok(())
-    }
-
     pub(crate) async fn update_api_ledger(&self, info: &StateUpdateInfo<S::Storage>) {
         let start = std::time::Instant::now();
         tracing::trace!(
@@ -733,6 +539,197 @@ where
             "LedgerAPI storage updated, notification has been sent");
 
         self.tx_cache_writer.prune(info.next_tx_number).await;
+    }
+
+    /// Create a new batch, if possible. Errors here are expected, because it's not always possible to create a new batch due to transient DA issues.
+    /// We can only create a new batch if we have a finalized slot available to use as our `visible_slot_number_after_increase`.
+    #[tracing::instrument(skip_all, level = "trace")]
+    async fn try_to_create_and_start_batch_if_none_in_progress(
+        &mut self,
+        leave_space_for_next_batch: bool,
+    ) -> Result<(), BatchCreationError> {
+        if self.executor.has_in_progress_batch() {
+            return Ok(());
+        }
+
+        let visible_increase = match next_visible_slot_number_increase(
+            &self.executor.checkpoint,
+            &self.latest_info,
+            leave_space_for_next_batch,
+            self.seq_config
+                .sequencer_kind_config
+                .ideal_lag_behind_finalized_slot,
+        ) {
+            Ok(visible_increase) => visible_increase,
+            Err(e) => {
+                warn!(
+                    "A batch was requested but the sequencer is not ready to produce one: {:?}",
+                    e
+                );
+                return Err(BatchCreationError::NoFinalizedSlotAvailable);
+            }
+        };
+
+        debug!(visible_increase, "No in-progress batch, starting a new one");
+
+        let visible_slot_number_after_increase = self
+            .executor
+            .checkpoint
+            .current_visible_slot_number()
+            .advance(visible_increase.get().into());
+
+        self.do_batch_start(visible_slot_number_after_increase, visible_increase)
+            .await
+    }
+
+    async fn do_batch_start(
+        &mut self,
+        visible_slot_number_after_increase: VisibleSlotNumber,
+        visible_increase: NonZero<u8>,
+    ) -> Result<(), BatchCreationError> {
+        if self.executor.has_in_progress_batch() {
+            return Ok(());
+        }
+
+        if let Some(height_to_stop_at) = self.stop_at_rollup_height {
+            let current_height = self.current_height();
+            if current_height >= height_to_stop_at {
+                debug!(%current_height, %height_to_stop_at,"The sequencer is at stop height and tried to create a batch (aborted due to stop height).");
+                return Err(BatchCreationError::PreferredSequencerAtStopHeight {
+                    current_height,
+                    height_to_stop_at,
+                });
+            }
+        }
+
+        if self.blob_sender_busy().is_some() {
+            warn!("The blob sender is busy, no batch could be started at this time.");
+            return Err(BatchCreationError::BlobSenderBusy);
+        }
+
+        let node_state_root = self
+            .node_root_hash()
+            .map_err(BatchCreationError::DatabaseError)?;
+
+        // DB operations handled by replica-aware db implementation
+        let sequence_number = self.get_and_inc_next_sequence_number();
+        let min_profit_per_tx = self.seq_config.sequencer_kind_config.minimum_profit_per_tx;
+
+        let start_block_data = StartBlockData {
+            sanity_check_visible_slot_number_after_increase: visible_slot_number_after_increase,
+            visible_increase,
+            node_state_root: node_state_root.clone(),
+            minimum_profit_per_tx: min_profit_per_tx,
+        };
+
+        let old_checkpoint = self
+            .executor
+            .checkpoint
+            .clone_with_empty_witness_dropping_temp_cache();
+
+        self.executor
+            .start_rollup_block(start_block_data.clone())
+            .await;
+
+        let state_roots = self.executor.state_roots.clone();
+
+        if state_roots.len() > 50 {
+            tracing::warn!("Executor: The computed state roots map is large, and cloning it can be costly in terms of time. state_roots len: {}", state_roots.len());
+        }
+
+        let notification = StartBlockNotification {
+            state_roots,
+            data: start_block_data,
+            checkpoint: old_checkpoint,
+        };
+
+        self.cache_warm_up_executor
+            .send_batch_start_notification(notification);
+
+        self.executor_events_sender
+            .start_batch(
+                visible_slot_number_after_increase,
+                visible_increase,
+                sequence_number,
+                self.executor
+                    .checkpoint
+                    .clone_with_empty_witness_dropping_temp_cache(),
+            )
+            .await;
+
+        Ok(())
+    }
+
+    async fn do_new_tx(
+        &mut self,
+        tx_hash: TxHash,
+        baked_tx: FullyBakedTx,
+    ) -> Result<
+        (
+            oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>,
+            <S as Spec>::Gas,
+        ),
+        AcceptTxError<S>,
+    > {
+        if self.shutdown_receiver.has_changed().unwrap_or(true) {
+            tracing::info!("The sequencer is shutting down. Cannot accept transactions");
+            return Err(AcceptTxError::Shutdown);
+        }
+
+        if !self.executor.has_in_progress_batch() {
+            panic!(
+                "No batch in progress, and no batch could be started. Please report this bug. {:?} {:?}",
+                &self.executor.checkpoint, self.latest_info
+            );
+        }
+
+        let sequence_number = self.current_sequence_number();
+        let Inner {
+            executor,
+            batch_size_tracker,
+            executor_events_sender,
+            cache_warm_up_executor,
+            ..
+        } = &mut *self;
+
+        let tx_len = baked_tx.data.len();
+        if !batch_size_tracker.can_fit_tx_bytes(tx_len) {
+            return Err(AcceptTxError::TxTooBig {
+                current_batch_size: batch_size_tracker.current_batch_size,
+                max_batch_size: batch_size_tracker.max_batch_size,
+            });
+        }
+
+        let baked_tx = cache_warm_up_executor.send_tx(baked_tx.clone());
+        let apply_tx_res = executor.apply_tx_to_in_progress_batch(baked_tx).await;
+
+        let (
+            AcceptedTxWithBudgetInfo {
+                accepted_tx,
+                remaining_slot_gas,
+                execution_time_micros,
+            },
+            tx_changes,
+        ) = match apply_tx_res {
+            Ok(res) => {
+                assert_eq!(
+                    tx_hash, res.0.accepted_tx.tx_hash,
+                    "The executor returned a different tx hash than expected"
+                );
+                res
+            }
+            Err(err) => {
+                tracing::debug!(%tx_hash, %err, "Transaction was dropped by the sequencer");
+                return Err(AcceptTxError::ExecutorError(err));
+            }
+        };
+
+        batch_size_tracker.add_tx(tx_len, execution_time_micros);
+        let rx = executor_events_sender
+            .send_accept_tx(accepted_tx, tx_changes, sequence_number)
+            .await;
+
+        Ok((rx, remaining_slot_gas))
     }
 }
 
@@ -1452,31 +1449,12 @@ where
 
                 self.send_response(resp, ret, "final_catchup").await;
             }
-            Message::DoBatchStartMsg {
-                visible_slot_number_after_increase,
-                visible_slots_to_advance,
-                reason,
-            } => {
-                self.process_do_batch_start(
-                    visible_slot_number_after_increase,
-                    visible_slots_to_advance,
-                    reason,
-                )
-                .await;
-            }
             Message::PruneSequencerDb { reason } => {
                 self.process_prune_sequencer_db(reason).await;
             }
             Message::ForceOverwriteStateForRecovery { info, reason } => {
                 self.process_force_overwrite_state_for_recovery(info, reason)
                     .await;
-            }
-            Message::DoNewTx {
-                tx_hash,
-                baked_tx,
-                reason,
-            } => {
-                self.process_do_new_tx(tx_hash, baked_tx, reason).await;
             }
             Message::WaitNodeResync { info, reason } => {
                 self.process_wait_for_node_resync(info, reason).await;
@@ -1499,6 +1477,20 @@ where
             }
             Message::SimpleStateUpdate { info } => {
                 self.process_new_storage(info).await;
+            }
+            Message::DoNewTx {
+                tx_hash: _,
+                baked_tx: _,
+                reason: _,
+            } => {
+                todo!()
+            }
+            Message::DoBatchStartMsg {
+                visible_slot_number_after_increase: _,
+                visible_slots_to_advance: _,
+                reason: _,
+            } => {
+                todo!()
             }
         }
 
@@ -1752,109 +1744,6 @@ where
             .await
     }
 
-    async fn process_accept_tx(
-        &mut self,
-        baked_tx: FullyBakedTx,
-        tx_hash: TxHash,
-        original_tx_queue_id: u64,
-        reason: &'static str,
-    ) -> Result<oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>, AcceptTxError<S>> {
-        let mut inner = self.get_inner_with_timing(reason).await;
-
-        // If the sequencer had to give out 503s at any point during the time we were waiting for the lock, we need to return a 503 - otherwise
-        // we've effectively jumped the line
-        let new_tx_queue_id = inner.tx_queue_id.load(Ordering::Acquire);
-        if new_tx_queue_id != original_tx_queue_id {
-            tracing::debug!(%tx_hash, "Transaction was queued before downtime. Dropping.");
-            return Err(AcceptTxError::SequencerOverloaded503);
-        }
-
-        inner
-            .check_readiness(
-                inner.seq_config.max_concurrent_blobs,
-                inner.stop_at_rollup_height,
-            )
-            .await
-            .map_err(AcceptTxError::NotFullySynced)?;
-
-        if let Err(batch_creation_error) = inner
-            .try_to_create_and_start_batch_if_none_in_progress(false)
-            .await
-        {
-            // On all errors, we treat the sequencer as having had downtime and clear out the transaction queue.
-            // Note that we'll increment the queue ID once per rejected tx. This is totally fine - we have 2**64 ids to play with
-            // and atomic increments are very cheap relative to the cost of executing the tx
-            inner.tx_queue_id.fetch_add(1, Ordering::AcqRel);
-
-            return Err(AcceptTxError::BatchError {
-                batch_creation_error,
-                nb_of_concurrent_blob_submissions: inner.nb_of_concurrent_blob_submissions(),
-            });
-        };
-
-        if inner.shutdown_receiver.has_changed().unwrap_or(true) {
-            tracing::info!("The sequencer is shutting down. Cannot accept transactions");
-            return Err(AcceptTxError::Shutdown);
-        }
-
-        if !inner.executor.has_in_progress_batch() {
-            panic!(
-                "No batch in progress, and no batch could be started. Please report this bug. {:?} {:?}",
-                &inner.executor.checkpoint, inner.latest_info
-            );
-        }
-
-        let sequence_number = inner.current_sequence_number();
-        let Inner {
-            executor,
-            batch_size_tracker,
-            executor_events_sender,
-            cache_warm_up_executor,
-            ..
-        } = &mut *inner;
-
-        let tx_len = baked_tx.data.len();
-        if !batch_size_tracker.can_fit_tx_bytes(tx_len) {
-            return Err(AcceptTxError::TxTooBig {
-                current_batch_size: batch_size_tracker.current_batch_size,
-                max_batch_size: batch_size_tracker.max_batch_size,
-            });
-        }
-
-        let baked_tx = cache_warm_up_executor.send_tx(baked_tx.clone());
-        let apply_tx_res = executor.apply_tx_to_in_progress_batch(baked_tx).await;
-
-        let (
-            AcceptedTxWithBudgetInfo {
-                accepted_tx,
-                remaining_slot_gas,
-                execution_time_micros,
-            },
-            tx_changes,
-        ) = match apply_tx_res {
-            Ok(res) => {
-                assert_eq!(
-                    tx_hash, res.0.accepted_tx.tx_hash,
-                    "The executor returned a different tx hash than expected"
-                );
-                res
-            }
-            Err(err) => {
-                tracing::debug!(%tx_hash, %err, "Transaction was dropped by the sequencer");
-                return Err(AcceptTxError::ExecutorError(err));
-            }
-        };
-
-        batch_size_tracker.add_tx(tx_len, execution_time_micros);
-        let rx = executor_events_sender
-            .send_accept_tx(accepted_tx, tx_changes, sequence_number)
-            .await;
-
-        inner.close_batch_if_nearly_full(remaining_slot_gas).await;
-
-        Ok(rx)
-    }
-
     async fn process_latest_slot_number(&mut self, reason: &'static str) -> SlotNumber {
         let inner = self.get_inner_with_timing(reason).await;
         inner.latest_info.slot_number
@@ -1955,25 +1844,6 @@ where
         Ok(data)
     }
 
-    async fn process_do_batch_start(
-        &mut self,
-        visible_slot_number_after_increase: VisibleSlotNumber,
-        visible_slots_to_advance: NonZero<u8>,
-        reason: &'static str,
-    ) {
-        let mut inner = self.get_inner_with_timing(reason).await;
-        if let Err(err) = inner
-            .inner_do_batch_start(visible_slot_number_after_increase, visible_slots_to_advance)
-            .await
-        {
-            tracing::error!(
-                error = %err,
-                "Error: while calling inner_do_batch_start."
-            );
-            panic!("Error: while calling inner_do_batch_start. The sequencer can no longer accept transactions!");
-        }
-    }
-
     async fn process_prune_sequencer_db(&mut self, reason: &'static str) {
         let start_prune = std::time::Instant::now();
         let mut inner = self.get_inner_with_timing(reason).await;
@@ -2014,31 +1884,6 @@ where
             .force_overwrite_state(info.clone(), recovery_executor)
             .await;
         inner.update_api_ledger(&info).await;
-    }
-
-    async fn process_do_new_tx(
-        &mut self,
-        tx_hash: TxHash,
-        baked_tx: FullyBakedTx,
-        reason: &'static str,
-    ) {
-        let mut inner = self.get_inner_with_timing(reason).await;
-        let execution_time_micros = inner.executor.replay_tx(tx_hash, baked_tx.clone()).await;
-        inner
-            .batch_size_tracker
-            .add_tx(baked_tx.data.len(), execution_time_micros);
-        inner
-            .executor_events_sender
-            .insert_tx_without_confirmation(baked_tx, tx_hash)
-            .await;
-        let checkpoint = inner
-            .executor
-            .checkpoint
-            .clone_with_empty_witness_dropping_temp_cache();
-        inner
-            .executor_events_sender
-            .force_update_api_state(checkpoint)
-            .await;
     }
 
     async fn process_wait_for_node_resync(
@@ -2107,6 +1952,53 @@ where
     async fn process_close_current_batch(&mut self, reason: &'static str) {
         let mut inner = self.get_inner_with_timing(reason).await;
         inner.close_current_batch().await;
+    }
+
+    async fn process_accept_tx(
+        &mut self,
+        baked_tx: FullyBakedTx,
+        tx_hash: TxHash,
+        original_tx_queue_id: u64,
+        reason: &'static str,
+    ) -> Result<oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>, AcceptTxError<S>> {
+        let mut inner = self.get_inner_with_timing(reason).await;
+
+        // If the sequencer had to give out 503s at any point during the time we were waiting for the lock, we need to return a 503 - otherwise
+        // we've effectively jumped the line
+        let new_tx_queue_id = inner.tx_queue_id.load(Ordering::Acquire);
+        if new_tx_queue_id != original_tx_queue_id {
+            tracing::debug!(%tx_hash, "Transaction was queued before downtime. Dropping.");
+            return Err(AcceptTxError::SequencerOverloaded503);
+        }
+
+        inner
+            .check_readiness(
+                inner.seq_config.max_concurrent_blobs,
+                inner.stop_at_rollup_height,
+            )
+            .await
+            .map_err(AcceptTxError::NotFullySynced)?;
+
+        if let Err(batch_creation_error) = inner
+            .try_to_create_and_start_batch_if_none_in_progress(false)
+            .await
+        {
+            // On all errors, we treat the sequencer as having had downtime and clear out the transaction queue.
+            // Note that we'll increment the queue ID once per rejected tx. This is totally fine - we have 2**64 ids to play with
+            // and atomic increments are very cheap relative to the cost of executing the tx
+            inner.tx_queue_id.fetch_add(1, Ordering::AcqRel);
+
+            return Err(AcceptTxError::BatchError {
+                batch_creation_error,
+                nb_of_concurrent_blob_submissions: inner.nb_of_concurrent_blob_submissions(),
+            });
+        };
+
+        let (rx, remaining_slot_gas) = inner.do_new_tx(tx_hash, baked_tx).await?;
+
+        inner.close_batch_if_nearly_full(remaining_slot_gas).await;
+
+        Ok(rx)
     }
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -16,7 +16,6 @@ mod update_state;
 
 use crate::preferred::block_executor::RollupBlockExecutorConfig;
 use crate::preferred::cache_warm_up_executor::CacheWarmUpExecutor;
-use crate::preferred::replica::event_handler::ReplicaEventProcessor;
 use crate::preferred::replica::replica_sync_task::ReplicaSyncTask;
 use async_trait::async_trait;
 use axum::http::StatusCode;
@@ -89,7 +88,7 @@ where
     Rt: Runtime<S>,
     Da: DaService<Spec = S::Da>,
 {
-    synchronized_state_updator: SequencerStateUpdator<S, Rt>,
+    synchronized_state_updator: Arc<SequencerStateUpdator<S, Rt>>,
     tx_status_manager: TxStatusManager<S::Da>,
     blobs_sender_channel: broadcast::Sender<BlobExecutionStatus<Da::Spec>>,
     api_state: ApiState<S>,
@@ -270,8 +269,9 @@ where
         .spawn();
         handles.push(side_effects_task);
 
+        let synchronized_state_updator = Arc::new(synchronized_state_updator);
         let seq = Arc::new(PreferredSequencer {
-            synchronized_state_updator,
+            synchronized_state_updator: synchronized_state_updator.clone(),
             tx_status_manager: tx_status_manager.clone(),
             transaction_cache: cached_txs,
             blobs_sender_channel,
@@ -296,7 +296,9 @@ where
                 )
                 .await?;
 
-                handles.push(replica_task.start(ReplicaEventProcessor {}).await);
+                let replica_task_handle = replica_task.start(synchronized_state_updator).await;
+                handles.push(replica_task_handle.data_fetcher_handle);
+                handles.push(replica_task_handle.sync_task_handle);
             }
         }
         handles.push(tokio::spawn({

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
@@ -1,10 +1,23 @@
+use crate::preferred::inner::SequencerStateUpdator;
 use crate::preferred::replica::event_receiver::DbData;
 use crate::preferred::replica::replica_sync_task::ReplicaEventHandler;
 use async_trait::async_trait;
-
-pub struct ReplicaEventProcessor {}
+use sov_modules_api::Runtime;
+use sov_modules_api::Spec;
+use std::sync::Arc;
 
 #[async_trait]
-impl ReplicaEventHandler for ReplicaEventProcessor {
-    async fn on_da_event(&self, _data: DbData) {}
+impl<S, Rt> ReplicaEventHandler for Arc<SequencerStateUpdator<S, Rt>>
+where
+    S: Spec,
+    Rt: Runtime<S>,
+{
+    async fn on_da_event(&self, data: DbData) {
+        match data {
+            DbData::BatchStart(_batch_to_store) => {}
+            DbData::Transaction(_tx) => {}
+            DbData::BatchEnd(_batch_to_store) => {}
+            DbData::NewProof => {}
+        }
+    }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -8,6 +8,7 @@ use sqlx::PgPool;
 use sqlx::Row;
 use std::str::FromStr;
 use tokio::sync::watch;
+use tokio::task::JoinHandle;
 use tracing::{debug, error, trace};
 
 const MAX_DB_ERRORS_ALLOWED: u32 = 10;
@@ -109,7 +110,7 @@ impl EventReceiver {
         }
     }
 
-    pub(crate) async fn spawn_db_data_fetcher(&mut self) {
+    pub(crate) async fn spawn_db_data_fetcher(&mut self) -> JoinHandle<()> {
         // Create a separate persistent connection pool for querying transaction data
         let query_pool = match PgPoolOptions::default()
             .max_connections(5) // Small pool since we're just doing simple queries
@@ -204,7 +205,7 @@ impl EventReceiver {
                     }
                 }
             }
-        });
+        })
     }
 
     pub(crate) async fn recv(&mut self) -> Option<DbData> {

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -9,6 +9,11 @@ pub(crate) trait ReplicaEventHandler: Send + Sync + 'static {
     async fn on_da_event(&self, batch: DbData);
 }
 
+pub(crate) struct ReplicaTaskHandles {
+    pub(crate) data_fetcher_handle: JoinHandle<()>,
+    pub(crate) sync_task_handle: JoinHandle<()>,
+}
+
 pub(crate) struct ReplicaSyncTask {
     shutdown_sender: watch::Sender<()>,
     postgres_connection_string: String,
@@ -25,17 +30,17 @@ impl ReplicaSyncTask {
         })
     }
 
-    pub(crate) async fn start<R: ReplicaEventHandler>(&mut self, handler: R) -> JoinHandle<()> {
+    pub(crate) async fn start<R: ReplicaEventHandler>(&mut self, handler: R) -> ReplicaTaskHandles {
         let mut event_receiver = EventReceiver::new(
             self.postgres_connection_string.clone(),
             self.shutdown_sender.clone(),
         )
         .await;
 
-        event_receiver.spawn_db_data_fetcher().await;
+        let data_fetcher_handle = event_receiver.spawn_db_data_fetcher().await;
         let shutdown_receiver = self.shutdown_sender.subscribe();
 
-        tokio::spawn(async move {
+        let sync_task_handle = tokio::spawn(async move {
             loop {
                 if shutdown_receiver.has_changed().unwrap_or(true) {
                     break;
@@ -45,7 +50,12 @@ impl ReplicaSyncTask {
                     handler.on_da_event(data).await;
                 }
             }
-        })
+        });
+
+        ReplicaTaskHandles {
+            data_fetcher_handle,
+            sync_task_handle,
+        }
     }
 }
 

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use crate::postgres::create_postgres_container;
 use crate::postgres::CreatePostgresError;
 use crate::postgres::PostgresImage;
+use crate::Transaction;
 use crate::{
     TEST_DEFAULT_PROVER_ADDRESS, TEST_DEFAULT_SEQUENCER_ADDRESS, TEST_MAX_BATCH_SIZE,
     TEST_MAX_CONCURRENT_BLOBS, TEST_NUM_CACHE_WARMUP_WORKERS,
@@ -18,6 +19,7 @@ use crate::{
 use anyhow::Context;
 use derivative::Derivative;
 use serde::Deserialize;
+use sov_api_spec::types::TxInfoWithConfirmation;
 use sov_api_spec::WsSubscription;
 use sov_blob_sender::BlobExecutionStatus;
 use sov_cli::wallet_state::PrivateKeyAndAddress;
@@ -852,6 +854,14 @@ where
         let current_height = get_height(&self.client).await.unwrap();
         let end_height = current_height.get() + delta;
         self.wait_for_height(end_height).await;
+    }
+
+    pub async fn send_tx_to_sequencer(
+        &self,
+        tx: &Transaction<R::Runtime, R::Spec>,
+    ) -> Result<TxInfoWithConfirmation, anyhow::Error> {
+        let resp = self.client.client.send_txs_to_sequencer(&[tx]).await?;
+        Ok(resp[0].clone())
     }
 }
 

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -21,12 +21,23 @@ use sov_test_utils::test_rollup::TestRollup;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::watch;
+use tokio::time::Duration;
 
 type S = <ExternalMockDemoRollup<Native> as RollupBlueprint<Native>>::Spec;
 
 fn random_address() -> <S as Spec>::Address {
     let pk = <<S as Spec>::CryptoSpec as CryptoSpec>::PrivateKey::generate();
     pk.pub_key().credential_id().into()
+}
+
+async fn create_da_service_manual() -> (StorableMockDaService, SocketAddr) {
+    let da_service = StorableMockDaService::new_in_memory_manual(MockAddress::new([0; 32])).await;
+
+    let addr = start_server(da_service.clone(), "127.0.0.1", 0)
+        .await
+        .unwrap();
+
+    (da_service, addr)
 }
 
 async fn create_da_service() -> (StorableMockDaService, watch::Sender<()>, SocketAddr) {
@@ -38,6 +49,21 @@ async fn create_da_service() -> (StorableMockDaService, watch::Sender<()>, Socke
         .unwrap();
 
     (da_service, shutdown_sender, addr)
+}
+
+async fn wait_for_height(
+    test_rollup: &TestRollup<ExternalMockDemoRollup<Native>>,
+    da_service: &StorableMockDaService,
+    height: u64,
+) {
+    loop {
+        let h = test_rollup.height().await;
+        da_service.produce_block_now().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if h.get() >= height {
+            break;
+        }
+    }
 }
 
 async fn start_rollup(
@@ -83,12 +109,7 @@ async fn test_replica_receives_txs_from_da() {
 
     let height_before_tx = test_rollup.height().await;
 
-    test_rollup
-        .client
-        .client
-        .send_txs_to_sequencer(&[tx])
-        .await
-        .unwrap();
+    test_rollup.send_tx_to_sequencer(&tx).await.unwrap();
 
     test_rollup
         .wait_for_height(height_before_tx.get() + 5)
@@ -117,13 +138,15 @@ async fn test_replica_receives_txs_from_postgres() {
         }
     };
 
-    let (_, shutdown_sender, addr) = create_da_service().await;
+    let (da_service, addr) = create_da_service_manual().await;
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
 
     let test_rollup = start_rollup(false, addr, postgres.clone()).await;
     let replica_test_rollup = start_rollup(true, addr, postgres).await;
 
     let token_id = config_gas_token_id();
+
+    da_service.produce_n_blocks_now(20).await.unwrap();
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     let receiver_addr = random_address();
@@ -137,17 +160,9 @@ async fn test_replica_receives_txs_from_postgres() {
     );
 
     let height_before_tx = test_rollup.height().await;
+    test_rollup.send_tx_to_sequencer(&tx).await.unwrap();
 
-    test_rollup
-        .client
-        .client
-        .send_txs_to_sequencer(&[tx])
-        .await
-        .unwrap();
-
-    test_rollup
-        .wait_for_height(height_before_tx.get() + 5)
-        .await;
+    wait_for_height(&test_rollup, &da_service, height_before_tx.get() + 5).await;
 
     let receiver_balance = replica_test_rollup
         .client
@@ -157,5 +172,4 @@ async fn test_replica_receives_txs_from_postgres() {
 
     assert_eq!(receiver_balance.0, 100);
     let _ = test_rollup.shutdown().await;
-    let _ = shutdown_sender.send(());
 }


### PR DESCRIPTION
# Description
This PR introduces the following changes:

1. Implements `ReplicaEventHandler for SequencerStateUpdator` — the method dispatching logic will be added in the next PR.
2. Makes` CacheWarmUpExecutor` optional, so replicas do not warm up the cache.
3. Refactors` inner.rs` into helper methods — these new methods will be reused for replica state updates in the next PR.
4. Moves `test_replica_receives_txs_from_postgres` to manual block production to allow better control over timing.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

