### PR TITLE
Replica add `validate_db_data_from_replica` method.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -352,7 +352,7 @@ impl PreferredSequencerCache {
         self.event_stream = Some(sender);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub(crate) struct BatchToStore {
     pub blob_id: BlobInternalId,
     pub sequence_number: SequenceNumber,
@@ -534,8 +534,9 @@ impl PreferredSequencerDb {
         prune_up_to_including: SequenceNumber,
     ) -> anyhow::Result<()> {
         if let Some(backend) = &mut self.backend {
-            let prune_up_to_including = prune_up_to_including.saturating_sub(PRUNING_LAG);
-            backend.prune(prune_up_to_including).await?;
+            if let Some(prune_up_to_including) = prune_up_to_including.checked_sub(PRUNING_LAG) {
+                backend.prune(prune_up_to_including).await?;
+            }
         }
         Ok(())
     }

--- a/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
@@ -332,7 +332,7 @@ mod tests {
                 blob_id: BlobInternalId::from(batch),
             };
 
-            db.begin_rollup_block(batch_to_store.clone()).await.unwrap();
+            db.begin_rollup_block(batch_to_store).await.unwrap();
 
             for (i, (tx, tx_hash)) in txs.iter().zip(tx_hashes.iter()).enumerate() {
                 db.add_tx(SequenceNumber::from(batch), i as u64, tx.clone(), *tx_hash)

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -823,6 +823,11 @@ enum Message<S: Spec, Rt: Runtime<S>> {
     SimpleStateUpdate {
         info: StateUpdateInfo<S::Storage>,
     },
+
+    CloseCurrentBatch {
+        reason: &'static str,
+    },
+
     DoBatchStartMsg {
         resp: oneshot::Sender<Result<(), ReplicaError<S>>>,
         batch_from_master: BatchToStore,
@@ -830,11 +835,15 @@ enum Message<S: Spec, Rt: Runtime<S>> {
     },
     DoNewTx {
         resp: oneshot::Sender<Result<(), ReplicaError<S>>>,
+        seq_nr_from_master: u64,
         tx_hash: TxHash,
         baked_tx: FullyBakedTx,
         reason: &'static str,
     },
-    CloseCurrentBatch {
+
+    DoCloseCurrentBatch {
+        resp: oneshot::Sender<Result<(), ReplicaError<S>>>,
+        batch_from_master: BatchToStore,
         reason: &'static str,
     },
 }
@@ -1187,6 +1196,12 @@ where
             Err(SequencerStateUpdatorError::Unexpected)
         }
     }
+    pub(crate) async fn close_current_batch_msg(
+        &self,
+        reason: &'static str,
+    ) -> Result<(), SequencerStateUpdatorError> {
+        self.send(Message::CloseCurrentBatch { reason }).await
+    }
 
     pub(crate) async fn latest_slot_number_msg(
         &self,
@@ -1218,12 +1233,14 @@ where
 
     pub(crate) async fn do_new_tx_msg_replica(
         &self,
+        seq_nr_from_master: u64,
         tx_hash: TxHash,
         baked_tx: FullyBakedTx,
         reason: &'static str,
     ) -> Result<(), ReplicaError<S>> {
         let (resp, recv) = oneshot::channel();
         self.send(Message::DoNewTx {
+            seq_nr_from_master,
             resp,
             tx_hash,
             baked_tx,
@@ -1235,11 +1252,20 @@ where
         Ok(())
     }
 
-    pub(crate) async fn close_current_batch_msg(
+    pub(crate) async fn close_current_batch_msg_replica(
         &self,
+        batch_from_master: BatchToStore,
         reason: &'static str,
-    ) -> Result<(), SequencerStateUpdatorError> {
-        self.send(Message::CloseCurrentBatch { reason }).await
+    ) -> Result<(), ReplicaError<S>> {
+        let (resp, recv) = oneshot::channel();
+        self.send(Message::DoCloseCurrentBatch {
+            resp,
+            batch_from_master,
+            reason,
+        })
+        .await?;
+        self.recv(recv).await??;
+        Ok(())
     }
 }
 
@@ -1500,7 +1526,9 @@ where
             Message::SimpleStateUpdate { info } => {
                 self.process_new_storage(info).await;
             }
-
+            Message::CloseCurrentBatch { reason } => {
+                self.process_close_current_batch(reason).await;
+            }
             Message::DoBatchStartMsg {
                 resp,
                 batch_from_master,
@@ -1513,22 +1541,30 @@ where
                 self.send_response(resp, ret, "process_do_batch_start_replica")
                     .await;
             }
-
             Message::DoNewTx {
                 resp,
+                seq_nr_from_master,
                 tx_hash,
                 baked_tx,
                 reason,
             } => {
                 let ret = self
-                    .process_do_new_tx_replica(baked_tx, tx_hash, reason)
+                    .process_do_new_tx_replica(seq_nr_from_master, baked_tx, tx_hash, reason)
                     .await;
 
                 self.send_response(resp, ret, "process_do_new_tx_replica")
                     .await;
             }
-            Message::CloseCurrentBatch { reason } => {
-                self.process_close_current_batch(reason).await;
+            Message::DoCloseCurrentBatch {
+                resp,
+                batch_from_master,
+                reason,
+            } => {
+                let ret = self
+                    .process_close_current_batch_replica(batch_from_master, reason)
+                    .await;
+                self.send_response(resp, ret, "process_do_batch_start_replica")
+                    .await;
             }
         }
 
@@ -2036,6 +2072,10 @@ where
 
         Ok(rx)
     }
+    async fn process_close_current_batch(&mut self, reason: &'static str) {
+        let mut inner = self.get_inner_with_timing(reason).await;
+        inner.close_current_batch().await;
+    }
 
     async fn process_do_batch_start_replica(
         &mut self,
@@ -2043,28 +2083,15 @@ where
         reason: &'static str,
     ) -> Result<(), ReplicaError<S>> {
         let mut inner = self.get_inner_with_timing(reason).await;
-
-        if let Err(e) = &inner.is_ready {
-            return Err(ReplicaError::NotReady(
-                e.clone(),
-                DbData::BatchStart(batch_from_master),
-            ));
-        }
-
-        let seq_nr_of_next_blob_for_this_executor = inner.sequence_number_of_next_blob;
+        let seq_nr_of_next_blob_for_this_executor = inner.current_sequence_number() + 1;
         let seq_nr_from_master = batch_from_master.sequence_number;
 
-        if seq_nr_of_next_blob_for_this_executor > seq_nr_from_master {
-            return Err(ReplicaError::Rejected(DBDataRejected::ExecutorAhead(
-                seq_nr_of_next_blob_for_this_executor,
-            )));
-        }
-
-        if seq_nr_of_next_blob_for_this_executor < seq_nr_from_master {
-            return Err(ReplicaError::Rejected(DBDataRejected::ExecutorBehind(
-                DbData::BatchStart(batch_from_master),
-            )));
-        }
+        validate_db_data_from_replica(
+            &inner.is_ready,
+            DbData::BatchStart(batch_from_master),
+            seq_nr_of_next_blob_for_this_executor,
+            seq_nr_from_master,
+        )?;
 
         inner
             .do_batch_start(
@@ -2078,22 +2105,72 @@ where
 
     async fn process_do_new_tx_replica(
         &mut self,
+        seq_nr_from_master: u64,
         baked_tx: FullyBakedTx,
         tx_hash: TxHash,
         reason: &'static str,
     ) -> Result<(), ReplicaError<S>> {
         let mut inner = self.get_inner_with_timing(reason).await;
+        let seq_nr_of_current_blob_for_this_executor = inner.current_sequence_number();
+
+        validate_db_data_from_replica(
+            &inner.is_ready,
+            DbData::Transaction(seq_nr_from_master, baked_tx.clone(), tx_hash),
+            seq_nr_of_current_blob_for_this_executor,
+            seq_nr_from_master,
+        )?;
+
         let _ = inner
             .do_new_tx(tx_hash, baked_tx)
             .await
-            .map_err(ReplicaError::NewTx)?;
+            .map_err(ReplicaError::NewTx)?
+            .0
+            .await;
         Ok(())
     }
 
-    async fn process_close_current_batch(&mut self, reason: &'static str) {
+    async fn process_close_current_batch_replica(
+        &mut self,
+        batch_from_master: BatchToStore,
+        reason: &'static str,
+    ) -> Result<(), ReplicaError<S>> {
         let mut inner = self.get_inner_with_timing(reason).await;
+        let seq_nr_of_current_blob_for_this_executor = inner.current_sequence_number() + 1;
+        let seq_nr_from_master = batch_from_master.sequence_number;
+
+        validate_db_data_from_replica(
+            &inner.is_ready,
+            DbData::BatchEnd(batch_from_master),
+            seq_nr_of_current_blob_for_this_executor,
+            seq_nr_from_master,
+        )?;
         inner.close_current_batch().await;
+
+        Ok(())
     }
+}
+
+fn validate_db_data_from_replica<S: Spec>(
+    is_ready: &Result<(), SequencerNotReadyDetails>,
+    ret: DbData,
+    seq_nr_for_this_executor: u64,
+    seq_nr_from_master: u64,
+) -> Result<(), ReplicaError<S>> {
+    if let Err(err) = is_ready {
+        return Err(ReplicaError::NotReady(err.clone(), ret));
+    }
+
+    if seq_nr_for_this_executor > seq_nr_from_master {
+        return Err(ReplicaError::Rejected(DBDataRejected::ExecutorAhead(
+            seq_nr_for_this_executor,
+        )));
+    }
+
+    if seq_nr_for_this_executor < seq_nr_from_master {
+        return Err(ReplicaError::Rejected(DBDataRejected::ExecutorBehind(ret)));
+    }
+
+    Ok(())
 }
 
 #[derive(Debug)]

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
@@ -48,13 +48,29 @@ where
 {
     #[allow(clippy::match_same_arms)]
     async fn on_db_event(&self, data: DbData) -> Result<(), DBDataRejected> {
-        match data {
-            DbData::BatchStart(_) => {}
-            DbData::Transaction(_, _, _) => {}
-            DbData::BatchEnd(_) => {}
-            DbData::NewProof => {}
+        let res: Result<(), ReplicaError<S>> = match data {
+            DbData::BatchStart(_) => Ok(()),
+            DbData::Transaction(_, _, _) => Ok(()),
+            DbData::BatchEnd(_) => Ok(()),
+            DbData::NewProof => Ok(()),
         };
 
-        Ok(())
+        match res {
+            Ok(_) => return Ok(()),
+            Err(ReplicaError::Rejected(db_data_rejected)) => return Err(db_data_rejected),
+            Err(ReplicaError::NotReady(_sequencer_not_ready_details, db_data_rejected)) => {
+                return Err(DBDataRejected::ExecutorBehind(db_data_rejected))
+            }
+            Err(ReplicaError::Creation(batch_creation_error)) => {
+                panic!("Replica failed to create a new batch. Error: {batch_creation_error:?}");
+            }
+            Err(ReplicaError::NewTx(error)) => {
+                panic!("Replica failed to apply a new transaction. Error: {error:?}");
+            }
+            Err(ReplicaError::Shutdown) => return Ok(()),
+            Err(ReplicaError::UnexpectedShutdown) => {
+                panic!("Replica unexpectedly shut down");
+            }
+        };
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
@@ -67,7 +67,10 @@ where
             Err(ReplicaError::NewTx(error)) => {
                 panic!("Replica failed to apply a new transaction. Error: {error:?}");
             }
-            Err(ReplicaError::Shutdown) => return Ok(()),
+            Err(ReplicaError::Shutdown) => {
+                // Replica shut down gracefully, this case is handled by the caller.
+                return Ok(());
+            }
             Err(ReplicaError::UnexpectedShutdown) => {
                 panic!("Replica unexpectedly shut down");
             }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -1,4 +1,3 @@
-use crate::preferred::exit_rollup;
 use crate::preferred::replica::db_data::row_to_event;
 use crate::preferred::replica::db_data::rows;
 use crate::preferred::replica::db_data::DbData;
@@ -84,7 +83,6 @@ impl EventReceiver {
 
     pub(crate) async fn spawn_db_data_fetcher(mut self) -> JoinHandle<()> {
         let mut nb_of_consecutive_db_errors = 0;
-        let shutdown_sender = self.shutdown_sender.clone();
         let shutdown_receiver = self.shutdown_sender.subscribe();
 
         tokio::spawn(async move {
@@ -106,10 +104,9 @@ impl EventReceiver {
                         match err {
                             EventReceiverError::ParsingError(e) => {
                                 // This should never happen, so we shut down the replica immediately
-                                error!(
+                                panic!(
                                     "Failed to parse notification: {e:?}. Shutting down replica."
                                 );
-                                exit_rollup(&shutdown_sender).await;
                             }
                             EventReceiverError::DbError(e) => {
                                 error!("Failed to receive notifications from database: {e:?}. Shutting down replica.");
@@ -120,8 +117,7 @@ impl EventReceiver {
 
                                 // Since network errors can occur, we will retry receiving a few times before initiating replica shutdown.
                                 if nb_of_consecutive_db_errors >= MAX_DB_ERRORS_ALLOWED {
-                                    error!("Failed to connect to the database after {nb_of_consecutive_db_errors} attempts. Shutting down replica.");
-                                    exit_rollup(&shutdown_sender).await;
+                                    panic!("Failed to connect to the database after {nb_of_consecutive_db_errors} attempts. Shutting down replica.");
                                 }
 
                                 nb_of_consecutive_db_errors += 1;
@@ -132,14 +128,12 @@ impl EventReceiver {
                                 prev_event_type,
                                 event_type,
                             ) => {
-                                error!("Invalid event sequence in the db: {prev_event_type:?} {event_type:?}. Replica shutting down.");
-                                exit_rollup(&self.shutdown_sender).await;
+                                panic!("Invalid event sequence in the db: {prev_event_type:?} {event_type:?}. Replica shutting down.");
                             }
                             EventReceiverError::DbRowDoesNotExist(event_id) => {
-                                error!(
+                                panic!(
                                     "Db row does not exist for event id: {event_id:?}. Replica shutting down."
                                 );
-                                exit_rollup(&self.shutdown_sender).await;
                             }
                         }
                     }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -212,7 +212,7 @@ mod tests {
                 TestCase::CompleteBatch(seq_nr, nb_of_txs) => {
                     index = 0;
                     let stored_batch = new_batch_to_store(seq_nr);
-                    db.begin_rollup_block(stored_batch.clone()).await.unwrap();
+                    db.begin_rollup_block(stored_batch).await.unwrap();
 
                     for i in 0..nb_of_txs {
                         let tx = FullyBakedTx::new(vec![i as u8]);


### PR DESCRIPTION
# Description

This PR introduces the following changes:
1. Replaces `exit_rollup` with `panic` in the replica sync task.
2. Fixes a minor bug in the db pruning height calculation.
3. Adds a `validate_db_data_from_replica` method that checks whether data from the DB can be applied on the executor.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
