### PR TITLE
Add "execution time" config for modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-11-22
+- #2102 Adds `ModuleExecutionConfig` associated type to the `Runtime` trait, allowing modules to customize their offchain environment.
+
 # 2025-11-17
 - ##2082 **Breaking change**: Increase the granularity of EVM log timestamps. Logs within the same block can now have different timestamps.
 # 2025-11-14

--- a/crates/module-system/sov-modules-api/src/module/mod.rs
+++ b/crates/module-system/sov-modules-api/src/module/mod.rs
@@ -32,6 +32,19 @@ pub trait Module: Clone {
     /// Configuration for the genesis method.
     type Config;
 
+    /// Configuration for initializing offchain components.
+    ///
+    /// This type defines the configuration needed to initialize offchain components for the module.
+    /// Unlike [`Module::Config`] which is used during genesis (a one-time, deterministic initialization
+    /// that happens when the rollup is deployed), `ExecutionConfig` is used to configure offchain
+    /// components such as:
+    /// - Metrics collectors and monitoring endpoints
+    /// - External service integrations
+    ///
+    /// This configuration is typically loaded from environment variables or configuration files
+    /// at startup, and can differ between different instances in the same rollup network.
+    type ExecutionConfig;
+
     /// Module defined argument to the call method.
     type CallMessage: CallMessage;
 
@@ -58,6 +71,88 @@ pub trait Module: Clone {
         _config: &Self::Config,
         _state: &mut impl GenesisState<Self::Spec>,
     ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Initializes offchain components for the module.
+    ///
+    /// This method is called at startup (before processing any blocks) to initialize
+    /// offchain components that the module needs. Unlike [`Module::genesis`],
+    /// which is called once during rollup deployment and must be deterministic, `init` can perform
+    /// non-deterministic operations and is called on every startup.
+    ///
+    /// Common use cases include:
+    /// - Initializing metrics collectors
+    /// - Connecting to external services
+    ///
+    /// # Determinism
+    /// Unlike [`Module::genesis`] and [`Module::call`], this method does NOT need to be deterministic.
+    /// Different instances can have different configurations for offchain components as long as they
+    /// produce the same state transitions when processing blocks.
+    ///
+    /// # Errors
+    /// Returns an error if initialization fails. This will typically cause startup to fail.
+    ///
+    /// # Default Implementation
+    /// The default implementation does nothing and returns `Ok(())`. Override this method if your
+    /// module needs to initialize offchain components.
+    ///
+    /// # Example
+    ///
+    /// A common pattern is to store the configuration in a global variable (using [`std::sync::OnceLock`])
+    /// and then access it from hooks like [`BlockHooks`]:
+    ///
+    /// ```rust,ignore
+    /// use std::sync::OnceLock;
+    /// use sov_modules_api::{Module, BlockHooks, StateCheckpoint};
+    ///
+    /// // Define the execution configuration for offchain components
+    /// #[derive(Clone)]
+    /// struct MyModuleExecutionConfig {
+    ///     metrics_endpoint: String,
+    ///     enable_detailed_logging: bool,
+    /// }
+    ///
+    /// // Global storage for the configuration
+    /// static EXECUTION_CONFIG: OnceLock<MyModuleExecutionConfig> = OnceLock::new();
+    ///
+    /// #[derive(Clone)]
+    /// struct MyModule { /* ... */ }
+    ///
+    /// impl Module for MyModule {
+    ///     type ExecutionConfig = MyModuleExecutionConfig;
+    ///     // ... other associated types ...
+    ///
+    ///     // Initialize offchain components at startup
+    ///     fn init(config: &Self::ExecutionConfig) -> Result<(), Box<dyn std::error::Error>> {
+    ///         EXECUTION_CONFIG.set(config.clone())
+    ///             .map_err(|_| "Execution config already initialized")?;
+    ///
+    ///         // Perform any other initialization (e.g., connect to metrics endpoint)
+    ///         println!("Connecting to metrics at: {}", config.metrics_endpoint);
+    ///
+    ///         Ok(())
+    ///     }
+    ///
+    ///     // ... other trait methods ...
+    /// }
+    ///
+    /// // Access the configuration in BlockHooks
+    /// impl BlockHooks for MyModule {
+    ///     type Spec = /* ... */;
+    ///
+    ///     fn end_rollup_block_hook(&mut self, state: &mut StateCheckpoint<Self::Spec>) {
+    ///         // Access the execution configuration
+    ///         if let Some(config) = EXECUTION_CONFIG.get() {
+    ///             if config.enable_detailed_logging {
+    ///                 println!("Block completed - detailed logging enabled");
+    ///             }
+    ///             // Submit metrics to the configured endpoint, etc.
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    fn init(_config: &Self::ExecutionConfig) -> Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 
@@ -279,6 +374,50 @@ where
             config,
             state,
         )?)
