### PR TITLE
Alleviate API state contention by wrapping in an Arc

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -205,9 +205,8 @@ where
             "Attempting to use preferred sequencer with an incompatible rollup. Set your sequencer config to `standard` in your rollup's config.toml file or change your kernel to be compatible with soft confirmations."
         );
 
-        let (checkpoint_sender, checkpoint_receiver) = watch::channel(StateCheckpoint::new(
-            latest_state_update.storage.clone(),
-            &runtime.kernel(),
+        let (checkpoint_sender, checkpoint_receiver) = watch::channel(Arc::new(
+            StateCheckpoint::new(latest_state_update.storage.clone(), &runtime.kernel()),
         ));
         let api_state = ApiState::build(
             Arc::new(()),

--- a/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
@@ -1,7 +1,8 @@
 use std::collections::VecDeque;
 
-use sov_modules_api::{Runtime, Spec, StateCheckpoint, TxChangeSet};
+use sov_modules_api::{Runtime, Spec, StateCheckpoint};
 use sov_rollup_interface::node::da::DaService;
+use std::sync::Arc;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 use tracing::{error, warn};
@@ -23,7 +24,7 @@ where
     Rt: Runtime<S>,
     Da: DaService<Spec = S::Da>,
 {
-    pub checkpoint_sender: watch::Sender<StateCheckpoint<S>>,
+    pub checkpoint_sender: watch::Sender<std::sync::Arc<StateCheckpoint<S>>>,
     pub blob_sender: PreferredBlobSender<Da>,
     pub db: PreferredSequencerDb,
     pub executor_events_receiver: mpsc::Receiver<ExecutorEvent<S, Rt>>,
@@ -40,17 +41,9 @@ where
     /// Syncs [`ApiState`]s with the latest [`StateCheckpoint`].
     #[tracing::instrument(skip_all, level = "trace")]
     fn update_api_state(&self, checkpoint: StateCheckpoint<S>) {
-        if self.checkpoint_sender.send(checkpoint).is_err() {
+        if self.checkpoint_sender.send(Arc::new(checkpoint)).is_err() {
             tracing::debug!("Could not send checkpoint because the receiver has been dropped; this probably means the rollup is shutting down");
         }
-    }
-
-    /// Applies the changes to the current [`StateCheckpoint`].
-    #[tracing::instrument(skip_all, level = "trace")]
-    fn update_api_state_with_changes(&self, changes: TxChangeSet) {
-        self.checkpoint_sender.send_modify(|checkpoint| {
-            checkpoint.apply_tx_changes(changes);
-        });
     }
 
     #[tracing::instrument(skip_all, level = "trace")]
@@ -135,13 +128,24 @@ where
                     )
                     .await?;
 
+                let mut new_checkpoint: StateCheckpoint<_> = (*(*self.checkpoint_sender.borrow()))
+                    .clone_with_empty_witness_dropping_temp_cache();
+                let mut oneshot_and_txs = Vec::with_capacity(txs_to_insert.len());
                 for contents in txs_to_insert {
                     self.transaction_cache
                         .insert(contents.accepted_tx.clone())
                         .await;
                     // If the receiver is no longer listening, just don't send the confirmation.
-                    self.update_api_state_with_changes(contents.tx_changes);
-                    let _ = contents.oneshot_sender.send(contents.accepted_tx);
+                    // Apply all updates in a single batch
+                    new_checkpoint.apply_tx_changes(contents.tx_changes);
+                    oneshot_and_txs.push((contents.oneshot_sender, contents.accepted_tx));
+                }
+                // Send the checkpoint once whole batch is applied to prevent lock contention
+                self.checkpoint_sender
+                    .send_replace(Arc::new(new_checkpoint));
+                // Send tx confirmations after API state is updated
+                for (oneshot, tx) in oneshot_and_txs {
+                    let _ = oneshot.send(tx);
                 }
             }
             ExecutorEvent::CloseBatch(batch, checkpoint) => {
@@ -285,7 +289,9 @@ fn drain_consecutive_accepted_txs<S: Spec, Rt: Runtime<S>>(
 
 #[cfg(test)]
 mod tests {
-    use sov_modules_api::{ApiTxEffect, FullyBakedTx, Gas, SuccessfulTxContents, TxHash};
+    use sov_modules_api::{
+        ApiTxEffect, FullyBakedTx, Gas, SuccessfulTxContents, TxChangeSet, TxHash,
+    };
     use sov_test_utils::{generate_optimistic_runtime, TestSpec as S};
     use tokio::sync::oneshot;
 

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -89,7 +89,7 @@ where
     runtime: Rt,
     txsm: TxStatusManager<S::Da>,
     inner: Mutex<Inner<S, Rt, Da>>,
-    checkpoint_sender: watch::Sender<StateCheckpoint<S>>,
+    checkpoint_sender: watch::Sender<Arc<StateCheckpoint<S>>>,
     api_state: ApiState<S>,
     da_address: <S::Da as DaSpec>::Address,
     config: SequencerConfig<S::Address, StdSequencerConfig>,
@@ -133,8 +133,10 @@ where
         let kernel_with_slot_mapping = runtime.kernel_with_slot_mapping();
 
         let latest_state_update = state_update_receiver.borrow().clone();
-        let checkpoint =
-            StateCheckpoint::new(latest_state_update.storage.clone(), &runtime.kernel());
+        let checkpoint = Arc::new(StateCheckpoint::new(
+            latest_state_update.storage.clone(),
+            &runtime.kernel(),
+        ));
         let (checkpoint_sender, checkpoint_receiver) = watch::channel(checkpoint);
 
         let api_state = ApiState::build(
@@ -674,7 +676,9 @@ where
         {
             let mut inner = self.inner.lock().await;
             self.checkpoint_sender
-                .send(checkpoint.clone_with_empty_witness_dropping_temp_cache())
+                .send(Arc::new(
+                    checkpoint.clone_with_empty_witness_dropping_temp_cache(),
+                ))
                 .ok();
             inner.checkpoint = Some(checkpoint);
         }

--- a/crates/full-node/sov-sequencer/src/test_stateless.rs
+++ b/crates/full-node/sov-sequencer/src/test_stateless.rs
@@ -44,7 +44,7 @@ pub struct TestStatelessSequencer<R, S: Spec, Da: DaService> {
     blob_sender: Arc<Mutex<BlobSender<Da, TxStatusBlobSenderHooks<Da::Spec>, LedgerDb>>>,
     tx_status_manager: TxStatusManager<S::Da>,
     _r: PhantomData<R>,
-    state_sender: watch::Sender<StateCheckpoint<S>>,
+    state_sender: watch::Sender<Arc<StateCheckpoint<S>>>,
     api_ledger_db: LedgerDb,
 }
 
@@ -71,7 +71,8 @@ where
             storage: storage.clone(),
             mempool: vec![],
         });
-        let (state_sender, _rec) = watch::channel(StateCheckpoint::new(storage, &runtime.kernel()));
+        let (state_sender, _rec) =
+            watch::channel(Arc::new(StateCheckpoint::new(storage, &runtime.kernel())));
         let tx_status_manager = TxStatusManager::default();
 
         let nb_of_concurrent_blob_submissions = Arc::new(AtomicUsize::new(0));

--- a/crates/module-system/sov-modules-api/src/rest/mod.rs
+++ b/crates/module-system/sov-modules-api/src/rest/mod.rs
@@ -177,7 +177,7 @@ impl<T: ModuleInfo + Default> HasCustomRestApi for &T {
 pub struct ApiState<S: Spec, T = ()> {
     #[deref]
     inner: Arc<T>,
-    checkpoint_receiver: watch::Receiver<StateCheckpoint<S>>,
+    checkpoint_receiver: watch::Receiver<Arc<StateCheckpoint<S>>>,
     kernel: Arc<dyn KernelWithSlotMapping<S>>,
     /// The `height` query parameter extracted from the request, when applicable.
     requested_height: Option<HeightParam>,
@@ -188,7 +188,7 @@ impl<S: Spec, T> ApiState<S, T> {
     /// [`StateCheckpoint`]s.
     pub fn build(
         inner: Arc<T>,
-        checkpoint_receiver: watch::Receiver<StateCheckpoint<S>>,
+        checkpoint_receiver: watch::Receiver<Arc<StateCheckpoint<S>>>,
         kernel: Arc<dyn KernelWithSlotMapping<S>>,
         requested_height: Option<HeightParam>,
     ) -> Self {
@@ -233,7 +233,8 @@ impl<S: Spec, T> ApiState<S, T> {
         &self,
         height_param: Option<HeightParam>,
     ) -> Result<ApiStateAccessor<S>, anyhow::Error> {
-        let checkpoint = self.checkpoint_receiver.borrow();
+        // Do a quick/cheap arc clone to avoid blocking the checkpoint receiver
+        let checkpoint: Arc<_> = self.checkpoint_receiver.borrow().clone();
 
         let kernel = self.kernel.clone();
 
@@ -287,7 +288,7 @@ impl<S: Spec, T> ApiState<S, T> {
     }
 
     /// Returns the checkpoint receiver.
-    pub fn checkpoint_receiver(&self) -> watch::Receiver<StateCheckpoint<S>> {
+    pub fn checkpoint_receiver(&self) -> watch::Receiver<Arc<StateCheckpoint<S>>> {
         self.checkpoint_receiver.clone()
     }
 }

--- a/crates/module-system/sov-modules-api/tests/integration/rest_api.rs
+++ b/crates/module-system/sov-modules-api/tests/integration/rest_api.rs
@@ -135,10 +135,10 @@ async fn rest_api_routes() {
 
     let storage_manager = sov_test_utils::storage::SimpleStorageManager::new();
     let storage = storage_manager.create_storage();
-    let (_sender, receiver) = tokio::sync::watch::channel(StateCheckpoint::new(
+    let (_sender, receiver) = tokio::sync::watch::channel(Arc::new(StateCheckpoint::new(
         storage,
         &MockKernel::<TestSpec>::default(),
-    ));
+    )));
     let runtime = MyRuntime::<TestSpec>::default();
     let state = ApiState::build(
         Arc::new(()),

--- a/crates/module-system/sov-test-utils/src/runtime/mod.rs
+++ b/crates/module-system/sov-test-utils/src/runtime/mod.rs
@@ -175,9 +175,9 @@ pub struct TestRunner<
     state_root: <S::Storage as Storage>::Root,
     storage_manager: Sm,
     /// A channel to send the storage over. This should be subscribed to the same channel as [`Self::checkpoint_receiver`].
-    checkpoint_sender: watch::Sender<StateCheckpoint<S>>,
+    checkpoint_sender: watch::Sender<Arc<StateCheckpoint<S>>>,
     /// The corresponding receiving end of the channel.
-    checkpoint_receiver: watch::Receiver<StateCheckpoint<S>>,
+    checkpoint_receiver: watch::Receiver<Arc<StateCheckpoint<S>>>,
     axum_server: axum_server::Handle,
     /// Test runner configuration.
     pub config: RunnerConfig<S::Da>,
@@ -456,7 +456,7 @@ where
     fn synchronize_storage_channel(&mut self) {
         let storage = self.storage_manager.create_prover_storage();
         self.checkpoint_sender
-            .send(StateCheckpoint::new(storage, &RT::default().kernel()))
+            .send(Arc::new(StateCheckpoint::new(storage, &RT::default().kernel())))
             .expect("Failed to send storage, the storage channel is closed. This is a bug. Please report it.");
     }
 
@@ -478,10 +478,10 @@ where
 
         let stf_state = storage_manager.create_prover_storage();
 
-        let (sender, receiver) = watch::channel(StateCheckpoint::new(
+        let (sender, receiver) = watch::channel(Arc::new(StateCheckpoint::new(
             stf_state.clone(),
             &RT::default().kernel(),
-        ));
+        )));
 
         let (state_root, change_set) =
             stf.init_chain(&Default::default(), stf_state, genesis_config);


### PR DESCRIPTION
# Description

Under GTE's benchmark load, API state updates became a significant bottleneck. Previously, we put a raw `StateCheckpoint` into the API state channel; this allowed us to update it cheaply from the rollup's side effects task using `watch::update_in_place`. However, we have to clone the entire state checkpoint each time we serve an API query. Because EVM tooling performs so many writes, this meant that there was significant contention for the `watch::channel`'s internal read-write lock; each clone could take 100s of microseconds, and we could easily need 1000 or more clones per second. 

This PR ameliorates the issue by wrapping the StateCheckpoint in an Arc. This allows us to do the outer clones very cheaply at the expense of requiring a deep-copy in the side effects thread. To mitigate the cost of the deep-copy this PR takes advantage of our pre-existing batching strategy; we require only one checkpoint clone for each batch of txs processed by the side effects thread. 

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
