### PR TITLE
Add module associated error type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11215,6 +11215,7 @@ dependencies = [
  "proptest",
  "schemars 0.8.22",
  "serde",
+ "serde_json",
  "sov-bank",
  "sov-chain-state",
  "sov-modules-api",

--- a/crates/full-node/sov-rollup-apis/src/endpoints/simulate.rs
+++ b/crates/full-node/sov-rollup-apis/src/endpoints/simulate.rs
@@ -20,9 +20,9 @@ use sov_modules_api::rest::StateUpdateReceiver;
 use sov_modules_api::sov_universal_wallet::schema::{RollupRoots, SchemaError};
 use sov_modules_api::transaction::{Credentials, PriorityFeeBips, TxDetails};
 use sov_modules_api::{
-    get_runtime_schema, AuthenticatedTransactionData, CredentialId, DaSpec, EventModuleName,
-    FullyBakedTx, Gas, GasArray, HexHash, HexString, Runtime, Spec, StateCheckpoint,
-    StateProvider as _, WorkingSet,
+    get_runtime_schema, AuthenticatedTransactionData, CredentialId, DaSpec, ErrorContext,
+    EventModuleName, FullyBakedTx, Gas, GasArray, HexHash, HexString, Runtime, Spec,
+    StateCheckpoint, StateProvider as _, WorkingSet,
 };
 use sov_modules_stf_blueprint::{apply_tx, get_gas_used, ApplyTxResult};
 use sov_rest_utils::{json_obj, preconfigured_router_layers, ErrorObject};
@@ -201,7 +201,7 @@ pub struct FailOutcome {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RevertOutcome {
     /// Details about the revert reason.
-    pub detail: serde_json::Value,
+    pub detail: ErrorContext,
 }
 
 /// The outcome of a transaction simulation.
@@ -347,7 +347,7 @@ impl<S: Spec, R: Runtime<S>> SovereignSimulate<S, R> {
                 reason: e.error.to_string(),
             }),
             TxEffect::Reverted(e) => SimulateOutcome::Reverted(RevertOutcome {
-                detail: e.reason.error_detail().unwrap_or_default(),
+                detail: e.reason.error_detail().unwrap_or(json_obj!({})),
             }),
             TxEffect::Successful(_) => SimulateOutcome::Success(SuccessOutcome {
                 priority_fee: result.transaction_consumption.priority_fee().0,

--- a/crates/full-node/sov-rollup-apis/src/endpoints/simulate.rs
+++ b/crates/full-node/sov-rollup-apis/src/endpoints/simulate.rs
@@ -197,6 +197,13 @@ pub struct FailOutcome {
     pub reason: String,
 }
 
+/// Reverted simulation outcome with details.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevertOutcome {
+    /// Details about the revert reason.
+    pub detail: serde_json::Value,
+}
+
 /// The outcome of a transaction simulation.
 ///
 /// This enum represents the three possible outcomes when simulating a transaction:
@@ -207,7 +214,7 @@ pub enum SimulateOutcome<E> {
     /// The transaction executed successfully.
     Success(SuccessOutcome<E>),
     /// The transaction was reverted during execution.
-    Reverted(FailOutcome),
+    Reverted(RevertOutcome),
     /// The transaction was skipped due to pre-execution errors.
     Skipped(FailOutcome),
 }
@@ -339,8 +346,8 @@ impl<S: Spec, R: Runtime<S>> SovereignSimulate<S, R> {
             TxEffect::Skipped(e) => SimulateOutcome::Skipped(FailOutcome {
                 reason: e.error.to_string(),
             }),
-            TxEffect::Reverted(e) => SimulateOutcome::Reverted(FailOutcome {
-                reason: e.reason.to_string(),
+            TxEffect::Reverted(e) => SimulateOutcome::Reverted(RevertOutcome {
+                detail: e.reason.error_detail().unwrap_or_default(),
             }),
             TxEffect::Successful(_) => SimulateOutcome::Success(SuccessOutcome {
                 priority_fee: result.transaction_consumption.priority_fee().0,

--- a/crates/full-node/sov-rollup-apis/tests/integration/rest_api.rs
+++ b/crates/full-node/sov-rollup-apis/tests/integration/rest_api.rs
@@ -194,12 +194,15 @@ async fn test_simulation_fail() {
         .await
         .unwrap();
     let actual = response.json::<serde_json::Value>().await.unwrap();
-    // Test raw JSON to ensure it's acutally usable
     let expected = serde_json::json!({
         "outcome": "reverted",
-        // we lose the context because of how module errors are currently implemented
-        // the actual reason for the failure is the sender doesnt have enough balance
-        "reason": "Failed to transfer token_id=token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"
+        "detail": {
+            "call": "transfer_token",
+            "error_code": "underflow",
+            "base": "0",
+            "subtrahend": "1000",
+            "message": format!("Insufficient balance for account {}", sender.address()),
+        },
     });
 
     assert_eq!(actual, expected);

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -32,7 +32,7 @@ use super::state_root_compute::StateRootComputeRequest;
 use super::{
     Confirmation, PreferredBatchToReplay, PreferredSequencerConfig, VisibleSlotNumberIncrease,
 };
-use crate::common::{generic_accept_tx_error, AcceptedTx};
+use crate::common::AcceptedTx;
 use crate::preferred::async_batch::{ExecutedTxResponse, MaybeAsyncBatch};
 use crate::preferred::exit_rollup;
 use crate::preferred::transaction_subscriptions::TxResultWriter;
@@ -85,7 +85,17 @@ impl<S: Spec> RollupBlockExecutorError<S> {
                 reject_reason_to_error(reason, call)
             }
             RollupBlockExecutorError::UnsuccessfulTransaction { receipt } => {
-                generic_accept_tx_error(receipt)
+                let details = match receipt.receipt {
+                    sov_rollup_interface::stf::TxEffect::Reverted(reverted) => {
+                        reverted.reason.error_detail().unwrap_or(json_obj!({}))
+                    }
+                    _ => json_obj!({}),
+                };
+                ErrorObject {
+                    status: StatusCode::BAD_REQUEST,
+                    message: "Transaction execution unsuccessful".to_string(),
+                    details,
+                }
             }
             RollupBlockExecutorError::UnexpectedFailure => ErrorObject {
                 status: StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -90,7 +90,7 @@ impl<S: Spec> RollupBlockExecutorError<S> {
                         reverted.reason.error_detail().unwrap_or(json_obj!({}))
                     }
                     _ => json_obj!({
-                        "message": format!("{:?}", receipt),
+                        "error": format!("{:?}", receipt),
                     }),
                 };
                 ErrorObject {

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -89,7 +89,9 @@ impl<S: Spec> RollupBlockExecutorError<S> {
                     sov_rollup_interface::stf::TxEffect::Reverted(reverted) => {
                         reverted.reason.error_detail().unwrap_or(json_obj!({}))
                     }
-                    _ => json_obj!({}),
+                    _ => json_obj!({
+                        "message": format!("{:?}", receipt),
+                    }),
                 };
                 ErrorObject {
                     status: StatusCode::BAD_REQUEST,

--- a/crates/full-node/sov-sequencer/tests/integration/utils.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/utils.rs
@@ -177,13 +177,14 @@ impl<S: Spec> Module for ModuleWithVersionedStateAccessInSlotHook<S> {
     type Config = ();
     type CallMessage = ();
     type Event = ();
+    type Error = anyhow::Error;
 
     fn call(
         &mut self,
         _msg: Self::CallMessage,
         _context: &Context<Self::Spec>,
         _state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/crates/module-system/hyperlane/src/igp/mod.rs
+++ b/crates/module-system/hyperlane/src/igp/mod.rs
@@ -74,6 +74,7 @@ impl<S: Spec> Module for InterchainGasPaymaster<S> {
     type Config = ();
     type CallMessage = call::CallMessage<S>;
     type Event = Event<S>;
+    type Error = anyhow::Error;
 
     fn genesis(
         &mut self,
@@ -89,7 +90,7 @@ impl<S: Spec> Module for InterchainGasPaymaster<S> {
         message: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl sov_modules_api::TxState<Self::Spec>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match message {
             CallMessage::ClaimRewards { relayer_address } => {
                 self.claim(relayer_address, context, state)?;

--- a/crates/module-system/hyperlane/src/lib.rs
+++ b/crates/module-system/hyperlane/src/lib.rs
@@ -120,6 +120,8 @@ where
 
     type Event = Event;
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
@@ -135,7 +137,7 @@ where
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             call::CallMessage::Dispatch {
                 domain,

--- a/crates/module-system/hyperlane/src/merkle/mod.rs
+++ b/crates/module-system/hyperlane/src/merkle/mod.rs
@@ -38,6 +38,7 @@ impl<S: Spec> Module for MerkleTreeHook<S> {
     type Config = ();
     type CallMessage = ();
     type Event = Event;
+    type Error = anyhow::Error;
 
     fn genesis(
         &mut self,

--- a/crates/module-system/hyperlane/src/test_recipient.rs
+++ b/crates/module-system/hyperlane/src/test_recipient.rs
@@ -121,13 +121,14 @@ impl<S: Spec> Module for TestRecipient<S> {
     type Config = ();
     type CallMessage = CallMessage;
     type Event = Event<S>;
+    type Error = anyhow::Error;
 
     fn call(
         &mut self,
         msg: Self::CallMessage,
         _context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             CallMessage::Register { address, ism } => {
                 self.register(address, ism, state)?;

--- a/crates/module-system/hyperlane/src/warp/mod.rs
+++ b/crates/module-system/hyperlane/src/warp/mod.rs
@@ -619,7 +619,7 @@ where
         state: &mut impl TxState<S>,
     ) -> anyhow::Result<TokenId> {
         let holder: DerivedHolder = warp_route.0.into();
-        self.bank.create_token(
+        Ok(self.bank.create_token(
             format!("Synthetic token for {warp_route}"),
             Some(decimals),
             Amount::ZERO,              // No initial balance
@@ -628,7 +628,7 @@ where
             None,                // No supply cap
             holder.to_payable(), // The mint authority is the warp route
             state,
-        )
+        )?)
     }
 
     /// "Enroll" a remote router on another chain. Whenever this route needs to send/receive funds on that chain,

--- a/crates/module-system/hyperlane/src/warp/mod.rs
+++ b/crates/module-system/hyperlane/src/warp/mod.rs
@@ -262,13 +262,14 @@ where
     type Config = ();
     type CallMessage = CallMessage<S>;
     type Event = Event<S>;
+    type Error = anyhow::Error;
 
     fn call(
         &mut self,
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             CallMessage::Register {
                 admin,

--- a/crates/module-system/hyperlane/tests/integration/igp/post_mailbox_send.rs
+++ b/crates/module-system/hyperlane/tests/integration/igp/post_mailbox_send.rs
@@ -659,7 +659,7 @@ fn transfer_with_various_gas_prices_and_scales() {
 
     // error that signals that admin didn't have enough funds to pay the gas price
     // it is a "success" error for tests that check possible overflows during gas calculation
-    let not_enough_funds_err = "Failed to transfer token";
+    let not_enough_funds_err = "Insufficient balance for account";
 
     // gas_price * desination_gas overflow u128, brought back to u128 by exchange_rate
     let big_destination_gas_price_overflows_u128 = TestCase {

--- a/crates/module-system/hyperlane/tests/integration/warp/transfer.rs
+++ b/crates/module-system/hyperlane/tests/integration/warp/transfer.rs
@@ -314,7 +314,7 @@ fn test_transfer_inbound_fails_various_edge_cases() {
         warp_route_id,
         other.address().to_sender(),
         Amount(101), // Amount is more than the amount of locked tokens
-        "Failed to transfer token",
+        "Insufficient balance for account",
     );
 
     // Check that the correct transfer still succeeds after all of these failures
@@ -351,7 +351,7 @@ fn test_transfer_remote_fails_if_not_enough_balance() {
             match result.tx_receipt {
                 TxEffect::Reverted(reason) => {
                     assert!(
-                        reason.reason.to_string().contains("Failed to transfer"),
+                        reason.reason.to_string().contains("Insufficient balance for account"),
                         "Transaction should be reverted with the correct error but reverted with: {}",
                         reason.reason
                     );
@@ -794,7 +794,7 @@ fn test_collateral_route() {
         warp_route_id,
         Amount(100),
         relayer.address(),
-        "Failed to transfer token",
+        "Insufficient balance for account",
     );
     // Inbound transfer should fail because the warp module has no tokens
     do_inbound_transfer_failure(
@@ -805,7 +805,7 @@ fn test_collateral_route() {
         warp_route_id,
         other.address().to_sender(),
         Amount(100),
-        "Failed to transfer token",
+        "Insufficient balance for account",
     );
     // Outbound transfer from the other user should succeed, since we minted the token to him
     do_outbound_transfer(
@@ -903,7 +903,7 @@ fn test_synthetic_route(
         warp_route_id,
         amount_received_inbound,
         relayer.address(),
-        format!("supply=0 is less than burn amount={amount_received_inbound}"),
+        format!("Underflow occurred: Total supply underflow when burning, 0 - {amount_received_inbound}"),
     );
     // Inbound transfer should succeed
     do_inbound_transfer_success_with_scaled_amount(
@@ -936,7 +936,7 @@ fn test_synthetic_route(
         warp_route_id,
         amount_bigger_than_balance,
         relayer.address(),
-        format!("supply={amount_received_inbound} is less than burn amount={amount_bigger_than_balance}"),
+        format!("Underflow occurred: Total supply underflow when burning, {amount_received_inbound} - {amount_bigger_than_balance}"),
     );
     // Outbound transfer should succeed
     do_outbound_transfer(

--- a/crates/module-system/hyperlane/tests/integration/with_agent/preferred_sequencer_runtime.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/preferred_sequencer_runtime.rs
@@ -27,13 +27,14 @@ impl<S: Spec> Module for RoutingRecipient<S> {
     type Config = ();
     type CallMessage = ();
     type Event = ();
+    type Error = anyhow::Error;
 
     fn call(
         &mut self,
         _msg: Self::CallMessage,
         _context: &Context<Self::Spec>,
         _state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/crates/module-system/module-implementations/integration-tests/tests/accessory_state.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/accessory_state.rs
@@ -45,6 +45,7 @@ impl<S: Spec> Module for TestAccessoryModule<S> {
     type Config = ();
     type CallMessage = CallMessage;
     type Event = ();
+    type Error = anyhow::Error;
 
     fn genesis(
         &mut self,
@@ -60,7 +61,7 @@ impl<S: Spec> Module for TestAccessoryModule<S> {
         msg: Self::CallMessage,
         _context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             CallMessage::SetAccessoryValue(value) => {
                 let unmetered_state = &mut state.to_unmetered();

--- a/crates/module-system/module-implementations/integration-tests/tests/hooks_derive/hook_override_works.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/hooks_derive/hook_override_works.rs
@@ -23,6 +23,7 @@ impl<S: Spec> Module for CorrectHooksOverride<S> {
     type Config = ();
     type CallMessage = ();
     type Event = ();
+    type Error = anyhow::Error;
 
     fn genesis(
         &mut self,
@@ -39,7 +40,7 @@ impl<S: Spec> Module for CorrectHooksOverride<S> {
         _msg: Self::CallMessage,
         _context: &Context<Self::Spec>,
         _state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/crates/module-system/module-implementations/integration-tests/tests/hooks_derive/incorrect_hooks_override.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/hooks_derive/incorrect_hooks_override.rs
@@ -25,6 +25,7 @@ impl<S: Spec> Module for IncorrectHooksOverride<S> {
     type Config = ();
     type CallMessage = ();
     type Event = ();
+    type Error = anyhow::Error;
 
     fn genesis(
         &mut self,

--- a/crates/module-system/module-implementations/integration-tests/tests/kernel_interactions/mod.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/kernel_interactions/mod.rs
@@ -39,6 +39,7 @@ impl<S: Spec> Module for TestVisibleHashModule<S> {
     type Config = ();
     type CallMessage = ();
     type Event = ();
+    type Error = anyhow::Error;
 
     fn genesis(
         &mut self,

--- a/crates/module-system/module-implementations/module-template/src/lib.rs
+++ b/crates/module-system/module-implementations/module-template/src/lib.rs
@@ -46,6 +46,8 @@ impl<S: Spec> Module for ExampleModule<S> {
 
     type Event = Event;
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
@@ -61,7 +63,7 @@ impl<S: Spec> Module for ExampleModule<S> {
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             CallMessage::SetValue(new_value) => Ok(self.set_value(new_value, context, state)?),
         }

--- a/crates/module-system/module-implementations/sov-accounts/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-accounts/src/lib.rs
@@ -60,6 +60,8 @@ impl<S: Spec> Module for Accounts<S> {
 
     type Event = ();
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
@@ -74,7 +76,7 @@ impl<S: Spec> Module for Accounts<S> {
         msg: Self::CallMessage,
         context: &Context<S>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             call::CallMessage::InsertCredentialId(new_credential_id) => {
                 Ok(self.insert_credential_id(new_credential_id, context, state)?)

--- a/crates/module-system/module-implementations/sov-accounts/tests/integration/main.rs
+++ b/crates/module-system/module-implementations/sov-accounts/tests/integration/main.rs
@@ -1,7 +1,7 @@
 use sov_accounts::{Accounts, CallMessage, Response};
 use sov_modules_api::transaction::{UnsignedTransaction, Version1};
 use sov_modules_api::{
-    CryptoSpec, Error, PrivateKey, PublicKey, RawTx, Runtime, SkippedTxContents, Spec, TxEffect,
+    CryptoSpec, PrivateKey, PublicKey, RawTx, Runtime, SkippedTxContents, Spec, TxEffect,
 };
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
 use sov_test_utils::runtime::TestRunner;

--- a/crates/module-system/module-implementations/sov-accounts/tests/integration/main.rs
+++ b/crates/module-system/module-implementations/sov-accounts/tests/integration/main.rs
@@ -144,8 +144,10 @@ fn test_update_account_fails() {
         )),
         assert: Box::new(move |result, _state| {
             if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                assert_eq!(err.to_string(), "New CredentialId already exists");
+                assert_eq!(
+                    contents.reason.to_string(),
+                    "New CredentialId already exists"
+                );
             }
         }),
     });
@@ -555,8 +557,10 @@ fn test_disable_custom_account_mappings() {
         )),
         assert: Box::new(move |result, _state| match result.tx_receipt {
             TxEffect::Reverted(contents) => {
-                let Error::ModuleError(err) = contents.reason;
-                assert_eq!(err.to_string(), "Custom account mappings are disabled");
+                assert_eq!(
+                    contents.reason.to_string(),
+                    "Custom account mappings are disabled"
+                );
             }
             _ => panic!("Expected reverted transaction"),
         }),

--- a/crates/module-system/module-implementations/sov-attester-incentives/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-attester-incentives/src/lib.rs
@@ -130,6 +130,8 @@ where
 
     type Event = Event<S>;
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
@@ -145,7 +147,7 @@ where
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         if !self.should_reward_fees(state) {
             return Err(anyhow::anyhow!(
                 "Attester incentives call message received when operating in zk mode"

--- a/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/unbonding.rs
+++ b/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/unbonding.rs
@@ -2,7 +2,7 @@ use sov_attester_incentives::{CustomError, UnbondingInfo};
 use sov_mock_da::MockAddress;
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::registration_lib::RegistrationError;
-use sov_modules_api::Error::ModuleError;
+use sov_modules_api::Error;
 use sov_modules_api::{Amount, Spec, StateAccessorError};
 use sov_rollup_interface::common::SlotNumber;
 use sov_test_utils::runtime::TestRunner;
@@ -156,18 +156,14 @@ fn try_unbond_too_early() {
             match &result.tx_receipt {
                 sov_modules_api::TxEffect::Reverted(reason) => {
                     assert_eq!(
-                        reason.reason,
-                        ModuleError(
-                            RegistrationError::<
-                                MockAddress,
-                                MockAddress,
-                                StateAccessorError<<S as Spec>::Gas>,
-                                _,
-                            >::Custom(
-                                CustomError::UnbondingNotFinalized(addr)
-                            )
-                            .into(),
-                        ),
+                        reason.reason.to_string(),
+                        RegistrationError::<
+                            MockAddress,
+                            MockAddress,
+                            StateAccessorError<<S as Spec>::Gas>,
+                            _,
+                        >::Custom(CustomError::UnbondingNotFinalized(addr))
+                        .to_string(),
                         "Transaction reverted, but with unexpected reason"
                     );
                 }
@@ -228,18 +224,16 @@ fn try_skip_two_phase_unbonding() {
             match &result.tx_receipt {
                 sov_modules_api::TxEffect::Reverted(reason) => {
                     assert_eq!(
-                        reason.reason,
-                        ModuleError(
-                            RegistrationError::<
-                                MockAddress,
-                                MockAddress,
-                                StateAccessorError<<S as Spec>::Gas>,
-                                _,
-                            >::Custom(
-                                CustomError::AttesterIsNotUnbonding(addr)
-                            )
-                            .into(),
-                        ),
+                        reason.reason.to_string(),
+                        RegistrationError::<
+                            MockAddress,
+                            MockAddress,
+                            StateAccessorError<<S as Spec>::Gas>,
+                            _,
+                        >::Custom(CustomError::AttesterIsNotUnbonding(
+                            addr
+                        ))
+                        .to_string(),
                         "Transaction reverted, but with unexpected reason"
                     );
                 }
@@ -292,18 +286,16 @@ fn try_bond_while_unbonding() {
             match &result.tx_receipt {
                 sov_modules_api::TxEffect::Reverted(reason) => {
                     assert_eq!(
-                        reason.reason,
-                        ModuleError(
-                            RegistrationError::<
-                                MockAddress,
-                                MockAddress,
-                                StateAccessorError<<S as Spec>::Gas>,
-                                _,
-                            >::Custom(CustomError::AttesterIsUnbonding(
-                                attester_address
-                            ))
-                            .into(),
-                        ),
+                        reason.reason.to_string(),
+                        RegistrationError::<
+                            MockAddress,
+                            MockAddress,
+                            StateAccessorError<<S as Spec>::Gas>,
+                            _,
+                        >::Custom(CustomError::AttesterIsUnbonding(
+                            attester_address
+                        ))
+                        .to_string(),
                         "Transaction reverted, but with unexpected reason"
                     );
                 }

--- a/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/unbonding.rs
+++ b/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/unbonding.rs
@@ -2,7 +2,6 @@ use sov_attester_incentives::{CustomError, UnbondingInfo};
 use sov_mock_da::MockAddress;
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::registration_lib::RegistrationError;
-use sov_modules_api::Error;
 use sov_modules_api::{Amount, Spec, StateAccessorError};
 use sov_rollup_interface::common::SlotNumber;
 use sov_test_utils::runtime::TestRunner;

--- a/crates/module-system/module-implementations/sov-bank/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-bank/Cargo.toml
@@ -20,6 +20,7 @@ derive_more = { workspace = true, features = ["display"] }
 proptest = { workspace = true, optional = true }
 schemars = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 strum = { workspace = true }
@@ -38,20 +39,20 @@ sov-test-utils = { workspace = true }
 [features]
 default = []
 arbitrary = [
-	"sov-modules-api/arbitrary",
-	"dep:proptest",
-	"sov-bank/arbitrary",
-	"sov-state/arbitrary",
-	"sov-test-utils/arbitrary",
-	"sov-rollup-interface/arbitrary"
+  "sov-modules-api/arbitrary",
+  "dep:proptest",
+  "sov-bank/arbitrary",
+  "sov-state/arbitrary",
+  "sov-test-utils/arbitrary",
+  "sov-rollup-interface/arbitrary",
 ]
 native = [
-	"sov-bank/native",
-	"sov-modules-api/native",
-	"sov-state/native",
-	"sov-chain-state/native",
-	"sov-modules-stf-blueprint/native",
-	"sov-rollup-interface/native"
+  "sov-bank/native",
+  "sov-modules-api/native",
+  "sov-state/native",
+  "sov-chain-state/native",
+  "sov-modules-stf-blueprint/native",
+  "sov-rollup-interface/native",
 ]
 cli = ["native"]
 test-utils = []

--- a/crates/module-system/module-implementations/sov-bank/src/call.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/call.rs
@@ -1,4 +1,3 @@
-use anyhow::{bail, Context as _, Result};
 use schemars::JsonSchema;
 use sov_modules_api::macros::{serialize, UniversalWallet};
 use sov_modules_api::{
@@ -9,6 +8,10 @@ use sov_rollup_interface::common::SizedSafeString;
 use sov_state::{EventContainer, User};
 use strum::{EnumDiscriminants, EnumIs, EnumIter, VariantArray};
 
+use crate::error::{
+    ArithmeticError, BurnTokenError, CommonError, CreateTokenError, FreezeTokenError,
+    MintTokenError, TransferTokenError, UpdateAdminError,
+};
 use crate::event::Event;
 use crate::token::unique_holders;
 use crate::utils::{get_token_id_metered, Payable, TokenHolderRef};
@@ -106,24 +109,25 @@ impl<S: Spec> Bank<S> {
         supply_cap: Option<Amount>,
         minter: impl Payable<S>,
         state: &mut impl TxState<S>,
-    ) -> Result<TokenId> {
+    ) -> Result<TokenId, CreateTokenError> {
         tracing::trace!(%minter, "Create token request");
 
         if let Some(decimals) = token_decimals {
-            anyhow::ensure!(
-                decimals <= Amount::MAX_DECIMALS,
-                "Too many decimal places: {}, maximum allowed for a token: {}",
-                decimals,
-                Amount::MAX_DECIMALS
-            );
+            if decimals > Amount::MAX_DECIMALS {
+                return Err(CreateTokenError::TooManyDecimals {
+                    provided: decimals,
+                    max_allowed: Amount::MAX_DECIMALS,
+                });
+            }
         };
 
-        if initial_balance > supply_cap.unwrap_or(Amount::MAX) {
-            bail!(
-                "Requested initial balance {} is greater than the supply cap {}",
+        let supply_cap = supply_cap.unwrap_or(Amount::MAX);
+
+        if initial_balance > supply_cap {
+            return Err(CreateTokenError::InitialBalanceExceedsSupplyCap {
                 initial_balance,
-                supply_cap.unwrap_or(Amount::MAX)
-            );
+                supply_cap,
+            });
         }
 
         let mint_to_address = mint_to_address.as_token_holder();
@@ -138,22 +142,31 @@ impl<S: Spec> Bank<S> {
         let token = Token::<S> {
             name: token_name.to_owned(),
             total_supply: initial_balance,
-            supply_cap: supply_cap.unwrap_or(Amount::MAX),
+            supply_cap,
             admins: admins.clone(),
         };
 
-        if self.tokens.get(&token_id, state)?.is_some() {
-            bail!(
-                "Token with id already exists {}, name={} minter={}",
-                token_id,
-                token_name,
-                minter.as_token_holder()
-            );
-        }
-        self.balances
-            .set(&(mint_to_address, &token_id), &initial_balance, state)?;
+        let token_exists = self
+            .tokens
+            .get(&token_id, state)
+            .map_err(CoreModuleError::state_read)?
+            .is_some();
 
-        self.tokens.set(&token_id, &token, state)?;
+        if token_exists {
+            return Err(CreateTokenError::TokenAlreadyExists {
+                token_id: token_id.to_string(),
+                name: token_name,
+                minter: minter.as_token_holder().to_string(),
+            })?;
+        }
+
+        self.balances
+            .set(&(mint_to_address, &token_id), &initial_balance, state)
+            .map_err(CoreModuleError::state_write)?;
+
+        self.tokens
+            .set(&token_id, &token, state)
+            .map_err(CoreModuleError::state_write)?;
 
         tracing::trace!(
             %token_id,
@@ -175,7 +188,7 @@ impl<S: Spec> Bank<S> {
                 },
                 mint_to_address: mint_to_address.into(),
                 minter: minter.as_token_holder().into(),
-                supply_cap: supply_cap.unwrap_or(Amount::MAX),
+                supply_cap,
                 admins,
             },
         );
@@ -189,7 +202,7 @@ impl<S: Spec> Bank<S> {
         coins: Coins,
         context: &Context<S>,
         state: &mut impl TxState<S>,
-    ) -> Result<()> {
+    ) -> Result<(), TransferTokenError> {
         self.transfer_with_memo(to, coins, None, context, state)
     }
 
@@ -201,7 +214,7 @@ impl<S: Spec> Bank<S> {
         memo: Option<String>,
         context: &Context<S>,
         state: &mut impl TxState<S>,
-    ) -> Result<()> {
+    ) -> Result<(), TransferTokenError> {
         tracing::trace!("Transfer token request");
 
         let to = to.as_token_holder();
@@ -245,25 +258,30 @@ impl<S: Spec> Bank<S> {
         coins: Coins,
         owner: impl Payable<S>,
         state: &mut impl TxState<S>,
-    ) -> Result<()> {
+    ) -> Result<(), BurnTokenError> {
         tracing::trace!("Handling Burn call");
 
         let mut token = self
             .tokens
-            .get_or_err(&coins.token_id, state)?
-            .with_context(|| format!("Failed to get token_id={}", &coins.token_id))?;
+            .get(&coins.token_id, state)
+            .map_err(CoreModuleError::state_read)?
+            .ok_or_else(|| CommonError::TokenNotFound {
+                token_id: coins.token_id,
+            })?;
 
         token.total_supply = token
             .total_supply
             .checked_sub(coins.amount)
             .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Total supply underflow when burning, supply={} is less than burn amount={}",
-                    token.total_supply,
-                    coins.amount
-                )
+                CommonError::Arithmetic(ArithmeticError::Underflow {
+                    base: token.total_supply,
+                    subtrahend: coins.amount,
+                    message: "Total supply underflow when burning".to_owned(),
+                })
             })?;
-        self.tokens.set(&coins.token_id, &token, state)?;
+        self.tokens
+            .set(&coins.token_id, &token, state)
+            .map_err(CoreModuleError::state_write)?;
 
         let owner: TokenHolderRef<'_, S> = owner.as_token_holder();
         self.decrease_balance_checked(&coins.token_id, owner, coins.amount, state)?;
@@ -293,16 +311,8 @@ impl<S: Spec> Bank<S> {
         coins: Coins,
         context: &Context<S>,
         state: &mut impl TxState<S>,
-    ) -> Result<()> {
-        let token_id = coins.token_id;
-        self.burn(coins, context.sender(), state).with_context(|| {
-            format!(
-                "Failed to burn token_id={} owner={}",
-                token_id,
-                context.sender()
-            )
-        })?;
-        Ok(())
+    ) -> Result<(), BurnTokenError> {
+        self.burn(coins, context.sender(), state)
     }
 
     /// Mints the `coins`to the address `mint_to_identity` using the externally owned account ("EOA") supplied by
@@ -316,7 +326,7 @@ impl<S: Spec> Bank<S> {
         mint_to_identity: impl Payable<S>,
         context: &Context<S>,
         state: &mut impl TxState<S>,
-    ) -> Result<()> {
+    ) -> Result<(), MintTokenError> {
         self.mint(
             coins,
             mint_to_identity,
@@ -335,32 +345,42 @@ impl<S: Spec> Bank<S> {
         mint_to_identity: impl Payable<S>,
         authorizer: impl Payable<S>,
         state: &mut impl TxState<S>,
-    ) -> Result<()> {
+    ) -> Result<(), MintTokenError> {
         tracing::trace!(%authorizer, "Mint token request");
 
         let mint_to_identity = mint_to_identity.as_token_holder();
         let mut token = self
             .tokens
-            .get_or_err(&coins.token_id, state)?
-            .with_context(|| format!("Failed to get token_id={}", &coins.token_id))?;
+            .get(&coins.token_id, state)
+            .map_err(CoreModuleError::state_read)?
+            .ok_or_else(|| CommonError::TokenNotFound {
+                token_id: coins.token_id,
+            })?;
 
         let authorizer = authorizer.as_token_holder();
-        token
-            .update_for_mint_if_allowed(authorizer, coins.amount)
-            .with_context(|| format!("Failed to mint token_id={}", &coins.token_id))?;
-        self.tokens.set(&coins.token_id, &token, state)?;
+        token.update_for_mint_if_allowed(authorizer, coins.amount)?;
+        self.tokens
+            .set(&coins.token_id, &token, state)
+            .map_err(CoreModuleError::state_write)?;
 
-        let to_balance: Amount = self
+        let current_to_balance = self
             .balances
-            .get(&(mint_to_identity, &coins.token_id), state)?
-            .unwrap_or_default()
+            .get(&(mint_to_identity, &coins.token_id), state)
+            .map_err(CoreModuleError::state_read)?
+            .unwrap_or_default();
+        let to_balance: Amount = current_to_balance
             .checked_add(coins.amount)
-            .ok_or(anyhow::Error::msg(
-                "Account balance overflow in the mint method of bank module",
-            ))?;
+            .ok_or_else(|| {
+                CommonError::Arithmetic(ArithmeticError::Overflow {
+                    base: current_to_balance,
+                    addend: coins.amount,
+                    message: format!("Mint account balance overflow {mint_to_identity}"),
+                })
+            })?;
 
         self.balances
-            .set(&(mint_to_identity, &coins.token_id), &to_balance, state)?;
+            .set(&(mint_to_identity, &coins.token_id), &to_balance, state)
+            .map_err(CoreModuleError::state_write)?;
 
         tracing::trace!(
             %authorizer,
@@ -407,7 +427,7 @@ impl<S: Spec> Bank<S> {
         token_id: TokenId,
         context: &Context<S>,
         state: &mut impl TxState<S>,
-    ) -> Result<()> {
+    ) -> Result<(), FreezeTokenError> {
         let sender_ref = context.sender();
         let sender = sender_ref.as_token_holder();
 
@@ -415,14 +435,15 @@ impl<S: Spec> Bank<S> {
 
         let mut token = self
             .tokens
-            .get_or_err(&token_id, state)?
-            .with_context(|| format!("Failed to get token_id={}", &token_id))?;
+            .get(&token_id, state)
+            .map_err(CoreModuleError::state_read)?
+            .ok_or_else(|| CommonError::TokenNotFound { token_id })?;
 
-        token
-            .freeze(sender)
-            .with_context(|| format!("Failed to freeze token_id={}", &token_id))?;
+        token.freeze(sender)?;
 
-        self.tokens.set(&token_id, &token, state)?;
+        self.tokens
+            .set(&token_id, &token, state)
+            .map_err(CoreModuleError::state_write)?;
 
         tracing::trace!(
             freezer = %sender,
@@ -449,14 +470,17 @@ impl<S: Spec> Bank<S> {
         token_id: TokenId,
         context: &Context<S>,
         state: &mut impl TxState<S>,
-    ) -> Result<()> {
+    ) -> Result<(), UpdateAdminError> {
         let mut token = self
             .tokens
-            .get_or_err(&token_id, state)?
-            .with_context(|| format!("Failed to get token_id={}", &token_id))?;
+            .get(&token_id, state)
+            .map_err(CoreModuleError::state_read)?
+            .ok_or_else(|| CommonError::TokenNotFound { token_id })?;
 
         token.update_admin(new_address, context.sender())?;
-        self.tokens.set(&token_id, &token, state)?;
+        self.tokens
+            .set(&token_id, &token, state)
+            .map_err(CoreModuleError::state_write)?;
         Ok(())
     }
 }
@@ -471,14 +495,11 @@ impl<S: Spec> Bank<S> {
         to: impl Payable<S>,
         coins: Coins,
         state: &mut impl StateAccessor,
-    ) -> Result<()> {
+    ) -> Result<(), TransferTokenError> {
         let from = from.as_token_holder();
         let to = to.as_token_holder();
 
         self.do_transfer(from, to, &coins.token_id, coins.amount, state)
-            .with_context(|| format!("Failed to transfer token_id={}", &coins.token_id))?;
-
-        Ok(())
     }
 
     /// Transfers the set of `coins` from the address `from` to the address `to` with an optional memo.
@@ -521,15 +542,22 @@ impl<S: Spec> Bank<S> {
         token_id: &TokenId,
         amount: Amount,
         state: &mut impl StateAccessor,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), TransferTokenError> {
         if from == to {
             let balance = self
                 .balances
-                .get(&(from, token_id), state)?
+                .get(&(from, token_id), state)
+                .map_err(CoreModuleError::state_read)?
                 .unwrap_or(Amount::ZERO);
 
             if amount > balance {
-                anyhow::bail!("Token transfer to self failed. Self: {from}, transfer amount: {amount}, balance: {balance}.")
+                return Err(TransferTokenError::InsufficientBalance {
+                    amount,
+                    balance,
+                    from: from.to_string(),
+                    to: to.to_string(),
+                    token_id: token_id.to_string(),
+                });
             }
 
             tracing::trace!("Token transfer succeeded because it was transferring tokens to self.");
@@ -545,18 +573,27 @@ impl<S: Spec> Bank<S> {
 
         let current_to_balance = self
             .balances
-            .get(&(to, token_id), state)?
+            .get(&(to, token_id), state)
+            .map_err(CoreModuleError::state_read)?
             .unwrap_or(Amount::ZERO);
-        let to_balance = current_to_balance.checked_add(amount).with_context(|| {
-            format!(
-                "Account balance overflow for {to} when adding {amount} to current balance {current_to_balance}"
-            )
+
+        let to_balance = current_to_balance.checked_add(amount).ok_or_else(|| {
+            CommonError::Arithmetic(ArithmeticError::Overflow {
+                base: current_to_balance,
+                addend: amount,
+                message: format!("Balance overflow for account {to}"),
+            })
         })?;
 
-        self.balances.set(&(from, token_id), &from_balance, state)?;
-        self.balances.set(&(to, token_id), &to_balance, state)?;
+        self.balances
+            .set(&(from, token_id), &from_balance, state)
+            .map_err(CoreModuleError::state_write)?;
+        self.balances
+            .set(&(to, token_id), &to_balance, state)
+            .map_err(CoreModuleError::state_write)?;
         Ok(())
     }
+
     // Check that amount can be deducted from address
     // Returns new balance after subtraction.
     fn decrease_balance_checked(
@@ -565,19 +602,24 @@ impl<S: Spec> Bank<S> {
         from: TokenHolderRef<'_, S>,
         amount: Amount,
         state: &mut impl StateAccessor,
-    ) -> anyhow::Result<Amount> {
+    ) -> Result<Amount, CommonError> {
         let balance = self
             .balances
-            .get(&(from, token_id), state)?
+            .get(&(from, token_id), state)
+            .map_err(CoreModuleError::state_read)?
             .unwrap_or(Amount::ZERO);
 
-        let new_balance = match balance.checked_sub(amount) {
-            Some(from_balance) => from_balance,
-            None => bail!(format!(
-                "Insufficient balance from={from}, got={balance}, needed={amount}",
-            )),
-        };
-        self.balances.set(&(from, token_id), &new_balance, state)?;
+        let new_balance = balance.checked_sub(amount).ok_or_else(|| {
+            CommonError::Arithmetic(ArithmeticError::Underflow {
+                base: balance,
+                subtrahend: amount,
+                message: format!("Insufficient balance for account {from}"),
+            })
+        })?;
+
+        self.balances
+            .set(&(from, token_id), &new_balance, state)
+            .map_err(CoreModuleError::state_write)?;
         Ok(new_balance)
     }
 

--- a/crates/module-system/module-implementations/sov-bank/src/call.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/call.rs
@@ -1,8 +1,8 @@
 use schemars::JsonSchema;
 use sov_modules_api::macros::{serialize, UniversalWallet};
 use sov_modules_api::{
-    Context, EventEmitter, ModuleInfo, RuntimeDiscriminant, SafeString, SafeVec, Spec,
-    StateAccessor, StateReader, TxState, CoreModuleError
+    Context, CoreModuleError, EventEmitter, ModuleInfo, RuntimeDiscriminant, SafeString, SafeVec,
+    Spec, StateAccessor, StateReader, TxState,
 };
 use sov_rollup_interface::common::SizedSafeString;
 use sov_state::{EventContainer, User};

--- a/crates/module-system/module-implementations/sov-bank/src/call.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/call.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use sov_modules_api::macros::{serialize, UniversalWallet};
 use sov_modules_api::{
     Context, EventEmitter, ModuleInfo, RuntimeDiscriminant, SafeString, SafeVec, Spec,
-    StateAccessor, StateReader, TxState,
+    StateAccessor, StateReader, TxState, CoreModuleError
 };
 use sov_rollup_interface::common::SizedSafeString;
 use sov_state::{EventContainer, User};
@@ -512,12 +512,11 @@ impl<S: Spec> Bank<S> {
         coins: Coins,
         memo: Option<String>,
         state: &mut (impl StateAccessor + EventContainer),
-    ) -> Result<()> {
+    ) -> Result<(), TransferTokenError> {
         let from = from.as_token_holder();
         let to = to.as_token_holder();
 
-        self.do_transfer(from, to, &coins.token_id, coins.amount, state)
-            .with_context(|| format!("Failed to transfer token_id={}", &coins.token_id))?;
+        self.do_transfer(from, to, &coins.token_id, coins.amount, state)?;
 
         self.emit_event(
             state,

--- a/crates/module-system/module-implementations/sov-bank/src/error.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/error.rs
@@ -1,0 +1,375 @@
+use crate::token::TokenId;
+use sov_modules_api::{Amount, CoreModuleError, ErrorDetail};
+
+/// Errors that occur during arithmetic operations on token amounts.
+///
+/// These errors are returned when mathematical operations (addition, subtraction)
+/// on token balances or supplies would result in overflow or underflow conditions.
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[serde(tag = "error_code", rename_all = "snake_case")]
+pub enum ArithmeticError {
+    /// An arithmetic overflow occurred during addition.
+    #[error("Overflow occurred: {message}, {base} + {addend}")]
+    Overflow {
+        /// The base amount before the addition operation.
+        base: Amount,
+        /// The amount being added to the base.
+        addend: Amount,
+        /// A descriptive message about the overflow context.
+        message: String,
+    },
+    /// An arithmetic underflow occurred during subtraction.
+    #[error("Underflow occurred: {message}, {base} - {subtrahend}")]
+    Underflow {
+        /// The base amount before the subtraction operation.
+        base: Amount,
+        /// The amount being subtracted from the base.
+        subtrahend: Amount,
+        /// A descriptive message about the underflow context.
+        message: String,
+    },
+}
+
+/// Common errors that can occur across different bank operations.
+///
+/// These errors represent shared failure conditions that can happen during
+/// various token operations like transfers, mints, burns, and administrative actions.
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[serde(tag = "error_code", rename_all = "snake_case")]
+pub enum CommonError {
+    /// An error occurred in a core module operation.
+    #[error(transparent)]
+    CoreModuleError(#[from] CoreModuleError),
+    /// An arithmetic error occurred during a mathematical operation.
+    #[error(transparent)]
+    Arithmetic(#[from] ArithmeticError),
+    /// The caller is not authorized to perform the requested operation on this token.
+    #[error("Caller {caller} is not an admin for token {token_name}")]
+    NotAdmin {
+        /// The address of the caller who attempted the operation.
+        caller: String,
+        /// The name of the token they tried to access.
+        token_name: String,
+    },
+    /// The requested token does not exist.
+    #[error("Token not found: {token_id}")]
+    TokenNotFound {
+        /// The ID of the token that was not found.
+        token_id: TokenId,
+    },
+    /// The token is frozen and cannot be operated on.
+    #[error("Token is frozen: {name}")]
+    TokenFrozen {
+        /// The name of the frozen token.
+        name: String,
+    },
+}
+
+/// Errors that can occur during token creation.
+///
+/// These errors are returned when attempting to create a new token fails due to
+/// validation issues, conflicting tokens, or other constraints.
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[serde(tag = "error_code", rename_all = "snake_case")]
+pub enum CreateTokenError {
+    /// A common error occurred during token creation.
+    #[error(transparent)]
+    Common(#[from] CommonError),
+    /// The specified number of decimal places exceeds the maximum allowed.
+    #[error("Too many decimals: {provided}, max allowed is {max_allowed}")]
+    TooManyDecimals {
+        /// The number of decimals provided in the request.
+        provided: u8,
+        /// The maximum number of decimals allowed.
+        max_allowed: u8,
+    },
+    /// The initial balance exceeds the token's supply cap.
+    #[error(
+        "Requested initial balance {initial_balance} is greater than the supply cap {supply_cap}"
+    )]
+    InitialBalanceExceedsSupplyCap {
+        /// The requested initial balance for the token.
+        initial_balance: Amount,
+        /// The maximum supply cap for the token.
+        supply_cap: Amount,
+    },
+    /// A token with the same ID already exists.
+    #[error("Token with id already exists {token_id}, name={name} minter={minter}")]
+    TokenAlreadyExists {
+        /// The ID of the existing token.
+        token_id: String,
+        /// The name of the existing token.
+        name: String,
+        /// The address of the token minter.
+        minter: String,
+    },
+}
+
+/// Errors that can occur during token transfers.
+///
+/// These errors are returned when attempting to transfer tokens fails due to
+/// insufficient balances, invalid tokens, or other transfer constraints.
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[serde(tag = "error_code", rename_all = "snake_case")]
+pub enum TransferTokenError {
+    /// A common error occurred during token transfer.
+    #[error(transparent)]
+    Common(#[from] CommonError),
+    /// The sender has insufficient balance to complete the transfer.
+    #[error("Insufficient balance: amount={amount}, balance={balance}, from={from}, to={to}, token_id={token_id}")]
+    InsufficientBalance {
+        /// The amount requested to transfer.
+        amount: Amount,
+        /// The actual balance available.
+        balance: Amount,
+        /// The sender's address.
+        from: String,
+        /// The recipient's address.
+        to: String,
+        /// The ID of the token being transferred.
+        token_id: String,
+    },
+}
+
+/// Errors that can occur during token freezing operations.
+///
+/// These errors are returned when attempting to freeze a token fails due to
+/// authorization issues or other constraints.
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[serde(tag = "error_code", rename_all = "snake_case")]
+pub enum FreezeTokenError {
+    /// A common error occurred during token freezing.
+    #[error(transparent)]
+    Common(#[from] CommonError),
+}
+
+/// Errors that can occur during token burning operations.
+///
+/// These errors are returned when attempting to burn (permanently destroy) tokens
+/// fails due to insufficient balance, invalid tokens, or other constraints.
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[serde(tag = "error_code", rename_all = "snake_case")]
+pub enum BurnTokenError {
+    /// A common error occurred during token burning.
+    #[error(transparent)]
+    Common(#[from] CommonError),
+}
+
+/// Errors that can occur during token minting operations.
+///
+/// These errors are returned when attempting to mint new tokens fails due to
+/// authorization issues, supply cap violations, or other constraints.
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[serde(tag = "error_code", rename_all = "snake_case")]
+pub enum MintTokenError {
+    /// A common error occurred during token minting.
+    #[error(transparent)]
+    Common(#[from] CommonError),
+    /// The minting operation would exceed the token's supply cap.
+    #[error("Minting this amount would exceed the supply cap: supply_cap={supply_cap}, new_supply={new_supply}")]
+    SupplyCapExceeded {
+        /// The maximum allowed supply for the token.
+        supply_cap: Amount,
+        /// The total supply that would result from the mint operation.
+        new_supply: Amount,
+        /// The name of the token.
+        token_name: String,
+    },
+}
+
+/// Errors that can occur during admin update operations.
+///
+/// These errors are returned when attempting to add or remove token administrators
+/// fails due to validation issues or existing state conflicts.
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[serde(tag = "error_code", rename_all = "snake_case")]
+pub enum UpdateAdminError {
+    /// A common error occurred during admin update.
+    #[error(transparent)]
+    Common(#[from] CommonError),
+    /// The admin to be replaced does not exist for this token.
+    #[error("Admin to replace {admin_to_replace} does not exist for token {token_name}")]
+    AdminDoesNotExist {
+        /// The address of the admin that was expected to exist.
+        admin_to_replace: String,
+        /// The name of the token.
+        token_name: String,
+    },
+    /// The admin to be added already exists for this token.
+    #[error("Admin {new_admin} already exists for token {token_name}")]
+    AdminAlreadyExists {
+        /// The address of the admin that already exists.
+        new_admin: String,
+        /// The name of the token.
+        token_name: String,
+    },
+}
+
+/// The top-level error type for all bank module operations.
+///
+/// This enum wraps all specific error types that can occur during different
+/// bank operations, providing a unified error interface for the module.
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[serde(tag = "call", rename_all = "snake_case")]
+pub enum Error {
+    /// An error occurred during token creation.
+    #[error("Token creation error: {0}")]
+    CreateToken(#[from] CreateTokenError),
+    /// An error occurred during token transfer.
+    #[error("Token transfer error: {0}")]
+    TransferToken(#[from] TransferTokenError),
+    /// An error occurred during token freezing.
+    #[error("Token freeze error: {0}")]
+    FreezeToken(#[from] FreezeTokenError),
+    /// An error occurred during token burning.
+    #[error("Token burn error: {0}")]
+    BurnToken(#[from] BurnTokenError),
+    /// An error occurred during token minting.
+    #[error("Token mint error: {0}")]
+    MintToken(#[from] MintTokenError),
+    /// An error occurred during admin update.
+    #[error("Token update admin error: {0}")]
+    UpdateAdmin(#[from] UpdateAdminError),
+}
+
+impl ErrorDetail for Error {
+    fn error_detail(&self) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(serde_json::to_value(self).expect("Bank error serialization should not fail"))
+    }
+}
+
+macro_rules! impl_from_core_errors {
+    ($error_type:ty) => {
+        impl From<::sov_modules_api::CoreModuleError> for $error_type {
+            fn from(err: ::sov_modules_api::CoreModuleError) -> Self {
+                CommonError::from(err).into()
+            }
+        }
+
+        impl From<anyhow::Error> for $error_type {
+            fn from(err: anyhow::Error) -> Self {
+                CommonError::from(::sov_modules_api::CoreModuleError::Generic(err)).into()
+            }
+        }
+    };
+}
+
+impl_from_core_errors!(CreateTokenError);
+impl_from_core_errors!(TransferTokenError);
+impl_from_core_errors!(FreezeTokenError);
+impl_from_core_errors!(BurnTokenError);
+impl_from_core_errors!(MintTokenError);
+impl_from_core_errors!(UpdateAdminError);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_arithmetic_error_details() {
+        let err = Error::CreateToken(CreateTokenError::Common(CommonError::Arithmetic(
+            ArithmeticError::Overflow {
+                base: Amount(100),
+                addend: Amount(50),
+                message: "Addition overflow".to_string(),
+            },
+        )));
+        let detail = err.error_detail().unwrap();
+        let expected = serde_json::json!({
+            "call": "create_token",
+            "error_code": "overflow",
+            "base": "100",
+            "addend": "50",
+            "message": "Addition overflow"
+        });
+        assert_eq!(detail, expected);
+    }
+
+    #[test]
+    fn test_create_token_too_many_decimals() {
+        let err = Error::CreateToken(CreateTokenError::TooManyDecimals {
+            provided: 20,
+            max_allowed: 18,
+        });
+        let detail = err.error_detail().unwrap();
+        let expected = serde_json::json!({
+            "call": "create_token",
+            "error_code": "too_many_decimals",
+            "provided": 20,
+            "max_allowed": 18
+        });
+        assert_eq!(detail, expected);
+    }
+
+    #[test]
+    fn test_transfer_insufficient_balance() {
+        let err = Error::TransferToken(TransferTokenError::InsufficientBalance {
+            amount: Amount(100),
+            balance: Amount(50),
+            from: "addr1".to_string(),
+            to: "addr2".to_string(),
+            token_id: "token123".to_string(),
+        });
+        let detail = err.error_detail().unwrap();
+        let expected = serde_json::json!({
+            "call": "transfer_token",
+            "error_code": "insufficient_balance",
+            "amount": "100",
+            "balance": "50",
+            "from": "addr1",
+            "to": "addr2",
+            "token_id": "token123"
+        });
+        assert_eq!(detail, expected);
+    }
+
+    #[test]
+    fn test_mint_supply_cap_exceeded() {
+        let err = Error::MintToken(MintTokenError::SupplyCapExceeded {
+            supply_cap: Amount(1000),
+            new_supply: Amount(1500),
+            token_name: "TestToken".to_string(),
+        });
+        let detail = err.error_detail().unwrap();
+        let expected = serde_json::json!({
+            "call": "mint_token",
+            "error_code": "supply_cap_exceeded",
+            "supply_cap": "1000",
+            "new_supply": "1500",
+            "token_name": "TestToken"
+        });
+        assert_eq!(detail, expected);
+    }
+
+    #[test]
+    fn test_update_admin_does_not_exist() {
+        let err = Error::UpdateAdmin(UpdateAdminError::AdminDoesNotExist {
+            admin_to_replace: "old_admin".to_string(),
+            token_name: "TestToken".to_string(),
+        });
+        let detail = err.error_detail().unwrap();
+        let expected = serde_json::json!({
+            "call": "update_admin",
+            "error_code": "admin_does_not_exist",
+            "admin_to_replace": "old_admin",
+            "token_name": "TestToken"
+        });
+        assert_eq!(detail, expected);
+    }
+
+    #[test]
+    fn test_common_error_not_admin() {
+        let err = Error::CreateToken(CreateTokenError::Common(CommonError::NotAdmin {
+            caller: "unauthorized_user".to_string(),
+            token_name: "TestToken".to_string(),
+        }));
+        let detail = err.error_detail().unwrap();
+        let expected = serde_json::json!({
+            "call": "create_token",
+            "error_code": "not_admin",
+            "caller": "unauthorized_user",
+            "token_name": "TestToken"
+        });
+        assert_eq!(detail, expected);
+    }
+}

--- a/crates/module-system/module-implementations/sov-bank/src/error.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/error.rs
@@ -1,5 +1,5 @@
 use crate::token::TokenId;
-use sov_modules_api::{rest::utils::json_obj, Amount, CoreModuleError, ErrorContext, ErrorDetail};
+use sov_modules_api::{err_detail, Amount, CoreModuleError, ErrorContext, ErrorDetail};
 
 /// Errors that occur during arithmetic operations on token amounts.
 ///
@@ -234,7 +234,7 @@ pub enum Error {
 
 impl ErrorDetail for Error {
     fn error_detail(&self) -> Result<ErrorContext, Box<dyn std::error::Error + Send + Sync>> {
-        Ok(json_obj!(self))
+        Ok(err_detail!(self))
     }
 }
 
@@ -275,7 +275,7 @@ mod tests {
             },
         )));
         let detail = err.error_detail().unwrap();
-        let expected = json_obj!({
+        let expected = err_detail!({
             "call": "create_token",
             "error_code": "overflow",
             "base": "100",
@@ -292,7 +292,7 @@ mod tests {
             max_allowed: 18,
         });
         let detail = err.error_detail().unwrap();
-        let expected = json_obj!({
+        let expected = err_detail!({
             "call": "create_token",
             "error_code": "too_many_decimals",
             "provided": 20,
@@ -311,7 +311,7 @@ mod tests {
             token_id: "token123".to_string(),
         });
         let detail = err.error_detail().unwrap();
-        let expected = json_obj!({
+        let expected = err_detail!({
             "call": "transfer_token",
             "error_code": "insufficient_balance",
             "amount": "100",
@@ -331,7 +331,7 @@ mod tests {
             token_name: "TestToken".to_string(),
         });
         let detail = err.error_detail().unwrap();
-        let expected = json_obj!({
+        let expected = err_detail!({
             "call": "mint_token",
             "error_code": "supply_cap_exceeded",
             "supply_cap": "1000",
@@ -348,7 +348,7 @@ mod tests {
             token_name: "TestToken".to_string(),
         });
         let detail = err.error_detail().unwrap();
-        let expected = json_obj!({
+        let expected = err_detail!({
             "call": "update_admin",
             "error_code": "admin_does_not_exist",
             "admin_to_replace": "old_admin",
@@ -364,7 +364,7 @@ mod tests {
             token_name: "TestToken".to_string(),
         }));
         let detail = err.error_detail().unwrap();
-        let expected = json_obj!({
+        let expected = err_detail!({
             "call": "create_token",
             "error_code": "not_admin",
             "caller": "unauthorized_user",

--- a/crates/module-system/module-implementations/sov-bank/src/error.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/error.rs
@@ -1,5 +1,5 @@
 use crate::token::TokenId;
-use sov_modules_api::{Amount, CoreModuleError, ErrorDetail};
+use sov_modules_api::{rest::utils::json_obj, Amount, CoreModuleError, ErrorContext, ErrorDetail};
 
 /// Errors that occur during arithmetic operations on token amounts.
 ///
@@ -233,8 +233,8 @@ pub enum Error {
 }
 
 impl ErrorDetail for Error {
-    fn error_detail(&self) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
-        Ok(serde_json::to_value(self).expect("Bank error serialization should not fail"))
+    fn error_detail(&self) -> Result<ErrorContext, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(json_obj!(self))
     }
 }
 
@@ -275,7 +275,7 @@ mod tests {
             },
         )));
         let detail = err.error_detail().unwrap();
-        let expected = serde_json::json!({
+        let expected = json_obj!({
             "call": "create_token",
             "error_code": "overflow",
             "base": "100",
@@ -292,7 +292,7 @@ mod tests {
             max_allowed: 18,
         });
         let detail = err.error_detail().unwrap();
-        let expected = serde_json::json!({
+        let expected = json_obj!({
             "call": "create_token",
             "error_code": "too_many_decimals",
             "provided": 20,
@@ -311,7 +311,7 @@ mod tests {
             token_id: "token123".to_string(),
         });
         let detail = err.error_detail().unwrap();
-        let expected = serde_json::json!({
+        let expected = json_obj!({
             "call": "transfer_token",
             "error_code": "insufficient_balance",
             "amount": "100",
@@ -331,7 +331,7 @@ mod tests {
             token_name: "TestToken".to_string(),
         });
         let detail = err.error_detail().unwrap();
-        let expected = serde_json::json!({
+        let expected = json_obj!({
             "call": "mint_token",
             "error_code": "supply_cap_exceeded",
             "supply_cap": "1000",
@@ -348,7 +348,7 @@ mod tests {
             token_name: "TestToken".to_string(),
         });
         let detail = err.error_detail().unwrap();
-        let expected = serde_json::json!({
+        let expected = json_obj!({
             "call": "update_admin",
             "error_code": "admin_does_not_exist",
             "admin_to_replace": "old_admin",
@@ -364,7 +364,7 @@ mod tests {
             token_name: "TestToken".to_string(),
         }));
         let detail = err.error_detail().unwrap();
-        let expected = serde_json::json!({
+        let expected = json_obj!({
             "call": "create_token",
             "error_code": "not_admin",
             "caller": "unauthorized_user",

--- a/crates/module-system/module-implementations/sov-bank/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/lib.rs
@@ -75,6 +75,8 @@ impl<S: Spec> Module for Bank<S> {
 
     type Event = Event<S>;
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
@@ -89,7 +91,7 @@ impl<S: Spec> Module for Bank<S> {
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             call::CallMessage::CreateToken {
                 token_name,

--- a/crates/module-system/module-implementations/sov-bank/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/lib.rs
@@ -7,7 +7,17 @@ pub mod derived_holder;
 mod test_utils;
 
 pub use capability::ReserveGasError;
+/// Error types for bank module operations.
+///
+/// This module contains all error types that can occur during bank operations
+/// such as token creation, transfers, minting, burning, and administrative actions.
+pub mod error;
 mod genesis;
+/// The main error type for bank module operations.
+///
+/// This is a re-export of the top-level `Error` enum from the error module,
+/// providing a convenient way to access bank operation errors.
+pub use error::Error;
 #[cfg(feature = "native")]
 mod query;
 #[cfg(feature = "native")]
@@ -75,7 +85,7 @@ impl<S: Spec> Module for Bank<S> {
 
     type Event = Event<S>;
 
-    type Error = anyhow::Error;
+    type Error = error::Error;
 
     fn genesis(
         &mut self,

--- a/crates/module-system/module-implementations/sov-bank/src/token.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/token.rs
@@ -16,6 +16,7 @@ use sov_modules_api::{impl_hash32_type, Spec};
 use sov_state::{BorshCodec, EncodeLike, StateItemEncoder};
 use thiserror::Error;
 
+use crate::error::{CommonError, FreezeTokenError, MintTokenError, UpdateAdminError};
 use crate::utils::{Payable, TokenHolder, TokenHolderRef};
 use crate::Amount;
 
@@ -228,10 +229,12 @@ impl<S: Spec> Token<S> {
 
     /// admins: Vec<Address> is used to determine if the token is frozen or not
     /// If the vector is empty when the function is called, this means the token is already frozen
-    pub(crate) fn freeze(&mut self, sender: TokenHolderRef<'_, S>) -> anyhow::Result<()> {
+    pub(crate) fn freeze(&mut self, sender: TokenHolderRef<'_, S>) -> Result<(), FreezeTokenError> {
         let sender = sender.as_token_holder();
         if self.admins.is_empty() {
-            bail!("Token {} is already frozen", self.name)
+            return Err(CommonError::TokenFrozen {
+                name: self.name.to_string(),
+            })?;
         }
         self.assert_is_admin(sender)?;
         self.admins = vec![];
@@ -242,13 +245,13 @@ impl<S: Spec> Token<S> {
         &mut self,
         new_admin: Option<S::Address>,
         admin_to_replace: &S::Address,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), UpdateAdminError> {
         // Check if the `admin_to_replace` is in the admin list.
         let Some(current_admin_pos) = self.find_admin_index(admin_to_replace) else {
-            bail!(
-                "Cannot update admin: `{admin_to_replace}` is not in the admin list for the specified token {}",
-                self.name
-            );
+            return Err(UpdateAdminError::AdminDoesNotExist {
+                admin_to_replace: admin_to_replace.to_string(),
+                token_name: self.name.to_string(),
+            });
         };
 
         if let Some(new_admin) = new_admin {
@@ -257,7 +260,10 @@ impl<S: Spec> Token<S> {
 
             // 1. If `new_admin` is already in the list, do nothing to avoid duplicates.
             if self.find_admin_index(&new_admin).is_some() {
-                bail!("`{new_admin}` is already a member of the admin list.");
+                return Err(UpdateAdminError::AdminAlreadyExists {
+                    new_admin: new_admin.to_string(),
+                    token_name: self.name.to_string(),
+                });
             };
 
             // 2. Replace the `admin_to_replace` with the `new_admin``.
@@ -282,21 +288,29 @@ impl<S: Spec> Token<S> {
         &mut self,
         authorizer: TokenHolderRef<'_, S>,
         amount: Amount,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), MintTokenError> {
         if self.admins.is_empty() {
-            bail!("Attempt to mint frozen token {}", self.name)
+            return Err(CommonError::TokenFrozen {
+                name: self.name.to_string(),
+            })?;
         }
 
         self.assert_is_admin(authorizer)?;
 
-        let new_supply = self
-            .total_supply
-            .checked_add(amount)
-            .ok_or(anyhow::Error::msg(
-                "Total Supply overflow in the mint method of bank module",
-            ))?;
+        let new_supply = self.total_supply.checked_add(amount).ok_or_else(|| {
+            CommonError::Arithmetic(crate::error::ArithmeticError::Overflow {
+                base: self.total_supply,
+                addend: amount,
+                message: "Total supply overflow when minting tokens".to_string(),
+            })
+        })?;
+
         if new_supply > self.supply_cap {
-            anyhow::bail!("Attempted to mint more than the supply cap of token. Max supply: {}. Current supply: {}. Minted amount: {}", self.supply_cap, self.total_supply, amount)
+            return Err(MintTokenError::SupplyCapExceeded {
+                new_supply,
+                supply_cap: self.supply_cap,
+                token_name: self.name.to_string(),
+            });
         }
 
         self.total_supply = new_supply;
@@ -304,14 +318,17 @@ impl<S: Spec> Token<S> {
         Ok(())
     }
 
-    fn assert_is_admin(&self, sender: TokenHolderRef<'_, S>) -> anyhow::Result<()> {
+    fn assert_is_admin(&self, sender: TokenHolderRef<'_, S>) -> Result<(), CommonError> {
         for minter in self.admins.iter() {
             if sender == minter.as_token_holder() {
                 return Ok(());
             }
         }
 
-        bail!("Sender {} is not an admin of token {}", sender, self.name)
+        Err(CommonError::NotAdmin {
+            caller: sender.to_string(),
+            token_name: self.name.clone(),
+        })
     }
 }
 

--- a/crates/module-system/module-implementations/sov-bank/tests/integration/burn_test.rs
+++ b/crates/module-system/module-implementations/sov-bank/tests/integration/burn_test.rs
@@ -1,509 +1,409 @@
-// use sov_bank::event::Event;
-// use sov_bank::utils::TokenHolder;
-// use sov_bank::{config_gas_token_id, Bank, Coins};
-// use sov_modules_api::prelude::UnwrapInfallible;
-// use sov_modules_api::{Amount, Error, TxEffect};
-// use sov_test_utils::runtime::genesis::TestTokenName;
-// use sov_test_utils::{AsUser, TransactionTestCase};
-//
-// use crate::helpers::{setup, TestBankRuntimeEvent, TestData, RT};
-//
-// type S = sov_test_utils::TestSpec;
-//
-// /// We can burn tokens that are deployed on the bank.
-// #[test]
-// fn burn_deployed_tokens_happy_path() {
-//     let (
-//         TestData {
-//             token_name,
-//             token_id,
-//             user_high_token_balance,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     let user_token_balance = user_high_token_balance.token_balance(&token_name).unwrap();
-//
-//     let user_address = user_high_token_balance.address();
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-//             sov_bank::CallMessage::Burn {
-//                 coins: Coins {
-//                     amount: user_token_balance,
-//                     token_id,
-//                 },
-//             },
-//         ),
-//         assert: Box::new(move |result, state| {
-//             assert!(result.tx_receipt.is_successful());
-//             assert_eq!(result.events.len(), 1);
-//             assert_eq!(
-//                 TestBankRuntimeEvent::Bank(Event::TokenBurned {
-//                     owner: TokenHolder::User(user_address),
-//                     coins: Coins {
-//                         amount: user_token_balance,
-//                         token_id
-//                     }
-//                 }),
-//                 result.events[0]
-//             );
-//
-//             // Check that the user's balance is now zero
-//             assert_eq!(
-//                 Bank::<S>::default()
-//                     .get_balance_of(&user_address, token_id, state)
-//                     .unwrap_infallible(),
-//                 Some(Amount::ZERO),
-//                 "The user's balance should be zero"
-//             );
-//         }),
-//     });
-// }
-//
-// #[test]
-// fn burn_deployed_tokens_no_balance_fails() {
-//     let (
-//         TestData {
-//             token_id,
-//             user_no_token_balance,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     let user_address = user_no_token_balance.address();
-//     const BURN_AMOUNT: u128 = 1;
-//
-//     let initial_total_supply = runner.query_visible_state(|state| {
-//         Bank::<S>::default()
-//             .get_total_supply_of(&token_id, state)
-//             .unwrap_infallible()
-//             .unwrap()
-//     });
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: user_no_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-//             sov_bank::CallMessage::Burn {
-//                 coins: Coins {
-//                     amount: BURN_AMOUNT.into(),
-//                     token_id,
-//                 },
-//             },
-//         ),
-//         assert: Box::new(move |result, state| {
-//             assert!(
-//                 matches!(result.tx_receipt, TxEffect::Reverted(..)),
-//                 "The transaction should have been reverted"
-//             );
-//
-//             // Burn by another user, who doesn't have tokens at all
-//             match result.tx_receipt {
-//                 TxEffect::Reverted(contents) => {
-//                     let Error::ModuleError(err) = contents.reason;
-//                     let mut chain = err.chain();
-//
-//                     let message_1 = chain.next().unwrap().to_string();
-//                     let message_2 = chain.next().unwrap().to_string();
-//
-//                     assert!(chain.next().is_none());
-//                     assert_eq!(
-//                         message_1,
-//                         format!("Failed to burn token_id={token_id} owner={user_address}")
-//                     );
-//
-//                     assert_eq!(
-//                         format!(
-//                             "Insufficient balance from={user_address}, got=0, needed={BURN_AMOUNT}",
-//                         ),
-//                         message_2,
-//                         "The error message is incorrect"
-//                     );
-//                 }
-//                 _ => {
-//                     panic!("The transaction should have been reverted")
-//                 }
-//             }
-//
-//             let final_total_supply = Bank::<S>::default()
-//                 .get_total_supply_of(&token_id, state)
-//                 .unwrap_infallible()
-//                 .unwrap();
-//
-//             assert_eq!(
-//                 initial_total_supply, final_total_supply,
-//                 "The token supply shouldn't have changed"
-//             );
-//         }),
-//     });
-// }
-//
-// #[test]
-// fn burn_more_than_deployed_tokens_fails() {
-//     let (
-//         TestData {
-//             token_id,
-//             user_high_token_balance,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     let total_token_supply = runner.query_visible_state(|state| {
-//         Bank::<S>::default()
-//             .get_total_supply_of(&token_id, state)
-//             .unwrap_infallible()
-//             .unwrap()
-//     });
-//
-//     let to_burn = total_token_supply.checked_add(Amount::new(1)).unwrap();
-//
-//     let user_address = user_high_token_balance.address();
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-//             sov_bank::CallMessage::Burn {
-//                 coins: Coins {
-//                     amount: to_burn,
-//                     token_id,
-//                 },
-//             },
-//         ),
-//         assert: Box::new(move |result, state| match result.tx_receipt {
-//             TxEffect::Reverted(contents) => {
-//                 let Error::ModuleError(err) = contents.reason;
-//                 let mut chain = err.chain();
-//
-//                 let message_1 = chain.next().unwrap().to_string();
-//                 let message_2 = chain.next().unwrap().to_string();
-//
-//                 assert!(chain.next().is_none());
-//                 assert_eq!(
-//                     message_1,
-//                     format!("Failed to burn token_id={token_id} owner={user_address}",)
-//                 );
-//
-//                 assert_eq!(
-//                     format!(
-//                         "Total supply underflow when burning, supply=300000 is less than burn amount={to_burn}",
-//                     ),
-//                     message_2,
-//                     "The error message is incorrect"
-//                 );
-//
-//                 let final_total_supply = Bank::<S>::default()
-//                     .get_total_supply_of(&token_id, state)
-//                     .unwrap_infallible()
-//                     .unwrap();
-//
-//                 assert_eq!(
-//                     total_token_supply, final_total_supply,
-//                     "The token supply shouldn't have changed"
-//                 );
-//             }
-//             _ => panic!("The outcome is incorrect"),
-//         }),
-//     });
-// }
-//
-// #[test]
-// fn burn_more_than_available_balance_fails() {
-//     let (
-//         TestData {
-//             token_id,
-//             token_name,
-//             user_high_token_balance,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     let initial_token_supply = runner.query_visible_state(|state| {
-//         Bank::<S>::default()
-//             .get_total_supply_of(&token_id, state)
-//             .unwrap_infallible()
-//             .unwrap()
-//     });
-//
-//     let user_token_balance = user_high_token_balance.token_balance(&token_name).unwrap();
-//
-//     let user_address = user_high_token_balance.address();
-//
-//     let to_burn = user_token_balance.checked_add(Amount::new(1)).unwrap();
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-//             sov_bank::CallMessage::Burn {
-//                 coins: Coins {
-//                     amount: to_burn,
-//                     token_id,
-//                 },
-//             },
-//         ),
-//         assert: Box::new(move |result, state| match result.tx_receipt {
-//             TxEffect::Reverted(contents) => {
-//                 let Error::ModuleError(err) = contents.reason;
-//                 let mut chain = err.chain();
-//
-//                 let message_1 = chain.next().unwrap().to_string();
-//                 let message_2 = chain.next().unwrap().to_string();
-//
-//                 assert!(chain.next().is_none());
-//                 assert_eq!(
-//                     message_1,
-//                     format!(
-//                         "Failed to burn token_id={token_id} owner={user_address}"
-//                     )
-//                 );
-//
-//                 assert_eq!(
-//                     format!(
-//                         "Insufficient balance from={user_address}, got={user_token_balance}, needed={to_burn}",
-//                     ),
-//                     message_2,
-//                     "The error message is incorrect"
-//                 );
-//
-//                 let final_total_supply = Bank::<S>::default()
-//                     .get_total_supply_of(&token_id, state)
-//                     .unwrap_infallible()
-//                     .unwrap();
-//
-//                 assert_eq!(
-//                     initial_token_supply, final_total_supply,
-//                     "The token supply shouldn't have changed"
-//                 );
-//             }
-//             _ => {
-//                 panic!("The transaction does not have the expected outcome.")
-//             }
-//         }),
-//     });
-// }
-//
-// #[test]
-// fn test_burning_zero_tokens_works() {
-//     let (
-//         TestData {
-//             token_name,
-//             token_id,
-//             user_high_token_balance,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     let user_token_balance = user_high_token_balance.token_balance(&token_name).unwrap();
-//
-//     let user_address = user_high_token_balance.address();
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-//             sov_bank::CallMessage::Burn {
-//                 coins: Coins {
-//                     amount: Amount::ZERO,
-//                     token_id,
-//                 },
-//             },
-//         ),
-//         assert: Box::new(move |result, state| {
-//             assert!(result.tx_receipt.is_successful());
-//             assert_eq!(result.events.len(), 1);
-//             assert_eq!(
-//                 TestBankRuntimeEvent::Bank(Event::TokenBurned {
-//                     owner: TokenHolder::User(user_address),
-//                     coins: Coins {
-//                         amount: Amount::ZERO,
-//                         token_id
-//                     }
-//                 }),
-//                 result.events[0]
-//             );
-//
-//             // Check that the user's balance hasn't changed
-//             assert_eq!(
-//                 Bank::<S>::default()
-//                     .get_balance_of(&user_address, token_id, state)
-//                     .unwrap_infallible(),
-//                 Some(user_token_balance),
-//                 "The user's balance shouldn't have changed"
-//             );
-//         }),
-//     });
-// }
-//
-// #[test]
-// fn test_burning_zero_tokens_for_user_with_no_balance() {
-//     let (
-//         TestData {
-//             token_id,
-//             user_no_token_balance,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     let user_address = user_no_token_balance.address();
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: user_no_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-//             sov_bank::CallMessage::Burn {
-//                 coins: Coins {
-//                     amount: Amount::ZERO,
-//                     token_id,
-//                 },
-//             },
-//         ),
-//         assert: Box::new(move |result, state| {
-//             assert!(result.tx_receipt.is_successful());
-//             assert_eq!(result.events.len(), 1);
-//             assert_eq!(
-//                 TestBankRuntimeEvent::Bank(Event::TokenBurned {
-//                     owner: TokenHolder::User(user_address),
-//                     coins: Coins {
-//                         amount: Amount::ZERO,
-//                         token_id
-//                     }
-//                 }),
-//                 result.events[0]
-//             );
-//
-//             // Check that the user's balance hasn't changed
-//             assert_eq!(
-//                 Bank::<S>::default()
-//                     .get_balance_of(&user_address, token_id, state)
-//                     .unwrap_infallible(),
-//                 Some(Amount::ZERO),
-//                 "The user's balance shouldn't have changed"
-//             );
-//         }),
-//     });
-// }
-//
-// #[test]
-// fn burn_unknown_token_fails() {
-//     let (
-//         TestData {
-//             user_high_token_balance,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     const AMOUNT_TO_BURN: u128 = 0;
-//
-//     let other_token_id = TestTokenName::new("OtherToken".to_string()).id();
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-//             sov_bank::CallMessage::Burn {
-//                 coins: Coins {
-//                     amount: AMOUNT_TO_BURN.into(),
-//                     token_id: other_token_id,
-//                 },
-//             },
-//         ),
-//         assert: Box::new(move |result, _| {
-//             assert!(
-//                 matches!(result.tx_receipt, TxEffect::Reverted(..)),
-//                 "The transaction should have been reverted"
-//             );
-//
-//             match result.tx_receipt {
-//                 TxEffect::Reverted(contents) => {
-//                     let Error::ModuleError(err) = contents.reason;
-//                     let mut chain = err.chain();
-//
-//                     let message_1 = chain.next().unwrap().to_string();
-//                     let message_2 = chain.next().unwrap().to_string();
-//                     let message_3 = chain.next().unwrap().to_string();
-//
-//                     assert!(chain.next().is_none());
-//
-//                     assert_eq!(
-//                         format!(
-//                             "Failed to burn token_id={other_token_id} owner={}",
-//                             user_high_token_balance.address()
-//                         ),
-//                         message_1,
-//                         "The first message is incorrect"
-//                     );
-//
-//                     assert_eq!(
-//                         format!("Failed to get token_id={other_token_id}"),
-//                         message_2,
-//                         "The second message is incorrect"
-//                     );
-//
-//                     // Note, no token ID in the root cause the message.
-//                     let expected_error_part =
-//                         "Value not found for prefix:";
-//                     assert!(message_3.starts_with(expected_error_part), "The third message is incorrect. Expected a message: {expected_error_part}, Got: {message_3}");
-//                 }
-//                 _ => {
-//                     panic!("The transaction does not have the expected outcome.")
-//                 }
-//             }
-//         }),
-//     });
-// }
-//
-// /// Simple test to check that burning the gas token works.
-// #[test]
-// fn burn_gas_token_also_works() {
-//     let (
-//         TestData {
-//             user_high_token_balance,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     let user_gas_balance = user_high_token_balance.available_gas_balance;
-//     let user_address = user_high_token_balance.address();
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-//             sov_bank::CallMessage::Burn {
-//                 coins: Coins {
-//                     // Note: we are only burning half of the gas balance because some of it is
-//                     // already consumed (for pre-execution checks) by the time we are reaching the burn method of the `Bank` module.
-//                     amount: in_half(user_gas_balance),
-//                     token_id: config_gas_token_id(),
-//                 },
-//             },
-//         ),
-//         assert: Box::new(move |result, state| {
-//             assert!(result.tx_receipt.is_successful());
-//             assert_eq!(result.events.len(), 1);
-//             assert_eq!(
-//                 TestBankRuntimeEvent::Bank(Event::TokenBurned {
-//                     owner: TokenHolder::User(user_address),
-//                     coins: Coins {
-//                         amount: in_half(user_gas_balance),
-//                         token_id: config_gas_token_id()
-//                     }
-//                 }),
-//                 result.events[0]
-//             );
-//
-//             // Check that the user's gas balance is now equal to the burnt amount minus the gas used to send the transaction
-//             assert_eq!(
-//                 Bank::<S>::default()
-//                     .get_balance_of(&user_address, config_gas_token_id(), state)
-//                     .unwrap_infallible(),
-//                 Some(
-//                     in_half(user_gas_balance)
-//                         .checked_sub(result.gas_value_used)
-//                         .unwrap()
-//                 ),
-//                 "The user's balance should be zero"
-//             );
-//         }),
-//     });
-// }
-//
-// fn in_half(amount: Amount) -> Amount {
-//     amount.checked_div(Amount::new(2)).unwrap()
-// }
+use sov_bank::event::Event;
+use sov_bank::utils::TokenHolder;
+use sov_bank::{config_gas_token_id, Bank, Coins};
+use sov_modules_api::prelude::UnwrapInfallible;
+use sov_modules_api::{Amount, TxEffect};
+use sov_test_utils::runtime::genesis::TestTokenName;
+use sov_test_utils::{AsUser, TransactionTestCase};
+
+use crate::helpers::{setup, TestBankRuntimeEvent, TestData, RT};
+
+type S = sov_test_utils::TestSpec;
+
+/// We can burn tokens that are deployed on the bank.
+#[test]
+fn burn_deployed_tokens_happy_path() {
+    let (
+        TestData {
+            token_name,
+            token_id,
+            user_high_token_balance,
+            ..
+        },
+        mut runner,
+    ) = setup();
+
+    let user_token_balance = user_high_token_balance.token_balance(&token_name).unwrap();
+
+    let user_address = user_high_token_balance.address();
+
+    runner.execute_transaction(TransactionTestCase {
+        input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+            sov_bank::CallMessage::Burn {
+                coins: Coins {
+                    amount: user_token_balance,
+                    token_id,
+                },
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(result.events.len(), 1);
+            assert_eq!(
+                TestBankRuntimeEvent::Bank(Event::TokenBurned {
+                    owner: TokenHolder::User(user_address),
+                    coins: Coins {
+                        amount: user_token_balance,
+                        token_id
+                    }
+                }),
+                result.events[0]
+            );
+
+            // Check that the user's balance is now zero
+            assert_eq!(
+                Bank::<S>::default()
+                    .get_balance_of(&user_address, token_id, state)
+                    .unwrap_infallible(),
+                Some(Amount::ZERO),
+                "The user's balance should be zero"
+            );
+        }),
+    });
+}
+
+#[test]
+fn burn_deployed_tokens_no_balance_fails() {
+    let (
+        TestData {
+            token_id,
+            user_no_token_balance,
+            ..
+        },
+        mut runner,
+    ) = setup();
+
+    let user_address = user_no_token_balance.address();
+    const BURN_AMOUNT: u128 = 1;
+
+    let initial_total_supply = runner.query_visible_state(|state| {
+        Bank::<S>::default()
+            .get_total_supply_of(&token_id, state)
+            .unwrap_infallible()
+            .unwrap()
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: user_no_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+            sov_bank::CallMessage::Burn {
+                coins: Coins {
+                    amount: BURN_AMOUNT.into(),
+                    token_id,
+                },
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(
+                matches!(result.tx_receipt, TxEffect::Reverted(..)),
+                "The transaction should have been reverted"
+            );
+
+            // Burn by another user, who doesn't have tokens at all
+            match result.tx_receipt {
+                TxEffect::Reverted(contents) => {
+                    let actual = contents.reason.to_string();
+                    let expected = format!(
+                        "Token burn error: Underflow occurred: Insufficient balance for account {user_address}, 0 - 1"
+                    );
+                    assert_eq!(actual, expected);
+                }
+                _ => {
+                    panic!("The transaction should have been reverted")
+                }
+            }
+
+            let final_total_supply = Bank::<S>::default()
+                .get_total_supply_of(&token_id, state)
+                .unwrap_infallible()
+                .unwrap();
+
+            assert_eq!(
+                initial_total_supply, final_total_supply,
+                "The token supply shouldn't have changed"
+            );
+        }),
+    });
+}
+
+#[test]
+fn burn_more_than_deployed_tokens_fails() {
+    let (
+        TestData {
+            token_id,
+            user_high_token_balance,
+            ..
+        },
+        mut runner,
+    ) = setup();
+
+    let total_token_supply = runner.query_visible_state(|state| {
+        Bank::<S>::default()
+            .get_total_supply_of(&token_id, state)
+            .unwrap_infallible()
+            .unwrap()
+    });
+
+    let to_burn = total_token_supply.checked_add(Amount::new(1)).unwrap();
+
+    runner.execute_transaction(TransactionTestCase {
+        input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+            sov_bank::CallMessage::Burn {
+                coins: Coins {
+                    amount: to_burn,
+                    token_id,
+                },
+            },
+        ),
+        assert: Box::new(move |result, _state| match result.tx_receipt {
+            TxEffect::Reverted(contents) => {
+                    let actual = contents.reason.to_string();
+                    let expected = "Token burn error: Underflow occurred: Total supply underflow when burning, 300000 - 300001".to_string();
+                    assert_eq!(actual, expected);
+            }
+            _ => panic!("The outcome is incorrect"),
+        }),
+    });
+}
+
+#[test]
+fn burn_more_than_available_balance_fails() {
+    let (
+        TestData {
+            token_id,
+            token_name,
+            user_high_token_balance,
+            ..
+        },
+        mut runner,
+    ) = setup();
+
+    let user_token_balance = user_high_token_balance.token_balance(&token_name).unwrap();
+
+    let user_address = user_high_token_balance.address();
+
+    let to_burn = user_token_balance.checked_add(Amount::new(1)).unwrap();
+
+    runner.execute_transaction(TransactionTestCase {
+        input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+            sov_bank::CallMessage::Burn {
+                coins: Coins {
+                    amount: to_burn,
+                    token_id,
+                },
+            },
+        ),
+        assert: Box::new(move |result, _state| match result.tx_receipt {
+            TxEffect::Reverted(contents) => {
+                    let actual = contents.reason.to_string();
+                    let expected = format!(
+                    "Token burn error: Underflow occurred: Insufficient balance for account {user_address}, 100000 - 100001"
+                    );
+                    assert_eq!(actual, expected);
+            }
+            _ => {
+                panic!("The transaction does not have the expected outcome.")
+            }
+        }),
+    });
+}
+
+#[test]
+fn test_burning_zero_tokens_works() {
+    let (
+        TestData {
+            token_name,
+            token_id,
+            user_high_token_balance,
+            ..
+        },
+        mut runner,
+    ) = setup();
+
+    let user_token_balance = user_high_token_balance.token_balance(&token_name).unwrap();
+
+    let user_address = user_high_token_balance.address();
+
+    runner.execute_transaction(TransactionTestCase {
+        input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+            sov_bank::CallMessage::Burn {
+                coins: Coins {
+                    amount: Amount::ZERO,
+                    token_id,
+                },
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(result.events.len(), 1);
+            assert_eq!(
+                TestBankRuntimeEvent::Bank(Event::TokenBurned {
+                    owner: TokenHolder::User(user_address),
+                    coins: Coins {
+                        amount: Amount::ZERO,
+                        token_id
+                    }
+                }),
+                result.events[0]
+            );
+
+            // Check that the user's balance hasn't changed
+            assert_eq!(
+                Bank::<S>::default()
+                    .get_balance_of(&user_address, token_id, state)
+                    .unwrap_infallible(),
+                Some(user_token_balance),
+                "The user's balance shouldn't have changed"
+            );
+        }),
+    });
+}
+
+#[test]
+fn test_burning_zero_tokens_for_user_with_no_balance() {
+    let (
+        TestData {
+            token_id,
+            user_no_token_balance,
+            ..
+        },
+        mut runner,
+    ) = setup();
+
+    let user_address = user_no_token_balance.address();
+
+    runner.execute_transaction(TransactionTestCase {
+        input: user_no_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+            sov_bank::CallMessage::Burn {
+                coins: Coins {
+                    amount: Amount::ZERO,
+                    token_id,
+                },
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(result.events.len(), 1);
+            assert_eq!(
+                TestBankRuntimeEvent::Bank(Event::TokenBurned {
+                    owner: TokenHolder::User(user_address),
+                    coins: Coins {
+                        amount: Amount::ZERO,
+                        token_id
+                    }
+                }),
+                result.events[0]
+            );
+
+            // Check that the user's balance hasn't changed
+            assert_eq!(
+                Bank::<S>::default()
+                    .get_balance_of(&user_address, token_id, state)
+                    .unwrap_infallible(),
+                Some(Amount::ZERO),
+                "The user's balance shouldn't have changed"
+            );
+        }),
+    });
+}
+
+#[test]
+fn burn_unknown_token_fails() {
+    let (
+        TestData {
+            user_high_token_balance,
+            ..
+        },
+        mut runner,
+    ) = setup();
+
+    const AMOUNT_TO_BURN: u128 = 0;
+
+    let other_token_id = TestTokenName::new("OtherToken".to_string()).id();
+
+    runner.execute_transaction(TransactionTestCase {
+        input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+            sov_bank::CallMessage::Burn {
+                coins: Coins {
+                    amount: AMOUNT_TO_BURN.into(),
+                    token_id: other_token_id,
+                },
+            },
+        ),
+        assert: Box::new(move |result, _| {
+            assert!(
+                matches!(result.tx_receipt, TxEffect::Reverted(..)),
+                "The transaction should have been reverted"
+            );
+
+            match result.tx_receipt {
+                TxEffect::Reverted(contents) => {
+                    let actual = contents.reason.to_string();
+                    let expected = "Token burn error: Token not found: token_1ufea3079pzvmwuy2tq9u45gm9djhqxxaevjeq3qergz9fdshlqyq9pvkzr".to_string();
+                    assert_eq!(actual, expected);
+                }
+                _ => {
+                    panic!("The transaction does not have the expected outcome.")
+                }
+            }
+        }),
+    });
+}
+
+/// Simple test to check that burning the gas token works.
+#[test]
+fn burn_gas_token_also_works() {
+    let (
+        TestData {
+            user_high_token_balance,
+            ..
+        },
+        mut runner,
+    ) = setup();
+
+    let user_gas_balance = user_high_token_balance.available_gas_balance;
+    let user_address = user_high_token_balance.address();
+
+    runner.execute_transaction(TransactionTestCase {
+        input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+            sov_bank::CallMessage::Burn {
+                coins: Coins {
+                    // Note: we are only burning half of the gas balance because some of it is
+                    // already consumed (for pre-execution checks) by the time we are reaching the burn method of the `Bank` module.
+                    amount: in_half(user_gas_balance),
+                    token_id: config_gas_token_id(),
+                },
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(result.events.len(), 1);
+            assert_eq!(
+                TestBankRuntimeEvent::Bank(Event::TokenBurned {
+                    owner: TokenHolder::User(user_address),
+                    coins: Coins {
+                        amount: in_half(user_gas_balance),
+                        token_id: config_gas_token_id()
+                    }
+                }),
+                result.events[0]
+            );
+
+            // Check that the user's gas balance is now equal to the burnt amount minus the gas used to send the transaction
+            assert_eq!(
+                Bank::<S>::default()
+                    .get_balance_of(&user_address, config_gas_token_id(), state)
+                    .unwrap_infallible(),
+                Some(
+                    in_half(user_gas_balance)
+                        .checked_sub(result.gas_value_used)
+                        .unwrap()
+                ),
+                "The user's balance should be zero"
+            );
+        }),
+    });
+}
+
+fn in_half(amount: Amount) -> Amount {
+    amount.checked_div(Amount::new(2)).unwrap()
+}

--- a/crates/module-system/module-implementations/sov-bank/tests/integration/burn_test.rs
+++ b/crates/module-system/module-implementations/sov-bank/tests/integration/burn_test.rs
@@ -1,509 +1,509 @@
-use sov_bank::event::Event;
-use sov_bank::utils::TokenHolder;
-use sov_bank::{config_gas_token_id, Bank, Coins};
-use sov_modules_api::prelude::UnwrapInfallible;
-use sov_modules_api::{Amount, Error, TxEffect};
-use sov_test_utils::runtime::genesis::TestTokenName;
-use sov_test_utils::{AsUser, TransactionTestCase};
-
-use crate::helpers::{setup, TestBankRuntimeEvent, TestData, RT};
-
-type S = sov_test_utils::TestSpec;
-
-/// We can burn tokens that are deployed on the bank.
-#[test]
-fn burn_deployed_tokens_happy_path() {
-    let (
-        TestData {
-            token_name,
-            token_id,
-            user_high_token_balance,
-            ..
-        },
-        mut runner,
-    ) = setup();
-
-    let user_token_balance = user_high_token_balance.token_balance(&token_name).unwrap();
-
-    let user_address = user_high_token_balance.address();
-
-    runner.execute_transaction(TransactionTestCase {
-        input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-            sov_bank::CallMessage::Burn {
-                coins: Coins {
-                    amount: user_token_balance,
-                    token_id,
-                },
-            },
-        ),
-        assert: Box::new(move |result, state| {
-            assert!(result.tx_receipt.is_successful());
-            assert_eq!(result.events.len(), 1);
-            assert_eq!(
-                TestBankRuntimeEvent::Bank(Event::TokenBurned {
-                    owner: TokenHolder::User(user_address),
-                    coins: Coins {
-                        amount: user_token_balance,
-                        token_id
-                    }
-                }),
-                result.events[0]
-            );
-
-            // Check that the user's balance is now zero
-            assert_eq!(
-                Bank::<S>::default()
-                    .get_balance_of(&user_address, token_id, state)
-                    .unwrap_infallible(),
-                Some(Amount::ZERO),
-                "The user's balance should be zero"
-            );
-        }),
-    });
-}
-
-#[test]
-fn burn_deployed_tokens_no_balance_fails() {
-    let (
-        TestData {
-            token_id,
-            user_no_token_balance,
-            ..
-        },
-        mut runner,
-    ) = setup();
-
-    let user_address = user_no_token_balance.address();
-    const BURN_AMOUNT: u128 = 1;
-
-    let initial_total_supply = runner.query_visible_state(|state| {
-        Bank::<S>::default()
-            .get_total_supply_of(&token_id, state)
-            .unwrap_infallible()
-            .unwrap()
-    });
-
-    runner.execute_transaction(TransactionTestCase {
-        input: user_no_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-            sov_bank::CallMessage::Burn {
-                coins: Coins {
-                    amount: BURN_AMOUNT.into(),
-                    token_id,
-                },
-            },
-        ),
-        assert: Box::new(move |result, state| {
-            assert!(
-                matches!(result.tx_receipt, TxEffect::Reverted(..)),
-                "The transaction should have been reverted"
-            );
-
-            // Burn by another user, who doesn't have tokens at all
-            match result.tx_receipt {
-                TxEffect::Reverted(contents) => {
-                    let Error::ModuleError(err) = contents.reason;
-                    let mut chain = err.chain();
-
-                    let message_1 = chain.next().unwrap().to_string();
-                    let message_2 = chain.next().unwrap().to_string();
-
-                    assert!(chain.next().is_none());
-                    assert_eq!(
-                        message_1,
-                        format!("Failed to burn token_id={token_id} owner={user_address}")
-                    );
-
-                    assert_eq!(
-                        format!(
-                            "Insufficient balance from={user_address}, got=0, needed={BURN_AMOUNT}",
-                        ),
-                        message_2,
-                        "The error message is incorrect"
-                    );
-                }
-                _ => {
-                    panic!("The transaction should have been reverted")
-                }
-            }
-
-            let final_total_supply = Bank::<S>::default()
-                .get_total_supply_of(&token_id, state)
-                .unwrap_infallible()
-                .unwrap();
-
-            assert_eq!(
-                initial_total_supply, final_total_supply,
-                "The token supply shouldn't have changed"
-            );
-        }),
-    });
-}
-
-#[test]
-fn burn_more_than_deployed_tokens_fails() {
-    let (
-        TestData {
-            token_id,
-            user_high_token_balance,
-            ..
-        },
-        mut runner,
-    ) = setup();
-
-    let total_token_supply = runner.query_visible_state(|state| {
-        Bank::<S>::default()
-            .get_total_supply_of(&token_id, state)
-            .unwrap_infallible()
-            .unwrap()
-    });
-
-    let to_burn = total_token_supply.checked_add(Amount::new(1)).unwrap();
-
-    let user_address = user_high_token_balance.address();
-
-    runner.execute_transaction(TransactionTestCase {
-        input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-            sov_bank::CallMessage::Burn {
-                coins: Coins {
-                    amount: to_burn,
-                    token_id,
-                },
-            },
-        ),
-        assert: Box::new(move |result, state| match result.tx_receipt {
-            TxEffect::Reverted(contents) => {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-
-                let message_1 = chain.next().unwrap().to_string();
-                let message_2 = chain.next().unwrap().to_string();
-
-                assert!(chain.next().is_none());
-                assert_eq!(
-                    message_1,
-                    format!("Failed to burn token_id={token_id} owner={user_address}",)
-                );
-
-                assert_eq!(
-                    format!(
-                        "Total supply underflow when burning, supply=300000 is less than burn amount={to_burn}",
-                    ),
-                    message_2,
-                    "The error message is incorrect"
-                );
-
-                let final_total_supply = Bank::<S>::default()
-                    .get_total_supply_of(&token_id, state)
-                    .unwrap_infallible()
-                    .unwrap();
-
-                assert_eq!(
-                    total_token_supply, final_total_supply,
-                    "The token supply shouldn't have changed"
-                );
-            }
-            _ => panic!("The outcome is incorrect"),
-        }),
-    });
-}
-
-#[test]
-fn burn_more_than_available_balance_fails() {
-    let (
-        TestData {
-            token_id,
-            token_name,
-            user_high_token_balance,
-            ..
-        },
-        mut runner,
-    ) = setup();
-
-    let initial_token_supply = runner.query_visible_state(|state| {
-        Bank::<S>::default()
-            .get_total_supply_of(&token_id, state)
-            .unwrap_infallible()
-            .unwrap()
-    });
-
-    let user_token_balance = user_high_token_balance.token_balance(&token_name).unwrap();
-
-    let user_address = user_high_token_balance.address();
-
-    let to_burn = user_token_balance.checked_add(Amount::new(1)).unwrap();
-
-    runner.execute_transaction(TransactionTestCase {
-        input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-            sov_bank::CallMessage::Burn {
-                coins: Coins {
-                    amount: to_burn,
-                    token_id,
-                },
-            },
-        ),
-        assert: Box::new(move |result, state| match result.tx_receipt {
-            TxEffect::Reverted(contents) => {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-
-                let message_1 = chain.next().unwrap().to_string();
-                let message_2 = chain.next().unwrap().to_string();
-
-                assert!(chain.next().is_none());
-                assert_eq!(
-                    message_1,
-                    format!(
-                        "Failed to burn token_id={token_id} owner={user_address}"
-                    )
-                );
-
-                assert_eq!(
-                    format!(
-                        "Insufficient balance from={user_address}, got={user_token_balance}, needed={to_burn}",
-                    ),
-                    message_2,
-                    "The error message is incorrect"
-                );
-
-                let final_total_supply = Bank::<S>::default()
-                    .get_total_supply_of(&token_id, state)
-                    .unwrap_infallible()
-                    .unwrap();
-
-                assert_eq!(
-                    initial_token_supply, final_total_supply,
-                    "The token supply shouldn't have changed"
-                );
-            }
-            _ => {
-                panic!("The transaction does not have the expected outcome.")
-            }
-        }),
-    });
-}
-
-#[test]
-fn test_burning_zero_tokens_works() {
-    let (
-        TestData {
-            token_name,
-            token_id,
-            user_high_token_balance,
-            ..
-        },
-        mut runner,
-    ) = setup();
-
-    let user_token_balance = user_high_token_balance.token_balance(&token_name).unwrap();
-
-    let user_address = user_high_token_balance.address();
-
-    runner.execute_transaction(TransactionTestCase {
-        input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-            sov_bank::CallMessage::Burn {
-                coins: Coins {
-                    amount: Amount::ZERO,
-                    token_id,
-                },
-            },
-        ),
-        assert: Box::new(move |result, state| {
-            assert!(result.tx_receipt.is_successful());
-            assert_eq!(result.events.len(), 1);
-            assert_eq!(
-                TestBankRuntimeEvent::Bank(Event::TokenBurned {
-                    owner: TokenHolder::User(user_address),
-                    coins: Coins {
-                        amount: Amount::ZERO,
-                        token_id
-                    }
-                }),
-                result.events[0]
-            );
-
-            // Check that the user's balance hasn't changed
-            assert_eq!(
-                Bank::<S>::default()
-                    .get_balance_of(&user_address, token_id, state)
-                    .unwrap_infallible(),
-                Some(user_token_balance),
-                "The user's balance shouldn't have changed"
-            );
-        }),
-    });
-}
-
-#[test]
-fn test_burning_zero_tokens_for_user_with_no_balance() {
-    let (
-        TestData {
-            token_id,
-            user_no_token_balance,
-            ..
-        },
-        mut runner,
-    ) = setup();
-
-    let user_address = user_no_token_balance.address();
-
-    runner.execute_transaction(TransactionTestCase {
-        input: user_no_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-            sov_bank::CallMessage::Burn {
-                coins: Coins {
-                    amount: Amount::ZERO,
-                    token_id,
-                },
-            },
-        ),
-        assert: Box::new(move |result, state| {
-            assert!(result.tx_receipt.is_successful());
-            assert_eq!(result.events.len(), 1);
-            assert_eq!(
-                TestBankRuntimeEvent::Bank(Event::TokenBurned {
-                    owner: TokenHolder::User(user_address),
-                    coins: Coins {
-                        amount: Amount::ZERO,
-                        token_id
-                    }
-                }),
-                result.events[0]
-            );
-
-            // Check that the user's balance hasn't changed
-            assert_eq!(
-                Bank::<S>::default()
-                    .get_balance_of(&user_address, token_id, state)
-                    .unwrap_infallible(),
-                Some(Amount::ZERO),
-                "The user's balance shouldn't have changed"
-            );
-        }),
-    });
-}
-
-#[test]
-fn burn_unknown_token_fails() {
-    let (
-        TestData {
-            user_high_token_balance,
-            ..
-        },
-        mut runner,
-    ) = setup();
-
-    const AMOUNT_TO_BURN: u128 = 0;
-
-    let other_token_id = TestTokenName::new("OtherToken".to_string()).id();
-
-    runner.execute_transaction(TransactionTestCase {
-        input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-            sov_bank::CallMessage::Burn {
-                coins: Coins {
-                    amount: AMOUNT_TO_BURN.into(),
-                    token_id: other_token_id,
-                },
-            },
-        ),
-        assert: Box::new(move |result, _| {
-            assert!(
-                matches!(result.tx_receipt, TxEffect::Reverted(..)),
-                "The transaction should have been reverted"
-            );
-
-            match result.tx_receipt {
-                TxEffect::Reverted(contents) => {
-                    let Error::ModuleError(err) = contents.reason;
-                    let mut chain = err.chain();
-
-                    let message_1 = chain.next().unwrap().to_string();
-                    let message_2 = chain.next().unwrap().to_string();
-                    let message_3 = chain.next().unwrap().to_string();
-
-                    assert!(chain.next().is_none());
-
-                    assert_eq!(
-                        format!(
-                            "Failed to burn token_id={other_token_id} owner={}",
-                            user_high_token_balance.address()
-                        ),
-                        message_1,
-                        "The first message is incorrect"
-                    );
-
-                    assert_eq!(
-                        format!("Failed to get token_id={other_token_id}"),
-                        message_2,
-                        "The second message is incorrect"
-                    );
-
-                    // Note, no token ID in the root cause the message.
-                    let expected_error_part =
-                        "Value not found for prefix:";
-                    assert!(message_3.starts_with(expected_error_part), "The third message is incorrect. Expected a message: {expected_error_part}, Got: {message_3}");
-                }
-                _ => {
-                    panic!("The transaction does not have the expected outcome.")
-                }
-            }
-        }),
-    });
-}
-
-/// Simple test to check that burning the gas token works.
-#[test]
-fn burn_gas_token_also_works() {
-    let (
-        TestData {
-            user_high_token_balance,
-            ..
-        },
-        mut runner,
-    ) = setup();
-
-    let user_gas_balance = user_high_token_balance.available_gas_balance;
-    let user_address = user_high_token_balance.address();
-
-    runner.execute_transaction(TransactionTestCase {
-        input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
-            sov_bank::CallMessage::Burn {
-                coins: Coins {
-                    // Note: we are only burning half of the gas balance because some of it is
-                    // already consumed (for pre-execution checks) by the time we are reaching the burn method of the `Bank` module.
-                    amount: in_half(user_gas_balance),
-                    token_id: config_gas_token_id(),
-                },
-            },
-        ),
-        assert: Box::new(move |result, state| {
-            assert!(result.tx_receipt.is_successful());
-            assert_eq!(result.events.len(), 1);
-            assert_eq!(
-                TestBankRuntimeEvent::Bank(Event::TokenBurned {
-                    owner: TokenHolder::User(user_address),
-                    coins: Coins {
-                        amount: in_half(user_gas_balance),
-                        token_id: config_gas_token_id()
-                    }
-                }),
-                result.events[0]
-            );
-
-            // Check that the user's gas balance is now equal to the burnt amount minus the gas used to send the transaction
-            assert_eq!(
-                Bank::<S>::default()
-                    .get_balance_of(&user_address, config_gas_token_id(), state)
-                    .unwrap_infallible(),
-                Some(
-                    in_half(user_gas_balance)
-                        .checked_sub(result.gas_value_used)
-                        .unwrap()
-                ),
-                "The user's balance should be zero"
-            );
-        }),
-    });
-}
-
-fn in_half(amount: Amount) -> Amount {
-    amount.checked_div(Amount::new(2)).unwrap()
-}
+// use sov_bank::event::Event;
+// use sov_bank::utils::TokenHolder;
+// use sov_bank::{config_gas_token_id, Bank, Coins};
+// use sov_modules_api::prelude::UnwrapInfallible;
+// use sov_modules_api::{Amount, Error, TxEffect};
+// use sov_test_utils::runtime::genesis::TestTokenName;
+// use sov_test_utils::{AsUser, TransactionTestCase};
+//
+// use crate::helpers::{setup, TestBankRuntimeEvent, TestData, RT};
+//
+// type S = sov_test_utils::TestSpec;
+//
+// /// We can burn tokens that are deployed on the bank.
+// #[test]
+// fn burn_deployed_tokens_happy_path() {
+//     let (
+//         TestData {
+//             token_name,
+//             token_id,
+//             user_high_token_balance,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     let user_token_balance = user_high_token_balance.token_balance(&token_name).unwrap();
+//
+//     let user_address = user_high_token_balance.address();
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+//             sov_bank::CallMessage::Burn {
+//                 coins: Coins {
+//                     amount: user_token_balance,
+//                     token_id,
+//                 },
+//             },
+//         ),
+//         assert: Box::new(move |result, state| {
+//             assert!(result.tx_receipt.is_successful());
+//             assert_eq!(result.events.len(), 1);
+//             assert_eq!(
+//                 TestBankRuntimeEvent::Bank(Event::TokenBurned {
+//                     owner: TokenHolder::User(user_address),
+//                     coins: Coins {
+//                         amount: user_token_balance,
+//                         token_id
+//                     }
+//                 }),
+//                 result.events[0]
+//             );
+//
+//             // Check that the user's balance is now zero
+//             assert_eq!(
+//                 Bank::<S>::default()
+//                     .get_balance_of(&user_address, token_id, state)
+//                     .unwrap_infallible(),
+//                 Some(Amount::ZERO),
+//                 "The user's balance should be zero"
+//             );
+//         }),
+//     });
+// }
+//
+// #[test]
+// fn burn_deployed_tokens_no_balance_fails() {
+//     let (
+//         TestData {
+//             token_id,
+//             user_no_token_balance,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     let user_address = user_no_token_balance.address();
+//     const BURN_AMOUNT: u128 = 1;
+//
+//     let initial_total_supply = runner.query_visible_state(|state| {
+//         Bank::<S>::default()
+//             .get_total_supply_of(&token_id, state)
+//             .unwrap_infallible()
+//             .unwrap()
+//     });
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: user_no_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+//             sov_bank::CallMessage::Burn {
+//                 coins: Coins {
+//                     amount: BURN_AMOUNT.into(),
+//                     token_id,
+//                 },
+//             },
+//         ),
+//         assert: Box::new(move |result, state| {
+//             assert!(
+//                 matches!(result.tx_receipt, TxEffect::Reverted(..)),
+//                 "The transaction should have been reverted"
+//             );
+//
+//             // Burn by another user, who doesn't have tokens at all
+//             match result.tx_receipt {
+//                 TxEffect::Reverted(contents) => {
+//                     let Error::ModuleError(err) = contents.reason;
+//                     let mut chain = err.chain();
+//
+//                     let message_1 = chain.next().unwrap().to_string();
+//                     let message_2 = chain.next().unwrap().to_string();
+//
+//                     assert!(chain.next().is_none());
+//                     assert_eq!(
+//                         message_1,
+//                         format!("Failed to burn token_id={token_id} owner={user_address}")
+//                     );
+//
+//                     assert_eq!(
+//                         format!(
+//                             "Insufficient balance from={user_address}, got=0, needed={BURN_AMOUNT}",
+//                         ),
+//                         message_2,
+//                         "The error message is incorrect"
+//                     );
+//                 }
+//                 _ => {
+//                     panic!("The transaction should have been reverted")
+//                 }
+//             }
+//
+//             let final_total_supply = Bank::<S>::default()
+//                 .get_total_supply_of(&token_id, state)
+//                 .unwrap_infallible()
+//                 .unwrap();
+//
+//             assert_eq!(
+//                 initial_total_supply, final_total_supply,
+//                 "The token supply shouldn't have changed"
+//             );
+//         }),
+//     });
+// }
+//
+// #[test]
+// fn burn_more_than_deployed_tokens_fails() {
+//     let (
+//         TestData {
+//             token_id,
+//             user_high_token_balance,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     let total_token_supply = runner.query_visible_state(|state| {
+//         Bank::<S>::default()
+//             .get_total_supply_of(&token_id, state)
+//             .unwrap_infallible()
+//             .unwrap()
+//     });
+//
+//     let to_burn = total_token_supply.checked_add(Amount::new(1)).unwrap();
+//
+//     let user_address = user_high_token_balance.address();
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+//             sov_bank::CallMessage::Burn {
+//                 coins: Coins {
+//                     amount: to_burn,
+//                     token_id,
+//                 },
+//             },
+//         ),
+//         assert: Box::new(move |result, state| match result.tx_receipt {
+//             TxEffect::Reverted(contents) => {
+//                 let Error::ModuleError(err) = contents.reason;
+//                 let mut chain = err.chain();
+//
+//                 let message_1 = chain.next().unwrap().to_string();
+//                 let message_2 = chain.next().unwrap().to_string();
+//
+//                 assert!(chain.next().is_none());
+//                 assert_eq!(
+//                     message_1,
+//                     format!("Failed to burn token_id={token_id} owner={user_address}",)
+//                 );
+//
+//                 assert_eq!(
+//                     format!(
+//                         "Total supply underflow when burning, supply=300000 is less than burn amount={to_burn}",
+//                     ),
+//                     message_2,
+//                     "The error message is incorrect"
+//                 );
+//
+//                 let final_total_supply = Bank::<S>::default()
+//                     .get_total_supply_of(&token_id, state)
+//                     .unwrap_infallible()
+//                     .unwrap();
+//
+//                 assert_eq!(
+//                     total_token_supply, final_total_supply,
+//                     "The token supply shouldn't have changed"
+//                 );
+//             }
+//             _ => panic!("The outcome is incorrect"),
+//         }),
+//     });
+// }
+//
+// #[test]
+// fn burn_more_than_available_balance_fails() {
+//     let (
+//         TestData {
+//             token_id,
+//             token_name,
+//             user_high_token_balance,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     let initial_token_supply = runner.query_visible_state(|state| {
+//         Bank::<S>::default()
+//             .get_total_supply_of(&token_id, state)
+//             .unwrap_infallible()
+//             .unwrap()
+//     });
+//
+//     let user_token_balance = user_high_token_balance.token_balance(&token_name).unwrap();
+//
+//     let user_address = user_high_token_balance.address();
+//
+//     let to_burn = user_token_balance.checked_add(Amount::new(1)).unwrap();
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+//             sov_bank::CallMessage::Burn {
+//                 coins: Coins {
+//                     amount: to_burn,
+//                     token_id,
+//                 },
+//             },
+//         ),
+//         assert: Box::new(move |result, state| match result.tx_receipt {
+//             TxEffect::Reverted(contents) => {
+//                 let Error::ModuleError(err) = contents.reason;
+//                 let mut chain = err.chain();
+//
+//                 let message_1 = chain.next().unwrap().to_string();
+//                 let message_2 = chain.next().unwrap().to_string();
+//
+//                 assert!(chain.next().is_none());
+//                 assert_eq!(
+//                     message_1,
+//                     format!(
+//                         "Failed to burn token_id={token_id} owner={user_address}"
+//                     )
+//                 );
+//
+//                 assert_eq!(
+//                     format!(
+//                         "Insufficient balance from={user_address}, got={user_token_balance}, needed={to_burn}",
+//                     ),
+//                     message_2,
+//                     "The error message is incorrect"
+//                 );
+//
+//                 let final_total_supply = Bank::<S>::default()
+//                     .get_total_supply_of(&token_id, state)
+//                     .unwrap_infallible()
+//                     .unwrap();
+//
+//                 assert_eq!(
+//                     initial_token_supply, final_total_supply,
+//                     "The token supply shouldn't have changed"
+//                 );
+//             }
+//             _ => {
+//                 panic!("The transaction does not have the expected outcome.")
+//             }
+//         }),
+//     });
+// }
+//
+// #[test]
+// fn test_burning_zero_tokens_works() {
+//     let (
+//         TestData {
+//             token_name,
+//             token_id,
+//             user_high_token_balance,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     let user_token_balance = user_high_token_balance.token_balance(&token_name).unwrap();
+//
+//     let user_address = user_high_token_balance.address();
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+//             sov_bank::CallMessage::Burn {
+//                 coins: Coins {
+//                     amount: Amount::ZERO,
+//                     token_id,
+//                 },
+//             },
+//         ),
+//         assert: Box::new(move |result, state| {
+//             assert!(result.tx_receipt.is_successful());
+//             assert_eq!(result.events.len(), 1);
+//             assert_eq!(
+//                 TestBankRuntimeEvent::Bank(Event::TokenBurned {
+//                     owner: TokenHolder::User(user_address),
+//                     coins: Coins {
+//                         amount: Amount::ZERO,
+//                         token_id
+//                     }
+//                 }),
+//                 result.events[0]
+//             );
+//
+//             // Check that the user's balance hasn't changed
+//             assert_eq!(
+//                 Bank::<S>::default()
+//                     .get_balance_of(&user_address, token_id, state)
+//                     .unwrap_infallible(),
+//                 Some(user_token_balance),
+//                 "The user's balance shouldn't have changed"
+//             );
+//         }),
+//     });
+// }
+//
+// #[test]
+// fn test_burning_zero_tokens_for_user_with_no_balance() {
+//     let (
+//         TestData {
+//             token_id,
+//             user_no_token_balance,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     let user_address = user_no_token_balance.address();
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: user_no_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+//             sov_bank::CallMessage::Burn {
+//                 coins: Coins {
+//                     amount: Amount::ZERO,
+//                     token_id,
+//                 },
+//             },
+//         ),
+//         assert: Box::new(move |result, state| {
+//             assert!(result.tx_receipt.is_successful());
+//             assert_eq!(result.events.len(), 1);
+//             assert_eq!(
+//                 TestBankRuntimeEvent::Bank(Event::TokenBurned {
+//                     owner: TokenHolder::User(user_address),
+//                     coins: Coins {
+//                         amount: Amount::ZERO,
+//                         token_id
+//                     }
+//                 }),
+//                 result.events[0]
+//             );
+//
+//             // Check that the user's balance hasn't changed
+//             assert_eq!(
+//                 Bank::<S>::default()
+//                     .get_balance_of(&user_address, token_id, state)
+//                     .unwrap_infallible(),
+//                 Some(Amount::ZERO),
+//                 "The user's balance shouldn't have changed"
+//             );
+//         }),
+//     });
+// }
+//
+// #[test]
+// fn burn_unknown_token_fails() {
+//     let (
+//         TestData {
+//             user_high_token_balance,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     const AMOUNT_TO_BURN: u128 = 0;
+//
+//     let other_token_id = TestTokenName::new("OtherToken".to_string()).id();
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+//             sov_bank::CallMessage::Burn {
+//                 coins: Coins {
+//                     amount: AMOUNT_TO_BURN.into(),
+//                     token_id: other_token_id,
+//                 },
+//             },
+//         ),
+//         assert: Box::new(move |result, _| {
+//             assert!(
+//                 matches!(result.tx_receipt, TxEffect::Reverted(..)),
+//                 "The transaction should have been reverted"
+//             );
+//
+//             match result.tx_receipt {
+//                 TxEffect::Reverted(contents) => {
+//                     let Error::ModuleError(err) = contents.reason;
+//                     let mut chain = err.chain();
+//
+//                     let message_1 = chain.next().unwrap().to_string();
+//                     let message_2 = chain.next().unwrap().to_string();
+//                     let message_3 = chain.next().unwrap().to_string();
+//
+//                     assert!(chain.next().is_none());
+//
+//                     assert_eq!(
+//                         format!(
+//                             "Failed to burn token_id={other_token_id} owner={}",
+//                             user_high_token_balance.address()
+//                         ),
+//                         message_1,
+//                         "The first message is incorrect"
+//                     );
+//
+//                     assert_eq!(
+//                         format!("Failed to get token_id={other_token_id}"),
+//                         message_2,
+//                         "The second message is incorrect"
+//                     );
+//
+//                     // Note, no token ID in the root cause the message.
+//                     let expected_error_part =
+//                         "Value not found for prefix:";
+//                     assert!(message_3.starts_with(expected_error_part), "The third message is incorrect. Expected a message: {expected_error_part}, Got: {message_3}");
+//                 }
+//                 _ => {
+//                     panic!("The transaction does not have the expected outcome.")
+//                 }
+//             }
+//         }),
+//     });
+// }
+//
+// /// Simple test to check that burning the gas token works.
+// #[test]
+// fn burn_gas_token_also_works() {
+//     let (
+//         TestData {
+//             user_high_token_balance,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     let user_gas_balance = user_high_token_balance.available_gas_balance;
+//     let user_address = user_high_token_balance.address();
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: user_high_token_balance.create_plain_message::<RT, sov_bank::Bank<S>>(
+//             sov_bank::CallMessage::Burn {
+//                 coins: Coins {
+//                     // Note: we are only burning half of the gas balance because some of it is
+//                     // already consumed (for pre-execution checks) by the time we are reaching the burn method of the `Bank` module.
+//                     amount: in_half(user_gas_balance),
+//                     token_id: config_gas_token_id(),
+//                 },
+//             },
+//         ),
+//         assert: Box::new(move |result, state| {
+//             assert!(result.tx_receipt.is_successful());
+//             assert_eq!(result.events.len(), 1);
+//             assert_eq!(
+//                 TestBankRuntimeEvent::Bank(Event::TokenBurned {
+//                     owner: TokenHolder::User(user_address),
+//                     coins: Coins {
+//                         amount: in_half(user_gas_balance),
+//                         token_id: config_gas_token_id()
+//                     }
+//                 }),
+//                 result.events[0]
+//             );
+//
+//             // Check that the user's gas balance is now equal to the burnt amount minus the gas used to send the transaction
+//             assert_eq!(
+//                 Bank::<S>::default()
+//                     .get_balance_of(&user_address, config_gas_token_id(), state)
+//                     .unwrap_infallible(),
+//                 Some(
+//                     in_half(user_gas_balance)
+//                         .checked_sub(result.gas_value_used)
+//                         .unwrap()
+//                 ),
+//                 "The user's balance should be zero"
+//             );
+//         }),
+//     });
+// }
+//
+// fn in_half(amount: Amount) -> Amount {
+//     amount.checked_div(Amount::new(2)).unwrap()
+// }

--- a/crates/module-system/module-implementations/sov-bank/tests/integration/create_token_test.rs
+++ b/crates/module-system/module-implementations/sov-bank/tests/integration/create_token_test.rs
@@ -346,16 +346,14 @@ fn test_create_token_fails_with_duplicate_ids() {
             }),
             assert: Box::new(move |result, _state| {
                 if let TxEffect::Reverted(contents) = result.tx_receipt {
-                    let sov_modules_api::Error::ModuleError(err) = contents.reason;
-                    assert_eq!(
-                        err.to_string(),
-                        format!(
-                            "Token with id already exists {}, name={} minter={}",
-                            token_id,
-                            token_name,
-                            minter.address()
-                        )
+                    let actual = contents.reason.to_string();
+                    let expected = format!(
+                        "Token creation error: Token with id already exists {}, name={} minter={}",
+                        token_id,
+                        token_name,
+                        minter.address()
                     );
+                    assert_eq!(actual, expected);
                 } else {
                     panic!("The transaction should have failed");
                 }

--- a/crates/module-system/module-implementations/sov-bank/tests/integration/freeze_test.rs
+++ b/crates/module-system/module-implementations/sov-bank/tests/integration/freeze_test.rs
@@ -1,5 +1,5 @@
 use sov_bank::{Bank, TokenId};
-use sov_modules_api::{Amount, Error, TxEffect};
+use sov_modules_api::{Amount, TxEffect};
 use sov_test_utils::{AsUser, TransactionTestCase};
 
 use crate::helpers::{setup, TestBankRuntimeEvent, TestData, RT, S};
@@ -47,16 +47,9 @@ fn freeze_token_happy_path() {
         }),
         assert: Box::new(move |result, _| {
             if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                let message_1 = chain.next().unwrap().to_string();
-                let message_2 = chain.next().unwrap().to_string();
-                assert!(chain.next().is_none());
-                assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
-                assert_eq!(
-                    format!("Attempt to mint frozen token {token_name}"),
-                    message_2
-                );
+                let actual = contents.reason.to_string();
+                let expected = format!("Token mint error: Token is frozen: {token_name}");
+                assert_eq!(actual, expected);
             } else {
                 panic!("The transaction should have reverted");
             }
@@ -90,13 +83,9 @@ fn freeze_another_time_fails() {
             .create_plain_message::<RT, Bank<S>>(sov_bank::CallMessage::Freeze { token_id }),
         assert: Box::new(move |result, _| {
             if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                let message_1 = chain.next().unwrap().to_string();
-                let message_2 = chain.next().unwrap().to_string();
-                assert!(chain.next().is_none());
-                assert_eq!(format!("Failed to freeze token_id={token_id}"), message_1);
-                assert_eq!(format!("Token {token_name} is already frozen"), message_2);
+                let actual = contents.reason.to_string();
+                let expected = format!("Token freeze error: Token is frozen: {token_name}");
+                assert_eq!(actual, expected);
             } else {
                 panic!("The transaction should have reverted");
             }
@@ -125,16 +114,11 @@ fn unauthorized_minter_cannot_freeze_token() {
             .create_plain_message::<RT, Bank<S>>(sov_bank::CallMessage::Freeze { token_id }),
         assert: Box::new(move |result, _| {
             if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                let message_1 = chain.next().unwrap().to_string();
-                let message_2 = chain.next().unwrap().to_string();
-                assert!(chain.next().is_none());
-                assert_eq!(format!("Failed to freeze token_id={token_id}"), message_1);
-                assert_eq!(
-                    format!("Sender {unauthorized_address} is not an admin of token {token_name}"),
-                    message_2
+                let actual = contents.reason.to_string();
+                let expected = format!(
+                    "Token freeze error: Caller {unauthorized_address} is not an admin for token {token_name}"
                 );
+                assert_eq!(actual, expected);
             } else {
                 panic!("The transaction should have reverted");
             }
@@ -153,10 +137,9 @@ fn test_freeze_fails_if_token_id_doesnt_exist() {
             .create_plain_message::<RT, Bank<S>>(sov_bank::CallMessage::Freeze { token_id }),
         assert: Box::new(move |result, _| {
             if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                let message_1 = chain.next().unwrap().to_string();
-                assert_eq!(format!("Failed to get token_id={token_id}"), message_1);
+                let actual = contents.reason.to_string();
+                let expected = format!("Token freeze error: Token not found: {token_id}");
+                assert_eq!(actual, expected);
             } else {
                 panic!("The transaction should have reverted");
             }

--- a/crates/module-system/module-implementations/sov-bank/tests/integration/main.rs
+++ b/crates/module-system/module-implementations/sov-bank/tests/integration/main.rs
@@ -1,11 +1,11 @@
 mod archival_query_test;
-mod burn_test;
+// mod burn_test;
 mod capability_test;
-mod create_token_test;
-mod freeze_test;
+// mod create_token_test;
+// mod freeze_test;
 mod helpers;
 mod init;
-mod mint_test;
-mod transfer_test;
+// mod mint_test;
+// mod transfer_test;
 mod update_admin;
 mod wallet_test;

--- a/crates/module-system/module-implementations/sov-bank/tests/integration/main.rs
+++ b/crates/module-system/module-implementations/sov-bank/tests/integration/main.rs
@@ -1,11 +1,11 @@
 mod archival_query_test;
-// mod burn_test;
+mod burn_test;
 mod capability_test;
-// mod create_token_test;
-// mod freeze_test;
+mod create_token_test;
+mod freeze_test;
 mod helpers;
 mod init;
-// mod mint_test;
-// mod transfer_test;
+mod mint_test;
+mod transfer_test;
 mod update_admin;
 mod wallet_test;

--- a/crates/module-system/module-implementations/sov-bank/tests/integration/mint_test.rs
+++ b/crates/module-system/module-implementations/sov-bank/tests/integration/mint_test.rs
@@ -1,318 +1,318 @@
-use sov_bank::{Bank, CallMessage, Coins, TokenId};
-use sov_modules_api::prelude::UnwrapInfallible;
-use sov_modules_api::{Amount, Error, SafeVec, TxEffect};
-use sov_test_utils::{AsUser, TransactionTestCase};
-
-use crate::helpers::{setup, TestBankRuntimeEvent, TestData, RT};
-
-type S = sov_test_utils::TestSpec;
-
-const MINT_AMOUNT: Amount = Amount::new(100);
-const INITIAL_BALANCE: Amount = Amount::new(100);
-
-/// Tests that a user can mint tokens.
-#[test]
-fn mint_token_success() {
-    let (
-        TestData {
-            token_id,
-            minter,
-            user_no_token_balance,
-            ..
-        },
-        mut runner,
-    ) = setup();
-
-    runner.execute_transaction(TransactionTestCase {
-        input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-            coins: Coins {
-                amount: MINT_AMOUNT,
-                token_id,
-            },
-            mint_to_address: user_no_token_balance.address(),
-        }),
-        assert: Box::new(move |result, state| {
-            assert!(result.tx_receipt.is_successful());
-            assert_eq!(result.events.len(), 1);
-            assert_eq!(
-                result.events[0],
-                TestBankRuntimeEvent::Bank(sov_bank::event::Event::TokenMinted {
-                    mint_to_identity: sov_bank::utils::TokenHolder::User(
-                        user_no_token_balance.address()
-                    ),
-                    authorizer: sov_bank::utils::TokenHolder::User(minter.address()),
-                    coins: Coins {
-                        amount: MINT_AMOUNT,
-                        token_id
-                    }
-                })
-            );
-
-            assert_eq!(
-                Bank::<S>::default()
-                    .get_balance_of(&user_no_token_balance.address(), token_id, state)
-                    .unwrap_infallible(),
-                Some(MINT_AMOUNT)
-            );
-        }),
-    });
-}
-
-#[test]
-fn mint_token_fails_if_user_unauthorized() {
-    let (
-        TestData {
-            token_name,
-            token_id,
-            user_high_token_balance: unauthorized_minter,
-            ..
-        },
-        mut runner,
-    ) = setup();
-
-    runner.execute_transaction(TransactionTestCase {
-        input: unauthorized_minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-            coins: Coins {
-                amount: Amount::ZERO,
-                token_id,
-            },
-            mint_to_address: unauthorized_minter.address(),
-        }),
-        assert: Box::new(move |result, _state| {
-            if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                let message_1 = chain.next().unwrap().to_string();
-                let message_2 = chain.next().unwrap().to_string();
-                assert!(chain.next().is_none());
-                assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
-                assert_eq!(
-                    message_2,
-                    format!(
-                        "Sender {} is not an admin of token {}",
-                        unauthorized_minter.address(),
-                        token_name
-                    ),
-                );
-            } else {
-                panic!("The transaction should have failed");
-            }
-        }),
-    });
-}
-
-/// The token originator shouldn't be able to mint tokens he created.
-#[test]
-fn try_create_token_and_mint_should_fail_if_not_authorized() {
-    let (
-        TestData {
-            token_name,
-            token_id,
-            user_no_token_balance: user,
-            ..
-        },
-        mut runner,
-    ) = setup();
-
-    runner.execute(
-        user.create_plain_message::<RT, Bank<S>>(CallMessage::CreateToken {
-            token_name: token_name.to_string().try_into().unwrap(),
-            token_decimals: None,
-            supply_cap: None,
-            initial_balance: Amount::new(100),
-            mint_to_address: user.address(),
-            admins: SafeVec::new(),
-        }),
-    );
-
-    runner.execute_transaction(TransactionTestCase {
-        input: user.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-            coins: Coins {
-                amount: INITIAL_BALANCE,
-                token_id,
-            },
-            mint_to_address: user.address(),
-        }),
-        assert: Box::new(move |result, _state| {
-            if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                let message_1 = chain.next().unwrap().to_string();
-                let message_2 = chain.next().unwrap().to_string();
-                assert!(chain.next().is_none());
-                assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
-                assert_eq!(
-                    message_2,
-                    format!(
-                        "Sender {} is not an admin of token {}",
-                        user.address(),
-                        token_name
-                    ),
-                );
-            } else {
-                panic!("The transaction should have failed");
-            }
-        }),
-    });
-}
-
-#[test]
-fn mint_token_account_balance_overflow() {
-    let (
-        TestData {
-            token_id, minter, ..
-        },
-        mut runner,
-    ) = setup();
-
-    runner.execute_transaction(TransactionTestCase {
-        input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-            coins: Coins {
-                amount: Amount::MAX,
-                token_id,
-            },
-            mint_to_address: minter.address(),
-        }),
-        assert: Box::new(move |result, _state| {
-            if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                let message_1 = chain.next().unwrap().to_string();
-                let message_2 = chain.next().unwrap().to_string();
-                assert!(chain.next().is_none());
-                assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
-                assert_eq!(
-                    message_2,
-                    "Total Supply overflow in the mint method of bank module",
-                );
-            } else {
-                panic!("The transaction should have failed");
-            }
-        }),
-    });
-}
-
-#[test]
-fn mint_token_total_supply_overflow() {
-    let (
-        TestData {
-            token_name,
-            token_id,
-            minter,
-            ..
-        },
-        mut runner,
-    ) = setup();
-
-    let minter_balance = minter.token_balance(&token_name).unwrap();
-
-    runner.execute_transaction(TransactionTestCase {
-        input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-            coins: Coins {
-                amount: Amount::MAX
-                    .checked_sub(minter_balance)
-                    .unwrap()
-                    .checked_sub(Amount::new(1))
-                    .unwrap(),
-                token_id,
-            },
-            mint_to_address: minter.address(),
-        }),
-        assert: Box::new(move |result, _state| {
-            if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                let message_1 = chain.next().unwrap().to_string();
-                let message_2 = chain.next().unwrap().to_string();
-                assert!(chain.next().is_none());
-                assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
-                assert_eq!(
-                    message_2,
-                    "Total Supply overflow in the mint method of bank module",
-                );
-            } else {
-                panic!("The transaction should have failed");
-            }
-        }),
-    });
-}
-
-#[test]
-fn test_mint_token_fails_if_token_doesnt_exist() {
-    let (
-        TestData {
-            user_high_token_balance: unauthorized_minter,
-            ..
-        },
-        mut runner,
-    ) = setup();
-    let invalid_token_id = TokenId::generate::<S>("invalid");
-
-    runner.execute_transaction(TransactionTestCase {
-        input: unauthorized_minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-            coins: Coins {
-                amount: Amount::new(50),
-                token_id: invalid_token_id,
-            },
-            mint_to_address: unauthorized_minter.address(),
-        }),
-        assert: Box::new(move |result, _state| {
-            if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                let message_1 = chain.next().unwrap().to_string();
-                assert_eq!(
-                    message_1,
-                    format!("Failed to get token_id={invalid_token_id}")
-                );
-            } else {
-                panic!("The transaction should have failed");
-            }
-        }),
-    });
-}
-
-#[test]
-fn test_mint_token_fails_if_token_is_frozen() {
-    let (
-        TestData {
-            token_id,
-            token_name,
-            minter,
-            ..
-        },
-        mut runner,
-    ) = setup();
-
-    runner
-        .execute_transaction(TransactionTestCase {
-            input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Freeze { token_id }),
-            assert: Box::new(move |result, _state| {
-                assert!(result.tx_receipt.is_successful());
-            }),
-        })
-        .execute_transaction(TransactionTestCase {
-            input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-                coins: Coins {
-                    amount: Amount::new(50),
-                    token_id,
-                },
-                mint_to_address: minter.address(),
-            }),
-            assert: Box::new(move |result, _state| {
-                if let TxEffect::Reverted(contents) = result.tx_receipt {
-                    let Error::ModuleError(err) = contents.reason;
-                    let mut chain = err.chain();
-                    let message_1 = chain.next().unwrap().to_string();
-                    let message_2 = chain.next().unwrap().to_string();
-                    assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
-                    assert_eq!(
-                        message_2,
-                        format!("Attempt to mint frozen token {token_name}")
-                    );
-                } else {
-                    panic!("The transaction should have failed");
-                }
-            }),
-        });
-}
+// use sov_bank::{Bank, CallMessage, Coins, TokenId};
+// use sov_modules_api::prelude::UnwrapInfallible;
+// use sov_modules_api::{Amount, Error, SafeVec, TxEffect};
+// use sov_test_utils::{AsUser, TransactionTestCase};
+//
+// use crate::helpers::{setup, TestBankRuntimeEvent, TestData, RT};
+//
+// type S = sov_test_utils::TestSpec;
+//
+// const MINT_AMOUNT: Amount = Amount::new(100);
+// const INITIAL_BALANCE: Amount = Amount::new(100);
+//
+// /// Tests that a user can mint tokens.
+// #[test]
+// fn mint_token_success() {
+//     let (
+//         TestData {
+//             token_id,
+//             minter,
+//             user_no_token_balance,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+//             coins: Coins {
+//                 amount: MINT_AMOUNT,
+//                 token_id,
+//             },
+//             mint_to_address: user_no_token_balance.address(),
+//         }),
+//         assert: Box::new(move |result, state| {
+//             assert!(result.tx_receipt.is_successful());
+//             assert_eq!(result.events.len(), 1);
+//             assert_eq!(
+//                 result.events[0],
+//                 TestBankRuntimeEvent::Bank(sov_bank::event::Event::TokenMinted {
+//                     mint_to_identity: sov_bank::utils::TokenHolder::User(
+//                         user_no_token_balance.address()
+//                     ),
+//                     authorizer: sov_bank::utils::TokenHolder::User(minter.address()),
+//                     coins: Coins {
+//                         amount: MINT_AMOUNT,
+//                         token_id
+//                     }
+//                 })
+//             );
+//
+//             assert_eq!(
+//                 Bank::<S>::default()
+//                     .get_balance_of(&user_no_token_balance.address(), token_id, state)
+//                     .unwrap_infallible(),
+//                 Some(MINT_AMOUNT)
+//             );
+//         }),
+//     });
+// }
+//
+// #[test]
+// fn mint_token_fails_if_user_unauthorized() {
+//     let (
+//         TestData {
+//             token_name,
+//             token_id,
+//             user_high_token_balance: unauthorized_minter,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: unauthorized_minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+//             coins: Coins {
+//                 amount: Amount::ZERO,
+//                 token_id,
+//             },
+//             mint_to_address: unauthorized_minter.address(),
+//         }),
+//         assert: Box::new(move |result, _state| {
+//             if let TxEffect::Reverted(contents) = result.tx_receipt {
+//                 let Error::ModuleError(err) = contents.reason;
+//                 let mut chain = err.chain();
+//                 let message_1 = chain.next().unwrap().to_string();
+//                 let message_2 = chain.next().unwrap().to_string();
+//                 assert!(chain.next().is_none());
+//                 assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
+//                 assert_eq!(
+//                     message_2,
+//                     format!(
+//                         "Sender {} is not an admin of token {}",
+//                         unauthorized_minter.address(),
+//                         token_name
+//                     ),
+//                 );
+//             } else {
+//                 panic!("The transaction should have failed");
+//             }
+//         }),
+//     });
+// }
+//
+// /// The token originator shouldn't be able to mint tokens he created.
+// #[test]
+// fn try_create_token_and_mint_should_fail_if_not_authorized() {
+//     let (
+//         TestData {
+//             token_name,
+//             token_id,
+//             user_no_token_balance: user,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     runner.execute(
+//         user.create_plain_message::<RT, Bank<S>>(CallMessage::CreateToken {
+//             token_name: token_name.to_string().try_into().unwrap(),
+//             token_decimals: None,
+//             supply_cap: None,
+//             initial_balance: Amount::new(100),
+//             mint_to_address: user.address(),
+//             admins: SafeVec::new(),
+//         }),
+//     );
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: user.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+//             coins: Coins {
+//                 amount: INITIAL_BALANCE,
+//                 token_id,
+//             },
+//             mint_to_address: user.address(),
+//         }),
+//         assert: Box::new(move |result, _state| {
+//             if let TxEffect::Reverted(contents) = result.tx_receipt {
+//                 let Error::ModuleError(err) = contents.reason;
+//                 let mut chain = err.chain();
+//                 let message_1 = chain.next().unwrap().to_string();
+//                 let message_2 = chain.next().unwrap().to_string();
+//                 assert!(chain.next().is_none());
+//                 assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
+//                 assert_eq!(
+//                     message_2,
+//                     format!(
+//                         "Sender {} is not an admin of token {}",
+//                         user.address(),
+//                         token_name
+//                     ),
+//                 );
+//             } else {
+//                 panic!("The transaction should have failed");
+//             }
+//         }),
+//     });
+// }
+//
+// #[test]
+// fn mint_token_account_balance_overflow() {
+//     let (
+//         TestData {
+//             token_id, minter, ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+//             coins: Coins {
+//                 amount: Amount::MAX,
+//                 token_id,
+//             },
+//             mint_to_address: minter.address(),
+//         }),
+//         assert: Box::new(move |result, _state| {
+//             if let TxEffect::Reverted(contents) = result.tx_receipt {
+//                 let Error::ModuleError(err) = contents.reason;
+//                 let mut chain = err.chain();
+//                 let message_1 = chain.next().unwrap().to_string();
+//                 let message_2 = chain.next().unwrap().to_string();
+//                 assert!(chain.next().is_none());
+//                 assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
+//                 assert_eq!(
+//                     message_2,
+//                     "Total Supply overflow in the mint method of bank module",
+//                 );
+//             } else {
+//                 panic!("The transaction should have failed");
+//             }
+//         }),
+//     });
+// }
+//
+// #[test]
+// fn mint_token_total_supply_overflow() {
+//     let (
+//         TestData {
+//             token_name,
+//             token_id,
+//             minter,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     let minter_balance = minter.token_balance(&token_name).unwrap();
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+//             coins: Coins {
+//                 amount: Amount::MAX
+//                     .checked_sub(minter_balance)
+//                     .unwrap()
+//                     .checked_sub(Amount::new(1))
+//                     .unwrap(),
+//                 token_id,
+//             },
+//             mint_to_address: minter.address(),
+//         }),
+//         assert: Box::new(move |result, _state| {
+//             if let TxEffect::Reverted(contents) = result.tx_receipt {
+//                 let Error::ModuleError(err) = contents.reason;
+//                 let mut chain = err.chain();
+//                 let message_1 = chain.next().unwrap().to_string();
+//                 let message_2 = chain.next().unwrap().to_string();
+//                 assert!(chain.next().is_none());
+//                 assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
+//                 assert_eq!(
+//                     message_2,
+//                     "Total Supply overflow in the mint method of bank module",
+//                 );
+//             } else {
+//                 panic!("The transaction should have failed");
+//             }
+//         }),
+//     });
+// }
+//
+// #[test]
+// fn test_mint_token_fails_if_token_doesnt_exist() {
+//     let (
+//         TestData {
+//             user_high_token_balance: unauthorized_minter,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//     let invalid_token_id = TokenId::generate::<S>("invalid");
+//
+//     runner.execute_transaction(TransactionTestCase {
+//         input: unauthorized_minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+//             coins: Coins {
+//                 amount: Amount::new(50),
+//                 token_id: invalid_token_id,
+//             },
+//             mint_to_address: unauthorized_minter.address(),
+//         }),
+//         assert: Box::new(move |result, _state| {
+//             if let TxEffect::Reverted(contents) = result.tx_receipt {
+//                 let Error::ModuleError(err) = contents.reason;
+//                 let mut chain = err.chain();
+//                 let message_1 = chain.next().unwrap().to_string();
+//                 assert_eq!(
+//                     message_1,
+//                     format!("Failed to get token_id={invalid_token_id}")
+//                 );
+//             } else {
+//                 panic!("The transaction should have failed");
+//             }
+//         }),
+//     });
+// }
+//
+// #[test]
+// fn test_mint_token_fails_if_token_is_frozen() {
+//     let (
+//         TestData {
+//             token_id,
+//             token_name,
+//             minter,
+//             ..
+//         },
+//         mut runner,
+//     ) = setup();
+//
+//     runner
+//         .execute_transaction(TransactionTestCase {
+//             input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Freeze { token_id }),
+//             assert: Box::new(move |result, _state| {
+//                 assert!(result.tx_receipt.is_successful());
+//             }),
+//         })
+//         .execute_transaction(TransactionTestCase {
+//             input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+//                 coins: Coins {
+//                     amount: Amount::new(50),
+//                     token_id,
+//                 },
+//                 mint_to_address: minter.address(),
+//             }),
+//             assert: Box::new(move |result, _state| {
+//                 if let TxEffect::Reverted(contents) = result.tx_receipt {
+//                     let Error::ModuleError(err) = contents.reason;
+//                     let mut chain = err.chain();
+//                     let message_1 = chain.next().unwrap().to_string();
+//                     let message_2 = chain.next().unwrap().to_string();
+//                     assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
+//                     assert_eq!(
+//                         message_2,
+//                         format!("Attempt to mint frozen token {token_name}")
+//                     );
+//                 } else {
+//                     panic!("The transaction should have failed");
+//                 }
+//             }),
+//         });
+// }

--- a/crates/module-system/module-implementations/sov-bank/tests/integration/mint_test.rs
+++ b/crates/module-system/module-implementations/sov-bank/tests/integration/mint_test.rs
@@ -1,318 +1,279 @@
-// use sov_bank::{Bank, CallMessage, Coins, TokenId};
-// use sov_modules_api::prelude::UnwrapInfallible;
-// use sov_modules_api::{Amount, Error, SafeVec, TxEffect};
-// use sov_test_utils::{AsUser, TransactionTestCase};
-//
-// use crate::helpers::{setup, TestBankRuntimeEvent, TestData, RT};
-//
-// type S = sov_test_utils::TestSpec;
-//
-// const MINT_AMOUNT: Amount = Amount::new(100);
-// const INITIAL_BALANCE: Amount = Amount::new(100);
-//
-// /// Tests that a user can mint tokens.
-// #[test]
-// fn mint_token_success() {
-//     let (
-//         TestData {
-//             token_id,
-//             minter,
-//             user_no_token_balance,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-//             coins: Coins {
-//                 amount: MINT_AMOUNT,
-//                 token_id,
-//             },
-//             mint_to_address: user_no_token_balance.address(),
-//         }),
-//         assert: Box::new(move |result, state| {
-//             assert!(result.tx_receipt.is_successful());
-//             assert_eq!(result.events.len(), 1);
-//             assert_eq!(
-//                 result.events[0],
-//                 TestBankRuntimeEvent::Bank(sov_bank::event::Event::TokenMinted {
-//                     mint_to_identity: sov_bank::utils::TokenHolder::User(
-//                         user_no_token_balance.address()
-//                     ),
-//                     authorizer: sov_bank::utils::TokenHolder::User(minter.address()),
-//                     coins: Coins {
-//                         amount: MINT_AMOUNT,
-//                         token_id
-//                     }
-//                 })
-//             );
-//
-//             assert_eq!(
-//                 Bank::<S>::default()
-//                     .get_balance_of(&user_no_token_balance.address(), token_id, state)
-//                     .unwrap_infallible(),
-//                 Some(MINT_AMOUNT)
-//             );
-//         }),
-//     });
-// }
-//
-// #[test]
-// fn mint_token_fails_if_user_unauthorized() {
-//     let (
-//         TestData {
-//             token_name,
-//             token_id,
-//             user_high_token_balance: unauthorized_minter,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: unauthorized_minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-//             coins: Coins {
-//                 amount: Amount::ZERO,
-//                 token_id,
-//             },
-//             mint_to_address: unauthorized_minter.address(),
-//         }),
-//         assert: Box::new(move |result, _state| {
-//             if let TxEffect::Reverted(contents) = result.tx_receipt {
-//                 let Error::ModuleError(err) = contents.reason;
-//                 let mut chain = err.chain();
-//                 let message_1 = chain.next().unwrap().to_string();
-//                 let message_2 = chain.next().unwrap().to_string();
-//                 assert!(chain.next().is_none());
-//                 assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
-//                 assert_eq!(
-//                     message_2,
-//                     format!(
-//                         "Sender {} is not an admin of token {}",
-//                         unauthorized_minter.address(),
-//                         token_name
-//                     ),
-//                 );
-//             } else {
-//                 panic!("The transaction should have failed");
-//             }
-//         }),
-//     });
-// }
-//
-// /// The token originator shouldn't be able to mint tokens he created.
-// #[test]
-// fn try_create_token_and_mint_should_fail_if_not_authorized() {
-//     let (
-//         TestData {
-//             token_name,
-//             token_id,
-//             user_no_token_balance: user,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     runner.execute(
-//         user.create_plain_message::<RT, Bank<S>>(CallMessage::CreateToken {
-//             token_name: token_name.to_string().try_into().unwrap(),
-//             token_decimals: None,
-//             supply_cap: None,
-//             initial_balance: Amount::new(100),
-//             mint_to_address: user.address(),
-//             admins: SafeVec::new(),
-//         }),
-//     );
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: user.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-//             coins: Coins {
-//                 amount: INITIAL_BALANCE,
-//                 token_id,
-//             },
-//             mint_to_address: user.address(),
-//         }),
-//         assert: Box::new(move |result, _state| {
-//             if let TxEffect::Reverted(contents) = result.tx_receipt {
-//                 let Error::ModuleError(err) = contents.reason;
-//                 let mut chain = err.chain();
-//                 let message_1 = chain.next().unwrap().to_string();
-//                 let message_2 = chain.next().unwrap().to_string();
-//                 assert!(chain.next().is_none());
-//                 assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
-//                 assert_eq!(
-//                     message_2,
-//                     format!(
-//                         "Sender {} is not an admin of token {}",
-//                         user.address(),
-//                         token_name
-//                     ),
-//                 );
-//             } else {
-//                 panic!("The transaction should have failed");
-//             }
-//         }),
-//     });
-// }
-//
-// #[test]
-// fn mint_token_account_balance_overflow() {
-//     let (
-//         TestData {
-//             token_id, minter, ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-//             coins: Coins {
-//                 amount: Amount::MAX,
-//                 token_id,
-//             },
-//             mint_to_address: minter.address(),
-//         }),
-//         assert: Box::new(move |result, _state| {
-//             if let TxEffect::Reverted(contents) = result.tx_receipt {
-//                 let Error::ModuleError(err) = contents.reason;
-//                 let mut chain = err.chain();
-//                 let message_1 = chain.next().unwrap().to_string();
-//                 let message_2 = chain.next().unwrap().to_string();
-//                 assert!(chain.next().is_none());
-//                 assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
-//                 assert_eq!(
-//                     message_2,
-//                     "Total Supply overflow in the mint method of bank module",
-//                 );
-//             } else {
-//                 panic!("The transaction should have failed");
-//             }
-//         }),
-//     });
-// }
-//
-// #[test]
-// fn mint_token_total_supply_overflow() {
-//     let (
-//         TestData {
-//             token_name,
-//             token_id,
-//             minter,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     let minter_balance = minter.token_balance(&token_name).unwrap();
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-//             coins: Coins {
-//                 amount: Amount::MAX
-//                     .checked_sub(minter_balance)
-//                     .unwrap()
-//                     .checked_sub(Amount::new(1))
-//                     .unwrap(),
-//                 token_id,
-//             },
-//             mint_to_address: minter.address(),
-//         }),
-//         assert: Box::new(move |result, _state| {
-//             if let TxEffect::Reverted(contents) = result.tx_receipt {
-//                 let Error::ModuleError(err) = contents.reason;
-//                 let mut chain = err.chain();
-//                 let message_1 = chain.next().unwrap().to_string();
-//                 let message_2 = chain.next().unwrap().to_string();
-//                 assert!(chain.next().is_none());
-//                 assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
-//                 assert_eq!(
-//                     message_2,
-//                     "Total Supply overflow in the mint method of bank module",
-//                 );
-//             } else {
-//                 panic!("The transaction should have failed");
-//             }
-//         }),
-//     });
-// }
-//
-// #[test]
-// fn test_mint_token_fails_if_token_doesnt_exist() {
-//     let (
-//         TestData {
-//             user_high_token_balance: unauthorized_minter,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//     let invalid_token_id = TokenId::generate::<S>("invalid");
-//
-//     runner.execute_transaction(TransactionTestCase {
-//         input: unauthorized_minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-//             coins: Coins {
-//                 amount: Amount::new(50),
-//                 token_id: invalid_token_id,
-//             },
-//             mint_to_address: unauthorized_minter.address(),
-//         }),
-//         assert: Box::new(move |result, _state| {
-//             if let TxEffect::Reverted(contents) = result.tx_receipt {
-//                 let Error::ModuleError(err) = contents.reason;
-//                 let mut chain = err.chain();
-//                 let message_1 = chain.next().unwrap().to_string();
-//                 assert_eq!(
-//                     message_1,
-//                     format!("Failed to get token_id={invalid_token_id}")
-//                 );
-//             } else {
-//                 panic!("The transaction should have failed");
-//             }
-//         }),
-//     });
-// }
-//
-// #[test]
-// fn test_mint_token_fails_if_token_is_frozen() {
-//     let (
-//         TestData {
-//             token_id,
-//             token_name,
-//             minter,
-//             ..
-//         },
-//         mut runner,
-//     ) = setup();
-//
-//     runner
-//         .execute_transaction(TransactionTestCase {
-//             input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Freeze { token_id }),
-//             assert: Box::new(move |result, _state| {
-//                 assert!(result.tx_receipt.is_successful());
-//             }),
-//         })
-//         .execute_transaction(TransactionTestCase {
-//             input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
-//                 coins: Coins {
-//                     amount: Amount::new(50),
-//                     token_id,
-//                 },
-//                 mint_to_address: minter.address(),
-//             }),
-//             assert: Box::new(move |result, _state| {
-//                 if let TxEffect::Reverted(contents) = result.tx_receipt {
-//                     let Error::ModuleError(err) = contents.reason;
-//                     let mut chain = err.chain();
-//                     let message_1 = chain.next().unwrap().to_string();
-//                     let message_2 = chain.next().unwrap().to_string();
-//                     assert_eq!(message_1, format!("Failed to mint token_id={token_id}"));
-//                     assert_eq!(
-//                         message_2,
-//                         format!("Attempt to mint frozen token {token_name}")
-//                     );
-//                 } else {
-//                     panic!("The transaction should have failed");
-//                 }
-//             }),
-//         });
-// }
+use sov_bank::{Bank, CallMessage, Coins, TokenId};
+use sov_modules_api::prelude::UnwrapInfallible;
+use sov_modules_api::{Amount, SafeVec, TxEffect};
+use sov_test_utils::{AsUser, TransactionTestCase};
+
+use crate::helpers::{setup, TestBankRuntimeEvent, TestData, RT};
+
+type S = sov_test_utils::TestSpec;
+
+const MINT_AMOUNT: Amount = Amount::new(100);
+const INITIAL_BALANCE: Amount = Amount::new(100);
+
+/// Tests that a user can mint tokens.
+#[test]
+fn mint_token_success() {
+    let (
+        TestData {
+            token_id,
+            minter,
+            user_no_token_balance,
+            ..
+        },
+        mut runner,
+    ) = setup();
+
+    runner.execute_transaction(TransactionTestCase {
+        input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+            coins: Coins {
+                amount: MINT_AMOUNT,
+                token_id,
+            },
+            mint_to_address: user_no_token_balance.address(),
+        }),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(result.events.len(), 1);
+            assert_eq!(
+                result.events[0],
+                TestBankRuntimeEvent::Bank(sov_bank::event::Event::TokenMinted {
+                    mint_to_identity: sov_bank::utils::TokenHolder::User(
+                        user_no_token_balance.address()
+                    ),
+                    authorizer: sov_bank::utils::TokenHolder::User(minter.address()),
+                    coins: Coins {
+                        amount: MINT_AMOUNT,
+                        token_id
+                    }
+                })
+            );
+
+            assert_eq!(
+                Bank::<S>::default()
+                    .get_balance_of(&user_no_token_balance.address(), token_id, state)
+                    .unwrap_infallible(),
+                Some(MINT_AMOUNT)
+            );
+        }),
+    });
+}
+
+#[test]
+fn mint_token_fails_if_user_unauthorized() {
+    let (
+        TestData {
+            token_name,
+            token_id,
+            user_high_token_balance: unauthorized_minter,
+            ..
+        },
+        mut runner,
+    ) = setup();
+
+    runner.execute_transaction(TransactionTestCase {
+        input: unauthorized_minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+            coins: Coins {
+                amount: Amount::ZERO,
+                token_id,
+            },
+            mint_to_address: unauthorized_minter.address(),
+        }),
+        assert: Box::new(move |result, _state| {
+            if let TxEffect::Reverted(contents) = result.tx_receipt {
+                let actual = contents.reason.to_string();
+                let expected = format!(
+                    "Token mint error: Caller {} is not an admin for token {}",
+                    unauthorized_minter.address(),
+                    token_name
+                );
+                assert_eq!(actual, expected);
+            } else {
+                panic!("The transaction should have failed");
+            }
+        }),
+    });
+}
+
+/// The token originator shouldn't be able to mint tokens he created.
+#[test]
+fn try_create_token_and_mint_should_fail_if_not_authorized() {
+    let (
+        TestData {
+            token_name,
+            token_id,
+            user_no_token_balance: user,
+            ..
+        },
+        mut runner,
+    ) = setup();
+
+    runner.execute(
+        user.create_plain_message::<RT, Bank<S>>(CallMessage::CreateToken {
+            token_name: token_name.to_string().try_into().unwrap(),
+            token_decimals: None,
+            supply_cap: None,
+            initial_balance: Amount::new(100),
+            mint_to_address: user.address(),
+            admins: SafeVec::new(),
+        }),
+    );
+
+    runner.execute_transaction(TransactionTestCase {
+        input: user.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+            coins: Coins {
+                amount: INITIAL_BALANCE,
+                token_id,
+            },
+            mint_to_address: user.address(),
+        }),
+        assert: Box::new(move |result, _state| {
+            if let TxEffect::Reverted(contents) = result.tx_receipt {
+                let actual = contents.reason.to_string();
+                let expected = format!(
+                    "Token mint error: Caller {} is not an admin for token TestToken(BankToken)",
+                    user.address()
+                );
+                assert_eq!(actual, expected);
+            } else {
+                panic!("The transaction should have failed");
+            }
+        }),
+    });
+}
+
+#[test]
+fn mint_token_account_balance_overflow() {
+    let (
+        TestData {
+            token_id, minter, ..
+        },
+        mut runner,
+    ) = setup();
+
+    runner.execute_transaction(TransactionTestCase {
+        input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+            coins: Coins {
+                amount: Amount::MAX,
+                token_id,
+            },
+            mint_to_address: minter.address(),
+        }),
+        assert: Box::new(move |result, _state| {
+            if let TxEffect::Reverted(contents) = result.tx_receipt {
+                let actual = contents.reason.to_string();
+                let expected = "Token mint error: Overflow occurred: Total supply overflow when minting tokens, 300000 + 340282366920938463463374607431768211455";
+                assert_eq!(actual, expected);
+            } else {
+                panic!("The transaction should have failed");
+            }
+        }),
+    });
+}
+
+#[test]
+fn mint_token_total_supply_overflow() {
+    let (
+        TestData {
+            token_name,
+            token_id,
+            minter,
+            ..
+        },
+        mut runner,
+    ) = setup();
+
+    let minter_balance = minter.token_balance(&token_name).unwrap();
+
+    runner.execute_transaction(TransactionTestCase {
+        input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+            coins: Coins {
+                amount: Amount::MAX
+                    .checked_sub(minter_balance)
+                    .unwrap()
+                    .checked_sub(Amount::new(1))
+                    .unwrap(),
+                token_id,
+            },
+            mint_to_address: minter.address(),
+        }),
+        assert: Box::new(move |result, _state| {
+            if let TxEffect::Reverted(contents) = result.tx_receipt {
+                let actual = contents.reason.to_string();
+                let expected = "Token mint error: Overflow occurred: Total supply overflow when minting tokens, 300000 + 340282366920938463463374607431768111454";
+                assert_eq!(actual, expected);
+            } else {
+                panic!("The transaction should have failed");
+            }
+        }),
+    });
+}
+
+#[test]
+fn test_mint_token_fails_if_token_doesnt_exist() {
+    let (
+        TestData {
+            user_high_token_balance: unauthorized_minter,
+            ..
+        },
+        mut runner,
+    ) = setup();
+    let invalid_token_id = TokenId::generate::<S>("invalid");
+
+    runner.execute_transaction(TransactionTestCase {
+        input: unauthorized_minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+            coins: Coins {
+                amount: Amount::new(50),
+                token_id: invalid_token_id,
+            },
+            mint_to_address: unauthorized_minter.address(),
+        }),
+        assert: Box::new(move |result, _state| {
+            if let TxEffect::Reverted(contents) = result.tx_receipt {
+                let actual = contents.reason.to_string();
+                let expected = format!("Token mint error: Token not found: {invalid_token_id}");
+                assert_eq!(actual, expected);
+            } else {
+                panic!("The transaction should have failed");
+            }
+        }),
+    });
+}
+
+#[test]
+fn test_mint_token_fails_if_token_is_frozen() {
+    let (
+        TestData {
+            token_id,
+            token_name,
+            minter,
+            ..
+        },
+        mut runner,
+    ) = setup();
+
+    runner
+        .execute_transaction(TransactionTestCase {
+            input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Freeze { token_id }),
+            assert: Box::new(move |result, _state| {
+                assert!(result.tx_receipt.is_successful());
+            }),
+        })
+        .execute_transaction(TransactionTestCase {
+            input: minter.create_plain_message::<RT, Bank<S>>(CallMessage::Mint {
+                coins: Coins {
+                    amount: Amount::new(50),
+                    token_id,
+                },
+                mint_to_address: minter.address(),
+            }),
+            assert: Box::new(move |result, _state| {
+                if let TxEffect::Reverted(contents) = result.tx_receipt {
+                    let actual = contents.reason.to_string();
+                    let expected = format!("Token mint error: Token is frozen: {token_name}");
+                    assert_eq!(actual, expected);
+                } else {
+                    panic!("The transaction should have failed");
+                }
+            }),
+        });
+}

--- a/crates/module-system/module-implementations/sov-bank/tests/integration/transfer_test.rs
+++ b/crates/module-system/module-implementations/sov-bank/tests/integration/transfer_test.rs
@@ -1,7 +1,7 @@
 use sov_bank::utils::TokenHolder;
 use sov_bank::{config_gas_token_id, Bank, CallMessage, Coins};
 use sov_modules_api::prelude::UnwrapInfallible;
-use sov_modules_api::{Amount, Error, TxEffect};
+use sov_modules_api::{Amount, TxEffect};
 use sov_test_utils::runtime::genesis::TestTokenName;
 use sov_test_utils::{AsUser, TestUser, TransactionTestCase};
 
@@ -158,7 +158,6 @@ fn transfer_balance_too_low() {
         mut runner,
     ) = setup();
 
-    let user_high_token_balance_address = user_high_token_balance.address();
     let user_high_token_initial_balance =
         user_high_token_balance.token_balance(&token_name).unwrap();
 
@@ -176,37 +175,11 @@ fn transfer_balance_too_low() {
                 token_id,
             },
         }),
-        assert: Box::new(move |result, state| {
+        assert: Box::new(move |result, _state| {
             if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                let message_1 = chain.next().unwrap().to_string();
-                let message_2 = chain.next().unwrap().to_string();
-                assert!(chain.next().is_none());
-                assert_eq!(
-                    format!("Failed to transfer token_id={token_id}",),
-                    message_1
-                );
-                assert_eq!(
-                    format!(
-                        "Insufficient balance from={user_high_token_balance_address}, got={user_high_token_initial_balance}, needed={transfer_amount}",
-                    ),
-                    message_2,
-                );
-
-                assert_eq!(
-                    Bank::<S>::default()
-                        .get_balance_of(&user_high_token_balance_address, token_id, state)
-                        .unwrap_infallible(),
-                    Some(user_high_token_initial_balance)
-                );
-
-                assert_eq!(
-                    Bank::<S>::default()
-                        .get_balance_of(&user_no_token_balance_address, token_id, state)
-                        .unwrap_infallible(),
-                    None
-                );
+                let actual = contents.reason.to_string();
+                let expected = format!("Token transfer error: Underflow occurred: Insufficient balance for account {}, 100000 - 100001", user_high_token_balance.address());
+                assert_eq!(actual, expected);
             } else {
                 panic!("The transaction should have failed");
             }
@@ -237,19 +210,9 @@ fn transfer_non_existent_token() {
         }),
         assert: Box::new(move |result, _state| {
             if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                let message_1 = chain.next().unwrap().to_string();
-                let message_2 = chain.next().unwrap().to_string();
-                println!("{message_1}\n{message_2}");
-                assert!(chain.next().is_none());
-
-                assert!(message_1.starts_with(
-                    "Failed to transfer token_id=token_1ry733wdf5jt2hkgyljcgy54k3julqqtvrf9j2wfty0l7tnrrdqyqq4a0a3"
-                ));
-                assert!(message_2.starts_with(
-                    "Insufficient balance from="
-                ));
+                let actual = contents.reason.to_string();
+                let expected = format!("Token transfer error: Underflow occurred: Insufficient balance for account {}, 0 - 1", user.address());
+                assert_eq!(actual, expected);
             } else {
                 panic!("The transaction should have failed");
             }
@@ -270,7 +233,6 @@ fn transfer_sender_does_not_have_balance() {
         mut runner,
     ) = setup();
 
-    let sender_address = user_no_token_balance.address();
     let receiver_address = user_high_token_balance.address();
 
     runner.execute_transaction(TransactionTestCase {
@@ -283,24 +245,9 @@ fn transfer_sender_does_not_have_balance() {
         }),
         assert: Box::new(move |result, _state| {
             if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                let message_1 = chain.next().unwrap().to_string();
-                let message_2 = chain.next().unwrap().to_string();
-                assert!(chain.next().is_none());
-
-                assert_eq!(
-                    format!("Failed to transfer token_id={token_id}"),
-                    message_1
-                );
-
-                assert_eq!(
-                    format!(
-                        "Insufficient balance from={sender_address}, got=0, needed={TRANSFER_AMOUNT}",
-                    ),
-                    message_2,
-                    "The error message is incorrect"
-                );
+                let actual = contents.reason.to_string();
+                let expected = format!("Token transfer error: Underflow occurred: Insufficient balance for account {}, 0 - 10", user_no_token_balance.address());
+                assert_eq!(actual, expected);
             } else {
                 panic!("The transaction should have failed");
             }

--- a/crates/module-system/module-implementations/sov-bank/tests/integration/update_admin.rs
+++ b/crates/module-system/module-implementations/sov-bank/tests/integration/update_admin.rs
@@ -113,12 +113,11 @@ fn test_update_admin() {
             assert: Box::new(move |result, state| {
                 assert!(result.tx_receipt.is_reverted());
                 if let TxEffect::Reverted(contents) = result.tx_receipt {
-                    let Error::ModuleError(err) = contents.reason;
                     let msg = format!(
                         "`{}` is already a member of the admin list",
                         admins.current_admin.address()
                     );
-                    assert!(err.to_string().contains(&msg));
+                    assert!(contents.reason.to_string().contains(&msg));
                 }
 
                 assert_eq!(get_admins(&token_id, state), admins.original_admins());
@@ -137,12 +136,11 @@ fn test_update_admin() {
             assert: Box::new(move |result, state| {
                 assert!(result.tx_receipt.is_reverted());
                 if let TxEffect::Reverted(contents) = result.tx_receipt {
-                    let Error::ModuleError(err) = contents.reason;
                     let msg = format!(
                         "Cannot update admin: `{}` is not in the admin list for the specified token Token1",
                         minter.address()
                     );
-                    assert!(err.to_string().contains(&msg));
+                    assert!(contents.reason.to_string().contains(&msg));
                 }
                 assert_eq!(get_admins(&token_id, state), admins.original_admins());
             }),
@@ -179,12 +177,11 @@ fn test_update_admin() {
             assert: Box::new(move |result, state| {
                 assert!(result.tx_receipt.is_reverted());
                 if let TxEffect::Reverted(contents) = result.tx_receipt {
-                    let Error::ModuleError(err) = contents.reason;
                     let msg = format!(
                         "Cannot update admin: `{}` is not in the admin list for the specified token Token1",
                         admins.current_admin.address()
                     );
-                    assert!(err.to_string().contains(&msg));
+                    assert!(contents.reason.to_string().contains(&msg));
                 }
                 assert_eq!(get_admins(&token_id, state), admins.updated_admins());
             }),

--- a/crates/module-system/module-implementations/sov-bank/tests/integration/update_admin.rs
+++ b/crates/module-system/module-implementations/sov-bank/tests/integration/update_admin.rs
@@ -1,6 +1,6 @@
 use sov_bank::utils::TokenHolder;
 use sov_bank::{get_token_id, Amount, Bank, TokenId};
-use sov_modules_api::{Address, ApiStateAccessor, Error, TxEffect};
+use sov_modules_api::{Address, ApiStateAccessor, TxEffect};
 use sov_test_utils::{AsUser, TestUser, TransactionTestCase};
 
 use crate::helpers::*;
@@ -113,11 +113,12 @@ fn test_update_admin() {
             assert: Box::new(move |result, state| {
                 assert!(result.tx_receipt.is_reverted());
                 if let TxEffect::Reverted(contents) = result.tx_receipt {
-                    let msg = format!(
-                        "`{}` is already a member of the admin list",
+                    let actual = contents.reason.to_string();
+                    let expected = format!(
+                        "Token update admin error: Admin {} already exists for token Token1",
                         admins.current_admin.address()
                     );
-                    assert!(contents.reason.to_string().contains(&msg));
+                    assert_eq!(actual, expected);
                 }
 
                 assert_eq!(get_admins(&token_id, state), admins.original_admins());
@@ -136,11 +137,9 @@ fn test_update_admin() {
             assert: Box::new(move |result, state| {
                 assert!(result.tx_receipt.is_reverted());
                 if let TxEffect::Reverted(contents) = result.tx_receipt {
-                    let msg = format!(
-                        "Cannot update admin: `{}` is not in the admin list for the specified token Token1",
-                        minter.address()
-                    );
-                    assert!(contents.reason.to_string().contains(&msg));
+                    let actual = contents.reason.to_string();
+                    let expected = format!("Token update admin error: Admin to replace {minter_address} does not exist for token Token1");
+                    assert_eq!(actual, expected);
                 }
                 assert_eq!(get_admins(&token_id, state), admins.original_admins());
             }),
@@ -177,11 +176,9 @@ fn test_update_admin() {
             assert: Box::new(move |result, state| {
                 assert!(result.tx_receipt.is_reverted());
                 if let TxEffect::Reverted(contents) = result.tx_receipt {
-                    let msg = format!(
-                        "Cannot update admin: `{}` is not in the admin list for the specified token Token1",
-                        admins.current_admin.address()
-                    );
-                    assert!(contents.reason.to_string().contains(&msg));
+                    let actual = contents.reason.to_string();
+                    let expected = format!("Token update admin error: Admin to replace {} does not exist for token Token1", admins.current_admin.address());
+                    assert_eq!(actual, expected);
                 }
                 assert_eq!(get_admins(&token_id, state), admins.updated_admins());
             }),

--- a/crates/module-system/module-implementations/sov-blob-storage/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-blob-storage/src/lib.rs
@@ -265,6 +265,7 @@ impl<S: Spec> Module for BlobStorage<S> {
     type Config = ();
     type CallMessage = NotInstantiable;
     type Event = ();
+    type Error = anyhow::Error;
 
     fn genesis(
         &mut self,
@@ -280,7 +281,7 @@ impl<S: Spec> Module for BlobStorage<S> {
         _message: Self::CallMessage,
         _context: &sov_modules_api::Context<Self::Spec>,
         _state: &mut impl sov_modules_api::TxState<Self::Spec>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -578,6 +578,8 @@ impl<S: Spec> Module for ChainState<S> {
 
     type Event = Event<S>;
 
+    type Error = anyhow::Error;
+
     /// Genesis is called when a rollup is deployed and can be used to set initial state values in the module.
     fn genesis(
         &mut self,
@@ -594,7 +596,7 @@ impl<S: Spec> Module for ChainState<S> {
         message: Self::CallMessage,
         context: &sov_modules_api::Context<Self::Spec>,
         state: &mut impl sov_modules_api::TxState<Self::Spec>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         use sov_modules_api::EventEmitter;
         match message {
             CallMessage::TerminateSetupMode => {

--- a/crates/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/lib.rs
@@ -165,6 +165,8 @@ where
 
     type Event = ();
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
@@ -179,7 +181,7 @@ where
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         self.execute_call(msg, context, state)
     }
 }

--- a/crates/module-system/module-implementations/sov-operator-incentives/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-operator-incentives/src/lib.rs
@@ -29,12 +29,14 @@ impl<S: Spec> sov_modules_api::Module for OperatorIncentives<S> {
 
     type Event = ();
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
         config: &Self::Config,
         state: &mut impl GenesisState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         self.init_module(config, state)
     }
 
@@ -43,7 +45,7 @@ impl<S: Spec> sov_modules_api::Module for OperatorIncentives<S> {
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             CallMessage::UpdateRewardAddress { new_reward_address } => {
                 Ok(self.update_address(new_reward_address, context, state)?)

--- a/crates/module-system/module-implementations/sov-paymaster/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-paymaster/src/lib.rs
@@ -146,12 +146,14 @@ impl<S: Spec> Module for Paymaster<S> {
 
     type Event = Event<S>;
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
         config: &Self::Config,
         state: &mut impl GenesisState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         // The initialization logic
         self.init_module(config, state)
     }
@@ -161,7 +163,7 @@ impl<S: Spec> Module for Paymaster<S> {
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             CallMessage::RegisterPaymaster { policy } => {
                 self.register_paymaster(policy, context, state)?;

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/lib.rs
@@ -70,12 +70,14 @@ impl<S: Spec> sov_modules_api::Module for ProverIncentives<S> {
 
     type Event = Event<S>;
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
         config: &Self::Config,
         state: &mut impl GenesisState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         // The initialization logic
         self.init_module(config, state)
     }
@@ -85,7 +87,7 @@ impl<S: Spec> sov_modules_api::Module for ProverIncentives<S> {
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         if !self.should_reward_fees(state) {
             return Err(anyhow::anyhow!(
                 "Prover incentives call message received when operating in optimistic mode"

--- a/crates/module-system/module-implementations/sov-revenue-share/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-revenue-share/src/lib.rs
@@ -49,6 +49,7 @@ impl<S: Spec> Module for RevenueShare<S> {
     type Config = ();
     type CallMessage = CallMessage<S>;
     type Event = ();
+    type Error = anyhow::Error;
 
     fn genesis(
         &mut self,
@@ -69,7 +70,7 @@ impl<S: Spec> Module for RevenueShare<S> {
         msg: Self::CallMessage,
         context: &sov_modules_api::Context<S>,
         state: &mut impl sov_modules_api::TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             CallMessage::ActivateRevenueShare => {
                 self.activate_revenue_share(context, state)?;

--- a/crates/module-system/module-implementations/sov-revenue-share/tests/integration/revenue_share_tests.rs
+++ b/crates/module-system/module-implementations/sov-revenue-share/tests/integration/revenue_share_tests.rs
@@ -59,13 +59,14 @@ impl<S: Spec> Module for TestHelper<S> {
     type Config = ();
     type CallMessage = TestHelperCallMessage<S>;
     type Event = ();
+    type Error = anyhow::Error;
 
     fn call(
         &mut self,
         msg: Self::CallMessage,
         context: &sov_modules_api::Context<S>,
         state: &mut impl sov_modules_api::TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             TestHelperCallMessage::PayRevenueShare {
                 token_id,

--- a/crates/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
@@ -189,12 +189,14 @@ impl<S: Spec> Module for SequencerRegistry<S> {
 
     type Event = Event<S>;
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
         config: &Self::Config,
         state: &mut impl GenesisState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         self.init_module(config, state)
     }
 
@@ -203,7 +205,7 @@ impl<S: Spec> Module for SequencerRegistry<S> {
         message: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match message {
             CallMessage::Register { da_address, amount } => {
                 Ok(self.register(&da_address, amount, context, state)?)

--- a/crates/module-system/module-implementations/sov-sequencer-registry/tests/integration/registration_mechanism.rs
+++ b/crates/module-system/module-implementations/sov-sequencer-registry/tests/integration/registration_mechanism.rs
@@ -2,7 +2,6 @@ use sov_mock_da::MockAddress;
 use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::transaction::PriorityFeeBips;
-use sov_modules_api::Error::ModuleError;
 use sov_modules_api::{Amount, Gas, GasArray, GasSpec, GetGasPrice, TxEffect};
 use sov_sequencer_registry::{CallMessage, CustomError};
 use sov_test_utils::runtime::{TestRunner, ValueSetter};
@@ -172,15 +171,13 @@ fn test_registration_bond_too_small() {
         assert: Box::new(move |result, _state| match &result.tx_receipt {
             TxEffect::Reverted(reason) => {
                 assert_eq!(
-                    reason.reason,
-                    ModuleError(
-                        TestSequencerRegistryError::InsufficientStakeAmount {
-                            address: seq_address,
-                            bond_amount: amount_to_register,
-                            minimum_bond_amount: Amount::new(1000)
-                        }
-                        .into(),
-                    ),
+                    reason.reason.to_string(),
+                    TestSequencerRegistryError::InsufficientStakeAmount {
+                        address: seq_address,
+                        bond_amount: amount_to_register,
+                        minimum_bond_amount: Amount::new(1000)
+                    }
+                    .to_string(),
                     "Transaction reverted, but with unexpected reason"
                 );
             }
@@ -227,14 +224,12 @@ fn test_registration_not_enough_funds() {
         assert: Box::new(move |result, _state| match &result.tx_receipt {
             TxEffect::Reverted(reason) => {
                 assert_eq!(
-                    reason.reason,
-                    ModuleError(
-                        TestSequencerRegistryError::InsufficientFundsToRegister {
-                            address: additional_sequencer_address,
-                            amount: amount_to_register,
-                        }
-                        .into(),
-                    ),
+                    reason.reason.to_string(),
+                    TestSequencerRegistryError::InsufficientFundsToRegister {
+                        address: additional_sequencer_address,
+                        amount: amount_to_register,
+                    }
+                    .to_string(),
                     "Transaction reverted, but with unexpected reason"
                 );
             }
@@ -274,11 +269,9 @@ fn test_registration_second_time() {
         assert: Box::new(move |result, _state| match &result.tx_receipt {
             TxEffect::Reverted(reason) => {
                 assert_eq!(
-                    reason.reason,
-                    ModuleError(
-                        TestSequencerRegistryError::AlreadyRegistered(other_sequencer_address)
-                            .into(),
-                    ),
+                    reason.reason.to_string(),
+                    TestSequencerRegistryError::AlreadyRegistered(other_sequencer_address)
+                        .to_string(),
                     "Transaction reverted, but with unexpected reason"
                 );
             }
@@ -531,15 +524,11 @@ fn cannot_exit_with_own_batch() {
         assert: Box::new(move |result, _state| match &result.tx_receipt {
             TxEffect::Reverted(reason) => {
                 assert_eq!(
-                    reason.reason,
-                    ModuleError(
-                        TestSequencerRegistryError::Custom(
-                            CustomError::CannotUnregisterDuringOwnBatch(
-                                default_sequencer.da_address,
-                            )
-                        )
-                        .into(),
-                    ),
+                    reason.reason.to_string(),
+                    TestSequencerRegistryError::Custom(
+                        CustomError::CannotUnregisterDuringOwnBatch(default_sequencer.da_address,)
+                    )
+                    .to_string(),
                     "Transaction reverted, but with unexpected reason"
                 );
             }
@@ -588,16 +577,14 @@ fn test_exit_different_sender_fails() {
         assert: Box::new(move |result, _state| match &result.tx_receipt {
             TxEffect::Reverted(reason) => {
                 assert_eq!(
-                    reason.reason,
-                    ModuleError(
-                        TestSequencerRegistryError::Custom(
-                            CustomError::SuppliedAddressDoesNotMatchTxSender {
-                                parameter: second_sequencer_address,
-                                sender: additional_sequencer_address,
-                            },
-                        )
-                        .into(),
-                    ),
+                    reason.reason.to_string(),
+                    TestSequencerRegistryError::Custom(
+                        CustomError::SuppliedAddressDoesNotMatchTxSender {
+                            parameter: second_sequencer_address,
+                            sender: additional_sequencer_address,
+                        },
+                    )
+                    .to_string(),
                     "Transaction reverted, but with unexpected reason"
                 );
             }
@@ -625,16 +612,14 @@ fn test_exit_different_sender_fails() {
         assert: Box::new(move |result, _state| match &result.tx_receipt {
             TxEffect::Reverted(reason) => {
                 assert_eq!(
-                    reason.reason,
-                    ModuleError(
-                        TestSequencerRegistryError::Custom(
-                            CustomError::SuppliedAddressDoesNotMatchTxSender {
-                                parameter: second_sequencer.address(),
-                                sender: additional_sequencer.address(),
-                            },
-                        )
-                        .into(),
-                    ),
+                    reason.reason.to_string(),
+                    TestSequencerRegistryError::Custom(
+                        CustomError::SuppliedAddressDoesNotMatchTxSender {
+                            parameter: second_sequencer.address(),
+                            sender: additional_sequencer.address(),
+                        },
+                    )
+                    .to_string(),
                     "Transaction reverted, but with unexpected reason"
                 );
             }
@@ -745,16 +730,14 @@ fn test_balance_increase_fails_if_insufficient_funds() {
         assert: Box::new(move |result, _state| match &result.tx_receipt {
             TxEffect::Reverted(reason) => {
                 assert_eq!(
-                    reason.reason,
-                    ModuleError(
-                        TestSequencerRegistryError::InsufficientFundsToTopUpAccount {
-                            address: default_sequencer_address,
-                            amount_to_add: default_sequencer_balance
-                                .checked_add(SEQUENCE_STAKE)
-                                .unwrap(),
-                        }
-                        .into(),
-                    ),
+                    reason.reason.to_string(),
+                    TestSequencerRegistryError::InsufficientFundsToTopUpAccount {
+                        address: default_sequencer_address,
+                        amount_to_add: default_sequencer_balance
+                            .checked_add(SEQUENCE_STAKE)
+                            .unwrap(),
+                    }
+                    .to_string(),
                     "Transaction reverted, but with unexpected reason"
                 );
             }
@@ -815,13 +798,11 @@ fn test_balance_increase_fails_for_unknown_sequencer() {
         assert: Box::new(move |result, _state| match &result.tx_receipt {
             TxEffect::Reverted(reason) => {
                 assert_eq!(
-                    reason.reason,
-                    ModuleError(
-                        TestSequencerRegistryError::IsNotRegistered(MockAddress::from(
-                            NON_DEFAULT_SEQUENCER_DA_ADDRESS,
-                        ))
-                        .into()
-                    ),
+                    reason.reason.to_string(),
+                    TestSequencerRegistryError::IsNotRegistered(MockAddress::from(
+                        NON_DEFAULT_SEQUENCER_DA_ADDRESS,
+                    ))
+                    .to_string(),
                     "Transaction reverted, but with unexpected reason"
                 );
             }

--- a/crates/module-system/module-implementations/sov-synthetic-load/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-synthetic-load/src/lib.rs
@@ -49,12 +49,14 @@ impl<S: Spec> Module for SyntheticLoad<S> {
 
     type Event = Event;
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
         _config: &Self::Config,
         state: &mut impl GenesisState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         self.init_module(state)
     }
 
@@ -63,7 +65,7 @@ impl<S: Spec> Module for SyntheticLoad<S> {
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         let mut state_wrapped = state.to_revertable();
         let state = &mut state_wrapped;
         let res = match msg {

--- a/crates/module-system/module-implementations/sov-test-modules/src/access_pattern/mod.rs
+++ b/crates/module-system/module-implementations/sov-test-modules/src/access_pattern/mod.rs
@@ -285,12 +285,14 @@ impl<S: Spec> Module for AccessPattern<S> {
 
     type Event = ();
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
         config: &Self::Config,
         state: &mut impl GenesisState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         // The initialization logic
         self.admin.set(&config.admin, state).map_err(Into::into)
     }
@@ -300,7 +302,7 @@ impl<S: Spec> Module for AccessPattern<S> {
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         let admin = self
             .admin
             .get(state)

--- a/crates/module-system/module-implementations/sov-test-modules/src/cache_module.rs
+++ b/crates/module-system/module-implementations/sov-test-modules/src/cache_module.rs
@@ -121,12 +121,14 @@ impl<S: Spec> Module for CacheAndRevertTester<S> {
 
     type Event = Event;
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
         _config: &Self::Config,
         _state: &mut impl GenesisState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -135,7 +137,7 @@ impl<S: Spec> Module for CacheAndRevertTester<S> {
         msg: Self::CallMessage,
         _context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             CallMessage::TestAndSetU8(msg) => msg.run(state),
             CallMessage::TestAndSetU16(msg) => msg.run(state),

--- a/crates/module-system/module-implementations/sov-test-modules/src/gas.rs
+++ b/crates/module-system/module-implementations/sov-test-modules/src/gas.rs
@@ -58,12 +58,14 @@ impl<S: Spec> Module for GasTester<S> {
 
     type Event = ();
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
         _config: &Self::Config,
         _state: &mut impl GenesisState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -72,7 +74,7 @@ impl<S: Spec> Module for GasTester<S> {
         msg: Self::CallMessage,
         _context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             CallMessage::SetValue { value } => {
                 self.charge_gas(

--- a/crates/module-system/module-implementations/sov-test-modules/src/hooks_count/mod.rs
+++ b/crates/module-system/module-implementations/sov-test-modules/src/hooks_count/mod.rs
@@ -57,12 +57,14 @@ impl<S: Spec> Module for HooksCount<S> {
 
     type Event = Event;
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
         _config: &Self::Config,
         state: &mut impl GenesisState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         // The initialization logic
         self.init_module(state)
     }
@@ -72,7 +74,7 @@ impl<S: Spec> Module for HooksCount<S> {
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             CallMessage::AssertVisibleSlotNumber {
                 expected_visible_slot_number,

--- a/crates/module-system/module-implementations/sov-test-modules/tests/integration/bench_pattern/mod.rs
+++ b/crates/module-system/module-implementations/sov-test-modules/tests/integration/bench_pattern/mod.rs
@@ -1,6 +1,5 @@
 use borsh::BorshSerialize;
 use sha2::Digest;
-use sov_modules_api::Error::ModuleError;
 use sov_modules_api::{CryptoSpec, PrivateKey, Spec};
 use sov_test_modules::access_pattern::{
     AccessPattern, AccessPatternGenesisConfig, AccessPatternMessages, HooksConfig,
@@ -418,15 +417,10 @@ fn test_setting_value_not_admin() {
         ),
         assert: Box::new(move |result, _state| {
             match &result.tx_receipt {
-                sov_modules_api::TxEffect::Reverted(reason) => match &reason.reason {
-                    ModuleError(err) => {
-                        assert!(err
-                            .chain()
-                            .next()
-                            .unwrap()
-                            .to_string()
-                            .contains("sender is not an admin"));
-                    }
+                sov_modules_api::TxEffect::Reverted(reason) => {
+                    let actual = reason.reason.to_string();
+                    let expected = format!("The transaction sender is not an admin of the access patterns module. Sender {}", non_admin.address());
+                    assert_eq!(actual, expected);
                 },
                 unexpected => panic!("Expected transaction to revert, but got: {unexpected:?}"),
             };

--- a/crates/module-system/module-implementations/sov-test-modules/tests/integration/gas/mod.rs
+++ b/crates/module-system/module-implementations/sov-test-modules/tests/integration/gas/mod.rs
@@ -1,6 +1,6 @@
 use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::UnwrapInfallible;
-use sov_modules_api::{Amount, Error, Gas, GasSpec, Spec, TxEffect};
+use sov_modules_api::{Amount, Gas, GasSpec, Spec, TxEffect};
 use sov_test_modules::gas::{CallMessage, GasTester};
 use sov_test_utils::{
     AsUser, AtomicAmount, TransactionTestAssert, TransactionTestCase, TEST_DEFAULT_USER_BALANCE,

--- a/crates/module-system/module-implementations/sov-test-modules/tests/integration/gas/mod.rs
+++ b/crates/module-system/module-implementations/sov-test-modules/tests/integration/gas/mod.rs
@@ -198,16 +198,9 @@ fn not_enough_gas_wont_panic() {
             );
 
             if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                assert_eq!(chain.len(), 1, "The error chain is incorrect");
-
-                assert!(
-                    chain.next().unwrap().to_string().contains(
-                        "The amount to charge is greater than the funds available in the meter."
-                    ),
-                    "The error message is incorrect"
-                );
+                let actual = contents.reason.to_string();
+                let expected = "The amount to charge is greater than the funds available in the meter.".to_owned();
+                assert!(actual.contains(&expected));
             } else {
                 panic!("The transaction outcome is incorrect")
             }
@@ -230,16 +223,9 @@ fn very_high_gas_to_charge_should_overflow() {
             );
 
             if let TxEffect::Reverted(contents) = result.tx_receipt {
-                let Error::ModuleError(err) = contents.reason;
-                let mut chain = err.chain();
-                assert_eq!(chain.len(), 1, "The error chain is incorrect");
-
-                assert!(
-                        chain.next().unwrap().to_string().contains(
-                            "Gas calculation overflow: Charge Funds: Unable to charge gas, because the calculation overflows"
-                        ),
-                        "The error message is incorrect"
-                    );
+                let actual = contents.reason.to_string();
+                let expected = "Gas calculation overflow: Charge Funds: Unable to charge gas, because the calculation overflows".to_owned();
+                assert!(actual.contains(&expected));
             } else {
                 panic!("The transaction outcome is incorrect")
             }

--- a/crates/module-system/module-implementations/sov-test-modules/tests/integration/gas/mod.rs
+++ b/crates/module-system/module-implementations/sov-test-modules/tests/integration/gas/mod.rs
@@ -199,7 +199,9 @@ fn not_enough_gas_wont_panic() {
 
             if let TxEffect::Reverted(contents) = result.tx_receipt {
                 let actual = contents.reason.to_string();
-                let expected = "The amount to charge is greater than the funds available in the meter.".to_owned();
+                let expected =
+                    "The amount to charge is greater than the funds available in the meter."
+                        .to_owned();
                 assert!(actual.contains(&expected));
             } else {
                 panic!("The transaction outcome is incorrect")

--- a/crates/module-system/module-implementations/sov-test-state-consistency/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-test-state-consistency/src/lib.rs
@@ -86,12 +86,14 @@ impl<S: Spec> Module for StateConsistency<S> {
 
     type Event = Event<S>;
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
         _config: &Self::Config,
         state: &mut impl GenesisState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         self.accessory_value.set(&0, state)?;
         Ok(())
     }
@@ -101,7 +103,7 @@ impl<S: Spec> Module for StateConsistency<S> {
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         match msg {
             CallMessage::UpdateValue { old_check, new } => {
                 self.update_value(old_check, new, context, state)

--- a/crates/module-system/module-implementations/sov-uniqueness/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-uniqueness/src/lib.rs
@@ -104,12 +104,14 @@ impl<S: Spec> Module for Uniqueness<S> {
 
     type Event = ();
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
         _config: &Self::Config,
         _state: &mut impl GenesisState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -118,7 +120,7 @@ impl<S: Spec> Module for Uniqueness<S> {
         _msg: Self::CallMessage,
         _context: &Context<S>,
         _state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         unreachable!()
     }
 }

--- a/crates/module-system/module-implementations/sov-value-setter/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-value-setter/src/lib.rs
@@ -65,6 +65,8 @@ impl<S: Spec> Module for ValueSetter<S> {
 
     type Event = Event;
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
@@ -80,7 +82,7 @@ impl<S: Spec> Module for ValueSetter<S> {
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         let mut state_wrapped = state.to_revertable();
         let state = &mut state_wrapped;
         let res = match msg {

--- a/crates/module-system/module-implementations/sov-value-setter/tests/integration/tests.rs
+++ b/crates/module-system/module-implementations/sov-value-setter/tests/integration/tests.rs
@@ -1,6 +1,5 @@
 use sov_modules_api::macros::UniversalWallet;
 use sov_modules_api::sov_universal_wallet::schema::Schema;
-use sov_modules_api::Error::ModuleError;
 use sov_test_utils::runtime::genesis::zk::config::HighLevelZkGenesisConfig;
 use sov_test_utils::runtime::{TestRunner, ValueSetter};
 use sov_test_utils::{generate_zk_runtime, AsUser, TestSpec, TestUser, TransactionTestCase};
@@ -65,23 +64,21 @@ fn test_setting_value_not_admin() {
             value: 5,
             gas: None,
         }),
-        assert: Box::new(move |result, _state| {
-            match &result.tx_receipt {
-                sov_modules_api::TxEffect::Reverted(reason) => {
-                    assert_eq!(
-                        &reason.reason,
-                        &ModuleError(
-                            SetValueError::<S>::WrongSender {
-                                sender: non_admin.address(),
-                                admin: admin.address()
-                            }
-                            .into()
-                        ),
-                        "Transaction reverted, but with unexpected reason"
-                    );
-                }
-                unexpected => panic!("Expected transaction to revert, but got: {unexpected:?}"),
-            };
+        assert: Box::new(move |_result, _state| {
+            // match &result.tx_receipt {
+            //     sov_modules_api::TxEffect::Reverted(reason) => {
+            //         assert_eq!(
+            //             &reason.reason,
+            //             &SetValueError::<S>::WrongSender {
+            //                 sender: non_admin.address(),
+            //                 admin: admin.address()
+            //             }
+            //             .into(),
+            //             "Transaction reverted, but with unexpected reason"
+            //         );
+            //     }
+            //     unexpected => panic!("Expected transaction to revert, but got: {unexpected:?}"),
+            // };
         }),
     });
 }

--- a/crates/module-system/module-implementations/sov-value-setter/tests/integration/tests.rs
+++ b/crates/module-system/module-implementations/sov-value-setter/tests/integration/tests.rs
@@ -64,21 +64,21 @@ fn test_setting_value_not_admin() {
             value: 5,
             gas: None,
         }),
-        assert: Box::new(move |_result, _state| {
-            // match &result.tx_receipt {
-            //     sov_modules_api::TxEffect::Reverted(reason) => {
-            //         assert_eq!(
-            //             &reason.reason,
-            //             &SetValueError::<S>::WrongSender {
-            //                 sender: non_admin.address(),
-            //                 admin: admin.address()
-            //             }
-            //             .into(),
-            //             "Transaction reverted, but with unexpected reason"
-            //         );
-            //     }
-            //     unexpected => panic!("Expected transaction to revert, but got: {unexpected:?}"),
-            // };
+        assert: Box::new(move |result, _state| {
+            match &result.tx_receipt {
+                sov_modules_api::TxEffect::Reverted(reason) => {
+                    assert_eq!(
+                        &reason.reason.to_string(),
+                        &SetValueError::<S>::WrongSender {
+                            sender: non_admin.address(),
+                            admin: admin.address()
+                        }
+                        .to_string(),
+                        "Transaction reverted, but with unexpected reason"
+                    );
+                }
+                unexpected => panic!("Expected transaction to revert, but got: {unexpected:?}"),
+            };
         }),
     });
 }

--- a/crates/module-system/sov-capabilities/src/lib.rs
+++ b/crates/module-system/sov-capabilities/src/lib.rs
@@ -183,12 +183,12 @@ where
     ) -> anyhow::Result<()> {
         let rewarded_prover_module = self.get_prover_token_holder(oprating_mode, state);
         // Transfer the penalty from the sequencer bank to the sequencer
-        self.bank.transfer_from(
+        Ok(self.bank.transfer_from(
             self.bank.id.clone().to_payable(),
             rewarded_prover_module.to_owned(),
             gas_coins(amount),
             state,
-        )
+        )?)
     }
 
     fn return_escrowed_funds_to_sequencer<

--- a/crates/module-system/sov-modules-api/src/common/error.rs
+++ b/crates/module-system/sov-modules-api/src/common/error.rs
@@ -3,8 +3,8 @@
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
-use serde::{ser::Error as _, Deserialize, Serialize};
 use crate::rest::utils::json_obj;
+use serde::{ser::Error as _, Deserialize, Serialize};
 
 /// A bech32 address parse error.
 #[derive(Debug, thiserror::Error)]

--- a/crates/module-system/sov-modules-api/src/common/error.rs
+++ b/crates/module-system/sov-modules-api/src/common/error.rs
@@ -3,8 +3,26 @@
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
-use crate::rest::utils::json_obj;
 use serde::{ser::Error as _, Deserialize, Serialize};
+
+/// Exactly like [`serde_json::Value`], but returns a JSON object instead of a
+/// JSON value.
+#[macro_export]
+macro_rules! json_obj {
+    ($($json:tt)+) => {
+        $crate::to_json_object(::serde_json::json!($($json)+))
+    };
+}
+
+/// Calls [`serde_json::to_value`] on the given value but panics if the
+/// resulting value is not a JSON object.
+pub fn to_json_object<T: Serialize>(value: T) -> serde_json::Map<String, serde_json::Value> {
+    let value = serde_json::to_value(value).unwrap();
+    match value {
+        serde_json::Value::Object(obj) => obj,
+        _ => panic!("Expected serialization to produce a JSON object; got {value:?}"),
+    }
+}
 
 /// A bech32 address parse error.
 #[derive(Debug, thiserror::Error)]

--- a/crates/module-system/sov-modules-api/src/common/error.rs
+++ b/crates/module-system/sov-modules-api/src/common/error.rs
@@ -1,5 +1,10 @@
 //! Module error definitions.
 
+use std::fmt::{Debug, Display};
+use std::sync::Arc;
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
 /// A bech32 address parse error.
 #[derive(Debug, thiserror::Error)]
 pub enum Bech32ParseError {
@@ -14,113 +19,176 @@ pub enum Bech32ParseError {
     WrongLength(usize, usize),
 }
 
-/// General error type in the Module System.
-#[derive(Debug, thiserror::Error)]
-pub enum ModuleError {
-    /// Custom error thrown by a module.
-    #[error(transparent)]
-    ModuleError(#[from] anyhow::Error),
+// TODO: Error associated type needs to derive Debug + Display + Serialize + DeserializeOwned + 'static
+
+/// TODO
+pub trait ErrorDetail: Debug + Display {
+    /// TODO
+    fn error_detail(&self) -> Result<serde_json::Value, ()>;
 }
 
-impl serde::Serialize for ModuleError {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let error = match self {
-            ModuleError::ModuleError(e) => format!("{e:}"),
-        };
-        error.serialize(serializer)
+impl ErrorDetail for anyhow::Error {
+    fn error_detail(&self) -> Result<serde_json::Value, ()> {
+        Ok(serde_json::json!({ "message": format!("{self}") }))
     }
 }
 
-impl<'de> serde::Deserialize<'de> for ModuleError {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let error = String::deserialize(deserializer)?;
-        Ok(Self::ModuleError(anyhow::Error::msg(error)))
+/// TODO
+#[derive(Debug, Clone)]
+pub struct ModuleError(Arc<dyn ErrorDetail + Send + Sync>);
+
+impl ModuleError {
+    /// TODO
+    pub fn error_detail(&self) -> Result<serde_json::Value, ()> {
+        self.0.error_detail()
     }
 }
 
-/// We are manually implementing clone because the inner [`anyhow::Error`] doesn't implement clone.
-/// We need to manually loop through the error chain to not loose any of the error context. The intermediate
-/// error types are not clonable so we need to manually convert them to strings.
-impl Clone for ModuleError {
-    fn clone(&self) -> Self {
-        match self {
-            Self::ModuleError(anyhow_err) => {
-                let mut chain = anyhow_err.chain();
-
-                Self::ModuleError(if let Some(err) = chain.next() {
-                    let mut output = anyhow::Error::msg(err.to_string());
-
-                    for outer_err in chain {
-                        output = output.context(anyhow::Error::msg(outer_err.to_string()));
-                    }
-
-                    output
-                } else {
-                    anyhow::anyhow!("Empty error message")
-                })
-            }
-        }
+impl Display for ModuleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 
 impl PartialEq for ModuleError {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::ModuleError(e1), Self::ModuleError(e2)) => e1.to_string() == e2.to_string(),
-        }
+        self.to_string() == other.to_string()
     }
 }
 
 impl Eq for ModuleError {}
 
-#[cfg(test)]
-mod test {
-    use anyhow::anyhow;
-
-    use crate::ModuleError;
-
-    #[test]
-    fn test_module_error_roundtrip() {
-        let error = ModuleError::ModuleError(anyhow::Error::msg("test"));
-        let serialized = serde_json::to_string(&error).unwrap();
-        let deserialized: ModuleError = serde_json::from_str(&serialized).unwrap();
-        // We can only asserts start, because RUST_BACKTRACE can alter full output
-        assert!(deserialized.to_string().starts_with("test"));
-    }
-
-    /// Tests that the inner error context gets correctly propagated when copying an error.
-    #[test]
-    fn test_module_error_copy() {
-        let error = anyhow!("Inner message").context("Outer context".to_string());
-
-        let cloned_err = ModuleError::ModuleError(error).clone();
-
-        match cloned_err {
-            ModuleError::ModuleError(cloned_err) => {
-                let mut chained_clone = cloned_err.chain();
-
-                assert_eq!(
-                    chained_clone.len(),
-                    2,
-                    "The cloned error doesn't have the correct length"
-                );
-                assert_eq!(
-                    chained_clone.next().unwrap().to_string(),
-                    "Inner message",
-                    "The inner message has not been correctly cloned"
-                );
-                assert_eq!(
-                    chained_clone.next().unwrap().to_string(),
-                    "Outer context",
-                    "The outer context has not been correctly cloned"
-                );
-            }
-        }
+impl<T: ErrorDetail + Send + Sync + 'static> From<T> for ModuleError {
+    fn from(value: T) -> Self {
+        Self(Arc::new(value))
     }
 }
+
+impl Serialize for ModuleError {
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        todo!()
+    }
+}
+
+impl<'de> Deserialize<'de> for ModuleError {
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        todo!()
+    }
+}
+
+// General error type in the Module System.
+// #[derive(Debug, thiserror::Error)]
+// pub enum ModuleError {
+//     /// Custom error thrown by a module.
+//     #[error(transparent)]
+//     ModuleError(#[from] anyhow::Error),
+// }
+//
+// impl serde::Serialize for ModuleError {
+//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+//     where
+//         S: serde::Serializer,
+//     {
+//         let error = match self {
+//             ModuleError::ModuleError(e) => format!("{e:}"),
+//         };
+//         error.serialize(serializer)
+//     }
+// }
+//
+// impl<'de> serde::Deserialize<'de> for ModuleError {
+//     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+//     where
+//         D: serde::Deserializer<'de>,
+//     {
+//         let error = String::deserialize(deserializer)?;
+//         Ok(Self::ModuleError(anyhow::Error::msg(error)))
+//     }
+// }
+//
+// /// We are manually implementing clone because the inner [`anyhow::Error`] doesn't implement clone.
+// /// We need to manually loop through the error chain to not loose any of the error context. The intermediate
+// /// error types are not clonable so we need to manually convert them to strings.
+// impl Clone for ModuleError {
+//     fn clone(&self) -> Self {
+//         match self {
+//             Self::ModuleError(anyhow_err) => {
+//                 let mut chain = anyhow_err.chain();
+//
+//                 Self::ModuleError(if let Some(err) = chain.next() {
+//                     let mut output = anyhow::Error::msg(err.to_string());
+//
+//                     for outer_err in chain {
+//                         output = output.context(anyhow::Error::msg(outer_err.to_string()));
+//                     }
+//
+//                     output
+//                 } else {
+//                     anyhow::anyhow!("Empty error message")
+//                 })
+//             }
+//         }
+//     }
+// }
+//
+// impl PartialEq for ModuleError {
+//     fn eq(&self, other: &Self) -> bool {
+//         match (self, other) {
+//             (Self::ModuleError(e1), Self::ModuleError(e2)) => e1.to_string() == e2.to_string(),
+//         }
+//     }
+// }
+//
+// impl Eq for ModuleError {}
+
+// #[cfg(test)]
+// mod test {
+//     use anyhow::anyhow;
+//
+//     use crate::ModuleError;
+//
+//     #[test]
+//     fn test_module_error_roundtrip() {
+//         let error = ModuleError::ModuleError(anyhow::Error::msg("test"));
+//         let serialized = serde_json::to_string(&error).unwrap();
+//         let deserialized: ModuleError = serde_json::from_str(&serialized).unwrap();
+//         // We can only asserts start, because RUST_BACKTRACE can alter full output
+//         assert!(deserialized.to_string().starts_with("test"));
+//     }
+//
+//     /// Tests that the inner error context gets correctly propagated when copying an error.
+//     #[test]
+//     fn test_module_error_copy() {
+//         let error = anyhow!("Inner message").context("Outer context".to_string());
+//
+//         let cloned_err = ModuleError::ModuleError(error).clone();
+//
+//         match cloned_err {
+//             ModuleError::ModuleError(cloned_err) => {
+//                 let mut chained_clone = cloned_err.chain();
+//
+//                 assert_eq!(
+//                     chained_clone.len(),
+//                     2,
+//                     "The cloned error doesn't have the correct length"
+//                 );
+//                 assert_eq!(
+//                     chained_clone.next().unwrap().to_string(),
+//                     "Inner message",
+//                     "The inner message has not been correctly cloned"
+//                 );
+//                 assert_eq!(
+//                     chained_clone.next().unwrap().to_string(),
+//                     "Outer context",
+//                     "The outer context has not been correctly cloned"
+//                 );
+//             }
+//         }
+//     }
+// }

--- a/crates/module-system/sov-modules-api/src/common/error.rs
+++ b/crates/module-system/sov-modules-api/src/common/error.rs
@@ -19,32 +19,59 @@ pub enum Bech32ParseError {
     WrongLength(usize, usize),
 }
 
-/// todo
+/// Core error types that can occur during module operations.
+///
+/// This enum provides a unified error interface for fundamental module system operations,
+/// particularly around state access and generic error handling. All variants are transparent
+/// to preserve the original error information while providing structured error categorization.
 #[derive(Debug, thiserror::Error)]
 pub enum CoreModuleError {
-    /// todo
+    /// A generic error that doesn't fit into specific categories.
+    ///
+    /// This variant wraps arbitrary errors using `anyhow::Error`, providing a catch-all
+    /// for unexpected errors or errors from external dependencies that don't have
+    /// specific handling in the module system.
     #[error(transparent)]
     Generic(#[from] anyhow::Error),
-    ///todo
+    /// An error occurred while reading from the module's state.
+    ///
+    /// This variant captures errors that occur during state read operations, such as
+    /// accessing stored values, iterating over state entries, or deserializing state data.
     #[error(transparent)]
     StateRead(Box<dyn std::error::Error + Send + Sync>),
-    /// TODO
+    /// An error occurred while writing to the module's state.
+    ///
+    /// This variant captures errors that occur during state write operations, such as
+    /// setting values, deleting entries, or serializing data for storage. Common causes
+    /// include gas limit exceeded during writes.
     #[error(transparent)]
     StateWrite(Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl CoreModuleError {
-    /// todo
+    /// Creates a new `StateRead` error variant from any error type.
+    ///
+    /// This constructor function provides a convenient way to wrap state read errors
+    /// into the standardized `CoreModuleError::StateRead` variant.
+    ///
+    /// The `E` type parameter follows the same trait bounds used on state accessors.
     pub fn state_read<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
         Self::StateRead(Box::new(err))
     }
 
-    /// TODO
+    /// Creates a new `StateWrite` error variant from any error type.
+    ///
+    /// This constructor function provides a convenient way to wrap state write errors
+    /// into the standardized `CoreModuleError::StateWrite` variant.
+    ///
+    /// The `E` type parameter follows the same trait bounds used on state accessors.
     pub fn state_write<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
         Self::StateWrite(Box::new(err))
     }
 }
 
+/// Errors are serializable in order to provide structured error information for the [`ErrorDetail`] trait.
+/// [`anyhow::Error`] & State errors don't implement `Serialize` so we have to do it manually here.
 impl serde::Serialize for CoreModuleError {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -79,9 +106,42 @@ impl ErrorDetail for CoreModuleError {
     }
 }
 
-/// TODO
+/// Trait for providing structured error details as JSON for client-side applications.
+///
+/// This trait defines how module errors should be returned to client-side applications by
+/// providing rich, structured information about failure conditions that can be serialized
+/// and transmitted over APIs. It's the primary mechanism for exposing module errors through
+/// rollup simulation endpoints and error reporting systems.
+///
+/// **Module implementations should implement this trait on their `Error` associated type**
+/// to provide useful structured data to client-side applications, enabling proper error
+/// handling, user feedback, and debugging capabilities.
+///
+/// The trait requires `Debug + Display` to ensure all error types can be both printed for
+/// debugging and formatted for user-facing messages, while the `error_detail` method provides
+/// machine-readable structured data for client consumption.
 pub trait ErrorDetail: Debug + Display {
-    /// TODO
+    /// Returns detailed error information as a structured JSON value.
+    ///
+    /// This method should serialize the error into a `serde_json::Value` containing all relevant
+    /// information about the failure. The JSON structure can include error codes, context,
+    /// and any parameters that caused the failure to enable proper error handling and debugging.
+    ///
+    /// # Returns
+    /// - `Ok(serde_json::Value)` - Structured error details in JSON format
+    /// - `Err(Box<dyn Error>)` - If serialization fails (though implementations should avoid this)
+    ///
+    /// # Examples
+    /// Typical JSON structure might include:
+    /// ```json
+    /// {
+    ///   "error_code": "insufficient_balance",
+    ///   "amount": "100",
+    ///   "balance": "50",
+    ///   "from": "addr1",
+    ///   "to": "addr2"
+    /// }
+    /// ```
     fn error_detail(&self) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>>;
 }
 
@@ -91,6 +151,15 @@ impl ErrorDetail for anyhow::Error {
     }
 }
 
+/// A type-erased error representation used for deserializing `ModuleError`.
+///
+/// Since `ModuleError` wraps `dyn ErrorDetail` trait objects, it cannot directly deserialize
+/// back to the original concrete error type. This struct serves as a type-less container
+/// that holds the raw JSON error data, allowing `ModuleError` to implement `Deserialize`
+/// by wrapping any deserialized error data in this generic representation.
+///
+/// When `ModuleError` is deserialized, the JSON data is captured in this struct, which
+/// then implements `ErrorDetail` by simply returning the stored JSON data unchanged.
 #[derive(Clone, Debug, derive_more::Display)]
 struct DeserializedError {
     data: serde_json::Value,
@@ -102,12 +171,28 @@ impl ErrorDetail for DeserializedError {
     }
 }
 
-/// TODO
+/// A type-erased module error that implements `ErrorDetail`.
+///
+/// This struct wraps any error type that implements `ErrorDetail` in a thread-safe,
+/// cloneable wrapper. It's used throughout the module system to provide a uniform
+/// error interface while preserving the detailed error information from specific
+/// module implementations.
+///
+/// The wrapper uses `Arc` for efficient cloning and to satisfy the `Send + Sync`
+/// requirements for use across thread boundaries in the rollup system.
 #[derive(Debug, Clone, derive_more::Display)]
 pub struct ModuleError(Arc<dyn ErrorDetail + Send + Sync>);
 
 impl ModuleError {
-    /// TODO
+    /// Extracts detailed error information as structured JSON.
+    ///
+    /// This method delegates to the underlying error's `error_detail` implementation
+    /// to provide rich, structured information about the failure condition. The returned
+    /// JSON can be used for API responses, logging, and debugging.
+    ///
+    /// # Returns
+    /// - `Ok(serde_json::Value)` - Structured error details from the wrapped error
+    /// - `Err(Box<dyn Error>)` - If the underlying error detail extraction fails
     pub fn error_detail(
         &self,
     ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {

--- a/crates/module-system/sov-modules-api/src/common/error.rs
+++ b/crates/module-system/sov-modules-api/src/common/error.rs
@@ -4,6 +4,7 @@ use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
 use serde::{ser::Error as _, Deserialize, Serialize};
+use sov_rest_utils::json_obj;
 
 /// A bech32 address parse error.
 #[derive(Debug, thiserror::Error)]
@@ -101,10 +102,46 @@ impl serde::Serialize for CoreModuleError {
 }
 
 impl ErrorDetail for CoreModuleError {
-    fn error_detail(&self) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
-        Ok(serde_json::to_value(self).expect("Serialization of CoreModuleError should not fail"))
+    fn error_detail(&self) -> Result<ErrorContext, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(json_obj!(self))
     }
 }
+
+/// Type alias for structured error detail objects.
+///
+/// This represents the standardized format for error details returned by the `ErrorDetail` trait.
+/// It's a JSON object (map) containing structured information about error conditions, including
+/// error codes, parameters, and contextual data that client-side applications can parse and
+/// handle appropriately.
+///
+/// # Examples
+/// ```json
+/// {
+///   "error_code": "insufficient_balance",
+///   "amount": "100",
+///   "balance": "50",
+///   "from": "addr1",
+///   "to": "addr2"
+/// }
+/// ```
+/// Type alias for structured error detail objects.
+///
+/// This represents the standardized format for error details returned by the `ErrorDetail` trait.
+/// It's a JSON object (map) containing structured information about error conditions, including
+/// error codes, parameters, and contextual data that client-side applications can parse and
+/// handle appropriately.
+///
+/// # Examples
+/// ```json
+/// {
+///   "error_code": "insufficient_balance",
+///   "amount": "100",
+///   "balance": "50",
+///   "from": "addr1",
+///   "to": "addr2"
+/// }
+/// ```
+pub type ErrorContext = serde_json::Map<String, serde_json::Value>;
 
 /// Trait for providing structured error details as JSON for client-side applications.
 ///
@@ -117,18 +154,27 @@ impl ErrorDetail for CoreModuleError {
 /// to provide useful structured data to client-side applications, enabling proper error
 /// handling, user feedback, and debugging capabilities.
 ///
+/// ## Error Response Structure
+///
+/// When a module call fails, the structured error details returned by this trait are
+/// automatically inserted into the `detail` field of the error response sent to clients.
+/// This provides rich, machine-readable context about the failure beyond just the error message.
+///
 /// The trait requires `Debug + Display` to ensure all error types can be both printed for
 /// debugging and formatted for user-facing messages, while the `error_detail` method provides
 /// machine-readable structured data for client consumption.
 pub trait ErrorDetail: Debug + Display {
-    /// Returns detailed error information as a structured JSON value.
+    /// Returns detailed error information as a structured JSON object.
     ///
-    /// This method should serialize the error into a `serde_json::Value` containing all relevant
-    /// information about the failure. The JSON structure can include error codes, context,
-    /// and any parameters that caused the failure to enable proper error handling and debugging.
+    /// This method should serialize the error into an `ErrorContext` (JSON object) containing
+    /// all relevant information about the failure. The JSON structure should include error codes,
+    /// context, and any parameters that caused the failure to enable proper error handling and debugging.
+    ///
+    /// **The returned JSON object will be automatically inserted into the `detail` field**
+    /// of error responses when module calls fail, providing clients with structured error information.
     ///
     /// # Returns
-    /// - `Ok(serde_json::Value)` - Structured error details in JSON format
+    /// - `Ok(ErrorContext)` - Structured error details as a JSON object
     /// - `Err(Box<dyn Error>)` - If serialization fails (though implementations should avoid this)
     ///
     /// # Examples
@@ -142,12 +188,12 @@ pub trait ErrorDetail: Debug + Display {
     ///   "to": "addr2"
     /// }
     /// ```
-    fn error_detail(&self) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>>;
+    fn error_detail(&self) -> Result<ErrorContext, Box<dyn std::error::Error + Send + Sync>>;
 }
 
 impl ErrorDetail for anyhow::Error {
-    fn error_detail(&self) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
-        Ok(serde_json::json!({ "message": format!("{self}") }))
+    fn error_detail(&self) -> Result<ErrorContext, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(json_obj!({ "message": format!("{self}") }))
     }
 }
 
@@ -160,14 +206,24 @@ impl ErrorDetail for anyhow::Error {
 ///
 /// When `ModuleError` is deserialized, the JSON data is captured in this struct, which
 /// then implements `ErrorDetail` by simply returning the stored JSON data unchanged.
-#[derive(Clone, Debug, derive_more::Display)]
+#[derive(Clone, Debug)]
 struct DeserializedError {
-    data: serde_json::Value,
+    data: ErrorContext,
 }
 
 impl ErrorDetail for DeserializedError {
-    fn error_detail(&self) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+    fn error_detail(&self) -> Result<ErrorContext, Box<dyn std::error::Error + Send + Sync>> {
         Ok(self.data.clone())
+    }
+}
+
+impl std::fmt::Display for DeserializedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Deserialized error: {}",
+            serde_json::to_string(&self.data).unwrap()
+        )
     }
 }
 
@@ -191,11 +247,9 @@ impl ModuleError {
     /// JSON can be used for API responses, logging, and debugging.
     ///
     /// # Returns
-    /// - `Ok(serde_json::Value)` - Structured error details from the wrapped error
+    /// - `Ok(ErrorContext)` - Structured error details from the wrapped error
     /// - `Err(Box<dyn Error>)` - If the underlying error detail extraction fails
-    pub fn error_detail(
-        &self,
-    ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+    pub fn error_detail(&self) -> Result<ErrorContext, Box<dyn std::error::Error + Send + Sync>> {
         self.0.error_detail()
     }
 }
@@ -231,7 +285,7 @@ impl<'de> Deserialize<'de> for ModuleError {
     where
         D: serde::Deserializer<'de>,
     {
-        let value = serde_json::Value::deserialize(deserializer)?;
+        let value = serde_json::Map::deserialize(deserializer)?;
         Ok(Self(Arc::new(DeserializedError { data: value })))
     }
 }

--- a/crates/module-system/sov-modules-api/src/common/error.rs
+++ b/crates/module-system/sov-modules-api/src/common/error.rs
@@ -3,7 +3,7 @@
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{ser::Error as _, Deserialize, Serialize};
 
 /// A bech32 address parse error.
 #[derive(Debug, thiserror::Error)]
@@ -19,34 +19,99 @@ pub enum Bech32ParseError {
     WrongLength(usize, usize),
 }
 
-// TODO: Error associated type needs to derive Debug + Display + Serialize + DeserializeOwned + 'static
+/// todo
+#[derive(Debug, thiserror::Error)]
+pub enum CoreModuleError {
+    /// todo
+    #[error(transparent)]
+    Generic(#[from] anyhow::Error),
+    ///todo
+    #[error(transparent)]
+    StateRead(Box<dyn std::error::Error + Send + Sync>),
+    /// TODO
+    #[error(transparent)]
+    StateWrite(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl CoreModuleError {
+    /// todo
+    pub fn state_read<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
+        Self::StateRead(Box::new(err))
+    }
+
+    /// TODO
+    pub fn state_write<E: std::error::Error + Send + Sync + 'static>(err: E) -> Self {
+        Self::StateWrite(Box::new(err))
+    }
+}
+
+impl serde::Serialize for CoreModuleError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let mut state = serializer.serialize_struct("CoreModuleError", 2)?;
+
+        match self {
+            CoreModuleError::Generic(e) => {
+                state.serialize_field("error_code", "generic")?;
+                state.serialize_field("message", &e.to_string())?;
+            }
+            CoreModuleError::StateRead(e) => {
+                state.serialize_field("error_code", "state_read")?;
+                state.serialize_field("message", &e.to_string())?;
+            }
+            CoreModuleError::StateWrite(e) => {
+                state.serialize_field("error_code", "state_write")?;
+                state.serialize_field("message", &e.to_string())?;
+            }
+        }
+
+        state.end()
+    }
+}
+
+impl ErrorDetail for CoreModuleError {
+    fn error_detail(&self) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(serde_json::to_value(self).expect("Serialization of CoreModuleError should not fail"))
+    }
+}
 
 /// TODO
 pub trait ErrorDetail: Debug + Display {
     /// TODO
-    fn error_detail(&self) -> Result<serde_json::Value, ()>;
+    fn error_detail(&self) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>>;
 }
 
 impl ErrorDetail for anyhow::Error {
-    fn error_detail(&self) -> Result<serde_json::Value, ()> {
+    fn error_detail(&self) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
         Ok(serde_json::json!({ "message": format!("{self}") }))
     }
 }
 
+#[derive(Clone, Debug, derive_more::Display)]
+struct DeserializedError {
+    data: serde_json::Value,
+}
+
+impl ErrorDetail for DeserializedError {
+    fn error_detail(&self) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(self.data.clone())
+    }
+}
+
 /// TODO
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, derive_more::Display)]
 pub struct ModuleError(Arc<dyn ErrorDetail + Send + Sync>);
 
 impl ModuleError {
     /// TODO
-    pub fn error_detail(&self) -> Result<serde_json::Value, ()> {
+    pub fn error_detail(
+        &self,
+    ) -> Result<serde_json::Value, Box<dyn std::error::Error + Send + Sync>> {
         self.0.error_detail()
-    }
-}
-
-impl Display for ModuleError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
     }
 }
 
@@ -65,130 +130,23 @@ impl<T: ErrorDetail + Send + Sync + 'static> From<T> for ModuleError {
 }
 
 impl Serialize for ModuleError {
-    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        todo!()
+        self.0
+            .error_detail()
+            .map_err(S::Error::custom)?
+            .serialize(serializer)
     }
 }
 
 impl<'de> Deserialize<'de> for ModuleError {
-    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        todo!()
+        let value = serde_json::Value::deserialize(deserializer)?;
+        Ok(Self(Arc::new(DeserializedError { data: value })))
     }
 }
-
-// General error type in the Module System.
-// #[derive(Debug, thiserror::Error)]
-// pub enum ModuleError {
-//     /// Custom error thrown by a module.
-//     #[error(transparent)]
-//     ModuleError(#[from] anyhow::Error),
-// }
-//
-// impl serde::Serialize for ModuleError {
-//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-//     where
-//         S: serde::Serializer,
-//     {
-//         let error = match self {
-//             ModuleError::ModuleError(e) => format!("{e:}"),
-//         };
-//         error.serialize(serializer)
-//     }
-// }
-//
-// impl<'de> serde::Deserialize<'de> for ModuleError {
-//     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-//     where
-//         D: serde::Deserializer<'de>,
-//     {
-//         let error = String::deserialize(deserializer)?;
-//         Ok(Self::ModuleError(anyhow::Error::msg(error)))
-//     }
-// }
-//
-// /// We are manually implementing clone because the inner [`anyhow::Error`] doesn't implement clone.
-// /// We need to manually loop through the error chain to not loose any of the error context. The intermediate
-// /// error types are not clonable so we need to manually convert them to strings.
-// impl Clone for ModuleError {
-//     fn clone(&self) -> Self {
-//         match self {
-//             Self::ModuleError(anyhow_err) => {
-//                 let mut chain = anyhow_err.chain();
-//
-//                 Self::ModuleError(if let Some(err) = chain.next() {
-//                     let mut output = anyhow::Error::msg(err.to_string());
-//
-//                     for outer_err in chain {
-//                         output = output.context(anyhow::Error::msg(outer_err.to_string()));
-//                     }
-//
-//                     output
-//                 } else {
-//                     anyhow::anyhow!("Empty error message")
-//                 })
-//             }
-//         }
-//     }
-// }
-//
-// impl PartialEq for ModuleError {
-//     fn eq(&self, other: &Self) -> bool {
-//         match (self, other) {
-//             (Self::ModuleError(e1), Self::ModuleError(e2)) => e1.to_string() == e2.to_string(),
-//         }
-//     }
-// }
-//
-// impl Eq for ModuleError {}
-
-// #[cfg(test)]
-// mod test {
-//     use anyhow::anyhow;
-//
-//     use crate::ModuleError;
-//
-//     #[test]
-//     fn test_module_error_roundtrip() {
-//         let error = ModuleError::ModuleError(anyhow::Error::msg("test"));
-//         let serialized = serde_json::to_string(&error).unwrap();
-//         let deserialized: ModuleError = serde_json::from_str(&serialized).unwrap();
-//         // We can only asserts start, because RUST_BACKTRACE can alter full output
-//         assert!(deserialized.to_string().starts_with("test"));
-//     }
-//
-//     /// Tests that the inner error context gets correctly propagated when copying an error.
-//     #[test]
-//     fn test_module_error_copy() {
-//         let error = anyhow!("Inner message").context("Outer context".to_string());
-//
-//         let cloned_err = ModuleError::ModuleError(error).clone();
-//
-//         match cloned_err {
-//             ModuleError::ModuleError(cloned_err) => {
-//                 let mut chained_clone = cloned_err.chain();
-//
-//                 assert_eq!(
-//                     chained_clone.len(),
-//                     2,
-//                     "The cloned error doesn't have the correct length"
-//                 );
-//                 assert_eq!(
-//                     chained_clone.next().unwrap().to_string(),
-//                     "Inner message",
-//                     "The inner message has not been correctly cloned"
-//                 );
-//                 assert_eq!(
-//                     chained_clone.next().unwrap().to_string(),
-//                     "Outer context",
-//                     "The outer context has not been correctly cloned"
-//                 );
-//             }
-//         }
-//     }
-// }

--- a/crates/module-system/sov-modules-api/src/common/error.rs
+++ b/crates/module-system/sov-modules-api/src/common/error.rs
@@ -4,7 +4,7 @@ use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
 use serde::{ser::Error as _, Deserialize, Serialize};
-use sov_rest_utils::json_obj;
+use crate::rest::utils::json_obj;
 
 /// A bech32 address parse error.
 #[derive(Debug, thiserror::Error)]

--- a/crates/module-system/sov-modules-api/src/common/error.rs
+++ b/crates/module-system/sov-modules-api/src/common/error.rs
@@ -5,10 +5,42 @@ use std::sync::Arc;
 
 use serde::{ser::Error as _, Deserialize, Serialize};
 
-/// Exactly like [`serde_json::Value`], but returns a JSON object instead of a
-/// JSON value.
+/// Macro for creating structured error detail objects for the `ErrorDetail` trait.
+///
+/// This macro provides a convenient way to create `ErrorContext` objects (JSON objects)
+/// that contain structured error information. It accepts the same syntax as `serde_json::json!`
+/// but ensures the result is always a JSON object, which is required by the `ErrorDetail` trait.
+///
+/// The macro is particularly useful in `ErrorDetail` implementations where you need to
+/// provide rich, structured error information to client applications.
+///
+/// # Panics
+/// Panics if the provided JSON does not serialize to a JSON object (e.g., if you pass
+/// a primitive value, array, or null instead of an object with key-value pairs).
+///
+/// # Examples
+/// ```
+/// use sov_modules_api::err_detail;
+///
+/// // Create error details for insufficient balance
+/// let details = err_detail!({
+///     "error_code": "insufficient_balance",
+///     "amount": "100",
+///     "balance": "50",
+///     "token_id": "token123"
+/// });
+///
+/// // Create error details with dynamic values
+/// let amount = 100u64;
+/// let balance = 50u64;
+/// let details = err_detail!({
+///     "error_code": "insufficient_balance",
+///     "amount": amount.to_string(),
+///     "balance": balance.to_string()
+/// });
+/// ```
 #[macro_export]
-macro_rules! json_obj {
+macro_rules! err_detail {
     ($($json:tt)+) => {
         $crate::to_json_object(::serde_json::json!($($json)+))
     };
@@ -121,7 +153,7 @@ impl serde::Serialize for CoreModuleError {
 
 impl ErrorDetail for CoreModuleError {
     fn error_detail(&self) -> Result<ErrorContext, Box<dyn std::error::Error + Send + Sync>> {
-        Ok(json_obj!(self))
+        Ok(err_detail!(self))
     }
 }
 
@@ -211,7 +243,7 @@ pub trait ErrorDetail: Debug + Display {
 
 impl ErrorDetail for anyhow::Error {
     fn error_detail(&self) -> Result<ErrorContext, Box<dyn std::error::Error + Send + Sync>> {
-        Ok(json_obj!({ "message": format!("{self}") }))
+        Ok(err_detail!({ "message": format!("{self}") }))
     }
 }
 

--- a/crates/module-system/sov-modules-api/src/module/mod.rs
+++ b/crates/module-system/sov-modules-api/src/module/mod.rs
@@ -44,6 +44,9 @@ pub trait Module: Clone {
         + core::marker::Send
         + PartialEq;
 
+    /// Error type returned by module operations.
+    type Error;
+
     /// Genesis is called once when a rollup is deployed.
     ///
     /// You should use this function to initialize all of your module's `StateValue`s and run any other
@@ -86,7 +89,7 @@ pub trait Module: Clone {
         _message: Self::CallMessage,
         _context: &Context<Self::Spec>,
         _state: &mut impl TxState<Self::Spec>,
-    ) -> anyhow::Result<()>;
+    ) -> Result<(), Self::Error>;
 
     /// Attempts to charge the provided amount of gas from the working set reverting the transaction if unsuccessful.
     ///

--- a/crates/module-system/sov-modules-api/src/module/mod.rs
+++ b/crates/module-system/sov-modules-api/src/module/mod.rs
@@ -44,8 +44,8 @@ pub trait Module: Clone {
         + core::marker::Send
         + PartialEq;
 
-    /// Error type returned by module operations.
-    type Error;
+    /// Error type returned by [`Module::call`].
+    type Error: Debug + std::fmt::Display + Send + Sync + 'static;
 
     /// Genesis is called once when a rollup is deployed.
     ///

--- a/crates/module-system/sov-modules-api/src/reexport_macros.rs
+++ b/crates/module-system/sov-modules-api/src/reexport_macros.rs
@@ -290,6 +290,7 @@ pub use sov_modules_macros::ModuleInfo;
 /// # impl<S: Spec> sov_modules_api::Module for MyModule<S> {
 /// #    type Spec = S;
 /// #    type Config = ();
+/// #    type Error = anyhow::Error;
 /// #    type CallMessage = ();
 /// #    type Event = ();
 /// #
@@ -329,6 +330,7 @@ pub use sov_modules_macros::ModuleInfo;
 /// # impl<S: Spec> sov_modules_api::Module for MyModule<S> {
 /// #    type Spec = S;
 /// #    type Config = ();
+/// #    type Error = anyhow::Error;
 /// #    type CallMessage = ();
 /// #    type Event = ();
 /// #
@@ -372,6 +374,7 @@ pub use sov_modules_macros::ModuleInfo;
 /// # impl<S: Spec> sov_modules_api::Module for MyModule<S> {
 /// #    type Spec = S;
 /// #    type Config = ();
+/// #    type Error = anyhow::Error;
 /// #    type CallMessage = ();
 /// #    type Event = ();
 /// #

--- a/crates/module-system/sov-modules-api/src/reexport_macros.rs
+++ b/crates/module-system/sov-modules-api/src/reexport_macros.rs
@@ -298,7 +298,7 @@ pub use sov_modules_macros::ModuleInfo;
 /// #        _msg: Self::CallMessage,
 /// #        _context: &Context<Self::Spec>,
 /// #        _state: &mut impl sov_modules_api::state::TxState<S>,
-/// #    ) -> anyhow::Result<()> {
+/// #    ) -> Result<(), Self::Error> {
 /// #        unimplemented!()
 /// #    }
 /// # }
@@ -337,7 +337,7 @@ pub use sov_modules_macros::ModuleInfo;
 /// #        _msg: Self::CallMessage,
 /// #        _context: &Context<Self::Spec>,
 /// #        _state: &mut impl sov_modules_api::state::TxState<S>,
-/// #    ) -> anyhow::Result<()> {
+/// #    ) -> Result<(), Self::Error> {
 /// #        unimplemented!()
 /// #    }
 /// # }
@@ -380,7 +380,7 @@ pub use sov_modules_macros::ModuleInfo;
 /// #        _msg: Self::CallMessage,
 /// #        _context: &Context<Self::Spec>,
 /// #        _state: &mut impl sov_modules_api::state::TxState<S>,
-/// #    ) -> anyhow::Result<()> {
+/// #    ) -> Result<(), Self::Error> {
 /// #        unimplemented!()
 /// #    }
 /// # }

--- a/crates/module-system/sov-modules-api/src/rest/mod.rs
+++ b/crates/module-system/sov-modules-api/src/rest/mod.rs
@@ -133,7 +133,7 @@ impl<M: ModuleInfo> HasRestApi<M::Spec> for &M {
 /// #        _msg: Self::CallMessage,
 /// #        _context: &Context<Self::Spec>,
 /// #        _state: &mut impl sov_modules_api::state::TxState<S>,
-/// #    ) -> anyhow::Result<()> {
+/// #    ) -> Result<(), Self::Error> {
 /// #        unimplemented!()
 /// #    }
 /// # }

--- a/crates/module-system/sov-modules-api/src/rest/mod.rs
+++ b/crates/module-system/sov-modules-api/src/rest/mod.rs
@@ -125,6 +125,7 @@ impl<M: ModuleInfo> HasRestApi<M::Spec> for &M {
 /// # impl<S: Spec> sov_modules_api::Module for MyModule<S> {
 /// #    type Spec = S;
 /// #    type Config = ();
+/// #    type Error = anyhow::Error;
 /// #    type CallMessage = ();
 /// #    type Event = ();
 /// #

--- a/crates/module-system/sov-modules-api/tests/integration/rest_api.rs
+++ b/crates/module-system/sov-modules-api/tests/integration/rest_api.rs
@@ -102,13 +102,14 @@ where
     type Config = ();
     type CallMessage = ();
     type Event = ();
+    type Error = anyhow::Error;
 
     fn call(
         &mut self,
         _message: Self::CallMessage,
         _context: &Context<Self::Spec>,
         _state: &mut impl TxState<Self::Spec>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/crates/module-system/sov-modules-macros/src/dispatch/genesis.rs
+++ b/crates/module-system/sov-modules-macros/src/dispatch/genesis.rs
@@ -94,7 +94,7 @@ impl GenesisMacro {
             quote::quote! {
                 // Ensure that the user didn't accidentally set the same discriminant for multiple modules
                 if !discriminants.insert(::sov_modules_api::ModuleInfo::discriminant(&self.#ident)) {
-                    return Err(::sov_modules_api::Error::ModuleError(::anyhow::Error::msg(format!("Duplicate module discriminant for {}. Update your constants.toml to give each module a unique discriminant", std::any::type_name_of_val(&self.#ident)))));
+                    return Err(::anyhow::Error::msg(format!("Duplicate module discriminant for {}. Update your constants.toml to give each module a unique discriminant", std::any::type_name_of_val(&self.#ident))).into());
                 }
             }
         });
@@ -108,7 +108,7 @@ impl GenesisMacro {
                 for module in sorted_modules {
                     match module {
                         #(#matches)*
-                        _ => Err(::sov_modules_api::Error::ModuleError(::anyhow::Error::msg(format!("Module not found. Please verify that the module is included in the Runtime: {:?}", module)))),
+                        _ => Err(::anyhow::Error::msg(format!("Module not found. Please verify that the module is included in the Runtime: {:?}", module)).into()),
                     }?
                 }
         }

--- a/crates/module-system/sov-modules-macros/tests/integration/derive_wallet.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/derive_wallet.rs
@@ -49,6 +49,7 @@ pub mod first_test_module {
         type Config = MockGenesisParams;
         type CallMessage = MyStruct;
         type Event = ();
+        type Error = anyhow::Error;
 
         fn genesis(
             &mut self,
@@ -111,6 +112,7 @@ pub mod second_test_module {
         type Config = ();
         type CallMessage = MyEnum;
         type Event = ();
+        type Error = anyhow::Error;
 
         fn genesis(
             &mut self,

--- a/crates/module-system/sov-modules-macros/tests/integration/dispatch.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/dispatch.rs
@@ -30,7 +30,7 @@ pub mod first_test_module {
             Ok(self
                 .state_in_first_struct
                 .get(state)
-                .map_err(|e| Error::ModuleError(e.into()))?
+                .map_err(|e| anyhow::anyhow!(e))?
                 .unwrap())
         }
     }
@@ -108,7 +108,7 @@ pub mod second_test_module {
             Ok(self
                 .state_in_second_struct
                 .get(state)
-                .map_err(|e| Error::ModuleError(e.into()))?
+                .map_err(|e| anyhow::anyhow!(e))?
                 .unwrap())
         }
     }
@@ -199,9 +199,10 @@ pub mod third_test_module {
             &self,
             state: &mut WorkingSet<S>,
         ) -> Result<Option<OtherGeneric>, Error> {
-            self.state_in_third_struct
+            Ok(self
+                .state_in_third_struct
                 .get(state)
-                .map_err(|e| Error::ModuleError(e.into()))
+                .map_err(|e| anyhow::anyhow!(e))?)
         }
     }
 

--- a/crates/module-system/sov-modules-macros/tests/integration/dispatch.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/dispatch.rs
@@ -61,6 +61,7 @@ pub mod first_test_module {
         type Config = Config;
         type CallMessage = u8;
         type Event = Event;
+        type Error = anyhow::Error;
 
         fn genesis(
             &mut self,
@@ -131,6 +132,7 @@ pub mod second_test_module {
         type Config = ();
         type CallMessage = u8;
         type Event = Event;
+        type Error = anyhow::Error;
 
         fn genesis(
             &mut self,
@@ -222,6 +224,7 @@ pub mod third_test_module {
         type Config = ();
         type CallMessage = OtherGeneric;
         type Event = Event;
+        type Error = anyhow::Error;
 
         fn genesis(
             &mut self,

--- a/crates/module-system/sov-modules-macros/tests/integration/module_info.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/module_info.rs
@@ -42,6 +42,7 @@ mod test_module {
         type Config = ();
         type CallMessage = ();
         type Event = ();
+        type Error = anyhow::Error;
 
         fn call(
             &mut self,
@@ -85,6 +86,7 @@ mod second_test_module {
     impl<S: Spec> Module for SecondTestStruct<S> {
         type Spec = S;
         type Config = ();
+        type Error = anyhow::Error;
         type CallMessage = ();
         type Event = ();
 

--- a/crates/module-system/sov-modules-macros/tests/integration/regression_tests/versioned_state_items_are_compatible_with_module_rest_api_macro.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/regression_tests/versioned_state_items_are_compatible_with_module_rest_api_macro.rs
@@ -23,6 +23,7 @@ impl<S: Spec> Module for TestModule<S> {
     type Config = ();
     type CallMessage = ();
     type Event = ();
+    type Error = anyhow::Error;
 
     fn call(
         &mut self,

--- a/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/misc.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/misc.rs
@@ -47,6 +47,8 @@ where
 
     type Event = ();
 
+    type Error = anyhow::Error;
+
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<S::Da as DaSpec>::BlockHeader,

--- a/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/rpc_gen_associated_types.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/rpc_gen_associated_types.rs
@@ -58,6 +58,7 @@ pub mod my_module {
         type Config = D;
         type CallMessage = D;
         type Event = ();
+        type Error = anyhow::Error;
 
         fn genesis(
             &mut self,

--- a/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/rpc_gen_associated_types_nested.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/rpc_gen_associated_types_nested.rs
@@ -72,6 +72,7 @@ pub mod my_module {
         type Config = D;
         type CallMessage = D;
         type Event = ();
+        type Error = anyhow::Error;
 
         fn genesis(
             &mut self,

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/module_info/field_missing_attribute.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/module_info/field_missing_attribute.rs
@@ -23,6 +23,8 @@ impl<S: Spec> Module for TestStruct<S> {
 
     type Event = ();
 
+    type Error = anyhow::Error;
+
     fn call(
         &mut self,
         _message: Self::CallMessage,

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs
@@ -2,7 +2,7 @@ use jsonrpsee::core::RpcResult;
 use sov_modules_api::macros::{expose_rpc, rpc_gen};
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::{
-    ApiStateAccessor, Context, DaSpec, DispatchCall, Error, Genesis, MessageCodec, Module,
+    ApiStateAccessor, Context, DaSpec, DispatchCall, Genesis, MessageCodec, Module,
     ModuleId, ModuleInfo, Spec, StateValue, TxState,
 };
 
@@ -51,8 +51,8 @@ pub mod my_module {
         type Spec = S;
         type Config = D;
         type CallMessage = ();
-        type Event = ();
         type Error = anyhow::Error;
+        type Event = ();
 
         fn genesis(
             &mut self,
@@ -72,7 +72,7 @@ pub mod my_module {
         ) -> anyhow::Result<()> {
             self.data
                 .set(10, state)
-                .map_err(|e| Error::ModuleError(e.into()))?;
+                .map_err(|e| anyhow::anyhow!(e))?;
             Ok(())
         }
     }

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs
@@ -52,6 +52,7 @@ pub mod my_module {
         type Config = D;
         type CallMessage = ();
         type Event = ();
+        type Error = anyhow::Error;
 
         fn genesis(
             &mut self,

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.stderr
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.stderr
@@ -1,15 +1,15 @@
 error: Chain state field not found. The Genesis macro may only be used if your runtime contains the `sov_chain_state::ChainState` module with the name `chain_state`. If you need a custom chain name, reach out to the SDK developers for support.
-   --> tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs:107:19
+   --> tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs:108:19
     |
-107 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+108 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                   ^^^^^^^
     |
     = note: this error originates in the derive macro `Genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0310]: the parameter type `T` may not live long enough
-   --> tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs:107:28
+   --> tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs:108:28
     |
-107 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+108 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^
     |                            |
     |                            the parameter type `T` must be valid for the static lifetime...
@@ -23,13 +23,13 @@ note: ...that is required by this bound
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider adding an explicit lifetime bound
     |
-108 | struct Runtime<S: Spec, T: TestSpec + 'static> {
+109 | struct Runtime<S: Spec, T: TestSpec + 'static> {
     |                                     +++++++++
 
 error[E0310]: the parameter type `T` may not live long enough
-   --> tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs:107:28
+   --> tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs:108:28
     |
-107 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+108 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^
     |                            |
     |                            the parameter type `T` must be valid for the static lifetime...
@@ -43,13 +43,13 @@ note: ...that is required by this bound
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider adding an explicit lifetime bound
     |
-108 | struct Runtime<S: Spec, T: TestSpec + 'static> {
+109 | struct Runtime<S: Spec, T: TestSpec + 'static> {
     |                                     +++++++++
 
 error[E0310]: the parameter type `T` may not live long enough
-   --> tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs:107:28
+   --> tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs:108:28
     |
-107 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+108 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^
     |                            |
     |                            the parameter type `T` must be valid for the static lifetime...
@@ -63,13 +63,13 @@ note: ...that is required by this bound
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider adding an explicit lifetime bound
     |
-108 | struct Runtime<S: Spec, T: TestSpec + 'static> {
+109 | struct Runtime<S: Spec, T: TestSpec + 'static> {
     |                                     +++++++++
 
 error[E0308]: mismatched types
-  --> tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs:73:22
+  --> tests/integration/trybuild/rpc/expose_rpc_associated_type_not_static.rs:74:22
    |
-73 |                 .set(10, state)
+74 |                 .set(10, state)
    |                  --- ^^ expected `&D`, found integer
    |                  |
    |                  arguments to this method are incorrect

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs
@@ -55,6 +55,7 @@ pub mod my_module {
         type Config = D;
         type CallMessage = D;
         type Event = ();
+        type Error = anyhow::Error;
 
         fn genesis(
             &mut self,

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs
@@ -2,7 +2,7 @@ use jsonrpsee::core::RpcResult;
 use sov_modules_api::macros::{expose_rpc, rpc_gen};
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::{
-    ApiStateAccessor, Context, DaSpec, DispatchCall, Error, Genesis, MessageCodec, Module,
+    ApiStateAccessor, Context, DaSpec, DispatchCall, Genesis, MessageCodec, Module,
     ModuleId, ModuleInfo, Spec, StateValue, TxState,
 };
 
@@ -76,7 +76,7 @@ pub mod my_module {
         ) -> anyhow::Result<()> {
             self.data
                 .set(&msg, state)
-                .map_err(|e| Error::ModuleError(e.into()))?;
+                .map_err(|e| anyhow::anyhow!(e))?;
             Ok(())
         }
     }

--- a/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.stderr
+++ b/crates/module-system/sov-modules-macros/tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:16
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:113:16
     |
-112 | struct Runtime<T: TestSpec, S: Spec> {
+113 | struct Runtime<T: TestSpec, S: Spec> {
     |                ^ the trait `sov_modules_api::Spec` is not implemented for `T`
     |
 note: required by a bound in `sov_modules_api::Genesis::Spec`
@@ -11,25 +11,25 @@ note: required by a bound in `sov_modules_api::Genesis::Spec`
     |                ^^^^ required by this bound in `Genesis::Spec`
 help: consider further restricting type parameter `T` with trait `Spec`
     |
-112 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
+113 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
     |                            +++++++++++++++++++++++
 
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:19
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:19
     |
-111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+112 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                   ^^^^^^^ the trait `sov_modules_api::Spec` is not implemented for `T`
     |
     = note: this error originates in the derive macro `Genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `T` with trait `Spec`
     |
-112 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
+113 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
     |                            +++++++++++++++++++++++
 
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:110:1
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:1
     |
-110 | #[expose_rpc]
+111 | #[expose_rpc]
     | ^^^^^^^^^^^^^ the trait `sov_modules_api::Spec` is not implemented for `T`
     |
 note: required by a bound in `ApiState`
@@ -40,13 +40,13 @@ note: required by a bound in `ApiState`
     = note: this error originates in the attribute macro `expose_rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `T` with trait `Spec`
     |
-112 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
+113 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
     |                            +++++++++++++++++++++++
 
 error[E0277]: `ActualSpec` doesn't implement `std::fmt::Debug`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:120:19
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:121:19
     |
-120 | impl TestSpec for ActualSpec {
+121 | impl TestSpec for ActualSpec {
     |                   ^^^^^^^^^^ `ActualSpec` cannot be formatted using `{:?}`
     |
     = help: the trait `std::fmt::Debug` is not implemented for `ActualSpec`
@@ -60,14 +60,14 @@ note: required by a bound in `TestSpec`
     |                             ^^^^^^^^^^^^^^^ required by this bound in `TestSpec`
 help: consider annotating `ActualSpec` with `#[derive(Debug)]`
     |
-118 + #[derive(Debug)]
-119 | struct ActualSpec;
+119 + #[derive(Debug)]
+120 | struct ActualSpec;
     |
 
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:16
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:113:16
     |
-112 | struct Runtime<T: TestSpec, S: Spec> {
+113 | struct Runtime<T: TestSpec, S: Spec> {
     |                ^ the trait `sov_modules_api::Spec` is not implemented for `T`
     |
 note: required by a bound in `sov_modules_api::DispatchCall::Spec`
@@ -77,13 +77,13 @@ note: required by a bound in `sov_modules_api::DispatchCall::Spec`
     |                ^^^^ required by this bound in `DispatchCall::Spec`
 help: consider further restricting type parameter `T` with trait `Spec`
     |
-112 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
+113 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
     |                            +++++++++++++++++++++++
 
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:28
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:28
     |
-111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+112 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^ the trait `sov_modules_api::Spec` is not implemented for `T`
     |
 note: required by a bound in `StateProvider`
@@ -94,15 +94,15 @@ note: required by a bound in `StateProvider`
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `T` with trait `Spec`
     |
-112 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
+113 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
     |                            +++++++++++++++++++++++
 
 error[E0271]: type mismatch resolving `<QueryModule<S, <T as TestSpec>::Data> as ModuleInfo>::Spec == T`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:19
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:19
     |
-111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+112 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                   ^^^^^^^ type mismatch resolving `<QueryModule<S, <T as TestSpec>::Data> as ModuleInfo>::Spec == T`
-112 | struct Runtime<T: TestSpec, S: Spec> {
+113 | struct Runtime<T: TestSpec, S: Spec> {
     |                -            - found type parameter
     |                |
     |                expected type parameter
@@ -120,11 +120,11 @@ note: expected this to be `T`
     = note: this error originates in the derive macro `Genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<ChainState<S> as ModuleInfo>::Spec == T`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:19
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:19
     |
-111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+112 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                   ^^^^^^^ expected type parameter `T`, found type parameter `S`
-112 | struct Runtime<T: TestSpec, S: Spec> {
+113 | struct Runtime<T: TestSpec, S: Spec> {
     |                -            - found type parameter
     |                |
     |                expected type parameter
@@ -137,9 +137,9 @@ error[E0271]: type mismatch resolving `<ChainState<S> as ModuleInfo>::Spec == T`
     = note: this error originates in the derive macro `Genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `impl ::sov_modules_api::GenesisState<<Self as ::sov_modules_api::Genesis>::Spec>: GenesisState<S>` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:19
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:19
     |
-111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+112 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                   ^^^^^^^ the trait `GenesisState<S>` is not implemented for `impl ::sov_modules_api::GenesisState<<Self as ::sov_modules_api::Genesis>::Spec>`
     |
 note: required by a bound in `sov_modules_api::Genesis::genesis`
@@ -153,9 +153,9 @@ note: required by a bound in `sov_modules_api::Genesis::genesis`
     = note: this error originates in the derive macro `Genesis` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `T: sov_modules_api::Spec` is not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:28
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:28
     |
-111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+112 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^ the trait `sov_modules_api::Spec` is not implemented for `T`
     |
     = note: required for `WorkingSet<T, I>` to implement `GasMeter`
@@ -171,15 +171,15 @@ note: required by a bound in `sov_modules_api::Module::call`
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider further restricting type parameter `T` with trait `Spec`
     |
-112 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
+113 | struct Runtime<T: TestSpec + sov_modules_api::Spec, S: Spec> {
     |                            +++++++++++++++++++++++
 
 error[E0271]: type mismatch resolving `<WorkingSet<T, I> as GasMeter>::Spec == S`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:28
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:28
     |
-111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+112 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^ expected type parameter `S`, found type parameter `T`
-112 | struct Runtime<T: TestSpec, S: Spec> {
+113 | struct Runtime<T: TestSpec, S: Spec> {
     |                -            - expected type parameter
     |                |
     |                found type parameter
@@ -200,14 +200,14 @@ note: required by a bound in `sov_modules_api::Module::call`
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:28
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:28
     |
-111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+112 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^
     |                            |
     |                            expected `&Context<S>`, found `&Context<T>`
     |                            arguments to this function are incorrect
-112 | struct Runtime<T: TestSpec, S: Spec> {
+113 | struct Runtime<T: TestSpec, S: Spec> {
     |                -            - expected type parameter
     |                |
     |                found type parameter
@@ -224,11 +224,11 @@ note: method defined here
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<QueryModule<S, <T as TestSpec>::Data> as ModuleInfo>::Spec == T`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:28
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:28
     |
-111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+112 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^ type mismatch resolving `<QueryModule<S, <T as TestSpec>::Data> as ModuleInfo>::Spec == T`
-112 | struct Runtime<T: TestSpec, S: Spec> {
+113 | struct Runtime<T: TestSpec, S: Spec> {
     |                -            - found type parameter
     |                |
     |                expected type parameter
@@ -246,11 +246,11 @@ note: expected this to be `T`
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<ChainState<S> as ModuleInfo>::Spec == T`
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:28
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:112:28
     |
-111 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
+112 | #[derive(Default, Genesis, DispatchCall, MessageCodec)]
     |                            ^^^^^^^^^^^^ expected type parameter `T`, found type parameter `S`
-112 | struct Runtime<T: TestSpec, S: Spec> {
+113 | struct Runtime<T: TestSpec, S: Spec> {
     |                -            - found type parameter
     |                |
     |                expected type parameter
@@ -263,9 +263,9 @@ error[E0271]: type mismatch resolving `<ChainState<S> as ModuleInfo>::Spec == T`
     = note: this error originates in the derive macro `DispatchCall` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the method `clone` exists for struct `ApiState<T>`, but its trait bounds were not satisfied
-   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:110:1
+   --> tests/integration/trybuild/rpc/expose_rpc_first_generic_not_spec.rs:111:1
     |
-110 | #[expose_rpc]
+111 | #[expose_rpc]
     | ^^^^^^^^^^^^^ method cannot be called on `ApiState<T>` due to unsatisfied trait bounds
     |
    ::: $WORKSPACE/crates/module-system/sov-modules-api/src/rest/mod.rs
@@ -279,5 +279,5 @@ error[E0599]: the method `clone` exists for struct `ApiState<T>`, but its trait 
     = note: this error originates in the attribute macro `expose_rpc` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider restricting the type parameter to satisfy the trait bound
     |
-110 | #[expose_rpc] where T: sov_modules_api::Spec
+111 | #[expose_rpc] where T: sov_modules_api::Spec
     |               ++++++++++++++++++++++++++++++

--- a/crates/module-system/sov-test-utils/src/runtime/mod.rs
+++ b/crates/module-system/sov-test-utils/src/runtime/mod.rs
@@ -27,7 +27,7 @@ use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::rest::{ApiState, HasRestApi};
 use sov_modules_api::{
     Amount, ApiStateAccessor, ApplySlotOutput, BlobReaderTrait, CryptoSpec, DaSpec, EncodeCall,
-    Error, Gas, Genesis, InfallibleStateAccessor, Module, PrivateKey, Spec, StateCheckpoint,
+    Gas, Genesis, InfallibleStateAccessor, Module, PrivateKey, Spec, StateCheckpoint,
     TransactionReceipt, TxEffect, VersionReader, VisibleSlotNumber, *,
 };
 use sov_modules_stf_blueprint::{get_gas_used, StfBlueprint};
@@ -989,7 +989,7 @@ pub fn assert_tx_reverted_with_reason<S: Spec>(result: TxEffect<S>, reason: anyh
     if let TxEffect::Reverted(contents) = result {
         assert_eq!(
             &contents.reason,
-            &Error::ModuleError(reason),
+            &reason.into(),
             "The transaction should have reverted because instead the outcome was {contents:?}"
         );
     } else {

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -4454,6 +4454,7 @@ dependencies = [
  "derive_more 1.0.0",
  "schemars 0.8.22",
  "serde",
+ "serde_json",
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -4014,6 +4014,7 @@ dependencies = [
  "derive_more 1.0.0",
  "schemars 0.8.22",
  "serde",
+ "serde_json",
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -5910,6 +5910,7 @@ dependencies = [
  "derive_more 1.0.0",
  "schemars 0.8.21",
  "serde",
+ "serde_json",
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -5516,6 +5516,7 @@ dependencies = [
  "derive_more 1.0.0",
  "schemars 0.8.21",
  "serde",
+ "serde_json",
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",


### PR DESCRIPTION
# Description

Adds `Module::Error` associated type to modules. Set to `anyhow::Error` to preserve current behaviour except for `sov_bank` was changed to use it's own `Error` type. This was done in this PR because with the changes in this PR we would lose the `anyhow` error chain and thus many bank tests would be broken.

Adds a `ErrorDetail` trait the `Module::Error` should implement. This trait decides how errors are returned from the REST api.

This PR has a large diff but I couldn't see a sensible way to split it into multiple PRs so will list some points of interest below:

- New error traits/utilities/etc: https://github.com/Sovereign-Labs/sovereign-sdk/pull/1975/files#diff-415c56381b3f95e7f7fe5f966b7fa526921510f155604b69f0ac102d9f10b597
- Bank module error: https://github.com/Sovereign-Labs/sovereign-sdk/pull/1975/files#diff-5f98eb7f09ddbce3523f743be0fa835d7e6f8713a6ea471c301447faaa951d87 (the bank module changes in general would also be good to look over)

---

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
