### PR TITLE
Making `DaSerive::get_signer` return Option of the Address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-11-05
+- #2025 Breaking change for DaService implementations: `DaService::get_signer` now returns option. It is possible to return None if DaService can be configured without signer.
+
 # 2025-11-01
 - #2013 Ensure `eth_getLogsWithCursor` respects a 1MB response size limit. Fix its cursor deserialization behavior to match other chains.
 - #2006 Add associated Error type to the EVM module.

--- a/crates/adapters/celestia/src/checker.rs
+++ b/crates/adapters/celestia/src/checker.rs
@@ -1,12 +1,12 @@
 //! Utilities to check Celestia adapter in production settings.
 
-use std::collections::HashMap;
-use std::hash::{DefaultHasher, Hash, Hasher};
-
+use anyhow::Context;
 use rand::RngCore;
 use sov_rollup_interface::common::HexHash;
 use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait};
 use sov_rollup_interface::node::da::{DaService, SlotData};
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
 
 use crate::CelestiaService;
 
@@ -32,7 +32,10 @@ async fn check_blobs_roundtrip(
     blobs: &[Vec<u8>],
 ) -> anyhow::Result<()> {
     let mut sent_blobs: HashMap<u64, HexHash> = HashMap::with_capacity(blobs.len());
-    let sender = da_service.get_signer().await;
+    let sender = da_service
+        .get_signer()
+        .await
+        .context("Checker can only run with DaService supporting submission")?;
 
     let head_before = da_service.get_head_block_header().await?;
     // Padding from the previous round

--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -495,14 +495,8 @@ impl DaService for CelestiaService {
         .await
     }
 
-    // TODO: Follow up: Should this become and Result or Option?
-    async fn get_signer(&self) -> <Self::Spec as DaSpec>::Address {
-        match self.signer_address.clone() {
-            None => {
-                panic!("Node is not configured for submission, signer address is unknown");
-            }
-            Some(signer) => signer,
-        }
+    async fn get_signer(&self) -> Option<<Self::Spec as DaSpec>::Address> {
+        self.signer_address.clone()
     }
 }
 

--- a/crates/adapters/celestia/src/da_service/tests.rs
+++ b/crates/adapters/celestia/src/da_service/tests.rs
@@ -66,7 +66,10 @@ async fn test_submit_blob_correct() -> anyhow::Result<()> {
     let dev_node = crate::test_helper::docker::CelestiaDevNode::start().await?;
     let config = dev_node.get_config().await?;
     let da_service = CelestiaService::new(config, rollup_params).await;
-    let signer = da_service.get_signer().await;
+    let signer = da_service
+        .get_signer()
+        .await
+        .expect("Should be configured with signer");
 
     let blob = vec![1, 2, 3, 4, 5, 11, 12, 13, 14, 15];
     let height_before = da_service.get_head_block_header().await?.height();
@@ -90,7 +93,10 @@ async fn test_submit_proof_correct() -> anyhow::Result<()> {
     let da_service = CelestiaService::new(config, ROLLUP_PARAMS_DEV).await;
 
     let zk_proof: Vec<u8> = vec![1, 2, 3, 4, 5, 11, 12, 13, 14, 15];
-    let signer = da_service.get_signer().await;
+    let signer = da_service
+        .get_signer()
+        .await
+        .expect("Should be configured with signer");
 
     let height_before = da_service.get_head_block_header().await?.height();
     let response = da_service.send_proof(&zk_proof).await.await??;

--- a/crates/adapters/celestia/src/test_helper/docker.rs
+++ b/crates/adapters/celestia/src/test_helper/docker.rs
@@ -301,7 +301,7 @@ async fn test_service_starts() -> anyhow::Result<()> {
     tracing::info!("CONFIG: {:?}", config);
     let da_service = CelestiaService::new(config, crate::test_helper::ROLLUP_PARAMS_DEV).await;
     let signer = da_service.get_signer().await;
-    assert_eq!(signer, dev_node.get_signer_address(0).await?);
+    assert_eq!(signer, Some(dev_node.get_signer_address(0).await?));
     let header_1 = da_service.get_head_block_header().await?;
     let blob = vec![0, 1, 2, 3, 4];
     let _result = da_service.send_transaction(&blob).await.await??;

--- a/crates/adapters/mock-da/src/in_memory/service.rs
+++ b/crates/adapters/mock-da/src/in_memory/service.rs
@@ -432,8 +432,8 @@ impl DaService for MockDaService {
             .collect())
     }
 
-    async fn get_signer(&self) -> <Self::Spec as DaSpec>::Address {
-        self.sequencer_da_address
+    async fn get_signer(&self) -> Option<<Self::Spec as DaSpec>::Address> {
+        Some(self.sequencer_da_address)
     }
 }
 

--- a/crates/adapters/mock-da/src/storable/rpc/client.rs
+++ b/crates/adapters/mock-da/src/storable/rpc/client.rs
@@ -190,7 +190,7 @@ impl DaService for StorableMockDaClient {
         Ok(proofs)
     }
 
-    async fn get_signer(&self) -> <Self::Spec as DaSpec>::Address {
+    async fn get_signer(&self) -> Option<<Self::Spec as DaSpec>::Address> {
         let url = self.url("/signer").expect("Bad url");
         let response = self
             .client
@@ -202,6 +202,6 @@ impl DaService for StorableMockDaClient {
         let signer_response: SignerResponse = handle_response(response)
             .await
             .expect("Failed to parse signer response");
-        signer_response.address
+        Some(signer_response.address)
     }
 }

--- a/crates/adapters/mock-da/src/storable/rpc/server.rs
+++ b/crates/adapters/mock-da/src/storable/rpc/server.rs
@@ -190,7 +190,11 @@ pub(crate) async fn get_proofs_at_handler(
 pub(crate) async fn get_signer_handler(
     State(state): State<AppState>,
 ) -> Result<Json<SignerResponse>, (StatusCode, Json<ErrorResponse>)> {
-    let address = state.da_service.get_signer().await;
+    let address = state
+        .da_service
+        .get_signer()
+        .await
+        .expect("MockDa always has signer");
     Ok(Json(SignerResponse { address }))
 }
 

--- a/crates/adapters/mock-da/src/storable/service.rs
+++ b/crates/adapters/mock-da/src/storable/service.rs
@@ -94,7 +94,7 @@ impl DaService for StorableMockDaService {
         self.block_producer_handle.lock().await.take()
     }
 
-    async fn get_signer(&self) -> <Self::Spec as DaSpec>::Address {
-        self.sequencer_da_address
+    async fn get_signer(&self) -> Option<<Self::Spec as DaSpec>::Address> {
+        Some(self.sequencer_da_address)
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -17,6 +17,7 @@ mod update_state;
 use crate::preferred::block_executor::RollupBlockExecutorConfig;
 use crate::preferred::cache_warm_up_executor::CacheWarmUpExecutor;
 use crate::preferred::replica::replica_sync_task::ReplicaSyncTask;
+use anyhow::Context;
 use async_trait::async_trait;
 use axum::http::StatusCode;
 use batch_size_tracker::BatchSizeTracker;
@@ -132,7 +133,10 @@ where
     ) -> anyhow::Result<(Arc<Self>, Vec<JoinHandle<()>>)> {
         let shutdown_receiver = shutdown_sender.subscribe();
         let latest_state_update = state_update_receiver.borrow().clone();
-        let da_address = da.get_signer().await;
+        let da_address = da
+            .get_signer()
+            .await
+            .context("Sequencer must have DaService configured with submit support")?;
 
         debug!(
             ?latest_state_update,

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -2,6 +2,7 @@
 
 mod mempool;
 
+use anyhow::Context;
 use async_trait::async_trait;
 use axum::http::StatusCode;
 pub use full_node_configs::sequencer::StdSequencerConfig;
@@ -126,7 +127,9 @@ where
         let checkpoint =
             StateCheckpoint::new(latest_state_update.storage.clone(), &runtime.kernel());
 
-        let da_address = da.get_signer().await;
+        let da_address = da.get_signer().await.context(
+            "Standard sequencer require DaService to be configured with submitting support",
+        )?;
 
         let nb_of_concurrent_blob_submissions = Arc::new(AtomicUsize::new(0));
         let (blob_sender, blob_sender_handle) = BlobSender::new(

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -230,7 +230,9 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     background_handles,
                     proof_sender: sequencer,
                     api_ledger_db: api_ledger_db.clone(),
-                    da_address: da_service.get_signer().await.context("Full node with standard sequencer require DaService with signer support")?,
+                    da_address: da_service.get_signer().await.context(
+                        "Full node with standard sequencer require DaService with signer support",
+                    )?,
                 })
             }
             SequencerKindConfig::Preferred(seq_config) => {
@@ -260,7 +262,9 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     background_handles,
                     proof_sender: sequencer,
                     api_ledger_db: api_ledger_db.clone(),
-                    da_address: da_service.get_signer().await.context("Full node with preferred sequencer require DaService with signer support")?,
+                    da_address: da_service.get_signer().await.context(
+                        "Full node with preferred sequencer require DaService with signer support",
+                    )?,
                 })
             }
         }

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -230,7 +230,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     background_handles,
                     proof_sender: sequencer,
                     api_ledger_db: api_ledger_db.clone(),
-                    da_address: da_service.get_signer().await,
+                    da_address: da_service.get_signer().await.context("XX")?,
                 })
             }
             SequencerKindConfig::Preferred(seq_config) => {
@@ -260,7 +260,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     background_handles,
                     proof_sender: sequencer,
                     api_ledger_db: api_ledger_db.clone(),
-                    da_address: da_service.get_signer().await,
+                    da_address: da_service.get_signer().await.context("XX")?,
                 })
             }
         }

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -230,7 +230,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     background_handles,
                     proof_sender: sequencer,
                     api_ledger_db: api_ledger_db.clone(),
