### PR TITLE
Unify package versions and reduce `git` dependencies in preparation for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4909,23 +4909,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "full-node-configs"
-version = "0.3.0"
-dependencies = [
- "anyhow",
- "insta",
- "schemars 0.8.22",
- "serde",
- "sov-db",
- "sov-metrics",
- "sov-mock-da",
- "sov-modules-api",
- "sov-rollup-interface",
- "toml 0.8.23",
- "tracing",
-]
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10216,8 +10199,9 @@ dependencies = [
 
 [[package]]
 name = "rockbound"
-version = "1.0.0"
-source = "git+https://github.com/sovereign-labs/rockbound?rev=ec19b7f93228edefb75717a83ddff85b8ea6c2ec#ec19b7f93228edefb75717a83ddff85b8ea6c2ec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d89e2ac1e12b28ccdc6721aa0e4419bdbdcef8168b1983dbd6e3e2786bf3320"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -11801,7 +11785,6 @@ dependencies = [
  "demo-stf-json-client",
  "ethereum-types",
  "ethers",
- "full-node-configs",
  "futures",
  "hex",
  "jsonrpsee",
@@ -11829,6 +11812,7 @@ dependencies = [
  "sov-db",
  "sov-eth-client",
  "sov-ethereum",
+ "sov-full-node-configs",
  "sov-kernels",
  "sov-metrics",
  "sov-mock-da",
@@ -12075,6 +12059,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sov-full-node-configs"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "insta",
+ "schemars 0.8.22",
+ "serde",
+ "sov-db",
+ "sov-metrics",
+ "sov-mock-da",
+ "sov-modules-api",
+ "sov-rollup-interface",
+ "toml 0.8.23",
+ "tracing",
+]
+
+[[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
 dependencies = [
@@ -12251,11 +12252,11 @@ dependencies = [
 name = "sov-module-schemas"
 version = "0.3.0"
 dependencies = [
- "full-node-configs",
  "schemars 0.8.22",
  "serde_json",
  "sov-accounts",
  "sov-bank",
+ "sov-full-node-configs",
  "sov-metrics",
  "sov-mock-da",
  "sov-mock-zkvm",
@@ -12683,7 +12684,6 @@ dependencies = [
  "derivative",
  "derive_more 1.0.0",
  "flume",
- "full-node-configs",
  "futures",
  "hex",
  "jsonrpsee",
@@ -12705,6 +12705,7 @@ dependencies = [
  "sov-blob-storage",
  "sov-chain-state",
  "sov-db",
+ "sov-full-node-configs",
  "sov-kernels",
  "sov-metrics",
  "sov-mock-da",
@@ -12760,7 +12761,7 @@ dependencies = [
 
 [[package]]
 name = "sov-soak-testing"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12797,7 +12798,7 @@ dependencies = [
 
 [[package]]
 name = "sov-soak-testing-lib"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12927,7 +12928,6 @@ dependencies = [
  "bincode",
  "borsh",
  "derivative",
- "full-node-configs",
  "futures",
  "futures-util",
  "hex",
@@ -12941,6 +12941,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "sov-db",
+ "sov-full-node-configs",
  "sov-metrics",
  "sov-mock-da",
  "sov-mock-zkvm",
@@ -13151,7 +13152,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -13176,7 +13177,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "bech32 0.11.0",
  "borsh",
@@ -13192,7 +13193,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -15523,13 +15524,14 @@ dependencies = [
 
 [[package]]
 name = "utoipa"
-version = "5.0.0-beta.0"
-source = "git+https://github.com/juhaku/utoipa.git?rev=a985d8c1340f80ab69b2b0e5de799df98d567732#a985d8c1340f80ab69b2b0e5de799df98d567732"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
  "indexmap 2.11.1",
  "serde",
  "serde_json",
- "utoipa-gen 5.0.0-beta.0",
+ "utoipa-gen 5.4.0",
 ]
 
 [[package]]
@@ -15546,8 +15548,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.0.0-beta.0"
-source = "git+https://github.com/juhaku/utoipa.git?rev=a985d8c1340f80ab69b2b0e5de799df98d567732#a985d8c1340f80ab69b2b0e5de799df98d567732"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15556,18 +15559,19 @@ dependencies = [
 
 [[package]]
 name = "utoipa-swagger-ui"
-version = "7.1.1-beta.0"
-source = "git+https://github.com/juhaku/utoipa.git?rev=a985d8c1340f80ab69b2b0e5de799df98d567732#a985d8c1340f80ab69b2b0e5de799df98d567732"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4b5ac679cc6dfc5ea3f2823b0291c777750ffd5e13b21137e0f7ac0e8f9617"
 dependencies = [
  "axum 0.7.9",
+ "base64 0.22.1",
  "mime_guess",
  "regex",
- "reqwest 0.12.23",
  "rust-embed",
  "serde",
  "serde_json",
  "url",
- "utoipa 5.0.0-beta.0",
+ "utoipa 5.4.0",
  "zip 2.4.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ sov-accounts = { path = "crates/module-system/module-implementations/sov-account
 sov-ledger-apis = { path = "crates/full-node/sov-ledger-apis", default-features = false, version = "0.3" }
 sov-rollup-apis = { path = "crates/full-node/sov-rollup-apis", default-features = false, version = "0.3" }
 sov-api-spec = { path = "crates/full-node/sov-api-spec", default-features = false, version = "0.3" }
-full-node-configs = { path = "crates/full-node/full-node-configs", version = "0.3" }
+sov-full-node-configs = { path = "crates/full-node/full-node-configs", version = "0.3" }
 sov-eth-dev-signer = { path = "crates/full-node/sov-eth-dev-signer", default-features = false, version = "0.3" }
 sov-eth-dev-generator = { path = "crates/full-node/sov-eth-dev-generator", default-features = false, version = "0.3" }
 sov-modules-api = { path = "crates/module-system/sov-modules-api", default-features = false, version = "0.3" }
@@ -173,17 +173,17 @@ sov-test-utils = { path = "crates/module-system/sov-test-utils", default-feature
 sov-rpc-eth-types = { path = "crates/utils/sov-rpc-eth-types", default-features = false, version = "0.3" }
 sov-db = { path = "crates/full-node/sov-db", default-features = false, version = "0.3" }
 rest-api-load-testing = { path = "crates/utils/rest-api-load-testing" }
-sov-universal-wallet = { path = "crates/universal-wallet/schema" }
-sov-universal-wallet-macros = { path = "crates/universal-wallet/macros" }
-sov-universal-wallet-macro-helpers = { path = "crates/universal-wallet/macro-helpers" }
+sov-universal-wallet = { path = "crates/universal-wallet/schema", version = "0.3" }
+sov-universal-wallet-macros = { path = "crates/universal-wallet/macros", version = "0.3" }
+sov-universal-wallet-macro-helpers = { path = "crates/universal-wallet/macro-helpers", version = "0.3" }
 sov-zkvm-utils = { path = "crates/utils/sov-zkvm-utils" }
 sov-build = { path = "crates/utils/sov-build" }
 workspace-hack = { path = "crates/utils/workspace-hack" }
-nearly-linear = { path = "crates/utils/nearly-linear" }
+nearly-linear = { path = "crates/utils/nearly-linear", version = "0.3" }
 # Dependencies maintained by Sovereign
 jmt = { git = "https://github.com/penumbra-zone/jmt.git", rev = "f60beb0fa54d9231706f62a8b1315e3c57855590", default-features = false }
 reltester = { git = "https://github.com/sovereign-labs/reltester.git", rev = "d6209abff72929f5ba41614f5cea3e4a748428c3" }
-rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "ec19b7f93228edefb75717a83ddff85b8ea6c2ec" }
+rockbound = { version = "0.1.0" }
 nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
 # Uncomment this when a new preview is released
@@ -258,7 +258,7 @@ tracing-test = { version = "0.2.5", features = [
     "no-env-filter",
 ] } # https://docs.rs/tracing-test/latest/tracing_test/#per-crate-filtering
 utoipa = "4.2"
-utoipa-swagger-ui = { git = "https://github.com/juhaku/utoipa.git", rev = "a985d8c1340f80ab69b2b0e5de799df98d567732", features = ["axum", "debug-embed"] }
+utoipa-swagger-ui = { version = "8", features = ["axum", "debug-embed"] }
 unwrap-infallible = "0.1.5"
 bech32 = { version = "0.11" }
 derive_more = { version = "1.0", default-features = false, features = ["std"] }

--- a/crates/full-node/full-node-configs/Cargo.toml
+++ b/crates/full-node/full-node-configs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "full-node-configs"
+name = "sov-full-node-configs"
 description = "Configs only for sov-sequencer and sov-stf-runner"
 version.workspace = true
 edition.workspace = true

--- a/crates/full-node/sov-sequencer/Cargo.toml
+++ b/crates/full-node/sov-sequencer/Cargo.toml
@@ -27,7 +27,7 @@ futures = { workspace = true }
 hex = { workspace = true }
 jsonrpsee = { workspace = true, features = ["client", "server"] }
 mini-moka = "0.10"
-full-node-configs = { workspace = true }
+sov-full-node-configs = { workspace = true }
 rockbound = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/full-node/sov-sequencer/src/config.rs
+++ b/crates/full-node/sov-sequencer/src/config.rs
@@ -1,1 +1,1 @@
-pub use full_node_configs::sequencer::*;
+pub use sov_full_node_configs::sequencer::*;

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -23,7 +23,7 @@ use batch_size_tracker::BatchSizeTracker;
 use db::postgres::PostgresBackend;
 use db::rocksdb::RocksDbBackend;
 use db::{PreferredSequencerDb, PreferredSequencerReadBatch, PreferredSequencerReadBlob};
-pub use full_node_configs::sequencer::{PreferredSequencerConfig, RecoveryStrategy};
+pub use sov_full_node_configs::sequencer::{PreferredSequencerConfig, RecoveryStrategy};
 use futures::Stream;
 use inner::*;
 use preferred_blob_sender::PreferredBlobSender;

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -4,7 +4,7 @@ mod mempool;
 
 use async_trait::async_trait;
 use axum::http::StatusCode;
-pub use full_node_configs::sequencer::StdSequencerConfig;
+pub use sov_full_node_configs::sequencer::StdSequencerConfig;
 use sov_blob_sender::{new_blob_id, BlobSender};
 use sov_db::ledger_db::LedgerDb;
 use sov_metrics::{AuthAndProcessMetrics, AuthAndProcessTimings};

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -10,7 +10,7 @@ use backon::Retryable;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use borsh::{BorshDeserialize, BorshSerialize};
-use full_node_configs::sequencer::default_ideal_lag_behind_finalized_slot;
+use sov_full_node_configs::sequencer::default_ideal_lag_behind_finalized_slot;
 use futures::future;
 use serde_json::Number;
 use sov_api_spec::types::{

--- a/crates/full-node/sov-stf-runner/Cargo.toml
+++ b/crates/full-node/sov-stf-runner/Cargo.toml
@@ -25,7 +25,7 @@ borsh = { workspace = true }
 serde = { workspace = true }
 strum = { workspace = true }
 tower = { workspace = true, features = ["util"] }
-full-node-configs = { workspace = true }
+sov-full-node-configs = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client", "server"] }
 tokio = { workspace = true, features = ["net", "sync", "rt-multi-thread", "time"] }
 hex = { workspace = true }

--- a/crates/full-node/sov-stf-runner/src/config.rs
+++ b/crates/full-node/sov-stf-runner/src/config.rs
@@ -1,5 +1,5 @@
-use full_node_configs::runner::RollupConfig as RollupConfigBase;
-pub use full_node_configs::runner::{
+use sov_full_node_configs::runner::RollupConfig as RollupConfigBase;
+pub use sov_full_node_configs::runner::{
     from_toml_path, CorsConfiguration, HttpServerConfig, ProofManagerConfig, RunnerConfig,
 };
 pub use sov_metrics::{MonitoringConfig, TelegrafSocketConfig};

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use full_node_configs::runner::{CorsConfiguration, ProofManagerConfig, RunnerConfig};
+use sov_full_node_configs::runner::{CorsConfiguration, ProofManagerConfig, RunnerConfig};
 use jsonrpsee::RpcModule;
 use sov_db::ledger_db::{LedgerDb, SlotCommit};
 use sov_db::schema::{DeltaReader, SchemaBatch};

--- a/crates/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-evm/Cargo.toml
@@ -9,7 +9,7 @@ repository = { workspace = true }
 
 version = { workspace = true }
 readme = "README.md"
-publish = false
+publish = true 
 
 [lints]
 workspace = true

--- a/crates/module-system/module-schemas/Cargo.toml
+++ b/crates/module-system/module-schemas/Cargo.toml
@@ -21,7 +21,7 @@ sov-modules-api = { workspace = true, features = ["native"] }
 sov-mock-da = { workspace = true, features = ["native"] }
 sov-mock-zkvm = { workspace = true, features = ["native"] }
 sov-rollup-interface = { workspace = true, features = ["native"] }
-full-node-configs = { workspace = true }
+sov-full-node-configs = { workspace = true }
 sov-metrics = { workspace = true, features = ["native"] }
 
 # Modules

--- a/crates/module-system/module-schemas/build.rs
+++ b/crates/module-system/module-schemas/build.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::{self, Write};
 
-use full_node_configs::runner::RollupConfig;
+use sov_full_node_configs::runner::RollupConfig;
 use schemars::schema_for;
 use sov_metrics::MonitoringConfig;
 use sov_mock_da::verifier::MockDaSpec;

--- a/crates/universal-wallet/macro-helpers/Cargo.toml
+++ b/crates/universal-wallet/macro-helpers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sov-universal-wallet-macro-helpers"
 description = "Macro helpers for sov-universal-wallet-macros"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = { workspace = true }

--- a/crates/universal-wallet/macros/Cargo.toml
+++ b/crates/universal-wallet/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sov-universal-wallet-macros"
 description = "Macros for sov-universall-wallet"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = { workspace = true }

--- a/crates/universal-wallet/schema/Cargo.toml
+++ b/crates/universal-wallet/schema/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sov-universal-wallet"
 description = "UniversallWallet for Sovereign rollups"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = { workspace = true }

--- a/crates/utils/sov-soak-testing-lib/Cargo.toml
+++ b/crates/utils/sov-soak-testing-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sov-soak-testing-lib"
-version = "0.1.0"
+version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -411,7 +411,7 @@ expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
 license-files = []
 
 [[licenses.clarify]]
-name = "full-node-configs"
+name = "sov-full-node-configs"
 expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
 license-files = []
 

--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -34,7 +34,7 @@ sov-modules-stf-blueprint = { workspace = true, features = ["native"] }
 sov-risc0-adapter = { workspace = true, features = ["native"] }
 sov-sequencer = { workspace = true }
 sov-sp1-adapter = { workspace = true, features = ["native"] }
-full-node-configs = { workspace = true }
+sov-full-node-configs = { workspace = true }
 sov-state = { workspace = true, features = ["native"] }
 
 demo-stf = { workspace = true, features = ["native"] }

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "bech32",
  "borsh",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -4439,7 +4439,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -4459,7 +4459,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "bech32",
  "borsh",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -6335,7 +6335,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -6355,7 +6355,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "bech32",
  "borsh",
@@ -6371,7 +6371,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -5935,7 +5935,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -5955,7 +5955,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "bech32",
  "borsh",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",

--- a/examples/demo-rollup/sov-soak-testing/Cargo.toml
+++ b/examples/demo-rollup/sov-soak-testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sov-soak-testing"
-version = "0.1.0"
+version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }

--- a/examples/demo-rollup/tests/bank/helpers.rs
+++ b/examples/demo-rollup/tests/bank/helpers.rs
@@ -1,7 +1,7 @@
 use crate::test_helpers::build_transfer_token_tx;
 use anyhow::Context;
 use demo_stf::runtime::{Runtime, RuntimeCall};
-use full_node_configs::sequencer::{RecoveryStrategy, SequencerKindConfig};
+use sov_full_node_configs::sequencer::{RecoveryStrategy, SequencerKindConfig};
 use futures::StreamExt;
 use sov_bank::event::Event as BankEvent;
 use sov_bank::TokenId;

--- a/examples/demo-rollup/tests/bank/op_rollup/bank_tests.rs
+++ b/examples/demo-rollup/tests/bank/op_rollup/bank_tests.rs
@@ -3,7 +3,7 @@ use crate::bank::helpers::*;
 use crate::bank::{TOKEN_DECIMALS, TOKEN_NAME};
 use crate::test_helpers::*;
 use anyhow::Context;
-use full_node_configs::sequencer::{RecoveryStrategy, SequencerKindConfig};
+use sov_full_node_configs::sequencer::{RecoveryStrategy, SequencerKindConfig};
 use futures::StreamExt;
 use serde::Deserialize;
 use sov_cli::NodeClient;

--- a/examples/demo-rollup/tests/resync/mod.rs
+++ b/examples/demo-rollup/tests/resync/mod.rs
@@ -11,7 +11,7 @@ use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use demo_stf::runtime::{Runtime as DemoRuntime, RuntimeCall};
 use demo_stf_json_client::types::RuntimeAnyJsonValue;
-use full_node_configs::sequencer::SequencerKindConfig;
+use sov_full_node_configs::sequencer::SequencerKindConfig;
 use futures::StreamExt;
 use sov_api_spec::types::{SyncStatus, TxStatus};
 use sov_demo_rollup::{mock_da_risc0_host_args, MockDemoRollup};

--- a/packages_to_publish.yml
+++ b/packages_to_publish.yml
@@ -1,4 +1,5 @@
 - sov-rollup-interface
+- nearly-linear
 - sov-universal-wallet
 - sov-universal-wallet-macros
 - sov-universal-wallet-macro-helpers
@@ -10,7 +11,11 @@
 - sov-state
 - sov-modules-macros # Requires --no-verify because it writes outside of OUT_DIR.
 - sov-modules-api
+# Release modules here:
+- sov-kernels
+- sov-capabilities
 - sov-metrics
+- sov-full-node-configs
 - sov-sequencer
 - sov-modules-stf-blueprint
 - sov-stf-runner
@@ -21,7 +26,12 @@
 - sov-rollup-apis
 - sov-zkvm-utils
 - sov-build
-- full-node-configs
+- sov-ethereum #TODO: Find correct spot in order
+- sov-eip-712 #TODO: Find correct spot in order
+- sov-eip-712-auth #TODO: Find correct spot in order
+- sov-solana-offchain-auth #TODO: Find correct spot in order
+- sov-rpc-eth-types #TODO: Find correct spot in order
+- sov-address #TODO: Find correct spot in order
 
 # Modules
 - sov-accounts
@@ -32,6 +42,11 @@
 - sov-blob-storage
 - sov-solana-offchain-auth
 - sov-uniqueness
+- sov-evm
+- sov-paymaster
+- sov-operator-incentives
+- sov-attester-incentives
+- sov-revenue-share
 
 # Adapters
 - sov-risc0-adapter


### PR DESCRIPTION
# Description

This PR makes consistency improvements in `Cargo.toml` files across the workspace in preparation for the `0.4` release. These include...
 - Unifying package versions
 - Switching to a `crates.io` release of `rockbound`
 - Renaming `full-node-config` to `sov-full-node-config`
 - Updating `packages-to-publish.yaml` with new crates since the previous release.

Several additional changes will be needed once `reth`, `nomt`, and `jmt` publish their new versions.

