### PR TITLE
Refactors WebSocket RPC handling code for improved readability and organization.

### DIFF
--- a/crates/full-node/sov-stf-runner/src/http/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/http/mod.rs
@@ -2,11 +2,8 @@ use std::net::SocketAddr;
 
 use axum::body::HttpBody;
 use axum::error_handling::HandleErrorLayer;
-use axum::extract::ws::{Message, WebSocket};
 use axum::http::StatusCode;
 use axum::ServiceExt;
-use futures_util::sink::SinkExt;
-use futures_util::stream::StreamExt;
 use jsonrpsee::server::ServerConfig;
 use jsonrpsee::RpcModule;
 use tokio::sync::watch;
@@ -14,6 +11,8 @@ use tower::BoxError;
 use tower_http::cors::CorsLayer;
 use tower_http::normalize_path::NormalizePathLayer;
 use tower_layer::Layer;
+
+mod ws;
 
 use crate::CorsConfiguration;
 
@@ -143,163 +142,6 @@ async fn measure_time(
     });
 
     response
-}
-
-async fn ws_rpc_handler(
-    ws: axum::extract::ws::WebSocketUpgrade,
-    rpc_methods: RpcModule<()>,
-    shutdown_receiver: watch::Receiver<()>,
-) -> impl axum::response::IntoResponse {
-    ws.on_upgrade(move |socket| async move {
-        handle_socket(socket, rpc_methods, shutdown_receiver.clone()).await;
-    })
-}
-
-// To support duplex communication socket is split into 2 streams,
-// each stream is processed in their own task
-// 1. Reader task receives requests from websocket and pushes appropriate responses into the mpsc channel to the writer task.
-//    In the case of subscriptions, the reader task clones `tokio::sync::mpsc::Sender` and spawns another task,
-//    where subscription responses are piped to the writer task.
-// 2. Writer task listens to [`tokio::sync::mpsc::Receiver`] and writes responses to websocket.
-//
-// When the WebSocket closes, the writer task exits and drops the socket_responses receiver,
-// which causes all subscription forwarding tasks to stop sending (their send() calls will fail).
-async fn handle_socket(
-    socket: WebSocket,
-    rpc_methods: RpcModule<()>,
-    shutdown_receiver: watch::Receiver<()>,
-) {
-    let (sender, receiver) = socket.split();
-
-    let (socket_requests, socket_responses) = tokio::sync::mpsc::channel(128);
-
-    tokio::spawn(handle_socket_write(
-        socket_responses,
-        sender,
-        shutdown_receiver.clone(),
-    ));
-    tokio::spawn(handle_socket_read(
-        receiver,
-        socket_requests,
-        rpc_methods,
-        shutdown_receiver.clone(),
-    ));
-}
-
-async fn handle_rpc_message(
-    text: &str,
-    socket_responses: &tokio::sync::mpsc::Sender<Message>,
-    rpc_methods: &RpcModule<()>,
-    use_binary: bool,
-) {
-    // Buffer size picked up from `jsonrpsee` crate examples
-    match rpc_methods.raw_json_request(text, 1).await {
-        Ok((rpc_response, mut receiver)) => {
-            tracing::trace!("RPC request processed successfully: {}", rpc_response);
-            let response_message = if use_binary {
-                Message::Binary(rpc_response.to_string().into_bytes())
-            } else {
-                Message::Text(rpc_response.to_string())
-            };
-
-            if socket_responses.send(response_message).await.is_err() {
-                tracing::error!("Websocket sender has been closed, aborting websocket");
-                return;
-            }
-
-            if !receiver.is_closed() {
-                let subscription_responses = socket_responses.clone();
-                tokio::task::spawn(async move {
-                    tracing::trace!("Spawning subscription responses loop");
-                    while let Some(message) = receiver.recv().await {
-                        tracing::trace!("Subscription message received: {}", message);
-                        let sub_message = if use_binary {
-                            Message::Binary(message.to_string().into_bytes())
-                        } else {
-                            Message::Text(message.to_string())
-                        };
-                        if let Err(error) = subscription_responses.send(sub_message).await {
-                            tracing::debug!(%error, "WebSocket closed, stopping subscription forwarding");
-                            break;
-                        }
-                    }
-                    tracing::trace!("Subscription forwarding task finished");
-                });
-            }
-        }
-        Err(error) => {
-            tracing::error!(%error, "Error while processing RPC request");
-        }
-    }
-}
-
-async fn handle_socket_read(
-    mut socket_requests: futures_util::stream::SplitStream<WebSocket>,
-    socket_responses: tokio::sync::mpsc::Sender<Message>,
-    rpc_methods: RpcModule<()>,
-    mut shutdown_receiver: watch::Receiver<()>,
-) {
-    loop {
-        tokio::select! {
-            Some(Ok(msg)) = socket_requests.next() => {
-                tracing::trace!(message = ?msg, "Message received from websocket");
-                match msg {
-                    Message::Text(text) => {
-                        handle_rpc_message(&text, &socket_responses, &rpc_methods, false).await;
-                    }
-                    Message::Binary(data) => {
-                        // Parse binary frame as UTF-8 JSON-RPC request
-                        match std::str::from_utf8(&data) {
-                            Ok(text) => {
-                                handle_rpc_message(text, &socket_responses, &rpc_methods, true).await;
-                            }
-                            Err(error) => {
-                                tracing::error!(%error, "Invalid UTF-8 in binary WebSocket frame");
-                            }
-                        }
-                    }
-                    Message::Pong(_) => {}
-                    Message::Ping(ping) => {
-                        if socket_responses.send(Message::Pong(ping)).await.is_err() {
-                            tracing::error!("Websocket sender has been closed, aborting websocket");
-                            break;
-                        }
-                    }
-                    Message::Close(_) => {
-                        break;
-                    }
-                }
-            }
-            _ = shutdown_receiver.changed() => {
-                tracing::debug!("Shutdown signal received, stopping WebSocket read handler");
-                break;
-            }
-        }
-    }
-    tracing::trace!("WebSocket read handler finished");
-}
-
-async fn handle_socket_write(
-    mut socket_requests: tokio::sync::mpsc::Receiver<Message>,
-    mut socket_responses: futures_util::stream::SplitSink<WebSocket, Message>,
-    mut shutdown_receiver: watch::Receiver<()>,
-) {
-    loop {
-        tokio::select! {
-            Some(response) = socket_requests.recv() => {
-                if let Err(error) = socket_responses.send(response).await {
-                    tracing::debug!(%error, "WebSocket closed, stopping writer task");
-                    break;
-                }
-                tracing::trace!("Message sent to websocket");
-            }
-            _ = shutdown_receiver.changed() => {
-                tracing::debug!("Shutdown signal received, stopping WebSocket write handler");
-                break;
-            }
-        }
-    }
-    tracing::trace!("WebSocket write handler finished");
 }
 
 #[cfg(test)]

