### PR TITLE
Latest block subscription with sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - #2077 **Breaking change**: The `Sequencer` implementations have been made cheaply cloneable, and the `accept_tx()` method has been made cancellation-safe. This has two effects:
   * *Breaking*: any API handler definitions that currently use `Arc<Seq: Sequencer>` need to be modified to use `Seq: Sequencer` directly instead. This is likely to affect rollup definitions, especially ones implementing `sequencer_additional_apis()`.
   * *Advisory*: any custom transaction APIs invoking `Sequencer::accept_tx()` in their handlers previously had to make the call inside a tokio task. This is no longer necessary, and handlers *should* remove any `tokio::spawn()` wrapping the `accept_tx()` call to avoid the unnecessary overhead and reduce tokio runtime contention.
-- #2079 Blocks & logs subscriptions now yield only as soon as the block is confirmed.
+- #2079 Blocks subscriptions now yield only as soon as the block is confirmed.
 - #2079 Added size field on the block header in RPC requests/subscriptions.
 - #2081 Switched jmt and utoipa dependencies to crates.io.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - #2077 **Breaking change**: The `Sequencer` implementations have been made cheaply cloneable, and the `accept_tx()` method has been made cancellation-safe. This has two effects:
   * *Breaking*: any API handler definitions that currently use `Arc<Seq: Sequencer>` need to be modified to use `Seq: Sequencer` directly instead. This is likely to affect rollup definitions, especially ones implementing `sequencer_additional_apis()`.
   * *Advisory*: any custom transaction APIs invoking `Sequencer::accept_tx()` in their handlers previously had to make the call inside a tokio task. This is no longer necessary, and handlers *should* remove any `tokio::spawn()` wrapping the `accept_tx()` call to avoid the unnecessary overhead and reduce tokio runtime contention.
+- #2079 Blocks & logs subscriptions now yield only as soon as the block is confirmed.
+- #2079 Added size field on the block header in RPC requests/subscriptions.
 
 # 2025-11-12
 - #2071 Optimize WebSocket message delivery by batching writes. Messages are now grouped (up to 128 at a time) and flushed together, reducing system calls and improving throughput for WebSocket subscriptions.

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -1,8 +1,6 @@
 use super::watermark::Watermark;
 use crate::Ethereum;
-use alloy_consensus::Sealed;
 use alloy_rpc_types::Filter;
-use alloy_rpc_types::Header;
 use jsonrpsee::DisconnectError;
 use jsonrpsee::SubscriptionMessage;
 use jsonrpsee::SubscriptionSink;
@@ -15,6 +13,7 @@ use sov_evm::Receipt;
 use sov_modules_api::capabilities::HasKernel;
 use sov_modules_api::ApiStateAccessor;
 use sov_modules_api::Spec;
+use sov_rpc_eth_types::EthApiError;
 use sov_sequencer::Sequencer;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -26,6 +25,8 @@ pub enum Error {
     BlockDoesNotExist,
     #[error("Receipt does not exist")]
     ReceiptDoesNotExist,
+    #[error(transparent)]
+    EthApi(#[from] EthApiError),
     #[error(transparent)]
     Disconnect(#[from] DisconnectError),
 }
@@ -100,8 +101,8 @@ where
     /// Stream new block headers to the subscriber.
     pub async fn blocks(&self) -> Result<(), Error> {
         let mut state = self.ethereum.api_state_accessor();
-        let pending_block = self.evm.pending_block(&mut state);
-        let mut block_watermark = Watermark::new(..pending_block.header.number + 1);
+        let latest_block = self.evm.latest_block(&mut state);
+        let mut block_watermark = Watermark::new(..latest_block.header.number + 1);
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
         let mut shutdown_receiver = self.ethereum.shutdown_receiver.clone();
@@ -115,11 +116,12 @@ where
                     }
 
                     let mut state = self.ethereum.api_state_accessor();
-                    let pending_block = self.evm.pending_block(&mut state);
+                    let latest_block = self.evm.latest_block(&mut state);
 
-                    for block_number in block_watermark.advance(..pending_block.header.number + 1) {
+                    for block_number in block_watermark.advance(..latest_block.header.number + 1) {
                         let block = self.get_block(block_number, &mut state)?;
-                        self.send_block_header(&block).await?;
+                        let rpc_header = self.evm.get_rpc_header(block, &mut state)?;
+                        self.send(&rpc_header).await?;
                     }
                 }
                 _ = shutdown_receiver.changed() => {
@@ -181,13 +183,6 @@ where
             }
         }
         Ok(())
-    }
-
-    async fn send_block_header(&self, block: &MaybeSealedBlock) -> Result<(), DisconnectError> {
-        let hash = block.hash().unwrap_or_default();
-        let header = Sealed::new_unchecked(block.header().clone(), hash);
-        let rpc_header = Header::from_consensus(header, None, None);
-        self.send(&rpc_header).await
     }
 
     async fn send<T: Serialize + Debug>(&self, data: &T) -> Result<(), DisconnectError> {

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -27,7 +27,7 @@ use crate::evm::primitive_types::{Receipt, TransactionSigned, TxSignedAndRecover
 use crate::executor::get_cfg_env;
 use crate::helpers::{from_recovered_with_block_context, prepare_call_env};
 pub use crate::primitive_types::MaybeSealedBlock;
-use crate::{verify_contract_creation_allowlist, Evm};
+use crate::{verify_contract_creation_allowlist, Evm, SealedBlock};
 use maybe_archival_state::MaybeArchivalState;
 
 pub(crate) mod error;
@@ -114,6 +114,20 @@ where
         Ok(body)
     }
 
+    /// Gets RPC Block Header including the size
+    pub fn get_rpc_header(
+        &self,
+        block: MaybeSealedBlock,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Result<Header, EthApiError> {
+        let block_size = alloy_consensus::Block::rlp_length_for(
+            block.header(),
+            &self.get_block_body(&block, state)?,
+        );
+        let header = Header::from_consensus(block.into(), None, Some(U256::from(block_size)));
+        Ok(header)
+    }
+
     fn get_block(
         &self,
         block_number: Option<String>,
@@ -124,12 +138,8 @@ where
             return Ok(None);
         };
         let transactions = self.get_block_transactions(&block, kind, state)?;
-        let block_size = alloy_consensus::Block::rlp_length_for(
-            block.header(),
-            &self.get_block_body(&block, state)?,
-        );
         Ok(Some(Block {
-            header: Header::from_consensus(block.into(), None, Some(U256::from(block_size))),
+            header: self.get_rpc_header(block, state)?,
             transactions,
             uncles: vec![],
             withdrawals: None,
@@ -288,6 +298,15 @@ where
                 Some(MaybeSealedBlock::Pending(pending_block))
             }
         })
+    }
+
+    /// Retrieves the latest block.
+    pub fn latest_block(&self, state: &mut ApiStateAccessor<S>) -> SealedBlock {
+        let block_numbers = self.block_numbers(state);
+        self.blocks
+            .get(block_numbers.end(), state)
+            .unwrap_infallible()
+            .expect("Block should exist as index is inside block_numbers")
     }
 
     /// Retrieves the pending block.

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -10,6 +10,7 @@ use alloy_rpc_types::{
     TransactionReceipt, TransactionRequest,
 };
 use alloy_rpc_types::{BlockTransactionsKind, Header};
+use reth_primitives::BlockBody;
 use revm::context::result::ResultAndState;
 use revm::context::{BlockEnv, CfgEnv};
 use sov_address::{EthereumAddress, FromVmAddress};
@@ -95,6 +96,24 @@ where
         Ok(txs)
     }
 
