### PR TITLE
Add get_nonce() to the TransactionAuthorizer

### DIFF
--- a/crates/module-system/sov-capabilities/src/lib.rs
+++ b/crates/module-system/sov-capabilities/src/lib.rs
@@ -243,6 +243,17 @@ impl<S: Spec, T> TransactionAuthorizer<S> for StandardProvenRollupCapabilities<'
         )
     }
 
+    /// Fetches the latest nonce for an account
+    fn get_nonce(
+        &self,
+        auth_data: &AuthorizationData<S>,
+        state: &mut impl StateAccessor,
+    ) -> anyhow::Result<Option<u64>> {
+        self.uniqueness
+            .next_nonce(&auth_data.credential_id, state)
+            .map(Some)
+    }
+
     /// Marks a transaction as having been executed, preventing it from executing again.
     fn mark_tx_attempted(
         &mut self,

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authorization.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authorization.rs
@@ -41,6 +41,13 @@ pub trait TransactionAuthorizer<S: Spec> {
         state: &mut impl StateAccessor,
     ) -> anyhow::Result<()>;
 
+    /// Fetches the latest nonce for an account, for rollups that are nonce-enabled.
+    fn get_nonce(
+        &self,
+        auth_data: &AuthorizationData<S>,
+        state: &mut impl StateAccessor,
+    ) -> anyhow::Result<Option<u64>>;
+
     /// Marks a transaction as having been executed, preventing it from executing again.
     fn mark_tx_attempted(
         &mut self,


### PR DESCRIPTION
# Description

This allows fetching an account's nonce through the runtime directly, rather than having to construct `sov_uniqueness::Default()`. It returns an option allowing rollups with no nonce support (and alternative capabilities implementations, e.g. not using sov_uniqueness) to return `None`.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
