### PR TITLE
Add support for tracing pending blocks and transactions in the EVM RPC layer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-10-21
+- #1930 Add support for tracing pending blocks and transactions via `debug_traceBlockByNumber` and `debug_traceTransaction`.
+
 # 2025-10-20
 - #1912 Add multi-worker support to EVM logs soak tests with log retrieval via `eth_getLogs`. Workers are automatically funded from root account and use WebSocket connections for better real-time performance.
 - #1924 **Breaking change** rollup's batch and proof namespace needs to be specified in `constants.toml` as `BATCH_NAMESPACE` and `PROOF_NAMESPACE`.

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -8,7 +8,7 @@ use alloy_consensus::{
 use alloy_consensus::{EthereumTxEnvelope, TxEip4844};
 use alloy_primitives::TxHash;
 use alloy_primitives::{Address, Sealable, Sealed, B256};
-use derive_more::{Deref, DerefMut};
+use derive_more::{Deref, DerefMut, From};
 use derive_new::new;
 use reth_ethereum_primitives::serde_bincode_compat::Receipt as ReceiptBincodeCompat;
 use serde_with::serde_as;
@@ -171,6 +171,7 @@ impl<'de> serde::Deserialize<'de> for SealedBlock {
 
 #[cfg(feature = "native")]
 /// Sealed or pending block.
+#[derive(From, Debug)]
 pub enum MaybeSealedBlock {
     /// SealedBlock
     Sealed(SealedBlock),

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/maybe_archival_state.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/maybe_archival_state.rs
@@ -1,0 +1,28 @@
+use derive_more::From;
+use sov_modules_api::{ApiStateAccessor, Spec};
+use std::ops::{Deref, DerefMut};
+
+#[derive(From)]
+pub(crate) enum MaybeArchivalState<'a, S: Spec> {
+    Current(&'a mut ApiStateAccessor<S>),
+    Archival(Box<ApiStateAccessor<S>>),
+}
+
+impl<'a, S: Spec> Deref for MaybeArchivalState<'a, S> {
+    type Target = ApiStateAccessor<S>;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Current(a) => a,
+            Self::Archival(a) => a,
+        }
+    }
+}
+
+impl<'a, S: Spec> DerefMut for MaybeArchivalState<'a, S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::Current(a) => a,
+            Self::Archival(a) => a,
+        }
+    }
+}

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -8,13 +8,9 @@ use alloy_rpc_types::{
     TransactionReceipt, TransactionRequest,
 };
 use alloy_rpc_types::{BlockTransactionsKind, Header};
-use alloy_rpc_types_trace::geth::GethTrace;
-use alloy_rpc_types_trace::geth::{GethDebugBuiltInTracerType, GethDebugTracerType};
-use alloy_rpc_types_trace::geth::{GethDebugTracingOptions, TraceResult};
 use jsonrpsee::core::RpcResult;
-use revm::context::result::{ExecResultAndState, ResultAndState};
-use revm::context::{BlockEnv, CfgEnv, TxEnv};
-use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
+use revm::context::result::ResultAndState;
+use revm::context::{BlockEnv, CfgEnv};
 use sov_address::{EthereumAddress, FromVmAddress};
 use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::UnwrapInfallible;
@@ -22,19 +18,18 @@ use sov_modules_api::{ApiStateAccessor, Spec};
 use sov_rollup_interface::common::RollupHeight;
 use sov_rpc_eth_types::{EthApiError, RpcInvalidTransactionError};
 
-use crate::conversions::replay_tx_env;
-use crate::db::commit::FallibleDatabaseCommit;
 use crate::db::EvmDb;
 use crate::error::into_rpc_error;
 use crate::evm::executor;
 use crate::evm::primitive_types::{Receipt, TransactionSigned, TxSignedAndRecovered};
-use crate::executor::{get_cfg_env, inspect, transact_commit};
+use crate::executor::get_cfg_env;
 use crate::helpers::{from_recovered_with_block_context, prepare_call_env};
 pub use crate::primitive_types::MaybeSealedBlock;
 use crate::Evm;
 
 pub(crate) mod error;
 pub(crate) mod handlers;
+mod trace;
 
 /// Result of String => BlockNr conversion
 #[derive(Debug)]
@@ -173,130 +168,6 @@ where
             .map(|index| self.get_receipt_by_index(index, state))
             .collect::<Option<Vec<_>>>()?;
         Some(receipts)
