### PR TITLE
Add additional tests to the tx nonce queues to verify that failing transactions abort queue drain

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
@@ -1699,6 +1699,156 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_failed_immediate_execution_does_not_trigger_drain() {
+        // Test that when a TX with the current nonce fails, the queue is NOT drained.
+        // This is the opposite of test_immediate_execution_triggers_drain.
+        let backend = MockTxExecutionBackend::new()
+            .with_current_nonce(0)
+            .with_failure_at_nonce(0); // TX with nonce 0 will fail
+
+        let queues = TxNonceQueues::new(backend.clone(), 10, 5000);
+        let credential_id = CredentialId::from([1u8; 32]);
+
+        // Submit TXs with nonces 1, 2, 3 (should be queued)
+        let mut handles = vec![];
+        for nonce in 1u8..=3 {
+            let queues = queues.clone();
+            let handle = tokio::spawn(async move {
+                queues
+                    .handle_new_tx(
+                        create_test_tx(nonce),
+                        TxHash::from([nonce; 32]),
+                        nonce as u64,
+                        credential_id,
+                        0,
+                    )
+                    .await
+            });
+            handles.push(handle);
+        }
+
+        // Give queued TXs time to settle
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Submit TX with nonce 0 (current nonce) - should fail and NOT trigger drain
+        let result = queues
+            .handle_new_tx(
+                create_test_tx(0),
+                TxHash::from([0; 32]),
+                0,
+                credential_id,
+                0,
+            )
+            .await;
+
+        // TX 0 should return an error (failed execution)
+        assert!(result.is_ok()); // No sequencer error
+        let inner = result.unwrap();
+        assert!(inner.is_err()); // But the TX itself failed
+
+        // Wait a bit to ensure drain would have happened if triggered
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Verify NO TXs were successfully executed (TX 0 failed, drain not triggered)
+        let executed = backend.get_executed_nonces();
+        assert!(
+            executed.is_empty(),
+            "No transactions should have executed successfully"
+        );
+
+        // Verify nonce didn't change (TX 0 failed, so nonce stays at 0)
+        assert_eq!(backend.get_current_nonce_for_user(&credential_id), 0);
+
+        // Drop handles to clean up (they'll be cancelled)
+        drop(handles);
+    }
+
+    #[tokio::test]
+    async fn test_drain_stops_at_failing_transaction() {
+        // Test that when a TX in the queue fails during drain, the drain stops
+        // and subsequent queued TXs are not executed.
+        let backend = MockTxExecutionBackend::new()
+            .with_current_nonce(0)
+            .with_failure_at_nonce(2); // TX with nonce 2 will fail
+
+        let queues = TxNonceQueues::new(backend.clone(), 10, 5000);
+        let credential_id = CredentialId::from([1u8; 32]);
+
+        // Submit TXs with nonces 1, 2, 3 (should be queued)
+        let mut handles = vec![];
+        for nonce in 1u8..=3 {
+            let queues = queues.clone();
+            let handle = tokio::spawn(async move {
+                queues
+                    .handle_new_tx(
+                        create_test_tx(nonce),
+                        TxHash::from([nonce; 32]),
+                        nonce as u64,
+                        credential_id,
+                        0,
+                    )
+                    .await
+            });
+            handles.push(handle);
+        }
+
+        // Give queued TXs time to settle
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Submit TX with nonce 0 (current nonce) - should succeed and trigger drain
+        let result = queues
+            .handle_new_tx(
+                create_test_tx(0),
+                TxHash::from([0; 32]),
+                0,
+                credential_id,
+                0,
+            )
+            .await;
+
+        // TX 0 should succeed
+        assert!(result.is_ok());
+        let inner = result.unwrap();
+        assert!(inner.is_ok());
+        let rx = inner.unwrap();
+        assert!(rx.await.is_ok());
+
+        // Wait for drain to proceed (it should execute 1, then fail on 2, then stop)
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Check the results of the queued TXs
+        let mut handles_iter = handles.into_iter();
+
+        // TX 1 should have succeeded
+        let result_1 = handles_iter.next().unwrap().await.unwrap();
+        assert!(result_1.is_ok());
+        let inner_1 = result_1.unwrap();
+        assert!(inner_1.is_ok());
+        let rx_1 = inner_1.unwrap();
+        assert!(rx_1.await.is_ok());
+
+        // TX 2 should have failed
+        let result_2 = handles_iter.next().unwrap().await.unwrap();
+        assert!(result_2.is_ok()); // No sequencer error
+        let inner_2 = result_2.unwrap();
+        assert!(inner_2.is_err()); // But the TX itself failed
+
+        // Verify executed nonces: 0 and 1 only (2 failed, 3 never tried)
+        let executed = backend.get_executed_nonces();
+        assert_eq!(
+            executed,
+            vec![0, 1],
+            "Should execute 0 and 1, but stop at failing nonce 2"
+        );
+
+        // Verify nonce is 2 (0 and 1 succeeded and incremented nonce, 2 failed)
+        assert_eq!(backend.get_current_nonce_for_user(&credential_id), 2);
+
+        // Drop remaining handle to clean up
+        drop(handles_iter);
+    }
+
+    #[tokio::test]
     async fn test_queue_cleanup_respects_last_popped() {
         // This test verifies that cleanup_queue_if_empty() doesn't prune a queue
         // if last_popped is still tracking useful information

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_tx_nonce_queue.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_tx_nonce_queue.rs
@@ -137,6 +137,27 @@ fn tx_set_value(key: &Ed25519PrivateKey, nonce: u64, value_to_set: u64) -> RawTx
     RawTx::new(borsh::to_vec(&tx).unwrap())
 }
 
