### PR TITLE
Bumping `PAST_TRANSACTION_GENERATION` to be compatible with ms

### DIFF
--- a/constants.testing.toml
+++ b/constants.testing.toml
@@ -35,7 +35,7 @@ MAX_VISIBLE_HEIGHT_INCREASE_PER_SLOT = 10
 UNREGISTERED_BLOBS_PER_SLOT = 5
 # How many past transaction generations into the past to keep per-account buckets for
 # Higher numbers give more flexibility to avoid collisions, lower numbers reduce the maximum amount of storage used
-PAST_TRANSACTION_GENERATIONS = 5
+PAST_TRANSACTION_GENERATIONS = 5_000
 # The maximum number of transactions hashes we remember per credential. 
 # Higher numbers allow accounts to send more transactions without updating their generation number. 
 # This is more user friendly for power users, but increases the worst case cost of the uniqueness check.

--- a/constants.toml
+++ b/constants.toml
@@ -50,7 +50,8 @@ STATE_ROOT_DELAY_BLOCKS = 3
 UNREGISTERED_BLOBS_PER_SLOT = 5
 # How many past transaction generations into the past to keep per-account buckets for
 # Higher numbers give more flexibility to avoid collisions, lower numbers reduce the maximum amount of storage used
-PAST_TRANSACTION_GENERATIONS = 5
+# Preferrably to use milliseconds as a value in tx
+PAST_TRANSACTION_GENERATIONS = 5_000
 # The maximum number of transactions hashes we remember per credential. 
 # Higher numbers allow accounts to send more transactions without updating their generation number. 
 # This is more user friendly for power users, but increases the worst case cost of the uniqueness check.

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1838,7 +1838,8 @@ async fn seq_many_invalid_txs() {
     }
 
     let client = test_rollup.api_client().clone();
