### PR TITLE
Soak generator: add restart on timer

### DIFF
--- a/crates/utils/sov-soak-testing-lib/src/lib.rs
+++ b/crates/utils/sov-soak-testing-lib/src/lib.rs
@@ -191,8 +191,11 @@ where
         worker_id: u128,
         num_workers: u32,
         validity: Distribution<MessageValidity>,
+        restart_after: Option<std::time::Duration>,
     ) -> anyhow::Result<()> {
-        prepare_and_send_txs(self.modules, client, rx, worker_id, num_workers, validity).await
+        let x = rx.clone();
+        println!("Will restart after {restart_after:?}");
+        prepare_and_send_txs(self.modules, &client, rx, worker_id, num_workers, validity).await
     }
 }
 
@@ -271,7 +274,7 @@ pub fn setup_harness<R: Runtime<S> + Clone, S: Spec>(rng_salt: u128) -> TestGene
 
 async fn prepare_and_send_txs<R: Runtime<S> + Clone, S: Spec>(
     modules: Vec<BasicModuleRef<S, R>>,
-    client: sov_api_spec::Client,
+    client: &sov_api_spec::Client,
     rx: Receiver<bool>,
     worker_id: u128,
     num_workers: u32,

--- a/crates/utils/sov-soak-testing-lib/src/lib.rs
+++ b/crates/utils/sov-soak-testing-lib/src/lib.rs
@@ -184,18 +184,53 @@ where
     /// - `worker_id`: Unique identifier for this worker
     /// - `num_workers`: Total number of parallel workers
     /// - `validity`: Distribution of valid vs invalid messages
+    /// - `restart_after`: Optional duration after which to restart the worker
     pub async fn run(
         self,
         client: sov_api_spec::Client,
         rx: Receiver<bool>,
-        worker_id: u128,
+        mut worker_id: u128,
         num_workers: u32,
         validity: Distribution<MessageValidity>,
         restart_after: Option<std::time::Duration>,
     ) -> anyhow::Result<()> {
-        let x = rx.clone();
-        println!("Will restart after {restart_after:?}");
-        prepare_and_send_txs(self.modules, &client, rx, worker_id, num_workers, validity).await
+        loop {
+            tracing::info!(worker_id, ?restart_after, "Starting worker");
+            let result = if let Some(duration) = restart_after {
+                tokio::select! {
+                    result = prepare_and_send_txs(
+                        self.modules.clone(),
+                        &client,
+                        rx.clone(),
+                        worker_id,
+                        num_workers,
+                        validity.clone()
+                    ) => {
+                        // If prepare_and_send_txs completes (likely an error), return immediately
+                        return result;
+                    }
+                    _ = tokio::time::sleep(duration) => {
+                        // Timer expired, restart with incremented worker_id
+                        tracing::info!("Timer expired for worker {worker_id}, restarting with new worker_id");
+                        worker_id += num_workers as u128;
+                        continue;
+                    }
+                }
+            } else {
+                // No restart timer, just run until completion
+                prepare_and_send_txs(
+                    self.modules.clone(),
+                    &client,
+                    rx.clone(),
+                    worker_id,
+                    num_workers,
+                    validity.clone(),
+                )
+                .await
+            };
+
+            return result;
+        }
     }
 }
 

--- a/examples/demo-rollup/sov-soak-testing/src/bin/generator.rs
+++ b/examples/demo-rollup/sov-soak-testing/src/bin/generator.rs
@@ -53,8 +53,8 @@ struct Args {
     tx_type: TxType,
 
     /// After that many seconds main loop will restart with salt incremented by number of workerAs
-    #[arg(short, long, default_value = "None")]
-    restart_after_seconds: Option<usize>,
+    #[arg(long, default_value = "None")]
+    restart_after_seconds: Option<u64>,
 }
 
 #[derive(Clone, Copy, Debug, clap::ValueEnum)]

