### PR TITLE
Add `vendored` feature flag for swagger-ui to prevent curl during build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15612,8 +15612,15 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa 5.4.0",
+ "utoipa-swagger-ui-vendored",
  "zip",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ tracing-test = { version = "0.2.5", features = [
     "no-env-filter",
 ] } # https://docs.rs/tracing-test/latest/tracing_test/#per-crate-filtering
 utoipa = "4.2"
-utoipa-swagger-ui = { version = "7.1.1-rc.0", features = ["axum", "debug-embed"] }
+utoipa-swagger-ui = { version = "7.1.1-rc.0", features = ["axum", "debug-embed", "vendored"] }
 unwrap-infallible = "0.1.5"
 bech32 = { version = "0.11" }
 derive_more = { version = "1.0", default-features = false, features = ["std"] }


### PR DESCRIPTION
# Description

WE HAD ENOUGH!

Docs: https://github.com/juhaku/utoipa/blob/master/utoipa-swagger-ui/README.md#build-config

> Tip
> Use vendored feature flag to use vendored Swagger UI. This is especially useful for no network environments.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