-    }
-
-    fn trace_block_by_number(
-        &self,
-        block: BlockNumberOrTag,
-        opts: GethDebugTracingOptions,
-        state: &mut ApiStateAccessor<S>,
-    ) -> Result<Vec<TraceResult>, EthApiError> {
-        let block_number = self.resolve_block_number(block, state);
-        // Get transaction and block data
-        let block = self.block(block_number, state)?;
-        let mut archival_state = self.archival_state_pre_block(block_number, state)?;
-
-        let block_env = self.block_env(&mut archival_state)?;
-
-        let cfg = self.cfg(&mut archival_state)?;
-        let cfg_env = get_cfg_env(&block_env, cfg, None);
-
-        // Replay previous transactions in the block
-        let mut evm_db = self.db(&mut archival_state);
-
-        let mut traces = vec![];
-        for tx_idx in block.transactions {
-            let tx = self
-                .transaction(tx_idx, state)
-                .ok_or_else(|| EthApiError::PrunedHistoryUnavailable)?;
-
-            let result = self.trace_transaction_inner(
-                &block_env,
-                replay_tx_env(&tx),
-                cfg_env.clone(),
-                &mut evm_db,
-                &opts,
-            )?;
-            traces.push(TraceResult::new_success(result, Some(*tx.hash())));
-        }
-        Ok(traces)
-    }
-
-    fn trace_transaction(
-        &self,
-        tx_hash: B256,
-        opts: GethDebugTracingOptions,
-        state: &mut ApiStateAccessor<S>,
-    ) -> Result<GethTrace, EthApiError> {
-        // Get transaction and block data
-        let traced_tx = self.tx(tx_hash, state)?;
-        let block = self.block(traced_tx.block_number, state)?;
-
-        let mut archival_state = self.archival_state_pre_block(traced_tx.block_number, state)?;
-
-        let block_env = self.block_env(&mut archival_state)?;
-
-        let cfg = self.cfg(&mut archival_state)?;
-        let cfg_env = get_cfg_env(&block_env, cfg, None);
-
-        // Replay previous transactions in the block
-        let mut evm_db = self.db(&mut archival_state);
-
-        for tx_idx in block.transactions {
-            let tx = self
-                .transaction(tx_idx, state)
-                .ok_or_else(|| EthApiError::PrunedHistoryUnavailable)?;
-
-            // Skip the transaction we're tracing
-            if *tx.signed_transaction.hash() == tx_hash {
-                break;
-            }
-
-            transact_commit(&mut evm_db, &block_env, replay_tx_env(&tx), cfg_env.clone())
-                .map_err(EthApiError::from)?;
-        }
-
-        // Trace the target transaction
-        self.trace_transaction_inner(
-            &block_env,
-            replay_tx_env(&traced_tx),
-            cfg_env,
-            &mut evm_db,
-            &opts,
-        )
-    }
-
-    fn trace_transaction_inner(
-        &self,
-        block_env: &BlockEnv,
-        tx_env: TxEnv,
-        cfg: CfgEnv,
-        db: &mut EvmDb<ApiStateAccessor<S>, S>,
-        opts: &GethDebugTracingOptions,
-    ) -> Result<GethTrace, EthApiError> {
-        let GethDebugTracingOptions {
-            tracer,
-            tracer_config,
-            ..
-        } = opts;
-        if let Some(tracer) = tracer {
-            return match tracer {
-                GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::CallTracer) => {
-                    let call_config = tracer_config
-                        .clone()
-                        .into_call_config()
-                        .map_err(|_| EthApiError::InvalidTracerConfig)?;
-
-                    let inspector_config =
-                        TracingInspectorConfig::from_geth_call_config(&call_config);
-                    let mut inspector = TracingInspector::new(inspector_config);
-
-                    let gas_limit = tx_env.gas_limit;
-                    let ExecResultAndState { result, state } =
-                        inspect(&mut *db, block_env, tx_env, cfg, &mut inspector)?;
-                    db.commit(state)?;
-
-                    inspector.set_transaction_gas_limit(gas_limit);
-                    let frame = inspector
-                        .geth_builder()
-                        .geth_call_traces(call_config, result.gas_used());
-
-                    return Ok(frame.into());
-                }
-                _ => Err(EthApiError::Unsupported("unsupported tracer")),
-            };
-        };
-        Err(EthApiError::Unsupported("unsupported tracer"))
     }
 
     fn call(

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -1,3 +1,5 @@
+use std::ops::DerefMut;
+
 use alloy_consensus::Sealed;
 use alloy_consensus::{transaction::Recovered, Transaction as TransactionTrait, TxReceipt};
 use alloy_eips::BlockNumberOrTag;
@@ -26,9 +28,12 @@ use crate::executor::get_cfg_env;
 use crate::helpers::{from_recovered_with_block_context, prepare_call_env};
 pub use crate::primitive_types::MaybeSealedBlock;
 use crate::Evm;
+use maybe_archival_state::MaybeArchivalState;
 
 pub(crate) mod error;
 pub(crate) mod handlers;
+pub(crate) mod maybe_archival_state;
+
 mod trace;
 
 /// Result of String => BlockNr conversion
@@ -353,32 +358,6 @@ where
                 .expect("The impossible happened: block_env is not set."),
             MaybeSealedBlock::Sealed(sealed_block) => BlockEnv::from(sealed_block),
         })
