### PR TITLE
Add solana-signable-rollup

### DIFF
--- a/typescript/.changeset/config.json
+++ b/typescript/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "restricted",
-  "baseBranch": "master",
+  "baseBranch": "dev",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/typescript/.changeset/yellow-frogs-notice.md
+++ b/typescript/.changeset/yellow-frogs-notice.md
@@ -1,0 +1,9 @@
+---
+"@sovereign-sdk/web3": minor
+---
+
+Added support for encoding transactions as a solana offchain messages, for rollups that use the corresponding authenticator. Use the `SolanaSignableRollup` and select the desired encoding.
+
+-   `"standard"` uses the normal rollup transaction submission
+-   `"solana"` uses the Solana offchain message signing format, for use with Solana wallets
+-   `"solanaSimple"` uses a simplified Solana offchain format that does not implement the full offchain message spec, for compatibility with some wallets

--- a/typescript/packages/web3/src/rollup/index.ts
+++ b/typescript/packages/web3/src/rollup/index.ts
@@ -1,2 +1,3 @@
 export * from "./rollup";
 export * from "./standard-rollup";
+export * from "./solana-signable-rollup";

--- a/typescript/packages/web3/src/rollup/solana-signable-rollup.test.ts
+++ b/typescript/packages/web3/src/rollup/solana-signable-rollup.test.ts
@@ -1,0 +1,371 @@
+import SovereignClient from "@sovereign-sdk/client";
+import type { Signer } from "@sovereign-sdk/signers";
+import { Ed25519Signer } from "@sovereign-sdk/signers";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  SolanaSignableRollup,
+  createSolanaPreamble,
+  createSolanaSignableRollup,
+} from "./solana-signable-rollup";
+import { StandardRollup } from "./standard-rollup";
+
+vi.mock("@sovereign-sdk/client");
+
+function createMockClient(overrides?: {
+  chainId?: number;
+  chainName?: string;
+  chainHash?: string;
+}) {
+  const mockClient = new SovereignClient();
+  const chainId = overrides?.chainId || 1;
+
+  mockClient.rollup = {
+    constants: {
+      retrieve: vi.fn().mockResolvedValue({ chain_id: chainId }),
+    },
+    schema: {
+      retrieve: vi.fn().mockResolvedValue({
+        schema: overrides?.chainName ? { chain_name: overrides.chainName } : {},
+        chain_hash:
+          overrides?.chainHash ||
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+      }),
+    },
+  } as any;
+
+  return mockClient;
+}
+
+function createMockSerializer(overrides?: any) {
+  return {
+    serializeUnsignedTx: vi.fn().mockReturnValue(new Uint8Array(10)),
+    serializeTx: vi.fn().mockReturnValue(new Uint8Array(10)),
+    serializeRuntimeCall: vi.fn().mockReturnValue(new Uint8Array(10)),
+    schema: overrides?.schema || {},
+    ...overrides,
+  } as any;
+}
+
+function createMockSigner() {
+  return {
+    sign: vi.fn().mockResolvedValue(new Uint8Array(64)),
+    publicKey: vi.fn().mockResolvedValue(new Uint8Array(32)),
+  } as any;
+}
+
+describe("SolanaSignableRollup", () => {
+  it("should create a SolanaSignableRollup instance", async () => {
+    const mockClient = createMockClient();
+    const rollup = await createSolanaSignableRollup({ client: mockClient });
+    expect(rollup).toBeInstanceOf(SolanaSignableRollup);
+  });
+
+  it("should delegate all StandardRollup methods", async () => {
+    const mockClient = createMockClient();
+
+    // Add sequencer mock for transaction submission
+    mockClient.sequencer = {
+      txs: {
+        create: vi.fn().mockResolvedValue({ id: "test-hash" }),
+      },
+    } as any;
+
+    const rollup = await createSolanaSignableRollup({
+      client: mockClient,
+      getSerializer: () => createMockSerializer(),
+    });
+
+    // Check that key methods are available
+    expect(typeof rollup.call).toBe("function");
+    expect(typeof rollup.signAndSubmitTransaction).toBe("function");
+    expect(typeof rollup.simulate).toBe("function");
+    expect(typeof rollup.serializer).toBe("function");
+    expect(typeof rollup.submitTransaction).toBe("function");
+
+    // Verify that standard authenticator works
+    const result = await rollup.call({ test: "runtime" } as any, {
+      signer: createMockSigner(),
+      authenticator: "standard",
+    });
+
+    expect(result).toHaveProperty("response");
+    expect(result).toHaveProperty("transaction");
+    expect(result.response.id).toBe("test-hash");
+  });
+
+  it("should pass configuration to createStandardRollup", async () => {
+    const mockClient = createMockClient({ chainId: 42 });
+
+    const customConfig = {
+      client: mockClient,
+      context: {
+        defaultTxDetails: {
+          chain_id: 42,
+          max_priority_fee_bips: 100,
+          max_fee: "200000000",
+          gas_limit: null,
+        },
+      },
+    };
+
+    const rollup = await createSolanaSignableRollup(customConfig);
+
+    expect(rollup.context.defaultTxDetails.chain_id).toBe(42);
+    expect(rollup.context.defaultTxDetails.max_priority_fee_bips).toBe(100);
+    expect(rollup.context.defaultTxDetails.max_fee).toBe("200000000");
+  });
+
+  it("should work without any configuration", async () => {
+    const mockClient = createMockClient();
+    vi.mocked(SovereignClient).mockImplementation(() => mockClient as any);
+
+    const rollup = await createSolanaSignableRollup();
+
+    expect(rollup).toBeInstanceOf(SolanaSignableRollup);
+    expect(rollup.context.defaultTxDetails.chain_id).toBe(1);
+  });
+
+  it("should allow custom Solana endpoint configuration", async () => {
+    const mockClient = createMockClient();
+    const customEndpoint = "/custom/solana-tx-endpoint";
+
+    // Capture the endpoint and payload sent to the client
+    let capturedEndpoint: string | undefined;
+    let capturedPayload: any;
+    mockClient.post = vi
+      .fn()
+      .mockImplementation((endpoint: string, payload: any) => {
+        capturedEndpoint = endpoint;
+        capturedPayload = payload;
+        return Promise.resolve({ id: "test-tx-hash" });
+      });
+
+    const rollup = await createSolanaSignableRollup(
+      {
+        client: mockClient,
+        getSerializer: () =>
+          createMockSerializer({ schema: { chain_name: "TestChain" } }),
+      },
+      customEndpoint,
+    );
+
+    // Submit a Solana transaction to verify the custom endpoint is used
+    await rollup.signAndSubmitTransaction(
+      {
+        runtime_call: { test: "call" },
+        uniqueness: { generation: 123 },
+        details: {
+          max_priority_fee_bips: 0,
+          max_fee: "1000",
+          gas_limit: null,
+          chain_id: 1,
+        },
+      } as any,
+      {
+        signer: createMockSigner(),
+        authenticator: "solanaSimple",
+      },
+    );
+
+    expect(capturedEndpoint).toBe(customEndpoint);
+    expect(capturedPayload).toHaveProperty("body");
+  });
+
+  describe("byte-level compatibility with Rust implementation", () => {
+    it("should generate identical bytes to Rust test_submit_raw_signed_message_transaction", async () => {
+      // This test verifies that our TypeScript implementation generates the exact same bytes
+      // as the Rust implementation
+
+      // These values were generated using the test_submit_raw_signed_message_transaction() test from the sov-solana-offchain-auth crate.
+      // The signer private key was logged, and the serde serialization of the AcceptTx was logged.
+      const privateKeyHex =
+        "4096e0037e7dc13c28730b01e303ea4679a05e019f68a5ee8aec6c1968cac707";
+      const expectedJson =
+        '{"body":"cAEAAHsicnVudGltZV9jYWxsIjp7ImJhbmsiOnsidHJhbnNmZXIiOnsidG8iOiI0emR3SE5hRWE1bnBIdFJ0YVozUkwxbTZycHR1UVo2UkJMSEc2Y0F5VkhqTCIsImNvaW5zIjp7ImFtb3VudCI6IjEwMDAwIiwidG9rZW5faWQiOiJ0b2tlbl8xbnlsMGUweXdlcmFnZnNhdHlndDI0em1kOGpycjJ2cXR2ZGZwdHpqaHhrZ3V6Mnh4eDN2czB5MDd1NyJ9fX19LCJ1bmlxdWVuZXNzIjp7ImdlbmVyYXRpb24iOjB9LCJkZXRhaWxzIjp7Im1heF9wcmlvcml0eV9mZWVfYmlwcyI6MCwibWF4X2ZlZSI6IjEwMDAwMDAwMDAwMCIsImdhc19saW1pdCI6WzEwMDAwMDAwMDAsMTAwMDAwMDAwMF0sImNoYWluX2lkIjo0MzIxfSwiY2hhaW5fbmFtZSI6IlRlc3RDaGFpbiJ9CwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwuMdhE5OjziHniAzu9qaFH0I50R93Apv2VgyONYPuLm3nN3Cr4cJwZ5ii6YYXxr7LsW3qcL0NAJfIvmUZroK+fuM18D3Hj+NsFn+nmN9jCjiWhjbQO1/79i365l424Erwg="}';
+
+      const mockClient = createMockClient({
+        chainId: 4321,
+        chainName: "TestChain",
+        chainHash:
+          "0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+      });
+
+      // Capture the actual payload sent to the endpoint
+      let capturedPayload: any;
+      mockClient.post = vi
+        .fn()
+        .mockImplementation((path: string, options: any) => {
+          capturedPayload = options;
+          return Promise.resolve({ id: "test-tx-hash" });
+        });
+
+      const rollup = await createSolanaSignableRollup({
+        client: mockClient,
+        getSerializer: (schema: any) =>
+          ({
+            schema,
+          }) as any,
+      });
+
+      const signer = new Ed25519Signer(privateKeyHex);
+
+      // Transaction matching Rust test
+      const runtimeCall = {
+        bank: {
+          transfer: {
+            to: "4zdwHNaEa5npHtRtaZ3RL1m6rptuQZ6RBLHG6cAyVHjL",
+            coins: {
+              amount: "10000",
+              token_id:
+                "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7",
+            },
+          },
+        },
+      };
+
+      const unsignedTx = {
+        runtime_call: runtimeCall,
+        uniqueness: { generation: 0 },
+        details: {
+          max_priority_fee_bips: 0,
+          max_fee: "100000000000",
+          gas_limit: [1000000000, 1000000000],
+          chain_id: 4321,
+        },
+      };
+
+      await rollup.signAndSubmitTransaction(unsignedTx, {
+        signer,
+        authenticator: "solanaSimple",
+      });
+
+      // Compare the entire POST body with the expected JSON from the Rust test
+      const actualJson = JSON.stringify(capturedPayload);
+      expect(actualJson).toBe(expectedJson);
+    });
+
+    it("should generate identical bytes to Rust test_ledger_signature_validation", async () => {
+      // This test verifies that our TypeScript implementation generates the exact same bytes
+      // as the Rust implementation for spec-compliant messages with preamble
+
+      // These values will be generated from the test_ledger_signature_validation() test
+      // from the sov-solana-offchain-auth crate
+      const knownPubkeyHex =
+        "70248c99a1d39769831c99706948b9851585cba907a677d112f9a3694cbcb4cd";
+      const knownSignatureHex =
+        "71204c3487b8e637cffaa5e9dc409efe2f1e98db6b557041181a368f4c487bbd407f72c43f08aa44b75f219e6fb3ce4681785dd72ee3eebe4e641ade8289370d";
+      const expectedJson =
+        '{"body":"xAEAAP9zb2xhbmEgb2ZmY2hhaW4ACwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsAAXAkjJmh05dpgxyZcGlIuYUVhcupB6Z30RL5o2lMvLTNbwF7InJ1bnRpbWVfY2FsbCI6eyJiYW5rIjp7InRyYW5zZmVyIjp7InRvIjoiNHpkd0hOYUVhNW5wSHRSdGFaM1JMMW02cnB0dVFaNlJCTEhHNmNBeVZIakwiLCJjb2lucyI6eyJhbW91bnQiOiI1MDAwIiwidG9rZW5faWQiOiJ0b2tlbl8xbnlsMGUweXdlcmFnZnNhdHlndDI0em1kOGpycjJ2cXR2ZGZwdHpqaHhrZ3V6Mnh4eDN2czB5MDd1NyJ9fX19LCJ1bmlxdWVuZXNzIjp7ImdlbmVyYXRpb24iOjB9LCJkZXRhaWxzIjp7Im1heF9wcmlvcml0eV9mZWVfYmlwcyI6MCwibWF4X2ZlZSI6IjEwMDAwMDAwMDAwMCIsImdhc19saW1pdCI6WzEwMDAwMDAwMDAsMTAwMDAwMDAwMF0sImNoYWluX2lkIjo0MzIxfSwiY2hhaW5fbmFtZSI6IlRlc3RDaGFpbiJ9cSBMNIe45jfP+qXp3ECe/i8emNtrVXBBGBo2j0xIe71Af3LEPwiqRLdfIZ5vs85GgXhd1y7j7r5OZBregok3DQ=="}';
+
+      const mockClient = createMockClient({
+        chainId: 4321,
+        chainName: "TestChain",
+        chainHash:
+          "0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
+      });
+
+      // Capture the actual payload sent to the endpoint
+      let capturedPayload: any;
+      mockClient.post = vi
+        .fn()
+        .mockImplementation((path: string, options: any) => {
+          capturedPayload = options;
+          return Promise.resolve({ id: "test-tx-hash" });
+        });
+
+      const rollup = await createSolanaSignableRollup({
+        client: mockClient,
+        getSerializer: (schema: any) =>
+          ({
+            schema,
+          }) as any,
+      });
+
+      // Mock the signer to return the known public key and signature from Rust test
+      const signer = {
+        publicKey: vi
+          .fn()
+          .mockResolvedValue(
+            new Uint8Array(Buffer.from(knownPubkeyHex, "hex")),
+          ),
+        sign: vi
+          .fn()
+          .mockResolvedValue(
+            new Uint8Array(Buffer.from(knownSignatureHex, "hex")),
+          ),
+      } as any;
+
+      // Transaction matching Rust test
+      const runtimeCall = {
+        bank: {
+          transfer: {
+            to: "4zdwHNaEa5npHtRtaZ3RL1m6rptuQZ6RBLHG6cAyVHjL",
+            coins: {
+              amount: "5000",
+              token_id:
+                "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7",
+            },
+          },
+        },
+      };
+
+      const unsignedTx = {
+        runtime_call: runtimeCall,
+        uniqueness: { generation: 0 },
+        details: {
+          max_priority_fee_bips: 0,
+          max_fee: "100000000000",
+          gas_limit: [1000000000, 1000000000],
+          chain_id: 4321,
+        },
+      };
+
+      await rollup.signAndSubmitTransaction(unsignedTx, {
+        signer,
+        authenticator: "solana",
+      });
+
+      // Compare the entire POST body with the expected JSON from the Rust test
+      const actualJson = JSON.stringify(capturedPayload);
+      expect(actualJson).toBe(expectedJson);
+    });
+  });
+
+  describe("createSolanaPreamble", () => {
+    it("should create a valid preamble with correct structure", () => {
+      const pubkey = new Uint8Array(32).fill(1);
+      const chainHash = new Uint8Array(32).fill(2);
+      const messageLength = 100;
+
+      const preamble = createSolanaPreamble(pubkey, chainHash, messageLength);
+
+      // Check total length
+      expect(preamble.length).toBe(85);
+
+      // Check signing domain (first 16 bytes)
+      // First byte should be 0xff, followed by "solana offchain"
+      expect(preamble[0]).toBe(0xff);
+      const signingDomainText = new TextDecoder().decode(preamble.slice(1, 16));
+      expect(signingDomainText).toBe("solana offchain");
+
+      // Check header version
+      expect(preamble[16]).toBe(0);
+
+      // Check application domain (chain hash)
+      expect(preamble.slice(17, 49)).toEqual(chainHash);
+
+      // Check message format
+      expect(preamble[49]).toBe(0);
+
+      // Check signer count
+      expect(preamble[50]).toBe(1);
+
+      // Check signer (public key)
+      expect(preamble.slice(51, 83)).toEqual(pubkey);
+
+      // Check message length (little-endian u16)
+      const view = new DataView(preamble.buffer);
+      expect(view.getUint16(83, true)).toBe(messageLength);
+    });
+  });
+});

--- a/typescript/packages/web3/src/rollup/solana-signable-rollup.test.ts
+++ b/typescript/packages/web3/src/rollup/solana-signable-rollup.test.ts
@@ -9,28 +9,22 @@ import {
 } from "./solana-signable-rollup";
 import { StandardRollup } from "./standard-rollup";
 
-vi.mock("@sovereign-sdk/client");
-
 function createMockClient(overrides?: {
   chainId?: number;
   chainName?: string;
   chainHash?: string;
 }) {
-  const mockClient = new SovereignClient();
+  const mockClient = new SovereignClient({ fetch: vi.fn() });
   const chainId = overrides?.chainId || 1;
 
   mockClient.rollup = {
-    constants: {
-      retrieve: vi.fn().mockResolvedValue({ chain_id: chainId }),
-    },
-    schema: {
-      retrieve: vi.fn().mockResolvedValue({
-        schema: overrides?.chainName ? { chain_name: overrides.chainName } : {},
-        chain_hash:
-          overrides?.chainHash ||
-          "0x0000000000000000000000000000000000000000000000000000000000000000",
-      }),
-    },
+    constants: vi.fn().mockResolvedValue({ chain_id: chainId }),
+    schema: vi.fn().mockResolvedValue({
+      schema: overrides?.chainName ? { chain_name: overrides.chainName } : {},
+      chain_hash:
+        overrides?.chainHash ||
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+    }),
   } as any;
 
   return mockClient;
@@ -63,12 +57,8 @@ describe("SolanaSignableRollup", () => {
   it("should delegate all StandardRollup methods", async () => {
     const mockClient = createMockClient();
 
-    // Add sequencer mock for transaction submission
-    mockClient.sequencer = {
-      txs: {
-        create: vi.fn().mockResolvedValue({ id: "test-hash" }),
-      },
-    } as any;
+    // Mock the post method for transaction submission
+    mockClient.post = vi.fn().mockResolvedValue({ id: "test-hash" });
 
     const rollup = await createSolanaSignableRollup({
       client: mockClient,
@@ -117,9 +107,8 @@ describe("SolanaSignableRollup", () => {
 
   it("should work without any configuration", async () => {
     const mockClient = createMockClient();
-    vi.mocked(SovereignClient).mockImplementation(() => mockClient as any);
 
-    const rollup = await createSolanaSignableRollup();
+    const rollup = await createSolanaSignableRollup({ client: mockClient });
 
     expect(rollup).toBeInstanceOf(SolanaSignableRollup);
     expect(rollup.context.defaultTxDetails.chain_id).toBe(1);

--- a/typescript/packages/web3/src/rollup/solana-signable-rollup.ts
+++ b/typescript/packages/web3/src/rollup/solana-signable-rollup.ts
@@ -1,0 +1,554 @@
+import type SovereignClient from "@sovereign-sdk/client";
+import type { Signer } from "@sovereign-sdk/signers";
+import { Base64 } from "js-base64";
+import type { Subscription, SubscriptionToCallbackMap } from "../subscriptions";
+import type { DeepPartial } from "../utils";
+import type { RollupConfig, TransactionResult } from "./rollup";
+import {
+  type StandardRollup,
+  type StandardRollupContext,
+  type StandardRollupSpec,
+  type Transaction,
+  type UnsignedTransaction,
+  createStandardRollup,
+  standardTypeBuilder,
+} from "./standard-rollup";
+
+export type SolanaOffchainUnsignedTransaction<RuntimeCall> = {
+  runtime_call: RuntimeCall;
+  uniqueness: { nonce: number } | { generation: number };
+  details: {
+    max_priority_fee_bips: number;
+    max_fee: string;
+    gas_limit: number[] | null;
+    chain_id: number;
+  };
+  chain_name: string;
+};
+
+export type SolanaOffchainSimpleMessage = {
+  signed_message: Uint8Array;
+  chain_hash: Uint8Array;
+  pubkey: Uint8Array;
+  signature: Uint8Array;
+};
+
+export type SolanaOffchainSpecCompliantMessage = {
+  signed_message_with_preamble: Uint8Array;
+  signature: Uint8Array;
+};
+
+export type Authenticator = "standard" | "solanaSimple" | "solana";
+
+// Borsh serialization constants
+const VEC_LENGTH_PREFIX_SIZE = 4;
+const CHAIN_HASH_SIZE = 32;
+const PUBKEY_SIZE = 32;
+const SIGNATURE_SIZE = 64;
+const PREAMBLE_LENGTH = 85;
+
+// Solana preamble constants
+const SIGNING_DOMAIN = new Uint8Array([
+  0xff,
+  ...new TextEncoder().encode("solana offchain"),
+]);
+const HEADER_VERSION = 0;
+const MESSAGE_FORMAT = 0;
+const SINGLE_SIGNER_COUNT = 1;
+
+/**
+ * Creates a Solana offchain message preamble according to the spec.
+ * See https://docs.anza.xyz/proposals/off-chain-message-signing#message-preamble
+ */
+export function createSolanaPreamble(
+  pubkey: Uint8Array,
+  chainHash: Uint8Array,
+  messageLength: number,
+): Uint8Array {
+  const preamble = new Uint8Array(PREAMBLE_LENGTH);
+  let offset = 0;
+
+  // signing_domain: [u8; 16] = b"\xffsolana offchain"
+  preamble.set(SIGNING_DOMAIN, offset);
+  offset += 16;
+
+  // header_version: u8 = 0 (ASCII format, hw-wallet compatible)
+  preamble[offset] = HEADER_VERSION;
+  offset += 1;
+
+  // application_domain: [u8; 32] (chain_hash)
+  preamble.set(chainHash, offset);
+  offset += 32;
+
+  // message_format: u8 = 0 (ASCII format)
+  preamble[offset] = MESSAGE_FORMAT;
+  offset += 1;
+
+  // signer_count: u8 = 1 (single signer)
+  preamble[offset] = SINGLE_SIGNER_COUNT;
+  offset += 1;
+
+  // signer: [u8; 32] (public key)
+  preamble.set(pubkey, offset);
+  offset += 32;
+
+  // message_length: [u8; 2] (little-endian u16)
+  new DataView(preamble.buffer, offset).setUint16(0, messageLength, true);
+
+  return preamble;
+}
+
+export class SolanaSignableRollup<RuntimeCall> {
+  private inner: StandardRollup<RuntimeCall>;
+  private solanaEndpoint: string;
+  private typeBuilder = standardTypeBuilder<StandardRollupSpec<RuntimeCall>>();
+
+  constructor(
+    inner: StandardRollup<RuntimeCall>,
+    solanaEndpoint = "/sequencer/accept-solana-offchain-tx",
+  ) {
+    this.inner = inner;
+    this.solanaEndpoint = solanaEndpoint;
+  }
+
+  /**
+   * Submits serialized data to the Solana endpoint.
+   */
+  private async submitSerializedMessage(
+    serializedMessage: Uint8Array,
+  ): Promise<SovereignClient.Sequencer.TxCreateResponse> {
+    return await this.inner.http.post<
+      string,
+      SovereignClient.Sequencer.TxCreateResponse
+    >(this.solanaEndpoint, {
+      body: Base64.fromUint8Array(serializedMessage),
+    });
+  }
+
+  /**
+   * Submits a Solana offchain message to the rollup.
+   */
+  private async submitSolanaMessage(
+    solanaMessage: SolanaOffchainSimpleMessage,
+  ): Promise<SovereignClient.Sequencer.TxCreateResponse> {
+    const serializedMessage = this.serializeSolanaMessage(solanaMessage);
+    return this.submitSerializedMessage(serializedMessage);
+  }
+
+  /**
+   * Submits a Solana spec-compliant message to the rollup.
+   */
+  private async submitSolanaSpecMessage(
+    solanaMessage: SolanaOffchainSpecCompliantMessage,
+  ): Promise<SovereignClient.Sequencer.TxCreateResponse> {
+    const serializedMessage = this.serializeSolanaSpecMessage(solanaMessage);
+    return this.submitSerializedMessage(serializedMessage);
+  }
+
+  /**
+   * Helper to build an unsigned transaction using the standard type builder.
+   */
+  private async buildUnsignedTransaction(
+    runtimeCall: RuntimeCall,
+    overrides?: DeepPartial<UnsignedTransaction<RuntimeCall>>,
+  ): Promise<UnsignedTransaction<RuntimeCall>> {
+    return this.typeBuilder.unsignedTransaction({
+      runtimeCall,
+      overrides: overrides ?? {},
+      rollup: this.inner,
+    });
+  }
+
+  /**
+   * Helper to build a transaction result object.
+   */
+  private async buildTransactionResult(
+    response: SovereignClient.Sequencer.TxCreateResponse,
+    unsignedTx: UnsignedTransaction<RuntimeCall>,
+    pubkey: Uint8Array,
+    signature: Uint8Array,
+  ): Promise<TransactionResult<Transaction<RuntimeCall>>> {
+    const transaction = await this.typeBuilder.transaction({
+      unsignedTx,
+      sender: pubkey,
+      signature,
+      rollup: this.inner,
+    });
+    return { response, transaction };
+  }
+
+  /**
+   * Helper to create and serialize a SolanaOffchainUnsignedTransaction to JSON bytes.
+   */
+  private async createSolanaJsonBytes(
+    unsignedTx: UnsignedTransaction<RuntimeCall>,
+  ): Promise<Uint8Array> {
+    const serializer = await this.inner.serializer();
+    const schema = serializer.schema;
+    const chainName = schema.chain_name || "";
+
+    const solanaUnsignedTx: SolanaOffchainUnsignedTransaction<RuntimeCall> = {
+      runtime_call: unsignedTx.runtime_call,
+      uniqueness: unsignedTx.uniqueness,
+      details: unsignedTx.details,
+      chain_name: chainName,
+    };
+
+    // JSON serialize the Solana unsigned transaction
+    return new TextEncoder().encode(JSON.stringify(solanaUnsignedTx));
+  }
+
+  /**
+   * Signs an unsigned transaction using Solana offchain simple signing and submits it.
+   * Returns the transaction result in the same format as standard rollup.
+   */
+  private async signWithSolanaSimpleAndSubmit(
+    unsignedTx: UnsignedTransaction<RuntimeCall>,
+    signer: Signer,
+  ): Promise<TransactionResult<Transaction<RuntimeCall>>> {
+    const jsonBytes = await this.createSolanaJsonBytes(unsignedTx);
+
+    const pubkey = await signer.publicKey();
+    const chainHash = await this.inner.chainHash();
+
+    const signature = await signer.sign(jsonBytes);
+
+    // Build and submit result
+    const solanaMessage: SolanaOffchainSimpleMessage = {
+      signed_message: jsonBytes,
+      chain_hash: chainHash,
+      pubkey: pubkey,
+      signature: signature,
+    };
+
+    const response = await this.submitSolanaMessage(solanaMessage);
+    return this.buildTransactionResult(response, unsignedTx, pubkey, signature);
+  }
+
+  /**
+   * Signs an unsigned transaction using Solana spec-compliant signing and submits it.
+   * Returns the transaction result in the same format as standard rollup.
+   */
+  private async signWithSolanaSpecAndSubmit(
+    unsignedTx: UnsignedTransaction<RuntimeCall>,
+    signer: Signer,
+  ): Promise<TransactionResult<Transaction<RuntimeCall>>> {
+    const jsonBytes = await this.createSolanaJsonBytes(unsignedTx);
+
+    const pubkey = await signer.publicKey();
+    const chainHash = await this.inner.chainHash();
+
+    // Create preamble and combine with message
+    const preamble = createSolanaPreamble(pubkey, chainHash, jsonBytes.length);
+    const signedMessageWithPreamble = new Uint8Array(
+      preamble.length + jsonBytes.length,
+    );
+    signedMessageWithPreamble.set(preamble, 0);
+    signedMessageWithPreamble.set(jsonBytes, preamble.length);
+    const signature = await signer.sign(signedMessageWithPreamble);
+
+    // Build and submit result
+    const solanaMessage: SolanaOffchainSpecCompliantMessage = {
+      signed_message_with_preamble: signedMessageWithPreamble,
+      signature: signature,
+    };
+
+    const response = await this.submitSolanaSpecMessage(solanaMessage);
+    return this.buildTransactionResult(response, unsignedTx, pubkey, signature);
+  }
+
+  /**
+   * Performs a runtime call transaction with the specified authenticator.
+   *
+   * @param runtimeCall - The runtime call to execute
+   * @param params - Parameters including signer, authenticator type, and optional overrides
+   * @param options - Optional request options
+   * @returns The transaction result including hash and transaction object
+   */
+  async call(
+    runtimeCall: RuntimeCall,
+    params: {
+      signer: Signer;
+      authenticator: Authenticator;
+      overrides?: DeepPartial<UnsignedTransaction<RuntimeCall>>;
+    },
+    options?: SovereignClient.RequestOptions,
+  ): Promise<TransactionResult<Transaction<RuntimeCall>>> {
+    // Dispatch based on authenticator
+    switch (params.authenticator) {
+      case "standard":
+        return this.inner.call(
+          runtimeCall,
+          {
+            signer: params.signer,
+            overrides: params.overrides,
+          },
+          options,
+        );
+      case "solanaSimple": {
+        const unsignedTx = await this.buildUnsignedTransaction(
+          runtimeCall,
+          params.overrides,
+        );
+        return this.signWithSolanaSimpleAndSubmit(unsignedTx, params.signer);
+      }
+      case "solana": {
+        const unsignedTx = await this.buildUnsignedTransaction(
+          runtimeCall,
+          params.overrides,
+        );
+        return this.signWithSolanaSpecAndSubmit(unsignedTx, params.signer);
+      }
+      default:
+        throw new Error(`Unsupported authenticator: ${params.authenticator}`);
+    }
+  }
+
+  /**
+   * Signs and submits a transaction with the specified authenticator.
+   *
+   * @param unsignedTx - The unsigned transaction to sign and submit
+   * @param params - Parameters including signer and authenticator type
+   * @param options - Optional request options
+   * @returns The transaction result
+   */
+  async signAndSubmitTransaction(
+    unsignedTx: UnsignedTransaction<RuntimeCall>,
+    params: { signer: Signer; authenticator: Authenticator },
+    options?: SovereignClient.RequestOptions,
+  ): Promise<TransactionResult<Transaction<RuntimeCall>>> {
+    switch (params.authenticator) {
+      case "standard":
+        return this.inner.signAndSubmitTransaction(
+          unsignedTx,
+          {
+            signer: params.signer,
+          },
+          options,
+        );
+      case "solanaSimple":
+        return this.signWithSolanaSimpleAndSubmit(unsignedTx, params.signer);
+      case "solana":
+        return this.signWithSolanaSpecAndSubmit(unsignedTx, params.signer);
+      default:
+        throw new Error(`Unsupported authenticator: ${params.authenticator}`);
+    }
+  }
+
+  /**
+   * Submits a standard transaction.
+   */
+  async submitTransaction(
+    transaction: StandardRollupSpec<RuntimeCall>["Transaction"],
+    authenticator: "standard",
+    options?: SovereignClient.RequestOptions,
+  ): Promise<SovereignClient.Sequencer.TxCreateResponse>;
+
+  /**
+   * Submits a Solana offchain message.
+   */
+  async submitTransaction(
+    transaction: SolanaOffchainSimpleMessage,
+    authenticator: "solanaSimple",
+    options?: SovereignClient.RequestOptions,
+  ): Promise<SovereignClient.Sequencer.TxCreateResponse>;
+
+  /**
+   * Submits a Solana spec-compliant message.
+   */
+  async submitTransaction(
+    transaction: SolanaOffchainSpecCompliantMessage,
+    authenticator: "solana",
+    options?: SovereignClient.RequestOptions,
+  ): Promise<SovereignClient.Sequencer.TxCreateResponse>;
+
+  /**
+   * Submits a transaction with the specified authenticator.
+   *
+   * @param transaction - Either a standard transaction or a Solana message
+   * @param authenticator - The authenticator type to use
+   * @param options - Optional request options
+   * @returns The transaction response
+   */
+  async submitTransaction(
+    transaction:
+      | StandardRollupSpec<RuntimeCall>["Transaction"]
+      | SolanaOffchainSimpleMessage
+      | SolanaOffchainSpecCompliantMessage,
+    authenticator: Authenticator,
+    options?: SovereignClient.RequestOptions,
+  ): Promise<SovereignClient.Sequencer.TxCreateResponse> {
+    switch (authenticator) {
+      case "standard":
+        return this.inner.submitTransaction(
+          transaction as StandardRollupSpec<RuntimeCall>["Transaction"],
+          options,
+        );
+      case "solanaSimple": {
+        // For Solana simple, we expect a SolanaOffchainSimpleMessage
+        const solanaMessage = transaction as SolanaOffchainSimpleMessage;
+        return await this.submitSolanaMessage(solanaMessage);
+      }
+      case "solana": {
+        // For Solana spec-compliant, we expect a SolanaOffchainSpecCompliantMessage
+        const solanaMessage = transaction as SolanaOffchainSpecCompliantMessage;
+        return await this.submitSolanaSpecMessage(solanaMessage);
+      }
+      default:
+        throw new Error(`Unsupported authenticator: ${authenticator}`);
+    }
+  }
+
+  async simulate(
+    runtimeMessage: RuntimeCall,
+    params: Parameters<StandardRollup<RuntimeCall>["simulate"]>[1],
+  ) {
+    return this.inner.simulate(runtimeMessage, params);
+  }
+
+  async dedup(address: Uint8Array) {
+    return this.inner.dedup(address);
+  }
+
+  async serializer() {
+    return this.inner.serializer();
+  }
+
+  async chainHash() {
+    return this.inner.chainHash();
+  }
+
+  async healthcheck(timeout?: number) {
+    return this.inner.healthcheck(timeout);
+  }
+
+  subscribe<T extends keyof SubscriptionToCallbackMap>(
+    type: T,
+    callback: SubscriptionToCallbackMap[T],
+  ): Subscription {
+    return this.inner.subscribe(type, callback);
+  }
+
+  get context() {
+    return this.inner.context;
+  }
+
+  get ledger() {
+    return this.inner.ledger;
+  }
+
+  get sequencer() {
+    return this.inner.sequencer;
+  }
+
+  get rollup() {
+    return this.inner.rollup;
+  }
+
+  get http() {
+    return this.inner.http;
+  }
+
+  /**
+   * Helper method to serialize a SolanaOffchainSimpleMessage using borsh encoding.
+   */
+  private serializeSolanaMessage(
+    message: SolanaOffchainSimpleMessage,
+  ): Uint8Array {
+    // Validate message field lengths
+    if (message.chain_hash.length !== CHAIN_HASH_SIZE) {
+      throw new Error(
+        `Invalid chain hash length: expected ${CHAIN_HASH_SIZE} bytes, got ${message.chain_hash.length}`,
+      );
+    }
+
+    if (message.pubkey.length !== PUBKEY_SIZE) {
+      throw new Error(
+        `Invalid public key length: expected ${PUBKEY_SIZE} bytes, got ${message.pubkey.length}`,
+      );
+    }
+
+    if (message.signature.length !== SIGNATURE_SIZE) {
+      throw new Error(
+        `Invalid signature length: expected ${SIGNATURE_SIZE} bytes, got ${message.signature.length}`,
+      );
+    }
+
+    // Calculate total size using constants
+    const totalSize =
+      VEC_LENGTH_PREFIX_SIZE +
+      message.signed_message.length +
+      CHAIN_HASH_SIZE +
+      PUBKEY_SIZE +
+      SIGNATURE_SIZE;
+
+    const buffer = new Uint8Array(totalSize);
+    let offset = 0;
+
+    // Serialize Vec<u8> with length prefix (little-endian u32)
+    const view = new DataView(buffer.buffer);
+    view.setUint32(offset, message.signed_message.length, true);
+    offset += VEC_LENGTH_PREFIX_SIZE;
+    buffer.set(message.signed_message, offset);
+    offset += message.signed_message.length;
+
+    // Serialize chain_hash [u8; 32]
+    buffer.set(message.chain_hash, offset);
+    offset += CHAIN_HASH_SIZE;
+
+    // Serialize pubkey [u8; 32]
+    buffer.set(message.pubkey, offset);
+    offset += PUBKEY_SIZE;
+
+    // Serialize signature [u8; 64]
+    buffer.set(message.signature, offset);
+
+    return buffer;
+  }
+
+  /**
+   * Helper method to serialize a SolanaOffchainSpecCompliantMessage using borsh encoding.
+   */
+  private serializeSolanaSpecMessage(
+    message: SolanaOffchainSpecCompliantMessage,
+  ): Uint8Array {
+    // Validate signature length
+    if (message.signature.length !== SIGNATURE_SIZE) {
+      throw new Error(
+        `Invalid signature length: expected ${SIGNATURE_SIZE} bytes, got ${message.signature.length}`,
+      );
+    }
+
+    // Calculate total size
+    const totalSize =
+      VEC_LENGTH_PREFIX_SIZE +
+      message.signed_message_with_preamble.length +
+      SIGNATURE_SIZE;
+
+    const buffer = new Uint8Array(totalSize);
+    let offset = 0;
+
+    // Serialize Vec<u8> with length prefix (little-endian u32)
+    const view = new DataView(buffer.buffer);
+    view.setUint32(offset, message.signed_message_with_preamble.length, true);
+    offset += VEC_LENGTH_PREFIX_SIZE;
+    buffer.set(message.signed_message_with_preamble, offset);
+    offset += message.signed_message_with_preamble.length;
+
+    // Serialize signature [u8; 64]
+    buffer.set(message.signature, offset);
+
+    return buffer;
+  }
+}
+
+export async function createSolanaSignableRollup<RuntimeCall>(
+  rollupConfig?: Partial<RollupConfig<DeepPartial<StandardRollupContext>>>,
+  solanaEndpoint = "/sequencer/accept-solana-offchain-tx",
+) {
+  // Create a standard rollup first
+  const standardRollup = await createStandardRollup<RuntimeCall>(rollupConfig);
+
+  // Wrap it with SolanaSignableRollup
+  return new SolanaSignableRollup<RuntimeCall>(standardRollup, solanaEndpoint);
+}

--- a/typescript/packages/web3/src/rollup/solana-signable-rollup.ts
+++ b/typescript/packages/web3/src/rollup/solana-signable-rollup.ts
@@ -1,5 +1,6 @@
 import type SovereignClient from "@sovereign-sdk/client";
 import type { Signer } from "@sovereign-sdk/signers";
+import type { Transaction, UnsignedTransaction } from "@sovereign-sdk/types";
 import { Base64 } from "js-base64";
 import type { Subscription, SubscriptionToCallbackMap } from "../subscriptions";
 import type { DeepPartial } from "../utils";
@@ -8,8 +9,6 @@ import {
   type StandardRollup,
   type StandardRollupContext,
   type StandardRollupSpec,
-  type Transaction,
-  type UnsignedTransaction,
   createStandardRollup,
   standardTypeBuilder,
 } from "./standard-rollup";
@@ -117,12 +116,12 @@ export class SolanaSignableRollup<RuntimeCall> {
   private async submitSerializedMessage(
     serializedMessage: Uint8Array,
   ): Promise<SovereignClient.Sequencer.TxCreateResponse> {
-    return await this.inner.http.post<
-      string,
-      SovereignClient.Sequencer.TxCreateResponse
-    >(this.solanaEndpoint, {
-      body: Base64.fromUint8Array(serializedMessage),
-    });
+    return await this.inner.http.post<SovereignClient.Sequencer.TxCreateResponse>(
+      this.solanaEndpoint,
+      {
+        body: Base64.fromUint8Array(serializedMessage),
+      },
+    );
   }
 
   /**


### PR DESCRIPTION
# Description

Adds logic for encoding and submitting transactions to the `sov-solana-offchain-auth` authenticator.

The encoding logic is drastically different (the transaction formats, the signing formats etc.) so this PR adds a completely separate `solana-signable-rollup` that implements everything necessary for it. In the future it'd be nice to add enough abstraction to the normal rollup to be able to have pluggable encoding, but that's out of scope for now.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