--- a/examples/demo-rollup/sov-soak-testing/src/bin/generator.rs
+++ b/examples/demo-rollup/sov-soak-testing/src/bin/generator.rs
@@ -51,6 +51,10 @@ struct Args {
     #[arg(short, long, default_value = "mixed")]
     /// The distribution of token transfers vs. synthetic load transactions to generate.
     tx_type: TxType,
+
+    /// After that many seconds main loop will restart with salt incremented by number of workerAs
+    #[arg(short, long, default_value = "None")]
+    restart_after_seconds: Option<usize>,
 }
 
 #[derive(Clone, Copy, Debug, clap::ValueEnum)]
@@ -72,6 +76,7 @@ async fn run_soak_test_with_demo_runtime<R, S>(
     num_workers: u32,
     validity: Distribution<MessageValidity>,
     tx_type: TxType,
+    restart_after: Option<std::time::Duration>,
 ) -> anyhow::Result<()>
 where
     R: Runtime<S> + EncodeCall<Bank<S>> + EncodeCall<SyntheticLoad<S>> + Clone,
@@ -86,7 +91,7 @@ where
     };
 
     runner
-        .run(client, rx, worker_id, num_workers, validity)
+        .run(client, rx, worker_id, num_workers, validity, restart_after)
         .await
 }
 
@@ -98,6 +103,7 @@ async fn worker_task(
     runtime: SelectedRuntime,
     validity_profile: ValidityProfile,
     tx_type: TxType,
+    restart_after: Option<std::time::Duration>,
 ) -> anyhow::Result<()> {
     let validity = validity_profile.get_validity();
 
@@ -110,6 +116,7 @@ async fn worker_task(
                 num_workers,
                 validity,
                 tx_type,
+                restart_after,
             )
             .await
         }
@@ -121,6 +128,7 @@ async fn worker_task(
                 num_workers,
                 validity,
                 tx_type,
+                restart_after,
             )
             .await
         }
@@ -132,6 +140,7 @@ async fn worker_task(
                 num_workers,
                 validity,
                 tx_type,
+                restart_after,
             )
             .await
         }
