### PR TITLE
Failover: Change `node_id` type to String

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13844,7 +13844,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "uuid 1.18.1",
  "webpki-roots 0.26.11",
 ]
 
@@ -13927,7 +13926,6 @@ dependencies = [
  "thiserror 2.0.16",
  "time",
  "tracing",
- "uuid 1.18.1",
  "whoami",
 ]
 
@@ -13967,7 +13965,6 @@ dependencies = [
  "thiserror 2.0.16",
  "time",
  "tracing",
- "uuid 1.18.1",
  "whoami",
 ]
 
@@ -13995,7 +13992,6 @@ dependencies = [
  "time",
  "tracing",
  "url",
- "uuid 1.18.1",
 ]
 
 [[package]]

--- a/crates/full-node/sov-sequencer/Cargo.toml
+++ b/crates/full-node/sov-sequencer/Cargo.toml
@@ -37,7 +37,7 @@ serde_yaml = { workspace = true }
 serde_with = { workspace = true, features = ["base64"] }
 sov-blob-sender = { workspace = true }
 sov-blob-storage = { workspace = true, features = ["native"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls-ring-webpki", "postgres", "migrate", "uuid", "time"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls-ring-webpki", "postgres", "migrate", "time"] }
 sov-kernels = { workspace = true, features = ["native"] }
 sov-metrics = { workspace = true }
 sov-rest-utils = { workspace = true }

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -9,7 +9,6 @@
 //! invariants and we'd rather have an application crash due to broken
 //! invariants than to have bugs that result in subtle state inconsistencies.
 
-use uuid::Uuid;
 pub mod postgres;
 pub mod rocksdb;
 use crate::preferred::PostgresBackend;
