### PR TITLE
Make sequencer cloneable and accept_tx() cancel-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2025-11-14
+- #2077 **Breaking change**: The `Sequencer` implementations have been made cheaply cloneable, and the `accept_tx()` method has been made cancellation-safe. This has two effects:
+  * *Breaking*: any API handler definitions that currently use `Arc<Seq: Sequencer>` need to be modified to use `Seq: Sequencer` directly instead. This is likely to affect rollup definitions, especially ones implementing `sequencer_additional_apis()`.
+  * *Advisory*: any custom transaction APIs invoking `Sequencer::accept_tx()` in their handlers previously had to make the call inside a tokio task. This is no longer necessary, and handlers *should* remove any `tokio::spawn()` wrapping the `accept_tx()` call to avoid the unnecessary overhead and reduce tokio runtime contention.
+
 # 2025-11-12
 - #2071 Optimize WebSocket message delivery by batching writes. Messages are now grouped (up to 128 at a time) and flushed together, reducing system calls and improving throughput for WebSocket subscriptions.
 - #2070 **Breaking change**: The `MeteredSignature::charge_gas()` method signature changes from taking a `msg: &[u8]` parameter to `msg_len: usize`, as signature verification gas cost only depends on the number of bytes. This has no other impact except for direct users of the `MeteredSignature` struct.

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -61,21 +61,12 @@ where
     })?;
 
     let seq = ethereum.sequencer.clone();
-    tokio::spawn(async move { seq.accept_tx(tx).await })
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "A panic occurred while accepting an ethereum transaction");
-            to_jsonrpsee_error_object(
-                "An internal error occurred while processing the transaction",
-                ETH_RPC_ERROR,
-            )
-        })?
-        .map_err(|e| {
-            to_jsonrpsee_error_object(
-                format!("{} - '{}' ({:?})", e.status, e.message, e.details),
-                ETH_RPC_ERROR,
-            )
-        })?;
+    seq.accept_tx(tx).await.map_err(|e| {
+        to_jsonrpsee_error_object(
+            format!("{} - '{}' ({:?})", e.status, e.message, e.details),
+            ETH_RPC_ERROR,
+        )
+    })?;
 
     on_success(tx_hash, ethereum)
 }

--- a/crates/full-node/sov-ethereum/src/lib.rs
+++ b/crates/full-node/sov-ethereum/src/lib.rs
@@ -1,7 +1,6 @@
 mod handlers;
 
 use std::convert::Infallible;
-use std::sync::Arc;
 
 use alloy_primitives::{B256, U256};
 use jsonrpsee::types::{ErrorCode, ErrorObjectOwned};
@@ -27,7 +26,7 @@ pub struct EthRpcConfig {
     pub shutdown_receiver: tokio::sync::watch::Receiver<()>,
 }
 
-pub fn get_ethereum_rpc<S, Seq>(eth_rpc_config: EthRpcConfig, sequencer: Arc<Seq>) -> RpcModule<()>
+pub fn get_ethereum_rpc<S, Seq>(eth_rpc_config: EthRpcConfig, sequencer: Seq) -> RpcModule<()>
 where
     S: Spec,
     Seq: Sequencer<Spec = S>,
