### PR TITLE
chore: remove unused import from Risc0 ZKVM module

### DIFF
--- a/crates/adapters/risc0/src/crypto.rs
+++ b/crates/adapters/risc0/src/crypto.rs
@@ -1,5 +1,4 @@
 //! Cryptography optimized for the Rrisc0 Zkvm.
-use std::hash::Hash;
 #[cfg(feature = "native")]
 use std::str::FromStr;
 
@@ -525,4 +524,5 @@ mod hex_tests {
 
         assert_eq!(pub_key_lower, pub_key_upper);
     }
+
 }


### PR DESCRIPTION
# Description

This PR performs a small cleanup in the Risc0 cryptography module:

* Removed an unused import:

  ```rust
  use std::hash::Hash;
  ```

  which was redundant since `Hash` is already derived via `#[derive(Hash)]` on `Risc0PublicKey`.

