### PR TITLE
Stop using ..Default::default() on Reth types so that we don't miss fields

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -58,7 +58,7 @@ pub fn create_tx_env(tx: &TransactionSigned, signer: Address, nonce: u64, gas_li
         chain_id: tx.chain_id(),
         // We don't set gas_price nor the gas_priority_fee.
         // We disable the EVM logic charging gas at the beginning of the TX and instead rely on sov gas metering
-        ..Default::default()
+        ..Default::default() // TODO
     }
 }
 
@@ -122,7 +122,7 @@ pub(crate) fn create_block_env(
             excess_blob_gas: EXCESS_BLOB_GAS,
             blob_gasprice: BLOB_GAS_PRICE,
         }),
-        ..Default::default()
+        ..Default::default() // TODO
     }
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -58,7 +58,13 @@ pub fn create_tx_env(tx: &TransactionSigned, signer: Address, nonce: u64, gas_li
         chain_id: tx.chain_id(),
         // We don't set gas_price nor the gas_priority_fee.
         // We disable the EVM logic charging gas at the beginning of the TX and instead rely on sov gas metering
-        ..Default::default() // TODO
+        // Default values
+        gas_price: 0,
+        access_list: vec![].into(),
+        gas_priority_fee: None,
+        blob_hashes: vec![],
+        max_fee_per_blob_gas: 0,
+        authorization_list: vec![],
     }
 }
 
@@ -122,7 +128,8 @@ pub(crate) fn create_block_env(
             excess_blob_gas: EXCESS_BLOB_GAS,
             blob_gasprice: BLOB_GAS_PRICE,
         }),
-        ..Default::default() // TODO
+        // Default values
+        difficulty: U256::ZERO,
     }
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -109,7 +109,7 @@ fn init_block(config: &EvmGenesisConfig, base_fee: u64) -> Block {
         timestamp: config.genesis_timestamp,
         excess_blob_gas: Some(EXCESS_BLOB_GAS),
         base_fee_per_gas: Some(base_fee),
-        ..Default::default()
+        ..Default::default() // TODO
     };
 
     Block {

--- a/crates/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -1,5 +1,6 @@
 use alloy_consensus::constants::KECCAK_EMPTY;
-use alloy_primitives::{Address, B256, U256};
+use alloy_consensus::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
+use alloy_primitives::{Address, Bloom, B256, B64, U256};
 use alloy_primitives::{BlockNumber, Bytes};
 use revm::primitives::hardfork::SpecId;
 use revm::state::AccountInfo;
@@ -109,7 +110,22 @@ fn init_block(config: &EvmGenesisConfig, base_fee: u64) -> Block {
         timestamp: config.genesis_timestamp,
         excess_blob_gas: Some(EXCESS_BLOB_GAS),
         base_fee_per_gas: Some(base_fee),
-        ..Default::default() // TODO
+        // Default values
+        parent_hash: B256::ZERO,
+        ommers_hash: EMPTY_OMMER_ROOT_HASH,
+        transactions_root: EMPTY_ROOT_HASH,
+        receipts_root: EMPTY_ROOT_HASH,
+        logs_bloom: Bloom::default(),
+        difficulty: U256::ZERO,
+        number: 0,
+        gas_used: 0,
+        extra_data: Bytes::default(),
+        mix_hash: B256::ZERO,
+        nonce: B64::ZERO,
+        withdrawals_root: None,
+        blob_gas_used: None,
+        parent_beacon_block_root: None,
+        requests_hash: None,
     };
 
     Block {

--- a/crates/module-system/module-implementations/sov-evm/src/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/helpers.rs
@@ -40,7 +40,10 @@ pub(crate) fn prepare_call_env(
         data: input.try_into_unique_input()?.unwrap_or_default(),
         chain_id,
         access_list: access_list.unwrap_or_default(),
-        ..Default::default() // TODO
+        // Default values
+        blob_hashes: vec![],
+        max_fee_per_blob_gas: 0,
+        authorization_list: vec![],
     };
 
     Ok(env)
@@ -58,7 +61,9 @@ pub(crate) fn from_recovered_with_block_context(
         block_hash,
         block_number: Some(block_number),
         index,
-        ..Default::default() // TODO
+        // Default values
+        hash: None,
+        base_fee: None,
     };
     alloy_rpc_types::Transaction::from_transaction(tx.convert(), tx_info)
 }

--- a/crates/module-system/module-implementations/sov-evm/src/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/helpers.rs
@@ -40,7 +40,7 @@ pub(crate) fn prepare_call_env(
         data: input.try_into_unique_input()?.unwrap_or_default(),
         chain_id,
         access_list: access_list.unwrap_or_default(),
-        ..Default::default()
+        ..Default::default() // TODO
     };
 
     Ok(env)
@@ -58,7 +58,7 @@ pub(crate) fn from_recovered_with_block_context(
         block_hash,
         block_number: Some(block_number),
         index,
-        ..Default::default()
+        ..Default::default() // TODO
     };
     alloy_rpc_types::Transaction::from_transaction(tx.convert(), tx_info)
 }

