### PR TITLE
Bug fix: remove extra transaction causing pinning tests to pass incorrectly. Fix inverted`if`

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -119,8 +119,6 @@ where
         )
         .inspect_err(|err| tracing::debug!(error = ?err, "Ran out of gas while getting checking pinned contract list updates"))
         .map_err(|err| anyhow::anyhow!("EVM transaction error: {err:?}"))?;
-        
-        tracing::warn!("Pinned contract list updates: {:?}", new_pinned_contracts);
 
         // We don't use transact_commit as it does not support returning an error
         start_timer!(state_commit);
@@ -367,7 +365,6 @@ pub(crate) fn get_pinned_contract_list_updates<DB: Database<Error = E>, E: DBErr
 ) -> Result<Vec<Address>, E> {
     use alloy_consensus::constants::KECCAK_EMPTY;
     let Some(execution_config) = EVM_EXECUTION_CONFIG.get() else {
-        tracing::error!("No evm execution config");
         return Ok(Vec::new());
     };
 
@@ -379,7 +376,6 @@ pub(crate) fn get_pinned_contract_list_updates<DB: Database<Error = E>, E: DBErr
         .privileged_deployer_addresses
         .contains(signer)
     {
-        tracing::error!("Signer not privileged");
         return Ok(Vec::new());
     };
 

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -119,6 +119,8 @@ where
         )
         .inspect_err(|err| tracing::debug!(error = ?err, "Ran out of gas while getting checking pinned contract list updates"))
         .map_err(|err| anyhow::anyhow!("EVM transaction error: {err:?}"))?;
+        
+        tracing::warn!("Pinned contract list updates: {:?}", new_pinned_contracts);
 
         // We don't use transact_commit as it does not support returning an error
         start_timer!(state_commit);
@@ -365,6 +367,7 @@ pub(crate) fn get_pinned_contract_list_updates<DB: Database<Error = E>, E: DBErr
 ) -> Result<Vec<Address>, E> {
     use alloy_consensus::constants::KECCAK_EMPTY;
     let Some(execution_config) = EVM_EXECUTION_CONFIG.get() else {
+        tracing::error!("No evm execution config");
         return Ok(Vec::new());
     };
 
@@ -376,6 +379,7 @@ pub(crate) fn get_pinned_contract_list_updates<DB: Database<Error = E>, E: DBErr
         .privileged_deployer_addresses
         .contains(signer)
     {
+        tracing::error!("Signer not privileged");
         return Ok(Vec::new());
     };
 
@@ -387,12 +391,12 @@ pub(crate) fn get_pinned_contract_list_updates<DB: Database<Error = E>, E: DBErr
             .as_ref()
             .is_some_and(|code| !code.is_empty());
         if is_contract {
-            let was_contract = db
+            let was_not_contract = db
                 .basic(*address)?
                 .map(|acc| acc.code_hash == KECCAK_EMPTY)
                 .unwrap_or(true);
             // If it wasn't a contract before, and it is now, it was just deployed. Pin it if necessary.
-            if !was_contract {
+            if was_not_contract {
                 new_pinned_contracts.push(*address);
             }
         }

--- a/examples/demo-rollup/tests/evm/evm_ram_pinning.rs
+++ b/examples/demo-rollup/tests/evm/evm_ram_pinning.rs
@@ -78,8 +78,6 @@ async fn test_ram_pinning_config_updates() -> anyhow::Result<()> {
 
     tracing::info!("Deploying contract");
     let contract = SimpleStorage::deploy(client).await?;
-    let _tx = contract.set(U256::from(1)).send().await?;
-
     let exec_config: EvmExecutionConfigContents =
         serde_json::from_str(&std::fs::read_to_string(&exec_config_path)?)?;
     assert_eq!(

--- a/examples/demo-rollup/tests/evm/evm_ram_pinning.rs
+++ b/examples/demo-rollup/tests/evm/evm_ram_pinning.rs
@@ -2,7 +2,6 @@
 use std::path::PathBuf;
 
 use alloy::signers::local::PrivateKeySigner;
-use alloy_primitives::U256;
 use sov_demo_rollup::mock_da_risc0_host_args;
 use sov_demo_rollup::MockNomtDemoRollup;
 use sov_evm::execution_config::EvmExecutionConfigContents;


### PR DESCRIPTION
# Description

This PR fixes a bug in the ram pinning tests which caused it to pass because the contract was pinned for the wrong reason (because of an unrelated transaction). It also fixes the pinning logic to work on contract creation, rather than when contracts are touched.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
