### PR TITLE
Fixes a bug in sequencer nonce queue when a transaction is rejected.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
@@ -44,7 +44,7 @@ struct AddressQueue<S: Spec, Rt: Runtime<S>> {
     txs: BTreeMap<u64, QueuedTx<S, Rt>>,
     /// Tracks a nonce that has been removed from the queue for execution but hasn't completed yet,
     /// since it's no longer in the queue but it still satisfies the prerequisite for future nonces
-    last_popped: Option<u64>,
+    last_executed: Option<u64>,
 }
 
 impl<S: Spec, Rt: Runtime<S>> Debug for AddressQueue<S, Rt> {
@@ -53,7 +53,7 @@ impl<S: Spec, Rt: Runtime<S>> Debug for AddressQueue<S, Rt> {
             f,
             "{{ nonces: {:?}, last_popped: {:?} }}",
             self.txs.keys().cloned().collect::<Vec<_>>(),
-            self.last_popped
+            self.last_executed
         )
     }
 }
@@ -62,7 +62,7 @@ impl<S: Spec, Rt: Runtime<S>> AddressQueue<S, Rt> {
     fn new() -> Self {
         Self {
             txs: BTreeMap::new(),
-            last_popped: None,
+            last_executed: None,
         }
     }
 
@@ -83,8 +83,8 @@ impl<S: Spec, Rt: Runtime<S>> AddressQueue<S, Rt> {
     /// started up, hence we pass the nonce as an argument. But if there already is one, then
     /// logically this should only ever be called with an incremented nonce (since all transactions
     /// are marked in the queue, and it's not possible for a user to skip nonces).
-    fn set_or_increment_last_popped(&mut self, nonce: u64) {
-        if let Some(current_last_popped) = self.last_popped {
+    fn set_or_increment_last_executed(&mut self, nonce: u64) {
+        if let Some(current_last_popped) = self.last_executed {
             // This should only happen if there's a bug. It could be an assert_eq!, but the actual
             // impact of a bug would be spurious transaction rejections for a user, which is bad UX
             // but probably not worth crashing the sequencer over.
@@ -92,24 +92,12 @@ impl<S: Spec, Rt: Runtime<S>> AddressQueue<S, Rt> {
                 tracing::error!("Sequencer inconsistency: tx nonce queue: {current_last_popped} + 1 did not match {nonce}, when incrementing the last popped nonce. This should not happen.");
             }
         }
-        self.last_popped = Some(nonce);
-    }
-
-    /// The last popped transaction is used to optimistically satisfy pre-requisites. But if we
-    /// know the last popped transaction failed, we should actually decrement it and start evicting
-    /// any following transactions that relied on it.
-    fn fail_last_popped(&mut self, nonce: u64) {
-        // Same as above, it's a bug, but let's not crash over it
-        if self.last_popped.is_none_or(|p| p != nonce) {
-            tracing::error!("Sequencer inconsistency: tx nonce queue: last popped {:?} did not match {nonce}, when decrementing the last popped nonce. This should not happen.", self.last_popped);
-        }
-        self.last_popped = self.last_popped.and_then(|p| p.checked_sub(1));
-        // Decrementing nonce 0 will result in resetting to None
+        self.last_executed = Some(nonce);
     }
 
     /// Returns the next expected nonce based on the last popped transaction (if any).
     fn next_nonce_from_popped(&self) -> u64 {
-        self.last_popped.map(|n| n.saturating_add(1)).unwrap_or(0)
+        self.last_executed.map(|n| n.saturating_add(1)).unwrap_or(0)
     }
 
     /// Check if there's a contiguous sequence of transactions from `current_nonce` to `tx_nonce` (inclusive).
@@ -326,7 +314,7 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                 // So last_popped is stale when N < M (i.e., API state has caught up past
                 // last_popped)
                 let current_nonce = self.submitter.get_current_nonce_for_user(credential_id);
-                let should_prune = queue.last_popped.map(|n| n < current_nonce).unwrap_or(true); // Prune if no last_popped
+                let should_prune = queue.last_executed.map(|n| n < current_nonce).unwrap_or(true); // Prune if no last_popped
 
                 if should_prune {
                     entry.remove();
@@ -336,27 +324,17 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
     }
 
     /// Mark a nonce as executed (state transition complete, but DB persistence not yet complete).
-    /// This is used to prevent a race condition where a transaction's DB operation hasn't completed
-    /// yet (so API state still shows the old nonce), but a subsequent transaction arrives and should
-    /// execute immediately rather than getting queued.
-    fn mark_popped(&self, credential_id: &CredentialId, nonce: u64) {
+    /// This is because the actual state update is delayed until the transaction is persisted to
+    /// DB, so API state still shows the old nonce. But we want to already start exectuting the
+    /// next transaction (if there is one) - no need to block the user's queue on DB persistence.
+    fn mark_executed(&self, credential_id: &CredentialId, nonce: u64) {
         let mut queue = self
             .queues
             .entry(*credential_id)
             .or_insert_with(AddressQueue::new);
-        queue.set_or_increment_last_popped(nonce);
+        queue.set_or_increment_last_executed(nonce);
     }
 
-    /// If we called `mark_popped()` earlier, but the transaction failed, we should no longer use
-    /// its nonce optimistically.
-    fn unmark_popped(&self, credential_id: &CredentialId, nonce: u64) {
-        let Some(mut queue) = self.queues.get_mut(credential_id) else {
-            return;
-        };
-        queue.fail_last_popped(nonce);
-    }
-
-    /// Check if there's a contiguous sequence of transactions up to target_nonce
     fn has_prerequisites_to_nonce(
         &self,
         credential_id: &CredentialId,
@@ -396,10 +374,8 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                     return None;
                 }
                 Ordering::Equal => {
-                    // First transaction is the next expected nonce. Pop it and mark as executing.
-                    let nonce = *head_entry.key();
+                    // First transaction is the next expected nonce. Pop and return it.
                     let tx = head_entry.remove();
-                    queue_lock.set_or_increment_last_popped(nonce);
                     return Some(tx);
                 }
             }
@@ -439,9 +415,9 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
             let _ = queued_tx.result_sender.send(result);
 
             if should_continue {
+                self.mark_executed(credential_id, expected_nonce);
                 expected_nonce += 1;
             } else {
-                self.unmark_popped(credential_id, expected_nonce);
                 tracing::debug!("Transaction execution failed, stopping nonce queue drain");
                 return;
             }
@@ -467,7 +443,7 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
         // Get the next nonce based on what we've popped from the queue - this tracks transactions
         // that have been accepted for execution but whose DB persistence may not have completed yet
         let next_nonce_from_queue = match &locked_user_queue {
-            Entry::Occupied(entry) => entry.get().last_popped.unwrap_or(0),
+            Entry::Occupied(entry) => entry.get().last_executed.unwrap_or(0),
             Entry::Vacant(_) => 0,
         };
 
@@ -545,12 +521,6 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
 
         match action {
             Action::ExecuteNow(baked_tx) => {
-                // Conceptually, the TX goes straight to the head of the queue and is immediately
-                // popped.
-                // We obviously don't physically insert and pop it, but we mark it as the last
-                // popped for accounting purposes. E.g. since we have this tx, it can now satisfy
-                // prerequisite checks for any queued txs.
-                self.mark_popped(&credential_id, tx_nonce);
 
                 let res = self
                     .submitter
@@ -565,6 +535,10 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                 // If the transaction succeeded, the user's nonce will have incremented.
                 // Trigger a drain of the queue for any transactions which are now valid.
                 if res.as_ref().is_ok_and(|r| r.is_ok()) {
+                    // Mark the nonce as successfully executed so the next nonce can be drained.
+                    self.mark_executed(&credential_id, tx_nonce);
+
+                    // Now spawn the drain task
                     let queues = self.clone();
                     let starting_nonce = tx_nonce + 1;
                     tokio::spawn(async move {
@@ -572,8 +546,6 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                             .drain_any_ready_transactions(&credential_id, starting_nonce)
                             .await;
                     });
-                } else {
-                    self.unmark_popped(&credential_id, tx_nonce);
                 }
                 res
             }
@@ -805,7 +777,7 @@ mod tests {
         assert!(!queue.has_contiguous_sequence_to(1, 0));
 
         // Now we mark tx 0 as executing, even though the user's nonce isn't updated yet
-        queue.set_or_increment_last_popped(0);
+        queue.set_or_increment_last_executed(0);
 
         // Should succeed - last_popped fills the first position
         assert!(queue.has_contiguous_sequence_to(4, 0));
@@ -823,7 +795,7 @@ mod tests {
         let mut queue: AddressQueue<TestSpec, TestRuntime> = AddressQueue::new();
 
         // Empty queue, but last_popped = 5
-        queue.set_or_increment_last_popped(5);
+        queue.set_or_increment_last_executed(5);
 
         // Should succeed when target equals last_popped
         assert!(queue.has_contiguous_sequence_to(5, 5));
@@ -843,7 +815,7 @@ mod tests {
         // Queue has [2, 3], last_popped = 0 (stale, before current_nonce)
         queue.insert(2, create_mock_queued_tx(2));
         queue.insert(3, create_mock_queued_tx(3));
-        queue.set_or_increment_last_popped(0);
+        queue.set_or_increment_last_executed(0);
 
         // Should succeed - stale marker doesn't affect check starting at 2
         assert!(queue.has_contiguous_sequence_to(3, 2));
@@ -859,7 +831,7 @@ mod tests {
         // Queue has [5, 6], last_popped = 4
         queue.insert(5, create_mock_queued_tx(2));
         queue.insert(6, create_mock_queued_tx(3));
-        queue.set_or_increment_last_popped(4);
+        queue.set_or_increment_last_executed(4);
 
         // Nonce is stale at 1 but we know 4 is already executing, so should succeed
         assert!(queue.has_contiguous_sequence_to(4, 1));
@@ -884,7 +856,7 @@ mod tests {
 
         // Queue has [2], last_popped = 0 (with gap)
         queue.insert(2, create_mock_queued_tx(2));
-        queue.set_or_increment_last_popped(0);
+        queue.set_or_increment_last_executed(0);
 
         // Since we're currently executing 0, then nonce 1 is valid
         assert!(queue.has_contiguous_sequence_to(1, 0));

--- a/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
@@ -89,7 +89,7 @@ impl<S: Spec, Rt: Runtime<S>> AddressQueue<S, Rt> {
             // impact of a bug would be spurious transaction rejections for a user, which is bad UX
             // but probably not worth crashing the sequencer over.
             if current_last_popped + 1 != nonce {
-                tracing::error!("Sequencer inconsistency: tx nonce queue: {current_last_popped} + 1 did not match {nonce}, when incrementing the last popped nonce. This should not happen.")
+                tracing::error!("Sequencer inconsistency: tx nonce queue: {current_last_popped} + 1 did not match {nonce}, when incrementing the last popped nonce. This should not happen.");
             }
         }
         self.last_popped = Some(nonce);
@@ -103,7 +103,7 @@ impl<S: Spec, Rt: Runtime<S>> AddressQueue<S, Rt> {
         if self.last_popped.is_none_or(|p| p != nonce) {
             tracing::error!("Sequencer inconsistency: tx nonce queue: last popped {:?} did not match {nonce}, when decrementing the last popped nonce. This should not happen.", self.last_popped);
         }
-        self.last_popped = self.last_popped.map(|p| p.checked_sub(1)).flatten();
+        self.last_popped = self.last_popped.and_then(|p| p.checked_sub(1));
         // Decrementing nonce 0 will result in resetting to None
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
@@ -314,7 +314,10 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                 // So last_popped is stale when N < M (i.e., API state has caught up past
                 // last_popped)
                 let current_nonce = self.submitter.get_current_nonce_for_user(credential_id);
-                let should_prune = queue.last_executed.map(|n| n < current_nonce).unwrap_or(true); // Prune if no last_popped
+                let should_prune = queue
+                    .last_executed
+                    .map(|n| n < current_nonce)
+                    .unwrap_or(true); // Prune if no last_popped
 
                 if should_prune {
                     entry.remove();
@@ -521,7 +524,6 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
 
         match action {
             Action::ExecuteNow(baked_tx) => {
-
                 let res = self
                     .submitter
                     .execute_tx(

--- a/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
@@ -79,8 +79,32 @@ impl<S: Spec, Rt: Runtime<S>> AddressQueue<S, Rt> {
     }
 
     /// Mark a nonce as currently being executed (removed from queue but not yet committed).
-    fn set_last_popped(&mut self, nonce: u64) {
+    /// The queue may be empty if the user had not yet sent a transaction since the sequencer
+    /// started up, hence we pass the nonce as an argument. But if there already is one, then
+    /// logically this should only ever be called with an incremented nonce (since all transactions
+    /// are marked in the queue, and it's not possible for a user to skip nonces).
+    fn set_or_increment_last_popped(&mut self, nonce: u64) {
+        if let Some(current_last_popped) = self.last_popped {
+            // This should only happen if there's a bug. It could be an assert_eq!, but the actual
+            // impact of a bug would be spurious transaction rejections for a user, which is bad UX
+            // but probably not worth crashing the sequencer over.
+            if current_last_popped + 1 != nonce {
+                tracing::error!("Sequencer inconsistency: tx nonce queue: {current_last_popped} + 1 did not match {nonce}, when incrementing the last popped nonce. This should not happen.")
+            }
+        }
         self.last_popped = Some(nonce);
+    }
+
+    /// The last popped transaction is used to optimistically satisfy pre-requisites. But if we
+    /// know the last popped transaction failed, we should actually decrement it and start evicting
+    /// any following transactions that relied on it.
+    fn fail_last_popped(&mut self, nonce: u64) {
+        // Same as above, it's a bug, but let's not crash over it
+        if self.last_popped.is_none_or(|p| p != nonce) {
+            tracing::error!("Sequencer inconsistency: tx nonce queue: last popped {:?} did not match {nonce}, when decrementing the last popped nonce. This should not happen.", self.last_popped);
+        }
+        self.last_popped = self.last_popped.map(|p| p.checked_sub(1)).flatten();
+        // Decrementing nonce 0 will result in resetting to None
     }
 
     /// Returns the next expected nonce based on the last popped transaction (if any).
@@ -320,7 +344,16 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
             .queues
             .entry(*credential_id)
             .or_insert_with(AddressQueue::new);
-        queue.set_last_popped(nonce);
+        queue.set_or_increment_last_popped(nonce);
+    }
+
+    /// If we called `mark_popped()` earlier, but the transaction failed, we should no longer use
+    /// its nonce optimistically.
+    fn unmark_popped(&self, credential_id: &CredentialId, nonce: u64) {
+        let Some(mut queue) = self.queues.get_mut(credential_id) else {
+            return;
+        };
+        queue.fail_last_popped(nonce);
     }
 
     /// Check if there's a contiguous sequence of transactions up to target_nonce
@@ -366,7 +399,7 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                     // First transaction is the next expected nonce. Pop it and mark as executing.
                     let nonce = *head_entry.key();
                     let tx = head_entry.remove();
-                    queue_lock.set_last_popped(nonce);
+                    queue_lock.set_or_increment_last_popped(nonce);
                     return Some(tx);
                 }
             }
@@ -408,6 +441,7 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
             if should_continue {
                 expected_nonce += 1;
             } else {
+                self.unmark_popped(credential_id, expected_nonce);
                 tracing::debug!("Transaction execution failed, stopping nonce queue drain");
                 return;
             }
@@ -433,7 +467,7 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
         // Get the next nonce based on what we've popped from the queue - this tracks transactions
         // that have been accepted for execution but whose DB persistence may not have completed yet
         let next_nonce_from_queue = match &locked_user_queue {
-            Entry::Occupied(entry) => entry.get().next_nonce_from_popped(),
+            Entry::Occupied(entry) => entry.get().last_popped.unwrap_or(0),
             Entry::Vacant(_) => 0,
         };
 
@@ -538,6 +572,8 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                             .drain_any_ready_transactions(&credential_id, starting_nonce)
                             .await;
                     });
+                } else {
+                    self.unmark_popped(&credential_id, tx_nonce);
                 }
                 res
             }
@@ -769,7 +805,7 @@ mod tests {
         assert!(!queue.has_contiguous_sequence_to(1, 0));
 
         // Now we mark tx 0 as executing, even though the user's nonce isn't updated yet
-        queue.set_last_popped(0);
+        queue.set_or_increment_last_popped(0);
 
         // Should succeed - last_popped fills the first position
         assert!(queue.has_contiguous_sequence_to(4, 0));
@@ -787,7 +823,7 @@ mod tests {
         let mut queue: AddressQueue<TestSpec, TestRuntime> = AddressQueue::new();
 
         // Empty queue, but last_popped = 5
-        queue.set_last_popped(5);
+        queue.set_or_increment_last_popped(5);
 
         // Should succeed when target equals last_popped
         assert!(queue.has_contiguous_sequence_to(5, 5));
@@ -807,7 +843,7 @@ mod tests {
         // Queue has [2, 3], last_popped = 0 (stale, before current_nonce)
         queue.insert(2, create_mock_queued_tx(2));
         queue.insert(3, create_mock_queued_tx(3));
-        queue.set_last_popped(0);
+        queue.set_or_increment_last_popped(0);
 
         // Should succeed - stale marker doesn't affect check starting at 2
         assert!(queue.has_contiguous_sequence_to(3, 2));
@@ -823,7 +859,7 @@ mod tests {
         // Queue has [5, 6], last_popped = 4
         queue.insert(5, create_mock_queued_tx(2));
         queue.insert(6, create_mock_queued_tx(3));
-        queue.set_last_popped(4);
+        queue.set_or_increment_last_popped(4);
 
         // Nonce is stale at 1 but we know 4 is already executing, so should succeed
         assert!(queue.has_contiguous_sequence_to(4, 1));
@@ -848,7 +884,7 @@ mod tests {
 
         // Queue has [2], last_popped = 0 (with gap)
         queue.insert(2, create_mock_queued_tx(2));
-        queue.set_last_popped(0);
+        queue.set_or_increment_last_popped(0);
 
         // Since we're currently executing 0, then nonce 1 is valid
         assert!(queue.has_contiguous_sequence_to(1, 0));
@@ -1758,5 +1794,89 @@ mod tests {
             !queues.queues.contains_key(&credential_id),
             "Queue should be pruned after API state catches up"
         );
+    }
+
+    #[tokio::test]
+    async fn test_failed_tx_does_not_allow_future_nonce_immediate_execution() {
+        // When a transaction fails, transactions with higher nonces should still be
+        // queued (not executed immediately), because the actual account nonce hasn't
+        // changed.
+
+        let backend = MockTxExecutionBackend::new()
+            .with_current_nonce(0)
+            .with_failure_at_nonce(0);
+
+        let queues = TxNonceQueues::new(
+            backend.clone(),
+            10,
+            100, // Short timeout (100ms) so test completes quickly
+        );
+        let credential_id = CredentialId::from([1u8; 32]);
+
+        // Submit failing tx 0
+        let result_0 = queues
+            .handle_new_tx(
+                create_test_tx(0),
+                TxHash::from([0; 32]),
+                0,
+                credential_id,
+                0,
+            )
+            .await;
+
+        assert!(result_0.unwrap().is_err());
+        assert_eq!(backend.get_current_nonce_for_user(&credential_id), 0);
+
+        // Tx 1 should be queued, since tx 0 failed execution so the user's nonce is still 0
+        let handle_1 = tokio::spawn({
+            let queues = queues.clone();
+            async move {
+                queues
+                    .handle_new_tx(
+                        create_test_tx(1),
+                        TxHash::from([1; 32]),
+                        1,
+                        credential_id,
+                        0,
+                    )
+                    .await
+            }
+        });
+
+        // Wait longer than the queue timeout (100ms) so tx 1 times out of the queue
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // It should not have been executed
+        let executed = backend.get_executed_nonces();
+        assert_eq!(
+            Vec::<u64>::new(),
+            executed,
+            "TX with nonce 1 should be queued (not executed) when actual nonce is 0, and the set of executed transactions should have been empty"
+        );
+
+        // TX 1's handle should have completed with a timeout error
+        let result_1 = handle_1.await.unwrap();
+        assert!(result_1.is_ok()); // No sequencer error
+        let inner = result_1.unwrap();
+        assert!(inner.is_err()); // TX was rejected
+
+        // Verify it was rejected due to queue timeout (not immediate rejection)
+        match inner.unwrap_err() {
+            AcceptTxError::NewTxError(DoNewTxError::ExecutorError(
+                RollupBlockExecutorError::UnsuccessfulTransaction { receipt },
+            )) => match receipt.receipt {
+                sov_rollup_interface::stf::TxEffect::Skipped(contents) => match contents.error {
+                    TxProcessingError::CheckUniquenessFailed(msg) => {
+                        assert!(
+                            msg.contains("timed out"),
+                            "Error should indicate queue timeout: \"{msg}\""
+                        );
+                    }
+                    _ => panic!("Expected CheckUniquenessFailed error"),
+                },
+                _ => panic!("Expected Skipped receipt"),
+            },
+            _ => panic!("Expected UnsuccessfulTransaction error"),
+        }
     }
 }

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -971,7 +971,7 @@
         "max_fee": {
           "description": "The maximum fee that the sequencer will pay for the timestamp oracle update tx.",
           "type": "integer",
-          "format": "uint128",
+          "format": "uint64",
           "minimum": 0.0
         },
         "priority_fee_percentage": {

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -2573,8 +2573,7 @@ checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
 [[package]]
 name = "nomt-core"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeb4e411c8185c33c906539b78330a8478a2d4819de338efb6511b33cc73207"
+source = "git+https://github.com/thrumdev/nomt.git?rev=4189c7dc3dc710fef526591ee73860e462a135de#4189c7dc3dc710fef526591ee73860e462a135de"
 dependencies = [
  "arrayvec",
  "bitvec",

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -2284,8 +2284,7 @@ checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
 [[package]]
 name = "nomt-core"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeb4e411c8185c33c906539b78330a8478a2d4819de338efb6511b33cc73207"
+source = "git+https://github.com/thrumdev/nomt.git?rev=4189c7dc3dc710fef526591ee73860e462a135de#4189c7dc3dc710fef526591ee73860e462a135de"
 dependencies = [
  "arrayvec",
  "bitvec",

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -3489,8 +3489,7 @@ dependencies = [
 [[package]]
 name = "nomt-core"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeb4e411c8185c33c906539b78330a8478a2d4819de338efb6511b33cc73207"
+source = "git+https://github.com/thrumdev/nomt.git?rev=4189c7dc3dc710fef526591ee73860e462a135de#4189c7dc3dc710fef526591ee73860e462a135de"
 dependencies = [
  "arrayvec",
  "bitvec",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -3205,8 +3205,7 @@ dependencies = [
 [[package]]
 name = "nomt-core"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feeb4e411c8185c33c906539b78330a8478a2d4819de338efb6511b33cc73207"
+source = "git+https://github.com/thrumdev/nomt.git?rev=4189c7dc3dc710fef526591ee73860e462a135de#4189c7dc3dc710fef526591ee73860e462a135de"
 dependencies = [
  "arrayvec",
  "bitvec",


### PR DESCRIPTION
# Description

The nonce queue optimistically keeps track of nonces submitted for execution, since the actual API state only updates after a transaction is persisted to the DB; tracking the executing nonce locally allows queueing up transactions with consecutive nonces without waiting for the DB latency.

The problem was that this locally tracked "last submitted for execution" nonce did not get reset if said submitted transaction actually got rejected. This had two consequences: first and less importantly, transactions would not be evicted even when no longer having all pre-requisites. This could've had a theoretical memory impact if someone filled their queue with transactions and then sent a rejected transaction at the head, resulting in the sequencer keeping the entire queue in memory forever.

The more important issue was that the sequencer would then consider transactions with the next nonce valid and would submit them for execution. They would then always get rejected due to the user's nonce, of course, not having been actually incremented by the previous (rejected) transaction. This would spiral into a vicious cycle of invalidating and rejecting large swathes of transactions and causing terrible user experience.

Incidentally, this tracking could use a refactor to be less error-prone. The way the data structure is laid out right now, it has to be manually incremented and decremented, which led to this issue. For now this PR should fix Relay's issues, and a refactor can be made afterwards.

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [ ] ~~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
