### PR TITLE
Fix graceful shutdown with active WebSocket subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-11-05
+- #2027 Fix graceful shutdown with active WebSocket subscriptions. The rollup now properly shuts down within 2-5 seconds when Ctrl+C is pressed, even with active `eth_subscribe` connections.
+
 # 2025-11-01
 - #2013 Ensure `eth_getLogsWithCursor` respects a 1MB response size limit. Fix its cursor deserialization behavior to match other chains.
 - #2006 Add associated Error type to the EVM module.

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -65,18 +65,33 @@ where
         let mut block = self.get_block(pending_block.header.number - 1, &mut state)?;
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
-        while state_updates.changed().await.is_ok() {
-            let mut state = self.ethereum.api_state_accessor();
-            let pending_block = self.evm.pending_block(&mut state);
+        let mut shutdown_receiver = self.ethereum.shutdown_receiver.clone();
 
-            for tx_idx in tx_watermark.advance(..pending_block.transactions.end) {
-                let receipt = self.get_receipt(tx_idx, &mut state)?;
+        loop {
+            tokio::select! {
+                result = state_updates.changed() => {
+                    if result.is_err() {
+                        tracing::debug!("Subscription state updates channel closed, terminating logs subscription");
+                        break;
+                    }
 
-                if block.number() != receipt.block_number {
-                    block = self.get_block(receipt.block_number, &mut state)?;
+                    let mut state = self.ethereum.api_state_accessor();
+                    let pending_block = self.evm.pending_block(&mut state);
+
+                    for tx_idx in tx_watermark.advance(..pending_block.transactions.end) {
+                        let receipt = self.get_receipt(tx_idx, &mut state)?;
+
+                        if block.number() != receipt.block_number {
+                            block = self.get_block(receipt.block_number, &mut state)?;
+                        }
+
+                        self.send_matching_logs(&receipt, &block, &filter).await?;
+                    }
                 }
-
-                self.send_matching_logs(&receipt, &block, &filter).await?;
+                _ = shutdown_receiver.changed() => {
+                    tracing::info!("Shutdown signal received, terminating logs subscription gracefully");
+                    break;
+                }
             }
         }
         Ok(())
@@ -89,13 +104,28 @@ where
         let mut block_watermark = Watermark::new(..pending_block.header.number + 1);
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
-        while state_updates.changed().await.is_ok() {
-            let mut state = self.ethereum.api_state_accessor();
-            let pending_block = self.evm.pending_block(&mut state);
+        let mut shutdown_receiver = self.ethereum.shutdown_receiver.clone();
 
-            for block_number in block_watermark.advance(..pending_block.header.number + 1) {
-                let block = self.get_block(block_number, &mut state)?;
-                self.send_block_header(&block).await?;
+        loop {
+            tokio::select! {
+                result = state_updates.changed() => {
+                    if result.is_err() {
+                        tracing::debug!("Subscription state updates channel closed, terminating blocks subscription");
+                        break;
+                    }
+
+                    let mut state = self.ethereum.api_state_accessor();
+                    let pending_block = self.evm.pending_block(&mut state);
+
+                    for block_number in block_watermark.advance(..pending_block.header.number + 1) {
+                        let block = self.get_block(block_number, &mut state)?;
+                        self.send_block_header(&block).await?;
+                    }
+                }
+                _ = shutdown_receiver.changed() => {
+                    tracing::info!("Shutdown signal received, terminating blocks subscription gracefully");
+                    break;
+                }
             }
         }
         Ok(())

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -196,7 +196,7 @@ where
                 .expect("Failed to serialize subscription message");
 
         self.sink.send(msg).await.inspect_err(|err| {
-            tracing::info!(%err, "The subscription client disconnected from the server.");
+            tracing::debug!(%err, "The subscription client disconnected from the server.");
         })
     }
 }

--- a/crates/full-node/sov-ethereum/src/lib.rs
+++ b/crates/full-node/sov-ethereum/src/lib.rs
@@ -25,6 +25,8 @@ pub struct EthRpcConfig {
     pub extension: SeqConfigExtension,
     /// Whether to buffer raw transactions with a future nonce. If true, we'll retry the transaction a few times to see if the missing intermediate nonce was consumed.
     pub buffer_raw_txs: bool,
+    /// Shutdown signal receiver for graceful termination
+    pub shutdown_receiver: tokio::sync::watch::Receiver<()>,
 }
 
 pub fn get_ethereum_rpc<S, Seq>(eth_rpc_config: EthRpcConfig, sequencer: Arc<Seq>) -> RpcModule<()>
@@ -40,6 +42,7 @@ where
         eth_signer,
         extension,
         buffer_raw_txs,
+        shutdown_receiver,
     } = eth_rpc_config;
 
     let mut rpc = RpcModule::new(Ethereum {
@@ -48,6 +51,7 @@ where
         eth_signer,
         extension,
         buffer_raw_txs,
+        shutdown_receiver,
     });
 
     register_rpc_methods::<S, Seq>(&mut rpc).expect("Failed to register sequencer RPC methods");
@@ -106,6 +110,7 @@ struct Ethereum<S: Spec, Seq: Sequencer<Spec = S>> {
     eth_signer: Signers,
     extension: SeqConfigExtension,
     buffer_raw_txs: bool,
+    shutdown_receiver: tokio::sync::watch::Receiver<()>,
 }
 
 impl<S, Seq> Ethereum<S, Seq>

--- a/crates/full-node/sov-stf-runner/src/http.rs
+++ b/crates/full-node/sov-stf-runner/src/http.rs
@@ -27,7 +27,8 @@ pub(crate) async fn start_http_server(
     let listener = tokio::net::TcpListener::bind(listen_address_http).await?;
     let rest_address = listener.local_addr()?;
 
-    let (rpc_router, server_handle) = rpc_module_to_router(methods, cors_configuration);
+    let (rpc_router, server_handle) =
+        rpc_module_to_router(methods, cors_configuration, shutdown_receiver.clone());
 
     let handle = tokio::spawn(async move {
         tracing::info!(%rest_address, "Starting HTTP server");
@@ -67,6 +68,7 @@ pub(crate) async fn start_http_server(
 pub fn rpc_module_to_router(
     methods: RpcModule<()>,
     cors_config: CorsConfiguration,
+    shutdown_receiver: watch::Receiver<()>,
 ) -> (axum::Router, jsonrpsee::server::ServerHandle) {
     let (stop_handle, server_handle) = jsonrpsee::server::stop_channel();
 
@@ -102,9 +104,11 @@ pub fn rpc_module_to_router(
     (
         axum::Router::new().route(
             "/",
-            axum::routing::get(move |ws_upgrade| ws_rpc_handler(ws_upgrade, methods.clone()))
-                .post_service(rpc_service)
-                .layer(cors_layer),
+            axum::routing::get(move |ws_upgrade| {
+                ws_rpc_handler(ws_upgrade, methods.clone(), shutdown_receiver)
+            })
+            .post_service(rpc_service)
+            .layer(cors_layer),
         ),
         server_handle,
     )
@@ -144,9 +148,10 @@ async fn measure_time(
 async fn ws_rpc_handler(
     ws: axum::extract::ws::WebSocketUpgrade,
     rpc_methods: RpcModule<()>,
+    shutdown_receiver: watch::Receiver<()>,
 ) -> impl axum::response::IntoResponse {
     ws.on_upgrade(move |socket| async move {
-        handle_socket(socket, rpc_methods).await;
+        handle_socket(socket, rpc_methods, shutdown_receiver.clone()).await;
     })
 }
 
@@ -156,13 +161,29 @@ async fn ws_rpc_handler(
 //    In the case of subscriptions, the reader task clones `tokio::sync::mpsc::Sender` and spawns another task,
 //    where subscription responses are piped to the writer task.
 // 2. Writer task listens to [`tokio::sync::mpsc::Receiver`] and writes responses to websocket.
-async fn handle_socket(socket: WebSocket, rpc_methods: RpcModule<()>) {
+//
+// When the WebSocket closes, the writer task exits and drops the socket_responses receiver,
+// which causes all subscription forwarding tasks to stop sending (their send() calls will fail).
+async fn handle_socket(
+    socket: WebSocket,
+    rpc_methods: RpcModule<()>,
+    shutdown_receiver: watch::Receiver<()>,
+) {
     let (sender, receiver) = socket.split();
 
     let (socket_requests, socket_responses) = tokio::sync::mpsc::channel(10);
 
-    tokio::spawn(handle_socket_write(socket_responses, sender));
-    tokio::spawn(handle_socket_read(receiver, socket_requests, rpc_methods));
+    tokio::spawn(handle_socket_write(
+        socket_responses,
+        sender,
+        shutdown_receiver.clone(),
+    ));
+    tokio::spawn(handle_socket_read(
+        receiver,
+        socket_requests,
+        rpc_methods,
+        shutdown_receiver.clone(),
+    ));
 }
 
 async fn handle_rpc_message(
@@ -198,10 +219,11 @@ async fn handle_rpc_message(
                             Message::Text(message.to_string())
                         };
                         if let Err(error) = subscription_responses.send(sub_message).await {
-                            tracing::error!(%error, "Error while sending RPC response");
+                            tracing::debug!(%error, "WebSocket closed, stopping subscription forwarding");
+                            break;
                         }
                     }
-                    tracing::trace!("Subscription channel closed");
+                    tracing::trace!("Subscription forwarding task finished");
                 });
             }
         }
@@ -215,32 +237,41 @@ async fn handle_socket_read(
     mut socket_requests: futures_util::stream::SplitStream<WebSocket>,
     socket_responses: tokio::sync::mpsc::Sender<Message>,
     rpc_methods: RpcModule<()>,
+    mut shutdown_receiver: watch::Receiver<()>,
 ) {
-    while let Some(Ok(msg)) = socket_requests.next().await {
-        tracing::trace!(message = ?msg, "Message received from websocket");
-        match msg {
-            Message::Text(text) => {
-                handle_rpc_message(&text, &socket_responses, &rpc_methods, false).await;
-            }
-            Message::Binary(data) => {
-                // Parse binary frame as UTF-8 JSON-RPC request
-                match std::str::from_utf8(&data) {
-                    Ok(text) => {
-                        handle_rpc_message(text, &socket_responses, &rpc_methods, true).await;
+    loop {
+        tokio::select! {
+            Some(Ok(msg)) = socket_requests.next() => {
+                tracing::trace!(message = ?msg, "Message received from websocket");
+                match msg {
+                    Message::Text(text) => {
+                        handle_rpc_message(&text, &socket_responses, &rpc_methods, false).await;
                     }
-                    Err(error) => {
-                        tracing::error!(%error, "Invalid UTF-8 in binary WebSocket frame");
+                    Message::Binary(data) => {
+                        // Parse binary frame as UTF-8 JSON-RPC request
+                        match std::str::from_utf8(&data) {
+                            Ok(text) => {
+                                handle_rpc_message(text, &socket_responses, &rpc_methods, true).await;
+                            }
+                            Err(error) => {
+                                tracing::error!(%error, "Invalid UTF-8 in binary WebSocket frame");
+                            }
+                        }
+                    }
+                    Message::Pong(_) => {}
+                    Message::Ping(ping) => {
+                        if socket_responses.send(Message::Pong(ping)).await.is_err() {
+                            tracing::error!("Websocket sender has been closed, aborting websocket");
+                            break;
+                        }
+                    }
+                    Message::Close(_) => {
+                        break;
                     }
                 }
             }
-            Message::Pong(_) => {}
-            Message::Ping(ping) => {
-                if socket_responses.send(Message::Pong(ping)).await.is_err() {
-                    tracing::error!("Websocket sender has been closed, aborting websocket");
-                    break;
-                }
-            }
-            Message::Close(_) => {
+            _ = shutdown_receiver.changed() => {
+                tracing::debug!("Shutdown signal received, stopping WebSocket read handler");
                 break;
             }
         }
@@ -251,13 +282,24 @@ async fn handle_socket_read(
 async fn handle_socket_write(
     mut socket_requests: tokio::sync::mpsc::Receiver<Message>,
     mut socket_responses: futures_util::stream::SplitSink<WebSocket, Message>,
+    mut shutdown_receiver: watch::Receiver<()>,
 ) {
-    while let Some(response) = socket_requests.recv().await {
-        if let Err(error) = socket_responses.send(response).await {
-            tracing::error!(%error, "Error while sending RPC response");
+    loop {
+        tokio::select! {
+            Some(response) = socket_requests.recv() => {
+                if let Err(error) = socket_responses.send(response).await {
+                    tracing::debug!(%error, "WebSocket closed, stopping writer task");
+                    break;
+                }
+                tracing::trace!("Message sent to websocket");
+            }
+            _ = shutdown_receiver.changed() => {
+                tracing::debug!("Shutdown signal received, stopping WebSocket write handler");
+                break;
+            }
         }
-        tracing::trace!("Message sent to websocket");
     }
+    tracing::trace!("WebSocket write handler finished");
 }
 
 #[cfg(test)]

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -181,6 +181,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         &self,
         _sequencer: Arc<Seq>,
         _rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        _shutdown_receiver: watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>
     where
         Seq: Sequencer<Spec = Self::Spec, Rt = Self::Runtime, Da = Self::DaService>,
@@ -218,7 +219,11 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     .await?;
 
                 let mut endpoints = self
-                    .sequencer_additional_apis(sequencer.clone(), rollup_config)
+                    .sequencer_additional_apis(
+                        sequencer.clone(),
+                        rollup_config,
+                        shutdown_receiver.clone(),
+                    )
                     .await?;
                 endpoints.axum_router = endpoints.axum_router.merge(
                     SequencerApis::rest_api_server(sequencer.clone(), shutdown_receiver),
@@ -248,7 +253,11 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     .await?;
 
                 let mut endpoints = self
-                    .sequencer_additional_apis(sequencer.clone(), rollup_config)
+                    .sequencer_additional_apis(
+                        sequencer.clone(),
+                        rollup_config,
+                        shutdown_receiver.clone(),
+                    )
                     .await?;
                 endpoints.axum_router = endpoints.axum_router.merge(
                     SequencerApis::rest_api_server(sequencer.clone(), shutdown_receiver),

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
@@ -105,6 +105,7 @@ where
         &self,
         sequencer: Arc<Seq>,
         _rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        _shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>
     where
         Seq: Sequencer<Spec = Self::Spec, Rt = Self::Runtime, Da = Self::DaService>,

--- a/examples/demo-rollup/src/celestia_nomt_rollup.rs
+++ b/examples/demo-rollup/src/celestia_nomt_rollup.rs
@@ -133,6 +133,7 @@ impl FullNodeBlueprint<Native> for CelestiaNomtDemoRollup<Native> {
         &self,
         sequencer: Arc<Seq>,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>
     where
         Seq: Sequencer<Spec = Self::Spec, Rt = Self::Runtime, Da = Self::DaService>,
@@ -142,6 +143,7 @@ impl FullNodeBlueprint<Native> for CelestiaNomtDemoRollup<Native> {
             eth_signer,
             extension: rollup_config.extension_or_panic(),
             buffer_raw_txs: true,
+            shutdown_receiver,
         };
 
         Ok(NodeEndpoints {

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -119,6 +119,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
         &self,
         sequencer: Arc<Seq>,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>
     where
         Seq: Sequencer<Spec = Self::Spec, Rt = Self::Runtime, Da = Self::DaService>,
@@ -128,6 +129,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
             eth_signer,
             extension: rollup_config.extension_or_panic(),
             buffer_raw_txs: true,
+            shutdown_receiver,
         };
 
         Ok(NodeEndpoints {

--- a/examples/demo-rollup/src/external_mock_nomt_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_nomt_rollup.rs
@@ -118,6 +118,7 @@ impl FullNodeBlueprint<Native> for ExternalMockNomtDemoRollup<Native> {
         &self,
         sequencer: Arc<Seq>,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>
     where
         Seq: Sequencer<Spec = Self::Spec, Rt = Self::Runtime, Da = Self::DaService>,
@@ -127,6 +128,7 @@ impl FullNodeBlueprint<Native> for ExternalMockNomtDemoRollup<Native> {
             eth_signer,
             extension: rollup_config.extension_or_panic(),
             buffer_raw_txs: true,
+            shutdown_receiver,
         };
 
         Ok(NodeEndpoints {

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -102,6 +102,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
         &self,
         sequencer: Arc<Seq>,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>
     where
         Seq: Sequencer<Spec = Self::Spec, Rt = Self::Runtime, Da = Self::DaService>,
@@ -111,6 +112,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
             eth_signer,
             extension: rollup_config.extension_or_panic(),
             buffer_raw_txs: true,
+            shutdown_receiver,
         };
 
         Ok(NodeEndpoints {

--- a/examples/demo-rollup/src/mock_nomt_rollup.rs
+++ b/examples/demo-rollup/src/mock_nomt_rollup.rs
@@ -115,6 +115,7 @@ impl FullNodeBlueprint<Native> for MockNomtDemoRollup<Native> {
         &self,
         sequencer: Arc<Seq>,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>
     where
         Seq: Sequencer<Spec = Self::Spec, Rt = Self::Runtime, Da = Self::DaService>,
@@ -124,6 +125,7 @@ impl FullNodeBlueprint<Native> for MockNomtDemoRollup<Native> {
             eth_signer,
             extension: rollup_config.extension_or_panic(),
             buffer_raw_txs: true,
+            shutdown_receiver,
         };
 
         Ok(NodeEndpoints {

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -101,6 +101,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
         &self,
         sequencer: Arc<Seq>,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>
     where
         Seq: Sequencer<Spec = Self::Spec, Rt = Self::Runtime, Da = Self::DaService>,
@@ -110,6 +111,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
             eth_signer,
             extension: rollup_config.extension_or_panic(),
             buffer_raw_txs: true,
+            shutdown_receiver,
         };
 
         Ok(NodeEndpoints {


### PR DESCRIPTION
# Description


When `eth_subscribe` WebSocket connections were active, the rollup would hang indefinitely on Ctrl+C instead of shutting down gracefully.

## Root Cause

- Subscription handlers in `sov-ethereum` weren't aware of shutdown signals
- WebSocket handler tasks used `while let` loops with no shutdown exit path
- Subscription forwarding tasks logged errors but continued running after WebSocket closure

## Solution

1. **Thread shutdown_receiver through the WebSocket pipeline** - from HTTP server → ws_rpc_handler → handle_socket → read/write tasks

2. **Convert loops to `tokio::select!`** - Both subscription handlers and WebSocket tasks now respond to shutdown signals

3. **Exit on send failure** - Subscription forwarding tasks now `break` instead of logging errors when WebSocket closes

4. **Downgrade logs** - WebSocket closure logs changed from ERROR to DEBUG (expected behavior)

----

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
