### PR TITLE
Fix signature gas metering in remaining authenticators

### DIFF
--- a/crates/module-system/sov-eip712-auth/src/lib.rs
+++ b/crates/module-system/sov-eip712-auth/src/lib.rs
@@ -3,18 +3,17 @@ use std::sync::OnceLock;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use sov_modules_api::capabilities::{
-    self, calculate_hash_metered, extract_authorization_data, verify_chain_id, AuthenticationError,
-    AuthenticationOutput, AuthorizationData, BatchFromUnregisteredSequencer, FatalError,
-    TransactionAuthenticator, UnregisteredAuthenticationError,
+    self, calculate_hash_metered, extract_authorization_data, extract_authorization_data_v1,
+    verify_chain_id, AuthenticationError, AuthenticationOutput, BatchFromUnregisteredSequencer,
+    FatalError, TransactionAuthenticator, UnregisteredAuthenticationError,
 };
 use sov_modules_api::sov_universal_wallet::schema::Schema;
 use sov_modules_api::transaction::{
-    AuthenticatedTransactionAndRawHash, Credentials, PubKeyAndSignature, Transaction,
-    TransactionVerificationError,
+    AuthenticatedTransactionAndRawHash, Transaction, TransactionVerificationError,
 };
 use sov_modules_api::{
-    CryptoSpec, DispatchCall, FullyBakedTx, GasMeter, MeteredBorshDeserialize,
-    MeteredBorshDeserializeError, Multisig, ProvableStateReader, RawTx, Runtime, Spec, TxHash,
+    DispatchCall, FullyBakedTx, GasMeter, MeteredBorshDeserialize, MeteredBorshDeserializeError,
+    ProvableStateReader, RawTx, Runtime, Spec, TxHash,
 };
 use sov_state::User;
 
@@ -241,31 +240,13 @@ fn verify_and_decode_tx<
         }
         Transaction::V1(tx_v1) => {
             verify_chain_id(&tx_v1.details, raw_tx_hash)?;
-            // TODO: this logic is duplicated (and also doesn't charge gas for the credential), we
-            // should use extract_authorization_data_v1() here
-            let multisig = Multisig::new(
-                tx_v1.min_signers,
-                tx_v1
-                    .signatures
-                    .iter()
-                    .map(|s| s.pub_key.clone())
-                    .chain(tx_v1.unused_pub_keys.iter().cloned())
-                    .collect::<Vec<_>>(),
-            );
-            verify_eip712_multisig_signature::<S, D, SP>(
-                &tx,
-                &multisig,
-                &tx_v1.signatures,
-                raw_tx_hash,
-            )?;
-            let credential_id = multisig.credential_id::<<S::CryptoSpec as CryptoSpec>::Hasher>();
-            let authorization_data = AuthorizationData {
-                uniqueness: tx_v1.uniqueness,
-                tx_hash: raw_tx_hash,
-                credential_id,
-                credentials: Credentials::new(multisig),
-                default_address: credential_id.into(),
-            };
+            verify_eip712_signature::<S, D, SP>(&tx, raw_tx_hash, meter)?;
+            let authorization_data = extract_authorization_data_v1::<
+                S,
+                D,
+                <S::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec,
+            >(tx_v1, raw_tx_hash, meter)?;
+
             let runtime_call = tx_v1.runtime_call.clone();
             let tx_and_raw_hash = AuthenticatedTransactionAndRawHash {
                 raw_tx_hash,
@@ -355,37 +336,6 @@ fn verify_eip712_signature<
                 raw_tx_hash,
             ),
         });
