### PR TITLE
Replica: DB pruning fix.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -31,6 +31,9 @@ use tokio::sync::{mpsc, watch};
 use crate::common::WithCachedTxHashes;
 use crate::preferred::{exit_rollup, track_in_progress_batch_size};
 
+// Don’t prune the data from the database immediately — give the replica some time to read it before it is pruned.
+const PRUNING_LAG: u64 = 10;
+
 #[async_trait]
 pub trait PreferredSequencerDbBackend: Send + Sync + 'static {
     async fn begin_rollup_block(&mut self, stored_batch: BatchToStore) -> anyhow::Result<()>;
@@ -531,6 +534,7 @@ impl PreferredSequencerDb {
         prune_up_to_including: SequenceNumber,
     ) -> anyhow::Result<()> {
         if let Some(backend) = &mut self.backend {
+            let prune_up_to_including = prune_up_to_including.saturating_sub(PRUNING_LAG);
             backend.prune(prune_up_to_including).await?;
         }
         Ok(())

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -23,6 +23,9 @@ pub(crate) enum EventReceiverError {
 
     #[error("Invalid event sequence in the db: {0:?} {1:?}. Replica shutting down.")]
     InvalidEventSequence(Option<EventType>, EventType),
+
+    #[error("DB row does not exist: {0}")]
+    DbRowDoesNotExist(u64),
 }
 
 pub(crate) struct EventReceiver {
@@ -138,6 +141,12 @@ impl EventReceiver {
                                 error!("Invalid event sequence in the db: {prev_event_type:?} {event_type:?}. Replica shutting down.");
                                 exit_rollup(&self.shutdown_sender).await;
                             }
+                            EventReceiverError::DbRowDoesNotExist(event_id) => {
+                                error!(
+                                    "Db row does not exist for event id: {event_id:?}. Replica shutting down."
+                                );
+                                exit_rollup(&self.shutdown_sender).await;
+                            }
                         }
                     }
                 }
@@ -225,6 +234,10 @@ impl EventReceiver {
 
             // Query and process events for this page
             let db_rows = rows(&self.query_pool, page_end, current_event_id).await?;
+
+            if db_rows.is_empty() {
+                return Err(EventReceiverError::DbRowDoesNotExist(current_event_id));
+            }
 
             for row in db_rows {
                 let (event, event_type) = row_to_event(row)?;


### PR DESCRIPTION
# Description

Fixes a bug where the replica attempts to read data from PostgreSQL after the master has already pruned it.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

