### PR TITLE
Replace custom FallibleDatabaseCommit with revm's TryDatabaseCommit

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -3,6 +3,7 @@ use reth_primitives::TransactionSigned;
 use revm::context::result::{EVMError, ExecResultAndState, ExecutionResult};
 use revm::context::{BlockEnv, CfgEnv, TxEnv};
 use revm::primitives::hardfork::SpecId;
+use revm_database_interface::TryDatabaseCommit;
 use sov_address::{EthereumAddress, FromVmAddress};
 use sov_metrics::{save_elapsed, start_timer};
 use sov_modules_api::macros::{serialize, UniversalWallet};
@@ -13,7 +14,7 @@ use sov_modules_api::{Context, GasSpec, Spec, TxState};
 use std::convert::Infallible;
 
 use crate::conversions::{convert_to_tx_signed, create_tx_env};
-use crate::db::{self, commit::FallibleDatabaseCommit, metrics::MetricsDb};
+use crate::db::{self, metrics::MetricsDb};
 use crate::evm::primitive_types::{Receipt, TxSignedAndRecovered};
 use crate::evm::RlpEvmTransaction;
 use crate::executor::{get_cfg_env, transact};
@@ -94,7 +95,7 @@ where
         save_elapsed!(execution_time SINCE execution);
         // We don't use transact_commit as it does not support returning an error
         start_timer!(state_commit);
-        db.commit(state_changes)
+        db.try_commit(state_changes)
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         save_elapsed!(state_commit_time SINCE state_commit);
 

--- a/crates/module-system/module-implementations/sov-evm/src/db/commit.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/db/commit.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{Address, U256};
 use itertools::Itertools;
 use revm::primitives::HashMap;
 use revm::state::{Account, EvmStorageSlot};
-use revm_database_interface::DBErrorMarker;
+use revm_database_interface::TryDatabaseCommit;
 use sov_address::{EthereumAddress, FromVmAddress};
 use sov_modules_api::{Spec, StateAccessor};
 
@@ -10,21 +10,13 @@ use super::EvmDb;
 use crate::db::{DbAccount, Error};
 use crate::{to_rollup_address, to_rollup_balance};
 
