### PR TITLE
Improvements of  debuggability of celestia adapter and runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2025-11-06
 - #2032 Upgrade Reth/Revm to 1.9.0
+- #2036 Extends documentation of runner config
 
 # 2025-11-05
 - #2027 Fix graceful shutdown with active WebSocket subscriptions. The rollup now properly shuts down within 2-5 seconds when Ctrl+C is pressed, even with active `eth_subscribe` connections.

--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -237,14 +237,16 @@ impl CelestiaService {
         let client = &self.read_client;
         let result =
             tokio::time::timeout(self.request_timeout, client.header().get_by_height(height)).await;
+        let response_time = start.elapsed();
         let is_success = matches!(result, Ok(Ok(_)));
         tracing::trace!(
             height,
             is_success,
+            ?response_time,
             "Call to header.GetByHeight is completed"
         );
         sov_metrics::track_metrics(|tracker| {
-            tracker.submit(GetBlockHeaderMeasurement::new(start.elapsed(), is_success));
+            tracker.submit(GetBlockHeaderMeasurement::new(response_time, is_success));
         });
         let extended_header = flatten_timeout(result)?;
         Ok(extended_header.into())
@@ -344,10 +346,15 @@ impl CelestiaService {
             self.read_client.header().network_head(),
         )
         .await;
+        let response_time = start.elapsed();
         let is_success = matches!(result, Ok(Ok(_)));
-        tracing::trace!(is_success, "Call to header.NetworkHead is completed");
+        tracing::trace!(
+            is_success,
+            ?response_time,
+            "Call to header.NetworkHead is completed"
+        );
         sov_metrics::track_metrics(|tracker| {
-            tracker.submit(GetChainHeadMeasurement::new(start.elapsed(), is_success));
+            tracker.submit(GetChainHeadMeasurement::new(response_time, is_success));
         });
         let header = flatten_timeout(result)?;
 

--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -276,6 +276,7 @@ impl CelestiaService {
         &self,
         height: u64,
     ) -> anyhow::Result<FilteredCelestiaBlock> {
+        tracing::trace!(height, "Getting block, firing requests");
         let start_get_block = Instant::now();
 
         let header_future = run_maybe_retryable_async_fn_with_retries(
@@ -299,10 +300,10 @@ impl CelestiaService {
             rollup_batch_rows_future,
             rollup_proof_rows_future,
         )?;
+        let futures_time = start_get_block.elapsed();
+        tracing::trace!(height, time = ?futures_time, "All requests have been completed, building relevant data..");
 
         let square_width = header.dah.square_width();
-
-        let futures_time = start_get_block.elapsed();
 
         let build_relevant_data_start = std::time::Instant::now();
         let batch_ns_metrics = NamespaceDataMetrics::new(&batch_rows);
@@ -329,6 +330,7 @@ impl CelestiaService {
             };
             tracker.submit(get_block_measurement);
         });
+        tracing::trace!(height, "get_block_at metrics send, returning");
         FilteredCelestiaBlock::new(rollup_batch_shares, rollup_proof_shares, header)
     }
 

--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -232,11 +232,17 @@ impl CelestiaService {
         &self,
         height: u64,
     ) -> Result<CelestiaHeader, MaybeRetryable<anyhow::Error>> {
+        tracing::trace!(height, "Making call to header.GetByHeight");
         let start = std::time::Instant::now();
         let client = &self.read_client;
         let result =
             tokio::time::timeout(self.request_timeout, client.header().get_by_height(height)).await;
         let is_success = matches!(result, Ok(Ok(_)));
+        tracing::trace!(
+            height,
+            is_success,
+            "Call to header.GetByHeight is completed"
+        );
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(GetBlockHeaderMeasurement::new(start.elapsed(), is_success));
         });
