### PR TITLE
Return authorization data from the native-only decode_serialized_tx method in the TransactionAuthenticator trait

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -292,7 +292,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             panic!("Accepting a transaction, yet there's no in-progress batch. This is a bug in the sequencer, please report it.");
         };
 
-        let call = Rt::Auth::decode_serialized_tx(&baked_tx.tx)?;
+        let (call, _) = Rt::Auth::decode_serialized_tx(&baked_tx.tx)?;
         let call = Rt::wrap_call(call);
 
         if let Err(TrySendError::Full(_)) = task_state.tx_sender.try_send(baked_tx) {

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -848,7 +848,7 @@ where
         // Check if this transaction has a configured delay
         let runtime = Rt::default();
         let call = match Rt::Auth::decode_serialized_tx(&baked_tx) {
-            Ok(call) => call,
+            Ok((call, _)) => call,
             Err(_) => {
                 return Err(ErrorObject {
                     status: StatusCode::BAD_REQUEST,

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -65,7 +65,7 @@ generate_optimistic_runtime_with_kernel!(
     },
     transaction_priority_wrapper: |call: &sov_modules_api::FullyBakedTx| {
         use sov_modules_api::capabilities::TransactionAuthenticator;
-        let Ok(call) = Self::Auth::decode_serialized_tx(call) else {
+        let Ok((call, _)) = Self::Auth::decode_serialized_tx(call) else {
             return 0;
         };
         match call {

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -221,19 +221,28 @@ where
     #[cfg(feature = "native")]
     fn decode_serialized_tx(
         tx: &FullyBakedTx,
-    ) -> Result<Self::Decodable, sov_modules_api::capabilities::FatalError> {
+    ) -> Result<(Self::Decodable, AuthorizationData<S>), sov_modules_api::capabilities::FatalError>
+    {
         let auth_variant: EvmAuthenticatorInput = borsh::from_slice(&tx.data).map_err(|e| {
             sov_modules_api::capabilities::FatalError::DeserializationFailed(e.to_string())
         })?;
 
         match auth_variant {
             EvmAuthenticatorInput::Evm(raw_tx) => {
-                let (call, _tx) = decode_evm_tx(&raw_tx.data)?;
-                Ok(EvmAuthenticatorInput::Evm(call::CallMessage { rlp: call }))
+                let (call, tx) = decode_evm_tx(&raw_tx.data)?;
+                let hash = TxHash::new(**tx.hash());
+                let signer = recover_evm_signer(&tx, hash).map_err(|e| {
+                    sov_modules_api::capabilities::FatalError::DeserializationFailed(e.to_string())
+                })?;
+                let auth_data = extract_evm_authorization_data::<S>(signer, hash, tx.nonce());
+                Ok((
+                    EvmAuthenticatorInput::Evm(call::CallMessage { rlp: call }),
+                    auth_data,
+                ))
             }
             EvmAuthenticatorInput::Standard(raw_tx) => {
-                let call = capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)?;
-                Ok(EvmAuthenticatorInput::Standard(call))
+                let (call, auth) = capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)?;
+                Ok((EvmAuthenticatorInput::Standard(call), auth))
             }
         }
     }

--- a/crates/module-system/sov-eip712-auth/src/lib.rs
+++ b/crates/module-system/sov-eip712-auth/src/lib.rs
@@ -82,23 +82,22 @@ where
     #[cfg(feature = "native")]
     fn decode_serialized_tx(
         tx: &FullyBakedTx,
-    ) -> Result<Self::Decodable, sov_modules_api::capabilities::FatalError> {
+    ) -> Result<(Self::Decodable, AuthorizationData<S>), sov_modules_api::capabilities::FatalError>
+    {
         let auth_variant: Eip712AuthenticatorInput = borsh::from_slice(&tx.data).map_err(|e| {
             sov_modules_api::capabilities::FatalError::DeserializationFailed(e.to_string())
         })?;
 
         match auth_variant {
             Eip712AuthenticatorInput::Standard(raw_tx) => {
-                let call = sov_modules_api::capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)?;
-                Ok(call)
+                sov_modules_api::capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)
             }
             Eip712AuthenticatorInput::Eip712(raw_tx) => {
-                let call = sov_modules_api::capabilities::decode_sov_tx_with_cryptospec::<
+                sov_modules_api::capabilities::decode_sov_tx_with_cryptospec::<
                     S,
                     Rt,
                     <<S as Spec>::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec,
-                >(&raw_tx.data)?;
-                Ok(call)
+                >(&raw_tx.data)
             }
         }
     }

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -64,7 +64,9 @@ pub trait TransactionAuthenticator<S: Spec> {
     /// Decode a transaction into a message.
     /// This method doesn’t charge gas for deserialization, so it’s meant for off-chain code only (hence to the `native` feature).
     #[cfg(feature = "native")]
-    fn decode_serialized_tx(tx: &FullyBakedTx) -> Result<Self::Decodable, FatalError>;
+    fn decode_serialized_tx(
+        tx: &FullyBakedTx,
+    ) -> Result<(Self::Decodable, AuthorizationData<S>), FatalError>;
 
     /// Authenticates raw transaction that is submitted from unregistered sequencers for the
     /// purpose of forced registration (circumventing censorship by currently registered sequencers).
@@ -120,7 +122,9 @@ where
     type Input = AuthenticatorInput;
 
     #[cfg(feature = "native")]
-    fn decode_serialized_tx(tx: &FullyBakedTx) -> Result<Self::Decodable, FatalError> {
+    fn decode_serialized_tx(
+        tx: &FullyBakedTx,
+    ) -> Result<(Self::Decodable, AuthorizationData<S>), FatalError> {
         let AuthenticatorInput::Standard(tx) = borsh::from_slice(&tx.data)
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
 
@@ -455,7 +459,7 @@ pub fn authenticate_unregistered<
 #[cfg(feature = "native")]
 pub fn decode_sov_tx<S: Spec, D: DispatchCall<Spec = S>>(
     raw_tx: &[u8],
-) -> Result<D::Decodable, FatalError> {
+) -> Result<(D::Decodable, AuthorizationData<S>), FatalError> {
     decode_sov_tx_with_cryptospec::<S, D, <S as Spec>::CryptoSpec>(raw_tx)
 }
 /// Decode bytes as a Sovereign SDK transaction, returning the message and tx info.
@@ -463,12 +467,23 @@ pub fn decode_sov_tx<S: Spec, D: DispatchCall<Spec = S>>(
 #[cfg(feature = "native")]
 pub fn decode_sov_tx_with_cryptospec<S: Spec, D: DispatchCall<Spec = S>, C: CryptoSpecExt>(
     mut raw_tx: &[u8],
-) -> Result<D::Decodable, FatalError> {
+) -> Result<(D::Decodable, AuthorizationData<S>), FatalError> {
     let tx =
         <Transaction<D, S, C> as MeteredBorshDeserialize<S>>::unmetered_deserialize(&mut raw_tx)
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
 
-    Ok(tx.call())
+    let mut unmeter = crate::UnlimitedGasMeter::<S>::default();
+    let authorization_data = match &tx {
+        Transaction::V0(v0) => {
+            extract_authorization_data::<S, D, C>(v0, calculate_hash::<S>(raw_tx), &mut unmeter)
+        }
+        Transaction::V1(v1) => {
+            extract_authorization_data_v1::<S, D, C>(v1, calculate_hash::<S>(raw_tx), &mut unmeter)
+        }
+    }
+    .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
+
+    Ok((tx.call(), authorization_data))
 }
 
 /// Calculates the hash of `data` and charges gas.

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -228,17 +228,41 @@ fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage
 }
 
 /// Decode bytes as a Sovereign SDK transaction, returning the message and tx info.
-pub fn decode_solana_json_tx<S, D>(raw_tx: &[u8]) -> Result<D::Decodable, FatalError>
+#[cfg(feature = "native")]
+pub fn decode_solana_json_tx<S, D>(
+    raw_tx: &[u8],
+) -> Result<
+    (
+        D::Decodable,
+        sov_modules_api::capabilities::AuthorizationData<S>,
+    ),
+    FatalError,
+>
 where
     S: Spec,
     D: DispatchCall<Spec = S>,
     <D as DispatchCall>::Decodable: Serialize + DeserializeOwned,
 {
+    use sov_modules_api::{capabilities::calculate_hash, PublicKey};
+
     let unpacked_message = unpack_solana_message::<S>(raw_tx)?;
     let solana_unsigned_tx: SolanaOffchainUnsignedTransaction<D, S> =
         serde_json::from_slice(unpacked_message.json_bytes())
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
-    Ok(solana_unsigned_tx.into_unsigned_tx().call())
+    let unsigned_tx = solana_unsigned_tx.into_unsigned_tx();
+
+    let pub_key = unpacked_message.pub_key;
+    let credential_id = pub_key.credential_id();
+
+    let auth_data = sov_modules_api::capabilities::AuthorizationData {
+        uniqueness: unsigned_tx.uniqueness,
+        tx_hash: calculate_hash::<S>(raw_tx),
+        credential_id,
+        credentials: sov_modules_api::transaction::Credentials::new(pub_key),
+        default_address: credential_id.into(),
+    };
+
+    Ok((unsigned_tx.call(), auth_data))
 }
 
 pub fn authenticate<Accessor, S, D>(

--- a/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
@@ -50,7 +50,13 @@ where
     #[cfg(feature = "native")]
     fn decode_serialized_tx(
         tx: &FullyBakedTx,
-    ) -> Result<Self::Decodable, sov_modules_api::capabilities::FatalError> {
+    ) -> Result<
+        (
+            Self::Decodable,
+            sov_modules_api::capabilities::AuthorizationData<S>,
+        ),
+        sov_modules_api::capabilities::FatalError,
+    > {
         use crate::authentication::decode_solana_json_tx;
 
         let auth_variant: SolanaOffchainAuthenticatorInput =
@@ -60,12 +66,10 @@ where
 
         match auth_variant {
             SolanaOffchainAuthenticatorInput::Standard(raw_tx) => {
-                let call = sov_modules_api::capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)?;
-                Ok(call)
+                sov_modules_api::capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)
             }
             SolanaOffchainAuthenticatorInput::SolanaOffchain(raw_tx) => {
-                let call = decode_solana_json_tx::<S, Rt>(&raw_tx.data)?;
-                Ok(call)
+                decode_solana_json_tx::<S, Rt>(&raw_tx.data)
             }
         }
     }


### PR DESCRIPTION
# Description

To allow the sequencer to intelligently queue TXs based on their nonce, we need to be able to access the uniqueness data as well as the credential ID. The current nonce queue implementation in sov-ethereum does this by calling `authenticate()`, but for most authenticators this requires additional useless work such as most notably signature checks. By returning the `AuthorizationData` from `decode_serialized_tx()`, we can get the information needed without running duplicate signature checks for every transaction.

We do however calculate the hash which is currently unnecessary for the upcoming nonce queue feature. IMO it's clean to be able to access the existing AuthorizationData struct, but if we wanted to save an additional hashing operation we could create a new type that omits it.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
