### PR TITLE
Lifting metrics initialization from runner to rollup blueprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2025-10-21
 - #1930 Add support for tracing pending blocks and transactions via `debug_traceBlockByNumber` and `debug_traceTransaction`.
+- #1936 Fixes warnings about metrics during rollup startup
 
 # 2025-10-20
 - #1917 Add support for logs from pending blocks in `eth_getLogs` and introduce `LogsWithCursorProvider` trait in `sov-eth-client` for paginated log retrieval with `eth_getLogsWithCursor`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12376,6 +12376,7 @@ dependencies = [
  "sov-cli",
  "sov-db",
  "sov-ledger-apis",
+ "sov-metrics",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-rollup-apis",

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -8,7 +8,7 @@ use full_node_configs::runner::{CorsConfiguration, ProofManagerConfig, RunnerCon
 use jsonrpsee::RpcModule;
 use sov_db::ledger_db::{LedgerDb, SlotCommit};
 use sov_db::schema::{DeltaReader, SchemaBatch};
-use sov_metrics::{MonitoringConfig, RunnerMetrics};
+use sov_metrics::RunnerMetrics;
 
 use sov_rollup_interface::common::{RollupHeight, SlotNumber};
 use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait, DaSpec};
@@ -154,7 +154,6 @@ where
         prev_state_root: Stf::StateRoot,
         state_height_tracker: Box<dyn ProvableHeightTracker>,
         shutdown_receiver: watch::Receiver<()>,
-        monitoring_config: MonitoringConfig,
         start_at_rollup_height: Option<RollupHeight>,
         stop_at_rollup_height: Option<RollupHeight>,
         sync_state: Arc<DaSyncState>,
@@ -166,19 +165,6 @@ where
         // But when REST and RPC handlers start, sender is used to get another subscription.
         let (secondary_shutdown_sender, mut secondary_shutdown_receiver) = watch::channel(());
         secondary_shutdown_receiver.mark_unchanged();