-
-    #[cfg(feature = "native")]
-    SIGNATURE_CACHE.insert(raw_tx_hash, res.clone());
-
-    res
-}
-
-fn verify_eip712_multisig_signature<
-    S: Spec<CryptoSpec: Secp256k1CryptoSpec>,
-    D: DispatchCall<Spec = S>,
-    SP: SchemaProvider,
->(
-    tx: &Transaction<D, S, <S::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec>,
-    multisig: &Multisig<
-        <<S::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec as CryptoSpec>::PublicKey,
-    >,
-    signatures: &[PubKeyAndSignature<<S::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec>],
-    raw_tx_hash: TxHash,
-) -> Result<(), AuthenticationError> {
-    #[cfg(feature = "native")]
-    if let Some(known_result) = SIGNATURE_CACHE.get(&raw_tx_hash) {
-        return known_result;
-    }
-
-    let msg = get_eip712_hash::<S, D, SP>(tx, raw_tx_hash)?;
-    let res = multisig.verify_signature(&msg, signatures).map_err(|e| {
-        AuthenticationError::FatalError(
-            FatalError::SigVerificationFailed(e.to_string()),
-            raw_tx_hash,
-        )
-    });
 
     #[cfg(feature = "native")]
     SIGNATURE_CACHE.insert(raw_tx_hash, res.clone());

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -12,8 +12,7 @@ use sov_modules_api::transaction::{
     self, AuthenticatedTransactionAndRawHash, TransactionCallable, TxDetails, UnsignedTransaction,
 };
 use sov_modules_api::{
-    charge_gas_to_deserialize_json, CryptoSpec, DispatchCall, GasMeter, MeteredSignature,
-    ProvableStateReader, SafeString, Spec, TxHash,
+    charge_gas_to_deserialize_json, CryptoSpec, DispatchCall, GasMeter, MeteredSigVerificationError, MeteredSignature, ProvableStateReader, SafeString, Signature, Spec, TxHash
 };
 
 #[cfg(feature = "native")]
@@ -161,26 +160,35 @@ fn verify_solana_signature<S: Spec>(
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<(), AuthenticationError> {
+    // Charge gas first, before checking the cache
+    MeteredSignature::new::<S>(signature.clone())
+        .charge_gas(meter, signed_bytes)
+        .map_err(|e| match e {
+            MeteredSigVerificationError::GasError(e) => {
+                AuthenticationError::OutOfGas(format!(
+                    "Signature verification ran out of gas: {e}"
+                ))
+            }
+            MeteredSigVerificationError::BadSignature(e) => {
+                AuthenticationError::FatalError(
+                    FatalError::SigVerificationFailed(e.to_string()),
+                    raw_tx_hash
+                )
+            }
+        })?;
+
     #[cfg(feature = "native")]
     if let Some(known_result) = SIGNATURE_CACHE.get(&raw_tx_hash) {
         return known_result;
     }
 
-    let res = MeteredSignature::new::<S>(signature.clone())
-        .verify(pub_key, signed_bytes, meter)
-        .map_err(|e| match e {
-            sov_modules_api::MeteredSigVerificationError::BadSignature(err) => {
-                AuthenticationError::FatalError(
-                    FatalError::SigVerificationFailed(err.to_string()),
-                    raw_tx_hash,
-                )
-            }
-            sov_modules_api::MeteredSigVerificationError::GasError(err) => {
-                AuthenticationError::OutOfGas(format!(
-                    "Signature verification ran out of gas: {err}"
-                ))
-            }
-        });
+    // Now do the unmetered verification
+    let res = signature.verify(pub_key, signed_bytes).map_err(|err| {
+        AuthenticationError::FatalError(
+            FatalError::SigVerificationFailed(err.to_string()),
+            raw_tx_hash,
+        )
+    });
 
     #[cfg(feature = "native")]
     SIGNATURE_CACHE.insert(raw_tx_hash, res.clone());

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -12,7 +12,9 @@ use sov_modules_api::transaction::{
     self, AuthenticatedTransactionAndRawHash, TransactionCallable, TxDetails, UnsignedTransaction,
 };
 use sov_modules_api::{
-    charge_gas_to_deserialize_json, CryptoSpec, DispatchCall, GasMeter, MeteredSigVerificationError, MeteredSignature, ProvableStateReader, SafeString, Signature, Spec, TxHash
+    charge_gas_to_deserialize_json, CryptoSpec, DispatchCall, GasMeter,
+    MeteredSigVerificationError, MeteredSignature, ProvableStateReader, SafeString, Signature,
+    Spec, TxHash,
 };
 
 #[cfg(feature = "native")]
@@ -165,16 +167,12 @@ fn verify_solana_signature<S: Spec>(
         .charge_gas(meter, signed_bytes)
         .map_err(|e| match e {
             MeteredSigVerificationError::GasError(e) => {
-                AuthenticationError::OutOfGas(format!(
-                    "Signature verification ran out of gas: {e}"
-                ))
+                AuthenticationError::OutOfGas(format!("Signature verification ran out of gas: {e}"))
             }
-            MeteredSigVerificationError::BadSignature(e) => {
-                AuthenticationError::FatalError(
-                    FatalError::SigVerificationFailed(e.to_string()),
-                    raw_tx_hash
-                )
-            }
+            MeteredSigVerificationError::BadSignature(e) => AuthenticationError::FatalError(
+                FatalError::SigVerificationFailed(e.to_string()),
+                raw_tx_hash,
+            ),
         })?;
 
     #[cfg(feature = "native")]

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -164,7 +164,7 @@ fn verify_solana_signature<S: Spec>(
 ) -> Result<(), AuthenticationError> {
     // Charge gas first, before checking the cache
     MeteredSignature::new::<S>(signature.clone())
-        .charge_gas(meter, signed_bytes)
+        .charge_gas(meter, signed_bytes.len())
         .map_err(|e| match e {
             MeteredSigVerificationError::GasError(e) => {
                 AuthenticationError::OutOfGas(format!("Signature verification ran out of gas: {e}"))
@@ -180,7 +180,7 @@ fn verify_solana_signature<S: Spec>(
         return known_result;
     }
 
-    // Now do the unmetered verification
+    // Now perform the verification (unmetered)
     let res = signature.verify(pub_key, signed_bytes).map_err(|err| {
         AuthenticationError::FatalError(
             FatalError::SigVerificationFailed(err.to_string()),

--- a/crates/module-system/sov-solana-offchain-auth/src/lib.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod authentication;
-pub mod capabilities;
 pub mod utils;
+
+mod capabilities;
+pub use capabilities::*;

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
@@ -24,7 +24,7 @@ use sov_sequencer::{ProofBlobSender, Sequencer, TxStatus};
 use sov_stf_runner::RollupConfig;
 use sov_test_utils::RtAgnosticBlueprint;
 
-use sov_solana_offchain_auth::capabilities::SolanaOffchainAuthenticatorTrait;
+use sov_solana_offchain_auth::SolanaOffchainAuthenticatorTrait;
 
 /// A test blueprint that extends RtAgnosticBlueprint with Solana offchain auth endpoints
 pub struct SolanaOffchainAuthBlueprint<S: Spec, R: RuntimeTrait<S>> {

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
@@ -27,10 +27,10 @@ use sov_solana_offchain_auth::authentication::{
     SolanaOffchainSimpleMessage, SolanaOffchainSpecCompliantMessage,
     SolanaOffchainUnsignedTransaction,
 };
-use sov_solana_offchain_auth::capabilities::{
+use sov_solana_offchain_auth::utils::make_preamble_for_message;
+use sov_solana_offchain_auth::{
     SolanaOffchainAuthenticator, SolanaOffchainAuthenticatorInput, SolanaOffchainAuthenticatorTrait,
 };
-use sov_solana_offchain_auth::utils::make_preamble_for_message;
 use sov_state::{DefaultStorageSpec, ProverStorage};
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
 use sov_test_utils::runtime::{BankConfig, Runtime as _};


### PR DESCRIPTION
# Description

There were two outstanding gas metering issues:
 * In the solana-offchain authenticator, the recent signature caching change resulted in inconsistent gas charging. The other authenticators split gas charging from verification to fix this, but the solana authenticator hadn't gotten updated yet; this PR brings it in line with the rest.
 * In the EIP712 authenticator, the V1 verification flow was using duplicated custom logic for multisigs, which also didn't charge gas correctly. This PR simplifies it by switching to using the standard helper methods which handle both V0 and V1 as well as gas charging.

Also edits the export from the sov-solana-offchain-auth module to be more ergonomic.

- [ ] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] ~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
