### PR TITLE
Tone down time oracle log message

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/timestamp.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/timestamp.rs
@@ -41,8 +41,9 @@ impl<S: Spec> TimingOracleConfigWithPrivateKey<S> {
                 None => {
                     let key = <S::CryptoSpec as CryptoSpec>::PrivateKey::generate();
                     tracing::info!(
-                        "Generated ephemeral oracle key with pubkey hex: 0x{}. Make sure the paymaster is enabled.",
-                        hex::encode(key.pub_key().as_ref())
+                        pub_key = %hex::encode(key.pub_key().as_ref()),
+                        "Generated ephemeral oracle key. Make sure the paymaster is enabled.",
+
                     );
                     Ok(key)
                 }
@@ -92,7 +93,7 @@ where
         loop {
             tokio::select! {
                  _ = ticker.tick() => {}
-                 _ = shutdown_receiver.changed() => { break;}
+                 _ = shutdown_receiver.changed() => { break; }
             }
 
             let now = std::time::SystemTime::now()
@@ -135,15 +136,15 @@ where
 
             let baked_tx = Rt::Auth::encode_with_standard_auth(raw_tx);
 
-            if let Err(e) = seq.accept_tx(baked_tx).await {
+            if let Err(error) = seq.accept_tx(baked_tx).await {
                 // Reduce log spam by only logging 1 of every 100 consecutive failures
                 if consecutive_failures % 100 == 0 {
-                    tracing::error!(error = ?e, "Error submitting timestamp oracle update tx");
+                    tracing::error!(?error, "Error submitting timestamp oracle update tx");
                 }
                 consecutive_failures += 1;
             } else {
                 consecutive_failures = 0;
-                tracing::info!(%timestamp, "Successfully submitted timestamp oracle update tx");
+                tracing::trace!(%timestamp, "Successfully submitted timestamp oracle update tx");
             }
         }
     });


### PR DESCRIPTION
# Description
<img width="954" height="429" alt="Screenshot 2025-11-24 at 09 17 37" src="https://github.com/user-attachments/assets/0e2fec1e-51b1-46c1-8f16-202cc06ae4f0" />

This message produces a lot of log entries

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existings tests are passing

## Docs

