### PR TITLE
Readable EVM OOG errors (Part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-11-01
+- #2006 Add associated Error type to the EVM module.
+
 # 2025-10-31
 - #2002 **Resync breaking change**. This PR moves rollup configuration files to demo-rollup/configs directory. 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11859,6 +11859,7 @@ dependencies = [
  "schemars 0.8.22",
  "secp256k1 0.30.0",
  "serde",
+ "serde_json",
  "serde_with",
  "sov-address",
  "sov-bank",

--- a/crates/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-evm/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = { workspace = true }
 bytes = { workspace = true }
 derive_more = { workspace = true, features = ["deref_mut"] }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde_with = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 derive-new = { workspace = true }

--- a/crates/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/lib.rs
@@ -39,11 +39,13 @@ pub use authenticate::{
     authenticate, decode_evm_tx, EthereumAuthenticator, EvmAuthenticator, EvmAuthenticatorInput,
 };
 pub use revm::primitives::hardfork::SpecId;
+use serde::Serialize;
 use sov_address::{EthereumAddress, FromVmAddress};
 use sov_bank::Amount;
 use sov_modules_api::{
-    AccessoryStateMap, AccessoryStateValue, Context, DaSpec, GenesisState, Module, ModuleId,
-    ModuleInfo, Spec, StateMap, StateValue, StateVec, TxState,
+    err_detail, AccessoryStateMap, AccessoryStateValue, Context, CoreModuleError, DaSpec,
+    ErrorContext, ErrorDetail, GenesisState, Module, ModuleId, ModuleInfo, Spec, StateMap,
+    StateValue, StateVec, TxState,
 };
 use sov_state::codec::BcsCodec;
 
@@ -57,6 +59,7 @@ pub use crate::evm::primitive_types::{Receipt, SealedBlock};
 pub use conversions::convert_to_tx_signed;
 pub use conversions::create_tx_env;
 use revm::state::Bytecode;
+use thiserror::Error;
 
 /// These values are associated with EIP-4844, which we do not support, but they must be set to a value other than None for CANCUN.
 const EXCESS_BLOB_GAS: u64 = 0;
@@ -153,6 +156,29 @@ pub struct Evm<S: Spec> {
     phantom: core::marker::PhantomData<S>,
 }
 
+/// The top-level error type for all EVM module operations.
+///
+/// This enum wraps all specific error types that can occur during different
+/// EVM operations, providing a unified error interface for the module.
+#[derive(Debug, Error, Serialize)]
+pub enum Error {
+    /// An error occurred in a core module operation.
+    #[error(transparent)]
+    CoreModuleError(#[from] CoreModuleError),
+}
+
+impl ErrorDetail for Error {
+    fn error_detail(&self) -> Result<ErrorContext, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(err_detail!(self))
+    }
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(err: anyhow::Error) -> Self {
+        CoreModuleError::Generic(err).into()
+    }
+}
+
 impl<S: Spec> Module for Evm<S>
 where
     S::Address: FromVmAddress<EthereumAddress>,
@@ -165,7 +191,7 @@ where
 
     type Event = ();
 
-    type Error = anyhow::Error;
+    type Error = Error;
 
     fn genesis(
         &mut self,
@@ -181,8 +207,8 @@ where
         msg: Self::CallMessage,
         context: &Context<Self::Spec>,
         state: &mut impl TxState<S>,
-    ) -> Result<(), Self::Error> {
-        self.execute_call(msg, context, state)
+    ) -> Result<(), Error> {
+        Ok(self.execute_call(msg, context, state)?)
     }
 }
 

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -4582,6 +4582,7 @@ dependencies = [
  "revm-database-interface",
  "schemars 0.8.22",
  "serde",
+ "serde_json",
  "serde_with",
  "sov-address",
  "sov-bank",

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -4116,6 +4116,7 @@ dependencies = [
  "revm-database-interface",
  "schemars 0.8.22",
  "serde",
+ "serde_json",
  "serde_with",
  "sov-address",
  "sov-bank",

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -6037,6 +6037,7 @@ dependencies = [
  "revm-database-interface",
  "schemars 0.8.21",
  "serde",
+ "serde_json",
  "serde_with",
  "sov-address",
  "sov-bank",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -5618,6 +5618,7 @@ dependencies = [
  "revm-database-interface",
  "schemars 0.8.21",
  "serde",
+ "serde_json",
  "serde_with",
  "sov-address",
  "sov-bank",

--- a/examples/demo-rollup/tests/evm/evm_oog_error.rs
+++ b/examples/demo-rollup/tests/evm/evm_oog_error.rs
@@ -1,0 +1,26 @@
+use crate::evm::evm_test_helper::alloy_client;
+use crate::evm::evm_test_helper::setup_test_rollup;
+use crate::evm::evm_test_helper::EVM_EXTENSION;
+use alloy::contract::Error;
+use alloy::transports::RpcError;
+use sov_test_utils::SimpleStorage;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn returns_readable_oog_error() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    let client = alloy_client(rollup.http_addr);
+    rollup.wait_for_next_blocks(1).await;
+
+    let err = SimpleStorage::deploy_builder(client)
+        .gas(50_000)
+        .deploy()
+        .await
+        .unwrap_err();
+    let Error::TransportError(RpcError::ErrorResp(payload)) = err else {
+        panic!("Expected transport error")
+    };
+    let data = payload.data.unwrap();
+    assert_eq!(data.get(), "\"400 Bad Request - 'Transaction execution unsuccessful' ({\\\"message\\\": String(\\\"EVM execution error: Halt { reason: OutOfGas(Basic), gas_used: 38614 }\\\")})\"");
+
+    Ok(())
+}

--- a/examples/demo-rollup/tests/evm/evm_oog_error.rs
+++ b/examples/demo-rollup/tests/evm/evm_oog_error.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+
 use crate::evm::evm_test_helper::alloy_client;
 use crate::evm::evm_test_helper::setup_test_rollup;
 use crate::evm::evm_test_helper::EVM_EXTENSION;
@@ -5,14 +7,10 @@ use alloy::contract::Error;
 use alloy::transports::RpcError;
 use sov_test_utils::SimpleStorage;
 
-#[tokio::test(flavor = "multi_thread")]
-async fn returns_readable_oog_error() -> anyhow::Result<()> {
-    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(1).await;
-
+async fn deploy_with_gas(addr: SocketAddr, gas: u64) -> String {
+    let client = alloy_client(addr);
     let err = SimpleStorage::deploy_builder(client)
-        .gas(50_000)
+        .gas(gas)
         .deploy()
         .await
         .unwrap_err();
@@ -20,7 +18,17 @@ async fn returns_readable_oog_error() -> anyhow::Result<()> {
         panic!("Expected transport error")
     };
     let data = payload.data.unwrap();
-    assert_eq!(data.get(), "\"400 Bad Request - 'Transaction execution unsuccessful' ({\\\"message\\\": String(\\\"EVM execution error: Halt { reason: OutOfGas(Basic), gas_used: 38614 }\\\")})\"");
+    data.get().into()
+}
+
+/// Currently those OOG errors are far from readable and this test is here for demonstration and regression detection
+#[tokio::test(flavor = "multi_thread")]
+async fn returns_readable_oog_error() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    rollup.wait_for_next_blocks(1).await;
+
+    assert_eq!(deploy_with_gas(rollup.http_addr, 0).await, "\"400 Bad Request - 'Transaction execution unsuccessful' ({\\\"error\\\": String(\\\"TransactionReceipt { tx_hash: 0x79ac94a6435e0941eca945e2270e649de138f2f3aa973688cc67ded90d817358, body_to_save: \\\\\\\"<removed>\\\\\\\", events: [], receipt: Skipped(SkippedTxContents { gas_used: GasUnit[3426, 3426], error: OutOfGas(\\\\\\\"The amount to charge is greater than the funds available in the meter. Amount to charge 61668, remaining_funds  0, price GasPrice[9, 9]\\\\\\\") }) }\\\")})\"");
+    assert_eq!(deploy_with_gas(rollup.http_addr, 20_000).await, "\"400 Bad Request - 'Transaction execution unsuccessful' ({\\\"CoreModuleError\\\": Object {\\\"error_code\\\": String(\\\"generic\\\"), \\\"message\\\": String(\\\"EVM execution error: Halt { reason: OutOfGas(Basic), gas_used: 8614 }\\\")}})\"");
 
     Ok(())
 }

--- a/examples/demo-rollup/tests/evm/mod.rs
+++ b/examples/demo-rollup/tests/evm/mod.rs
@@ -4,6 +4,7 @@ mod evm_block_hash;
 mod evm_gas_estimation;
 mod evm_logs;
 mod evm_no_gas_limit;
+mod evm_oog_error;
 mod evm_rpc;
 mod evm_soft_conf;
 mod evm_subscribe;


### PR DESCRIPTION
# Description

This PR adds a test that shows - how do we currently report OutOfGas errors in the EVM module.
It also adds an associated Error type in the EVM module that will allow us to return more readable errors.
Currently this type just wraps `anyhow::Error` through `CoreModuleError`.

----
- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
