### PR TITLE
Stabilizing celestia docker-based tests

### DIFF
--- a/crates/adapters/celestia/src/da_service/tests.rs
+++ b/crates/adapters/celestia/src/da_service/tests.rs
@@ -28,7 +28,11 @@ async fn collect_all_blobs_between(
 ) -> anyhow::Result<(Vec<BlobWithSender>, Vec<BlobWithSender>)> {
     // Adding one more height to the current head to accommodate for blob inclusion.
     // Even by the time submiPayForBlob has returned it should be included, we observed flakyness.
-    let height_after = da_service.get_head_block_header().await?.height().saturating_add(1);
+    let height_after = da_service
+        .get_head_block_header()
+        .await?
+        .height()
+        .saturating_add(1);
     let mut collected_batch_blobs = Vec::new();
     let mut collected_proof_blobs = Vec::new();
 

--- a/crates/adapters/celestia/src/da_service/tests.rs
+++ b/crates/adapters/celestia/src/da_service/tests.rs
@@ -26,7 +26,9 @@ async fn collect_all_blobs_between(
     da_service: &CelestiaService,
     height_before: u64,
 ) -> anyhow::Result<(Vec<BlobWithSender>, Vec<BlobWithSender>)> {
-    let height_after = da_service.get_head_block_header().await?.height();
+    // Adding one more height to the current head to accommodate for blob inclusion.
+    // Even by the time submiPayForBlob has returned it should be included, we observed flakyness.
+    let height_after = da_service.get_head_block_header().await?.height().saturating_add(1);
     let mut collected_batch_blobs = Vec::new();
     let mut collected_proof_blobs = Vec::new();
 

--- a/crates/adapters/celestia/src/da_service/tests.rs
+++ b/crates/adapters/celestia/src/da_service/tests.rs
@@ -27,7 +27,7 @@ async fn collect_all_blobs_between(
     height_before: u64,
 ) -> anyhow::Result<(Vec<BlobWithSender>, Vec<BlobWithSender>)> {
     // Adding one more height to the current head to accommodate for blob inclusion.
-    // Even by the time submiPayForBlob has returned it should be included, we observed flakyness.
+    // Even though by the time submiPayForBlob has returned it should be included, we observed flakyness.
     let height_after = da_service
         .get_head_block_header()
         .await?


### PR DESCRIPTION
# Description

Adding extra 1 block of waiting, in case if celestia docker returns earlier and blob is actually included in the next block.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues


## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
