### PR TITLE
Debugging `test_replica_start_stop`

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,6 +24,12 @@ filter = 'package(sov-sequencer) & test(/pinned_cache::/)'
 priority = 90                                                        # try to run it first, so it doesn't add up at the end
 threads-required = 3
 
+[[profile.default.overrides]]
+filter = 'package(sov-demo-rollup) & test(/replica::/)'
+priority = 90                                                        # try to run it first, so it doesn't add up at the end
+threads-required = 3
+
+
 
 [profile.ci]
 default-filter = 'all()'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - #2070 **Breaking change**: The `MeteredSignature::charge_gas()` method signature changes from taking a `msg: &[u8]` parameter to `msg_len: usize`, as signature verification gas cost only depends on the number of bytes. This has no other impact except for direct users of the `MeteredSignature` struct.
 
 # 2025-11-11
+- #2078 Fixing the test in demo-rollup
 - #2004 The sequencer will now buffer and intelligently reorder transactions with a nonce that arrive out-of-order within a short window of time. Adds `max_future_nonce_delta` and `future_nonce_transaction_timeout_millis` optional config options that allow configuring the limits of how eagerly the sequencer will try to buffer nonces.
   - **Breaking change** Removes the `buffer_raw_txs` field from EthRpcConfig (as this is now handled by the sequencer). This change is only breaking for EVM rollups.
 - #2074 Renaming crate `full-node-configs` to `sov-full-node-configs`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.1.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e856112bfa0d9adc85bd7c13db03fad0e71d1d6fb4c2010e475b6718108236"
+checksum = "c0df1987ed0ff2d0159d76b52e7ddfc4e4fbddacc54d2fbee765e0d14d7c01b5"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8698,9 +8698,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a6df7eab65fc7bee654a421404947e10a0f7085b6951bf2ea395f4659fb0cf"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
  "indoc",
  "libc",