--- a/crates/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -139,7 +139,7 @@ impl<S: Spec> BlockHooks for Evm<S> {
                 .map(|blob_gas| blob_gas.excess_blob_gas),
 
             base_fee_per_gas: Some(block_env.basefee),
-            ..Default::default()
+            ..Default::default() // TODO
         };
 
         let end_tx_index = start_tx_index

--- a/crates/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -2,9 +2,8 @@ use crate::conversions::create_block_env;
 use crate::evm::primitive_types::{Block, TransactionSigned};
 use crate::{Evm, PendingTransaction};
 use alloy_consensus::proofs::{calculate_receipt_root, calculate_transaction_root};
-use alloy_consensus::TxReceipt;
-use alloy_primitives::Bloom;
-use alloy_primitives::B256;
+use alloy_consensus::{TxReceipt, EMPTY_OMMER_ROOT_HASH};
+use alloy_primitives::{Bloom, Bytes, B256, B64, U256};
 #[cfg(feature = "native")]
 use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::UnwrapInfallible;
@@ -137,9 +136,16 @@ impl<S: Spec> BlockHooks for Evm<S> {
             excess_blob_gas: block_env
                 .blob_excess_gas_and_price
                 .map(|blob_gas| blob_gas.excess_blob_gas),
-
             base_fee_per_gas: Some(block_env.basefee),
-            ..Default::default() // TODO
+            // Default values
+            ommers_hash: EMPTY_OMMER_ROOT_HASH,
+            difficulty: U256::ZERO,
+            extra_data: Bytes::default(),
+            nonce: B64::ZERO,
+            withdrawals_root: None,
+            blob_gas_used: None,
+            parent_beacon_block_root: None,
+            requests_hash: None,
         };
 
         let end_tx_index = start_tx_index

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -1,9 +1,9 @@
 use std::ops::DerefMut;
 
-use alloy_consensus::Sealed;
 use alloy_consensus::{transaction::Recovered, Transaction as TransactionTrait, TxReceipt};
+use alloy_consensus::{Sealed, EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::{Address, BlockNumber};
+use alloy_primitives::{Address, BlockNumber, Bloom, B64};
 use alloy_primitives::{Bytes, TxKind, B256, U256};
 use alloy_rpc_types::{
     Block, BlockTransactions, Log, ReceiptEnvelope, ReceiptWithBloom, Transaction,
@@ -302,8 +302,23 @@ where
                 .blob_excess_gas_and_price
                 .map(|blob_gas| blob_gas.excess_blob_gas),
             base_fee_per_gas: Some(current_block_env.basefee),
-
-            ..Default::default() // TODO
+            // Default values
+            ommers_hash: EMPTY_OMMER_ROOT_HASH,
+            beneficiary: Address::ZERO,
+            state_root: EMPTY_ROOT_HASH,
+            transactions_root: EMPTY_ROOT_HASH,
+            receipts_root: EMPTY_ROOT_HASH,
+            logs_bloom: Bloom::default(),
+            difficulty: U256::ZERO,
+            gas_limit: 0,
+            gas_used: 0,
+            extra_data: Bytes::default(),
+            mix_hash: B256::ZERO,
+            nonce: B64::ZERO,
+            withdrawals_root: None,
+            blob_gas_used: None,
+            parent_beacon_block_root: None,
+            requests_hash: None,
         };
 
         crate::Block {

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -113,7 +113,8 @@ where
         Some(Block {
             header,
             transactions,
-            ..Default::default()
+            uncles: vec![],
+            withdrawals: None,
         })
     }
 
@@ -302,7 +303,7 @@ where
                 .map(|blob_gas| blob_gas.excess_blob_gas),
             base_fee_per_gas: Some(current_block_env.basefee),
 
-            ..Default::default()
+            ..Default::default() // TODO
         };
 
         crate::Block {


### PR DESCRIPTION
# Description

- Marked all locations where Reth types were using `Default::default()`
- Replaced default instantiations with explicit field initialization
- Prevents subtle bugs from implicit default values on critical blockchain types

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
