### PR TITLE
Integrate replica sync task and `PreferredSequencer`

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -289,6 +289,11 @@ impl PreferredSequencerCache {
         blob_id
     }
 
+    pub fn clean_all_batches(&mut self) {
+        self.completed_blobs.clear();
+        self.in_progress_batch = None;
+    }
+
     pub async fn insert_proof_blob(
         &mut self,
         blob_id: BlobInternalId,

--- a/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
@@ -137,6 +137,10 @@ impl<S: Spec, Rt: Runtime<S>> ExecutorEventsSender<S, Rt> {
         .await;
     }
 
+    pub fn clean_all_batches_from_cache(&mut self) {
+        self.cache.clean_all_batches();
+    }
+
     pub(crate) async fn start_batch(
         &mut self,
         visible_slot_number_after_increase: VisibleSlotNumber,

--- a/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
@@ -137,10 +137,6 @@ impl<S: Spec, Rt: Runtime<S>> ExecutorEventsSender<S, Rt> {
         .await;
     }
 
-    pub fn clean_all_batches_from_cache(&mut self) {
-        self.cache.clean_all_batches();
-    }
-
     pub(crate) async fn start_batch(
         &mut self,
         visible_slot_number_after_increase: VisibleSlotNumber,
@@ -284,6 +280,10 @@ impl<S: Spec, Rt: Runtime<S>> ExecutorEventsSender<S, Rt> {
             })
             .chain(maybe_in_progress_batch)
             .collect::<Vec<_>>()
+    }
+
+    pub fn clean_all_batches_from_cache(&mut self) {
+        self.cache.clean_all_batches();
     }
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -311,13 +311,9 @@ where
 
         // Creates a new executor for recovery. This must *not* be called to create executors
         // under other circumstances, since it causes side effects on the transaction cache.
-        let recovery_executor = RollupBlockExecutor::<_, Rt>::new_with_tx_cache_writer(
-            info,
-            self.tx_cache_writer.clone(), // Recovery executor fills the cache
-            self.rollup_exec_config.clone(),
-            self.seq_config.clone(),
-            Default::default(), // Since we're entering recovery, we don't re-use any of the uncommitted changes
-        );
+
+        // Since we're entering recovery, we don't re-use any of the uncommitted changes
+        let recovery_executor = self.new_executor_with_empty_uncommitted_changes(info);
 
         self.force_overwrite_state(info.clone(), recovery_executor)
             .await;
@@ -564,6 +560,20 @@ where
         self.do_batch_start(visible_slot_number_after_increase, visible_increase)
             .await
     }
+
+    fn new_executor_with_empty_uncommitted_changes(
+        &self,
+        info: &StateUpdateInfo<S::Storage>,
+    ) -> RollupBlockExecutor<S, Rt> {
+        let transaction_cache_write_handle = self.tx_cache_writer.clone();
+        RollupBlockExecutor::<_, Rt>::new_with_tx_cache_writer(
+            info,
+            transaction_cache_write_handle,
+            self.rollup_exec_config.clone(),
+            self.seq_config.clone(),
+            Default::default(),
+        )
+    }
 }
 
 // Methods in this block are shared between Master and Replica.
@@ -805,6 +815,7 @@ enum Message<S: Spec, Rt: Runtime<S>> {
     },
     WaitNodeResync {
         info: StateUpdateInfo<S::Storage>,
+        distance: u64,
         reason: &'static str,
     },
     #[cfg(feature = "test-utils")]
@@ -828,12 +839,12 @@ enum Message<S: Spec, Rt: Runtime<S>> {
         reason: &'static str,
     },
 