+    }
+}
+
+/// Allows a module to initialize offchain components.
+///
+/// This trait provides a standardized interface for initializing offchain components when
+/// starting up. It is automatically implemented for all types that implement [`Module`].
+///
+/// The primary purpose of this trait is to abstract over the [`Module::init`] method, allowing
+/// code to initialize all modules in a uniform way without needing to know the specific
+/// types of each module.
+///
+/// # Relationship to Other Traits
+/// - [`ExecutionInit`] is to [`Module::init`] what [`Genesis`] is to [`Module::genesis`]
+/// - Like [`Genesis`], this trait is blanket-implemented for all [`Module`] types
+/// - Unlike [`Genesis`], initialization here is non-deterministic and happens on every startup
+///
+/// # When to Use
+/// Use this trait when initializing modules at startup.
+/// Module developers typically don't need to interact with this trait directly - they should
+/// implement [`Module::init`] instead.
+pub trait ExecutionInit {
+    /// Configuration type for offchain components.
+    ///
+    /// This is the same as [`Module::ExecutionConfig`].
+    type Config;
+
+    /// Initializes the module's offchain components.
+    ///
+    /// See [`Module::init`] for detailed documentation on this method's purpose and behavior.
+    ///
+    /// # Errors
+    /// Returns an error if initialization fails, which will typically cause startup to fail.
+    fn init(config: &Self::Config) -> Result<(), Box<dyn std::error::Error>>;
+}
+
+impl <T> ExecutionInit for T
+where
+    T: Module,
+{
+    type Config = <Self as Module>::ExecutionConfig;
+
+    fn init(config: &Self::Config) -> Result<(), Box<dyn std::error::Error>> {
+        <Self as Module>::init(config)
     }
 }
 

--- a/crates/module-system/sov-modules-api/src/module/mod.rs
+++ b/crates/module-system/sov-modules-api/src/module/mod.rs
@@ -410,7 +410,7 @@ pub trait ExecutionInit {
     fn init(config: &Self::Config) -> Result<(), Box<dyn std::error::Error>>;
 }
 
