### PR TITLE
Allow reverted txs onchain via config

### DIFF
--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -179,6 +179,8 @@ pub struct PreferredSequencerConfig {
     /// lock contention.
     #[serde(default = "default_future_nonce_transaction_timeout_millis")]
     pub future_nonce_transaction_timeout_millis: u64,
+    #[serde(default)]
+    pub allow_failed_txs: bool,
 }
 
 impl Default for PreferredSequencerConfig {
@@ -198,6 +200,7 @@ impl Default for PreferredSequencerConfig {
             future_nonce_transaction_timeout_millis:
                 default_future_nonce_transaction_timeout_millis(),
             timing_oracle: None,
+            allow_failed_txs: false,
         }
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
@@ -25,7 +25,7 @@ use crate::common::sender_is_allowed;
 /// - Reverted transactions are only included if `allow_failed_txs` is true.
 /// - Skipped transactions are never included (they represent pre-execution failures
 ///   like invalid signature, invalid nonce, etc.).
-pub fn is_tx_included<S: Spec>(receipt: &TransactionReceipt<S>, allow_failed_txs: bool) -> bool {
+pub fn should_be_included<S: Spec>(receipt: &TransactionReceipt<S>, allow_failed_txs: bool) -> bool {
     receipt.receipt.is_successful() || (receipt.receipt.is_reverted() && allow_failed_txs)
 }
 
@@ -252,7 +252,7 @@ impl<S: Spec> AsyncBatchResponder<S> {
             return (dirty_scratchpad.revert(), TxControlFlow::IgnoreTx);
         };
 
-        if !is_tx_included(&receipt, self.allow_failed_txs) {
+        if !should_be_included(&receipt, self.allow_failed_txs) {
             let response = ExecutedTxResponse {
                 receipt: receipt.clone(),
                 tx_changes: dirty_scratchpad.tx_changes(execution_context),

--- a/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
@@ -44,6 +44,7 @@ impl<S: Spec> MaybeAsyncBatch<S> {
         sequencer_admins: Arc<Vec<S::Address>>,
         address: S::Address,
         is_responsible_for_gating_admins: bool,
+        allow_failed_txs: bool,
     ) -> Self {
         Self::Async {
             txs_receiver,
@@ -53,6 +54,7 @@ impl<S: Spec> MaybeAsyncBatch<S> {
                 result_channel,
                 admins: sequencer_admins,
                 tx_profit_threshold,
+                allow_failed_txs,
                 // This will get overwritten by the pre-flight hook.
                 unix_timestamp_micros: AtomicU64::new(0),
                 is_responsible_for_gating_admins,
@@ -163,6 +165,7 @@ pub struct AsyncBatchResponder<S: Spec> {
     result_channel: Sender<Result<ExecutedTxResponse<S>, RejectReason>>,
     admins: Arc<Vec<S::Address>>,
     tx_profit_threshold: u128,
+    allow_failed_txs: bool,
     /// The timestamp of the start of the latest tx in microseconds since the UNIX epoch
     /// We use an atomic u64 to avoid requiring a mutex. Note that this is set during the pre-flight hook.
     /// and read during the post-tx hook. It may not be meaningful before the pre-flight hook is called.
@@ -185,6 +188,7 @@ impl<S: Spec> AsyncBatchResponder<S> {
             result_channel: self.result_channel.clone(),
             admins: self.admins.clone(),
             tx_profit_threshold: self.tx_profit_threshold,
+            allow_failed_txs: self.allow_failed_txs,
             unix_timestamp_micros: AtomicU64::new(0),
             is_responsible_for_gating_admins: self.is_responsible_for_gating_admins,
         }
@@ -237,7 +241,7 @@ impl<S: Spec> AsyncBatchResponder<S> {
             return (dirty_scratchpad.revert(), TxControlFlow::IgnoreTx);
         };
 
-        if !receipt.receipt.is_successful() {
+        if !receipt.receipt.is_successful()  && !self.allow_failed_txs {
             let response = ExecutedTxResponse {
                 receipt: receipt.clone(),
                 tx_changes: dirty_scratchpad.tx_changes(execution_context),

--- a/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
@@ -241,7 +241,9 @@ impl<S: Spec> AsyncBatchResponder<S> {
             return (dirty_scratchpad.revert(), TxControlFlow::IgnoreTx);
         };
 
-        if !receipt.receipt.is_successful()  && !self.allow_failed_txs {
+        if receipt.receipt.is_skipped()
+            || (receipt.receipt.is_reverted() && !self.allow_failed_txs)
+        {
             let response = ExecutedTxResponse {
                 receipt: receipt.clone(),
                 tx_changes: dirty_scratchpad.tx_changes(execution_context),

--- a/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
@@ -18,6 +18,17 @@ use tokio::sync::oneshot;
 use super::{RejectReason, Spec, StateCheckpoint};
 use crate::common::sender_is_allowed;
 
+/// Returns true if a transaction with the given receipt would be included on-chain
+/// (incrementing the user's nonce), based on the `allow_failed_txs` configuration.
+///
+/// - Successful transactions are always included.
+/// - Reverted transactions are only included if `allow_failed_txs` is true.
+/// - Skipped transactions are never included (they represent pre-execution failures
+///   like invalid signature, invalid nonce, etc.).
+pub fn is_tx_included<S: Spec>(receipt: &TransactionReceipt<S>, allow_failed_txs: bool) -> bool {
+    receipt.receipt.is_successful() || (receipt.receipt.is_reverted() && allow_failed_txs)
+}
+
 /// A batch that might be received async from some producer
 #[derive(Debug)]
 pub enum MaybeAsyncBatch<S: Spec> {
@@ -241,9 +252,7 @@ impl<S: Spec> AsyncBatchResponder<S> {
             return (dirty_scratchpad.revert(), TxControlFlow::IgnoreTx);
         };
 
-        if receipt.receipt.is_skipped()
-            || (receipt.receipt.is_reverted() && !self.allow_failed_txs)
-        {
+        if !is_tx_included(&receipt, self.allow_failed_txs) {
             let response = ExecutedTxResponse {
                 receipt: receipt.clone(),
                 tx_changes: dirty_scratchpad.tx_changes(execution_context),

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -328,7 +328,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             call: call_message_repr::<Rt>(&call),
         })?;
 
-        if !receipt.receipt.is_successful() {
+        if !receipt.receipt.is_successful() && !self.seq_config.sequencer_kind_config.allow_failed_txs {
             return Err(RollupBlockExecutorError::UnsuccessfulTransaction { receipt });
         }
 
@@ -551,6 +551,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
                 sequencer_da_address: self.da_address.clone(),
                 executor_context,
                 is_responsible_for_gating_admins,
+                allow_failed_txs: self.seq_config.sequencer_kind_config.allow_failed_txs,
             };
 
             move || rollup_block_task_body::<S, Rt>(ctx)
@@ -803,6 +804,7 @@ struct RollupBlockTaskContext<S: Spec> {
     /// Whether this instance of the executor is responsible for gating admins.
     /// This is not true for replicas or when replaying txs that have already been accepted
     is_responsible_for_gating_admins: bool,
+    allow_failed_txs: bool,
 }
 
 fn rollup_block_task_body<S, Rt>(ctx: RollupBlockTaskContext<S>) -> BlockExecutionOutput<S>
@@ -826,6 +828,7 @@ where
         sequencer_da_address,
         executor_context,
         is_responsible_for_gating_admins,
+        allow_failed_txs,
     } = ctx;
 
     let _span = match executor_context {
@@ -870,6 +873,7 @@ where
                 admin_addresses,
                 sequencer_rollup_address,
                 is_responsible_for_gating_admins,
+                allow_failed_txs,
             )),
             reserved_gas_tokens: Some(needed_gas_escrow),
             sender: sequencer_da_address.clone(),

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -328,7 +328,10 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             call: call_message_repr::<Rt>(&call),
         })?;
 
-        if !receipt.receipt.is_successful() && !self.seq_config.sequencer_kind_config.allow_failed_txs {
+        if receipt.receipt.is_skipped()
+            || (receipt.receipt.is_reverted()
+                && !self.seq_config.sequencer_kind_config.allow_failed_txs)
+        {
             return Err(RollupBlockExecutorError::UnsuccessfulTransaction { receipt });
         }
 

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -328,7 +328,10 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             call: call_message_repr::<Rt>(&call),
         })?;
 
-        if !is_tx_included(&receipt, self.seq_config.sequencer_kind_config.allow_failed_txs) {
+        if !is_tx_included(
+            &receipt,
+            self.seq_config.sequencer_kind_config.allow_failed_txs,
+        ) {
             return Err(RollupBlockExecutorError::UnsuccessfulTransaction { receipt });
         }
 

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -33,7 +33,7 @@ use super::{
     Confirmation, PreferredBatchToReplay, PreferredSequencerConfig, VisibleSlotNumberIncrease,
 };
 use crate::common::AcceptedTx;
-use crate::preferred::async_batch::{ExecutedTxResponse, MaybeAsyncBatch};
+use crate::preferred::async_batch::{is_tx_included, ExecutedTxResponse, MaybeAsyncBatch};
 use crate::preferred::exit_rollup;
 use crate::preferred::transaction_subscriptions::TxResultWriter;
 use crate::SequencerConfig;
@@ -328,10 +328,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             call: call_message_repr::<Rt>(&call),
         })?;
 
-        if receipt.receipt.is_skipped()
-            || (receipt.receipt.is_reverted()
-                && !self.seq_config.sequencer_kind_config.allow_failed_txs)
-        {
+        if !is_tx_included(&receipt, self.seq_config.sequencer_kind_config.allow_failed_txs) {
             return Err(RollupBlockExecutorError::UnsuccessfulTransaction { receipt });
         }
 

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -33,7 +33,7 @@ use super::{
     Confirmation, PreferredBatchToReplay, PreferredSequencerConfig, VisibleSlotNumberIncrease,
 };
 use crate::common::AcceptedTx;
-use crate::preferred::async_batch::{is_tx_included, ExecutedTxResponse, MaybeAsyncBatch};
+use crate::preferred::async_batch::{should_be_included, ExecutedTxResponse, MaybeAsyncBatch};
 use crate::preferred::exit_rollup;
 use crate::preferred::transaction_subscriptions::TxResultWriter;
 use crate::SequencerConfig;
@@ -328,7 +328,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
             call: call_message_repr::<Rt>(&call),
         })?;
 
-        if !is_tx_included(
+        if !should_be_included(
             &receipt,
             self.seq_config.sequencer_kind_config.allow_failed_txs,
         ) {

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -319,6 +319,10 @@
         "recovery_strategy"
       ],
       "properties": {
+        "allow_failed_txs": {
+          "default": false,
+          "type": "boolean"
+        },
         "batch_execution_time_limit_millis": {
           "description": "Target time in milliseconds to spend executing all the txs in a single batch. Batches will be closed when they exceed this value.",
           "type": "integer",

--- a/crates/module-system/sov-modules-api/src/common/error.rs
+++ b/crates/module-system/sov-modules-api/src/common/error.rs
@@ -3,6 +3,7 @@
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
+use crate::prelude::serde::de::Error;
 use serde::{ser::Error as _, Deserialize, Serialize};
 
 /// Macro for creating structured error detail objects for the `ErrorDetail` trait.
@@ -271,8 +272,9 @@ impl std::fmt::Display for DeserializedError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Deserialized error: {}",
-            serde_json::to_string(&self.data).unwrap()
+            "{}",
+            serde_json::to_string(&self.data)
+                .unwrap_or_else(|e| format!("Error serializing error: {e}"))
         )
     }
 }
@@ -323,10 +325,17 @@ impl Serialize for ModuleError {
     where
         S: serde::Serializer,
     {
-        self.0
-            .error_detail()
-            .map_err(S::Error::custom)?
-            .serialize(serializer)
+        // Handle binary serialization
+        if !serializer.is_human_readable() {
+            let err = self.0.error_detail().map_err(S::Error::custom)?;
+            let json = serde_json::to_string(&err).map_err(S::Error::custom)?;
+            serializer.serialize_str(&json)
+        } else {
+            self.0
+                .error_detail()
+                .map_err(S::Error::custom)?
+                .serialize(serializer)
+        }
     }
 }
 
@@ -335,7 +344,34 @@ impl<'de> Deserialize<'de> for ModuleError {
     where
         D: serde::Deserializer<'de>,
     {
-        let value = serde_json::Map::deserialize(deserializer)?;
-        Ok(Self(Arc::new(DeserializedError { data: value })))
+        if !deserializer.is_human_readable() {
+            let json = String::deserialize(deserializer)?;
+            let value: ErrorContext = serde_json::from_str(&json).map_err(D::Error::custom)?;
+            Ok(Self(Arc::new(DeserializedError { data: value })))
+        } else {
+            let value: ErrorContext = Deserialize::deserialize(deserializer)?;
+            Ok(Self(Arc::new(DeserializedError { data: value })))
+        }
     }
+}
+
+/// Test that the module serializes identically (using JSON, which is what we serve) after a roundtrip through bincode.
+#[test]
+fn test_module_error_serialization_bincode() {
+    let error = ModuleError::from(anyhow::anyhow!("test error"));
+    let serialized = bincode::serialize(&error).unwrap();
+    let deserialized: ModuleError = bincode::deserialize(&serialized).unwrap();
+    assert_eq!(
+        serde_json::to_string(&error).unwrap(),
+        serde_json::to_string(&deserialized).unwrap()
+    );
+}
+
+/// Test that the module serializes identically (using JSON, which is what we serve) after a roundtrip through serde_json.
+#[test]
+fn test_module_error_serialization_json() {
+    let error = ModuleError::from(anyhow::anyhow!("test error"));
+    let json = serde_json::to_string(&error).unwrap();
+    let deserialized: ModuleError = serde_json::from_str(&json).unwrap();
+    assert_eq!(json, serde_json::to_string(&deserialized).unwrap());
 }


### PR DESCRIPTION
# Description

Adds a config option to make the preferred sequencer post reverted TXs on chain. This wastes user gas but brings the behaviour in line with mainline Ethereum and similar chains.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
