### PR TITLE
Improve EVM RPC Error Handling and Type Safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12366,6 +12366,7 @@ dependencies = [
  "reth-primitives-traits",
  "revm",
  "serde",
+ "sov-modules-api",
  "thiserror 1.0.69",
 ]
 

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -242,6 +242,7 @@ impl MaybeSealedBlock {
     }
 }
 
+#[cfg(feature = "native")]
 impl From<MaybeSealedBlock> for Sealed<Header> {
     fn from(block: MaybeSealedBlock) -> Sealed<Header> {
         let hash = block.hash().unwrap_or_default();

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -232,6 +232,22 @@ impl MaybeSealedBlock {
             Self::Pending(pending) => &pending.header,
         }
     }
+
+    /// The block header.
+    pub fn into_header(self) -> Header {
+        match self {
+            Self::Sealed(block) => block.header.into_inner(),
+            Self::Pending(pending) => pending.header,
+        }
+    }
+}
+
+impl From<MaybeSealedBlock> for Sealed<Header> {
+    fn from(block: MaybeSealedBlock) -> Sealed<Header> {
+        let hash = block.hash().unwrap_or_default();
+        let header = block.into_header();
+        Sealed::new_unchecked(header, hash)
+    }
 }
 
 /// TODO: Can we replace this with Reth type?

--- a/crates/module-system/module-implementations/sov-evm/src/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/helpers.rs
@@ -69,7 +69,7 @@ pub(crate) fn from_recovered_with_block_context(
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::Address;
+    use alloy_primitives::{Address, U256};
     use revm::context::TransactTo;
 
     use super::*;

--- a/crates/module-system/module-implementations/sov-evm/src/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/helpers.rs
@@ -1,7 +1,7 @@
 use alloy_consensus::transaction::Recovered;
 use alloy_primitives::BlockNumber;
 use alloy_primitives::TxKind;
-use alloy_primitives::{B256, U256};
+use alloy_primitives::B256;
 use alloy_rpc_types::{TransactionInfo, TransactionRequest};
 use revm::context::{BlockEnv, TransactionType, TxEnv};
 use sov_rpc_eth_types::EthResult;
@@ -54,13 +54,12 @@ pub(crate) fn from_recovered_with_block_context(
     tx: Recovered<TransactionSigned>,
     block_hash: Option<B256>,
     block_number: BlockNumber,
-    tx_index: U256,
+    tx_index: u64,
 ) -> alloy_rpc_types::Transaction {
-    let index = Some(tx_index.to::<u64>());
     let tx_info = TransactionInfo {
         block_hash,
         block_number: Some(block_number),
-        index,
+        index: Some(tx_index),
         // Default values
         hash: None,
         base_fee: None,

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -79,7 +79,7 @@ where
             .map(|number| hex::encode(number.to_be_bytes()));
         let kind = details.unwrap_or_default().into();
         Ok(match block_number_hex {
-            Some(block_number_hex) => self.get_block(Some(block_number_hex), kind, state),
+            Some(block_number_hex) => self.get_block(Some(block_number_hex), kind, state)?,
             None => None,
         })
     }
@@ -97,7 +97,7 @@ where
             "EVM module JSON-RPC request to `eth_getBlockByNumber`"
         );
         let kind = details.unwrap_or_default().into();
-        Ok(self.get_block(block_number, kind, state))
+        Ok(self.get_block(block_number, kind, state)?)
     }
 
     /// Handler for: `eth_getBalance`
@@ -216,7 +216,7 @@ where
             block_number,
             "EVM module JSON-RPC request to `eth_getBlockReceipts`"
         );
-        Ok(self.get_receipts(block_number, state))
+        Ok(self.get_receipts(block_number, state)?)
     }
 
     /// Handler for: `eth_getTransactionReceipt`

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -43,8 +43,6 @@ pub enum PendingOrBlock {
     Pending,
     /// Block number.
     Number(u64),
-    /// Invalid block number.
-    Invalid(String),
 }
 
 const ABSOLUTE_MARGIN: u64 = 100_000;
