### PR TITLE
`Replica:` Start processing soft confirmations only at `BatchStart` boundaries.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/replica/db_data.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/db_data.rs
@@ -46,6 +46,7 @@ pub(crate) enum EventType {
 }
 
 impl EventType {
+    #[allow(clippy::match_same_arms)]
     pub(crate) fn is_event_sequence_valid(prev: Option<Self>, current: Self) -> bool {
         match (prev, current) {
             (Some(EventType::BatchStart), EventType::BatchStart) => false,

--- a/crates/full-node/sov-sequencer/src/preferred/replica/db_data.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/db_data.rs
@@ -1,0 +1,187 @@
+use crate::preferred::db::BatchToStore;
+use crate::preferred::db::StoredBlob;
+use crate::Serialize;
+use serde::Deserialize;
+use sov_modules_api::FullyBakedTx;
+use sqlx::postgres::PgRow;
+use sqlx::PgPool;
+use sqlx::Row;
+use std::io;
+use std::num::ParseIntError;
+use std::str::FromStr;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ParsingError {
+    #[error("Invalid event_type: {0}")]
+    InvalidEventType(String),
+
+    #[error("Invalid CSV format: expected 4 fields, got {0}")]
+    InvalidCsvFormat(usize),
+
+    #[error("Invalid event_id '{0}': {1}")]
+    InvalidEventId(String, #[source] ParseIntError),
+
+    #[error("Invalid sequence_number '{0}': {1}")]
+    InvalidSequenceNumber(String, #[source] ParseIntError),
+
+    #[error("Invalid index_in_batch '{0}': {1}")]
+    InvalidIndexInBatch(String, #[source] ParseIntError),
+
+    #[error("Unexpected proof: sequence number: '{0}'")]
+    UnexpectedProof(u64),
+
+    #[error("Borsh deserialization error: '{0}'")]
+    Borsh(io::Error),
+}
+
+/// Event type enum for type-safe parsing
+#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq, sqlx::Type)]
+#[serde(rename_all = "snake_case")]
+#[sqlx(type_name = "event_type", rename_all = "snake_case")]
+pub(crate) enum EventType {
+    Transaction,
+    BatchStart,
+    BatchEnd,
+    NewProof,
+}
+
+impl EventType {
+    pub(crate) fn is_event_sequence_valid(prev: Option<Self>, current: Self) -> bool {
+        match (prev, current) {
+            (Some(EventType::BatchStart), EventType::BatchStart) => false,
+            (Some(EventType::Transaction), EventType::BatchStart) => false,
+            (Some(EventType::BatchEnd), EventType::Transaction) => false,
+            (Some(EventType::BatchEnd), EventType::BatchEnd) => false,
+            (None, EventType::BatchStart) => true,
+            (None, _) => false,
+            (_, _) => true,
+        }
+    }
+}
+
+impl FromStr for EventType {
+    type Err = ParsingError;
+
+    fn from_str(s: &str) -> Result<Self, ParsingError> {
+        match s {
+            "transaction" => Ok(EventType::Transaction),
+            "batch_start" => Ok(EventType::BatchStart),
+            "batch_end" => Ok(EventType::BatchEnd),
+            "new_proof" => Ok(EventType::NewProof),
+            _ => Err(ParsingError::InvalidEventType(s.to_string())),
+        }
+    }
+}
+
+/// Structure representing the CSV payload from PostgreSQL NOTIFY
+#[derive(Debug)]
+pub(crate) struct EventsNotificationPayload {
+    pub(crate) event_id: u64,
+    pub(crate) sequence_number: u64,
+    pub(crate) event_type: EventType,
+    pub(crate) index_in_batch: Option<u64>, // Only present for transaction events
+}
+
+impl EventsNotificationPayload {
+    pub(crate) fn parse_csv(payload: &str) -> Result<Self, ParsingError> {
+        let parts: Vec<&str> = payload.split(',').collect();
+        if parts.len() != 4 {
+            return Err(ParsingError::InvalidCsvFormat(parts.len()));
+        }
+
+        Ok(EventsNotificationPayload {
+            event_id: parts[0]
+                .parse()
+                .map_err(|e| ParsingError::InvalidEventId(parts[0].to_string(), e))?,
+            sequence_number: parts[1]
+                .parse()
+                .map_err(|e| ParsingError::InvalidSequenceNumber(parts[1].to_string(), e))?,
+            event_type: parts[2].parse()?,
+            index_in_batch: if parts[3].is_empty() {
+                None
+            } else {
+                Some(
+                    parts[3]
+                        .parse()
+                        .map_err(|e| ParsingError::InvalidIndexInBatch(parts[3].to_string(), e))?,
+                )
+            },
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DbData {
+    BatchStart(BatchToStore),
+    Transaction(FullyBakedTx),
+    BatchEnd(BatchToStore),
+    NewProof,
+}
+
+impl DbData {
+    pub(crate) fn is_batch_end(&self) -> bool {
+        matches!(self, DbData::BatchEnd(_))
+    }
+}
+
+pub(crate) async fn rows(
+    query_pool: &PgPool,
+    page_end: u64,
+    current_event_id: u64,
+) -> Result<Vec<PgRow>, sqlx::Error> {
+    // Query and process events for this page
+    sqlx::query(
+        "SELECT event_id, sequence_number, index_in_batch, event_type, hash, data FROM events
+                 WHERE event_id >= $1 AND event_id <= $2
+                 ORDER BY event_id ASC",
+    )
+    .bind(current_event_id as i64)
+    .bind(page_end as i64)
+    .fetch_all(query_pool)
+    .await
+}
+
+pub(crate) fn row_to_event(row: PgRow) -> Result<(DbData, EventType), ParsingError> {
+    let event_type: EventType = row.get("event_type");
+    let sequence_number = row.get::<i64, _>("sequence_number") as u64;
+    let data: Vec<u8> = row.get("data");
+
+    let event = match event_type {
+        EventType::BatchStart => {
+            let batch_to_store = parse_serialized_batch(data, sequence_number)?;
+            DbData::BatchStart(batch_to_store)
+        }
+        EventType::Transaction => {
+            let baked_tx = FullyBakedTx::new(data);
+            DbData::Transaction(baked_tx)
+        }
+
+        EventType::BatchEnd => {
+            let batch_to_store = parse_serialized_batch(data, sequence_number)?;
+            DbData::BatchEnd(batch_to_store)
+        }
+        EventType::NewProof => DbData::NewProof,
+    };
+
+    Ok((event, event_type))
+}
+
+fn parse_serialized_batch(
+    data: Vec<u8>,
+    sequence_number: u64,
+) -> Result<BatchToStore, ParsingError> {
+    let stored_blob: StoredBlob = borsh::from_slice(&data).map_err(ParsingError::Borsh)?;
+    match stored_blob {
+        StoredBlob::Batch {
+            visible_slot_number_after_increase,
+            visible_slots_to_advance,
+            blob_id,
+        } => Ok(BatchToStore {
+            visible_slot_number_after_increase,
+            visible_slots_to_advance,
+            blob_id,
+            sequence_number,
+        }),
+        StoredBlob::Proof { .. } => Err(ParsingError::UnexpectedProof(sequence_number)),
+    }
+}

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
@@ -1,5 +1,5 @@
 use crate::preferred::inner::SequencerStateUpdator;
-use crate::preferred::replica::event_receiver::DbData;
+use crate::preferred::replica::db_data::DbData;
 use crate::preferred::replica::replica_sync_task::ReplicaEventHandler;
 use async_trait::async_trait;
 use sov_modules_api::Runtime;

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -176,7 +176,7 @@ impl EventReceiver {
             // and use its event_id as the target.
             Some(start_id) => {
                 let notify = self.recv_notifications().await?;
-                assert!(notify.event_id > start_id);
+                assert!(notify.event_id >= start_id);
                 (start_id, notify.event_id)
             }
             // Otherwise, `None` indicates the replica has just started.

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -100,9 +100,9 @@ impl EventReceiver {
                 }
 
                 match self.fetch_data(start_event_id, prev_event_type).await {
-                    Ok((next_event_id, event_type)) => {
+                    Ok((event_id, event_type)) => {
                         nb_of_consecutive_db_errors = 0;
-                        start_event_id = Some(next_event_id + 1);
+                        start_event_id = Some(event_id + 1);
                         prev_event_type = event_type;
                     }
                     Err(err) => {

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -14,7 +14,7 @@ use tracing::{error, trace};
 const MAX_DB_ERRORS_ALLOWED: u32 = 10;
 
 // Process events in pages to avoid excessive memory consumption
-const PAGE_SIZE: i64 = 2000;
+pub(crate) const PAGE_SIZE: usize = 2000;
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum EventReceiverError {
@@ -34,14 +34,16 @@ pub(crate) struct EventReceiver {
     shutdown_sender: watch::Sender<()>,
     listener: PgListener,
     query_pool: PgPool,
+    page_size: usize,
 }
 
 impl EventReceiver {
     pub(crate) async fn new(
         connection_string: String,
         shutdown_sender: watch::Sender<()>,
+        page_size: usize,
     ) -> (Self, tokio::sync::mpsc::Receiver<DbData>) {
-        let (db_data_sender, db_data_receiver) = tokio::sync::mpsc::channel(PAGE_SIZE as usize);
+        let (db_data_sender, db_data_receiver) = tokio::sync::mpsc::channel(page_size);
 
         // Create a separate persistent connection pool for querying transaction data
         let query_pool = match PgPoolOptions::default()
@@ -80,6 +82,7 @@ impl EventReceiver {
                 shutdown_sender,
                 listener,
                 query_pool,
+                page_size,
             },
             db_data_receiver,
         )
@@ -213,7 +216,7 @@ impl EventReceiver {
         // After analyzing real-world workloads, we can revisit this optimization. Implementing it would only affect
         // the contents of this method and would not require significant refactoring.
         while current_event_id <= target_event_id {
-            let page_end = std::cmp::min(current_event_id + PAGE_SIZE as u64, target_event_id);
+            let page_end = std::cmp::min(current_event_id + self.page_size as u64, target_event_id);
 
             trace!(
                 "Processing backfill page: events {} to {}",

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -13,9 +13,6 @@ use tracing::{error, trace};
 
 const MAX_DB_ERRORS_ALLOWED: u32 = 10;
 
-// Process events in pages to avoid excessive memory consumption
-pub(crate) const PAGE_SIZE: usize = 2000;
-
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum EventReceiverError {
     #[error("Error while querying for  db data: {0}")]

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -176,6 +176,7 @@ impl EventReceiver {
             // and use its event_id as the target.
             Some(start_id) => {
                 let notify = self.recv_notifications().await?;
+                assert!(notify.event_id > start_id);
                 (start_id, notify.event_id)
             }
             // Otherwise, `None` indicates the replica has just started.

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -1,87 +1,20 @@
-use crate::preferred::db::{BatchToStore, StoredBlob};
 use crate::preferred::exit_rollup;
-use anyhow::anyhow;
-use serde::{Deserialize, Serialize};
-use sov_modules_api::FullyBakedTx;
+use crate::preferred::replica::db_data::row_to_event;
+use crate::preferred::replica::db_data::rows;
+use crate::preferred::replica::db_data::DbData;
+use crate::preferred::replica::db_data::EventType;
+use crate::preferred::replica::db_data::EventsNotificationPayload;
+use crate::preferred::replica::db_data::ParsingError;
 use sqlx::postgres::{PgListener, PgPoolOptions};
 use sqlx::PgPool;
-use sqlx::Row;
-use std::str::FromStr;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
-use tracing::{debug, error, trace};
+use tracing::{error, trace};
 
 const MAX_DB_ERRORS_ALLOWED: u32 = 10;
 
 // Process events in pages to avoid excessive memory consumption
 const PAGE_SIZE: i64 = 2000;
-
-/// Event type enum for type-safe parsing
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, sqlx::Type)]
-#[serde(rename_all = "snake_case")]
-#[sqlx(type_name = "event_type", rename_all = "snake_case")]
-pub(crate) enum EventType {
-    Transaction,
-    BatchStart,
-    BatchEnd,
-    NewProof,
-}
-
-impl FromStr for EventType {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "transaction" => Ok(EventType::Transaction),
-            "batch_start" => Ok(EventType::BatchStart),
-            "batch_end" => Ok(EventType::BatchEnd),
-            "new_proof" => Ok(EventType::NewProof),
-            _ => Err(anyhow!("Invalid event type: {}", s)),
-        }
-    }
-}
-
-/// Structure representing the CSV payload from PostgreSQL NOTIFY
-#[derive(Debug)]
-pub(crate) struct EventsNotificationPayload {
-    pub(crate) event_id: u64,
-    pub(crate) sequence_number: u64,
-    pub(crate) event_type: EventType,
-    pub(crate) index_in_batch: Option<u64>, // Only present for transaction events
-}
-
-impl EventsNotificationPayload {
-    pub(crate) fn parse_csv(payload: &str) -> anyhow::Result<Self> {
-        let parts: Vec<&str> = payload.split(',').collect();
-        if parts.len() != 4 {
-            return Err(anyhow!(
-                "Invalid CSV format: expected 4 fields, got {}",
-                parts.len()
-            ));
-        }
-
-        Ok(EventsNotificationPayload {
-            event_id: parts[0]
-                .parse()
-                .map_err(|e| anyhow!("Invalid event_id '{}': {}", parts[0], e))?,
-            sequence_number: parts[1]
-                .parse()
-                .map_err(|e| anyhow!("Invalid sequence_number '{}': {}", parts[1], e))?,
-            event_type: parts[2]
-                .parse()
-                .map_err(|e| anyhow!("Invalid event_type '{}': {}", parts[2], e))?,
-            index_in_batch: if parts[3].is_empty() {
-                None
-            } else {
-                Some(
-                    parts[3]
-                        .parse()
-                        .map_err(|e| anyhow!("Invalid index_in_batch '{}': {}", parts[3], e))?,
-                )
-            },
-        })
-    }
-}
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum EventReceiverError {
@@ -89,90 +22,88 @@ pub(crate) enum EventReceiverError {
     DbError(#[from] sqlx::Error),
 
     #[error("Error while parsing the db notification: {0}")]
-    ParsingError(#[from] anyhow::Error),
+    ParsingError(#[from] ParsingError),
+
+    #[error("Invalid event sequence in the db: {0:?} {1:?}. Replica shutting down.")]
+    InvalidEventSequence(Option<EventType>, EventType),
 }
 
 pub(crate) struct EventReceiver {
     connection_string: String,
     db_data_sender: tokio::sync::mpsc::Sender<DbData>,
-    db_data_receiver: tokio::sync::mpsc::Receiver<DbData>,
     shutdown_sender: watch::Sender<()>,
+    listener: PgListener,
+    query_pool: PgPool,
 }
 
 impl EventReceiver {
-    pub(crate) async fn new(connection_string: String, shutdown_sender: watch::Sender<()>) -> Self {
+    pub(crate) async fn new(
+        connection_string: String,
+        shutdown_sender: watch::Sender<()>,
+    ) -> (Self, tokio::sync::mpsc::Receiver<DbData>) {
         let (db_data_sender, db_data_receiver) = tokio::sync::mpsc::channel(PAGE_SIZE as usize);
-        Self {
-            connection_string,
-            db_data_sender,
-            db_data_receiver,
-            shutdown_sender,
-        }
-    }
 
-    pub(crate) async fn spawn_db_data_fetcher(&mut self) -> JoinHandle<()> {
         // Create a separate persistent connection pool for querying transaction data
         let query_pool = match PgPoolOptions::default()
             .max_connections(5) // Small pool since we're just doing simple queries
-            .connect(&self.connection_string)
+            .connect(&connection_string)
             .await
         {
             Ok(pool) => pool,
             Err(e) => {
                 error!("Failed to connect to PostgreSQL: {e:?}. Replica shutting down.");
-                exit_rollup(&self.shutdown_sender).await;
-                unreachable!("EventReceiver: impossible happened rollup didn't exit");
-            }
-        };
-
-        let mut start_event_id = match latest_event_id(&query_pool).await {
-            Ok(latest_event_id) => latest_event_id,
-            Err(e) => {
-                error!("Failed to get latest event id: {e:?}. Replica shutting down.");
-                exit_rollup(&self.shutdown_sender).await;
+                exit_rollup(&shutdown_sender).await;
                 unreachable!("EventReceiver: impossible happened rollup didn't exit");
             }
         };
 
         // Create a dedicated listener for PostgreSQL LISTEN/NOTIFY
-        let mut listener = match PgListener::connect(&self.connection_string).await {
+        let mut listener = match PgListener::connect(&connection_string).await {
             Ok(listener) => listener,
             Err(e) => {
                 error!("Failed to create PostgreSQL listener: {e:?}. Replica shutting down.");
-                exit_rollup(&self.shutdown_sender).await;
+                exit_rollup(&shutdown_sender).await;
                 unreachable!("EventReceiver: impossible happened rollup didn't exit");
             }
         };
 
         if let Err(e) = listener.listen("events_changes").await {
             error!("Failed to listen on events_changes channel: {e:?}. Replica shutting down.");
-            exit_rollup(&self.shutdown_sender).await;
+            exit_rollup(&shutdown_sender).await;
             unreachable!("EventReceiver: impossible happened rollup didn't exit");
         }
 
+        (
+            Self {
+                connection_string,
+                db_data_sender,
+                shutdown_sender,
+                listener,
+                query_pool,
+            },
+            db_data_receiver,
+        )
+    }
+
+    pub(crate) async fn spawn_db_data_fetcher(mut self) -> JoinHandle<()> {
         let mut nb_of_consecutive_db_errors = 0;
         let shutdown_sender = self.shutdown_sender.clone();
         let shutdown_receiver = self.shutdown_sender.subscribe();
 
-        let mut db_data_sender = self.db_data_sender.clone();
-
         tokio::spawn(async move {
+            let mut start_event_id = None;
+            let mut prev_event_type = None;
+
             loop {
                 if shutdown_receiver.has_changed().unwrap_or(true) {
                     break;
                 }
 
-                match Self::fetch_data(
-                    start_event_id,
-                    &query_pool,
-                    &mut listener,
-                    &mut db_data_sender,
-                )
-                .await
-                {
-                    Ok(next_event_id) => {
+                match self.fetch_data(start_event_id, prev_event_type).await {
+                    Ok((next_event_id, event_type)) => {
                         nb_of_consecutive_db_errors = 0;
                         start_event_id = Some(next_event_id + 1);
+                        prev_event_type = event_type;
                     }
                     Err(err) => {
                         match err {
@@ -183,7 +114,6 @@ impl EventReceiver {
                                 );
                                 exit_rollup(&shutdown_sender).await;
                             }
-
                             EventReceiverError::DbError(e) => {
                                 error!("Failed to receive notifications from database: {e:?}. Shutting down replica.");
 
@@ -201,6 +131,13 @@ impl EventReceiver {
                                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                                 continue;
                             }
+                            EventReceiverError::InvalidEventSequence(
+                                prev_event_type,
+                                event_type,
+                            ) => {
+                                error!("Invalid event sequence in the db: {prev_event_type:?} {event_type:?}. Replica shutting down.");
+                                exit_rollup(&self.shutdown_sender).await;
+                            }
                         }
                     }
                 }
@@ -208,24 +145,20 @@ impl EventReceiver {
         })
     }
 
-    pub(crate) async fn recv(&mut self) -> Option<DbData> {
-        self.db_data_receiver.recv().await
-    }
-
     async fn recv_notifications(
-        listener: &mut PgListener,
+        &mut self,
     ) -> Result<EventsNotificationPayload, EventReceiverError> {
         let mut last_notification = None;
 
         // We only care about the latest notification from the DB,
         // since the backfill logic allows us to skip earlier ones.
-        while let Some(p) = listener.next_buffered() {
+        while let Some(p) = self.listener.next_buffered() {
             last_notification = Some(p);
         }
 
         let pg_notification = match last_notification {
             Some(notification) => notification,
-            None => listener.recv().await?,
+            None => self.listener.recv().await?,
         };
 
         let payload = pg_notification.payload();
@@ -234,40 +167,45 @@ impl EventReceiver {
     }
 
     async fn fetch_data(
+        &mut self,
         start_event_id: Option<u64>,
-        query_pool: &PgPool,
-        listener: &mut PgListener,
-        db_data_sender: &mut tokio::sync::mpsc::Sender<DbData>,
-    ) -> Result<u64, EventReceiverError> {
-        let notification = Self::recv_notifications(listener).await?;
+        mut prev_event_type: Option<EventType>,
+    ) -> Result<(u64, Option<EventType>), EventReceiverError> {
+        let (start_event_id, target_event_id) = match start_event_id {
+            // If we already have a start id, just wait for the next notification
+            // and use its event_id as the target.
+            Some(start_id) => {
+                let notify = self.recv_notifications().await?;
+                (start_id, notify.event_id)
+            }
+            // Otherwise, `None` indicates the replica has just started.
+            // Keep listening for events until a `BatchStart` notification is received,
+            // then use that event's ID as both the starting and target event ID.
+            None => loop {
+                let notify = self.recv_notifications().await?;
+                if matches!(notify.event_type, EventType::BatchStart) {
+                    break (notify.event_id, notify.event_id);
+                }
+            },
+        };
 
-        Self::backfill_to_event_id(
-            query_pool,
-            start_event_id,
-            notification.event_id,
-            db_data_sender,
-        )
-        .await?;
+        prev_event_type = self
+            .backfill_to_event_id(start_event_id, target_event_id, prev_event_type)
+            .await?;
 
-        Ok(notification.event_id)
+        Ok((target_event_id, prev_event_type))
     }
 
     async fn backfill_to_event_id(
-        query_pool: &PgPool,
-        current_event_id: Option<u64>,
+        &mut self,
+        mut current_event_id: u64,
         target_event_id: u64,
-        db_data_sender: &mut tokio::sync::mpsc::Sender<DbData>,
-    ) -> Result<(), EventReceiverError> {
-        let mut current_event_id = current_event_id.unwrap_or(1);
-
-        // If we're already caught up, nothing to do
-        if current_event_id > target_event_id {
-            return Ok(());
-        }
-
-        debug!(
+        mut prev_event_type: Option<EventType>,
+    ) -> Result<Option<EventType>, EventReceiverError> {
+        trace!(
             "Backfilling events from {} to {}",
-            current_event_id, target_event_id
+            current_event_id,
+            target_event_id
         );
 
         // Currently, we fetch data in a loop. One possible (but not yet necessary) optimization would be to issue
@@ -284,89 +222,25 @@ impl EventReceiver {
             );
 
             // Query and process events for this page
-            let events = sqlx::query(
-                "SELECT event_id, sequence_number, index_in_batch, event_type, hash, data FROM events 
-                 WHERE event_id >= $1 AND event_id <= $2
-                 ORDER BY event_id ASC",
-            )
-            .bind(current_event_id as i64)
-            .bind(page_end as i64)
-            .fetch_all(query_pool)
-            .await?;
+            let db_rows = rows(&self.query_pool, page_end, current_event_id).await?;
 
-            for row in events {
-                let event_type: EventType = row.get("event_type");
-                let sequence_number = row.get::<i64, _>("sequence_number") as u64;
+            for row in db_rows {
+                let (event, event_type) = row_to_event(row)?;
 
-                match event_type {
-                    EventType::BatchStart => {
-                        let batch_data: Vec<u8> = row.get("data");
-                        let batch_to_store = parse_serialized_batch(batch_data, sequence_number)?;
-
-                        let _ = db_data_sender
-                            .send(DbData::BatchStart(batch_to_store))
-                            .await;
-                    }
-                    EventType::Transaction => {
-                        let tx_data: Vec<u8> = row.get("data");
-
-                        let baked_tx = FullyBakedTx::new(tx_data);
-                        let _ = db_data_sender.send(DbData::Transaction(baked_tx)).await;
-                    }
-
-                    EventType::BatchEnd => {
-                        let batch_data: Vec<u8> = row.get("data");
-                        let batch_to_store = parse_serialized_batch(batch_data, sequence_number)?;
-
-                        let _ = db_data_sender.send(DbData::BatchEnd(batch_to_store)).await;
-                    }
-                    EventType::NewProof => {
-                        let _ = db_data_sender.send(DbData::NewProof).await;
-                    }
+                if !(EventType::is_event_sequence_valid(prev_event_type, event_type)) {
+                    return Err(EventReceiverError::InvalidEventSequence(
+                        prev_event_type,
+                        event_type,
+                    ));
                 }
+
+                let _ = self.db_data_sender.send(event).await;
+                prev_event_type = Some(event_type);
             }
 
             current_event_id = page_end + 1;
         }
 
-        Ok(())
+        Ok(prev_event_type)
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum DbData {
-    BatchStart(BatchToStore),
-    Transaction(FullyBakedTx),
-    BatchEnd(BatchToStore),
-    NewProof,
-}
-
-fn parse_serialized_batch(data: Vec<u8>, sequence_number: u64) -> anyhow::Result<BatchToStore> {
-    let stored_blob: StoredBlob = borsh::from_slice(&data)?;
-
-    match stored_blob {
-        StoredBlob::Batch {
-            visible_slot_number_after_increase,
-            visible_slots_to_advance,
-            blob_id,
-        } => Ok(BatchToStore {
-            visible_slot_number_after_increase,
-            visible_slots_to_advance,
-            blob_id,
-            sequence_number,
-        }),
-        StoredBlob::Proof { .. } => Err(anyhow::anyhow!(
-            "Expected batch blob but found proof blob for sequence_number {}",
-            sequence_number
-        )),
-    }
-}
-
-async fn latest_event_id(query_pool: &PgPool) -> Result<Option<u64>, sqlx::Error> {
-    Ok(
-        sqlx::query_scalar::<_, Option<i64>>("SELECT MAX(event_id) FROM events")
-            .fetch_one(query_pool)
-            .await?
-            .map(|id| id as u64),
-    )
 }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/mod.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+pub(crate) mod db_data;
 pub(crate) mod event_handler;
 pub(crate) mod event_receiver;
 pub(crate) mod replica_sync_task;

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -1,8 +1,11 @@
 use crate::preferred::replica::db_data::DbData;
-use crate::preferred::replica::event_receiver::{EventReceiver, PAGE_SIZE};
+use crate::preferred::replica::event_receiver::EventReceiver;
 use async_trait::async_trait;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
+
+// Process events in pages to avoid excessive memory consumption
+const PAGE_SIZE: usize = 2000;
 
 #[async_trait]
 pub(crate) trait ReplicaEventHandler: Send + Sync + 'static {

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -1,4 +1,4 @@
-use crate::preferred::replica::event_receiver::DbData;
+use crate::preferred::replica::db_data::DbData;
 use crate::preferred::replica::event_receiver::EventReceiver;
 use async_trait::async_trait;
 use tokio::sync::watch;
@@ -31,7 +31,7 @@ impl ReplicaSyncTask {
     }
 
     pub(crate) async fn start<R: ReplicaEventHandler>(&mut self, handler: R) -> ReplicaTaskHandles {
-        let mut event_receiver = EventReceiver::new(
+        let (event_receiver, mut db_data_receiver) = EventReceiver::new(
             self.postgres_connection_string.clone(),
             self.shutdown_sender.clone(),
         )
@@ -46,7 +46,7 @@ impl ReplicaSyncTask {
                     break;
                 }
 
-                if let Some(data) = event_receiver.recv().await {
+                if let Some(data) = db_data_receiver.recv().await {
                     handler.on_da_event(data).await;
                 }
             }
@@ -73,6 +73,7 @@ mod tests {
     };
 
     use std::num::NonZero;
+    use std::vec;
     use tokio::sync::mpsc;
 
     #[derive(Clone)]
@@ -90,54 +91,129 @@ mod tests {
     #[async_trait]
     impl ReplicaEventHandler for TestHandler {
         async fn on_da_event(&self, data: DbData) {
-            self.send.send(data).await.unwrap();
+            let _ = self.send.send(data).await;
         }
     }
 
-    fn create_test_data(test_case: Vec<usize>) -> Vec<DbData> {
-        let mut data = Vec::new();
-
-        for (seq_nr, nb_of_txs) in test_case.into_iter().enumerate() {
-            let stored_batch = BatchToStore {
-                sequence_number: (seq_nr as u64),
-                blob_id: (seq_nr + 99) as u128,
-                visible_slot_number_after_increase: VisibleSlotNumber::new_dangerous(1),
-                visible_slots_to_advance: NonZero::new(1).unwrap(),
-            };
-
-            data.push(DbData::BatchStart(stored_batch.clone()));
-
-            for i in 0..nb_of_txs {
-                data.push(DbData::Transaction(FullyBakedTx::new(vec![i as u8])));
-            }
-
-            data.push(DbData::BatchEnd(stored_batch));
+    fn new_batch_to_store(sequence_number: u64) -> BatchToStore {
+        BatchToStore {
+            sequence_number,
+            blob_id: (sequence_number + 99) as u128,
+            visible_slot_number_after_increase: VisibleSlotNumber::new_dangerous(1),
+            visible_slots_to_advance: NonZero::new(1).unwrap(),
         }
-
-        data
     }
 
-    async fn execute(mut db: PostgresBackend, data: Vec<DbData>) {
+    #[derive(Debug, Clone)]
+    enum TestCase {
+        CompleteBatch(u64, usize),
+        BatchStart(u64),
+        Transaction,
+        BatchEnd(u64),
+    }
+
+    async fn execute(mut db: PostgresBackend, data: Vec<TestCase>) {
+        let mut index = 0;
+        let mut sequence_nr = 0;
         for db_data in data {
             match db_data {
-                DbData::BatchStart(stored_batch) => {
-                    db.begin_rollup_block(stored_batch).await.unwrap();
-                }
-                DbData::Transaction(tx) => {
-                    db.add_tx(1, 0, tx, TxHash::new([1; 32])).await.unwrap();
-                }
-                DbData::BatchEnd(stored_batch) => {
+                TestCase::CompleteBatch(seq_nr, nb_of_txs) => {
+                    index = 0;
+                    let stored_batch = new_batch_to_store(seq_nr);
+                    db.begin_rollup_block(stored_batch.clone()).await.unwrap();
+
+                    for i in 0..nb_of_txs {
+                        let tx = FullyBakedTx::new(vec![i as u8]);
+                        db.add_tx(seq_nr, i as u64, tx, TxHash::new([1; 32]))
+                            .await
+                            .unwrap();
+                    }
+
                     db.end_rollup_block(stored_batch).await.unwrap();
                 }
-                DbData::NewProof => {
-                    unimplemented!()
+                TestCase::BatchStart(seq_nr) => {
+                    sequence_nr = seq_nr;
+                    index = 0;
+                    let stored_batch = new_batch_to_store(seq_nr);
+                    db.begin_rollup_block(stored_batch).await.unwrap();
                 }
-            }
+                TestCase::Transaction => {
+                    let tx = FullyBakedTx::new(vec![index as u8]);
+                    db.add_tx(sequence_nr, index, tx, TxHash::new([1; 32]))
+                        .await
+                        .unwrap();
+                    index += 1;
+                }
+                TestCase::BatchEnd(seq_nr) => {
+                    let stored_batch = new_batch_to_store(seq_nr);
+                    db.end_rollup_block(stored_batch).await.unwrap();
+                }
+            };
         }
+    }
+
+    fn to_db_data(test_cases: &Vec<TestCase>) -> Vec<DbData> {
+        let mut data = Vec::new();
+        let mut index = 0;
+        for test_case in test_cases {
+            match test_case {
+                TestCase::CompleteBatch(seq_nr, nb_of_txs) => {
+                    data.push(DbData::BatchStart(new_batch_to_store(*seq_nr)));
+                    for i in 0..*nb_of_txs {
+                        data.push(DbData::Transaction(FullyBakedTx::new(vec![i as u8])));
+                    }
+                    data.push(DbData::BatchEnd(new_batch_to_store(*seq_nr)));
+                }
+                TestCase::BatchStart(seq_nr) => {
+                    index = 0;
+                    data.push(DbData::BatchStart(new_batch_to_store(*seq_nr)));
+                }
+                TestCase::Transaction => {
+                    data.push(DbData::Transaction(FullyBakedTx::new(vec![index as u8])));
+                    index += 1;
+                }
+                TestCase::BatchEnd(seq_nr) => {
+                    data.push(DbData::BatchEnd(new_batch_to_store(*seq_nr)));
+                }
+            };
+        }
+        data
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_notifications() {
+        let test_data = vec![
+            TestCase::BatchStart(1),
+            TestCase::Transaction,
+            TestCase::Transaction,
+            TestCase::Transaction,
+            TestCase::BatchEnd(1),
+            TestCase::CompleteBatch(2, 0),
+            TestCase::CompleteBatch(3, 1000),
+            TestCase::CompleteBatch(4, 2),
+        ];
+
+        let expected = to_db_data(&test_data);
+        run(test_data, expected).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_notifications_start_event_id() {
+        let test_data = vec![
+            TestCase::Transaction,
+            TestCase::Transaction,
+            TestCase::Transaction,
+            TestCase::CompleteBatch(7, 3),
+            TestCase::BatchStart(8),
+            TestCase::Transaction,
+            TestCase::Transaction,
+        ];
+
+        let expected = to_db_data(&test_data).into_iter().skip(3).collect();
+        run(test_data, expected).await;
+    }
+
+    async fn run(test_cases: Vec<TestCase>, expected: Vec<DbData>) {
         let dir = tempfile::tempdir().unwrap();
 
         let postgres = create_postgres_container(&dir.path().join("postgres_data")).await;
@@ -157,43 +233,19 @@ mod tests {
             .await
             .unwrap();
 
-        let (sync_task_ready_snd, mut sync_task_ready_rcv) = mpsc::channel(1);
-
-        let test_data = create_test_data(vec![1, 0, 1000, 2]);
-        {
-            let test_data = test_data.clone();
-            tokio::spawn(async move {
-                sync_task_ready_rcv.recv().await.unwrap();
-                execute(db, test_data).await;
-            });
-        }
-
         let (shutdown_snd, _shutdown_rcv) = watch::channel(());
+        let mut sync_task = ReplicaSyncTask::new(postgres_connection_string, shutdown_snd)
+            .await
+            .unwrap();
+
         let (test_handler, mut recv) = TestHandler::new();
-        {
-            let conn_str = postgres_connection_string.clone();
-            let test_handler = test_handler.clone();
-            let shutdown_snd = shutdown_snd.clone();
-            tokio::spawn(async move {
-                let mut sync_task = ReplicaSyncTask::new(conn_str, shutdown_snd).await.unwrap();
-                sync_task.start(test_handler).await;
-                sync_task_ready_snd.send(()).await.unwrap();
-            });
-        }
+        sync_task.start(test_handler).await;
 
-        // Check if replica sync task received the notification.
-        for data in test_data {
+        execute(db, test_cases).await;
+
+        for data in expected {
             let recv_data = recv.recv().await.unwrap();
-            assert_eq!(recv_data, data);
+            assert_eq!(recv_data, data, "Expected: {data:?}, got: {recv_data:?}");
         }
-
-        shutdown_snd.send(()).unwrap();
     }
 }
-
-// 1. Data start with Transaction
-// 2. Data start with EndBatch
-// Check that
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_notifications_start_event_id() {}

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -190,3 +190,10 @@ mod tests {
         shutdown_snd.send(()).unwrap();
     }
 }
+
+// 1. Data start with Transaction
+// 2. Data start with EndBatch
+// Check that
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_notifications_start_event_id() {}

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -1,5 +1,5 @@
 use crate::preferred::replica::db_data::DbData;
-use crate::preferred::replica::event_receiver::EventReceiver;
+use crate::preferred::replica::event_receiver::{EventReceiver, PAGE_SIZE};
 use async_trait::async_trait;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -17,6 +17,7 @@ pub(crate) struct ReplicaTaskHandles {
 pub(crate) struct ReplicaSyncTask {
     shutdown_sender: watch::Sender<()>,
     postgres_connection_string: String,
+    page_size: usize,
 }
 
 impl ReplicaSyncTask {
@@ -24,9 +25,18 @@ impl ReplicaSyncTask {
         postgres_connection_string: String,
         shutdown_sender: watch::Sender<()>,
     ) -> anyhow::Result<Self> {
+        Self::new_with_page_size(postgres_connection_string, shutdown_sender, PAGE_SIZE).await
+    }
+
+    pub(crate) async fn new_with_page_size(
+        postgres_connection_string: String,
+        shutdown_sender: watch::Sender<()>,
+        page_size: usize,
+    ) -> anyhow::Result<Self> {
         Ok(Self {
             postgres_connection_string,
             shutdown_sender,
+            page_size,
         })
     }
 
@@ -34,6 +44,7 @@ impl ReplicaSyncTask {
         let (event_receiver, mut db_data_receiver) = EventReceiver::new(
             self.postgres_connection_string.clone(),
             self.shutdown_sender.clone(),
+            self.page_size,
         )
         .await;
 
@@ -234,9 +245,10 @@ mod tests {
             .unwrap();
 
         let (shutdown_snd, _shutdown_rcv) = watch::channel(());
-        let mut sync_task = ReplicaSyncTask::new(postgres_connection_string, shutdown_snd)
-            .await
-            .unwrap();
+        let mut sync_task =
+            ReplicaSyncTask::new_with_page_size(postgres_connection_string, shutdown_snd, 8)
+                .await
+                .unwrap();
 
         let (test_handler, mut recv) = TestHandler::new();
         sync_task.start(test_handler).await;

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -162,7 +162,7 @@ async fn test_replica_receives_txs_from_postgres() {
     let height_before_tx = test_rollup.height().await;
     test_rollup.send_tx_to_sequencer(&tx).await.unwrap();
 
-    wait_for_height(&test_rollup, &da_service, height_before_tx.get() + 1).await;
+    wait_for_height(&test_rollup, &da_service, height_before_tx.get() + 5).await;
 
     let receiver_balance = replica_test_rollup
         .client

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -162,7 +162,7 @@ async fn test_replica_receives_txs_from_postgres() {
     let height_before_tx = test_rollup.height().await;
     test_rollup.send_tx_to_sequencer(&tx).await.unwrap();
 
-    wait_for_height(&test_rollup, &da_service, height_before_tx.get() + 5).await;
+    wait_for_height(&test_rollup, &da_service, height_before_tx.get() + 1).await;
 
     let receiver_balance = replica_test_rollup
         .client


### PR DESCRIPTION
# Description

This PR introduces the following changes:
1. Refactored the `replica sync task` for better maintainability.
2. Added an additional condition to the `replica sync task`: after a replica restart, it will not apply any events from Postgres until it receives the first `BatchStart` event. This ensures that the replica does not start processing soft confirmations from the middle of a batch.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
