### PR TITLE
Celsetia: Devnet: Update version and wait for provision to be completed

### DIFF
--- a/crates/adapters/celestia/README.md
+++ b/crates/adapters/celestia/README.md
@@ -159,14 +159,14 @@ Follow these steps (all paths are from root of the repo):
 
 1. **Update version tags in [`docker/Makefile`](../../../docker/Makefile)**:
    ```makefile
-   CELESTIA_DEVNET_VALIDATOR_TAG := v5.0.2-mocha  # Update this version
-   CELESTIA_DEVNET_BRIDGE_TAG := v0.27.4-mocha    # Update this version
+   CELESTIA_DEVNET_VALIDATOR_TAG := v6.2.0-mocha  # Update this version
+   CELESTIA_DEVNET_BRIDGE_TAG := v0.28.2-mocha    # Update this version
    ```
 
 2. **Update matching tags in `crates/adapters/celestia/src/test_helper/docker.rs`**:
    ```rust
-   const VALIDATOR_TAG: &str = "v5.0.2-mocha";
-   const BRIDGE_TAG: &str = "v0.27.4-mocha";
+   const VALIDATOR_TAG: &str = "v6.2.0-mocha";
+   const BRIDGE_TAG: &str = "v0.28.2-mocha";
    ```
 
 3. **Build the new docker images**:

