### PR TITLE
Add retries to replica test

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1419,7 +1419,6 @@ async fn max_batch_execution_time() {
     let _ = client.send_raw_tx_to_sequencer(&tx_5).await.unwrap();
     let _ = client.send_raw_tx_to_sequencer(&tx_6).await.unwrap();
 
-
     let wait_slot_timeout = std::time::Duration::from_millis(max_batch_exec_time_millis) * 4;
     let mut slot_summaries = Vec::new();
 

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1356,7 +1356,7 @@ async fn test_sequencer_event_stream_filtering() {
 /// This way this test can validate that only **execution time** of tx counts
 #[tokio::test(flavor = "multi_thread")]
 async fn max_batch_execution_time() {
-    // Timeout the batch after 3 seconds of **execution time**.
+    // Timeout the batch after 2 seconds of **execution time**.
     let max_batch_exec_time_millis = 2000;
     let approx_batch_time_millis = 400;
     let (test_rollup, admin) = create_test_rollup(
@@ -1377,21 +1377,27 @@ async fn max_batch_execution_time() {
         .await
         .unwrap();
 
+    // Tx1: Takes longer than the batch timeout, causing batch 0 to close
     let tx_1 = tx_set_value_and_sleep(
         &admin.private_key,
         0,
         1,
         max_batch_exec_time_millis + approx_batch_time_millis,
     );
+    // After tx 2, batch 1: execution time: 50%
     let tx_2 = tx_set_value_and_sleep(&admin.private_key, 0, 2, max_batch_exec_time_millis / 2);
+    // After tx 3, batch 1: execution time: 100% + cushion. Close batch 1 and create batch 2
     let tx_3 = tx_set_value_and_sleep(
         &admin.private_key,
         1,
         3,
         (max_batch_exec_time_millis / 2) + approx_batch_time_millis,
     );
+    // After tx 4, batch 2: execution time: 33%
     let tx_4 = tx_set_value_and_sleep(&admin.private_key, 1, 4, max_batch_exec_time_millis / 3);
+    // After tx 5, batch 2: execution time: 66%
     let tx_5 = tx_set_value_and_sleep(&admin.private_key, 2, 5, max_batch_exec_time_millis / 3);
+    // After tx 6, batch 2: execution time: 100% + cushion. Close batch 2
     let tx_6 = tx_set_value_and_sleep(
         &admin.private_key,
         3,
@@ -1413,7 +1419,8 @@ async fn max_batch_execution_time() {
     let _ = client.send_raw_tx_to_sequencer(&tx_5).await.unwrap();
     let _ = client.send_raw_tx_to_sequencer(&tx_6).await.unwrap();
 
-    let wait_slot_timeout = std::time::Duration::from_millis(max_batch_exec_time_millis) * 3;
+
+    let wait_slot_timeout = std::time::Duration::from_millis(max_batch_exec_time_millis) * 4;
     let mut slot_summaries = Vec::new();
 
     #[derive(Debug, PartialEq)]

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -100,22 +100,24 @@ async fn send_transfers(
             start_nonce + n,
         );
         let mut retry_duration = Duration::from_millis(100);
+        // Send the tx with retries, up to 7 attempts (about 30 seconds)
         for attempt in 1..=7 {
             match test_rollup.send_tx_to_sequencer(&tx).await {
                 Ok(_) => break,
                 Err(e) => {
                     if e.to_string().contains("The node fell out of sync") {
-                        continue;
+                        if attempt == 7 {
+                            panic!("Failed to send tx after 7 attempts (about 30 seconds). This probably means that the test is too heavy.: {e}");
+                        }
+                        tokio::time::sleep(retry_duration).await;
+                        retry_duration *= 2;
+                    } else {
+                        panic!("Unexpected error while sending tx: {e}");
                     }
-                    panic!("Unexpected error while sending tx: {}", e);
                 }
             }
-            tokio::time::sleep(retry_duration).await;
-            retry_duration *= 2;
-            if attempt == 7 {
-                panic!("Failed to send tx after 7 attempts (about 30 seconds). This probably means that the test is too heavy.: {e}");
-            }
         }
+        // Wait between each successful send, to avoid overwhelming the sequencer
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 }

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -99,7 +99,23 @@ async fn send_transfers(
             AMOUNT,
             start_nonce + n,
         );
-        test_rollup.send_tx_to_sequencer(&tx).await.unwrap();
+        let mut retry_duration = Duration::from_millis(100);
+        for attempt in 1..=7 {
+            match test_rollup.send_tx_to_sequencer(&tx).await {
+                Ok(_) => break,
+                Err(e) => {
+                    if e.to_string().contains("The node fell out of sync") {
+                        continue;
+                    }
+                    panic!("Unexpected error while sending tx: {}", e);
+                }
+            }
+            tokio::time::sleep(retry_duration).await;
+            retry_duration *= 2;
+            if attempt == 7 {
+                panic!("Failed to send tx after 7 attempts (about 30 seconds). This probably means that the test is too heavy.: {e}");
+            }
+        }
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
 }


### PR DESCRIPTION
# Description

This PR hopes to reduce the flakiness of the replica start-stop tests by adding retries with backoff on tx submission.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
