### PR TITLE
Fix flaky: `test_rollup_resync` test

### DIFF
--- a/examples/demo-rollup/tests/resync/mod.rs
+++ b/examples/demo-rollup/tests/resync/mod.rs
@@ -333,6 +333,7 @@ async fn test_rollup_resync() -> anyhow::Result<()> {
         (Level::WARN, "State Transition Info is not consumed fast enough, cannot prune older entries. Please check that consumer works.".to_string()),
         (Level::WARN, "The node is unsynced and doesn't know it. This probably means that you wiped the node DB and are resyncing.".to_string()),
         (Level::WARN, "Metics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown".to_string()),
+        (Level::WARN, "Cache warm up task: Transaction could not be applied on the executor.".to_string()),
     ];
 
     let mut recorded_errors_warnings =


### PR DESCRIPTION
# Description

For more information see the description of: https://github.com/Sovereign-Labs/sovereign-sdk/pull/2059.

In `test_rollup_resync`, we occasionally observe a newly added log message appearing due to a timing issue.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

Related to: https://github.com/Sovereign-Labs/sovereign-sdk/pull/2059.