-impl <T> ExecutionInit for T
+impl<T> ExecutionInit for T
 where
     T: Module,
 {

--- a/crates/module-system/sov-modules-api/src/module/mod.rs
+++ b/crates/module-system/sov-modules-api/src/module/mod.rs
@@ -32,19 +32,6 @@ pub trait Module: Clone {
     /// Configuration for the genesis method.
     type Config;
 
-    /// Configuration for initializing offchain components.
-    ///
-    /// This type defines the configuration needed to initialize offchain components for the module.
-    /// Unlike [`Module::Config`] which is used during genesis (a one-time, deterministic initialization
-    /// that happens when the rollup is deployed), `ExecutionConfig` is used to configure offchain
-    /// components such as:
-    /// - Metrics collectors and monitoring endpoints
-    /// - External service integrations
-    ///
-    /// This configuration is typically loaded from environment variables or configuration files
-    /// at startup, and can differ between different instances in the same rollup network.
-    type ExecutionConfig;
-
     /// Module defined argument to the call method.
     type CallMessage: CallMessage;
 
@@ -71,88 +58,6 @@ pub trait Module: Clone {
         _config: &Self::Config,
         _state: &mut impl GenesisState<Self::Spec>,
     ) -> anyhow::Result<()> {
-        Ok(())
-    }
-
-    /// Initializes offchain components for the module.
-    ///
-    /// This method is called at startup (before processing any blocks) to initialize
-    /// offchain components that the module needs. Unlike [`Module::genesis`],
-    /// which is called once during rollup deployment and must be deterministic, `init` can perform
-    /// non-deterministic operations and is called on every startup.
-    ///
-    /// Common use cases include:
-    /// - Initializing metrics collectors
-    /// - Connecting to external services
-    ///
-    /// # Determinism
-    /// Unlike [`Module::genesis`] and [`Module::call`], this method does NOT need to be deterministic.
-    /// Different instances can have different configurations for offchain components as long as they
-    /// produce the same state transitions when processing blocks.
-    ///
-    /// # Errors
-    /// Returns an error if initialization fails. This will typically cause startup to fail.
-    ///
-    /// # Default Implementation
-    /// The default implementation does nothing and returns `Ok(())`. Override this method if your
-    /// module needs to initialize offchain components.
-    ///
-    /// # Example
-    ///
-    /// A common pattern is to store the configuration in a global variable (using [`std::sync::OnceLock`])
-    /// and then access it from hooks like [`BlockHooks`]:
-    ///
-    /// ```rust,ignore
-    /// use std::sync::OnceLock;
-    /// use sov_modules_api::{Module, BlockHooks, StateCheckpoint};
-    ///
-    /// // Define the execution configuration for offchain components
-    /// #[derive(Clone)]
-    /// struct MyModuleExecutionConfig {
-    ///     metrics_endpoint: String,
-    ///     enable_detailed_logging: bool,
-    /// }
-    ///
-    /// // Global storage for the configuration
-    /// static EXECUTION_CONFIG: OnceLock<MyModuleExecutionConfig> = OnceLock::new();
-    ///
-    /// #[derive(Clone)]
-    /// struct MyModule { /* ... */ }
-    ///
-    /// impl Module for MyModule {
-    ///     type ExecutionConfig = MyModuleExecutionConfig;
-    ///     // ... other associated types ...
-    ///
-    ///     // Initialize offchain components at startup
-    ///     fn init(config: &Self::ExecutionConfig) -> Result<(), Box<dyn std::error::Error>> {
-    ///         EXECUTION_CONFIG.set(config.clone())
-    ///             .map_err(|_| "Execution config already initialized")?;
-    ///
-    ///         // Perform any other initialization (e.g., connect to metrics endpoint)
-    ///         println!("Connecting to metrics at: {}", config.metrics_endpoint);
-    ///
-    ///         Ok(())
-    ///     }
-    ///
-    ///     // ... other trait methods ...
-    /// }
-    ///
-    /// // Access the configuration in BlockHooks
-    /// impl BlockHooks for MyModule {
-    ///     type Spec = /* ... */;
-    ///
-    ///     fn end_rollup_block_hook(&mut self, state: &mut StateCheckpoint<Self::Spec>) {
-    ///         // Access the execution configuration
-    ///         if let Some(config) = EXECUTION_CONFIG.get() {
-    ///             if config.enable_detailed_logging {
-    ///                 println!("Block completed - detailed logging enabled");
-    ///             }
-    ///             // Submit metrics to the configured endpoint, etc.
-    ///         }
-    ///     }
-    /// }
-    /// ```
-    fn init(_config: &Self::ExecutionConfig) -> Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
 
@@ -382,43 +287,94 @@ where
 /// This trait provides a standardized interface for initializing offchain components when
 /// starting up. It is automatically implemented for all types that implement [`Module`].
 ///
-/// The primary purpose of this trait is to abstract over the [`Module::init`] method, allowing
+/// The primary purpose of this trait is to abstract over module initialization, allowing
 /// code to initialize all modules in a uniform way without needing to know the specific
 /// types of each module.
 ///
 /// # Relationship to Other Traits
-/// - [`ExecutionInit`] is to [`Module::init`] what [`Genesis`] is to [`Module::genesis`]
+/// - [`ExecutionInit`] is similar to [`Genesis`] but for offchain components
 /// - Like [`Genesis`], this trait is blanket-implemented for all [`Module`] types
 /// - Unlike [`Genesis`], initialization here is non-deterministic and happens on every startup
 ///
 /// # When to Use
 /// Use this trait when initializing modules at startup.
-/// Module developers typically don't need to interact with this trait directly - they should
-/// implement [`Module::init`] instead.
+/// Module developers typically don't need to interact with this trait directly.
 pub trait ExecutionInit {
     /// Configuration type for offchain components.
-    ///
-    /// This is the same as [`Module::ExecutionConfig`].
     type Config;
 
-    /// Initializes the module's offchain components.
+    /// Initializes offchain components for the module.
     ///
-    /// See [`Module::init`] for detailed documentation on this method's purpose and behavior.
+    /// This method is called at startup (before processing any blocks) to initialize
+    /// offchain components that the module needs. Unlike [`Module::genesis`],
+    /// which is called once during rollup deployment and must be deterministic, `init` can perform
+    /// non-deterministic operations and is called on every startup.
+    ///
+    /// Common use cases include:
+    /// - Initializing metrics collectors
+    /// - Connecting to external services
+    ///
+    /// # Determinism
+    /// Unlike [`Module::genesis`] and [`Module::call`], this method does NOT need to be deterministic.
+    /// Different instances can have different configurations for offchain components as long as they
+    /// produce the same state transitions when processing blocks.
     ///
     /// # Errors
-    /// Returns an error if initialization fails, which will typically cause startup to fail.
+    /// Returns an error if initialization fails. This will typically cause startup to fail.
+    ///
+    /// # Example
+    ///
+    /// A common pattern is to store the configuration in a global variable (using [`std::sync::OnceLock`])
+    /// and then access it from hooks like [`BlockHooks`]:
+    ///
+    /// ```rust,ignore
+    /// use std::sync::OnceLock;
+    /// use sov_modules_api::{ExecutionInit, BlockHooks, StateCheckpoint};
+    ///
+    /// // Define the execution configuration for offchain components
+    /// #[derive(Clone)]
+    /// struct MyModuleExecutionConfig {
+    ///     metrics_endpoint: String,
+    ///     enable_detailed_logging: bool,
+    /// }
+    ///
+    /// // Global storage for the configuration
+    /// static EXECUTION_CONFIG: OnceLock<MyModuleExecutionConfig> = OnceLock::new();
+    ///
+    /// #[derive(Clone)]
+    /// struct MyModule { /* ... */ }
+    ///
+    /// impl ExecutionInit for MyModule {
+    ///     type Config = MyModuleExecutionConfig;
+    ///
+    ///     // Initialize offchain components at startup
+    ///     fn init(config: &Self::Config) -> Result<(), Box<dyn std::error::Error>> {
+    ///         EXECUTION_CONFIG.set(config.clone())
+    ///             .map_err(|_| "Execution config already initialized")?;
+    ///
+    ///         // Perform any other initialization (e.g., connect to metrics endpoint)
+    ///         println!("Connecting to metrics at: {}", config.metrics_endpoint);
+    ///
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// // Access the configuration in BlockHooks
+    /// impl BlockHooks for MyModule {
+    ///     type Spec = /* ... */;
+    ///
+    ///     fn end_rollup_block_hook(&mut self, state: &mut StateCheckpoint<Self::Spec>) {
+    ///         // Access the execution configuration
+    ///         if let Some(config) = EXECUTION_CONFIG.get() {
+    ///             if config.enable_detailed_logging {
+    ///                 println!("Block completed - detailed logging enabled");
+    ///             }
+    ///             // Submit metrics to the configured endpoint, etc.
+    ///         }
+    ///     }
+    /// }
+    /// ```
     fn init(config: &Self::Config) -> Result<(), Box<dyn std::error::Error>>;
-}
-
-impl<T> ExecutionInit for T
-where
-    T: Module,
-{
-    type Config = <Self as Module>::ExecutionConfig;
-
-    fn init(config: &Self::Config) -> Result<(), Box<dyn std::error::Error>> {
-        <Self as Module>::init(config)
-    }
 }
 
 #[cfg(test)]

--- a/crates/module-system/sov-modules-api/src/runtime/mod.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/mod.rs
@@ -33,19 +33,33 @@ pub enum OperatingMode {
     Operator,
 }
 
-/// todod
+/// This trait defines an interface to pass runtime configuration values for modules.
+/// This is configuration that is ran off-chain, for example metric gathering configuration.
+/// This is distinct from genesis configuration, which is passed to the runtime at genesis time
+/// and stored on-chain.
+///
+/// This configuration and function does not need to be deterministic, as it is not executed
+/// on-chain.
 pub trait ModuleExecutionConfig {
-    /// todod
-    type Input;
+    /// Input type for configuration.
+    /// This could be a config struct that holds sub configuration for each runtime module
+    /// that requires such configuration.
+    type Input: Clone + Send + Sync;
 
-    /// todod
-    fn configure(input: &Self::Input) -> ();
+    /// Execute configuration for modules.
+    /// This function is called once at runtime startup and will typically pass specific module
+    /// configuration values to each module that requires it.
+    fn configure(_input: &Self::Input) -> Result<(), Box<dyn std::error::Error + Send + Sync>>;
 }
 
+// Allow assigning `()` as the ModuleExecutionConfig when no configuration is needed.
+// Acts as a no-op implementation.
 impl ModuleExecutionConfig for () {
     type Input = ();
 
-    fn configure(_input: &Self::Input) -> () {}
+    fn configure(_input: &Self::Input) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        Ok(())
+    }
 }
 
 #[cfg(feature = "native")]
@@ -75,7 +89,7 @@ pub trait Runtime<S: Spec>:
     /// GenesisInput type.
     type GenesisInput: std::fmt::Debug + Clone + Send + Sync;
 
-    /// TODO
+    /// ModuleExecutionConfiguration type.
     type ModuleExecutionConfig: ModuleExecutionConfig;
 
     /// Responsible for authenticating transactions.

--- a/crates/module-system/sov-modules-api/src/runtime/mod.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/mod.rs
@@ -33,6 +33,21 @@ pub enum OperatingMode {
     Operator,
 }
 
+/// todod
+pub trait ModuleExecutionConfig {
+    /// todod
+    type Input;
+
+    /// todod
+    fn configure(input: &Self::Input) -> ();
+}
+
+impl ModuleExecutionConfig for () {
+    type Input = ();
+
+    fn configure(_input: &Self::Input) -> () {}
+}
+
 #[cfg(feature = "native")]
 /// This trait has to be implemented by a runtime in order to be used in `StfBlueprint`.
 ///
@@ -59,6 +74,9 @@ pub trait Runtime<S: Spec>:
 
     /// GenesisInput type.
     type GenesisInput: std::fmt::Debug + Clone + Send + Sync;
+
+    /// TODO
+    type ModuleExecutionConfig: ModuleExecutionConfig;
 
     /// Responsible for authenticating transactions.
     type Auth: TransactionAuthenticator<S>;

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -15,11 +15,11 @@ use sov_modules_api::capabilities::{HasCapabilities, HasKernel, ProofProcessor, 
 use sov_modules_api::execution_mode::ExecutionMode;
 use sov_modules_api::provable_height_tracker::MaximumProvableHeight;
 use sov_modules_api::rest::{ApiState, StateUpdateReceiver};
-use sov_modules_api::GenesisParamsTrait;
 use sov_modules_api::{
     DaSpec, NodeEndpoints, OperatingMode, ProofSender, Spec, StateCheckpoint, StateUpdateInfo,
     SyncStatus, VersionReader, ZkVerifier,
 };
+use sov_modules_api::{GenesisParamsTrait, ModuleExecutionConfig};
 use sov_modules_stf_blueprint::{GenesisParams, Runtime as RuntimeTrait, StfBlueprint};
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::node::da::{DaService, SlotData};
@@ -160,6 +160,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         prover_config: Option<RollupProverConfig<<Self::Spec as Spec>::InnerZkvm>>,
         start_at_rollup_height: Option<RollupHeight>,
         stop_at_rollup_height: Option<RollupHeight>,
+        exec_config: Option<<<Self::Runtime as RuntimeTrait<Self::Spec>>::ModuleExecutionConfig as ModuleExecutionConfig>::Input>,
     ) -> anyhow::Result<Rollup<Self, M>>
     where
         <Self::Spec as Spec>::Storage: NativeStorage,
@@ -172,6 +173,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             prover_config,
             start_at_rollup_height,
             stop_at_rollup_height,
+            exec_config,
         )
         .await
     }
