### PR TITLE
Add tokio runtime metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12112,6 +12112,7 @@ dependencies = [
  "sp1-lib",
  "strum 0.26.3",
  "tokio",
+ "tokio-metrics",
  "toml 0.8.23",
  "tracing",
 ]
@@ -14483,6 +14484,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01bbf7db0b3f5eee8930a119fe99bfa1438de1095fe3d26b25e652a5933ef3f"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,6 +285,7 @@ risc0-zkvm = { version = "2.1", default-features = false }
 risc0-zkvm-platform = "2.0"
 risc0-build = "2.1"
 flume = { version = "0.11.1", features = ["async"] }
+tokio-metrics = { version = "0.4.0" }
 
 # EVM dependencies
 ethereum-types = { version = "0.14.1", default-features = false }
@@ -331,6 +332,7 @@ inherits = "dev"
 debug = false
 strip = true
 codegen-units = 256
+
 
 [profile.dev.package.sov-modules-macros]
 # Set the optimization level to 3 for the sov-modules-macros crate. This

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/full-node/full-node-configs/src/runner.rs
+assertion_line: 226
 expression: config
 ---
 {
@@ -69,6 +70,7 @@ expression: config
   "monitoring": {
     "telegraf_address": "udp://192.168.4.5:8543",
     "max_datagram_size": 1024,
-    "max_pending_metrics": 2560
+    "max_pending_metrics": 2560,
+    "tokio_runtime_metrics_interval_millis": 500
   }
 }

--- a/crates/full-node/sov-metrics/Cargo.toml
+++ b/crates/full-node/sov-metrics/Cargo.toml
@@ -24,6 +24,7 @@ derivative = { workspace = true, optional = true }
 sov-rollup-interface = { workspace = true }
 derive_more = { workspace = true, features = ["deref_mut", "deref"], optional = true }
 derive-new = { workspace = true }
+tokio-metrics = { workspace = true, optional = true }
 
 anyhow = { workspace = true }
 risc0-zkvm = { workspace = true, default-features = false, features = [
@@ -61,7 +62,7 @@ native = [
     "dep:derivative",
     "dep:schemars",
     "dep:derive_more",
-    "dep:derivative",
+    "dep:tokio-metrics",
     "sov-rollup-interface/native",
     "sov-metrics/native"
 ]

--- a/crates/full-node/sov-metrics/src/influxdb/config.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/config.rs
@@ -120,6 +120,13 @@ pub struct MonitoringConfig {
     /// This is a number of metrics, not serialized bytes.
     /// The total number of bytes to be held in memory might vary per metric + `max_datagram_size`
     pub max_pending_metrics: Option<u32>,
+    /// How often to collect tokio runtime metrics. Defaults to 500ms.
+    #[serde(default = "default_tokio_runtime_metrics_interval_millis")]
+    pub tokio_runtime_metrics_interval_millis: u64,
+}
+
+const fn default_tokio_runtime_metrics_interval_millis() -> u64 {
+    500
 }
 
 impl MonitoringConfig {
@@ -136,6 +143,7 @@ impl MonitoringConfig {
             )),
             max_datagram_size: None,
             max_pending_metrics: None,
+            tokio_runtime_metrics_interval_millis: default_tokio_runtime_metrics_interval_millis(),
         }
     }
 

--- a/crates/full-node/sov-metrics/src/influxdb/mod.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/mod.rs
@@ -14,10 +14,10 @@ pub use config::{MonitoringConfig, TelegrafSocketConfig};
 #[cfg(feature = "gas-constant-estimation")]
 pub use gas_constant_estimation::{GasConstantTracker, GAS_CONSTANTS};
 pub use tracker::{
-    init_metrics_tracker, timestamp, BatchMetrics, BatchOutcome, HttpMetrics, RpcMetrics,
-    RunnerMetrics, RunnerProcessStfChangesMetrics, SlotProcessingMetrics, TransactionEffect,
-    TransactionProcessingMetrics, UserSpaceSlotProcessingMetrics, ZkCircuit, ZkProvingTime,
-    ZkVmExecutionChunk,
+    init_metrics_tracker, spawn_tokio_runtime_metrics_task, timestamp, BatchMetrics, BatchOutcome,
+    HttpMetrics, RpcMetrics, RunnerMetrics, RunnerProcessStfChangesMetrics, SlotProcessingMetrics,
+    TransactionEffect, TransactionProcessingMetrics, UserSpaceSlotProcessingMetrics, ZkCircuit,
+    ZkProvingTime, ZkVmExecutionChunk,
 };
 
 pub(crate) type SerializableMetric = Box<dyn Metric>;
