### PR TITLE
Implement `process_do_batch_start_replica` and `process_do_new_tx_replica methods`

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -534,8 +534,9 @@ impl PreferredSequencerDb {
         prune_up_to_including: SequenceNumber,
     ) -> anyhow::Result<()> {
         if let Some(backend) = &mut self.backend {
-            let prune_up_to_including = prune_up_to_including.saturating_sub(PRUNING_LAG);
-            backend.prune(prune_up_to_including).await?;
+            let x = prune_up_to_including.saturating_sub(PRUNING_LAG);
+            println!("prune_db {} {}", x, prune_up_to_including);
+            backend.prune(x).await?;
         }
         Ok(())
     }

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -534,9 +534,8 @@ impl PreferredSequencerDb {
         prune_up_to_including: SequenceNumber,
     ) -> anyhow::Result<()> {
         if let Some(backend) = &mut self.backend {
-            let x = prune_up_to_including.saturating_sub(PRUNING_LAG);
-            println!("prune_db {} {}", x, prune_up_to_including);
-            backend.prune(x).await?;
+            let prune_up_to_including = prune_up_to_including.saturating_sub(PRUNING_LAG);
+            backend.prune(prune_up_to_including).await?;
         }
         Ok(())
     }

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -962,6 +962,7 @@ where
     shutdown_receiver: watch::Receiver<()>,
 }
 
+#[derive(Debug)]
 /// Describes errors that can occur when updating the sequencer state.
 /// This type intentionally does *not* implement `std::error::Error` or `std::fmt::Debug` so that it cannot be directly converted to an `anyhow::Error`.
 /// To convert to anyhow, first convert to a `StateUpdateError` or similar. This is done to ensure backward compatibility with existing code that
@@ -1202,14 +1203,15 @@ where
         &self,
         batch_from_master: BatchToStore,
         reason: &'static str,
-    ) -> Result<Result<(), ReplicaError<S>>, SequencerStateUpdatorError> {
+    ) -> Result<(), ReplicaError<S>> {
         let (resp, recv) = oneshot::channel();
-        self.send(Message::DoBatchStartMsg {
-            resp,
-            batch_from_master,
-            reason,
-        })
-        .await?;
+        match self
+            .send(Message::DoBatchStartMsg {
+                resp,
+                batch_from_master,
+                reason,
+            })
+            .await {};
         self.recv(recv).await
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -1205,14 +1205,15 @@ where
         reason: &'static str,
     ) -> Result<(), ReplicaError<S>> {
         let (resp, recv) = oneshot::channel();
-        match self
-            .send(Message::DoBatchStartMsg {
-                resp,
-                batch_from_master,
-                reason,
-            })
-            .await {};
-        self.recv(recv).await
+        self.send(Message::DoBatchStartMsg {
+            resp,
+            batch_from_master,
+            reason,
+        })
+        .await?;
+
+        self.recv(recv).await??;
+        Ok(())
     }
 
     pub(crate) async fn do_new_tx_msg_replica(
@@ -1220,7 +1221,7 @@ where
         tx_hash: TxHash,
         baked_tx: FullyBakedTx,
         reason: &'static str,
-    ) -> Result<Result<(), ReplicaError<S>>, SequencerStateUpdatorError> {
+    ) -> Result<(), ReplicaError<S>> {
         let (resp, recv) = oneshot::channel();
         self.send(Message::DoNewTx {
             resp,
@@ -1229,7 +1230,9 @@ where
             reason,
         })
         .await?;
-        self.recv(recv).await
+
+        self.recv(recv).await??;
+        Ok(())
     }
 
     pub(crate) async fn close_current_batch_msg(

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -2039,6 +2039,13 @@ where
     ) -> Result<(), ReplicaError<S>> {
         let mut inner = self.get_inner_with_timing(reason).await;
 
+        if let Err(e) = &inner.is_ready {
+            return Err(ReplicaError::NotReady(
+                e.clone(),
+                DbData::BatchStart(batch_from_master),
+            ));
+        }
+
         let seq_nr_of_next_blob_for_this_executor = inner.sequence_number_of_next_blob;
         let seq_nr_from_master = batch_from_master.sequence_number;
 
@@ -2052,13 +2059,6 @@ where
             return Err(ReplicaError::Rejected(DBDataRejected::ExecutorBehind(
                 DbData::BatchStart(batch_from_master),
             )));
-        }
-
-        if let Err(e) = &inner.is_ready {
-            return Err(ReplicaError::NotReady(
-                e.clone(),
-                DbData::BatchStart(batch_from_master),
-            ));
         }
 
         inner

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -1,11 +1,4 @@
 #![allow(dead_code)]
