### PR TITLE
WS Speedup. Replaces: https://github.com/Sovereign-Labs/sovereign-sdk/pull/2051

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12043,6 +12043,8 @@ dependencies = [
  "sov-eth-client",
  "sov-test-utils",
  "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12040,6 +12040,7 @@ dependencies = [
  "futures",
  "rand 0.8.5",
  "reqwest 0.12.23",
+ "serde",
  "sov-eth-client",
  "sov-test-utils",
  "tokio",

--- a/crates/full-node/sov-stf-runner/src/http/ws.rs
+++ b/crates/full-node/sov-stf-runner/src/http/ws.rs
@@ -1,12 +1,13 @@
 use axum::extract::ws::{Message, WebSocket};
 use axum::extract::WebSocketUpgrade;
 use axum::response::IntoResponse;
+use axum::Error;
 use futures::stream::{SplitSink, SplitStream};
 use futures_util::sink::SinkExt;
 use futures_util::stream::StreamExt;
 use jsonrpsee::core::JsonRawValue;
 use jsonrpsee::RpcModule;
-use sov_rollup_interface::consume_until_shutdown;
+use sov_rollup_interface::{consume_many_until_shutdown, consume_until_shutdown};
 use tokio::spawn;
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, trace};
@@ -162,21 +163,36 @@ async fn subscription_forwarder_task(
     }
 }
 