-    DoBatchStartMsg {
+    ReplicaBatchStartMsg {
         resp: oneshot::Sender<Result<(), ReplicaError<S>>>,
         batch_from_master: BatchToStore,
         reason: &'static str,
     },
-    DoNewTx {
+    ReplicaNewTx {
         resp: oneshot::Sender<Result<(), ReplicaError<S>>>,
         seq_nr_from_master: u64,
         tx_hash: TxHash,
@@ -841,7 +852,7 @@ enum Message<S: Spec, Rt: Runtime<S>> {
         reason: &'static str,
     },
 
-    DoCloseCurrentBatch {
+    ReplicaCloseCurrentBatch {
         resp: oneshot::Sender<Result<(), ReplicaError<S>>>,
         batch_from_master: BatchToStore,
         reason: &'static str,
@@ -1129,9 +1140,15 @@ where
     pub(crate) async fn wait_for_node_resync_msg(
         &self,
         info: StateUpdateInfo<S::Storage>,
+        distance: u64,
         reason: &'static str,
     ) -> Result<(), SequencerStateUpdatorError> {
-        self.send(Message::WaitNodeResync { info, reason }).await
+        self.send(Message::WaitNodeResync {
+            info,
+            distance,
+            reason,
+        })
+        .await
     }
 
     /// Closes the current batch
@@ -1220,7 +1237,7 @@ where
         reason: &'static str,
     ) -> Result<(), ReplicaError<S>> {
         let (resp, recv) = oneshot::channel();
-        self.send(Message::DoBatchStartMsg {
+        self.send(Message::ReplicaBatchStartMsg {
             resp,
             batch_from_master,
             reason,
@@ -1239,7 +1256,7 @@ where
         reason: &'static str,
     ) -> Result<(), ReplicaError<S>> {
         let (resp, recv) = oneshot::channel();
-        self.send(Message::DoNewTx {
+        self.send(Message::ReplicaNewTx {
             seq_nr_from_master,
             resp,
             tx_hash,
@@ -1258,7 +1275,7 @@ where
         reason: &'static str,
     ) -> Result<(), ReplicaError<S>> {
         let (resp, recv) = oneshot::channel();
-        self.send(Message::DoCloseCurrentBatch {
+        self.send(Message::ReplicaCloseCurrentBatch {
             resp,
             batch_from_master,
             reason,
@@ -1507,8 +1524,13 @@ where
                 self.process_force_overwrite_state_for_recovery(info, reason)
                     .await;
             }
-            Message::WaitNodeResync { info, reason } => {
-                self.process_wait_for_node_resync(info, reason).await;
+            Message::WaitNodeResync {
+                info,
+                distance,
+                reason,
+            } => {
+                self.process_wait_for_node_resync(info, distance, reason)
+                    .await;
             }
             #[cfg(feature = "test-utils")]
             Message::ForceCloseCurrentBatch { reason: _reason } => {
@@ -1529,7 +1551,7 @@ where
             Message::CloseCurrentBatch { reason } => {
                 self.process_close_current_batch(reason).await;
             }
-            Message::DoBatchStartMsg {
+            Message::ReplicaBatchStartMsg {
                 resp,
                 batch_from_master,
                 reason,
@@ -1541,7 +1563,7 @@ where
                 self.send_response(resp, ret, "process_do_batch_start_replica")
                     .await;
             }
-            Message::DoNewTx {
+            Message::ReplicaNewTx {
                 resp,
                 seq_nr_from_master,
                 tx_hash,
@@ -1555,7 +1577,7 @@ where
                 self.send_response(resp, ret, "process_do_new_tx_replica")
                     .await;
             }
-            Message::DoCloseCurrentBatch {
+            Message::ReplicaCloseCurrentBatch {
                 resp,
                 batch_from_master,
                 reason,
@@ -1780,15 +1802,9 @@ where
                         .await;
 
                     // On `should_flush_tx_cache` we have to refill the cache the first time we `replay_soft_confirmations_on_top_of_node_state`
-                    let tx_cache_writer = inner.tx_cache_writer.clone();
                     Some(Box::new(
-                        RollupBlockExecutor::<_, Rt>::new_with_tx_cache_writer(
-                            info,
-                            tx_cache_writer,
-                            inner.rollup_exec_config.clone(),
-                            inner.seq_config.clone(),
-                            Default::default(), // Since we're replaying from the node state, don't reuse any uncommitted changes
-                        ),
+                        // Since we're replaying from the node state, don't reuse any uncommitted changes
+                        inner.new_executor_with_empty_uncommitted_changes(info),
                     ))
                 } else {
                     let rollup_height =
@@ -1951,16 +1967,8 @@ where
     ) {
         let mut inner = self.get_inner_with_timing(reason).await;
 
-        // Creates a new executor for recovery. This must *not* be called to create executors
-        // under other circumstances, since it causes side effects on the transaction cache.
-        let transaction_cache_write_handle = inner.tx_cache_writer.clone();
-        let recovery_executor = RollupBlockExecutor::<_, Rt>::new_with_tx_cache_writer(
-            &info,
-            transaction_cache_write_handle,
-            inner.rollup_exec_config.clone(),
-            inner.seq_config.clone(),
-            Default::default(), // Since we're entering recovery, we don't re-use any of the uncommitted changes
-        );
+        // Since we're entering recovery, we don't re-use any of the uncommitted changes
+        let recovery_executor = inner.new_executor_with_empty_uncommitted_changes(&info);
 
         inner
             .force_overwrite_state(info.clone(), recovery_executor)
@@ -1971,6 +1979,7 @@ where
     async fn process_wait_for_node_resync(
         &mut self,
         info: StateUpdateInfo<S::Storage>,
+        distance: u64,
         reason: &'static str,
     ) {
         let mut inner = self.get_inner_with_timing(reason).await;
@@ -1997,16 +2006,17 @@ where
             .update_state_for_recovery(checkpoint)
             .await;
 
+        let recovery_executor = inner.new_executor_with_empty_uncommitted_changes(&info);
+
+        inner
+            .force_overwrite_state(info.clone(), recovery_executor)
+            .await;
+
         inner.update_api_ledger(&info).await;
 
-        // TODO
-        if info.sync_status.target_da_height() - info.sync_status.synced_da_height() <= 1 {
+        if inner.is_replica() && info.sync_status.distance() <= distance {
             inner.is_ready = Ok(());
         }
-
-        drop(inner);
-        self.process_force_overwrite_state_for_recovery(info, "xxx")
-            .await;
     }
 
     /// Closes the current batch

--- a/crates/full-node/sov-sequencer/src/preferred/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/inner.rs
@@ -1716,7 +1716,15 @@ where
             condition_are_there_batches_to_replay,
             condition_node_is_unsynced_and_doesnt_know_it,
         ) {
-            (true, _, _, true, _) => PreferredSeqOperation::Unreachable,
+            (true, _, _, true, _) => {
+                if inner.is_replica() {
+                    inner.executor_events_sender.clean_all_batches_from_cache();
+                    PreferredSeqOperation::WaitForNodeResyncToTip
+                } else {
+                    PreferredSeqOperation::Unreachable
+                }
+            }
+
             (true, _, false, false, _) => {
                 warn!("The node has a higher sequence number than the sequencer, but we're very close to the chain tip, i.e. we don't expect to be simply syncing. This could mean there is another preferred sequencer running (which is not supported and will likely lead to issues), or you very recently restarted the node and there's still some in-flight blobs. Resyncing to the chain tip.");
                 inner.is_ready = Err(SequencerNotReadyDetails::Syncing {
@@ -1990,6 +1998,15 @@ where
             .await;
 
         inner.update_api_ledger(&info).await;
+
+        // TODO
+        if info.sync_status.target_da_height() - info.sync_status.synced_da_height() <= 1 {
+            inner.is_ready = Ok(());
+        }
+
+        drop(inner);
+        self.process_force_overwrite_state_for_recovery(info, "xxx")
+            .await;
     }
 
     /// Closes the current batch
@@ -2083,7 +2100,8 @@ where
         reason: &'static str,
     ) -> Result<(), ReplicaError<S>> {
         let mut inner = self.get_inner_with_timing(reason).await;
-        let seq_nr_of_next_blob_for_this_executor = inner.current_sequence_number() + 1;
+
+        let seq_nr_of_next_blob_for_this_executor = inner.sequence_number_of_next_blob;
         let seq_nr_from_master = batch_from_master.sequence_number;
 
         validate_db_data_from_replica(
@@ -2126,6 +2144,7 @@ where
             .map_err(ReplicaError::NewTx)?
             .0
             .await;
+
         Ok(())
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -480,7 +480,7 @@ where
             let is_synced = info.sync_status.distance() <= distance_to_tip;
 
             self.synchronized_state_updator
-                .wait_for_node_resync_msg(info, "wait_for_node_resync")
+                .wait_for_node_resync_msg(info, distance_to_tip, "wait_for_node_resync")
                 .await
                 .map_err(|e| e.into_state_update_error())?;
 

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
@@ -49,9 +49,18 @@ where
     #[allow(clippy::match_same_arms)]
     async fn on_db_event(&self, data: DbData) -> Result<(), DBDataRejected> {
         let res: Result<(), ReplicaError<S>> = match data {
-            DbData::BatchStart(_) => Ok(()),
-            DbData::Transaction(_, _, _) => Ok(()),
-            DbData::BatchEnd(_) => Ok(()),
+            DbData::BatchStart(batch_to_store) => {
+                self.do_batch_start_msg_replica(batch_to_store, "replica_start_batch")
+                    .await
+            }
+            DbData::Transaction(seq, tx, tx_hash) => {
+                self.do_new_tx_msg_replica(seq, tx_hash, tx, "replica_new_tx")
+                    .await
+            }
+            DbData::BatchEnd(batch_to_store) => {
+                self.close_current_batch_msg_replica(batch_to_store, "replica_close_batch")
+                    .await
+            }
             DbData::NewProof => Ok(()),
         };
 

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -129,7 +129,8 @@ async fn test_replica_receives_txs_from_postgres() {
     let (da_service, addr) = create_da_service_manual().await;
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
 
-    let test_rollup = start_rollup(false, addr, postgres.clone()).await;
+    let replica_test_rollup = start_rollup(true, addr, postgres.clone()).await;
+    let test_rollup = start_rollup(false, addr, postgres).await;
 
     for _ in 0..20 {
         da_service.produce_block_now().await.unwrap();
@@ -141,7 +142,6 @@ async fn test_replica_receives_txs_from_postgres() {
 
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
-    let replica_test_rollup = start_rollup(true, addr, postgres).await;
     let token_id = config_gas_token_id();
 
     let receiver_addr = random_address();
@@ -154,21 +154,9 @@ async fn test_replica_receives_txs_from_postgres() {
         0,
     );
 
-    let height_before_tx = test_rollup.height().await;
     test_rollup.send_tx_to_sequencer(&tx).await.unwrap();
-    let gap = 5;
-    // producing blocks, like it is standard periodic production
-    for _ in 0..gap {
-        da_service.produce_block_now().await.unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(
-            sov_test_utils::TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS,
-        ))
-        .await;
-    }
 
-    test_rollup
-        .wait_for_height(height_before_tx.get() + gap)
-        .await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
     let receiver_balance = replica_test_rollup
         .client


### PR DESCRIPTION
# Description

This PR includes the following updates:
1. Renamed replica-related messages from `DoXX` to `ReplicaXX`.
2. Completed the implementation of `SequencerStateUpdator::on_db_event`. Replica-specific state update methods are now fully integrated.
3. Added handling for the `PreferredSeqOperation::Unreachable` case, which is now applicable to replicas. 

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