--- a/crates/adapters/celestia/src/test_helper/docker.rs
+++ b/crates/adapters/celestia/src/test_helper/docker.rs
@@ -292,9 +292,9 @@ impl CelestiaDevNode {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_service_starts() -> anyhow::Result<()> {
-    sov_test_utils::logging::initialize_or_change_logging_with_filter(
-        "debug,bollard=info,h2=warn,hyper=warn,jsonrpsee=warn,sov_metrics=off,tower=warn,",
-    );
+    // sov_test_utils::logging::initialize_or_change_logging_with_filter(
+    //     "debug,bollard=info,h2=warn,hyper=warn,jsonrpsee=warn,sov_metrics=off,tower=warn,",
+    // );
     let dev_node = CelestiaDevNode::start().await?;
 
     let config = dev_node.get_config().await?;

--- a/crates/adapters/celestia/src/test_helper/docker.rs
+++ b/crates/adapters/celestia/src/test_helper/docker.rs
@@ -40,7 +40,7 @@ impl Image for CelestiaValidator {
     fn ready_conditions(&self) -> Vec<WaitFor> {
         vec![
             WaitFor::healthcheck(),
-            WaitFor::message_on_either_std("Genesis hash has been saved."),
+            WaitFor::message_on_either_std("Genesis hash has been saved"),
         ]
     }
 

--- a/crates/adapters/celestia/src/test_helper/docker.rs
+++ b/crates/adapters/celestia/src/test_helper/docker.rs
@@ -18,11 +18,13 @@ use tokio::time::sleep;
 use uuid::Uuid;
 
 const VALIDATOR_IMAGE: &str = "ghcr.io/sovereign-labs/celestia-validator-devnet";
-const VALIDATOR_TAG: &str = "v5.0.2-mocha";
+const VALIDATOR_TAG: &str = "v6.2.0-mocha";
 const BRIDGE_IMAGE: &str = "ghcr.io/sovereign-labs/celestia-bridge-devnet";
-const BRIDGE_TAG: &str = "v0.27.4-mocha";
+const BRIDGE_TAG: &str = "v0.28.2-mocha";
 const VALIDATOR_GRPC_PORT: u16 = 9090;
 const BRIDGE_RPC_PORT: u16 = 26658;
+
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(90);
 
 pub struct CelestiaValidator;
 
@@ -36,7 +38,10 @@ impl Image for CelestiaValidator {
     }
 
     fn ready_conditions(&self) -> Vec<WaitFor> {
-        vec![WaitFor::healthcheck()]
+        vec![
+            WaitFor::healthcheck(),
+            WaitFor::message_on_either_std("Provisioning finished."),
+        ]
     }
 
     fn env_vars(
@@ -106,6 +111,7 @@ impl CelestiaDevNode {
                 "/credentials",
             ))
             .with_mount(Mount::volume_mount(genesis_volume.clone(), "/genesis"))
+            .with_startup_timeout(STARTUP_TIMEOUT)
             .start()
             .await
             .context("failed to start validator container")?;

--- a/crates/adapters/celestia/src/test_helper/docker.rs
+++ b/crates/adapters/celestia/src/test_helper/docker.rs
@@ -40,7 +40,7 @@ impl Image for CelestiaValidator {
     fn ready_conditions(&self) -> Vec<WaitFor> {
         vec![
             WaitFor::healthcheck(),
-            WaitFor::message_on_either_std("Provisioning finished."),
+            WaitFor::message_on_either_std("Genesis hash has been saved."),
         ]
     }
 
@@ -123,6 +123,7 @@ impl CelestiaDevNode {
         tracing::info!(
             id = validator.id(),
             port = validator_grpc_port,
+            time = ?start.elapsed(),
             "Validator container started successfully"
         );
 
@@ -291,9 +292,9 @@ impl CelestiaDevNode {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_service_starts() -> anyhow::Result<()> {
-    // sov_test_utils::logging::initialize_or_change_logging_with_filter(
-    //     "debug,bollard=info,h2=warn,hyper=warn,jsonrpsee=warn,sov_metrics=off,tower=warn,",
-    // );
+    sov_test_utils::logging::initialize_or_change_logging_with_filter(
+        "debug,bollard=info,h2=warn,hyper=warn,jsonrpsee=warn,sov_metrics=off,tower=warn,",
+    );
     let dev_node = CelestiaDevNode::start().await?;
 
     let config = dev_node.get_config().await?;

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,9 +10,9 @@ HYPERLANE_CLI_TAG := sov-integration-3
 
 # Celestia Docker image constants
 CELESTIA_DEVNET_VALIDATOR_IMAGE := ghcr.io/sovereign-labs/celestia-validator-devnet
-CELESTIA_DEVNET_VALIDATOR_TAG := v5.0.2-mocha
+CELESTIA_DEVNET_VALIDATOR_TAG := v6.2.0-mocha
 CELESTIA_DEVNET_BRIDGE_IMAGE := ghcr.io/sovereign-labs/celestia-bridge-devnet
-CELESTIA_DEVNET_BRIDGE_TAG := v0.27.4-mocha
+CELESTIA_DEVNET_BRIDGE_TAG := v0.28.2-mocha
 
 docker_compose := docker compose -f $(DOCKER_COMPOSE_CFG)
 

--- a/docker/celestia/Dockerfile.bridge
+++ b/docker/celestia/Dockerfile.bridge
@@ -2,7 +2,7 @@
 # Based on:
 # https://github.com/celestiaorg/celestia-node/blob/main/Dockerfile
 
-ARG CELESTIA_NODE_TAG=v0.27.4-mocha
+ARG CELESTIA_NODE_TAG=v0.28.2-mocha
 
 FROM ghcr.io/celestiaorg/celestia-node:${CELESTIA_NODE_TAG} AS celestia-node
 

--- a/docker/celestia/Dockerfile.validator
+++ b/docker/celestia/Dockerfile.validator
@@ -2,7 +2,7 @@
 # Based on:
 # https://github.com/celestiaorg/celestia-app/blob/main/Dockerfile
 
-ARG CELESTIA_APP_TAG=v5.0.2-mocha
+ARG CELESTIA_APP_TAG=v6.2.0-mocha
 
 FROM ghcr.io/celestiaorg/celestia-app:${CELESTIA_APP_TAG} AS celestia-app
 

--- a/docker/celestia/run-bridge.sh
+++ b/docker/celestia/run-bridge.sh
@@ -83,6 +83,8 @@ main() {
     --core.ip validator \
     --keyring.keyname "$NODE_NAME" \
     --p2p.network "$P2P_NETWORK" \
+    --log.level.module share/discovery:error \
+    --log.level.module module/p2p:fatal \
     --rpc.addr "0.0.0.0"
 }
 

--- a/docker/celestia/run-validator.sh
+++ b/docker/celestia/run-validator.sh
@@ -46,16 +46,18 @@ wait_for_block() {
   echo "$block_hash"
 }
 
-# Saves the hash of the genesis node and the keys funded with the coins
-# to the directory shared with the bridge node
-provision_bridge_nodes() {
-  local genesis_hash
-  local last_node_idx=$((BRIDGE_COUNT - 1))
+save_genesis_hash() {
+    local genesis_hash
+    # Save the genesis hash for the bridge
+    genesis_hash=$(wait_for_block 1)
+    echo "Saving a genesis hash=$genesis_hash to $GENESIS_HASH_FILE"
+    # TODO: check exit code, and compare what has been written.
+    echo "$genesis_hash" > "$GENESIS_HASH_FILE"
+    echo "Genesis hash has been saved"
+}
 
-  # Save the genesis hash for the bridge
-  genesis_hash=$(wait_for_block 1)
-  echo "Saving a genesis hash to $GENESIS_HASH_FILE"
-  echo "$genesis_hash" > "$GENESIS_HASH_FILE"
+fund_bridge_nodes() {
+  local last_node_idx=$((BRIDGE_COUNT - 1))
 
   # Get or create the keys for bridge nodes
   for node_idx in $(seq 0 "$last_node_idx"); do
@@ -63,6 +65,7 @@ provision_bridge_nodes() {
     local key_file="$CREDENTIALS_DIR/$bridge_name.key"
     local addr_file="$CREDENTIALS_DIR/$bridge_name.addr"
 
+    # Generate key, if necessary, otherwise just add it to keystore
     if [ ! -e "$key_file" ]; then
       # if key don't exist yet, then create and export it
       # create a new key
@@ -85,36 +88,12 @@ provision_bridge_nodes() {
       echo "password" | celestia-appd keys import "$bridge_name" "$key_file" \
         --keyring-backend="test"
     fi
-  done
 
-  # Transfer the coins to bridge nodes addresses
-  # Coins transfer need to be after validator registers EVM address, which happens in block 2.
-  # see `setup_private_validator`
-  local start_block=2
-
-  for node_idx in $(seq 0 "$last_node_idx"); do
-    # TODO: <https://github.com/celestiaorg/celestia-app/issues/2869>
-    # we need to transfer the coins for each node in separate
-    # block, or the signing of all but the first one will fail.
-    # Unfortunately multi-send only works with >= 2 bridge nodes,
-    # so we still rely on this hack.
-    wait_for_block $((start_block + node_idx))
-
-    local bridge_name="bridge-$node_idx"
     local bridge_address
-
     bridge_address=$(node_address "$bridge_name")
-
-    echo "Transferring $BRIDGE_COINS coins to the $bridge_name"
-    echo "y" | celestia-appd tx bank send \
-      "$NODE_NAME" \
-      "$bridge_address" \
-      "$BRIDGE_COINS" \
-      --fees 21000utia
+    celestia-appd genesis add-genesis-account "$bridge_address" "$BRIDGE_COINS"
   done
-
-  # !! This is the last log entry that indicates the setup has finished for all the nodes
-  echo "Provisioning finished."
+  echo "Funded bridge nodes"
 }
 
 # Set up the validator for a private alone network.
@@ -135,6 +114,9 @@ setup_private_validator() {
     --keyring-backend="test" \
     --chain-id "$P2P_NETWORK" \
     --gas-prices "1utia"
+  # Add bridge node keys and fund them in genesis
+  fund_bridge_nodes
+
   # Collect the genesis transactions and form a genesis.json
   celestia-appd genesis collect-gentxs
 
@@ -155,39 +137,32 @@ setup_private_validator() {
   # enable unsafe CORS since we don't do security properly in CI
   dasel put -f "$CONFIG_DIR/config/app.toml" -t bool -v true grpc-web.enable-unsafe-cors
 
-  echo "~~~~~~~~~~~~~~~~"
-  echo "APP CONFIG:"
+  echo "================================"
+  echo "APP CONFIG: app.toml"
   cat "$CONFIG_DIR/config/app.toml"
-
-
-  # TODO: convert this to dasel
-  # Set proper defaults and change ports
-  # If you encounter: `sed: -I or -i may not be used with stdin` on MacOS you can mitigate by installing gnu-sed
-  # https://gist.github.com/andre3k1/e3a1a7133fded5de5a9ee99c87c6fa0d?permalink_comment_id=3082272#gistcomment-3082272
-  sed -i'.bak' 's|"tcp://127.0.0.1:26657"|"tcp://0.0.0.0:26657"|g' "$CONFIG_DIR/config/config.toml"
-  sed -i'.bak' 's|"null"|"kv"|g' "$CONFIG_DIR/config/config.toml"
+  echo "================================"
 
   # Enable prometheus
-  sed -i'.bak' 's/prometheus = false/prometheus = true/g' "$CONFIG_DIR/config/config.toml"
-  sed -i'.bak' 's/prometheus_listen_addr = ":26660"/prometheus_listen_addr = "0.0.0.0:26660"/g' "$CONFIG_DIR/config/config.toml"
+  dasel put -f "$CONFIG_DIR/config/config.toml" -t bool -v true instrumentation.prometheus
+  dasel put -f "$CONFIG_DIR/config/config.toml" -t string -v '0.0.0.0:26660' instrumentation.prometheus_listen_addr
 
-  # Adjusting for faster block times
+  # Adjusting for faster block times. Default values are in comments above
   # Numbers are derived by trial and error.
   # timeout_commit = "11s"
-  sed -i'.bak' 's/^timeout_commit\s*=.*/timeout_commit = "500ms"/g' "$CONFIG_DIR/config/config.toml"
+  dasel put -f "$CONFIG_DIR/config/config.toml" -t string -v '500ms' consensus.timeout_commit
   # timeout_propose = "10s"
-  sed -i'.bak' 's/^timeout_propose\s*=.*/timeout_propose = "50ms"/g' "$CONFIG_DIR/config/config.toml"
+  dasel put -f "$CONFIG_DIR/config/config.toml" -t string -v '4000ms' consensus.timeout_propose
   # timeout_propose_delta = "500ms"
-  sed -i'.bak' 's/^timeout_propose_delta\s*=.*/timeout_propose_delta = "10ms"/g' "$CONFIG_DIR/config/config.toml"
+  dasel put -f "$CONFIG_DIR/config/config.toml" -t string -v '10ms' consensus.timeout_propose_delta
   # timeout_prevote = "1s"
-  sed -i'.bak' 's/^timeout_prevote\s*=.*/timeout_prevote = "10ms"/g' "$CONFIG_DIR/config/config.toml"
+  dasel put -f "$CONFIG_DIR/config/config.toml" -t string -v '10ms' consensus.timeout_prevote
   # timeout_prevote_delta = "500ms"
-  sed -i'.bak' 's/^timeout_prevote_delta\s*=.*/timeout_prevote_delta = "10ms"/g' "$CONFIG_DIR/config/config.toml"
+  dasel put -f "$CONFIG_DIR/config/config.toml" -t string -v '10ms' consensus.timeout_prevote_delta
   # timeout_precommit = "1s"
-  sed -i'.bak' 's/^timeout_precommit\s*=.*/timeout_precommit = "20ms"/g' "$CONFIG_DIR/config/config.toml"
+  dasel put -f "$CONFIG_DIR/config/config.toml" -t string -v '20ms' consensus.timeout_precommit
   # timeout_precommit_delta = "500ms"
-  sed -i'.bak' 's/^timeout_precommit_delta\s*=.*/timeout_precomm_delta = "10ms"/g' "$CONFIG_DIR/config/config.toml"
-  echo "================================"
+  dasel put -f "$CONFIG_DIR/config/config.toml" -t string -v '10ms' consensus.timeout_precommit_delta
+
   echo "Final Private Validator Config:"
   cat "$CONFIG_DIR/config/config.toml"
   echo "End of Final Private Validator Config:"
@@ -195,10 +170,10 @@ setup_private_validator() {
 }
 
 main() {
-  # Configure stuff
   setup_private_validator
-  # Spawn a job to provision a bridge node later
-  provision_bridge_nodes &
+
+  # Spawn a job to save genesis_hash
+  save_genesis_hash &
   # Start the celestia-app
   echo "Configuration finished. Running a validator node..."
   celestia-appd start --api.enable --grpc.enable --force-no-bbr

--- a/docker/celestia/run-validator.sh
+++ b/docker/celestia/run-validator.sh
@@ -4,8 +4,8 @@
 set -euxo pipefail
 
 # Amount of bridge nodes to setup, taken from the first argument
-# or 10 if not provided
-BRIDGE_COUNT="${1:-10}"
+# or 5 if not provided
+BRIDGE_COUNT="${1:-5}"
 # a private local network
 P2P_NETWORK="private"
 # a validator node configuration directory
@@ -187,7 +187,11 @@ setup_private_validator() {
   sed -i'.bak' 's/^timeout_precommit\s*=.*/timeout_precommit = "20ms"/g' "$CONFIG_DIR/config/config.toml"
   # timeout_precommit_delta = "500ms"
   sed -i'.bak' 's/^timeout_precommit_delta\s*=.*/timeout_precomm_delta = "10ms"/g' "$CONFIG_DIR/config/config.toml"
+  echo "================================"
+  echo "Final Private Validator Config:"
   cat "$CONFIG_DIR/config/config.toml"
+  echo "End of Final Private Validator Config:"
+  echo "==================================="
 }
 
 main() {

--- a/docker/docker-compose.celestia.yml
+++ b/docker/docker-compose.celestia.yml
@@ -1,10 +1,10 @@
 services:
   validator:
-    image: ghcr.io/sovereign-labs/celestia-validator-devnet:v5.0.2-mocha
+    image: ghcr.io/sovereign-labs/celestia-validator-devnet:v6.2.0-mocha
     hostname: validator
     environment:
       NO_COLOR: 1
-    # uncomment to provide amount of sequencers to provision (default: 10)
+    # uncomment to provide amount of sequencers to provision (default: 5)
     # command: [ "/opt/entrypoint.sh", "2" ]
     ports:
       - "127.0.0.1:9090:9090"
@@ -15,7 +15,7 @@ services:
       - genesis:/genesis
 
   sequencer-0:
-    image: ghcr.io/sovereign-labs/celestia-bridge-devnet:v0.27.4-mocha
+    image: ghcr.io/sovereign-labs/celestia-bridge-devnet:v0.28.2-mocha
     hostname: sequencer-0
     depends_on:
       - validator


### PR DESCRIPTION
# Description

This is the first follow up of https://github.com/Sovereign-Labs/sovereign-sdk/pull/1981

Which addresses some instability of CelestiaDevNode.

## Changes

* Upgrade celestia versions:
  * node: from `v0.27.4-mocha` to the latest `v0.28.2-mocha`
  * app: from `v5.0.2-mocha` to the latest `v6.2.0-mocha`
* Changed prebuilt celestia validator and bridge setup:
  * Validator funds all brdige wallets in genesis, so we don't need to wait several blocks during startup
  * Minor: switched remaining validator configuration updates to dasel for simplicity and robustness
  * Bridge: toned down warnings/errors in p2p and sync modules, because of private setup.
  * Changed default number of pre-funded bridge wallets from 10 to 5.
  

- [x] Internal change ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to # 1630

## Testing
All existing tests are passing

## Docs
No updates

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
