### PR TITLE
Fix foundry: coerce 'latest' -> 'pending' for getBlockByNumber,

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -346,7 +346,9 @@ where
                 match pending_or_block_nr {
                     PendingOrBlock::Pending => MaybeArchivalState::Current(state),
                     PendingOrBlock::Number(number) => {
-                        if number == state.rollup_height_to_access().get() || (number == state.rollup_height_to_access().get() + 1) {
+                        if number == state.rollup_height_to_access().get()
+                            || (number == state.rollup_height_to_access().get() + 1)
+                        {
                             return Ok(MaybeArchivalState::Current(state));
                         }
                         let archival_state = state

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -16,7 +16,7 @@ use revm::context::{BlockEnv, CfgEnv};
 use sov_address::{EthereumAddress, FromVmAddress};
 use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::UnwrapInfallible;
-use sov_modules_api::{ApiStateAccessor, Spec};
+use sov_modules_api::{ApiStateAccessor, Spec, VersionReader};
 use sov_rollup_interface::common::RollupHeight;
 use sov_rpc_eth_types::{EthApiError, RpcInvalidTransactionError};
 
@@ -253,6 +253,12 @@ where
         block_number: Option<String>,
         state: &mut ApiStateAccessor<S>,
     ) -> Option<MaybeSealedBlock> {
+        if let Some(block_number) = &block_number {
+            if block_number == "latest" {
+                tracing::warn!("Overwriting latest block with pending block");
+                return Some(MaybeSealedBlock::Pending(self.pending_block(state)));
+            }
+        }
         let pending_or_block_nr = self.str_to_block_nr(block_number, state);
 
         match pending_or_block_nr {
@@ -340,6 +346,9 @@ where
                 match pending_or_block_nr {
                     PendingOrBlock::Pending => MaybeArchivalState::Current(state),
                     PendingOrBlock::Number(number) => {
+                        if number == state.rollup_height_to_access().get() || (number == state.rollup_height_to_access().get() + 1) {
+                            return Ok(MaybeArchivalState::Current(state));
+                        }
                         let archival_state = state
                             .get_archival_state(RollupHeight::new(number))
                             .map_err(into_rpc_error)?;

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/archival_state.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/archival_state.rs
@@ -38,7 +38,7 @@ fn test_state_at_invalid_depth() {
     }
     runner.query_visible_state(|state| {
         let err = evm
-            .get_balance(to.address(), Some("0x03".into()), state)
+            .get_balance(to.address(), Some("0x04".into()), state)
             .unwrap_err();
         assert_eq!(
             err.message(),

--- a/examples/demo-rollup/tests/evm/evm_rpc.rs
+++ b/examples/demo-rollup/tests/evm/evm_rpc.rs
@@ -27,7 +27,7 @@ async fn eth_get_block_by_number() -> anyhow::Result<()> {
     rollup.pause_preferred_batches().await;
 
     assert_eq!(by_number(&client, Earliest).await?.unwrap().number, 0);
-    assert_eq!(by_number(&client, Latest).await?.unwrap().number, 0);
+    assert_eq!(by_number(&client, Latest).await?.unwrap().number, 1);
     assert_eq!(by_number(&client, Pending).await?.unwrap().number, 1);
     assert_eq!(by_number(&client, 1.into()).await?.unwrap().number, 1);
     assert_eq!(by_number(&client, 2.into()).await?, None);
@@ -37,7 +37,7 @@ async fn eth_get_block_by_number() -> anyhow::Result<()> {
     rollup.pause_preferred_batches().await;
 
     assert_eq!(by_number(&client, Earliest).await?.unwrap().number, 0);
-    assert_eq!(by_number(&client, Latest).await?.unwrap().number, 1);
+    assert_eq!(by_number(&client, Latest).await?.unwrap().number, 2);
     assert_eq!(by_number(&client, Pending).await?.unwrap().number, 2);
 
     assert_eq!(by_number(&client, 1.into()).await?.unwrap().number, 1);
@@ -67,7 +67,7 @@ async fn eth_get_block_by_hash() -> anyhow::Result<()> {
     rollup.wait_for_next_blocks(1).await;
     rollup.pause_preferred_batches().await;
 
-    let latest_hash = by_number(&client, Latest).await?.unwrap().hash;
+    let latest_hash = by_number(&client, Latest).await?.unwrap().parent_hash;
     let latest = by_hash(&client, latest_hash).await?.unwrap();
     assert_eq!(latest.hash, latest_hash);
     assert_eq!(latest.number, 1);
@@ -90,7 +90,10 @@ async fn eth_get_block_receipts() -> anyhow::Result<()> {
     usdc.mint(Address::ZERO, parse_ether("1")?).submit().await?;
     rollup.pause_preferred_batches().await;
 
-    let latest_receipts = client.get_block_receipts(BlockId::latest()).await?.unwrap();
+    let latest_receipts = client
+        .get_block_receipts(BlockId::Number(BlockNumberOrTag::Number(1)))
+        .await?
+        .unwrap();
     assert_eq!(latest_receipts.len(), 0);
 
     let mut pending_receipts = client

--- a/examples/demo-rollup/tests/evm/evm_soft_conf.rs
+++ b/examples/demo-rollup/tests/evm/evm_soft_conf.rs
@@ -26,11 +26,8 @@ async fn evm_test_soft_confirmations() -> anyhow::Result<()> {
                 .eth_get_block_by_number(Some("pending".to_string()))
                 .await;
 
-            assert_eq!(pending_block.parent_hash, latest_block.hash.unwrap());
-            assert_eq!(
-                pending_block.number.unwrap(),
-                latest_block.number.unwrap() + 1
-            );
+            assert_eq!(pending_block.parent_hash, latest_block.parent_hash);
+            assert_eq!(pending_block.number.unwrap(), latest_block.number.unwrap());
             assert!(pending_block.transactions.is_empty());
             assert!(latest_block.transactions.is_empty());
         }

--- a/examples/demo-rollup/tests/evm/evm_tx.rs
+++ b/examples/demo-rollup/tests/evm/evm_tx.rs
@@ -55,7 +55,7 @@ async fn sanity_checks(test_client: &SimpleStorageClient) {
 
     assert!(latest_block.number.unwrap().as_u64() > 0);
     assert!(latest_block.number > earliest_block.number);
-    assert!(pending_block.number > latest_block.number);
+    assert!(pending_block.number == latest_block.number);
     assert_eq!(pending_block.hash, Some(H256::zero()));
 
     // Nonce should be 0 before any transactions


### PR DESCRIPTION
Coerce 'latest' -> 'pending' for getBlockByNumber, and allow querying the 'pending' block by requesting height N+1 in EVM RPC handlers
