### PR TITLE
Speed up RPC websocket reads/writes. Handle lag in logs soak test with subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12043,6 +12043,8 @@ dependencies = [
  "sov-eth-client",
  "sov-test-utils",
  "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]

--- a/crates/full-node/sov-stf-runner/src/http.rs
+++ b/crates/full-node/sov-stf-runner/src/http.rs
@@ -235,7 +235,8 @@ async fn handle_rpc_message(
             Err(error) => {
                 tracing::error!(%error, "Error while processing RPC request");
             }
-        }});
+        }
+    });
 }
 
 async fn handle_socket_read(
@@ -314,7 +315,7 @@ async fn handle_socket_write(
                     break;
                 }
                 tracing::trace!("{} messages sent to websocket", num_items);
-                
+
             }
             _ = shutdown_receiver.changed() => {
                 tracing::debug!("Shutdown signal received, stopping WebSocket write handler");

--- a/crates/full-node/sov-stf-runner/src/http.rs
+++ b/crates/full-node/sov-stf-runner/src/http.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use axum::body::HttpBody;
 use axum::error_handling::HandleErrorLayer;
@@ -187,50 +188,54 @@ async fn handle_socket(
 }
 
 async fn handle_rpc_message(
-    text: &str,
+    text: String,
     socket_responses: &tokio::sync::mpsc::Sender<Message>,
     rpc_methods: &RpcModule<()>,
     use_binary: bool,
 ) {
-    // Buffer size picked up from `jsonrpsee` crate examples
-    match rpc_methods.raw_json_request(text, 1).await {
-        Ok((rpc_response, mut receiver)) => {
-            tracing::trace!("RPC request processed successfully: {}", rpc_response);
-            let response_message = if use_binary {
-                Message::Binary(rpc_response.to_string().into_bytes())
-            } else {
-                Message::Text(rpc_response.to_string())
-            };
+    // Spawn a task per inbound request
+    let socket_responses = socket_responses.clone();
+    let rpc_methods = rpc_methods.clone();
+    tokio::spawn(async move {
+        // Buffer size picked up from `jsonrpsee` crate examples
+        match rpc_methods.raw_json_request(&text, 1).await {
+            Ok((rpc_response, mut receiver)) => {
+                tracing::trace!("RPC request processed successfully: {}", rpc_response);
+                let response_message = if use_binary {
+                    Message::Binary(rpc_response.to_string().into_bytes())
+                } else {
+                    Message::Text(rpc_response.to_string())
+                };
 
-            if socket_responses.send(response_message).await.is_err() {
-                tracing::error!("Websocket sender has been closed, aborting websocket");
-                return;
-            }
+                if socket_responses.send(response_message).await.is_err() {
+                    tracing::error!("Websocket sender has been closed, aborting websocket");
+                    return;
+                }
 
-            if !receiver.is_closed() {
-                let subscription_responses = socket_responses.clone();
-                tokio::task::spawn(async move {
-                    tracing::trace!("Spawning subscription responses loop");
-                    while let Some(message) = receiver.recv().await {
-                        tracing::trace!("Subscription message received: {}", message);
-                        let sub_message = if use_binary {
-                            Message::Binary(message.to_string().into_bytes())
-                        } else {
-                            Message::Text(message.to_string())
-                        };
-                        if let Err(error) = subscription_responses.send(sub_message).await {
-                            tracing::debug!(%error, "WebSocket closed, stopping subscription forwarding");
-                            break;
+                if !receiver.is_closed() {
+                    let subscription_responses = socket_responses.clone();
+                    tokio::task::spawn(async move {
+                        tracing::trace!("Spawning subscription responses loop");
+                        while let Some(message) = receiver.recv().await {
+                            tracing::trace!("Subscription message received: {}", message);
+                            let sub_message = if use_binary {
+                                Message::Binary(message.to_string().into_bytes())
+                            } else {
+                                Message::Text(message.to_string())
+                            };
+                            if let Err(error) = subscription_responses.send(sub_message).await {
+                                tracing::debug!(%error, "WebSocket closed, stopping subscription forwarding");
+                                break;
+                            }
                         }
-                    }
-                    tracing::trace!("Subscription forwarding task finished");
-                });
+                        tracing::trace!("Subscription forwarding task finished");
+                    });
+                }
             }
-        }
-        Err(error) => {
-            tracing::error!(%error, "Error while processing RPC request");
-        }
-    }
+            Err(error) => {
+                tracing::error!(%error, "Error while processing RPC request");
+            }
+        }});
 }
 
 async fn handle_socket_read(
@@ -245,11 +250,11 @@ async fn handle_socket_read(
                 tracing::trace!(message = ?msg, "Message received from websocket");
                 match msg {
                     Message::Text(text) => {
-                        handle_rpc_message(&text, &socket_responses, &rpc_methods, false).await;
+                        handle_rpc_message(text, &socket_responses, &rpc_methods, false).await;
                     }
                     Message::Binary(data) => {
                         // Parse binary frame as UTF-8 JSON-RPC request
-                        match std::str::from_utf8(&data) {
+                        match String::from_utf8(data) {
                             Ok(text) => {
                                 handle_rpc_message(text, &socket_responses, &rpc_methods, true).await;
                             }
@@ -284,14 +289,32 @@ async fn handle_socket_write(
     mut socket_responses: futures_util::stream::SplitSink<WebSocket, Message>,
     mut shutdown_receiver: watch::Receiver<()>,
 ) {
+    let mut pending = Vec::with_capacity(128);
     loop {
         tokio::select! {
             Some(response) = socket_requests.recv() => {
-                if let Err(error) = socket_responses.send(response).await {
+                // Drain all available messages into the pending buffer (up to 128)
+                // Then send as a batch and flush once
+                pending.push(response);
+                while let Ok(response) = socket_requests.try_recv() {
+                    pending.push(response);
+                    if pending.len() >= 128 {
+                        break;
+                    }
+                }
+                let num_items = pending.len();
+                for item in pending.drain(..) {
+                    if let Err(error) = socket_responses.feed(item).await {
+                        tracing::debug!(%error, "WebSocket closed, stopping writer task");
+                        break;
+                    }
+                }
+                if let Err(error) = socket_responses.flush().await {
                     tracing::debug!(%error, "WebSocket closed, stopping writer task");
                     break;
                 }
-                tracing::trace!("Message sent to websocket");
+                tracing::trace!("{} messages sent to websocket", num_items);
+                
             }
             _ = shutdown_receiver.changed() => {
                 tracing::debug!("Shutdown signal received, stopping WebSocket write handler");
@@ -299,7 +322,6 @@ async fn handle_socket_write(
             }
         }
     }
-    tracing::trace!("WebSocket write handler finished");
 }
 
 #[cfg(test)]

--- a/crates/full-node/sov-stf-runner/src/http.rs
+++ b/crates/full-node/sov-stf-runner/src/http.rs
@@ -1,5 +1,4 @@
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use axum::body::HttpBody;
 use axum::error_handling::HandleErrorLayer;

--- a/crates/utils/sov-evm-soak-testing/Cargo.toml
+++ b/crates/utils/sov-evm-soak-testing/Cargo.toml
@@ -20,6 +20,8 @@ rand = { workspace = true }
 clap = { workspace = true }
 reqwest = { workspace = true }
 futures = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/utils/sov-evm-soak-testing/src/logs.rs
+++ b/crates/utils/sov-evm-soak-testing/src/logs.rs
@@ -7,7 +7,6 @@ use alloy_primitives::U256;
 use alloy_pubsub::Subscription;
 use anyhow::Result;
 use futures::future::try_join_all;
-use futures::StreamExt;
 use sov_eth_client::LogsWithCursorProvider;
 use sov_test_utils::SimpleStorage;
 use sov_test_utils::Submit;

--- a/crates/utils/sov-evm-soak-testing/src/logs.rs
+++ b/crates/utils/sov-evm-soak-testing/src/logs.rs
@@ -116,8 +116,9 @@ async fn stream_logs(mut subscription: Subscription<Log>, expected_count: usize)
                             count += 1;
                         }
                         Err(broadcast::error::TryRecvError::Lagged(amount)) => {
-                                println!("Subscription lagged by {amount} during try_recv");
-                            let amount: usize = amount.try_into().expect("Failed to convert u64 to usize");
+                            println!("Subscription lagged by {amount} during try_recv");
+                            let amount: usize =
+                                amount.try_into().expect("Failed to convert u64 to usize");
                             count += amount;
                         }
                         Err(_) => {
@@ -128,12 +129,12 @@ async fn stream_logs(mut subscription: Subscription<Log>, expected_count: usize)
                 if count == expected_count {
                     break;
                 }
-            },
+            }
             Ok(Err(e)) => match e {
                 broadcast::error::RecvError::Closed => {
                     println!("Subscription closed");
                     break;
-                },
+                }
                 broadcast::error::RecvError::Lagged(amount) => {
                     println!("Subscription lagged by {amount}");
                     let amount: usize = amount.try_into().expect("Failed to convert u64 to usize");

--- a/crates/utils/sov-evm-soak-testing/src/logs.rs
+++ b/crates/utils/sov-evm-soak-testing/src/logs.rs
@@ -13,6 +13,7 @@ use sov_test_utils::SimpleStorage;
 use sov_test_utils::Submit;
 use std::net::SocketAddr;
 use std::time::Instant;
+use tokio::sync::broadcast;
 
 use crate::{alloy_client, fund_worker_accounts, validate_worker_count, LogsRetrievalMode};
 use crate::{alloy_ws_client, derive_worker_key};
@@ -99,14 +100,53 @@ async fn retrieve_logs(client: DynProvider, from_block: u64) -> Result<()> {
     Ok(())
 }
 
-async fn stream_logs(subscription: Subscription<Log>, expected_count: usize) -> Result<()> {
+async fn stream_logs(mut subscription: Subscription<Log>, expected_count: usize) -> Result<()> {
     let timer = Instant::now();
-    let mut stream = subscription.into_stream();
+    // let mut stream = subscription.into_stream();
     let mut count = 0;
-    while let Some(_item) = stream.next().await {
-        count += 1;
-        if count == expected_count {
-            break;
+    let mut timeouts = 0;
+    loop {
+        match tokio::time::timeout(std::time::Duration::from_secs(1), subscription.recv()).await {
+            Ok(Ok(_item)) => {
+                // On successful recv, drain all available messages before `await`ing again
+                count += 1;
+                loop {
+                    match subscription.try_recv() {
+                        Ok(_item) => {
+                            count += 1;
+                        }
+                        Err(broadcast::error::TryRecvError::Lagged(amount)) => {
+                                println!("Subscription lagged by {amount} during try_recv");
+                            let amount: usize = amount.try_into().expect("Failed to convert u64 to usize");
+                            count += amount;
+                        }
+                        Err(_) => {
+                            break;
+                        }
+                    }
+                }
+                if count == expected_count {
+                    break;
+                }
+            },
+            Ok(Err(e)) => match e {
+                broadcast::error::RecvError::Closed => {
+                    println!("Subscription closed");
+                    break;
+                },
+                broadcast::error::RecvError::Lagged(amount) => {
+                    println!("Subscription lagged by {amount}");
+                    let amount: usize = amount.try_into().expect("Failed to convert u64 to usize");
+                    count += amount;
+                }
+            },
+            Err(_) => {
+                println!("Timeout receiving log {count}. Timeouts: {timeouts} (shutdown after 10 timeouts)");
+                timeouts += 1;
+                if timeouts >= 10 {
+                    break;
+                }
+            }
         }
     }
     assert_eq!(count, expected_count);

--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -7,10 +7,10 @@ use alloy::{hex, providers::DynProvider};
 use alloy_primitives::U256;
 use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};
-use tracing_subscriber::EnvFilter;
 use futures::future::try_join_all;
 use reqwest::Url;
 use std::net::SocketAddr;
+use tracing_subscriber::EnvFilter;
 
 mod logs;
 mod simple_storage;
@@ -204,10 +204,10 @@ async fn run_simple_storage_test(rpc_addr: SocketAddr, private_key: &str) -> Res
 async fn main() -> Result<()> {
     let args = Args::parse();
     tracing_subscriber::fmt()
-    .with_env_filter(
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug")),
-    )
-    .init();
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug")),
+        )
+        .init();
 
     match args.test {
         TestType::Uniswap { count, num_workers } => {

--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -7,6 +7,7 @@ use alloy::{hex, providers::DynProvider};
 use alloy_primitives::U256;
 use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};
+use tracing_subscriber::EnvFilter;
 use futures::future::try_join_all;
 use reqwest::Url;
 use std::net::SocketAddr;
@@ -174,6 +175,10 @@ async fn fund_worker_accounts(
 ) -> Result<()> {
     let root_balance = root_client.get_balance(root_signer.address()).await?;
     let transfer_amount = root_balance.wrapping_div(U256::from(num_workers));
+    if transfer_amount == U256::ZERO {
+        tracing::warn!("Root balance is too low to fund all workers. Skipping funding. This is fine if the paymaster is enabled.");
+        return Ok(());
+    }
 
     for worker_idx in 0..num_workers {
         let worker_signer: PrivateKeySigner =
@@ -198,6 +203,11 @@ async fn run_simple_storage_test(rpc_addr: SocketAddr, private_key: &str) -> Res
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
+    tracing_subscriber::fmt()
+    .with_env_filter(
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug")),
+    )
+    .init();
 
     match args.test {
         TestType::Uniswap { count, num_workers } => {


### PR DESCRIPTION
# Description

This PR makes two changes to our handling of RPC websocket subscriptions:
1. All inbound requests are `tokio::spawn`ed before handling. This ensures that any long running requests (like realtime_sendRawTransaction) don't block the inbound channel.
2. The `write` handler now batches requests to avoid `await` when possible:
  a. Drain the outbound queue of up to 128 requests per `await`
  b. Send all available messages using `feed` instead of `send`, then `flush` once. This prevents us from `flush`ing after each message which improves efficiency significantly.


This PR also revises our log soak test to handle channel lag by...
1. Setting up a tracing subscriber so that messages from alloy aren't swallowed by default
2. Switching from a tokio stream back to a raw receiver so that we can count `lag` messages

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
