### PR TITLE
Fix: eth_sendTransaction fails for contract deployments without gas limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2025-10-29
 - #1838 Add binary WebSocket frame support to RPC server and client.
+- #1997 Fix `eth_sendTransaction` contract deployments without gas limit by converting `to: null` to `TxKind::Create`.
 
 # 2025-10-28
 - #1987 Added `newHeads` subscription to `eth_subscribe`.

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -49,7 +49,6 @@ where
     Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
     F: Fn(B256, Arc<Ethereum<S, Seq>>) -> Result<T, ErrorObjectOwned>,
 {
-    dbg!();
     let raw_evm_tx = RlpEvmTransaction { rlp: data.to_vec() };
     let (tx_hash, raw_message) = ethereum
         .make_raw_tx(raw_evm_tx)

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -1,5 +1,7 @@
 mod get_logs;
 mod subscribe;
+#[cfg(feature = "local")]
+use alloy_primitives::TxKind;
 use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types::TransactionReceipt;
 pub use get_logs::{Cursor, LogHandlers};
@@ -47,6 +49,7 @@ where
     Seq::Rt: HasKernel<S> + EthereumAuthenticator<S> + Default + Send + Sync + 'static,
     F: Fn(B256, Arc<Ethereum<S, Seq>>) -> Result<T, ErrorObjectOwned>,
 {
+    dbg!();
     let raw_evm_tx = RlpEvmTransaction { rlp: data.to_vec() };
     let (tx_hash, raw_message) = ethereum
         .make_raw_tx(raw_evm_tx)
@@ -207,6 +210,13 @@ pub(crate) mod signer {
                 &mut state,
             )?;
             transaction_request.gas = Some(estimated_gas.to::<u64>());
+
+            // For contract deployments, convert `to: None` to `to: Some(TxKind::Create)`
+            // The JSON-RPC spec uses `null` or omitted `to` field for contract deployments,
+            // but alloy's `build_typed_tx()` requires `Some(TxKind::Create)`
+            if transaction_request.to.is_none() {
+                transaction_request.to = Some(TxKind::Create);
+            }
 
             let transaction = transaction_request
                 .build_typed_tx()

--- a/examples/demo-rollup/tests/evm/evm_no_gas_limit.rs
+++ b/examples/demo-rollup/tests/evm/evm_no_gas_limit.rs
@@ -1,0 +1,47 @@
+use crate::evm::evm_test_helper::alloy_client;
+use crate::evm::evm_test_helper::setup_test_rollup;
+use crate::evm::evm_test_helper::EVM_EXTENSION;
+use crate::evm::evm_test_helper::SENDER_PRIV_KEY;
+use alloy::primitives::B256;
+use alloy::providers::Provider;
+use alloy::signers::local::PrivateKeySigner;
+use sov_test_utils::SimpleStorage;
+
+/// Verifies that contract deployments works when `to` and `gas` are absent.
+/// The handler should auto-estimate gas and convert `to: None` to `to: Some(TxKind::Create)`.
+#[tokio::test(flavor = "multi_thread")]
+async fn contract_deploy_via_eth_send_transaction_with_no_gas_limit() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    rollup.wait_for_next_blocks(1).await;
+    let signer: PrivateKeySigner = SENDER_PRIV_KEY.parse().unwrap();
+    let from = signer.address();
+    let client = alloy_client(rollup.http_addr);
+
+    let deploy = SimpleStorage::deploy_builder(client.clone());
+    let deploy_request = deploy.into_transaction_request();
+    let bytecode = deploy_request.input.into_input();
+
+    // Make a raw RPC call to eth_sendTransaction with contract deployment
+    // (to=None, no gas limit, only gas price)
+    let params = serde_json::json!([{
+        "from": from,
+        "maxFeePerGas": "0x1",
+        "maxPriorityFeePerGas": "0x1",
+        "data": bytecode,
+    }]);
+
+    // Should auto-estimate gas and deploy the contract
+    let tx_hash: B256 = client
+        .client()
+        .request("eth_sendTransaction", &params)
+        .await?;
+    let receipt = client
+        .get_transaction_receipt(tx_hash)
+        .await?
+        .expect("Receipt should exist");
+
+    assert!(receipt.contract_address.is_some());
+    assert!(receipt.status());
+
+    Ok(())
+}

--- a/examples/demo-rollup/tests/evm/evm_test_helper.rs
+++ b/examples/demo-rollup/tests/evm/evm_test_helper.rs
@@ -23,7 +23,8 @@ use sov_test_utils::test_rollup::get_appropriate_rollup_prover_config;
 use sov_test_utils::test_rollup::{RollupBuilder, TestRollup};
 use sov_test_utils::LegacySimpleStorage;
 
-const SENDER_PRIV_KEY: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+pub(crate) const SENDER_PRIV_KEY: &str =
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 
 pub(crate) const EVM_EXTENSION: SeqConfigExtension = SeqConfigExtension {
     max_log_limit: 20000,

--- a/examples/demo-rollup/tests/evm/mod.rs
+++ b/examples/demo-rollup/tests/evm/mod.rs
@@ -3,6 +3,7 @@ mod evm_balances;
 mod evm_block_hash;
 mod evm_gas_estimation;
 mod evm_logs;
+mod evm_no_gas_limit;
 mod evm_rpc;
 mod evm_soft_conf;
 mod evm_subscribe;


### PR DESCRIPTION
# Description


Fixes `eth_sendTransaction` failing with "Transaction conversion error" when deploying contracts without specifying gas limit.

## Problem

Contract deployments via `eth_sendTransaction` (no `to` field, no `gas` field) fail because alloy's `build_typed_tx()` requires `to: Some(TxKind::Create)` but the JSON-RPC spec uses `to: null`.

## Solution

Convert `to: None` to `to: Some(TxKind::Create)` before calling `build_typed_tx()` in the `eth_send_transaction` handler.

---

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
- Added test `examples/demo-rollup/tests/evm/evm_no_gas_limit.rs` to verify fix

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
