### PR TITLE
DA Namespace `constants.toml` follow up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2025-10-20
 - #1924 **Breaking change** rollup's batch and proof namespace needs to be specified in `constants.toml` as `BATCH_NAMESPACE` and `PROOF_NAMESPACE`.
+- #1925 Simplifies batch and proof namespace declaration: `BATCH_NAMESPACE = { byte_string = "sov-test-b" }` or `PROOF_NAMESPACE = { hex = "0x736f762d746573742d70" }`
 - #1925 removes the `genesis_height` param from the rollup_config.toml file. Genesis height is now *only* read from the genesis config file (usually `genesis.json`).
 
 # 2025-10-16

--- a/constants.testing.toml
+++ b/constants.testing.toml
@@ -234,8 +234,6 @@ BYTE_STRING_SINGLE = { byte_string = "a" }
 # Const byte string (cannot be overridden at runtime)
 CONST_BYTE_STRING = { const = { byte_string = "constant" } }
 
-# --- Byte string constants (invalid - for trybuild tests) ---
-
 
 BANK_DISCRIMINANT = 0
 ACCOUNTS_DISCRIMINANT = 1

--- a/constants.testing.toml
+++ b/constants.testing.toml
@@ -196,7 +196,45 @@ ARRAY_OF_U8 = [
     11,
 ]
 
+# --- Hex constants (valid) ---
+# Short hex (2 bytes)
+HEX_SHORT = { hex = "0xaabb" }
+# Medium hex (10 bytes, like namespace)
+HEX_MEDIUM = { hex = "0x736f762d746573742d70" }
+# Long hex (32 bytes, like hash)
+HEX_LONG = { hex = "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20" }
+# Hex without 0x prefix (also valid)
+HEX_NO_PREFIX = { hex = "aabbccdd" }
+# Empty hex (0 bytes)
+HEX_EMPTY = { hex = "0x" }
+# Const hex (cannot be overridden at runtime)
+CONST_HEX_ARRAY = { const = { hex = "0x0102030405" } }
 
+# --- Hex constants (invalid - for trybuild tests) ---
+# Invalid hex character 'z'
+HEX_INVALID_STRING = { hex = "0xzzzz" }
+# Odd length hex string (incomplete byte)
+HEX_ODD_LENGTH = { hex = "0xaaa" }
+
+# --- Byte string constants (valid) ---
+# ASCII string (10 bytes)
+BYTE_STRING_ASCII = { byte_string = "sov-test-b" }
+# Short ASCII (5 bytes)
+BYTE_STRING_SHORT = { byte_string = "hello" }
+# UTF-8 with Cyrillic - exactly 10 bytes (5 cyrillic chars × 2 bytes each)
+BYTE_STRING_UTF8 = { byte_string = "абвгд" }
+# UTF-8 with emoji + ASCII - exactly 10 bytes (🎉=4 + "hello"=5 + "!"=1)
+BYTE_STRING_EMOJI = { byte_string = "🎉hello!" }
+# UTF-8 mixed - exactly 10 bytes (Hi!=3 + мир=6 + !=1)
+BYTE_STRING_MIXED = { byte_string = "Hi!мир!" }
+# Empty string (0 bytes)
+BYTE_STRING_EMPTY = { byte_string = "" }
+# Single character
+BYTE_STRING_SINGLE = { byte_string = "a" }
+# Const byte string (cannot be overridden at runtime)
+CONST_BYTE_STRING = { const = { byte_string = "constant" } }
+
+# --- Byte string constants (invalid - for trybuild tests) ---
 
 
 BANK_DISCRIMINANT = 0
@@ -238,7 +276,7 @@ TEST_ACCESSORY_MODULE_DISCRIMINANT = 245
 MY_MODULE_DISCRIMINANT = 246
 TEST_MODULE_DISCRIMINANT = 247
 ROUTING_RECIPIENT_DISCRIMINANT = 248
