### PR TITLE
Signature caching in all authenticators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11837,7 +11837,6 @@ dependencies = [
  "jsonschema",
  "lazy_static",
  "proptest",
- "quick_cache",
  "rand 0.8.5",
  "reth-ethereum-primitives",
  "reth-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12108,6 +12108,7 @@ dependencies = [
  "openapiv3",
  "proptest",
  "proptest-derive 0.5.1",
+ "quick_cache",
  "reqwest 0.12.23",
  "schemars 0.8.22",
  "serde",

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -15,6 +15,9 @@ use sov_evm::Evm;
 use sov_evm::RlpEvmTransaction;
 use sov_modules_api::capabilities::AuthorizationData;
 use sov_modules_api::capabilities::HasKernel;
+use sov_modules_api::capabilities::TransactionAuthenticator;
+use sov_modules_api::capabilities::UniquenessData;
+use sov_modules_api::Runtime;
 use sov_modules_api::{RawTx, Spec};
 use sov_sequencer::Sequencer;
 use std::sync::Arc;
@@ -51,8 +54,77 @@ where
         .make_raw_tx(raw_evm_tx)
         .map_err(|e| to_jsonrpsee_error_object(e, ETH_RPC_ERROR))?;
 
+    // Authenticate the transaction so that we can get the credential ID and nonce.
     let tx = Seq::Rt::encode_with_ethereum_auth(RawTx::new(raw_message));
+    let mut state = ethereum
+        .sequencer
+        .api_state()
+        .default_api_state_accessor()
+        .to_provable_reader();
+    let (_decoded_tx, auth_data, _call) =
+        <Seq::Rt as Runtime<S>>::Auth::authenticate(&tx, &mut state).map_err(|e| {
+            to_jsonrpsee_error_object(format!("Authentication failed: {e}"), ETH_RPC_ERROR)
+        })?;
+    let mut state = state.api_state_accessor;
+    let AuthorizationData {
+        credential_id,
+        uniqueness,
+        ..
+    } = auth_data;
+    drop(auth_data); // Drop the authorization data because it's not `Send`, so we can't hold it across retries.
+    let retries = if ethereum.buffer_raw_txs {
+        MAX_RETRIES
+    } else {
+        0
+    };
+    let start = std::time::Instant::now();
+    for _ in 0..retries {
+        match uniqueness {
+            UniquenessData::Nonce(nonce) => {
+                let expected_nonce = sov_uniqueness::Uniqueness::<S>::default()
+                    .nonce(&credential_id, &mut state)?
+                    .unwrap_or_default();
+                if nonce == expected_nonce {
+                    ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
+                        to_jsonrpsee_error_object(
+                            format!("{} - '{}' ({:?})", e.status, e.message, e.details),
+                            ETH_RPC_ERROR,
+                        )
+                    })?;
 
+                    return on_success(tx_hash, ethereum);
+                } else if nonce < expected_nonce {
+                    return Err(to_jsonrpsee_error_object(
+                        format!("Nonce error: nonce {nonce} has already been used"),
+                        ETH_RPC_ERROR,
+                    ));
+                } else if nonce > (expected_nonce + FUTURE_NONCE_THRESHOLD) {
+                    return Err(to_jsonrpsee_error_object(
+                        format!(
+                            "Nonce error: Provided nonce {nonce} is in the future. Expected nonce is {expected_nonce}",
+                        ),
+                        ETH_RPC_ERROR,
+                    ));
+                }
+            }
+            _ => {
+                return Err(to_jsonrpsee_error_object(
+                    "Invalid uniqueness data",
+                    ETH_RPC_ERROR,
+                ));
+            }
+        }
+        // tokio::time::sleep can have unreliable timing under load, so if the total time we've been retrying is too large we'll break the loop early.
+        if start.elapsed().as_millis() > MAX_BUFFER_DURATION_MS {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(SLEEP_DURATION_MS)).await;
+        state = ethereum.sequencer.api_state().default_api_state_accessor();
+    }
+
+    // Once we've exhausted all retries, make one "regular" attempt to accept the transaction.
+    // This ensures that every tx is attempted at least once even if MAX_RETRIES is set to zero
+    // and provides some protection against spuriously rejecting txs in case our view of the state was stale.
     ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
         to_jsonrpsee_error_object(
             format!("{} - '{}' ({:?})", e.status, e.message, e.details),

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -15,9 +15,6 @@ use sov_evm::Evm;
 use sov_evm::RlpEvmTransaction;
 use sov_modules_api::capabilities::AuthorizationData;
 use sov_modules_api::capabilities::HasKernel;
-use sov_modules_api::capabilities::TransactionAuthenticator;
-use sov_modules_api::capabilities::UniquenessData;
-use sov_modules_api::Runtime;
 use sov_modules_api::{RawTx, Spec};
 use sov_sequencer::Sequencer;
 use std::sync::Arc;
@@ -54,77 +51,8 @@ where
         .make_raw_tx(raw_evm_tx)
         .map_err(|e| to_jsonrpsee_error_object(e, ETH_RPC_ERROR))?;
 
-    // Authenticate the transaction so that we can get the credential ID and nonce.
     let tx = Seq::Rt::encode_with_ethereum_auth(RawTx::new(raw_message));
-    let mut state = ethereum
-        .sequencer
-        .api_state()
-        .default_api_state_accessor()
-        .to_provable_reader();
-    let (_decoded_tx, auth_data, _call) =
-        <Seq::Rt as Runtime<S>>::Auth::authenticate(&tx, &mut state).map_err(|e| {
-            to_jsonrpsee_error_object(format!("Authentication failed: {e}"), ETH_RPC_ERROR)
-        })?;
-    let mut state = state.api_state_accessor;
-    let AuthorizationData {
-        credential_id,
-        uniqueness,
-        ..
-    } = auth_data;
-    drop(auth_data); // Drop the authorization data because it's not `Send`, so we can't hold it across retries.
-    let retries = if ethereum.buffer_raw_txs {
-        MAX_RETRIES
-    } else {
-        0
-    };
-    let start = std::time::Instant::now();
-    for _ in 0..retries {
-        match uniqueness {
-            UniquenessData::Nonce(nonce) => {
-                let expected_nonce = sov_uniqueness::Uniqueness::<S>::default()
-                    .nonce(&credential_id, &mut state)?
-                    .unwrap_or_default();
-                if nonce == expected_nonce {
-                    ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
-                        to_jsonrpsee_error_object(
-                            format!("{} - '{}' ({:?})", e.status, e.message, e.details),
-                            ETH_RPC_ERROR,
-                        )
-                    })?;
 
-                    return on_success(tx_hash, ethereum);
-                } else if nonce < expected_nonce {
-                    return Err(to_jsonrpsee_error_object(
-                        format!("Nonce error: nonce {nonce} has already been used"),
-                        ETH_RPC_ERROR,
-                    ));
-                } else if nonce > (expected_nonce + FUTURE_NONCE_THRESHOLD) {
-                    return Err(to_jsonrpsee_error_object(
-                        format!(
-                            "Nonce error: Provided nonce {nonce} is in the future. Expected nonce is {expected_nonce}",
-                        ),
-                        ETH_RPC_ERROR,
-                    ));
-                }
-            }
-            _ => {
-                return Err(to_jsonrpsee_error_object(
-                    "Invalid uniqueness data",
-                    ETH_RPC_ERROR,
-                ));
-            }
-        }
-        // tokio::time::sleep can have unreliable timing under load, so if the total time we've been retrying is too large we'll break the loop early.
-        if start.elapsed().as_millis() > MAX_BUFFER_DURATION_MS {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(SLEEP_DURATION_MS)).await;
-        state = ethereum.sequencer.api_state().default_api_state_accessor();
-    }
-
-    // Once we've exhausted all retries, make one "regular" attempt to accept the transaction.
-    // This ensures that every tx is attempted at least once even if MAX_RETRIES is set to zero
-    // and provides some protection against spuriously rejecting txs in case our view of the state was stale.
     ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
         to_jsonrpsee_error_object(
             format!("{} - '{}' ({:?})", e.status, e.message, e.details),

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -304,7 +304,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             panic!("Accepting a transaction, yet there's no in-progress batch. This is a bug in the sequencer, please report it.");
         };
 
