### PR TITLE
Fix `eth_getLogsWithCursor` deserialization and response size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 2025-11-01
+- #2013 Ensure `eth_getLogsWithCursor` respects a 1MB response size limit. Fix its cursor deserialization behavior to match other chains.
 - #2006 Add associated Error type to the EVM module.
 
 # 2025-10-31

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -24,7 +24,12 @@ impl Default for SequencerKindConfig {
 pub struct SeqConfigExtension {
     pub max_log_limit: usize,
     /// The maximum size of the response to the eth_getLogs RPC endpoint. Use 1MB - 30KB for a safe default.
+    #[serde(default = "default_response_size_limit")]
     pub response_size_limit: usize,
+}
+
+fn default_response_size_limit() -> usize {
+    (1024 * 1024) - (1024 * 30) // Limit our response size to 1MB, leaving 30kb for headers, overhead, and misestimation.
 }
 
 /// Sequencer configuration.

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -23,6 +23,8 @@ impl Default for SequencerKindConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, Copy)]
 pub struct SeqConfigExtension {
     pub max_log_limit: usize,
+    /// The maximum size of the response to the eth_getLogs RPC endpoint. Use 1MB - 30KB for a safe default.
+    pub response_size_limit: usize,
 }
 
 /// Sequencer configuration.

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
@@ -41,6 +41,7 @@ where
             None,
             ethereum.extension.max_log_limit,
             state,
+            ethereum.extension.response_size_limit,
         );
         Ok(service.logs_for_filter().await?.logs)
     }
@@ -53,8 +54,13 @@ where
         let state = ethereum.api_state_accessor();
         let FilterWithCursor { cursor, filter } = parameters.one::<FilterWithCursor>()?;
         let cursor = cursor.map(|s| Cursor::unpack(&s)).transpose()?;
-        let service =
-            LogsService::<S, Seq>::new(filter, cursor, ethereum.extension.max_log_limit, state);
+        let service = LogsService::<S, Seq>::new(
+            filter,
+            cursor,
+            ethereum.extension.max_log_limit,
+            state,
+            ethereum.extension.response_size_limit,
+        );
         Ok(service.logs_for_filter().await?)
     }
 }

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
@@ -26,6 +26,9 @@ use std::ops::Range;
 use std::ops::RangeInclusive;
 use thiserror::Error;
 
+/// Limit our response size to 1MB, leaving 30kb for headers, overhead, and misestimation.
+const RESPONSE_SIZE_LIMIT: usize = (1024 * 1024) - (1024 * 30);
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Receipt for index {0} not found. The state may have already been pruned.")]
@@ -72,6 +75,7 @@ pub struct LogsService<S: Spec, Seq: Sequencer<Spec = S>> {
     max_logs: Immutable<usize>,
     evm: Evm<S>,
     logs: Vec<Log>,
+    logs_serialized_size: usize,
     state: ApiStateAccessor<S>,
     _phantom: PhantomData<(S, Seq)>,
 }
@@ -96,6 +100,7 @@ where
             state,
             evm: Evm::<S>::default(),
             logs: vec![],
+            logs_serialized_size: 0,
             _phantom: PhantomData,
         }
     }
