### PR TITLE
Ignore logs emmited in `SEQUENCER_WARM_UP` execution context.

### DIFF
--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
@@ -60,8 +60,16 @@ pub fn initialize_logging() -> Option<OtelGuard> {
 
     if let Some(otel) = otel.as_ref() {
         layers = layers
-            .and_then(otel.otel_tracing_layer().with_filter(get_env_filter()))
-            .and_then(otel.otel_logging_layer().with_filter(get_env_filter()))
+            .and_then(
+                otel.otel_tracing_layer()
+                    .with_filter(get_env_filter())
+                    .with_filter(IgnoreSpan(ExecutionContext::SEQUENCER_WARM_UP)),
+            )
+            .and_then(
+                otel.otel_logging_layer()
+                    .with_filter(get_env_filter())
+                    .with_filter(IgnoreSpan(ExecutionContext::SEQUENCER_WARM_UP)),
+            )
             .boxed();
     }
 


### PR DESCRIPTION
# Description

This PR fixes a bug where logs emitted in the `SEQUENCER_WARM_UP` context were ignored in `fmt::layer()`, but not in other layers. As a result, these logs were incorrectly appearing in Grafana.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
