### PR TITLE
Chunk REST WS writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-11-12
+- #2071 Optimize WebSocket message delivery by batching writes. Messages are now grouped (up to 128 at a time) and flushed together, reducing system calls and improving throughput for WebSocket subscriptions.
+
 # 2025-11-11
 - #2004 The sequencer will now buffer and intelligently reorder transactions with a nonce that arrive out-of-order within a short window of time. Adds `max_future_nonce_delta` and `future_nonce_transaction_timeout_millis` optional config options that allow configuring the limits of how eagerly the sequencer will try to buffer nonces.
   - **Breaking change** Removes the `buffer_raw_txs` field from EthRpcConfig (as this is now handled by the sequencer). This change is only breaking for EVM rollups.

--- a/crates/utils/sov-rest-utils/src/lib.rs
+++ b/crates/utils/sov-rest-utils/src/lib.rs
@@ -42,7 +42,7 @@ use axum::response::{IntoResponse, Response};
 use axum::{Json, Router};
 pub use axum_extractors::{Path, Query};
 pub use filter::{Filter, FilterError, FilterQuery};
-use futures::StreamExt;
+use futures::{SinkExt, StreamExt};
 pub use pagination::{PageSelection, PaginatedResponse, Pagination};
 use serde::Serialize;
 pub use sorting::{Sorting, SortingOrder};
@@ -175,18 +175,23 @@ pub fn cors_layer_opt(
     tower::util::option_layer(if enable { Some(cors_layer()) } else { None })
 }
 
+const MAX_BATCH_SIZE: usize = 128;
+
 /// A utility function for serving some data inside a [`futures::Stream`] over a
 /// WebSocket connection.
 pub async fn serve_generic_ws_subscription<S, M, E>(
     mut socket: WebSocket,
-    mut subscription: S,
+    subscription: S,
     mut shutdown_receiver: tokio::sync::watch::Receiver<()>,
 ) where
     S: futures::Stream<Item = Result<M, E>> + Unpin,
     E: ReportableWsError,
     M: Clone + serde::Serialize + Send + Sync + 'static,
 {
-    loop {
+    // Use ready_chunks to automatically batch items that are immediately available
+    let mut chunked_subscription = subscription.ready_chunks(MAX_BATCH_SIZE);
+
+    'outer: loop {
         tokio::select! {
             msg = socket.recv() => {
                 match msg {
@@ -204,30 +209,38 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
                     },
                 }
             },
-            data_res = subscription.next() => {
-                match data_res {
-                    Some(Ok(data)) => {
-                        let serialized = match serde_json::to_string(&data) {
-                            Ok(serialized) => serialized,
-                            Err(err) => {
-                                error!(?err, "Failed to serialize data for WebSocket; this is a bug, please report it");
-                                break;
+            chunk_opt = chunked_subscription.next() => {
+                match chunk_opt {
+                    Some(chunk) => {
+                        for item in chunk {
+                            match item {
+                                Ok(data) => {
+                                    let serialized = match serde_json::to_string(&data) {
+                                        Ok(serialized) => serialized,
+                                        Err(err) => {
+                                            error!(?err, "Failed to serialize data for WebSocket; this is a bug, please report it");
+                                            break 'outer;
+                                        }
+                                    };
+                                    if let Err(err) = socket.feed(serialized.into()).await {
+                                        warn!(?err, "WebSocket error while sending data");
+                                        // Keep the loop going.
+                                    }
+                                }
+                                Err(err) => {
+                                    // Convert error to ErrorObject and send it to the client
+                                     if let Err(send_err) = socket.send(err.to_json().into()).await {
+                                        warn!(err=?send_err, "WebSocket error while sending error");
+                                        // keep the loop going.
+                                    }
+                                    if !err.is_recoverable() {
+                                        break 'outer;
+                                    }
+                                }
                             }
-                        };
-                        let message = ws::Message::Text(serialized);
-                        if let Err(err) = socket.send(message).await {
-                            warn!(?err, "WebSocket error while sending data");
-                            // Keep the loop going.
                         }
-                    },
-                    Some(Err(err)) => {
-                        // Convert error to ErrorObject and send it to the client
-                        if let Err(send_err) = socket.send(ws::Message::Text(err.to_json())).await {
-                            warn!(err=?send_err, "WebSocket error while sending error");
-                            // keep the loop going.
-                        }
-                        if !err.is_recoverable() {
-                            break;
+                        if let Err(err) = socket.flush().await {
+                            trace!(?err, "Failed to flush the socket");
                         }
                     },
                     None => {
@@ -239,6 +252,7 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
             _ = shutdown_receiver.changed() => break,
         }
     }
+
     tracing::trace!("Closing websocket subscription");
     socket.close().await.ok();
 }

--- a/crates/utils/sov-rest-utils/src/lib.rs
+++ b/crates/utils/sov-rest-utils/src/lib.rs
@@ -35,7 +35,7 @@ pub mod test_utils;
 use std::fmt::Debug;
 
 use axum::body::Body;
-use axum::extract::ws::{self, WebSocket};
+use axum::extract::ws::WebSocket;
 use axum::extract::Request;
 use axum::http::{HeaderName, StatusCode};
 use axum::response::{IntoResponse, Response};


### PR DESCRIPTION
# Description

Optimizes WebSocket message delivery by batching writes instead of sending messages individually. This reduces system calls and improves throughput for WebSocket subscriptions.

## Changes

- **Batching**: Messages are now batched using `ready_chunks(128)` to group items that are immediately available
- **Deferred flushing**: Uses `socket.feed()` to queue messages and `socket.flush()` to send batched messages in a single operation
- **Performance**: Reduces per-message overhead by minimizing system calls

## Technical Details

**Before**: Each message triggered an immediate `socket.send()` call, resulting in one system call per message.

**After**: Messages are queued with `socket.feed()` and flushed together after processing up to 128 ready items.

## Impact

- **Behavior**: No functional changes - error handling and shutdown logic remain identical
- **Compatibility**: No API changes, fully backward compatible


-----

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
