### PR TITLE
Update to rockbound with fixed caching behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10222,8 +10222,8 @@ dependencies = [
 
 [[package]]
 name = "rockbound"
-version = "1.0.0"
-source = "git+https://github.com/sovereign-labs/rockbound?rev=2ff46aca3d2cffcb07f958d34329a9cc8c6ebd2c#2ff46aca3d2cffcb07f958d34329a9cc8c6ebd2c"
+version = "0.1.0"
+source = "git+https://github.com/sovereign-labs/rockbound?rev=6289a56f9ab2a74d8136ae0752963b1dddd41d4d#6289a56f9ab2a74d8136ae0752963b1dddd41d4d"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ nearly-linear = { path = "crates/utils/nearly-linear", version = "0.3" }
 # Dependencies maintained by Sovereign
 jmt = { version = "0.12.0", default-features = false }
 reltester = { git = "https://github.com/sovereign-labs/reltester.git", rev = "d6209abff72929f5ba41614f5cea3e4a748428c3" }
-rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "2ff46aca3d2cffcb07f958d34329a9cc8c6ebd2c" }
+rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "6289a56f9ab2a74d8136ae0752963b1dddd41d4d" }
 nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
 nomt-core = { version = "1.0.2", default-features = false, features = ["borsh", "serde"] }

--- a/crates/full-node/sov-blob-sender/src/db.rs
+++ b/crates/full-node/sov-blob-sender/src/db.rs
@@ -22,7 +22,6 @@ impl BlobSenderDb {
             Self::DB_NAME,
             Self::TABLES.iter().copied(),
             &gen_rocksdb_options(&Default::default(), false),
-            0, // We don't need a cache for blobs since the table is not configured for caching anyway
         )?;
 
         Ok(Self { db })

--- a/crates/full-node/sov-db/src/accessory_db.rs
+++ b/crates/full-node/sov-db/src/accessory_db.rs
@@ -26,6 +26,7 @@ impl AccessoryDb {
             name: Self::DB_NAME,
             path_suffix: Self::DB_PATH_SUFFIX,
             columns: ACCESSORY_TABLES.to_vec(),
+            cacheable_columns: vec![],
         }
     }
 

--- a/crates/full-node/sov-db/src/flat_db.rs
+++ b/crates/full-node/sov-db/src/flat_db.rs
@@ -108,10 +108,17 @@ impl FlatStateDb {
     pub fn get_rockbound_options(
         columns: Vec<ColumnFamilyDescriptor>,
     ) -> DbOptions<ColumnFamilyDescriptor> {
+        let cacheable_columns = vec![
+            NomtCommittedVersion::<UserNamespace>::COLUMN_FAMILY_NAME.to_string(),
+            NomtCommittedVersion::<KernelNamespace>::COLUMN_FAMILY_NAME.to_string(),
+            NomtStateValues::<UserNamespace>::COLUMN_FAMILY_NAME.to_string(),
+            NomtStateValues::<KernelNamespace>::COLUMN_FAMILY_NAME.to_string(),
+        ];
         DbOptions {
             name: Self::DB_NAME,
             path_suffix: Self::DB_PATH_SUFFIX,
             columns,
+            cacheable_columns,
         }
     }
 

--- a/crates/full-node/sov-db/src/historical_state.rs
+++ b/crates/full-node/sov-db/src/historical_state.rs
@@ -131,6 +131,7 @@ impl HistoricalStateReader {
                 .chain(KernelNamespace::get_jmt_table_names())
                 .chain(vec![StateRootHashes::table_name()])
                 .collect(),
+            cacheable_columns: vec![],
         }
     }
 

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -267,6 +267,7 @@ impl LedgerDb {
             name: Self::DB_NAME,
             path_suffix: Self::DB_PATH_SUFFIX,
             columns: LEDGER_TABLES.to_vec(),
+            cacheable_columns: vec![],
         }
     }
 

--- a/crates/full-node/sov-db/src/lib.rs
+++ b/crates/full-node/sov-db/src/lib.rs
@@ -55,6 +55,7 @@ pub struct DbOptions<Columns = rockbound::schema::ColumnFamilyName> {
     pub(crate) path_suffix: &'static str,
     /// A set of colums that this db is going to use.
     pub(crate) columns: Vec<Columns>,
+    pub(crate) cacheable_columns: Vec<String>,
 }
 
 impl<T> DbOptions<T> {
@@ -64,6 +65,7 @@ impl<T> DbOptions<T> {
             name: self.name,
             path_suffix: self.path_suffix,
             columns: self.columns.into_iter().map(f).collect(),
+            cacheable_columns: self.cacheable_columns,
         }
     }
 }
@@ -76,7 +78,7 @@ impl DbOptions {
     ) -> anyhow::Result<rockbound::DB> {
         let config = rocks_db_config::gen_rocksdb_options(&Default::default(), false);
         let db_path = path.as_ref().join(self.path_suffix);
-        rockbound::DB::open(db_path, self.name, self.columns, &config, 0) // We only setup the cache for NOMT - which is done in FlatStateDb. Use 0 for all other databases.
+        rockbound::DB::open(db_path, self.name, self.columns, &config)
     }
 }
 
@@ -89,7 +91,14 @@ impl DbOptions<ColumnFamilyDescriptor> {
     ) -> anyhow::Result<rockbound::DB> {
         let config = rocks_db_config::gen_rocksdb_options(&Default::default(), false);
         let db_path = path.as_ref().join(self.path_suffix);
-        rockbound::DB::open_with_cfds(&config, db_path, self.name, self.columns, cache_size)
+        rockbound::DB::open_with_cfds(
+            &config,
+            db_path,
+            self.name,
+            self.columns,
+            self.cacheable_columns,
+            cache_size,
+        )
     }
 }
 

--- a/crates/full-node/sov-db/src/state_db.rs
+++ b/crates/full-node/sov-db/src/state_db.rs
@@ -85,6 +85,7 @@ impl StateDb {
                 .into_iter()
                 .chain(KernelNamespace::get_jmt_table_names())
                 .collect(),
+            cacheable_columns: vec![], // Caching is only enabled for NOMT - which is done in FlatStateDb.
         }
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
@@ -167,7 +167,6 @@ impl RocksDbBackend {
             Self::DB_NAME,
             Self::TABLES.iter().copied(),
             &gen_rocksdb_options(&Default::default(), false),
-            0, // We don't need a cache for preferred sequencer since the table is not configured for caching anyway
         )?);
 
         // There's an edge case where we might have an in-progress batch but no completed blobs. In that case,


### PR DESCRIPTION
# Description

There was a bug in a previous version of rockbound where writes to un-cached column families could still be inserted into the cache. This was functionally correct (the cache was consistent), but meant that good keys were evicted faster than needed. This PR updates to a version of rockbound that fixes the issue.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
