### PR TITLE
Fix metrics tracking for eth_sendRawTransactionSync

### DIFF
--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -97,8 +97,8 @@ where
                 format!("The transaction was added to the mempool but wasn't processed in {timeout_ms}ms."),
                 None::<()>,
             );
-            track_metrics("eth_sendRawTransactionSync", start, &Err(err));
-            Err(err)
+            track_metrics("eth_sendRawTransactionSync", start, &RpcResult::<Option<Receipt>>::Err(err.clone()));
+            err
         })?;
         track_metrics("eth_sendRawTransactionSync", start, &result);
         result

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -92,11 +92,13 @@ where
         )
         .await
         .map_err(|_| {
-            ErrorObjectOwned::owned(
+            let err = ErrorObjectOwned::owned(
                 TIMEOUT_CODE,
                 format!("The transaction was added to the mempool but wasn't processed in {timeout_ms}ms."),
                 None::<()>,
-            )
+            );
+            track_metrics("eth_sendRawTransactionSync", start, &Err(err));
+            Err(err)
         })?;
         track_metrics("eth_sendRawTransactionSync", start, &result);
         result


### PR DESCRIPTION
# Description

This one-liner fixes a bug which caused metrics tracking to be skipped in `eth_sendRawTransactionSync` whenever a timeout occurred.