### PR TITLE
fix: reuse runtime and avoid duplicate StateCheckpoint creation

### DIFF
--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -113,7 +113,8 @@ where
         let latest_state_update = state_update_receiver.borrow().clone();
         let checkpoint =
             StateCheckpoint::new(latest_state_update.storage.clone(), &runtime.kernel());
-        let (checkpoint_sender, checkpoint_receiver) = watch::channel(checkpoint);
+        let (checkpoint_sender, checkpoint_receiver) =
+            watch::channel(checkpoint.clone_with_empty_witness_dropping_temp_cache());
 
         let api_state = ApiState::build(
             Arc::new(()),
@@ -123,8 +124,6 @@ where
         );
 
         let txsm = TxStatusManager::default();
-        let checkpoint =
-            StateCheckpoint::new(latest_state_update.storage.clone(), &runtime.kernel());
 
         let da_address = da.get_signer().await;
 
@@ -163,7 +162,7 @@ where
             inner: inner.into(),
             txsm,
             api_state,
-            runtime: Rt::default(),
+            runtime,
             checkpoint_sender,
             config: config.clone(),
             api_ledger_db,


### PR DESCRIPTION
This change removes redundant initialization in StdSequencer::create by reusing the originally created Runtime instance instead of constructing a second one for the struct field, and by creating the StateCheckpoint only once. The initial API watch channel is seeded with a lightweight clone using clone_with_empty_witness_dropping_temp_cache, while the full checkpoint is kept internally. This aligns the create path with the existing update_state pattern, reduces unnecessary allocations and witness handling in the channel, and preserves behavior with a cleaner and more efficient initialization.