### PR TITLE
Fix fetch block reorg aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2025-11-06
 - #2032 Upgrade Reth/Revm to 1.9.0
 - #2036 Extends documentation of runner config
+- #2042 Fixes runner polling issue
 
 # 2025-11-05
 - #2027 Fix graceful shutdown with active WebSocket subscriptions. The rollup now properly shuts down within 2-5 seconds when Ctrl+C is pressed, even with active `eth_subscribe` connections.

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -54,6 +54,7 @@ impl StorableMockDaLayer {
 
         entity::setup_db(&conn).await?;
         let last_seen_block = entity::query_last_saved_block(&conn).await?;
+        tracing::trace!(?last_seen_block, "Initializing StorableMockDaLayer from DB");
         let next_height = (last_seen_block.height as u32)
             .checked_add(1)
             .expect("next_height overflow");

--- a/crates/adapters/mock-da/src/storable/local_service.rs
+++ b/crates/adapters/mock-da/src/storable/local_service.rs
@@ -24,6 +24,7 @@ use crate::{
 const DEFAULT_BLOCK_WAITING_TIME: Duration = Duration::from_secs(3600);
 // Time to accommodate rare cases of lock waiting time or latency to the database.
 const EXTRA_TIME_FOR_MAX_BLOCK: Duration = Duration::from_secs(10);
+const GET_BLOCK_ATTEMPTS: usize = 10;
 
 impl BlockProducingConfig {
     fn get_max_waiting_time_for_block(&self) -> Duration {
@@ -368,15 +369,27 @@ impl StorableMockDaService {
 
         let height = height as u32;
 
-        self.wait_for_height(height).await?;
+        for _ in 0..GET_BLOCK_ATTEMPTS {
+            self.wait_for_height(height).await?;
+            let block = {
+                let da_layer = self.da_layer.read().await;
+                match da_layer.get_block_at(height).await {
+                    Ok(block) => block,
+                    Err(err) => {
+                        tracing::trace!(error = ?err, "Error from DaLayer");
+                        let error_string = err.to_string();
+                        if error_string.contains("has not been produced yet") {
+                            continue;
+                        }
+                        return Err(anyhow::anyhow!(err));
+                    }
+                }
+            };
 
-        let block = {
-            let da_layer = self.da_layer.read().await;
-            da_layer.get_block_at(height).await?
-        };
-
-        tracing::trace!(block_header = %block.header().display(), "Block retrieved");
-        Ok(block)
+            tracing::trace!(block_header = %block.header().display(), "Block retrieved");
+            return Ok(block);
+        }
+        anyhow::bail!("Failed to get block after {GET_BLOCK_ATTEMPTS} attempts");
     }
 
     pub(crate) async fn get_block_header_at_inner(

--- a/crates/full-node/sov-stf-runner/src/da_utils.rs
+++ b/crates/full-node/sov-stf-runner/src/da_utils.rs
@@ -1,18 +1,31 @@
 //! Helper utilities for interacting with the DA layer.
+
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use sov_rollup_interface::da::BlockHeaderTrait;
-use sov_rollup_interface::node::da::{DaService, SlotData};
+use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::node::DaSyncState;
 
 const MAX_GET_BLOCK_ATTEMPTS: u32 = 10;
 
+async fn get_new_head_height_if_roll_back(
+    sync_state: &DaSyncState,
+    requested_height: u64,
+    polling_interval: Duration,
+) -> u64 {
+    loop {
+        let target_height = sync_state.target_da_height.load(Ordering::Relaxed);
+        if target_height < requested_height {
+            return target_height;
+        }
+        tokio::time::sleep(polling_interval).await;
+    }
+}
+
 /// Tries to fetch block at given height.
 /// If `DaSyncState.target_height` becomes lower in the case of re-org, the function fetches a new head instead.
 /// Because DaSyncState is polling target height periodically,
-/// there is a possibility that this function won't notice change in target height if the polling interval of DaSyncState is too high.
-/// To mitigate this, it retries to call `get_block_at` several times before giving up and returning an error.
+/// there is a possibility that this function won't notice change in target height if the polling interval of DaSyncState is too high, but that's fine
 pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
     da_service: &Da,
     sync_state: &DaSyncState,
@@ -26,68 +39,44 @@ pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
         total_timeout = ?da_total_timeout,
         "Fetch polling for a block"
     );
+
     let mut requested_height = height;
-    let mut interval = tokio::time::interval(polling_interval);
 
-    let check_height = |h| -> u64 {
-        let target_height = sync_state.target_da_height.load(Ordering::Relaxed);
-        // Allow requesting height next after head, this is a normal operation.
-        let highest_allowed_to_request = target_height.saturating_add(1);
-
-        if highest_allowed_to_request < h {
-            tracing::info!(
-                new_head_height = target_height,
-                h,
-                "Head height decreased below currently requesting, re-requesting at new head"
-            );
-            target_height
-        } else {
-            h
-        }
-    };
-
-    let mut attempt = 0;
-    let sleep = tokio::time::sleep(da_total_timeout);
-    tokio::pin!(sleep);
-
-    loop {
+    // During each iteration of the loop, it will try to fetch da block at given height
+    // If head rolls back below requested,
+    // requested height will be changed to height and new iteration of the loop continues
+    // We allow chain to consecutively rewind of `MAX_GET_BLOCK_ATTEMPTS` after that it will error
+    for attempt in 1..=MAX_GET_BLOCK_ATTEMPTS {
+        // If the head rolled back below requested height, we will try to request the head instead.
+        let rolled_back_head_future =
+            get_new_head_height_if_roll_back(sync_state, height, polling_interval);
+        // DaService suppose to do all necessary retries on failures.
+        // Runner only limits the total time of this activity.
+        let get_block_future =
+            tokio::time::timeout(da_total_timeout, da_service.get_block_at(requested_height));
         tokio::select! {
-            result = da_service.get_block_at(requested_height) => {
-                tracing::trace!(
-                    requested_height,
-                    original_height = height,
-                    is_err = result.is_err(),
-                    attempt,
-                    "Received result from `get_block_at`");
-                match result {
-                    Ok(block) => {
-                        tracing::trace!(block_header = %block.header().display(), "Block fetched, returning");
-                        return Ok(block);
+            get_block_result = get_block_future => {
+                // Just flatten timeout, but return as is
+                match get_block_result {
+                    Ok(inner_result) => {
+                        return inner_result.map_err(|error| anyhow::anyhow!("Error from DaService: {error:?}"));
                     }
-                    Err(err) => {
-                        tracing::trace!(?err, requested_height, attempt, "Error fetching block");
-                        attempt += 1;
-                        let requestable_height = check_height(requested_height);
-                        if requestable_height != requested_height {
-                            tracing::info!(requestable_height, "Request able height has changed, trying again");
-                            requested_height = requestable_height;
-                            continue;
-                        } else if attempt >= MAX_GET_BLOCK_ATTEMPTS {
-                            anyhow::bail!("Failed to fetch block after {MAX_GET_BLOCK_ATTEMPTS} attempts. Last error: {:?}", err);
-                        } else {
-                            // What if the target height is not updated, and we've returning early.
-                            // Basically we should note that if the polling interval is more than (block_time * attempts) it will error in case of rewind.
-                            tracing::info!(requestable_height, attempt, "Height hasn't changed, retrying again.");
-                        }
+                    Err(_) => {
+                        anyhow::bail!("Timeout getting block from DaService after {da_total_timeout:?}");
                     }
                 }
             }
-            _ = interval.tick() => {
-                requested_height = check_height(requested_height);
-            }
-            _ = &mut sleep => {
-                anyhow::bail!("Total timeout after {:?} while trying fetching block at height {}", da_total_timeout, requested_height);
+            rolled_back_height = rolled_back_head_future => {
+                tracing::warn!(
+                    requested_height,
+                    new_da_head_height = rolled_back_height,
+                    attempt,
+                    ouf_of_attempts = MAX_GET_BLOCK_ATTEMPTS,
+                    "DA head has rolled back below requested height. Updating requested height and retrying");
+                requested_height = rolled_back_height;
             }
         }
     }
+
+    anyhow::bail!("Failed to fetch block after {MAX_GET_BLOCK_ATTEMPTS} of attempts");
 }

--- a/crates/full-node/sov-stf-runner/src/da_utils.rs
+++ b/crates/full-node/sov-stf-runner/src/da_utils.rs
@@ -20,11 +20,22 @@ async fn get_new_head_height_if_roll_back(sync_state: &DaSyncState, requested_he
     loop {
         let status = *rx.borrow_and_update();
         let target_height = status.target_da_height();
+        tracing::trace!(?status, "Received SyncStatus update from the channel");
         // Requesting one block ahead of the current head is normal behavior
         // when the node is fully synced and waiting for the next block.
         if target_height.saturating_add(1) < requested_height {
+            tracing::trace!(
+                requested_height,
+                target_height,
+                "Received head is below expected, exit condition hit"
+            );
             return target_height;
         }
+        tracing::trace!(
+            requested_height,
+            target_height,
+            "Received head is in expected range, keep waiting for new value"
+        );
         if rx.changed().await.is_err() {
             // Sender dropped, fall back to reading the atomic value
             return sync_state.target_da_height.load(Ordering::Relaxed);

--- a/crates/full-node/sov-stf-runner/src/da_utils.rs
+++ b/crates/full-node/sov-stf-runner/src/da_utils.rs
@@ -51,21 +51,17 @@ pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
 
     let mut requested_height = height;
 
-    // During each iteration of the loop, it will try to fetch da block at given height
-    // If head rolls back below requested,
-    // requested height will be changed to height and new iteration of the loop continues
-    // We allow chain to consecutively rewind of `MAX_GET_BLOCK_ATTEMPTS` after that it will error
+    // Retry up to MAX_GET_BLOCK_ATTEMPTS times if the chain reorgs during fetch.
+    // Each iteration races between fetching the block and detecting a reorg.
     for attempt in 1..=MAX_GET_BLOCK_ATTEMPTS {
-        // If the head rolled back below requested height, we will try to request the head instead.
         let rolled_back_head_future =
             get_new_head_height_if_roll_back(sync_state, requested_height);
-        // DaService suppose to do all necessary retries on failures.
-        // Runner only limits the total time of this activity.
+        // DaService handles its own retries for transient failures.
+        // We only enforce a total timeout per attempt.
         let get_block_future =
             tokio::time::timeout(da_total_timeout, da_service.get_block_at(requested_height));
         tokio::select! {
             get_block_result = get_block_future => {
-                // Just flatten timeout, but return as is
                 match get_block_result {
                     Ok(inner_result) => {
                         return inner_result.map_err(|error| anyhow::anyhow!("Error from DaService: {error:?}"));
@@ -80,12 +76,12 @@ pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
                     requested_height,
                     new_da_head_height = rolled_back_height,
                     attempt,
-                    ouf_of_attempts = MAX_GET_BLOCK_ATTEMPTS,
-                    "DA head has rolled back below requested height. Updating requested height and retrying");
+                    out_of_attempts = MAX_GET_BLOCK_ATTEMPTS,
+                    "DA head rolled back below requested height, retrying with new head");
                 requested_height = rolled_back_height;
             }
         }
     }
 
-    anyhow::bail!("Failed to fetch block after {MAX_GET_BLOCK_ATTEMPTS} of attempts");
+    anyhow::bail!("Failed to fetch block after {MAX_GET_BLOCK_ATTEMPTS} consecutive reorgs");
 }

--- a/crates/full-node/sov-stf-runner/src/da_utils.rs
+++ b/crates/full-node/sov-stf-runner/src/da_utils.rs
@@ -8,30 +8,35 @@ use sov_rollup_interface::node::DaSyncState;
 
 const MAX_GET_BLOCK_ATTEMPTS: u32 = 10;
 
-/// This function never terminates unless there's reorg.
-/// So it should be used in `tokio::select` with some other future that will terminate eventually
+/// Waits for the DA head to roll back below the requested height.
+///
+/// This function blocks indefinitely until a reorg occurs. It must be used in `tokio::select!`
+/// with another future that will eventually complete (e.g., `get_block_at`).
+///
+/// Returns the new target height once it drops below `requested_height - 1`.
+/// Note: Requesting `target_height + 1` is normal when the node is synced and waiting for the next block.
 async fn get_new_head_height_if_roll_back(sync_state: &DaSyncState, requested_height: u64) -> u64 {
     let mut rx = sync_state.sync_status_sender.subscribe();
     loop {
         let status = *rx.borrow_and_update();
         let target_height = status.target_da_height();
-        // It is allowed to query height following head,
-        // this is normal when the node is fully synced and waits for the next block
+        // Requesting one block ahead of the current head is normal behavior
+        // when the node is fully synced and waiting for the next block.
         if target_height.saturating_add(1) < requested_height {
             return target_height;
         }
         if rx.changed().await.is_err() {
-            // Sender dropped, fall back to reading atomic
+            // Sender dropped, fall back to reading the atomic value
             return sync_state.target_da_height.load(Ordering::Relaxed);
         }
     }
 }
 
-/// Tries to fetch block at given height.
-/// If `DaSyncState.target_height` becomes lower in the case of re-org, the function fetches a new head instead.
-/// Because [`DaSyncState`] is polling target height periodically,
-/// there is a possibility that this function won't notice a change in target height if the polling interval of [`DaSyncState`] is too high.
-/// To mitigate this, it retries to call [`DaService::get_block_at`] several times before giving up and returning an error.
+/// Fetches a DA block at the given height with reorg awareness.
+///
+/// If the DA head rolls back during the fetch (reorg detected), this function automatically
+/// retries with the new head height. Allows up to `MAX_GET_BLOCK_ATTEMPTS` consecutive reorgs
+/// before returning an error.
 pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
     da_service: &Da,
     sync_state: &DaSyncState,

--- a/crates/full-node/sov-stf-runner/src/da_utils.rs
+++ b/crates/full-node/sov-stf-runner/src/da_utils.rs
@@ -29,9 +29,9 @@ async fn get_new_head_height_if_roll_back(sync_state: &DaSyncState, requested_he
 
 /// Tries to fetch block at given height.
 /// If `DaSyncState.target_height` becomes lower in the case of re-org, the function fetches a new head instead.
-/// Because DaSyncState is polling target height periodically,
-/// there is a possibility that this function won't notice change in target height if the polling interval of DaSyncState is too high.
-/// To mitigate this, it retries to call `get_block_at` several times before giving up and returning an error.
+/// Because [`DaSyncState`] is polling target height periodically,
+/// there is a possibility that this function won't notice a change in target height if the polling interval of [`DaSyncState`] is too high.
+/// To mitigate this, it retries to call [`DaService::get_block_at`] several times before giving up and returning an error.
 pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
     da_service: &Da,
     sync_state: &DaSyncState,

--- a/crates/full-node/sov-stf-runner/src/da_utils.rs
+++ b/crates/full-node/sov-stf-runner/src/da_utils.rs
@@ -8,13 +8,15 @@ use sov_rollup_interface::node::DaSyncState;
 
 const MAX_GET_BLOCK_ATTEMPTS: u32 = 10;
 
+/// This function never terminates unless there's reorg.
+/// So it should be used in `tokio::select` with some other future that will terminate eventually
 async fn get_new_head_height_if_roll_back(sync_state: &DaSyncState, requested_height: u64) -> u64 {
     let mut rx = sync_state.sync_status_sender.subscribe();
     loop {
         let status = *rx.borrow_and_update();
         let target_height = status.target_da_height();
         // It is allowed to query height following head,
-        // this is normal when node is fully synced and waits for the next block
+        // this is normal when the node is fully synced and waits for the next block
         if target_height.saturating_add(1) < requested_height {
             return target_height;
         }
@@ -27,6 +29,7 @@ async fn get_new_head_height_if_roll_back(sync_state: &DaSyncState, requested_he
 
 /// Tries to fetch block at given height.
 /// If `DaSyncState.target_height` becomes lower in the case of re-org, the function fetches a new head instead.
+/// It does not handle case when reorg happens, but the length of new change isn't changed or increased. This should be handled by the caller.
 pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
     da_service: &Da,
     sync_state: &DaSyncState,

--- a/crates/full-node/sov-stf-runner/src/da_utils.rs
+++ b/crates/full-node/sov-stf-runner/src/da_utils.rs
@@ -8,34 +8,33 @@ use sov_rollup_interface::node::DaSyncState;
 
 const MAX_GET_BLOCK_ATTEMPTS: u32 = 10;
 
-async fn get_new_head_height_if_roll_back(
-    sync_state: &DaSyncState,
-    requested_height: u64,
-    polling_interval: Duration,
-) -> u64 {
+async fn get_new_head_height_if_roll_back(sync_state: &DaSyncState, requested_height: u64) -> u64 {
+    let mut rx = sync_state.sync_status_sender.subscribe();
     loop {
-        let target_height = sync_state.target_da_height.load(Ordering::Relaxed);
-        if target_height < requested_height {
+        let status = *rx.borrow_and_update();
+        let target_height = status.target_da_height();
+        // It is allowed to query height following head,
+        // this is normal when node is fully synced and waits for the next block
+        if target_height.saturating_add(1) < requested_height {
             return target_height;
         }
-        tokio::time::sleep(polling_interval).await;
+        if rx.changed().await.is_err() {
+            // Sender dropped, fall back to reading atomic
+            return sync_state.target_da_height.load(Ordering::Relaxed);
+        }
     }
 }
 
 /// Tries to fetch block at given height.
 /// If `DaSyncState.target_height` becomes lower in the case of re-org, the function fetches a new head instead.
-/// Because DaSyncState is polling target height periodically,
-/// there is a possibility that this function won't notice change in target height if the polling interval of DaSyncState is too high, but that's fine
 pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
     da_service: &Da,
     sync_state: &DaSyncState,
     height: u64,
-    polling_interval: Duration,
     da_total_timeout: Duration,
 ) -> anyhow::Result<Da::FilteredBlock> {
     tracing::trace!(
         height,
-        ?polling_interval,
         total_timeout = ?da_total_timeout,
         "Fetch polling for a block"
     );
@@ -48,8 +47,7 @@ pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
     // We allow chain to consecutively rewind of `MAX_GET_BLOCK_ATTEMPTS` after that it will error
     for attempt in 1..=MAX_GET_BLOCK_ATTEMPTS {
         // If the head rolled back below requested height, we will try to request the head instead.
-        let rolled_back_head_future =
-            get_new_head_height_if_roll_back(sync_state, height, polling_interval);
+        let rolled_back_head_future = get_new_head_height_if_roll_back(sync_state, height);
         // DaService suppose to do all necessary retries on failures.
         // Runner only limits the total time of this activity.
         let get_block_future =

--- a/crates/full-node/sov-stf-runner/src/da_utils.rs
+++ b/crates/full-node/sov-stf-runner/src/da_utils.rs
@@ -52,7 +52,8 @@ pub(crate) async fn fetch_block_reorg_aware<Da: DaService>(
     // We allow chain to consecutively rewind of `MAX_GET_BLOCK_ATTEMPTS` after that it will error
     for attempt in 1..=MAX_GET_BLOCK_ATTEMPTS {
         // If the head rolled back below requested height, we will try to request the head instead.
-        let rolled_back_head_future = get_new_head_height_if_roll_back(sync_state, height);
+        let rolled_back_head_future =
+            get_new_head_height_if_roll_back(sync_state, requested_height);
         // DaService suppose to do all necessary retries on failures.
         // Runner only limits the total time of this activity.
         let get_block_future =

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -760,7 +760,6 @@ pub async fn make_da_sync_state<Da: DaService<Error = anyhow::Error>>(
     stop_at_rollup_height: Option<RollupHeight>,
     ledger_db: &LedgerDb,
     da_service: &Da,
-    sync_status_sender: watch::Sender<SyncStatus>,
 ) -> anyhow::Result<Arc<DaSyncState>> {
     let next_item_numbers = ledger_db.get_next_items_numbers()?;
     let last_slot_processed_before_shutdown = next_item_numbers.slot_number.saturating_sub(1);
@@ -772,6 +771,22 @@ pub async fn make_da_sync_state<Da: DaService<Error = anyhow::Error>>(
         .await?
         .height();
 
+    let initial_sync_status = SyncStatus::Syncing {
+        synced_da_height: da_height_processed,
+        target_da_height,
+    };
+
+    let (sync_status_sender, _sync_status_receiver) =
+        tokio::sync::watch::channel(initial_sync_status);
+
+    tracing::debug!(
+        da_height_processed,
+        genesis_da_height,
+        target_da_height,
+        ?stop_at_rollup_height,
+        ?initial_sync_status,
+        "Initializing new instance of DaSyncState"
+    );
     let sync_state = Arc::new(DaSyncState {
         synced_da_height: da_height_processed.into(),
         target_da_height: AtomicU64::new(target_da_height),

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -207,7 +207,6 @@ where
             stf_info_sender,
             state_height_tracker,
             sync_state.clone(),
-            da_polling_interval,
             da_total_timeout,
         )?;
 
@@ -485,7 +484,6 @@ where
                 self.da_service.as_ref(),
                 self.sync_state.as_ref(),
                 next_da_height,
-                self.da_polling_interval,
                 self.da_total_timeout,
             )
             .await?

--- a/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
@@ -215,7 +215,7 @@ where
                 );
             }
             tracing::info!(
-                old_blok = %filtered_block.header().display(),
+                old_block = %filtered_block.header().display(),
                 new_block = %new_block.header().display(),
                 time = ?start.elapsed(),
                 "Chosen fork point"

--- a/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
@@ -96,7 +96,6 @@ where
     max_provable_slot_number_tracker: Box<dyn ProvableHeightTracker>,
     is_initialized: bool,
     da_sync_state: Arc<DaSyncState>,
-    da_polling_interval: std::time::Duration,
     da_total_timeout: std::time::Duration,
 }
 
@@ -121,7 +120,6 @@ where
         stf_info_sender: Option<StfInfoSender<StateRoot, Witness, Da::Spec>>,
         state_height_tracker: Box<dyn ProvableHeightTracker>,
         da_sync_state: Arc<DaSyncState>,
-        da_polling_interval: std::time::Duration,
         da_total_timeout: std::time::Duration,
     ) -> anyhow::Result<Self> {
         Ok(Self {
@@ -135,7 +133,6 @@ where
             max_provable_slot_number_tracker: state_height_tracker,
             is_initialized: false,
             da_sync_state,
-            da_polling_interval,
             da_total_timeout,
         })
     }
@@ -773,7 +770,6 @@ where
                         da_service,
                         self.da_sync_state.as_ref(),
                         next_candidate_height,
-                        self.da_polling_interval,
                         self.da_total_timeout,
                     ),
                     da_service.get_head_block_header(),

--- a/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
@@ -1055,7 +1055,6 @@ where
         None,
         Box::new(InfiniteHeight),
         sync_state,
-        std::time::Duration::from_millis(10),
         std::time::Duration::from_millis(3_600_000),
     )?;
     state_manager.startup().await?;

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -196,11 +196,11 @@ pub async fn initialize_runner(
         .create_state_after(&finalized_header)
         .unwrap();
     let ledger_db = LedgerDb::with_reader(ledger_state).unwrap();
-    let (sync_sender, _sync_status_receiver) = watch::channel(SyncStatus::START);
 
-    let da_sync_state = make_da_sync_state(0, None, &ledger_db, da_service.as_ref(), sync_sender)
+    let da_sync_state = make_da_sync_state(0, None, &ledger_db, da_service.as_ref())
         .await
         .unwrap();
+    let _sync_status_receiver = da_sync_state.sync_status_sender.subscribe();
     let (state_update_sender, state_update_recv) = watch::channel(
         bootstrap_state_update_info(&mut storage_manager, da_sync_state.as_ref())
             .await

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -122,10 +122,9 @@ async fn test_runner_with_background_da_service(
     let genesis_header = block.header().clone();
     let (_, ledger_state) = storage_manager.create_state_after(&genesis_header).unwrap();
 
-    let (sync_sender, mut sync_status_receiver) = watch::channel(SyncStatus::START);
     let ledger_db = LedgerDb::with_reader(ledger_state).unwrap();
-    let da_sync_state =
-        make_da_sync_state(0, None, &ledger_db, da_service.as_ref(), sync_sender).await?;
+    let da_sync_state = make_da_sync_state(0, None, &ledger_db, da_service.as_ref()).await?;
+    let mut sync_status_receiver = da_sync_state.sync_status_sender.subscribe();
 
     let (state_update_sender, _state_update_recv) = watch::channel(
         bootstrap_state_update_info(&mut storage_manager, da_sync_state.as_ref()).await?,

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -401,17 +401,15 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             }
         };
 
-        let (sync_status_sender, sync_status_receiver) =
-            tokio::sync::watch::channel(SyncStatus::START);
-
         let da_sync_state = make_da_sync_state(
             genesis_slot_number,
             stop_at_rollup_height,
             &ledger_db,
             da_service.as_ref(),
-            sync_status_sender,
         )
         .await?;
+
+        let sync_status_receiver = da_sync_state.sync_status_sender.subscribe();
 
         let state_update_info =
             query_state_update_info(&ledger_db, prover_storage.clone(), da_sync_state.as_ref())

--- a/crates/rollup-interface/src/node/da.rs
+++ b/crates/rollup-interface/src/node/da.rs
@@ -126,7 +126,7 @@ pub trait DaService: Clone + Send + Sync + 'static {
     /// The error type for fallible methods.
     type Error: Debug + Send + Sync + Display;
 
-    /// Fetch the block at the given height, waiting for one to be mined if necessary.
+    /// Fetch the block at the given height, **waiting for one to be mined** if necessary.
     ///
     /// The returned block may not be final, and can be reverted without a consensus violation.
     /// Calls to this method for the same height are allowed to return different results.

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -154,6 +154,7 @@ async fn start_stop_empty(
         (Level::WARN, "Skipping pruning of sequence number because it's already been pruned".to_string()),
         (Level::WARN, "The node is unsynced and doesn't know it. This probably means that you wiped the node DB and are resyncing.".to_string()),
         (Level::WARN, "Metics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown".to_string()),
+        (Level::WARN, "DA head rolled back below requested height, retrying with new head".to_string()),
     ];
 
     let mut recorded_errors_warnings =
@@ -549,6 +550,7 @@ async fn test_start_prover_manual() -> anyhow::Result<()> {
             Level::WARN,
             "Metics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown".to_string(),
         ),
+        (Level::WARN, "DA head rolled back below requested height, retrying with new head".to_string())
     ];
     recorded_errors_warnings.retain(|e| !known.contains(e));
     // We could've checked `.is_empty`, but in case of failure, we will see errors immediately.

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -15,8 +15,8 @@ use sov_bank::{config_gas_token_id, Coins};
 use sov_db::storage_manager::NomtStorageManager;
 use sov_demo_rollup::{mock_da_risc0_host_args, MockDemoRollup};
 use sov_mock_da::storable::layer::StorableMockDaLayer;
-use sov_mock_da::BlockProducingConfig;
 use sov_mock_da::MockHash;
+use sov_mock_da::{BlockProducingConfig, MockDaConfig};
 use sov_mock_zkvm::crypto::private_key::Ed25519PrivateKey;
 use sov_modules_api::execution_mode::Native;
 use sov_modules_api::Amount;
@@ -154,7 +154,6 @@ async fn start_stop_empty(
         (Level::WARN, "Skipping pruning of sequence number because it's already been pruned".to_string()),
         (Level::WARN, "The node is unsynced and doesn't know it. This probably means that you wiped the node DB and are resyncing.".to_string()),
         (Level::WARN, "Metics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown".to_string()),
-        (Level::WARN, "DA head rolled back below requested height, retrying with new head".to_string()),
     ];
 
     let mut recorded_errors_warnings =
@@ -421,6 +420,8 @@ async fn test_start_prover_manual() -> anyhow::Result<()> {
     let second_chunk = 4;
     let jump_size = first_chunk + second_chunk;
 
+    let mock_da_dir = tempfile::tempdir()?;
+
     let rollup_builder = RollupBuilder::<MockDemoRollup<Native>>::new(
         test_genesis_source(OperatingMode::Zk),
         BlockProducingConfig::Periodic {
@@ -438,9 +439,10 @@ async fn test_start_prover_manual() -> anyhow::Result<()> {
             sequencer_conf.disable_state_root_consistency_checks = true;
         }
         c.aggregated_proof_block_jump = jump_size;
+    })
+    .set_da_config(|da_config| {
+        da_config.connection_string = MockDaConfig::sqlite_in_dir(mock_da_dir.path()).unwrap();
     });
-
-    let mock_da_dir = &rollup_storage_dir;
 
     {
         let mut storable_mock_da_layer =
@@ -550,7 +552,6 @@ async fn test_start_prover_manual() -> anyhow::Result<()> {
             Level::WARN,
             "Metics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown".to_string(),
         ),
-        (Level::WARN, "DA head rolled back below requested height, retrying with new head".to_string())
     ];
     recorded_errors_warnings.retain(|e| !known.contains(e));
     // We could've checked `.is_empty`, but in case of failure, we will see errors immediately.


### PR DESCRIPTION
# Description

Changes behavior of `fetch_block_reorg_aware`.

Previous implementation could cancel future of `DaService::get_block_at` if it fails to complete under `da_polling_interval`, which might be not the case under normal operation, but with some network delays.

`fetch_block_reorg_aware` is completely rewritten, **so it is better to review file `crates/full-node/sov-stf-runner/src/da_utils.rs` as whole**

### How it works now:

* `DaService::get_block_at` is wrapped in tokio::timeout with parameter from `runner.total_da_timeout` to have upper limit of how long `get_block_at` can actually take.
* Concurrent future is started, which check if head rolled back below requested. This futures terminates on this case. So if head has rolled back below requested height before `DaService::get_block_at` is completed, it will try to fetch new head instead.

### Minor changes:

* Runner: Instead of polling, it subscribes to changes from `DaSyncState`.
* Correctly initialize `DaSyncState` with values from DB. Previously first instance of SyncStatus in channel was "Start", which is target and synced == 0. Which lead to unnecessary reorg like behaviour in runner. It was previously masked, but new approach uncovered it.
* MockDa: Fix in StorableMockDa**Service**, so it actually waits for new block even if reorg happend between waiting and fetching.

- [x] Internal change ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] ~~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~~

## Linked Issues
- Fixes #2037

## Testing
All existing tests are passing

## Docs
No updates
