### PR TITLE
fix: allow undefined optional fields in JSON to Borsh serialization

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -2,8 +2,9 @@
 //! thus test sequencer + node interactions.
 
 use crate::utils::{
-    generate_paymaster_tx, generate_txs, new_test_rollup, pause_update_state,
-    tempdir_inside_codebase_dir, tx_set_value_with_gas, ModuleWithVersionedStateAccessInSlotHook,
+    generate_paymaster_tx, generate_txs, new_test_rollup, new_test_rollup_with_backend,
+    pause_update_state, tempdir_inside_codebase_dir, tx_set_value_with_gas,
+    ModuleWithVersionedStateAccessInSlotHook, TestSequencerDbBackend,
     MAX_BATCH_EXECUTION_TIME_MILLIS,
 };
 use backon::Retryable;
@@ -569,7 +570,10 @@ async fn sequencer_filled_up_block() {
 
     let dir = tempdir_inside_codebase_dir();
 
-    let test_rollup = new_test_rollup::<TestRuntime<TestSpec>>(
+    let max_batch_size = TEST_MAX_BATCH_SIZE;
+    let blob_processing_timeout_secs = TEST_BLOB_PROCESSING_TIMEOUT;
+
+    let Some(test_rollup) = new_test_rollup_with_backend::<TestRuntime<TestSpec>>(
         dir.clone(),
         genesis_params
             .runtime
@@ -579,15 +583,19 @@ async fn sequencer_filled_up_block() {
         genesis_params,
         0,
         true,
-        TEST_MAX_BATCH_SIZE,
+        max_batch_size,
         BlockProducingConfig::Manual,
         None,
-        60,
-        MAX_BATCH_EXECUTION_TIME_MILLIS,
+        blob_processing_timeout_secs,
+        400, // Set the batch time limit to twice the block time
         None,
         TEST_FINALIZATION_BLOCKS,
+        TestSequencerDbBackend::Postgres { allow_skip: true },
     )
-    .await;
+    .await
+    else {
+        return;
+    };
 
     let mut da_layer = DaLayerWithSubscription::new(&test_rollup).await;
     da_layer.produce_and_wait_for_n_slots(5).await;

--- a/crates/full-node/sov-sequencer/tests/integration/utils.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/utils.rs
@@ -217,8 +217,13 @@ pub mod pause_update_state {
     }
 }
 
+pub enum TestSequencerDbBackend {
+    RocksDb,
+    Postgres { allow_skip: bool },
+}
+
 #[allow(clippy::too_many_arguments)]
-pub async fn new_test_rollup<RT: Runtime<TestSpec> + HasRestApi<TestSpec>>(
+pub async fn new_test_rollup_with_backend<RT: Runtime<TestSpec> + HasRestApi<TestSpec>>(
     dir: Arc<tempfile::TempDir>,
     seq_da_address: MockAddress,
     genesis_params: GenesisParams<<RT as Runtime<TestSpec>>::GenesisConfig>,
@@ -231,8 +236,9 @@ pub async fn new_test_rollup<RT: Runtime<TestSpec> + HasRestApi<TestSpec>>(
     max_batch_execution_time_millis: u64,
     stop_at_rollup_height: Option<RollupHeight>,
     finalization_blocks: u32,
-) -> TestRollup<RtAgnosticBlueprint<TestSpec, RT>> {
-    let builder = RollupBuilder::<RtAgnosticBlueprint<TestSpec, RT>>::new(
+    backend: TestSequencerDbBackend,
+) -> Option<TestRollup<RtAgnosticBlueprint<TestSpec, RT>>> {
+    let mut builder = RollupBuilder::<RtAgnosticBlueprint<TestSpec, RT>>::new(
         GenesisSource::CustomParams(genesis_params),
         block_producing_config,
         finalization_blocks,
@@ -256,7 +262,86 @@ pub async fn new_test_rollup<RT: Runtime<TestSpec> + HasRestApi<TestSpec>>(
     .with_preferred_seq_min_profit_per_tx(minimum_profit_per_tx)
     .with_preferred_seq_recovery_strategy(sov_sequencer::preferred::RecoveryStrategy::TryToSave);
 
-    builder.start().await.unwrap()
+    match backend {
+        TestSequencerDbBackend::RocksDb => {}
+        TestSequencerDbBackend::Postgres { allow_skip } => {
+            const DEV_SERVER_CPUS: usize = 96;
+
+            if std::env::var("SOV_TEST_SKIP_DOCKER")
+                .map_or(false, |value| value == "1")
+            {
+                tracing::warn!(
+                    "Skipping Postgres-backed rollup: SOV_TEST_SKIP_DOCKER=1 was set"
+                );
+                return None;
+            }
+
+            if num_cpus::get() == DEV_SERVER_CPUS {
+                tracing::warn!(
+                    "Skipping Postgres-backed rollup: detected machine with {DEV_SERVER_CPUS} threads (dev server heuristic)"
+                );
+                return None;
+            }
+
+            builder = match builder.with_postgres_sequencer().await {
+                Ok(builder) => builder,
+                Err(error) => {
+                    if allow_skip {
+                        tracing::warn!(
+                            ?error,
+                            "Skipping Postgres-backed rollup: failed to start Postgres container"
+                        );
+                        return None;
+                    }
+
+                    eprintln!("Error starting rollup builder: {error:?}");
+                    eprintln!(
+                        "To skip docker based tests run with the env var SOV_TEST_SKIP_DOCKER=1"
+                    );
+                    panic!("Unable to proceed without docker");
+                }
+            };
+        }
+    }
+
+    Some(builder.start().await.unwrap())
+}
+
+/// Builds a rollup backed by RocksDb.
+/// Call [`new_test_rollup_with_backend`] with [`TestSequencerDbBackend::Postgres`]
+/// for tests that require the Postgres-backed sequencer.
+#[allow(clippy::too_many_arguments)]
+pub async fn new_test_rollup<RT: Runtime<TestSpec> + HasRestApi<TestSpec>>(
+    dir: Arc<tempfile::TempDir>,
+    seq_da_address: MockAddress,
+    genesis_params: GenesisParams<<RT as Runtime<TestSpec>>::GenesisConfig>,
+    minimum_profit_per_tx: u128,
+    automatic_batch_production: bool,
+    max_batch_size_bytes: usize,
+    block_producing_config: BlockProducingConfig,
+    rollup_prover_config: Option<RollupProverConfig<MockZkvm>>,
+    blob_processing_timeout_secs: u64,
+    max_batch_execution_time_millis: u64,
+    stop_at_rollup_height: Option<RollupHeight>,
+    finalization_blocks: u32,
+) -> TestRollup<RtAgnosticBlueprint<TestSpec, RT>> {
+    new_test_rollup_with_backend(
+        dir,
+        seq_da_address,
+        genesis_params,
+        minimum_profit_per_tx,
+        automatic_batch_production,
+        max_batch_size_bytes,
+        block_producing_config,
+        rollup_prover_config,
+        blob_processing_timeout_secs,
+        max_batch_execution_time_millis,
+        stop_at_rollup_height,
+        finalization_blocks,
+        TestSequencerDbBackend::RocksDb,
+    )
+    .await
+    .expect("RocksDb backend should always be available")
 }
 
 pub fn encode_call_with_fee<RT: Runtime<TestSpec>>(

--- a/crates/full-node/sov-sequencer/tests/integration/utils.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/utils.rs
@@ -267,8 +267,12 @@ pub async fn new_test_rollup_with_backend<RT: Runtime<TestSpec> + HasRestApi<Tes
         TestSequencerDbBackend::Postgres { allow_skip } => {
             const DEV_SERVER_CPUS: usize = 96;
 
-            if std::env::var("SOV_TEST_SKIP_DOCKER").is_ok_and(|value| value == "1") {
-                tracing::warn!("Skipping Postgres-backed rollup: SOV_TEST_SKIP_DOCKER=1 was set");
+            if std::env::var("SOV_TEST_SKIP_DOCKER")
+                .map_or(false, |value| value == "1")
+            {
+                tracing::warn!(
+                    "Skipping Postgres-backed rollup: SOV_TEST_SKIP_DOCKER=1 was set"
+                );
                 return None;
             }
 

--- a/crates/full-node/sov-sequencer/tests/integration/utils.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/utils.rs
@@ -267,12 +267,8 @@ pub async fn new_test_rollup_with_backend<RT: Runtime<TestSpec> + HasRestApi<Tes
         TestSequencerDbBackend::Postgres { allow_skip } => {
             const DEV_SERVER_CPUS: usize = 96;
 
-            if std::env::var("SOV_TEST_SKIP_DOCKER")
-                .map_or(false, |value| value == "1")
-            {
-                tracing::warn!(
-                    "Skipping Postgres-backed rollup: SOV_TEST_SKIP_DOCKER=1 was set"
-                );
+            if std::env::var("SOV_TEST_SKIP_DOCKER").is_ok_and(|value| value == "1") {
+                tracing::warn!("Skipping Postgres-backed rollup: SOV_TEST_SKIP_DOCKER=1 was set");
                 return None;
             }
 

--- a/crates/module-system/sov-modules-api/tests/integration/transaction.rs
+++ b/crates/module-system/sov-modules-api/tests/integration/transaction.rs
@@ -258,4 +258,35 @@ mod web3_compatibility {
         let result = schema.json_to_borsh(0, json);
         assert!(result.is_ok(), "{ASSERT_MSG}. Error: {result:?}");
     }
+
+    #[test]
+    fn test_tx_wallet_serialization_missing_gas_field() {
+        let json = r#"
+        {"versioned_tx": {"V0":
+            {
+                "signature": "c5a11079c4fd275060d306833d203064f6d7e9840022fab66e53d512d7280169b5707aab240e030ae6e352f4387d8877752722d87f1815dc7064c38a503b3e02",
+                "pub_key": "1ea77bb8f81915816c4e985c680fa990377dc948f11d834b6eb187fb2a53cce6",
+                "runtime_call": {
+                    "value_setter": {
+                        "set_value": {
+                            "value": 4
+                        }
+                    }
+                },
+                "uniqueness": {
+                    "generation": 2
+                },
+                "details": {
+                    "max_priority_fee_bips": 1,
+                    "max_fee": 10000,
+                    "gas_limit": null,
+                    "chain_id": 1337
+                }
+    }}
+        }"#;
+        let schema = Schema::of_single_type::<Transaction<Runtime, TestSpec>>().unwrap();
+
+        let result = schema.json_to_borsh(0, json);
+        assert!(result.is_ok(), "{ASSERT_MSG}. Error: {result:?}");
+    }
 }

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -123,6 +123,26 @@ pub struct RollupBuilder<R: FullNodeBlueprint<Native>> {
 }
 
 impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
+    /// Uses the preferred sequencer with Postgres as a database.
+    async fn with_postgres_sequencer(mut self) -> anyhow::Result<Self> {
+        let postgres =
+            create_postgres_container(&self.config.storage.path().join("postgres_data")).await
+            .with_context(|| "Failed to start Postgres container. This is most likely because (1) the Docker daemon is not running or (2) Docker Desktop doesn't have file sharing permissions to the repository directory")?;
+
+        let postgres_connection_string =
+            connection_string_from_postgres_container(&postgres).await?;
+
+        match &mut self.config.sequencer_config {
+            SequencerKindConfig::Preferred(ref mut config) => {
+                config.postgres_connection_string = Some(postgres_connection_string);
+                self.postgres_container_opt = Some(Arc::new(postgres));
+            }
+            _ => panic!("Can't use Postgres with a non-preferred sequencer"),
+        }
+
+        Ok(self)
+    }
+
     /// See [`PreferredSequencerConfig::minimum_profit_per_tx`].
     pub fn with_preferred_seq_min_profit_per_tx(mut self, minimum_profit_per_tx: u128) -> Self {
         if let SequencerKindConfig::Preferred(ref mut config) = &mut self.config.sequencer_config {
@@ -459,26 +479,6 @@ where
             config: Self::default_config(finalization_blocks, storage_path, false),
             with_secondary_sequencer: None,
         }
-    }
-
-    /// Uses the preferred sequencer with Postgres as a database.
-    pub async fn with_postgres_sequencer(mut self) -> anyhow::Result<Self> {
-        let postgres =
-            create_postgres_container(&self.config.storage.path().join("postgres_data")).await
-            .with_context(|| "Failed to start Postgres container. This is most likely because (1) the Docker daemon is not running or (2) Docker Desktop doesn't have file sharing permissions to the repository directory")?;
-
-        let postgres_connection_string =
-            connection_string_from_postgres_container(&postgres).await?;
-
-        match &mut self.config.sequencer_config {
-            SequencerKindConfig::Preferred(ref mut config) => {
-                config.postgres_connection_string = Some(postgres_connection_string);
-                self.postgres_container_opt = Some(Arc::new(postgres));
-            }
-            _ => panic!("Can't use Postgres with a non-preferred sequencer"),
-        }
-
-        Ok(self)
     }
 
     /// Creates a new [`TestRollup`] and starts running it in a background Tokio

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -123,26 +123,6 @@ pub struct RollupBuilder<R: FullNodeBlueprint<Native>> {
 }
 
 impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
-    /// Uses the preferred sequencer with Postgres as a database.
-    async fn with_postgres_sequencer(mut self) -> anyhow::Result<Self> {
-        let postgres =
-            create_postgres_container(&self.config.storage.path().join("postgres_data")).await
-            .with_context(|| "Failed to start Postgres container. This is most likely because (1) the Docker daemon is not running or (2) Docker Desktop doesn't have file sharing permissions to the repository directory")?;
-
-        let postgres_connection_string =
-            connection_string_from_postgres_container(&postgres).await?;
-
-        match &mut self.config.sequencer_config {
-            SequencerKindConfig::Preferred(ref mut config) => {
-                config.postgres_connection_string = Some(postgres_connection_string);
-                self.postgres_container_opt = Some(Arc::new(postgres));
-            }
-            _ => panic!("Can't use Postgres with a non-preferred sequencer"),
-        }
-
-        Ok(self)
-    }
-
     /// See [`PreferredSequencerConfig::minimum_profit_per_tx`].
     pub fn with_preferred_seq_min_profit_per_tx(mut self, minimum_profit_per_tx: u128) -> Self {
         if let SequencerKindConfig::Preferred(ref mut config) = &mut self.config.sequencer_config {
@@ -479,6 +459,26 @@ where
             config: Self::default_config(finalization_blocks, storage_path, false),
             with_secondary_sequencer: None,
         }
+    }
+
+    /// Uses the preferred sequencer with Postgres as a database.
+    pub async fn with_postgres_sequencer(mut self) -> anyhow::Result<Self> {
+        let postgres =
+            create_postgres_container(&self.config.storage.path().join("postgres_data")).await
+            .with_context(|| "Failed to start Postgres container. This is most likely because (1) the Docker daemon is not running or (2) Docker Desktop doesn't have file sharing permissions to the repository directory")?;
+
+        let postgres_connection_string =
+            connection_string_from_postgres_container(&postgres).await?;
+
+        match &mut self.config.sequencer_config {
+            SequencerKindConfig::Preferred(ref mut config) => {
+                config.postgres_connection_string = Some(postgres_connection_string);
+                self.postgres_container_opt = Some(Arc::new(postgres));
+            }
+            _ => panic!("Can't use Postgres with a non-preferred sequencer"),
+        }
+
+        Ok(self)
     }
 
     /// Creates a new [`TestRollup`] and starts running it in a background Tokio

--- a/crates/universal-wallet/schema/src/visitors/json_to_borsh.rs
+++ b/crates/universal-wallet/schema/src/visitors/json_to_borsh.rs
@@ -30,6 +30,7 @@ pub enum EncodeError {
     #[error(transparent)]
     UnresolvedType(#[from] ResolutionError),
     #[error("Expected type or field {name}, but it was not present")]
+    // Optional fields are synthesized as JSON nulls in visit_struct; other patterns still error until explicitly supported.
     MissingType { name: String },
     #[error("Type {container_name} did not have serde metadata present in the schema. The schema is either malformed or does not support JSON parsing.")]
     MissingMetadata { container_name: String },
@@ -224,7 +225,7 @@ impl<W: std::io::Write, L: LinkingScheme> TypeVisitor<L, ContainerSerdeMetadata>
         &mut self,
         s: &Struct<L>,
         schema: &impl TypeResolver<LinkingScheme = L, Metadata = ContainerSerdeMetadata>,
-        mut context: Context<L>,
+        context: Context<L>,
     ) -> Self::ReturnType {
         let mut json_fields = match context.value {
             Value::Object(o) => o,
@@ -245,19 +246,24 @@ impl<W: std::io::Write, L: LinkingScheme> TypeVisitor<L, ContainerSerdeMetadata>
 
         for (field, field_serde) in s.fields.iter().zip(serde_metadata.fields_or_variants) {
             // TODO: ensure skip is handled correctly
-            let json_value =
-                json_fields
-                    .remove(&field_serde.name)
-                    .ok_or(EncodeError::MissingType {
-                        name: format!("{}.{}", s.type_name, field.display_name),
-                    })?;
             let inner_type = schema.resolve_or_err(&field.value)?;
-            context.value = json_value;
-            context.current_link = field.value.clone();
+            let field_value = match json_fields.remove(&field_serde.name) {
+                Some(value) => value,
+                None => {
+                    if let Ty::Option { .. } = &inner_type {
+                        // Optional fields may be omitted; fabricating JSON null lets visit_option encode the 0-tag None variant.
+                        Value::Null
+                    } else {
+                        return Err(EncodeError::MissingType {
+                            name: format!("{}.{}", s.type_name, field.display_name),
+                        });
+                    }
+                }
+            };
             // TODO: adjust `Context` so it can return references to views over the full JSON,
-            // without needing to clone. This is slightly annoying to ensure lifetimes are
+            // without needing to move data out. This is slightly annoying to ensure lifetimes are
             // correctly managed. Easiest solution is likely using JSON paths using value.pointer()
-            inner_type.visit(schema, self, context.clone())?;
+            inner_type.visit(schema, self, Context::from_val(field_value, &field.value))?;
         }
         if !json_fields.is_empty() {
             return Err(EncodeError::UnusedInput {

--- a/crates/universal-wallet/schema/src/visitors/json_to_borsh.rs
+++ b/crates/universal-wallet/schema/src/visitors/json_to_borsh.rs
@@ -30,7 +30,6 @@ pub enum EncodeError {
     #[error(transparent)]
     UnresolvedType(#[from] ResolutionError),
     #[error("Expected type or field {name}, but it was not present")]
-    // Optional fields are synthesized as JSON nulls in visit_struct; other patterns still error until explicitly supported.
     MissingType { name: String },
     #[error("Type {container_name} did not have serde metadata present in the schema. The schema is either malformed or does not support JSON parsing.")]
     MissingMetadata { container_name: String },


### PR DESCRIPTION
## Description

This PR fixes issue #1738 by allowing optional fields to be undefined in JSON input when serializing to Borsh format.

## Problem

Previously, when using the TypeScript SDK, optional fields in call messages (like `relayer` in `TransferRemote`) required explicit `null` values even when they were optional. Omitting these fields would result in the error:

```
failed to call rollup: SerializationError: Expected type or field __SovVirtualWallet_CallMessage_TransferRemote.relayer, but it was not present
```

## Solution

Modified the `visit_struct` method in `json_to_borsh.rs` to:

1. Check if a missing field is an `Option` type
2. If it is optional, create a `Value::Null` instead of throwing an error
3. This allows the `visit_option` method to properly encode the `None` variant

## Changes

- Updated `visit_struct` to handle missing optional fields gracefully
- Added explanatory comment about optional field handling
- Improved error handling for truly missing required fields

## Testing

The fix ensures that TypeScript interfaces with optional fields (marked with `?`) can omit those fields in JSON input, improving the developer experience.

## Related Issue

Fixes #1738