### PR TITLE
fix: doc for FlatStateDb::get_rockbound_options to reference FlatStateDb

### DIFF
--- a/crates/full-node/sov-db/src/flat_db.rs
+++ b/crates/full-node/sov-db/src/flat_db.rs
@@ -104,7 +104,7 @@ impl FlatStateDb {
         &self.kernel
     }
 
-    /// [`DbOptions`] for [`HistoricalStateReader`].
+    /// [`DbOptions`] for [`FlatStateDb`].
     pub fn get_rockbound_options(
         columns: Vec<ColumnFamilyDescriptor>,
     ) -> DbOptions<ColumnFamilyDescriptor> {


### PR DESCRIPTION
Corrected an inaccurate doc comment that referenced HistoricalStateReader. 
FlatStateDb::get_rockbound_options() constructs DbOptions using FlatStateDb’s DB_NAME and DB_PATH_SUFFIX and is used when initializing the flat state RocksDB(s) in FlatStateDb::new().