### PR TITLE
Add web3 signer that uses the Ledger solana app

### DIFF
--- a/typescript/.changeset/loud-oranges-walk.md
+++ b/typescript/.changeset/loud-oranges-walk.md
@@ -1,0 +1,6 @@
+---
+"@sovereign-sdk/signers": minor
+"@sovereign-sdk/web3": minor
+---
+
+Adds a Signer implementation for Ledger devices with the Solana app, intended to be used with the `SolanaSignableRollup` on rollups that use the `sov-solana-offchain-auth` authenticator crate.

--- a/typescript/packages/signers/package.json
+++ b/typescript/packages/signers/package.json
@@ -28,6 +28,7 @@
   "types": "./dist/index.d.ts",
   "devDependencies": {
     "@metamask/providers": "^18.1.0",
+    "bs58": "^6.0.0",
     "tsup": "^8.3.0",
     "typescript": "^5.6.3",
     "vitest": "4.0.7"
@@ -40,6 +41,11 @@
     "access": "public"
   },
   "dependencies": {
+    "@ledgerhq/hw-app-solana": "^7.5.2",
+    "@ledgerhq/hw-transport": "^6.31.9",
+    "@ledgerhq/hw-transport-webhid": "^6.30.5",
+    "@ledgerhq/hw-transport-webusb": "^6.29.9",
+    "@ledgerhq/hw-transport-node-hid": "^6.29.10",
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.5.0",
     "@noble/secp256k1": "^2.3.0",

--- a/typescript/packages/signers/src/index.ts
+++ b/typescript/packages/signers/src/index.ts
@@ -3,3 +3,4 @@ export * from "./snap";
 export * from "./ed25519";
 export * from "./secp256k1";
 export * from "./privy";
+export * from "./ledger-solana";

--- a/typescript/packages/signers/src/ledger-solana.test.manual.ts
+++ b/typescript/packages/signers/src/ledger-solana.test.manual.ts
@@ -1,0 +1,154 @@
+/**
+ * Manual test script for Ledger hardware wallet
+ *
+ * Prerequisites:
+ * 1. Connect your Ledger device via USB
+ * 2. Unlock it and open the Solana app
+ * 3. Run: pnpm tsx src/ledger.test.manual.ts
+ *
+ */
+
+import bs58 from "bs58";
+import { Ed25519Signer } from "./ed25519";
+import { LedgerSolanaSigner } from "./ledger-solana";
+
+// Solana preamble creation (copied from web3 package to avoid circular dependency)
+function createSolanaPreamble(
+  pubkey: Uint8Array,
+  chainHash: Uint8Array,
+  messageLength: number,
+): Uint8Array {
+  const SIGNING_DOMAIN = new Uint8Array([
+    0xff,
+    ...new TextEncoder().encode("solana offchain"),
+  ]);
+  const preamble = new Uint8Array(85); // PREAMBLE_LENGTH
+  let offset = 0;
+  preamble.set(SIGNING_DOMAIN, offset);
+  offset += 16;
+  preamble[offset] = 0; // HEADER_VERSION
+  offset += 1;
+  preamble.set(chainHash, offset);
+  offset += 32;
+  preamble[offset] = 0; // MESSAGE_FORMAT
+  offset += 1;
+  preamble[offset] = 1; // SINGLE_SIGNER_COUNT
+  offset += 1;
+  preamble.set(pubkey, offset);
+  offset += 32;
+  new DataView(preamble.buffer, offset).setUint16(0, messageLength, true);
+
+  return preamble;
+}
+
+// Test data from solana-signable-rollup.test.ts (matching Rust tests)
+const TEST_RUNTIME_CALL = {
+  bank: {
+    transfer: {
+      to: "4zdwHNaEa5npHtRtaZ3RL1m6rptuQZ6RBLHG6cAyVHjL",
+      coins: {
+        amount: "5000",
+        token_id:
+          "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7",
+      },
+    },
+  },
+};
+
+// Chain hash matching the test (from solana-signable-rollup.test.ts)
+const TEST_CHAIN_HASH = new Uint8Array(32).fill(0x0b);
+
+const TEST_MESSAGE = Buffer.from(
+  JSON.stringify({
+    runtime_call: TEST_RUNTIME_CALL,
+    uniqueness: { generation: 0 },
+    details: {
+      max_priority_fee_bips: 0,
+      max_fee: "100000000000",
+      gas_limit: [1000000000, 1000000000],
+      chain_id: 4321,
+    },
+    chain_name: "TestChain",
+  }),
+);
+
+async function testLedgerSolanaSigner() {
+  console.log("🔌 Ledger Hardware Wallet Test");
+  console.log("================================\n");
+
+  console.log("📋 Test Configuration:");
+  console.log("- Derivation path: 44'/501' (default Solana account)");
+  console.log(
+    "- Chain hash:",
+    Buffer.from(TEST_CHAIN_HASH).toString("hex"),
+    "\n",
+  );
+
+  const ledger = new LedgerSolanaSigner();
+
+  try {
+    // Test 1: Get public key
+    console.log("1️⃣  Getting public key from Ledger...");
+    const publicKey = await ledger.publicKey();
+    console.log("✅ Public key retrieved:");
+    console.log("   Hex:    ", Buffer.from(publicKey).toString("hex"));
+    console.log("   Base58: ", bs58.encode(publicKey));
+
+    // Test 2: Create message with preamble
+    console.log("2  Signing message with preamble...");
+    const preamble = createSolanaPreamble(
+      publicKey,
+      TEST_CHAIN_HASH,
+      TEST_MESSAGE.length,
+    );
+    const messageWithPreamble = Buffer.concat([preamble, TEST_MESSAGE]);
+
+    // Test 3: Sign message with preamble
+    console.log(
+      "⚠️  Please check your Ledger device and approve the signing request",
+    );
+
+    const signature = await ledger.sign(messageWithPreamble);
+    console.log("✅ Message signed:");
+    console.log(
+      "   Signature hex:    ",
+      Buffer.from(signature).toString("hex"),
+    );
+    console.log("   Signature base58: ", bs58.encode(signature));
+    console.log("   Signature length: ", signature.length, "bytes\n");
+
+    // Test 4: Signature verification
+    console.log("4️⃣  Signature verification using Ed25519:");
+
+    // For Ed25519, we can verify the signature
+    try {
+      const ed25519 = await import("@noble/ed25519");
+      const isValid = await ed25519.verifyAsync(
+        signature,
+        messageWithPreamble,
+        publicKey,
+      );
+      console.log("✅ Signature verification:", isValid ? "PASSED" : "FAILED");
+
+      if (!isValid) {
+        console.error("❌ Signature verification failed!");
+      }
+    } catch (e) {
+      console.log("⚠️  Could not verify signature:", e);
+    }
+
+    console.log("\n✅ All tests completed successfully!");
+  } catch (error) {
+    console.error("\n❌ Test failed:", error);
+    console.error(
+      "Make sure you have the Solana app open on the Ledger, otherwise the test errors instantly.",
+    );
+    process.exit(1);
+  } finally {
+    await ledger.disconnect();
+    console.log("\n🔌 Disconnected from Ledger");
+  }
+}
+
+// Run the test
+testLedgerSolanaSigner().catch(console.error);

--- a/typescript/packages/signers/src/ledger-solana.ts
+++ b/typescript/packages/signers/src/ledger-solana.ts
@@ -1,0 +1,107 @@
+import Solana from "@ledgerhq/hw-app-solana";
+import type Transport from "@ledgerhq/hw-transport";
+import type { Signer } from "./signer";
+
+export class LedgerSolanaSigner implements Signer {
+  private transport: Transport | null = null;
+  private solanaApp: Solana | null = null;
+  private derivationPath: string;
+
+  constructor(derivationPath = "44'/501'") {
+    this.derivationPath = derivationPath;
+  }
+
+  private async connect(): Promise<void> {
+    if (this.transport && this.solanaApp) {
+      return;
+    }
+
+    try {
+      if (typeof window !== "undefined") {
+        // Browser environment - use WebHID or WebUSB
+        const TransportWebHID = (await import("@ledgerhq/hw-transport-webhid"))
+          .default;
+        const TransportWebUSB = (await import("@ledgerhq/hw-transport-webusb"))
+          .default;
+
+        if (await TransportWebHID.isSupported()) {
+          this.transport = await TransportWebHID.create();
+        } else if (await TransportWebUSB.isSupported()) {
+          this.transport = await TransportWebUSB.create();
+        } else {
+          throw new Error(
+            "No supported Ledger transport available (WebHID or WebUSB)",
+          );
+        }
+      } else {
+        // Assuming node environment
+        try {
+          const TransportNodeHid = (
+            await import("@ledgerhq/hw-transport-node-hid")
+          ).default;
+          this.transport = await TransportNodeHid.create();
+        } catch (e) {
+          throw new Error(
+            "Failed to connect via Node HID transport. Make sure your Ledger is connected.",
+          );
+        }
+      }
+
+      const solana = new Solana(this.transport);
+      const version = await solana.getAppConfiguration().then((r) => r.version);
+      const [major, minor, patch] = version.split(".").map(Number);
+      if (major < 1 || (major === 1 && minor < 8)) {
+        throw new Error(
+          "Signing off-chain messages requires Solana Ledger App 1.8.0 or later",
+        );
+      }
+      this.solanaApp = solana;
+    } catch (error) {
+      throw new Error(`Failed to connect to Ledger device: ${error}`);
+    }
+  }
+
+  public async sign(message: Uint8Array): Promise<Uint8Array> {
+    await this.connect();
+
+    if (!this.solanaApp) {
+      throw new Error("Ledger Solana app not initialized");
+    }
+
+    try {
+      const result = await this.solanaApp.signOffchainMessage(
+        this.derivationPath,
+        Buffer.from(message),
+      );
+      return new Uint8Array(result.signature);
+    } catch (error) {
+      throw new Error(`Failed to sign message with Ledger: ${error}`);
+    }
+  }
+
+  public async publicKey(): Promise<Uint8Array> {
+    await this.connect();
+
+    if (!this.solanaApp) {
+      throw new Error("Ledger Solana app not initialized");
+    }
+
+    try {
+      const result = await this.solanaApp.getAddress(
+        this.derivationPath,
+        false,
+      );
+      return new Uint8Array(result.address);
+    } catch (error) {
+      throw new Error(`Failed to get public key from Ledger: ${error}`);
+    }
+  }
+
+  public async disconnect(): Promise<void> {
+    if (this.transport) {
+      await this.transport.close();
+      this.transport = null;
+      this.solanaApp = null;
+    }
+  }
+}

--- a/typescript/packages/web3/src/rollup/solana-signable-rollup.test.ts
+++ b/typescript/packages/web3/src/rollup/solana-signable-rollup.test.ts
@@ -1,6 +1,6 @@
 import SovereignClient from "@sovereign-sdk/client";
 import type { Signer } from "@sovereign-sdk/signers";
-import { Ed25519Signer } from "@sovereign-sdk/signers";
+import { Ed25519Signer, LedgerSolanaSigner } from "@sovereign-sdk/signers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   SolanaSignableRollup,
@@ -317,6 +317,106 @@ describe("SolanaSignableRollup", () => {
       // Compare the entire POST body with the expected JSON from the Rust test
       const actualJson = JSON.stringify(capturedPayload);
       expect(actualJson).toBe(expectedJson);
+    });
+  });
+
+  describe("solanaAuto authenticator", () => {
+    it("should use 'solana' authenticator for LedgerSolanaSigner", async () => {
+      const mockClient = createMockClient();
+
+      // Capture the actual payload sent to the endpoint
+      let capturedPayload: any;
+      mockClient.post = vi
+        .fn()
+        .mockImplementation((path: string, options: any) => {
+          capturedPayload = options;
+          return Promise.resolve({ id: "test-tx-hash" });
+        });
+
+      const rollup = await createSolanaSignableRollup({
+        client: mockClient,
+        getSerializer: () =>
+          createMockSerializer({ schema: { chain_name: "TestChain" } }),
+      });
+
+      // Create a real LedgerSolanaSigner instance and mock its methods
+      const ledgerSigner = new LedgerSolanaSigner();
+      vi.spyOn(ledgerSigner, "publicKey").mockResolvedValue(new Uint8Array(32));
+      vi.spyOn(ledgerSigner, "sign").mockResolvedValue(new Uint8Array(64));
+
+      await rollup.signAndSubmitTransaction(
+        {
+          runtime_call: { test: "call" },
+          uniqueness: { generation: 123 },
+          details: {
+            max_priority_fee_bips: 0,
+            max_fee: "1000",
+            gas_limit: null,
+            chain_id: 1,
+          },
+        } as any,
+        {
+          signer: ledgerSigner,
+          authenticator: "solanaAuto",
+        },
+      );
+
+      // Verify that spec-compliant message was sent (it will have the preamble)
+      const bodyJson = JSON.parse(JSON.stringify(capturedPayload));
+      const decodedBody = Buffer.from(bodyJson.body, "base64");
+
+      // Check for Solana offchain signing domain in preamble
+      // The spec-compliant message has a 4-byte length prefix, then the preamble starts with 0xff
+      expect(decodedBody[4]).toBe(0xff); // Skip 4-byte length prefix
+      const signingDomain = new TextDecoder().decode(decodedBody.slice(5, 20)); // 4 + 1 + 15 = 20
+      expect(signingDomain).toBe("solana offchain");
+    });
+
+    it("should use 'solanaSimple' authenticator for Ed25519Signer", async () => {
+      const mockClient = createMockClient();
+
+      // Capture the actual payload sent to the endpoint
+      let capturedPayload: any;
+      mockClient.post = vi
+        .fn()
+        .mockImplementation((path: string, options: any) => {
+          capturedPayload = options;
+          return Promise.resolve({ id: "test-tx-hash" });
+        });
+
+      const rollup = await createSolanaSignableRollup({
+        client: mockClient,
+        getSerializer: () =>
+          createMockSerializer({ schema: { chain_name: "TestChain" } }),
+      });
+
+      // Create a regular Ed25519Signer
+      const ed25519Signer = createMockSigner();
+
+      await rollup.signAndSubmitTransaction(
+        {
+          runtime_call: { test: "call" },
+          uniqueness: { generation: 123 },
+          details: {
+            max_priority_fee_bips: 0,
+            max_fee: "1000",
+            gas_limit: null,
+            chain_id: 1,
+          },
+        } as any,
+        {
+          signer: ed25519Signer,
+          authenticator: "solanaAuto",
+        },
+      );
+
+      // Verify that simple message was sent (no preamble)
+      const bodyJson = JSON.parse(JSON.stringify(capturedPayload));
+      const decodedBody = Buffer.from(bodyJson.body, "base64");
+
+      // Simple message starts with a length prefix (4 bytes) followed by the JSON message
+      // It should NOT have the 0xff signing domain marker
+      expect(decodedBody[0]).not.toBe(0xff);
     });
   });
 

