### PR TITLE
Shut down rollup when registered Toko task finishes unexpectedly.

### DIFF
--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -687,6 +687,7 @@ fn spawn_task_monitor(
 
         let mut was_graceful = if let Err(error) = result {
             tracing::error!(error = %error, "background task joined with error");
+            _ = shutdown_sender.send(());
             false
         } else {
             // If shutdown receiver hasn't changed then it's implied that one of the handles
@@ -707,6 +708,7 @@ fn spawn_task_monitor(
         for handle in handles {
             if let Err(error) = handle.await {
                 tracing::error!(error = %error, "Additional background task joined with error");
+                _ = shutdown_sender.send(());
                 was_graceful = false;
             }
         }


### PR DESCRIPTION
# Description

We correctly detect when a (registered) Toko task finishes unexpectedly, but we don’t take any action on it.
In the current implementation, if a task finishes early (for example, via panic), an error is logged but the rollup continues running.
This change modifies the behavior so that the rollup shuts down in such cases.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