-                    da_address: da_service.get_signer().await.context("XX")?,
+                    da_address: da_service.get_signer().await.context("Full node with standard sequencer require DaService with signer support")?,
                 })
             }
             SequencerKindConfig::Preferred(seq_config) => {
@@ -260,7 +260,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     background_handles,
                     proof_sender: sequencer,
                     api_ledger_db: api_ledger_db.clone(),
-                    da_address: da_service.get_signer().await.context("XX")?,
+                    da_address: da_service.get_signer().await.context("Full node with preferred sequencer require DaService with signer support")?,
                 })
             }
         }

--- a/crates/rollup-interface/src/node/da.rs
+++ b/crates/rollup-interface/src/node/da.rs
@@ -250,8 +250,9 @@ pub trait DaService: Clone + Send + Sync + 'static {
         None
     }
 
-    /// Returns a [`DaSpec::Address`] that signs blobs submitted by this instance of [`DaService`]
-    async fn get_signer(&self) -> <Self::Spec as DaSpec>::Address;
+    /// Returns a [`DaSpec::Address`] that signs blobs submitted by this instance of [`DaService`].
+    /// If `None` means that instance of DaService is not capable of sending blobs and can be used only in node mode.
+    async fn get_signer(&self) -> Option<<Self::Spec as DaSpec>::Address>;
 }
 
 /// Retry the given async function with the given backoff policy.


### PR DESCRIPTION
# Description

This way it is possible to initialize DaService without any signer when only node is suppose to run.

This is not currently supported, but "NoOpSequencer" can be easily added to have "only-node" mode

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All Existing tests are passing

## Docs
Docstrings have been updated