### PR TITLE
Move out the `authenticate_unregistered()` functionality to sov-modules-api

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -308,34 +308,16 @@ where
         };
 
         let (tx_and_raw_hash, auth_data, runtime_call) =
-            sov_modules_api::capabilities::authenticate::<_, S, Rt>(
+            sov_modules_api::capabilities::authenticate_unregistered::<_, S, Rt>(
                 &input.data,
-                &Rt::CHAIN_HASH,
                 state,
-            )
-            .map_err(|e| match e {
-                AuthenticationError::FatalError(err, hash) => {
-                    UnregisteredAuthenticationError::FatalError(err, hash)
-                }
-                AuthenticationError::OutOfGas(err) => {
-                    UnregisteredAuthenticationError::OutOfGas(err)
-                }
-            })?;
+            )?;
 
-        if Rt::allow_unregistered_tx(&runtime_call) {
-            Ok((
-                tx_and_raw_hash,
-                auth_data,
-                EvmAuthenticatorInput::Standard(runtime_call),
-            ))
-        } else {
-            Err(UnregisteredAuthenticationError::FatalError(
-                FatalError::Other(
-                    "The runtime call included in the transaction was invalid.".to_string(),
-                ),
-                tx_and_raw_hash.raw_tx_hash,
-            ))?
-        }
+        Ok((
+            tx_and_raw_hash,
+            auth_data,
+            EvmAuthenticatorInput::Standard(runtime_call),
+        ))
     }
 
     fn add_standard_auth(tx: RawTx) -> Self::Input {

--- a/crates/module-system/sov-eip712-auth/src/lib.rs
+++ b/crates/module-system/sov-eip712-auth/src/lib.rs
@@ -156,31 +156,7 @@ where
             return Err(UnregisteredAuthenticationError::InvalidAuthenticationDiscriminant);
         };
 
-        let (tx_and_raw_hash, auth_data, runtime_call) =
-            sov_modules_api::capabilities::authenticate::<_, S, Rt>(
-                &input.data,
-                &Rt::CHAIN_HASH,
-                state,
-            )
-            .map_err(|e| match e {
-                AuthenticationError::FatalError(err, hash) => {
-                    UnregisteredAuthenticationError::FatalError(err, hash)
-                }
-                AuthenticationError::OutOfGas(err) => {
-                    UnregisteredAuthenticationError::OutOfGas(err)
-                }
-            })?;
-
-        if Rt::allow_unregistered_tx(&runtime_call) {
-            Ok((tx_and_raw_hash, auth_data, runtime_call))
-        } else {
-            Err(UnregisteredAuthenticationError::FatalError(
-                FatalError::Other(
-                    "The runtime call included in the transaction was invalid.".to_string(),
-                ),
-                tx_and_raw_hash.raw_tx_hash,
-            ))?
-        }
+        sov_modules_api::capabilities::authenticate_unregistered::<_, S, Rt>(&input.data, state)
     }
 
     fn add_standard_auth(tx: RawTx) -> Self::Input {

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -154,11 +154,7 @@ where
         let AuthenticatorInput::Standard(input) = borsh::from_slice(&batch.tx.data)
             .map_err(|_| UnregisteredAuthenticationError::InvalidAuthenticationDiscriminant)?;
 
-        Ok(crate::capabilities::authenticate::<_, S, Rt>(
-            &input.data,
-            &Rt::CHAIN_HASH,
-            pre_exec_ws,
-        )?)
+        authenticate_unregistered::<Accessor, S, Rt>(&input.data, pre_exec_ws)
     }
 
     fn add_standard_auth(tx: RawTx) -> Self::Input {
@@ -424,6 +420,35 @@ pub fn authenticate<
         };
 
     verify_and_decode_tx::<S, D>(raw_tx_hash, tx, chain_hash, state)
+}
+
+/// Authenticate raw unregistered sov-transaction.
+pub fn authenticate_unregistered<
+    Accessor: ProvableStateReader<sov_state::User, Spec = S>,
+    S: Spec,
+    Rt: Runtime<S> + DispatchCall<Spec = S>,
+>(
+    raw_tx: &[u8],
+    pre_exec_ws: &mut Accessor,
+) -> Result<AuthenticationOutput<S, Rt::Decodable>, UnregisteredAuthenticationError> {
+    let (tx_and_raw_hash, auth_data, runtime_call) =
+        authenticate::<_, S, Rt>(raw_tx, &Rt::CHAIN_HASH, pre_exec_ws).map_err(|e| match e {
+            AuthenticationError::FatalError(err, hash) => {
+                UnregisteredAuthenticationError::FatalError(err, hash)
+            }
+            AuthenticationError::OutOfGas(err) => UnregisteredAuthenticationError::OutOfGas(err),
+        })?;
+
+    if Rt::allow_unregistered_tx(&runtime_call) {
+        Ok((tx_and_raw_hash, auth_data, runtime_call))
+    } else {
+        Err(UnregisteredAuthenticationError::FatalError(
+            FatalError::Other(
+                "The runtime call included in the transaction was invalid.".to_string(),
+            ),
+            tx_and_raw_hash.raw_tx_hash,
+        ))?
+    }
 }
 
 /// Decode bytes as a Sovereign SDK transaction, returning the message and tx info.

--- a/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
@@ -4,8 +4,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sov_modules_api::capabilities::{
-    AuthenticationError, BatchFromUnregisteredSequencer, FatalError, TransactionAuthenticator,
-    UnregisteredAuthenticationError,
+    BatchFromUnregisteredSequencer, TransactionAuthenticator, UnregisteredAuthenticationError,
 };
 use sov_modules_api::macros::config_value;
 use sov_modules_api::{DispatchCall, FullyBakedTx, ProvableStateReader, RawTx, Runtime, Spec};
@@ -136,31 +135,7 @@ where
             return Err(UnregisteredAuthenticationError::InvalidAuthenticationDiscriminant);
         };
 
-        let (tx_and_raw_hash, auth_data, runtime_call) =
-            sov_modules_api::capabilities::authenticate::<_, S, Rt>(
-                &input.data,
-                &Rt::CHAIN_HASH,
-                state,
-            )
-            .map_err(|e| match e {
-                AuthenticationError::FatalError(err, hash) => {
-                    UnregisteredAuthenticationError::FatalError(err, hash)
-                }
-                AuthenticationError::OutOfGas(err) => {
-                    UnregisteredAuthenticationError::OutOfGas(err)
-                }
-            })?;
-
-        if Rt::allow_unregistered_tx(&runtime_call) {
-            Ok((tx_and_raw_hash, auth_data, runtime_call))
-        } else {
-            Err(UnregisteredAuthenticationError::FatalError(
-                FatalError::Other(
-                    "The runtime call included in the transaction was invalid.".to_string(),
-                ),
-                tx_and_raw_hash.raw_tx_hash,
-            ))?
-        }
+        sov_modules_api::capabilities::authenticate_unregistered::<_, S, Rt>(&input.data, state)
     }
 
     fn add_standard_auth(tx: RawTx) -> Self::Input {


### PR DESCRIPTION
# Description

Most of the authenticators had duplicated code there. The logic is nearly identical since only standard sov transactions can be unregistered, so it can be handled almost entirely in sov-modules-api.

One thing to note is that the default `RollupAuthenticator` implementation actually had a simpler version that did not check for `Rt::allow_unregistered_tx(runtime_call)`. I assume that was just an oversight.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