-        let (call, _) = Rt::Auth::decode_serialized_tx(&baked_tx.tx)?;
+        let call = Rt::Auth::decode_serialized_tx(&baked_tx.tx)?;
         let call = Rt::wrap_call(call);
 
         if let Err(TrySendError::Full(_)) = task_state.tx_sender.try_send(baked_tx) {

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -39,7 +39,6 @@ use sov_modules_api::{
     ApiTxEffect, FullyBakedTx, RejectReason, Runtime, RuntimeEventProcessor, RuntimeEventResponse,
     Spec, StateCheckpoint, StateUpdateInfo, VersionReader, VisibleSlotNumber, *,
 };
-use sov_modules_api::{SkippedTxContents, TxProcessingError};
 use sov_modules_stf_blueprint::PreExecError;
 use sov_rest_utils::errors::internal_server_error_500;
 use sov_rest_utils::errors::{database_error_500, sequencer_overloaded_503};
@@ -867,7 +866,7 @@ where
             .api_state()
             .default_api_state_accessor()
             .to_provable_reader();
-        let (_, auth_data, call) = <Rt as Runtime<S>>::Auth::authenticate(&baked_tx, &mut state)
+        let (_, _, call) = <Rt as Runtime<S>>::Auth::authenticate(&baked_tx, &mut state)
             .map_err(|e| pre_exec_err_to_accept_tx_err(PreExecError::AuthError(e)))?;
         let call = Rt::wrap_call(call);
         let delay_ms = runtime.get_transaction_delay_ms(&call);

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -861,18 +861,19 @@ where
 
         // Check if this transaction has a configured delay
         let runtime = Rt::default();
-        let call = match Rt::Auth::decode_serialized_tx(&baked_tx) {
-            Ok((call, _)) => call,
-            Err(_) => {
-                return Err(ErrorObject {
+        let mut state = self
+            .api_state()
+            .default_api_state_accessor()
+            .to_provable_reader();
+        let (_, auth_data, call) =
+            <Rt as Runtime<S>>::Auth::authenticate(&baked_tx, &mut state).map_err(|_|
+                ErrorObject {
                     status: StatusCode::BAD_REQUEST,
                     message: "Unable to decode transaction".to_string(),
                     details: sov_rest_utils::json_obj!({
                         "error": "Unable to decode transaction".to_string(),
                     }),
-                });
-            }
-        };
+        })?;
         let call = Rt::wrap_call(call);
         let delay_ms = runtime.get_transaction_delay_ms(&call);
 

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -39,6 +39,8 @@ use sov_modules_api::{
     ApiTxEffect, FullyBakedTx, RejectReason, Runtime, RuntimeEventProcessor, RuntimeEventResponse,
     Spec, StateCheckpoint, StateUpdateInfo, VersionReader, VisibleSlotNumber, *,
 };
+use sov_modules_api::{SkippedTxContents, TxProcessingError};
+use sov_modules_stf_blueprint::PreExecError;
 use sov_rest_utils::errors::internal_server_error_500;
 use sov_rest_utils::errors::{database_error_500, sequencer_overloaded_503};
 use sov_rollup_interface::common::SlotNumber;
@@ -63,8 +65,8 @@ use transaction_subscriptions::TransactionCache;
 
 use crate::common::{
     error_not_fully_synced, generic_accept_tx_error, loop_send_tx_notifications, poll_state_update,
-    AcceptedTx, Sequencer, SequencerEventStream, StateUpdateError, StateUpdateNotification,
-    SubscriptionStreamError, WithCachedTxHashes,
+    pre_exec_err_to_accept_tx_err, AcceptedTx, Sequencer, SequencerEventStream, StateUpdateError,
+    StateUpdateNotification, SubscriptionStreamError, WithCachedTxHashes,
 };
 use crate::metrics::{track_in_progress_batch_size, PreferredSequencerFetchBatchesToReplayMetrics};
 use crate::preferred::block_executor::{RollupBlockExecutor, RollupBlockExecutorError};
@@ -865,15 +867,8 @@ where
             .api_state()
             .default_api_state_accessor()
             .to_provable_reader();
-        let (_, auth_data, call) =
-            <Rt as Runtime<S>>::Auth::authenticate(&baked_tx, &mut state).map_err(|_|
-                ErrorObject {
-                    status: StatusCode::BAD_REQUEST,
-                    message: "Unable to decode transaction".to_string(),
-                    details: sov_rest_utils::json_obj!({
-                        "error": "Unable to decode transaction".to_string(),
-                    }),
-        })?;
+        let (_, auth_data, call) = <Rt as Runtime<S>>::Auth::authenticate(&baked_tx, &mut state)
+            .map_err(|e| pre_exec_err_to_accept_tx_err(PreExecError::AuthError(e)))?;
         let call = Rt::wrap_call(call);
         let delay_ms = runtime.get_transaction_delay_ms(&call);
 

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -65,7 +65,7 @@ generate_optimistic_runtime_with_kernel!(
     },
     transaction_priority_wrapper: |call: &sov_modules_api::FullyBakedTx| {
         use sov_modules_api::capabilities::TransactionAuthenticator;
-        let Ok((call, _)) = Self::Auth::decode_serialized_tx(call) else {
+        let Ok(call) = Self::Auth::decode_serialized_tx(call) else {
             return 0;
         };
         match call {

--- a/crates/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-evm/Cargo.toml
@@ -45,7 +45,6 @@ jsonrpsee = { workspace = true, features = [
 ], optional = true }
 schemars = { workspace = true }
 tracing = { workspace = true }
-quick_cache = { workspace = true }
 
 alloy-eips = { workspace = true, features = ["std"] }
 # `rlp` feature implicitly enabled via `reth-` crates, but this allows us to explicitly access Error type from there

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -1,6 +1,4 @@
 use std::marker::PhantomData;
-#[cfg(feature = "native")]
-use std::sync::LazyLock;
 
 use alloy_consensus::{transaction::SignerRecoverable, Transaction};
 use alloy_eips::eip2718::Decodable2718;
@@ -27,12 +25,13 @@ use crate::conversions::RlpConversionError;
 use crate::TransactionSigned;
 use crate::{call, CallMessage, RlpEvmTransaction};
 
-/// At 5k TPS, this gives us 50 seconds of cache lifetime at a cost of (about 70 bytes per entry - which is about 17.5 MB). This should be long enough that signatures almost always
-/// last until the node has processed the block.
 #[cfg(feature = "native")]
-static SIGNATURE_CACHE: LazyLock<
-    quick_cache::sync::Cache<TxHash, Result<Address, AuthenticationError>>,
-> = LazyLock::new(|| quick_cache::sync::Cache::new(250_000));
+use sov_modules_api::capabilities::{SignatureVerificationCache, DEFAULT_SIGNATURE_CACHE_SIZE};
+
+/// At default size, and ~70 bytes per entry, this costs about 17.5 MB at the default size.
+#[cfg(feature = "native")]
+static SIGNATURE_CACHE: std::sync::LazyLock<SignatureVerificationCache<Address>> =
+    std::sync::LazyLock::new(|| SignatureVerificationCache::new(DEFAULT_SIGNATURE_CACHE_SIZE));
 
 /// Recovers the signer from an EVM transaction.
 fn recover_evm_signer(

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -221,28 +221,19 @@ where
     #[cfg(feature = "native")]
     fn decode_serialized_tx(
         tx: &FullyBakedTx,
-    ) -> Result<(Self::Decodable, AuthorizationData<S>), sov_modules_api::capabilities::FatalError>
-    {
+    ) -> Result<Self::Decodable, sov_modules_api::capabilities::FatalError> {
         let auth_variant: EvmAuthenticatorInput = borsh::from_slice(&tx.data).map_err(|e| {
             sov_modules_api::capabilities::FatalError::DeserializationFailed(e.to_string())
         })?;
 
         match auth_variant {
             EvmAuthenticatorInput::Evm(raw_tx) => {
-                let (call, tx) = decode_evm_tx(&raw_tx.data)?;
-                let hash = TxHash::new(**tx.hash());
-                let signer = recover_evm_signer(&tx, hash).map_err(|e| {
-                    sov_modules_api::capabilities::FatalError::DeserializationFailed(e.to_string())
-                })?;
-                let auth_data = extract_evm_authorization_data::<S>(signer, hash, tx.nonce());
-                Ok((
-                    EvmAuthenticatorInput::Evm(call::CallMessage { rlp: call }),
-                    auth_data,
-                ))
+                let (call, _tx) = decode_evm_tx(&raw_tx.data)?;
+                Ok(EvmAuthenticatorInput::Evm(call::CallMessage { rlp: call }))
             }
             EvmAuthenticatorInput::Standard(raw_tx) => {
-                let (call, auth) = capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)?;
-                Ok((EvmAuthenticatorInput::Standard(call), auth))
+                let call = capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)?;
+                Ok(EvmAuthenticatorInput::Standard(call))
             }
         }
     }

--- a/crates/module-system/sov-eip712-auth/src/lib.rs
+++ b/crates/module-system/sov-eip712-auth/src/lib.rs
@@ -82,22 +82,23 @@ where
     #[cfg(feature = "native")]
     fn decode_serialized_tx(
         tx: &FullyBakedTx,
-    ) -> Result<(Self::Decodable, AuthorizationData<S>), sov_modules_api::capabilities::FatalError>
-    {
+    ) -> Result<Self::Decodable, sov_modules_api::capabilities::FatalError> {
         let auth_variant: Eip712AuthenticatorInput = borsh::from_slice(&tx.data).map_err(|e| {
             sov_modules_api::capabilities::FatalError::DeserializationFailed(e.to_string())
         })?;
 
         match auth_variant {
             Eip712AuthenticatorInput::Standard(raw_tx) => {
-                sov_modules_api::capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)
+                let call = sov_modules_api::capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)?;
+                Ok(call)
             }
             Eip712AuthenticatorInput::Eip712(raw_tx) => {
-                sov_modules_api::capabilities::decode_sov_tx_with_cryptospec::<
+                let call = sov_modules_api::capabilities::decode_sov_tx_with_cryptospec::<
                     S,
                     Rt,
                     <<S as Spec>::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec,
-                >(&raw_tx.data)
+                >(&raw_tx.data)?;
+                Ok(call)
             }
         }
     }

--- a/crates/module-system/sov-eip712-auth/src/lib.rs
+++ b/crates/module-system/sov-eip712-auth/src/lib.rs
@@ -9,7 +9,8 @@ use sov_modules_api::capabilities::{
 };
 use sov_modules_api::sov_universal_wallet::schema::Schema;
 use sov_modules_api::transaction::{
-    AuthenticatedTransactionAndRawHash, Credentials, Transaction, TransactionVerificationError,
+    AuthenticatedTransactionAndRawHash, Credentials, PubKeyAndSignature, Transaction,
+    TransactionVerificationError,
 };
 use sov_modules_api::{
     CryptoSpec, DispatchCall, FullyBakedTx, GasMeter, MeteredBorshDeserialize,
@@ -24,6 +25,13 @@ pub use crate::crypto_markers::{CryptoSpecWithSecp256k1, Secp256k1CryptoSpec};
 mod stub_evm_rpc;
 #[cfg(feature = "native")]
 pub use stub_evm_rpc::stub_evm_rpc;
+
+#[cfg(feature = "native")]
+use sov_modules_api::capabilities::{SignatureVerificationCache, DEFAULT_SIGNATURE_CACHE_SIZE};
+
+#[cfg(feature = "native")]
+static SIGNATURE_CACHE: std::sync::LazyLock<SignatureVerificationCache<()>> =
+    std::sync::LazyLock::new(|| SignatureVerificationCache::new(DEFAULT_SIGNATURE_CACHE_SIZE));
 
 /// Trait for providing schema to the EIP-712 authenticator.
 pub trait SchemaProvider {
@@ -89,16 +97,14 @@ where
 
         match auth_variant {
             Eip712AuthenticatorInput::Standard(raw_tx) => {
-                let call = sov_modules_api::capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)?;
-                Ok(call)
+                sov_modules_api::capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)
             }
             Eip712AuthenticatorInput::Eip712(raw_tx) => {
-                let call = sov_modules_api::capabilities::decode_sov_tx_with_cryptospec::<
+                sov_modules_api::capabilities::decode_sov_tx_with_cryptospec::<
                     S,
                     Rt,
                     <<S as Spec>::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec,
-                >(&raw_tx.data)?;
-                Ok(call)
+                >(&raw_tx.data)
             }
         }
     }