@@ -122,6 +122,7 @@ mod tests {
             // Setting low, so each metric is published immediately
             max_datagram_size: Some(1),
             max_pending_metrics: None,
+            tokio_runtime_metrics_interval_millis: 500,
         };
 
         let (metrics_back_sender, mut metrics_back_receiver) = tokio::sync::mpsc::channel(100);
@@ -217,6 +218,7 @@ mod tests {
             // Setting low, so each metric is published immediately
             max_datagram_size: Some(1),
             max_pending_metrics: None,
+            tokio_runtime_metrics_interval_millis: 500,
         };
 
         let (metrics_back_sender, mut metrics_back_receiver) = tokio::sync::mpsc::channel(100);

--- a/crates/full-node/sov-metrics/src/influxdb/publisher.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/publisher.rs
@@ -289,6 +289,7 @@ mod tests {
             max_datagram_size: Some(max_udp_size as u32),
             // Does not matter, we set our own channel size.
             max_pending_metrics: None,
+            tokio_runtime_metrics_interval_millis: 500,
         };
 
         let (sender, receiver) = tokio::sync::mpsc::channel(10);
@@ -380,6 +381,7 @@ mod tests {
             telegraf_address: TelegrafSocketConfig::udp(socket.local_addr()?),
             max_datagram_size: Some(1),
             max_pending_metrics: None,
+            tokio_runtime_metrics_interval_millis: 500,
         };
 
         let (_shutdown_sender, mut shutdown_receiver) = watch::channel(());

--- a/crates/full-node/sov-metrics/src/influxdb/snapshots/sov_metrics__influxdb__config__tests__only_tcp.snap
+++ b/crates/full-node/sov-metrics/src/influxdb/snapshots/sov_metrics__influxdb__config__tests__only_tcp.snap
@@ -1,9 +1,11 @@
 ---
 source: crates/full-node/sov-metrics/src/influxdb/config.rs
+assertion_line: 197
 expression: config
 ---
 {
   "telegraf_address": "tcp://127.0.0.1:8094",
   "max_datagram_size": null,
-  "max_pending_metrics": null
+  "max_pending_metrics": null,
+  "tokio_runtime_metrics_interval_millis": 500
 }

--- a/crates/full-node/sov-metrics/src/influxdb/snapshots/sov_metrics__influxdb__config__tests__only_udp.snap
+++ b/crates/full-node/sov-metrics/src/influxdb/snapshots/sov_metrics__influxdb__config__tests__only_udp.snap
@@ -1,9 +1,11 @@
 ---
 source: crates/full-node/sov-metrics/src/influxdb/config.rs
+assertion_line: 177
 expression: config
 ---
 {
   "telegraf_address": "udp://127.0.0.1:8094",
   "max_datagram_size": null,
-  "max_pending_metrics": null
+  "max_pending_metrics": null,
+  "tokio_runtime_metrics_interval_millis": 500
 }

--- a/crates/full-node/sov-metrics/src/influxdb/snapshots/sov_metrics__influxdb__config__tests__udp_when_not_specified.snap
+++ b/crates/full-node/sov-metrics/src/influxdb/snapshots/sov_metrics__influxdb__config__tests__udp_when_not_specified.snap
@@ -1,9 +1,11 @@
 ---
 source: crates/full-node/sov-metrics/src/influxdb/config.rs
+assertion_line: 207
 expression: config
 ---
 {
   "telegraf_address": "udp://127.0.0.1:8094",
   "max_datagram_size": null,
-  "max_pending_metrics": null
+  "max_pending_metrics": null,
+  "tokio_runtime_metrics_interval_millis": 500
 }

--- a/crates/full-node/sov-metrics/src/influxdb/snapshots/sov_metrics__influxdb__config__tests__udp_with_other_params.snap
+++ b/crates/full-node/sov-metrics/src/influxdb/snapshots/sov_metrics__influxdb__config__tests__udp_with_other_params.snap
@@ -1,9 +1,11 @@
 ---
 source: crates/full-node/sov-metrics/src/influxdb/config.rs
+assertion_line: 188
 expression: config
 ---
 {
   "telegraf_address": "udp://127.0.0.1:8094",
   "max_datagram_size": 508,
-  "max_pending_metrics": 100
+  "max_pending_metrics": 100,
+  "tokio_runtime_metrics_interval_millis": 500
 }

--- a/crates/full-node/sov-metrics/src/influxdb/tracker.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/tracker.rs
@@ -725,3 +725,70 @@ impl Metric for DroppedMetrics {
         )
     }
 }
