### PR TITLE
Eliminate redundant genesis_height config from rollup.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-10-20
+- #1925 removes the `genesis_height` param from the rollup_config.toml file. Genesis height is now *only* read from the genesis config file (usually `genesis.json`).
+
 # 2025-10-16
 - #1897 Fix gas estimation for transactions with many logs by charging for log storage in receipts.
 - #1893 Removes wrapper `Transaction` structure. Now `Transaction` is a enum of versions directly.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12340,6 +12340,7 @@ dependencies = [
  "serde",
  "sov-address",
  "sov-bank",
+ "sov-chain-state",
  "sov-metrics",
  "sov-modules-api",
  "sov-modules-macros",

--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -14,8 +14,6 @@ pub const DEFAULT_CONCURRENT_SYNC_TASKS: u8 = 5;
 /// Configuration for StateTransitionRunner.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 pub struct RunnerConfig {
-    /// DA start height.
-    pub genesis_height: u64,
     /// Polling interval for the DA service to check the sync status (in milliseconds).
     pub da_polling_interval_ms: u64,
     /// How much total time DA service has to provide block, including re-orgs, retries, etc.

--- a/crates/full-node/full-node-configs/src/snapshots/full_node_configs__runner__tests__correct_config.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/full_node_configs__runner__tests__correct_config.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/full-node/full-node-configs/src/runner.rs
-assertion_line: 222
+assertion_line: 219
 expression: config
 ---
 {
@@ -22,7 +22,6 @@ expression: config
     "pruner_max_batch_size": null
   },
   "runner": {
-    "genesis_height": 31337,
     "da_polling_interval_ms": 10000,
     "da_total_timeout_secs": 600,
     "http_config": {

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -51,7 +51,6 @@ where
     da_polling_interval: Duration,
     da_total_timeout: Duration,
     da_service: Arc<Da>,
-    da_height_at_genesis: u64,
     stf: Stf,
     state_manager: StateManager<Stf::StateRoot, Stf::Witness, Sm, Da>,
     listen_address_http: SocketAddr,
@@ -193,7 +192,6 @@ where
             .expect("The impossible happened  first_unprocessed_height_at_startup overflowed");
 
         debug!(
-            %runner_config.genesis_height,
             %first_unprocessed_height_at_startup,
             proof_manager_config = ?pm_config,
             "Initializing StfRunner");
@@ -240,7 +238,6 @@ where
             da_polling_interval,
             da_total_timeout,
             da_service: da_service.clone(),
-            da_height_at_genesis: runner_config.genesis_height,
             stf,
             state_manager,
             listen_address_http,
@@ -373,7 +370,7 @@ where
     }
 
     /// Runs the rollup.
-    pub async fn run_in_process(&mut self) -> anyhow::Result<()> {
+    pub async fn run_in_process(&mut self, genesis_da_height: u64) -> anyhow::Result<()> {
         self.state_manager.startup().await?;
 
         let mut next_da_height = self.first_unprocessed_height_at_startup;
@@ -403,6 +400,7 @@ where
                     next_da_height,
                     &start_at_rollup_height,
                     &stop_at_rollup_height,
+                    genesis_da_height,
                 ),
                 &shutdown_receiver,
             )
@@ -472,6 +470,7 @@ where
         mut next_da_height: NextDaHeightToProcess,
         start_at_rollup_height: &Option<RollupHeight>,
         stop_at_rollup_height: &Option<RollupHeight>,
+        genesis_da_height: u64,
     ) -> anyhow::Result<Option<NextDaHeightToProcess>> {
         let loop_start = std::time::Instant::now();
         let prev_state_root = self.get_state_root().clone();
@@ -628,7 +627,7 @@ where
         self.state_manager
             .process_stf_changes(
                 &self.da_service,
-                self.da_height_at_genesis,
+                genesis_da_height,
                 slot_result.change_set,
                 transition_data,
                 data_to_commit,
@@ -771,7 +770,7 @@ fn error_if_tokio_runtime_is_not_multi_threaded() -> anyhow::Result<()> {
 
 /// Creates a new `DaSyncState`
 pub async fn make_da_sync_state<Da: DaService<Error = anyhow::Error>>(
-    runner_config: &RunnerConfig,
+    genesis_da_height: u64,
     stop_at_rollup_height: Option<RollupHeight>,
     ledger_db: &LedgerDb,
     da_service: &Da,
@@ -782,7 +781,7 @@ pub async fn make_da_sync_state<Da: DaService<Error = anyhow::Error>>(
 
     debug!(%last_slot_processed_before_shutdown);
     let da_height_processed =
-        runner_config.genesis_height + last_slot_processed_before_shutdown.get();
+        genesis_da_height + last_slot_processed_before_shutdown.get();
 
     let target_da_height = get_target_block(da_service, &stop_at_rollup_height)
         .await?

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -780,8 +780,7 @@ pub async fn make_da_sync_state<Da: DaService<Error = anyhow::Error>>(
     let last_slot_processed_before_shutdown = next_item_numbers.slot_number.saturating_sub(1);
 
     debug!(%last_slot_processed_before_shutdown);
-    let da_height_processed =
-        genesis_da_height + last_slot_processed_before_shutdown.get();
+    let da_height_processed = genesis_da_height + last_slot_processed_before_shutdown.get();
 
     let target_da_height = get_target_block(da_service, &stop_at_rollup_height)
         .await?

--- a/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use futures::StreamExt;
 use proptest::prelude::*;
 use rand::SeedableRng;
+use serde::Deserialize;
 use sov_db::storage_manager::{NativeChangeSet, NativeStorageManager};
 use sov_mock_da::storable::layer::StorableMockDaLayer;
 use sov_mock_da::storable::StorableMockDaService;
@@ -19,6 +20,7 @@ use sov_rollup_interface::common::{HexHash, RollupHeight, SlotNumber};
 use sov_rollup_interface::da::{DaSpec, RelevantBlobIters};
 use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
 use sov_rollup_interface::node::SyncStatus;
+use sov_rollup_interface::stf::GenesisParams;
 use sov_rollup_interface::stf::{
     ApplySlotOutput, BatchReceipt, ExecutionContext, StateTransitionFunction,
 };
@@ -28,6 +30,15 @@ use sov_state::{
 };
 
 use super::*;
+
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct MockGenesisParams;
+
+impl GenesisParams for MockGenesisParams {
+    fn genesis_slot_number(&self) -> u64 {
+        0
+    }
+}
 
 /// A mock implementation of the [`StateTransitionFunction`]
 #[derive(PartialEq, Debug, Clone, Eq, serde::Serialize, serde::Deserialize, Default)]
@@ -39,7 +50,7 @@ impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, 
     type Address = Vec<u8>;
     type StateRoot = <ProverStorage<S> as Storage>::Root;
     type GasPrice = ();
-    type GenesisParams = ();
+    type GenesisParams = MockGenesisParams;
     type PreState = ();
     type ChangeSet = ();
     type StorageProof = ();

--- a/crates/full-node/sov-stf-runner/tests/integration/aggregated_proof_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/aggregated_proof_tests.rs
@@ -158,7 +158,7 @@ async fn spawn(
     .await;
 
     let join_handle = tokio::spawn(async move {
-        runner.run_in_process().await.map_err(|error| {
+        runner.run_in_process(0).await.map_err(|error| {
             tracing::warn!(?error, "Runner returned a error during execution");
             error
         })

--- a/crates/full-node/sov-stf-runner/tests/integration/aggregated_proof_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/aggregated_proof_tests.rs
@@ -142,7 +142,7 @@ async fn spawn(
     };
     let init_variant = InitVariant::Genesis {
         block: genesis_block,
-        genesis_params: vec![1],
+        genesis_params: vec![1].into(),
     };
 
     let da_service =

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/hash_stf.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/hash_stf.rs
@@ -7,7 +7,7 @@ use sov_modules_api::{
 };
 use sov_rollup_interface::common::RollupHeight;
 use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait, DaSpec, RelevantBlobIters};
-use sov_rollup_interface::stf::{ApplySlotOutput, StateTransitionFunction};
+use sov_rollup_interface::stf::{ApplySlotOutput, GenesisParams, StateTransitionFunction};
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
 use sov_rollup_interface::zk::{ZkVerifier, Zkvm};
 use sov_state::namespaces::User;
@@ -62,12 +62,29 @@ impl HashStf {
     }
 }
 
+#[derive(Default, Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(transparent)]
+/// The genesis params for the HashStf. This is a simple wrapper around a vector of bytes.
+pub struct HashStfGenesisParams(pub Vec<u8>);
+
+impl GenesisParams for HashStfGenesisParams {
+    fn genesis_slot_number(&self) -> u64 {
+        0
+    }
+}
+
+impl From<Vec<u8>> for HashStfGenesisParams {
+    fn from(value: Vec<u8>) -> Self {
+        Self(value)
+    }
+}
+
 impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, OuterVm, Da>
     for HashStf
 {
     type Address = MockAddress;
     type StateRoot = StorageRoot<S>;
-    type GenesisParams = Vec<u8>;
+    type GenesisParams = HashStfGenesisParams;
     type PreState = ProverStorage<S>;
     type ChangeSet = NativeChangeSet;
     type TxReceiptContents = ();
@@ -84,7 +101,7 @@ impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, 
         params: Self::GenesisParams,
     ) -> (Self::StateRoot, Self::ChangeSet) {
         let mut hasher = sha2::Sha256::new();
-        hasher.update(params);
+        hasher.update(params.0);
 
         HashStf::save_from_hasher(
             hasher,

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -182,15 +182,9 @@ pub async fn initialize_runner(
     let ledger_db = LedgerDb::with_reader(ledger_state).unwrap();
     let (sync_sender, _sync_status_receiver) = watch::channel(SyncStatus::START);
 
-    let da_sync_state = make_da_sync_state(
-        0,
-        None,
-        &ledger_db,
-        da_service.as_ref(),
-        sync_sender,
-    )
-    .await
-    .unwrap();
+    let da_sync_state = make_da_sync_state(0, None, &ledger_db, da_service.as_ref(), sync_sender)
+        .await
+        .unwrap();
     let (state_update_sender, state_update_recv) = watch::channel(
         bootstrap_state_update_info(&mut storage_manager, da_sync_state.as_ref())
             .await

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -183,7 +183,7 @@ pub async fn initialize_runner(
     let (sync_sender, _sync_status_receiver) = watch::channel(SyncStatus::START);
 
     let da_sync_state = make_da_sync_state(
-        &rollup_config.runner,
+        0,
         None,
         &ledger_db,
         da_service.as_ref(),
@@ -396,7 +396,6 @@ pub fn rollup_config_with_da<Da: DaService<Config = MockDaConfig>>(
     RollupConfig {
         storage: RollupDbConfig::default_in_path(path.to_path_buf()),
         runner: RunnerConfig {
-            genesis_height: 0,
             da_polling_interval_ms: get_da_polling_interval_ms(&da_config),
             da_total_timeout_secs: get_da_total_timeout_secs(&da_config),
             http_config: HttpServerConfig::localhost_on_free_port(),

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_initialization_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_initialization_tests.rs
@@ -30,7 +30,7 @@ async fn init_and_restart_inner() {
     };
     let init_variant: MockInitVariant = InitVariant::Genesis {
         block: genesis_block,
-        genesis_params: vec![1],
+        genesis_params: vec![1].into(),
     };
 
     let tmpdir = tempfile::tempdir().unwrap();

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -128,7 +128,7 @@ async fn test_runner_with_background_da_service(
     let (sync_sender, mut sync_status_receiver) = watch::channel(SyncStatus::START);
     let ledger_db = LedgerDb::with_reader(ledger_state).unwrap();
     let da_sync_state = make_da_sync_state(
-        &rollup_config.runner,
+        0,
         None,
         &ledger_db,
         da_service.as_ref(),
@@ -143,11 +143,12 @@ async fn test_runner_with_background_da_service(
 
     sync_status_receiver.mark_unchanged();
 
-    let genesis_params = vec![1, 2, 3, 4, 5].into();
+    let genesis_params = vec![1, 2, 3, 4, 5];
+    let genesis_da_height = 0;
 
     let init_variant: MockInitVariant = InitVariant::Genesis {
         block,
-        genesis_params,
+        genesis_params: genesis_params.into(),
     };
     let (prev_state_root, _genesis_state_root) =
         init_variant.initialize(&stf, &mut storage_manager).await?;
@@ -171,7 +172,7 @@ async fn test_runner_with_background_da_service(
     .await?;
 
     let runner_task = tokio::spawn(async move {
-        runner.run_in_process().await.map_err(|error| {
+        runner.run_in_process(genesis_da_height).await.map_err(|error| {
             tracing::warn!(?error, "Runner return execution with error");
             error
         })
@@ -325,7 +326,7 @@ async fn check_runner(
     let (mut runner, test_node) =
         initialize_runner(da_service, tmpdir.path(), init_variant, 1, None).await;
     let before = *runner.get_state_root();
-    let end = runner.run_in_process().await;
+    let end = runner.run_in_process(0).await;
     // TODO: Subscribe to block notifications and shutdown runner afterwards.
     assert!(end.is_err());
     let after = *runner.get_state_root();

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -127,15 +127,9 @@ async fn test_runner_with_background_da_service(
 
     let (sync_sender, mut sync_status_receiver) = watch::channel(SyncStatus::START);
     let ledger_db = LedgerDb::with_reader(ledger_state).unwrap();
-    let da_sync_state = make_da_sync_state(
-        0,
-        None,
-        &ledger_db,
-        da_service.as_ref(),
-        sync_sender,
-    )
-    .await
-    .unwrap();
+    let da_sync_state = make_da_sync_state(0, None, &ledger_db, da_service.as_ref(), sync_sender)
+        .await
+        .unwrap();
 
     let (state_update_sender, _state_update_recv) = watch::channel(
         bootstrap_state_update_info(&mut storage_manager, da_sync_state.as_ref()).await?,
@@ -172,10 +166,13 @@ async fn test_runner_with_background_da_service(
     .await?;
 
     let runner_task = tokio::spawn(async move {
-        runner.run_in_process(genesis_da_height).await.map_err(|error| {
-            tracing::warn!(?error, "Runner return execution with error");
-            error
-        })
+        runner
+            .run_in_process(genesis_da_height)
+            .await
+            .map_err(|error| {
+                tracing::warn!(?error, "Runner return execution with error");
+                error
+            })
     });
 
     let mut synced_da_height = 0;

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -86,7 +86,7 @@ async fn test_simple_reorg_case() {
 
     let init_variant: MockInitVariant = InitVariant::Genesis {
         block: genesis_block,
-        genesis_params,
+        genesis_params: genesis_params.into(),
     };
 
     check_runner(da_service, &tmp_dir, init_variant, expected_state_root).await;
@@ -143,7 +143,7 @@ async fn test_runner_with_background_da_service(
 
     sync_status_receiver.mark_unchanged();
 
-    let genesis_params = vec![1, 2, 3, 4, 5];
+    let genesis_params = vec![1, 2, 3, 4, 5].into();
 
     let init_variant: MockInitVariant = InitVariant::Genesis {
         block,
@@ -306,7 +306,7 @@ async fn test_instant_finality_data_stored() -> anyhow::Result<()> {
 
     let init_variant: MockInitVariant = InitVariant::Genesis {
         block: genesis_block,
-        genesis_params,
+        genesis_params: genesis_params.into(),
     };
 
     check_runner(da_service, &tmp_dir, init_variant, expected_state_root).await;
@@ -387,7 +387,7 @@ fn get_result_from_blocks(
             &stf,
             &Default::default(),
             storage,
-            genesis_params.to_vec(),
+            genesis_params.to_vec().into(),
         );
     storage_manager.commit(change_set);
 

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -701,7 +701,6 @@
       "type": "object",
       "required": [
         "da_polling_interval_ms",
-        "genesis_height",
         "http_config"
       ],
       "properties": {
@@ -723,12 +722,6 @@
         "da_total_timeout_secs": {
           "description": "How much total time DA service has to provide block, including re-orgs, retries, etc. Exceeding this timeout will lead to rollup shutdown.",
           "default": 600,
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        },
-        "genesis_height": {
-          "description": "DA start height.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0

--- a/crates/module-system/sov-modules-api/src/lib.rs
+++ b/crates/module-system/sov-modules-api/src/lib.rs
@@ -108,9 +108,9 @@ pub use sov_rollup_interface::node::{DaSyncState, SyncStatus};
 pub use sov_rollup_interface::optimistic::{SerializedAttestation, SerializedChallenge};
 pub use sov_rollup_interface::reexports::digest;
 pub use sov_rollup_interface::stf::{
-    ApplySlotOutput, BatchReceipt, ExecutionContext, IgnoredTransactionReceipt, InvalidProofError,
-    ProofOutcome, ProofReceipt, ProofReceiptContents, ProofSender, StateTransitionFunction,
-    StoredEvent,
+    ApplySlotOutput, BatchReceipt, ExecutionContext, GenesisParams as GenesisParamsTrait,
+    IgnoredTransactionReceipt, InvalidProofError, ProofOutcome, ProofReceipt, ProofReceiptContents,
+    ProofSender, StateTransitionFunction, StoredEvent,
 };
 pub use sov_rollup_interface::zk::aggregated_proof::{
     AggregatedProofPublicData, CodeCommitment, SerializedAggregatedProof,

--- a/crates/module-system/sov-modules-api/src/runtime/mod.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/mod.rs
@@ -7,6 +7,8 @@ use std::io;
 use borsh::{BorshDeserialize, BorshSerialize};
 use capabilities::{HasCapabilities, HasKernel, TransactionAuthenticator};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "native")]
+use sov_rollup_interface::stf::GenesisParams;
 
 #[cfg(feature = "native")]
 use crate::hooks::FinalizeHook;
@@ -52,7 +54,7 @@ pub trait Runtime<S: Spec>:
     const CHAIN_HASH: [u8; 32];
 
     /// GenesisConfig type.
-    type GenesisConfig: Clone + Send + Sync;
+    type GenesisConfig: Clone + Send + Sync + GenesisParams;
 
     /// GenesisInput type.
     type GenesisInput: std::fmt::Debug + Clone + Send + Sync;

--- a/crates/module-system/sov-modules-macros/Cargo.toml
+++ b/crates/module-system/sov-modules-macros/Cargo.toml
@@ -72,7 +72,8 @@ native = [
 	"sov-rollup-interface/native",
 	"sov-state/native",
 	"sov-address/native",
-	"sov-metrics?/native"
+	"sov-metrics?/native",
+	"sov-chain-state/native"
 ]
 arbitrary = [
 	"sov-modules-macros/arbitrary",

--- a/crates/module-system/sov-modules-macros/Cargo.toml
+++ b/crates/module-system/sov-modules-macros/Cargo.toml
@@ -42,6 +42,7 @@ sov-metrics = { workspace = true, optional = true }
 [dev-dependencies]
 sov-modules-macros = { path = ".", features = ["native"] }
 sov-modules-api = { workspace = true, features = ["native", "test-utils"] }
+sov-chain-state = { workspace = true, features = ["native"] }
 borsh = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client", "macros", "server"] }
 schemars = { workspace = true }

--- a/crates/module-system/sov-modules-macros/src/dispatch/genesis.rs
+++ b/crates/module-system/sov-modules-macros/src/dispatch/genesis.rs
@@ -49,7 +49,7 @@ impl GenesisMacro {
             &type_generics,
             where_clause,
             &config_attributes,
-        );
+        )?;
         let genesis_fn_body = Self::make_genesis_fn_body(&fields);
 
         // Implements the Genesis trait
@@ -120,7 +120,8 @@ impl GenesisMacro {
         type_generics: &TypeGenerics,
         where_clause: Option<&WhereClause>,
         attributes: &[proc_macro2::TokenStream],
-    ) -> proc_macro2::TokenStream {
+    ) -> Result<proc_macro2::TokenStream, syn::Error> {
+        let chain_state_field_name = fields.iter().find(|field| field.ident == "chain_state").ok_or_else(|| syn::Error::new(Span::call_site(), "Chain state field not found. The Genesis macro may only be used if your runtime contains the `sov_chain_state::ChainState` module with the name `chain_state`. If you need a custom chain name, reach out to the SDK developers for support."))?.ident.clone();
         let field_names = fields.iter().map(|field| &field.ident);
 
         let fields: &Vec<proc_macro2::TokenStream> = &fields
@@ -135,7 +136,7 @@ impl GenesisMacro {
             })
             .collect();
 
-        quote::quote! {
+        Ok(quote::quote! {
             #[doc = "Initial configuration for the rollup."]
             #(#attributes)*
             pub struct GenesisConfig #impl_generics #where_clause{
@@ -151,6 +152,12 @@ impl GenesisMacro {
                     }
                 }
             }
-        }
+
+            impl #impl_generics ::sov_modules_api::GenesisParamsTrait for GenesisConfig #type_generics #where_clause {
+                fn genesis_slot_number(&self) -> u64 {
+                    self.#chain_state_field_name.genesis_da_height as u64
+                }
+            }
+        })
     }
 }

--- a/crates/module-system/sov-modules-macros/tests/integration/derive_wallet.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/derive_wallet.rs
@@ -38,9 +38,15 @@ pub mod first_test_module {
         phantom: std::marker::PhantomData<S>,
     }
 
+    #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+    #[serde(transparent)]
+    pub struct MockGenesisParams {
+        pub genesis_da_height: u64,
+    }
+
     impl<S: Spec> Module for FirstTestStruct<S> {
         type Spec = S;
-        type Config = ();
+        type Config = MockGenesisParams;
         type CallMessage = MyStruct;
         type Event = ();
 
@@ -129,7 +135,7 @@ pub mod second_test_module {
 
 #[derive(Default, Genesis, PartialEq, Eq, DispatchCall, MessageCodec, CliWallet)]
 pub struct Runtime<S: Spec> {
-    pub first: first_test_module::FirstTestStruct<S>,
+    pub chain_state: first_test_module::FirstTestStruct<S>,
     pub second: second_test_module::SecondTestStruct<S>,
 }
 
@@ -137,14 +143,14 @@ pub struct Runtime<S: Spec> {
 fn build_runtime_call() {
     use sov_modules_api::prelude::clap::Parser;
 
-    let expected_foo = RuntimeCall::First(first_test_module::MyStruct {
+    let expected_foo = RuntimeCall::ChainState(first_test_module::MyStruct {
         first_field: 1,
         str_field: SizedSafeString::<10>::try_from("hello").unwrap(),
     });
     let foo_from_cli: RuntimeSubcommand<JsonStringArg, TestSpec> =
         <RuntimeSubcommand<JsonStringArg, TestSpec>>::try_parse_from([
             "main",
-            "first",
+            "chain-state",
             "--json",
             r#"{"first_field": 1, "str_field": "hello"}"#,
             "--chain-id",

--- a/crates/module-system/sov-modules-macros/tests/integration/dispatch.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/dispatch.rs
@@ -51,9 +51,14 @@ pub mod first_test_module {
         FirstModuleEnum3(Vec<u8>),
     }
 
+    #[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize, Default)]
+    pub struct Config {
+        pub genesis_da_height: u64,
+    }
+
     impl<S: Spec> Module for FirstTestStruct<S> {
         type Spec = S;
-        type Config = ();
+        type Config = Config;
         type CallMessage = u8;
         type Event = Event;
 
@@ -249,7 +254,7 @@ mod custom_attributes {
     use super::*;
     #[derive(Default, Genesis, DispatchCall, Event, MessageCodec)]
     struct Runtime<S: Spec> {
-        pub first: first_test_module::FirstTestStruct<S>,
+        pub chain_state: first_test_module::FirstTestStruct<S>,
         pub second: second_test_module::SecondTestStruct<S>,
     }
     #[test]
@@ -266,7 +271,7 @@ mod derive_event {
     use super::*;
     #[derive(Default, Genesis, DispatchCall, Event, MessageCodec)]
     struct Runtime<S: Spec> {
-        pub first: first_test_module::FirstTestStruct<S>,
+        pub chain_state: first_test_module::FirstTestStruct<S>,
         pub second: second_test_module::SecondTestStruct<S>,
     }
 
@@ -274,10 +279,14 @@ mod derive_event {
     fn derive_event() {
         // Check to see if the runtime events are getting initialized correctly
         let _event =
-            RuntimeEvent::<TestSpec>::First(first_test_module::Event::FirstModuleEnum1(10));
-        let _event = RuntimeEvent::<TestSpec>::First(first_test_module::Event::FirstModuleEnum2);
+            RuntimeEvent::<TestSpec>::ChainState(first_test_module::Event::FirstModuleEnum1(10));
         let _event =
-            RuntimeEvent::<TestSpec>::First(first_test_module::Event::FirstModuleEnum3(vec![1; 3]));
+            RuntimeEvent::<TestSpec>::ChainState(first_test_module::Event::FirstModuleEnum2);
+        let _event =
+            RuntimeEvent::<TestSpec>::ChainState(first_test_module::Event::FirstModuleEnum3(vec![
+                1;
+                3
+            ]));
         let event = RuntimeEvent::<TestSpec>::Second(second_test_module::Event::SecondModuleEnum);
         let discriminant: &'static str = event.discriminant().into();
         assert_eq!(discriminant, "Second");
@@ -294,7 +303,7 @@ mod derive_genesis {
         S: Spec,
         T: ModuleThreeStorable,
     {
-        pub first: first_test_module::FirstTestStruct<S>,
+        pub chain_state: first_test_module::FirstTestStruct<S>,
         pub second: second_test_module::SecondTestStruct<S>,
         pub third: third_test_module::ThirdTestStruct<S, T>,
     }
@@ -305,7 +314,7 @@ mod derive_genesis {
         let mut state =
             sov_modules_api::StateCheckpoint::new(storage, &MockKernel::<ZkTestSpec>::default());
         let runtime = &mut Runtime::<ZkTestSpec, u32>::default();
-        let config = GenesisConfig::new((), (), ());
+        let config = GenesisConfig::new(Default::default(), (), ());
         let mut genesis_state =
             state.to_genesis_state_accessor::<Runtime<ZkTestSpec, u32>>(&config);
         runtime
@@ -315,7 +324,7 @@ mod derive_genesis {
 
         {
             let response = runtime
-                .first
+                .chain_state
                 .get_state_value(&mut working_set)
                 .expect("The working set should be unmetered");
             assert_eq!(response, 1);
@@ -351,7 +360,7 @@ mod derive_dispatch {
         S: Spec,
         T: ModuleThreeStorable,
     {
-        pub first: first_test_module::FirstTestStruct<S>,
+        pub chain_state: first_test_module::FirstTestStruct<S>,
         pub second: second_test_module::SecondTestStruct<S>,
         pub third: third_test_module::ThirdTestStruct<S, T>,
     }
@@ -367,7 +376,7 @@ mod derive_dispatch {
 
         let mut state =
             sov_modules_api::StateCheckpoint::new(storage, &MockKernel::<ZkTestSpec>::default());
-        let config = GenesisConfig::new((), (), ());
+        let config = GenesisConfig::new(Default::default(), (), ());
         let mut genesis_state =
             state.to_genesis_state_accessor::<Runtime<ZkTestSpec, u32>>(&config);
         runtime
@@ -392,7 +401,7 @@ mod derive_dispatch {
             )
             .unwrap();
 
-            assert_eq!(runtime.module_id(&module), runtime.first.id());
+            assert_eq!(runtime.module_id(&module), runtime.chain_state.id());
             runtime
                 .dispatch_call(module, &mut working_set, &context)
                 .unwrap();
@@ -400,7 +409,7 @@ mod derive_dispatch {
 
         {
             let response = runtime
-                .first
+                .chain_state
                 .get_state_value(&mut working_set)
                 .expect("The working set should be unmetered");
             assert_eq!(response, value);

--- a/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/rpc_gen_associated_types.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/rpc_gen_associated_types.rs
@@ -110,6 +110,7 @@ pub mod my_module {
 #[expose_rpc]
 #[derive(Default, Genesis, DispatchCall, MessageCodec)]
 struct Runtime<S: Spec, T: TestSpec> {
+    pub chain_state: sov_chain_state::ChainState<S>,
     pub first: my_module::QueryModule<S, T::Data>,
 }
 
@@ -127,7 +128,15 @@ fn associated_types() {
     let storage = ZkStorage::new();
     let mut state = StateCheckpoint::new(storage, &MockKernel::<S>::default());
     let runtime = &mut Runtime::<S, ActualSpec>::default();
-    let config = GenesisConfig::new(22);
+    let chain_state_config = sov_chain_state::ChainStateConfig::<S> {
+        current_time: sov_rollup_interface::da::Time::from_secs(0),
+        operating_mode: sov_modules_api::OperatingMode::Zk,
+        inner_code_commitment: Default::default(),
+        outer_code_commitment: Default::default(),
+        genesis_da_height: 0,
+        admin: None,
+    };
+    let config = GenesisConfig::new(chain_state_config, 22);
     let mut genesis_state = state.to_genesis_state_accessor::<RT>(&config);
     runtime
         .genesis(&Default::default(), &config, &mut genesis_state)

--- a/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/rpc_gen_associated_types_nested.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/rpc_gen_associated_types_nested.rs
@@ -124,6 +124,7 @@ pub mod my_module {
 #[expose_rpc]
 #[derive(Default, Genesis, DispatchCall, MessageCodec)]
 struct Runtime<S: Spec, T: TestSpec> {
+    pub chain_state: sov_chain_state::ChainState<S>,
     pub first: my_module::QueryModule<S, <<T as TestSpec>::Message as Message>::Data>,
 }
 
@@ -148,7 +149,15 @@ fn associated_types_nested() {
     let storage = ZkStorage::new();
     let mut state = StateCheckpoint::new(storage, &MockKernel::<S>::default());
     let runtime = &mut Runtime::<S, ActualSpec>::default();
-    let config = GenesisConfig::new(22);
+    let chain_state_config = sov_chain_state::ChainStateConfig::<S> {
+        current_time: sov_rollup_interface::da::Time::from_secs(0),
+        operating_mode: sov_modules_api::OperatingMode::Zk,
+        inner_code_commitment: Default::default(),
+        outer_code_commitment: Default::default(),
+        genesis_da_height: 0,
+        admin: None,
+    };
+    let config = GenesisConfig::new(chain_state_config, 22);
     let mut genesis_state = state.to_genesis_state_accessor::<RT>(&config);
     runtime
         .genesis(&Default::default(), &config, &mut genesis_state)

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/dispatch/derive_event_no_default_attrs.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/dispatch/derive_event_no_default_attrs.rs
@@ -7,6 +7,7 @@ use sov_modules_api::{DispatchCall, Event, Genesis, MessageCodec, Spec};
 #[event(no_default_attrs)]
 struct Runtime<S: Spec> {
     pub bank: sov_bank::Bank<S>,
+    pub chain_state: sov_chain_state::ChainState<S>,
 }
 
 fn main() {}

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.stderr
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.stderr
@@ -1,3 +1,11 @@
+error: Chain state field not found. The Genesis macro may only be used if your runtime contains the `sov_chain_state::ChainState` module with the name `chain_state`. If you need a custom chain name, reach out to the SDK developers for support.
+   --> tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs:107:19
+    |
+107 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+    |                   ^^^^^^^
+    |
+    = note: this error originates in the derive macro `Genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0310]: the parameter type `T` may not live long enough
    --> tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs:107:28
     |

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs
@@ -111,6 +111,7 @@ pub mod my_module {
 #[derive(Default, Genesis, DispatchCall, MessageCodec)]
 struct Runtime<T: TestSpec, S: Spec> {
     pub first: my_module::QueryModule<S, T::Data>,
+    pub chain_state: sov_chain_state::ChainState<S>,
 }
 
 #[derive(Default, Clone, PartialEq, Eq)]

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.stderr
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.stderr
@@ -44,9 +44,9 @@ help: consider further restricting type parameter `T` with trait `Spec`
     |                            +++++++++++++++++++++++
 
 error[E0277]: `ActualSpec` doesn't implement `std::fmt::Debug`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:119:19
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:120:19
     |
-119 | impl TestSpec for ActualSpec {
+120 | impl TestSpec for ActualSpec {
     |                   ^^^^^^^^^^ `ActualSpec` cannot be formatted using `{:?}`
     |
     = help: the trait `std::fmt::Debug` is not implemented for `ActualSpec`
@@ -60,8 +60,8 @@ note: required by a bound in `TestSpec`
     |                             ^^^^^^^^^^^^^^^ required by this bound in `TestSpec`
 help: consider annotating `ActualSpec` with `#[derive(Debug)]`
     |
-117 + #[derive(Debug)]
-118 | struct ActualSpec;
+118 + #[derive(Debug)]
+119 | struct ActualSpec;
     |
 
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied
@@ -117,6 +117,23 @@ note: expected this to be `T`
     = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
     = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
     = note: required for the cast from `&QueryModule<S, <T as TestSpec>::Data>` to `&dyn sov_modules_api::ModuleInfo<Spec = T>`
+    = note: this error originates in the derive macro `Genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<ChainState<S> as ModuleInfo>::Spec == T`
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:19
+    |
+111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+    |                   ^^^^^^^ expected type parameter `T`, found type parameter `S`
+112 | struct Runtime<T: TestSpec, S: Spec> {
+    |                -            - found type parameter
+    |                |
+    |                expected type parameter
+    |
+    = note: expected type parameter `T`
+               found type parameter `S`
+    = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+    = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+    = note: required for the cast from `&sov_chain_state::ChainState<S>` to `&dyn sov_modules_api::ModuleInfo<Spec = T>`
     = note: this error originates in the derive macro `Genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `impl ::sov_modules_api::GenesisState<<Self as ::sov_modules_api::Genesis>::Spec>: GenesisState<S>` is not satisfied
@@ -226,6 +243,23 @@ note: expected this to be `T`
     = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
     = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
     = note: required for the cast from `&QueryModule<S, <T as TestSpec>::Data>` to `&dyn sov_modules_api::ModuleInfo<Spec = T>`
+    = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<ChainState<S> as ModuleInfo>::Spec == T`
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:28
+    |
+111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+    |                            ^^^^^^^^^^^^ expected type parameter `T`, found type parameter `S`
+112 | struct Runtime<T: TestSpec, S: Spec> {
+    |                -            - found type parameter
+    |                |
+    |                expected type parameter
+    |
+    = note: expected type parameter `T`
+               found type parameter `S`
+    = note: a type parameter was expected, but a different one was found; you might be missing a type parameter or trait bound
+    = note: for more information, visit https://doc.rust-lang.org/book/ch10-02-traits.html#traits-as-parameters
+    = note: required for the cast from `&sov_chain_state::ChainState<S>` to `&dyn sov_modules_api::ModuleInfo<Spec = T>`
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the method `clone` exists for struct `ApiState<T>`, but its trait bounds were not satisfied

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/endpoints.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/endpoints.rs
@@ -345,7 +345,6 @@ mod tests {
         public_address: Option<&str>,
     ) -> RunnerConfig {
         RunnerConfig {
-            genesis_height: 0,
             da_polling_interval_ms: 0,
             da_total_timeout_secs: 0,
             http_config: sov_stf_runner::HttpServerConfig {

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use async_trait::async_trait;
 pub use endpoints::*;
+use sov_modules_api::GenesisParamsTrait;
 use sov_db::ledger_db::LedgerDb;
 use sov_db::schema::{DeltaReader, SchemaBatch};
 use sov_modules_api::capabilities::{HasCapabilities, HasKernel, ProofProcessor, RollupHeight};
@@ -329,15 +330,16 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             "Recovering the state root"
         );
         let native_stf = StfBlueprint::new();
+        let genesis_slot_number = genesis_params.genesis_slot_number();
         let (prover_storage, prev_state_root, genesis_state_root) = match prev_root {
             // Missing prev_root means need for initialization
             None => {
                 info!(
-                    rollup_genesis_height = rollup_config.runner.genesis_height,
+                    rollup_genesis_height = genesis_params.genesis_slot_number(),
                     "Rollup state is empty, performing genesis initialization. Requesting genesis DA block"
                 );
                 let rollup_genesis_block = da_service
-                    .get_block_at(rollup_config.runner.genesis_height)
+                    .get_block_at(genesis_params.genesis_slot_number())
                     .await?;
 
                 let genesis_header = rollup_genesis_block.header().clone();
@@ -379,7 +381,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             tokio::sync::watch::channel(SyncStatus::START);
 
         let da_sync_state = make_da_sync_state(
-            &rollup_config.runner,
+            genesis_slot_number,
             stop_at_rollup_height,
             &ledger_db,
             da_service.as_ref(),
@@ -531,6 +533,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             shutdown_sender: main_shutdown_sender,
             secondary_shutdown_sender,
             background_handles,
+            genesis_slot_number,
         })
     }
 }
@@ -589,6 +592,9 @@ pub struct Rollup<S: FullNodeBlueprint<M>, M: ExecutionMode> {
     /// A way to gracefully shut down background tasks.
     pub shutdown_sender: tokio::sync::watch::Sender<()>,
 
+    /// The genesis slot number.
+    pub genesis_slot_number: u64,
+
     // Trigger after the runner has finished.
     secondary_shutdown_sender: tokio::sync::watch::Sender<()>,
 
@@ -625,7 +631,7 @@ impl<S: FullNodeBlueprint<M>, M: ExecutionMode> Rollup<S, M> {
         let monitoring_task =
             spawn_task_monitor(self.shutdown_sender.clone(), self.background_handles);
 
-        runner.run_in_process().await?;
+        runner.run_in_process(self.genesis_slot_number).await?;
         tracing::info!("STF Runner has completed execution");
 
         if self.shutdown_sender.send(()).is_err() {

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -9,13 +9,13 @@ use std::sync::Arc;
 use anyhow::Context;
 use async_trait::async_trait;
 pub use endpoints::*;
-use sov_modules_api::GenesisParamsTrait;
 use sov_db::ledger_db::LedgerDb;
 use sov_db::schema::{DeltaReader, SchemaBatch};
 use sov_modules_api::capabilities::{HasCapabilities, HasKernel, ProofProcessor, RollupHeight};
 use sov_modules_api::execution_mode::ExecutionMode;
 use sov_modules_api::provable_height_tracker::MaximumProvableHeight;
 use sov_modules_api::rest::{ApiState, StateUpdateReceiver};
+use sov_modules_api::GenesisParamsTrait;
 use sov_modules_api::{
     DaSpec, NodeEndpoints, OperatingMode, ProofSender, Spec, StateCheckpoint, StateUpdateInfo,
     SyncStatus, VersionReader, ZkVerifier,

--- a/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -256,6 +256,7 @@ where
     S: Spec,
     RT: Runtime<S>,
     RT: HasKernel<S>,
+    GenesisParams<<RT as Genesis>::Config>: GenesisParamsTrait,
 {
     type StateRoot = <S::Storage as Storage>::Root;
 

--- a/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -387,6 +387,7 @@ where
     S: Spec,
     RT: Runtime<S>,
     RT: HasKernel<S>,
+    GenesisParams<<RT as Genesis>::Config>: GenesisParamsTrait,
 {
     #[cfg_attr(feature = "bench", sov_modules_api::cycle_tracker)]
     fn select_and_validate_blobs<CF: InjectedControlFlow<S> + Clone>(
@@ -411,6 +412,7 @@ where
     S: Spec,
     RT: Runtime<S>,
     RT: HasKernel<S>,
+    GenesisParams<<RT as Genesis>::Config>: GenesisParamsTrait,
 {
     /// Run a state transition using the STF blueprint.
     // Similar to `apply_slot`, but enables the injection of a custom `InjectedControlFlow`.

--- a/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -16,7 +16,7 @@ use sov_modules_api::{
 use sov_state::SlotValue;
 mod proof_processing;
 use sov_modules_api::{PrivilegedKernelAccessor, SlotGasMeter};
-use sov_rollup_interface::stf::{DiscardedBlob, ProofReceipt};
+use sov_rollup_interface::stf::{DiscardedBlob, GenesisParams as GenesisParamsTrait, ProofReceipt};
 mod sequencer_mode;
 use sov_modules_api::{IterableBatchWithId, TxReceiptContents};
 #[cfg(feature = "test-utils")]
@@ -69,6 +69,12 @@ pub struct ApplyTxResult<S: Spec> {
 pub struct GenesisParams<RuntimeConfig> {
     /// The runtime genesis parameters
     pub runtime: RuntimeConfig,
+}
+
+impl<RuntimeConfig: GenesisParamsTrait> GenesisParamsTrait for GenesisParams<RuntimeConfig> {
+    fn genesis_slot_number(&self) -> u64 {
+        self.runtime.genesis_slot_number()
+    }
 }
 
 impl<S, RT> StfBlueprint<S, RT>

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -309,7 +309,6 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
         RollupConfig {
             storage: RollupDbConfig::default_in_path(self.config.storage.path().to_path_buf()),
             runner: RunnerConfig {
-                genesis_height: 0,
                 da_polling_interval_ms: 30,
                 da_total_timeout_secs: 3_600,
                 http_config: HttpServerConfig::on_host_port(

--- a/crates/rollup-interface/src/state_machine/stf/mod.rs
+++ b/crates/rollup-interface/src/state_machine/stf/mod.rs
@@ -278,7 +278,7 @@ pub trait StateTransitionFunction<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> {
     type Address: Serialize + DeserializeOwned + Clone + Debug;
 
     /// The initial params of the rollup.
-    type GenesisParams;
+    type GenesisParams: GenesisParams;
 
     /// State of the rollup before transition.
     type PreState;
@@ -335,4 +335,10 @@ pub trait StateTransitionFunction<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> {
         relevant_blobs: RelevantBlobIters<&mut [<Da as DaSpec>::BlobTransaction]>,
         execution_context: ExecutionContext,
     ) -> ApplySlotOutput<InnerVm, OuterVm, Da, Self>;
+}
+
+/// The parameters for the genesis block.
+pub trait GenesisParams {
+    /// Returns the slot number (aka DA block number) at which the genesis block should be applied.
+    fn genesis_slot_number(&self) -> u64;
 }

--- a/examples/demo-rollup/celestia_rollup_config.toml
+++ b/examples/demo-rollup/celestia_rollup_config.toml
@@ -49,10 +49,7 @@ backoff_max_times = 10
 path = "demo_data"
 state_cache_size = 4294967296 # 4GB. Default is 1GB.
 
-# We define the rollup's genesis to occur at block number `genesis_height`. The rollup will ignore
-# any blocks before this height, and any blobs at this height will not be processed
 [runner]
-genesis_height = 3
 # Block time for celestia is configured in `docker/run-validator.sh` and we try to set this one to be lower,
 # So status is updated more frequently.
 da_polling_interval_ms = 500

--- a/examples/demo-rollup/mock_rollup_config.toml
+++ b/examples/demo-rollup/mock_rollup_config.toml
@@ -47,8 +47,6 @@ state_cache_size = 4294967296 # 4GB. Default is 1GB.
 # We define the rollup's genesis to occur at block number `genesis_height`. The rollup will ignore
 # any blocks before this height, and any blobs at this height will not be processed
 [runner]
-genesis_height = 0
-
 # da.block_time is 1s, so status updater will try to poll it 20 times during it.
 da_polling_interval_ms = 50
 # da_total_timeout_secs = 600 # Total timeout for DA service including re-orgs and retries

--- a/examples/demo-rollup/stf/README.md
+++ b/examples/demo-rollup/stf/README.md
@@ -73,6 +73,9 @@ pub struct MyRuntime<S: Spec> {
 
     #[allow(unused)]
     accounts: sov_accounts::Accounts<S>,
+
+    #[allow(unused)]
+    chain_state: sov_chain_state::ChainState<S>,
 }
 
 fn main() {}

--- a/examples/demo-simple-stf/README.md
+++ b/examples/demo-simple-stf/README.md
@@ -174,7 +174,7 @@ fn test_stf_success() {
     let address = MockAddress::from([1; 32]);
 
     let stf = &mut CheckHashPreimageStf::default();
-    StateTransitionFunction::<MockZkvm, MockZkvm, MockDaSpec>::init_chain(stf, &Default::default(), (), ());
+    StateTransitionFunction::<MockZkvm, MockZkvm, MockDaSpec>::init_chain(stf, &Default::default(), (), Default::default());
 
     let mut batch_blobs = {
         let incorrect_preimage = vec![1; 32];

--- a/examples/demo-simple-stf/src/lib.rs
+++ b/examples/demo-simple-stf/src/lib.rs
@@ -5,6 +5,7 @@ use std::fmt::Display;
 use sha2::Digest;
 use sov_rollup_interface::common::RollupHeight;
 use sov_rollup_interface::da::{BlobReaderTrait, DaSpec, RelevantBlobIters};
+use sov_rollup_interface::stf::GenesisParams as GenesisParamsTrait;
 use sov_rollup_interface::stf::{ApplySlotOutput, BatchReceipt, StateTransitionFunction};
 use sov_rollup_interface::zk::Zkvm;
 
@@ -38,6 +39,16 @@ impl Display for Root {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+/// Genesis parameters for the rollup.
+pub struct GenesisParams;
+
+impl GenesisParamsTrait for GenesisParams {
+    fn genesis_slot_number(&self) -> u64 {
+        0
+    }
+}
+
 impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, OuterVm, Da>
     for CheckHashPreimageStf
 {
@@ -49,7 +60,7 @@ impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, 
     type GasPrice = ();
 
     // This represents the initial configuration of the rollup, but it is not supported in this tutorial.
-    type GenesisParams = ();
+    type GenesisParams = GenesisParams;
     type PreState = ();
     type ChangeSet = ();
 

--- a/examples/demo-simple-stf/src/lib.rs
+++ b/examples/demo-simple-stf/src/lib.rs
@@ -39,7 +39,7 @@ impl Display for Root {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
 /// Genesis parameters for the rollup.
 pub struct GenesisParams;
 

--- a/examples/demo-simple-stf/tests/stf_test.rs
+++ b/examples/demo-simple-stf/tests/stf_test.rs
@@ -14,7 +14,7 @@ fn test_stf_success() {
         stf,
         &MockBlockHeader::default(),
         (),
-        (),
+        demo_simple_stf::GenesisParams,
     );
 
     let mut batch_blobs = {


### PR DESCRIPTION
# Description
This PR causes the runner to read its `genesis_height` value from the STF genesis params rather than having it configured separately in the runner's toml.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
