### PR TITLE
Rate limiting: track `execution_time_micros, gas_used` for failed txs

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
@@ -177,11 +177,24 @@ pub struct AsyncBatchResponder<S: Spec> {
 }
 
 impl<S: Spec> AsyncBatchResponder<S> {
-    fn send_item(&self, item: AsyncBatchResult<S>) {
+    fn send_async_btach_result(&self, item: AsyncBatchResult<S>) {
         // Try a simple non-blocking send first, then fall back to blocking the runtime if that fails
         if let Err(TrySendError::Full(item)) = self.result_channel.try_send(item) {
             let _ = Handle::current().block_on(async move { self.result_channel.send(item).await });
         }
+    }
+
+    fn send(
+        &self,
+        gas_used: <S as Spec>::Gas,
+        execution_time_micros: u64,
+        inner_result: Result<ExecutedTxResponse<S>, RejectReason>,
+    ) {
+        self.send_async_btach_result(AsyncBatchResult {
+            gas_used,
+            execution_time_micros,
+            inner_result,
+        });
     }
 
     /// Create a new responder for a single tx that shares the same config as the old value. Note that the timestamp is a fresh atomic initialized to zero
@@ -224,11 +237,11 @@ impl<S: Spec> AsyncBatchResponder<S> {
         } else {
             let execution_time_micros =
                 time_now_to_u64() - self.unix_timestamp_micros.load(Ordering::SeqCst);
-            self.send_item(AsyncBatchResult {
-                gas_used: S::Gas::zero(),
+            self.send(
+                S::Gas::zero(),
                 execution_time_micros,
-                inner_result: Err(RejectReason::SenderMustBeAdmin),
-            });
+                Err(RejectReason::SenderMustBeAdmin),
+            );
             TxControlFlow::IgnoreTx
         }
     }
@@ -249,11 +262,11 @@ impl<S: Spec> AsyncBatchResponder<S> {
             execution_status,
         } = provisional_outcome;
         let MaybeExecuted::Executed(receipt) = execution_status else {
-            self.send_item(AsyncBatchResult {
+            self.send(
                 gas_used,
                 execution_time_micros,
-                inner_result: Err(RejectReason::SequencerOutOfGas),
-            });
+                Err(RejectReason::SequencerOutOfGas),
+            );
             return (dirty_scratchpad.revert(), TxControlFlow::IgnoreTx);
         };
 
@@ -264,23 +277,19 @@ impl<S: Spec> AsyncBatchResponder<S> {
                 remaining_slot_gas: *slot_gas_meter_before_tx.remaining_preferred_slot_gas(), // Since we ignore this tx, the remaining gas limit is unchanged
             };
 
-            self.send_item(AsyncBatchResult {
-                gas_used,
-                execution_time_micros,
-                inner_result: Ok(response),
-            });
+            self.send(gas_used, execution_time_micros, Ok(response));
             return (dirty_scratchpad.revert(), TxControlFlow::IgnoreTx);
         }
 
         if penalty > reward || reward.saturating_sub(penalty) < self.tx_profit_threshold {
-            self.send_item(AsyncBatchResult {
+            self.send(
                 gas_used,
                 execution_time_micros,
-                inner_result: Err(RejectReason::InsufficientReward {
+                Err(RejectReason::InsufficientReward {
                     expected: self.tx_profit_threshold,
                     found: reward.saturating_sub(penalty).0,
                 }),
-            });
+            );
 
             return (dirty_scratchpad.revert(), TxControlFlow::IgnoreTx);
         }
@@ -296,11 +305,7 @@ impl<S: Spec> AsyncBatchResponder<S> {
             remaining_slot_gas,
         };
 
-        self.send_item(AsyncBatchResult {
-            gas_used,
-            execution_time_micros,
-            inner_result: Ok(response),
-        });
+        self.send(gas_used, execution_time_micros, Ok(response));
         (
             dirty_scratchpad.commit(),
             TxControlFlow::ContinueProcessing(receipt),

--- a/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
@@ -5,8 +5,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::preferred::cache_warm_up_executor::FullyBakedTxWithMaybeChangeSet;
 use sov_modules_api::state::TxScratchpad;
 use sov_modules_api::{
-    ChangeSet, Context, DispatchCall, ExecutionContext, FullyBakedTx, GasArray, IncrementalBatch,
-    InjectedControlFlow, IterableBatchWithId, MaybeExecuted, NoOpControlFlow,
+    ChangeSet, Context, DispatchCall, ExecutionContext, FullyBakedTx, Gas, GasArray,
+    IncrementalBatch, InjectedControlFlow, IterableBatchWithId, MaybeExecuted, NoOpControlFlow,
     ProvisionalSequencerOutcome, Runtime, SlotGasMeter, TransactionReceipt, TxChangeSet,
     TxControlFlow,
 };
@@ -39,7 +39,7 @@ impl<S: Spec> MaybeAsyncBatch<S> {
     pub fn new_async(
         txs_receiver: Receiver<FullyBakedTxWithMaybeChangeSet>,
         setup_sender: oneshot::Sender<ChangeSet>,
-        result_channel: Sender<Result<ExecutedTxResponse<S>, RejectReason>>,
+        result_channel: Sender<AsyncBatchResult<S>>,
         tx_profit_threshold: u128,
         sequencer_admins: Arc<Vec<S::Address>>,
         address: S::Address,
@@ -102,7 +102,7 @@ impl<S: Spec> InjectedControlFlow<S> for MaybeAsyncBatchControlFlow<S> {
         provisional_outcome: ProvisionalSequencerOutcome<S>,
         dirty_scratchpad: TxScratchpad<S, StateCheckpoint<S>>,
         slot_gas_meter_before_tx: &SlotGasMeter<S>,
-        gas_used: &<S as Spec>::Gas,
+        gas_used: <S as Spec>::Gas,
         execution_context: ExecutionContext,
     ) -> (StateCheckpoint<S>, TxControlFlow<TransactionReceipt<S>>) {
         match self {
@@ -148,19 +148,25 @@ impl<S: Spec> InjectedControlFlow<S> for MaybeAsyncBatchControlFlow<S> {
     }
 }
 
+/// The response from the sequencer for a submitted transaction, along with the resources consumed by that transaction.
+pub(crate) struct AsyncBatchResult<S: Spec> {
+    pub(crate) execution_time_micros: u64,
+    pub(crate) gas_used: <S as Spec>::Gas,
+    pub(crate) inner_result: Result<ExecutedTxResponse<S>, RejectReason>,
+}
+
 /// The response from the sequencer to a submitted tx that was actually executed. Note that this
 /// transaction may not have been successful!
 pub(crate) struct ExecutedTxResponse<S: Spec> {
-    pub receipt: TransactionReceipt<S>,
-    pub tx_changes: TxChangeSet,
-    pub remaining_slot_gas: <S as Spec>::Gas,
-    pub execution_time_micros: u64,
+    pub(crate) receipt: TransactionReceipt<S>,
+    pub(crate) tx_changes: TxChangeSet,
+    pub(crate) remaining_slot_gas: <S as Spec>::Gas,
 }
 
 /// The channel responsible for notifying an async tx submitter of the txs result
 #[derive(Debug)]
 pub struct AsyncBatchResponder<S: Spec> {
-    result_channel: Sender<Result<ExecutedTxResponse<S>, RejectReason>>,
+    result_channel: Sender<AsyncBatchResult<S>>,
     admins: Arc<Vec<S::Address>>,
     tx_profit_threshold: u128,
     /// The timestamp of the start of the latest tx in microseconds since the UNIX epoch
@@ -171,7 +177,7 @@ pub struct AsyncBatchResponder<S: Spec> {
 }
 
 impl<S: Spec> AsyncBatchResponder<S> {
-    fn send_item(&self, item: Result<ExecutedTxResponse<S>, RejectReason>) {
+    fn send_item(&self, item: AsyncBatchResult<S>) {
         // Try a simple non-blocking send first, then fall back to blocking the runtime if that fails
         if let Err(TrySendError::Full(item)) = self.result_channel.try_send(item) {
             let _ = Handle::current().block_on(async move { self.result_channel.send(item).await });
@@ -191,6 +197,10 @@ impl<S: Spec> AsyncBatchResponder<S> {
     }
 }
 
+fn time_now_to_u64() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).expect("SystemTime::now() returned something earlier than the UNIX epoch. This should be unreachable.").as_micros().try_into().expect("Unix time in micros overflowed u64. This should be unreachable for the next 300,000 years")
+}
+
 impl<S: Spec> AsyncBatchResponder<S> {
     fn pre_flight<RT: Runtime<S>>(
         &self,
@@ -198,7 +208,7 @@ impl<S: Spec> AsyncBatchResponder<S> {
         context: &Context<S>,
         call: &<RT as DispatchCall>::Decodable,
     ) -> TxControlFlow<()> {
-        let start_time: u64 = SystemTime::now().duration_since(UNIX_EPOCH).expect("SystemTime::now() returned something earlier than the UNIX epoch. This should be unreachable.").as_micros().try_into().expect("Unix time in micros overflowed u64. This should be unreachable for the next 300,000 years");
+        let start_time: u64 = time_now_to_u64();
         self.unix_timestamp_micros
             .store(start_time, Ordering::SeqCst);
         if !self.is_responsible_for_gating_admins
@@ -212,7 +222,13 @@ impl<S: Spec> AsyncBatchResponder<S> {
         {
             TxControlFlow::ContinueProcessing(())
         } else {
-            self.send_item(Err(RejectReason::SenderMustBeAdmin));
+            let execution_time_micros =
+                time_now_to_u64() - self.unix_timestamp_micros.load(Ordering::SeqCst);
+            self.send_item(AsyncBatchResult {
+                gas_used: S::Gas::zero(),
+                execution_time_micros,
+                inner_result: Err(RejectReason::SenderMustBeAdmin),
+            });
             TxControlFlow::IgnoreTx
         }
     }
@@ -222,18 +238,22 @@ impl<S: Spec> AsyncBatchResponder<S> {
         provisional_outcome: ProvisionalSequencerOutcome<S>,
         dirty_scratchpad: TxScratchpad<S, StateCheckpoint<S>>,
         slot_gas_meter_before_tx: &SlotGasMeter<S>,
-        gas_used: &<S as Spec>::Gas,
+        gas_used: <S as Spec>::Gas,
         execution_context: ExecutionContext,
     ) -> (StateCheckpoint<S>, TxControlFlow<TransactionReceipt<S>>) {
-        let end_time: u64 = SystemTime::now().duration_since(UNIX_EPOCH).expect("SystemTime::now() returned something earlier than the UNIX epoch. This should be unreachable.").as_micros().try_into().expect("Unix time in micros overflowed u64. This should be unreachable for the next 300,000 years");
-        let execution_time = end_time - self.unix_timestamp_micros.load(Ordering::SeqCst);
+        let execution_time_micros =
+            time_now_to_u64() - self.unix_timestamp_micros.load(Ordering::SeqCst);
         let ProvisionalSequencerOutcome {
             reward,
             penalty,
             execution_status,
         } = provisional_outcome;
         let MaybeExecuted::Executed(receipt) = execution_status else {
-            self.send_item(Err(RejectReason::SequencerOutOfGas));
+            self.send_item(AsyncBatchResult {
+                gas_used,
+                execution_time_micros,
+                inner_result: Err(RejectReason::SequencerOutOfGas),
+            });
             return (dirty_scratchpad.revert(), TxControlFlow::IgnoreTx);
         };
 
@@ -242,23 +262,31 @@ impl<S: Spec> AsyncBatchResponder<S> {
                 receipt: receipt.clone(),
                 tx_changes: dirty_scratchpad.tx_changes(execution_context),
                 remaining_slot_gas: *slot_gas_meter_before_tx.remaining_preferred_slot_gas(), // Since we ignore this tx, the remaining gas limit is unchanged
-                execution_time_micros: execution_time,
             };
 
-            self.send_item(Ok(response));
+            self.send_item(AsyncBatchResult {
+                gas_used,
+                execution_time_micros,
+                inner_result: Ok(response),
+            });
             return (dirty_scratchpad.revert(), TxControlFlow::IgnoreTx);
         }
 
         if penalty > reward || reward.saturating_sub(penalty) < self.tx_profit_threshold {
-            self.send_item(Err(RejectReason::InsufficientReward {
-                expected: self.tx_profit_threshold,
-                found: reward.saturating_sub(penalty).0,
-            }));
+            self.send_item(AsyncBatchResult {
+                gas_used,
+                execution_time_micros,
+                inner_result: Err(RejectReason::InsufficientReward {
+                    expected: self.tx_profit_threshold,
+                    found: reward.saturating_sub(penalty).0,
+                }),
+            });
+
             return (dirty_scratchpad.revert(), TxControlFlow::IgnoreTx);
         }
 
         let remaining_slot_gas = (*slot_gas_meter_before_tx.remaining_preferred_slot_gas())
-            .checked_sub(*gas_used)
+            .checked_sub(gas_used)
             // SAFETY: We always enforce that the gas used is less than the remaining slot gas limit
             .expect("Impossible happened: SlotGasMeter underflow when charging gas.");
 
@@ -266,10 +294,13 @@ impl<S: Spec> AsyncBatchResponder<S> {
             receipt: receipt.clone(),
             tx_changes: dirty_scratchpad.tx_changes(execution_context),
             remaining_slot_gas,
-            execution_time_micros: execution_time,
         };
 
-        self.send_item(Ok(response));
+        self.send_item(AsyncBatchResult {
+            gas_used,
+            execution_time_micros,
+            inner_result: Ok(response),
+        });
         (
             dirty_scratchpad.commit(),
             TxControlFlow::ContinueProcessing(receipt),

--- a/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/async_batch.rs
@@ -177,7 +177,7 @@ pub struct AsyncBatchResponder<S: Spec> {
 }
 
 impl<S: Spec> AsyncBatchResponder<S> {
-    fn send_async_btach_result(&self, item: AsyncBatchResult<S>) {
+    fn send_async_batch_result(&self, item: AsyncBatchResult<S>) {
         // Try a simple non-blocking send first, then fall back to blocking the runtime if that fails
         if let Err(TrySendError::Full(item)) = self.result_channel.try_send(item) {
             let _ = Handle::current().block_on(async move { self.result_channel.send(item).await });
@@ -190,7 +190,7 @@ impl<S: Spec> AsyncBatchResponder<S> {
         execution_time_micros: u64,
         inner_result: Result<ExecutedTxResponse<S>, RejectReason>,
     ) {
-        self.send_async_btach_result(AsyncBatchResult {
+        self.send_async_batch_result(AsyncBatchResult {
             gas_used,
             execution_time_micros,
             inner_result,

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -34,7 +34,7 @@ use super::{
     Confirmation, PreferredBatchToReplay, PreferredSequencerConfig, VisibleSlotNumberIncrease,
 };
 use crate::common::AcceptedTx;
-use crate::preferred::async_batch::{ExecutedTxResponse, MaybeAsyncBatch};
+use crate::preferred::async_batch::{AsyncBatchResult, ExecutedTxResponse, MaybeAsyncBatch};
 use crate::preferred::exit_rollup;
 use crate::preferred::transaction_subscriptions::TxResultWriter;
 use crate::SequencerConfig;
@@ -163,6 +163,15 @@ where
     phantom: PhantomData<Rt>,
 }
 
+/// RollupBlockExecutorError along with the resources consumed by that transaction.
+pub(crate) struct RollupBlockExecutorErrorWithBudget<S: Spec> {
+    #[allow(dead_code)]
+    pub(crate) execution_time_micros: u64,
+    #[allow(dead_code)]
+    pub(crate) gas_used: <S as Spec>::Gas,
+    pub(crate) inner_err: RollupBlockExecutorError<S>,
+}
+
 impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
     /// The maximum number of transactions that can be buffered before incoming txs start getting
     /// rejected.
@@ -278,7 +287,8 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
     pub async fn apply_tx_to_in_progress_batch(
         &mut self,
         baked_tx: FullyBakedTxWithMaybeChangeSet,
-    ) -> Result<(AcceptedTxWithBudgetInfo<S, Rt>, TxChangeSet), RollupBlockExecutorError<S>> {
+    ) -> Result<(AcceptedTxWithBudgetInfo<S, Rt>, TxChangeSet), RollupBlockExecutorErrorWithBudget<S>>
+    {
         let result = self.apply_tx_to_in_progress_batch_inner(baked_tx).await;
 
         match result {
@@ -305,37 +315,64 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
         baked_tx: FullyBakedTxWithMaybeChangeSet,
     ) -> Result<
         (TransactionReceipt<S>, <S as Spec>::Gas, u64, TxChangeSet),
-        RollupBlockExecutorError<S>,
+        RollupBlockExecutorErrorWithBudget<S>,
     > {
         let Some(task_state) = self.rollup_block_task_state.as_mut() else {
             panic!("Accepting a transaction, yet there's no in-progress batch. This is a bug in the sequencer, please report it.");
         };
 
-        let call = Rt::Auth::decode_serialized_tx(&baked_tx.tx)?;
+        let call = Rt::Auth::decode_serialized_tx(&baked_tx.tx).map_err(|e| {
+            RollupBlockExecutorErrorWithBudget {
+                execution_time_micros: 0,
+                gas_used: <S as Spec>::Gas::zero(),
+                inner_err: RollupBlockExecutorError::DecodeCall(e),
+            }
+        })?;
         let call = Rt::wrap_call(call);
 
         if let Err(TrySendError::Full(_)) = task_state.tx_sender.try_send(baked_tx) {
-            return Err(RollupBlockExecutorError::Overloaded);
+            return Err(RollupBlockExecutorErrorWithBudget {
+                execution_time_micros: 0,
+                gas_used: <S as Spec>::Gas::zero(),
+                inner_err: RollupBlockExecutorError::Overloaded,
+            });
         }
 
         let Some(result) = task_state.result_receiver.recv().await else {
             tracing::error!("The rollup block executor task failed unexpectedly. Gracefully shutting down the sequencer.");
             let _ = self.shutdown_sender.send(()); // We don't care if this fails, because that would mean the sequencer is already shutting down - which is exactly what we want.
-            return Err(RollupBlockExecutorError::UnexpectedFailure);
+            return Err(RollupBlockExecutorErrorWithBudget {
+                execution_time_micros: 0,
+                gas_used: <S as Spec>::Gas::zero(),
+                inner_err: RollupBlockExecutorError::UnexpectedFailure,
+            });
         };
+
+        let AsyncBatchResult {
+            execution_time_micros,
+            gas_used,
+            inner_result,
+        } = result;
 
         let ExecutedTxResponse {
             receipt,
             tx_changes,
             remaining_slot_gas,
+        } = inner_result.map_err(|reason| RollupBlockExecutorErrorWithBudget {
             execution_time_micros,
-        } = result.map_err(|reason| RollupBlockExecutorError::Rejected {
-            reason,
-            call: call_message_repr::<Rt>(&call),
+            gas_used,
+            inner_err: RollupBlockExecutorError::Rejected {
+                reason,
+                call: call_message_repr::<Rt>(&call),
+            },
         })?;
 
         if !receipt.receipt.is_successful() {
-            return Err(RollupBlockExecutorError::UnsuccessfulTransaction { receipt });
+            return Err(RollupBlockExecutorErrorWithBudget {
+                execution_time_micros,
+                gas_used,
+                inner_err: RollupBlockExecutorError::UnsuccessfulTransaction { receipt },
+            });
         }
 
         self.checkpoint.apply_tx_changes(tx_changes.clone());
@@ -455,7 +492,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
                 }
                 output.execution_time_micros
             }
-            Err(err) => {
+            Err(RollupBlockExecutorErrorWithBudget { inner_err: err, .. }) => {
                 tracing::error!(
                     error = %err,
                     %tx_hash,
@@ -779,7 +816,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
 struct BackgroundTaskState<S: Spec> {
     handle: JoinHandle<BlockExecutionOutput<S>>,
     tx_sender: mpsc::Sender<FullyBakedTxWithMaybeChangeSet>,
-    result_receiver: mpsc::Receiver<Result<ExecutedTxResponse<S>, RejectReason>>,
+    result_receiver: mpsc::Receiver<AsyncBatchResult<S>>,
 }
 
 impl<S: Spec> BackgroundTaskState<S> {
@@ -800,7 +837,7 @@ struct RollupBlockTaskContext<S: Spec> {
     // --------
     tx_receiver: mpsc::Receiver<FullyBakedTxWithMaybeChangeSet>,
     setup_sender: oneshot::Sender<ChangeSet>,
-    result_sender: mpsc::Sender<Result<ExecutedTxResponse<S>, RejectReason>>,
+    result_sender: mpsc::Sender<AsyncBatchResult<S>>,
     shutdown_notifier: mpsc::Sender<()>,
     // Config values
     // --------

--- a/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+use crate::preferred::block_executor::RollupBlockExecutorErrorWithBudget;
 use crate::preferred::block_executor::StartBlockData;
 use crate::preferred::PreferredSequencerConfig;
 use crate::preferred::RollupBlockExecutor;
@@ -262,7 +263,7 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
                                     // This can happen if the transaction on the main executor has already finished.
                                     let _ = tx_with_sender.sender.send(tx_change_set);
                                 },
-                                Err(err) => {
+                                Err(RollupBlockExecutorErrorWithBudget{inner_err:err, ..}) => {
                                     tracing::trace!(%err, "WarmUp worker task failed to execute transaction.");
                                     continue;
                                 }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -1,10 +1,10 @@
 use crate::metrics::{
     track_sequence_number, PreferredSequencerChannelMetrics, PreferredSequencerChannelMetricsBatch,
 };
-use crate::preferred::block_executor::StartBlockData;
 use crate::preferred::block_executor::{
     AcceptedTxWithBudgetInfo, RollupBlockExecutor, RollupBlockExecutorError,
 };
+use crate::preferred::block_executor::{RollupBlockExecutorErrorWithBudget, StartBlockData};
 use crate::preferred::cache_warm_up_executor::{CacheWarmUpExecutor, StartBlockNotification};
 use crate::preferred::db::latest_finalized_sequence_number;
 use crate::preferred::executor_events::ExecutorEventsSender;
@@ -717,7 +717,7 @@ where
                 );
                 res
             }
-            Err(err) => {
+            Err(RollupBlockExecutorErrorWithBudget { inner_err: err, .. }) => {
                 tracing::debug!(%tx_hash, %err, "Transaction was dropped by the sequencer");
                 return Err(DoNewTxError::ExecutorError(err));
             }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -663,6 +663,7 @@ where
         &mut self,
         tx_hash: TxHash,
         baked_tx: FullyBakedTx,
+        //credential_id: CredentialId,
     ) -> Result<
         (
             oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>,

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -663,7 +663,6 @@ where
         &mut self,
         tx_hash: TxHash,
         baked_tx: FullyBakedTx,
-        //credential_id: CredentialId,
     ) -> Result<
         (
             oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>,

--- a/crates/module-system/sov-modules-api/src/batch.rs
+++ b/crates/module-system/sov-modules-api/src/batch.rs
@@ -349,7 +349,7 @@ pub trait InjectedControlFlow<S: Spec> {
         provisional_outcome: ProvisionalSequencerOutcome<S>,
         dirty_scratchpad: TxScratchpad<S, StateCheckpoint<S>>,
         slot_gas_meter_before_tx: &SlotGasMeter<S>,
-        gas_used: &<S as Spec>::Gas,
+        gas_used: <S as Spec>::Gas,
         exec_context: ExecutionContext,
     ) -> (StateCheckpoint<S>, TxControlFlow<TransactionReceipt<S>>);
 }
@@ -388,7 +388,7 @@ impl<S: Spec> InjectedControlFlow<S> for NoOpControlFlow {
         provisional_outcome: ProvisionalSequencerOutcome<S>,
         dirty_scratchpad: TxScratchpad<S, StateCheckpoint<S>>,
         _slot_gas_meter_before_tx: &SlotGasMeter<S>,
-        _gas_used: &<S as Spec>::Gas,
+        _gas_used: <S as Spec>::Gas,
         _execution_context: ExecutionContext,
     ) -> (StateCheckpoint<S>, TxControlFlow<TransactionReceipt<S>>) {
         match provisional_outcome.execution_status {

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
@@ -513,7 +513,7 @@ where
             provisional_outcome,
             dirty_scratchpad,
             slot_gas_meter,
-            &gas_used,
+            gas_used,
             execution_context,
         );
         match outcome {

--- a/crates/module-system/sov-test-utils/src/runtime/mod.rs
+++ b/crates/module-system/sov-test-utils/src/runtime/mod.rs
@@ -1022,7 +1022,7 @@ impl<S: Spec> InjectedControlFlow<S> for SeqControlFlow {
         provisional_outcome: ProvisionalSequencerOutcome<S>,
         dirty_scratchpad: TxScratchpad<S, StateCheckpoint<S>>,
         _slot_gas_meter_before_tx: &SlotGasMeter<S>,
-        _gas_used: &<S as Spec>::Gas,
+        _gas_used: <S as Spec>::Gas,
         execution_context: ExecutionContext,
     ) -> (StateCheckpoint<S>, TxControlFlow<TransactionReceipt<S>>) {
         let ProvisionalSequencerOutcome {


### PR DESCRIPTION
# Description

For #2173, we will also apply rate limits to unsuccessful transactions. The resources we need to track and limit are `tx execution_time` and `gas_used`, but until now, the sequencer has received these values only on the happy path—when the transaction succeeded.

This PR adds `execution_time_micros and gas_used` to the failure path as well, so they are returned together with `RollupBlockExecutorError`. This additional data is not currently used anywhere; it will be used as input to the `RateLimiter` in an upcoming PR.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to https://github.com/Sovereign-Labs/sovereign-sdk/issues/2173

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
