### PR TITLE
feat(avail): handle all MultiAddress variants in transaction parsing

### DIFF
--- a/crates/adapters/avail/src/spec/transaction.rs
+++ b/crates/adapters/avail/src/spec/transaction.rs
@@ -51,8 +51,29 @@ impl AvailBlobTransaction {
     #[cfg(feature = "native")]
     pub fn new(unchecked_extrinsic: &AppUncheckedExtrinsic) -> anyhow::Result<Self> {
         let address = match &unchecked_extrinsic.signature {
-            //TODO: Handle other types of MultiAddress.
             Some((subxt::utils::MultiAddress::Id(id), _, _)) => AvailAddress::from(id.clone().0),
+            Some((subxt::utils::MultiAddress::Address32(addr), _, _)) => AvailAddress::from(*addr),
+            Some((subxt::utils::MultiAddress::Raw(raw), _, _)) => {
+                if raw.len() == 32 {
+                    let mut addr = [0u8; 32];
+                    addr.copy_from_slice(raw);
+                    AvailAddress::from(addr)
+                } else {
+                    return Err(anyhow!(
+                        "Raw MultiAddress must be 32 bytes to convert to AvailAddress."
+                    ));
+                }
+            }
+            Some((subxt::utils::MultiAddress::Index(_), _, _)) => {
+                return Err(anyhow!(
+                    "Index MultiAddress cannot be converted to AvailAddress without account lookup."
+                ))
+            }
+            Some((subxt::utils::MultiAddress::Address20(_), _, _)) => {
+                return Err(anyhow!(
+                    "Address20 MultiAddress cannot be converted to AvailAddress."
+                ))
+            }
             _ => {
                 return Err(anyhow!(
                     "Unsigned extrinsic being used to create AvailBlobTransaction."


### PR DESCRIPTION
# Description

Implement handling for all MultiAddress enum variants (Address32, Raw, Index, Address20) in AvailBlobTransaction::new().

- Address32: direct conversion to AvailAddress
- Raw: conversion if 32 bytes, error otherwise
- Index: returns error (requires account lookup)
- Address20: returns error (cannot convert 20 bytes to 32 bytes)

Resolves TODO at line 54.