+
+// See https://docs.rs/tokio-metrics/latest/tokio_metrics/struct.RuntimeMetrics.html for an up to date list of available fields and their descriptions.
+impl Metric for tokio_metrics::RuntimeMetrics {
+    fn measurement_name(&self) -> &'static str {
+        "sov_rollup_tokio_runtime"
+    }
+
+    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        let workers_count = self.workers_count;
+        let total_park_count = self.total_park_count;
+        let total_busy_duration = self.total_busy_duration.as_micros();
+        let global_queue_depth = self.global_queue_depth;
+
+        write!(buffer, "{} workers_count={workers_count},total_park_count={total_park_count},total_busy_duration_us={total_busy_duration},global_queue_depth={global_queue_depth}", self.measurement_name())?;
+
+        #[cfg(tokio_unstable)]
+        {
+            let mean_poll_duration_us = self.mean_poll_duration.as_micros();
+            let mean_poll_duration_worker_max_us = self.mean_poll_duration_worker_max.as_micros();
+            let mean_poll_duration_worker_min_us = self.mean_poll_duration_worker_min.as_micros();
+            let total_noop_count = self.total_noop_count;
+            let max_noop_count = self.max_noop_count;
+            let num_remote_schedules = self.num_remote_schedules;
+            let total_local_schedule_count = self.total_local_schedule_count;
+            let max_local_schedule_count = self.max_local_schedule_count;
+            let total_polls_count = self.total_polls_count;
+            let min_polls_count = self.min_polls_count;
+            let max_polls_count = self.max_polls_count;
+            let total_local_queue_depth = self.total_local_queue_depth;
+            let max_local_queue_depth = self.max_local_queue_depth;
+            let blocking_queue_depth = self.blocking_queue_depth;
+            let blocking_threads_count = self.blocking_threads_count;
+            let idle_blocking_threads_count = self.idle_blocking_threads_count;
+            let live_tasks_count = self.live_tasks_count;
+            let budget_forced_yield_count = self.budget_forced_yield_count;
+            let io_driver_ready_count = self.io_driver_ready_count;
+            write!(buffer, ",mean_poll_duration_us={mean_poll_duration_us},mean_poll_duration_worker_max_us={mean_poll_duration_worker_max_us},mean_poll_duration_worker_min_us={mean_poll_duration_worker_min_us},total_noop_count={total_noop_count},max_noop_count={max_noop_count},num_remote_schedules={num_remote_schedules},total_local_schedule_count={total_local_schedule_count},max_local_schedule_count={max_local_schedule_count},total_polls_count={total_polls_count},min_polls_count={min_polls_count},max_polls_count={max_polls_count},total_local_queue_depth={total_local_queue_depth},max_local_queue_depth={max_local_queue_depth},blocking_queue_depth={blocking_queue_depth},blocking_threads_count={blocking_threads_count},idle_blocking_threads_count={idle_blocking_threads_count},live_tasks_count={live_tasks_count},budget_forced_yield_count={budget_forced_yield_count},io_driver_ready_count={io_driver_ready_count}")?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Spawns a task to monitor tokio runtime metrics and submit them to the metrics tracker.
+pub fn spawn_tokio_runtime_metrics_task(
+    metrics_interval: std::time::Duration,
+    mut shutdown_receiver: tokio::sync::watch::Receiver<()>,
+) -> tokio::task::JoinHandle<()> {
+    let handle = tokio::runtime::Handle::current();
+    // construct the runtime metrics monitor
+    let runtime_monitor = tokio_metrics::RuntimeMonitor::new(&handle);
+
+    // print runtime metrics every 500ms
+    tokio::spawn(async move {
+        for interval in runtime_monitor.intervals() {
+            crate::track_metrics(|tracker| {
+                tracker.submit(interval);
+            });
+            tokio::select! {
+                _ = tokio::time::sleep(metrics_interval) => {},
+                _ = shutdown_receiver.changed() => {
+                    break;
+                }
+            }
+        }
+    })
+}

--- a/crates/full-node/sov-metrics/src/influxdb/tracker.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/tracker.rs
@@ -774,10 +774,9 @@ pub fn spawn_tokio_runtime_metrics_task(
     mut shutdown_receiver: tokio::sync::watch::Receiver<()>,
 ) -> tokio::task::JoinHandle<()> {
     let handle = tokio::runtime::Handle::current();
-    // construct the runtime metrics monitor
     let runtime_monitor = tokio_metrics::RuntimeMonitor::new(&handle);
 
-    // print runtime metrics every 500ms
+    // print runtime metrics every metrics_interval
     tokio::spawn(async move {
         for interval in runtime_monitor.intervals() {
             crate::track_metrics(|tracker| {

--- a/crates/full-node/sov-metrics/src/lib.rs
+++ b/crates/full-node/sov-metrics/src/lib.rs
@@ -14,11 +14,11 @@ pub use influx_db_nonnative::{
 
 #[cfg(feature = "native")]
 pub use influxdb::{
-    init_metrics_tracker, safe_telegraf_string, timestamp, track_metrics, BatchMetrics,
-    BatchOutcome, HttpMetrics, Metric, MetricsTracker, MonitoringConfig, RpcMetrics, RunnerMetrics,
-    RunnerProcessStfChangesMetrics, SlotProcessingMetrics, TelegrafSocketConfig, TransactionEffect,
-    TransactionProcessingMetrics, UserSpaceSlotProcessingMetrics, ZkCircuit, ZkProvingTime,
-    ZkVmExecutionChunk,
+    init_metrics_tracker, safe_telegraf_string, spawn_tokio_runtime_metrics_task, timestamp,
+    track_metrics, BatchMetrics, BatchOutcome, HttpMetrics, Metric, MetricsTracker,
+    MonitoringConfig, RpcMetrics, RunnerMetrics, RunnerProcessStfChangesMetrics,
+    SlotProcessingMetrics, TelegrafSocketConfig, TransactionEffect, TransactionProcessingMetrics,
+    UserSpaceSlotProcessingMetrics, ZkCircuit, ZkProvingTime, ZkVmExecutionChunk,
 };
 #[cfg(all(feature = "native", feature = "gas-constant-estimation"))]
 pub use influxdb::{GasConstantTracker, GAS_CONSTANTS};

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -301,6 +301,13 @@
               "$ref": "#/definitions/TelegrafSocketConfig"
             }
           ]
+        },
+        "tokio_runtime_metrics_interval_millis": {
+          "description": "How often to collect tokio runtime metrics. Defaults to 500ms.",
+          "default": 500,
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         }
       }
     },

--- a/crates/module-system/sov-modules-macros/tests/integration/metrics.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/metrics.rs
@@ -46,6 +46,7 @@ async fn test_metrics_macro() {
             telegraf_address: TelegrafSocketConfig::udp(channel.local_addr().unwrap()),
             max_datagram_size: Some(1),
             max_pending_metrics: None,
+            tokio_runtime_metrics_interval_millis: 500,
         },
         shutdown_receiver,
     );
@@ -108,6 +109,7 @@ async fn test_metrics_macro_without_input() {
             telegraf_address: TelegrafSocketConfig::udp(channel.local_addr().unwrap()),
             max_datagram_size: Some(1),
             max_pending_metrics: None,
+            tokio_runtime_metrics_interval_millis: 500,
         },
         shutdown_receiver,
     );

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -303,9 +303,15 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         let receiver_for_metrics = secondary_shutdown_receiver.clone();
         let monitoring_config = rollup_config.monitoring.clone();
         if let Some(metrics_handle) =
-            sov_metrics::init_metrics_tracker(&monitoring_config, receiver_for_metrics)
+            sov_metrics::init_metrics_tracker(&monitoring_config, receiver_for_metrics.clone())
         {
             background_handles.push(metrics_handle);
+            background_handles.push(sov_metrics::spawn_tokio_runtime_metrics_task(
+                std::time::Duration::from_millis(
+                    monitoring_config.tokio_runtime_metrics_interval_millis,
+                ),
+                receiver_for_metrics,
+            ));
         } else {
             tracing::warn!("Metics have been initialized outside of the rollup blueprint, some measurements can be lost on shutdown");
         };

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -354,6 +354,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                 telegraf_address: self.config.telegraf_address,
                 max_datagram_size: None,
                 max_pending_metrics: None,
+                tokio_runtime_metrics_interval_millis: 500,
             },
         }
     }

--- a/examples/demo-rollup/configs/mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/mock_rollup_config.toml
@@ -64,6 +64,7 @@ bind_port = 12346
 
 [monitoring]
 telegraf_address = "udp://127.0.0.1:8094"
+tokio_runtime_metrics_interval_millis = 500
 # Defines how many measurements a rollup node will accumulate before sending it to the Telegraf.
 # It is expected from the rollup node to produce metrics all the time,
 # so measurements are buffered by size and not sent by time.


### PR DESCRIPTION
# Description

This PR adds metrics on the tokio runtime, including all of the available fields that I though were likely to be relevant and excluding the rest. 

Example graph included below: 
<img width="1136" height="278" alt="Screenshot 2025-11-14 at 4 21 04 PM" src="https://github.com/user-attachments/assets/d86e0478-08d5-4abe-8125-d4b412ea4fe1" />

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

