### PR TITLE
Port EVM related fixses

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -64,6 +64,7 @@ fn create_auth_tx_and_hash<S: Spec>(
 ) -> Result<AuthenticatedTransactionAndRawHash<S>, AuthenticationError> {
     let tx_hash = TxHash::new(**tx.hash());
     let tx_chain_id = validate_chain_id(tx.chain_id(), tx_hash)?;
+    // TODO Sometimes evm has problems with gas estimation.
     let gas_limit = tx.gas_limit();
     let gas_limit: <S as Spec>::Gas = [gas_limit, gas_limit].into();
     let max_fee = gas_limit


### PR DESCRIPTION
# Description

- [ ] 837a2db **increase gas limit, missing in dev**
- [ ] 3b65d57 skippee, looks like we already have this changes~~
- [ ] e43a006 skipped ETHEREUM_BLOCK_GAS_LIMIT is increased to 1000_000_000~~
- [ ] 0677945 skipped (to be confirmed). The filter is flattened in `dev`~~
- [ ] 22f1804 skipped (the flatten over cursor was removed in a later commit)~~
- [ ] f3adfaf skipped (we have support for `response_size_limit` in the dev)~~
- [ ] 4c0fbbf skipped (the relevant changes ware already ported)
- [ ] 6bfbeae skipped (the code was already ported)
- [ ] 4fdcf38 skipped (there is no `flatten` in dev)
- [ ] 6150076 skipped (the relevant changes ware already ported)
- [ ] b6deaa0  skipped (the relevant changes ware already ported)
- [ ] 9da1bd3 skipped (the relevant changes ware already ported)
- [ ] 5694030 skipped (the relevant changes ware already ported)
- [ ] 6ce5a4c **missing in dev**
- [ ] 1cf3050 **missing in dev**
- [ ] 1fb01f3 **missing in dev**
- [ ] 2b3e4c8 **missing in dev but probably we don't need it**
- [ ] 0a3868c **missing in dev**
- [ ] f025786 **missing in dev**

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
