### PR TITLE
fix: implement no-op verify_relevant_tx_list

### DIFF
--- a/crates/adapters/avail/src/verifier.rs
+++ b/crates/adapters/avail/src/verifier.rs
@@ -25,7 +25,7 @@ impl DaVerifier for Verifier {
             <Self::Spec as DaSpec>::CompletenessProof,
         >,
     ) -> Result<(), Self::Error> {
-        todo!()
+        Ok(())
     }
 
     fn new(_params: <Self::Spec as DaSpec>::ChainParams) -> Self {


### PR DESCRIPTION
This change implements the no-op Avail DA verifier by returning Ok(()) from verify_relevant_tx_list, which aligns with the design where the light client performs data verification and proofs are unit types