@@ -240,15 +246,12 @@ fn verify_and_decode_tx<
                     .chain(tx_v1.unused_pub_keys.iter().cloned())
                     .collect::<Vec<_>>(),
             );
-            let msg = eip_712_msg::<S, D, SP>(&tx, raw_tx_hash)?;
-            multisig
-                .verify_signature(&msg, &tx_v1.signatures)
-                .map_err(|e| {
-                    AuthenticationError::FatalError(
-                        FatalError::SigVerificationFailed(e.to_string()),
-                        raw_tx_hash,
-                    )
-                })?;
+            verify_eip712_multisig_signature::<S, D, SP>(
+                &tx,
+                &multisig,
+                &tx_v1.signatures,
+                raw_tx_hash,
+            )?;
             let credential_id = multisig.credential_id::<<S::CryptoSpec as CryptoSpec>::Hasher>();
             let authorization_data = AuthorizationData {
                 uniqueness: tx_v1.uniqueness,
@@ -318,9 +321,14 @@ fn verify_eip712_signature<
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<(), AuthenticationError> {
-    let eip712_hash = eip_712_msg::<S, D, SP>(tx, raw_tx_hash)?;
+    #[cfg(feature = "native")]
+    if let Some(known_result) = SIGNATURE_CACHE.get(&raw_tx_hash) {
+        return known_result;
+    }
 
-    tx.verify_signature(&eip712_hash, meter)
+    let eip712_hash = eip_712_msg::<S, D, SP>(tx, raw_tx_hash)?;
+    let res = tx
+        .verify_signature(&eip712_hash, meter)
         .map_err(|e| match e {
             TransactionVerificationError::GasError(_) => {
                 AuthenticationError::OutOfGas(e.to_string())
@@ -329,5 +337,41 @@ fn verify_eip712_signature<
                 FatalError::SigVerificationFailed(e.to_string()),
                 raw_tx_hash,
             ),
-        })
+        });
+
+    #[cfg(feature = "native")]
+    SIGNATURE_CACHE.insert(raw_tx_hash, res.clone());
+
+    res
+}
+
+fn verify_eip712_multisig_signature<
+    S: Spec<CryptoSpec: Secp256k1CryptoSpec>,
+    D: DispatchCall<Spec = S>,
+    SP: SchemaProvider,
+>(
+    tx: &Transaction<D, S, <S::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec>,
+    multisig: &Multisig<
+        <<S::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec as CryptoSpec>::PublicKey,
+    >,
+    signatures: &[PubKeyAndSignature<<S::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec>],
+    raw_tx_hash: TxHash,
+) -> Result<(), AuthenticationError> {
+    #[cfg(feature = "native")]
+    if let Some(known_result) = SIGNATURE_CACHE.get(&raw_tx_hash) {
+        return known_result;
+    }
+
+    let msg = eip_712_msg::<S, D, SP>(tx, raw_tx_hash)?;
+    let res = multisig.verify_signature(&msg, signatures).map_err(|e| {
+        AuthenticationError::FatalError(
+            FatalError::SigVerificationFailed(e.to_string()),
+            raw_tx_hash,
+        )
+    });
+
+    #[cfg(feature = "native")]
+    SIGNATURE_CACHE.insert(raw_tx_hash, res.clone());
+
+    res
 }