@@ -224,18 +222,19 @@ where
         &self,
         block_number: Option<String>,
         state: &mut ApiStateAccessor<S>,
-    ) -> PendingOrBlock {
+    ) -> Result<PendingOrBlock, EthApiError> {
         let block_number_str = block_number.unwrap_or_else(|| "latest".into());
 
-        match block_number_str.as_str() {
+        Ok(match block_number_str.as_str() {
             "earliest" => PendingOrBlock::Number(*self.block_numbers(state).start()),
             "latest" => PendingOrBlock::Number(*self.block_numbers(state).end()),
             "pending" => PendingOrBlock::Pending,
-            number => match u64::from_str_radix(number.trim_start_matches("0x"), 16) {
-                Ok(nr) => PendingOrBlock::Number(nr),
-                Err(_) => PendingOrBlock::Invalid(block_number_str),
-            },
-        }
+            number => {
+                let number = u64::from_str_radix(number.trim_start_matches("0x"), 16)
+                    .map_err(|e| EthApiError::InvalidBlockNumber(block_number_str, e))?;
+                PendingOrBlock::Number(number)
+            }
+        })
     }
 
     /// Converts BlockNumberOrTag into number.
@@ -262,17 +261,13 @@ where
         block_number: Option<String>,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<Option<MaybeSealedBlock>, EthApiError> {
-        let pending_or_block_nr = self.str_to_block_nr(block_number, state);
+        let pending_or_block_nr = self.str_to_block_nr(block_number, state)?;
 
         match pending_or_block_nr {
             PendingOrBlock::Number(nr) => Ok(self.get_maybe_sealed_block(nr, state)),
             PendingOrBlock::Pending => {
                 let pending_block = self.pending_block(state);
                 Ok(Some(MaybeSealedBlock::Pending(pending_block)))
-            }
-            PendingOrBlock::Invalid(invalid) => {
-                tracing::error!(invalid, "Invalid block number");
-                Ok(None)
             }
         }
     }
@@ -339,7 +334,7 @@ where
             None => MaybeArchivalState::Current(state),
             Some(number) if number == "latest" => MaybeArchivalState::Current(state),
             _ => {
-                let pending_or_block_nr = self.str_to_block_nr(block_number, state);
+                let pending_or_block_nr = self.str_to_block_nr(block_number, state)?;
                 match pending_or_block_nr {
                     PendingOrBlock::Pending => MaybeArchivalState::Current(state),
                     PendingOrBlock::Number(number) => {
@@ -347,9 +342,6 @@ where
                             .get_archival_state(RollupHeight::new(number))
                             .map_err(into_rpc_error)?;
                         MaybeArchivalState::Archival(archival_state.into())
-                    }
-                    PendingOrBlock::Invalid(_) => {
-                        return Err(EthApiError::UnknownBlockOrTxIndex.into());
                     }
                 }
             }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -10,7 +10,6 @@ use alloy_rpc_types::{
     TransactionReceipt, TransactionRequest,
 };
 use alloy_rpc_types::{BlockTransactionsKind, Header};
-use jsonrpsee::core::RpcResult;
 use revm::context::result::ResultAndState;
 use revm::context::{BlockEnv, CfgEnv};
 use sov_address::{EthereumAddress, FromVmAddress};
@@ -21,7 +20,6 @@ use sov_rollup_interface::common::RollupHeight;
 use sov_rpc_eth_types::{EthApiError, RpcInvalidTransactionError};
 
 use crate::db::EvmDb;
-use crate::error::into_rpc_error;
 use crate::evm::executor;
 use crate::evm::primitive_types::{Receipt, TransactionSigned, TxSignedAndRecovered};
 use crate::executor::get_cfg_env;