@@ -252,6 +258,7 @@ impl CelestiaService {
         let start = std::time::Instant::now();
         let client = &self.read_client;
         let ns = self.rollup_namespace(&namespace);
+        tracing::trace!(height, %ns, "Making call to share.GetNamespaceData");
         let result = tokio::time::timeout(
             self.request_timeout,
             client.share().get_namespace_data(height, namespace),
@@ -259,6 +266,7 @@ impl CelestiaService {
         .await;
         let is_success = matches!(result, Ok(Ok(_)));
         let response_time = start.elapsed();
+        tracing::trace!(height, %ns, ?is_success, ?response_time, "Call to share.GetNamespaceData is completed");
         let measurement = GetNamespaceDataMeasurement::new(ns, response_time, is_success);
         sov_metrics::track_metrics(|tracker| tracker.submit(measurement));
         flatten_timeout(result)
@@ -327,6 +335,7 @@ impl CelestiaService {
     async fn get_head_block_header_inner(
         &self,
     ) -> Result<CelestiaHeader, MaybeRetryable<anyhow::Error>> {
+        tracing::trace!("Making call to header.NetworkHead");
         let start = std::time::Instant::now();
         let result = tokio::time::timeout(
             self.request_timeout,
@@ -334,6 +343,7 @@ impl CelestiaService {
         )
         .await;
         let is_success = matches!(result, Ok(Ok(_)));
+        tracing::trace!(is_success, "Call to header.NetworkHead is completed");
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(GetChainHeadMeasurement::new(start.elapsed(), is_success));
         });

--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -22,11 +22,12 @@ pub struct RunnerConfig {
     pub da_total_timeout_secs: u64,
     /// HTTP Server configuration: On this socket REST API and RPC endpoints are going to listen.
     pub http_config: HttpServerConfig,
-    /// How many concurrent tasks to prefetch DA block during sync
+    /// How many concurrent tasks to prefetch DA block during sync.
     #[serde(default = "default_concurrent_sync_tasks")]
     pub concurrent_sync_tasks: u8,
     /// How many blocks maximum will be stored in memory.
     /// It affects total concurrent requests done do DA service.
+    /// It should be larger than `concurrent_sync_tasks.
     #[serde(default = "default_prefetch_blocks_capacity")]
     pub pre_fetched_blocks_capacity: NonZero<usize>,
     /// Whether to save transaction bodies to the database.

--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -27,7 +27,7 @@ pub struct RunnerConfig {
     pub concurrent_sync_tasks: u8,
     /// How many blocks maximum will be stored in memory.
     /// It affects total concurrent requests done do DA service.
-    /// It should be larger than `concurrent_sync_tasks.
+    /// It should be larger than `concurrent_sync_tasks`.
     #[serde(default = "default_prefetch_blocks_capacity")]
     pub pre_fetched_blocks_capacity: NonZero<usize>,
     /// Whether to save transaction bodies to the database.

--- a/crates/full-node/sov-stf-runner/src/da_pre_fetcher.rs
+++ b/crates/full-node/sov-stf-runner/src/da_pre_fetcher.rs
@@ -32,7 +32,7 @@ where
         shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<(Self, tokio::task::JoinHandle<anyhow::Result<()>>)> {
         if bulk_size as usize > channel_capacity {
-            anyhow::bail!("pre_fetched_blocks_capacity={channel_capacity} should be larger than concurrent_sync_tasks={bulk_size");
+            anyhow::bail!("pre_fetched_blocks_capacity={channel_capacity} should be larger than concurrent_sync_tasks={bulk_size}");
         }
         tracing::info!(%start_height, %bulk_size, ?channel_capacity, "Initializing FinalizedBlocksBulkFetcher");
         let (blocks_sender, blocks_receiver) = tokio::sync::mpsc::channel(channel_capacity);

--- a/crates/full-node/sov-stf-runner/src/da_pre_fetcher.rs
+++ b/crates/full-node/sov-stf-runner/src/da_pre_fetcher.rs
@@ -31,6 +31,8 @@ where
         channel_capacity: usize,
         shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<(Self, tokio::task::JoinHandle<anyhow::Result<()>>)> {
+        // TODO: ERROR IF bulk_size > channel_capacity!!!
+        tracing::info!(%start_height, %bulk_size, ?channel_capacity, "Initializing FinalizedBlocksBulkFetcher");
         let (blocks_sender, blocks_receiver) = tokio::sync::mpsc::channel(channel_capacity);
 
         let last_finalized_height = da_service
@@ -74,6 +76,8 @@ where
     /// Wrapper around [`DaService::get_block_at`]
     #[tracing::instrument(skip(self))]
     pub async fn get_block_at(&mut self, height: u64) -> Result<Da::FilteredBlock, Da::Error> {
+        tracing::trace!("getting block");
+        // Expects blocks in range [start_height, last_finalized_height] (inclusive)
         if height > self.last_finalized_height || height < self.start_height {
             tracing::trace!(
                 height,
@@ -83,11 +87,13 @@ where
             );
             return self.da_service.get_block_at(height).await;
         }
+        tracing::trace!(height, "Requested height is inside pre-fetched range..");
 
         let span = info_span!("recv_channel_blocks");
         let block_opt = async {
             while let Some(block) = self.blocks.recv().await {
                 let block_height = block.header().height();
+                tracing::trace!(height = block_height, "Inspecting block");
                 self.start_height = block_height;
                 if block_height == height {
                     return Some(block);
@@ -103,6 +109,7 @@ where
         .await;
 
         if let Some(block) = block_opt {
+            tracing::trace!("Return block fetched from channel");
             Ok(block)
         } else {
             tracing::info!(
@@ -134,6 +141,7 @@ where
         last_finalized_height: u64,
         bulk_size: u8,
     ) -> Self {
+        tracing::info!(start_height, last_height = %last_finalized_height, bulk_size, "Initializing BlockFetcher");
         BlockFetcher {
             da_service,
             blocks,
@@ -171,13 +179,23 @@ where
         tracing::trace!(
             start = self.start_height,
             last_finalized_height = self.last_finalized_height,
+            bulk_size = self.bulk_size,
             "Running bulk block fetcher"
         );
+        let mut first_fetched_height: Option<u64> = None;
+        let mut last_fetched_height: Option<u64> = None;
+        let start_time = std::time::Instant::now();
+        // actually puts blocks in range [start_height, last_finalized_height) (exclusive of last_finalized_height)
         while self.start_height < self.last_finalized_height {
             let start_height = self.start_height;
             let end_height = std::cmp::min(
                 start_height + self.bulk_size as u64,
                 self.last_finalized_height,
+            );
+            tracing::trace!(
+                start_height,
+                end_height,
+                "loop iteration, going to reserve permit"
             );
 
             // Before doing a bunch of concurrent calls to DaService,
@@ -193,6 +211,7 @@ where
             {
                 Some(p) => p?,
                 None => {
+                    tracing::trace!("Stopping because couldn't reserve more permits");
                     break;
                 }
             };
@@ -226,13 +245,19 @@ where
                     Some(Some(block_result)) => {
                         let block = block_result?;
                         blocks_fetched += 1;
+                        let this_height = block.header().height();
                         permit
                             .next()
                             .expect("reserved less permits that bulk_size. Bug")
                             .send(block);
+                        if first_fetched_height.is_none() {
+                            first_fetched_height = Some(this_height);
+                        }
+                        last_fetched_height = Some(this_height);
                     }
                     Some(None) => {
                         // Stream ended
+                        tracing::trace!("Stopping because stream ended");
                         break;
                     }
                     None => {
@@ -243,6 +268,7 @@ where
             }
 
             if blocks_fetched == 0 {
+                tracing::trace!("Fetched zero blocks, breaking");
                 break;
             }
 
@@ -257,7 +283,14 @@ where
             self.start_height = end_height + 1;
         }
 
-        tracing::info!("BlockFetcher synced all finalized headers");
+        tracing::info!(
+            start = self.start_height,
+            last_finalized_at_start = self.last_finalized_height,
+            ?first_fetched_height,
+            ?last_fetched_height,
+            commpletion_time = ?start_time.elapsed(),
+            "BlockFetcher synced all finalized headers"
+        );
 
         Ok(())
     }

--- a/crates/full-node/sov-stf-runner/src/da_pre_fetcher.rs
+++ b/crates/full-node/sov-stf-runner/src/da_pre_fetcher.rs
@@ -12,7 +12,7 @@ use tokio::sync::mpsc::Receiver;
 use tracing::{info_span, Instrument as _};
 
 /// Service that pre-fetcher blocks from given start height up to last finalized height at the moment of construction.
-/// After that it proxies all requests to underlying DaService.
+/// After that it proxies all requests to underlying [`DaService`].
 pub struct FinalizedBlocksBulkFetcher<Da: DaService> {
     da_service: Arc<Da>,
     blocks: Receiver<Da::FilteredBlock>,
@@ -31,7 +31,9 @@ where
         channel_capacity: usize,
         shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<(Self, tokio::task::JoinHandle<anyhow::Result<()>>)> {
-        // TODO: ERROR IF bulk_size > channel_capacity!!!
+        if bulk_size as usize > channel_capacity {
+            anyhow::bail!("pre_fetched_blocks_capacity={channel_capacity} should be larger than concurrent_sync_tasks={bulk_size");
+        }
         tracing::info!(%start_height, %bulk_size, ?channel_capacity, "Initializing FinalizedBlocksBulkFetcher");
         let (blocks_sender, blocks_receiver) = tokio::sync::mpsc::channel(channel_capacity);
 
@@ -76,9 +78,9 @@ where
     /// Wrapper around [`DaService::get_block_at`]
     #[tracing::instrument(skip(self))]
     pub async fn get_block_at(&mut self, height: u64) -> Result<Da::FilteredBlock, Da::Error> {
-        tracing::trace!("getting block");
-        // Expects blocks in range [start_height, last_finalized_height] (inclusive)
-        if height > self.last_finalized_height || height < self.start_height {
+        tracing::trace!(height, "getting block");
+        // Expects pre-fetched blocks in range [start_height, last_finalized_height) (exclusive)
+        if height >= self.last_finalized_height || height < self.start_height {
             tracing::trace!(
                 height,
                 start_height = self.start_height,
@@ -87,7 +89,7 @@ where
             );
             return self.da_service.get_block_at(height).await;
         }
-        tracing::trace!(height, "Requested height is inside pre-fetched range..");
+        tracing::trace!(height, "Requested height is inside pre-fetched range.");
 
         let span = info_span!("recv_channel_blocks");
         let block_opt = async {
@@ -185,7 +187,8 @@ where
         let mut first_fetched_height: Option<u64> = None;
         let mut last_fetched_height: Option<u64> = None;
         let start_time = std::time::Instant::now();
-        // actually puts blocks in range [start_height, last_finalized_height) (exclusive of last_finalized_height)
+        // Puts blocks in range [start_height, last_finalized_height).
+        // (exclusive of last_finalized_height)
         while self.start_height < self.last_finalized_height {
             let start_height = self.start_height;
             let end_height = std::cmp::min(
@@ -256,12 +259,10 @@ where
                         last_fetched_height = Some(this_height);
                     }
                     Some(None) => {
-                        // Stream ended
                         tracing::trace!("Stopping because stream ended");
                         break;
                     }
                     None => {
-                        // Shutdown signal received
                         return Ok(());
                     }
                 }

--- a/crates/full-node/sov-stf-runner/src/da_utils.rs
+++ b/crates/full-node/sov-stf-runner/src/da_utils.rs
@@ -10,7 +10,7 @@ const MAX_GET_BLOCK_ATTEMPTS: u32 = 10;
 
 /// Tries to fetch block at given height.
 /// If `DaSyncState.target_height` becomes lower in the case of re-org, the function fetches a new head instead.
-/// Because DaSyncState is polling target height periodically,
+/// Because [`DaSyncState`] is polling target height periodically,
 /// there is a possibility that this function won't notice change in target height if the polling interval of DaSyncState is too high.
 /// To mitigate this, it retries to call `get_block_at` several times before giving up and returning an error.
 pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
@@ -77,15 +77,12 @@ pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
                         } else if attempt >= MAX_GET_BLOCK_ATTEMPTS {
                             anyhow::bail!("Failed to fetch block after {MAX_GET_BLOCK_ATTEMPTS} attempts. Last error: {:?}", err);
                         } else {
-                            // What if the target height is not updated, and we've returning early.
-                            // Basically we should note that if the polling interval is more than (block_time * attempts) it will error in case of rewind.
                             tracing::info!(requestable_height, attempt, "Height hasn't changed, retrying again.");
                         }
                     }
                 }
             }
             _ = interval.tick() => {
-                // TODO: Need to add a way to know if future above has been cancelled.
                 requested_height = check_height(requested_height);
             }
             _ = &mut sleep => {

--- a/crates/full-node/sov-stf-runner/src/da_utils.rs
+++ b/crates/full-node/sov-stf-runner/src/da_utils.rs
@@ -51,6 +51,8 @@ pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
     tokio::pin!(sleep);
 
     loop {
+        // Maybe instead of `interval.tick` we should use total_timeout?
+        // Because it is for rewind.
         tokio::select! {
             result = da_service.get_block_at(requested_height) => {
                 tracing::trace!(

--- a/crates/full-node/sov-stf-runner/src/da_utils.rs
+++ b/crates/full-node/sov-stf-runner/src/da_utils.rs
@@ -83,6 +83,7 @@ pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
                 }
             }
             _ = interval.tick() => {
+                // TODO: Need to add a way to know if future above has been cancelled.
                 requested_height = check_height(requested_height);
             }
             _ = &mut sleep => {

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -710,7 +710,7 @@
       ],
       "properties": {
         "concurrent_sync_tasks": {
-          "description": "How many concurrent tasks to prefetch DA block during sync",
+          "description": "How many concurrent tasks to prefetch DA block during sync.",
           "default": 5,
           "type": "integer",
           "format": "uint8",
@@ -738,7 +738,7 @@
           ]
         },
         "pre_fetched_blocks_capacity": {
-          "description": "How many blocks maximum will be stored in memory. It affects total concurrent requests done do DA service.",
+          "description": "How many blocks maximum will be stored in memory. It affects total concurrent requests done do DA service. It should be larger than `concurrent_sync_tasks.",
           "default": 20,
           "type": "integer",
           "format": "uint",

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -738,7 +738,7 @@
           ]
         },
         "pre_fetched_blocks_capacity": {
-          "description": "How many blocks maximum will be stored in memory. It affects total concurrent requests done do DA service. It should be larger than `concurrent_sync_tasks.",
+          "description": "How many blocks maximum will be stored in memory. It affects total concurrent requests done do DA service. It should be larger than `concurrent_sync_tasks`.",
           "default": 20,
           "type": "integer",
           "format": "uint",

--- a/crates/rollup-interface/src/node/da.rs
+++ b/crates/rollup-interface/src/node/da.rs
@@ -135,7 +135,7 @@ pub trait DaService: Clone + Send + Sync + 'static {
     ///
     /// The returned block may not be final, and can be reverted without a consensus violation.
     /// Calls to this method for the same height are allowed to return different results.
-    /// Should always returns the block at that height on the best fork.
+    /// Should always return the block at that height on the best fork.
     async fn get_block_at(&self, height: u64) -> Result<Self::FilteredBlock, Self::Error>;
 
     /// Similar to [`DaService::get_block_at`], but only returns the block header and not the whole block.

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -76,9 +76,8 @@ state_cache_size = 4294967296 # 4GB. Default is 1GB.
 separate_archival_state = true
 
 [runner]
-# Block time for celestia is configured in `docker/run-validator.sh` and we try to set this one to be lower,
-# So status is updated more frequently.
-da_polling_interval_ms = 500
+# 3 times per regular celestia block
+da_polling_interval_ms = 2_000
 # Celestia configured to give ~216s to retry, so we limit it at 300 to eliminate any locks or slow read.
 # This field is the safeguard against any long blocking in DaService.
 # The default value is: 600

--- a/examples/demo-rollup/configs/mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/mock_rollup_config.toml
@@ -52,7 +52,7 @@ separate_archival_state = true
 da_polling_interval_ms = 50
 # da_total_timeout_secs = 600 # Total timeout for DA service including re-orgs and retries
 # concurrent_sync_tasks = 5 # Number of concurrent tasks to get blocks from DA service
-# pre_fetched_blocks_capacity = 20 # How many blocks pre-fetcher put into the channel for the node to consume before holding off next requests
+# pre_fetched_blocks_capacity = 20 # How many blocks pre-fetcher put into the channel for the node to consume before holding off next requests. Should be larger than `concurrent_sync_tasks`
 # save_tx_bodies = false # Whether to save transaction bodies to the database
 
 [runner.http_config]


### PR DESCRIPTION
# Description

* More trace logs in sov-celestia-adapter and sov-stf-runner
* Fix off by one error in DaPreFetcher. Non critical, but `Didn't find block in pre-fetched when it should've been, calling DaService` log line should not appear anymore
* Add check of runner config if concurrent tasks have higher value than channel size.

Actual outcome of investigation is moved to separate issue: https://github.com/Sovereign-Labs/sovereign-sdk/issues/2037

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1630

## Testing
Existing tests are passing

## Docs
No updates
