### PR TITLE
Prover: remove redundant prover_address clone and single-source its usage

### DIFF
--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
@@ -115,8 +115,6 @@ where
                 prover_address: self.prover_address.clone(),
             };
 
-            let prover_address = self.prover_address.clone();
-
             inner_vm.add_hint(&data);
 
             self.pool.spawn(move || {
@@ -125,14 +123,18 @@ where
 
                     let mut prover_state = prover_state_clone.write().expect("Lock was poisoned");
 
-                    let StateTransitionWitness {
-                        initial_state_root,
-                        final_state_root,
-                        da_block_header,
-                        relevant_proofs,
-                        relevant_blobs: blobs,
-                        ..
-                    } = data.stf_witness;
+                    let StateTransitionWitnessWithAddress {
+                        stf_witness:
+                            StateTransitionWitness {
+                                initial_state_root,
+                                final_state_root,
+                                da_block_header,
+                                relevant_proofs,
+                                relevant_blobs: blobs,
+                                ..
+                            },
+                        prover_address,
+                    } = data;
 
                     verifier
                         .da_verifier


### PR DESCRIPTION


## Description:
- Summary: Replace duplicated local variable with destructuring to use a single source of truth for prover_address.
- Scope: crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
- Change:
  - Drop local prover_address clone.
  - Destructure StateTransitionWitnessWithAddress inside the worker to access prover_address directly.
- Rationale: Eliminates duplication and unnecessary clone, reducing cognitive load and desync risk.