+/// Helper that creates a rejected transaction. Uses AssertVisibleSlotNumber with an impossibly
+/// high slot number to ensure the module rejects the transaction.
+fn tx_reject(key: &Ed25519PrivateKey, nonce: u64) -> RawTx {
+    let msg = <TestRuntime<TestSpec> as DispatchCall>::Decodable::ValueSetter(
+        sov_value_setter::CallMessage::AssertVisibleSlotNumber {
+            expected_visible_slot_number: 10_000_000_000,
+        },
+    );
+
+    let tx_details = default_test_tx_details::<TestSpec>();
+    let tx = test_signed_transaction::<TestRuntime<TestSpec>, TestSpec>(
+        key,
+        &msg,
+        UniquenessData::Nonce(nonce),
+        &<TestRuntime<TestSpec> as Runtime<TestSpec>>::CHAIN_HASH,
+        tx_details,
+    );
+
+    RawTx::new(borsh::to_vec(&tx).unwrap())
+}
+
 async fn submit_tx_set_value(
     client: &Client,
     key: &Ed25519PrivateKey,
@@ -247,6 +268,68 @@ async fn test_out_of_order_nonces() {
 
     // Sanity check
     query_set_value(&test_rollup, 4).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_failed_transaction_aborts_drain() {
+    let (test_rollup, admin) = create_test_rollup(DEFAULT_SIZE, DEFAULT_TIMEOUT).await;
+    let client = test_rollup.api_client().clone();
+    let key = admin.private_key();
+
+    // Submit 5 transactions with reverse order nonces, starting from 0 (4, 3, 2, 1, 0)
+    // Nonce 2 will fail, which should result in 0 and 1 executed, 2 rejected and 3, 4 timing out
+    // as a consequence
+
+    let nonces = (2..5).rev().collect::<Vec<_>>(); // 4, 3: will fail
+    let mut handles = vec![];
+    for nonce in nonces {
+        let client = client.clone();
+        let key = key.clone();
+        let handle = tokio::spawn(async move {
+            submit_tx_set_value(&client, &key, nonce, false).await;
+        });
+        handles.push(handle);
+
+        // Small delay to ensure transactions arrive in the intended order
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    {
+        let client = client.clone();
+        let key = key.clone();
+        let handle = tokio::spawn(async move {
+            let tx = tx_reject(&key, 2);
+            let res = client
+                .accept_tx(&api_types::AcceptTxBody {
+                    body: BASE64_STANDARD.encode(&tx),
+                })
+                .await;
+            res.unwrap_err();
+        });
+        handles.push(handle);
+    }
+
+    let nonces = (0..2).rev().collect::<Vec<_>>(); // 1, 0: will be included
+    let mut handles = vec![];
+    for nonce in nonces {
+        let client = client.clone();
+        let key = key.clone();
+        let handle = tokio::spawn(async move {
+            submit_tx_set_value(&client, &key, nonce, true).await;
+        });
+        handles.push(handle);
+
+        // Small delay to ensure transactions arrive in the intended order
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // Wait for all submissions to complete
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    // Sanity check
+    query_set_value(&test_rollup, 1).await.unwrap();
 }
 
 /// Test transactions timing out from the queue.


### PR DESCRIPTION
# Description

Verifies that the sequencer does not try to submit transactions from the queue if a previous transaction was rejected.

This was a missing test case from the existing tests. All the new tests pass so it seems there was no bug, but now it's covered so we can be confident.

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [ ] ~~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
