### PR TITLE
Add extra information when the sequencer nonce queues reject a tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7089,8 +7089,7 @@ dependencies = [
 [[package]]
 name = "nomt"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705307a2ab047b0ac978479652ba19e995d022794785b6a165a0f7f24739908c"
+source = "git+https://github.com/thrumdev/nomt.git?rev=4189c7dc3dc710fef526591ee73860e462a135de#4189c7dc3dc710fef526591ee73860e462a135de"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7119,8 +7118,7 @@ dependencies = [
 [[package]]
 name = "nomt-core"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeb4e411c8185c33c906539b78330a8478a2d4819de338efb6511b33cc73207"
+source = "git+https://github.com/thrumdev/nomt.git?rev=4189c7dc3dc710fef526591ee73860e462a135de#4189c7dc3dc710fef526591ee73860e462a135de"
 dependencies = [
  "arrayvec",
  "bitvec",

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -1255,17 +1255,39 @@ fn err_cant_fit_tx(current_batch_size: usize, max_batch_size: usize, tx_len: usi
     }
 }
 
+/// Helper enum for error logging when the nonce queue rejects a transaction.
+enum InvalidNonceReason {
+    /// Nonce is in the past or beyond the queue limit. Tx rejected immediately when received.
+    Invalid,
+    /// Tx was queued but the timeout was reached before pre-requisites were all received, so tx
+    /// was evicted from the queue.
+    Timeout,
+    /// Tx was queued but executor oneshot was dropped. This happens on sequencer shutdown OR if
+    /// the queue enters an inconsistent state and internally evicts stale transactions (which
+    /// should almost never happen in practice unless the queue has a bug).
+    EvictedBeforeExecution,
+}
+
 /// Helper function to create an invalid nonce error
 fn err_invalid_nonce<S: Spec, Rt: Runtime<S>>(
     tx_hash: TxHash,
     tx_nonce: u64,
     expected_nonce: u64,
+    nonce_when_queued: u64,
+    instant_queued: std::time::Instant,
     credential_id: CredentialId,
+    queue_rejection_reason: InvalidNonceReason,
 ) -> Result<tx_nonce_queue::TransactionReceiverResult<S, Rt>, SequencerStateUpdatorError> {
     // Match the error format from sov-uniqueness check_nonce_uniqueness
+    let queue_error_msg = match queue_rejection_reason {
+        InvalidNonceReason::Invalid => "The sequencer did not attempt to queue the transaction as it was not within valid queue limits (either in the past, or beyond the max limit).".to_string(),
+        InvalidNonceReason::Timeout => format!("The sequencer queued the transaction for reordering {} ms ago, when the user's nonce was {nonce_when_queued}. In that time, the sequencer did not receive all the transactions leading up to this tx's nonce, so it has timed out and is being evicted from the queue.", instant_queued.elapsed().as_millis()),
+        InvalidNonceReason::EvictedBeforeExecution => format!("The transaction was dropped from the nonce reordering queue (after spending {} ms in it) for an unknown reason. This should normally only happen when the sequencer is shutting down.", instant_queued.elapsed().as_millis()),
+    };
     let error_msg = format!(
-        "Tx bad nonce for credential id: {credential_id}, expected: {expected_nonce}, but found: {tx_nonce}"
+        "Tx bad nonce for credential id: {credential_id}, expected: {expected_nonce}, but found: {tx_nonce}. {queue_error_msg}"
     );
+    tracing::debug!("Sequencer rejecting nonce transaction with error: {error_msg}");
     let receipt = TransactionReceipt {
         tx_hash,
         body_to_save: None,

--- a/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
@@ -542,7 +542,8 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                 res
             }
             Action::WaitForQueue(mut queue_rx) => {
-                let user_nonce_when_queued = self.submitter.get_current_nonce_for_user(&credential_id);
+                let user_nonce_when_queued =
+                    self.submitter.get_current_nonce_for_user(&credential_id);
                 let queued_at = Instant::now();
                 loop {
                     tokio::select! {
@@ -591,9 +592,15 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                     }
                 }
             }
-            Action::Reject(current_nonce) => {
-                err_invalid_nonce::<S, Rt>(tx_hash, tx_nonce, current_nonce, current_nonce, Instant::now(), credential_id, InvalidNonceReason::Invalid)
-            }
+            Action::Reject(current_nonce) => err_invalid_nonce::<S, Rt>(
+                tx_hash,
+                tx_nonce,
+                current_nonce,
+                current_nonce,
+                Instant::now(),
+                credential_id,
+                InvalidNonceReason::Invalid,
+            ),
         }
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
@@ -9,6 +9,7 @@ use std::cmp::Ordering;
 use std::collections::{btree_map::OccupiedEntry, BTreeMap};
 use std::fmt::Debug;
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::sync::oneshot;
 
 use crate::common::AcceptedTx;
@@ -16,7 +17,7 @@ use crate::common::AcceptedTx;
 use super::sync_sequencer_state::{
     AcceptTxError, SequencerStateUpdator, SequencerStateUpdatorError,
 };
-use super::{err_invalid_nonce, Confirmation};
+use super::{err_invalid_nonce, Confirmation, InvalidNonceReason};
 
 pub(crate) type TransactionReceiverResult<S, Rt> =
     Result<oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>, AcceptTxError<S>>;
@@ -541,6 +542,8 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                 res
             }
             Action::WaitForQueue(mut queue_rx) => {
+                let user_nonce_when_queued = self.submitter.get_current_nonce_for_user(&credential_id);
+                let queued_at = Instant::now();
                 loop {
                     tokio::select! {
                         rx = &mut queue_rx => {
@@ -551,12 +554,15 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                                 // queue it can be evicted (dropping it and the sender).
                                 // Since the transaction was queued and therefore had an incorrect
                                 // nonce to begin with, we conservatively reject with a nonce error.
-                                let current_nonce = self.submitter.get_current_nonce_for_user(&credential_id);
+                                let user_current_nonce = self.submitter.get_current_nonce_for_user(&credential_id);
                                 err_invalid_nonce::<S, Rt>(
                                     tx_hash,
                                     tx_nonce,
-                                    current_nonce,
+                                    user_current_nonce,
+                                    user_nonce_when_queued,
+                                    queued_at,
                                     credential_id,
+                                    InvalidNonceReason::EvictedBeforeExecution,
                                 )
                             });
                         },
@@ -564,8 +570,8 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                                 self.future_nonce_transaction_timeout_millis
                         )) => {
                             // Timeout waiting for prerequisite transactions
-                            let current_nonce = self.submitter.get_current_nonce_for_user(&credential_id);
-                            if self.has_prerequisites_to_nonce(&credential_id, tx_nonce, current_nonce) {
+                            let user_current_nonce = self.submitter.get_current_nonce_for_user(&credential_id);
+                            if self.has_prerequisites_to_nonce(&credential_id, tx_nonce, user_current_nonce) {
                                 // Still has a valid path to execution, keep waiting
                                 continue;
                             } else {
@@ -574,8 +580,11 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                                 break err_invalid_nonce::<S, Rt>(
                                     tx_hash,
                                     tx_nonce,
-                                    current_nonce,
+                                    user_current_nonce,
+                                    user_nonce_when_queued,
+                                    queued_at,
                                     credential_id,
+                                    InvalidNonceReason::Timeout,
                                 );
                             }
                         }
@@ -583,7 +592,7 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                 }
             }
             Action::Reject(current_nonce) => {
-                err_invalid_nonce::<S, Rt>(tx_hash, tx_nonce, current_nonce, credential_id)
+                err_invalid_nonce::<S, Rt>(tx_hash, tx_nonce, current_nonce, current_nonce, Instant::now(), credential_id, InvalidNonceReason::Invalid)
             }
         }
     }


### PR DESCRIPTION
# Description

Should help debug or at least provide visibility when transactions are rejected with nonce errors.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
