### PR TITLE
Fix off-by-one bug in `replica_sync_task::run_handler` and add replica start/stop tests

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -97,14 +97,25 @@ impl ReplicaSyncTask {
 
                     Err(DBDataRejected::ExecutorAhead(executor_seq_nr)) => {
                         // The executor is ahead of the db drain the queue and wait until we catch up.
-                        while let Ok(new_data) = db_data_receiver.try_recv() {
-                            if new_data.sequence_number() > executor_seq_nr {
+                        loop {
+                            let fut =
+                                future_or_shutdown(db_data_receiver.recv(), &shutdown_receiver);
+
+                            let FutureOrShutdownOutput::Output(Some(new_data)) = fut.await else {
+                                break 'outer;
+                            };
+
+                            assert!(
+                                new_data.sequence_number() <= executor_seq_nr,
+                                "The sequence number must be consecutive"
+                            );
+
+                            if new_data.sequence_number() == executor_seq_nr {
                                 assert!(matches!(new_data, DbData::BatchStart(_)));
                                 data = new_data;
                                 continue 'inner;
                             }
                         }
-                        break 'inner;
                     }
 
                     Err(DBDataRejected::ExecutorBehind(db_data)) => {
@@ -376,8 +387,8 @@ mod tests {
 
         let seq_nr = 3;
         let test_cases = to_db_data(&test_cases);
-        // We skip batch 1,2 and 3 so 15 db messages in total.
-        let expected = test_cases.iter().skip(15).cloned().collect();
+        // We skip batch 1, 2 so 10 db messages in total.
+        let expected = test_cases.iter().skip(10).cloned().collect();
         check_sync_task(test_cases.clone(), expected, seq_nr).await;
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/conditions_table.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/conditions_table.rs
@@ -150,6 +150,7 @@ pub(crate) async fn operation_for_replica<S: Spec, Rt: Runtime<S>>(
                 let mut rt = Rt::default();
                 let node_sequence_number =
                     get_next_sequence_number_according_to_node(info, &mut rt);
+
                 inner.sequence_number_of_next_blob = node_sequence_number;
 
                 let executor = Some(Box::new(

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -785,6 +785,12 @@ where
         let seq_nr_of_next_blob_for_this_executor = inner.sequence_number_of_next_blob;
         let seq_nr_from_master = batch_from_master.sequence_number;
 
+        debug!(
+            % seq_nr_from_master,
+            % seq_nr_of_next_blob_for_this_executor,
+            "Entering process_do_batch_start_replica"
+        );
+
         validate_db_data_from_replica(
             inner.has_finished_startup,
             &inner.is_ready,
@@ -799,6 +805,12 @@ where
                 batch_from_master.visible_slots_to_advance,
             )
             .await?;
+
+        debug!(
+            % seq_nr_from_master,
+            % seq_nr_of_next_blob_for_this_executor,
+            "Exiting process_do_batch_start_replica"
+        );
 
         Ok(())
     }
@@ -840,6 +852,12 @@ where
         let seq_nr_of_current_blob_for_this_executor = inner.current_sequence_number();
         let seq_nr_from_master = batch_from_master.sequence_number;
 
+        debug!(
+            % seq_nr_from_master,
+            % seq_nr_of_current_blob_for_this_executor,
+            "Entering process_close_current_batch_replica"
+        );
+
         validate_db_data_from_replica(
             inner.has_finished_startup,
             &inner.is_ready,
@@ -849,6 +867,12 @@ where
         )?;
 
         inner.close_current_batch().await;
+
+        debug!(
+            % seq_nr_from_master,
+            % seq_nr_of_current_blob_for_this_executor,
+            "Exiting process_close_current_batch_replica"
+        );
 
         Ok(())
     }

--- a/examples/demo-rollup/tests/replica/start_stop.rs
+++ b/examples/demo-rollup/tests/replica/start_stop.rs
@@ -259,6 +259,6 @@ async fn test_replica_start_stop_many_times() {
     }
 
     let _ = replica_test_rollup.shutdown().await;
-    test_rollup.shutdown().await.unwrap();
+    let _ = test_rollup.shutdown().await;
     let _ = da_shutdown.send(());
 }

--- a/examples/demo-rollup/tests/replica/start_stop.rs
+++ b/examples/demo-rollup/tests/replica/start_stop.rs
@@ -3,7 +3,6 @@ use super::*;
 use tokio::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "This test is temporarily ignored"]
 async fn test_replica_start_stop() {
     let postgres = PostgresData::create_postgres().await;
 
@@ -196,5 +195,70 @@ async fn test_replica_start_stop() {
 
     let _ = replica_test_rollup.shutdown().await;
     let _ = test_rollup.shutdown().await;
+    let _ = da_shutdown.send(());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_replica_start_stop_many_times() {
+    let postgres = PostgresData::create_postgres().await;
+
+    let postgres = match postgres {
+        Ok(pg) => Some(pg),
+        Err(CreatePostgresError::DockerNotSupported) => return,
+        Err(CreatePostgresError::DockerError(e)) => {
+            panic!("Failed to create Postgres container: {e}");
+        }
+    };
+
+    let (_da_service, da_shutdown, addr) = create_da_service_periodic().await;
+    let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
+    let receiver_addr = random_address();
+
+    let test_rollup = start_rollup(false, addr, postgres.clone()).await;
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
+
+    let nb_of_txs = 300;
+
+    let mut replica_test_rollup = start_rollup(true, addr, postgres).await;
+    for i in 0..10 {
+        let builder = replica_test_rollup.shutdown().await.unwrap();
+
+        let height_before_tx = test_rollup.height().await;
+        test_rollup
+            .wait_for_height(height_before_tx.get() + 25)
+            .await;
+
+        replica_test_rollup = builder.start_test_rollup().await.unwrap();
+        replica_test_rollup
+            .wait_for_sequencer_ready()
+            .await
+            .unwrap();
+
+        let mut event_subscription = replica_test_rollup
+            .api_client()
+            .subscribe_to_events_with_filter("Bank/*")
+            .await
+            .unwrap();
+
+        send_transfers(
+            i * nb_of_txs,
+            nb_of_txs,
+            key_and_address.clone(),
+            receiver_addr,
+            &test_rollup,
+        )
+        .await;
+
+        wait_for_all_events_with_timeout(
+            Duration::from_millis(100),
+            nb_of_txs,
+            &mut event_subscription,
+        )
+        .await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let _ = replica_test_rollup.shutdown().await;
+    test_rollup.shutdown().await.unwrap();
     let _ = da_shutdown.send(());
 }

--- a/examples/demo-rollup/tests/replica/start_stop.rs
+++ b/examples/demo-rollup/tests/replica/start_stop.rs
@@ -220,7 +220,7 @@ async fn test_replica_start_stop_many_times() {
     let nb_of_txs = 300;
 
     let mut replica_test_rollup = start_rollup(true, addr, postgres).await;
-    for i in 0..10 {
+    for i in 0..3 {
         let builder = replica_test_rollup.shutdown().await.unwrap();
 
         let height_before_tx = test_rollup.height().await;
@@ -255,6 +255,16 @@ async fn test_replica_start_stop_many_times() {
             &mut event_subscription,
         )
         .await;
+
+        let receiver_balance = replica_test_rollup
+            .client
+            .get_balance::<S>(&receiver_addr, &config_gas_token_id(), None)
+            .await
+            .unwrap();
+
+        let expected_balance = AMOUNT * ((nb_of_txs * (i + 1)) as u128);
+        assert_eq!(receiver_balance.0, expected_balance);
+
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 


### PR DESCRIPTION
# Description

This PR includes the following changes:
1. Adds additional tests for replica start/stop scenarios.
2. Fixes an off-by-one bug in replica_sync_task::run_handler.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
