### PR TITLE
Reject log subscriptions with block filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-10-22
+- #1937 Reject log subscriptions with block filters.
+
 # 2025-10-21
 - #1930 Add support for tracing pending blocks and transactions via `debug_traceBlockByNumber` and `debug_traceTransaction`.
 

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -3,7 +3,8 @@ use crate::Ethereum;
 use alloy_rpc_types::pubsub::Params;
 use alloy_rpc_types::pubsub::SubscriptionKind;
 use alloy_rpc_types::Filter;
-use jsonrpsee::types::{ErrorObjectOwned, Params as JRpcParams};
+use alloy_rpc_types::FilterBlockOption;
+use jsonrpsee::types::Params as JRpcParams;
 use jsonrpsee::PendingSubscriptionSink;
 use jsonrpsee::SubscriptionMessage;
 use jsonrpsee::{Extensions, SubscriptionSink};
@@ -14,6 +15,7 @@ use sov_modules_api::capabilities::HasKernel;
 use sov_modules_api::Spec;
 use sov_sequencer::Sequencer;
 use std::sync::Arc;
+use thiserror::Error;
 
 use crate::handlers::ETH_RPC_ERROR;
 
@@ -35,10 +37,12 @@ where
     S::Address: FromVmAddress<EthereumAddress>,
     Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
 {
-    let log_filter = match validate_params_for_log_subscription(parameters) {
+    let eth_subscribe = parameters.parse::<EthSubscribe>()?;
+    let log_filter = match validate_params_for_log_subscription(eth_subscribe) {
         Ok(log_filter) => log_filter,
         Err(e) => {
-            pending.reject(ErrorObjectOwned::from(e)).await;
+            let rpc_err = to_jsonrpsee_error_object(e, ETH_RPC_ERROR);
+            pending.reject(rpc_err).await;
             return Ok(());
         }
     };
@@ -144,49 +148,31 @@ async fn stream_logs<S, Seq>(
     }
 }
 
+#[derive(Error, Debug)]
+enum ParamsValidationError {
+    #[error("Block Option parameters are not supported in LOG subscriptions. Please use eth_getLogs or eth_getLogsWithCursor")]
+    BlockOptionParam,
+    #[error("Boolean parameters are not supported in LOG subscriptions")]
+    BoolParam,
+    #[error("Only LOG subscriptions are supported")]
+    OnlyLogSubscription,
+}
+
 fn validate_params_for_log_subscription(
-    parameters: JRpcParams<'static>,
-) -> Result<Box<Filter>, ErrorObjectOwned> {
-    let eth_subscribe = parameters.parse::<EthSubscribe>()?;
-
-    let log_filter = match &eth_subscribe.kind {
-        SubscriptionKind::Logs => match eth_subscribe.params {
-            Params::Logs(filter) => {
-                match filter.block_option {
-                    alloy_rpc_types::FilterBlockOption::Range {
-                        from_block,
-                        to_block,
-                    } => {
-                        if from_block.is_some() || to_block.is_some() {
-                            tracing::warn!(
-                                "Block Option parameters are not supported in LOG subscriptions: Range"
-                            );
-                        }
-                    }
-                    alloy_rpc_types::FilterBlockOption::AtBlockHash(_) => {
-                        tracing::warn!(
-                            "Block Option parameters are not supported in LOG subscriptions: AtBlockHash"
-                        );
-                    }
-                }
-
-                filter
+    eth_subscribe: EthSubscribe,
+) -> Result<Box<Filter>, ParamsValidationError> {
+    if eth_subscribe.kind != SubscriptionKind::Logs {
+        return Err(ParamsValidationError::OnlyLogSubscription);
+    }
+    match eth_subscribe.params {
+        Params::Logs(filter) => {
+            if filter.block_option == FilterBlockOption::default() {
+                Ok(filter)
+            } else {
+                Err(ParamsValidationError::BlockOptionParam)
             }
-            Params::Bool(_) => {
-                return Err(to_jsonrpsee_error_object(
-                    "Boolean parameters are not supported in LOG subscriptions.",
-                    ETH_RPC_ERROR,
-                ));
-            }
-            _ => Default::default(),
-        },
-        _ => {
-            return Err(to_jsonrpsee_error_object(
-                "Only LOG subscriptions are supported.",
-                ETH_RPC_ERROR,
-            ))
         }
-    };
-
-    Ok(log_filter)
+        Params::Bool(_) => Err(ParamsValidationError::BoolParam),
+        Params::None => Ok(Default::default()),
+    }
 }

--- a/examples/demo-rollup/tests/evm/evm_subscribe.rs
+++ b/examples/demo-rollup/tests/evm/evm_subscribe.rs
@@ -1,12 +1,16 @@
 use std::ops::Range;
 use std::sync::Arc;
 
+use crate::evm::evm_test_helper::alloy_ws_client;
+use crate::evm::evm_test_helper::setup_test_rollup;
 use crate::evm::evm_test_helper::setup_with_simple_storage;
 use crate::evm::evm_test_helper::EVM_EXTENSION;
+use alloy::transports::RpcError;
 use alloy_primitives::Address;
 use alloy_primitives::TxHash;
 use alloy_primitives::B256;
 use alloy_primitives::U256;
+use alloy_provider::Provider;
 use alloy_rpc_types_eth::Filter;
 use sov_demo_rollup::MockDemoRollup;
 use sov_eth_client::SimpleStorageClient;
@@ -116,6 +120,22 @@ async fn evm_test_log_subscription_with_pending_blcok() {
         assert_eq!(log.block_number.unwrap(), block_nr);
         assert!(log.block_timestamp.unwrap() == 0);
     }
+}
+
+// Tests for block range.
+#[tokio::test(flavor = "multi_thread")]
+async fn evm_test_log_subscription_with_block_range_returns_an_error() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    let client = alloy_ws_client(rollup.http_addr).await;
+    let filter = Filter::new().select(0..=0);
+    let err = client.subscribe_logs(&filter).await.unwrap_err();
+    let RpcError::ErrorResp(payload) = err else {
+        panic!("Expected subscription error")
+    };
+    let data = payload.data.unwrap();
+    assert_eq!(data.get(), "\"Block Option parameters are not supported in LOG subscriptions. Please use eth_getLogs or eth_getLogsWithCursor\"");
+
+    Ok(())
 }
 
 // Subscription test with filtering.

--- a/examples/demo-rollup/tests/evm/evm_test_helper.rs
+++ b/examples/demo-rollup/tests/evm/evm_test_helper.rs
@@ -6,6 +6,7 @@ use alloy::signers::local::PrivateKeySigner;
 use alloy_provider::DynProvider;
 use alloy_provider::Provider as _;
 use alloy_provider::ProviderBuilder;
+use alloy_provider::WsConnect;
 use ethers::core::abi::Address;
 use futures::future::join_all;
 use reqwest::Url;
@@ -63,6 +64,18 @@ pub(crate) async fn create_simple_storage_client(
 ) -> SimpleStorageClient {
     let contract = LegacySimpleStorage::default();
     SimpleStorageClient::new(private_key, contract, rest_port).await
+}
+
+pub(crate) async fn alloy_ws_client(socket: SocketAddr) -> DynProvider {
+    let signer: PrivateKeySigner = SENDER_PRIV_KEY.parse().unwrap();
+    let url = Url::parse(&format!("ws://{socket}/rpc")).unwrap();
+    let ws = WsConnect::new(url);
+    ProviderBuilder::new()
+        .wallet(signer)
+        .connect_ws(ws)
+        .await
+        .unwrap()
+        .erased()
 }
 
 pub(crate) fn alloy_client(socket: SocketAddr) -> DynProvider {


### PR DESCRIPTION
# Description

Subscriptions are used to subscribe new logs and not for getting historical ones. For that - eth_getLogs should be used.
We used to emit a warning - but still create a null subscription. Now we return a proper error. Also added a test for it.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
