### PR TITLE
Switch signature metering to take len instead of full msg, optimise eip712 authenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 # 2025-11-11
 - #2004 The sequencer will now buffer and intelligently reorder transactions with a nonce that arrive out-of-order within a short window of time. Adds `max_future_nonce_delta` and `future_nonce_transaction_timeout_millis` optional config options that allow configuring the limits of how eagerly the sequencer will try to buffer nonces.
   - **Breaking change** Removes the `buffer_raw_txs` field from EthRpcConfig (as this is now handled by the sequencer). This change is only breaking for EVM rollups.
+# 2025-11-12
+- #2070 **Breaking change**: The `MeteredSignature::charge_gas()` method signature changes from taking a `msg: &[u8]` parameter to `msg_len: usize`, as signature verification gas cost only depends on the number of bytes. This has no other impact except for direct users of the `MeteredSignature` struct.
 
 # 2025-11-06
 - #2039 Add WebSocket subscription support to EVM logs soak tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 # 2025-11-12
 - #2071 Optimize WebSocket message delivery by batching writes. Messages are now grouped (up to 128 at a time) and flushed together, reducing system calls and improving throughput for WebSocket subscriptions.
+- #2070 **Breaking change**: The `MeteredSignature::charge_gas()` method signature changes from taking a `msg: &[u8]` parameter to `msg_len: usize`, as signature verification gas cost only depends on the number of bytes. This has no other impact except for direct users of the `MeteredSignature` struct.
 
 # 2025-11-11
 - #2004 The sequencer will now buffer and intelligently reorder transactions with a nonce that arrive out-of-order within a short window of time. Adds `max_future_nonce_delta` and `future_nonce_transaction_timeout_millis` optional config options that allow configuring the limits of how eagerly the sequencer will try to buffer nonces.
   - **Breaking change** Removes the `buffer_raw_txs` field from EthRpcConfig (as this is now handled by the sequencer). This change is only breaking for EVM rollups.
-# 2025-11-12
-- #2070 **Breaking change**: The `MeteredSignature::charge_gas()` method signature changes from taking a `msg: &[u8]` parameter to `msg_len: usize`, as signature verification gas cost only depends on the number of bytes. This has no other impact except for direct users of the `MeteredSignature` struct.
 
 # 2025-11-06
 - #2039 Add WebSocket subscription support to EVM logs soak tests.

--- a/crates/module-system/sov-eip712-auth/src/lib.rs
+++ b/crates/module-system/sov-eip712-auth/src/lib.rs
@@ -33,6 +33,10 @@ use sov_modules_api::capabilities::{SignatureVerificationCache, DEFAULT_SIGNATUR
 static SIGNATURE_CACHE: std::sync::LazyLock<SignatureVerificationCache<()>> =
     std::sync::LazyLock::new(|| SignatureVerificationCache::new(DEFAULT_SIGNATURE_CACHE_SIZE));
 
+/// The length of an EIP712 signing hash in bytes.
+/// EIP712 hashes are 66 bytes: 1 byte prefix (0x19) + 1 byte version (0x01) + 32 bytes domain separator + 32 bytes struct hash.
+const EIP712_HASH_LENGTH: usize = 66;
+
 /// Trait for providing schema to the EIP-712 authenticator.
 pub trait SchemaProvider {
     /// The schema as borsh-serialized bytes, typically from build-time generation.
@@ -273,14 +277,14 @@ fn verify_and_decode_tx<
     }
 }
 
