### PR TITLE
Improve error message when retrieving a recipient ism

### DIFF
--- a/crates/module-system/hyperlane/Cargo.toml
+++ b/crates/module-system/hyperlane/Cargo.toml
@@ -31,7 +31,6 @@ futures = { workspace = true }
 hex = { workspace = true }
 indoc = "2"
 reqwest = { workspace = true }
-serde_json = { workspace = true }
 strum = { workspace = true }
 tempfile = { workspace = true }
 testcontainers = { workspace = true }
@@ -53,6 +52,7 @@ derive_more = { workspace = true }
 schemars = { workspace = true }
 k256 = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sha3 = { workspace = true }
 ruint = { workspace = true }
@@ -63,25 +63,25 @@ tracing = { workspace = true }
 default = []
 evm = ["sov-address/evm"]
 arbitrary = [
-	"dep:proptest-derive",
-	"dep:arbitrary",
-	"dep:proptest",
-	"sov-address/arbitrary",
-	"sov-bank/arbitrary",
-	"sov-hyperlane-integration/arbitrary",
-	"sov-modules-api/arbitrary",
-	"sov-state/arbitrary",
-	"sov-test-utils/arbitrary",
-	"ruint/arbitrary",
-	"sov-mock-da/arbitrary",
+  "dep:proptest-derive",
+  "dep:arbitrary",
+  "dep:proptest",
+  "sov-address/arbitrary",
+  "sov-bank/arbitrary",
+  "sov-hyperlane-integration/arbitrary",
+  "sov-modules-api/arbitrary",
+  "sov-state/arbitrary",
+  "sov-test-utils/arbitrary",
+  "ruint/arbitrary",
+  "sov-mock-da/arbitrary",
 ]
 test-utils = ["arbitrary"]
 native = [
-	"sov-modules-api/native",
-	"sov-value-setter/native",
-	"sov-state/native",
-	"sov-address/native",
-	"sov-bank/native",
-	"sov-hyperlane-integration/native",
-	"sov-mock-da/native",
+  "sov-modules-api/native",
+  "sov-value-setter/native",
+  "sov-state/native",
+  "sov-address/native",
+  "sov-bank/native",
+  "sov-hyperlane-integration/native",
+  "sov-mock-da/native",
 ]

--- a/crates/module-system/hyperlane/src/api.rs
+++ b/crates/module-system/hyperlane/src/api.rs
@@ -7,7 +7,7 @@ use sov_modules_api::prelude::axum::http::StatusCode;
 use sov_modules_api::prelude::serde_json::json;
 use sov_modules_api::prelude::utoipa::openapi::OpenApi;
 use sov_modules_api::prelude::{axum, UnwrapInfallible};
-use sov_modules_api::rest::utils::{errors, json_obj, ApiResult, Path, Query, ErrorObject};
+use sov_modules_api::rest::utils::{errors, json_obj, ApiResult, ErrorObject, Path, Query};
 use sov_modules_api::rest::{ApiState, HasCustomRestApi};
 use sov_modules_api::{ApiStateAccessor, CredentialId, HexHash, Spec};
 

--- a/crates/module-system/hyperlane/src/api.rs
+++ b/crates/module-system/hyperlane/src/api.rs
@@ -87,19 +87,19 @@ impl<S: Spec, R: Recipient<S>> Mailbox<S, R> {
         state: &ApiState<S, Self>,
         address: &HexHash,
         mut accessor: ApiStateAccessor<S>,
-    ) -> Result<Ism, Response> {
+    ) -> Result<Ism, Box<Response>> {
         let ism = state
             .recipients
             .ism(address, &mut accessor)
             .map_err(errors::internal_server_error_response_500)?
-            .ok_or_else(|| ErrorObject {
+            .ok_or_else(|| Box::new(ErrorObject {
                 status: StatusCode::NOT_FOUND,
                 message: "Failed to retrieve Recipient ISM".to_string(),
                 details: json_obj!({
                     "error": format!("Either the recipient doesn't exist or no ISM is set for the recipient"),
                     "recipient": address.to_string(),
                 })
-            }.into_response())?;
+            }.into_response()))?;
         Ok(ism)
     }
 
@@ -121,7 +121,7 @@ impl<S: Spec, R: Recipient<S>> Mailbox<S, R> {
         Path(address): Path<HexHash>,
         accessor: ApiStateAccessor<S>,
     ) -> Result<Response, Response> {
-        let ism = Self::get_ism(&state, &address, accessor)?;
+        let ism = Self::get_ism(&state, &address, accessor).map_err(|e| *e)?;
         let ism_kind = ism.ism_kind() as u8;
         Ok(Json(json!({"ism_kind": ism_kind})).into_response())
     }
