### PR TITLE
Send slack notifications if acceptance tests fail

### DIFF
--- a/.github/workflows/acceptance_test_promote.yml
+++ b/.github/workflows/acceptance_test_promote.yml
@@ -22,6 +22,7 @@ jobs:
           echo "Test duration: ${{ github.event.client_payload.test_duration_seconds }}s"
 
       - name: Validate payload
+        id: validate
         run: |
           if [ -z "${{ github.event.client_payload.commit_sha }}" ]; then
             echo "❌ Missing required field: commit_sha"
@@ -29,22 +30,16 @@ jobs:
           fi
           echo "✅ Payload validation passed"
 
-      - uses: actions/checkout@v5
+      - name: Checkout commit
+        id: checkout
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.client_payload.commit_sha }}
           fetch-depth: 0
           ssh-key: ${{ secrets.ACCEPTANCE_TEST_DEPLOY_KEY }}
 
-      - name: Verify commit exists
-        run: |
-          COMMIT_SHA="${{ github.event.client_payload.commit_sha }}"
-          if ! git cat-file -e "$COMMIT_SHA" 2>/dev/null; then
-            echo "❌ Commit $COMMIT_SHA not found in repository"
-            exit 1
-          fi
-          echo "✅ Commit verified: $(git log -1 --oneline $COMMIT_SHA)"
-
       - name: Promote to nightly on success
+        id: promote
         if: github.event.action == 'acceptance-test-success'
         run: |
           git config user.name "github-actions[bot]"
@@ -74,22 +69,35 @@ jobs:
           echo "Commit: $COMMIT_MESSAGE"
           echo "Test duration: ${{ github.event.client_payload.test_duration_seconds }}s"
 
-      - name: Slack notification on failure
+      - name: Slack notification on acceptance test failure
         if: github.event.action == 'acceptance-test-failure'
+        uses: slackapi/slack-github-action@v2.1.1
         env:
-          NIGHTLY_BRANCH: ${{ env.NIGHTLY_BRANCH }}
-          COMMIT_SHA: ${{ github.event.client_payload.commit_sha }}
-          ERROR_DETAILS: ${{ github.event.client_payload.error_details }}
-        run: |
-          SHORT_SHA=$(echo "$COMMIT_SHA" | cut -c1-7)
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "❌ *Nightly acceptance tests failed*\n\nCommit `${{ github.event.client_payload.commit_sha }}` failed to be promoted to nightly.\n\n*Test duration:* ${{ github.event.client_payload.test_duration_seconds }}s\n\n*View details:* SSH to the build server and `less -R /opt/acceptance-server/test-runs/${{ github.event.client_payload.commit_sha }}/logs/output.log`\n\n*Workflow run:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          echo "❌ Acceptance test failed for commit $SHORT_SHA"
-          echo "Branch: $NIGHTLY_BRANCH"
-          echo "Test duration: ${{ github.event.client_payload.test_duration_seconds }}s"
-          echo ""
-          echo "Error details (last 20 lines):"
-          echo "$ERROR_DETAILS"
-          echo ""
-          echo "TODO: Send Slack notification to configured channel"
+      - name: Slack notification on fast-forward failure
+        if: steps.promote.outcome == 'failure'
+        uses: slackapi/slack-github-action@v2.1.1
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "⚠️ *Fast-forward to nightly failed*\n\nCannot fast-forward `${{ env.NIGHTLY_BRANCH }}` to commit `${{ github.event.client_payload.commit_sha }}`.\n\nThe nightly branch has diverged from the dev branch. Manual intervention required.\n\n*Workflow run:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          exit 1
+      - name: Slack notification on validation failure
+        if: failure() && (steps.validate.outcome == 'failure' || steps.checkout.outcome == 'failure')
+        uses: slackapi/slack-github-action@v2.1.1
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "🚨 *Nightly promotion validation failed*\n\nInvalid payload or commit in repository dispatch event.\n\n*Event type:* `${{ github.event.action }}`\n*Commit ref:* `${{ github.event.client_payload.commit_sha }}`\n\n*Workflow run:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
# Description

Notify in the dedicated slack channel on test failure. Also notify if tests passed but `nightly` couldn't be fast-forwarded from `dev` (branches diverged), or if the workflow parameters were incorrect (shouldn't happen unless the runner server has a bug so still good to know if it ever does).

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