@@ -101,7 +100,7 @@ where
 }
 
 struct Ethereum<S: Spec, Seq: Sequencer<Spec = S>> {
-    sequencer: Arc<Seq>,
+    sequencer: Seq,
     #[cfg(feature = "local")]
     eth_signer: Signers,
     extension: SeqConfigExtension,

--- a/crates/full-node/sov-sequencer/src/common.rs
+++ b/crates/full-node/sov-sequencer/src/common.rs
@@ -163,6 +163,10 @@ pub trait Sequencer: Send + Sync + 'static {
     /// implementation itself is responsible for "encoding" the transaction.
     ///
     /// Can return an error if transaction is invalid or mempool is full.
+    ///
+    /// Safe for use in cancellable APIs, but the actual transaction submission cannot safely be
+    /// cancelled and will continue executing even if the thread `accept_tx()` was called on is
+    /// killed.
     async fn accept_tx(
         &self,
         tx: FullyBakedTx,
@@ -391,7 +395,7 @@ pub async fn react_to_state_updates<S, Fut>(
 }
 
 pub async fn loop_call_update_state<Seq: Sequencer>(
-    seq: Arc<Seq>,
+    seq: Seq,
     state_update_receiver: StateUpdateReceiver<<Seq::Spec as Spec>::Storage>,
     shutdown_receiver: watch::Receiver<()>,
 ) {

--- a/crates/full-node/sov-sequencer/src/common.rs
+++ b/crates/full-node/sov-sequencer/src/common.rs
@@ -90,7 +90,7 @@ pub(crate) type SequencerEventStream<Rt> = Pin<
 /// The [`Sequencer`] trait is responsible for accepting transactions and
 /// assembling them into batches.
 #[async_trait]
-pub trait Sequencer: Send + Sync + 'static {
+pub trait Sequencer: Clone + Send + Sync + 'static {
     /// What data is returned to clients when a transaction is accepted.
     type Confirmation: Clone + serde::Serialize + Send + Sync + 'static;
     /// The rollup spec.

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -94,7 +94,7 @@ const RECOVERY_ERROR_MESSAGE_ON_NONE_STRATEGY: &str = "The preferred sequencer i
 /// A [`Sequencer`] with instant transaction confirmation.
 #[derive(derivative::Derivative)]
 #[derivative(Clone(bound = ""))]
-pub struct PreferredSequencer<S, Rt, Da> (Arc<PreferredSequencerFields<S, Rt, Da>>)
+pub struct PreferredSequencer<S, Rt, Da>(Arc<PreferredSequencerFields<S, Rt, Da>>)
 where
     S: Spec,
     Rt: Runtime<S>,
@@ -104,7 +104,7 @@ impl<S, Rt, Da> Deref for PreferredSequencer<S, Rt, Da>
 where
     S: Spec,
     Rt: Runtime<S>,
-    Da: DaService<Spec = S::Da>
+    Da: DaService<Spec = S::Da>,
 {
     type Target = PreferredSequencerFields<S, Rt, Da>;
 

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -56,6 +56,7 @@ use state_root_compute::StateRootBackgroundTaskState;
 use std::boxed::Box;
 use std::marker::PhantomData;
 use std::num::NonZero;
+use std::ops::Deref;
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -91,7 +92,29 @@ type VisibleSlotNumberIncrease = NonZero<u8>;
 const RECOVERY_ERROR_MESSAGE_ON_NONE_STRATEGY: &str = "The preferred sequencer is too far behind, and the visible slot number has lagged more than the allowed deferred slots count. This means some non-preferred batches may have been included by the node, if there were any. If this happened, already provided soft confirmations may now no longer be valid. Because the recovery_strategy config was set to None, we are not attempting recovery at this point. You should either: a) delete everything from the preferred_sequencer database (thus annulling all currently pending soft confirmations), which will allow you to restart the sequencer fresh; or b) set the recovery_strategy config value to TryToSave, in which case all pending batches will be flushed to be executed on a best-effort basis. The latter may save some soft-confirmations if they have not been invalidated yet. However, IF a non-preferred batch has been included, AND some soft-confirmations have been invalidated by it, this will cause the sequencer to be penalised for every invalid batch; ensure your sequencer bond is sufficient to cover any penalties to be able to continue operating uninterrupted.";
 
 /// A [`Sequencer`] with instant transaction confirmation.
-pub struct PreferredSequencer<S, Rt, Da>
+#[derive(derivative::Derivative)]
+#[derivative(Clone(bound = ""))]
+pub struct PreferredSequencer<S, Rt, Da> (Arc<PreferredSequencerFields<S, Rt, Da>>)
+where
+    S: Spec,
+    Rt: Runtime<S>,
+    Da: DaService<Spec = S::Da>;
+
+impl<S, Rt, Da> Deref for PreferredSequencer<S, Rt, Da>
+where
+    S: Spec,
+    Rt: Runtime<S>,
+    Da: DaService<Spec = S::Da>
+{
+    type Target = PreferredSequencerFields<S, Rt, Da>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// The inner fields of a `PreferredSequencer`. Should be accessed through the parent struct's Arc.
+pub struct PreferredSequencerFields<S, Rt, Da>
 where
     S: Spec,
     Rt: Runtime<S>,
@@ -138,7 +161,7 @@ where
         api_ledger_db: LedgerDb,
         shutdown_sender: watch::Sender<()>,
         stop_at_rollup_height: Option<RollupHeight>,
-    ) -> anyhow::Result<(Arc<Self>, Vec<JoinHandle<()>>)> {
+    ) -> anyhow::Result<(Self, Vec<JoinHandle<()>>)> {
         let shutdown_receiver = shutdown_sender.subscribe();
         let latest_state_update = state_update_receiver.borrow().clone();
         let da_address = da
@@ -297,7 +320,7 @@ where
                 .sequencer_kind_config
                 .future_nonce_transaction_timeout_millis,
         );
-        let seq = Arc::new(PreferredSequencer {
+        let seq = PreferredSequencer(Arc::new(PreferredSequencerFields {
             synchronized_state_updator: synchronized_state_updator.clone(),
             tx_status_manager: tx_status_manager.clone(),
             transaction_cache: cached_txs,
@@ -311,7 +334,7 @@ where
             tx_queue_id,
             stop_at_rollup_height,
             test_only_state_update_notification_sender: broadcast::channel(100).0,
-        });
+        }));
 
         // Launch replica sync task only for replicas.
         if config.sequencer_kind_config.is_replica {
@@ -553,6 +576,140 @@ where
         self.wait_for_node_resync(state_update_receiver, shutdown_receiver, 1, current_info)
             .await
     }
+
+    #[tracing::instrument(skip_all, level = "trace")]
+    async fn accept_tx_inner(
+        &self,
+        baked_tx: FullyBakedTx,
+    ) -> Result<AcceptedTx<<Self as Sequencer>::Confirmation>, ErrorObject> {
+        if self.shutdown_receiver.has_changed().unwrap_or(true) {
+            tracing::info!("The sequencer is shutting down. Cannot accept transactions");
+            return Err(shut_down_error());
+        }
+
+        let original_tx_queue_id = self.tx_queue_id.load(Ordering::Acquire);
+
+        let tx_hash = Rt::Auth::compute_tx_hash(&baked_tx).map_err(generic_accept_tx_error)?;
+        tracing::debug!(%tx_hash, "Executing accept_tx");
+
+        // Check if this transaction has a configured delay
+        let runtime = Rt::default();
+        let mut state = self
+            .api_state()
+            .default_api_state_accessor()
+            .to_provable_reader();
+        let (_, auth_data, call) = <Rt as Runtime<S>>::Auth::authenticate(&baked_tx, &mut state)
+            .map_err(|e| pre_exec_err_to_accept_tx_err(PreExecError::AuthError(e)))?;
+        let call = Rt::wrap_call(call);
+        let delay_ms = runtime.get_transaction_delay_ms(&call);
+        // We need to destructure auth_data because it's not `Send`.
+        let uniqueness = auth_data.uniqueness;
+        let credential_id = auth_data.credential_id;
+        drop(auth_data);
+
+        if delay_ms > 0 {
+            tracing::debug!(%tx_hash, delay_ms, "Delaying transaction processing");
+            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            tracing::debug!(%tx_hash, "Transaction delay completed, proceeding with processing");
+        }
+
+        let tx_len = baked_tx.data.len();
+
+        let (outer_res, is_nonce_based) = match uniqueness {
+            UniquenessData::Generation(_) => (
+                self.synchronized_state_updator
+                    .accept_tx_msg(&baked_tx, tx_hash, original_tx_queue_id, "accept_tx")
+                    .await,
+                false,
+            ),
+            UniquenessData::Nonce(tx_nonce) => (
+                self.tx_nonce_queues
+                    .handle_new_tx(
+                        baked_tx,
+                        tx_hash,
+                        tx_nonce,
+                        credential_id,
+                        original_tx_queue_id,
+                    )
+                    .await,
+                true,
+            ),
+        };
+
+        let res = match outer_res {
+            Ok(inner_res) => inner_res,
+            Err(SequencerStateUpdatorError::Shutdown) => {
+                return Err(shut_down_error());
+            }
+            Err(SequencerStateUpdatorError::Unexpected) => {
+                return Err(internal_server_error_500(
+                    "Unexpected Error. The sequencer is unable to accept transactions.",
+                ));
+            }
+        };
+
+        match res {
+            Ok(rx) => {
+                let result = rx.await.map_err(database_error_500)?;
+                // After DB persistence completes, notify the nonce queue so it can clean up if needed
+                if is_nonce_based {
+                    self.tx_nonce_queues.mark_completed(&credential_id);
+                }
+                Ok(result)
+            }
+            Err(e) => match e {
+                AcceptTxError::SequencerOverloaded503 => {
+                    return Err(sequencer_overloaded_503("Other"));
+                }
+                AcceptTxError::NotFullySynced(details) => {
+                    return Err(error_not_fully_synced(details))
+                }
+                AcceptTxError::BatchError {
+                    batch_creation_error,
+                    nb_of_concurrent_blob_submissions,
+                } => match batch_creation_error {
+                    BatchCreationError::NoFinalizedSlotAvailable => {
+                        return Err(sequencer_overloaded_503("No finalized slots available"));
+                    }
+                    BatchCreationError::BlobSenderBusy => {
+                        return Err(error_not_fully_synced(
+                            SequencerNotReadyDetails::WaitingOnBlobSender {
+                                max_concurrent_blobs: self.config.max_concurrent_blobs,
+                                nb_of_blobs_in_flight: nb_of_concurrent_blob_submissions,
+                            },
+                        ));
+                    }
+                    BatchCreationError::DatabaseError(e) => {
+                        return Err(database_error_500(e));
+                    }
+                    BatchCreationError::PreferredSequencerAtStopHeight {
+                        height_to_stop_at,
+                        current_height,
+                    } => {
+                        return Err(error_not_fully_synced(
+                            SequencerNotReadyDetails::PreferredSequencerAtStopHeight {
+                                height_to_stop_at,
+                                current_height,
+                            },
+                        ));
+                    }
+                },
+                AcceptTxError::NewTxError(err) => match err {
+                    DoNewTxError::TxTooBig {
+                        current_batch_size,
+                        max_batch_size,
+                    } => return Err(err_cant_fit_tx(current_batch_size, max_batch_size, tx_len)),
+                    DoNewTxError::ExecutorError(err) => {
+                        return Err(RollupBlockExecutorError::into_http_error(err));
+                    }
+                    DoNewTxError::Shutdown => {
+                        return Err(shut_down_error());
+                    }
+                },
+                AcceptTxError::ReplicaMode => return Err(replica_mode_error()),
+            },
+        }
+    }
 }
 
 pub(crate) fn slot_count_delta_acceptable_lower_bound(
@@ -587,7 +744,7 @@ fn raw_max_deferred_slots_delay(max_allowed_node_distance_behind: u64) -> u64 {
 }
 
 async fn update_state_task<S, Rt, Da>(
-    seq: Arc<PreferredSequencer<S, Rt, Da>>,
+    seq: PreferredSequencer<S, Rt, Da>,
     mut state_update_receiver: StateUpdateReceiver<S::Storage>,
     shutdown_receiver: watch::Receiver<()>,
 ) where
@@ -647,7 +804,7 @@ pub(crate) enum PreferredSeqOperation<S: Spec, Rt: Runtime<S>> {
 
 #[tracing::instrument(skip_all, level = "debug")]
 async fn update_state_task_inner<S, Rt, Da>(
-    seq: Arc<PreferredSequencer<S, Rt, Da>>,
+    seq: PreferredSequencer<S, Rt, Da>,
     state_update_receiver: &mut StateUpdateReceiver<S::Storage>,
     shutdown_receiver: &watch::Receiver<()>,
 ) -> anyhow::Result<()>
@@ -868,138 +1025,19 @@ where
         unimplemented!("The preferred sequencer manages its own state updates; do not call update_state() on it. If you see this, this is a bug, please report it.")
     }
 
-    #[tracing::instrument(skip_all, level = "trace")]
     async fn accept_tx(
         &self,
         baked_tx: FullyBakedTx,
     ) -> Result<AcceptedTx<Self::Confirmation>, ErrorObject> {
-        if self.shutdown_receiver.has_changed().unwrap_or(true) {
-            tracing::info!("The sequencer is shutting down. Cannot accept transactions");
-            return Err(shut_down_error());
-        }
-
-        let original_tx_queue_id = self.tx_queue_id.load(Ordering::Acquire);
-
-        let tx_hash = Rt::Auth::compute_tx_hash(&baked_tx).map_err(generic_accept_tx_error)?;
-        tracing::debug!(%tx_hash, "Executing accept_tx");
-
-        // Check if this transaction has a configured delay
-        let runtime = Rt::default();
-        let mut state = self
-            .api_state()
-            .default_api_state_accessor()
-            .to_provable_reader();
-        let (_, auth_data, call) = <Rt as Runtime<S>>::Auth::authenticate(&baked_tx, &mut state)
-            .map_err(|e| pre_exec_err_to_accept_tx_err(PreExecError::AuthError(e)))?;
-        let call = Rt::wrap_call(call);
-        let delay_ms = runtime.get_transaction_delay_ms(&call);
-        // We need to destructure auth_data because it's not `Send`.
-        let uniqueness = auth_data.uniqueness;
-        let credential_id = auth_data.credential_id;
-        drop(auth_data);
-
-        if delay_ms > 0 {
-            tracing::debug!(%tx_hash, delay_ms, "Delaying transaction processing");
-            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
-            tracing::debug!(%tx_hash, "Transaction delay completed, proceeding with processing");
-        }
-
-        let tx_len = baked_tx.data.len();
-
-        let (outer_res, is_nonce_based) = match uniqueness {
-            UniquenessData::Generation(_) => (
-                self.synchronized_state_updator
-                    .accept_tx_msg(&baked_tx, tx_hash, original_tx_queue_id, "accept_tx")
-                    .await,
-                false,
-            ),
-            UniquenessData::Nonce(tx_nonce) => (
-                self.tx_nonce_queues
-                    .handle_new_tx(
-                        baked_tx,
-                        tx_hash,
-                        tx_nonce,
-                        credential_id,
-                        original_tx_queue_id,
-                    )
-                    .await,
-                true,
-            ),
-        };
-
-        let res = match outer_res {
-            Ok(inner_res) => inner_res,
-            Err(SequencerStateUpdatorError::Shutdown) => {
-                return Err(shut_down_error());
-            }
-            Err(SequencerStateUpdatorError::Unexpected) => {
-                return Err(internal_server_error_500(
-                    "Unexpected Error. The sequencer is unable to accept transactions.",
-                ));
-            }
-        };
-
-        match res {
-            Ok(rx) => {
-                let result = rx.await.map_err(database_error_500)?;
-                // After DB persistence completes, notify the nonce queue so it can clean up if needed
-                if is_nonce_based {
-                    self.tx_nonce_queues.mark_completed(&credential_id);
-                }
-                Ok(result)
-            }
-            Err(e) => match e {
-                AcceptTxError::SequencerOverloaded503 => {
-                    return Err(sequencer_overloaded_503("Other"));
-                }
-                AcceptTxError::NotFullySynced(details) => {
-                    return Err(error_not_fully_synced(details))
-                }
-                AcceptTxError::BatchError {
-                    batch_creation_error,
-                    nb_of_concurrent_blob_submissions,
-                } => match batch_creation_error {
-                    BatchCreationError::NoFinalizedSlotAvailable => {
-                        return Err(sequencer_overloaded_503("No finalized slots available"));
-                    }
-                    BatchCreationError::BlobSenderBusy => {
-                        return Err(error_not_fully_synced(
-                            SequencerNotReadyDetails::WaitingOnBlobSender {
-                                max_concurrent_blobs: self.config.max_concurrent_blobs,
-                                nb_of_blobs_in_flight: nb_of_concurrent_blob_submissions,
-                            },
-                        ));
-                    }
-                    BatchCreationError::DatabaseError(e) => {
-                        return Err(database_error_500(e));
-                    }
-                    BatchCreationError::PreferredSequencerAtStopHeight {
-                        height_to_stop_at,
-                        current_height,
-                    } => {
-                        return Err(error_not_fully_synced(
-                            SequencerNotReadyDetails::PreferredSequencerAtStopHeight {
-                                height_to_stop_at,
-                                current_height,
-                            },
-                        ));
-                    }
-                },
-                AcceptTxError::NewTxError(err) => match err {
-                    DoNewTxError::TxTooBig {
-                        current_batch_size,
-                        max_batch_size,
-                    } => return Err(err_cant_fit_tx(current_batch_size, max_batch_size, tx_len)),
-                    DoNewTxError::ExecutorError(err) => {
-                        return Err(RollupBlockExecutorError::into_http_error(err));
-                    }
-                    DoNewTxError::Shutdown => {
-                        return Err(shut_down_error());
-                    }
-                },
-                AcceptTxError::ReplicaMode => return Err(replica_mode_error()),
-            },
-        }
+        let sequencer = self.clone();
+        tokio::spawn(async move { sequencer.accept_tx_inner(baked_tx).await })
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "A panic occurred while accepting a transaction");
+                sov_rest_utils::errors::internal_server_error_500(
+                    "An internal error occurred while processing the transaction",
+                )
+            })?
     }
 
     async fn tx_status(

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -237,14 +237,10 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             Seq::Spec,
         >>::encode_with_standard_auth(raw_tx);
 
-        let tx_with_hash = tokio::spawn(async move { state.sequencer.accept_tx(baked_tx).await })
+        let tx_with_hash = state
+            .sequencer
+            .accept_tx(baked_tx)
             .await
-            .map_err(|e| {
-                tracing::error!(error = %e, "A panic occurred while accepting a transaction");
-                sov_rest_utils::errors::internal_server_error_response_500(
-                    "An internal error occurred while processing the transaction",
-                )
-            })?
             .map_err(|e| {
                 if e.status.is_server_error() {
                     tracing::error!(error = ?e, "Error accepting transaction");

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -1,7 +1,6 @@
 //! Utilities and definitions for the sequencer's REST APIs.
 
 use std::pin::Pin;
-use std::sync::Arc;
 
 use axum::extract::ws::WebSocket;
 use axum::extract::{ws, State, WebSocketUpgrade};
@@ -51,15 +50,15 @@ pub struct StartFrom {
 #[derive(derivative::Derivative)]
 #[derivative(Clone(bound = ""))]
 pub struct SequencerApis<Seq: Sequencer> {
-    sequencer: Arc<Seq>,
+    sequencer: Seq,
     shutdown_receiver: Receiver<()>,
 }
 
 impl<Seq: Sequencer> SequencerApis<Seq> {
     /// Creates a new Axum router for this sequencer.
-    pub fn rest_api_server(seq: Arc<Seq>, shutdown_receiver: Receiver<()>) -> axum::Router<()> {
+    pub fn rest_api_server(sequencer: Seq, shutdown_receiver: Receiver<()>) -> axum::Router<()> {
         let state = Self {
-            sequencer: seq,
+            sequencer,
             shutdown_receiver,
         };
 
@@ -237,16 +236,12 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             Seq::Spec,
         >>::encode_with_standard_auth(raw_tx);
 
-        let tx_with_hash = state
-            .sequencer
-            .accept_tx(baked_tx)
-            .await
-            .map_err(|e| {
-                if e.status.is_server_error() {
-                    tracing::error!(error = ?e, "Error accepting transaction");
-                }
-                IntoResponse::into_response(e)
-            })?;
+        let tx_with_hash = state.sequencer.accept_tx(baked_tx).await.map_err(|e| {
+            if e.status.is_server_error() {
+                tracing::error!(error = ?e, "Error accepting transaction");
+            }
+            IntoResponse::into_response(e)
+        })?;
 
         Ok(TxInfoWithConfirmation {
             id: tx_with_hash.tx_hash,
@@ -292,7 +287,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
 
     async fn subscribe_txs_starting_from(
         start_from: Option<u64>,
-        sequencer: Arc<Seq>,
+        sequencer: Seq,
     ) -> Pin<
         Box<
             dyn futures::Stream<

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -59,7 +59,29 @@ where
 /// Transactions are included in batches by following a largest-first,
 /// least-recent-first priority. Only transactions that were successfully
 /// dispatched are included.
-pub struct StdSequencer<S, Rt, Da>
+#[derive(derivative::Derivative)]
+#[derivative(Clone(bound = ""))]
+pub struct StdSequencer<S, Rt, Da>(Arc<StdSequencerFields<S, Rt, Da>>)
+where
+    S: Spec,
+    Rt: Runtime<S>,
+    Da: DaService<Spec = S::Da>;
+
+impl<S, Rt, Da> std::ops::Deref for StdSequencer<S, Rt, Da>
+where
+    S: Spec,
+    Rt: Runtime<S>,
+    Da: DaService<Spec = S::Da>,
+{
+    type Target = StdSequencerFields<S, Rt, Da>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// The inner fields of a `StdSequencer`. Should be accessed through the parent struct's Arc.
+pub struct StdSequencerFields<S, Rt, Da>
 where
     S: Spec,
     Rt: Runtime<S>,
@@ -106,7 +128,7 @@ where
         ledger_db: LedgerDb,
         api_ledger_db: LedgerDb,
         shutdown_sender: watch::Sender<()>,
-    ) -> anyhow::Result<(Arc<Self>, Vec<JoinHandle<()>>)> {
+    ) -> anyhow::Result<(Self, Vec<JoinHandle<()>>)> {
         let shutdown_receiver = shutdown_sender.subscribe();
         let mut runtime = Rt::default();
         let kernel_with_slot_mapping = runtime.kernel_with_slot_mapping();
@@ -162,7 +184,7 @@ where
             )?,
         };
 
-        let seq = Arc::new(StdSequencer {
+        let seq = StdSequencer(Arc::new(StdSequencerFields {
             inner: inner.into(),
             txsm,
             api_state,
@@ -171,7 +193,7 @@ where
             config: config.clone(),
             api_ledger_db,
             da_address,
-        });
+        }));
 
         handles.push(tokio::spawn({
             loop_call_update_state(
@@ -488,6 +510,101 @@ where
 
         Ok(())
     }
+
+    async fn accept_tx_inner(
+        &self,
+        baked_tx: FullyBakedTx,
+    ) -> Result<AcceptedTx<<Self as Sequencer>::Confirmation>, ErrorObject> {
+        tracing::trace!(
+            baked_tx = hex::encode(&baked_tx),
+            "`accept_tx` has been called"
+        );
+
+        if baked_tx.data.len() > self.max_batch_size_bytes().get() {
+            return Err(ErrorObject {
+                status: StatusCode::PAYLOAD_TOO_LARGE,
+                message: "Transaction is too big".to_string(),
+                details: json_obj!({
+                    "max_allowed_size": self.max_batch_size_bytes(),
+                    "submitted_size": baked_tx.data.len(),
+                }),
+            });
+        }
+
+        let mut inner = self.inner.lock().await;
+        let state_checkpoint = inner
+            .checkpoint
+            .take()
+            .expect("Absent checkpoint; this is a bug, please report it");
+
+        // This closure helps us make sure that we always put the
+        // state checkpoint back into `self` at the end of the function.
+        let (new_checkpoint, response) = (|mut checkpoint: StateCheckpoint<S>| {
+            let mut runtime: Rt = Default::default();
+            let gas_price = runtime.chain_state().base_fee_per_gas(&mut checkpoint).expect("Impossible to get the gas price for the current slot. This is a bug. Please report it");
+
+            let (tx_scratchpad, output_res) =
+                tx_auth::<S, Rt, _>(checkpoint.to_tx_scratchpad(), gas_price, &baked_tx.clone());
+
+            let (auth_output, gas_meter) = match output_res {
+                Ok(ok) => ok,
+                Err(error) => {
+                    return (
+                        tx_scratchpad.revert(),
+                        Err(pre_exec_err_to_accept_tx_err(error)),
+                    );
+                }
+            };
+
+            let tx_hash = auth_output.0.raw_tx_hash;
+
+            let gas_info = gas_meter.gas_info();
+            let tx = auth_output.0.authenticated_tx;
+
+            let working_set_gas_meter = tx.gas_meter(gas_info.gas_price, <S::Gas>::MAX);
+
+            let mut working_set =
+                WorkingSet::create_working_set(tx_scratchpad, &tx, working_set_gas_meter);
+
+            if let Err(err) = working_set.charge_gas(gas_info.gas_used) {
+                let (scratchpad, _) = working_set.revert();
+
+                return (
+                    scratchpad.revert(),
+                    Err(ErrorObject {
+                        // Not enough gas, so 403 seems appropriate.
+                        status: StatusCode::FORBIDDEN,
+                        message: "Not enough gas for pre-execution checks".to_string(),
+                        details: json_obj!({
+                            "error": err.to_string()
+                        }),
+                    }),
+                );
+            };
+
+            (working_set.finalize().0.commit(), Ok(tx_hash))
+        })(state_checkpoint);
+
+        let tx_hash = response?;
+        {
+            inner.mempool.add_new_tx(tx_hash, baked_tx.clone());
+            tracing::trace!(
+                %tx_hash,
+                "Transaction has been added to the mempool"
+            );
+        }
+
+        inner.checkpoint = Some(new_checkpoint);
+
+        self.tx_status_manager()
+            .notify(tx_hash, TxStatus::Submitted);
+
+        Ok(AcceptedTx {
+            tx: baked_tx,
+            tx_hash,
+            confirmation: EmptyConfirmation {},
+        })
+    }
 }
 
 #[cfg(feature = "test-utils")]
@@ -585,95 +702,15 @@ where
         &self,
         baked_tx: FullyBakedTx,
     ) -> Result<AcceptedTx<Self::Confirmation>, ErrorObject> {
-        tracing::trace!(
-            baked_tx = hex::encode(&baked_tx),
-            "`accept_tx` has been called"
-        );
-
-        if baked_tx.data.len() > self.max_batch_size_bytes().get() {
-            return Err(ErrorObject {
-                status: StatusCode::PAYLOAD_TOO_LARGE,
-                message: "Transaction is too big".to_string(),
-                details: json_obj!({
-                    "max_allowed_size": self.max_batch_size_bytes(),
-                    "submitted_size": baked_tx.data.len(),
-                }),
-            });
-        }
-
-        let mut inner = self.inner.lock().await;
-        let state_checkpoint = inner
-            .checkpoint
-            .take()
-            .expect("Absent checkpoint; this is a bug, please report it");
-
-        // This closure helps us make sure that we always put the
-        // state checkpoint back into `self` at the end of the function.
-        let (new_checkpoint, response) = (|mut checkpoint: StateCheckpoint<S>| {
-            let mut runtime: Rt = Default::default();
-            let gas_price = runtime.chain_state().base_fee_per_gas(&mut checkpoint).expect("Impossible to get the gas price for the current slot. This is a bug. Please report it");
-
-            let (tx_scratchpad, output_res) =
-                tx_auth::<S, Rt, _>(checkpoint.to_tx_scratchpad(), gas_price, &baked_tx.clone());
-
-            let (auth_output, gas_meter) = match output_res {
-                Ok(ok) => ok,
-                Err(error) => {
-                    return (
-                        tx_scratchpad.revert(),
-                        Err(pre_exec_err_to_accept_tx_err(error)),
-                    );
-                }
-            };
-
-            let tx_hash = auth_output.0.raw_tx_hash;
-
-            let gas_info = gas_meter.gas_info();
-            let tx = auth_output.0.authenticated_tx;
-
-            let working_set_gas_meter = tx.gas_meter(gas_info.gas_price, <S::Gas>::MAX);
-
-            let mut working_set =
-                WorkingSet::create_working_set(tx_scratchpad, &tx, working_set_gas_meter);
-
-            if let Err(err) = working_set.charge_gas(gas_info.gas_used) {
-                let (scratchpad, _) = working_set.revert();
-
-                return (
-                    scratchpad.revert(),
-                    Err(ErrorObject {
-                        // Not enough gas, so 403 seems appropriate.
-                        status: StatusCode::FORBIDDEN,
-                        message: "Not enough gas for pre-execution checks".to_string(),
-                        details: json_obj!({
-                            "error": err.to_string()
-                        }),
-                    }),
-                );
-            };
-
-            (working_set.finalize().0.commit(), Ok(tx_hash))
-        })(state_checkpoint);
-
-        let tx_hash = response?;
-        {
-            inner.mempool.add_new_tx(tx_hash, baked_tx.clone());
-            tracing::trace!(
-                %tx_hash,
-                "Transaction has been added to the mempool"
-            );
-        }
-
-        inner.checkpoint = Some(new_checkpoint);
-
-        self.tx_status_manager()
-            .notify(tx_hash, TxStatus::Submitted);
-
-        Ok(AcceptedTx {
-            tx: baked_tx,
-            tx_hash,
-            confirmation: EmptyConfirmation {},
-        })
+        let sequencer = self.clone();
+        tokio::spawn(async move { sequencer.accept_tx_inner(baked_tx).await })
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "A panic occurred while accepting a transaction");
+                sov_rest_utils::errors::internal_server_error_500(
+                    "An internal error occurred while processing the transaction",
+                )
+            })?
     }
 
     async fn tx_status(

--- a/crates/full-node/sov-sequencer/src/test_stateless.rs
+++ b/crates/full-node/sov-sequencer/src/test_stateless.rs
@@ -36,7 +36,8 @@ struct Inner<S: Spec> {
 /// Sequencer that accepts any transaction without verification.
 /// Build a batch out of all accepted transactions in the order they were received.
 /// Does not impose any restrictions on transaction validity or batch size.
-#[derive(Clone)]
+#[derive(derivative::Derivative)]
+#[derivative(Clone(bound = ""))]
 pub struct TestStatelessSequencer<R, S: Spec, Da: DaService> {
     inner: Arc<Mutex<Inner<S>>>,
     #[allow(clippy::type_complexity)]
@@ -62,7 +63,7 @@ where
         config: &SequencerConfig<<S as Spec>::Address, ()>,
         ledger_db: LedgerDb,
         shutdown_sender: watch::Sender<()>,
-    ) -> anyhow::Result<(Arc<Self>, Vec<JoinHandle<()>>)> {
+    ) -> anyhow::Result<(Self, Vec<JoinHandle<()>>)> {
         let shutdown_receiver = shutdown_sender.subscribe();
         let mut runtime = R::default();
         let storage = state_update_receiver.borrow().storage.clone();
@@ -74,7 +75,7 @@ where
         let tx_status_manager = TxStatusManager::default();
 
         let nb_of_concurrent_blob_submissions = Arc::new(AtomicUsize::new(0));
-        let seq = Arc::new(Self {
+        let seq = Self {
             inner: inner.into(),
             blob_sender: Arc::new(Mutex::new(
                 BlobSender::new(
@@ -95,7 +96,7 @@ where
             _r: Default::default(),
             state_sender,
             api_ledger_db: ledger_db.clone(),
-        });
+        };
 
         let mut handles = vec![];
         handles.push(tokio::spawn({

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -179,7 +179,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
     /// Injects additional HTTP APIs for the sequencer.
     async fn sequencer_additional_apis<Seq>(
         &self,
-        _sequencer: Arc<Seq>,
+        _sequencer: Seq,
         _rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _shutdown_receiver: watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>
@@ -233,7 +233,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     api_state: sequencer.api_state(),
                     endpoints,
                     background_handles,
-                    proof_sender: sequencer,
+                    proof_sender: Arc::new(sequencer),
                     api_ledger_db: api_ledger_db.clone(),
                     da_address: da_service.get_signer().await.context(
                         "Full node with standard sequencer require DaService with signer support",
@@ -269,7 +269,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     api_state: sequencer.api_state(),
                     endpoints,
                     background_handles,
-                    proof_sender: sequencer,
+                    proof_sender: Arc::new(sequencer),
                     api_ledger_db: api_ledger_db.clone(),
                     da_address: da_service.get_signer().await.context(
                         "Full node with preferred sequencer require DaService with signer support",

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
@@ -103,7 +103,7 @@ where
 
     async fn sequencer_additional_apis<Seq>(
         &self,
-        sequencer: Arc<Seq>,
+        sequencer: Seq,
         _rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>
@@ -166,7 +166,7 @@ where
 
 /// Handler for accepting Solana offchain authenticated transactions
 async fn accept_solana_offchain_tx<Seq>(
-    State(sequencer): State<Arc<Seq>>,
+    State(sequencer): State<Seq>,
     tx: Json<AcceptTx>,
 ) -> ApiResult<TxInfoWithConfirmation<DaBlobHash<<Seq::Da as DaService>::Spec>, Seq::Confirmation>>
 where
@@ -178,15 +178,7 @@ where
     let encoded_tx = Seq::Rt::encode_with_solana_offchain_auth(raw_tx);
 
     // Submit to sequencer (similar to axum_accept_tx but with Solana auth)
-    let tx_with_hash = tokio::spawn(async move { sequencer.accept_tx(encoded_tx).await })
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "A panic occurred while accepting a Solana offchain transaction");
-            sov_rest_utils::errors::internal_server_error_response_500(
-                "An internal error occurred while processing the transaction",
-            )
-        })?
-    .map_err(|e| {
+    let tx_with_hash = sequencer.accept_tx(encoded_tx).await.map_err(|e| {
         if e.status.is_server_error() {
             tracing::error!(error = ?e, "Error accepting Solana offchain transaction");
         }

--- a/crates/module-system/sov-test-utils/src/sequencer.rs
+++ b/crates/module-system/sov-test-utils/src/sequencer.rs
@@ -46,7 +46,7 @@ pub struct TestSequencerSetup<Rt: Runtime<TestSpec>> {
     // so it doesn't go out of scope and close the channel immediately.
     _state_update_sender: watch::Sender<StateUpdateInfo<<TestSpec as Spec>::Storage>>,
     /// The sequencer used in the test.
-    pub sequencer: Arc<StdSequencer<TestSpec, Rt, StorableMockDaService>>,
+    pub sequencer: StdSequencer<TestSpec, Rt, StorableMockDaService>,
     /// The admin private key used to create an external user account for transaction handling.
     pub admin_private_key: TestPrivateKey,
     /// The Axum server handle used to start the Axum server.

--- a/examples/demo-rollup/src/celestia_nomt_rollup.rs
+++ b/examples/demo-rollup/src/celestia_nomt_rollup.rs
@@ -131,7 +131,7 @@ impl FullNodeBlueprint<Native> for CelestiaNomtDemoRollup<Native> {
 
     async fn sequencer_additional_apis<Seq>(
         &self,
-        sequencer: Arc<Seq>,
+        sequencer: Seq,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -117,7 +117,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
 
     async fn sequencer_additional_apis<Seq>(
         &self,
-        sequencer: Arc<Seq>,
+        sequencer: Seq,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>

--- a/examples/demo-rollup/src/external_mock_nomt_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_nomt_rollup.rs
@@ -116,7 +116,7 @@ impl FullNodeBlueprint<Native> for ExternalMockNomtDemoRollup<Native> {
 
     async fn sequencer_additional_apis<Seq>(
         &self,
-        sequencer: Arc<Seq>,
+        sequencer: Seq,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -100,7 +100,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
 
     async fn sequencer_additional_apis<Seq>(
         &self,
-        sequencer: Arc<Seq>,
+        sequencer: Seq,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>

--- a/examples/demo-rollup/src/mock_nomt_rollup.rs
+++ b/examples/demo-rollup/src/mock_nomt_rollup.rs
@@ -113,7 +113,7 @@ impl FullNodeBlueprint<Native> for MockNomtDemoRollup<Native> {
 
     async fn sequencer_additional_apis<Seq>(
         &self,
-        sequencer: Arc<Seq>,
+        sequencer: Seq,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -99,7 +99,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
 
     async fn sequencer_additional_apis<Seq>(
         &self,
-        sequencer: Arc<Seq>,
+        sequencer: Seq,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> anyhow::Result<NodeEndpoints>


### PR DESCRIPTION
# Description

Wrap all the internals of PreferredSequencer and StdSequencer inside `Arc`s, and derive Clone on them. This allows `Sequencer::accept_tx()` to spawn a tokio task by cloning `self`, which in turn allows using `accept_tx()` directly in REST api handlers without having to remember to spawn in every handler.

Review notes: a large chunk of the diff is the former body of `accept_tx()` being moved out of `impl Sequencer for PreferredSequencer` and into `impl Sequencer { accept_tx_inner() }`. There are no changes to the actual body of the function.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