@@ -388,39 +387,34 @@ impl PreferredSequencerDb {
         storage_path: &Path,
         postgres_connection_string: &Option<String>,
     ) -> anyhow::Result<(Self, bool)> {
-        if let Some(postgres_connection_string) = &postgres_connection_string {
-            let postgres_backend = PostgresBackend::connect(postgres_connection_string).await?;
-
-            match is_replica {
-                Some(true) => Ok((
-                    Self {
-                        backend: None,
-                        shutdown_sender: shutdown_sender.clone(),
-                    },
-                    true,
-                )),
-                Some(false) | None => {
-                    postgres_backend.try_update_leader(Uuid::nil()).await?;
-                    Ok((
-                        Self {
-                            backend: None,
-                            shutdown_sender: shutdown_sender.clone(),
-                        },
-                        true,
-                    ))
-                }
-            }
-        } else {
-            let backend: Option<Box<dyn PreferredSequencerDbBackend>> =
-                Some(Box::new(RocksDbBackend::new(storage_path).await?));
-            Ok((
+        let is_replica = is_replica.unwrap_or(false);
+        if is_replica {
+            return Ok((
                 Self {
-                    backend,
+                    backend: None,
                     shutdown_sender: shutdown_sender.clone(),
                 },
-                false,
-            ))
+                is_replica,
+            ));
         }
+
+        let backend: Option<Box<dyn PreferredSequencerDbBackend>> = {
+            if let Some(postgres_connection_string) = &postgres_connection_string {
+                Some(Box::new(
+                    PostgresBackend::connect(postgres_connection_string).await?,
+                ))
+            } else {
+                Some(Box::new(RocksDbBackend::new(storage_path).await?))
+            }
+        };
+
+        Ok((
+            Self {
+                backend,
+                shutdown_sender: shutdown_sender.clone(),
+            },
+            is_replica,
+        ))
     }
 
     pub(crate) async fn initial_data(

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -387,34 +387,49 @@ impl PreferredSequencerDb {
         storage_path: &Path,
         postgres_connection_string: &Option<String>,
     ) -> anyhow::Result<(Self, bool)> {
-        let is_replica = is_replica.unwrap_or(false);
-        if is_replica {
-            return Ok((
+        if let Some(postgres_connection_string) = &postgres_connection_string {
+            let postgres_backend = PostgresBackend::connect(postgres_connection_string).await?;
+
+            match is_replica {
+                Some(true) => {
+                    postgres_backend.try_update_leader(Uuid::nil()).await?;
+                    Ok((
+                        Self {
+                            backend: None,
+                            shutdown_sender: shutdown_sender.clone(),
+                        },
+                        true,
+                    ))
+                }
+                Some(false) => Ok((
+                    Self {
+                        backend: Some(Box::new(postgres_backend)),
+                        shutdown_sender: shutdown_sender.clone(),
+                    },
+                    false,
+                )),
+                None => {
+                    postgres_backend.try_update_leader(Uuid::nil()).await?;
+                    Ok((
+                        Self {
+                            backend: None,
+                            shutdown_sender: shutdown_sender.clone(),
+                        },
+                        true,
+                    ))
+                }
+            }
+        } else {
+            let backend: Option<Box<dyn PreferredSequencerDbBackend>> =
+                Some(Box::new(RocksDbBackend::new(storage_path).await?));
+            Ok((
                 Self {
-                    backend: None,
+                    backend,
                     shutdown_sender: shutdown_sender.clone(),
                 },
-                is_replica,
-            ));
+                false,
+            ))
         }
-
-        let backend: Option<Box<dyn PreferredSequencerDbBackend>> = {
-            if let Some(postgres_connection_string) = &postgres_connection_string {
-                Some(Box::new(
-                    PostgresBackend::connect(postgres_connection_string).await?,
-                ))
-            } else {
-                Some(Box::new(RocksDbBackend::new(storage_path).await?))
-            }
-        };
-
-        Ok((
-            Self {
-                backend,
-                shutdown_sender: shutdown_sender.clone(),
-            },
-            is_replica,
-        ))
     }
 
     pub(crate) async fn initial_data(

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -9,6 +9,7 @@
 //! invariants and we'd rather have an application crash due to broken
 //! invariants than to have bugs that result in subtle state inconsistencies.
 
+use uuid::Uuid;
 pub mod postgres;
 pub mod rocksdb;
 use crate::preferred::PostgresBackend;
@@ -391,24 +392,14 @@ impl PreferredSequencerDb {
             let postgres_backend = PostgresBackend::connect(postgres_connection_string).await?;
 
             match is_replica {
-                Some(true) => {
-                    postgres_backend.try_update_leader(Uuid::nil()).await?;
-                    Ok((
-                        Self {
-                            backend: None,
-                            shutdown_sender: shutdown_sender.clone(),
-                        },
-                        true,
-                    ))
-                }
-                Some(false) => Ok((
+                Some(true) => Ok((
                     Self {
-                        backend: Some(Box::new(postgres_backend)),
+                        backend: None,
                         shutdown_sender: shutdown_sender.clone(),
                     },
-                    false,
+                    true,
                 )),
-                None => {
+                Some(false) | None => {
                     postgres_backend.try_update_leader(Uuid::nil()).await?;
                     Ok((
                         Self {

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/001_init.sql
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/001_init.sql
@@ -88,3 +88,13 @@ CREATE TRIGGER leader_changes_trigger
     AFTER INSERT OR UPDATE ON sequencer_leader
     FOR EACH ROW
     EXECUTE FUNCTION notify_leader_changes();
+
+
+CREATE FUNCTION is_leader(p_node_id bigint)
+RETURNS boolean AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM sequencer_leader
+        WHERE singleton = 1 AND node_id = p_node_id
+    );
+$$ LANGUAGE sql STABLE;

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/001_init.sql
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/001_init.sql
@@ -90,7 +90,7 @@ CREATE TRIGGER leader_changes_trigger
     EXECUTE FUNCTION notify_leader_changes();
 
 
-CREATE FUNCTION is_leader(p_node_id bigint)
+CREATE FUNCTION is_leader(p_node_id UUID)
 RETURNS boolean AS $$
     SELECT EXISTS (
         SELECT 1

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/001_init.sql
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/001_init.sql
@@ -63,8 +63,8 @@ CREATE TRIGGER events_changes_trigger
 CREATE TABLE IF NOT EXISTS sequencer_leader (
     -- Singleton constraint - only one row allowed in this table
     singleton INTEGER GENERATED ALWAYS AS (1) STORED UNIQUE,
-    -- Node ID of the current leader (UUID v7)
-    node_id UUID NOT NULL,
+    -- Node ID of the current leader
+    node_id TEXT NOT NULL,
     -- Timestamp when the leader last sent a heartbeat
     last_updated TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     -- Primary key on the singleton to enforce single row
@@ -90,7 +90,7 @@ CREATE TRIGGER leader_changes_trigger
     EXECUTE FUNCTION notify_leader_changes();
 
 
-CREATE FUNCTION is_leader(p_node_id UUID)
+CREATE FUNCTION is_leader(p_node_id TEXT)
 RETURNS boolean AS $$
     SELECT EXISTS (
         SELECT 1

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -24,6 +24,7 @@ pub struct PostgresBackend {
     pool: PgPool,
     backoff_policy: ExponentialBuilder,
     time_delta: Duration,
+    node_id: String,
 }
 
 // We need a macro to get around lifetime issues with async functions. Otherwise, Rust complains about FnMut
@@ -55,12 +56,14 @@ macro_rules! run_with_retries {
 
 impl PostgresBackend {
     pub async fn connect(connection_string: &str) -> anyhow::Result<Self> {
-        Self::connect_with_time_delta(connection_string, Duration::ZERO).await
+        Self::connect_with_time_delta(connection_string, Duration::ZERO, "NODE_ID".to_string())
+            .await
     }
 
     async fn connect_with_time_delta(
         connection_string: &str,
         time_delta: Duration,
+        node_id: String,
     ) -> anyhow::Result<Self> {
         // This backoff policy should usually terminate in a second.
         // Running the numbers... We do 8 retries, doubling the sleep each time that yields 256ms max delay and an average delay of ~50ms
@@ -88,6 +91,7 @@ impl PostgresBackend {
             pool,
             backoff_policy,
             time_delta,
+            node_id,
         })
     }
 
@@ -474,48 +478,60 @@ mod tests {
             .unwrap();
 
         let time_delta = Duration::from_millis(1000);
-        let mut db =
-            PostgresBackend::connect_with_time_delta(&postgres_connection_string, time_delta)
-                .await
-                .unwrap();
 
         let node_id_1 = String::from("node_id_1");
         let node_id_2 = String::from("node_id_2");
+        let mut db_1 = PostgresBackend::connect_with_time_delta(
+            &postgres_connection_string,
+            time_delta,
+            node_id_1.clone(),
+        )
+        .await
+        .unwrap();
+
+        let mut db_2 = PostgresBackend::connect_with_time_delta(
+            &postgres_connection_string,
+            time_delta,
+            node_id_2.clone(),
+        )
+        .await
+        .unwrap();
 
         {
             // Updating the same node id should change the last updated time in the db.
-            let leader_1 = db.maybe_update_leader(&node_id_1).await.unwrap();
-            let updated_leader_1 = db.maybe_update_leader(&node_id_1).await.unwrap();
+            let leader_1 = db_1.maybe_update_leader(&node_id_1).await.unwrap();
+            let updated_leader_1 = db_1.maybe_update_leader(&node_id_1).await.unwrap();
 
             assert_eq!(leader_1.node_id, node_id_1);
             assert_eq!(leader_1.node_id, updated_leader_1.node_id);
             assert!(leader_1.last_updated < updated_leader_1.last_updated);
 
             // Updating a different node id shouldn't change anything as the time delta is too big.
-            let leader_2 = db.maybe_update_leader(&node_id_2).await;
+            let leader_2 = db_2.maybe_update_leader(&node_id_2).await;
             assert!(leader_2.is_none());
 
-            let leader = db.get_sequencer_leader().await.unwrap().unwrap();
+            let leader = db_2.get_sequencer_leader().await.unwrap().unwrap();
             assert_eq!(updated_leader_1, leader);
         }
 
-        let time_delta = Duration::from_millis(0);
-        db.time_delta = time_delta;
         {
+            let time_delta = Duration::from_millis(0);
+            db_2.time_delta = time_delta;
             // Now we should be able to update db as the time delta is zero.
-            let leader_2 = db.maybe_update_leader(&node_id_2).await.unwrap();
+            let leader_2 = db_2.maybe_update_leader(&node_id_2).await.unwrap();
             assert_eq!(leader_2.node_id, node_id_2);
         }
 
-        let time_delta = Duration::from_millis(10);
-        db.time_delta = time_delta;
         {
-            let leader_1 = db.maybe_update_leader(&node_id_1).await;
+            let time_delta = Duration::from_millis(10);
+            db_1.time_delta = time_delta;
+
+            let leader_1 = db_1.maybe_update_leader(&node_id_1).await;
             assert!(leader_1.is_none());
 
             // Wait for more than 10ms and update the leader.
             tokio::time::sleep(Duration::from_millis(15)).await;
-            let leader_1 = db.maybe_update_leader(&node_id_1).await.unwrap();
+            let leader_1 = db_1.maybe_update_leader(&node_id_1).await.unwrap();
             assert_eq!(leader_1.node_id, node_id_1);
         }
     }

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -512,16 +512,14 @@ mod tests {
         }
 
         {
-            let time_delta = Duration::from_millis(0);
-            db_2.time_delta = time_delta;
+            db_2.time_delta = Duration::ZERO;
             // Now we should be able to update db as the time delta is zero.
             let leader_2 = db_2.maybe_update_leader().await.unwrap();
             assert_eq!(leader_2.node_id, node_id_2);
         }
 
         {
-            let time_delta = Duration::from_millis(10);
-            db_1.time_delta = time_delta;
+            db_1.time_delta = Duration::from_millis(10);
 
             let leader_1 = db_1.maybe_update_leader().await;
             assert!(leader_1.is_none());

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -24,6 +24,7 @@ struct SequencerLeader {
 pub struct PostgresBackend {
     pool: PgPool,
     backoff_policy: ExponentialBuilder,
+    time_delta: Duration,
 }
 
 // We need a macro to get around lifetime issues with async functions. Otherwise, Rust complains about FnMut
@@ -55,6 +56,13 @@ macro_rules! run_with_retries {
 
 impl PostgresBackend {
     pub async fn connect(connection_string: &str) -> anyhow::Result<Self> {
+        Self::connect_with_time_delta(connection_string, Duration::ZERO).await
+    }
+
+    async fn connect_with_time_delta(
+        connection_string: &str,
+        time_delta: Duration,
+    ) -> anyhow::Result<Self> {
         // This backoff policy should usually terminate in a second.
         // Running the numbers... We do 8 retries, doubling the sleep each time that yields 256ms max delay and an average delay of ~50ms
         // So total runtime is ~400 ms of sleeping. If we also account for 50ms latency on each roundtrip, we get about 800ms total time
@@ -80,6 +88,7 @@ impl PostgresBackend {
         Ok(Self {
             pool,
             backoff_policy,
+            time_delta,
         })
     }
 
@@ -211,12 +220,9 @@ impl PostgresBackend {
         })
     }
 
-    async fn try_update_leader(
-        &self,
-        node_id: Uuid,
-        time_delta: Duration,
-    ) -> anyhow::Result<Option<SequencerLeader>> {
-        let time_delta: i64 = time_delta
+    async fn try_update_leader(&self, node_id: Uuid) -> anyhow::Result<Option<SequencerLeader>> {
+        let time_delta: i64 = self
+            .time_delta
             .as_millis()
             .try_into()
             // It is ok to `expect` as time_delta should be much smaller than i64::MAX
@@ -442,12 +448,8 @@ mod tests {
     };
 
     impl PostgresBackend {
-        async fn maybe_update_leader(
-            &self,
-            node_id: Uuid,
-            time_delta: Duration,
-        ) -> Option<SequencerLeader> {
-            self.try_update_leader(node_id, time_delta).await.unwrap()
+        async fn maybe_update_leader(&self, node_id: Uuid) -> Option<SequencerLeader> {
+            self.try_update_leader(node_id).await.unwrap()
         }
     }
 
@@ -467,25 +469,26 @@ mod tests {
             .await
             .unwrap();
 
-        let db = PostgresBackend::connect(&postgres_connection_string)
-            .await
-            .unwrap();
-
         let time_delta = Duration::from_millis(1000);
+        let mut db =
+            PostgresBackend::connect_with_time_delta(&postgres_connection_string, time_delta)
+                .await
+                .unwrap();
+
         let node_id_1 = uuid::Uuid::from_u128(1);
         let node_id_2 = uuid::Uuid::from_u128(2);
 
         {
             // Updating the same node id should change the last updated time in the db.
-            let leader_1 = db.maybe_update_leader(node_id_1, time_delta).await.unwrap();
-            let updated_leader_1 = db.maybe_update_leader(node_id_1, time_delta).await.unwrap();
+            let leader_1 = db.maybe_update_leader(node_id_1).await.unwrap();
+            let updated_leader_1 = db.maybe_update_leader(node_id_1).await.unwrap();
 
             assert_eq!(leader_1.node_id, node_id_1);
             assert_eq!(leader_1.node_id, updated_leader_1.node_id);
             assert!(leader_1.last_updated < updated_leader_1.last_updated);
 
             // Updating a different node id shouldn't change anything as the time delta is too big.
-            let leader_2 = db.maybe_update_leader(node_id_2, time_delta).await;
+            let leader_2 = db.maybe_update_leader(node_id_2).await;
             assert!(leader_2.is_none());
 
             let leader = db.get_sequencer_leader().await.unwrap().unwrap();
@@ -493,20 +496,22 @@ mod tests {
         }
 
         let time_delta = Duration::from_millis(0);
+        db.time_delta = time_delta;
         {
             // Now we should be able to update db as the time delta is zero.
-            let leader_2 = db.maybe_update_leader(node_id_2, time_delta).await.unwrap();
+            let leader_2 = db.maybe_update_leader(node_id_2).await.unwrap();
             assert_eq!(leader_2.node_id, node_id_2);
         }
 
         let time_delta = Duration::from_millis(10);
+        db.time_delta = time_delta;
         {
-            let leader_1 = db.maybe_update_leader(node_id_1, time_delta).await;
+            let leader_1 = db.maybe_update_leader(node_id_1).await;
             assert!(leader_1.is_none());
 
             // Wait for more than 10ms and update the leader.
             tokio::time::sleep(Duration::from_millis(15)).await;
-            let leader_1 = db.maybe_update_leader(node_id_1, time_delta).await.unwrap();
+            let leader_1 = db.maybe_update_leader(node_id_1).await.unwrap();
             assert_eq!(leader_1.node_id, node_id_1);
         }
     }

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -16,7 +16,7 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Debug, FromRow, PartialEq)]
-struct SequencerLeader {
+pub(crate) struct SequencerLeader {
     node_id: Uuid,
     last_updated: OffsetDateTime,
 }
@@ -220,7 +220,10 @@ impl PostgresBackend {
         })
     }
 
-    async fn try_update_leader(&self, node_id: Uuid) -> anyhow::Result<Option<SequencerLeader>> {
+    pub(crate) async fn try_update_leader(
+        &self,
+        node_id: Uuid,
+    ) -> anyhow::Result<Option<SequencerLeader>> {
         let time_delta: i64 = self
             .time_delta
             .as_millis()
@@ -251,7 +254,9 @@ impl PostgresBackend {
         Ok(res)
     }
 
-    async fn get_sequencer_leader(&self) -> Result<Option<SequencerLeader>, sqlx::Error> {
+    pub(crate) async fn get_sequencer_leader(
+        &self,
+    ) -> Result<Option<SequencerLeader>, sqlx::Error> {
         let res = run_with_retries!(
             &self.backoff_policy,
             sqlx::query_as::<_, SequencerLeader>(

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -223,10 +223,7 @@ impl PostgresBackend {
         })
     }
 
-    pub(crate) async fn try_update_leader(
-        &self,
-        node_id: &str,
-    ) -> anyhow::Result<Option<SequencerLeader>> {
+    pub(crate) async fn try_update_leader(&self) -> anyhow::Result<Option<SequencerLeader>> {
         let time_delta: i64 = self
             .time_delta
             .as_millis()
@@ -248,7 +245,7 @@ impl PostgresBackend {
                             sequencer_leader.node_id = EXCLUDED.node_id
                             OR sequencer_leader.last_updated < EXCLUDED.last_updated - ($2 * INTERVAL '1 millisecond')
                         RETURNING node_id, last_updated",)
-        .bind(node_id)
+        .bind(&self.node_id)
         .bind(time_delta)
         .fetch_optional(&self.pool),
             "postgres_db_backend_try_update_leader"
@@ -456,8 +453,8 @@ mod tests {
     };
 
     impl PostgresBackend {
-        async fn maybe_update_leader(&self, node_id: &str) -> Option<SequencerLeader> {
-            self.try_update_leader(node_id).await.unwrap()
+        async fn maybe_update_leader(&self) -> Option<SequencerLeader> {
+            self.try_update_leader().await.unwrap()
         }
     }
 
@@ -498,16 +495,16 @@ mod tests {
         .unwrap();
 
         {
-            // Updating the same node id should change the last updated time in the db.
-            let leader_1 = db_1.maybe_update_leader(&node_id_1).await.unwrap();
-            let updated_leader_1 = db_1.maybe_update_leader(&node_id_1).await.unwrap();
+            // Updating the same node_id should change the last updated time in the db.
+            let leader_1 = db_1.maybe_update_leader().await.unwrap();
+            let updated_leader_1 = db_1.maybe_update_leader().await.unwrap();
 
             assert_eq!(leader_1.node_id, node_id_1);
             assert_eq!(leader_1.node_id, updated_leader_1.node_id);
             assert!(leader_1.last_updated < updated_leader_1.last_updated);
 
             // Updating a different node id shouldn't change anything as the time delta is too big.
-            let leader_2 = db_2.maybe_update_leader(&node_id_2).await;
+            let leader_2 = db_2.maybe_update_leader().await;
             assert!(leader_2.is_none());
 
             let leader = db_2.get_sequencer_leader().await.unwrap().unwrap();
@@ -518,7 +515,7 @@ mod tests {
             let time_delta = Duration::from_millis(0);
             db_2.time_delta = time_delta;
             // Now we should be able to update db as the time delta is zero.
-            let leader_2 = db_2.maybe_update_leader(&node_id_2).await.unwrap();
+            let leader_2 = db_2.maybe_update_leader().await.unwrap();
             assert_eq!(leader_2.node_id, node_id_2);
         }
 
@@ -526,12 +523,12 @@ mod tests {
             let time_delta = Duration::from_millis(10);
             db_1.time_delta = time_delta;
 
-            let leader_1 = db_1.maybe_update_leader(&node_id_1).await;
+            let leader_1 = db_1.maybe_update_leader().await;
             assert!(leader_1.is_none());
 
             // Wait for more than 10ms and update the leader.
             tokio::time::sleep(Duration::from_millis(15)).await;
-            let leader_1 = db_1.maybe_update_leader(&node_id_1).await.unwrap();
+            let leader_1 = db_1.maybe_update_leader().await.unwrap();
             assert_eq!(leader_1.node_id, node_id_1);
         }
     }

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -13,11 +13,10 @@ use sqlx::postgres::{PgPool, PgPoolOptions};
 use sqlx::FromRow;
 use sqlx::{PgConnection, Postgres};
 use time::OffsetDateTime;
-use uuid::Uuid;
 
 #[derive(Debug, FromRow, PartialEq)]
 pub(crate) struct SequencerLeader {
-    node_id: Uuid,
+    node_id: String,
     last_updated: OffsetDateTime,
 }
 
@@ -222,7 +221,7 @@ impl PostgresBackend {
 
     pub(crate) async fn try_update_leader(
         &self,
-        node_id: Uuid,
+        node_id: &str,
     ) -> anyhow::Result<Option<SequencerLeader>> {
         let time_delta: i64 = self
             .time_delta
@@ -453,7 +452,7 @@ mod tests {
     };
 
     impl PostgresBackend {
-        async fn maybe_update_leader(&self, node_id: Uuid) -> Option<SequencerLeader> {
+        async fn maybe_update_leader(&self, node_id: &str) -> Option<SequencerLeader> {
             self.try_update_leader(node_id).await.unwrap()
         }
     }
@@ -480,20 +479,20 @@ mod tests {
                 .await
                 .unwrap();
 
-        let node_id_1 = uuid::Uuid::from_u128(1);
-        let node_id_2 = uuid::Uuid::from_u128(2);
+        let node_id_1 = String::from("node_id_1");
+        let node_id_2 = String::from("node_id_2");
 
         {
             // Updating the same node id should change the last updated time in the db.
-            let leader_1 = db.maybe_update_leader(node_id_1).await.unwrap();
-            let updated_leader_1 = db.maybe_update_leader(node_id_1).await.unwrap();
+            let leader_1 = db.maybe_update_leader(&node_id_1).await.unwrap();
+            let updated_leader_1 = db.maybe_update_leader(&node_id_1).await.unwrap();
 
             assert_eq!(leader_1.node_id, node_id_1);
             assert_eq!(leader_1.node_id, updated_leader_1.node_id);
             assert!(leader_1.last_updated < updated_leader_1.last_updated);
 
             // Updating a different node id shouldn't change anything as the time delta is too big.
-            let leader_2 = db.maybe_update_leader(node_id_2).await;
+            let leader_2 = db.maybe_update_leader(&node_id_2).await;
             assert!(leader_2.is_none());
 
             let leader = db.get_sequencer_leader().await.unwrap().unwrap();
@@ -504,19 +503,19 @@ mod tests {
         db.time_delta = time_delta;
         {
             // Now we should be able to update db as the time delta is zero.
-            let leader_2 = db.maybe_update_leader(node_id_2).await.unwrap();
+            let leader_2 = db.maybe_update_leader(&node_id_2).await.unwrap();
             assert_eq!(leader_2.node_id, node_id_2);
         }
 
         let time_delta = Duration::from_millis(10);
         db.time_delta = time_delta;
         {
-            let leader_1 = db.maybe_update_leader(node_id_1).await;
+            let leader_1 = db.maybe_update_leader(&node_id_1).await;
             assert!(leader_1.is_none());
 
             // Wait for more than 10ms and update the leader.
             tokio::time::sleep(Duration::from_millis(15)).await;
-            let leader_1 = db.maybe_update_leader(node_id_1).await.unwrap();
+            let leader_1 = db.maybe_update_leader(&node_id_1).await.unwrap();
             assert_eq!(leader_1.node_id, node_id_1);
         }
     }


### PR DESCRIPTION
# Description

This PR introduces the following changes:
1. Changes node_id type from UUID to String
2. Adds `time_delta` to `PostgresBackend` (code review from the previous PR)

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