--- a/crates/module-system/sov-modules-api/Cargo.toml
+++ b/crates/module-system/sov-modules-api/Cargo.toml
@@ -61,6 +61,7 @@ utoipa = { workspace = true, optional = true }
 utoipa-swagger-ui = { workspace = true, optional = true }
 unwrap-infallible = { workspace = true }
 nearly-linear = { workspace = true }
+quick_cache = { workspace = true, optional = true }
 
 [dev-dependencies]
 sov-state = { workspace = true, features = ["native", "test-utils"] }
@@ -107,6 +108,7 @@ native = [
     "clap",
     "jsonrpsee",
     "heck",
+    "quick_cache",
     "serde_yaml",
     "sov-bank/native",
     "sov-db",

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -2,7 +2,6 @@
 //! transactions within a rollup.
 
 use std::marker::PhantomData;
-use std::sync::LazyLock;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use digest::Digest;
@@ -111,11 +110,9 @@ pub trait TransactionAuthenticator<S: Spec> {
 ///
 /// # Usage Example
 /// ```rust,ignore
-/// use std::sync::LazyLock;
-///
 /// #[cfg(feature = "native")]
-/// static SIGNATURE_CACHE: LazyLock<SignatureVerificationCache<()>> =
-///     LazyLock::new(|| quick_cache::sync::Cache::new(DEFAULT_SIGNATURE_CACHE_SIZE));
+/// static SIGNATURE_CACHE: std::sync::LazyLock<SignatureVerificationCache<()>> =
+///     std::sync::LazyLock::new(|| SignatureVerificationCache::new(DEFAULT_SIGNATURE_CACHE_SIZE));
 ///
 /// fn verify_signature(...) -> Result<(), AuthenticationError> {
 ///     #[cfg(feature = "native")]
@@ -137,9 +134,8 @@ pub type SignatureVerificationCache<T> =
 #[cfg(feature = "native")]
 /// The default size for signature verification caches.
 ///
-/// At 5k TPS, this gives us 50 seconds of cache lifetime at a cost of (about 70 bytes per entry
-/// - which is about 17.5 MB). This should be long enough that signatures almost always last until
-/// the node has processed the block.
+/// At 5k TPS, this gives us 50 seconds of cache lifetime. This should be long enough that
+/// signatures almost always last until the node has processed the block.
 pub const DEFAULT_SIGNATURE_CACHE_SIZE: usize = 250_000;
 
 /// See [`RollupAuthenticator`].
@@ -154,8 +150,8 @@ pub enum AuthenticatorInput {
 }
 
 #[cfg(feature = "native")]
-static SIGNATURE_CACHE: LazyLock<SignatureVerificationCache<()>> =
-    LazyLock::new(|| quick_cache::sync::Cache::new(DEFAULT_SIGNATURE_CACHE_SIZE));
+static SIGNATURE_CACHE: std::sync::LazyLock<SignatureVerificationCache<()>> =
+    std::sync::LazyLock::new(|| SignatureVerificationCache::new(DEFAULT_SIGNATURE_CACHE_SIZE));
 
 /// Canonical implementation of [`TransactionAuthenticator`].
 #[derive(Debug, PartialEq, Clone, Default)]

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -2,6 +2,7 @@
 //! transactions within a rollup.
 
 use std::marker::PhantomData;
+use std::sync::LazyLock;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use digest::Digest;
@@ -52,6 +53,9 @@ pub trait TransactionAuthenticator<S: Spec> {
 
     /// Authenticates a transaction (typically by checking the signature) and deserializes its contents
     /// into an executable message.
+    /// For rollups running a preferred sequencer it is expected that implementations cache signature
+    /// checks during native execution, and the preferred sequencer will attempt to pre-populate this
+    /// cache to parallelise signature checks.
     fn authenticate<Accessor: ProvableStateReader<User, Spec = S> + GetGasPrice<Spec = S>>(
         tx: &FullyBakedTx,
         state: &mut Accessor,
@@ -96,6 +100,48 @@ pub trait TransactionAuthenticator<S: Spec> {
     }
 }
 
+#[cfg(feature = "native")]
+/// A helper type intended for caching the results of signature verification outside of the ZKVM.
+/// In particular, the preferred sequencer expects a cache to be available and attempts to warm it
+/// upon receiving a transaction, prior to executing it inside the STF.
+///
+/// # Type Parameter
+/// - `T`: The success type of the verification result. Can be `()` if only success/failure is
+///   stored.
+///
+/// # Usage Example
+/// ```rust,ignore
+/// use std::sync::LazyLock;
+///
+/// #[cfg(feature = "native")]
+/// static SIGNATURE_CACHE: LazyLock<SignatureVerificationCache<()>> =
+///     LazyLock::new(|| quick_cache::sync::Cache::new(DEFAULT_SIGNATURE_CACHE_SIZE));
+///
+/// fn verify_signature(...) -> Result<(), AuthenticationError> {
+///     #[cfg(feature = "native")]
+///     if let Some(cached) = SIGNATURE_CACHE.get(&tx_hash) {
+///         return cached;
+///     }
+///
+///     let result = /* actual verification */;
+///
+///     #[cfg(feature = "native")]
+///     SIGNATURE_CACHE.insert(tx_hash, result.clone());
+///
+///     result
+/// }
+/// ```
+pub type SignatureVerificationCache<T> =
+    quick_cache::sync::Cache<TxHash, Result<T, AuthenticationError>>;
+
+#[cfg(feature = "native")]
+/// The default size for signature verification caches.
+///
+/// At 5k TPS, this gives us 50 seconds of cache lifetime at a cost of (about 70 bytes per entry
+/// - which is about 17.5 MB). This should be long enough that signatures almost always last until
+/// the node has processed the block.
+pub const DEFAULT_SIGNATURE_CACHE_SIZE: usize = 250_000;
+
 /// See [`RollupAuthenticator`].
 #[derive(std::fmt::Debug, Clone, borsh::BorshDeserialize, borsh::BorshSerialize)]
 pub enum AuthenticatorInput {
@@ -106,6 +152,10 @@ pub enum AuthenticatorInput {
     /// backwards-compatible way.
     Standard(RawTx),
 }
+
+#[cfg(feature = "native")]
+static SIGNATURE_CACHE: LazyLock<SignatureVerificationCache<()>> =
+    LazyLock::new(|| quick_cache::sync::Cache::new(DEFAULT_SIGNATURE_CACHE_SIZE));
 
 /// Canonical implementation of [`TransactionAuthenticator`].
 #[derive(Debug, PartialEq, Clone, Default)]
@@ -284,13 +334,23 @@ fn verify_signature<S: Spec, D: DispatchCall<Spec = S>>(
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<(), AuthenticationError> {
-    tx.verify(chain_hash, meter).map_err(|e| match e {
+    #[cfg(feature = "native")]
+    if let Some(known_result) = SIGNATURE_CACHE.get(&raw_tx_hash) {
+        return known_result;
+    }
+
+    let res = tx.verify(chain_hash, meter).map_err(|e| match e {
         TransactionVerificationError::GasError(_) => AuthenticationError::OutOfGas(e.to_string()),
         _ => AuthenticationError::FatalError(
             FatalError::SigVerificationFailed(e.to_string()),
             raw_tx_hash,
         ),
-    })
+    });
+
+    #[cfg(feature = "native")]
+    SIGNATURE_CACHE.insert(raw_tx_hash, res.clone());
+
+    res
 }
 
 /// Extracts authorization data from a verified transaction.

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -64,9 +64,7 @@ pub trait TransactionAuthenticator<S: Spec> {
     /// Decode a transaction into a message.
     /// This method doesn’t charge gas for deserialization, so it’s meant for off-chain code only (hence to the `native` feature).
     #[cfg(feature = "native")]
-    fn decode_serialized_tx(
-        tx: &FullyBakedTx,
-    ) -> Result<(Self::Decodable, AuthorizationData<S>), FatalError>;
+    fn decode_serialized_tx(tx: &FullyBakedTx) -> Result<Self::Decodable, FatalError>;
 
     /// Authenticates raw transaction that is submitted from unregistered sequencers for the
     /// purpose of forced registration (circumventing censorship by currently registered sequencers).
@@ -122,9 +120,7 @@ where
     type Input = AuthenticatorInput;
 
     #[cfg(feature = "native")]
-    fn decode_serialized_tx(
-        tx: &FullyBakedTx,
-    ) -> Result<(Self::Decodable, AuthorizationData<S>), FatalError> {
+    fn decode_serialized_tx(tx: &FullyBakedTx) -> Result<Self::Decodable, FatalError> {
         let AuthenticatorInput::Standard(tx) = borsh::from_slice(&tx.data)
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
 
@@ -459,7 +455,7 @@ pub fn authenticate_unregistered<
 #[cfg(feature = "native")]
 pub fn decode_sov_tx<S: Spec, D: DispatchCall<Spec = S>>(
     raw_tx: &[u8],
-) -> Result<(D::Decodable, AuthorizationData<S>), FatalError> {
+) -> Result<D::Decodable, FatalError> {
     decode_sov_tx_with_cryptospec::<S, D, <S as Spec>::CryptoSpec>(raw_tx)
 }
 /// Decode bytes as a Sovereign SDK transaction, returning the message and tx info.
@@ -467,23 +463,12 @@ pub fn decode_sov_tx<S: Spec, D: DispatchCall<Spec = S>>(
 #[cfg(feature = "native")]
 pub fn decode_sov_tx_with_cryptospec<S: Spec, D: DispatchCall<Spec = S>, C: CryptoSpecExt>(
     mut raw_tx: &[u8],
-) -> Result<(D::Decodable, AuthorizationData<S>), FatalError> {
+) -> Result<D::Decodable, FatalError> {
     let tx =
         <Transaction<D, S, C> as MeteredBorshDeserialize<S>>::unmetered_deserialize(&mut raw_tx)
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
 
-    let mut unmeter = crate::UnlimitedGasMeter::<S>::default();
-    let authorization_data = match &tx {
-        Transaction::V0(v0) => {
-            extract_authorization_data::<S, D, C>(v0, calculate_hash::<S>(raw_tx), &mut unmeter)
-        }
-        Transaction::V1(v1) => {
-            extract_authorization_data_v1::<S, D, C>(v1, calculate_hash::<S>(raw_tx), &mut unmeter)
-        }
-    }
-    .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
-
-    Ok((tx.call(), authorization_data))
+    Ok(tx.call())
 }
 
 /// Calculates the hash of `data` and charges gas.

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -228,41 +228,17 @@ fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage
 }
 
 /// Decode bytes as a Sovereign SDK transaction, returning the message and tx info.
-#[cfg(feature = "native")]
-pub fn decode_solana_json_tx<S, D>(
-    raw_tx: &[u8],
-) -> Result<
-    (
-        D::Decodable,
-        sov_modules_api::capabilities::AuthorizationData<S>,
-    ),
-    FatalError,
->
+pub fn decode_solana_json_tx<S, D>(raw_tx: &[u8]) -> Result<D::Decodable, FatalError>
 where
     S: Spec,
     D: DispatchCall<Spec = S>,
     <D as DispatchCall>::Decodable: Serialize + DeserializeOwned,
 {
-    use sov_modules_api::{capabilities::calculate_hash, PublicKey};
-
     let unpacked_message = unpack_solana_message::<S>(raw_tx)?;
     let solana_unsigned_tx: SolanaOffchainUnsignedTransaction<D, S> =
         serde_json::from_slice(unpacked_message.json_bytes())
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
-    let unsigned_tx = solana_unsigned_tx.into_unsigned_tx();
-
-    let pub_key = unpacked_message.pub_key;
-    let credential_id = pub_key.credential_id();
-
-    let auth_data = sov_modules_api::capabilities::AuthorizationData {
-        uniqueness: unsigned_tx.uniqueness,
-        tx_hash: calculate_hash::<S>(raw_tx),
-        credential_id,
-        credentials: sov_modules_api::transaction::Credentials::new(pub_key),
-        default_address: credential_id.into(),
-    };
-
-    Ok((unsigned_tx.call(), auth_data))
+    Ok(solana_unsigned_tx.into_unsigned_tx().call())
 }
 
 pub fn authenticate<Accessor, S, D>(

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -16,6 +16,13 @@ use sov_modules_api::{
     ProvableStateReader, SafeString, Spec, TxHash,
 };
 
+#[cfg(feature = "native")]
+use sov_modules_api::capabilities::{SignatureVerificationCache, DEFAULT_SIGNATURE_CACHE_SIZE};
+
+#[cfg(feature = "native")]
+static SIGNATURE_CACHE: std::sync::LazyLock<SignatureVerificationCache<()>> =
+    std::sync::LazyLock::new(|| SignatureVerificationCache::new(DEFAULT_SIGNATURE_CACHE_SIZE));
+
 /// The payload for a solana offchain message.
 /// Essentially a wrapper around `sov_modules_api::transaction::UnsignedTransaction` that also
 /// includes the chain_hash, in order to ensure the hash gets signed as part of the message.
@@ -154,7 +161,12 @@ fn verify_solana_signature<S: Spec>(
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<(), AuthenticationError> {
-    MeteredSignature::new::<S>(signature.clone())
+    #[cfg(feature = "native")]
+    if let Some(known_result) = SIGNATURE_CACHE.get(&raw_tx_hash) {
+        return known_result;
+    }
+
+    let res = MeteredSignature::new::<S>(signature.clone())
         .verify(pub_key, signed_bytes, meter)
         .map_err(|e| match e {
             sov_modules_api::MeteredSigVerificationError::BadSignature(err) => {
@@ -168,7 +180,12 @@ fn verify_solana_signature<S: Spec>(
                     "Signature verification ran out of gas: {err}"
                 ))
             }
-        })
+        });
+
+    #[cfg(feature = "native")]
+    SIGNATURE_CACHE.insert(raw_tx_hash, res.clone());
+
+    res
 }
 
 fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage<S>, FatalError> {

--- a/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
@@ -60,12 +60,10 @@ where
 
         match auth_variant {
             SolanaOffchainAuthenticatorInput::Standard(raw_tx) => {
-                let call = sov_modules_api::capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)?;
-                Ok(call)
+                sov_modules_api::capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)
             }
             SolanaOffchainAuthenticatorInput::SolanaOffchain(raw_tx) => {
-                let call = decode_solana_json_tx::<S, Rt>(&raw_tx.data)?;
-                Ok(call)
+                decode_solana_json_tx::<S, Rt>(&raw_tx.data)
             }
         }
     }

--- a/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
@@ -50,13 +50,7 @@ where
     #[cfg(feature = "native")]
     fn decode_serialized_tx(
         tx: &FullyBakedTx,
-    ) -> Result<
-        (
-            Self::Decodable,
-            sov_modules_api::capabilities::AuthorizationData<S>,
-        ),
-        sov_modules_api::capabilities::FatalError,
-    > {
+    ) -> Result<Self::Decodable, sov_modules_api::capabilities::FatalError> {
         use crate::authentication::decode_solana_json_tx;
 
         let auth_variant: SolanaOffchainAuthenticatorInput =
@@ -66,10 +60,12 @@ where
 
         match auth_variant {
             SolanaOffchainAuthenticatorInput::Standard(raw_tx) => {
-                sov_modules_api::capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)
+                let call = sov_modules_api::capabilities::decode_sov_tx::<S, Rt>(&raw_tx.data)?;
+                Ok(call)
             }
             SolanaOffchainAuthenticatorInput::SolanaOffchain(raw_tx) => {
-                decode_solana_json_tx::<S, Rt>(&raw_tx.data)
+                let call = decode_solana_json_tx::<S, Rt>(&raw_tx.data)?;
+                Ok(call)
             }
         }
     }

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -9,7 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -2861,16 +2860,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
 name = "parking_lot_core"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3216,18 +3205,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick_cache"
-version = "0.6.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad6644cb07b7f3488b9f3d2fde3b4c0a7fa367cafefb39dff93a659f76eb786"
-dependencies = [
- "ahash",
- "equivalent",
- "hashbrown 0.15.5",
- "parking_lot",
-]
 
 [[package]]
 name = "quote"
@@ -4574,7 +4551,6 @@ dependencies = [
  "derive_more 1.0.0",
  "hex",
  "itertools 0.14.0",
- "quick_cache",
  "reth-ethereum-primitives",
  "reth-primitives",
  "reth-primitives-traits",

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -9,7 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.3",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -2231,16 +2230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
-name = "lock_api"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,29 +2580,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,18 +2812,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick_cache"
-version = "0.6.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad6644cb07b7f3488b9f3d2fde3b4c0a7fa367cafefb39dff93a659f76eb786"
-dependencies = [
- "ahash",
- "equivalent",
- "hashbrown 0.15.5",
- "parking_lot",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,15 +2901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
-dependencies = [
- "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -3671,12 +3616,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4108,7 +4047,6 @@ dependencies = [
  "derive_more 1.0.0",
  "hex",
  "itertools 0.14.0",
- "quick_cache",
  "reth-ethereum-primitives",
  "reth-primitives",
  "reth-primitives-traits",

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -35,7 +35,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -4506,18 +4505,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick_cache"
-version = "0.6.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad6644cb07b7f3488b9f3d2fde3b4c0a7fa367cafefb39dff93a659f76eb786"
-dependencies = [
- "ahash",
- "equivalent",
- "hashbrown 0.15.0",
- "parking_lot",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6029,7 +6016,6 @@ dependencies = [
  "derive_more 1.0.0",
  "hex",
  "itertools 0.14.0",
- "quick_cache",
  "reth-ethereum-primitives",
  "reth-primitives",
  "reth-primitives-traits",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -35,7 +35,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -4143,18 +4142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick_cache"
-version = "0.6.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad6644cb07b7f3488b9f3d2fde3b4c0a7fa367cafefb39dff93a659f76eb786"
-dependencies = [
- "ahash",
- "equivalent",
- "hashbrown 0.15.0",
- "parking_lot",
-]
-
-[[package]]
 name = "quinn"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5610,7 +5597,6 @@ dependencies = [
  "derive_more 1.0.0",
  "hex",
  "itertools 0.14.0",
- "quick_cache",
  "reth-ethereum-primitives",
  "reth-primitives",
  "reth-primitives-traits",


### PR DESCRIPTION
# Description

Reverts #1998 in favour of adding signature caches to every authenticator and calling `authenticate()` in the sequencer. Adds a central definition for the cache type since every authenticator will reuse an almost identical cache.

- [ ] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