--- a/typescript/packages/web3/src/rollup/solana-signable-rollup.ts
+++ b/typescript/packages/web3/src/rollup/solana-signable-rollup.ts
@@ -1,5 +1,6 @@
 import type SovereignClient from "@sovereign-sdk/client";
 import type { Signer } from "@sovereign-sdk/signers";
+import { LedgerSolanaSigner } from "@sovereign-sdk/signers";
 import type { Transaction, UnsignedTransaction } from "@sovereign-sdk/types";
 import { Base64 } from "js-base64";
 import type { Subscription, SubscriptionToCallbackMap } from "../subscriptions";
@@ -37,7 +38,11 @@ export type SolanaOffchainSpecCompliantMessage = {
   signature: Uint8Array;
 };
 
-export type Authenticator = "standard" | "solanaSimple" | "solana";
+export type Authenticator =
+  | "standard"
+  | "solanaSimple"
+  | "solana"
+  | "solanaAuto";
 
 // Borsh serialization constants
 const VEC_LENGTH_PREFIX_SIZE = 4;
@@ -108,6 +113,15 @@ export class SolanaSignableRollup<RuntimeCall> {
   ) {
     this.inner = inner;
     this.solanaEndpoint = solanaEndpoint;
+  }
+
+  /**
+   * Determines the appropriate authenticator based on the signer type.
+   * Returns "solana" for LedgerSolanaSigner (hardware wallet with spec-compliant signing)
+   * and "solanaSimple" for software signers.
+   */
+  private getAutoAuthenticator(signer: Signer): "solana" | "solanaSimple" {
+    return signer instanceof LedgerSolanaSigner ? "solana" : "solanaSimple";
   }
 
   /**
@@ -273,8 +287,13 @@ export class SolanaSignableRollup<RuntimeCall> {
     },
     options?: SovereignClient.RequestOptions,
   ): Promise<TransactionResult<Transaction<RuntimeCall>>> {
+    const authenticator =
+      params.authenticator === "solanaAuto"
+        ? this.getAutoAuthenticator(params.signer)
+        : params.authenticator;
+
     // Dispatch based on authenticator
-    switch (params.authenticator) {
+    switch (authenticator) {
       case "standard":
         return this.inner.call(
           runtimeCall,
@@ -299,7 +318,7 @@ export class SolanaSignableRollup<RuntimeCall> {
         return this.signWithSolanaSpecAndSubmit(unsignedTx, params.signer);
       }
       default:
-        throw new Error(`Unsupported authenticator: ${params.authenticator}`);
+        throw new Error(`Unsupported authenticator: ${authenticator}`);
     }
   }
 
@@ -316,7 +335,12 @@ export class SolanaSignableRollup<RuntimeCall> {
     params: { signer: Signer; authenticator: Authenticator },
     options?: SovereignClient.RequestOptions,
   ): Promise<TransactionResult<Transaction<RuntimeCall>>> {
-    switch (params.authenticator) {
+    const authenticator =
+      params.authenticator === "solanaAuto"
+        ? this.getAutoAuthenticator(params.signer)
+        : params.authenticator;
+
+    switch (authenticator) {
       case "standard":
         return this.inner.signAndSubmitTransaction(
           unsignedTx,
@@ -330,7 +354,7 @@ export class SolanaSignableRollup<RuntimeCall> {
       case "solana":
         return this.signWithSolanaSpecAndSubmit(unsignedTx, params.signer);
       default:
-        throw new Error(`Unsupported authenticator: ${params.authenticator}`);
+        throw new Error(`Unsupported authenticator: ${authenticator}`);
     }
   }
 

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -194,6 +194,21 @@ importers:
 
   packages/signers:
     dependencies:
+      '@ledgerhq/hw-app-solana':
+        specifier: ^7.5.2
+        version: 7.6.0
+      '@ledgerhq/hw-transport':
+        specifier: ^6.31.9
+        version: 6.31.13
+      '@ledgerhq/hw-transport-node-hid':
+        specifier: ^6.29.10
+        version: 6.29.14
+      '@ledgerhq/hw-transport-webhid':
+        specifier: ^6.30.5
+        version: 6.30.9
+      '@ledgerhq/hw-transport-webusb':
+        specifier: ^6.29.9
+        version: 6.29.13
       '@noble/ed25519':
         specifier: ^2.1.0
         version: 2.3.0
@@ -216,6 +231,9 @@ importers:
       '@metamask/providers':
         specifier: ^18.1.0
         version: 18.1.0(webextension-polyfill@0.12.0)
+      bs58:
+        specifier: ^6.0.0
+        version: 6.0.0
       tsup:
         specifier: ^8.3.0
         version: 8.3.0(@swc/core@1.7.42)(postcss@8.5.3)(tsx@4.20.3)(typescript@5.6.3)(yaml@2.7.1)
@@ -850,6 +868,33 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
+  '@ledgerhq/devices@8.7.0':
+    resolution: {integrity: sha512-3pSOULPUhClk2oOxa6UnoyXW8+05FK7r6cpq2WiTey4kyIUjmIraO7AX9lhz9IU73dGVtBMdU+NCPPO2RYJaTQ==}
+
+  '@ledgerhq/errors@6.27.0':
+    resolution: {integrity: sha512-EE2hATONHdNP3YWFe3rZwwpSEzI5oN+q/xTjOulnjHZo84TLjungegEJ54A/Pzld0woulkkeVA27FbW5SAO1aA==}
+
+  '@ledgerhq/hw-app-solana@7.6.0':
+    resolution: {integrity: sha512-Y8ImqAJwOjc9kjN02OvK2G8xx8m/p57Cezg+lLKlHuRwQuLYzruInQASYsKGZWLhmH2rCuotE61Z91FY5JVdIw==}
+
+  '@ledgerhq/hw-transport-node-hid-noevents@6.30.14':
+    resolution: {integrity: sha512-QG5wd6kjJYYXSmGRoZkDAehX1iN9WdjgHYNW4QwWcw9G6QnAgAYLE6v1u4ZZVVLZ6DrmHKJVOzwm9njYJMit2w==}
+
+  '@ledgerhq/hw-transport-node-hid@6.29.14':
+    resolution: {integrity: sha512-SqawAnYecZz1tt2VHbhyQMhwadaKhsMjhv9gHu9MmAevLFSVCfgs+6qWmuT+kuxhD1zGneW5TxlW+4B+HcVtWg==}
+
+  '@ledgerhq/hw-transport-webhid@6.30.9':
+    resolution: {integrity: sha512-5if/V1NyOr4JuEX+NB/bxaE92TptpgX+r1mGmzDHG6Gs9/fX/HhKe1GVwwU5C7LvTFrdTgMzEs2aIkpoMM60Ag==}
+
+  '@ledgerhq/hw-transport-webusb@6.29.13':
+    resolution: {integrity: sha512-RhQMCX2kjpI5N+4EvepDtIH9opTJxmCAEWIip4Im+ScjoSvBI1wveE5aDFhjDsHJUcKIQzIbB5jSuv0DZaajFA==}
+
+  '@ledgerhq/hw-transport@6.31.13':
+    resolution: {integrity: sha512-MrJRDk74wY980ofiFPRpTHQBbRw1wDuKbdag1zqlO1xtJglymwwY03K2kvBNvkm1RTSCPUp/nAoNG+WThZuuew==}
+
+  '@ledgerhq/logs@6.13.0':
+    resolution: {integrity: sha512-4+qRW2Pc8V+btL0QEmdB2X+uyx0kOWMWE1/LWsq5sZy3Q5tpi4eItJS6mB0XL3wGW59RQ+8bchNQQ1OW/va8Og==}
+
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
@@ -1307,6 +1352,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/w3c-web-usb@1.0.13':
+    resolution: {integrity: sha512-N2nSl3Xsx8mRHZBvMSdNGtzMyeleTvtlEw+ujujgXalPqOjIA6UtrqcB6OzyUjkTbDm3J7P1RNK1lgoO7jxtsw==}
+
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
@@ -1494,6 +1542,12 @@ packages:
     resolution: {integrity: sha512-rkwNGW+3aQVSZoD0/o3mfPN6Yxh3Id0R/xzTVBVVpGNlVz8EGwusksxRlbk/A5iKTZt9zkMn3qIqmAt3vpfbzg==}
     engines: {node: '>=10'}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bip32-path@0.4.2:
+    resolution: {integrity: sha512-ZBMCELjJfcNMkz5bDuJ1WrYvjlhEF5k6mQ8vUr4N7MbVRsXei7ZOg8VhhwMfNiW68NWmLkgkc6WvTickrLGprQ==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -1667,11 +1721,23 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   detect-browser@5.3.0:
     resolution: {integrity: sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   diff@4.0.2:
@@ -1767,6 +1833,10 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
@@ -1819,6 +1889,9 @@ packages:
 
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1882,6 +1955,9 @@ packages:
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1932,6 +2008,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
@@ -2106,6 +2185,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -2116,6 +2199,9 @@ packages:
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
   minipass@3.3.6:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
@@ -2157,6 +2243,28 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  node-abi@3.80.0:
+    resolution: {integrity: sha512-LyPuZJcI9HVwzXK1GPxWNzrr+vr8Hp/3UqlmWxxh8p54U1ZbclOqbSog9lWHaCX+dBaiGi6n/hIX+mKu74GmPA==}
+    engines: {node: '>=10'}
+
+  node-addon-api@3.2.1:
+    resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
+
+  node-addon-api@6.1.0:
+    resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  node-hid@2.1.2:
+    resolution: {integrity: sha512-qhCyQqrPpP93F/6Wc/xUR7L8mAJW0Z6R7HMQV8jCHHksAxNDe/4z4Un/H9CpLOT+5K39OPyt9tIQlavxWES3lg==}
+    engines: {node: '>=10'}
     hasBin: true
 
   normalize-path@3.0.0:
@@ -2380,6 +2488,11 @@ packages:
   postgres-range@1.1.4:
     resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -2423,6 +2536,10 @@ packages:
   random@5.4.0:
     resolution: {integrity: sha512-Y147ufdzRqcQuBpKkoW7N3+B/SW4X6pF3ZfsNy+bF1r3i/I+j2zobnCp+9vN1nIJDjObI/174PCySTa3FECynQ==}
     engines: {node: '>=18'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -2481,6 +2598,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -2529,6 +2649,12 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -2607,6 +2733,10 @@ packages:
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   sucrase@3.35.0:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
@@ -2739,6 +2869,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   turbo-darwin-64@2.6.0:
     resolution: {integrity: sha512-6vHnLAubHj8Ib45Knu+oY0ZVCLO7WcibzAvt5b1E72YHqAs4y8meMAGMZM0jLqWPh/9maHDc16/qBCMxtW4pXg==}
     cpu: [x64]
@@ -2809,6 +2942,10 @@ packages:
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
+
+  usb@2.9.0:
+    resolution: {integrity: sha512-G0I/fPgfHUzWH8xo2KkDxTTFruUWfppgSFJ+bQxz/kVY2x15EQ/XDB7dqD1G432G4gBG4jYQuF3U7j/orSs5nw==}
+    engines: {node: '>=10.20.0 <11.x || >=12.17.0 <13.0 || >=14.0.0'}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -3456,6 +3593,63 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
+  '@ledgerhq/devices@8.7.0':
+    dependencies:
+      '@ledgerhq/errors': 6.27.0
+      '@ledgerhq/logs': 6.13.0
+      rxjs: 7.8.2
+      semver: 7.7.1
+
+  '@ledgerhq/errors@6.27.0': {}
+
+  '@ledgerhq/hw-app-solana@7.6.0':
+    dependencies:
+      '@ledgerhq/errors': 6.27.0
+      '@ledgerhq/hw-transport': 6.31.13
+      bip32-path: 0.4.2
+
+  '@ledgerhq/hw-transport-node-hid-noevents@6.30.14':
+    dependencies:
+      '@ledgerhq/devices': 8.7.0
+      '@ledgerhq/errors': 6.27.0
+      '@ledgerhq/hw-transport': 6.31.13
+      '@ledgerhq/logs': 6.13.0
+      node-hid: 2.1.2
+
+  '@ledgerhq/hw-transport-node-hid@6.29.14':
+    dependencies:
+      '@ledgerhq/devices': 8.7.0
+      '@ledgerhq/errors': 6.27.0
+      '@ledgerhq/hw-transport': 6.31.13
+      '@ledgerhq/hw-transport-node-hid-noevents': 6.30.14
+      '@ledgerhq/logs': 6.13.0
+      lodash: 4.17.21
+      node-hid: 2.1.2
+      usb: 2.9.0
+
+  '@ledgerhq/hw-transport-webhid@6.30.9':
+    dependencies:
+      '@ledgerhq/devices': 8.7.0
+      '@ledgerhq/errors': 6.27.0
+      '@ledgerhq/hw-transport': 6.31.13
+      '@ledgerhq/logs': 6.13.0
+
+  '@ledgerhq/hw-transport-webusb@6.29.13':
+    dependencies:
+      '@ledgerhq/devices': 8.7.0
+      '@ledgerhq/errors': 6.27.0
+      '@ledgerhq/hw-transport': 6.31.13
+      '@ledgerhq/logs': 6.13.0
+
+  '@ledgerhq/hw-transport@6.31.13':
+    dependencies:
+      '@ledgerhq/devices': 8.7.0
+      '@ledgerhq/errors': 6.27.0
+      '@ledgerhq/logs': 6.13.0
+      events: 3.3.0
+
+  '@ledgerhq/logs@6.13.0': {}
+
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.25.7
@@ -3885,6 +4079,8 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/w3c-web-usb@1.0.13': {}
+
   '@types/yargs-parser@21.0.3': {}
 
   '@types/yargs@17.0.33':
@@ -4083,6 +4279,12 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bip32-path@0.4.2: {}
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -4261,9 +4463,17 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
   detect-browser@5.3.0: {}
 
   detect-indent@6.1.0: {}
+
+  detect-libc@2.1.2: {}
 
   diff@4.0.2: {}
 
@@ -4420,6 +4630,8 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  expand-template@2.0.3: {}
+
   expect-type@1.2.2: {}
 
   extendable-error@0.1.7: {}
@@ -4462,6 +4674,8 @@ snapshots:
       picomatch: 4.0.3
 
   fecha@4.2.3: {}
+
+  file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -4514,6 +4728,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
     optional: true
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -4570,6 +4786,8 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   is-arrayish@0.3.2: {}
 
@@ -4733,6 +4951,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mimic-response@3.1.0: {}
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -4744,6 +4964,8 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
+
+  minimist@1.2.8: {}
 
   minipass@3.3.6:
     dependencies:
@@ -4776,6 +4998,24 @@ snapshots:
     optional: true
 
   nanoid@3.3.11: {}
+
+  napi-build-utils@2.0.0: {}
+
+  node-abi@3.80.0:
+    dependencies:
+      semver: 7.7.1
+
+  node-addon-api@3.2.1: {}
+
+  node-addon-api@6.1.0: {}
+
+  node-gyp-build@4.8.4: {}
+
+  node-hid@2.1.2:
+    dependencies:
+      bindings: 1.5.0
+      node-addon-api: 3.2.1
+      prebuild-install: 7.1.3
 
   normalize-path@3.0.0: {}
 
@@ -4948,6 +5188,21 @@ snapshots:
 
   postgres-range@1.1.4: {}
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.80.0
+      pump: 3.0.2
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.2
+      tunnel-agent: 0.6.0
+
   prettier@2.8.8: {}
 
   process-nextick-args@2.0.1: {}
@@ -4993,6 +5248,13 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   random@5.4.0: {}
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -5080,6 +5342,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.7.0
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -5109,6 +5375,14 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   simple-swizzle@0.2.2:
     dependencies:
@@ -5190,6 +5464,8 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-final-newline@2.0.0: {}
+
+  strip-json-comments@2.0.1: {}
 
   sucrase@3.35.0:
     dependencies:
@@ -5376,6 +5652,10 @@ snapshots:
       fsevents: 2.3.3
     optional: true
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   turbo-darwin-64@2.6.0:
     optional: true
 
@@ -5429,6 +5709,12 @@ snapshots:
       '@fastify/busboy': 2.1.1
 
   universalify@0.1.2: {}
+
+  usb@2.9.0:
+    dependencies:
+      '@types/w3c-web-usb': 1.0.13
+      node-addon-api: 6.1.0
+      node-gyp-build: 4.8.4
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
# Description

Adds a Ledger Solana signer, for using the solana offchain authenticator. In the solana-signable rollup, add a `"solanaAuto"` selector that encodes with the Ledger-compatible spec if LedgerSigner is used, and falls back to the simple raw message signing for other wallets.

Since Ledger is just using ed25519 signatures under the hood, unit testing would be trivial, so instead there's a manual test script that can be used by plugging in a Ledger device, and can be used to generate a signature, fetch the public key and verifies that the signature is verifiable.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] ~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