+const MAX_WRITE_BATCH_SIZE: usize = 128;
+
 async fn socket_writer_task(
     mut msg_rx: mpsc::Receiver<Message>,
     mut ws_writer: SplitSink<WebSocket, Message>,
     mut shutdown_receiver: watch::Receiver<()>,
 ) {
-    consume_until_shutdown! {
+    let mut pending = Vec::with_capacity(MAX_WRITE_BATCH_SIZE);
+    consume_many_until_shutdown! {
         "WebSocket writer",
-        msg_rx.recv(),
+        msg_rx.recv_many(&mut pending, MAX_WRITE_BATCH_SIZE),
         shutdown_receiver,
-        response => {
-            if let Err(error) = ws_writer.send(response).await {
+        count => {
+            if let Err(error) = write_batch(&mut pending, &mut ws_writer).await {
                 debug!(%error, "WebSocket closed, stopping writer task");
                 break;
             }
-            trace!("Message sent to websocket");
         }
     }
+}
+
+async fn write_batch(
+    buf: &mut Vec<Message>,
+    ws_writer: &mut SplitSink<WebSocket, Message>,
+) -> Result<(), Error> {
+    let count = buf.len();
+    for item in buf.drain(..) {
+        ws_writer.feed(item).await?;
+    }
+    ws_writer.flush().await?;
+    trace!("{count} messages sent to websocket");
+    Ok(())
 }

--- a/crates/full-node/sov-stf-runner/src/http/ws.rs
+++ b/crates/full-node/sov-stf-runner/src/http/ws.rs
@@ -12,6 +12,9 @@ use tokio::spawn;
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, error, trace};
 
+/// Capacity for channels forwarding subscription messages
+const BUF_SIZE: usize = 128;
+
 /// Convert content to a WebSocket message, using binary or text encoding
 fn to_ws_message(content: impl ToString, use_binary: bool) -> Message {
     let content_str = content.to_string();
@@ -48,7 +51,7 @@ async fn handle_socket(
 ) {
     let (ws_writer, ws_reader) = socket.split();
 
-    let (msg_tx, msg_rx) = mpsc::channel(128);
+    let (msg_tx, msg_rx) = mpsc::channel(BUF_SIZE);
 
     spawn(socket_writer_task(
         msg_rx,
@@ -119,7 +122,7 @@ async fn handle_rpc_message(
     shutdown_receiver: watch::Receiver<()>,
 ) {
     // Buffer size picked up from `jsonrpsee` crate examples
-    let (response, response_stream) = match rpc_methods.raw_json_request(&text, 1).await {
+    let (response, response_stream) = match rpc_methods.raw_json_request(&text, BUF_SIZE).await {
         Ok(res) => res,
         Err(error) => return error!(%error, "Error while processing RPC request"),
     };

--- a/crates/full-node/sov-stf-runner/src/http/ws.rs
+++ b/crates/full-node/sov-stf-runner/src/http/ws.rs
@@ -82,11 +82,11 @@ async fn socket_reader_task(
             };
             match msg {
                 Message::Text(text) => {
-                    handle_rpc_message(&text, &msg_tx, &rpc_methods, false, &shutdown_receiver).await;
+                    handle_rpc_message(text, &msg_tx, &rpc_methods, false, &shutdown_receiver).await;
                 }
                 Message::Binary(data) => {
                     // Parse binary frame as UTF-8 JSON-RPC request
-                    match std::str::from_utf8(&data) {
+                    match String::from_utf8(data) {
                         Ok(text) => {
                             handle_rpc_message(text, &msg_tx, &rpc_methods, true, &shutdown_receiver).await;
                         }
@@ -111,14 +111,14 @@ async fn socket_reader_task(
 }
 
 async fn handle_rpc_message(
-    text: &str,
+    text: String,
     msg_tx: &mpsc::Sender<Message>,
     rpc_methods: &RpcModule<()>,
     use_binary: bool,
     shutdown_receiver: &watch::Receiver<()>,
 ) {
     // Buffer size picked up from `jsonrpsee` crate examples
-    let (response, response_stream) = match rpc_methods.raw_json_request(text, 1).await {
+    let (response, response_stream) = match rpc_methods.raw_json_request(&text, 1).await {
         Ok(res) => res,
         Err(error) => return error!(%error, "Error while processing RPC request"),
     };

--- a/crates/full-node/sov-stf-runner/src/http/ws.rs
+++ b/crates/full-node/sov-stf-runner/src/http/ws.rs
@@ -82,13 +82,13 @@ async fn socket_reader_task(
             };
             match msg {
                 Message::Text(text) => {
-                    handle_rpc_message(text, &msg_tx, &rpc_methods, false, &shutdown_receiver).await;
+                    spawn(handle_rpc_message(text, msg_tx.clone(), rpc_methods.clone(), false, shutdown_receiver.clone()));
                 }
                 Message::Binary(data) => {
                     // Parse binary frame as UTF-8 JSON-RPC request
                     match String::from_utf8(data) {
                         Ok(text) => {
-                            handle_rpc_message(text, &msg_tx, &rpc_methods, true, &shutdown_receiver).await;
+                            spawn(handle_rpc_message(text, msg_tx.clone(), rpc_methods.clone(), true, shutdown_receiver.clone()));
                         }
                         Err(error) => {
                             error!(%error, "Invalid UTF-8 in binary WebSocket frame");
@@ -112,10 +112,10 @@ async fn socket_reader_task(
 
 async fn handle_rpc_message(
     text: String,
-    msg_tx: &mpsc::Sender<Message>,
-    rpc_methods: &RpcModule<()>,
+    msg_tx: mpsc::Sender<Message>,
+    rpc_methods: RpcModule<()>,
     use_binary: bool,
-    shutdown_receiver: &watch::Receiver<()>,
+    shutdown_receiver: watch::Receiver<()>,
 ) {
     // Buffer size picked up from `jsonrpsee` crate examples
     let (response, response_stream) = match rpc_methods.raw_json_request(&text, 1).await {

--- a/crates/rollup-interface/src/node/mod.rs
+++ b/crates/rollup-interface/src/node/mod.rs
@@ -91,3 +91,28 @@ macro_rules! consume_until_shutdown {
         }
     };
 }
+
+/// Same as consume_until_shutdown but consumes elements in batches
+#[macro_export]
+macro_rules! consume_many_until_shutdown {
+    (
+        $name:expr,
+        $recv_many:expr,
+        $shutdown:expr,
+        $var:ident => $body:block
+    ) => {
+        let name = $name;
+        loop {
+            tokio::select! {
+                _ = $shutdown.changed() => {
+                    tracing::debug!(%name, "Shutdown signal received, stopping task");
+                    break;
+                }
+                count = $recv_many => {
+                    tracing::trace!(%name, "{count} messages received");
+                    $body
+                }
+            }
+        }
+    };
+}

--- a/crates/utils/sov-evm-soak-testing/Cargo.toml
+++ b/crates/utils/sov-evm-soak-testing/Cargo.toml
@@ -22,6 +22,7 @@ reqwest = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+serde = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/utils/sov-evm-soak-testing/Cargo.toml
+++ b/crates/utils/sov-evm-soak-testing/Cargo.toml
@@ -20,6 +20,8 @@ rand = { workspace = true }
 clap = { workspace = true }
 reqwest = { workspace = true }
 futures = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/utils/sov-evm-soak-testing/src/logs.rs
+++ b/crates/utils/sov-evm-soak-testing/src/logs.rs
@@ -35,7 +35,7 @@ pub async fn run_logs_test(
     let root_client = alloy_ws_client(rpc_addr, root_signer.clone()).await?;
     fund_worker_accounts(&root_client, &root_signer, private_key, num_workers).await?;
 
-    match mode {
+    let ((logs_count, logs_time), (stream_count, stream_time)) = match mode {
         LogsRetrievalMode::Subscription { capacity } => {
             let subscription = root_client
                 .subscribe_logs(&Filter::new())
@@ -45,14 +45,18 @@ pub async fn run_logs_test(
             try_join!(
                 produce_logs(rpc_addr, private_key, num_workers, tx_count, logs_per_tx),
                 stream_logs(subscription, expected_count)
-            )?;
+            )
         }
         LogsRetrievalMode::WithCursor => {
             let from_block = root_client.get_block_number().await?;
-            produce_logs(rpc_addr, private_key, num_workers, tx_count, logs_per_tx).await?;
-            retrieve_logs(root_client, from_block).await?;
+            try_join!(
+                produce_logs(rpc_addr, private_key, num_workers, tx_count, logs_per_tx),
+                retrieve_logs(root_client, from_block)
+            )
         }
-    }
+    }?;
+    println!("Produced {logs_count} logs in {logs_time:?}");
+    println!("Streamed {stream_count} logs in {stream_time:?}");
 
     Ok(())
 }
@@ -63,7 +67,7 @@ async fn produce_logs(
     num_workers: usize,
     tx_count: usize,
     logs_per_tx: usize,
-) -> Result<()> {
+) -> Result<(usize, Duration)> {
     let timer = Instant::now();
     let mut handles = Vec::with_capacity(num_workers);
     for worker_idx in 0..num_workers {
@@ -85,22 +89,17 @@ async fn produce_logs(
         }));
     }
     try_join_all(handles).await?;
-    println!(
-        "Produced {} logs in {:?}",
-        num_workers * tx_count * logs_per_tx,
-        timer.elapsed()
-    );
-    Ok(())
+    Ok((num_workers * tx_count * logs_per_tx, timer.elapsed()))
 }
 
-async fn retrieve_logs(client: DynProvider, from_block: u64) -> Result<()> {
+async fn retrieve_logs(client: DynProvider, from_block: u64) -> Result<(usize, Duration)> {
     let filter: Filter = Filter::new()
         .from_block(from_block)
         .to_block(BlockNumberOrTag::Pending);
     let timer = Instant::now();
     let logs = client.get_all_logs_with_cursor(&filter).await?;
     println!("Retrieved {} logs in {:?}", logs.len(), timer.elapsed());
-    Ok(())
+    Ok((logs.len(), timer.elapsed()))
 }
 
 trait RecvMany {
@@ -121,11 +120,15 @@ impl<T: DeserializeOwned> RecvMany for Subscription<T> {
                 Err(_) => break,
             }
         }
+        println!("Subscription recevied {count} items");
         Ok(count)
     }
 }
 
-async fn stream_logs(mut subscription: Subscription<Log>, expected_count: usize) -> Result<()> {
+async fn stream_logs(
+    mut subscription: Subscription<Log>,
+    expected_count: usize,
+) -> Result<(usize, Duration)> {
     let timer = Instant::now();
     let mut count = 0;
     let mut timeouts = 0;
@@ -150,8 +153,7 @@ async fn stream_logs(mut subscription: Subscription<Log>, expected_count: usize)
             }
         }
     }
-    println!("Streamed {} logs in {:?}", expected_count, timer.elapsed());
-    Ok(())
+    Ok((count, timer.elapsed()))
 }
 
 pub struct LogsSoakTest<P, N> {

--- a/crates/utils/sov-evm-soak-testing/src/logs.rs
+++ b/crates/utils/sov-evm-soak-testing/src/logs.rs
@@ -111,6 +111,7 @@ async fn stream_logs(
     while count < expected_count && timeouts < 10 {
         match timeout(Duration::from_secs(1), subscription.recv_many()).await {
             Ok(Ok(received)) => {
+                println!("Subscription recevied {received} items");
                 count += received;
             }
             Ok(Err(RecvManyError::Closed)) => {

--- a/crates/utils/sov-evm-soak-testing/src/logs.rs
+++ b/crates/utils/sov-evm-soak-testing/src/logs.rs
@@ -7,12 +7,14 @@ use alloy_primitives::U256;
 use alloy_pubsub::Subscription;
 use anyhow::Result;
 use futures::future::try_join_all;
-use futures::StreamExt;
+use serde::de::DeserializeOwned;
 use sov_eth_client::LogsWithCursorProvider;
 use sov_test_utils::SimpleStorage;
 use sov_test_utils::Submit;
 use std::net::SocketAddr;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+use tokio::sync::broadcast::error::{RecvError, TryRecvError};
+use tokio::time::timeout;
 
 use crate::{alloy_client, fund_worker_accounts, validate_worker_count, LogsRetrievalMode};
 use crate::{alloy_ws_client, derive_worker_key};
@@ -99,17 +101,53 @@ async fn retrieve_logs(client: DynProvider, from_block: u64) -> Result<()> {
     Ok(())
 }
 
-async fn stream_logs(subscription: Subscription<Log>, expected_count: usize) -> Result<()> {
+trait RecvMany {
+    async fn recv_many(&mut self) -> Result<usize, RecvError>;
+}
+
+impl<T: DeserializeOwned> RecvMany for Subscription<T> {
+    async fn recv_many(&mut self) -> Result<usize, RecvError> {
+        self.recv().await?;
+        let mut count = 1;
+        loop {
+            match self.try_recv() {
+                Ok(_) => count += 1,
+                Err(TryRecvError::Lagged(n)) => {
+                    println!("Subscription lagged by {n} during try_recv");
+                    count += n as usize;
+                }
+                Err(_) => break,
+            }
+        }
+        Ok(count)
+    }
+}
+
+async fn stream_logs(mut subscription: Subscription<Log>, expected_count: usize) -> Result<()> {
     let timer = Instant::now();
-    let mut stream = subscription.into_stream();
     let mut count = 0;
-    while let Some(_item) = stream.next().await {
-        count += 1;
-        if count == expected_count {
-            break;
+    let mut timeouts = 0;
+    while count < expected_count && timeouts < 10 {
+        match timeout(Duration::from_secs(1), subscription.recv_many()).await {
+            Ok(Ok(received)) => {
+                count += received;
+            }
+            Ok(Err(RecvError::Closed)) => {
+                println!("Subscription closed");
+                break;
+            }
+            Ok(Err(RecvError::Lagged(n))) => {
+                println!("Subscription lagged by {n}");
+                count += n as usize;
+            }
+            Err(_) => {
+                println!(
+                    "Timeout receiving log {count}. Timeouts: {timeouts} (shutdown after 10 timeouts)"
+                );
+                timeouts += 1;
+            }
         }
     }
-    assert_eq!(count, expected_count);
     println!("Streamed {} logs in {:?}", expected_count, timer.elapsed());
     Ok(())
 }

--- a/crates/utils/sov-evm-soak-testing/src/logs.rs
+++ b/crates/utils/sov-evm-soak-testing/src/logs.rs
@@ -15,6 +15,7 @@ use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast::error::{RecvError, TryRecvError};
 use tokio::time::timeout;
+use tokio::try_join;
 
 use crate::{alloy_client, fund_worker_accounts, validate_worker_count, LogsRetrievalMode};
 use crate::{alloy_ws_client, derive_worker_key};
@@ -41,9 +42,10 @@ pub async fn run_logs_test(
                 .channel_size(capacity)
                 .await?;
             let expected_count = tx_count * logs_per_tx * num_workers;
-            produce_logs(rpc_addr, private_key, num_workers, tx_count, logs_per_tx).await?;
-            let handle = tokio::spawn(stream_logs(subscription, expected_count));
-            handle.await??;
+            try_join!(
+                produce_logs(rpc_addr, private_key, num_workers, tx_count, logs_per_tx),
+                stream_logs(subscription, expected_count)
+            )?;
         }
         LogsRetrievalMode::WithCursor => {
             let from_block = root_client.get_block_number().await?;

--- a/crates/utils/sov-evm-soak-testing/src/logs.rs
+++ b/crates/utils/sov-evm-soak-testing/src/logs.rs
@@ -7,16 +7,15 @@ use alloy_primitives::U256;
 use alloy_pubsub::Subscription;
 use anyhow::Result;
 use futures::future::try_join_all;
-use serde::de::DeserializeOwned;
 use sov_eth_client::LogsWithCursorProvider;
 use sov_test_utils::SimpleStorage;
 use sov_test_utils::Submit;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
-use tokio::sync::broadcast::error::{RecvError, TryRecvError};
 use tokio::time::timeout;
 use tokio::try_join;
 
+use crate::recv_many::{RecvMany, RecvManyError};
 use crate::{alloy_client, fund_worker_accounts, validate_worker_count, LogsRetrievalMode};
 use crate::{alloy_ws_client, derive_worker_key};
 
@@ -102,29 +101,6 @@ async fn retrieve_logs(client: DynProvider, from_block: u64) -> Result<(usize, D
     Ok((logs.len(), timer.elapsed()))
 }
 
-trait RecvMany {
-    async fn recv_many(&mut self) -> Result<usize, RecvError>;
-}
-
-impl<T: DeserializeOwned> RecvMany for Subscription<T> {
-    async fn recv_many(&mut self) -> Result<usize, RecvError> {
-        self.recv().await?;
-        let mut count = 1;
-        loop {
-            match self.try_recv() {
-                Ok(_) => count += 1,
-                Err(TryRecvError::Lagged(n)) => {
-                    println!("Subscription lagged by {n} during try_recv");
-                    count += n as usize;
-                }
-                Err(_) => break,
-            }
-        }
-        println!("Subscription recevied {count} items");
-        Ok(count)
-    }
-}
-
 async fn stream_logs(
     mut subscription: Subscription<Log>,
     expected_count: usize,
@@ -137,13 +113,9 @@ async fn stream_logs(
             Ok(Ok(received)) => {
                 count += received;
             }
-            Ok(Err(RecvError::Closed)) => {
+            Ok(Err(RecvManyError::Closed)) => {
                 println!("Subscription closed");
                 break;
-            }
-            Ok(Err(RecvError::Lagged(n))) => {
-                println!("Subscription lagged by {n}");
-                count += n as usize;
             }
             Err(_) => {
                 println!(

--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -10,6 +10,7 @@ use clap::{Parser, Subcommand};
 use futures::future::try_join_all;
 use reqwest::Url;
 use std::net::SocketAddr;
+use tracing_subscriber::EnvFilter;
 
 mod logs;
 mod simple_storage;
@@ -197,6 +198,8 @@ async fn run_simple_storage_test(rpc_addr: SocketAddr, private_key: &str) -> Res
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let filter = EnvFilter::try_from_default_env().unwrap_or("debug".into());
+    tracing_subscriber::fmt().with_env_filter(filter).init();
     let args = Args::parse();
 
     match args.test {

--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -10,6 +10,7 @@ use clap::{Parser, Subcommand};
 use futures::future::try_join_all;
 use reqwest::Url;
 use std::net::SocketAddr;
+use tracing::warn;
 use tracing_subscriber::EnvFilter;
 
 mod logs;
@@ -174,6 +175,10 @@ async fn fund_worker_accounts(
     num_workers: usize,
 ) -> Result<()> {
     let root_balance = root_client.get_balance(root_signer.address()).await?;
+    if root_balance == U256::ZERO {
+        warn!("Root balance is 0. Skipping funding. This is fine if the paymaster is enabled.");
+        return Ok(());
+    }
     let transfer_amount = root_balance.wrapping_div(U256::from(num_workers));
 
     for worker_idx in 0..num_workers {

--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -14,6 +14,7 @@ use tracing::warn;
 use tracing_subscriber::EnvFilter;
 
 mod logs;
+pub(crate) mod recv_many;
 mod simple_storage;
 mod uniswap;
 

--- a/crates/utils/sov-evm-soak-testing/src/recv_many.rs
+++ b/crates/utils/sov-evm-soak-testing/src/recv_many.rs
@@ -35,7 +35,6 @@ impl<T: DeserializeOwned> RecvMany for Subscription<T> {
                 Err(TryRecvError::Empty) => break,
             }
         }
-        println!("Subscription recevied {count} items");
         Ok(count)
     }
 }

--- a/crates/utils/sov-evm-soak-testing/src/recv_many.rs
+++ b/crates/utils/sov-evm-soak-testing/src/recv_many.rs
@@ -1,0 +1,41 @@
+use alloy_pubsub::Subscription;
+use serde::de::DeserializeOwned;
+use tokio::sync::broadcast::error::{RecvError, TryRecvError};
+
+pub enum RecvManyError {
+    Closed,
+}
+
+impl From<RecvError> for RecvManyError {
+    fn from(err: RecvError) -> Self {
+        match err {
+            RecvError::Lagged(n) => {
+                panic!("Subscription lagged by {n} during recv");
+            }
+            RecvError::Closed => Self::Closed,
+        }
+    }
+}
+
+pub trait RecvMany {
+    async fn recv_many(&mut self) -> Result<usize, RecvManyError>;
+}
+
+impl<T: DeserializeOwned> RecvMany for Subscription<T> {
+    async fn recv_many(&mut self) -> Result<usize, RecvManyError> {
+        self.recv().await?;
+        let mut count = 1;
+        loop {
+            match self.try_recv() {
+                Ok(_) => count += 1,
+                Err(TryRecvError::Lagged(n)) => {
+                    panic!("Subscription lagged by {n} during try_recv");
+                }
+                Err(TryRecvError::Closed) => return Err(RecvManyError::Closed),
+                Err(TryRecvError::Empty) => break,
+            }
+        }
+        println!("Subscription recevied {count} items");
+        Ok(count)
+    }
+}


### PR DESCRIPTION
# Description

After https://github.com/Sovereign-Labs/sovereign-sdk/pull/2043 got merged - https://github.com/Sovereign-Labs/sovereign-sdk/pull/2051 got conflicts. This PR fixes those.

Also - uses `try_join` to stream and produce logs in parallel resulting in no `channel lagged` messages (even after milling of logs).
In the version before - we were getting a huge `channel lagged: {a lot}` message at the beginning.
This allows us treating lags as errors and panicking on them as lags are unacceptable from the perspective of the user using this API to get all the logs.

Also - increased the capacity of the internal channels in jsonrpsee from 1 to 128 which brought another 2x speedup. But more importantly - subscription now finishes in a time very close that it takes to produce logs.

For example: Streamed 10M logs in 62.3s. Produced in 61.4s. (6 micros for a log). 0 lagged

-----

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