@@ -249,7 +254,9 @@ where
 
         // As logs iter is pre-enumerated - we keep correct indices
         for (idx, log) in logs_iter.skip(skipped_logs as usize) {
-            if self.logs.len() >= *self.max_logs {
+            
+            if self.logs.len() >= *self.max_logs 
+            {
                 return Ok(Some(Cursor {
                     block_height: header.number(),
                     tx_index_absolute,
@@ -269,6 +276,15 @@ where
                 log_index: Some(receipt.log_index_start + idx as u64),
                 removed: false,
             };
+            let log_size = serialized_size(&rpc_log);
+            if self.logs_serialized_size + log_size >= RESPONSE_SIZE_LIMIT {
+                return Ok(Some(Cursor {
+                    block_height: header.number(),
+                    tx_index_absolute,
+                    log_index_in_tx: idx as u32,
+                }));
+            }
+            self.logs_serialized_size += log_size;
             self.logs.push(rpc_log);
         }
         Ok(None)
@@ -307,4 +323,19 @@ where
         let block_number = block_nr_or_tag.unwrap_or_default();
         Ok(self.evm.resolve_block_number(block_number, &mut self.state))
     }
+}
+
+fn serialized_size(log: &Log) -> usize {
+        b"\"{address\":".len() + 44 // 20 byte address, hex-encoded + open/close quotes and 0x
+        + b",\"data\":".len() + 4 + log.inner.data.data.len() * 2 // 32 byte data, hex-encoded + open/close quotes and 0x + quotation marks
+        + b",\"topics\":[]".len() + log.inner.topics().len() * 68 // 32 byte topic, hex-encoded + open/close quotes and 0x
+        + b",\"blockHash\":".len() + 68 // Block hash (0x-prefixed + 32 data bytes) + quotation marks
+        + b",\"transactionHash\":".len() + 68 // Transaction hash (0x-prefixed + 32 data bytes) + quotation mark
+        + b",\"blockNumber\":".len() + 14 // Assume a billion blocks (plus open/close quotes and 0x prefix)
+        + b",\"blockTimestamp\":".len() + 16 // Conservatively assume a long time (current unix timestamp is only 8 hex digits, this assumes 12)
+        + b",\"transactionIndex\":".len() + 12 // Conservatively assume millions of txs per block (plus open/close quotes and 0x prefix)    
+        + b",\"logIndex\":".len() + 14 // Conservatively assume 256 logs per tx
+        + b",\"removed\":false}".len() // false is longer than true
+        // See example serialized log below: 
+        // r#"{"address":"0x0000000000000000000000000000000000000069","topics":["0x0000000000000000000000000000000000000000000000000000000000000069"],"data":"0x69","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000069","blockNumber":"0x69","blockTimestamp":"0x69","transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000069","transactionIndex":"0x69","logIndex":"0x69","removed":false}"#
 }

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
@@ -26,9 +26,6 @@ use std::ops::Range;
 use std::ops::RangeInclusive;
 use thiserror::Error;
 
-/// Limit our response size to 1MB, leaving 30kb for headers, overhead, and misestimation.
-const RESPONSE_SIZE_LIMIT: usize = (1024 * 1024) - (1024 * 30);
-
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Receipt for index {0} not found. The state may have already been pruned.")]
@@ -77,6 +74,7 @@ pub struct LogsService<S: Spec, Seq: Sequencer<Spec = S>> {
     logs: Vec<Log>,
     logs_serialized_size: usize,
     state: ApiStateAccessor<S>,
+    response_size_limit: Immutable<usize>,
     _phantom: PhantomData<(S, Seq)>,
 }
 
@@ -92,6 +90,7 @@ where
         cursor: Option<Cursor>,
         max_logs: usize,
         state: ApiStateAccessor<S>,
+        response_size_limit: usize,
     ) -> Self {
         Self {
             filter: filter.into(),
@@ -101,6 +100,7 @@ where
             evm: Evm::<S>::default(),
             logs: vec![],
             logs_serialized_size: 0,
+            response_size_limit: response_size_limit.into(),
             _phantom: PhantomData,
         }
     }
@@ -275,7 +275,7 @@ where
                 removed: false,
             };
             let log_size = serialized_size(&rpc_log);