@@ -131,7 +131,7 @@ impl<S: Spec, R: Recipient<S>> Mailbox<S, R> {
         Path(address): Path<HexHash>,
         accessor: ApiStateAccessor<S>,
     ) -> ApiResult<ValidatorsAndThreshold> {
-        let ism = Self::get_ism(&state, &address, accessor)?;
+        let ism = Self::get_ism(&state, &address, accessor).map_err(|e| *e)?;
         let Ism::MessageIdMultisig {
             validators,
             threshold,

--- a/crates/module-system/hyperlane/src/api.rs
+++ b/crates/module-system/hyperlane/src/api.rs
@@ -3,10 +3,11 @@ use axum::routing::get;
 use axum::Json;
 use serde::{Deserialize as _, Serialize};
 use sov_bank::{config_gas_token_id, Amount};
+use sov_modules_api::prelude::axum::http::StatusCode;
 use sov_modules_api::prelude::serde_json::json;
 use sov_modules_api::prelude::utoipa::openapi::OpenApi;
 use sov_modules_api::prelude::{axum, UnwrapInfallible};
-use sov_modules_api::rest::utils::{errors, ApiResult, Path, Query};
+use sov_modules_api::rest::utils::{errors, json_obj, ApiResult, Path, Query, ErrorObject};
 use sov_modules_api::rest::{ApiState, HasCustomRestApi};
 use sov_modules_api::{ApiStateAccessor, CredentialId, HexHash, Spec};
 
@@ -82,6 +83,26 @@ impl<S: Spec, R: Recipient<S>> HasCustomRestApi for Mailbox<S, R> {
 }
 
 impl<S: Spec, R: Recipient<S>> Mailbox<S, R> {
+    fn get_ism(
+        state: &ApiState<S, Self>,
+        address: &HexHash,
+        mut accessor: ApiStateAccessor<S>,
+    ) -> Result<Ism, Response> {
+        let ism = state
+            .recipients
+            .ism(address, &mut accessor)
+            .map_err(errors::internal_server_error_response_500)?
+            .ok_or_else(|| ErrorObject {
+                status: StatusCode::NOT_FOUND,
+                message: "Failed to retrieve Recipient ISM".to_string(),
+                details: json_obj!({
+                    "error": format!("Either the recipient doesn't exist or no ISM is set for the recipient"),
+                    "recipient": address.to_string(),
+                })
+            }.into_response())?;
+        Ok(ism)
+    }
+
     async fn get_nonce(
         state: ApiState<S, Self>,
         mut accessor: ApiStateAccessor<S>,
@@ -98,13 +119,9 @@ impl<S: Spec, R: Recipient<S>> Mailbox<S, R> {
     async fn get_recipient_ism(
         state: ApiState<S, Self>,
         Path(address): Path<HexHash>,
-        mut accessor: ApiStateAccessor<S>,
+        accessor: ApiStateAccessor<S>,
     ) -> Result<Response, Response> {
-        let ism = state
-            .recipients
-            .ism(&address, &mut accessor)
-            .map_err(|_| errors::not_found_404("Mailbox", address))?
-            .ok_or_else(|| errors::not_found_404("Mailbox", address))?;
+        let ism = Self::get_ism(&state, &address, accessor)?;
         let ism_kind = ism.ism_kind() as u8;
         Ok(Json(json!({"ism_kind": ism_kind})).into_response())
     }
@@ -112,14 +129,9 @@ impl<S: Spec, R: Recipient<S>> Mailbox<S, R> {
     async fn get_recipient_ism_validators_and_threshold(
         state: ApiState<S, Self>,
         Path(address): Path<HexHash>,
-        mut accessor: ApiStateAccessor<S>,
+        accessor: ApiStateAccessor<S>,
     ) -> ApiResult<ValidatorsAndThreshold> {
-        let ism = state
-            .recipients
-            .ism(&address, &mut accessor)
-            .map_err(|_| errors::not_found_404("Mailbox", address))?
-            .ok_or_else(|| errors::not_found_404("Mailbox", address))?;
-
+        let ism = Self::get_ism(&state, &address, accessor)?;
         let Ism::MessageIdMultisig {
             validators,
             threshold,


### PR DESCRIPTION
# Description

Improve a error message when retrieving a recipients ISM. The error message previously shown indicated it was a missing Mailbox which is not the case

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