@@ -8715,18 +8715,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77d387774f6f6eec64a004eac0ed525aab7fa1966d94b42f743797b3e395afb"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd13844a4242793e02df3e2ec093f540d948299a6a77ea9ce7afd8623f542be"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -8734,9 +8734,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf8f9f1108270b90d3676b8679586385430e5c0bb78bb5f043f95499c821a71"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -8746,9 +8746,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a3b2274450ba5288bc9b8c1b69ff569d1d61189d4bff38f8d22e03d17f932b"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -14628,9 +14628,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-metrics"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01bbf7db0b3f5eee8930a119fe99bfa1438de1095fe3d26b25e652a5933ef3f"
+checksum = "a34e87dd30650518a4e041bca77c931f3f5a19621eecdcd794f5c1813bca9e98"
 dependencies = [
  "futures-util",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13135,6 +13135,7 @@ dependencies = [
  "strum 0.26.3",
  "tempfile",
  "testcontainers",
+ "testcontainers-modules",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -463,8 +463,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_sequencer_leader_election() {
-        let dir = tempfile::tempdir().unwrap();
-        let postgres = create_postgres_container(&dir.path().join("postgres_data")).await;
+        let postgres = create_postgres_container().await;
         let postgres = match postgres {
             Ok(pg) => pg,
             Err(CreatePostgresError::DockerNotSupported) => return,

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -333,9 +333,7 @@ mod tests {
     }
 
     async fn run(test_cases: Vec<TestCase>, expected: Vec<DbData>, exec_seq_nr: u64) {
-        let dir = tempfile::tempdir().unwrap();
-
-        let postgres = create_postgres_container(&dir.path().join("postgres_data")).await;
+        let postgres = create_postgres_container().await;
         let postgres = match postgres {
             Ok(pg) => pg,
             Err(CreatePostgresError::DockerNotSupported) => return,

--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -205,6 +205,7 @@ async fn background_header_fetch_task<Da: DaService>(
     shutdown_rx: tokio::sync::watch::Receiver<()>,
 ) {
     let mut interval = tokio::time::interval(polling_interval);
+    tracing::info!(?interval, "Starting background fetcher task");
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
@@ -220,7 +221,7 @@ async fn background_header_fetch_task<Da: DaService>(
                     .await
                 {
                     FutureOrShutdownOutput::Shutdown => {
-                        tracing::info!("DA header provider received shutdown signal");
+                        tracing::info!("DA header provider received shutdown signal, stopping");
                         break;
                     }
                     FutureOrShutdownOutput::Output(Ok(finalized_header)) => {

--- a/crates/module-system/hyperlane/tests/integration/with_agent/helpers/docker.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/helpers/docker.rs
@@ -1,24 +1,7 @@
 use std::time::Duration;
 use testcontainers::core::client::docker_client_instance;
 use testcontainers::core::ExecResult;
-use testcontainers::ContainerAsync;
 use tokio::io::AsyncBufReadExt;
-
-pub async fn print_logs_from_container<T>(name: &str, container: &ContainerAsync<T>)
-where
-    T: testcontainers::Image,
-{
-    let _span = tracing::info_span!("docker_log", name = name).entered();
-    let mut stdout = container.stdout(false).lines();
-    while let Some(line) = stdout.next_line().await.unwrap() {
-        tracing::info!("stdout: {line}");
-    }
-
-    let mut stderr = container.stderr(false).lines();
-    while let Some(line) = stderr.next_line().await.unwrap() {
-        tracing::info!("stderr: {line}");
-    }
-}
 
 pub async fn print_logs_from_exec_result(name: &str, result: &mut ExecResult, timeout: Duration) {
     let _span = tracing::info_span!("docker_exec_log", name = name).entered();

--- a/crates/module-system/hyperlane/tests/integration/with_agent/helpers/evm.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/helpers/evm.rs
@@ -1,4 +1,3 @@
-use crate::with_agent::helpers::docker::print_logs_from_container;
 use crate::with_agent::helpers::hyperlane_cli::HyperlaneCliRunner;
 use crate::with_agent::helpers::{EVM_MAILBOX, RELAYER_ACCOUNT};
 use serde::de::DeserializeOwned;
@@ -7,6 +6,7 @@ use serde_json::{json, Value};
 use sov_hyperlane_integration::{EthAddress, Message};
 use sov_modules_api::macros::config_value;
 use sov_modules_api::{Amount, HexHash, HexString};
+use sov_test_utils::docker::print_logs_from_container;
 use testcontainers::core::ExecCommand;
 use testcontainers::runners::AsyncRunner;
 use testcontainers::{ContainerAsync, ImageExt};

--- a/crates/module-system/sov-test-utils/Cargo.toml
+++ b/crates/module-system/sov-test-utils/Cargo.toml
@@ -27,6 +27,7 @@ serde = { workspace = true }
 schemars = { workspace = true }
 serde_json = { workspace = true }
 testcontainers = { workspace = true }
+testcontainers-modules = { workspace = true, features = ["postgres"] }
 tracing = { workspace = true }
 hex = { workspace = true }
 num_cpus = { workspace = true }

--- a/crates/module-system/sov-test-utils/src/docker.rs
+++ b/crates/module-system/sov-test-utils/src/docker.rs
@@ -1,0 +1,20 @@
+//! Docker related test-utils
+use testcontainers::ContainerAsync;
+use tokio::io::AsyncBufReadExt;
+
+/// Printing logs from container
+pub async fn print_logs_from_container<T>(name: &str, container: &ContainerAsync<T>)
+where
+    T: testcontainers::Image,
+{
+    let _span = tracing::info_span!("docker_log", name = name).entered();
+    let mut stdout = container.stdout(false).lines();
+    while let Some(line) = stdout.next_line().await.unwrap() {
+        tracing::info!("stdout: {line}");
+    }
+
+    let mut stderr = container.stderr(false).lines();
+    while let Some(line) = stderr.next_line().await.unwrap() {
+        tracing::info!("stderr: {line}");
+    }
+}

--- a/crates/module-system/sov-test-utils/src/lib.rs
+++ b/crates/module-system/sov-test-utils/src/lib.rs
@@ -65,6 +65,7 @@ pub mod sequencer;
 /// Utilities for testing that require [`ProverStorage`].
 pub mod storage;
 
+pub mod docker;
 /// Utilities that specify an interface for testing.
 pub mod interface;
 

--- a/crates/module-system/sov-test-utils/src/postgres.rs
+++ b/crates/module-system/sov-test-utils/src/postgres.rs
@@ -23,6 +23,8 @@ pub async fn create_postgres_container() -> Result<ContainerAsync<Postgres>, Cre
 
     let img = Postgres::default()
         .with_tag("17-alpine")
+        .with_shm_size(256 * 1024 * 1024) // 256MB
+        .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
         .start()
         .await
         .map_err(|e| CreatePostgresError::DockerError(e.into()))?;
@@ -53,7 +55,7 @@ pub async fn connection_string_from_postgres_container(
     container: &ContainerAsync<Postgres>,
 ) -> anyhow::Result<String> {
     let postgres_connection_string = format!(
-        "postgres://postgres:postgres@{}:{}",
+        "postgres://postgres:postgres@{}:{}?sslmode=disable",
         container.get_host().await?,
         container.get_host_port_ipv4(5432).await?
     );

--- a/crates/module-system/sov-test-utils/src/postgres.rs
+++ b/crates/module-system/sov-test-utils/src/postgres.rs
@@ -1,40 +1,7 @@
 use sov_sequencer::preferred::PostgresConfig;
-use std::borrow::Cow;
-use testcontainers::core::WaitFor;
 use testcontainers::runners::AsyncRunner;
-use testcontainers::{ContainerAsync, Image};
-
-/// A Docker image for PostgreSQL.
-#[derive(Debug, Clone, Default)]
-pub struct PostgresImage;
-
-impl Image for PostgresImage {
-    fn name(&self) -> &str {
-        "postgres"
-    }
-
-    fn tag(&self) -> &str {
-        "17-alpine"
-    }
-
-    fn ready_conditions(&self) -> Vec<WaitFor> {
-        // See <https://github.com/testcontainers/testcontainers-rs-modules-community/issues/158>.
-        vec![
-            WaitFor::message_on_stderr("database system is ready to accept connections"),
-            WaitFor::message_on_stdout("database system is ready to accept connections"),
-        ]
-    }
-
-    fn env_vars(
-        &self,
-    ) -> impl IntoIterator<Item = (impl Into<Cow<'_, str>>, impl Into<Cow<'_, str>>)> {
-        [
-            ("POSTGRES_DB", "postgres"),
-            ("POSTGRES_USER", "postgres"),
-            ("POSTGRES_PASSWORD", "postgres"),
-        ]
-    }
-}
+use testcontainers::{ContainerAsync, ImageExt};
+use testcontainers_modules::postgres::Postgres;
 
 #[derive(Debug, thiserror::Error)]
 /// Error indicating problems when creating a Postgres container.
@@ -49,13 +16,13 @@ pub enum CreatePostgresError {
 }
 
 /// Creates a container with a PostgreSQL database.
-pub async fn create_postgres_container(
-) -> Result<ContainerAsync<PostgresImage>, CreatePostgresError> {
+pub async fn create_postgres_container() -> Result<ContainerAsync<Postgres>, CreatePostgresError> {
     if should_skip_postgres() {
         return Err(CreatePostgresError::DockerNotSupported);
     }
 
-    let img = PostgresImage
+    let img = Postgres::default()
+        .with_tag("17-alpine")
         .start()
         .await
         .map_err(|e| CreatePostgresError::DockerError(e.into()))?;
@@ -83,7 +50,7 @@ fn should_skip_postgres() -> bool {
 
 /// Returns the connection string for the PostgreSQL.
 pub async fn connection_string_from_postgres_container(
-    container: &ContainerAsync<PostgresImage>,
+    container: &ContainerAsync<Postgres>,
 ) -> anyhow::Result<String> {
     let postgres_connection_string = format!(
         "postgres://postgres:postgres@{}:{}",
@@ -96,7 +63,7 @@ pub async fn connection_string_from_postgres_container(
 
 /// Returns the connection string for the PostgreSQL.
 pub async fn config_from_postgres_container(
-    container: &ContainerAsync<PostgresImage>,
+    container: &ContainerAsync<Postgres>,
     node_id: String,
 ) -> anyhow::Result<PostgresConfig> {
     let postgres_connection_string = connection_string_from_postgres_container(container).await?;

--- a/crates/module-system/sov-test-utils/src/postgres.rs
+++ b/crates/module-system/sov-test-utils/src/postgres.rs
@@ -24,7 +24,6 @@ pub async fn create_postgres_container() -> Result<ContainerAsync<Postgres>, Cre
     let img = Postgres::default()
         .with_tag("17-alpine")
         .with_shm_size(256 * 1024 * 1024) // 256MB
-        .with_env_var("POSTGRES_HOST_AUTH_METHOD", "trust")
         .start()
         .await
         .map_err(|e| CreatePostgresError::DockerError(e.into()))?;

--- a/crates/module-system/sov-test-utils/src/postgres.rs
+++ b/crates/module-system/sov-test-utils/src/postgres.rs
@@ -1,11 +1,8 @@
 use sov_sequencer::preferred::PostgresConfig;
 use std::borrow::Cow;
-use std::path::Path;
-use testcontainers::core::Mount;
 use testcontainers::core::WaitFor;
 use testcontainers::runners::AsyncRunner;
-use testcontainers::{ContainerAsync, Image, ImageExt};
-use tracing::debug;
+use testcontainers::{ContainerAsync, Image};
 
 /// A Docker image for PostgreSQL.
 #[derive(Debug, Clone, Default)]
@@ -53,23 +50,12 @@ pub enum CreatePostgresError {
 
 /// Creates a container with a PostgreSQL database.
 pub async fn create_postgres_container(
-    dir: &Path,
 ) -> Result<ContainerAsync<PostgresImage>, CreatePostgresError> {
     if should_skip_postgres() {
         return Err(CreatePostgresError::DockerNotSupported);
     }
 
-    let postgres_data_dir = dir.join("postgres_data");
-    debug!(?postgres_data_dir, "Using Postgres data directory");
-
-    std::fs::create_dir_all(&postgres_data_dir)
-        .map_err(|e| CreatePostgresError::DockerError(e.into()))?;
-
     let img = PostgresImage
-        .with_mount(Mount::bind_mount(
-            postgres_data_dir.to_string_lossy(),
-            "/var/lib/postgresql/data",
-        ))
         .start()
         .await
         .map_err(|e| CreatePostgresError::DockerError(e.into()))?;

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 
 use crate::postgres::create_postgres_container;
 use crate::postgres::CreatePostgresError;
-use crate::postgres::PostgresImage;
 use crate::{Transaction, TEST_MOCK_DA_POLLING_INTERVAL};
 use crate::{
     TEST_DEFAULT_PROVER_ADDRESS, TEST_DEFAULT_SEQUENCER_ADDRESS, TEST_MAX_BATCH_SIZE,
@@ -54,6 +53,7 @@ use sov_stf_runner::{
     HttpServerConfig, MonitoringConfig, ProofManagerConfig, RollupConfig, RunnerConfig,
 };
 use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
@@ -419,7 +419,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
 }
 
 pub struct PostgresData {
-    postgres: ContainerAsync<PostgresImage>,
+    pub postgres: ContainerAsync<Postgres>,
     connection_string: String,
 }
 

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -59,7 +59,6 @@ use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tokio::time::Duration;
 use tokio_stream::StreamExt;
-use tracing::Instrument;
 
 /// Specifies how to source the genesis data for a rollup.
 #[derive(Derivative)]
@@ -286,27 +285,18 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
             other_handles.push(handle);
         }
 
-        let is_replica = match &self.config.sequencer_config {
-            SequencerKindConfig::Standard(_s) => false,
-            SequencerKindConfig::Preferred(p) => p.is_replica.unwrap_or_default(),
-        };
-
-        let span = tracing::info_span!("rollup_task", ?is_replica);
-        let rollup_task = tokio::spawn(
-            async move {
-                match rollup.run_and_report_addr(Some(rest_addr_tx)).await {
-                    Ok(()) => {
-                        tracing::info!("Completed running a rollup");
-                        Ok(())
-                    }
-                    Err(error) => {
-                        tracing::error!(?error, "Rollup execution returned an error");
-                        Err(error)
-                    }
+        let rollup_task = tokio::spawn(async move {
+            match rollup.run_and_report_addr(Some(rest_addr_tx)).await {
+                Ok(()) => {
+                    tracing::info!("Completed running a rollup");
+                    Ok(())
+                }
+                Err(error) => {
+                    tracing::error!(?error, "Rollup execution returned an error");
+                    Err(error)
                 }
             }
-            .instrument(span),
-        );
+        });
 
         let rest_addr = rest_addr_rx.await?;
 

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -53,7 +53,6 @@ pub use sov_stf_runner::processes::RollupProverConfig;
 use sov_stf_runner::{
     HttpServerConfig, MonitoringConfig, ProofManagerConfig, RollupConfig, RunnerConfig,
 };
-use tempfile::TempDir;
 use testcontainers::ContainerAsync;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -420,18 +419,15 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
 }
 
 pub struct PostgresData {
-    storage_path: TempDir,
     postgres: ContainerAsync<PostgresImage>,
     connection_string: String,
 }
 
 impl PostgresData {
     pub async fn create_postgres() -> Result<Arc<PostgresData>, CreatePostgresError> {
-        let dir = tempfile::tempdir().unwrap();
-        let pg = create_postgres_container(&dir.path().join("postgres_data")).await?;
+        let pg = create_postgres_container().await?;
 
         Ok(Arc::new(PostgresData {
-            storage_path: dir,
             connection_string: connection_string_from_postgres_container(&pg).await?,
             postgres: pg,
         }))

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 use anyhow::Context;
 use derivative::Derivative;
+use tracing::Instrument;
 use serde::Deserialize;
 use sov_api_spec::types::TxInfoWithConfirmation;
 use sov_api_spec::WsSubscription;
@@ -290,19 +291,22 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
             SequencerKindConfig::Preferred(p) => p.is_replica.unwrap_or_default(),
         };
 
-        let rollup_task = tokio::spawn(async move {
-            let _span = tracing::info_span!("rollup-kind", ?is_replica);
-            match rollup.run_and_report_addr(Some(rest_addr_tx)).await {
-                Ok(()) => {
-                    tracing::info!("Completed running a rollup");
-                    Ok(())
-                }
-                Err(error) => {
-                    tracing::error!(?error, "Rollup execution returned an error");
-                    Err(error)
+        let span = tracing::info_span!("rollup_task", ?is_replica);
+        let rollup_task = tokio::spawn(
+            async move {
+                match rollup.run_and_report_addr(Some(rest_addr_tx)).await {
+                    Ok(()) => {
+                        tracing::info!("Completed running a rollup");
+                        Ok(())
+                    }
+                    Err(error) => {
+                        tracing::error!(?error, "Rollup execution returned an error");
+                        Err(error)
+                    }
                 }
             }
-        });
+            .instrument(span),
+        );
 
         let rest_addr = rest_addr_rx.await?;
 

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -285,7 +285,13 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
             other_handles.push(handle);
         }
 
+        let is_replica = match &self.config.sequencer_config {
+            SequencerKindConfig::Standard(_s) => false,
+            SequencerKindConfig::Preferred(p) => p.is_replica.unwrap_or_default(),
+        };
+
         let rollup_task = tokio::spawn(async move {
+            let _span = tracing::info_span!("rollup-kind", ?is_replica);
             match rollup.run_and_report_addr(Some(rest_addr_tx)).await {
                 Ok(()) => {
                     tracing::info!("Completed running a rollup");

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 use anyhow::Context;
 use derivative::Derivative;
-use tracing::Instrument;
 use serde::Deserialize;
 use sov_api_spec::types::TxInfoWithConfirmation;
 use sov_api_spec::WsSubscription;
@@ -60,6 +59,7 @@ use tokio::task::JoinHandle;
 use tokio::time::timeout;
 use tokio::time::Duration;
 use tokio_stream::StreamExt;
+use tracing::Instrument;
 
 /// Specifies how to source the genesis data for a rollup.
 #[derive(Derivative)]

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -10,7 +10,7 @@ use sov_full_node_configs::sequencer::SequencerKindConfig;
 use sov_mock_da::storable::rpc::start_server;
 use sov_mock_da::storable::rpc::MockDaClientConfig;
 use sov_mock_da::storable::StorableMockDaService;
-use sov_mock_da::{MockAddress, MockDaConfig};
+use sov_mock_da::{BlockProducingConfig, MockAddress, MockDaConfig};
 use sov_modules_api::execution_mode::Native;
 use sov_modules_api::CryptoSpec;
 use sov_modules_api::OperatingMode;
@@ -23,7 +23,7 @@ use sov_test_utils::test_rollup::read_private_key;
 use sov_test_utils::test_rollup::PostgresData;
 use sov_test_utils::test_rollup::RollupBuilder;
 use sov_test_utils::test_rollup::TestRollup;
-use sov_test_utils::TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING;
+use sov_test_utils::{TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS, TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::watch;
@@ -55,7 +55,9 @@ async fn create_da_service_manual() -> (StorableMockDaService, SocketAddr) {
 async fn create_da_service_periodic() -> (StorableMockDaService, watch::Sender<()>, SocketAddr) {
     let (shutdown_sender, shutdown_receiver) = tokio::sync::watch::channel(());
     let mut da_config = MockDaConfig::instant_with_sender(TEST_SEQ_DA_ADDRESS);
-    da_config.block_producing = TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING;
+    da_config.block_producing = BlockProducingConfig::Periodic {
+        block_time_ms: TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS * 2,
+    };
 
     let da_service = StorableMockDaService::from_config(da_config, shutdown_receiver).await;
 

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -23,7 +23,7 @@ use sov_test_utils::test_rollup::read_private_key;
 use sov_test_utils::test_rollup::PostgresData;
 use sov_test_utils::test_rollup::RollupBuilder;
 use sov_test_utils::test_rollup::TestRollup;
-use sov_test_utils::{TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS, TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING};
+use sov_test_utils::TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::watch;

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -6,10 +6,11 @@ use sov_api_spec::types;
 use sov_bank::config_gas_token_id;
 use sov_cli::wallet_state::PrivateKeyAndAddress;
 use sov_demo_rollup::ExternalMockDemoRollup;
+use sov_full_node_configs::sequencer::SequencerKindConfig;
 use sov_mock_da::storable::rpc::start_server;
 use sov_mock_da::storable::rpc::MockDaClientConfig;
 use sov_mock_da::storable::StorableMockDaService;
-use sov_mock_da::{MockAddress, MockDaConfig};
+use sov_mock_da::{BlockProducingConfig, MockAddress, MockDaConfig};
 use sov_modules_api::execution_mode::Native;
 use sov_modules_api::CryptoSpec;
 use sov_modules_api::OperatingMode;
@@ -22,6 +23,7 @@ use sov_test_utils::test_rollup::read_private_key;
 use sov_test_utils::test_rollup::PostgresData;
 use sov_test_utils::test_rollup::RollupBuilder;
 use sov_test_utils::test_rollup::TestRollup;
+use sov_test_utils::TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::watch;
@@ -53,7 +55,10 @@ async fn create_da_service_manual() -> (StorableMockDaService, SocketAddr) {
 async fn create_da_service_periodic() -> (StorableMockDaService, watch::Sender<()>, SocketAddr) {
     let (shutdown_sender, shutdown_receiver) = tokio::sync::watch::channel(());
     let mut da_config = MockDaConfig::instant_with_sender(TEST_SEQ_DA_ADDRESS);
-    da_config.block_producing = sov_test_utils::TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING;
+    da_config.block_producing = BlockProducingConfig::Periodic {
+        // Longer block times so both rollups have enough time to do all the processing
+        block_time_ms: TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS * 2,
+    };
 
     let da_service = StorableMockDaService::from_config(da_config, shutdown_receiver).await;
 
@@ -79,6 +84,12 @@ async fn start_rollup(
         postgres,
     )
     .await
+    .set_config(|c| match &mut c.sequencer_config {
+        SequencerKindConfig::Standard(_) => {}
+        SequencerKindConfig::Preferred(p) => {
+            p.num_cache_warmup_workers = 0;
+        }
+    })
     .start_test_rollup()
     .await
     .unwrap()

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -10,7 +10,7 @@ use sov_full_node_configs::sequencer::SequencerKindConfig;
 use sov_mock_da::storable::rpc::start_server;
 use sov_mock_da::storable::rpc::MockDaClientConfig;
 use sov_mock_da::storable::StorableMockDaService;
-use sov_mock_da::{BlockProducingConfig, MockAddress, MockDaConfig};
+use sov_mock_da::{MockAddress, MockDaConfig};
 use sov_modules_api::execution_mode::Native;
 use sov_modules_api::CryptoSpec;
 use sov_modules_api::OperatingMode;
@@ -23,7 +23,7 @@ use sov_test_utils::test_rollup::read_private_key;
 use sov_test_utils::test_rollup::PostgresData;
 use sov_test_utils::test_rollup::RollupBuilder;
 use sov_test_utils::test_rollup::TestRollup;
-use sov_test_utils::TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS;
+use sov_test_utils::TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::watch;
@@ -55,10 +55,7 @@ async fn create_da_service_manual() -> (StorableMockDaService, SocketAddr) {
 async fn create_da_service_periodic() -> (StorableMockDaService, watch::Sender<()>, SocketAddr) {
     let (shutdown_sender, shutdown_receiver) = tokio::sync::watch::channel(());
     let mut da_config = MockDaConfig::instant_with_sender(TEST_SEQ_DA_ADDRESS);
-    da_config.block_producing = BlockProducingConfig::Periodic {
-        // Longer block times so both rollups have enough time to do all the processing
-        block_time_ms: TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS * 2,
-    };
+    da_config.block_producing = TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING;
 
     let da_service = StorableMockDaService::from_config(da_config, shutdown_receiver).await;
 

--- a/examples/demo-rollup/tests/replica/start_stop.rs
+++ b/examples/demo-rollup/tests/replica/start_stop.rs
@@ -4,7 +4,7 @@ use tokio::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_replica_start_stop() {
-    sov_test_utils::logging::initialize_or_change_logging_with_filter("info,sov=debug");
+    sov_test_utils::logging::initialize_or_change_logging_with_filter("info");
     let postgres = PostgresData::create_postgres().await;
 
     let postgres = match postgres {
@@ -21,6 +21,7 @@ async fn test_replica_start_stop() {
 
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
 
+    // Why replica starts first?
     let replica = postgres.clone().map(|pg| (pg, "replica".into()));
     let replica_test_rollup = start_rollup(true, addr, replica).await;
 
@@ -77,6 +78,8 @@ async fn test_replica_start_stop() {
         test_rollup
     };
 
+    // TODO: Read logs from postgres here.
+
     {
         let mut event_subscription = replica_test_rollup
             .api_client()
@@ -106,8 +109,11 @@ async fn test_replica_start_stop() {
             .await
             .unwrap();
 
+        // ERROR IS HERE
         assert_eq!(receiver_balance.0, 2 * (nb_of_txs as u128) * AMOUNT);
     }
+
+    // TODO: Read logs from postgres here.
 
     // Restart replica
     let replica_test_rollup = {
@@ -119,6 +125,8 @@ async fn test_replica_start_stop() {
             .unwrap();
         replica_test_rollup
     };
+
+    // TODO: Read logs from postgres here.
 
     {
         let mut event_subscription = replica_test_rollup
@@ -152,6 +160,8 @@ async fn test_replica_start_stop() {
         assert_eq!(receiver_balance.0, 3 * (nb_of_txs as u128) * AMOUNT);
     }
 
+    // TODO: Read logs from postgres here.
+
     // Restart replica and wait
     let replica_test_rollup = {
         let builder = replica_test_rollup.shutdown().await.unwrap();
@@ -168,6 +178,8 @@ async fn test_replica_start_stop() {
             .unwrap();
         replica_test_rollup
     };
+
+    // TODO: Read logs from postgres here.
 
     {
         let mut event_subscription = replica_test_rollup
@@ -200,6 +212,8 @@ async fn test_replica_start_stop() {
 
         assert_eq!(receiver_balance.0, 4 * (nb_of_txs as u128) * AMOUNT);
     }
+
+    // TODO: Read logs from postgres here.
 
     let _ = replica_test_rollup.shutdown().await;
     let _ = test_rollup.shutdown().await;

--- a/examples/demo-rollup/tests/replica/start_stop.rs
+++ b/examples/demo-rollup/tests/replica/start_stop.rs
@@ -4,8 +4,7 @@ use tokio::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_replica_start_stop() {
-    sov_test_utils::logging::initialize_or_change_logging_with_filter("info");
-    tracing::info!("STARTING test_replica_start_stop");
+    sov_test_utils::logging::initialize_or_change_logging_with_filter("info,tower=off,sqlx=trace");
     let postgres = PostgresData::create_postgres().await;
 
     let postgres = match postgres {
@@ -72,7 +71,7 @@ async fn test_replica_start_stop() {
         assert_eq!(receiver_balance.0, (nb_of_txs as u128) * AMOUNT);
     }
 
-    tracing::info!("===== RESTART MASTER 1");
+    tracing::info!("=== IN TEST: RESTART MASTER 1");
     // Restart master.
     let test_rollup = {
         let builder = test_rollup.shutdown().await.unwrap();
@@ -83,10 +82,9 @@ async fn test_replica_start_stop() {
 
     if let Some(pg_data) = &postgres {
         sov_test_utils::docker::print_logs_from_container("postgres", &pg_data.postgres).await;
-    } else {
-        tracing::info!("NO LUCK");
     }
 
+    tracing::info!("=== IN TEST: WAIT FOR EVENTS 0");
     {
         let mut event_subscription = replica_test_rollup
             .api_client()
@@ -104,7 +102,7 @@ async fn test_replica_start_stop() {
         .await;
 
         wait_for_all_events_with_timeout(
-            Duration::from_millis(100),
+            Duration::from_millis(300),
             nb_of_txs,
             &mut event_subscription,
         )
@@ -120,11 +118,9 @@ async fn test_replica_start_stop() {
         assert_eq!(receiver_balance.0, 2 * (nb_of_txs as u128) * AMOUNT);
     }
 
-    tracing::info!("=== RESTART REPLICA");
+    tracing::info!("=== IN TEST: RESTART REPLICA");
     if let Some(pg_data) = &postgres {
         sov_test_utils::docker::print_logs_from_container("postgres", &pg_data.postgres).await;
-    } else {
-        tracing::info!("NO LUCK");
     }
 
     // Restart replica
@@ -138,11 +134,9 @@ async fn test_replica_start_stop() {
         replica_test_rollup
     };
 
-    tracing::info!("READING EVENTS");
+    tracing::info!("=== IN TEST: READING EVENTS 1");
     if let Some(pg_data) = &postgres {
         sov_test_utils::docker::print_logs_from_container("postgres", &pg_data.postgres).await;
-    } else {
-        tracing::info!("NO LUCK");
     }
 
     {
@@ -162,7 +156,7 @@ async fn test_replica_start_stop() {
         .await;
 
         wait_for_all_events_with_timeout(
-            Duration::from_millis(100),
+            Duration::from_millis(300),
             nb_of_txs,
             &mut event_subscription,
         )
@@ -177,11 +171,9 @@ async fn test_replica_start_stop() {
         assert_eq!(receiver_balance.0, 3 * (nb_of_txs as u128) * AMOUNT);
     }
 
-    tracing::info!("RESTART REPLICA AND WAIT");
+    tracing::info!("=== IN TEST: RESTART REPLICA AND WAIT");
     if let Some(pg_data) = &postgres {
         sov_test_utils::docker::print_logs_from_container("postgres", &pg_data.postgres).await;
-    } else {
-        tracing::info!("NO LUCK");
     }
 
     // Restart replica and wait
@@ -201,11 +193,9 @@ async fn test_replica_start_stop() {
         replica_test_rollup
     };
 
-    tracing::info!("READ EVENTS AGAIN");
+    tracing::info!("=== IN TEST: READ EVENTS AGAIN");
     if let Some(pg_data) = &postgres {
         sov_test_utils::docker::print_logs_from_container("postgres", &pg_data.postgres).await;
-    } else {
-        tracing::info!("NO LUCK");
     }
     {
         let mut event_subscription = replica_test_rollup
@@ -224,7 +214,7 @@ async fn test_replica_start_stop() {
         .await;
 
         wait_for_all_events_with_timeout(
-            Duration::from_millis(100),
+            Duration::from_millis(300),
             nb_of_txs,
             &mut event_subscription,
         )
@@ -239,11 +229,8 @@ async fn test_replica_start_stop() {
         assert_eq!(receiver_balance.0, 4 * (nb_of_txs as u128) * AMOUNT);
     }
 
-    tracing::info!("Completing stuff");
     if let Some(pg_data) = &postgres {
         sov_test_utils::docker::print_logs_from_container("postgres", &pg_data.postgres).await;
-    } else {
-        tracing::info!("NO LUCK");
     }
 
     let _ = replica_test_rollup.shutdown().await;

--- a/examples/demo-rollup/tests/replica/start_stop.rs
+++ b/examples/demo-rollup/tests/replica/start_stop.rs
@@ -4,7 +4,7 @@ use tokio::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_replica_start_stop() {
-    sov_test_utils::logging::initialize_or_change_logging_with_filter("info,tower=off,sqlx=trace");
+    sov_test_utils::logging::initialize_or_change_logging_with_filter("info,tower=off");
     let postgres = PostgresData::create_postgres().await;
 
     let postgres = match postgres {

--- a/examples/demo-rollup/tests/replica/start_stop.rs
+++ b/examples/demo-rollup/tests/replica/start_stop.rs
@@ -4,6 +4,7 @@ use tokio::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_replica_start_stop() {
+    sov_test_utils::logging::initialize_or_change_logging_with_filter("info,sov=debug");
     let postgres = PostgresData::create_postgres().await;
 
     let postgres = match postgres {

--- a/examples/demo-rollup/tests/replica/start_stop.rs
+++ b/examples/demo-rollup/tests/replica/start_stop.rs
@@ -5,6 +5,7 @@ use tokio::time::Duration;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_replica_start_stop() {
     sov_test_utils::logging::initialize_or_change_logging_with_filter("info");
+    tracing::info!("STARTING test_replica_start_stop");
     let postgres = PostgresData::create_postgres().await;
 
     let postgres = match postgres {
@@ -38,6 +39,7 @@ async fn test_replica_start_stop() {
 
     let nb_of_txs = 300;
 
+    tracing::info!("===== 1 BEGIN");
     {
         let mut event_subscription = replica_test_rollup
             .api_client()
@@ -70,6 +72,7 @@ async fn test_replica_start_stop() {
         assert_eq!(receiver_balance.0, (nb_of_txs as u128) * AMOUNT);
     }
 
+    tracing::info!("===== RESTART MASTER 1");
     // Restart master.
     let test_rollup = {
         let builder = test_rollup.shutdown().await.unwrap();
@@ -78,7 +81,11 @@ async fn test_replica_start_stop() {
         test_rollup
     };
 
-    // TODO: Read logs from postgres here.
+    if let Some(pg_data) = &postgres {
+        sov_test_utils::docker::print_logs_from_container("postgres", &pg_data.postgres).await;
+    } else {
+        tracing::info!("NO LUCK");
+    }
 
     {
         let mut event_subscription = replica_test_rollup
@@ -113,7 +120,12 @@ async fn test_replica_start_stop() {
         assert_eq!(receiver_balance.0, 2 * (nb_of_txs as u128) * AMOUNT);
     }
 
-    // TODO: Read logs from postgres here.
+    tracing::info!("=== RESTART REPLICA");
+    if let Some(pg_data) = &postgres {
+        sov_test_utils::docker::print_logs_from_container("postgres", &pg_data.postgres).await;
+    } else {
+        tracing::info!("NO LUCK");
+    }
 
     // Restart replica
     let replica_test_rollup = {
@@ -126,7 +138,12 @@ async fn test_replica_start_stop() {
         replica_test_rollup
     };
 
-    // TODO: Read logs from postgres here.
+    tracing::info!("READING EVENTS");
+    if let Some(pg_data) = &postgres {
+        sov_test_utils::docker::print_logs_from_container("postgres", &pg_data.postgres).await;
+    } else {
+        tracing::info!("NO LUCK");
+    }
 
     {
         let mut event_subscription = replica_test_rollup
@@ -160,7 +177,12 @@ async fn test_replica_start_stop() {
         assert_eq!(receiver_balance.0, 3 * (nb_of_txs as u128) * AMOUNT);
     }
 
-    // TODO: Read logs from postgres here.
+    tracing::info!("RESTART REPLICA AND WAIT");
+    if let Some(pg_data) = &postgres {
+        sov_test_utils::docker::print_logs_from_container("postgres", &pg_data.postgres).await;
+    } else {
+        tracing::info!("NO LUCK");
+    }
 
     // Restart replica and wait
     let replica_test_rollup = {
@@ -179,8 +201,12 @@ async fn test_replica_start_stop() {
         replica_test_rollup
     };
 
-    // TODO: Read logs from postgres here.
-
+    tracing::info!("READ EVENTS AGAIN");
+    if let Some(pg_data) = &postgres {
+        sov_test_utils::docker::print_logs_from_container("postgres", &pg_data.postgres).await;
+    } else {
+        tracing::info!("NO LUCK");
+    }
     {
         let mut event_subscription = replica_test_rollup
             .api_client()
@@ -213,7 +239,12 @@ async fn test_replica_start_stop() {
         assert_eq!(receiver_balance.0, 4 * (nb_of_txs as u128) * AMOUNT);
     }
 
-    // TODO: Read logs from postgres here.
+    tracing::info!("Completing stuff");
+    if let Some(pg_data) = &postgres {
+        sov_test_utils::docker::print_logs_from_container("postgres", &pg_data.postgres).await;
+    } else {
+        tracing::info!("NO LUCK");
+    }
 
     let _ = replica_test_rollup.shutdown().await;
     let _ = test_rollup.shutdown().await;


### PR DESCRIPTION
# Description

* Disable cache warm up workers
* Switch to testcontainers-module: more robust start and fsync disabled for better perf
* Move function for printing logs from the docker container into test-utils allowing printing logs from postgresql docker container
* Disable SSL on postgresql connection to reduce connection issue
* Run postgres container without mounted volume to reduce docker issues
* Increase timeout for waiting for event

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)



## Testing
The whole point

## Docs
No updates
