### PR TITLE
Revisiting default celestia configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
+# 2025-11-24
+- #2109 Configuration changes in `sov-celestia-adapter`. Default values for `request_timeout_secs` and `tx_priority` has changed.
+  **It is recommended to remove those values and use defaults** unless there's a reason.
+  Here is minimal functioning celestia config:
+  ```toml
+  [da]
+  rpc_url = "ws://127.0.0.1:26658"
+  grpc_url = "http://127.0.0.1:9090"
+  signer_private_key = "0000000000000000000000000000000000000000000000000000000000000000"
+  ```
 # 2025-11-17
-- ##2082 **Breaking change**: Increase the granularity of EVM log timestamps. Logs within the same block can now have different timestamps.
+- #2082 **Breaking change**: Increase the granularity of EVM log timestamps. Logs within the same block can now have different timestamps.
 # 2025-11-14
 - #2076 Adds `TimingOracle` functionality. The feature is disabled by default, so it does not introduce any breaking changes.
 - #2077 **Breaking change**: The `Sequencer` implementations have been made cheaply cloneable, and the `accept_tx()` method has been made cancellation-safe. This has two effects:

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -199,5 +199,6 @@ pub(crate) fn default_factor() -> f32 {
 }
 
 pub(crate) fn default_request_timeout_seconds() -> NonZero<u64> {
-    NonZero::new(60).unwrap()
+    // 6 blocks + 1 second for jitter
+    NonZero::new(37).unwrap()
 }

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -47,8 +47,9 @@ pub struct CelestiaConfig {
     #[serde(default = "default_safe_lead_time_ms")]
     pub safe_lead_time_ms: u64,
 
-    /// Default is medium.
-    pub tx_priority: Option<TxPriority>,
+    /// Default is high.
+    #[serde(default = "default_tx_priority")]
+    pub tx_priority: TxPriority,
     /// Minimal time to wait before reattempting to request to celestia node.
     /// See [`backon::ExponentialBuilder`] for more details
     #[serde(default = "default_min_delay_ms")]
@@ -144,7 +145,7 @@ impl CelestiaConfig {
     }
 }
 
-pub(crate) fn default_safe_lead_time_ms() -> u64 {
+pub(crate) const fn default_safe_lead_time_ms() -> u64 {
     500
 }
 
@@ -162,6 +163,10 @@ fn default_grpc_auth_token() -> Option<String> {
 
 fn default_signer_private_key() -> Option<String> {
     std::env::var("SOV_CELESTIA_SIGNER_KEY").ok()
+}
+
+pub(crate) const fn default_tx_priority() -> TxPriority {
+    TxPriority::High
 }
 
 // Exponential backoff defaults:

--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -49,7 +49,7 @@ pub struct CelestiaService {
     safe_lead_time: Duration,
     backoff_policy: ExponentialBuilder,
     request_timeout: Duration,
-    tx_priority: Option<celestia_client::tx::TxPriority>,
+    tx_priority: celestia_client::tx::TxPriority,
 }
 
 impl CelestiaService {
@@ -62,7 +62,7 @@ impl CelestiaService {
         safe_lead_time: Duration,
         backoff_policy: ExponentialBuilder,
         request_timeout: Duration,
-        tx_priority: Option<celestia_client::tx::TxPriority>,
+        tx_priority: celestia_client::tx::TxPriority,
     ) -> Self {
         Self {
             submit_client: Arc::new(tokio::sync::Mutex::new(submit_client)),
@@ -89,9 +89,7 @@ impl CelestiaService {
 
     fn get_tx_config(&self) -> celestia_client::tx::TxConfig {
         let mut tx_config = celestia_client::tx::TxConfig::default();
-        if let Some(priority) = self.tx_priority.as_ref() {
-            tx_config = tx_config.with_priority(*priority);
-        }
+        tx_config = tx_config.with_priority(self.tx_priority);
         tx_config
     }
 
@@ -214,7 +212,7 @@ impl CelestiaService {
             Duration::from_millis(config.safe_lead_time_ms),
             backoff_policy,
             request_timeout,
-            config.tx_priority.map(Into::into),
+            config.tx_priority.into(),
         )
     }
 }

--- a/crates/adapters/celestia/src/test_helper/docker.rs
+++ b/crates/adapters/celestia/src/test_helper/docker.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use crate::config::{
     default_factor, default_max_delay_ms, default_max_times, default_min_delay_ms,
-    default_request_timeout_seconds, default_safe_lead_time_ms,
+    default_request_timeout_seconds, default_safe_lead_time_ms, default_tx_priority,
 };
 use crate::verifier::address::CelestiaAddress;
 use crate::{CelestiaConfig, CelestiaService};
@@ -281,7 +281,7 @@ impl CelestiaDevNode {
             signer_private_key: Some(key_0),
             request_timeout_secs: default_request_timeout_seconds(),
             safe_lead_time_ms: default_safe_lead_time_ms(),
-            tx_priority: None,
+            tx_priority: default_tx_priority(),
             backoff_min_delay_ms: default_min_delay_ms(),
             backoff_max_delay_ms: default_max_delay_ms(),
             backoff_max_times: default_max_times(),

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -36,7 +36,7 @@ signer_private_key = "aec34bb1cfae6e906594dc106af4057a9046f769e2eeed67d040f0107e
 
 # Options are "Low", "Medium" and "High"
 # Defines a priority of rollup blob transactions. Set it to "High" for faster inclusion.
-# Default: Medium
+# Default: High for better blob inclusion.
 #tx_priority = "High"
 
 # Exponential backoff configuration for retrying failed requests to Celestia node

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -31,9 +31,8 @@ grpc_url = "http://127.0.0.1:9090"
 signer_private_key = "aec34bb1cfae6e906594dc106af4057a9046f769e2eeed67d040f0107e15e167"
 
 # The maximum time to wait for a response to an RPC query against Celestia node.
-# Default: 60 seconds
-# We set it to allow skipping 5 blocks on mocha testnet
-request_timeout_secs = 30
+# Default: 37 seconds
+#request_timeout_secs = 37
 
 # Options are "Low", "Medium" and "High"
 # Defines a priority of rollup blob transactions. Set it to "High" for faster inclusion.


### PR DESCRIPTION
# Description

We've discovered that accidentally setting low `request_timeout_secs` might lead to blob being resumbitted constantly. 
Celestia block time is known, so it is possible to set reasonable default value.
It has been chosen to be 6 blocks + 1 second.

Low tx fees can issue is low blob inclusion, which can be caused be low fees. 
We deliberately set default value to be `High`, so users have to opt-in into slower and more usntable rollup.

**It is recommeneded to delete these values from starter examples**

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1630 

## Testing
All existing tests are passing

## Docs
No updates