-use std::collections::BTreeMap;
-use std::num::NonZero;
-use std::ops::Deref;
-use std::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
-
 use super::batch_size_tracker::BatchSizeTracker;
 use crate::metrics::{
     track_sequence_number, PreferredSequencerChannelMetrics, PreferredSequencerChannelMetricsBatch,
@@ -18,6 +11,9 @@ use crate::preferred::block_executor::{
 use crate::preferred::cache_warm_up_executor::{CacheWarmUpExecutor, StartBlockNotification};
 use crate::preferred::db::{latest_finalized_sequence_number, BatchToStore};
 use crate::preferred::executor_events::ExecutorEventsSender;
+use crate::preferred::replica::db_data::DbData;
+use crate::preferred::replica::event_handler::ReplicaError;
+use crate::preferred::replica::replica_sync_task::DBDataRejected;
 use crate::preferred::update_state::do_next_event;
 use crate::preferred::RollupBlockExecutorConfig;
 use crate::preferred::{
@@ -38,6 +34,12 @@ use sov_modules_api::{
     VersionReader, VisibleSlotNumber,
 };
 use sov_state::{NativeStorage, Storage};
+use std::collections::BTreeMap;
+use std::num::NonZero;
+use std::ops::Deref;
+use std::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
@@ -822,10 +824,12 @@ enum Message<S: Spec, Rt: Runtime<S>> {
         info: StateUpdateInfo<S::Storage>,
     },
     DoBatchStartMsg {
+        resp: oneshot::Sender<Result<(), ReplicaError<S>>>,
         batch_from_master: BatchToStore,
         reason: &'static str,
     },
     DoNewTx {
+        resp: oneshot::Sender<Result<(), ReplicaError<S>>>,
         tx_hash: TxHash,
         baked_tx: FullyBakedTx,
         reason: &'static str,
@@ -1198,12 +1202,15 @@ where
         &self,
         batch_from_master: BatchToStore,
         reason: &'static str,
-    ) -> Result<(), SequencerStateUpdatorError> {
+    ) -> Result<Result<(), ReplicaError<S>>, SequencerStateUpdatorError> {
+        let (resp, recv) = oneshot::channel();
         self.send(Message::DoBatchStartMsg {
+            resp,
             batch_from_master,
             reason,
         })
-        .await
+        .await?;
+        self.recv(recv).await
     }
 
     pub(crate) async fn do_new_tx_msg_replica(
@@ -1211,13 +1218,16 @@ where
         tx_hash: TxHash,
         baked_tx: FullyBakedTx,
         reason: &'static str,
-    ) -> Result<(), SequencerStateUpdatorError> {
+    ) -> Result<Result<(), ReplicaError<S>>, SequencerStateUpdatorError> {
+        let (resp, recv) = oneshot::channel();
         self.send(Message::DoNewTx {
+            resp,
             tx_hash,
             baked_tx,
             reason,
         })
-        .await
+        .await?;
+        self.recv(recv).await
     }
 
     pub(crate) async fn close_current_batch_msg(
@@ -1487,21 +1497,29 @@ where
             }
 
             Message::DoBatchStartMsg {
+                resp,
                 batch_from_master,
                 reason,
             } => {
-                let _ = self
+                let ret = self
                     .process_do_batch_start_replica(batch_from_master, reason)
+                    .await;
+
+                self.send_response(resp, ret, "process_do_batch_start_replica")
                     .await;
             }
 
             Message::DoNewTx {
+                resp,
                 tx_hash,
                 baked_tx,
                 reason,
             } => {
-                let _ = self
+                let ret = self
                     .process_do_new_tx_replica(baked_tx, tx_hash, reason)
+                    .await;
+
+                self.send_response(resp, ret, "process_do_new_tx_replica")
                     .await;
             }
             Message::CloseCurrentBatch { reason } => {
@@ -2018,8 +2036,30 @@ where
         &mut self,
         batch_from_master: BatchToStore,
         reason: &'static str,
-    ) -> Result<(), BatchCreationError> {
+    ) -> Result<(), ReplicaError<S>> {
         let mut inner = self.get_inner_with_timing(reason).await;
+
+        let seq_nr_of_next_blob_for_this_executor = inner.sequence_number_of_next_blob;
+        let seq_nr_from_master = batch_from_master.sequence_number;
+
+        if seq_nr_of_next_blob_for_this_executor > seq_nr_from_master {
+            return Err(ReplicaError::Rejected(DBDataRejected::ExecutorAhead(
+                seq_nr_of_next_blob_for_this_executor,
+            )));
+        }
+
+        if seq_nr_of_next_blob_for_this_executor < seq_nr_from_master {
+            return Err(ReplicaError::Rejected(DBDataRejected::ExecutorBehind(
+                DbData::BatchStart(batch_from_master),
+            )));
+        }
+
+        if let Err(e) = &inner.is_ready {
+            return Err(ReplicaError::NotReady(
+                e.clone(),
+                DbData::BatchStart(batch_from_master),
+            ));
+        }
 
         inner
             .do_batch_start(
@@ -2036,9 +2076,13 @@ where
         baked_tx: FullyBakedTx,
         tx_hash: TxHash,
         reason: &'static str,
-    ) {
+    ) -> Result<(), ReplicaError<S>> {
         let mut inner = self.get_inner_with_timing(reason).await;
-        let _ = inner.do_new_tx(tx_hash, baked_tx).await.unwrap();
+        let _ = inner
+            .do_new_tx(tx_hash, baked_tx)
+            .await
+            .map_err(ReplicaError::NewTx)?;
+        Ok(())
     }
 
     async fn process_close_current_batch(&mut self, reason: &'static str) {

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -1135,10 +1135,10 @@ async fn exit_rollup_inner(
     if shutdown_sender.send(()).is_err() {
         tracing::error!("Failed to send shutdown signal: {location}");
     }
-    sleep(Duration::from_secs(5)).await;
     let msg = format!("Calling std::process::exit(1): {location}");
     tracing::error!(msg);
     println!("{msg}");
+    sleep(Duration::from_secs(5)).await;
     std::process::exit(1);
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
@@ -31,6 +31,15 @@ pub(crate) enum ReplicaError<S: Spec> {
     Unexpected,
 }
 
+impl<S: Spec> From<SequencerStateUpdatorError> for ReplicaError<S> {
+    fn from(value: SequencerStateUpdatorError) -> Self {
+        match value {
+            SequencerStateUpdatorError::Shutdown => Self::Shutdown,
+            SequencerStateUpdatorError::Unexpected => Self::Unexpected,
+        }
+    }
+}
+
 #[async_trait]
 impl<S, Rt> ReplicaEventHandler for Arc<SequencerStateUpdator<S, Rt>>
 where

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
@@ -25,17 +25,17 @@ pub(crate) enum ReplicaError<S: Spec> {
     #[error("Failed to apply a new transaction on the replica.")]
     NewTx(DoNewTxError<S>),
 
-    #[error("TODO")]
+    #[error("The replica is shutting down.")]
     Shutdown,
-    #[error("TODO")]
-    Unexpected,
+    #[error("The replica encountered an unexpected shutdown.")]
+    UnexpectedShutdown,
 }
 
 impl<S: Spec> From<SequencerStateUpdatorError> for ReplicaError<S> {
     fn from(value: SequencerStateUpdatorError) -> Self {
         match value {
             SequencerStateUpdatorError::Shutdown => Self::Shutdown,
-            SequencerStateUpdatorError::Unexpected => Self::Unexpected,
+            SequencerStateUpdatorError::Unexpected => Self::UnexpectedShutdown,
         }
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
@@ -4,6 +4,7 @@ use crate::preferred::replica::replica_sync_task::DBDataRejected;
 use crate::preferred::replica::replica_sync_task::ReplicaEventHandler;
 use crate::preferred::BatchCreationError;
 use crate::preferred::DoNewTxError;
+use crate::preferred::SequencerStateUpdatorError;
 use crate::SequencerNotReadyDetails;
 use async_trait::async_trait;
 use sov_modules_api::Runtime;
@@ -23,6 +24,11 @@ pub(crate) enum ReplicaError<S: Spec> {
 
     #[error("Failed to apply a new transaction on the replica.")]
     NewTx(DoNewTxError<S>),
+
+    #[error("TODO")]
+    Shutdown,
+    #[error("TODO")]
+    Unexpected,
 }
 
 #[async_trait]

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
@@ -2,10 +2,28 @@ use crate::preferred::inner::SequencerStateUpdator;
 use crate::preferred::replica::db_data::DbData;
 use crate::preferred::replica::replica_sync_task::DBDataRejected;
 use crate::preferred::replica::replica_sync_task::ReplicaEventHandler;
+use crate::preferred::BatchCreationError;
+use crate::preferred::DoNewTxError;
+use crate::SequencerNotReadyDetails;
 use async_trait::async_trait;
 use sov_modules_api::Runtime;
 use sov_modules_api::Spec;
 use std::sync::Arc;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ReplicaError<S: Spec> {
+    #[error("The replica rejected the db data. DbData: {0:?}")]
+    Rejected(DBDataRejected),
+
+    #[error("Replica is not ready. Details: {0:?}. DbData: {1:?}")]
+    NotReady(SequencerNotReadyDetails, DbData),
+
+    #[error("Failed to create a new batch on the replica.")]
+    Creation(#[from] BatchCreationError),
+
+    #[error("Failed to apply a new transaction on the replica.")]
+    NewTx(DoNewTxError<S>),
+}
 
 #[async_trait]
 impl<S, Rt> ReplicaEventHandler for Arc<SequencerStateUpdator<S, Rt>>

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -53,9 +53,7 @@ impl EventReceiver {
         {
             Ok(pool) => pool,
             Err(e) => {
-                error!("Failed to connect to PostgreSQL: {e:?}. Replica shutting down.");
-                exit_rollup(&shutdown_sender).await;
-                unreachable!("EventReceiver: impossible happened rollup didn't exit");
+                panic!("Failed to connect to PostgreSQL: {e:?}. Replica shutting down.");
             }
         };
 
@@ -63,16 +61,12 @@ impl EventReceiver {
         let mut listener = match PgListener::connect(&connection_string).await {
             Ok(listener) => listener,
             Err(e) => {
-                error!("Failed to create PostgreSQL listener: {e:?}. Replica shutting down.");
-                exit_rollup(&shutdown_sender).await;
-                unreachable!("EventReceiver: impossible happened rollup didn't exit");
+                panic!("Failed to create PostgreSQL listener: {e:?}. Replica shutting down.");
             }
         };
 
         if let Err(e) = listener.listen("events_changes").await {
-            error!("Failed to listen on events_changes channel: {e:?}. Replica shutting down.");
-            exit_rollup(&shutdown_sender).await;
-            unreachable!("EventReceiver: impossible happened rollup didn't exit");
+            panic!("Failed to listen on events_changes channel: {e:?}. Replica shutting down.");
         }
 
         (

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -86,6 +86,10 @@ impl ReplicaSyncTask {
             };
 
             'inner: loop {
+                if shutdown_receiver.has_changed().unwrap_or(true) {
+                    break 'outer;
+                }
+
                 match handler.on_db_event(data).await {
                     Ok(_) => {
                         // The data was applied on the executor.

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -130,12 +130,19 @@ async fn test_replica_receives_txs_from_postgres() {
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
 
     let test_rollup = start_rollup(false, addr, postgres.clone()).await;
-    let replica_test_rollup = start_rollup(true, addr, postgres).await;
 
-    let token_id = config_gas_token_id();
+    for _ in 0..20 {
+        da_service.produce_block_now().await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(
+            sov_test_utils::TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS,
+        ))
+        .await;
+    }
 
-    da_service.produce_n_blocks_now(20).await.unwrap();
     test_rollup.wait_for_sequencer_ready().await.unwrap();
+
+    let replica_test_rollup = start_rollup(true, addr, postgres).await;
+    let token_id = config_gas_token_id();
 
     let receiver_addr = random_address();
 


### PR DESCRIPTION
# Description
This PR implements the `process_do_batch_start_replica` and `process_do_new_tx_replica` methods.
These methods are not yet integrated (they will be used in the replica sync task), but since the next PR will be quite complex, this one is submitted separately to help reduce that complexity.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)