-    }
-}
-
-use std::ops::{Deref, DerefMut};
-
-enum MaybeArchivalState<'a, S: Spec> {
-    Current(&'a mut ApiStateAccessor<S>),
-    Archival(Box<ApiStateAccessor<S>>),
-}
-
-impl<'a, S: Spec> Deref for MaybeArchivalState<'a, S> {
-    type Target = ApiStateAccessor<S>;
-    fn deref(&self) -> &Self::Target {
-        match self {
-            Self::Current(a) => a,
-            Self::Archival(a) => a,
-        }
-    }
-}
-
-impl<'a, S: Spec> DerefMut for MaybeArchivalState<'a, S> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        match self {
-            Self::Current(a) => a,
-            Self::Archival(a) => a,
-        }
     }
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
@@ -1,3 +1,5 @@
+use std::ops::DerefMut;
+
 use alloy_eips::BlockId;
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
@@ -12,6 +14,7 @@ use sov_address::{EthereumAddress, FromVmAddress};
 use sov_modules_api::{ApiStateAccessor, Spec};
 use sov_rpc_eth_types::EthApiError;
 
+use super::maybe_archival_state::MaybeArchivalState;
 use crate::conversions::replay_tx_env;
 use crate::db::commit::FallibleDatabaseCommit;
 use crate::db::EvmDb;
@@ -44,8 +47,15 @@ where
         &'a self,
         block_number: u64,
         state: &'a mut ApiStateAccessor<S>,
-        archival_storage: &'a mut Option<ApiStateAccessor<S>>,
-    ) -> Result<(MaybeSealedBlock, Vec<TxSignedAndRecovered>, crate::db::EvmDb<ApiStateAccessor<S>, S>, BlockEnv, CfgEnv), EthApiError> {
+    ) -> Result<
+        (
+            MaybeArchivalState<'a, S>,
+            Vec<TxSignedAndRecovered>,
+            BlockEnv,
+            CfgEnv,
+        ),
+        EthApiError,
+    > {
         // Get the block - could be pending or sealed
         let maybe_block = self
             .get_maybe_sealed_block(block_number, state)
@@ -56,20 +66,19 @@ where
 
         let is_pending = matches!(maybe_block, MaybeSealedBlock::Pending(_));
 
-        let exec_state: &'a mut ApiStateAccessor<S> = if is_pending {
-            state
+        let mut maybe_archival_state: MaybeArchivalState<'a, S> = if is_pending {
+            state.into()
         } else {
-            *archival_storage = Some(self.archival_state_pre_block(maybe_block.number(), state)?);
-            archival_storage.as_mut().unwrap()
+            let archival = self.archival_state_pre_block(maybe_block.number(), state)?;
+            Box::new(archival).into()
         };
+        let state = maybe_archival_state.deref_mut();
 
-        let block_env = self.block_env(exec_state)?;
-        let cfg = self.cfg(exec_state)?;
+        let block_env = self.block_env(state)?;
+        let cfg = self.cfg(state)?;
         let cfg_env = get_cfg_env(&block_env, cfg, None);
 
