### PR TITLE
Add support for WebSocket-based log subscriptions in the EVM soak testing tool, alongside the existing cursor-based log retrieval.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 2025-11-06
+- #2039 Add WebSocket subscription support to EVM logs soak tests.
 - #2032 Upgrade Reth/Revm to 1.9.0
 
 # 2025-11-05

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12034,6 +12034,7 @@ version = "0.3.0"
 dependencies = [
  "alloy",
  "alloy-primitives",
+ "alloy-pubsub",
  "anyhow",
  "clap",
  "futures",
@@ -14613,9 +14614,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,6 +291,7 @@ ethers = { version = "=2.0.14", default-features = false }
 
 alloy = { version = "1.0.37", default-features = false, features = ["std", "essentials"] }
 alloy-serde = { version = "1.0.37", default-features = false }
+alloy-pubsub = { version = "1.0.37", default-features = false }
 alloy-chains = { version = "0.2.14", default-features = false }
 alloy-primitives = { version = "1.4.0", default-features = false }
 alloy-sol-types = { version = "1.4.0", default-features = false }

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -17,6 +17,7 @@ mod params;
 mod service;
 pub(crate) mod watermark;
 
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) enum SubscriptionRequest {
     Logs(Box<Filter>),
     Heads,

--- a/crates/full-node/sov-stf-runner/src/http.rs
+++ b/crates/full-node/sov-stf-runner/src/http.rs
@@ -171,7 +171,7 @@ async fn handle_socket(
 ) {
     let (sender, receiver) = socket.split();
 
-    let (socket_requests, socket_responses) = tokio::sync::mpsc::channel(10);
+    let (socket_requests, socket_responses) = tokio::sync::mpsc::channel(128);
 
     tokio::spawn(handle_socket_write(
         socket_responses,

--- a/crates/utils/sov-eth-client/src/provider_ext.rs
+++ b/crates/utils/sov-eth-client/src/provider_ext.rs
@@ -7,6 +7,7 @@ use sov_rpc_eth_types::LogsWithMaybeCursor;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct LogsWithCursorParams {
+    #[serde(flatten)]
     pub filter: Filter,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,

--- a/crates/utils/sov-evm-soak-testing/Cargo.toml
+++ b/crates/utils/sov-evm-soak-testing/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { workspace = true }
 anyhow = { workspace = true }
 alloy = { workspace = true }
 alloy-primitives = { workspace = true }
+alloy-pubsub = { workspace = true }
 sov-test-utils = { workspace = true }
 rand = { workspace = true }
 clap = { workspace = true }

--- a/crates/utils/sov-evm-soak-testing/src/logs.rs
+++ b/crates/utils/sov-evm-soak-testing/src/logs.rs
@@ -1,19 +1,21 @@
 use alloy::eips::BlockNumberOrTag;
 use alloy::providers::DynProvider;
-use alloy::rpc::types::Filter;
+use alloy::rpc::types::{Filter, Log};
 use alloy::signers::local::PrivateKeySigner;
 use alloy::{network::Network, providers::Provider};
 use alloy_primitives::U256;
+use alloy_pubsub::Subscription;
 use anyhow::Result;
 use futures::future::try_join_all;
+use futures::StreamExt;
 use sov_eth_client::LogsWithCursorProvider;
 use sov_test_utils::SimpleStorage;
 use sov_test_utils::Submit;
 use std::net::SocketAddr;
 use std::time::Instant;
 
-use crate::derive_worker_key;
-use crate::{alloy_client, fund_worker_accounts, validate_worker_count};
+use crate::{alloy_client, fund_worker_accounts, validate_worker_count, LogsRetrievalMode};
+use crate::{alloy_ws_client, derive_worker_key};
 
 /// Spawns multiple log test workers, runs them, and retrieves all generated logs.
 pub async fn run_logs_test(
@@ -22,16 +24,31 @@ pub async fn run_logs_test(
     tx_count: usize,
     logs_per_tx: usize,
     num_workers: usize,
+    mode: LogsRetrievalMode,
 ) -> Result<()> {
     validate_worker_count(num_workers)?;
     // Set up root account and fund workers
     let root_signer: PrivateKeySigner = private_key.parse()?;
-    let root_client = alloy_client(rpc_addr, root_signer.clone())?;
+    let root_client = alloy_ws_client(rpc_addr, root_signer.clone()).await?;
     fund_worker_accounts(&root_client, &root_signer, private_key, num_workers).await?;
-    let from_block = root_client.get_block_number().await?;
 
-    produce_logs(rpc_addr, private_key, num_workers, tx_count, logs_per_tx).await?;
-    retrieve_logs(root_client, from_block).await?;
+    match mode {
+        LogsRetrievalMode::Subscription { capacity } => {
+            let subscription = root_client
+                .subscribe_logs(&Filter::new())
+                .channel_size(capacity)
+                .await?;
+            let expected_count = tx_count * logs_per_tx * num_workers;
+            produce_logs(rpc_addr, private_key, num_workers, tx_count, logs_per_tx).await?;
+            let handle = tokio::spawn(stream_logs(subscription, expected_count));
+            handle.await??;
+        }
+        LogsRetrievalMode::WithCursor => {
+            let from_block = root_client.get_block_number().await?;
+            produce_logs(rpc_addr, private_key, num_workers, tx_count, logs_per_tx).await?;
+            retrieve_logs(root_client, from_block).await?;
+        }
+    }
 
     Ok(())
 }
@@ -78,11 +95,22 @@ async fn retrieve_logs(client: DynProvider, from_block: u64) -> Result<()> {
         .to_block(BlockNumberOrTag::Pending);
     let timer = Instant::now();
     let logs = client.get_all_logs_with_cursor(&filter).await?;
-    println!(
-        "Retrieved {} logs in {:?}",
-        logs.len(),
-        timer.elapsed()
-    );
+    println!("Retrieved {} logs in {:?}", logs.len(), timer.elapsed());
+    Ok(())
+}
+
+async fn stream_logs(subscription: Subscription<Log>, expected_count: usize) -> Result<()> {
+    let timer = Instant::now();
+    let mut stream = subscription.into_stream();
+    let mut count = 0;
+    while let Some(_item) = stream.next().await {
+        count += 1;
+        if count == expected_count {
+            break;
+        }
+    }
+    assert_eq!(count, expected_count);
+    println!("Streamed {} logs in {:?}", expected_count, timer.elapsed());
     Ok(())
 }
 

--- a/crates/utils/sov-evm-soak-testing/src/logs.rs
+++ b/crates/utils/sov-evm-soak-testing/src/logs.rs
@@ -1,8 +1,76 @@
+use alloy::rpc::types::Filter;
+use alloy::signers::local::PrivateKeySigner;
 use alloy::{network::Network, providers::Provider};
 use alloy_primitives::U256;
 use anyhow::Result;
+use futures::future::try_join_all;
 use sov_test_utils::SimpleStorage;
 use sov_test_utils::Submit;
+use sov_eth_client::LogsWithCursorProvider;
+use std::net::SocketAddr;
+use std::time::Instant;
+use alloy::eips::BlockNumberOrTag;
+
+use crate::{alloy_client, fund_worker_accounts, validate_worker_count};
+use crate::derive_worker_key;
+
+/// Spawns multiple log test workers, runs them, and retrieves all generated logs.
+pub async fn run_logs_test(
+    rpc_addr: SocketAddr,
+    private_key: &str,
+    tx_count: usize,
+    logs_per_tx: usize,
+    num_workers: usize,
+) -> Result<()> {
+    validate_worker_count(num_workers)?;
+    // Set up root account and fund workers
+    let root_signer: PrivateKeySigner = private_key.parse()?;
+    let root_client = alloy_client(rpc_addr, root_signer.clone())?;
+    fund_worker_accounts(&root_client, &root_signer, private_key, num_workers).await?;
+    let from_block = root_client.get_block_number().await?;
+
+    // Spawn workers
+    let produce_logs = Instant::now();
+    let mut handles = Vec::with_capacity(num_workers);
+    for worker_idx in 0..num_workers {
+        let signer: PrivateKeySigner = derive_worker_key(private_key, worker_idx)?.parse()?;
+        let client = alloy_client(rpc_addr, signer.clone())?;
+
+        handles.push(tokio::spawn(async move {
+            match LogsSoakTest::new(client, worker_idx).await {
+                Ok(test) => {
+                    if let Err(e) = test.run(tx_count, logs_per_tx).await {
+                        eprintln!("Worker {worker_idx} error during run: {e:?}");
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Worker {worker_idx} failed to deploy contracts: {e:?}");
+                }
+            }
+            Ok::<(), anyhow::Error>(())
+        }));
+    }
+    try_join_all(handles).await?;
+    println!(
+        "Produced {} logs in {:?}",
+        num_workers * tx_count * logs_per_tx,
+        produce_logs.elapsed()
+    );
+
+    // Retrieve and count all logs
+    let filter: Filter = Filter::new()
+        .from_block(from_block)
+        .to_block(BlockNumberOrTag::Pending);
+    let fetch_logs = Instant::now();
+    let logs = root_client.get_all_logs_with_cursor(&filter).await?;
+    println!(
+        "Retrieved {} logs in {:?}",
+        logs.len(),
+        fetch_logs.elapsed()
+    );
+
+    Ok(())
+}
 
 pub struct LogsSoakTest<P, N> {
     contract: SimpleStorage::SimpleStorageInstance<P, N>,

--- a/crates/utils/sov-evm-soak-testing/src/logs.rs
+++ b/crates/utils/sov-evm-soak-testing/src/logs.rs
@@ -1,18 +1,19 @@
+use alloy::eips::BlockNumberOrTag;
+use alloy::providers::DynProvider;
 use alloy::rpc::types::Filter;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::{network::Network, providers::Provider};
 use alloy_primitives::U256;
 use anyhow::Result;
 use futures::future::try_join_all;
+use sov_eth_client::LogsWithCursorProvider;
 use sov_test_utils::SimpleStorage;
 use sov_test_utils::Submit;
-use sov_eth_client::LogsWithCursorProvider;
 use std::net::SocketAddr;
 use std::time::Instant;
-use alloy::eips::BlockNumberOrTag;
 
-use crate::{alloy_client, fund_worker_accounts, validate_worker_count};
 use crate::derive_worker_key;
+use crate::{alloy_client, fund_worker_accounts, validate_worker_count};
 
 /// Spawns multiple log test workers, runs them, and retrieves all generated logs.
 pub async fn run_logs_test(
@@ -29,8 +30,20 @@ pub async fn run_logs_test(
     fund_worker_accounts(&root_client, &root_signer, private_key, num_workers).await?;
     let from_block = root_client.get_block_number().await?;
 
-    // Spawn workers
-    let produce_logs = Instant::now();
+    produce_logs(rpc_addr, private_key, num_workers, tx_count, logs_per_tx).await?;
+    retrieve_logs(root_client, from_block).await?;
+
+    Ok(())
+}
+
+async fn produce_logs(
+    rpc_addr: SocketAddr,
+    private_key: &str,
+    num_workers: usize,
+    tx_count: usize,
+    logs_per_tx: usize,
+) -> Result<()> {
+    let timer = Instant::now();
     let mut handles = Vec::with_capacity(num_workers);
     for worker_idx in 0..num_workers {
         let signer: PrivateKeySigner = derive_worker_key(private_key, worker_idx)?.parse()?;
@@ -54,21 +67,22 @@ pub async fn run_logs_test(
     println!(
         "Produced {} logs in {:?}",
         num_workers * tx_count * logs_per_tx,
-        produce_logs.elapsed()
+        timer.elapsed()
     );
+    Ok(())
+}
 
-    // Retrieve and count all logs
+async fn retrieve_logs(client: DynProvider, from_block: u64) -> Result<()> {
     let filter: Filter = Filter::new()
         .from_block(from_block)
         .to_block(BlockNumberOrTag::Pending);
-    let fetch_logs = Instant::now();
-    let logs = root_client.get_all_logs_with_cursor(&filter).await?;
+    let timer = Instant::now();
+    let logs = client.get_all_logs_with_cursor(&filter).await?;
     println!(
         "Retrieved {} logs in {:?}",
         logs.len(),
-        fetch_logs.elapsed()
+        timer.elapsed()
     );
-
     Ok(())
 }
 

--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -1,6 +1,7 @@
+use crate::{logs::run_logs_test, uniswap::UniSoakTest};
 use alloy::network::TransactionBuilder;
-use alloy::providers::{Provider, ProviderBuilder};
-use alloy::rpc::types::{TransactionRequest};
+use alloy::providers::{Provider, ProviderBuilder, WsConnect};
+use alloy::rpc::types::TransactionRequest;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::{hex, providers::DynProvider};
 use alloy_primitives::U256;
@@ -9,7 +10,6 @@ use clap::{Parser, Subcommand};
 use futures::future::try_join_all;
 use reqwest::Url;
 use std::net::SocketAddr;
-use crate::{logs::run_logs_test, uniswap::UniSoakTest};
 
 mod logs;
 mod simple_storage;
@@ -65,7 +65,22 @@ enum TestType {
         /// Number of parallel workers to spawn
         #[arg(short, long, default_value = "1")]
         num_workers: usize,
+
+        #[command(subcommand)]
+        mode: LogsRetrievalMode,
     },
+}
+
+#[derive(Subcommand, Clone, Debug)]
+enum LogsRetrievalMode {
+    /// Retrieve logs using eth_subscribe
+    Subscription {
+        /// Channel capacity for the subscription
+        #[arg(short, long, default_value = "100000")]
+        capacity: usize,
+    },
+    /// Retrieve logs using cursor-based pagination
+    WithCursor,
 }
 
 /// Derives a unique private key for a worker by tweaking the root key.
@@ -87,6 +102,22 @@ pub(crate) fn alloy_client(rpc_addr: SocketAddr, signer: PrivateKeySigner) -> Re
     let client = ProviderBuilder::new()
         .wallet(signer)
         .connect_http(url)
+        .erased();
+    Ok(client)
+}
+
+/// Creates an Alloy WS client connected to the specified RPC server.
+pub(crate) async fn alloy_ws_client(
+    rpc_addr: SocketAddr,
+    signer: PrivateKeySigner,
+) -> Result<DynProvider> {
+    let url = Url::parse(&format!("ws://{rpc_addr}/rpc"))?;
+    let ws = WsConnect::new(url);
+    let client = ProviderBuilder::new()
+        .wallet(signer)
+        .connect_ws(ws)
+        .await
+        .unwrap()
         .erased();
     Ok(client)
 }
@@ -179,6 +210,7 @@ async fn main() -> Result<()> {
             tx_count,
             logs_per_tx,
             num_workers,
+            mode,
         } => {
             run_logs_test(
                 args.rpc_addr,
@@ -186,6 +218,7 @@ async fn main() -> Result<()> {
                 tx_count,
                 logs_per_tx,
                 num_workers,
+                mode,
             )
             .await?;
         }

--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -1,7 +1,6 @@
-use alloy::eips::BlockNumberOrTag;
 use alloy::network::TransactionBuilder;
 use alloy::providers::{Provider, ProviderBuilder};
-use alloy::rpc::types::{Filter, TransactionRequest};
+use alloy::rpc::types::{TransactionRequest};
 use alloy::signers::local::PrivateKeySigner;
 use alloy::{hex, providers::DynProvider};
 use alloy_primitives::U256;
@@ -10,10 +9,7 @@ use clap::{Parser, Subcommand};
 use futures::future::try_join_all;
 use reqwest::Url;
 use std::net::SocketAddr;
-use std::time::Instant;
-
-use crate::{logs::LogsSoakTest, uniswap::UniSoakTest};
-use sov_eth_client::LogsWithCursorProvider;
+use crate::{logs::run_logs_test, uniswap::UniSoakTest};
 
 mod logs;
 mod simple_storage;
@@ -158,64 +154,6 @@ async fn fund_worker_accounts(
 
         root_client.send_transaction(tx).await?.watch().await?;
     }
-    Ok(())
-}
-
-/// Spawns multiple log test workers, runs them, and retrieves all generated logs.
-async fn run_logs_test(
-    rpc_addr: SocketAddr,
-    private_key: &str,
-    tx_count: usize,
-    logs_per_tx: usize,
-    num_workers: usize,
-) -> Result<()> {
-    validate_worker_count(num_workers)?;
-    // Set up root account and fund workers
-    let root_signer: PrivateKeySigner = private_key.parse()?;
-    let root_client = alloy_client(rpc_addr, root_signer.clone())?;
-    fund_worker_accounts(&root_client, &root_signer, private_key, num_workers).await?;
-    let from_block = root_client.get_block_number().await?;
-
-    // Spawn workers
-    let produce_logs = Instant::now();
-    let mut handles = Vec::with_capacity(num_workers);
-    for worker_idx in 0..num_workers {
-        let signer: PrivateKeySigner = derive_worker_key(private_key, worker_idx)?.parse()?;
-        let client = alloy_client(rpc_addr, signer.clone())?;
-
-        handles.push(tokio::spawn(async move {
-            match LogsSoakTest::new(client, worker_idx).await {
-                Ok(test) => {
-                    if let Err(e) = test.run(tx_count, logs_per_tx).await {
-                        eprintln!("Worker {worker_idx} error during run: {e:?}");
-                    }
-                }
-                Err(e) => {
-                    eprintln!("Worker {worker_idx} failed to deploy contracts: {e:?}");
-                }
-            }
-            Ok::<(), anyhow::Error>(())
-        }));
-    }
-    try_join_all(handles).await?;
-    println!(
-        "Produced {} logs in {:?}",
-        num_workers * tx_count * logs_per_tx,
-        produce_logs.elapsed()
-    );
-
-    // Retrieve and count all logs
-    let filter: Filter = Filter::new()
-        .from_block(from_block)
-        .to_block(BlockNumberOrTag::Pending);
-    let fetch_logs = Instant::now();
-    let logs = root_client.get_all_logs_with_cursor(&filter).await?;
-    println!(
-        "Retrieved {} logs in {:?}",
-        logs.len(),
-        fetch_logs.elapsed()
-    );
-
     Ok(())
 }
 


### PR DESCRIPTION
# Description


### New Features
- **WebSocket subscription support**: Added `eth_subscribe` integration for real-time log streaming in soak tests
- **Configurable WebSocket channel capacity**: Increased default capacity to 100,000 to handle high-throughput scenarios

### Code Organization
- Refactored logs testing logic into dedicated `logs.rs` submodule
- Split log creation and fetching into separate phases for better test isolation

----

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