-EXAMPLE_MODULE_DISCRIMINANT = 249 
+EXAMPLE_MODULE_DISCRIMINANT = 249
 SYNTHETIC_LOAD_DISCRIMINANT = 250
 TEST_RECIPIENT_DISCRIMINANT = 251
 ACCESS_PATTERN_DISCRIMINANT = 252

--- a/constants.toml
+++ b/constants.toml
@@ -13,11 +13,13 @@ CHAIN_NAME = "TestChain"
 
 # The namespace used by the rollup to store its data.
 # Using byte_string to convert "sov-test-b" to ASCII bytes
+# Should be 10 bytes long for Celestia
 BATCH_NAMESPACE = { byte_string = "sov-test-b" }
 # The namespace used by the rollup to store aggregated ZK proofs.
 # This is "sov-test-p" encoded as ASCII bytes.
 # "hex" format is used as an example, that it is possible to define namespace as any sequence of bytes.
 # `python3 -c "import sys; print('0x' + sys.argv[1].encode().hex())" "sov-test-p"`
+# Should be 10 bytes long for Celestia
 PROOF_NAMESPACE = { hex = "0x736f762d746573742d70" }
 
 # We will keep only this many blocks in the EVM module.

--- a/constants.toml
+++ b/constants.toml
@@ -13,12 +13,12 @@ CHAIN_NAME = "TestChain"
 
 # The namespace used by the rollup to store its data.
 # Using byte_string to convert "sov-test-b" to ASCII bytes
-BATCH_NAMESPACE = { byte_string = "sov-test-b", type = "[u8; 10]" }
+BATCH_NAMESPACE = { byte_string = "sov-test-b" }
 # The namespace used by the rollup to store aggregated ZK proofs.
 # This is "sov-test-p" encoded as ASCII bytes.
 # "hex" format is used as an example, that it is possible to define namespace as any sequence of bytes.
 # `python3 -c "import sys; print('0x' + sys.argv[1].encode().hex())" "sov-test-p"`
-PROOF_NAMESPACE = { hex = "0x736f762d746573742d70", type = "[u8; 10]" }
+PROOF_NAMESPACE = { hex = "0x736f762d746573742d70" }
 
 # We will keep only this many blocks in the EVM module.
 EVM_BLOCK_PRUNING_THRESHOLD = 10000

--- a/crates/module-system/sov-modules-macros/src/compile_manifest_constants.rs
+++ b/crates/module-system/sov-modules-macros/src/compile_manifest_constants.rs
@@ -73,13 +73,11 @@ pub struct TomlBech32Value {
 #[derive(serde::Deserialize)]
 pub struct TomlHexValue {
     hex: String,
-    r#type: String,
 }
 
 #[derive(serde::Deserialize)]
 pub struct TomlByteStringValue {
     byte_string: String,
-    r#type: String,
 }
 
 pub enum AllowedTomlValue {
@@ -111,6 +109,8 @@ fn parse_constant_inner(value: &toml::Value, span: Span) -> syn::Result<AllowedT
                 Ok(AllowedTomlValue::Bech32(bech32_table))
             } else if let Ok(hex_table) = value.clone().try_into::<TomlHexValue>() {
                 Ok(AllowedTomlValue::Hex(hex_table))
+            } else if let Ok(byte_string_table) = value.clone().try_into::<TomlByteStringValue>() {
+                Ok(AllowedTomlValue::ByteString(byte_string_table))
             } else {
                 Err(error("table"))
             }
@@ -194,12 +194,10 @@ fn allowed_toml_value_to_const_expr(
             let bech32_type = format_ident!("{}", bech32.r#type);
             toml_bech32_value_to_rust(constant_name, &bech32.bech32, &bech32_type)?
         }
-        AllowedTomlValue::Hex(hex) => toml_hex_value_to_rust(constant_name, &hex.hex, &hex.r#type)?,
-        AllowedTomlValue::ByteString(byte_string) => toml_byte_string_value_to_rust(
-            constant_name,
-            &byte_string.byte_string,
-            &byte_string.r#type,
-        )?,
+        AllowedTomlValue::Hex(hex) => toml_hex_value_to_rust(constant_name, &hex.hex)?,
+        AllowedTomlValue::ByteString(byte_string) => {
+            toml_byte_string_value_to_rust(constant_name, &byte_string.byte_string)?
+        }
     })
 }
 