-        let evm_db = self.db(exec_state);
-
-        Ok((maybe_block, transactions, evm_db, block_env, cfg_env))
+        Ok((maybe_archival_state, transactions, block_env, cfg_env))
     }
 
     pub(super) fn trace_block_by_number(
@@ -81,9 +90,9 @@ where
         let block_number = self.resolve_block_number(block, state);
 
         // Setup execution environment (fetches block, preloads transactions, sets up state)
-        let mut archival_storage = None;
-        let (_maybe_block, txs_to_trace, mut evm_db, block_env, cfg_env) =
-            self.setup_trace_execution(block_number, state, &mut archival_storage)?;
+        let (mut state, txs_to_trace, block_env, cfg_env) =
+            self.setup_trace_execution(block_number, state)?;
+        let mut evm_db = self.db(state.deref_mut());
 
         // Trace all transactions in the block
         let mut traces = vec![];
@@ -117,9 +126,9 @@ where
             .ok_or(EthApiError::PrunedHistoryUnavailable)?;
 
         // Setup execution environment (fetches block, preloads transactions, sets up state)
-        let mut archival_storage = None;
-        let (_maybe_block, txs_to_replay, mut evm_db, block_env, cfg_env) =
-            self.setup_trace_execution(traced_tx.block_number, state, &mut archival_storage)?;
+        let (mut state, txs_to_replay, block_env, cfg_env) =
+            self.setup_trace_execution(traced_tx.block_number, state)?;
+        let mut evm_db = self.db(state.deref_mut());
 
         // Replay previous transactions in the block
         for tx in txs_to_replay {

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
@@ -1,0 +1,187 @@
+use alloy_eips::BlockId;
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::B256;
+use alloy_rpc_types_trace::geth::{
+    GethDebugBuiltInTracerType, GethDebugTracerType, GethDebugTracingOptions, GethTrace,
+    TraceResult,
+};
+use revm::context::result::ExecResultAndState;
+use revm::context::{BlockEnv, CfgEnv, TxEnv};
+use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
+use sov_address::{EthereumAddress, FromVmAddress};
+use sov_modules_api::{ApiStateAccessor, Spec};
+use sov_rpc_eth_types::EthApiError;
+
+use crate::conversions::replay_tx_env;
+use crate::db::commit::FallibleDatabaseCommit;
+use crate::db::EvmDb;
+use crate::evm::primitive_types::{MaybeSealedBlock, TxSignedAndRecovered};
+use crate::executor::{get_cfg_env, inspect, transact_commit};
+use crate::Evm;
+
+impl<S: Spec> Evm<S>
+where
+    S::Address: FromVmAddress<EthereumAddress>,
+{
+    /// Pre-load transactions from a block to avoid borrow conflicts
+    pub(super) fn preload_block_transactions(
+        &self,
+        maybe_block: &MaybeSealedBlock,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Result<Vec<TxSignedAndRecovered>, EthApiError> {
+        maybe_block
+            .tx_range()
+            .map(|tx_idx| {
+                self.transaction(tx_idx, state)
+                    .ok_or_else(|| EthApiError::PrunedHistoryUnavailable)
+            })
+            .collect()
+    }
+
+    /// Setup execution environment for tracing (handles both pending and sealed blocks)
+    /// Takes a block number, fetches it, and sets up everything needed for tracing
+    pub(super) fn setup_trace_execution<'a>(
+        &'a self,
+        block_number: u64,
+        state: &'a mut ApiStateAccessor<S>,
+        archival_storage: &'a mut Option<ApiStateAccessor<S>>,
+    ) -> Result<(MaybeSealedBlock, Vec<TxSignedAndRecovered>, crate::db::EvmDb<ApiStateAccessor<S>, S>, BlockEnv, CfgEnv), EthApiError> {
+        // Get the block - could be pending or sealed
+        let maybe_block = self
+            .get_maybe_sealed_block(block_number, state)
+            .ok_or_else(|| EthApiError::HeaderNotFound(BlockId::number(block_number)))?;
+
+        // Pre-load transactions to avoid borrow conflicts
+        let transactions = self.preload_block_transactions(&maybe_block, state)?;
+
+        let is_pending = matches!(maybe_block, MaybeSealedBlock::Pending(_));
+
+        let exec_state: &'a mut ApiStateAccessor<S> = if is_pending {
+            state
+        } else {
+            *archival_storage = Some(self.archival_state_pre_block(maybe_block.number(), state)?);
+            archival_storage.as_mut().unwrap()
+        };
+
+        let block_env = self.block_env(exec_state)?;
+        let cfg = self.cfg(exec_state)?;
+        let cfg_env = get_cfg_env(&block_env, cfg, None);
+
+        let evm_db = self.db(exec_state);
+
+        Ok((maybe_block, transactions, evm_db, block_env, cfg_env))
+    }
+
+    pub(super) fn trace_block_by_number(
+        &self,
+        block: BlockNumberOrTag,
+        opts: GethDebugTracingOptions,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Result<Vec<TraceResult>, EthApiError> {
+        let block_number = self.resolve_block_number(block, state);
+
+        // Setup execution environment (fetches block, preloads transactions, sets up state)
+        let mut archival_storage = None;
+        let (_maybe_block, txs_to_trace, mut evm_db, block_env, cfg_env) =
+            self.setup_trace_execution(block_number, state, &mut archival_storage)?;
+
+        // Trace all transactions in the block
+        let mut traces = vec![];
+
+        for tx in txs_to_trace {
+            let result = self.trace_transaction_inner(
+                &block_env,
+                replay_tx_env(&tx),
+                cfg_env.clone(),
+                &mut evm_db,
+                &opts,
+            )?;
+            traces.push(TraceResult::new_success(result, Some(*tx.hash())));
+        }
+
+        Ok(traces)
+    }
+
+    pub(super) fn trace_transaction(
+        &self,
+        tx_hash: B256,
+        opts: GethDebugTracingOptions,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Result<GethTrace, EthApiError> {
+        // Get transaction - could be in pending_transactions or sealed blocks
+        let tx_number = self
+            .tx_index(&tx_hash, state)
+            .ok_or(EthApiError::PrunedHistoryUnavailable)?;
+        let traced_tx = self
+            .transaction(tx_number, state)
+            .ok_or(EthApiError::PrunedHistoryUnavailable)?;
+
+        // Setup execution environment (fetches block, preloads transactions, sets up state)
+        let mut archival_storage = None;
+        let (_maybe_block, txs_to_replay, mut evm_db, block_env, cfg_env) =
+            self.setup_trace_execution(traced_tx.block_number, state, &mut archival_storage)?;
+
+        // Replay previous transactions in the block
+        for tx in txs_to_replay {
+            // Skip the transaction we're tracing
+            if *tx.signed_transaction.hash() == tx_hash {
+                break;
+            }
+
+            transact_commit(&mut evm_db, &block_env, replay_tx_env(&tx), cfg_env.clone())
+                .map_err(EthApiError::from)?;
+        }
+
+        // Trace the target transaction
+        self.trace_transaction_inner(
+            &block_env,
+            replay_tx_env(&traced_tx),
+            cfg_env,
+            &mut evm_db,
+            &opts,
+        )
+    }
+
+    pub(super) fn trace_transaction_inner(
+        &self,
+        block_env: &BlockEnv,
+        tx_env: TxEnv,
+        cfg: CfgEnv,
+        db: &mut EvmDb<ApiStateAccessor<S>, S>,
+        opts: &GethDebugTracingOptions,
+    ) -> Result<GethTrace, EthApiError> {
+        let GethDebugTracingOptions {
+            tracer,
+            tracer_config,
+            ..
+        } = opts;
+        if let Some(tracer) = tracer {
+            return match tracer {
+                GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::CallTracer) => {
+                    let call_config = tracer_config
+                        .clone()
+                        .into_call_config()
+                        .map_err(|_| EthApiError::InvalidTracerConfig)?;
+
+                    let inspector_config =
+                        TracingInspectorConfig::from_geth_call_config(&call_config);
+                    let mut inspector = TracingInspector::new(inspector_config);
+
+                    let gas_limit = tx_env.gas_limit;
+                    let ExecResultAndState { result, state } =
+                        inspect(&mut *db, block_env, tx_env, cfg, &mut inspector)?;
+                    db.commit(state)?;
+
+                    inspector.set_transaction_gas_limit(gas_limit);
+                    let frame = inspector
+                        .geth_builder()
+                        .geth_call_traces(call_config, result.gas_used());
+
+                    Ok(frame.into())
+                }
+                _ => Err(EthApiError::Unsupported("unsupported tracer")),
+            };
+        }
+        Err(EthApiError::Unsupported("unsupported tracer"))
+    }
+}

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
@@ -132,7 +132,7 @@ where
 
         // Replay previous transactions in the block
         for tx in txs_to_replay {
-            // Skip the transaction we're tracing
+            // As soon as we reach target tx - exit the loop
             if *tx.signed_transaction.hash() == tx_hash {
                 break;
             }

--- a/examples/demo-rollup/tests/evm/evm_tracing.rs
+++ b/examples/demo-rollup/tests/evm/evm_tracing.rs
@@ -1,7 +1,8 @@
 use alloy_primitives::utils::parse_ether;
 use alloy_primitives::Address;
 use alloy_provider::ext::DebugApi;
-use alloy_rpc_types_trace::geth::{CallConfig, GethDebugTracingOptions};
+use alloy_rpc_types_eth::BlockNumberOrTag;
+use alloy_rpc_types_trace::geth::{CallConfig, GethDebugTracingOptions, GethTrace};
 use sov_test_utils::Erc20;
 
 use crate::evm::evm_test_helper::alloy_client;
@@ -22,7 +23,64 @@ async fn debug_trace_pending_tx() -> anyhow::Result<()> {
     let trace = client
         .debug_trace_transaction(*mint_tx.tx_hash(), opts.clone())
         .await?;
-    dbg!(trace);
+
+    // Verify the trace structure for the pending transaction
+    match trace {
+        GethTrace::CallTracer(call_frame) => {
+            // Verify it's a CALL to the USDC contract
+            assert_eq!(call_frame.typ, "CALL");
+            assert_eq!(call_frame.to, Some(*usdc.address()));
+
+            // Verify the function signature is mint(address,uint256) = 0x40c10f19
+            assert!(call_frame.input.starts_with(&[0x40, 0xc1, 0x0f, 0x19]));
+
+            // Verify execution succeeded (no error, no revert)
+            assert!(call_frame.error.is_none());
+            assert!(call_frame.revert_reason.is_none());
+
+            // Verify gas was consumed (non-zero gas_used)
+            assert!(call_frame.gas_used > 0);
+        }
+        _ => panic!("Expected CallTracer variant, got {trace:?}"),
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn debug_trace_pending_block() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    rollup.wait_for_next_blocks(1).await;
+
+    let client = alloy_client(rollup.http_addr);
+    let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
+    let mint_tx = usdc.mint(Address::ZERO, parse_ether("1")?).send().await?;
+    rollup.pause_preferred_batches().await;
+
+    let opts = GethDebugTracingOptions::call_tracer(CallConfig::default());
+    let traces = client
+        .debug_trace_block_by_number(BlockNumberOrTag::Pending, opts.clone())
+        .await?;
+
+    // Should have 2 traces: deployment + mint
+    assert_eq!(traces.len(), 2);
+
+    // Second trace should be the mint transaction
+    assert_eq!(traces[1].tx_hash().unwrap(), *mint_tx.tx_hash());
+
+    // Verify the mint trace
+    if let alloy_rpc_types_trace::geth::TraceResult::Success { result, .. } = &traces[1] {
+        match result {
+            GethTrace::CallTracer(call_frame) => {
+                assert_eq!(call_frame.typ, "CALL");
+                assert_eq!(call_frame.to, Some(*usdc.address()));
+                assert!(call_frame.error.is_none());
+            }
+            _ => panic!("Expected CallTracer variant"),
+        }
+    } else {
+        panic!("Expected Success variant");
+    }
 
     Ok(())
 }

--- a/examples/demo-rollup/tests/evm/evm_tracing.rs
+++ b/examples/demo-rollup/tests/evm/evm_tracing.rs
@@ -9,6 +9,25 @@ use crate::evm::evm_test_helper::setup_test_rollup;
 use crate::evm::evm_test_helper::EVM_EXTENSION;
 
 #[tokio::test(flavor = "multi_thread")]
+async fn debug_trace_pending_tx() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    rollup.wait_for_next_blocks(1).await;
+
+    let client = alloy_client(rollup.http_addr);
+    let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
+    let mint_tx = usdc.mint(Address::ZERO, parse_ether("1")?).send().await?;
+    rollup.pause_preferred_batches().await;
+
+    let opts = GethDebugTracingOptions::call_tracer(CallConfig::default());
+    let trace = client
+        .debug_trace_transaction(*mint_tx.tx_hash(), opts.clone())
+        .await?;
+    dbg!(trace);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn debug_trace_block_by_number() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     rollup.wait_for_next_blocks(1).await;


### PR DESCRIPTION
# Description

- **Pending transaction tracing**: `debug_trace_transaction` now works on pending transactions
- **Pending block tracing**: `debug_trace_block_by_number` now works on pending blocks  
- **Code organization**: Extract trace-related logic into dedicated `trace.rs` module and move `MaybeArchivalState` to its own file
- **Helper utilities**: Add `From` derivation on `MaybePendingBlock` and `setup_trace_execution` helper for common trace setup logic
-----

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
- Test tracing pending transactions
- Test tracing pending blocks by number

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