-            if self.logs_serialized_size + log_size >= RESPONSE_SIZE_LIMIT {
+            if self.logs_serialized_size + log_size >= *self.response_size_limit {
                 return Ok(Some(Cursor {
                     block_height: header.number(),
                     tx_index_absolute,

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
@@ -254,9 +254,7 @@ where
 
         // As logs iter is pre-enumerated - we keep correct indices
         for (idx, log) in logs_iter.skip(skipped_logs as usize) {
-            
-            if self.logs.len() >= *self.max_logs 
-            {
+            if self.logs.len() >= *self.max_logs {
                 return Ok(Some(Cursor {
                     block_height: header.number(),
                     tx_index_absolute,
@@ -326,7 +324,7 @@ where
 }
 
 fn serialized_size(log: &Log) -> usize {
-        b"\"{address\":".len() + 44 // 20 byte address, hex-encoded + open/close quotes and 0x
+    b"\"{address\":".len() + 44 // 20 byte address, hex-encoded + open/close quotes and 0x
         + b",\"data\":".len() + 4 + log.inner.data.data.len() * 2 // 32 byte data, hex-encoded + open/close quotes and 0x + quotation marks
         + b",\"topics\":[]".len() + log.inner.topics().len() * 68 // 32 byte topic, hex-encoded + open/close quotes and 0x
         + b",\"blockHash\":".len() + 68 // Block hash (0x-prefixed + 32 data bytes) + quotation marks
@@ -336,6 +334,6 @@ fn serialized_size(log: &Log) -> usize {
         + b",\"transactionIndex\":".len() + 12 // Conservatively assume millions of txs per block (plus open/close quotes and 0x prefix)    
         + b",\"logIndex\":".len() + 14 // Conservatively assume 256 logs per tx
         + b",\"removed\":false}".len() // false is longer than true
-        // See example serialized log below: 
-        // r#"{"address":"0x0000000000000000000000000000000000000069","topics":["0x0000000000000000000000000000000000000000000000000000000000000069"],"data":"0x69","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000069","blockNumber":"0x69","blockTimestamp":"0x69","transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000069","transactionIndex":"0x69","logIndex":"0x69","removed":false}"#
+                                       // See example serialized log below:
+                                       // r#"{"address":"0x0000000000000000000000000000000000000069","topics":["0x0000000000000000000000000000000000000000000000000000000000000069"],"data":"0x69","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000069","blockNumber":"0x69","blockTimestamp":"0x69","transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000069","transactionIndex":"0x69","logIndex":"0x69","removed":false}"#
 }

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -745,8 +745,7 @@
       "description": "Configuration data used by sequencer extensions, such as EVM endpoints.",
       "type": "object",
       "required": [
-        "max_log_limit",
-        "response_size_limit"
+        "max_log_limit"
       ],
       "properties": {
         "max_log_limit": {
@@ -756,6 +755,7 @@
         },
         "response_size_limit": {
           "description": "The maximum size of the response to the eth_getLogs RPC endpoint. Use 1MB - 30KB for a safe default.",
+          "default": 1017856,
           "type": "integer",
           "format": "uint",
           "minimum": 0.0

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -745,10 +745,17 @@
       "description": "Configuration data used by sequencer extensions, such as EVM endpoints.",
       "type": "object",
       "required": [
-        "max_log_limit"
+        "max_log_limit",
+        "response_size_limit"
       ],
       "properties": {
         "max_log_limit": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "response_size_limit": {
+          "description": "The maximum size of the response to the eth_getLogs RPC endpoint. Use 1MB - 30KB for a safe default.",
           "type": "integer",
           "format": "uint",
           "minimum": 0.0

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -382,6 +382,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
             stop_at_rollup_height: None,
             extension: Some(SeqConfigExtension {
                 max_log_limit: 20000,
+                response_size_limit: (1024 * 1024) - (1024 * 30), // Limit our response size to 1MB, leaving 30kb for headers, overhead, and misestimation.
             }),
             num_cache_warmup_workers: TEST_NUM_CACHE_WARMUP_WORKERS,
         }

--- a/crates/utils/sov-eth-client/src/lib.rs
+++ b/crates/utils/sov-eth-client/src/lib.rs
@@ -18,7 +18,7 @@ mod rpc;
 pub use provider_ext::LogsWithCursorProvider;
 pub use rpc::RpcClient;
 
-const GAS: u64 = 9000000u64;
+const GAS: u64 = 100_000_000u64;
 const MAX_FEE_PER_GAS: u64 = 100;
 const MAX_PRIORITY_FEE_PER_GAS: u64 = 1;
 

--- a/crates/utils/sov-eth-client/src/rpc.rs
+++ b/crates/utils/sov-eth-client/src/rpc.rs
@@ -171,7 +171,10 @@ impl RpcClient {
             .unwrap()
     }
 
-    pub async fn get_logs_with_cursor_and_filter(&self, cursor_and_filter: &impl serde::Serialize) -> LogsWithMaybeCursor {
+    pub async fn get_logs_with_cursor_and_filter(
+        &self,
+        cursor_and_filter: &impl serde::Serialize,
+    ) -> LogsWithMaybeCursor {
         self.ws
             .request("eth_getLogsWithCursor", rpc_params![cursor_and_filter])
             .await

--- a/crates/utils/sov-eth-client/src/rpc.rs
+++ b/crates/utils/sov-eth-client/src/rpc.rs
@@ -170,6 +170,13 @@ impl RpcClient {
             .await
             .unwrap()
     }
+
+    pub async fn get_logs_with_cursor_and_filter(&self, cursor_and_filter: &impl serde::Serialize) -> LogsWithMaybeCursor {
+        self.ws
+            .request("eth_getLogsWithCursor", rpc_params![cursor_and_filter])
+            .await
+            .unwrap()
+    }
 }
 
 // Alloy pubsub client

--- a/crates/utils/sov-rpc-eth-types/src/filter_with_cursor.rs
+++ b/crates/utils/sov-rpc-eth-types/src/filter_with_cursor.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct FilterWithCursor {
     pub cursor: Option<String>,
+    #[serde(flatten)]
     pub filter: Filter,
 }
 

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -282,7 +282,6 @@ async fn evm_test_get_logs_at_max_response_size() {
     let nb_of_logs_per_tx: u32 = 5000;
 
     let rollup_and_client = RollupAndClient::new(20_000).await;
-    let start_tx = rollup_and_client.get_tx_count().await as u32;
 
     rollup_and_client
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
@@ -304,9 +303,6 @@ async fn evm_test_get_logs_at_max_response_size() {
         };
 
         let cursor = Cursor::unpack(&packed_cursor).unwrap();
-        let nb_of_logs_according_to_cursor =
-            nb_of_logs_according_to_cursor(cursor, nb_of_logs_per_tx);
-
         logs_with_cursor = rollup_and_client.get_logs_with_cursor(Some(cursor)).await;
         nb_of_logs_received += logs_with_cursor.logs.len();
     }

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -166,10 +166,69 @@ fn check_logs(filter: &Filter, logs: Vec<alloy_rpc_types_eth::Log>, expected_nb_
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn evm_test_get_logs_with_cursor_and_filter() {
+    let max_log_limit = 7;
+    let nb_of_txs = 9;
+    let nb_of_logs_per_tx: u32 = 12;
+
+    let rollup_and_client = RollupAndClient::new(max_log_limit).await;
+    let start_tx = rollup_and_client.get_tx_count().await as u32;
+
+    rollup_and_client
+        .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
+        .await;
+
+    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+
+    let mut nb_of_logs_received = 0;
+    let mut logs_with_cursor = rollup_and_client.get_logs_with_cursor_and_filter(&serde_json::json!({
+            "fromBlock": "0x0",
+            "toBlock": "latest",
+    })).await;
+
+    nb_of_logs_received += logs_with_cursor.logs.len();
+
+    let mut nb_of_logs_until_prev_cursor = start_tx * nb_of_logs_per_tx;
+    loop {
+        let packed_cursor = match logs_with_cursor.cursor {
+            Some(packed) => packed,
+            None => {
+                let total = (nb_of_txs * nb_of_logs_per_tx) as usize;
+                assert_eq!(logs_with_cursor.logs.len(), total % max_log_limit);
+                break;
+            }
+        };
+
+        let cursor = Cursor::unpack(&packed_cursor).unwrap();
+        let nb_of_logs_according_to_cursor =
+            nb_of_logs_according_to_cursor(cursor, nb_of_logs_per_tx);
+
+        // Every cursor gives max_log_limit logs.
+        assert_eq!(
+            nb_of_logs_according_to_cursor - nb_of_logs_until_prev_cursor,
+            max_log_limit as u32
+        );
+
+        nb_of_logs_until_prev_cursor = nb_of_logs_according_to_cursor;
+
+        logs_with_cursor = rollup_and_client.get_logs_with_cursor_and_filter(&serde_json::json!({
+            "fromBlock": "0x0",
+            "toBlock": "latest",
+            "cursor": packed_cursor,
+        })).await;
+        nb_of_logs_received += logs_with_cursor.logs.len();
+    }
+
+    assert_eq!(nb_of_logs_received as u32, nb_of_txs * nb_of_logs_per_tx);
+}
+
+
+
+#[tokio::test(flavor = "multi_thread")]
 async fn evm_test_get_logs_with_cursor() {
-    let max_log_limit = 9;
-    let nb_of_txs = 20;
-    let nb_of_logs_per_tx: u32 = 7;
+    let max_log_limit = 7;
+    let nb_of_txs = 9;
+    let nb_of_logs_per_tx: u32 = 2;
 
     let rollup_and_client = RollupAndClient::new(max_log_limit).await;
     let start_tx = rollup_and_client.get_tx_count().await as u32;
@@ -205,6 +264,48 @@ async fn evm_test_get_logs_with_cursor() {
             nb_of_logs_according_to_cursor - nb_of_logs_until_prev_cursor,
             max_log_limit as u32
         );
+
+        nb_of_logs_until_prev_cursor = nb_of_logs_according_to_cursor;
+
+        logs_with_cursor = rollup_and_client.get_logs_with_cursor(Some(cursor)).await;
+        nb_of_logs_received += logs_with_cursor.logs.len();
+    }
+
+    assert_eq!(nb_of_logs_received as u32, nb_of_txs * nb_of_logs_per_tx);
+}
+
+
+#[tokio::test(flavor = "multi_thread")]
+async fn evm_test_get_logs_at_max_response_size() {
+    let nb_of_txs = 3;
+    let nb_of_logs_per_tx: u32 = 5000;
+
+    let rollup_and_client = RollupAndClient::new(20_000).await;
+    let start_tx = rollup_and_client.get_tx_count().await as u32;
+
+    rollup_and_client
+        .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
+        .await;
+
+    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+
+    let mut nb_of_logs_received = 0;
+    let mut logs_with_cursor = rollup_and_client.get_logs_with_cursor(None).await;
+
+    nb_of_logs_received += logs_with_cursor.logs.len();
+
+    let mut nb_of_logs_until_prev_cursor = start_tx * nb_of_logs_per_tx;
+    loop {
+        let packed_cursor = match logs_with_cursor.cursor {
+            Some(packed) => packed,
+            None => {
+                break;
+            }
+        };
+
+        let cursor = Cursor::unpack(&packed_cursor).unwrap();
+        let nb_of_logs_according_to_cursor =
+            nb_of_logs_according_to_cursor(cursor, nb_of_logs_per_tx);
 
         nb_of_logs_until_prev_cursor = nb_of_logs_according_to_cursor;
 
@@ -312,5 +413,9 @@ impl RollupAndClient {
         };
 
         self.client.get_logs_with_cursor(&filter_with_cursor).await
+    }
+
+    async fn get_logs_with_cursor_and_filter(&self, cursor_and_filter: &impl serde::Serialize) -> LogsWithMaybeCursor {
+        self.client.get_logs_with_cursor_and_filter(cursor_and_filter).await
     }
 }

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -44,7 +44,11 @@ async fn evm_test_get_logs() {
     let nb_of_txs = 10;
     let nb_of_logs_per_tx = 5;
 
-    let rollup_and_client = RollupAndClient::new(EVM_EXTENSION.max_log_limit).await;
+    let rollup_and_client = RollupAndClient::new(
+        EVM_EXTENSION.max_log_limit,
+        EVM_EXTENSION.response_size_limit,
+    )
+    .await;
 
     // Make sure all the txs are in the same blcok.
     rollup_and_client
@@ -101,7 +105,11 @@ async fn evm_test_get_logs_range() {
     let nb_of_txs = 10;
     let nb_of_logs_per_tx = 5;
 
-    let rollup_and_client = RollupAndClient::new(EVM_EXTENSION.max_log_limit).await;
+    let rollup_and_client = RollupAndClient::new(
+        EVM_EXTENSION.max_log_limit,
+        EVM_EXTENSION.response_size_limit,
+    )
+    .await;
 
     let start_block = rollup_and_client
         .client
@@ -144,7 +152,8 @@ async fn evm_test_get_logs_range_limit() {
     let nb_of_txs = 20;
     let nb_of_logs_per_tx: u32 = 5;
 
-    let rollup_and_client = RollupAndClient::new(max_log_limit).await;
+    let rollup_and_client =
+        RollupAndClient::new(max_log_limit, EVM_EXTENSION.response_size_limit).await;
 
     rollup_and_client
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
@@ -171,7 +180,8 @@ async fn evm_test_get_logs_with_cursor_and_filter() {
     let nb_of_txs = 20;
     let nb_of_logs_per_tx: u32 = 7;
 
-    let rollup_and_client = RollupAndClient::new(max_log_limit).await;
+    let rollup_and_client =
+        RollupAndClient::new(max_log_limit, EVM_EXTENSION.response_size_limit).await;
     let start_tx = rollup_and_client.get_tx_count().await as u32;
 
     rollup_and_client
@@ -232,7 +242,8 @@ async fn evm_test_get_logs_with_cursor() {
     let nb_of_txs = 20;
     let nb_of_logs_per_tx: u32 = 7;
 
-    let rollup_and_client = RollupAndClient::new(max_log_limit).await;
+    let rollup_and_client =
+        RollupAndClient::new(max_log_limit, EVM_EXTENSION.response_size_limit).await;
     let start_tx = rollup_and_client.get_tx_count().await as u32;
 
     rollup_and_client
@@ -279,9 +290,10 @@ async fn evm_test_get_logs_with_cursor() {
 #[tokio::test(flavor = "multi_thread")]
 async fn evm_test_get_logs_at_max_response_size() {
     let nb_of_txs = 3;
-    let nb_of_logs_per_tx: u32 = 5000;
+    let nb_of_logs_per_tx: u32 = 40;
 
-    let rollup_and_client = RollupAndClient::new(20_000).await;
+    // Set a low limit on response sizes to force pagination.
+    let rollup_and_client = RollupAndClient::new(EVM_EXTENSION.max_log_limit, 1_000).await;
 
     rollup_and_client
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
@@ -294,13 +306,9 @@ async fn evm_test_get_logs_at_max_response_size() {
 
     nb_of_logs_received += logs_with_cursor.logs.len();
 
-    loop {
-        let packed_cursor = match logs_with_cursor.cursor {
-            Some(packed) => packed,
-            None => {
-                break;
-            }
-        };
+    let mut iters = 0;
+    while let Some(packed_cursor) = logs_with_cursor.cursor {
+        iters += 1;
 
         let cursor = Cursor::unpack(&packed_cursor).unwrap();
         logs_with_cursor = rollup_and_client.get_logs_with_cursor(Some(cursor)).await;
@@ -308,6 +316,7 @@ async fn evm_test_get_logs_at_max_response_size() {
     }
 
     assert_eq!(nb_of_logs_received as u32, nb_of_txs * nb_of_logs_per_tx);
+    assert!(iters > 1, "We should have reached the response size limit and been forced to paginate. This test might need adjusting, or pagination is broken.");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -316,7 +325,8 @@ async fn logs_resumed_from_the_middle_of_tx_have_correct_indices() {
     let nb_of_txs = 1;
     let nb_of_logs_per_tx: u32 = 2;
 
-    let rollup_and_client = RollupAndClient::new(max_log_limit).await;
+    let rollup_and_client =
+        RollupAndClient::new(max_log_limit, EVM_EXTENSION.response_size_limit).await;
 
     rollup_and_client
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, None)
@@ -358,8 +368,11 @@ struct RollupAndClient {
 }
 
 impl RollupAndClient {
-    async fn new(max_log_limit: usize) -> RollupAndClient {
-        let ext = SeqConfigExtension { max_log_limit };
+    async fn new(max_log_limit: usize, response_size_limit: usize) -> RollupAndClient {
+        let ext = SeqConfigExtension {
+            max_log_limit,
+            response_size_limit,
+        };
 
         let (test_rollup, evm_client, _) = setup_with_simple_storage(0, ext).await;
         let contract_address = evm_client.alloy_deploy_contract().await;

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -167,9 +167,9 @@ fn check_logs(filter: &Filter, logs: Vec<alloy_rpc_types_eth::Log>, expected_nb_
 
 #[tokio::test(flavor = "multi_thread")]
 async fn evm_test_get_logs_with_cursor_and_filter() {
-    let max_log_limit = 7;
-    let nb_of_txs = 9;
-    let nb_of_logs_per_tx: u32 = 12;
+    let max_log_limit = 9;
+    let nb_of_txs = 20;
+    let nb_of_logs_per_tx: u32 = 7;
 
     let rollup_and_client = RollupAndClient::new(max_log_limit).await;
     let start_tx = rollup_and_client.get_tx_count().await as u32;
@@ -181,10 +181,12 @@ async fn evm_test_get_logs_with_cursor_and_filter() {
     rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
 
     let mut nb_of_logs_received = 0;
-    let mut logs_with_cursor = rollup_and_client.get_logs_with_cursor_and_filter(&serde_json::json!({
-            "fromBlock": "0x0",
-            "toBlock": "latest",
-    })).await;
+    let mut logs_with_cursor = rollup_and_client
+        .get_logs_with_cursor_and_filter(&serde_json::json!({
+                "fromBlock": "0x0",
+                "toBlock": "latest",
+        }))
+        .await;
 
     nb_of_logs_received += logs_with_cursor.logs.len();
 
@@ -211,24 +213,24 @@ async fn evm_test_get_logs_with_cursor_and_filter() {
 
         nb_of_logs_until_prev_cursor = nb_of_logs_according_to_cursor;
 
-        logs_with_cursor = rollup_and_client.get_logs_with_cursor_and_filter(&serde_json::json!({
-            "fromBlock": "0x0",
-            "toBlock": "latest",
-            "cursor": packed_cursor,
-        })).await;
+        logs_with_cursor = rollup_and_client
+            .get_logs_with_cursor_and_filter(&serde_json::json!({
+                "fromBlock": "0x0",
+                "toBlock": "latest",
+                "cursor": packed_cursor,
+            }))
+            .await;
         nb_of_logs_received += logs_with_cursor.logs.len();
     }
 
     assert_eq!(nb_of_logs_received as u32, nb_of_txs * nb_of_logs_per_tx);
 }
 
-
-
 #[tokio::test(flavor = "multi_thread")]
 async fn evm_test_get_logs_with_cursor() {
-    let max_log_limit = 7;
-    let nb_of_txs = 9;
-    let nb_of_logs_per_tx: u32 = 2;
+    let max_log_limit = 9;
+    let nb_of_txs = 20;
+    let nb_of_logs_per_tx: u32 = 7;
 
     let rollup_and_client = RollupAndClient::new(max_log_limit).await;
     let start_tx = rollup_and_client.get_tx_count().await as u32;
@@ -274,7 +276,6 @@ async fn evm_test_get_logs_with_cursor() {
     assert_eq!(nb_of_logs_received as u32, nb_of_txs * nb_of_logs_per_tx);
 }
 
-
 #[tokio::test(flavor = "multi_thread")]
 async fn evm_test_get_logs_at_max_response_size() {
     let nb_of_txs = 3;
@@ -294,7 +295,6 @@ async fn evm_test_get_logs_at_max_response_size() {
 
     nb_of_logs_received += logs_with_cursor.logs.len();
 
-    let mut nb_of_logs_until_prev_cursor = start_tx * nb_of_logs_per_tx;
     loop {
         let packed_cursor = match logs_with_cursor.cursor {
             Some(packed) => packed,
@@ -306,8 +306,6 @@ async fn evm_test_get_logs_at_max_response_size() {
         let cursor = Cursor::unpack(&packed_cursor).unwrap();
         let nb_of_logs_according_to_cursor =
             nb_of_logs_according_to_cursor(cursor, nb_of_logs_per_tx);
-
-        nb_of_logs_until_prev_cursor = nb_of_logs_according_to_cursor;
 
         logs_with_cursor = rollup_and_client.get_logs_with_cursor(Some(cursor)).await;
         nb_of_logs_received += logs_with_cursor.logs.len();
@@ -415,7 +413,12 @@ impl RollupAndClient {
         self.client.get_logs_with_cursor(&filter_with_cursor).await
     }
 
-    async fn get_logs_with_cursor_and_filter(&self, cursor_and_filter: &impl serde::Serialize) -> LogsWithMaybeCursor {
-        self.client.get_logs_with_cursor_and_filter(cursor_and_filter).await
+    async fn get_logs_with_cursor_and_filter(
+        &self,
+        cursor_and_filter: &impl serde::Serialize,
+    ) -> LogsWithMaybeCursor {
+        self.client
+            .get_logs_with_cursor_and_filter(cursor_and_filter)
+            .await
     }
 }

--- a/examples/demo-rollup/tests/evm/evm_test_helper.rs
+++ b/examples/demo-rollup/tests/evm/evm_test_helper.rs
@@ -28,6 +28,7 @@ pub(crate) const SENDER_PRIV_KEY: &str =
 
 pub(crate) const EVM_EXTENSION: SeqConfigExtension = SeqConfigExtension {
     max_log_limit: 20000,
+    response_size_limit: (1024 * 1024) - (1024 * 30), // Limit our response size to 1MB, leaving 30kb for headers, overhead, and misestimation.
 };
 
 /// Starts test rollup node.  


### PR DESCRIPTION
# Description

This PR makes and tests two small changes to `eth_getLogsWithCursor`. 
1. Adds a `#[serde(flatten)]` directive on the Filter in `FilterWithCursor`. This prevents us diverging from other chains by requiring `{ "cursor:" "foo", "filter": {"address": "…"}}` instead of the more standard flat structure with inline filter fields
2. Estimates the size of the current response in `getLogsWithCursor` and automatically paginates before reaching 1MB. 
