### PR TITLE
Fix silent error handling in indexer event fetching

### DIFF
--- a/typescript/apps/indexer/src/indexer.test.ts
+++ b/typescript/apps/indexer/src/indexer.test.ts
@@ -45,11 +45,11 @@ describe("Indexer", () => {
       indexer.setAndCheckHealth(new SovereignClient.APIConnectionError({}));
       expect(indexer.isRollupHealthy).toBe(false);
     });
-    it("should set isRollupHealthy flag to true if not connection error", () => {
+    it("should set isRollupHealthy flag to false for generic errors", () => {
       const indexer = new Indexer({} as any) as any;
 
       indexer.setAndCheckHealth(new Error());
-      expect(indexer.isRollupHealthy).toBe(true);
+      expect(indexer.isRollupHealthy).toBe(false);
     });
   });
   describe("handleRollupOffline", () => {

--- a/typescript/apps/indexer/src/indexer.ts
+++ b/typescript/apps/indexer/src/indexer.ts
@@ -96,6 +96,7 @@ export class Indexer {
         module: event.module.name,
       }));
     } catch (err) {
+      logger.error("Failed to fetch rollup events", err);
       this.setAndCheckHealth(err);
       return [];
     }
@@ -130,8 +131,8 @@ export class Indexer {
     });
   }
 
-  private setAndCheckHealth(e: unknown): boolean {
-    this.isRollupHealthy = !(e instanceof SovereignClient.APIConnectionError);
+  private setAndCheckHealth(_e: unknown): boolean {
+    this.isRollupHealthy = false;
     return this.isRollupHealthy;
   }
 }


### PR DESCRIPTION


The indexer was silently swallowing all errors when fetching events from the rollup API. Any failure (HTTP 500, serialization errors, network issues) would return an empty array without logging or triggering the recovery mechanism. This created a false sense of normal operation while events were actually being skipped.

