### PR TITLE
Rate limiting: pass `SocketAddr` from Axum to `process_accept_tx`.

### DIFF
--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -280,6 +280,7 @@ fn track_metrics<T>(request_name: &'static str, start: Instant, result: &RpcResu
 
 // Gets the SocketAddr needed for rete-limiting.
 fn get_socket_addr(extensions: Extensions) -> Result<SocketAddr, ErrorObjectOwned> {
+    // The `SocketAddr`` was injected into the request extensions by specific middleware in `axum::serve`.
     extensions
         .get::<SocketAddr>()
         .copied()

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -34,6 +34,7 @@ use sov_rpc_eth_types::EthApiError;
 use sov_rpc_eth_types::LogWithExecutionTimestamp;
 use sov_sequencer::Sequencer;
 use std::marker::PhantomData;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -50,6 +51,8 @@ type Receipt = TransactionReceipt<ReceiptEnvelope<LogWithExecutionTimestamp>>;
 
 const MAX_TIMEOUT: u64 = 2_000; // 2 seconds
 
+const SOCKET_ADDRESS_ERROR: &'static str = "Unable to retrieve the peer socket address";
+
 pub struct Handlers<S, Seq>(PhantomData<(S, Seq)>);
 
 impl<S, Seq> Handlers<S, Seq>
@@ -62,11 +65,13 @@ where
     pub async fn eth_send_raw_transaction(
         parameters: JRpcParams<'static>,
         ethereum: Arc<Ethereum<S, Seq>>,
-        _: Extensions,
+        extensions: Extensions,
     ) -> RpcResult<B256> {
         let start = Instant::now();
+        let addr = get_socket_addr(extensions)?;
+
         let noop = |tx_hash, _| Ok(tx_hash);
-        let result = Self::process_raw_transaction(parameters.one()?, ethereum, noop).await;
+        let result = Self::process_raw_transaction(parameters.one()?, ethereum, noop, addr).await;
         track_metrics("eth_sendRawTransaction", start, &result);
         result
     }
@@ -74,7 +79,7 @@ where
     pub async fn eth_send_raw_transaction_sync(
         parameters: JRpcParams<'static>,
         ethereum: Arc<Ethereum<S, Seq>>,
-        _: Extensions,
+        extensions: Extensions,
     ) -> RpcResult<Option<Receipt>> {
         let start = Instant::now();
         let mut params = parameters.sequence();
@@ -86,9 +91,11 @@ where
                 ETH_RPC_ERROR,
             ));
         }
