### PR TITLE
Fix hyperlane quote-dispatch endpoint

### DIFF
--- a/crates/module-system/hyperlane/src/api.rs
+++ b/crates/module-system/hyperlane/src/api.rs
@@ -1,7 +1,7 @@
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Json;
-use serde::Serialize;
+use serde::{Deserialize as _, Serialize};
 use sov_bank::{config_gas_token_id, Amount};
 use sov_modules_api::prelude::serde_json::json;
 use sov_modules_api::prelude::utoipa::openapi::OpenApi;
@@ -12,6 +12,16 @@ use sov_modules_api::{ApiStateAccessor, CredentialId, HexHash, Spec};
 
 use crate::igp::RelayerWithDomainKey;
 use crate::{EthAddress, Ism, Mailbox, Recipient};
+
+fn deserialize_number_from_str<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    let s = String::deserialize(deserializer)?;
+    s.parse().map_err(serde::de::Error::custom)
+}
 
 /// A configuration of an [`Ism::MessageIdMultisig`].
 #[derive(Serialize)]
@@ -30,6 +40,7 @@ pub struct QuoteParams {
     /// Destination domain.
     pub destination_domain: u32,
     /// Gas limit.
+    #[serde(deserialize_with = "deserialize_number_from_str")]
     pub gas_limit: u128,
     /// Recipient address.
     pub recipient_address: HexHash,
@@ -55,7 +66,7 @@ impl<S: Spec, R: Recipient<S>> HasCustomRestApi for Mailbox<S, R> {
                 "/recipient-ism/:address/validators_and_threshold",
                 get(Self::get_recipient_ism_validators_and_threshold),
             )
-            .route("/quote_dispatch", get(Self::query_quote_dispatch))
+            .route("/quote-dispatch", get(Self::query_quote_dispatch))
             .with_state(state.with(self.clone()))
     }
 
@@ -160,5 +171,28 @@ impl<S: Spec, R: Recipient<S>> Mailbox<S, R> {
         };
 
         Ok(response.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr as _;
+
+    use sov_modules_api::prelude::axum::http::Uri;
+
+    use super::*;
+
+    #[test]
+    fn test_quote_query_params_handles_u128() {
+        let uri = Uri::from_static("https://0.0.0.0:12346/modules/mailbox/quote_dispatch?destination_domain=1399811149&gas_limit=500&recipient_address=0x71c7656ec7ab88b098defb751b7401b5f6d8976fae23aeb2342aedac24843ead");
+        let query_params: Query<QuoteParams> =
+            Query::try_from_uri(&uri).expect("Failed to parse query params");
+        assert_eq!(query_params.destination_domain, 1399811149);
+        assert_eq!(query_params.gas_limit, 500u128);
+        assert_eq!(
+            query_params.recipient_address,
+            HexHash::from_str("71c7656ec7ab88b098defb751b7401b5f6d8976fae23aeb2342aedac24843ead")
+                .unwrap()
+        );
     }
 }

--- a/crates/module-system/hyperlane/src/openapi-v3.yaml
+++ b/crates/module-system/hyperlane/src/openapi-v3.yaml
@@ -54,26 +54,32 @@ paths:
       operationId: "hyperlane_igp_quote_dispatch"
       tags: [Mailbox]
       parameters:
-        - name: destination-domain
+        - name: destination_domain
           in: query
           description: The destination domain ID.
           required: true
           schema:
             type: integer
             format: uint32
-        - name: relayer-address
+        - name: relayer
           in: query
           description: The address of relayer. Could be optional if default relayer address is present.
           required: false
           schema:
             type: string
-        - name: gas-limit
+        - name: gas_limit
           in: query
           description: The gas limit to use for the interchain transfer.
           required: true
           schema:
             type: integer
             format: uint128
+        - name: recipient_address
+          in: query
+          description: The address of the recipient.
+          required: true
+          schema:
+            $ref: "#/components/schemas/HyperlaneAddress"
       responses:
         "200":
           $ref: "#/components/responses/QuoteDispatchResponse"

--- a/crates/utils/sov-rest-utils/src/axum_extractors.rs
+++ b/crates/utils/sov-rest-utils/src/axum_extractors.rs
@@ -139,7 +139,7 @@ mod tests {
                     status: StatusCode::BAD_REQUEST,
                     message: "Invalid query string".to_string(),
                     details: json_obj!({
-                        "error": "Failed to deserialize query string"
+                        "error": "invalid digit found in string"
                     }),
                 }
             );

--- a/crates/utils/sov-rest-utils/src/axum_extractors.rs
+++ b/crates/utils/sov-rest-utils/src/axum_extractors.rs
@@ -4,6 +4,7 @@
 
 #![deny(missing_docs)]
 
+use std::error::Error;
 use std::fmt::Debug;
 
 use axum::extract::FromRequestParts;
@@ -30,12 +31,20 @@ impl<T: DeserializeOwned> Query<T> {
     pub fn try_from_uri(uri: &Uri) -> Result<Self, ErrorObject> {
         axum::extract::Query::<T>::try_from_uri(uri)
             .map(|q| Self(q.0))
-            .map_err(|err| ErrorObject {
-                status: StatusCode::BAD_REQUEST,
-                message: "Invalid query string".to_string(),
-                details: json_obj!({
-                    "error": err.to_string(),
-                }),
+            .map_err(|err| {
+                let error_message = err
+                    .source()
+                    .and_then(|source| source.source())
+                    .map(|root_cause| root_cause.to_string())
+                    .unwrap_or_else(|| err.to_string());
+
+                ErrorObject {
+                    status: StatusCode::BAD_REQUEST,
+                    message: "Invalid query string".to_string(),
+                    details: json_obj!({
+                        "error": error_message,
+                    }),
+                }
             })
     }
 }
@@ -92,6 +101,30 @@ mod tests {
         struct TestQuery {
             #[allow(unused)]
             integer: u8,
+        }
+
+        #[derive(Debug, serde::Deserialize)]
+        struct InvalidQuery {
+            #[allow(unused)]
+            unsupported: u128,
+        }
+
+        #[test]
+        fn test_query_unsupported_type_error_contains_reason_for_error() {
+            let uri = uri_with_query_params([("unsupported", "123456789012345678901234567890")]);
+            let result = Query::<InvalidQuery>::try_from_uri(&uri);
+            let err = result.unwrap_err();
+
+            assert_eq!(
+                err,
+                ErrorObject {
+                    status: StatusCode::BAD_REQUEST,
+                    message: "Invalid query string".to_string(),
+                    details: json_obj!({
+                        "error": "u128 is not supported"
+                    }),
+                }
+            );
         }
 
         #[test]


### PR DESCRIPTION
# Description

Fix issues with hyperlane quote-dispatch endpoint:

1. The endpoint that was mounted and the one defined in the openapi spec were different
2. The query params in openapi spec defined incorrect names
3. `QuoteParams` used `u128` which is unsupported data type so the endpoint was borked anyway
4. If Query params fail to deserialize include the actual reason for the failure in the response

---

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