-    let tx = tx_set_value(&admin.private_key, txs, 1_000_000);
+    let generation = config_value!("PAST_TRANSACTION_GENERATIONS") + txs;
+    let tx = tx_set_value(&admin.private_key, generation, 1_000_000);
 
     client
         .send_raw_tx_to_sequencer_with_retry(&tx)

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -9,7 +9,6 @@ use crate::utils::{
 use backon::Retryable;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
-use borsh::{BorshDeserialize, BorshSerialize};
 use full_node_configs::sequencer::default_ideal_lag_behind_finalized_slot;
 use futures::future;
 use serde_json::Number;
@@ -395,7 +394,8 @@ impl Default for TestState {
         Self {
             value_by_slot_number: Default::default(),
             _current_slot_number: Default::default(),
-            next_generation: 10, // initialize to a higher generation so that "invalid generation" actions are always possible
+            // initialize to a higher generation so that "invalid generation" actions are always possible
+            next_generation: config_value!("PAST_TRANSACTION_GENERATIONS") + 10,
             current_value: Default::default(),
         }
     }
@@ -2907,11 +2907,6 @@ async fn restart_after_big_batch_regression() {
     preferred_sequencer_is_resistant_to_miscellaneous_edge_cases(actions).await;
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Clone)]
-struct X {
-    data: Vec<Vec<u8>>,
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn flaky_batch_production_with_immediate_finalization() {
     let actions = vec![
@@ -3160,7 +3155,7 @@ pub(crate) async fn run_action_against_test_rollup(
             // This is a more complex action, as the sequencer cannot accept transactions on
             // startup until a StateUpdateInfo from the node has been processed.
             let test_rollup = test_rollup.restart().await?;
-            test_rollup.da_service.produce_block_now().await.unwrap();
+            test_rollup.da_service.produce_block_now().await?;
             sleep(Duration::from_millis(1500)).await;
             return Ok(test_rollup);
         }
@@ -3172,9 +3167,12 @@ pub(crate) async fn run_action_against_test_rollup(
                     test_state.current_value,
                 ),
                 InvalidGeneration::TooOld => {
-                    let bad_generation = test_state.next_generation
-                        - 1
-                        - config_value!("PAST_TRANSACTION_GENERATIONS");
+                    let bad_generation = test_state
+                        .next_generation
+                        .checked_sub(1)
+                        .expect("Next generation is to low for TooOld scenario")
+                        .checked_sub(config_value!("PAST_TRANSACTION_GENERATIONS"))
+                        .expect("Next generation is to low for TooOld scenario");
                     tx_set_value(key, bad_generation, test_state.current_value + 1)
                 }
             };

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/mod.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/mod.rs
@@ -339,7 +339,8 @@ pub fn create_txs<RT: Runtime<S> + EncodeCall<ValueSetter<S>>>(
     admin: &TestUser<S>,
     not_admin: &TestUser<S>,
 ) -> Vec<FullyBakedTx> {
-    let mut generation = 10;
+    let original_generation = config_value!("PAST_TRANSACTION_GENERATIONS") + 10;
+    let mut generation = original_generation;
     let mut txs: Vec<FullyBakedTx> = Vec::new();
     for status in statuses {
         match status {
@@ -355,7 +356,7 @@ pub fn create_txs<RT: Runtime<S> + EncodeCall<ValueSetter<S>>>(
                 generation += 1;
             }
             TxStatus::BadGeneration => {
-                if generation == 10 {
+                if generation == original_generation {
                     panic!("The first transaction will always have a valid generation");
                 } else {
                     let tx = create_tx_valid::<RT>(

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/sequencer.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/sequencer.rs
@@ -45,7 +45,7 @@ fn create_runner_and_blobs(
 // The sequencer should see only the effects of successful transactions.
 // This test verifies that unsuccessful transactions do not consume any gas.
 #[test]
-fn test_sequencer_process_only_sucessfull_tx() {
+fn test_sequencer_process_only_successful_txs() {
     // This sequence consumes the same amount of gas in the SEQUENCER, as a single TxStatus::Success in the NODE, so the cache after the initial revert is invalidated.
     check_seq_and_node_gas(vec![TxStatus::Reverted, TxStatus::Success]);
     // This sequence consumes the same amount of gas in the SEQUENCER as two TxStatus::Success in the NODE, so the revert doesn’t overly invalidate the cache
@@ -74,24 +74,24 @@ fn test_sequencer_process_only_sucessfull_tx() {
     ]);
 }
 
-fn check_seq_and_node_gas(txs: Vec<TxStatus>) {
+fn check_seq_and_node_gas(tx_statuses: Vec<TxStatus>) {
     // Each successful tx in txs has a different generation number.
     // Gas used in sequencer
     let gas_used_by_sequencer = {
-        let (mut runner, blobs) = create_runner_and_blobs(&txs);
+        let (mut runner, blobs) = create_runner_and_blobs(&tx_statuses);
         let result = runner.execute_as_sequencer::<RelevantBlobs<MockBlob>>(blobs.clone());
         let batch_receipt_1 = result.0.batch_receipts[0].clone();
         get_gas_from_txs(&batch_receipt_1.tx_receipts)
     };
 
     // Gas used in node only for successful transactions.
-    let sucess_txs: Vec<_> = txs
+    let successful_txs: Vec<_> = tx_statuses
         .into_iter()
         .filter(|tx| matches!(tx, TxStatus::Success))
         .collect();
 
     let gas_used_by_node = {
-        let (mut runner, blobs) = create_runner_and_blobs(&sucess_txs);
+        let (mut runner, blobs) = create_runner_and_blobs(&successful_txs);
         let result = runner.execute::<RelevantBlobs<MockBlob>>(blobs.clone());
         let batch_receipt_1 = result.0.batch_receipts[0].clone();
         get_gas_from_txs(&batch_receipt_1.tx_receipts)
@@ -99,9 +99,9 @@ fn check_seq_and_node_gas(txs: Vec<TxStatus>) {
     assert_eq!(gas_used_by_node, gas_used_by_sequencer);
 }
 
-/// Check if reverted tx is ignored by the sequecner.
+/// Check if reverted tx is ignored by the sequencer.
 #[test]
-fn test_sequencer_inores_reverted_tx() {
+fn test_sequencer_ignores_reverted_tx() {
     let (mut runner, blobs) = create_runner_and_blobs(&[TxStatus::Reverted]);
     let result = runner.execute_as_sequencer::<RelevantBlobs<MockBlob>>(blobs);
     let batch_receipt_1 = result.0.batch_receipts[0].clone();

--- a/crates/module-system/module-implementations/sov-paymaster/tests/integration/paymaster.rs
+++ b/crates/module-system/module-implementations/sov-paymaster/tests/integration/paymaster.rs
@@ -739,27 +739,14 @@ fn test_granular_policies() {
         // Basic test for user 1. Three transactions should be covered
         // Transaction 1.
         runner.do_value_setter_tx(&setup.user, TxOutcome::Executed);
-        // Set up a high generation for the next test. Transaction 2.
-        let high_generation = config_value!("PAST_TRANSACTION_GENERATIONS") * 3;
-        runner.do_value_setter_tx_with_generation(
-            &setup.user,
-            high_generation,
-            TxOutcome::Executed,
-        );
+        // Set up a high nonce for the next test. Transaction 2.
+        runner.do_value_setter_tx(&setup.user, TxOutcome::Executed);
         // Check that skipped transactions do not decrement the limit
-        runner.do_value_setter_tx_with_generation(&setup.user, 1, TxOutcome::Skipped);
+        runner.do_value_setter_tx_with_nonce(&setup.user, 1, TxOutcome::Skipped);
         // Should still have one more tx left. Transaction 3.
-        runner.do_value_setter_tx_with_generation(
-            &setup.user,
-            high_generation + 1,
-            TxOutcome::Executed,
-        );
+        runner.do_value_setter_tx(&setup.user, TxOutcome::Executed);
         // The third tx should fail due to no longer being covered
-        runner.do_value_setter_tx_with_generation(
-            &setup.user,
-            high_generation + 2,
-            TxOutcome::Skipped,
-        );
+        runner.do_value_setter_tx(&setup.user, TxOutcome::Skipped);
 
         // Other users should be unaffected by the first user having used up his coverage
         // User 2, transactions 1 and 2

--- a/crates/module-system/module-implementations/sov-paymaster/tests/integration/paymaster.rs
+++ b/crates/module-system/module-implementations/sov-paymaster/tests/integration/paymaster.rs
@@ -740,13 +740,26 @@ fn test_granular_policies() {
         // Transaction 1.
         runner.do_value_setter_tx(&setup.user, TxOutcome::Executed);
         // Set up a high generation for the next test. Transaction 2.
-        runner.do_value_setter_tx_with_generation(&setup.user, 500, TxOutcome::Executed);
+        let high_generation = config_value!("PAST_TRANSACTION_GENERATIONS") * 3;
+        runner.do_value_setter_tx_with_generation(
+            &setup.user,
+            high_generation,
+            TxOutcome::Executed,
+        );
         // Check that skipped transactions do not decrement the limit
         runner.do_value_setter_tx_with_generation(&setup.user, 1, TxOutcome::Skipped);
         // Should still have one more tx left. Transaction 3.
-        runner.do_value_setter_tx_with_generation(&setup.user, 501, TxOutcome::Executed);
+        runner.do_value_setter_tx_with_generation(
+            &setup.user,
+            high_generation + 1,
+            TxOutcome::Executed,
+        );
         // The third tx should fail due to no longer being covered
-        runner.do_value_setter_tx_with_generation(&setup.user, 502, TxOutcome::Skipped);
+        runner.do_value_setter_tx_with_generation(
+            &setup.user,
+            high_generation + 2,
+            TxOutcome::Skipped,
+        );
 
         // Other users should be unaffected by the first user having used up his coverage
         // User 2, transactions 1 and 2

--- a/crates/module-system/module-implementations/sov-paymaster/tests/integration/utils.rs
+++ b/crates/module-system/module-implementations/sov-paymaster/tests/integration/utils.rs
@@ -42,10 +42,10 @@ pub enum TxOutcome {
 // Use a trait to circumvent the orphan rule and add `do_value_setter_tx` to TestRunner
 pub trait DoValueSetterTx<S: Spec> {
     fn do_value_setter_tx(&mut self, user: &TestUser<S>, expected_outcome: TxOutcome);
-    fn do_value_setter_tx_with_generation(
+    fn do_value_setter_tx_with_nonce(
         &mut self,
         user: &TestUser<S>,
-        generation: u64,
+        nonce: u64,
         expected_outcome: TxOutcome,
     );
 }
@@ -93,10 +93,10 @@ where
         };
     }
 
-    fn do_value_setter_tx_with_generation(
+    fn do_value_setter_tx_with_nonce(
         &mut self,
         user: &TestUser<S>,
-        generation: u64,
+        nonce: u64,
         expected_outcome: TxOutcome,
     ) {
         match expected_outcome {
@@ -109,7 +109,7 @@ where
                 );
                 let input =
                     TransactionType::PreAuthenticated(input.to_serialized_authenticated_tx(
-                        &mut HashMap::from([(user.private_key().pub_key(), generation)]),
+                        &mut HashMap::from([(user.private_key().pub_key(), nonce)]),
                     ));
                 self.execute_skipped_transaction(TransactionTestCase {
                     input,
@@ -130,7 +130,7 @@ where
                 );
                 let input =
                     TransactionType::PreAuthenticated(input.to_serialized_authenticated_tx(
-                        &mut HashMap::from([(user.private_key().pub_key(), generation)]),
+                        &mut HashMap::from([(user.private_key().pub_key(), nonce)]),
                     ));
                 self.execute_transaction(TransactionTestCase {
                     input,

--- a/crates/module-system/module-implementations/sov-uniqueness/tests/integration/hooks_tests.rs
+++ b/crates/module-system/module-implementations/sov-uniqueness/tests/integration/hooks_tests.rs
@@ -1,6 +1,7 @@
 use sov_modules_api::capabilities::UniquenessData;
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::{CredentialId, HexHash, TxEffect};
+use sov_modules_api::macros::config_value;
 use sov_test_utils::{TransactionTestCase, TxProcessingError};
 use sov_uniqueness::Uniqueness;
 
@@ -132,8 +133,9 @@ fn send_tx_bad_generation_too_old() {
     let (admin, mut runner, evm_account) = setup();
 
     // initialise generation
+    let generation = config_value!("PAST_TRANSACTION_GENERATIONS") + 10;
     runner.execute_transaction(TransactionTestCase {
-        input: generate_default_tx(UniquenessData::Generation(10), &admin, &evm_account),
+        input: generate_default_tx(UniquenessData::Generation(generation), &admin, &evm_account),
         assert: Box::new(move |ctx, _state| {
             assert!(ctx.tx_receipt.is_successful());
         }),

--- a/crates/module-system/module-implementations/sov-uniqueness/tests/integration/hooks_tests.rs
+++ b/crates/module-system/module-implementations/sov-uniqueness/tests/integration/hooks_tests.rs
@@ -1,7 +1,7 @@
 use sov_modules_api::capabilities::UniquenessData;
+use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::{CredentialId, HexHash, TxEffect};
-use sov_modules_api::macros::config_value;
 use sov_test_utils::{TransactionTestCase, TxProcessingError};
 use sov_uniqueness::Uniqueness;
 

--- a/crates/module-system/sov-test-utils/src/interface/inputs.rs
+++ b/crates/module-system/sov-test-utils/src/interface/inputs.rs
@@ -140,11 +140,11 @@ impl<RT: Runtime<S>, S: Spec> TransactionType<RT, S> {
         key: <S::CryptoSpec as CryptoSpec>::PrivateKey,
         chain_hash: &[u8; 32],
         details: TxDetails<S>,
-        generation_numbers: &mut HashMap<<S::CryptoSpec as CryptoSpec>::PublicKey, u64>,
+        nonces: &mut HashMap<<S::CryptoSpec as CryptoSpec>::PublicKey, u64>,
     ) -> Transaction<RT, S> {
         let pub_key = key.pub_key();
-        let generation = *generation_numbers.get(&pub_key).unwrap_or(&0);
-        generation_numbers.insert(pub_key, generation + 1);
+        let nonce = *nonces.get(&pub_key).unwrap_or(&0);
+        nonces.insert(pub_key, nonce + 1);
         Transaction::<RT, S>::new_signed_tx(
             &key,
             chain_hash,
@@ -153,7 +153,7 @@ impl<RT: Runtime<S>, S: Spec> TransactionType<RT, S> {
                 details.chain_id,
                 details.max_priority_fee_bips,
                 details.max_fee,
-                UniquenessData::Generation(generation),
+                UniquenessData::Nonce(nonce),
                 details.gas_limit,
             ),
         )
@@ -165,9 +165,9 @@ impl<RT: Runtime<S>, S: Spec> TransactionType<RT, S> {
         key: <S::CryptoSpec as CryptoSpec>::PrivateKey,
         chain_hash: &[u8; 32],
         details: TxDetails<S>,
-        generations: &mut HashMap<<S::CryptoSpec as CryptoSpec>::PublicKey, u64>,
+        nonces: &mut HashMap<<S::CryptoSpec as CryptoSpec>::PublicKey, u64>,
     ) -> RawTx {
-        let tx = Self::sign(msg, key, chain_hash, details, generations);
+        let tx = Self::sign(msg, key, chain_hash, details, nonces);
 
         RawTx {
             data: borsh::to_vec(&tx).unwrap(),


### PR DESCRIPTION
# Description

To stabilize web3-js-integration tests 

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)



## Testing
Existing tests are passing

## Docs
No updates