@@ -292,10 +294,16 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         prover_config: Option<RollupProverConfig<<Self::Spec as Spec>::InnerZkvm>>,
         start_at_rollup_height: Option<RollupHeight>,
         stop_at_rollup_height: Option<RollupHeight>,
+        exec_config: Option<<<Self::Runtime as RuntimeTrait<Self::Spec>>::ModuleExecutionConfig as ModuleExecutionConfig>::Input>,
     ) -> anyhow::Result<Rollup<Self, M>>
     where
         <Self::Spec as Spec>::Storage: NativeStorage,
     {
+        if let Some(exec_config) = &exec_config {
+            tracing::debug!("Initializing module execution config");
+            <<Self::Runtime as RuntimeTrait<Self::Spec>>::ModuleExecutionConfig as ModuleExecutionConfig>::configure(exec_config).map_err(|e|anyhow::anyhow!(e))?;
+        }
+
         let (main_shutdown_sender, mut main_shutdown_receiver) = tokio::sync::watch::channel(());
         main_shutdown_receiver.mark_unchanged();
         let (secondary_shutdown_sender, mut secondary_shutdown_receiver) =

--- a/crates/module-system/sov-test-utils/src/runtime/macros.rs
+++ b/crates/module-system/sov-test-utils/src/runtime/macros.rs
@@ -121,6 +121,7 @@ macro_rules! generate_runtime_without_capabilities {
 
             type GenesisConfig = <Self as ::sov_modules_api::Genesis>::Config;
             type GenesisInput = ();
+            type ModuleExecutionConfig = ();
             type Auth = $auth;
 
             fn endpoints(api_state: sov_modules_api::rest::ApiState<S>) -> ::sov_modules_api::NodeEndpoints {

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -256,6 +256,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                         self.config.rollup_prover_config.clone(),
                         self.config.start_at_rollup_height,
                         self.config.stop_at_rollup_height,
+                        None,
                     )
                     .await?
             }
@@ -267,6 +268,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                         self.config.rollup_prover_config.clone(),
                         self.config.start_at_rollup_height,
                         self.config.stop_at_rollup_height,
+                        None,
                     )
                     .await?
             }

