### PR TITLE
Replica: Manage edge cases where the inner executor sequence number is either too new or too old.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/replica/db_data.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/db_data.rs
@@ -114,7 +114,7 @@ impl EventsNotificationPayload {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum DbData {
     BatchStart(BatchToStore),
-    Transaction(FullyBakedTx),
+    Transaction(u64, FullyBakedTx),
     BatchEnd(BatchToStore),
     NewProof,
 }
@@ -122,6 +122,16 @@ pub(crate) enum DbData {
 impl DbData {
     pub(crate) fn is_batch_end(&self) -> bool {
         matches!(self, DbData::BatchEnd(_))
+    }
+
+    pub(crate) fn sequence_number(&self) -> u64 {
+        match self {
+            DbData::BatchStart(batch_to_store) | DbData::BatchEnd(batch_to_store) => {
+                batch_to_store.sequence_number
+            }
+            DbData::Transaction(sequence_number, _) => *sequence_number,
+            DbData::NewProof => 0,
+        }
     }
 }
 
@@ -154,7 +164,7 @@ pub(crate) fn row_to_event(row: PgRow) -> Result<(DbData, EventType), ParsingErr
         }
         EventType::Transaction => {
             let baked_tx = FullyBakedTx::new(data);
-            DbData::Transaction(baked_tx)
+            DbData::Transaction(sequence_number, baked_tx)
         }
 
         EventType::BatchEnd => {

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
@@ -13,7 +13,7 @@ where
     S: Spec,
     Rt: Runtime<S>,
 {
-    async fn on_da_event(&self, data: DbData) -> Result<(), DBDataRejected> {
+    async fn on_db_event(&self, data: DbData) -> Result<(), DBDataRejected> {
         match data {
             DbData::BatchStart(_batch_to_store) => {}
             DbData::Transaction(_, _tx) => {}

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
@@ -1,5 +1,6 @@
 use crate::preferred::inner::SequencerStateUpdator;
 use crate::preferred::replica::db_data::DbData;
+use crate::preferred::replica::replica_sync_task::DBDataRejected;
 use crate::preferred::replica::replica_sync_task::ReplicaEventHandler;
 use async_trait::async_trait;
 use sov_modules_api::Runtime;
@@ -12,12 +13,14 @@ where
     S: Spec,
     Rt: Runtime<S>,
 {
-    async fn on_da_event(&self, data: DbData) {
+    async fn on_da_event(&self, data: DbData) -> Result<(), DBDataRejected> {
         match data {
             DbData::BatchStart(_batch_to_store) => {}
-            DbData::Transaction(_tx) => {}
+            DbData::Transaction(_, _tx) => {}
             DbData::BatchEnd(_batch_to_store) => {}
             DbData::NewProof => {}
-        }
+        };
+
+        Ok(())
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -5,6 +5,7 @@ use crate::preferred::replica::db_data::DbData;
 use crate::preferred::replica::db_data::EventType;
 use crate::preferred::replica::db_data::EventsNotificationPayload;
 use crate::preferred::replica::db_data::ParsingError;
+use sqlx::postgres::PgNotification;
 use sqlx::postgres::{PgListener, PgPoolOptions};
 use sqlx::PgPool;
 use tokio::sync::watch;
@@ -183,7 +184,8 @@ impl EventReceiver {
             // Keep listening for events until a `BatchStart` notification is received,
             // then use that event's ID as both the starting and target event ID.
             None => loop {
-                let notify = self.recv_notifications().await?;
+                let notify = self.listener.recv().await?;
+                let notify = EventsNotificationPayload::parse_csv(notify.payload())?;
                 if matches!(notify.event_type, EventType::BatchStart) {
                     break (notify.event_id, notify.event_id);
                 }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -5,7 +5,6 @@ use crate::preferred::replica::db_data::DbData;
 use crate::preferred::replica::db_data::EventType;
 use crate::preferred::replica::db_data::EventsNotificationPayload;
 use crate::preferred::replica::db_data::ParsingError;
-use sqlx::postgres::PgNotification;
 use sqlx::postgres::{PgListener, PgPoolOptions};
 use sqlx::PgPool;
 use tokio::sync::watch;

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -15,7 +15,7 @@ pub(crate) enum DBDataRejected {
 
 #[async_trait]
 pub(crate) trait ReplicaEventHandler: Send + Sync + 'static {
-    async fn on_da_event(&self, batch: DbData) -> Result<(), DBDataRejected>;
+    async fn on_db_event(&self, batch: DbData) -> Result<(), DBDataRejected>;
 }
 
 pub(crate) struct ReplicaTaskHandles {
@@ -85,7 +85,7 @@ impl ReplicaSyncTask {
             };
 
             'inner: loop {
-                match handler.on_da_event(data).await {
+                match handler.on_db_event(data).await {
                     Ok(_) => {
                         // The data was applied on the executor.
                         break 'inner;
@@ -165,7 +165,7 @@ mod tests {
 
     #[async_trait]
     impl ReplicaEventHandler for TestHandler {
-        async fn on_da_event(&self, data: DbData) -> Result<(), DBDataRejected> {
+        async fn on_db_event(&self, data: DbData) -> Result<(), DBDataRejected> {
             if data.sequence_number() < self.seq_nr() {
                 return Err(DBDataRejected::ExecutorAhead(self.seq_nr()));
             }
@@ -371,7 +371,7 @@ mod tests {
         let seq_nr = 3;
         let test_cases = to_db_data(&test_cases);
         // We skip batch 1,2 and 3 so 15 db messages in total.
-        let expected = test_cases.iter().cloned().skip(15).collect();
+        let expected = test_cases.iter().skip(15).cloned().collect();
         check_sync_task(test_cases.clone(), expected, seq_nr).await;
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -3,13 +3,19 @@ use crate::preferred::replica::event_receiver::EventReceiver;
 use async_trait::async_trait;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
+use tokio::time::Duration;
 
 // Process events in pages to avoid excessive memory consumption
 const PAGE_SIZE: usize = 2000;
 
+pub(crate) enum DBDataRejected {
+    ExecutorBehind(DbData),
+    ExecutorAhead(u64),
+}
+
 #[async_trait]
 pub(crate) trait ReplicaEventHandler: Send + Sync + 'static {
-    async fn on_da_event(&self, batch: DbData);
+    async fn on_da_event(&self, batch: DbData) -> Result<(), DBDataRejected>;
 }
 
 pub(crate) struct ReplicaTaskHandles {
@@ -44,7 +50,7 @@ impl ReplicaSyncTask {
     }
 
     pub(crate) async fn start<R: ReplicaEventHandler>(&mut self, handler: R) -> ReplicaTaskHandles {
-        let (event_receiver, mut db_data_receiver) = EventReceiver::new(
+        let (event_receiver, db_data_receiver) = EventReceiver::new(
             self.postgres_connection_string.clone(),
             self.shutdown_sender.clone(),
             self.page_size,
@@ -55,20 +61,56 @@ impl ReplicaSyncTask {
         let shutdown_receiver = self.shutdown_sender.subscribe();
 
         let sync_task_handle = tokio::spawn(async move {
-            loop {
-                if shutdown_receiver.has_changed().unwrap_or(true) {
-                    break;
-                }
-
-                if let Some(data) = db_data_receiver.recv().await {
-                    handler.on_da_event(data).await;
-                }
-            }
+            Self::run_handler(handler, db_data_receiver, shutdown_receiver).await;
         });
 
         ReplicaTaskHandles {
             data_fetcher_handle,
             sync_task_handle,
+        }
+    }
+
+    async fn run_handler<R: ReplicaEventHandler>(
+        handler: R,
+        mut db_data_receiver: tokio::sync::mpsc::Receiver<DbData>,
+        shutdown_receiver: watch::Receiver<()>,
+    ) {
+        'outer: loop {
+            if shutdown_receiver.has_changed().unwrap_or(true) {
+                break 'outer;
+            }
+
+            let Some(mut data) = db_data_receiver.recv().await else {
+                break 'outer;
+            };
+
+            'inner: loop {
+                match handler.on_da_event(data).await {
+                    Ok(_) => {
+                        // The data was applied on the executor.
+                        break 'inner;
+                    }
+
+                    Err(DBDataRejected::ExecutorAhead(executor_seq_nr)) => {
+                        // The executor is ahead of the db drain the queue and wait until we catch up.
+                        while let Ok(new_data) = db_data_receiver.try_recv() {
+                            if new_data.sequence_number() > executor_seq_nr {
+                                assert!(matches!(new_data, DbData::BatchStart(_)));
+                                data = new_data;
+                                continue 'inner;
+                            }
+                        }
+                        break 'inner;
+                    }
+
+                    Err(DBDataRejected::ExecutorBehind(db_data)) => {
+                        // The executor is behind the db: wait briefly and retry.
+                        data = db_data;
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        continue 'inner;
+                    }
+                }
+            }
         }
     }
 }
@@ -85,27 +127,59 @@ mod tests {
     use sov_test_utils::postgres::{
         connection_string_from_postgres_container, create_postgres_container, CreatePostgresError,
     };
+    use std::sync::atomic::Ordering;
+    use tokio::sync::mpsc::error::TryRecvError;
 
     use std::num::NonZero;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::Arc;
     use std::vec;
     use tokio::sync::mpsc;
 
     #[derive(Clone)]
     struct TestHandler {
         send: mpsc::Sender<DbData>,
+        exec_seq_nr: Arc<AtomicU64>,
     }
 
     impl TestHandler {
-        pub fn new() -> (Self, mpsc::Receiver<DbData>) {
-            let (send, recv) = mpsc::channel(1);
-            (Self { send }, recv)
+        pub fn new(seq_nr: u64) -> (Self, mpsc::Receiver<DbData>) {
+            let (send, recv) = mpsc::channel(100);
+            (
+                Self {
+                    send,
+                    exec_seq_nr: Arc::new(AtomicU64::new(seq_nr)),
+                },
+                recv,
+            )
+        }
+
+        fn inc_seq_nr(&self) {
+            self.exec_seq_nr.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn seq_nr(&self) -> u64 {
+            self.exec_seq_nr.load(Ordering::SeqCst)
         }
     }
 
     #[async_trait]
     impl ReplicaEventHandler for TestHandler {
-        async fn on_da_event(&self, data: DbData) {
+        async fn on_da_event(&self, data: DbData) -> Result<(), DBDataRejected> {
+            if data.sequence_number() < self.seq_nr() {
+                return Err(DBDataRejected::ExecutorAhead(self.seq_nr()));
+            }
+
+            if data.sequence_number() > self.seq_nr() + 1 {
+                return Err(DBDataRejected::ExecutorBehind(data));
+            }
+
+            if matches!(data, DbData::BatchEnd { .. }) {
+                self.inc_seq_nr();
+            }
+
             let _ = self.send.send(data).await;
+            Ok(())
         }
     }
 
@@ -118,17 +192,16 @@ mod tests {
         }
     }
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Copy)]
     enum TestCase {
         CompleteBatch(u64, usize),
         BatchStart(u64),
-        Transaction,
+        Transaction(u64),
         BatchEnd(u64),
     }
 
     async fn execute(mut db: PostgresBackend, data: Vec<TestCase>) {
         let mut index = 0;
-        let mut sequence_nr = 0;
         for db_data in data {
             match db_data {
                 TestCase::CompleteBatch(seq_nr, nb_of_txs) => {
@@ -146,14 +219,13 @@ mod tests {
                     db.end_rollup_block(stored_batch).await.unwrap();
                 }
                 TestCase::BatchStart(seq_nr) => {
-                    sequence_nr = seq_nr;
                     index = 0;
                     let stored_batch = new_batch_to_store(seq_nr);
                     db.begin_rollup_block(stored_batch).await.unwrap();
                 }
-                TestCase::Transaction => {
+                TestCase::Transaction(seq_nr) => {
                     let tx = FullyBakedTx::new(vec![index as u8]);
-                    db.add_tx(sequence_nr, index, tx, TxHash::new([1; 32]))
+                    db.add_tx(seq_nr, index, tx, TxHash::new([1; 32]))
                         .await
                         .unwrap();
                     index += 1;
@@ -169,25 +241,32 @@ mod tests {
     fn to_db_data(test_cases: &Vec<TestCase>) -> Vec<DbData> {
         let mut data = Vec::new();
         let mut index = 0;
+
         for test_case in test_cases {
-            match test_case {
+            match *test_case {
                 TestCase::CompleteBatch(seq_nr, nb_of_txs) => {
-                    data.push(DbData::BatchStart(new_batch_to_store(*seq_nr)));
-                    for i in 0..*nb_of_txs {
-                        data.push(DbData::Transaction(FullyBakedTx::new(vec![i as u8])));
+                    data.push(DbData::BatchStart(new_batch_to_store(seq_nr)));
+                    for i in 0..nb_of_txs {
+                        data.push(DbData::Transaction(
+                            seq_nr,
+                            FullyBakedTx::new(vec![i as u8]),
+                        ));
                     }
-                    data.push(DbData::BatchEnd(new_batch_to_store(*seq_nr)));
+                    data.push(DbData::BatchEnd(new_batch_to_store(seq_nr)));
                 }
                 TestCase::BatchStart(seq_nr) => {
                     index = 0;
-                    data.push(DbData::BatchStart(new_batch_to_store(*seq_nr)));
+                    data.push(DbData::BatchStart(new_batch_to_store(seq_nr)));
                 }
-                TestCase::Transaction => {
-                    data.push(DbData::Transaction(FullyBakedTx::new(vec![index as u8])));
+                TestCase::Transaction(seq_nr) => {
+                    data.push(DbData::Transaction(
+                        seq_nr,
+                        FullyBakedTx::new(vec![index as u8]),
+                    ));
                     index += 1;
                 }
                 TestCase::BatchEnd(seq_nr) => {
-                    data.push(DbData::BatchEnd(new_batch_to_store(*seq_nr)));
+                    data.push(DbData::BatchEnd(new_batch_to_store(seq_nr)));
                 }
             };
         }
@@ -198,9 +277,9 @@ mod tests {
     async fn test_notifications() {
         let test_data = vec![
             TestCase::BatchStart(1),
-            TestCase::Transaction,
-            TestCase::Transaction,
-            TestCase::Transaction,
+            TestCase::Transaction(1),
+            TestCase::Transaction(1),
+            TestCase::Transaction(1),
             TestCase::BatchEnd(1),
             TestCase::CompleteBatch(2, 0),
             TestCase::CompleteBatch(3, 1000),
@@ -208,26 +287,26 @@ mod tests {
         ];
 
         let expected = to_db_data(&test_data);
-        run(test_data, expected).await;
+        run(test_data, expected, 0).await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_notifications_start_event_id() {
         let test_data = vec![
-            TestCase::Transaction,
-            TestCase::Transaction,
-            TestCase::Transaction,
+            TestCase::Transaction(6),
+            TestCase::Transaction(6),
+            TestCase::Transaction(6),
             TestCase::CompleteBatch(7, 3),
             TestCase::BatchStart(8),
-            TestCase::Transaction,
-            TestCase::Transaction,
+            TestCase::Transaction(8),
+            TestCase::Transaction(8),
         ];
 
         let expected = to_db_data(&test_data).into_iter().skip(3).collect();
-        run(test_data, expected).await;
+        run(test_data, expected, 6).await;
     }
 
-    async fn run(test_cases: Vec<TestCase>, expected: Vec<DbData>) {
+    async fn run(test_cases: Vec<TestCase>, expected: Vec<DbData>, exec_seq_nr: u64) {
         let dir = tempfile::tempdir().unwrap();
 
         let postgres = create_postgres_container(&dir.path().join("postgres_data")).await;
@@ -253,7 +332,7 @@ mod tests {
                 .await
                 .unwrap();
 
-        let (test_handler, mut recv) = TestHandler::new();
+        let (test_handler, mut recv) = TestHandler::new(exec_seq_nr);
         sync_task.start(test_handler).await;
 
         execute(db, test_cases).await;
@@ -261,6 +340,96 @@ mod tests {
         for data in expected {
             let recv_data = recv.recv().await.unwrap();
             assert_eq!(recv_data, data, "Expected: {data:?}, got: {recv_data:?}");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sync_task_on_time() {
+        // The first batch has a seq_nr = 1 and an executor has seq_nr = 0.
+        let test_cases = vec![
+            TestCase::CompleteBatch(1, 3),
+            TestCase::CompleteBatch(2, 3),
+            TestCase::CompleteBatch(3, 3),
+        ];
+        let seq_nr = 0;
+
+        let test_cases = to_db_data(&test_cases);
+        check_sync_task(test_cases.clone(), test_cases, seq_nr).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sync_task_ahead() {
+        // The first batch has a seq_nr = 1 and an executor has seq_nr = 3.
+        let test_cases = vec![
+            TestCase::CompleteBatch(1, 3),
+            TestCase::CompleteBatch(2, 3),
+            TestCase::CompleteBatch(3, 3),
+            TestCase::CompleteBatch(4, 3),
+            TestCase::CompleteBatch(5, 3),
+        ];
+
+        let seq_nr = 3;
+        let test_cases = to_db_data(&test_cases);
+        // We skip batch 1,2 and 3 so 15 db messages in total.
+        let expected = test_cases.iter().cloned().skip(15).collect();
+        check_sync_task(test_cases.clone(), expected, seq_nr).await;
+    }
+
+    async fn check_sync_task(test_cases: Vec<DbData>, expected: Vec<DbData>, exec_seq_nr: u64) {
+        let (_shutdown_snd, shutdown_rcv) = watch::channel(());
+        let (db_data_sender, db_data_receiver) = tokio::sync::mpsc::channel(100);
+
+        for db_data in test_cases.clone() {
+            db_data_sender.send(db_data).await.unwrap();
+        }
+
+        let (test_handler, mut recv) = TestHandler::new(exec_seq_nr);
+        tokio::task::spawn(async move {
+            ReplicaSyncTask::run_handler(test_handler, db_data_receiver, shutdown_rcv).await;
+        });
+
+        for exp in expected.into_iter() {
+            let data = recv.recv().await.unwrap();
+            assert_eq!(data, exp);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_sync_task_behind() {
+        // The first batch has a seq_nr = 7 and an executor has seq_nr = 3.
+        let test_case = vec![TestCase::CompleteBatch(7, 3), TestCase::CompleteBatch(8, 3)];
+        let seq_nr = 3;
+        let test_case = to_db_data(&test_case);
+        let expected = test_case.clone();
+
+        let (_shutdown_snd, shutdown_rcv) = watch::channel(());
+        let (db_data_sender, db_data_receiver) = tokio::sync::mpsc::channel(100);
+
+        for db_data in test_case.clone() {
+            db_data_sender.send(db_data).await.unwrap();
+        }
+
+        let (test_handler, mut recv) = TestHandler::new(seq_nr);
+        let test_handler_clone = test_handler.clone();
+
+        tokio::task::spawn(async move {
+            ReplicaSyncTask::run_handler(test_handler, db_data_receiver, shutdown_rcv).await;
+        });
+
+        for exp in expected {
+            let data = loop {
+                match recv.try_recv() {
+                    Ok(ok) => break ok,
+                    Err(TryRecvError::Empty) => {
+                        // Simulate executor catching up.
+                        test_handler_clone.inc_seq_nr();
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        continue;
+                    }
+                    Err(_) => unreachable!(),
+                };
+            };
+            assert_eq!(data, exp);
         }
     }
 }


### PR DESCRIPTION
# Description

This PR introduces the following changes:
1. Adds a` DBDataRejected` error to `ReplicaEventHandler::on_da_event`.
This allows the inner executor to communicate when the `DbData` is too new or too old to be applied. The replica sync task now handles this error appropriately.
2. Adds tests covering the new error handling behavior.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