--- a/crates/full-node/sov-stf-runner/src/http/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/http/mod.rs
@@ -11,6 +11,7 @@ use tower::BoxError;
 use tower_http::cors::CorsLayer;
 use tower_http::normalize_path::NormalizePathLayer;
 use tower_layer::Layer;
+use ws::ws_rpc_handler;
 
 mod ws;
 

--- a/crates/full-node/sov-stf-runner/src/http/ws.rs
+++ b/crates/full-node/sov-stf-runner/src/http/ws.rs
@@ -34,42 +34,42 @@ async fn handle_socket(
     rpc_methods: RpcModule<()>,
     shutdown_receiver: watch::Receiver<()>,
 ) {
-    let (sender, receiver) = socket.split();
+    let (ws_writer, ws_reader) = socket.split();
 
-    let (socket_requests, socket_responses) = mpsc::channel(128);
+    let (msg_tx, msg_rx) = mpsc::channel(128);
 
     spawn(handle_socket_write(
-        socket_responses,
-        sender,
+        msg_rx,
+        ws_writer,
         shutdown_receiver.clone(),
     ));
     spawn(handle_socket_read(
-        receiver,
-        socket_requests,
+        ws_reader,
+        msg_tx,
         rpc_methods,
         shutdown_receiver.clone(),
     ));
 }
 
 async fn handle_socket_read(
-    mut socket_requests: SplitStream<WebSocket>,
-    socket_responses: mpsc::Sender<Message>,
+    mut ws_reader: SplitStream<WebSocket>,
+    msg_tx: mpsc::Sender<Message>,
     rpc_methods: RpcModule<()>,
     mut shutdown_receiver: watch::Receiver<()>,
 ) {
     loop {
         select! {
-            Some(Ok(msg)) = socket_requests.next() => {
+            Some(Ok(msg)) = ws_reader.next() => {
                 trace!(message = ?msg, "Message received from websocket");
                 match msg {
                     Message::Text(text) => {
-                        handle_rpc_message(&text, &socket_responses, &rpc_methods, false).await;
+                        handle_rpc_message(&text, &msg_tx, &rpc_methods, false).await;
                     }
                     Message::Binary(data) => {
                         // Parse binary frame as UTF-8 JSON-RPC request
                         match std::str::from_utf8(&data) {
                             Ok(text) => {
-                                handle_rpc_message(text, &socket_responses, &rpc_methods, true).await;
+                                handle_rpc_message(text, &msg_tx, &rpc_methods, true).await;
                             }
                             Err(error) => {
                                 error!(%error, "Invalid UTF-8 in binary WebSocket frame");
@@ -78,7 +78,7 @@ async fn handle_socket_read(
                     }
                     Message::Pong(_) => {}
                     Message::Ping(ping) => {
-                        if socket_responses.send(Message::Pong(ping)).await.is_err() {
+                        if msg_tx.send(Message::Pong(ping)).await.is_err() {
                             error!("Websocket sender has been closed, aborting websocket");
                             break;
                         }
@@ -99,7 +99,7 @@ async fn handle_socket_read(
 
 async fn handle_rpc_message(
     text: &str,
-    socket_responses: &mpsc::Sender<Message>,
+    msg_tx: &mpsc::Sender<Message>,
     rpc_methods: &RpcModule<()>,
     use_binary: bool,
 ) {
@@ -115,7 +115,7 @@ async fn handle_rpc_message(
         Message::Text(rpc_response.to_string())
     };
 
-    if socket_responses.send(response_message).await.is_err() {
+    if msg_tx.send(response_message).await.is_err() {
         return error!("Websocket sender has been closed, aborting websocket");
     }
     if receiver.is_closed() {
@@ -123,17 +123,17 @@ async fn handle_rpc_message(
     }
 
     trace!("Spawning subscription responses loop");
-    let subscription_responses = socket_responses.clone();
+    let subscription_msg_tx = msg_tx.clone();
     spawn(handle_subscription_response(
         receiver,
-        subscription_responses,
+        subscription_msg_tx,
         use_binary,
     ));
 }
 
 async fn handle_subscription_response(
     mut receiver: mpsc::Receiver<Box<JsonRawValue>>,
-    subscription_responses: mpsc::Sender<Message>,
+    msg_tx: mpsc::Sender<Message>,
     use_binary: bool,
 ) {
     while let Some(message) = receiver.recv().await {
@@ -143,7 +143,7 @@ async fn handle_subscription_response(
         } else {
             Message::Text(message.to_string())
         };
-        if let Err(error) = subscription_responses.send(sub_message).await {
+        if let Err(error) = msg_tx.send(sub_message).await {
             debug!(%error, "WebSocket closed, stopping subscription forwarding");
             break;
         }
@@ -152,14 +152,14 @@ async fn handle_subscription_response(
 }
 
 async fn handle_socket_write(
-    mut socket_requests: mpsc::Receiver<Message>,
-    mut socket_responses: SplitSink<WebSocket, Message>,
+    mut msg_rx: mpsc::Receiver<Message>,
+    mut ws_writer: SplitSink<WebSocket, Message>,
     mut shutdown_receiver: watch::Receiver<()>,
 ) {
     loop {
         select! {
-            Some(response) = socket_requests.recv() => {
-                if let Err(error) = socket_responses.send(response).await {
+            Some(response) = msg_rx.recv() => {
+                if let Err(error) = ws_writer.send(response).await {
                     debug!(%error, "WebSocket closed, stopping writer task");
                     break;
                 }

--- a/crates/full-node/sov-stf-runner/src/http/ws.rs
+++ b/crates/full-node/sov-stf-runner/src/http/ws.rs
@@ -6,8 +6,9 @@ use futures_util::sink::SinkExt;
 use futures_util::stream::StreamExt;
 use jsonrpsee::core::JsonRawValue;
 use jsonrpsee::RpcModule;
+use sov_rollup_interface::consume_until_shutdown;
+use tokio::spawn;
 use tokio::sync::{mpsc, watch};
-use tokio::{select, spawn};
 use tracing::{debug, error, trace};
 
 /// Convert content to a WebSocket message, using binary or text encoding
@@ -67,44 +68,46 @@ async fn socket_reader_task(
     rpc_methods: RpcModule<()>,
     mut shutdown_receiver: watch::Receiver<()>,
 ) {
-    loop {
-        select! {
-            Some(Ok(msg)) = ws_reader.next() => {
-                trace!(message = ?msg, "Message received from websocket");
-                match msg {
-                    Message::Text(text) => {
-                        handle_rpc_message(&text, &msg_tx, &rpc_methods, false, &shutdown_receiver).await;
-                    }
-                    Message::Binary(data) => {
-                        // Parse binary frame as UTF-8 JSON-RPC request
-                        match std::str::from_utf8(&data) {
-                            Ok(text) => {
-                                handle_rpc_message(text, &msg_tx, &rpc_methods, true, &shutdown_receiver).await;
-                            }
-                            Err(error) => {
-                                error!(%error, "Invalid UTF-8 in binary WebSocket frame");
-                            }
+    consume_until_shutdown! {
+        "WebSocket reader",
+        ws_reader.next(),
+        shutdown_receiver,
+        msg => {
+            let msg = match msg {
+                Err(error) => {
+                    debug!(%error, "WebSocket closed, stopping reader task");
+                    break;
+                },
+                Ok(msg) => msg,
+            };
+            match msg {
+                Message::Text(text) => {
+                    handle_rpc_message(&text, &msg_tx, &rpc_methods, false, &shutdown_receiver).await;
+                }
+                Message::Binary(data) => {
+                    // Parse binary frame as UTF-8 JSON-RPC request
+                    match std::str::from_utf8(&data) {
+                        Ok(text) => {
+                            handle_rpc_message(text, &msg_tx, &rpc_methods, true, &shutdown_receiver).await;
+                        }
+                        Err(error) => {
+                            error!(%error, "Invalid UTF-8 in binary WebSocket frame");
                         }
                     }
-                    Message::Pong(_) => {}
-                    Message::Ping(ping) => {
-                        if msg_tx.send(Message::Pong(ping)).await.is_err() {
-                            error!("Websocket sender has been closed, aborting websocket");
-                            break;
-                        }
-                    }
-                    Message::Close(_) => {
+                }
+                Message::Pong(_) => {}
+                Message::Ping(ping) => {
+                    if msg_tx.send(Message::Pong(ping)).await.is_err() {
+                        error!("Websocket sender has been closed, aborting websocket");
                         break;
                     }
                 }
-            }
-            _ = shutdown_receiver.changed() => {
-                debug!("Shutdown signal received, stopping WebSocket read handler");
-                break;
+                Message::Close(_) => {
+                    break;
+                }
             }
         }
     }
-    trace!("WebSocket read handler finished");
 }
 
 async fn handle_rpc_message(
@@ -145,23 +148,18 @@ async fn subscription_forwarder_task(
     use_binary: bool,
     mut shutdown_receiver: watch::Receiver<()>,
 ) {
-    loop {
-        select! {
-            Some(message) = receiver.recv() => {
-                trace!("Subscription message received: {}", message);
-                let sub_message = to_ws_message(message, use_binary);
-                if let Err(error) = msg_tx.send(sub_message).await {
-                    debug!(%error, "WebSocket closed, stopping subscription forwarding");
-                    break;
-                }
-            }
-            _ = shutdown_receiver.changed() => {
-                debug!("Shutdown signal received, stopping subscription forwarder");
+    consume_until_shutdown! {
+        "Subscription forwarder",
+        receiver.recv(),
+        shutdown_receiver,
+        message => {
+            let sub_message = to_ws_message(message, use_binary);
+            if let Err(error) = msg_tx.send(sub_message).await {
+                debug!(%error, "WebSocket closed, stopping subscription forwarding");
                 break;
             }
         }
     }
-    trace!("Subscription forwarding task finished");
 }
 
 async fn socket_writer_task(
@@ -169,20 +167,16 @@ async fn socket_writer_task(
     mut ws_writer: SplitSink<WebSocket, Message>,
     mut shutdown_receiver: watch::Receiver<()>,
 ) {
-    loop {
-        select! {
-            Some(response) = msg_rx.recv() => {
-                if let Err(error) = ws_writer.send(response).await {
-                    debug!(%error, "WebSocket closed, stopping writer task");
-                    break;
-                }
-                trace!("Message sent to websocket");
-            }
-            _ = shutdown_receiver.changed() => {
-                debug!("Shutdown signal received, stopping WebSocket write handler");
+    consume_until_shutdown! {
+        "WebSocket writer",
+        msg_rx.recv(),
+        shutdown_receiver,
+        response => {
+            if let Err(error) = ws_writer.send(response).await {
+                debug!(%error, "WebSocket closed, stopping writer task");
                 break;
             }
+            trace!("Message sent to websocket");
         }
     }
-    trace!("WebSocket write handler finished");
 }

--- a/crates/full-node/sov-stf-runner/src/http/ws.rs
+++ b/crates/full-node/sov-stf-runner/src/http/ws.rs
@@ -10,6 +10,16 @@ use tokio::sync::{mpsc, watch};
 use tokio::{select, spawn};
 use tracing::{debug, error, trace};
 
+/// Convert content to a WebSocket message, using binary or text encoding
+fn to_ws_message(content: impl ToString, use_binary: bool) -> Message {
+    let content_str = content.to_string();
+    if use_binary {
+        Message::Binary(content_str.into_bytes())
+    } else {
+        Message::Text(content_str)
+    }
+}
+
 pub async fn ws_rpc_handler(
     ws: WebSocketUpgrade,
     rpc_methods: RpcModule<()>,
@@ -110,11 +120,7 @@ async fn handle_rpc_message(
         Err(error) => return error!(%error, "Error while processing RPC request"),
     };
     trace!("RPC request processed successfully: {}", rpc_response);
-    let response_message = if use_binary {
-        Message::Binary(rpc_response.to_string().into_bytes())
-    } else {
-        Message::Text(rpc_response.to_string())
-    };
+    let response_message = to_ws_message(rpc_response, use_binary);
 
     if msg_tx.send(response_message).await.is_err() {
         return error!("Websocket sender has been closed, aborting websocket");
@@ -143,11 +149,7 @@ async fn subscription_forwarder_task(
         select! {
             Some(message) = receiver.recv() => {
                 trace!("Subscription message received: {}", message);
-                let sub_message = if use_binary {
-                    Message::Binary(message.to_string().into_bytes())
-                } else {
-                    Message::Text(message.to_string())
-                };
+                let sub_message = to_ws_message(message, use_binary);
                 if let Err(error) = msg_tx.send(sub_message).await {
                     debug!(%error, "WebSocket closed, stopping subscription forwarding");
                     break;

--- a/crates/full-node/sov-stf-runner/src/http/ws.rs
+++ b/crates/full-node/sov-stf-runner/src/http/ws.rs
@@ -4,6 +4,7 @@ use axum::response::IntoResponse;
 use futures::stream::{SplitSink, SplitStream};
 use futures_util::sink::SinkExt;
 use futures_util::stream::StreamExt;
+use jsonrpsee::core::JsonRawValue;
 use jsonrpsee::RpcModule;
 use tokio::sync::{mpsc, watch};
 use tokio::{select, spawn};
@@ -103,44 +104,51 @@ async fn handle_rpc_message(
     use_binary: bool,
 ) {
     // Buffer size picked up from `jsonrpsee` crate examples
-    match rpc_methods.raw_json_request(text, 1).await {
-        Ok((rpc_response, mut receiver)) => {
-            trace!("RPC request processed successfully: {}", rpc_response);
-            let response_message = if use_binary {
-                Message::Binary(rpc_response.to_string().into_bytes())
-            } else {
-                Message::Text(rpc_response.to_string())
-            };
+    let (rpc_response, receiver) = match rpc_methods.raw_json_request(text, 1).await {
+        Ok(res) => res,
+        Err(error) => return error!(%error, "Error while processing RPC request"),
+    };
+    trace!("RPC request processed successfully: {}", rpc_response);
+    let response_message = if use_binary {
+        Message::Binary(rpc_response.to_string().into_bytes())
+    } else {
+        Message::Text(rpc_response.to_string())
+    };
 
-            if socket_responses.send(response_message).await.is_err() {
-                error!("Websocket sender has been closed, aborting websocket");
-                return;
-            }
+    if socket_responses.send(response_message).await.is_err() {
+        return error!("Websocket sender has been closed, aborting websocket");
+    }
+    if receiver.is_closed() {
+        return;
+    }
 
-            if !receiver.is_closed() {
-                let subscription_responses = socket_responses.clone();
-                tokio::task::spawn(async move {
-                    trace!("Spawning subscription responses loop");
-                    while let Some(message) = receiver.recv().await {
-                        trace!("Subscription message received: {}", message);
-                        let sub_message = if use_binary {
-                            Message::Binary(message.to_string().into_bytes())
-                        } else {
-                            Message::Text(message.to_string())
-                        };
-                        if let Err(error) = subscription_responses.send(sub_message).await {
-                            debug!(%error, "WebSocket closed, stopping subscription forwarding");
-                            break;
-                        }
-                    }
-                    trace!("Subscription forwarding task finished");
-                });
-            }
-        }
-        Err(error) => {
-            error!(%error, "Error while processing RPC request");
+    trace!("Spawning subscription responses loop");
+    let subscription_responses = socket_responses.clone();
+    spawn(handle_subscription_response(
+        receiver,
+        subscription_responses,
+        use_binary,
+    ));
+}
+
+async fn handle_subscription_response(
+    mut receiver: mpsc::Receiver<Box<JsonRawValue>>,
+    subscription_responses: mpsc::Sender<Message>,
+    use_binary: bool,
+) {
+    while let Some(message) = receiver.recv().await {
+        trace!("Subscription message received: {}", message);
+        let sub_message = if use_binary {
+            Message::Binary(message.to_string().into_bytes())
+        } else {
+            Message::Text(message.to_string())
+        };
+        if let Err(error) = subscription_responses.send(sub_message).await {
+            debug!(%error, "WebSocket closed, stopping subscription forwarding");
+            break;
         }
     }
+    trace!("Subscription forwarding task finished");
 }
 
 async fn handle_socket_write(

--- a/crates/full-node/sov-stf-runner/src/http/ws.rs
+++ b/crates/full-node/sov-stf-runner/src/http/ws.rs
@@ -38,12 +38,12 @@ async fn handle_socket(
 
     let (msg_tx, msg_rx) = mpsc::channel(128);
 
-    spawn(handle_socket_write(
+    spawn(socket_writer_task(
         msg_rx,
         ws_writer,
         shutdown_receiver.clone(),
     ));
-    spawn(handle_socket_read(
+    spawn(socket_reader_task(
         ws_reader,
         msg_tx,
         rpc_methods,
@@ -51,7 +51,7 @@ async fn handle_socket(
     ));
 }
 
-async fn handle_socket_read(
+async fn socket_reader_task(
     mut ws_reader: SplitStream<WebSocket>,
     msg_tx: mpsc::Sender<Message>,
     rpc_methods: RpcModule<()>,
@@ -124,14 +124,14 @@ async fn handle_rpc_message(
 
     trace!("Spawning subscription responses loop");
     let subscription_msg_tx = msg_tx.clone();
-    spawn(handle_subscription_response(
+    spawn(subscription_forwarder_task(
         receiver,
         subscription_msg_tx,
         use_binary,
     ));
 }
 
-async fn handle_subscription_response(
+async fn subscription_forwarder_task(
     mut receiver: mpsc::Receiver<Box<JsonRawValue>>,
     msg_tx: mpsc::Sender<Message>,
     use_binary: bool,
@@ -151,7 +151,7 @@ async fn handle_subscription_response(
     trace!("Subscription forwarding task finished");
 }
 
-async fn handle_socket_write(
+async fn socket_writer_task(
     mut msg_rx: mpsc::Receiver<Message>,
     mut ws_writer: SplitSink<WebSocket, Message>,
     mut shutdown_receiver: watch::Receiver<()>,

--- a/crates/full-node/sov-stf-runner/src/http/ws.rs
+++ b/crates/full-node/sov-stf-runner/src/http/ws.rs
@@ -115,24 +115,24 @@ async fn handle_rpc_message(
     shutdown_receiver: &watch::Receiver<()>,
 ) {
     // Buffer size picked up from `jsonrpsee` crate examples
-    let (rpc_response, receiver) = match rpc_methods.raw_json_request(text, 1).await {
+    let (response, response_stream) = match rpc_methods.raw_json_request(text, 1).await {
         Ok(res) => res,
         Err(error) => return error!(%error, "Error while processing RPC request"),
     };
-    trace!("RPC request processed successfully: {}", rpc_response);
-    let response_message = to_ws_message(rpc_response, use_binary);
+    trace!("RPC request processed successfully: {}", response);
+    let response_message = to_ws_message(response, use_binary);
 
     if msg_tx.send(response_message).await.is_err() {
         return error!("Websocket sender has been closed, aborting websocket");
     }
-    if receiver.is_closed() {
+    if response_stream.is_closed() {
         return;
     }
 
     trace!("Spawning subscription responses loop");
     let subscription_msg_tx = msg_tx.clone();
     spawn(subscription_forwarder_task(
-        receiver,
+        response_stream,
         subscription_msg_tx,
         use_binary,
         shutdown_receiver.clone(),

--- a/crates/full-node/sov-stf-runner/src/http/ws.rs
+++ b/crates/full-node/sov-stf-runner/src/http/ws.rs
@@ -63,13 +63,13 @@ async fn socket_reader_task(
                 trace!(message = ?msg, "Message received from websocket");
                 match msg {
                     Message::Text(text) => {
-                        handle_rpc_message(&text, &msg_tx, &rpc_methods, false).await;
+                        handle_rpc_message(&text, &msg_tx, &rpc_methods, false, &shutdown_receiver).await;
                     }
                     Message::Binary(data) => {
                         // Parse binary frame as UTF-8 JSON-RPC request
                         match std::str::from_utf8(&data) {
                             Ok(text) => {
-                                handle_rpc_message(text, &msg_tx, &rpc_methods, true).await;
+                                handle_rpc_message(text, &msg_tx, &rpc_methods, true, &shutdown_receiver).await;
                             }
                             Err(error) => {
                                 error!(%error, "Invalid UTF-8 in binary WebSocket frame");
@@ -102,6 +102,7 @@ async fn handle_rpc_message(
     msg_tx: &mpsc::Sender<Message>,
     rpc_methods: &RpcModule<()>,
     use_binary: bool,
+    shutdown_receiver: &watch::Receiver<()>,
 ) {
     // Buffer size picked up from `jsonrpsee` crate examples
     let (rpc_response, receiver) = match rpc_methods.raw_json_request(text, 1).await {
@@ -128,6 +129,7 @@ async fn handle_rpc_message(
         receiver,
         subscription_msg_tx,
         use_binary,
+        shutdown_receiver.clone(),
     ));
 }
 
@@ -135,17 +137,26 @@ async fn subscription_forwarder_task(
     mut receiver: mpsc::Receiver<Box<JsonRawValue>>,
     msg_tx: mpsc::Sender<Message>,
     use_binary: bool,
+    mut shutdown_receiver: watch::Receiver<()>,
 ) {
-    while let Some(message) = receiver.recv().await {
-        trace!("Subscription message received: {}", message);
-        let sub_message = if use_binary {
-            Message::Binary(message.to_string().into_bytes())
-        } else {
-            Message::Text(message.to_string())
-        };
-        if let Err(error) = msg_tx.send(sub_message).await {
-            debug!(%error, "WebSocket closed, stopping subscription forwarding");
-            break;
+    loop {
+        select! {
+            Some(message) = receiver.recv() => {
+                trace!("Subscription message received: {}", message);
+                let sub_message = if use_binary {
+                    Message::Binary(message.to_string().into_bytes())
+                } else {
+                    Message::Text(message.to_string())
+                };
+                if let Err(error) = msg_tx.send(sub_message).await {
+                    debug!(%error, "WebSocket closed, stopping subscription forwarding");
+                    break;
+                }
+            }
+            _ = shutdown_receiver.changed() => {
+                debug!("Shutdown signal received, stopping subscription forwarder");
+                break;
+            }
         }
     }
     trace!("Subscription forwarding task finished");

--- a/crates/full-node/sov-stf-runner/src/http/ws.rs
+++ b/crates/full-node/sov-stf-runner/src/http/ws.rs
@@ -1,0 +1,167 @@
+use axum::extract::ws::{Message, WebSocket};
+use axum::extract::WebSocketUpgrade;
+use axum::response::IntoResponse;
+use futures::stream::{SplitSink, SplitStream};
+use futures_util::sink::SinkExt;
+use futures_util::stream::StreamExt;
+use jsonrpsee::RpcModule;
+use tokio::sync::{mpsc, watch};
+use tokio::{select, spawn};
+use tracing::{debug, error, trace};
+
+pub async fn ws_rpc_handler(
+    ws: WebSocketUpgrade,
+    rpc_methods: RpcModule<()>,
+    shutdown_receiver: watch::Receiver<()>,
+) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| async move {
+        handle_socket(socket, rpc_methods, shutdown_receiver.clone()).await;
+    })
+}
+
+// To support duplex communication socket is split into 2 streams,
+// each stream is processed in their own task
+// 1. Reader task receives requests from websocket and pushes appropriate responses into the mpsc channel to the writer task.
+//    In the case of subscriptions, the reader task clones `tokio::sync::mpsc::Sender` and spawns another task,
+//    where subscription responses are piped to the writer task.
+// 2. Writer task listens to [`tokio::sync::mpsc::Receiver`] and writes responses to websocket.
+//
+// When the WebSocket closes, the writer task exits and drops the socket_responses receiver,
+// which causes all subscription forwarding tasks to stop sending (their send() calls will fail).
+async fn handle_socket(
+    socket: WebSocket,
+    rpc_methods: RpcModule<()>,
+    shutdown_receiver: watch::Receiver<()>,
+) {
+    let (sender, receiver) = socket.split();
+
+    let (socket_requests, socket_responses) = mpsc::channel(128);
+
+    spawn(handle_socket_write(
+        socket_responses,
+        sender,
+        shutdown_receiver.clone(),
+    ));
+    spawn(handle_socket_read(
+        receiver,
+        socket_requests,
+        rpc_methods,
+        shutdown_receiver.clone(),
+    ));
+}
+
+async fn handle_socket_read(
+    mut socket_requests: SplitStream<WebSocket>,
+    socket_responses: mpsc::Sender<Message>,
+    rpc_methods: RpcModule<()>,
+    mut shutdown_receiver: watch::Receiver<()>,
+) {
+    loop {
+        select! {
+            Some(Ok(msg)) = socket_requests.next() => {
+                trace!(message = ?msg, "Message received from websocket");
+                match msg {
+                    Message::Text(text) => {
+                        handle_rpc_message(&text, &socket_responses, &rpc_methods, false).await;
+                    }
+                    Message::Binary(data) => {
+                        // Parse binary frame as UTF-8 JSON-RPC request
+                        match std::str::from_utf8(&data) {
+                            Ok(text) => {
+                                handle_rpc_message(text, &socket_responses, &rpc_methods, true).await;
+                            }
+                            Err(error) => {
+                                error!(%error, "Invalid UTF-8 in binary WebSocket frame");
+                            }
+                        }
+                    }
+                    Message::Pong(_) => {}
+                    Message::Ping(ping) => {
+                        if socket_responses.send(Message::Pong(ping)).await.is_err() {
+                            error!("Websocket sender has been closed, aborting websocket");
+                            break;
+                        }
+                    }
+                    Message::Close(_) => {
+                        break;
+                    }
+                }
+            }
+            _ = shutdown_receiver.changed() => {
+                debug!("Shutdown signal received, stopping WebSocket read handler");
+                break;
+            }
+        }
+    }
+    trace!("WebSocket read handler finished");
+}
+
+async fn handle_rpc_message(
+    text: &str,
+    socket_responses: &mpsc::Sender<Message>,
+    rpc_methods: &RpcModule<()>,
+    use_binary: bool,
+) {
+    // Buffer size picked up from `jsonrpsee` crate examples
+    match rpc_methods.raw_json_request(text, 1).await {
+        Ok((rpc_response, mut receiver)) => {
+            trace!("RPC request processed successfully: {}", rpc_response);
+            let response_message = if use_binary {
+                Message::Binary(rpc_response.to_string().into_bytes())
+            } else {
+                Message::Text(rpc_response.to_string())
+            };
+
+            if socket_responses.send(response_message).await.is_err() {
+                error!("Websocket sender has been closed, aborting websocket");
+                return;
+            }
+
+            if !receiver.is_closed() {
+                let subscription_responses = socket_responses.clone();
+                tokio::task::spawn(async move {
+                    trace!("Spawning subscription responses loop");
+                    while let Some(message) = receiver.recv().await {
+                        trace!("Subscription message received: {}", message);
+                        let sub_message = if use_binary {
+                            Message::Binary(message.to_string().into_bytes())
+                        } else {
+                            Message::Text(message.to_string())
+                        };
+                        if let Err(error) = subscription_responses.send(sub_message).await {
+                            debug!(%error, "WebSocket closed, stopping subscription forwarding");
+                            break;
+                        }
+                    }
+                    trace!("Subscription forwarding task finished");
+                });
+            }
+        }
+        Err(error) => {
+            error!(%error, "Error while processing RPC request");
+        }
+    }
+}
+
+async fn handle_socket_write(
+    mut socket_requests: mpsc::Receiver<Message>,
+    mut socket_responses: SplitSink<WebSocket, Message>,
+    mut shutdown_receiver: watch::Receiver<()>,
+) {
+    loop {
+        select! {
+            Some(response) = socket_requests.recv() => {
+                if let Err(error) = socket_responses.send(response).await {
+                    debug!(%error, "WebSocket closed, stopping writer task");
+                    break;
+                }
+                trace!("Message sent to websocket");
+            }
+            _ = shutdown_receiver.changed() => {
+                debug!("Shutdown signal received, stopping WebSocket write handler");
+                break;
+            }
+        }
+    }
+    trace!("WebSocket write handler finished");
+}

--- a/crates/rollup-interface/src/node/mod.rs
+++ b/crates/rollup-interface/src/node/mod.rs
@@ -54,8 +54,8 @@ pub enum FutureOrShutdownOutput<O> {
 /// * `debug!(%name, "Stream/channel closed, stopping task")` on close
 ///
 /// # Example
-/// ```rust
-/// consume_until_shutdown!(
+/// ```ignore
+/// sov_rollup_interface::consume_until_shutdown!(
 ///     "WebSocket reader",
 ///     ws_reader.next(),
 ///     shutdown_rx,

--- a/crates/rollup-interface/src/node/mod.rs
+++ b/crates/rollup-interface/src/node/mod.rs
@@ -37,3 +37,57 @@ pub enum FutureOrShutdownOutput<O> {
     /// The future should not be polled anymore.
     Shutdown,
 }
+
+/// Repeatedly receives messages until shutdown or channel close.
+///
+/// Works with any async source returning `Option<T>` (e.g. `recv()` or `next()`).
+///
+/// # Args
+/// * `$name` – task name (for structured logs, e.g. `"writer"` or `format!("task-{id}")`)
+/// * `$recv` – async expression like `rx.recv()` or `stream.next()`
+/// * `$shutdown` – `watch::Receiver<()>` for graceful stop
+/// * `$var => $body` – code run for each received item
+///
+/// Logs:
+/// * `trace!(%name, "Message received")` for each message
+/// * `debug!(%name, "Shutdown signal received, stopping task")` on shutdown
+/// * `debug!(%name, "Stream/channel closed, stopping task")` on close
+///
+/// # Example
+/// ```rust
+/// consume_until_shutdown!(
+///     "WebSocket reader",
+///     ws_reader.next(),
+///     shutdown_rx,
+///     msg => {
+///         handle(m).await,
+///     }
+/// );
+/// ```
+#[macro_export]
+macro_rules! consume_until_shutdown {
+    (
+        $name:expr,
+        $recv:expr,
+        $shutdown:expr,
+        $var:ident => $body:block
+    ) => {
+        let name = $name;
+        loop {
+            tokio::select! {
+                _ = $shutdown.changed() => {
+                    tracing::debug!(%name, "Shutdown signal received, stopping task");
+                    break;
+                }
+                maybe_item = $recv => {
+                    let Some($var) = maybe_item else {
+                        tracing::debug!(%name, "Stream/channel closed, stopping task");
+                        break;
+                    };
+                    tracing::trace!(%name, "Message received");
+                    $body
+                }
+            }
+        }
+    };
+}


### PR DESCRIPTION
# Description


## Changes

- **Module structure**: Extract WebSocket handling from `http.rs` into dedicated `http/ws.rs` module
- **Variable naming**: `sender/receiver` → `ws_writer/ws_reader`, `socket_requests/socket_responses` → `msg_tx/msg_rx`
- **Function naming**: `handle_socket_read/write` → `socket_reader_task/socket_writer_task`
- **Code cleanup**: Extract `to_ws_message` helper, add shutdown handling to subscription forwarder

No functional changes - purely a refactoring for better code clarity.

----

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