-fn eip_712_msg<
+fn get_eip712_hash<
     S: Spec<CryptoSpec: Secp256k1CryptoSpec>,
     D: DispatchCall<Spec = S>,
     SP: SchemaProvider,
 >(
     tx: &Transaction<D, S, <S::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec>,
     raw_tx_hash: TxHash,
-) -> Result<[u8; 66], AuthenticationError> {
+) -> Result<[u8; EIP712_HASH_LENGTH], AuthenticationError> {
     // Convert the transaction to unsigned transaction (removes signature)
     let unsigned_tx = tx.to_unsigned_transaction();
 
@@ -323,11 +327,7 @@ fn verify_eip712_signature<
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<(), AuthenticationError> {
-    // TODO: this could be cached as well, but would require querying the cache before charging gas
-    // and then on cache hit using it to charge gas before short-circuiting
-    let eip712_hash = eip_712_msg::<S, D, SP>(tx, raw_tx_hash)?;
-
-    tx.charge_gas_for_signature(&eip712_hash, meter)
+    tx.charge_gas_for_signature(EIP712_HASH_LENGTH, meter)
         .map_err(|e| match e {
             TransactionVerificationError::GasError(_) => {
                 AuthenticationError::OutOfGas(e.to_string())
@@ -343,6 +343,7 @@ fn verify_eip712_signature<
         return known_result;
     }
 
+    let eip712_hash = get_eip712_hash::<S, D, SP>(tx, raw_tx_hash)?;
     let res = tx
         .verify_signature_unmetered(&eip712_hash)
         .map_err(|e| match e {
@@ -378,7 +379,7 @@ fn verify_eip712_multisig_signature<
         return known_result;
     }
 
-    let msg = eip_712_msg::<S, D, SP>(tx, raw_tx_hash)?;
+    let msg = get_eip712_hash::<S, D, SP>(tx, raw_tx_hash)?;
     let res = multisig.verify_signature(&msg, signatures).map_err(|e| {
         AuthenticationError::FatalError(
             FatalError::SigVerificationFailed(e.to_string()),

--- a/crates/module-system/sov-modules-api/src/gas/metered_utils.rs
+++ b/crates/module-system/sov-modules-api/src/gas/metered_utils.rs
@@ -141,7 +141,7 @@ impl<GU: Gas, Sign: Signature> MeteredSignature<GU, Sign> {
     pub fn charge_gas<Meter: GasMeter<Spec: Spec<Gas = GU>>>(
         &self,
         meter: &mut Meter,
-        msg: &[u8],
+        msg_len: usize,
     ) -> Result<(), MeteredSigVerificationError<GU>> {
         meter
             .charge_gas(self.fixed_gas_to_charge_per_verification)
@@ -150,7 +150,7 @@ impl<GU: Gas, Sign: Signature> MeteredSignature<GU, Sign> {
         meter
             .charge_linear_gas(
                 self.gas_to_charge_per_byte_for_verification,
-                as_u32_or_panic(msg.len()),
+                as_u32_or_panic(msg_len),
             )
             .map_err(MeteredSigVerificationError::GasError)?;
 
@@ -161,7 +161,7 @@ impl<GU: Gas, Sign: Signature> MeteredSignature<GU, Sign> {
         meter
             .charge_linear_gas(
                 <Meter::Spec as GasSpec>::gas_to_charge_per_byte_hash_update(),
-                msg.len().try_into().map_err(|e: TryFromIntError| {
+                msg_len.try_into().map_err(|e: TryFromIntError| {
                     MeteredSigVerificationError::GasError(MeteringError::<Meter>::Overflow(
                         e.to_string(),
                     ))
@@ -182,7 +182,7 @@ impl<GU: Gas, Sign: Signature> MeteredSignature<GU, Sign> {
         msg: &[u8],
         meter: &mut Meter,
     ) -> Result<(), MeteredSigVerificationError<GU>> {
-        self.charge_gas(meter, msg)?;
+        self.charge_gas(meter, msg.len())?;
 
         self.inner
             .verify(pub_key, msg)

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -337,7 +337,7 @@ fn verify_signature<S: Spec, D: DispatchCall<Spec = S>>(
         )
     })?;
 
-    tx.charge_gas_for_signature(&serialized_tx, meter)
+    tx.charge_gas_for_signature(serialized_tx.len(), meter)
         .map_err(|e| match e {
             TransactionVerificationError::GasError(_) => {
                 AuthenticationError::OutOfGas(e.to_string())

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -428,20 +428,20 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
     /// Charge gas for verifying the transaction signature against the given message.
     pub fn charge_gas_for_signature(
         &self,
-        msg: &[u8],
+        msg_len: usize,
         meter: &mut impl GasMeter<Spec = S>,
     ) -> Result<(), TransactionVerificationError<S::Gas>> {
         match &self {
             Transaction::V0(inner) => {
                 MeteredSignature::new::<S>(inner.signature.clone())
-                    .charge_gas(meter, msg)
+                    .charge_gas(meter, msg_len)
                     .map_err(TransactionVerificationError::from)?;
             }
             Transaction::V1(inner) => {
                 for signature in inner.signatures.iter() {
                     // Charge gas for all the signatures up front before verifying. This way, we can switch to batch verification and the gas price will be the same.
                     MeteredSignature::new::<S>(signature.signature.clone())
-                        .charge_gas(meter, msg)
+                        .charge_gas(meter, msg_len)
                         .map_err(TransactionVerificationError::from)?;
                 }
             }


### PR DESCRIPTION
# Description

`MeteredSignature::charge_gas()` currently takes a `msg: &[u8]`, but then only actually charges gas based on the amount of bytes, i.e. `msg.len()`. This was causing an issue in the EIP712 authenticator, because the message is an EIP712 hash which is of a constant known size but actually computing the hash is quite expensive.

This PR switches `charge_gas()` to just take `len: usize`, because realistically the gas cost of a signature probably cannot ever depend on the actual byte contents of the message. This is a minor refactor and allows skipping this hash calculation in the EIP712 authenticator.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] ~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