@@ -157,6 +166,10 @@ async fn main() -> Result<(), anyhow::Error> {
         .build()?;
     let client = sov_api_spec::Client::new_with_client(&args.api_url, reqwest_client);
 
+    let restart_after = args
+        .restart_after_seconds
+        .map(std::time::Duration::from_secs);
+
     for i in 0..args.num_workers {
         worker_set.spawn(worker_task(
             client.clone(),
@@ -166,6 +179,7 @@ async fn main() -> Result<(), anyhow::Error> {
             args.runtime,
             args.validity_profile,
             args.tx_type,
+            restart_after,
         ));
     }
 


### PR DESCRIPTION
# Description

Generator can fail after a while for a couple reasons:

* arbitrary pre-allocated memory is exhausted
* internal state of accounts consumes all avaialbe host memory

This PR adds optional paramter `--restart-after-seconds` which will restart worker with new id after given amount of time. 

```
2025-11-21T11:14:51.480913Z DEBUG sov_soak_testing_lib: Sent 42 transactions in 148ms. Current throughput: 565.29 txs per second. Running throughput: 329.17 txs per second id=1016
2025-11-21T11:14:51.617696Z DEBUG sov_soak_testing_lib: Sent 44 transactions in 142ms. Current throughput: 619.48 txs per second. Running throughput: 337.14 txs per second id=1015
2025-11-21T11:14:51.780254Z DEBUG sov_soak_testing_lib: Sent 57 transactions in 230ms. Current throughput: 494.20 txs per second. Running throughput: 330.02 txs per second id=1016
2025-11-21T11:14:52.038254Z DEBUG sov_soak_testing_lib: Sent 65 transactions in 306ms. Current throughput: 423.49 txs per second. Running throughput: 336.50 txs per second id=1015
2025-11-21T11:14:52.139078Z DEBUG sov_soak_testing_lib: Sent 56 transactions in 281ms. Current throughput: 397.79 txs per second. Running throughput: 329.67 txs per second id=1016
2025-11-21T11:14:55.214518Z  INFO sov_soak_testing_lib: Timer expired for worker 1016, restarting with new worker_id
2025-11-21T11:14:55.214539Z  INFO sov_soak_testing_lib: Starting worker worker_id=1018 restart_after=Some(30s)
2025-11-21T11:14:55.214679Z  INFO sov_soak_testing_lib: Timer expired for worker 1015, restarting with new worker_id
2025-11-21T11:14:55.214718Z  INFO sov_soak_testing_lib: Starting worker worker_id=1017 restart_after=Some(30s)
2025-11-21T11:15:03.963027Z  WARN sov_api_spec::client: Failed to submit transaction. Retrying... err=Error Response: status: 503 Service Unavailable; headers: {"content-type": "application/json", "vary": "origin, access-control-request-method, access-control-request-headers", "access-control-allow-origin": "*", "access-control-expose-headers": "*", "content-length": "301", "date": "Fri, 21 Nov 2025 11:15:03 GMT"}; value: ApiError { details: {"Syncing": Object {"synced_da_height": Number(473), "target_da_height": Number(483)}}, message: "The node fell out of sync with the DA head, the sequencer is waiting to catch up. There may also be a small delay after the node has finished syncing.; No new transactions can be accepted, try again later", status: 503 } duration=200ms
// .. couple more of those, because of debug mode
2025-11-21T11:15:10.192228Z DEBUG sov_soak_testing_lib: Sent 17 transactions in 6233ms. Current throughput: 5.45 txs per second. Running throughput: 5.38 txs per second id=1018
2025-11-21T11:15:10.303195Z DEBUG sov_soak_testing_lib: Sent 64 transactions in 6271ms. Current throughput: 20.41 txs per second. Running throughput: 20.17 txs per second id=1017
2025-11-21T11:15:10.308020Z DEBUG sov_soak_testing_lib: Sent 36 transactions in 77ms. Current throughput: 934.22 txs per second. Running throughput: 16.48 txs per second id=1018
2025-11-21T11:15:10.533971Z DEBUG sov_soak_testing_lib: Sent 61 transactions in 143ms. Current throughput: 847.43 txs per second. Running throughput: 34.25 txs per second id=1018
2025-11-21T11:15:10.551129Z DEBUG sov_soak_testing_lib: Sent 85 transactions in 198ms. Current throughput: 854.83 txs per second. Running throughput: 45.20 txs per second id=1017
2025-11-21T11:15:10.654790Z DEBUG sov_soak_testing_lib: Sent 18 transactions in 57ms. Current throughput: 627.35 txs per second. Running throughput: 49.87 txs per second id=1017
2025-11-21T11:15:10.761431Z DEBUG sov_soak_testing_lib: Sent 54 transactions in 127ms. Current throughput: 848.60 txs per second. Running throughput: 48.81 txs per second id=1018
2025-11-21T11:15:10.952002Z DEBUG sov_soak_testing_lib: Sent 76 transactions in 194ms. Current throughput: 782.47 txs per second. Running throughput: 69.49 txs per second id=1017
2025-11-21T11:15:11.105838Z DEBUG sov_soak_testing_lib: Sent 94 transactions in 230ms. Current throughput: 816.89 txs per second. Running throughput: 72.49 txs per second id=1018
2025-11-21T11:15:11.207174Z DEBUG sov_soak_testing_lib: Sent 55 transactions in 146ms. Current throughput: 748.49 txs per second. Running throughput: 82.21 txs per second id=1017
2025-11-21T11:15:11.359416Z DEBUG sov_soak_testing_lib: Sent 70 transactions in 169ms. Current throughput: 827.96 txs per second. Running throughput: 88.75 txs per second id=1018
2025-11-21T11:15:11.456874Z DEBUG sov_soak_testing_lib: Sent 73 transactions in 181ms. Current throughput: 803.01 txs per second. Running throughput: 98.94 txs per second id=1017
2025-11-21T11:15:11.502590Z DEBUG sov_soak_testing_lib: Sent 23 transactions in 81ms. Current throughput: 565.24 txs per second. Running throughput: 93.11 txs per second id=1018
```

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Manually checked behvaiour

## Docs
Docstring added as a param
