### PR TITLE
Implement `newHeads` WebSocket Subscriptions (eth_subscribe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-10-28
+- #1987 Added `newHeads` subscription to `eth_subscribe`.
+
 # 2025-10-27
 - #1976 Fixed `eth_subscribe` parameter parsing to accept standard Ethereum JSON-RPC positional parameters.
 

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -1,8 +1,7 @@
+use crate::handlers::subscribe::params::parse;
 use crate::handlers::subscribe::params::validate;
 use crate::handlers::subscribe::service::Streamer;
 use crate::Ethereum;
-use alloy_rpc_types::pubsub::Params;
-use alloy_rpc_types::pubsub::SubscriptionKind;
 use alloy_rpc_types::Filter;
 use jsonrpsee::types::Params as JRpcParams;
 use jsonrpsee::Extensions;
@@ -35,20 +34,19 @@ where
     S::Address: FromVmAddress<EthereumAddress>,
     Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
 {
-    let mut parameters = parameters.sequence();
-    let kind: SubscriptionKind = parameters.next()?;
-    let params: Params = parameters.optional_next()?.unwrap_or_default();
+    let (kind, params) = match parse(parameters) {
+        Ok(v) => v,
+        Err(err) => return reject(pending, err).await,
+    };
 
     let request = match validate(kind, params) {
-        Ok(subscription_request) => subscription_request,
-        Err(err) => {
-            pending.reject(err).await;
-            return Ok(());
-        }
+        Ok(v) => v,
+        Err(err) => return reject(pending, err).await,
     };
-    let accepted = pending.accept().await?;
 
+    let accepted = pending.accept().await?;
     let streamer = Streamer::new(accepted, ethereum.clone());
+
     tokio::spawn(async move {
         match request {
             SubscriptionRequest::Heads => streamer.blocks().await,
@@ -56,5 +54,13 @@ where
         }
     });
 
+    Ok(())
+}
+
+async fn reject(
+    pending: PendingSubscriptionSink,
+    err: impl Into<jsonrpsee::types::ErrorObjectOwned>,
+) -> jsonrpsee::core::SubscriptionResult {
+    pending.reject(err).await;
     Ok(())
 }

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -1,10 +1,9 @@
-use crate::handlers::subscribe::service::ParamsValidationError;
+use crate::handlers::subscribe::params::validate;
 use crate::handlers::subscribe::service::Streamer;
-use crate::to_jsonrpsee_error_object;
 use crate::Ethereum;
 use alloy_rpc_types::pubsub::Params;
 use alloy_rpc_types::pubsub::SubscriptionKind;
-use alloy_rpc_types::FilterBlockOption;
+use alloy_rpc_types::Filter;
 use jsonrpsee::types::Params as JRpcParams;
 use jsonrpsee::Extensions;
 use jsonrpsee::PendingSubscriptionSink;
@@ -15,10 +14,14 @@ use sov_modules_api::Spec;
 use sov_sequencer::Sequencer;
 use std::sync::Arc;
 
+mod params;
 mod service;
 pub(crate) mod watermark;
 
-use crate::handlers::ETH_RPC_ERROR;
+pub(crate) enum SubscriptionRequest {
+    Logs(Box<Filter>),
+    Heads,
+}
 
 pub async fn eth_subscribe<S, Seq>(
     parameters: JRpcParams<'static>,
@@ -36,63 +39,22 @@ where
     let kind: SubscriptionKind = parameters.next()?;
     let params: Params = parameters.optional_next()?.unwrap_or_default();
 
-    match kind {
-        SubscriptionKind::NewHeads => {
-            // NewHeads doesn't accept parameters
-            if params != Params::None {
-                let rpc_err = to_jsonrpsee_error_object(
-                    ParamsValidationError::NewHeadsDoesNotAcceptParams,
-                    ETH_RPC_ERROR,
-                );
-                pending.reject(rpc_err).await;
-                return Ok(());
-            }
-
-            let accepted_sink = pending.accept().await?;
-            tokio::spawn(async move {
-                Streamer::new(accepted_sink, ethereum.clone())
-                    .blocks()
-                    .await
-            });
-        }
-        SubscriptionKind::Logs => {
-            let filter = match params {
-                Params::Logs(filter) => {
-                    if filter.block_option == FilterBlockOption::default() {
-                        Ok(filter)
-                    } else {
-                        Err(ParamsValidationError::BlockOptionParam)
-                    }
-                }
-                Params::Bool(_) => Err(ParamsValidationError::BoolParam),
-                Params::None => Ok(Default::default()),
-            };
-            let log_filter = match filter {
-                Ok(log_filter) => log_filter,
-                Err(e) => {
-                    let rpc_err = to_jsonrpsee_error_object(e, ETH_RPC_ERROR);
-                    pending.reject(rpc_err).await;
-                    return Ok(());
-                }
-            };
-
-            let accepted_sink = pending.accept().await?;
-            tokio::spawn(async move {
-                Streamer::new(accepted_sink, ethereum.clone())
-                    .logs(log_filter)
-                    .await
-            });
-        }
-        _ => {
-            // NewPendingTransactions not supported
-            let rpc_err = to_jsonrpsee_error_object(
-                ParamsValidationError::OnlyLogAndNewHeadsSubscription,
-                ETH_RPC_ERROR,
-            );
-            pending.reject(rpc_err).await;
+    let request = match validate(kind, params) {
+        Ok(subscription_request) => subscription_request,
+        Err(err) => {
+            pending.reject(err).await;
             return Ok(());
         }
-    }
+    };
+    let accepted = pending.accept().await?;
+
+    let streamer = Streamer::new(accepted, ethereum.clone());
+    tokio::spawn(async move {
+        match request {
+            SubscriptionRequest::Heads => streamer.blocks().await,
+            SubscriptionRequest::Logs(filter) => streamer.logs(filter).await,
+        }
+    });
 
     Ok(())
 }

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -1,21 +1,21 @@
+use crate::handlers::subscribe::service::ParamsValidationError;
+use crate::handlers::subscribe::service::Streamer;
 use crate::to_jsonrpsee_error_object;
 use crate::Ethereum;
 use alloy_rpc_types::pubsub::Params;
 use alloy_rpc_types::pubsub::SubscriptionKind;
-use alloy_rpc_types::Filter;
 use alloy_rpc_types::FilterBlockOption;
 use jsonrpsee::types::Params as JRpcParams;
+use jsonrpsee::Extensions;
 use jsonrpsee::PendingSubscriptionSink;
-use jsonrpsee::SubscriptionMessage;
-use jsonrpsee::{Extensions, SubscriptionSink};
 use sov_address::{EthereumAddress, FromVmAddress};
 pub use sov_evm::EthereumAuthenticator;
-use sov_evm::Evm;
 use sov_modules_api::capabilities::HasKernel;
 use sov_modules_api::Spec;
 use sov_sequencer::Sequencer;
 use std::sync::Arc;
-use thiserror::Error;
+
+mod service;
 
 use crate::handlers::ETH_RPC_ERROR;
 
@@ -35,142 +35,63 @@ where
     let kind: SubscriptionKind = parameters.next()?;
     let params: Params = parameters.optional_next()?.unwrap_or_default();
 
-    let log_filter = match validate_params_for_log_subscription(kind, params) {
-        Ok(log_filter) => log_filter,
-        Err(e) => {
-            let rpc_err = to_jsonrpsee_error_object(e, ETH_RPC_ERROR);
+    match kind {
+        SubscriptionKind::NewHeads => {
+            // NewHeads doesn't accept parameters
+            if params != Params::None {
+                let rpc_err = to_jsonrpsee_error_object(
+                    ParamsValidationError::NewHeadsDoesNotAcceptParams,
+                    ETH_RPC_ERROR,
+                );
+                pending.reject(rpc_err).await;
+                return Ok(());
+            }
+
+            let accepted_sink = pending.accept().await?;
+            tokio::spawn(async move {
+                Streamer::new(accepted_sink, ethereum.clone())
+                    .blocks()
+                    .await;
+            });
+        }
+        SubscriptionKind::Logs => {
+            let filter = match params {
+                Params::Logs(filter) => {
+                    if filter.block_option == FilterBlockOption::default() {
+                        Ok(filter)
+                    } else {
+                        Err(ParamsValidationError::BlockOptionParam)
+                    }
+                }
+                Params::Bool(_) => Err(ParamsValidationError::BoolParam),
+                Params::None => Ok(Default::default()),
+            };
+            let log_filter = match filter {
+                Ok(log_filter) => log_filter,
+                Err(e) => {
+                    let rpc_err = to_jsonrpsee_error_object(e, ETH_RPC_ERROR);
+                    pending.reject(rpc_err).await;
+                    return Ok(());
+                }
+            };
+
+            let accepted_sink = pending.accept().await?;
+            tokio::spawn(async move {
+                Streamer::new(accepted_sink, ethereum.clone())
+                    .logs(log_filter)
+                    .await;
+            });
+        }
+        _ => {
+            // NewPendingTransactions not supported
+            let rpc_err = to_jsonrpsee_error_object(
+                ParamsValidationError::OnlyLogAndNewHeadsSubscription,
+                ETH_RPC_ERROR,
+            );
             pending.reject(rpc_err).await;
             return Ok(());
         }
-    };
-
-    let accepted_sink = pending.accept().await?;
-
-    let _task = tokio::spawn(async move {
-        stream_logs(accepted_sink, log_filter, ethereum.clone()).await;
-    });
+    }
 
     Ok(())
-}
-
-async fn stream_logs<S, Seq>(
-    accepted_sink: SubscriptionSink,
-    filter: Box<Filter>,
-    ethereum: Arc<Ethereum<S, Seq>>,
-) where
-    S: Spec,
-    Seq: Sequencer<Spec = S>,
-    S::Address: FromVmAddress<EthereumAddress>,
-    Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
-{
-    let evm = Evm::<S>::default();
-    let state = &mut ethereum.api_state_accessor();
-
-    let pending_block = evm.pending_block(state);
-    let mut prev_last_tx_index = pending_block.transactions.end;
-
-    // Fetch the initial block. If it’s stale, it will be replaced below.
-    let start_block = pending_block.header.number - 1;
-    let Some(mut block) = evm.get_maybe_sealed_block(start_block, state) else {
-        tracing::error!(start_block, "Block does not exist");
-        return;
-    };
-
-    let state_updates = &mut ethereum.sequencer.api_state().checkpoint_receiver();
-
-    while state_updates.changed().await.is_ok() {
-        let state = &mut ethereum.api_state_accessor();
-
-        let pending_block = evm.pending_block(state);
-        let curr_last_tx_index = pending_block.transactions.end;
-
-        if curr_last_tx_index <= prev_last_tx_index {
-            continue;
-        }
-
-        for index in prev_last_tx_index..curr_last_tx_index {
-            let Some(receipt) = evm.receipt(index, state) else {
-                // This can happen if the state was pruned.
-                tracing::error!(index, "Receipt does not exist");
-                return;
-            };
-
-            if block.number() != receipt.block_number {
-                match evm.get_maybe_sealed_block(receipt.block_number, state) {
-                    Some(b) => block = b,
-                    None => {
-                        tracing::error!(
-                            block_number = receipt.block_number,
-                            "Block does not exist"
-                        );
-                        return;
-                    }
-                }
-            }
-
-            let transaction_index = index - block.transactions_start();
-
-            for (log_index_in_tx, log) in receipt.receipt.logs.into_iter().enumerate() {
-                if filter.matches(&log) {
-                    let rpc_log = alloy_rpc_types::Log {
-                        inner: log,
-                        block_hash: block.hash(),
-                        block_number: Some(block.number()),
-                        block_timestamp: Some(block.timestamp()),
-                        transaction_hash: Some(receipt.transaction_hash),
-                        transaction_index: Some(receipt.transaction_index),
-                        log_index: Some(receipt.log_index_start + log_index_in_tx as u64),
-                        removed: false,
-                    };
-
-                    assert_eq!(receipt.transaction_index, transaction_index);
-
-                    let msg = SubscriptionMessage::new(
-                        accepted_sink.method_name(),
-                        accepted_sink.subscription_id(),
-                        &rpc_log,
-                    )
-                    .unwrap_or_else(|err| {
-                        panic!("Impossible: can't serialize log. Log: {rpc_log:?}, Err: {err:?}",)
-                    });
-
-                    if let Err(err) = accepted_sink.send(msg).await {
-                        tracing::info!(%err, "The subscription client disconnected from the server.");
-                        return;
-                    }
-                }
-            }
-        }
-        prev_last_tx_index = curr_last_tx_index;
-    }
-}
-
-#[derive(Error, Debug)]
-enum ParamsValidationError {
-    #[error("Block Option parameters are not supported in LOG subscriptions. Please use eth_getLogs or eth_getLogsWithCursor")]
-    BlockOptionParam,
-    #[error("Boolean parameters are not supported in LOG subscriptions")]
-    BoolParam,
-    #[error("Only LOG subscriptions are supported")]
-    OnlyLogSubscription,
-}
-
-fn validate_params_for_log_subscription(
-    kind: SubscriptionKind,
-    params: Params,
-) -> Result<Box<Filter>, ParamsValidationError> {
-    if kind != SubscriptionKind::Logs {
-        return Err(ParamsValidationError::OnlyLogSubscription);
-    }
-    match params {
-        Params::Logs(filter) => {
-            if filter.block_option == FilterBlockOption::default() {
-                Ok(filter)
-            } else {
-                Err(ParamsValidationError::BlockOptionParam)
-            }
-        }
-        Params::Bool(_) => Err(ParamsValidationError::BoolParam),
-        Params::None => Ok(Default::default()),
-    }
 }

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -51,7 +51,7 @@ where
             tokio::spawn(async move {
                 Streamer::new(accepted_sink, ethereum.clone())
                     .blocks()
-                    .await;
+                    .await
             });
         }
         SubscriptionKind::Logs => {
@@ -79,7 +79,7 @@ where
             tokio::spawn(async move {
                 Streamer::new(accepted_sink, ethereum.clone())
                     .logs(log_filter)
-                    .await;
+                    .await
             });
         }
         _ => {

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -16,6 +16,7 @@ use sov_sequencer::Sequencer;
 use std::sync::Arc;
 
 mod service;
+pub(crate) mod watermark;
 
 use crate::handlers::ETH_RPC_ERROR;
 

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -31,8 +31,9 @@ where
     S::Address: FromVmAddress<EthereumAddress>,
     Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
 {
-    let (kind, params): (SubscriptionKind, Option<Params>) = parameters.parse()?;
-    let params = params.unwrap_or(Params::None);
+    let mut parameters = parameters.sequence();
+    let kind: SubscriptionKind = parameters.next()?;
+    let params: Params = parameters.optional_next()?.unwrap_or_default();
 
     let log_filter = match validate_params_for_log_subscription(kind, params) {
         Ok(log_filter) => log_filter,

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -31,9 +31,8 @@ where
     S::Address: FromVmAddress<EthereumAddress>,
     Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
 {
-    let mut parameters = parameters.sequence();
-    let kind: SubscriptionKind = parameters.next()?;
-    let params: Params = parameters.optional_next()?.unwrap_or_default();
+    let (kind, params): (SubscriptionKind, Option<Params>) = parameters.parse()?;
+    let params = params.unwrap_or(Params::None);
 
     let log_filter = match validate_params_for_log_subscription(kind, params) {
         Ok(log_filter) => log_filter,

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/params.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/params.rs
@@ -5,6 +5,7 @@ use alloy_rpc_types::pubsub::Params;
 use alloy_rpc_types::pubsub::SubscriptionKind;
 use alloy_rpc_types::FilterBlockOption;
 use jsonrpsee::types::ErrorObjectOwned;
+use jsonrpsee::types::Params as JRpcParams;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -23,6 +24,15 @@ impl From<Error> for ErrorObjectOwned {
     fn from(err: Error) -> Self {
         to_jsonrpsee_error_object(err, ETH_RPC_ERROR)
     }
+}
+
+pub fn parse(
+    parameters: JRpcParams<'static>,
+) -> Result<(SubscriptionKind, Params), ErrorObjectOwned> {
+    let mut parameters = parameters.sequence();
+    let kind = parameters.next()?;
+    let params = parameters.optional_next()?.unwrap_or_default();
+    Ok((kind, params))
 }
 
 pub fn validate(kind: SubscriptionKind, params: Params) -> Result<SubscriptionRequest, Error> {

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/params.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/params.rs
@@ -1,0 +1,52 @@
+use crate::handlers::subscribe::SubscriptionRequest;
+use crate::handlers::ETH_RPC_ERROR;
+use crate::to_jsonrpsee_error_object;
+use alloy_rpc_types::pubsub::Params;
+use alloy_rpc_types::pubsub::SubscriptionKind;
+use alloy_rpc_types::FilterBlockOption;
+use jsonrpsee::types::ErrorObjectOwned;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Block Option parameters are not supported in LOG subscriptions. Please use eth_getLogs or eth_getLogsWithCursor")]
+    BlockOptionParam,
+    #[error("Boolean parameters are not supported in LOG subscriptions")]
+    BoolParam,
+    #[error("Only LOG and newHeads subscriptions are supported")]
+    OnlyLogAndNewHeadsSubscription,
+    #[error("newHeads subscription does not accept parameters")]
+    NewHeadsDoesNotAcceptParams,
+}
+
+impl From<Error> for ErrorObjectOwned {
+    fn from(err: Error) -> Self {
+        to_jsonrpsee_error_object(err, ETH_RPC_ERROR)
+    }
+}
+
+pub fn validate(kind: SubscriptionKind, params: Params) -> Result<SubscriptionRequest, Error> {
+    match kind {
+        SubscriptionKind::NewHeads => {
+            if params != Params::None {
+                return Err(Error::NewHeadsDoesNotAcceptParams);
+            }
+            Ok(SubscriptionRequest::Heads)
+        }
+        SubscriptionKind::Logs => {
+            let filter = match params {
+                Params::Logs(filter) => {
+                    if filter.block_option == FilterBlockOption::default() {
+                        filter
+                    } else {
+                        return Err(Error::BlockOptionParam);
+                    }
+                }
+                Params::Bool(_) => return Err(Error::BoolParam),
+                Params::None => Default::default(),
+            };
+            Ok(SubscriptionRequest::Logs(filter))
+        }
+        _ => Err(Error::OnlyLogAndNewHeadsSubscription),
+    }
+}

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -86,14 +86,14 @@ where
     pub async fn blocks(&self) -> Result<(), Error> {
         let mut state = self.ethereum.api_state_accessor();
         let pending_block = self.evm.pending_block(&mut state);
-        let mut block_watermark = Watermark::new(..pending_block.header.number);
+        let mut block_watermark = Watermark::new(..pending_block.header.number + 1);
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
         while state_updates.changed().await.is_ok() {
             let mut state = self.ethereum.api_state_accessor();
             let pending_block = self.evm.pending_block(&mut state);
 
-            for block_number in block_watermark.advance(..pending_block.header.number) {
+            for block_number in block_watermark.advance(..pending_block.header.number + 1) {
                 let block = self.get_block(block_number, &mut state)?;
                 self.send_block_header(&block).await?;
             }

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -59,7 +59,8 @@ where
     pub async fn logs(&self, filter: Box<Filter>) -> Result<(), Error> {
         let mut state = self.ethereum.api_state_accessor();
         let pending_block = self.evm.pending_block(&mut state);
-        let mut tx_watermark = Watermark::new(pending_block.transactions.end);
+        // Tx range in block is exclusive therefore the last processed one is `pending_block.transactions.end - 1`
+        let mut tx_watermark = Watermark::new(pending_block.transactions.end - 1);
 
         // Fetch the initial block. If it's stale, it will be replaced below.
         let mut block = self.get_block(pending_block.header.number - 1, &mut state)?;
@@ -69,7 +70,7 @@ where
             let mut state = self.ethereum.api_state_accessor();
             let pending_block = self.evm.pending_block(&mut state);
 
-            for tx_idx in tx_watermark.advance(pending_block.transactions.end) {
+            for tx_idx in tx_watermark.advance(pending_block.transactions.end - 1) {
                 let receipt = self.get_receipt(tx_idx, &mut state)?;
 
                 if block.number() != receipt.block_number {

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -20,6 +20,16 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use thiserror::Error;
 
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Block does not eist")]
+    BlockDoesNotExist,
+    #[error("Receipt does not eist")]
+    ReceiptDoesNotExist,
+    #[error(transparent)]
+    Disconnect(#[from] DisconnectError),
+}
+
 pub struct Streamer<S, Seq>
 where
     S: Spec,
@@ -147,26 +157,4 @@ where
             tracing::info!(%err, "The subscription client disconnected from the server.");
         })
     }
-}
-
-#[derive(Error, Debug)]
-pub enum ParamsValidationError {
-    #[error("Block Option parameters are not supported in LOG subscriptions. Please use eth_getLogs or eth_getLogsWithCursor")]
-    BlockOptionParam,
-    #[error("Boolean parameters are not supported in LOG subscriptions")]
-    BoolParam,
-    #[error("Only LOG and newHeads subscriptions are supported")]
-    OnlyLogAndNewHeadsSubscription,
-    #[error("newHeads subscription does not accept parameters")]
-    NewHeadsDoesNotAcceptParams,
-}
-
-#[derive(Error, Debug)]
-pub enum Error {
-    #[error("Block does not eist")]
-    BlockDoesNotExist,
-    #[error("Receipt does not eist")]
-    ReceiptDoesNotExist,
-    #[error(transparent)]
-    Disconnect(#[from] DisconnectError),
 }

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -22,9 +22,9 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Block does not eist")]
+    #[error("Block does not exist")]
     BlockDoesNotExist,
-    #[error("Receipt does not eist")]
+    #[error("Receipt does not exist")]
     ReceiptDoesNotExist,
     #[error(transparent)]
     Disconnect(#[from] DisconnectError),
@@ -55,6 +55,61 @@ where
         }
     }
 
+    /// Stream new logs matching the provided filter to the subscriber.
+    pub async fn logs(&self, filter: Box<Filter>) -> Result<(), Error> {
+        let mut state = self.ethereum.api_state_accessor();
+        let pending_block = self.evm.pending_block(&mut state);
+        let mut tx_watermark = Watermark::new(pending_block.transactions.end);
+
+        // Fetch the initial block. If it's stale, it will be replaced below.
+        let mut block = self.get_block(pending_block.header.number - 1, &mut state)?;
+
+        let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
+        while state_updates.changed().await.is_ok() {
+            let mut state = self.ethereum.api_state_accessor();
+            let pending_block = self.evm.pending_block(&mut state);
+
+            for tx_idx in tx_watermark.advance(pending_block.transactions.end) {
+                let receipt = self.get_receipt(tx_idx, &mut state)?;
+
+                if block.number() != receipt.block_number {
+                    block = self.get_block(receipt.block_number, &mut state)?;
+                }
+
+                self.send_matching_logs(&receipt, &block, &filter).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Stream new block headers to the subscriber.
+    pub async fn blocks(&self) -> Result<(), Error> {
+        let mut state = self.ethereum.api_state_accessor();
+        let pending_block = self.evm.pending_block(&mut state);
+        let mut block_watermark = Watermark::new(pending_block.header.number - 1);
+
+        let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
+        while state_updates.changed().await.is_ok() {
+            let mut state = self.ethereum.api_state_accessor();
+            let pending_block = self.evm.pending_block(&mut state);
+
+            for block_number in block_watermark.advance(pending_block.header.number - 1) {
+                let block = self.get_block(block_number, &mut state)?;
+                self.send_block_header(&block).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+// Helper methods
+impl<S, Seq> Streamer<S, Seq>
+where
+    S: Spec,
+    Seq: Sequencer<Spec = S>,
+    S::Address: FromVmAddress<EthereumAddress>,
+    Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
+{
     fn get_block(
         &self,
         number: u64,
@@ -73,85 +128,42 @@ where
             .inspect_err(|_| tracing::error!(idx, "Receipt does not exist"))
     }
 
-    pub async fn logs(&self, filter: Box<Filter>) -> Result<(), Error> {
-        let mut state = self.ethereum.api_state_accessor();
-
-        let pending_block = self.evm.pending_block(&mut state);
-        let mut tx_watermark = Watermark::new(pending_block.transactions.end);
-
-        // Fetch the initial block. If it's stale, it will be replaced below.
-        let mut block = self.get_block(pending_block.header.number - 1, &mut state)?;
-
-        let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
-
-        while state_updates.changed().await.is_ok() {
-            let mut state = self.ethereum.api_state_accessor();
-
-            let pending_block = self.evm.pending_block(&mut state);
-
-            for index in tx_watermark.advance(pending_block.transactions.end) {
-                let receipt = self.get_receipt(index, &mut state)?;
-
-                if block.number() != receipt.block_number {
-                    let new_block = self.get_block(receipt.block_number, &mut state)?;
-                    block = new_block;
-                }
-
-                for (log_index_in_tx, log) in receipt.receipt.logs.into_iter().enumerate() {
-                    if filter.matches(&log) {
-                        let rpc_log = alloy_rpc_types::Log {
-                            inner: log,
-                            block_hash: block.hash(),
-                            block_number: Some(block.number()),
-                            block_timestamp: Some(block.timestamp()),
-                            transaction_hash: Some(receipt.transaction_hash),
-                            transaction_index: Some(receipt.transaction_index),
-                            log_index: Some(receipt.log_index_start + log_index_in_tx as u64),
-                            removed: false,
-                        };
-
-                        self.send(&rpc_log, "log").await?;
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    pub async fn blocks(&self) -> Result<(), Error> {
-        let mut state = self.ethereum.api_state_accessor();
-
-        let pending_block = self.evm.pending_block(&mut state);
-        let mut block_watermark = Watermark::new(pending_block.header.number - 1);
-
-        let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
-        while state_updates.changed().await.is_ok() {
-            let mut state = self.ethereum.api_state_accessor();
-
-            let pending_block = self.evm.pending_block(&mut state);
-
-            for block_number in block_watermark.advance(pending_block.header.number - 1) {
-                let block = self.get_block(block_number, &mut state)?;
-                let hash = block.hash().unwrap_or_default();
-                let header = Sealed::new_unchecked(block.header().clone(), hash);
-                let rpc_header = Header::from_consensus(header, None, None);
-
-                self.send(&rpc_header, "header").await?;
-            }
-        }
-        Ok(())
-    }
-
-    async fn send<T: Serialize + Debug>(
+    async fn send_matching_logs(
         &self,
-        data: &T,
-        data_type: &str,
+        receipt: &Receipt,
+        block: &MaybeSealedBlock,
+        filter: &Filter,
     ) -> Result<(), DisconnectError> {
+        for (log_index_in_tx, log) in receipt.receipt.logs.iter().enumerate() {
+            if filter.matches(log) {
+                let rpc_log = alloy_rpc_types::Log {
+                    inner: log.clone(),
+                    block_hash: block.hash(),
+                    block_number: Some(block.number()),
+                    block_timestamp: Some(block.timestamp()),
+                    transaction_hash: Some(receipt.transaction_hash),
+                    transaction_index: Some(receipt.transaction_index),
+                    log_index: Some(receipt.log_index_start + log_index_in_tx as u64),
+                    removed: false,
+                };
+
+                self.send(&rpc_log).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn send_block_header(&self, block: &MaybeSealedBlock) -> Result<(), DisconnectError> {
+        let hash = block.hash().unwrap_or_default();
+        let header = Sealed::new_unchecked(block.header().clone(), hash);
+        let rpc_header = Header::from_consensus(header, None, None);
+        self.send(&rpc_header).await
+    }
+
+    async fn send<T: Serialize + Debug>(&self, data: &T) -> Result<(), DisconnectError> {
         let msg =
             SubscriptionMessage::new(self.sink.method_name(), self.sink.subscription_id(), data)
-                .unwrap_or_else(|err| {
-                    panic!("Impossible: can't serialize {data_type}. Data: {data:?}, Err: {err:?}")
-                });
+                .expect("Failed to serialize subscription message");
 
         self.sink.send(msg).await.inspect_err(|err| {
             tracing::info!(%err, "The subscription client disconnected from the server.");

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -2,6 +2,7 @@ use crate::Ethereum;
 use alloy_consensus::Sealed;
 use alloy_rpc_types::Filter;
 use alloy_rpc_types::Header;
+use jsonrpsee::DisconnectError;
 use jsonrpsee::SubscriptionMessage;
 use jsonrpsee::SubscriptionSink;
 use serde::Serialize;
@@ -35,7 +36,7 @@ where
         Self { sink, ethereum }
     }
 
-    pub async fn logs(&self, filter: Box<Filter>) {
+    pub async fn logs(&self, filter: Box<Filter>) -> Result<(), Error> {
         let evm = Evm::<S>::default();
         let mut state = self.ethereum.api_state_accessor();
 
@@ -46,7 +47,7 @@ where
         let start_block = pending_block.header.number - 1;
         let Some(mut block) = evm.get_maybe_sealed_block(start_block, &mut state) else {
             tracing::error!(start_block, "Block does not exist");
-            return;
+            return Err(Error::BlockDoesNotExist);
         };
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
@@ -65,7 +66,7 @@ where
                 let Some(receipt) = evm.receipt(index, &mut state) else {
                     // This can happen if the state was pruned.
                     tracing::error!(index, "Receipt does not exist");
-                    return;
+                    return Err(Error::ReceiptDoesNotExist);
                 };
 
                 if block.number() != receipt.block_number {
@@ -76,7 +77,7 @@ where
                                 block_number = receipt.block_number,
                                 "Block does not exist"
                             );
-                            return;
+                            return Err(Error::BlockDoesNotExist);
                         }
                     }
                 }
@@ -98,17 +99,16 @@ where
 
                         assert_eq!(receipt.transaction_index, transaction_index);
 
-                        if !self.send_subscription_message(&rpc_log, "log").await {
-                            return;
-                        }
+                        self.send_subscription_message(&rpc_log, "log").await?;
                     }
                 }
             }
             prev_last_tx_index = curr_last_tx_index;
         }
+        Ok(())
     }
 
-    pub async fn blocks(&self) {
+    pub async fn blocks(&self) -> Result<(), Error> {
         let evm = Evm::<S>::default();
         let mut state = self.ethereum.api_state_accessor();
 
@@ -132,20 +132,20 @@ where
             for block_number in (prev_block_number + 1)..=current_block_number {
                 let Some(block) = evm.get_maybe_sealed_block(block_number, &mut state) else {
                     tracing::error!(block_number, "Block does not exist");
-                    return;
+                    return Err(Error::BlockDoesNotExist);
                 };
 
                 let hash = block.hash().unwrap_or_default();
                 let header = Sealed::new_unchecked(block.header().clone(), hash);
                 let rpc_header = Header::from_consensus(header, None, None);
 
-                if !self.send_subscription_message(&rpc_header, "header").await {
-                    return;
-                }
+                self.send_subscription_message(&rpc_header, "header")
+                    .await?;
             }
 
             prev_block_number = current_block_number;
         }
+        Ok(())
     }
 
     /// Helper function to send a message through the subscription sink
@@ -153,18 +153,16 @@ where
         &self,
         data: &T,
         data_type: &str,
-    ) -> bool {
+    ) -> Result<(), DisconnectError> {
         let msg =
             SubscriptionMessage::new(self.sink.method_name(), self.sink.subscription_id(), data)
                 .unwrap_or_else(|err| {
                     panic!("Impossible: can't serialize {data_type}. Data: {data:?}, Err: {err:?}")
                 });
 
-        if let Err(err) = self.sink.send(msg).await {
+        self.sink.send(msg).await.inspect_err(|err| {
             tracing::info!(%err, "The subscription client disconnected from the server.");
-            return false;
-        }
-        true
+        })
     }
 }
 
@@ -178,4 +176,14 @@ pub enum ParamsValidationError {
     OnlyLogAndNewHeadsSubscription,
     #[error("newHeads subscription does not accept parameters")]
     NewHeadsDoesNotAcceptParams,
+}
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Block does not eist")]
+    BlockDoesNotExist,
+    #[error("Receipt does not eist")]
+    ReceiptDoesNotExist,
+    #[error(transparent)]
+    Disconnect(#[from] DisconnectError),
 }

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -1,0 +1,181 @@
+use crate::Ethereum;
+use alloy_consensus::Sealed;
+use alloy_rpc_types::Filter;
+use alloy_rpc_types::Header;
+use jsonrpsee::SubscriptionMessage;
+use jsonrpsee::SubscriptionSink;
+use serde::Serialize;
+use sov_address::{EthereumAddress, FromVmAddress};
+pub use sov_evm::EthereumAuthenticator;
+use sov_evm::Evm;
+use sov_modules_api::capabilities::HasKernel;
+use sov_modules_api::Spec;
+use sov_sequencer::Sequencer;
+use std::fmt::Debug;
+use std::sync::Arc;
+use thiserror::Error;
+
+pub struct Streamer<S, Seq>
+where
+    S: Spec,
+    Seq: Sequencer<Spec = S>,
+{
+    sink: SubscriptionSink,
+    ethereum: Arc<Ethereum<S, Seq>>,
+}
+
+impl<S, Seq> Streamer<S, Seq>
+where
+    S: Spec,
+    Seq: Sequencer<Spec = S>,
+    S::Address: FromVmAddress<EthereumAddress>,
+    Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
+{
+    pub fn new(sink: SubscriptionSink, ethereum: Arc<Ethereum<S, Seq>>) -> Self {
+        Self { sink, ethereum }
+    }
+
+    pub async fn logs(&self, filter: Box<Filter>) {
+        let evm = Evm::<S>::default();
+        let mut state = self.ethereum.api_state_accessor();
+
+        let pending_block = evm.pending_block(&mut state);
+        let mut prev_last_tx_index = pending_block.transactions.end;
+
+        // Fetch the initial block. If it's stale, it will be replaced below.
+        let start_block = pending_block.header.number - 1;
+        let Some(mut block) = evm.get_maybe_sealed_block(start_block, &mut state) else {
+            tracing::error!(start_block, "Block does not exist");
+            return;
+        };
+
+        let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
+
+        while state_updates.changed().await.is_ok() {
+            let mut state = self.ethereum.api_state_accessor();
+
+            let pending_block = evm.pending_block(&mut state);
+            let curr_last_tx_index = pending_block.transactions.end;
+
+            if curr_last_tx_index <= prev_last_tx_index {
+                continue;
+            }
+
+            for index in prev_last_tx_index..curr_last_tx_index {
+                let Some(receipt) = evm.receipt(index, &mut state) else {
+                    // This can happen if the state was pruned.
+                    tracing::error!(index, "Receipt does not exist");
+                    return;
+                };
+
+                if block.number() != receipt.block_number {
+                    match evm.get_maybe_sealed_block(receipt.block_number, &mut state) {
+                        Some(b) => block = b,
+                        None => {
+                            tracing::error!(
+                                block_number = receipt.block_number,
+                                "Block does not exist"
+                            );
+                            return;
+                        }
+                    }
+                }
+
+                let transaction_index = index - block.transactions_start();
+
+                for (log_index_in_tx, log) in receipt.receipt.logs.into_iter().enumerate() {
+                    if filter.matches(&log) {
+                        let rpc_log = alloy_rpc_types::Log {
+                            inner: log,
+                            block_hash: block.hash(),
+                            block_number: Some(block.number()),
+                            block_timestamp: Some(block.timestamp()),
+                            transaction_hash: Some(receipt.transaction_hash),
+                            transaction_index: Some(receipt.transaction_index),
+                            log_index: Some(receipt.log_index_start + log_index_in_tx as u64),
+                            removed: false,
+                        };
+
+                        assert_eq!(receipt.transaction_index, transaction_index);
+
+                        if !self.send_subscription_message(&rpc_log, "log").await {
+                            return;
+                        }
+                    }
+                }
+            }
+            prev_last_tx_index = curr_last_tx_index;
+        }
+    }
+
+    pub async fn blocks(&self) {
+        let evm = Evm::<S>::default();
+        let mut state = self.ethereum.api_state_accessor();
+
+        let pending_block = evm.pending_block(&mut state);
+        let mut prev_block_number = pending_block.header.number - 1;
+
+        let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
+
+        while state_updates.changed().await.is_ok() {
+            let mut state = self.ethereum.api_state_accessor();
+
+            let pending_block = evm.pending_block(&mut state);
+            let current_block_number = pending_block.header.number - 1;
+
+            // Check if there's a new sealed block
+            if current_block_number <= prev_block_number {
+                continue;
+            }
+
+            // Send all new blocks from prev_block_number+1 to current_block_number
+            for block_number in (prev_block_number + 1)..=current_block_number {
+                let Some(block) = evm.get_maybe_sealed_block(block_number, &mut state) else {
+                    tracing::error!(block_number, "Block does not exist");
+                    return;
+                };
+
+                let hash = block.hash().unwrap_or_default();
+                let header = Sealed::new_unchecked(block.header().clone(), hash);
+                let rpc_header = Header::from_consensus(header, None, None);
+
+                if !self.send_subscription_message(&rpc_header, "header").await {
+                    return;
+                }
+            }
+
+            prev_block_number = current_block_number;
+        }
+    }
+
+    /// Helper function to send a message through the subscription sink
+    async fn send_subscription_message<T: Serialize + Debug>(
+        &self,
+        data: &T,
+        data_type: &str,
+    ) -> bool {
+        let msg =
+            SubscriptionMessage::new(self.sink.method_name(), self.sink.subscription_id(), data)
+                .unwrap_or_else(|err| {
+                    panic!("Impossible: can't serialize {data_type}. Data: {data:?}, Err: {err:?}")
+                });
+
+        if let Err(err) = self.sink.send(msg).await {
+            tracing::info!(%err, "The subscription client disconnected from the server.");
+            return false;
+        }
+        true
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ParamsValidationError {
+    #[error("Block Option parameters are not supported in LOG subscriptions. Please use eth_getLogs or eth_getLogsWithCursor")]
+    BlockOptionParam,
+    #[error("Boolean parameters are not supported in LOG subscriptions")]
+    BoolParam,
+    #[error("Only LOG and newHeads subscriptions are supported")]
+    OnlyLogAndNewHeadsSubscription,
+    #[error("newHeads subscription does not accept parameters")]
+    NewHeadsDoesNotAcceptParams,
+}

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -59,8 +59,7 @@ where
     pub async fn logs(&self, filter: Box<Filter>) -> Result<(), Error> {
         let mut state = self.ethereum.api_state_accessor();
         let pending_block = self.evm.pending_block(&mut state);
-        // Tx range in block is exclusive therefore the last processed one is `pending_block.transactions.end - 1`
-        let mut tx_watermark = Watermark::new(pending_block.transactions.end - 1);
+        let mut tx_watermark = Watermark::new(..pending_block.transactions.end);
 
         // Fetch the initial block. If it's stale, it will be replaced below.
         let mut block = self.get_block(pending_block.header.number - 1, &mut state)?;
@@ -70,7 +69,7 @@ where
             let mut state = self.ethereum.api_state_accessor();
             let pending_block = self.evm.pending_block(&mut state);
 
-            for tx_idx in tx_watermark.advance(pending_block.transactions.end - 1) {
+            for tx_idx in tx_watermark.advance(..pending_block.transactions.end) {
                 let receipt = self.get_receipt(tx_idx, &mut state)?;
 
                 if block.number() != receipt.block_number {
@@ -87,14 +86,14 @@ where
     pub async fn blocks(&self) -> Result<(), Error> {
         let mut state = self.ethereum.api_state_accessor();
         let pending_block = self.evm.pending_block(&mut state);
-        let mut block_watermark = Watermark::new(pending_block.header.number - 1);
+        let mut block_watermark = Watermark::new(..pending_block.header.number);
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
         while state_updates.changed().await.is_ok() {
             let mut state = self.ethereum.api_state_accessor();
             let pending_block = self.evm.pending_block(&mut state);
 
-            for block_number in block_watermark.advance(pending_block.header.number - 1) {
+            for block_number in block_watermark.advance(..pending_block.header.number) {
                 let block = self.get_block(block_number, &mut state)?;
                 self.send_block_header(&block).await?;
             }

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -1,3 +1,4 @@
+use super::watermark::Watermark;
 use crate::Ethereum;
 use alloy_consensus::Sealed;
 use alloy_rpc_types::Filter;
@@ -9,7 +10,10 @@ use serde::Serialize;
 use sov_address::{EthereumAddress, FromVmAddress};
 pub use sov_evm::EthereumAuthenticator;
 use sov_evm::Evm;
+use sov_evm::MaybeSealedBlock;
+use sov_evm::Receipt;
 use sov_modules_api::capabilities::HasKernel;
+use sov_modules_api::ApiStateAccessor;
 use sov_modules_api::Spec;
 use sov_sequencer::Sequencer;
 use std::fmt::Debug;
@@ -23,6 +27,7 @@ where
 {
     sink: SubscriptionSink,
     ethereum: Arc<Ethereum<S, Seq>>,
+    evm: Evm<S>,
 }
 
 impl<S, Seq> Streamer<S, Seq>
@@ -33,56 +38,54 @@ where
     Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
 {
     pub fn new(sink: SubscriptionSink, ethereum: Arc<Ethereum<S, Seq>>) -> Self {
-        Self { sink, ethereum }
+        Self {
+            sink,
+            ethereum,
+            evm: Default::default(),
+        }
+    }
+
+    fn get_block(
+        &self,
+        number: u64,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Result<MaybeSealedBlock, Error> {
+        self.evm
+            .get_maybe_sealed_block(number, state)
+            .ok_or(Error::BlockDoesNotExist)
+            .inspect_err(|_| tracing::error!(number, "Block does not exist"))
+    }
+
+    fn get_receipt(&self, idx: u64, state: &mut ApiStateAccessor<S>) -> Result<Receipt, Error> {
+        self.evm
+            .receipt(idx, state)
+            .ok_or(Error::ReceiptDoesNotExist)
+            .inspect_err(|_| tracing::error!(idx, "Receipt does not exist"))
     }
 
     pub async fn logs(&self, filter: Box<Filter>) -> Result<(), Error> {
-        let evm = Evm::<S>::default();
         let mut state = self.ethereum.api_state_accessor();
 
-        let pending_block = evm.pending_block(&mut state);
-        let mut prev_last_tx_index = pending_block.transactions.end;
+        let pending_block = self.evm.pending_block(&mut state);
+        let mut tx_watermark = Watermark::new(pending_block.transactions.end);
 
         // Fetch the initial block. If it's stale, it will be replaced below.
-        let start_block = pending_block.header.number - 1;
-        let Some(mut block) = evm.get_maybe_sealed_block(start_block, &mut state) else {
-            tracing::error!(start_block, "Block does not exist");
-            return Err(Error::BlockDoesNotExist);
-        };
+        let mut block = self.get_block(pending_block.header.number - 1, &mut state)?;
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
 
         while state_updates.changed().await.is_ok() {
             let mut state = self.ethereum.api_state_accessor();
 
-            let pending_block = evm.pending_block(&mut state);
-            let curr_last_tx_index = pending_block.transactions.end;
+            let pending_block = self.evm.pending_block(&mut state);
 
-            if curr_last_tx_index <= prev_last_tx_index {
-                continue;
-            }
-
-            for index in prev_last_tx_index..curr_last_tx_index {
-                let Some(receipt) = evm.receipt(index, &mut state) else {
-                    // This can happen if the state was pruned.
-                    tracing::error!(index, "Receipt does not exist");
-                    return Err(Error::ReceiptDoesNotExist);
-                };
+            for index in tx_watermark.advance(pending_block.transactions.end) {
+                let receipt = self.get_receipt(index, &mut state)?;
 
                 if block.number() != receipt.block_number {
-                    match evm.get_maybe_sealed_block(receipt.block_number, &mut state) {
-                        Some(b) => block = b,
-                        None => {
-                            tracing::error!(
-                                block_number = receipt.block_number,
-                                "Block does not exist"
-                            );
-                            return Err(Error::BlockDoesNotExist);
-                        }
-                    }
+                    let new_block = self.get_block(receipt.block_number, &mut state)?;
+                    block = new_block;
                 }
-
-                let transaction_index = index - block.transactions_start();
 
                 for (log_index_in_tx, log) in receipt.receipt.logs.into_iter().enumerate() {
                     if filter.matches(&log) {
@@ -97,59 +100,39 @@ where
                             removed: false,
                         };
 
-                        assert_eq!(receipt.transaction_index, transaction_index);
-
-                        self.send_subscription_message(&rpc_log, "log").await?;
+                        self.send(&rpc_log, "log").await?;
                     }
                 }
             }
-            prev_last_tx_index = curr_last_tx_index;
         }
         Ok(())
     }
 
     pub async fn blocks(&self) -> Result<(), Error> {
-        let evm = Evm::<S>::default();
         let mut state = self.ethereum.api_state_accessor();
 
-        let pending_block = evm.pending_block(&mut state);
-        let mut prev_block_number = pending_block.header.number - 1;
+        let pending_block = self.evm.pending_block(&mut state);
+        let mut block_watermark = Watermark::new(pending_block.header.number - 1);
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
-
         while state_updates.changed().await.is_ok() {
             let mut state = self.ethereum.api_state_accessor();
 
-            let pending_block = evm.pending_block(&mut state);
-            let current_block_number = pending_block.header.number - 1;
+            let pending_block = self.evm.pending_block(&mut state);
 
-            // Check if there's a new sealed block
-            if current_block_number <= prev_block_number {
-                continue;
-            }
-
-            // Send all new blocks from prev_block_number+1 to current_block_number
-            for block_number in (prev_block_number + 1)..=current_block_number {
-                let Some(block) = evm.get_maybe_sealed_block(block_number, &mut state) else {
-                    tracing::error!(block_number, "Block does not exist");
-                    return Err(Error::BlockDoesNotExist);
-                };
-
+            for block_number in block_watermark.advance(pending_block.header.number - 1) {
+                let block = self.get_block(block_number, &mut state)?;
                 let hash = block.hash().unwrap_or_default();
                 let header = Sealed::new_unchecked(block.header().clone(), hash);
                 let rpc_header = Header::from_consensus(header, None, None);
 
-                self.send_subscription_message(&rpc_header, "header")
-                    .await?;
+                self.send(&rpc_header, "header").await?;
             }
-
-            prev_block_number = current_block_number;
         }
         Ok(())
     }
 
-    /// Helper function to send a message through the subscription sink
-    async fn send_subscription_message<T: Serialize + Debug>(
+    async fn send<T: Serialize + Debug>(
         &self,
         data: &T,
         data_type: &str,

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/watermark.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/watermark.rs
@@ -1,31 +1,31 @@
-use std::ops::Range;
+use std::ops::{Range, RangeTo};
 
 /// An empty range used to represent no new items.
 const EMPTY_RANGE: Range<u64> = 0..0;
 
-/// Tracks the high-water mark of a monotonically increasing sequence.
+/// Tracks the high-water mark and emits only new items on each advance.
 ///
-/// Returns new items above the watermark on each advance.
+/// Returns the range of items that are new since the last processed position.
 /// https://en.wikipedia.org/wiki/Watermark_(data_synchronization)
 pub struct Watermark {
-    last_processed: u64,
+    processed: RangeTo<u64>,
 }
 
 impl Watermark {
-    pub fn new(last_processed: u64) -> Self {
-        Self { last_processed }
+    pub fn new(processed: RangeTo<u64>) -> Self {
+        Self { processed }
     }
 
-    /// Returns the range of new items from the last processed element to the new value.
+    /// Returns the range of new items that haven't been processed yet.
     ///
-    /// If the new value hasn't advanced past the last processed element, returns an empty range.
-    /// Otherwise, updates the last processed element and returns the range of new items.
-    pub fn advance(&mut self, latest: u64) -> Range<u64> {
-        if latest <= self.last_processed {
+    /// If the visible range hasn't advanced past the processed watermark, returns an empty range.
+    /// Otherwise, updates the watermark and returns the range of new items.
+    pub fn advance(&mut self, visible: RangeTo<u64>) -> Range<u64> {
+        if visible.end <= self.processed.end {
             return EMPTY_RANGE;
         }
-        let range = self.last_processed + 1..latest + 1;
-        self.last_processed = latest;
+        let range = self.processed.end + 1..visible.end;
+        self.processed = visible;
         range
     }
 }
@@ -36,47 +36,47 @@ mod tests {
 
     #[test]
     fn normal_progression() {
-        let mut watermark = Watermark::new(0);
+        let mut watermark = Watermark::new(..0);
 
-        let range = watermark.advance(2);
-        assert_eq!(range, 1..3);
-        assert_eq!(watermark.last_processed, 2);
+        let range = watermark.advance(..2);
+        assert_eq!(range, 1..2);
+        assert_eq!(watermark.processed, ..2);
     }
 
     #[test]
     fn no_change_returns_empty() {
-        let mut watermark = Watermark::new(0);
+        let mut watermark = Watermark::new(..0);
 
-        let range = watermark.advance(0);
+        let range = watermark.advance(..0);
         assert_eq!(range, EMPTY_RANGE);
-        assert_eq!(watermark.last_processed, 0);
+        assert_eq!(watermark.processed, ..0);
     }
 
     #[test]
     fn backward_movement_returns_empty() {
-        let mut watermark = Watermark::new(1);
+        let mut watermark = Watermark::new(..1);
 
-        let range = watermark.advance(0);
+        let range = watermark.advance(..0);
         assert_eq!(range, EMPTY_RANGE);
-        assert_eq!(watermark.last_processed, 1); // Last processed doesn't move backward
+        assert_eq!(watermark.processed, ..1); // Last processed doesn't move backward
     }
 
     #[test]
     fn multiple_advances() {
-        let mut watermark = Watermark::new(0);
+        let mut watermark = Watermark::new(..0);
 
-        assert_eq!(watermark.advance(3), 1..4);
-        assert_eq!(watermark.advance(3), EMPTY_RANGE);
-        assert_eq!(watermark.advance(5), 4..6);
-        assert_eq!(watermark.advance(5), EMPTY_RANGE);
-        assert_eq!(watermark.advance(7), 6..8);
+        assert_eq!(watermark.advance(..3), 1..3);
+        assert_eq!(watermark.advance(..3), EMPTY_RANGE);
+        assert_eq!(watermark.advance(..5), 4..5);
+        assert_eq!(watermark.advance(..5), EMPTY_RANGE);
+        assert_eq!(watermark.advance(..7), 6..7);
     }
 
     #[test]
     fn single_item_increment() {
-        let mut watermark = Watermark::new(0);
+        let mut watermark = Watermark::new(..0);
 
-        assert_eq!(watermark.advance(1), 1..2);
-        assert_eq!(watermark.advance(2), 2..3);
+        assert_eq!(watermark.advance(..1), 1..1);
+        assert_eq!(watermark.advance(..2), 2..2);
     }
 }

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/watermark.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/watermark.rs
@@ -1,0 +1,83 @@
+use std::ops::RangeInclusive;
+
+/// An empty range used to represent no new items.
+#[allow(clippy::reversed_empty_ranges)]
+const EMPTY_RANGE: RangeInclusive<u64> = 1..=0;
+
+/// Tracks the high-water mark of a monotonically increasing sequence.
+///
+/// Returns new items above the watermark on each advance.
+/// https://en.wikipedia.org/wiki/Watermark_(data_synchronization)
+pub struct Watermark {
+    mark: u64,
+}
+
+impl Watermark {
+    pub fn new(initial: u64) -> Self {
+        Self { mark: initial }
+    }
+
+    /// Returns the range of new items from the last mark to the new value.
+    ///
+    /// If the new value hasn't advanced past the current mark, returns an empty range.
+    /// Otherwise, updates the mark and returns the range of new items.
+    pub fn advance(&mut self, new_value: u64) -> RangeInclusive<u64> {
+        if new_value <= self.mark {
+            return EMPTY_RANGE;
+        }
+        let range = self.mark + 1..=new_value;
+        self.mark = new_value;
+        range
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normal_progression() {
+        let mut watermark = Watermark::new(0);
+
+        let range = watermark.advance(2);
+        assert_eq!(range, 1..=2);
+        assert_eq!(watermark.mark, 2);
+    }
+
+    #[test]
+    fn no_change_returns_empty() {
+        let mut watermark = Watermark::new(0);
+
+        let range = watermark.advance(0);
+        assert_eq!(range, EMPTY_RANGE);
+        assert_eq!(watermark.mark, 0);
+    }
+
+    #[test]
+    fn backward_movement_returns_empty() {
+        let mut watermark = Watermark::new(1);
+
+        let range = watermark.advance(0);
+        assert_eq!(range, EMPTY_RANGE);
+        assert_eq!(watermark.mark, 1); // Mark doesn't move backward
+    }
+
+    #[test]
+    fn multiple_advances() {
+        let mut watermark = Watermark::new(0);
+
+        assert_eq!(watermark.advance(3), 1..=3);
+        assert_eq!(watermark.advance(3), EMPTY_RANGE);
+        assert_eq!(watermark.advance(5), 4..=5);
+        assert_eq!(watermark.advance(5), EMPTY_RANGE);
+        assert_eq!(watermark.advance(7), 6..=7);
+    }
+
+    #[test]
+    fn single_item_increment() {
+        let mut watermark = Watermark::new(0);
+
+        assert_eq!(watermark.advance(1), 1..=1);
+        assert_eq!(watermark.advance(2), 2..=2);
+    }
+}

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/watermark.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/watermark.rs
@@ -1,32 +1,31 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 /// An empty range used to represent no new items.
-#[allow(clippy::reversed_empty_ranges)]
-const EMPTY_RANGE: RangeInclusive<u64> = 1..=0;
+const EMPTY_RANGE: Range<u64> = 0..0;
 
 /// Tracks the high-water mark of a monotonically increasing sequence.
 ///
 /// Returns new items above the watermark on each advance.
 /// https://en.wikipedia.org/wiki/Watermark_(data_synchronization)
 pub struct Watermark {
-    mark: u64,
+    last_processed: u64,
 }
 
 impl Watermark {
-    pub fn new(initial: u64) -> Self {
-        Self { mark: initial }
+    pub fn new(last_processed: u64) -> Self {
+        Self { last_processed }
     }
 
-    /// Returns the range of new items from the last mark to the new value.
+    /// Returns the range of new items from the last processed element to the new value.
     ///
-    /// If the new value hasn't advanced past the current mark, returns an empty range.
-    /// Otherwise, updates the mark and returns the range of new items.
-    pub fn advance(&mut self, new_value: u64) -> RangeInclusive<u64> {
-        if new_value <= self.mark {
+    /// If the new value hasn't advanced past the last processed element, returns an empty range.
+    /// Otherwise, updates the last processed element and returns the range of new items.
+    pub fn advance(&mut self, latest: u64) -> Range<u64> {
+        if latest <= self.last_processed {
             return EMPTY_RANGE;
         }
-        let range = self.mark + 1..=new_value;
-        self.mark = new_value;
+        let range = self.last_processed + 1..latest + 1;
+        self.last_processed = latest;
         range
     }
 }
@@ -40,8 +39,8 @@ mod tests {
         let mut watermark = Watermark::new(0);
 
         let range = watermark.advance(2);
-        assert_eq!(range, 1..=2);
-        assert_eq!(watermark.mark, 2);
+        assert_eq!(range, 1..3);
+        assert_eq!(watermark.last_processed, 2);
     }
 
     #[test]
@@ -50,7 +49,7 @@ mod tests {
 
         let range = watermark.advance(0);
         assert_eq!(range, EMPTY_RANGE);
-        assert_eq!(watermark.mark, 0);
+        assert_eq!(watermark.last_processed, 0);
     }
 
     #[test]
@@ -59,25 +58,25 @@ mod tests {
 
         let range = watermark.advance(0);
         assert_eq!(range, EMPTY_RANGE);
-        assert_eq!(watermark.mark, 1); // Mark doesn't move backward
+        assert_eq!(watermark.last_processed, 1); // Last processed doesn't move backward
     }
 
     #[test]
     fn multiple_advances() {
         let mut watermark = Watermark::new(0);
 
-        assert_eq!(watermark.advance(3), 1..=3);
+        assert_eq!(watermark.advance(3), 1..4);
         assert_eq!(watermark.advance(3), EMPTY_RANGE);
-        assert_eq!(watermark.advance(5), 4..=5);
+        assert_eq!(watermark.advance(5), 4..6);
         assert_eq!(watermark.advance(5), EMPTY_RANGE);
-        assert_eq!(watermark.advance(7), 6..=7);
+        assert_eq!(watermark.advance(7), 6..8);
     }
 
     #[test]
     fn single_item_increment() {
         let mut watermark = Watermark::new(0);
 
-        assert_eq!(watermark.advance(1), 1..=1);
-        assert_eq!(watermark.advance(2), 2..=2);
+        assert_eq!(watermark.advance(1), 1..2);
+        assert_eq!(watermark.advance(2), 2..3);
     }
 }

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/watermark.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/watermark.rs
@@ -24,7 +24,7 @@ impl Watermark {
         if visible.end <= self.processed.end {
             return EMPTY_RANGE;
         }
-        let range = self.processed.end + 1..visible.end;
+        let range = self.processed.end..visible.end;
         self.processed = visible;
         range
     }
@@ -39,7 +39,7 @@ mod tests {
         let mut watermark = Watermark::new(..0);
 
         let range = watermark.advance(..2);
-        assert_eq!(range, 1..2);
+        assert_eq!(range, 0..2);
         assert_eq!(watermark.processed, ..2);
     }
 
@@ -65,18 +65,18 @@ mod tests {
     fn multiple_advances() {
         let mut watermark = Watermark::new(..0);
 
-        assert_eq!(watermark.advance(..3), 1..3);
+        assert_eq!(watermark.advance(..3), 0..3);
         assert_eq!(watermark.advance(..3), EMPTY_RANGE);
-        assert_eq!(watermark.advance(..5), 4..5);
+        assert_eq!(watermark.advance(..5), 3..5);
         assert_eq!(watermark.advance(..5), EMPTY_RANGE);
-        assert_eq!(watermark.advance(..7), 6..7);
+        assert_eq!(watermark.advance(..7), 5..7);
     }
 
     #[test]
     fn single_item_increment() {
         let mut watermark = Watermark::new(..0);
 
-        assert_eq!(watermark.advance(..1), 1..1);
-        assert_eq!(watermark.advance(..2), 2..2);
+        assert_eq!(watermark.advance(..1), 0..1);
+        assert_eq!(watermark.advance(..2), 1..2);
     }
 }

--- a/examples/demo-rollup/tests/evm/evm_ws_watch.rs
+++ b/examples/demo-rollup/tests/evm/evm_ws_watch.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use alloy::network::TransactionBuilder;
 use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;
-use alloy::transports::RpcError;
 use alloy_primitives::{Address, B256};
 use futures::StreamExt;
 use tokio::time::timeout;

--- a/examples/demo-rollup/tests/evm/evm_ws_watch.rs
+++ b/examples/demo-rollup/tests/evm/evm_ws_watch.rs
@@ -52,12 +52,7 @@ async fn ws_subscribe_new_heads() -> anyhow::Result<()> {
     rollup.wait_for_next_blocks(1).await;
     let client = alloy_ws_client(rollup.http_addr).await;
 
-    let err = client.subscribe_blocks().await.unwrap_err();
-    let RpcError::ErrorResp(payload) = err else {
-        panic!("Expected subscription error")
-    };
-    let data = payload.data.unwrap();
-    assert_eq!(data.get(), "\"Only LOG subscriptions are supported\"");
+    let _ = timeout(Duration::from_secs(1), client.subscribe_blocks()).await??;
 
     Ok(())
 }

--- a/examples/demo-rollup/tests/evm/evm_ws_watch.rs
+++ b/examples/demo-rollup/tests/evm/evm_ws_watch.rs
@@ -52,7 +52,12 @@ async fn ws_subscribe_new_heads() -> anyhow::Result<()> {
     rollup.wait_for_next_blocks(1).await;
     let client = alloy_ws_client(rollup.http_addr).await;
 
-    let _ = timeout(Duration::from_secs(1), client.subscribe_blocks()).await??;
+    let err = client.subscribe_blocks().await.unwrap_err();
+    let RpcError::ErrorResp(payload) = err else {
+        panic!("Expected subscription error")
+    };
+    let data = payload.data.unwrap();
+    assert_eq!(data.get(), "\"Only LOG subscriptions are supported\"");
 
     Ok(())
 }

--- a/examples/demo-rollup/tests/evm/evm_ws_watch.rs
+++ b/examples/demo-rollup/tests/evm/evm_ws_watch.rs
@@ -1,8 +1,11 @@
+use std::time::Duration;
+
 use alloy::network::TransactionBuilder;
 use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;
 use alloy::transports::RpcError;
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
+use tokio::time::timeout;
 
 use crate::evm::evm_test_helper::alloy_ws_client;
 use crate::evm::evm_test_helper::setup_test_rollup;
@@ -10,6 +13,25 @@ use crate::evm::evm_test_helper::EVM_EXTENSION;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn ws_watch_returns_receipt() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    rollup.wait_for_next_blocks(1).await;
+    let client = alloy_ws_client(rollup.http_addr).await;
+
+    let tx = TransactionRequest::default().with_to(Address::ZERO);
+
+    let pending = client.send_transaction(tx).await?;
+
+    // This should complete very quickly (not hang)
+    // If this times out, it proves WebSocket .watch() is broken
+    let tx_hash = timeout(Duration::from_secs(1), pending.watch()).await??;
+
+    assert_ne!(tx_hash, B256::ZERO);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ws_get_receipt() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     rollup.wait_for_next_blocks(1).await;
     let client = alloy_ws_client(rollup.http_addr).await;

--- a/examples/demo-rollup/tests/evm/evm_ws_watch.rs
+++ b/examples/demo-rollup/tests/evm/evm_ws_watch.rs
@@ -5,6 +5,7 @@ use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;
 use alloy::transports::RpcError;
 use alloy_primitives::{Address, B256};
+use futures::StreamExt;
 use tokio::time::timeout;
 
 use crate::evm::evm_test_helper::alloy_ws_client;
@@ -39,9 +40,10 @@ async fn ws_get_receipt() -> anyhow::Result<()> {
     let tx = TransactionRequest::default().with_to(Address::ZERO);
     let pending = client.send_transaction(tx).await?;
     let hash = *pending.tx_hash();
-    let receipt = pending.get_receipt().await?;
 
-    assert_eq!(receipt.transaction_hash, hash);
+    let confirmed_hash = pending.watch().await?;
+
+    assert_eq!(confirmed_hash, hash);
 
     Ok(())
 }
@@ -49,15 +51,15 @@ async fn ws_get_receipt() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn ws_subscribe_new_heads() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
     let client = alloy_ws_client(rollup.http_addr).await;
+    let subscription = client.subscribe_blocks().await?;
+    rollup.wait_for_next_blocks(3).await;
 
-    let err = client.subscribe_blocks().await.unwrap_err();
-    let RpcError::ErrorResp(payload) = err else {
-        panic!("Expected subscription error")
-    };
-    let data = payload.data.unwrap();
-    assert_eq!(data.get(), "\"Only LOG subscriptions are supported\"");
+    let headers: Vec<_> = subscription.into_stream().take(3).collect().await;
+
+    assert_eq!(headers.len(), 3);
+    assert_eq!(headers[1].number, headers[0].number + 1);
+    assert_eq!(headers[2].number, headers[1].number + 1);
 
     Ok(())
 }


### PR DESCRIPTION
# Description

## Key Changes

- **New `Watermark` utility** for tracking monotonically increasing sequences
- **`newHeads` subscription** (new) - streams new block headers
- **`logs` subscription** (refactored) - fixes duplication bug with watermark pattern
- **Parameter validation module** - dedicated `params` module with `SubscriptionRequest` enum
- **Refactored service** - split into logical impl blocks with focused helper functions

-----

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