@@ -263,13 +261,13 @@ where
     ) -> Result<Option<MaybeSealedBlock>, EthApiError> {
         let pending_or_block_nr = self.str_to_block_nr(block_number, state)?;
 
-        match pending_or_block_nr {
-            PendingOrBlock::Number(nr) => Ok(self.get_maybe_sealed_block(nr, state)),
+        Ok(match pending_or_block_nr {
+            PendingOrBlock::Number(nr) => self.get_maybe_sealed_block(nr, state),
             PendingOrBlock::Pending => {
                 let pending_block = self.pending_block(state);
-                Ok(Some(MaybeSealedBlock::Pending(pending_block)))
+                Some(MaybeSealedBlock::Pending(pending_block))
             }
-        }
+        })
     }
 
     /// Retrieves the pending block.
@@ -329,7 +327,7 @@ where
         &self,
         block_number: Option<String>,
         state: &'a mut ApiStateAccessor<S>,
-    ) -> RpcResult<MaybeArchivalState<'a, S>> {
+    ) -> Result<MaybeArchivalState<'a, S>, EthApiError> {
         let state = match block_number {
             None => MaybeArchivalState::Current(state),
             Some(number) if number == "latest" => MaybeArchivalState::Current(state),
@@ -338,9 +336,7 @@ where
                 match pending_or_block_nr {
                     PendingOrBlock::Pending => MaybeArchivalState::Current(state),
                     PendingOrBlock::Number(number) => {
-                        let archival_state = state
-                            .get_archival_state(RollupHeight::new(number))
-                            .map_err(into_rpc_error)?;
+                        let archival_state = state.get_archival_state(RollupHeight::new(number))?;
                         MaybeArchivalState::Archival(archival_state.into())
                     }
                 }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -102,16 +102,12 @@ where
         let Some(block) = self.get_sealed_block_by_number(block_number, state)? else {
             return Ok(None);
         };
-        let hash = block.hash().unwrap_or_default();
-
         let Some(transactions) = self.get_block_transactions(&block, kind, state) else {
             return Ok(None);
         };
-        let header = Sealed::new_unchecked(block.header().clone(), hash);
-        let header = Header::from_consensus(header, None, None);
 
         Ok(Some(Block {
-            header,
+            header: Header::from_sealed(block.into()),
             transactions,
             uncles: vec![],
             withdrawals: None,

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -1,7 +1,7 @@
 use std::ops::DerefMut;
 
 use alloy_consensus::{transaction::Recovered, Transaction as TransactionTrait, TxReceipt};
-use alloy_consensus::{Sealed, EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
+use alloy_consensus::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Address, BlockNumber, Bloom, B64};
 use alloy_primitives::{Bytes, TxKind, B256, U256};
@@ -348,7 +348,7 @@ where
     ) -> Result<BlockEnv, EthApiError> {
         let maybe_blcok = self
             .get_sealed_block_by_number(block_number, state)?
-            .ok_or(EthApiError::UnknownBlockOrTxIndex)?;
+            .ok_or(EthApiError::UnknownBlock)?;
 
         Ok(match maybe_blcok {
             MaybeSealedBlock::Pending(_) => self.block_env(state).unwrap_infallible(),

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -102,20 +102,24 @@ where
         block_number: Option<String>,
         kind: BlockTransactionsKind,
         state: &mut ApiStateAccessor<S>,
-    ) -> Option<Block> {
-        let block = self.get_sealed_block_by_number(block_number, state)?;
+    ) -> Result<Option<Block>, EthApiError> {
+        let Some(block) = self.get_sealed_block_by_number(block_number, state)? else {
+            return Ok(None);
+        };
         let hash = block.hash().unwrap_or_default();
 
-        let transactions = self.get_block_transactions(&block, kind, state)?;
+        let Some(transactions) = self.get_block_transactions(&block, kind, state) else {
+            return Ok(None);
+        };
         let header = Sealed::new_unchecked(block.header().clone(), hash);
         let header = Header::from_consensus(header, None, None);
 
-        Some(Block {
+        Ok(Some(Block {
             header,
             transactions,
             uncles: vec![],
             withdrawals: None,
-        })
+        }))
     }
 
     fn get_contract_code(
@@ -167,13 +171,18 @@ where
         &self,
         block_number: Option<String>,
         state: &mut ApiStateAccessor<S>,
-    ) -> Option<Vec<TransactionReceipt>> {
-        let block = self.get_sealed_block_by_number(block_number, state)?;
-        let receipts = block
+    ) -> Result<Option<Vec<TransactionReceipt>>, EthApiError> {
+        let Some(block) = self.get_sealed_block_by_number(block_number, state)? else {
+            return Ok(None);
+        };
+        let Some(receipts) = block
             .tx_range()
             .map(|index| self.get_receipt_by_index(index, state))
-            .collect::<Option<Vec<_>>>()?;
-        Some(receipts)
+            .collect::<Option<Vec<_>>>()
+        else {
+            return Ok(None);
+        };
+        Ok(Some(receipts))
     }
 
     fn call(
@@ -252,18 +261,18 @@ where
         &self,
         block_number: Option<String>,
         state: &mut ApiStateAccessor<S>,
-    ) -> Option<MaybeSealedBlock> {
+    ) -> Result<Option<MaybeSealedBlock>, EthApiError> {
         let pending_or_block_nr = self.str_to_block_nr(block_number, state);
 
         match pending_or_block_nr {
-            PendingOrBlock::Number(nr) => self.get_maybe_sealed_block(nr, state),
+            PendingOrBlock::Number(nr) => Ok(self.get_maybe_sealed_block(nr, state)),
             PendingOrBlock::Pending => {
                 let pending_block = self.pending_block(state);
-                Some(MaybeSealedBlock::Pending(pending_block))
+                Ok(Some(MaybeSealedBlock::Pending(pending_block)))
             }
             PendingOrBlock::Invalid(invalid) => {
                 tracing::error!(invalid, "Invalid block number");
-                None
+                Ok(None)
             }
         }
     }
@@ -354,7 +363,7 @@ where
         state: &mut ApiStateAccessor<S>,
     ) -> Result<BlockEnv, EthApiError> {
         let maybe_blcok = self
-            .get_sealed_block_by_number(block_number, state)
+            .get_sealed_block_by_number(block_number, state)?
             .ok_or(EthApiError::UnknownBlockOrTxIndex)?;
 
         Ok(match maybe_blcok {

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -61,36 +61,36 @@ where
         block: &MaybeSealedBlock,
         kind: BlockTransactionsKind,
         state: &mut ApiStateAccessor<S>,
-    ) -> Option<BlockTransactions<Transaction>> {
+    ) -> Result<BlockTransactions<Transaction>, EthApiError> {
         let tx_range = block.tx_range();
+        let txs = tx_range
+            .map(|idx| self.tx(idx, state))
+            .collect::<Result<Vec<_>, _>>()?;
         let txs = match kind {
             BlockTransactionsKind::Full => {
-                let txs = tx_range
-                    .clone()
-                    .map(|idx| {
-                        let tx = self.transactions.get(&idx, state).unwrap_infallible()?;
-                        Some(from_recovered_with_block_context(
+                let txs = txs
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, tx)| {
+                        from_recovered_with_block_context(
                             tx.into(),
                             Some(block.hash().unwrap_or_default()),
                             block.number(),
-                            U256::from(idx - tx_range.start),
-                        ))
+                            U256::from(idx),
+                        )
                     })
-                    .collect::<Option<Vec<_>>>()?;
+                    .collect::<Vec<_>>();
                 BlockTransactions::Full(txs)
             }
             BlockTransactionsKind::Hashes => {
-                let hashes = tx_range
+                let hashes = txs
                     .into_iter()
-                    .map(|idx| {
-                        let tx = self.transactions.get(&idx, state).unwrap_infallible()?;
-                        Some(*tx.signed_transaction.hash())
-                    })
-                    .collect::<Option<Vec<_>>>()?;
+                    .map(|tx| *tx.signed_transaction.hash())
+                    .collect::<Vec<_>>();
                 BlockTransactions::Hashes(hashes)
             }
         };
-        Some(txs)
+        Ok(txs)
     }
 
     fn get_block(
@@ -102,10 +102,7 @@ where
         let Some(block) = self.get_sealed_block_by_number(block_number, state)? else {
             return Ok(None);
         };
-        let Some(transactions) = self.get_block_transactions(&block, kind, state) else {
-            return Ok(None);
-        };
-
+        let transactions = self.get_block_transactions(&block, kind, state)?;
         Ok(Some(Block {
             header: Header::from_sealed(block.into()),
             transactions,

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -74,9 +74,9 @@ where
                     .map(|(idx, tx)| {
                         from_recovered_with_block_context(
                             tx.into(),
-                            Some(block.hash().unwrap_or_default()),
+                            block.hash(),
                             block.number(),
-                            U256::from(idx),
+                            idx as u64,
                         )
                     })
                     .collect::<Vec<_>>();
@@ -131,7 +131,7 @@ where
         let tx_number = self.tx_index(&hash, state)?;
         let tx = self.transaction(tx_number, state)?;
         let block = self.get_maybe_sealed_block(tx.block_number, state)?;
-        let index = U256::from(tx_number - block.transactions_start());
+        let index = tx_number - block.transactions_start();
         let tx = from_recovered_with_block_context(tx.into(), block.hash(), block.number(), index);
         Some(tx)
     }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -63,30 +63,31 @@ where
         state: &mut ApiStateAccessor<S>,
     ) -> Result<BlockTransactions<Transaction>, EthApiError> {
         let tx_range = block.tx_range();
-        let txs = tx_range
-            .map(|idx| self.tx(idx, state))
-            .collect::<Result<Vec<_>, _>>()?;
         let txs = match kind {
             BlockTransactionsKind::Full => {
-                let txs = txs
+                let txs = tx_range
                     .into_iter()
                     .enumerate()
-                    .map(|(idx, tx)| {
-                        from_recovered_with_block_context(
+                    .map(|(pos, idx)| {
+                        let tx = self.tx(idx, state)?;
+                        Ok::<_, EthApiError>(from_recovered_with_block_context(
                             tx.into(),
                             block.hash(),
                             block.number(),
-                            idx as u64,
-                        )
+                            pos as u64,
+                        ))
                     })
-                    .collect::<Vec<_>>();
+                    .collect::<Result<Vec<_>, _>>()?;
                 BlockTransactions::Full(txs)
             }
             BlockTransactionsKind::Hashes => {
-                let hashes = txs
+                let hashes = tx_range
                     .into_iter()
-                    .map(|tx| *tx.signed_transaction.hash())
-                    .collect::<Vec<_>>();
+                    .map(|idx| {
+                        let tx = self.tx(idx, state)?;
+                        Ok::<_, EthApiError>(*tx.signed_transaction.hash())
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
                 BlockTransactions::Hashes(hashes)
             }
         };

--- a/crates/module-system/module-implementations/sov-evm/src/state_access.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/state_access.rs
@@ -47,19 +47,14 @@ impl<S: Spec> Evm<S> {
         Ok(block)
     }
 
-    /// Gets tx by hash. Fails if prunned
+    /// Gets tx by idx. Fails if not found
     pub fn tx<Accessor: AccessoryStateReader>(
         &self,
-        hash: B256,
+        idx: u64,
         state: &mut Accessor,
     ) -> Result<TxSignedAndRecovered, EthApiError> {
-        let Some(idx) = self.tx_index(&hash, state) else {
-            return Err(EthApiError::PrunedHistoryUnavailable);
-        };
-        let Some(tx) = self.transaction(idx, state) else {
-            return Err(EthApiError::PrunedHistoryUnavailable);
-        };
-        Ok(tx)
+        self.transaction(idx, state)
+            .ok_or(EthApiError::UnknownTxIndex(idx))
     }
 
     /// Gets archival state before block `number`

--- a/crates/utils/sov-rpc-eth-types/Cargo.toml
+++ b/crates/utils/sov-rpc-eth-types/Cargo.toml
@@ -13,7 +13,7 @@ alloy-primitives = { workspace = true }
 alloy-rpc-types = { workspace = true }
 jsonrpsee-types = { workspace = true }
 jsonrpsee-core = { workspace = true }
-sov-modules-api = { workspace = true }
+sov-modules-api = { workspace = true, features = ["native"] }
 thiserror = { workspace = true }
 revm = { workspace = true }
 alloy-eips = { workspace = true }

--- a/crates/utils/sov-rpc-eth-types/Cargo.toml
+++ b/crates/utils/sov-rpc-eth-types/Cargo.toml
@@ -13,6 +13,7 @@ alloy-primitives = { workspace = true }
 alloy-rpc-types = { workspace = true }
 jsonrpsee-types = { workspace = true }
 jsonrpsee-core = { workspace = true }
+sov-modules-api = { workspace = true }
 thiserror = { workspace = true }
 revm = { workspace = true }
 alloy-eips = { workspace = true }

--- a/crates/utils/sov-rpc-eth-types/src/eth_api_error.rs
+++ b/crates/utils/sov-rpc-eth-types/src/eth_api_error.rs
@@ -3,6 +3,7 @@ use alloy_rpc_types::error::EthRpcErrorCode;
 use alloy_rpc_types::request::TransactionInputError;
 use revm::context::result::InvalidTransaction;
 use revm::context_interface::result::{EVMError, InvalidHeader};
+use sov_modules_api::ApiStateAccessorError;
 use std::convert::Infallible;
 use std::num::ParseIntError;
 
@@ -43,6 +44,9 @@ pub enum EthApiError {
     /// Thrown when unable to parse numeric block number
     #[error("invalid block number {0} {1}")]
     InvalidBlockNumber(String, ParseIntError),
+    /// Thrown when unable to access specific rollup height
+    #[error(transparent)]
+    ApiStateAccess(#[from] ApiStateAccessorError),
     #[error(transparent)]
     InvalidHeader(#[from] InvalidHeader),
     /// Thrown when a call or transaction request (`eth_call`, `eth_estimateGas`,
@@ -87,6 +91,7 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             | EthApiError::EmptyRawTransactionData
             | EthApiError::ConflictingFeeFieldsInRequest
             | EthApiError::InvalidTracerConfig
+            | EthApiError::ApiStateAccess(_)
             | EthApiError::InvalidBlockNumber(_, _)
             | EthApiError::TransactionConversionError => invalid_params_rpc_err(error.to_string()),
             EthApiError::InvalidTransaction(err) => err.into(),

--- a/crates/utils/sov-rpc-eth-types/src/eth_api_error.rs
+++ b/crates/utils/sov-rpc-eth-types/src/eth_api_error.rs
@@ -39,12 +39,8 @@ pub enum EthApiError {
     /// Thrown when an unknown block or transaction index is encountered
     #[error("unknown block or tx index")]
     UnknownBlockOrTxIndex,
-    /// An internal error where prevrandao is not set in the evm's environment
-    #[error("prevrandao not in the EVM's environment after merge")]
-    PrevrandaoNotSet,
-    /// `excess_blob_gas` is not set for Cancun and above
-    #[error("excess blob gas missing in the EVM's environment after Cancun")]
-    ExcessBlobGasNotSet,
+    #[error(transparent)]
+    InvalidHeader(#[from] InvalidHeader),
     /// Thrown when a call or transaction request (`eth_call`, `eth_estimateGas`,
     /// `eth_sendTransaction`) contains conflicting fields (legacy, EIP-1559)
     #[error("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")]
@@ -89,9 +85,9 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             | EthApiError::InvalidTracerConfig
             | EthApiError::TransactionConversionError => invalid_params_rpc_err(error.to_string()),
             EthApiError::InvalidTransaction(err) => err.into(),
-            EthApiError::PrevrandaoNotSet
-            | EthApiError::ExcessBlobGasNotSet
-            | EthApiError::EvmCustom(_) => internal_rpc_err(error.to_string()),
+            EthApiError::InvalidHeader(_) | EthApiError::EvmCustom(_) => {
+                internal_rpc_err(error.to_string())
+            }
             EthApiError::UnknownBlockOrTxIndex => {
                 rpc_error_with_code(EthRpcErrorCode::ResourceNotFound.code(), error.to_string())
             }
@@ -107,15 +103,6 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             err @ EthApiError::TransactionInputError(_) => invalid_params_rpc_err(err.to_string()),
             EthApiError::PrunedHistoryUnavailable => rpc_error_with_code(4444, error.to_string()),
             EthApiError::Other(err) => err.to_rpc_error(),
-        }
-    }
-}
-
-impl From<InvalidHeader> for EthApiError {
-    fn from(value: InvalidHeader) -> Self {
-        match value {
-            InvalidHeader::ExcessBlobGasNotSet => Self::ExcessBlobGasNotSet,
-            InvalidHeader::PrevrandaoNotSet => Self::PrevrandaoNotSet,
         }
     }
 }

--- a/crates/utils/sov-rpc-eth-types/src/eth_api_error.rs
+++ b/crates/utils/sov-rpc-eth-types/src/eth_api_error.rs
@@ -4,6 +4,7 @@ use alloy_rpc_types::request::TransactionInputError;
 use revm::context::result::InvalidTransaction;
 use revm::context_interface::result::{EVMError, InvalidHeader};
 use std::convert::Infallible;
+use std::num::ParseIntError;
 
 use crate::utils::{
     block_id_to_str, internal_rpc_err, invalid_params_rpc_err, rpc_error_with_code,
@@ -39,6 +40,9 @@ pub enum EthApiError {
     /// Thrown when an unknown block or transaction index is encountered
     #[error("unknown block or tx index")]
     UnknownBlockOrTxIndex,
+    /// Thrown when unable to parse numeric block number
+    #[error("invalid block number {0} {1}")]
+    InvalidBlockNumber(String, ParseIntError),
     #[error(transparent)]
     InvalidHeader(#[from] InvalidHeader),
     /// Thrown when a call or transaction request (`eth_call`, `eth_estimateGas`,
@@ -83,6 +87,7 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             | EthApiError::EmptyRawTransactionData
             | EthApiError::ConflictingFeeFieldsInRequest
             | EthApiError::InvalidTracerConfig
+            | EthApiError::InvalidBlockNumber(_, _)
             | EthApiError::TransactionConversionError => invalid_params_rpc_err(error.to_string()),
             EthApiError::InvalidTransaction(err) => err.into(),
             EthApiError::InvalidHeader(_) | EthApiError::EvmCustom(_) => {

--- a/crates/utils/sov-rpc-eth-types/src/eth_api_error.rs
+++ b/crates/utils/sov-rpc-eth-types/src/eth_api_error.rs
@@ -25,9 +25,6 @@ pub enum EthApiError {
     /// When the transaction signature is invalid
     #[error("invalid transaction signature")]
     InvalidTransactionSignature,
-    // /// Errors related to the transaction pool
-    // #[error(transparent)]
-    // PoolError(RpcPoolError),
     /// Header not found for block hash/number/tag
     #[error("header not found")]
     HeaderNotFound(BlockId),
@@ -55,12 +52,6 @@ pub enum EthApiError {
     /// Errors related to invalid transactions
     #[error(transparent)]
     InvalidTransaction(#[from] RpcInvalidTransactionError),
-    // /// Thrown when constructing an RPC block from primitive block data fails
-    // #[error(transparent)]
-    // InvalidBlockData(#[from] BlockError),
-    // /// Error related to signing
-    // #[error(transparent)]
-    // Signing(#[from] SignError),
     /// Some feature is unsupported
     #[error("unsupported")]
     Unsupported(&'static str),
@@ -73,22 +64,9 @@ pub enum EthApiError {
     /// Evm generic purpose error.
     #[error("Revm error: {0}")]
     EvmCustom(String),
-    /// Bytecode override is invalid.
-    ///
-    /// This can happen if bytecode provided in an
-    /// [`AccountOverride`](alloy_rpc_types_eth::state::AccountOverride) is malformed, e.g. invalid
-    /// 7702 bytecode.
-    // #[error("Invalid bytecode: {0}")]
-    // InvalidBytecode(String),
     /// Error encountered when converting a transaction type
     #[error("Transaction conversion error")]
     TransactionConversionError,
-    // /// Error thrown when tracing with a muxTracer fails
-    // #[error(transparent)]
-    // MuxTracerError(#[from] MuxError),
-    // /// Error thrown when batch tx response channel fails
-    // #[error(transparent)]
-    // BatchTxRecvError(#[from] RecvError),
     /// Any other error
     #[error("{0}")]
     Other(Box<dyn ToRpcError>),

--- a/crates/utils/sov-rpc-eth-types/src/eth_api_error.rs
+++ b/crates/utils/sov-rpc-eth-types/src/eth_api_error.rs
@@ -38,9 +38,12 @@ pub enum EthApiError {
     /// See also <https://eips.ethereum.org/EIPS/eip-4444>
     #[error("pruned history unavailable")]
     PrunedHistoryUnavailable,
-    /// Thrown when an unknown block or transaction index is encountered
-    #[error("unknown block or tx index")]
-    UnknownBlockOrTxIndex,
+    /// Thrown when an unknown block
+    #[error("unknown block")]
+    UnknownBlock,
+    /// Thrown when an unknown tx index
+    #[error("unknown tx index {0}")]
+    UnknownTxIndex(u64),
     /// Thrown when unable to parse numeric block number
     #[error("invalid block number {0} {1}")]
     InvalidBlockNumber(String, ParseIntError),
@@ -98,7 +101,7 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EthApiError::InvalidHeader(_) | EthApiError::EvmCustom(_) => {
                 internal_rpc_err(error.to_string())
             }
-            EthApiError::UnknownBlockOrTxIndex => {
+            EthApiError::UnknownBlock | EthApiError::UnknownTxIndex(_) => {
                 rpc_error_with_code(EthRpcErrorCode::ResourceNotFound.code(), error.to_string())
             }
             // TODO(onbjerg): We rewrite the error message here because op-node does string matching


### PR DESCRIPTION

## Summary

Refactors error handling in the EVM RPC module to properly propagate errors instead of silently converting them to `None`.

## Changes

- **Removed `Invalid` variant from `PendingOrBlock` enum** - Block number parsing errors now propagate as `EthApiError::InvalidBlockNumber` instead of being silently handled

- **Split `UnknownBlockOrTxIndex` into specific errors** - `UnknownBlock`, `UnknownTxIndex(u64)`, and `InvalidBlockNumber(String, ParseIntError)` for better diagnostics

- **Changed RPC return types from `Option<T>` to `Result<Option<T>, EthApiError>`** - Affects `get_block_by_hash`, `get_block_by_number`, `get_block_receipts`. Errors now propagate with `?` operator

- **Simplified transaction retrieval** - Refactored `get_block_transactions` to use proper error handling. Changed `tx()` method signature from `tx(hash: B256)` to `tx(idx: u64)`

- **Type safety improvements** - Changed `tx_index` parameter from `U256` to `u64` in `from_recovered_with_block_context()` and related code to avoid needless double conversion

- **Added `From<MaybeSealedBlock>` for `Sealed<Header>`** - Simplifies header extraction in RPC code

-----

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