--- a/examples/demo-rollup/src/main.rs
+++ b/examples/demo-rollup/src/main.rs
@@ -234,6 +234,7 @@ async fn new_rollup_with_celestia_da(
             prover_config,
             start_at_rollup_height,
             stop_at_rollup_height,
+            None,
         )
         .await
 }
@@ -260,6 +261,7 @@ async fn new_rollup_with_celestia_da_and_nomt(
             prover_config,
             start_at_rollup_height,
             stop_at_rollup_height,
+            None,
         )
         .await
 }
@@ -289,6 +291,7 @@ async fn new_rollup_with_mock_da_and_jmt(
             prover_config,
             start_at_rollup_height,
             stop_at_rollup_height,
+            None,
         )
         .await
 }
@@ -318,6 +321,7 @@ async fn new_rollup_with_external_mock_da_and_jmt(
             prover_config,
             start_at_rollup_height,
             stop_at_rollup_height,
+            None,
         )
         .await
 }
@@ -347,6 +351,7 @@ async fn new_rollup_with_mock_da_and_nomt(
             prover_config,
             stop_at_rollup_height,
             start_at_rollup_height,
+            None,
         )
         .await
 }
@@ -376,6 +381,7 @@ async fn new_rollup_with_external_mock_da_and_nomt(
             prover_config,
             start_at_rollup_height,
             stop_at_rollup_height,
+            None,
         )
         .await
 }

--- a/examples/demo-rollup/stf/src/runtime.rs
+++ b/examples/demo-rollup/stf/src/runtime.rs
@@ -98,6 +98,9 @@ where
     #[cfg(feature = "native")]
     type GenesisInput = GenesisPaths;
 
+    #[cfg(feature = "native")]
+    type ModuleExecutionConfig = ();
+
     type Auth = sov_evm::EvmAuthenticator<S, Self>;
 
     #[cfg(feature = "native")]


### PR DESCRIPTION
# Description

Adds a mechanism to pass runtime configuration to modules to perform any setup for off-chain operations (such as metric gathering).

Open to bikeshedding on the naming of `ExecutionConfig` - `RuntimeConfig` seemed better to me but would be ambiguous when used in the same context as the rollup Runtime. 

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