-/// EVM database commit interface.
-pub trait FallibleDatabaseCommit {
-    type Error: DBErrorMarker + core::error::Error;
-
-    /// Commit changes to the database.
-    fn commit(&mut self, changes: HashMap<Address, Account>) -> Result<(), Self::Error>;
-}
-
-impl<'a, Ws: StateAccessor, S: Spec> FallibleDatabaseCommit for EvmDb<'a, Ws, S>
+impl<'a, Ws: StateAccessor, S: Spec> TryDatabaseCommit for EvmDb<'a, Ws, S>
 where
     S::Address: FromVmAddress<EthereumAddress>,
 {
     type Error = Error<Ws>;
 
-    fn commit(&mut self, changes: HashMap<Address, Account>) -> Result<(), Self::Error> {
+    fn try_commit(&mut self, changes: HashMap<Address, Account>) -> Result<(), Self::Error> {
         for (address, account) in changes
             .into_iter()
             // Sort addresses to avoid non-determinism in ZK
@@ -39,14 +31,14 @@ where
 
 impl<'a, Ws: StateAccessor, S: Spec> EvmDb<'a, Ws, S>
 where
-    EvmDb<'a, Ws, S>: FallibleDatabaseCommit<Error = Error<Ws>>,
+    EvmDb<'a, Ws, S>: TryDatabaseCommit<Error = Error<Ws>>,
     S::Address: FromVmAddress<EthereumAddress>,
 {
     fn commit_account(
         &mut self,
         address: Address,
         account: Account,
-    ) -> Result<(), <Self as FallibleDatabaseCommit>::Error> {
+    ) -> Result<(), <Self as TryDatabaseCommit>::Error> {
         // TODO figure out what to do when account is destroyed.
         // https://github.com/Sovereign-Labs/sovereign-sdk/issues/425
         if account.is_selfdestructed() {
@@ -87,7 +79,7 @@ where
         &mut self,
         address: Address,
         storage: HashMap<U256, EvmStorageSlot>,
-    ) -> Result<(), <Self as FallibleDatabaseCommit>::Error> {
+    ) -> Result<(), <Self as TryDatabaseCommit>::Error> {
         storage
             .into_iter()
             .sorted_by_key(|(key, _)| *key) // Sort keys explicitly to avoid non-determinism.

--- a/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -1,5 +1,4 @@
 use crate::{
-    db::commit::FallibleDatabaseCommit,
     get_spec_id,
     sov_evm::{SovEvm, StorageAccessInspector},
     EvmRuntimeConfig,
@@ -15,7 +14,7 @@ use revm::{
 };
 #[cfg(feature = "native")]
 use revm::{interpreter::interpreter::EthInterpreter, Inspector};
-use revm_database_interface::DBErrorMarker;
+use revm_database_interface::{DBErrorMarker, TryDatabaseCommit};
 use sov_modules_api::macros::config_value;
 
 /// The maximum contract code size is 512KiB by default.
@@ -44,10 +43,7 @@ pub(crate) fn get_cfg_env(
 }
 
 /// Execute an Ethereum transaction and commit it to the database.
-pub fn transact_commit<
-    DB: Database<Error = E> + FallibleDatabaseCommit<Error = E>,
-    E: DBErrorMarker,
->(
+pub fn transact_commit<DB: Database<Error = E> + TryDatabaseCommit<Error = E>, E: DBErrorMarker>(
     mut db: &mut DB,
     block_env: &BlockEnv,
     tx: TxEnv,
@@ -55,7 +51,7 @@ pub fn transact_commit<
 ) -> Result<ExecutionResult, EVMError<E>> {
     let ExecResultAndState { result, state } = transact(&mut db, block_env, tx, cfg)?;
     // We don't use transact_commit as it does not support returning an error
-    db.commit(state)?;
+    db.try_commit(state)?;
     Ok(result)
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -1,4 +1,3 @@
-use crate::db::commit::FallibleDatabaseCommit;
 use crate::error::into_rpc_error;
 use crate::rpc::error::ensure_success;
 use alloy_primitives::{Address, U64};
@@ -12,6 +11,7 @@ use alloy_rpc_types_trace::geth::{GethTrace, TraceResult};
 use jsonrpsee::core::RpcResult;
 use revm::context::result::ResultAndState;
 use revm::Database;
+use revm_database_interface::TryDatabaseCommit;
 use sov_address::{EthereumAddress, FromVmAddress};
 use sov_modules_api::macros::{config_value, rpc_gen};
 use sov_modules_api::prelude::UnwrapInfallible;
@@ -272,7 +272,7 @@ where
             state: changes,
         } = self.call(request, block_number, state)?;
         self.db(state)
-            .commit(changes)
+            .try_commit(changes)
             .expect("Gas meter is initialized with INF");
         let gas_used = result.gas_used();
 

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
@@ -9,6 +9,7 @@ use alloy_rpc_types_trace::geth::{
 };
 use revm::context::result::ExecResultAndState;
 use revm::context::{BlockEnv, CfgEnv, TxEnv};
+use revm_database_interface::TryDatabaseCommit;
 use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
 use sov_address::{EthereumAddress, FromVmAddress};
 use sov_modules_api::{ApiStateAccessor, Spec};
@@ -16,7 +17,6 @@ use sov_rpc_eth_types::EthApiError;
 
 use super::maybe_archival_state::MaybeArchivalState;
 use crate::conversions::replay_tx_env;
-use crate::db::commit::FallibleDatabaseCommit;
 use crate::db::EvmDb;
 use crate::evm::primitive_types::{MaybeSealedBlock, TxSignedAndRecovered};
 use crate::executor::{get_cfg_env, inspect, transact_commit};
@@ -179,7 +179,7 @@ where
                     let gas_limit = tx_env.gas_limit;
                     let ExecResultAndState { result, state } =
                         inspect(&mut *db, block_env, tx_env, cfg, &mut inspector)?;
-                    db.commit(state)?;
+                    db.try_commit(state)?;
 
                     inspector.set_transaction_gas_limit(gas_limit);
                     let frame = inspector


### PR DESCRIPTION
# Description

- Remove custom `FallibleDatabaseCommit` trait in favor of revm's standard `TryDatabaseCommit`
- Update all call sites to use `try_commit()` instead of `commit()`
------

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
