### PR TITLE
Improve replica logging and adjust cache warmup worker behavior.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -10,7 +10,7 @@ use sqlx::postgres::{PgListener, PgPoolOptions};
 use sqlx::PgPool;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
-use tracing::{error, trace};
+use tracing::{debug, error, trace};
 
 const MAX_DB_ERRORS_ALLOWED: u32 = 10;
 
@@ -128,6 +128,7 @@ impl EventReceiver {
                 panic!("Failed to listen on events_changes channel: {e:?}. Replica shutting down.");
             }
 
+            debug!("Relica event receiver started.");
             loop {
                 let fut = future_or_shutdown(
                     self.fetch_data(start_event_id, prev_event_type, &mut listener),
@@ -146,14 +147,14 @@ impl EventReceiver {
                     }
                     Err(err) => {
                         match err {
-                            EventReceiverError::ParsingError(e) => {
+                            EventReceiverError::ParsingError(err) => {
                                 // This should never happen, so we shut down the replica immediately
                                 panic!(
-                                    "Failed to parse notification: {e:?}. Shutting down replica."
+                                    "Failed to parse notification: {err:?}. Shutting down replica."
                                 );
                             }
-                            EventReceiverError::DbError(e) => {
-                                error!("Failed to receive notifications from database: {e:?}. Shutting down replica.");
+                            EventReceiverError::DbError(err) => {
+                                error!(?err, ?start_event_id, "Failed to receive notifications from database. Shutting down replica.");
 
                                 if shutdown_receiver.has_changed().unwrap_or(true) {
                                     break;
@@ -230,6 +231,7 @@ impl EventReceiver {
                 let notify = EventsNotificationPayload::parse_csv(notify.payload())?;
 
                 if matches!(notify.event_type, EventType::BatchStart) {
+                    debug!(?notify, "Relica received first BatchStart notification.");
                     break (notify.event_id, notify.event_id);
                 }
             },

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/conditions_table.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/conditions_table.rs
@@ -180,8 +180,9 @@ pub(crate) async fn operation_for_replica<S: Spec, Rt: Runtime<S>>(
                     slot_number_according_to_node=%info.slot_number,
                     %current_visible_slot_number,
                     deferred_slots = %config_value!("DEFERRED_SLOTS_COUNT"),
-                    "Sequencer has detected that it is past, or very close to, having the visible_slot_number lag behind the deferred_slots_count threshold.");
-            panic!("Replica does not support automatic recovery.");
+                    "Sequencer has detected that it is past, or very close to, having the visible_slot_number lag behind the deferred_slots_count threshold. Replica will keep syncing.");
+
+            PreferredSeqOperation::WaitForNodeResyncToTip
         }
         // Node is out of sync and doesn't know it. This is a rare edge case after a DB wipe.
         (_, _, _, _, true) => {

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -896,16 +896,19 @@ fn validate_db_data_from_replica<S: Spec>(
     }
 
     if let Err(err) = is_ready {
+        tracing::debug!(?err, "Replica not ready");
         return Err(ReplicaError::NotReady(err.clone(), ret));
     }
 
     if seq_nr_for_this_executor > seq_nr_from_master {
+        tracing::debug!(%seq_nr_for_this_executor, %seq_nr_from_master, "Replica is ahead of master.");
         return Err(ReplicaError::Rejected(DBDataRejected::ExecutorAhead(
             seq_nr_for_this_executor,
         )));
     }
 
     if seq_nr_for_this_executor < seq_nr_from_master {
+        tracing::debug!(%seq_nr_for_this_executor, %seq_nr_from_master, "Replica is behind master.");
         return Err(ReplicaError::Rejected(DBDataRejected::ExecutorBehind(ret)));
     }
 

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -127,6 +127,6 @@ batch_execution_time_limit_millis = 12000 # Do no more than 12 seconds worth of 
 # The sequencer optimistically pre-executes transactions across multiple worker threads.
 # This warms up caches so the main transaction executor can run with ready-to-use data.
 # This variable determines the number of worker threads.
-num_cache_warmup_workers = 5
+num_cache_warmup_workers = 0
 [sequencer.extension]
 max_log_limit = 20000

--- a/examples/demo-rollup/configs/external_mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/external_mock_rollup_config.toml
@@ -76,7 +76,7 @@ batch_execution_time_limit_millis = 2000 # Do no more than 2000ms of work per ba
 # The sequencer optimistically pre-executes transactions across multiple worker threads.
 # This warms up caches so the main transaction executor can run with ready-to-use data.
 # This variable determines the number of worker threads.
-num_cache_warmup_workers = 5
+num_cache_warmup_workers = 0
 # minimum_profit_per_tx = 0 # Minimum fee the preferred sequencer accepts per tx, in gas tokens
 # events_channel_size = 10000 # Size of Tokio channel for streaming events. Larger values increase memory usage
 postgres_connection_string = "postgresql://postgres:pass@localhost:5432/db" # HIGHLY RECOMMENDED: Use Postgres instead of RocksDB to soft confirmed transactions

--- a/examples/demo-rollup/configs/mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/mock_rollup_config.toml
@@ -103,7 +103,7 @@ batch_execution_time_limit_millis = 2000 # Do no more than 2000ms of work per ba
 # The sequencer optimistically pre-executes transactions across multiple worker threads.
 # This warms up caches so the main transaction executor can run with ready-to-use data.
 # This variable determines the number of worker threads.
-num_cache_warmup_workers = 5
+num_cache_warmup_workers = 0
 # minimum_profit_per_tx = 0 # Minimum fee the preferred sequencer accepts per tx, in gas tokens
 # events_channel_size = 10000 # Size of Tokio channel for streaming events. Larger values increase memory usage
 # postgres_connection_string = "postgresql://user:pass@host/db" # HIGHLY RECOMMENDED: Use Postgres instead of RocksDB to soft confirmed transactions

--- a/examples/demo-rollup/configs/replica_external_mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/replica_external_mock_rollup_config.toml
@@ -76,7 +76,7 @@ batch_execution_time_limit_millis = 2000 # Do no more than 2000ms of work per ba
 # The sequencer optimistically pre-executes transactions across multiple worker threads.
 # This warms up caches so the main transaction executor can run with ready-to-use data.
 # This variable determines the number of worker threads.
-num_cache_warmup_workers = 5
+num_cache_warmup_workers = 0
 # minimum_profit_per_tx = 0 # Minimum fee the preferred sequencer accepts per tx, in gas tokens
 # events_channel_size = 10000 # Size of Tokio channel for streaming events. Larger values increase memory usage
 postgres_connection_string = "postgresql://postgres:pass@localhost:5432/db" # HIGHLY RECOMMENDED: Use Postgres instead of RocksDB to soft confirmed transactions


### PR DESCRIPTION
# Description

This PR includes the following updates:
1. Added additional replica-related logs.
2. Set `num_cache_warmup_workers` to 0, as higher values did not yield any performance improvement.
3. Updated replica behavior during recovery to continuously sync.


- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
