### PR TITLE
Increase request size limit

### DIFF
--- a/crates/adapters/mock-da/src/storable/rpc/server.rs
+++ b/crates/adapters/mock-da/src/storable/rpc/server.rs
@@ -2,7 +2,7 @@ use super::types::*;
 use crate::storable::StorableMockDaService;
 use crate::{MockBlock, MockDaSpec};
 use axum::{
-    extract::{Path, State},
+    extract::{DefaultBodyLimit, Path, State},
     http::StatusCode,
     response::Json,
     routing::{get, post},
@@ -218,6 +218,7 @@ pub(crate) fn create_router(da_service: StorableMockDaService) -> Router {
         .route("/send-proof", post(send_proof_handler))
         .route("/proofs/:height", get(get_proofs_at_handler))
         .route("/signer", get(get_signer_handler))
+        .layer(DefaultBodyLimit::max(50 * 1024 * 1024)) // 50MB limit
         .with_state(state)
 }
 


### PR DESCRIPTION
# Description

This tiny PR raises the request size limit (i.e. max blob size) from 2MB to 50MB for mockda. This prevents blobs from getting stuck at the current 8MB limit.