-        let receiver_for_metrics = secondary_shutdown_receiver.clone();
-        let metrics_handle = tokio::spawn(async move {
-            if let Some(handle) =
-                sov_metrics::init_metrics_tracker(&monitoring_config, receiver_for_metrics)
-            {
-                handle.await?;
-            } else {
-                tracing::warn!("Metics have been initialized outside of runner, some measurements can be lost on shutdown");
-            };
-
-            Ok(())
-        });
-        background_handles.push(metrics_handle);
 
         let axum_config = &runner_config.http_config;
 

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -173,6 +173,22 @@ pub async fn initialize_runner(
 
     let rollup_config = rollup_config(&da_service, path, aggregated_proof_block_jump);
 
+    let mut tasks = JoinSet::new();
+    let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
+    shutdown_receiver.mark_unchanged();
+    let receiver_for_metrics = shutdown_receiver.clone();
+
+    let monitoring_config = rollup_config.monitoring.clone();
+    tasks.spawn(async move {
+        if let Some(handle) =
+            sov_metrics::init_metrics_tracker(&monitoring_config, receiver_for_metrics)
+        {
+            handle.await.expect("Metrics task errored");
+        } else {
+            tracing::warn!("Metics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown");
+        };
+    });
+
     let mut storage_manager: StorageManager = NativeStorageManager::new(path).unwrap();
 
     let finalized_header = da_service.get_last_finalized_block_header().await.unwrap();
@@ -191,15 +207,10 @@ pub async fn initialize_runner(
             .unwrap(),
     );
 
-    let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
-    shutdown_receiver.mark_unchanged();
-
     let (prev_state_root, genesis_state_root) = init_variant
         .initialize(&stf, &mut storage_manager)
         .await
         .unwrap();
-
-    let mut tasks = JoinSet::new();
 
     tasks.spawn({
         let ledger_updates = ledger_db.clone();
@@ -233,7 +244,6 @@ pub async fn initialize_runner(
         prev_state_root,
         Box::new(InfiniteHeight),
         shutdown_receiver.clone(),
-        rollup_config.monitoring.clone(),
         None,
         None,
         da_sync_state,

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -99,9 +99,6 @@ async fn test_runner_with_background_da_service(
     target_height: u64,
     da_config: MockDaConfig,
 ) -> anyhow::Result<()> {
-    // std::env::set_var("RUST_LOG", "info,sov_stf_runner=trace,sov_mock_da=debug");
-    // std::env::set_var("RUST_LOG", "info");
-    // sov_test_utils::initialize_logging();
     let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
     shutdown_receiver.mark_unchanged();
 
@@ -147,6 +144,8 @@ async fn test_runner_with_background_da_service(
     let (prev_state_root, _genesis_state_root) =
         init_variant.initialize(&stf, &mut storage_manager).await?;
 
+    // TODO: Init metrics here
+
     let mut runner: HashStfRunner<StorableMockDaService> = StateTransitionRunner::new(
         rollup_config.runner.clone(),
         None,
@@ -158,7 +157,6 @@ async fn test_runner_with_background_da_service(
         prev_state_root,
         Box::new(InfiniteHeight),
         shutdown_receiver.clone(),
-        rollup_config.monitoring.clone(),
         None,
         None,
         da_sync_state,

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -1,8 +1,13 @@
 use std::sync::Arc;
 
+use crate::helpers::hash_stf::{HashStf, S};
+use crate::helpers::runner_init::{
+    bootstrap_state_update_info, initialize_runner, HashStfRunner, InitVariant,
+};
 use anyhow::Context;
 use sov_db::ledger_db::LedgerDb;
 use sov_db::storage_manager::NativeStorageManager;
+use sov_metrics::MonitoringConfig;
 use sov_mock_da::storable::StorableMockDaService;
 use sov_mock_da::{
     BlockProducingConfig, MockAddress, MockBlob, MockBlock, MockBlockHeader, MockDaConfig,
@@ -23,11 +28,6 @@ use sov_stf_runner::StateTransitionRunner;
 use sov_test_utils::storage::SimpleStorageManager;
 use tempfile::TempDir;
 use tokio::sync::watch;
-
-use crate::helpers::hash_stf::{HashStf, S};
-use crate::helpers::runner_init::{
-    bootstrap_state_update_info, initialize_runner, HashStfRunner, InitVariant,
-};
 
 type MockInitVariant = InitVariant<HashStf, MockZkvm, MockZkvm, MockDaService>;
 
@@ -124,9 +124,8 @@ async fn test_runner_with_background_da_service(
 
     let (sync_sender, mut sync_status_receiver) = watch::channel(SyncStatus::START);
     let ledger_db = LedgerDb::with_reader(ledger_state).unwrap();
-    let da_sync_state = make_da_sync_state(0, None, &ledger_db, da_service.as_ref(), sync_sender)
-        .await
-        .unwrap();
+    let da_sync_state =
+        make_da_sync_state(0, None, &ledger_db, da_service.as_ref(), sync_sender).await?;
 
     let (state_update_sender, _state_update_recv) = watch::channel(
         bootstrap_state_update_info(&mut storage_manager, da_sync_state.as_ref()).await?,
@@ -144,7 +143,8 @@ async fn test_runner_with_background_da_service(
     let (prev_state_root, _genesis_state_root) =
         init_variant.initialize(&stf, &mut storage_manager).await?;
 
-    // TODO: Init metrics here
+    let _ =
+        sov_metrics::init_metrics_tracker(&MonitoringConfig::standard(), shutdown_receiver.clone());
 
     let mut runner: HashStfRunner<StorableMockDaService> = StateTransitionRunner::new(
         rollup_config.runner.clone(),

--- a/crates/module-system/sov-modules-rollup-blueprint/Cargo.toml
+++ b/crates/module-system/sov-modules-rollup-blueprint/Cargo.toml
@@ -27,6 +27,7 @@ sov-sequencer = { workspace = true, optional = true }
 sov-ledger-apis = { workspace = true, optional = true }
 sov-rollup-apis = { workspace = true, optional = true }
 sov-api-spec = { workspace = true, optional = true }
+sov-metrics = { workspace = true, optional = true }
 
 anyhow = { workspace = true }
 futures = { workspace = true, optional = true }
@@ -50,32 +51,34 @@ tracing-opentelemetry = { version = "0.28.0", default-features = false, features
 [features]
 default = ["native"]
 native = [
-    "async-trait",
-    "futures",
-    "console-subscriber",
-    "derivative",
-    "serde_json",
-    "sov-cli",
-    "sov-db",
-    "sov-ledger-apis",
-    "sov-rollup-apis",
-    "sov-api-spec",
-    "sov-modules-api/native",
-    "sov-modules-stf-blueprint/native",
-    "sov-rollup-apis",
-    "sov-rollup-interface/native",
-    "sov-sequencer",
-    "sov-state/native",
-    "sov-stf-runner",
-    "tokio",
-    "tracing",
-    "tracing-panic",
-    "tracing-subscriber",
-    "hex",
-    "opentelemetry",
-    "opentelemetry_sdk",
-    "opentelemetry-otlp",
-    "opentelemetry-appender-tracing",
-    "opentelemetry-semantic-conventions",
-    "tracing-opentelemetry",
+	"async-trait",
+	"futures",
+	"console-subscriber",
+	"derivative",
+	"serde_json",
+	"sov-cli",
+	"sov-db",
+	"sov-ledger-apis",
+	"sov-rollup-apis",
+	"sov-api-spec",
+	"sov-modules-api/native",
+	"sov-modules-stf-blueprint/native",
+	"sov-rollup-apis",
+	"sov-rollup-interface/native",
+	"sov-sequencer",
+	"sov-state/native",
+	"sov-stf-runner",
+	"sov-metrics",
+	"tokio",
+	"tracing",
+	"tracing-panic",
+	"tracing-subscriber",
+	"hex",
+	"opentelemetry",
+	"opentelemetry_sdk",
+	"opentelemetry-otlp",
+	"opentelemetry-appender-tracing",
+	"opentelemetry-semantic-conventions",
+	"tracing-opentelemetry",
+	"sov-metrics?/native"
 ]

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -286,6 +286,19 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             tokio::sync::watch::channel(());
         secondary_shutdown_receiver.mark_unchanged();
 
+        let receiver_for_metrics = secondary_shutdown_receiver.clone();
+        let monitoring_config = rollup_config.monitoring.clone();
+        let metrics_handle = tokio::spawn(async move {
+            if let Some(handle) =
+                sov_metrics::init_metrics_tracker(&monitoring_config, receiver_for_metrics)
+            {
+                handle.await.expect("Metrics task errored");
+            } else {
+                tracing::warn!("Metics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown");
+            };
+        });
+        let mut background_handles = vec![metrics_handle];
+
         let operating_mode =
             <Self::Runtime as RuntimeTrait<Self::Spec>>::operating_mode(&genesis_params.runtime);
         info!(?operating_mode, "Instantiating a new rollup");
@@ -413,7 +426,6 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         let (state_update_sender, state_update_receiver) =
             tokio::sync::watch::channel(state_update_info);
 
-        let mut background_handles = vec![];
         if let Some(handle) = da_service_handle {
             background_handles.push(handle);
         }
@@ -437,7 +449,6 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             prev_state_root,
             visible_state_height_tracker,
             main_shutdown_receiver.clone(),
-            rollup_config.monitoring.clone(),
             start_at_rollup_height,
             stop_at_rollup_height,
             da_sync_state.clone(),

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -285,19 +285,17 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         let (secondary_shutdown_sender, mut secondary_shutdown_receiver) =
             tokio::sync::watch::channel(());
         secondary_shutdown_receiver.mark_unchanged();
+        let mut background_handles = vec![];
 
         let receiver_for_metrics = secondary_shutdown_receiver.clone();
         let monitoring_config = rollup_config.monitoring.clone();
-        let metrics_handle = tokio::spawn(async move {
-            if let Some(handle) =
-                sov_metrics::init_metrics_tracker(&monitoring_config, receiver_for_metrics)
-            {
-                handle.await.expect("Metrics task errored");
-            } else {
-                tracing::warn!("Metics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown");
-            };
-        });
-        let mut background_handles = vec![metrics_handle];
+        if let Some(metrics_handle) =
+            sov_metrics::init_metrics_tracker(&monitoring_config, receiver_for_metrics)
+        {
+            background_handles.push(metrics_handle);
+        } else {
+            tracing::warn!("Metics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown");
+        };
 
         let operating_mode =
             <Self::Runtime as RuntimeTrait<Self::Spec>>::operating_mode(&genesis_params.runtime);

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -313,7 +313,7 @@ async fn test_start_prover_manual() -> anyhow::Result<()> {
         ),
         (
             Level::WARN,
-            "Metics have been initialized outside of rollup blueprint, some measurements can be lost on shutdown".to_string(),
+            "Metics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown".to_string(),
         ),
     ];
     recorded_errors_warnings.retain(|e| !known.contains(e));

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -122,7 +122,7 @@ async fn start_stop_empty(
         ),
         (Level::WARN, "Skipping pruning of sequence number because it's already been pruned".to_string()),
         (Level::WARN, "The node is unsynced and doesn't know it. This probably means that you wiped the node DB and are resyncing.".to_string()),
-        (Level::WARN, "Metics have been initialized outside of runner, some measurements can be lost on shutdown".to_string()),
+        (Level::WARN, "Metics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown".to_string()),
     ];
 
     let mut recorded_errors_warnings =
@@ -313,7 +313,7 @@ async fn test_start_prover_manual() -> anyhow::Result<()> {
         ),
         (
             Level::WARN,
-            "Metics have been initialized outside of runner, some measurements can be lost on shutdown".to_string(),
+            "Metics have been initialized outside of rollup blueprint, some measurements can be lost on shutdown".to_string(),
         ),
     ];
     recorded_errors_warnings.retain(|e| !known.contains(e));

--- a/examples/demo-rollup/tests/resync/mod.rs
+++ b/examples/demo-rollup/tests/resync/mod.rs
@@ -331,7 +331,7 @@ async fn test_rollup_resync() -> anyhow::Result<()> {
         // oddity that might be worth investigating.
         (Level::WARN, "State Transition Info is not consumed fast enough, cannot prune older entries. Please check that consumer works.".to_string()),
         (Level::WARN, "The node is unsynced and doesn't know it. This probably means that you wiped the node DB and are resyncing.".to_string()),
-        (Level::WARN, "Metics have been initialized outside of runner, some measurements can be lost on shutdown".to_string()),
+        (Level::WARN, "Metics have been initialized outside of rollup blueprint, some measurements can be lost on shutdown".to_string()),
     ];
 
     let mut recorded_errors_warnings =

--- a/examples/demo-rollup/tests/resync/mod.rs
+++ b/examples/demo-rollup/tests/resync/mod.rs
@@ -331,7 +331,7 @@ async fn test_rollup_resync() -> anyhow::Result<()> {
         // oddity that might be worth investigating.
         (Level::WARN, "State Transition Info is not consumed fast enough, cannot prune older entries. Please check that consumer works.".to_string()),
         (Level::WARN, "The node is unsynced and doesn't know it. This probably means that you wiped the node DB and are resyncing.".to_string()),
-        (Level::WARN, "Metics have been initialized outside of rollup blueprint, some measurements can be lost on shutdown".to_string()),
+        (Level::WARN, "Metics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown".to_string()),
     ];
 
     let mut recorded_errors_warnings =


### PR DESCRIPTION
# Description

Some metrics have been added to the code, that runs in rollup blueprint before stf runner kicks in. This results in 2 things

* Some metrics are lost
* Users are going to be confused by extra warning messages:

```
2025-10-20T12:15:35.166321Z  WARN init_blueprint: sov_metrics::influxdb: Submitting metrics to uninitialized metrics tracker. Submitted metrics will be dropped. Please call `sov_metrics::init_metrics_tracker` to prevent data loss.
2025-10-20T12:15:35.166346Z  WARN init_blueprint: sov_metrics::influxdb: Submitting metrics to uninitialized metrics tracker. Submitted metrics will be dropped. Please call `sov_metrics::init_metrics_tracker` to prevent data loss.
2025-10-20T12:15:35.166367Z  INFO init_blueprint: sov_db::storage_manager::nomt_based::groups: Starting pruner task iteration versions_to_keep=20
2025-10-20T12:15:35.166448Z  WARN init_blueprint: sov_metrics::influxdb: Submitting metrics to uninitialized metrics tracker. Submitted metrics will be dropped. Please call `sov_metrics::init_metrics_tracker` to prevent data loss.
2025-10-20T12:15:35.166472Z DEBUG init_blueprint: sov_db::storage_manager::nomt_based: Creating new storage from finalized data as block header is not in the saved chain block_header=sov_mock_da::types::MockBlockHeader prev_hash=0x0000000000000000000000000000000000000000000000000000000000000000 hash=0x0101010101010101010101010101010101010101010101010101010101010101 height=0
2025-10-20T12:15:35.166592Z DEBUG init_blueprint: sov_stf_runner::runner: last_slot_processed_before_shutdown=0
2025-10-20T12:15:35.166643Z  WARN sov_metrics::influxdb: Submitting metrics to uninitialized metrics tracker. Submitted metrics will be dropped. Please call `sov_metrics::init_metrics_tracker` to prevent data loss.
2025-10-20T12:15:35.166814Z  WARN sov_metrics::influxdb: Submitting metrics to uninitialized metrics tracker. Submitted metrics will be dropped. Please call `sov_metrics::init_metrics_tracker` to prevent data loss.
2025-10-20T12:15:35.167212Z DEBUG init_blueprint: sov_modules_rollup_blueprint::native_only: Rollup state initialization is completed prev_root_hash="0ff1a0eaf80436cdd9c6e3a085462a16d81494c8b915865e68ba3f87aa0b12f46dd8123b33fcf7ac3fb44b78169a5dc530d664bc4f3a872da4ac528e0d2be00f" raw_genesis_state_root="0ff1a0eaf80436cdd9c6e3a085462a16d81494c8b915865e68ba3f87aa0b12f46dd8123b33fcf7ac3fb44b78169a5dc530d664bc4f3a872da4ac528e0d2be00f" state_update_info=StateUpdateInfo { next_event_number: 0, next_tx_number: 0, slot_number: 0, latest_finalized_slot_number: 0, sync_status: Synced { synced_da_height: 0 }, .. }
2025-10-20T12:15:35.167370Z DEBUG init_blueprint: sov_stf_runner::runner: Initializing StfRunner runner_config.genesis_height=0 first_unprocessed_height_at_startup=1 proof_manager_config=Some(ProofManagerConfig { aggregated_proof_block_jump: 1, prover_address: Standard(AddressBech32("sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf")), max_number_of_transitions_in_db: 100, max_number_of_transitions_in_memory: 30 })
2025-10-20T12:15:35.167428Z DEBUG sov_metrics::influxdb::tracker: Metrics tracker initialized config=MonitoringConfig { telegraf_address: TelegrafSocketConfig { transport: Udp, addr: 127.0.0.1:8094 }, max_datagram_size: None, max_pending_metrics: None }
2025-10-20T12:15:35.167504Z TRACE sov_stf_runner::da_pre_fetcher: Running bulk block fetcher start=1 last_finalized_height=0
```

## Solution

Metrics initialization is now done in rollup blueprint, so genesis and all other preparation before runner starts won't have warnings.

Bonus point: metrics won't be stopped with runner, but later, so less metrics loss during shutdown.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Existing tests are passing

## Docs
No updates
