### PR TITLE
Separate transaction signature gas metering from verification

### DIFF
--- a/crates/module-system/sov-cli/tests/integration/transactions.rs
+++ b/crates/module-system/sov-cli/tests/integration/transactions.rs
@@ -14,9 +14,7 @@ use sov_test_utils::runtime::{
     Runtime as RuntimeTrait, RuntimeSubcommand as TestRuntimeSubcommand, TestOptimisticRuntime,
     TestOptimisticRuntimeCall,
 };
-use sov_test_utils::{
-    new_test_gas_meter, TestSpec, TEST_DEFAULT_MAX_FEE, TEST_DEFAULT_MAX_PRIORITY_FEE,
-};
+use sov_test_utils::{TestSpec, TEST_DEFAULT_MAX_FEE, TEST_DEFAULT_MAX_PRIORITY_FEE};
 
 type Runtime = TestOptimisticRuntime<TestSpec>;
 type RuntimeCall = TestOptimisticRuntimeCall<TestSpec>;
@@ -107,7 +105,7 @@ fn transaction_is_serialized_correctly() {
             ),
         );
 
-        tx.verify(&chain_hash, &mut new_test_gas_meter())
+        tx.verify_signature_unmetered(&tx.serialized_with_chain_hash(&chain_hash).unwrap())
             .expect("the computed signature is incorrect");
 
         assert_eq!(
@@ -194,9 +192,10 @@ fn transaction_signed_properly_from_file() {
     let signed_tx: Transaction<Runtime, TestSpec> =
         Transaction::unmetered_deserialize(&mut raw_signed_tx.as_slice()).unwrap();
     signed_tx
-        .verify(
-            &<Runtime as RuntimeTrait<TestSpec>>::CHAIN_HASH,
-            &mut new_test_gas_meter(),
+        .verify_signature_unmetered(
+            &signed_tx
+                .serialized_with_chain_hash(&<Runtime as RuntimeTrait<TestSpec>>::CHAIN_HASH)
+                .unwrap(),
         )
         .unwrap();
 
@@ -249,9 +248,10 @@ fn transaction_signed_properly_from_json_string() {
     let signed_tx: Transaction<Runtime, TestSpec> =
         Transaction::unmetered_deserialize(&mut raw_signed_tx.as_slice()).unwrap();
     signed_tx
-        .verify(
-            &<Runtime as RuntimeTrait<TestSpec>>::CHAIN_HASH,
-            &mut new_test_gas_meter(),
+        .verify_signature_unmetered(
+            &signed_tx
+                .serialized_with_chain_hash(&<Runtime as RuntimeTrait<TestSpec>>::CHAIN_HASH)
+                .unwrap(),
         )
         .unwrap();
     assert_eq!(&runtime_call, signed_tx.runtime_call());
@@ -310,9 +310,10 @@ fn transaction_signed_by_account_nickname() {
     let signed_tx: Transaction<Runtime, TestSpec> =
         Transaction::unmetered_deserialize(&mut raw_signed_tx.as_slice()).unwrap();
     signed_tx
-        .verify(
-            &<Runtime as RuntimeTrait<TestSpec>>::CHAIN_HASH,
-            &mut new_test_gas_meter(),
+        .verify_signature_unmetered(
+            &signed_tx
+                .serialized_with_chain_hash(&<Runtime as RuntimeTrait<TestSpec>>::CHAIN_HASH)
+                .unwrap(),
         )
         .unwrap();
 
@@ -369,9 +370,10 @@ fn transaction_outputs_json() {
     let signed_tx: Transaction<Runtime, TestSpec> =
         Transaction::unmetered_deserialize(&mut raw_signed_tx).unwrap();
     signed_tx
-        .verify(
-            &<Runtime as RuntimeTrait<TestSpec>>::CHAIN_HASH,
-            &mut new_test_gas_meter(),
+        .verify_signature_unmetered(
+            &signed_tx
+                .serialized_with_chain_hash(&<Runtime as RuntimeTrait<TestSpec>>::CHAIN_HASH)
+                .unwrap(),
         )
         .unwrap();
 }

--- a/crates/module-system/sov-eip712-auth/src/lib.rs
+++ b/crates/module-system/sov-eip712-auth/src/lib.rs
@@ -327,13 +327,16 @@ fn verify_eip712_signature<
     // and then on cache hit using it to charge gas before short-circuiting
     let eip712_hash = eip_712_msg::<S, D, SP>(tx, raw_tx_hash)?;
 
-    tx.charge_gas_for_signature(&eip712_hash, meter).map_err(|e| match e {
-        TransactionVerificationError::GasError(_) => AuthenticationError::OutOfGas(e.to_string()),
-        _ => AuthenticationError::FatalError(
-            FatalError::SigVerificationFailed(e.to_string()),
-            raw_tx_hash,
-        ),
-    })?;
+    tx.charge_gas_for_signature(&eip712_hash, meter)
+        .map_err(|e| match e {
+            TransactionVerificationError::GasError(_) => {
+                AuthenticationError::OutOfGas(e.to_string())
+            }
+            _ => AuthenticationError::FatalError(
+                FatalError::SigVerificationFailed(e.to_string()),
+                raw_tx_hash,
+            ),
+        })?;
 
     #[cfg(feature = "native")]
     if let Some(known_result) = SIGNATURE_CACHE.get(&raw_tx_hash) {

--- a/crates/module-system/sov-eip712-auth/src/lib.rs
+++ b/crates/module-system/sov-eip712-auth/src/lib.rs
@@ -237,6 +237,8 @@ fn verify_and_decode_tx<
         }
         Transaction::V1(tx_v1) => {
             verify_chain_id(&tx_v1.details, raw_tx_hash)?;
+            // TODO: this logic is duplicated (and also doesn't charge gas for the credential), we
+            // should use extract_authorization_data_v1() here
             let multisig = Multisig::new(
                 tx_v1.min_signers,
                 tx_v1
@@ -321,14 +323,25 @@ fn verify_eip712_signature<
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<(), AuthenticationError> {
+    // TODO: this could be cached as well, but would require querying the cache before charging gas
+    // and then on cache hit using it to charge gas before short-circuiting
+    let eip712_hash = eip_712_msg::<S, D, SP>(tx, raw_tx_hash)?;
+
+    tx.charge_gas_for_signature(&eip712_hash, meter).map_err(|e| match e {
+        TransactionVerificationError::GasError(_) => AuthenticationError::OutOfGas(e.to_string()),
+        _ => AuthenticationError::FatalError(
+            FatalError::SigVerificationFailed(e.to_string()),
+            raw_tx_hash,
+        ),
+    })?;
+
     #[cfg(feature = "native")]
     if let Some(known_result) = SIGNATURE_CACHE.get(&raw_tx_hash) {
         return known_result;
     }
 
-    let eip712_hash = eip_712_msg::<S, D, SP>(tx, raw_tx_hash)?;
     let res = tx
-        .verify_signature(&eip712_hash, meter)
+        .verify_signature_unmetered(&eip712_hash)
         .map_err(|e| match e {
             TransactionVerificationError::GasError(_) => {
                 AuthenticationError::OutOfGas(e.to_string())

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -330,13 +330,12 @@ fn verify_signature<S: Spec, D: DispatchCall<Spec = S>>(
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<(), AuthenticationError> {
-    let mut serialized_tx = borsh::to_vec(&tx.to_unsigned_transaction()).map_err(|e| {
+    let serialized_tx = tx.serialized_with_chain_hash(chain_hash).map_err(|e| {
         AuthenticationError::FatalError(
             FatalError::DeserializationFailed(e.to_string()),
             raw_tx_hash,
         )
     })?;
-    serialized_tx.extend_from_slice(chain_hash);
 
     tx.charge_gas_for_signature(&serialized_tx, meter)
         .map_err(|e| match e {

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -330,12 +330,25 @@ fn verify_signature<S: Spec, D: DispatchCall<Spec = S>>(
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<(), AuthenticationError> {
+    let mut serialized_tx = borsh::to_vec(&tx.to_unsigned_transaction()).map_err(|e| {
+        AuthenticationError::FatalError(FatalError::DeserializationFailed(e.to_string()), raw_tx_hash)
+    })?;
+    serialized_tx.extend_from_slice(chain_hash);
+
+    tx.charge_gas_for_signature(&serialized_tx, meter).map_err(|e| match e {
+        TransactionVerificationError::GasError(_) => AuthenticationError::OutOfGas(e.to_string()),
+        _ => AuthenticationError::FatalError(
+            FatalError::SigVerificationFailed(e.to_string()),
+            raw_tx_hash,
+        ),
+    })?;
+
     #[cfg(feature = "native")]
     if let Some(known_result) = SIGNATURE_CACHE.get(&raw_tx_hash) {
         return known_result;
     }
 
-    let res = tx.verify(chain_hash, meter).map_err(|e| match e {
+    let res = tx.verify_signature_unmetered(&serialized_tx).map_err(|e| match e {
         TransactionVerificationError::GasError(_) => AuthenticationError::OutOfGas(e.to_string()),
         _ => AuthenticationError::FatalError(
             FatalError::SigVerificationFailed(e.to_string()),

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -331,30 +331,40 @@ fn verify_signature<S: Spec, D: DispatchCall<Spec = S>>(
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<(), AuthenticationError> {
     let mut serialized_tx = borsh::to_vec(&tx.to_unsigned_transaction()).map_err(|e| {
-        AuthenticationError::FatalError(FatalError::DeserializationFailed(e.to_string()), raw_tx_hash)
+        AuthenticationError::FatalError(
+            FatalError::DeserializationFailed(e.to_string()),
+            raw_tx_hash,
+        )
     })?;
     serialized_tx.extend_from_slice(chain_hash);
 
-    tx.charge_gas_for_signature(&serialized_tx, meter).map_err(|e| match e {
-        TransactionVerificationError::GasError(_) => AuthenticationError::OutOfGas(e.to_string()),
-        _ => AuthenticationError::FatalError(
-            FatalError::SigVerificationFailed(e.to_string()),
-            raw_tx_hash,
-        ),
-    })?;
+    tx.charge_gas_for_signature(&serialized_tx, meter)
+        .map_err(|e| match e {
+            TransactionVerificationError::GasError(_) => {
+                AuthenticationError::OutOfGas(e.to_string())
+            }
+            _ => AuthenticationError::FatalError(
+                FatalError::SigVerificationFailed(e.to_string()),
+                raw_tx_hash,
+            ),
+        })?;
 
     #[cfg(feature = "native")]
     if let Some(known_result) = SIGNATURE_CACHE.get(&raw_tx_hash) {
         return known_result;
     }
 
-    let res = tx.verify_signature_unmetered(&serialized_tx).map_err(|e| match e {
-        TransactionVerificationError::GasError(_) => AuthenticationError::OutOfGas(e.to_string()),
-        _ => AuthenticationError::FatalError(
-            FatalError::SigVerificationFailed(e.to_string()),
-            raw_tx_hash,
-        ),
-    });
+    let res = tx
+        .verify_signature_unmetered(&serialized_tx)
+        .map_err(|e| match e {
+            TransactionVerificationError::GasError(_) => {
+                AuthenticationError::OutOfGas(e.to_string())
+            }
+            _ => AuthenticationError::FatalError(
+                FatalError::SigVerificationFailed(e.to_string()),
+                raw_tx_hash,
+            ),
+        });
 
     #[cfg(feature = "native")]
     SIGNATURE_CACHE.insert(raw_tx_hash, res.clone());

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -412,6 +412,19 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
         }
     }
 
+    /// Serialize the transaction, appending the runtime's chain_hash.
+    /// This is the standard serialization for Sovereign signature signing.
+    pub fn serialized_with_chain_hash(
+        &self,
+        chain_hash: &[u8; 32],
+    ) -> Result<Vec<u8>, TransactionVerificationError<S::Gas>> {
+        let mut serialized_tx = borsh::to_vec(&self.to_unsigned_transaction()).map_err(|e| {
+            TransactionVerificationError::TransactionDeserializationError(e.to_string())
+        })?;
+        serialized_tx.extend_from_slice(chain_hash);
+        Ok(serialized_tx)
+    }
+
     /// Charge gas for verifying the transaction signature against the given message.
     pub fn charge_gas_for_signature(
         &self,

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use sov_rollup_interface::common::SafeVec;
 #[cfg(feature = "native")]
 pub use sov_rollup_interface::crypto::PrivateKey;
-use sov_rollup_interface::crypto::SigVerificationError;
+use sov_rollup_interface::crypto::{Signature, SigVerificationError};
 use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
 use sov_rollup_interface::zk::CryptoSpec;
 use sov_rollup_interface::TxHash;
@@ -387,26 +387,6 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
         }
     }
 
-    /// Check whether the transaction has been signed correctly.
-    ///
-    /// # Errors
-    /// Returns an error if:
-    ///  * The signature is wrong
-    ///  * Serializing or hashing the transaction fails
-    ///  * Any operation runs out of gas
-    pub fn verify(
-        &self,
-        chain_hash: &[u8; 32],
-        meter: &mut impl GasMeter<Spec = S>,
-    ) -> Result<(), TransactionVerificationError<S::Gas>> {
-        let mut serialized_tx = borsh::to_vec(&self.to_unsigned_transaction()).map_err(|e| {
-            TransactionVerificationError::TransactionDeserializationError(e.to_string())
-        })?;
-        serialized_tx.extend_from_slice(chain_hash);
-
-        self.verify_signature(&serialized_tx, meter)
-    }
-
     /// Creates a new transaction with the provided metadata.
     pub fn new_with_details_v0(
         pub_key: C::PublicKey,
@@ -432,8 +412,8 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
         }
     }
 
-    /// Verify the transaction signature against the provided message.
-    pub fn verify_signature(
+    /// Charge gas for verifying the transaction signature against the given message.
+    pub fn charge_gas_for_signature(
         &self,
         msg: &[u8],
         meter: &mut impl GasMeter<Spec = S>,
@@ -441,7 +421,7 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
         match &self {
             Transaction::V0(inner) => {
                 MeteredSignature::new::<S>(inner.signature.clone())
-                    .verify(&inner.pub_key, msg, meter)
+                    .charge_gas(meter, msg)
                     .map_err(TransactionVerificationError::from)?;
             }
             Transaction::V1(inner) => {
@@ -451,6 +431,26 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
                         .charge_gas(meter, msg)
                         .map_err(TransactionVerificationError::from)?;
                 }
+            }
+        }
+        Ok(())
+    }
+
+
+    /// Verify the transaction signature against the provided message.
+    /// *Does not* charge gas for verification. Callers are responsible for calling
+    /// `charge_gas_for_signature()` with the same message for gas metering.
+    pub fn verify_signature_unmetered(
+        &self,
+        msg: &[u8],
+    ) -> Result<(), TransactionVerificationError<S::Gas>> {
+        match &self {
+            Transaction::V0(inner) => {
+                inner.signature
+                    .verify(&inner.pub_key, msg)
+                    .map_err(TransactionVerificationError::BadSignature)?;
+            }
+            Transaction::V1(inner) => {
                 let all_signers = inner
                     .signatures
                     .iter()

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use sov_rollup_interface::common::SafeVec;
 #[cfg(feature = "native")]
 pub use sov_rollup_interface::crypto::PrivateKey;
-use sov_rollup_interface::crypto::{Signature, SigVerificationError};
+use sov_rollup_interface::crypto::{SigVerificationError, Signature};
 use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
 use sov_rollup_interface::zk::CryptoSpec;
 use sov_rollup_interface::TxHash;
@@ -436,7 +436,6 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
         Ok(())
     }
 
-
     /// Verify the transaction signature against the provided message.
     /// *Does not* charge gas for verification. Callers are responsible for calling
     /// `charge_gas_for_signature()` with the same message for gas metering.
@@ -446,7 +445,8 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
     ) -> Result<(), TransactionVerificationError<S::Gas>> {
         match &self {
             Transaction::V0(inner) => {
-                inner.signature
+                inner
+                    .signature
                     .verify(&inner.pub_key, msg)
                     .map_err(TransactionVerificationError::BadSignature)?;
             }


### PR DESCRIPTION
# Description

This allows caching the verification step without affecting the gas metering.

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [ ] ~~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
