### PR TITLE
Remove unused `GUARANTEES_TRANSACTION_ORDERING` from `DaService`

### DIFF
--- a/crates/adapters/mock-da/src/in_memory/service.rs
+++ b/crates/adapters/mock-da/src/in_memory/service.rs
@@ -283,8 +283,6 @@ impl DaService for MockDaService {
     type FilteredBlock = MockBlock;
     type Error = anyhow::Error;
 
-    const GUARANTEES_TRANSACTION_ORDERING: bool = true;
-
     /// Gets block at given height
     /// If block is not available, waits until it is produced.
     /// It is possible to read non-finalized and last finalized blocks multiple times

--- a/crates/adapters/mock-da/src/storable/rpc/client.rs
+++ b/crates/adapters/mock-da/src/storable/rpc/client.rs
@@ -66,8 +66,6 @@ impl DaService for StorableMockDaClient {
     type FilteredBlock = MockBlock;
     type Error = anyhow::Error;
 
-    const GUARANTEES_TRANSACTION_ORDERING: bool = true;
-
     async fn get_block_at(&self, height: u64) -> Result<Self::FilteredBlock, Self::Error> {
         let url = self.url(&format!("/blocks/{height}"))?;
         let response = self.client.get(url).send().await?;

--- a/crates/adapters/mock-da/src/storable/service.rs
+++ b/crates/adapters/mock-da/src/storable/service.rs
@@ -18,8 +18,6 @@ impl DaService for StorableMockDaService {
     type FilteredBlock = MockBlock;
     type Error = anyhow::Error;
 
-    const GUARANTEES_TRANSACTION_ORDERING: bool = true;
-
     async fn get_block_at(&self, height: u64) -> Result<Self::FilteredBlock, Self::Error> {
         self.get_block_at_inner(height).await
     }

--- a/crates/rollup-interface/src/node/da.rs
+++ b/crates/rollup-interface/src/node/da.rs
@@ -126,11 +126,6 @@ pub trait DaService: Clone + Send + Sync + 'static {
     /// The error type for fallible methods.
     type Error: Debug + Send + Sync + Display;
 
-    /// Subsequent calls of [`DaService::send_transaction`] guarantee that the
-    /// transactions are published and land in the DA layer in the same order as
-    /// the method calls.
-    const GUARANTEES_TRANSACTION_ORDERING: bool = false;
-
     /// Fetch the block at the given height, waiting for one to be mined if necessary.
     ///
     /// The returned block may not be final, and can be reverted without a consensus violation.


### PR DESCRIPTION
# Description

It has been added in https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/2211 but not used anymore. Most of the real DaService won't guarantee ordering if high throughput is desired. Standard non-preferred sequencers should be designed accordingly

- [x] No change ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existing tests are passing

## Docs
No updates
