### PR TITLE
Clean up tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2025-10-21
 - #1930 Add support for tracing pending blocks and transactions via `debug_traceBlockByNumber` and `debug_traceTransaction`.
+- #1933 Cleans up demo-rollup tests
 
 # 2025-10-20
 - #1917 Add support for logs from pending blocks in `eth_getLogs` and introduce `LogsWithCursorProvider` trait in `sov-eth-client` for paginated log retrieval with `eth_getLogsWithCursor`.

--- a/crates/adapters/mock-da/src/storable/local_service.rs
+++ b/crates/adapters/mock-da/src/storable/local_service.rs
@@ -228,46 +228,6 @@ impl StorableMockDaService {
         .await
     }
 
-    /// Creates new [`StorableMockDaService`] with a given address.
-    /// Manual block production.
-    pub async fn new_in_memory_manual(sequencer_da_address: MockAddress) -> Self {
-        let da_layer = StorableMockDaLayer::new_in_memory(0)
-            .await
-            .expect("Failed to initialize StorableMockDaLayer");
-        let producing = BlockProducingConfig::OnBatchSubmit {
-            block_wait_timeout_ms: None,
-        };
-        Self::new(
-            sequencer_da_address,
-            Arc::new(RwLock::new(da_layer)),
-            producing,
-        )
-        .await
-    }
-
-    /// Creates new [`StorableMockDaService`] with a given address.
-    /// - Periodic block production.
-    /// - Data is stored only in memory.
-    pub async fn new_in_memory_periodic(
-        block_time_ms: u64,
-        sequencer_da_address: MockAddress,
-    ) -> (Self, watch::Sender<()>) {
-        let config = MockDaConfig {
-            connection_string: MockDaConfig::sqlite_in_memory(),
-            sender_address: sequencer_da_address,
-            finalization_blocks: 0,
-            block_producing: BlockProducingConfig::Periodic { block_time_ms },
-            da_layer: None,
-            randomization: None,
-        };
-
-        let (shutdown_sender, shutdown_receiver) = tokio::sync::watch::channel(());
-        (
-            StorableMockDaService::from_config(config, shutdown_receiver).await,
-            shutdown_sender,
-        )
-    }
-
     /// Creates new in memory [`StorableMockDaService`] from [`MockDaConfig`].
     pub async fn from_config(config: MockDaConfig, shutdown_receiver: watch::Receiver<()>) -> Self {
         let da_layer = match config.da_layer.as_ref() {

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -2264,12 +2264,7 @@ async fn flaky_txs_that_enter_before_downtime_are_dropped() {
     let fourth_tx = tx_set_value(&admin.private_key, 2, 9);
 
     // Submit the first tx. This should succeed. This verifies that our initialization works fine *and* causes the sequencer to be close out its current batch.
-    client
-        .accept_tx(&api_types::AcceptTxBody {
-            body: BASE64_STANDARD.encode(&first_tx),
-        })
-        .await
-        .unwrap();
+    client.send_raw_tx_to_sequencer(&first_tx).await.unwrap();
 
     // Produce a new block that includes this first tx.
     test_rollup
@@ -2282,10 +2277,9 @@ async fn flaky_txs_that_enter_before_downtime_are_dropped() {
 
     // Produce a second large delay tx and a second block since - for some reason - the sequencer seems to be holding one extra finalized slot in reserve.
     // This is now needed to exhaust the sequencer's buffer and prevent flakiness allowing us to test the downtime.
+    let second_large_tx = tx_set_value_and_sleep(&admin.private_key, 1, 0, 1200);
     client
-        .accept_tx(&api_types::AcceptTxBody {
-            body: BASE64_STANDARD.encode(tx_set_value_and_sleep(&admin.private_key, 1, 0, 1200)),
-        })
+        .send_raw_tx_to_sequencer_with_retry(&second_large_tx)
         .await
         .unwrap();
 
@@ -2298,14 +2292,12 @@ async fn flaky_txs_that_enter_before_downtime_are_dropped() {
     // Wait until the new batch is almost processed
     sleep(Duration::from_millis(1000)).await;
 
-    // Send off the delayed tx. It should arrive at the seqeuncer immediately and begin sleeping.
+    // Send off the delayed tx. It should arrive at the sequencer immediately and begin sleeping.
     let delayed_tx_handle = tokio::spawn({
         let client = client.clone();
         async move {
             let response = client
-                .accept_tx(&api_types::AcceptTxBody {
-                    body: BASE64_STANDARD.encode(&delayed_tx),
-                })
+                .send_raw_tx_to_sequencer(&delayed_tx)
                 .await
                 .unwrap_err()
                 .to_string();
@@ -2320,9 +2312,7 @@ async fn flaky_txs_that_enter_before_downtime_are_dropped() {
     // This is the "downtime" that we're testing for.
     tokio::time::sleep(Duration::from_millis(50)).await;
     let third_tx_response = client
-        .accept_tx(&api_types::AcceptTxBody {
-            body: BASE64_STANDARD.encode(&third_tx),
-        })
+        .send_raw_tx_to_sequencer(&third_tx)
         .await
         .unwrap_err()
         .to_string();

--- a/crates/full-node/sov-stf-runner/tests/integration/aggregated_proof_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/aggregated_proof_tests.rs
@@ -12,10 +12,12 @@ use tokio::task::JoinHandle;
 use crate::helpers::hash_stf::S;
 use crate::helpers::runner_init::{initialize_runner, InitVariant, TestNode};
 
+const TEST_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(90);
+
 #[tokio::test(flavor = "multi_thread")]
 async fn fetch_aggregated_proof_test_sync() -> anyhow::Result<()> {
     let test_case = TestCase::new(5);
-    run_make_proof_sync(test_case, 3).await?;
+    tokio::time::timeout(TEST_TOTAL_TIMEOUT, run_make_proof_sync(test_case, 3)).await??;
 
     Ok(())
 }
@@ -23,11 +25,7 @@ async fn fetch_aggregated_proof_test_sync() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn fetch_aggregated_proof_test_async() -> anyhow::Result<()> {
     let test_case = TestCase::new(5);
-    tokio::time::timeout(
-        std::time::Duration::from_secs(60),
-        run_make_proof_async(test_case, 3),
-    )
-    .await??;
+    tokio::time::timeout(TEST_TOTAL_TIMEOUT, run_make_proof_async(test_case, 3)).await??;
 
     Ok(())
 }

--- a/examples/demo-rollup/tests/bank/operator_rollup/bank_periodic_da_tests.rs
+++ b/examples/demo-rollup/tests/bank/operator_rollup/bank_periodic_da_tests.rs
@@ -1,12 +1,12 @@
-use std::str::FromStr;
-use std::sync::Arc;
-
+use futures::StreamExt;
 use sov_bank::config_gas_token_id;
 use sov_bank::derived_holder::DerivedHolder;
 use sov_cli::NodeClient;
 use sov_mock_da::storable::StorableMockDaService;
-use sov_modules_api::{OperatingMode, Spec};
+use sov_modules_api::{Amount, OperatingMode, Spec};
 use sov_test_utils::TestSpec;
+use std::str::FromStr;
+use std::sync::Arc;
 
 use crate::bank::helpers::*;
 use crate::bank::{TOKEN_DECIMALS, TOKEN_NAME};
@@ -35,6 +35,7 @@ async fn send_test_bank_txs(
     client: &NodeClient,
     da_service: Arc<StorableMockDaService>,
 ) -> anyhow::Result<()> {
+    let mut slots_subscription = client.client.subscribe_slots().await?;
     let (key, user_address, token_id, recipient_address) = create_keys_and_addresses();
     let token_id_response = client
         .get_token_id::<DemoRollupSpec>(TOKEN_NAME, Some(TOKEN_DECIMALS), &user_address)
@@ -42,8 +43,7 @@ async fn send_test_bank_txs(
 
     let reward_addr = <TestSpec as Spec>::Address::from_str(
         "sov1pv9skzctpv9skzctpv9skzctpv9skzctpv9skzctpv9skqm7ehv",
-    )
-    .unwrap();
+    )?;
 
     {
         let reward_amount = client
@@ -61,6 +61,10 @@ async fn send_test_bank_txs(
     let tx = build_create_token_tx(&key, 0, initial_balance);
 
     let slot_number = send_tx_and_wait_for_status(&[tx], client).await?;
+    let mut processed_slot = slots_subscription.next().await.unwrap()?;
+    while processed_slot.number < slot_number {
+        processed_slot = slots_subscription.next().await.unwrap()?;
+    }
 
     // Will cause a batch to be produced.
     da_service.produce_n_blocks_now(1).await.unwrap();
@@ -73,6 +77,9 @@ async fn send_test_bank_txs(
         let tx = build_transfer_token_tx(&key, token_id, recipient_address, 10, nonce);
 
         let slot_number = send_tx_and_wait_for_status(&[tx], client).await?;
+        while processed_slot.number < slot_number {
+            processed_slot = slots_subscription.next().await.unwrap()?;
+        }
 
         assert_slot_finality(client, slot_number, test_case.expected_head_finality()).await;
         assert_balance(
@@ -84,15 +91,14 @@ async fn send_test_bank_txs(
         )
         .await?;
 
-        da_service.produce_n_blocks_now(1).await.unwrap();
+        da_service.produce_n_blocks_now(1).await?;
     }
 
     {
         let reward_amount = client
             .get_balance::<TestSpec>(&reward_addr, &config_gas_token_id(), None)
-            .await
-            .unwrap();
-        assert!(reward_amount > 0);
+            .await?;
+        assert_ne!(reward_amount, Amount::ZERO);
     }
 
     // Check the derive holder api

--- a/examples/demo-rollup/tests/bank/zk_rollup/bank_periodic_da_tests.rs
+++ b/examples/demo-rollup/tests/bank/zk_rollup/bank_periodic_da_tests.rs
@@ -115,6 +115,9 @@ async fn send_test_bank_txs(test_case: TestCase, client: &NodeClient) -> anyhow:
     let transfer_amounts: Vec<u128> = (10u128..20).collect();
     let txs = build_multiple_transfers(&transfer_amounts, &key, token_id, recipient_address, 3);
     let slot_batch_n = send_tx_and_wait_for_status(&txs, client).await?;
+    while processed_slot.number < slot_batch_n {
+        processed_slot = slots_subscription.next().await.unwrap()?;
+    }
     assert_slot_finality(client, slot_batch_n, test_case.expected_head_finality()).await;
 
     // FIXME(@neysofu,

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -5,7 +5,7 @@ use sov_demo_rollup::ExternalMockDemoRollup;
 use sov_mock_da::storable::rpc::start_server;
 use sov_mock_da::storable::rpc::MockDaClientConfig;
 use sov_mock_da::storable::StorableMockDaService;
-use sov_mock_da::MockAddress;
+use sov_mock_da::{MockAddress, MockDaConfig};
 use sov_modules_api::execution_mode::Native;
 use sov_modules_api::CryptoSpec;
 use sov_modules_api::OperatingMode;
@@ -24,6 +24,7 @@ use tokio::sync::watch;
 use tokio::time::Duration;
 
 type S = <ExternalMockDemoRollup<Native> as RollupBlueprint<Native>>::Spec;
+const TEST_SEQ_DA_ADDRESS: MockAddress = MockAddress::new([0; 32]);
 
 fn random_address() -> <S as Spec>::Address {
     let pk = <<S as Spec>::CryptoSpec as CryptoSpec>::PrivateKey::generate();
@@ -31,7 +32,7 @@ fn random_address() -> <S as Spec>::Address {
 }
 
 async fn create_da_service_manual() -> (StorableMockDaService, SocketAddr) {
-    let da_service = StorableMockDaService::new_in_memory_manual(MockAddress::new([0; 32])).await;
+    let da_service = StorableMockDaService::new_in_memory(TEST_SEQ_DA_ADDRESS, 0).await;
 
     let addr = start_server(da_service.clone(), "127.0.0.1", 0)
         .await
@@ -40,9 +41,11 @@ async fn create_da_service_manual() -> (StorableMockDaService, SocketAddr) {
     (da_service, addr)
 }
 
-async fn create_da_service() -> (StorableMockDaService, watch::Sender<()>, SocketAddr) {
-    let (da_service, shutdown_sender) =
-        StorableMockDaService::new_in_memory_periodic(300, MockAddress::new([0; 32])).await;
+async fn create_da_service_periodic() -> (StorableMockDaService, watch::Sender<()>, SocketAddr) {
+    let (shutdown_sender, shutdown_receiver) = tokio::sync::watch::channel(());
+    let mut da_config = MockDaConfig::instant_with_sender(TEST_SEQ_DA_ADDRESS);
+    da_config.block_producing = sov_test_utils::TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING;
+    let da_service = StorableMockDaService::from_config(da_config, shutdown_receiver).await;
 
     let addr = start_server(da_service.clone(), "127.0.0.1", 0)
         .await
@@ -88,7 +91,7 @@ async fn start_rollup(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_replica_receives_txs_from_da() {
-    let (_, shutdown_sender, addr) = create_da_service().await;
+    let (_, shutdown_sender, addr) = create_da_service_periodic().await;
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
 
     let test_rollup = start_rollup(false, addr, None).await;

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -21,7 +21,6 @@ use sov_test_utils::test_rollup::TestRollup;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::watch;
-use tokio::time::Duration;
 
 type S = <ExternalMockDemoRollup<Native> as RollupBlueprint<Native>>::Spec;
 const TEST_SEQ_DA_ADDRESS: MockAddress = MockAddress::new([0; 32]);
@@ -53,21 +52,6 @@ async fn create_da_service_periodic() -> (StorableMockDaService, watch::Sender<(
         .unwrap();
 
     (da_service, shutdown_sender, addr)
-}
-
-async fn wait_for_height(
-    test_rollup: &TestRollup<ExternalMockDemoRollup<Native>>,
-    da_service: &StorableMockDaService,
-    height: u64,
-) {
-    loop {
-        let h = test_rollup.height().await;
-        da_service.produce_block_now().await.unwrap();
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        if h.get() >= height {
-            break;
-        }
-    }
 }
 
 async fn start_rollup(
@@ -165,8 +149,19 @@ async fn test_replica_receives_txs_from_postgres() {
 
     let height_before_tx = test_rollup.height().await;
     test_rollup.send_tx_to_sequencer(&tx).await.unwrap();
+    let gap = 5;
+    // producing blocks, like it is standard periodic production
+    for _ in 0..gap {
+        da_service.produce_block_now().await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(
+            sov_test_utils::TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS,
+        ))
+        .await;
+    }
 
-    wait_for_height(&test_rollup, &da_service, height_before_tx.get() + 5).await;
+    test_rollup
+        .wait_for_height(height_before_tx.get() + gap)
+        .await;
 
     let receiver_balance = replica_test_rollup
         .client

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -31,6 +31,7 @@ fn random_address() -> <S as Spec>::Address {
     pk.pub_key().credential_id().into()
 }
 
+// Actually creates DA service that produces block on batch submitted.
 async fn create_da_service_manual() -> (StorableMockDaService, SocketAddr) {
     let da_service = StorableMockDaService::new_in_memory(TEST_SEQ_DA_ADDRESS, 0).await;
 


### PR DESCRIPTION
# Description

* Removes extra methods on MockDaService that can be replaced with current one
* Adds explicit timeout for both proof fetch tests (discovered in https://github.com/Sovereign-Labs/sovereign-sdk/pull/1894)
* Adds slot waiting for bank tests (discovered in https://github.com/Sovereign-Labs/sovereign-sdk/pull/1894)

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Existing tests are passing

## Docs
No updates
