### PR TITLE
fix: `sov-build`: Flush at the end of writing `autogenerated.rs`

### DIFF
--- a/crates/utils/sov-build/src/lib.rs
+++ b/crates/utils/sov-build/src/lib.rs
@@ -200,6 +200,8 @@ impl Options {
             "#[allow(dead_code)]\npub const SCHEMA_JSON: &str = r#\"{schema_json}\"#;\n"
         )?;
 
+        file.flush()?;
+
         Ok(())
     }
 


### PR DESCRIPTION
# Description

Should fix error like this:


https://github.com/Sovereign-Labs/sovereign-sdk/actions/runs/18753029275/job/53497653987?pr=1957

```
 Compiling sov-transaction-generator v0.3.0 (/home/runner/work/sovereign-sdk/sovereign-sdk/crates/utils/transaction-generator)
error: this file contains an unclosed delimiter
 --> examples/demo-rollup/stf/src/../../autogenerated.rs:4:4618
  |
4 | ...= &[124, 0, 0, 0, 0, 11, 0, 0, 0, 84, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 2, 0, 0, 0, 2, 0, 0, 0, 86, 48, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 86, 49, 1, 0, 1, 0, 118, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 8, 0, 0, 0, 86, 101, 114, 115, 105, 111, 110, 48, 0, 0, 5, 0, 0, 0, 9, 0, 0, 0, 115, 105, 103, 110, 97, 116, 117, 114, 101, 0, 1, 1, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 112, 117, 98, 95, 107, 101, 121, 0, 1, 1, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 114, 117, 110, 116, 105, 109, 101, 95, 99, 97, 108, 108, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 117, 110, 105, 113, 117, 101, 110, 101, 115, 115, 0, 0, 113, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 100, 101, 116, 97, 105, 108, 115, 0, 0, 116, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 82, 117, 110, 116, 105, 109, 101, 67, 97, 108, 108, 13, 0, 0, 0, 4, 0, 0, 0, 66, 97, 110, 107, 0, 0, 1, 0, 4, 0, 0, 0, 0, 0, 0, 0, 17, 0, 0, 0, 83, 101, 113, 117, 101, 110, 99, 101, 114, 82, 101, 103, 105, 115, 116, 114, 121, 1, 0, 1, 0, 24, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 79, 112, 101, 114, 97, 116, 111, 114, 73, 110, 99, 101, 110, 116, 105, 118, 101, 115, 2, 0, 1, 0, 31, 0, 0, 0, 0, 0, 0, 0, 18, 0, 0, 0, 65, 116, 116, 101, 115, 116, 101, 114, 73, 110, 99, 101, 110, 116, 105, 118, 101, 115, 3, 0, 1, 0, 34, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 80, 114, 111, 118, 101, 114, 73, 110, 99, 101, 110, 116, 105, 118, 101, 115, 4, 0, 1, 0, 39, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 65, 99, 99, 111, 117, 110, 116, 115, 5, 0, 1, 0, 43, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 85, 110, 105, 113, 117, 101, 110, 101, 115, 115, 6, 0, 1, 0, 48, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 67, 104, 97, 105, 110, 83, 116, 97, 116, 101, 7, 0, 1, 0, 50, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 66, 108, 111, 98, 83, 116, 111, 114, 97, 103, 101, 8, 0, 1, 0, 52, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 80, 97, 121, 109, 97, 115, 116, 101, 114, 9, 0, 1, 0, 53, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 69, 118, 109, 10, 0, 1, 0, 82, 0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0, 65, 99, 99, 101, 115, 115, 80, 97, 116, 116, 101, 114, 110, 11, 0, 1, 0, 85, 0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0, 83, 121, 110, 116, 104, 101, 116, 105, 99, 76, 111, 97, 100, 12, 0, 1, 0, 108, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 1, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 67, 97, 108, 108, 77, 101, 115, 115, 97, 103, 101, 6, 0, 0, 0, 11, 0, 0, 0, 67, 114, 101, 97, 116, 101, 84, 111, 107, 101, 110, 0, 0, 1, 0, 6, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 84, 114, 97, 110, 115, 102, 101, 114, 1, 1, 26, 0, 0, 0, 84, 114, 97, 110, 115, 102, 101, 114, 32, 116, 111, 32, 97, 100, 100, 114, 101, 115, 115, 32, 123, 125, 32, 123, 125, 46, 1, 0, 16, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 66, 117, 114, 110, 2, 0, 1, 0, 19, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 77, 105, 110, 116, 3, 0, 1, 0, 20, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 70, 114, 101, 101, 122, 101, 4, 0, 1, 0, 21, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 85, 112, 100, 97, 116, 101, 65, 100, 109, 105, 110, 5, 0, 1, 0, 22, 0, 0, 0, 0, 0, 0, 0, 0, 1, 42, 0, 0, 0, 95, 95, 83, 111, 118, 86, 105, 114, 116, 117, 97, 108, 87, 97, 108, 108, 101, 116, 95, 67, 97, 108, 108, 77, 101, 115, 115, 97, 103, 101, 95, 67, 114, 101, 97, 116, 101, 84, 111, 107, 101, 110, 0, 0, 6, 0, 0, 0, 10, 0, 0, 0, 116, 111, 107, 101, 110, 95, 110, 97, 109, 101, 0, 1, 5, 0, 0, 0, 0, 14, 0, 0, 0, 116, 111, 107, 101, 110, 95, 100, 101, 99, 105, 109, 97, 108, 115, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 105, 110, 105, 116, 105, 97, 108, 95, 98, 97, 108, 97, 110, 99, 101, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 15, 0, 0, 0, 109, 105, 110, 116, 95, 116, 111, 95, 97, 100, 100, 114, 101, 115, 115, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 97, 100, 109, 105, 110, 115, 0, 0, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 115, 117, 112, 112, 108, 121, 95, 99, 97, 112, 0, 0, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 1, 0, 5, 1, 2, 0, 0, 1, 0, 0, 0, 1, 0, 9, 1, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 77, 117, 108, 116, 105, 65, 100, 100, 114, 101, 115, 115, 2, 0, 0, 0, 8, 0, 0, 0, 83, 116, 97, 110, 100, 97, 114, 100, 0, 0, 1, 0, 10, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 86, 109, 1, 0, 1, 0, 12, 0, 0, 0, 0, 0, 0, 0, 1, 2, 0, 0, 1, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 1, 0, 0, 0, 1, 1, 28, 0, 0, 0, 0, 0, 0, 0, 3, 3, 0, 0, 0, 115, 111, 118, 0, 0, 0, 0, 0, 2, 0, 0, 1, 0, 0, 0, 0, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 1, 0, 0, 0, 1, 1, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 13, 0, 9, 0, 0, 0, 0, 0, 0, 0, 3, 0, 8, 0, 
  |       - unclosed delimiter 
```

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
No updates

## Docs
No updates
