### PR TITLE
Fix allowlist bug; add additional test on ram pinning

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -1,4 +1,5 @@
 use alloy_primitives::{Address, B256};
+use alloy_consensus::constants::KECCAK_EMPTY;
 use reth_primitives::TransactionSigned;
 use revm::context::result::{EVMError, ExecResultAndState, ExecutionResult};
 use revm::context::{BlockEnv, CfgEnv, TxEnv};
@@ -110,7 +111,7 @@ where
         };
 
         save_elapsed!(execution_time SINCE execution);
-        verify_contract_creation_allowlist(&state_changes, &tx.signer, &cfg)?;
+        verify_contract_creation_allowlist(&state_changes, &tx.signer, &cfg, &mut db)?;
         #[cfg(feature = "native")]
         let new_pinned_contracts = get_pinned_contract_list_updates(
             &state_changes,
@@ -338,17 +339,29 @@ where
     }
 }
 
-pub(crate) fn verify_contract_creation_allowlist(
+pub(crate) fn verify_contract_creation_allowlist<DB: Database<Error = E>, E: DBErrorMarker + std::fmt::Display>(
     state_changes: &HashMap<Address, Account>,
     signer: &Address,
     cfg: &EvmRuntimeConfig,
+    db: &mut DB,
 ) -> Result<(), anyhow::Error> {
     if cfg.contract_creation_policy.allows(signer) {
         return Ok(());
     }
-    for account in state_changes.values() {
-        if let Some(ref code) = account.info.code {
-            if !code.is_empty() {
+    for (address, account) in state_changes.iter() {
+        let is_contract = account
+            .info
+            .code
+            .as_ref()
+            .is_some_and(|code| !code.is_empty());
+        if is_contract {
+            let was_not_contract = db
+                .basic(*address)
+                .map_err(|e| anyhow::anyhow!("Error while fetching previous contract data to verify allowlist: {e}"))?
+                .map(|acc| acc.code_hash == KECCAK_EMPTY)
+                .unwrap_or(true);
+            // If it wasn't a contract before, and it is now, it was just deployed. Pin it if necessary.
+            if was_not_contract {
                 bail!("Contract creation is only allowed from allowed addresses. {signer} is not on the list");
             }
         }
@@ -363,7 +376,6 @@ pub(crate) fn get_pinned_contract_list_updates<DB: Database<Error = E>, E: DBErr
     signer: &Address,
     db: &mut DB,
 ) -> Result<Vec<Address>, E> {
-    use alloy_consensus::constants::KECCAK_EMPTY;
     let Some(execution_config) = EVM_EXECUTION_CONFIG.get() else {
         return Ok(Vec::new());
     };

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -6,9 +6,7 @@ use revm::context::{BlockEnv, CfgEnv, TxEnv};
 use revm::primitives::hardfork::SpecId;
 use revm::primitives::HashMap;
 use revm::state::Account;
-#[cfg(feature = "native")]
 use revm::Database;
-#[cfg(feature = "native")]
 use revm_database_interface::DBErrorMarker;
 use revm_database_interface::TryDatabaseCommit;
 use sov_address::{EthereumAddress, FromVmAddress};

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -1,5 +1,5 @@
-use alloy_primitives::{Address, B256};
 use alloy_consensus::constants::KECCAK_EMPTY;
+use alloy_primitives::{Address, B256};
 use reth_primitives::TransactionSigned;
 use revm::context::result::{EVMError, ExecResultAndState, ExecutionResult};
 use revm::context::{BlockEnv, CfgEnv, TxEnv};
@@ -339,7 +339,10 @@ where
     }
 }
 
-pub(crate) fn verify_contract_creation_allowlist<DB: Database<Error = E>, E: DBErrorMarker + std::fmt::Display>(
+pub(crate) fn verify_contract_creation_allowlist<
+    DB: Database<Error = E>,
+    E: DBErrorMarker + std::fmt::Display,
+>(
     state_changes: &HashMap<Address, Account>,
     signer: &Address,
     cfg: &EvmRuntimeConfig,
@@ -357,7 +360,11 @@ pub(crate) fn verify_contract_creation_allowlist<DB: Database<Error = E>, E: DBE
         if is_contract {
             let was_not_contract = db
                 .basic(*address)
-                .map_err(|e| anyhow::anyhow!("Error while fetching previous contract data to verify allowlist: {e}"))?
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "Error while fetching previous contract data to verify allowlist: {e}"
+                    )
+                })?
                 .map(|acc| acc.code_hash == KECCAK_EMPTY)
                 .unwrap_or(true);
             // If it wasn't a contract before, and it is now, it was just deployed. Pin it if necessary.

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -201,9 +201,9 @@ where
         let caller = tx_env.caller;
         let cfg = self.cfg_infallible(state);
         let cfg_env = get_cfg_env(&block_env, &cfg, Some(get_cfg_env_template()));
-        let evm_db: EvmDb<_, S> = self.db(state);
-        let result = executor::transact(evm_db, &block_env, tx_env, cfg_env)?;
-        verify_contract_creation_allowlist(&result.state, &caller, &cfg)
+        let mut evm_db: EvmDb<_, S> = self.db(state);
+        let result = executor::transact(&mut evm_db, &block_env, tx_env, cfg_env)?;
+        verify_contract_creation_allowlist(&result.state, &caller, &cfg, &mut evm_db)
             .map_err(|e| EthApiError::other(into_rpc_error(e)))?;
         Ok(result)
     }

--- a/examples/demo-rollup/tests/evm/evm_ram_pinning.rs
+++ b/examples/demo-rollup/tests/evm/evm_ram_pinning.rs
@@ -2,6 +2,7 @@
 use std::path::PathBuf;
 
 use alloy::signers::local::PrivateKeySigner;
+use alloy_primitives::U256;
 use sov_demo_rollup::mock_da_risc0_host_args;
 use sov_demo_rollup::MockNomtDemoRollup;
 use sov_evm::execution_config::EvmExecutionConfigContents;

--- a/examples/demo-rollup/tests/evm/evm_ram_pinning.rs
+++ b/examples/demo-rollup/tests/evm/evm_ram_pinning.rs
@@ -13,10 +13,12 @@ use sov_sequencer::SequencerKindConfig;
 use sov_stf_runner::processes::RollupProverConfig;
 use sov_test_utils::test_rollup::{RollupBuilder, StoragePath, TestRollup};
 use sov_test_utils::SimpleStorage;
+use sov_test_utils::Submit;
 use tempfile::TempDir;
 
 use crate::evm::evm_test_helper::alloy_client_with_signer;
 use crate::evm::evm_test_helper::EVM_EXTENSION;
+use crate::evm::evm_test_helper::SECONDARY_SENDER_PRIV_KEY;
 use crate::evm::evm_test_helper::SENDER_PRIV_KEY;
 use crate::test_helpers::test_genesis_source;
 
@@ -91,6 +93,51 @@ async fn test_ram_pinning_config_updates() -> anyhow::Result<()> {
             .known_contracts_and_limits
             .contains_key(contract.address()),
         "Contract address should be in known contracts and limits"
+    );
+
+    Ok(())
+}
+
+/// Test that simply touching a contract from a privileged account does *not* cause it to be pinned; only deploying should do that.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_contract_not_pinned_on_touch() -> anyhow::Result<()> {
+    sov_test_utils::initialize_logging();
+    let temp_dir = tempfile::tempdir()?;
+    let exec_config_path = temp_dir.path().join("evm_execution_config.json");
+    let privileged_signer: PrivateKeySigner = SECONDARY_SENDER_PRIV_KEY.parse()?;
+    let exec_config_contents = EvmExecutionConfigContents {
+        default_bucket_size_limit: 100 * 1024 * 1024, // 100MB
+        privileged_deployer_addresses: vec![privileged_signer.address()],
+        known_contracts_and_limits: Default::default(),
+    };
+    std::fs::write(
+        &exec_config_path,
+        serde_json::to_string_pretty(&exec_config_contents)?,
+    )?;
+    let test_rollup =
+        start_node_with_ram_pinning(RollupProverConfig::Skip, temp_dir, exec_config_path.clone())
+            .await;
+    test_rollup.wait_for_next_blocks(1).await;
+    let client = alloy_client_with_signer(test_rollup.http_addr, SECONDARY_SENDER_PRIV_KEY);
+    let client_with_non_prvileged_signer =
+        alloy_client_with_signer(test_rollup.http_addr, SENDER_PRIV_KEY);
+
+    // Deploy the contract from the non-privliged adddress
+    let contract = SimpleStorage::deploy(client_with_non_prvileged_signer).await?;
+    // Touch it from the privileged address
+    let privileged = SimpleStorage::new(*contract.address(), client);
+    privileged.set(U256::ZERO).submit().await?;
+    let exec_config: EvmExecutionConfigContents =
+        serde_json::from_str(&std::fs::read_to_string(&exec_config_path)?)?;
+    assert_eq!(
+        exec_config.privileged_deployer_addresses,
+        vec![privileged_signer.address()]
+    );
+
+    // Verify that the contract isn't pinned.
+    assert!(
+        exec_config.known_contracts_and_limits.is_empty(),
+        "Known contracts and limits should be empty"
     );
 
     Ok(())


### PR DESCRIPTION
# Description

This PR tried to add an additonal test on EVM RAM pinnning behavior. Along the way, it was forced to fix a bug in our EVM contract deployer allowlist which prevented disallowed addresses from interacting with contracts at all. 

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