@@ -330,49 +328,25 @@ pub fn toml_bech32_value_to_rust(
 pub fn toml_hex_value_to_rust(
     constant_name: &syn::LitStr,
     hex_str: &str,
-    type_str: &str,
 ) -> syn::Result<syn::Expr> {
     let hex_str = hex_str.strip_prefix("0x").unwrap_or(hex_str);
     let bytes = hex::decode(hex_str)
         .map_err(|e| syn::Error::new(constant_name.span(), format!("Invalid hex string: {e}")))?;
 
-    bytes_to_array_expr(constant_name, &bytes, type_str)
+    bytes_to_array_expr(&bytes)
 }
 
 pub fn toml_byte_string_value_to_rust(
-    constant_name: &syn::LitStr,
+    _constant_name: &syn::LitStr,
     string: &str,
-    type_str: &str,
 ) -> syn::Result<syn::Expr> {
-    let bytes = string.as_bytes();
-    bytes_to_array_expr(constant_name, bytes, type_str)
+    bytes_to_array_expr(string.as_bytes())
 }
 
-fn bytes_to_array_expr(
-    constant_name: &syn::LitStr,
-    bytes: &[u8],
-    type_str: &str,
-) -> syn::Result<syn::Expr> {
-    // Validate array length if type is [u8; N]
-    if let Ok(syn::Type::Array(arr)) = syn::parse_str::<syn::Type>(type_str) {
-        if let syn::Expr::Lit(syn::ExprLit {
-            lit: syn::Lit::Int(len),
-            ..
-        }) = &arr.len
-        {
-            let expected: usize = len.base10_parse()?;
-            if bytes.len() != expected {
-                return Err(syn::Error::new(
-                    constant_name.span(),
-                    format!("Has {} bytes, expected {expected}", bytes.len()),
-                ));
-            }
-        }
-    }
-
-    // Generate [b1, b2, b3, ...]
+fn bytes_to_array_expr(bytes: &[u8]) -> syn::Result<syn::Expr> {
+    // Generate [1u8, 2u8, 3u8, ...] with u8 suffix for type inference
     let elems = bytes.iter().map(|b| {
-        let lit = syn::LitInt::new(&b.to_string(), Span::call_site());
+        let lit = syn::LitInt::new(&format!("{b}u8"), Span::call_site());
         syn::Expr::Lit(syn::ExprLit {
             attrs: Vec::new(),
             lit: syn::Lit::Int(lit),

--- a/crates/module-system/sov-modules-macros/tests/integration/main.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/main.rs
@@ -34,6 +34,10 @@ fn trybuild() {
     t.compile_fail("tests/integration/trybuild/constants/bech32_constant_not_a_string.rs");
     t.compile_fail("tests/integration/trybuild/constants/bech32_constant_prefix_too_short.rs");
     t.compile_fail("tests/integration/trybuild/constants/bech32_constant_prefix_too_long.rs");
+    t.compile_fail("tests/integration/trybuild/constants/hex_invalid_string.rs");
+    t.compile_fail("tests/integration/trybuild/constants/hex_odd_length.rs");
+    t.compile_fail("tests/integration/trybuild/constants/hex_too_long.rs");
+    t.compile_fail("tests/integration/trybuild/constants/hex_too_short.rs");
 
     t.compile_fail("tests/integration/trybuild/module_info/derive_on_enum_not_supported.rs");
     t.compile_fail("tests/integration/trybuild/module_info/field_missing_attribute.rs");

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_invalid_string.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_invalid_string.rs
@@ -1,0 +1,5 @@
+use sov_modules_api::macros::config_value;
+
+const NAMESPACE: [u8; 10] = config_value!("HEX_INVALID_STRING");
+
+fn main() {}

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_invalid_string.stderr
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_invalid_string.stderr
@@ -1,0 +1,5 @@
+error: Invalid hex string: Invalid character 'z' at position 0
+ --> tests/integration/trybuild/constants/hex_invalid_string.rs:3:43
+  |
+3 | const NAMESPACE: [u8; 10] = config_value!("HEX_INVALID_STRING");
+  |                                           ^^^^^^^^^^^^^^^^^^^^

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_odd_length.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_odd_length.rs
@@ -1,0 +1,5 @@
+use sov_modules_api::macros::config_value;
+
+const NAMESPACE: [u8; 2] = config_value!("HEX_ODD_LENGTH");
+
+fn main() {}

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_odd_length.stderr
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_odd_length.stderr
@@ -1,0 +1,5 @@
+error: Invalid hex string: Odd number of digits
+ --> tests/integration/trybuild/constants/hex_odd_length.rs:3:42
+  |
+3 | const NAMESPACE: [u8; 2] = config_value!("HEX_ODD_LENGTH");
+  |                                          ^^^^^^^^^^^^^^^^

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_too_long.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_too_long.rs
@@ -1,0 +1,6 @@
+use sov_modules_api::macros::config_value;
+
+// Actual value is 32 bytes
+const NAMESPACE: [u8; 10] = config_value!("HEX_LONG");
+
+fn main() {}

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_too_long.stderr
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_too_long.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+ --> tests/integration/trybuild/constants/hex_too_long.rs:4:29
+  |
+4 | const NAMESPACE: [u8; 10] = config_value!("HEX_LONG");
+  |                       --    ^^^^^^^^^^^^^^^^^^^^^^^^^ expected an array with a size of 10, found one with a size of 32
+  |                       |
+  |                       help: consider specifying the actual array length: `32`
+  |
+  = note: this error originates in the macro `config_value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_too_short.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_too_short.rs
@@ -1,0 +1,6 @@
+use sov_modules_api::macros::config_value;
+
+// Actual value is 2 bytes
+const NAMESPACE: [u8; 32] = config_value!("HEX_SHORT");
+
+fn main() {}

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_too_short.stderr
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/hex_too_short.stderr
@@ -1,0 +1,9 @@
+error[E0308]: mismatched types
+ --> tests/integration/trybuild/constants/hex_too_short.rs:4:29
+  |
+4 | const NAMESPACE: [u8; 32] = config_value!("HEX_SHORT");
+  |                       --    ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected an array with a size of 32, found one with a size of 2
+  |                       |
+  |                       help: consider specifying the actual array length: `2`
+  |
+  = note: this error originates in the macro `config_value` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/valid_constants.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/constants/valid_constants.rs
@@ -16,6 +16,24 @@ const CONST_STRING: &str = config_value!("CONST_STRING");
 const CONST_MATRIX_2x3: [[u8; 3]; 2] = config_value!("CONST_MATRIX_2x3");
 const CONST_MATRIX_2x3_I32: [[i32; 3]; 2] = config_value!("CONST_MATRIX_2x3");
 
+// Test hex constants (const and non-const)
+const CONST_HEX_ARRAY: [u8; 5] = config_value!("CONST_HEX_ARRAY");
+const HEX_SHORT: [u8; 2] = config_value!("HEX_SHORT");
+const HEX_MEDIUM: [u8; 10] = config_value!("HEX_MEDIUM");
+const HEX_LONG: [u8; 32] = config_value!("HEX_LONG");
+const HEX_NO_PREFIX: [u8; 4] = config_value!("HEX_NO_PREFIX");
+const HEX_EMPTY: [u8; 0] = config_value!("HEX_EMPTY");
+
+// Test byte_string constants (const and non-const)
+const CONST_BYTE_STRING: [u8; 8] = config_value!("CONST_BYTE_STRING");
+const BYTE_STRING_ASCII: [u8; 10] = config_value!("BYTE_STRING_ASCII");
+const BYTE_STRING_SHORT: [u8; 5] = config_value!("BYTE_STRING_SHORT");
+const BYTE_STRING_UTF8: [u8; 10] = config_value!("BYTE_STRING_UTF8");
+const BYTE_STRING_EMOJI: [u8; 10] = config_value!("BYTE_STRING_EMOJI");
+const BYTE_STRING_MIXED: [u8; 10] = config_value!("BYTE_STRING_MIXED");
+const BYTE_STRING_EMPTY: [u8; 0] = config_value!("BYTE_STRING_EMPTY");
+const BYTE_STRING_SINGLE: [u8; 1] = config_value!("BYTE_STRING_SINGLE");
+
 // Now, let's make sure that overridable constants compile AND that env. var.
 // reading logic works.
 // -----------------------------------------------------------------------------
@@ -54,6 +72,14 @@ fn array_of_u8() -> [u8; 32] {
 
 fn chain_id_u128() -> u128 {
     config_value!("CHAIN_ID")
+}
+
+fn hex_medium() -> [u8; 10] {
+    config_value!("HEX_MEDIUM")
+}
+
+fn byte_string_hello() -> [u8; 5] {
+    config_value!("BYTE_STRING_SHORT")
 }
 
 fn main() {
@@ -105,4 +131,34 @@ fn main() {
 
     env::set_var("SOV_TEST_CONST_OVERRIDE_CHAIN_ID", "0");
     assert_eq!(chain_id_u128(), 0);
+
+    // Test hex constants
+    assert_eq!(CONST_HEX_ARRAY, [1u8, 2, 3, 4, 5]);
+    assert_eq!(HEX_SHORT, [0xaa, 0xbb]);
+    let hex_medium_value: [u8; 10] = [0x73, 0x6f, 0x76, 0x2d, 0x74, 0x65, 0x73, 0x74, 0x2d, 0x70];
+    assert_eq!(HEX_MEDIUM, hex_medium_value,);
+    assert_eq!(hex_medium(), hex_medium_value);
+    let empty_bytes: [u8; 0] = [];
+    assert_eq!(HEX_NO_PREFIX, [0xaa, 0xbb, 0xcc, 0xdd]);
+    assert_eq!(HEX_EMPTY, empty_bytes);
+    assert_eq!(
+        HEX_LONG,
+        [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+            25, 26, 27, 28, 29, 30, 31, 32
+        ]
+    );
+
+    // Test byte_string constants
+    assert_eq!(CONST_BYTE_STRING, *b"constant");
+    assert_eq!(BYTE_STRING_ASCII, *b"sov-test-b");
+    assert_eq!(BYTE_STRING_SHORT, *b"hello");
+    assert_eq!(byte_string_hello(), *b"hello");
+    assert_eq!(BYTE_STRING_SINGLE, *b"a");
+    assert_eq!(BYTE_STRING_EMPTY, empty_bytes);
+
+    // UTF-8 tests (all 10 bytes)
+    assert_eq!(BYTE_STRING_UTF8, "абвгд".as_bytes());
+    assert_eq!(BYTE_STRING_EMOJI, "🎉hello!".as_bytes());
+    assert_eq!(BYTE_STRING_MIXED, "Hi!мир!".as_bytes());
 }


### PR DESCRIPTION
# Description

Follow up of https://github.com/Sovereign-Labs/sovereign-sdk/pull/1924

* Removes need to specify type. Since it only supports array of `u8` it will derive length based on input:
  ```toml
  BATCH_NAMESPACE = { byte_string = "sov-test-b" }
  PROOF_NAMESPACE = { hex = "0x736f762d746573742d70" }
  ```
* Adds tests

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
New tests have been added

## Docs
No updates