### PR TITLE
Set ETHEREUM_BLOCK_GAS_LIMIT to 1B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 2025-10-29
+- #1996 Set gas limit to 1B on ETH API access.
 - #1838 Add binary WebSocket frame support to RPC server and client.
 
 # 2025-10-28

--- a/crates/module-system/module-implementations/sov-evm/src/config.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/config.rs
@@ -1,7 +1,8 @@
-use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
+use alloy_eips::eip1559::MIN_PROTOCOL_BASE_FEE;
 use alloy_primitives::Address;
 use revm::primitives::hardfork::SpecId;
 use sov_modules_api::macros::config_value;
+use sov_modules_api::ETHEREUM_BLOCK_GAS_LIMIT;
 
 use crate::AccountData;
 
@@ -36,7 +37,7 @@ impl Default for EvmChainSpec {
         Self {
             limit_contract_code_size: None,
             coinbase: Address::ZERO,
-            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             hardforks: vec![(0, SpecId::CANCUN)],
         }
     }

--- a/crates/module-system/module-implementations/sov-evm/src/config.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/config.rs
@@ -144,7 +144,7 @@ mod tests {
                 "chain_spec":{
                     "limit_contract_code_size":null,
                     "coinbase":"0x0000000000000000000000000000000000000000",
-                    "block_gas_limit":30000000,
+                    "block_gas_limit":1000000000,
                     "hardforks":[[0,"CANCUN"]]
                 }
         }"#;

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
@@ -1,11 +1,11 @@
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_consensus::{BlockHeader, Header};
-use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
 use alloy_primitives::{Address, Bytes, U256};
 use revm::state::AccountInfo;
 use revm::Database;
 use sov_evm::{AccountData, Evm, EvmGenesisConfig, EvmRuntimeConfig, SpecId};
 use sov_modules_api::prelude::UnwrapInfallible;
+use sov_modules_api::ETHEREUM_BLOCK_GAS_LIMIT;
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
 use sov_test_utils::runtime::TestRunner;
 