+        let addr = get_socket_addr(extensions)?;
+
         let result = timeout(
             Duration::from_millis(timeout_ms),
-            Self::process_raw_transaction(data, ethereum, Self::get_receipt),
+            Self::process_raw_transaction(data, ethereum, Self::get_receipt, addr),
         )
         .await
         .map_err(|_| {
@@ -105,11 +112,14 @@ where
     pub async fn realtime_send_raw_transaction(
         parameters: JRpcParams<'static>,
         ethereum: Arc<Ethereum<S, Seq>>,
-        _: Extensions,
+        extensions: Extensions,
     ) -> RpcResult<Option<Receipt>> {
         let start = Instant::now();
+        let addr = get_socket_addr(extensions)?;
+
         let result =
-            Self::process_raw_transaction(parameters.one()?, ethereum, Self::get_receipt).await;
+            Self::process_raw_transaction(parameters.one()?, ethereum, Self::get_receipt, addr)
+                .await;
         track_metrics("realtime_sendRawTransaction", start, &result);
         result
     }
@@ -124,6 +134,7 @@ where
         data: Bytes,
         ethereum: Arc<Ethereum<S, Seq>>,
         on_success: F,
+        addr: SocketAddr,
     ) -> RpcResult<T>
     where
         F: Fn(B256, Arc<Ethereum<S, Seq>>) -> RpcResult<T>,
@@ -134,7 +145,7 @@ where
         Self::authenticate_tx(&tx, &ethereum)?;
 
         let seq = ethereum.sequencer.clone();
-        seq.accept_tx(tx).await.map_err(|e| {
+        seq.accept_tx(tx, addr).await.map_err(|e| {
             to_jsonrpsee_error_object(
                 format!("{} - '{}' ({:?})", e.status, e.message, e.details),
                 ETH_RPC_ERROR,
@@ -171,9 +182,10 @@ where
     pub async fn eth_send_transaction(
         parameters: JRpcParams<'static>,
         ethereum: Arc<Ethereum<S, Seq>>,
-        _: Extensions,
+        extensions: Extensions,
     ) -> RpcResult<B256> {
         let mut transaction_request: TransactionRequest = parameters.one()?;
+        let addr = get_socket_addr(extensions)?;
 
         let evm = Evm::<S>::default();
 
@@ -241,7 +253,7 @@ where
 
         let tx = Seq::Rt::encode_with_ethereum_auth(RawTx::new(raw_message));
 
-        ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
+        ethereum.sequencer.accept_tx(tx, addr).await.map_err(|e| {
             to_jsonrpsee_error_object(
                 format!("{} - '{}' ({:?})", e.status, e.message, e.details),
                 ETH_RPC_ERROR,
@@ -264,4 +276,12 @@ fn track_metrics<T>(request_name: &'static str, start: Instant, result: &RpcResu
     sov_metrics::track_metrics(|tracker| {
         tracker.submit(metrics);
     });
+}
+
+// Gets the SocketAddr needed for rete-limiting.
+fn get_socket_addr(extensions: Extensions) -> Result<SocketAddr, ErrorObjectOwned> {
+    extensions
+        .get::<SocketAddr>()
+        .copied()
+        .ok_or_else(|| to_jsonrpsee_error_object(SOCKET_ADDRESS_ERROR, ETH_RPC_ERROR))
 }

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -51,7 +51,7 @@ type Receipt = TransactionReceipt<ReceiptEnvelope<LogWithExecutionTimestamp>>;
 
 const MAX_TIMEOUT: u64 = 2_000; // 2 seconds
 
-const SOCKET_ADDRESS_ERROR: &'static str = "Unable to retrieve the peer socket address";
+const SOCKET_ADDRESS_ERROR: &str = "Unable to retrieve the peer socket address";
 
 pub struct Handlers<S, Seq>(PhantomData<(S, Seq)>);
 

--- a/crates/full-node/sov-rollup-apis/tests/integration/main.rs
+++ b/crates/full-node/sov-rollup-apis/tests/integration/main.rs
@@ -98,7 +98,7 @@ impl TestData {
             tokio::spawn(async move {
                 axum_server::Server::bind(SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 0)))
                     .handle(handle1)
-                    .serve(axum_router.into_make_service())
+                    .serve(axum_router.into_make_service_with_connect_info::<SocketAddr>())
                     .await
                     .unwrap();
             });

--- a/crates/full-node/sov-sequencer/src/common.rs
+++ b/crates/full-node/sov-sequencer/src/common.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::future::Future;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -170,6 +171,7 @@ pub trait Sequencer: Clone + Send + Sync + 'static {
     async fn accept_tx(
         &self,
         tx: FullyBakedTx,
+        addr: SocketAddr,
     ) -> Result<AcceptedTx<Self::Confirmation>, ErrorObject>;
 
     /// Can be used to query and update the status of transactions.

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -59,6 +59,7 @@ use sov_rollup_interface::TxHash;
 use state_root_compute::StateRootBackgroundTaskState;
 use std::boxed::Box;
 use std::marker::PhantomData;
+use std::net::SocketAddr;
 use std::num::NonZero;
 use std::ops::Deref;
 use std::path::Path;
@@ -608,6 +609,7 @@ where
     async fn accept_tx_inner(
         &self,
         baked_tx: FullyBakedTx,
+        socket_addr: SocketAddr,
     ) -> Result<AcceptedTx<<Self as Sequencer>::Confirmation>, ErrorObject> {
         if self.shutdown_receiver.has_changed().unwrap_or(true) {
             tracing::info!("The sequencer is shutting down. Cannot accept transactions");
@@ -645,7 +647,14 @@ where
         let (outer_res, is_nonce_based) = match uniqueness {
             UniquenessData::Generation(_) => (
                 self.synchronized_state_updator
-                    .accept_tx_msg(&baked_tx, tx_hash, original_tx_queue_id, "accept_tx")
+                    .accept_tx_msg(
+                        &baked_tx,
+                        tx_hash,
+                        original_tx_queue_id,
+                        credential_id,
+                        socket_addr,
+                        "accept_tx",
+                    )
                     .await,
                 false,
             ),
@@ -656,6 +665,7 @@ where
                         tx_hash,
                         tx_nonce,
                         credential_id,
+                        socket_addr,
                         original_tx_queue_id,
                     )
                     .await,
@@ -1058,9 +1068,10 @@ where
     async fn accept_tx(
         &self,
         baked_tx: FullyBakedTx,
+        socket_addr: SocketAddr,
     ) -> Result<AcceptedTx<Self::Confirmation>, ErrorObject> {
         let sequencer = self.clone();
-        tokio::spawn(async move { sequencer.accept_tx_inner(baked_tx).await })
+        tokio::spawn(async move { sequencer.accept_tx_inner(baked_tx, socket_addr).await })
             .await
             .map_err(|e| {
                 tracing::error!(error = %e, "A panic occurred while accepting a transaction");

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -663,6 +663,7 @@ where
         &mut self,
         tx_hash: TxHash,
         baked_tx: FullyBakedTx,
+        //credential_id: CredentialId,
     ) -> Result<
         (
             oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>,

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -663,7 +663,6 @@ where
         &mut self,
         tx_hash: TxHash,
         baked_tx: FullyBakedTx,
-        //credential_id: CredentialId,
     ) -> Result<
         (
             oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>,

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
@@ -19,9 +19,11 @@ use sov_blob_storage::SequenceNumber;
 use sov_db::ledger_db::LedgerDb;
 use sov_full_node_configs::sequencer::{PreferredSequencerConfig, SequencerConfig};
 use sov_modules_api::capabilities::RollupHeight;
+use sov_modules_api::CredentialId;
 use sov_modules_api::{FullyBakedTx, Runtime, Spec, StateUpdateInfo};
 use sov_state::Storage;
 use std::collections::BTreeMap;
+use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize};
 use std::sync::Arc;
 pub(crate) use sync_state::*;
@@ -63,6 +65,8 @@ pub(super) enum Message<S: Spec, Rt: Runtime<S>> {
         baked_tx: FullyBakedTx,
         tx_hash: TxHash,
         original_tx_queue_id: u64,
+        credential_id: CredentialId,
+        socket_addr: SocketAddr,
         reason: &'static str,
     },
 

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -27,10 +27,11 @@ use sov_blob_sender::BlobInternalId;
 use sov_blob_storage::SequenceNumber;
 use sov_modules_api::capabilities::RollupHeight;
 use sov_modules_api::{
-    FullyBakedTx, Runtime, Spec, StateCheckpoint, StateUpdateInfo, VersionReader,
+    CredentialId, FullyBakedTx, Runtime, Spec, StateCheckpoint, StateUpdateInfo, VersionReader,
 };
 use sov_state::Storage;
 use std::collections::BTreeMap;
+use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -229,10 +230,19 @@ where
                 baked_tx,
                 tx_hash,
                 original_tx_queue_id,
+                credential_id,
+                socket_addr,
                 reason,
             } => {
                 let ret = self
-                    .process_accept_tx(baked_tx, tx_hash, original_tx_queue_id, reason)
+                    .process_accept_tx(
+                        baked_tx,
+                        tx_hash,
+                        original_tx_queue_id,
+                        credential_id,
+                        socket_addr,
+                        reason,
+                    )
                     .await;
                 if let Err(AcceptTxError::NewTxError(DoNewTxError::ExecutorError(
                     RollupBlockExecutorError::UnexpectedFailure,
@@ -726,6 +736,8 @@ where
         baked_tx: FullyBakedTx,
         tx_hash: TxHash,
         original_tx_queue_id: u64,
+        _credential_id: CredentialId,
+        _socket_addr: SocketAddr,
         reason: &'static str,
     ) -> Result<oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>, AcceptTxError<S>> {
         let mut inner = self.get_inner_with_timing(reason).await;

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/updator.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/updator.rs
@@ -10,9 +10,11 @@ use crate::preferred::FetchBatches;
 use crate::preferred::PreferredSeqOperation;
 use crate::preferred::ProcessFinalCatchupData;
 use crate::{SequencerNotReadyDetails, TxHash};
+use core::net::SocketAddr;
 use sov_blob_sender::BlobInternalId;
 use sov_blob_storage::SequenceNumber;
 use sov_modules_api::capabilities::RollupHeight;
+use sov_modules_api::CredentialId;
 use sov_modules_api::{FullyBakedTx, Runtime, Spec, StateUpdateInfo};
 use sov_state::Storage;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -126,6 +128,8 @@ where
         baked_tx: &FullyBakedTx,
         tx_hash: TxHash,
         original_tx_queue_id: u64,
+        credential_id: CredentialId,
+        socket_addr: SocketAddr,
         reason: &'static str,
     ) -> Result<
         Result<oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>, AcceptTxError<S>>,
@@ -137,6 +141,8 @@ where
             baked_tx: baked_tx.clone(),
             tx_hash,
             original_tx_queue_id,
+            credential_id,
+            socket_addr,
             reason,
         })
         .await?;

--- a/crates/full-node/sov-sequencer/src/preferred/timestamp.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/timestamp.rs
@@ -1,3 +1,6 @@
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+
 use crate::common::Sequencer;
 use crate::preferred::PreferredSequencer;
 use crate::preferred::Runtime;
@@ -89,6 +92,7 @@ where
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut consecutive_failures = 0;
 
+    let socket_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
     let handle = tokio::spawn(async move {
         loop {
             tokio::select! {
@@ -136,7 +140,7 @@ where
 
             let baked_tx = Rt::Auth::encode_with_standard_auth(raw_tx);
 
-            if let Err(error) = seq.accept_tx(baked_tx).await {
+            if let Err(error) = seq.accept_tx(baked_tx, socket_addr).await {
                 // Reduce log spam by only logging 1 of every 100 consecutive failures
                 if consecutive_failures % 100 == 0 {
                     tracing::error!(?error, "Error submitting timestamp oracle update tx");

--- a/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/tx_nonce_queue.rs
@@ -8,6 +8,7 @@ use sov_rollup_interface::{crypto::CredentialId, TxHash};
 use std::cmp::Ordering;
 use std::collections::{btree_map::OccupiedEntry, BTreeMap};
 use std::fmt::Debug;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::oneshot;
 
@@ -142,6 +143,8 @@ pub trait TxExecutionBackend<S: Spec, Rt: Runtime<S>> {
         baked_tx: &FullyBakedTx,
         tx_hash: TxHash,
         original_tx_queue_id: u64,
+        credential_id: CredentialId,
+        socket_addr: SocketAddr,
         reason: &'static str,
     ) -> Result<TransactionReceiverResult<S, Rt>, SequencerStateUpdatorError>;
 }
@@ -180,10 +183,19 @@ impl<S: Spec, Rt: Runtime<S>> TxExecutionBackend<S, Rt> for SequencerTxExecution
         baked_tx: &FullyBakedTx,
         tx_hash: TxHash,
         original_tx_queue_id: u64,
+        credential_id: CredentialId,
+        socket_addr: SocketAddr,
         reason: &'static str,
     ) -> Result<TransactionReceiverResult<S, Rt>, SequencerStateUpdatorError> {
         self.state_updator
-            .accept_tx_msg(baked_tx, tx_hash, original_tx_queue_id, reason)
+            .accept_tx_msg(
+                baked_tx,
+                tx_hash,
+                original_tx_queue_id,
+                credential_id,
+                socket_addr,
+                reason,
+            )
             .await
     }
 }
@@ -378,6 +390,7 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
     async fn drain_any_ready_transactions(
         &self,
         credential_id: &CredentialId,
+        socket_addr: SocketAddr,
         mut expected_nonce: u64,
     ) {
         loop {
@@ -393,6 +406,8 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                     &queued_tx.tx,
                     queued_tx.tx_hash,
                     queued_tx.original_tx_queue_id,
+                    *credential_id,
+                    socket_addr,
                     "nonce_queue_trigger",
                 )
                 .await;
@@ -495,6 +510,7 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
         tx_hash: TxHash,
         tx_nonce: u64,
         credential_id: CredentialId,
+        socket_addr: SocketAddr,
         original_tx_queue_id: u64,
     ) -> Result<
         Result<oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>, AcceptTxError<S>>,
@@ -523,6 +539,8 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                         &baked_tx,
                         tx_hash,
                         original_tx_queue_id,
+                        credential_id,
+                        socket_addr,
                         "nonce_queue_immediate",
                     )
                     .await;
@@ -534,7 +552,11 @@ impl<Sb: TxExecutionBackend<S, Rt> + Sync + Send + Clone + 'static, S: Spec, Rt:
                     let starting_nonce = tx_nonce + 1;
                     tokio::spawn(async move {
                         queues
-                            .drain_any_ready_transactions(&credential_id, starting_nonce)
+                            .drain_any_ready_transactions(
+                                &credential_id,
+                                socket_addr,
+                                starting_nonce,
+                            )
                             .await;
                     });
                 }
@@ -605,12 +627,15 @@ mod tests {
     use sov_modules_api::{SkippedTxContents, TransactionReceipt, TxProcessingError};
     use sov_test_utils::runtime::TestOptimisticRuntime;
     use sov_test_utils::TestSpec;
+    use std::net::{Ipv4Addr, SocketAddrV4};
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Mutex;
     use std::time::Duration;
     use tokio::sync::oneshot;
 
     type TestRuntime = TestOptimisticRuntime<TestSpec>;
+
+    static SOCKET_ADDR: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0));
 
     // Helper to create a mock QueuedTx for testing
     fn create_mock_queued_tx(nonce: u8) -> QueuedTx<TestSpec, TestRuntime> {
@@ -947,7 +972,9 @@ mod tests {
         }
 
         // Drain starting from nonce 5 (3 and 4 should be silently evicted, 5 should execute)
-        queues.drain_any_ready_transactions(&credential_id, 5).await;
+        queues
+            .drain_any_ready_transactions(&credential_id, SOCKET_ADDR, 5)
+            .await;
 
         let executed_nonces = backend.get_executed_nonces();
         assert_eq!(
@@ -989,7 +1016,9 @@ mod tests {
         }
 
         // Drain starting from nonce 0
-        queues.drain_any_ready_transactions(&credential_id, 0).await;
+        queues
+            .drain_any_ready_transactions(&credential_id, SOCKET_ADDR, 0)
+            .await;
 
         // Should have executed exactly 2 transactions (0 and 1), then stopped at gap
         let executed_nonces = backend.get_executed_nonces();
@@ -1070,6 +1099,8 @@ mod tests {
             baked_tx: &FullyBakedTx,
             tx_hash: TxHash,
             _original_tx_queue_id: u64,
+            _credential_id: CredentialId,
+            _socket_addr: SocketAddr,
             _reason: &'static str,
         ) -> Result<TransactionReceiverResult<TestSpec, TestRuntime>, SequencerStateUpdatorError>
         {
@@ -1171,6 +1202,7 @@ mod tests {
                         TxHash::from([nonce; 32]),
                         nonce as u64,
                         credential_id,
+                        SOCKET_ADDR,
                         0,
                     )
                     .await
@@ -1188,6 +1220,7 @@ mod tests {
                 TxHash::from([0; 32]),
                 0,
                 credential_id,
+                SOCKET_ADDR,
                 0,
             )
             .await;
@@ -1235,6 +1268,7 @@ mod tests {
                 TxHash::from([4; 32]),
                 4,
                 credential_id,
+                SOCKET_ADDR,
                 0,
             )
             .await;
@@ -1300,6 +1334,7 @@ mod tests {
                 TxHash::from([11; 32]),
                 11,
                 credential_id,
+                SOCKET_ADDR,
                 0,
             )
             .await;
@@ -1355,6 +1390,7 @@ mod tests {
                         TxHash::from([2; 32]),
                         2,
                         credential_id,
+                        SOCKET_ADDR,
                         0,
                     )
                     .await
@@ -1371,6 +1407,7 @@ mod tests {
                 TxHash::from([0; 32]),
                 0,
                 credential_id,
+                SOCKET_ADDR,
                 0,
             )
             .await;
@@ -1392,6 +1429,7 @@ mod tests {
                 TxHash::from([1; 32]),
                 1,
                 credential_id,
+                SOCKET_ADDR,
                 0,
             )
             .await;
@@ -1430,6 +1468,7 @@ mod tests {
                         TxHash::from([1; 32]),
                         1,
                         credential_id,
+                        SOCKET_ADDR,
                         0,
                     )
                     .await
@@ -1505,6 +1544,7 @@ mod tests {
                         TxHash::from([nonce; 32]),
                         nonce as u64,
                         credential_id,
+                        SOCKET_ADDR,
                         0,
                     )
                     .await
@@ -1522,6 +1562,7 @@ mod tests {
                 TxHash::from([0; 32]),
                 0,
                 credential_id,
+                SOCKET_ADDR,
                 0,
             )
             .await;
@@ -1565,6 +1606,7 @@ mod tests {
                         TxHash::from([1; 32]),
                         1,
                         credential_id,
+                        SOCKET_ADDR,
                         0,
                     )
                     .await
@@ -1645,6 +1687,7 @@ mod tests {
                         TxHash::from([0; 32]),
                         0,
                         credential_id,
+                        SOCKET_ADDR,
                         0,
                     )
                     .await
@@ -1670,6 +1713,7 @@ mod tests {
                         TxHash::from([1; 32]),
                         1,
                         credential_id,
+                        SOCKET_ADDR,
                         0,
                     )
                     .await
@@ -1717,6 +1761,7 @@ mod tests {
                 TxHash::from([0; 32]),
                 0,
                 credential_id,
+                SOCKET_ADDR,
                 0,
             )
             .await;

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -227,7 +227,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
     }
 
     async fn axum_accept_tx(
-        ConnectInfo(addr): ConnectInfo<SocketAddr>,
+        connect_info: ConnectInfo<SocketAddr>,
         state: State<Self>,
         tx: Json<AcceptTx>,
     ) -> ApiResult<
@@ -240,7 +240,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
 
         let tx_with_hash = state
             .sequencer
-            .accept_tx(baked_tx, addr)
+            .accept_tx(baked_tx, connect_info.0)
             .await
             .map_err(|e| {
                 if e.status.is_server_error() {

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -1,9 +1,10 @@
 //! Utilities and definitions for the sequencer's REST APIs.
 
+use std::net::SocketAddr;
 use std::pin::Pin;
 
 use axum::extract::ws::WebSocket;
-use axum::extract::{ws, State, WebSocketUpgrade};
+use axum::extract::{ws, ConnectInfo, State, WebSocketUpgrade};
 use axum::response::IntoResponse;
 use axum::Json;
 use futures::StreamExt;
@@ -226,6 +227,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
     }
 
     async fn axum_accept_tx(
+        ConnectInfo(addr): ConnectInfo<SocketAddr>,
         state: State<Self>,
         tx: Json<AcceptTx>,
     ) -> ApiResult<
@@ -236,12 +238,16 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             Seq::Spec,
         >>::encode_with_standard_auth(raw_tx);
 
-        let tx_with_hash = state.sequencer.accept_tx(baked_tx).await.map_err(|e| {
-            if e.status.is_server_error() {
-                tracing::error!(error = ?e, "Error accepting transaction");
-            }
-            IntoResponse::into_response(e)
-        })?;
+        let tx_with_hash = state
+            .sequencer
+            .accept_tx(baked_tx, addr)
+            .await
+            .map_err(|e| {
+                if e.status.is_server_error() {
+                    tracing::error!(error = ?e, "Error accepting transaction");
+                }
+                IntoResponse::into_response(e)
+            })?;
 
         Ok(TxInfoWithConfirmation {
             id: tx_with_hash.tx_hash,

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -29,6 +29,7 @@ use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::node::DaSyncState;
 use std::boxed::Box;
 use std::marker::PhantomData;
+use std::net::SocketAddr;
 use std::num::NonZero;
 use std::path::Path;
 use std::sync::atomic::AtomicUsize;
@@ -706,6 +707,7 @@ where
     async fn accept_tx(
         &self,
         baked_tx: FullyBakedTx,
+        _socket_addr: SocketAddr,
     ) -> Result<AcceptedTx<Self::Confirmation>, ErrorObject> {
         let sequencer = self.clone();
         tokio::spawn(async move { sequencer.accept_tx_inner(baked_tx).await })

--- a/crates/full-node/sov-sequencer/src/test_stateless.rs
+++ b/crates/full-node/sov-sequencer/src/test_stateless.rs
@@ -13,6 +13,7 @@ use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::node::DaSyncState;
 use sov_rollup_interface::{StateUpdateInfo, TxHash};
 use std::marker::PhantomData;
+use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
@@ -239,6 +240,7 @@ where
     async fn accept_tx(
         &self,
         tx: FullyBakedTx,
+        _addr: SocketAddr,
     ) -> Result<AcceptedTx<Self::Confirmation>, ErrorObject> {
         Ok(self.accept_encoded_tx(tx).await)
     }

--- a/crates/full-node/sov-sequencer/tests/integration/websockets.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/websockets.rs
@@ -1,3 +1,5 @@
+use std::net::{Ipv4Addr, SocketAddr};
+
 use futures::stream::StreamExt;
 use sov_api_spec::types::TxStatus;
 use sov_sequencer::Sequencer;
@@ -7,6 +9,7 @@ use crate::utils::{generate_txs, RT};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn mempool_eviction_event() {
+    let socket_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
     let mempool_max_txs_count = 1;
     let sequencer = TestSequencerSetup::<RT>::with_real_sequencer_and_mempool_max_txs_count(
         mempool_max_txs_count.try_into().unwrap(),
@@ -30,7 +33,7 @@ async fn mempool_eviction_event() {
 
     sequencer
         .sequencer
-        .accept_tx(txs[0].fully_baked_tx.clone())
+        .accept_tx(txs[0].fully_baked_tx.clone(), socket_addr)
         .await
         .unwrap();
 
@@ -40,11 +43,12 @@ async fn mempool_eviction_event() {
         TxStatus::Submitted
     );
 
+    let socket_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
     // In the meantime, another transaction enters the mempool and causes the
     // first one to be evicted.
     sequencer
         .sequencer
-        .accept_tx(txs[1].fully_baked_tx.clone())
+        .accept_tx(txs[1].fully_baked_tx.clone(), socket_addr)
         .await
         .unwrap();
 

--- a/crates/full-node/sov-stf-runner/src/http/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/http/mod.rs
@@ -1,6 +1,6 @@
 use axum::body::HttpBody;
 use axum::error_handling::HandleErrorLayer;
-use axum::extract::Request;
+use axum::extract::{ConnectInfo, Request};
 use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::IntoResponse;
@@ -23,6 +23,50 @@ use tower_layer::{Identity, Layer};
 use crate::http::id_provider::HexIdProvider;
 use crate::CorsConfiguration;
 mod id_provider;
+
+// Middleware to inject SocketAddr from axum's ConnectInfo into the request extensions
+// so that jsonrpsee RPC handlers can access it via the Extensions parameter
+#[derive(Clone)]
+struct InjectSocketAddrLayer;
+
+impl<S> Layer<S> for InjectSocketAddrLayer {
+    type Service = InjectSocketAddrService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        InjectSocketAddrService { inner }
+    }
+}
+
+#[derive(Clone)]
+struct InjectSocketAddrService<S> {
+    inner: S,
+}
+
+impl<S, B> tower::Service<axum::http::Request<B>> for InjectSocketAddrService<S>
+where
+    S: tower::Service<axum::http::Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: axum::http::Request<B>) -> Self::Future {
+        // Extract SocketAddr from axum's ConnectInfo and insert it directly
+        // into extensions so jsonrpsee can access it
+        if let Some(ConnectInfo(addr)) = req.extensions().get::<ConnectInfo<SocketAddr>>().cloned()
+        {
+            req.extensions_mut().insert(addr);
+        }
+        self.inner.call(req)
+    }
+}
 
 pub(crate) async fn start_http_server(
     listen_address_http: &SocketAddr,
@@ -96,6 +140,11 @@ pub fn rpc_module_to_router(
     let http_service = error_layer.layer(http_service);
     let ws_service = error_layer.layer(ws_service);
 
+    // Wrap services with the SocketAddr injection layer
+    let inject_addr_layer = InjectSocketAddrLayer;
+    let http_service = inject_addr_layer.layer(http_service);
+    let ws_service = inject_addr_layer.layer(ws_service);
+
     let router = axum::routing::get_service(ws_service)
         .post_service(http_service)
         .layer(cors_layer);
@@ -111,6 +160,7 @@ fn http_service(
         .http_only()
         .max_connections(10_000)
         .build();
+
     ServerBuilder::with_config(config)
         .to_service_builder()
         .build(methods, stop_handle)

--- a/crates/full-node/sov-stf-runner/src/http/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/http/mod.rs
@@ -48,7 +48,9 @@ pub(crate) async fn start_http_server(
         // TODO: Is there a way to have max_connections and other params for axum::serve?
         let result = axum::serve(
             listener,
-            ServiceExt::<axum::extract::Request>::into_make_service(router),
+            ServiceExt::<axum::extract::Request>::into_make_service_with_connect_info::<SocketAddr>(
+                router,
+            ),
         )
         .with_graceful_shutdown(async move {
             shutdown_receiver.changed().await.ok();

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
@@ -1,7 +1,8 @@
 use std::marker::PhantomData;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
-use axum::extract::State;
+use axum::extract::{ConnectInfo, State};
 use axum::response::IntoResponse;
 use axum::routing::post;
 use axum::Json;
@@ -166,7 +167,8 @@ where
 
 /// Handler for accepting Solana offchain authenticated transactions
 async fn accept_solana_offchain_tx<Seq>(
-    State(sequencer): State<Seq>,
+    connect_info: ConnectInfo<SocketAddr>,
+    sequencer: State<Seq>,
     tx: Json<AcceptTx>,
 ) -> ApiResult<TxInfoWithConfirmation<DaBlobHash<<Seq::Da as DaService>::Spec>, Seq::Confirmation>>
 where
@@ -178,12 +180,16 @@ where
     let encoded_tx = Seq::Rt::encode_with_solana_offchain_auth(raw_tx);
 
     // Submit to sequencer (similar to axum_accept_tx but with Solana auth)
-    let tx_with_hash = sequencer.accept_tx(encoded_tx).await.map_err(|e| {
-        if e.status.is_server_error() {
-            tracing::error!(error = ?e, "Error accepting Solana offchain transaction");
-        }
-        IntoResponse::into_response(e)
-    })?;
+    let tx_with_hash = sequencer
+        .0
+        .accept_tx(encoded_tx, connect_info.0)
+        .await
+        .map_err(|e| {
+            if e.status.is_server_error() {
+                tracing::error!(error = ?e, "Error accepting Solana offchain transaction");
+            }
+            IntoResponse::into_response(e)
+        })?;
 
     Ok(TxInfoWithConfirmation {
         id: tx_with_hash.tx_hash,

--- a/crates/module-system/sov-test-utils/src/runtime/mod.rs
+++ b/crates/module-system/sov-test-utils/src/runtime/mod.rs
@@ -902,7 +902,7 @@ where
             tokio::spawn(async move {
                 axum_server::Server::bind(axum_addr)
                     .handle(handle_cloned)
-                    .serve(router.into_make_service())
+                    .serve(router.into_make_service_with_connect_info::<SocketAddr>())
                     .await
                     .unwrap();
             });

--- a/crates/module-system/sov-test-utils/src/sequencer.rs
+++ b/crates/module-system/sov-test-utils/src/sequencer.rs
@@ -178,7 +178,7 @@ impl<Rt: Runtime<TestSpec>> TestSequencerSetup<Rt> {
             tokio::spawn(async move {
                 axum_server::Server::bind(SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 0)))
                     .handle(handle1)
-                    .serve(router.into_make_service())
+                    .serve(router.into_make_service_with_connect_info::<SocketAddr>())
                     .await
                     .unwrap();
             });

--- a/crates/module-system/sov-test-utils/src/test_rollup.rs
+++ b/crates/module-system/sov-test-utils/src/test_rollup.rs
@@ -643,11 +643,14 @@ where
         let actual_port = actual_address.port();
 
         tokio::spawn(async move {
-            axum::serve(listener, ServiceExt::<Request>::into_make_service(router))
-                .with_graceful_shutdown(async move {
-                    shutdown_receiver.changed().await.ok();
-                })
-                .await
+            axum::serve(
+                listener,
+                ServiceExt::<Request>::into_make_service_with_connect_info::<SocketAddr>(router),
+            )
+            .with_graceful_shutdown(async move {
+                shutdown_receiver.changed().await.ok();
+            })
+            .await
         });
 
         let client = sov_api_spec::client::Client::new(&format!("http://127.0.0.1:{actual_port}"));


### PR DESCRIPTION
# Description
This is the first in a series of PRs to implement custom rate limiting in the sov-rollup.
The rate limiting will be applied in the `process_accept_tx` method, so the initial task is to pass all the required data to it. We will be creating limits based on both `IP` and `Address`.

This PR extracts the `SocketAddr` from Axum and passes it to `process_accept_tx` (together with the `CredentialId`).
Other than extracting and passing this data, the PR does not introduce or change any logic. The only tricky part was extracting the `SocketAddr` in jsonrpsee.

Related: https://github.com/Sovereign-Labs/sovereign-sdk/issues/2173

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

 
