### PR TITLE
Rename spans for better readability

### DIFF
--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
@@ -796,7 +796,8 @@ where
 
     // Begin the transaction processing phase.
     let raw_tx_hash = validated_output.0.raw_tx_hash;
-    let span = tracing::info_span!("process_transaction", tx_hash = %raw_tx_hash, idx = %idx).entered();
+    let span =
+        tracing::info_span!("process_transaction", tx_hash = %raw_tx_hash, idx = %idx).entered();
 
     #[cfg(feature = "native")]
     assert_eq!(

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
@@ -796,7 +796,7 @@ where
 
     // Begin the transaction processing phase.
     let raw_tx_hash = validated_output.0.raw_tx_hash;
-    let span = tracing::info_span!("transaction", id = %raw_tx_hash, idx = %idx).entered();
+    let span = tracing::info_span!("process_transaction", tx_hash = %raw_tx_hash, idx = %idx).entered();
 
     #[cfg(feature = "native")]
     assert_eq!(

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -153,7 +153,7 @@ where
         let Some(resolved_version) = self.get_version_to_use(version) else {
             return Ok(None);
         };
-        let _span = tracing::debug_span!("version", ?resolved_version, passed = ?version).entered();
+        let _span = tracing::debug_span!("NomtProverStorage::read_value", ?resolved_version, passed_version = ?version).entered();
         // TODO(@preston-evans98) Skip the useless to_vec here. https://github.com/Sovereign-Labs/sovereign-sdk/issues/1824
         let key_vec = key.as_ref().to_vec();
         let val = match N::NAMESPACE {


### PR DESCRIPTION
# Description

NomtProverStorage has span "version" which is actually about reading value from rocksdb


<img width="476" height="605" alt="Screenshot 2025-11-11 at 16 54 40" src="https://github.com/user-attachments/assets/6b7ba8b8-8424-4b95-8a18-e784d637fa73" />


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existing tests are passing

## Docs
No updaters