@@ -46,7 +46,7 @@ fn test_genesis_cfg() {
             evm.cfg_infallible(state),
             EvmRuntimeConfig {
                 chain_spec: sov_evm::EvmChainSpec {
-                    block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+                    block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
                     coinbase: Address::from([3u8; 20]),
                     limit_contract_code_size: Some(5000),
                     hardforks: vec![(0, SpecId::BERLIN), (1, SpecId::CANCUN)],
@@ -89,7 +89,7 @@ fn test_genesis_block() {
         let actual_block = &evm.blocks.get(&0, state).unwrap_infallible().unwrap();
         let expected_header = Header {
             state_root: actual_block.header().state_root(),
-            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             beneficiary,
             excess_blob_gas: Some(0),
             base_fee_per_gas: Some(0),
@@ -114,7 +114,7 @@ fn default_config() -> EvmGenesisConfig {
         initial_base_fee: 70,
         genesis_timestamp: 50,
         chain_spec: sov_evm::EvmChainSpec {
-            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT_30M,
+            block_gas_limit: ETHEREUM_BLOCK_GAS_LIMIT,
             coinbase: Address::from([3u8; 20]),
             limit_contract_code_size: Some(5000),
             hardforks: vec![(0, SpecId::BERLIN), (1, SpecId::CANCUN)],

--- a/crates/module-system/sov-modules-api/src/gas/meters/basic.rs
+++ b/crates/module-system/sov-modules-api/src/gas/meters/basic.rs
@@ -1,8 +1,10 @@
+use anyhow::Result;
 use core::fmt::Debug;
 
-use anyhow::Result;
-
 use crate::{Amount, Gas, GasArray, GasMeter, GasMeteringError, GetGasPrice, Spec};
+
+/// The default Ethereum block gas limit: 1B
+pub const ETHEREUM_BLOCK_GAS_LIMIT: u64 = 1_000_000_000;
 
 /// A struct that keeps track of the gas used.
 /// The gas meter continues running until it either depletes its funds or runs out of gas, depending on its configuration.
@@ -61,6 +63,12 @@ impl<S: Spec> BasicGasMeter<S> {
             remaining_funds: Some(remaining_funds),
             gas_price,
         }
+    }
+
+    /// Creates a new `BasicGasMeter` for API access with gas limit set at ETH block gas limit.
+    pub fn new_api(gas_price: <S::Gas as Gas>::Price) -> Self {
+        let remaining_gas = [ETHEREUM_BLOCK_GAS_LIMIT, ETHEREUM_BLOCK_GAS_LIMIT].into();
+        Self::new_with_funds_and_gas(Amount::MAX, remaining_gas, gas_price)
     }
 
     /// Creates a new `BasicGasMeter`

--- a/crates/module-system/sov-modules-api/src/gas/meters/mod.rs
+++ b/crates/module-system/sov-modules-api/src/gas/meters/mod.rs
@@ -1,6 +1,6 @@
 mod basic;
 mod slot;
 mod unlimited;
-pub use basic::{BasicGasMeter, GasInfo};
+pub use basic::{BasicGasMeter, GasInfo, ETHEREUM_BLOCK_GAS_LIMIT};
 pub use slot::SlotGasMeter;
 pub use unlimited::UnlimitedGasMeter;

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -17,9 +17,7 @@ use crate::capabilities::{KernelWithSlotMapping, RollupHeight};
 use crate::gas::GasArray;
 use crate::state::accessors::internals::AccessoryWrite;
 use crate::state::traits::PerBlockCache;
-use crate::{
-    Amount, BasicGasMeter, Gas, GasMeter, GetGasPrice, ProvableStateReader, Spec, VersionReader,
-};
+use crate::{BasicGasMeter, Gas, GasMeter, GetGasPrice, ProvableStateReader, Spec, VersionReader};
 
 fn get_slot_number(visible_slot_number: Option<VisibleSlotNumber>) -> Option<SlotNumber> {
     // This TODO is not a security risk.

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::GasMeteringError;
-use alloy_eips::eip1559::ETHEREUM_BLOCK_GAS_LIMIT_30M;
 use sov_metrics::{StateAccessMetric, StateMetrics};
 use sov_rollup_interface::common::{SlotNumber, VisibleSlotNumber};
 use sov_state::sequencer_state::MaybePresentValue;
@@ -540,11 +539,7 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
         gas_price: <S::Gas as Gas>::Price,
     ) -> Result<Self, ApiStateAccessorError> {
         let delta: &super::internals::Delta<<S as Spec>::Storage> = &state_checkpoint.delta;
-        let gas_meter = BasicGasMeter::new_with_funds_and_gas(
-            Amount::MAX,
-            [ETHEREUM_BLOCK_GAS_LIMIT_30M, ETHEREUM_BLOCK_GAS_LIMIT_30M].into(),
-            gas_price,
-        );
+        let gas_meter = BasicGasMeter::new_api(gas_price);
 
         let mut out = Self {
             storage: delta.inner.clone(),
@@ -596,11 +591,7 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
         kernel: Arc<dyn KernelWithSlotMapping<S>>,
         state_to_access: StateToAccess,
     ) -> Self {
-        let gas_meter = BasicGasMeter::new_with_funds_and_gas(
-            Amount::MAX,
-            [ETHEREUM_BLOCK_GAS_LIMIT_30M, ETHEREUM_BLOCK_GAS_LIMIT_30M].into(),
-            <S::Gas as Gas>::Price::ZEROED,
-        );
+        let gas_meter = BasicGasMeter::new_api(<S::Gas as Gas>::Price::ZEROED);
         Self {
             events: Vec::new(),
             gas_meter,


### PR DESCRIPTION
# Description

In the EVM cfg - we disable block gas limit. But it's still a DDOS vector. Therefore we set it to a big amount, but not INF.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