+    fn get_block_body(
+        &self,
+        block: &MaybeSealedBlock,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Result<BlockBody, EthApiError> {
+        let tx_range = block.tx_range();
+        let transactions = tx_range
+            .into_iter()
+            .map(|idx| Ok::<_, EthApiError>(self.tx(idx, state)?.signed_transaction))
+            .collect::<Result<_, _>>()?;
+        let body = BlockBody {
+            transactions,
+            ommers: vec![],
+            withdrawals: None,
+        };
+        Ok(body)
+    }
+
     fn get_block(
         &self,
         block_number: Option<String>,
@@ -105,8 +124,12 @@ where
             return Ok(None);
         };
         let transactions = self.get_block_transactions(&block, kind, state)?;
+        let block_size = alloy_consensus::Block::rlp_length_for(
+            block.header(),
+            &self.get_block_body(&block, state)?,
+        );
         Ok(Some(Block {
-            header: Header::from_sealed(block.into()),
+            header: Header::from_consensus(block.into(), None, Some(U256::from(block_size))),
             transactions,
             uncles: vec![],
             withdrawals: None,

--- a/examples/demo-rollup/tests/evm/evm_rpc.rs
+++ b/examples/demo-rollup/tests/evm/evm_rpc.rs
@@ -111,3 +111,15 @@ async fn eth_get_block_receipts() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn block_size() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    let client = alloy_client(rollup.http_addr);
+    rollup.pause_preferred_batches().await;
+
+    let header = by_number(&client, Latest).await?.unwrap();
+    assert_eq!(header.size.unwrap().to::<u64>(), 503);
+
+    Ok(())
+}

--- a/examples/demo-rollup/tests/evm/evm_ws_watch.rs
+++ b/examples/demo-rollup/tests/evm/evm_ws_watch.rs
@@ -18,7 +18,6 @@ async fn ws_watch_returns_receipt() -> anyhow::Result<()> {
     let client = alloy_ws_client(rollup.http_addr).await;
 
     let tx = TransactionRequest::default().with_to(Address::ZERO);
-
     let pending = client.send_transaction(tx).await?;
 
     // This should complete very quickly (not hang)
@@ -59,6 +58,20 @@ async fn ws_subscribe_new_heads() -> anyhow::Result<()> {
     assert_eq!(headers.len(), 3);
     assert_eq!(headers[1].number, headers[0].number + 1);
     assert_eq!(headers[2].number, headers[1].number + 1);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ws_subscribe_new_heads_sizes() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    let client = alloy_ws_client(rollup.http_addr).await;
+    let mut subscription = client.subscribe_blocks().await?;
+    rollup.wait_for_next_blocks(1).await;
+
+    let header = subscription.recv().await?;
+    assert_eq!(header.number, 1);
+    assert_eq!(header.size.unwrap().to::<u64>(), 513);
 
     Ok(())
 }


### PR DESCRIPTION
# Description

All RPC block methods including subscriptions now return the optional size field which is the RLP size of the block encoded.
Subscriptions now return latest blocks instead of pending:
* As for GTE request
* Pending blocks have incomplete sizes
----

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
