### PR TITLE
Only gather witness for NomtProverStorage with strict_mode

### DIFF
--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -299,7 +299,7 @@ where
     /// Should be called only when really needed.
     /// Will hold the read lock to all snapshots.
     /// **Commiting storage will be blocked until all built sessions are deallocated.**
-    /// Produces session does not collect witness!
+    /// Returned session does not collect witness!
     /// Use `Self::begin_both_sessions` if witness is needed
     #[tracing::instrument(skip(self))]
     pub fn begin_user_session(&self) -> anyhow::Result<nomt::Session<BinaryHasher<H>>> {
@@ -341,7 +341,7 @@ where
     /// Should be called only when really needed.
     /// Will hold the read lock to all snapshots.
     /// **Commiting storage will be blocked until all built sessions are deallocated.**
-    /// Produces session does not collect witness!
+    /// Returned session does not collect witness!
     /// Use `Self::begin_both_sessions` if witness is needed
     #[tracing::instrument(skip(self))]
     pub fn begin_kernel_session(&self) -> anyhow::Result<nomt::Session<BinaryHasher<H>>> {

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -383,7 +383,7 @@ where
 
     /// Begins both sessions at the same time.
     /// Should be used if both sessions are needed in same context. Prevents dead lock.
-    pub fn begin_both_sessions(&self) -> anyhow::Result<SessionsContainer<H>> {
+    pub fn begin_both_sessions(&self, with_witness: bool) -> anyhow::Result<SessionsContainer<H>> {
         let start = std::time::Instant::now();
         let mut kernel_overlays = Vec::with_capacity(self.relevant_snapshot_refs.len());
         let mut user_overlays = Vec::with_capacity(self.relevant_snapshot_refs.len());
@@ -401,24 +401,30 @@ where
                 user_overlays.push(&state_overlay.user);
                 overlays_count += 1;
             }
-            let kernel_params = SessionParams::default()
-                .overlay(kernel_overlays)
-                .map_err(|e| {
-                    anyhow::anyhow!(
-                        "Failed to construct session params for kernel session: {:?}",
-                        e
-                    )
-                })?
-                .witness_mode(WitnessMode::read_write());
-            let user_params = SessionParams::default()
+            let mut kernel_params =
+                SessionParams::default()
+                    .overlay(kernel_overlays)
+                    .map_err(|e| {
+                        anyhow::anyhow!(
+                            "Failed to construct session params for kernel session: {:?}",
+                            e
+                        )
+                    })?;
+            if with_witness {
+                kernel_params = kernel_params.witness_mode(WitnessMode::read_write());
+            }
+            let mut user_params = SessionParams::default()
                 .overlay(user_overlays)
                 .map_err(|e| {
                     anyhow::anyhow!(
                         "Failed to construct session params for user session: {:?}",
                         e
                     )
-                })?
-                .witness_mode(WitnessMode::read_write());
+                })?;
+            if with_witness {
+                user_params = user_params.witness_mode(WitnessMode::read_write());
+            }
+
             let kernel_session = self.state_db.kernel.begin_session(kernel_params);
             let user_session = self.state_db.user.begin_session(user_params);
             (kernel_session, user_session)

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -302,7 +302,9 @@ where
     /// Returned session does not collect witness!
     /// Use `Self::begin_both_sessions` if witness is needed
     #[tracing::instrument(skip(self))]
-    pub fn begin_user_session(&self) -> anyhow::Result<nomt::Session<BinaryHasher<H>>> {
+    pub fn begin_user_session_without_witness(
+        &self,
+    ) -> anyhow::Result<nomt::Session<BinaryHasher<H>>> {
         let start = std::time::Instant::now();
         let mut overlays = Vec::with_capacity(self.relevant_snapshot_refs.len());
         let mut overlays_count = 0;
@@ -344,7 +346,9 @@ where
     /// Returned session does not collect witness!
     /// Use `Self::begin_both_sessions` if witness is needed
     #[tracing::instrument(skip(self))]
-    pub fn begin_kernel_session(&self) -> anyhow::Result<nomt::Session<BinaryHasher<H>>> {
+    pub fn begin_kernel_session_without_witness(
+        &self,
+    ) -> anyhow::Result<nomt::Session<BinaryHasher<H>>> {
         let start = std::time::Instant::now();
         let mut overlays = Vec::with_capacity(self.relevant_snapshot_refs.len());
         let mut overlays_count = 0;
@@ -493,10 +497,10 @@ mod tests {
             let (key_path, data) = from_key(this_ref);
             let writes = vec![(key_path, nomt::KeyReadWrite::Write(data))];
 
-            let user_session = builder.begin_user_session().unwrap();
+            let user_session = builder.begin_user_session_without_witness().unwrap();
             let finished_user_session = user_session.finish(writes.clone()).unwrap();
 
-            let kernel_session = builder.begin_kernel_session().unwrap();
+            let kernel_session = builder.begin_kernel_session_without_witness().unwrap();
 
             let finished_kernel_session = kernel_session.finish(writes.clone()).unwrap();
             let overlay = StateFinishedSession::new(finished_user_session, finished_kernel_session)
@@ -509,8 +513,10 @@ mod tests {
         let check_builder =
             NomtSessionBuilder::<H, u64>::new(state_db.clone(), overlay_refs, all_overlays.clone());
         for commiting_ref in 0..rounds {
-            let user_session = check_builder.begin_user_session().unwrap();
-            let kernel_session = check_builder.begin_kernel_session().unwrap();
+            let user_session = check_builder.begin_user_session_without_witness().unwrap();
+            let kernel_session = check_builder
+                .begin_kernel_session_without_witness()
+                .unwrap();
             for this_ref in 0..rounds {
                 let (key_path, expected_value) = from_key(this_ref);
                 let user_value = user_session.read(key_path).unwrap();
@@ -591,8 +597,8 @@ mod tests {
                 all_overlays.clone(),
             );
 
-            let user_session = builder.begin_user_session().unwrap();
-            let kernel_session = builder.begin_kernel_session().unwrap();
+            let user_session = builder.begin_user_session_without_witness().unwrap();
+            let kernel_session = builder.begin_kernel_session_without_witness().unwrap();
 
             let finished_user_session = user_session.finish(initial_user_writes).unwrap();
             let finished_kernel_session = kernel_session.finish(initial_kernel_writes).unwrap();
@@ -605,8 +611,8 @@ mod tests {
         let base_builder =
             NomtSessionBuilder::<H, u64>::new(state_db.clone(), Vec::new(), all_overlays.clone());
 
-        let user_session = base_builder.begin_user_session().unwrap();
-        let kernel_session = base_builder.begin_kernel_session().unwrap();
+        let user_session = base_builder.begin_user_session_without_witness().unwrap();
+        let kernel_session = base_builder.begin_kernel_session_without_witness().unwrap();
         drop(base_builder);
 
         let finished_user_session = user_session.finish(base_user_writes).unwrap();
@@ -623,8 +629,8 @@ mod tests {
         let test_builder =
             NomtSessionBuilder::<H, u64>::new(state_db.clone(), vec![0], all_overlays.clone());
 
-        let user_session = test_builder.begin_user_session().unwrap();
-        let kernel_session = test_builder.begin_kernel_session().unwrap();
+        let user_session = test_builder.begin_user_session_without_witness().unwrap();
+        let kernel_session = test_builder.begin_kernel_session_without_witness().unwrap();
         drop(test_builder);
 
         let finished_user_session = user_session.finish(test_user_writes).unwrap();
@@ -658,8 +664,8 @@ mod tests {
         let builder =
             NomtSessionBuilder::<H, u64>::new(state_db.clone(), Vec::new(), all_overlays.clone());
 
-        let user_session = builder.begin_user_session().unwrap();
-        let kernel_session = builder.begin_kernel_session().unwrap();
+        let user_session = builder.begin_user_session_without_witness().unwrap();
+        let kernel_session = builder.begin_kernel_session_without_witness().unwrap();
 
         let user_value = user_session.read(user_key_path).unwrap();
         let kernel_value = kernel_session.read(kernel_key_path).unwrap();

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -299,6 +299,8 @@ where
     /// Should be called only when really needed.
     /// Will hold the read lock to all snapshots.
     /// **Commiting storage will be blocked until all built sessions are deallocated.**
+    /// Produces session does not collect witness!
+    /// Use `Self::begin_both_sessions` if witness is needed
     #[tracing::instrument(skip(self))]
     pub fn begin_user_session(&self) -> anyhow::Result<nomt::Session<BinaryHasher<H>>> {
         let start = std::time::Instant::now();
@@ -316,15 +318,12 @@ where
                 overlays.push(&state_overlay.user);
                 overlays_count += 1;
             }
-            let params = SessionParams::default()
-                .overlay(overlays)
-                .map_err(|e| {
-                    anyhow::anyhow!(
-                        "Failed to construct session params for user session: {:?}",
-                        e
-                    )
-                })?
-                .witness_mode(WitnessMode::read_write());
+            let params = SessionParams::default().overlay(overlays).map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to construct session params for user session: {:?}",
+                    e
+                )
+            })?;
             self.state_db.user.begin_session(params)
         };
         let init_time = start.elapsed();
@@ -342,6 +341,8 @@ where
     /// Should be called only when really needed.
     /// Will hold the read lock to all snapshots.
     /// **Commiting storage will be blocked until all built sessions are deallocated.**
+    /// Produces session does not collect witness!
+    /// Use `Self::begin_both_sessions` if witness is needed
     #[tracing::instrument(skip(self))]
     pub fn begin_kernel_session(&self) -> anyhow::Result<nomt::Session<BinaryHasher<H>>> {
         let start = std::time::Instant::now();
@@ -359,15 +360,12 @@ where
                 overlays.push(&state_overlay.kernel);
                 overlays_count += 1;
             }
-            let params = SessionParams::default()
-                .overlay(overlays)
-                .map_err(|e| {
-                    anyhow::anyhow!(
-                        "Failed to construct session params for kernel session: {:?}",
-                        e
-                    )
-                })?
-                .witness_mode(WitnessMode::read_write());
+            let params = SessionParams::default().overlay(overlays).map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to construct session params for kernel session: {:?}",
+                    e
+                )
+            })?;
             self.state_db.kernel.begin_session(params)
         };
         let init_time = start.elapsed();

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -125,7 +125,7 @@ where
         rockbound_snapshots: &HashMap<K, SnapshotGroup>,
         nomt_snapshots: Arc<RwLock<HashMap<K, StateOverlay>>>,
         pinned_cache: Option<Box<(dyn Any + Send + Sync)>>,
-        use_strict_mode: bool,
+        with_witness: bool,
     ) -> anyhow::Result<(S, DeltaReader)> {
         let mut historical_state_snapshots = Vec::with_capacity(relevant_snapshot_refs.len());
         let mut user_state_snapshots = Vec::with_capacity(relevant_snapshot_refs.len());
@@ -180,7 +180,7 @@ where
             state_session_builder,
             historical_state_mapper,
             accessory_db,
-            use_strict_mode,
+            with_witness,
             pinned_cache,
         );
         Ok((storage, ledger_reader))

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -93,7 +93,7 @@ where
         state_db: NomtSessionBuilder<H, K>,
         historical_state: HistoricalStateReader,
         accessory_db: AccessoryDb,
-        use_strict_mode: bool,
+        with_witness: bool,
         pinned_cache: Option<Box<(dyn Any + Send + Sync)>>,
     ) -> Self;
 }
@@ -162,7 +162,7 @@ where
     fn create_state_up_to(
         &self,
         block_hash: Da::SlotHash,
-        use_strict_mode: bool,
+        with_witness: bool,
         pinned_cache: Option<Box<(dyn Any + Send + Sync)>>,
     ) -> anyhow::Result<(S, DeltaReader)> {
         tracing::trace!(%block_hash, "Creating storage up to block hash");
@@ -194,7 +194,7 @@ where
             &self.rockbound_snapshots,
             self.nomt_snapshots.clone(),
             pinned_cache,
-            use_strict_mode,
+            with_witness,
         )
     }
 
@@ -266,7 +266,7 @@ where
     ) -> anyhow::Result<(Self::StfState, Self::LedgerState)> {
         // Storage created "after" a block is usually used outside of the node context,
         // So strict mode is not needed.
-        let use_strict_mode = false;
+        let with_witness = false;
         if !self.rockbound_snapshots.contains_key(&block_header.hash()) {
             tracing::debug!(block_header = %block_header.display(), "Creating new storage from finalized data as block header is not in the saved chain");
             self.db_group.create_storage(
@@ -274,10 +274,10 @@ where
                 &self.rockbound_snapshots,
                 self.nomt_snapshots.clone(),
                 None,
-                use_strict_mode,
+                with_witness,
             )
         } else {
-            self.create_state_up_to(block_header.hash(), use_strict_mode, None)
+            self.create_state_up_to(block_header.hash(), with_witness, None)
         }
     }
 

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -93,7 +93,7 @@ where
         state_db: NomtSessionBuilder<H, K>,
         historical_state: HistoricalStateReader,
         accessory_db: AccessoryDb,
-        with_witness: bool,
+        strict_with_witness: bool,
         pinned_cache: Option<Box<(dyn Any + Send + Sync)>>,
     ) -> Self;
 }

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -265,7 +265,7 @@ where
         block_header: &Da::BlockHeader,
     ) -> anyhow::Result<(Self::StfState, Self::LedgerState)> {
         // Storage created "after" a block is usually used outside of the node context,
-        // So strict mode is not needed.
+        // So witness is not needed.
         let with_witness = false;
         if !self.rockbound_snapshots.contains_key(&block_header.hash()) {
             tracing::debug!(block_header = %block_header.display(), "Creating new storage from finalized data as block header is not in the saved chain");

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/tests.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/tests.rs
@@ -48,8 +48,12 @@ impl TestableStorage for TestNomtStorage {
             accessory_db: _,
         } = self;
 
-        let user_session = state_session_builder.begin_user_session().unwrap();
-        let kernel_session = state_session_builder.begin_kernel_session().unwrap();
+        let user_session = state_session_builder
+            .begin_user_session_without_witness()
+            .unwrap();
+        let kernel_session = state_session_builder
+            .begin_kernel_session_without_witness()
+            .unwrap();
 
         let mut state_writes = Vec::with_capacity(items.len());
         let mut accessory_writes = Vec::with_capacity(items.len());
@@ -99,11 +103,17 @@ impl TestableStorage for TestNomtStorage {
         let schema_key = key.to_vec();
         let key_path = KeyPath::from(sha2::Sha256::digest(key));
         let kernel_value = {
-            let kernel_session = self.state_session_builder.begin_kernel_session().unwrap();
+            let kernel_session = self
+                .state_session_builder
+                .begin_kernel_session_without_witness()
+                .unwrap();
             kernel_session.read(key_path).unwrap()
         };
         let user_value = {
-            let user_session = self.state_session_builder.begin_user_session().unwrap();
+            let user_session = self
+                .state_session_builder
+                .begin_user_session_without_witness()
+                .unwrap();
             user_session.read(key_path).unwrap()
         };
         assert_eq!(kernel_value, user_value);
@@ -374,8 +384,12 @@ async fn test_root_hashes_match_after_crash() {
         let the_last_block = MockBlockHeader::from_height(blocks);
 
         let session_builder = get_session_builder_from_committed::<H, MockHash>(nomt.clone());
-        let user_session = session_builder.begin_user_session().unwrap();
-        let kernel_session = session_builder.begin_kernel_session().unwrap();
+        let user_session = session_builder
+            .begin_user_session_without_witness()
+            .unwrap();
+        let kernel_session = session_builder
+            .begin_kernel_session_without_witness()
+            .unwrap();
 
         let nomt_key = KeyPath::from(the_last_block.hash.0);
         let nomt_value = Some(the_last_block.hash.0.to_vec());

--- a/crates/full-node/sov-db/src/test_utils.rs
+++ b/crates/full-node/sov-db/src/test_utils.rs
@@ -70,7 +70,7 @@ impl crate::storage_manager::InitializableNativeNomtStorage<H, SlotHash> for Tes
         state_session_builder: crate::state_db_nomt::NomtSessionBuilder<H, SlotHash>,
         historical_state: crate::historical_state::HistoricalStateReader,
         accessory_db: AccessoryDb,
-        _use_strict_mode: bool,
+        _with_witness: bool,
         _pinned_cache: Option<Box<(dyn Any + Send + Sync)>>,
     ) -> Self {
         TestNomtStorage {

--- a/crates/full-node/sov-db/src/test_utils.rs
+++ b/crates/full-node/sov-db/src/test_utils.rs
@@ -57,8 +57,14 @@ impl TestNomtStorage {
         nomt::Session<nomt::hasher::BinaryHasher<H>>,
         nomt::Session<nomt::hasher::BinaryHasher<H>>,
     ) {
-        let user_session = self.state_session_builder.begin_user_session().unwrap();
-        let kernel_session = self.state_session_builder.begin_kernel_session().unwrap();
+        let user_session = self
+            .state_session_builder
+            .begin_user_session_without_witness()
+            .unwrap();
+        let kernel_session = self
+            .state_session_builder
+            .begin_kernel_session_without_witness()
+            .unwrap();
 
         (user_session, kernel_session)
     }

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -198,7 +198,7 @@ where
                     );
                     let nomt_session = self
                         .state_session_builder
-                        .begin_user_session()
+                        .begin_user_session_without_witness()
                         .expect("Failed to build user session");
                     let nomt_value = nomt_session.read(key_path).unwrap();
                     drop(nomt_session);
@@ -228,7 +228,7 @@ where
                     );
                     let nomt_session = self
                         .state_session_builder
-                        .begin_kernel_session()
+                        .begin_kernel_session_without_witness()
                         .expect("Failed to build kernel session");
                     let nomt_value = nomt_session.read(key_path).unwrap();
                     drop(nomt_session);

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -35,9 +35,10 @@ where
     state_session_builder: NomtSessionBuilder<S::Hasher, K>,
     historical_state: HistoricalStateReader,
     accessory: AccessoryDb,
-    /// If set to true, consistency between NOMT and rocksdb will be checked, in some cases.
+    /// If set to true, witness will be populated in all necessary places.
+    /// Also, will do consistency check between NOMT and rocksdb in some cases.
     /// Please check [`NomtProverStorage::should_check_dbs_sync`] for more details.
-    is_strict_mode: bool,
+    with_witness: bool,
     pinned_cache: Option<PinnedCache>,
 }
 
@@ -54,7 +55,7 @@ where
             state_session_builder: self.state_session_builder.clone(),
             historical_state: self.historical_state.clone(),
             accessory: self.accessory.clone(),
-            is_strict_mode: self.is_strict_mode,
+            with_witness: self.with_witness,
             pinned_cache: None,
         }
     }
@@ -80,14 +81,14 @@ where
         state_session_builder: NomtSessionBuilder<S::Hasher, K>,
         historical_state: HistoricalStateReader,
         accessory: AccessoryDb,
-        use_strict_mode: bool,
+        with_witness: bool,
         pinned_cache: Option<PinnedCache>,
     ) -> Self {
         Self {
             state_session_builder,
             historical_state,
             accessory,
-            is_strict_mode: use_strict_mode,
+            with_witness,
             pinned_cache,
         }
     }
@@ -100,7 +101,7 @@ where
     /// Allows changing strict mode for the existing storage.
     #[cfg(feature = "test-utils")]
     pub fn change_strict_mode(&mut self, use_strict_mode: bool) {
-        self.is_strict_mode = use_strict_mode;
+        self.with_witness = use_strict_mode;
     }
 
     /// Returns a double option: The outer option is `None` if there is no reasonable version to use,
@@ -135,7 +136,7 @@ where
     /// not the latest known to this storage.
     fn should_check_dbs_sync(&self, version_to_use: SlotNumber) -> bool {
         cfg!(debug_assertions) &&
-            self.is_strict_mode
+            self.with_witness
             // latest version can be equal to genesis in 2 cases: pre-genesis and at genesis.
             // Since genesis is a special case and not covered by normal stf transition,
             // we exclude this case for simpler testing.
@@ -399,7 +400,7 @@ where
         state_db: NomtSessionBuilder<S::Hasher, K>,
         historical_state: HistoricalStateReader,
         accessory_db: AccessoryDb,
-        use_strict_mode: bool,
+        with_witness: bool,
         pinned_cache: Option<Box<(dyn Any + Send + Sync)>>,
     ) -> Self {
         let pinned_cache: Option<PinnedCache> = pinned_cache.map(|c| *c.downcast().expect("Failed to downcast the pinned_cache argument to `NomtProverStorage`. This is a bug. Please report it."));
@@ -407,7 +408,7 @@ where
             state_db,
             historical_state,
             accessory_db,
-            use_strict_mode,
+            with_witness,
             pinned_cache,
         )
     }
@@ -472,7 +473,7 @@ where
     ) -> Option<SlotValue> {
         match self.read_value::<N>(key, None) {
             Ok(val) => {
-                if self.is_strict_mode {
+                if self.with_witness {
                     witness.add_hint(&val);
                 }
                 val
@@ -509,7 +510,7 @@ where
             kernel: kernel_session,
         } = self
             .state_session_builder
-            .begin_both_sessions(self.is_strict_mode)?;
+            .begin_both_sessions(self.with_witness)?;
         let starting_session_time = start.elapsed();
         tracing::debug!(%prev_state_root, %next_version, sesssion_starting_time = ?starting_session_time, "computing state update, sessions are live");
 
@@ -518,7 +519,7 @@ where
         let current_prev_root = StorageRoot::new(current_prev_user_root, current_prev_kernel_root);
 
         // Check staleness, pre-computation:
-        if self.is_strict_mode && current_prev_root != prev_state_root {
+        if self.with_witness && current_prev_root != prev_state_root {
             anyhow::bail!("stale storage on next_version={}, passed prev_state_root {} does not match the current prev_state_root {}",
                 next_version,
                 prev_state_root,
@@ -532,7 +533,7 @@ where
                 user_session,
                 &state_accesses.user,
                 witness,
-                self.is_strict_mode,
+                self.with_witness,
             )
             .context("user state")?
         };
@@ -543,7 +544,7 @@ where
                 kernel_session,
                 &state_accesses.kernel,
                 witness,
-                self.is_strict_mode,
+                self.with_witness,
             )
             .context("kernel state")?
         };
@@ -557,7 +558,7 @@ where
         );
 
         // Check staleness, post-computation. This should check if storage became stale during the computation.
-        if self.is_strict_mode && prev_state_root != finished_session_prev_root {
+        if self.with_witness && prev_state_root != finished_session_prev_root {
             anyhow::bail!("stale storage on next_version={}, passed prev_state_root {} does not match the current prev_state_root {}",
                 next_version,
                 prev_state_root,

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -38,7 +38,7 @@ where
     /// If set to true, witness will be populated in all necessary places.
     /// Also, will do consistency check between NOMT and rocksdb in some cases.
     /// Please check [`NomtProverStorage::should_check_dbs_sync`] for more details.
-    with_witness: bool,
+    strict_with_witness: bool,
     pinned_cache: Option<PinnedCache>,
 }
 
@@ -55,7 +55,7 @@ where
             state_session_builder: self.state_session_builder.clone(),
             historical_state: self.historical_state.clone(),
             accessory: self.accessory.clone(),
-            with_witness: self.with_witness,
+            strict_with_witness: self.strict_with_witness,
             pinned_cache: None,
         }
     }
@@ -75,20 +75,21 @@ where
     K: Clone,
 {
     /// Create the new instance of [`NomtProverStorage`] with the given sessions.
-    /// If `strict_mode` is set to true, consistency between NOMT and rocksdb will be checked, in some cases.
+    /// If `strict_with_witness` is set to true,
+    /// Witness will be recorded and consistency between NOMT and rocksdb will be checked in some cases.
     // Please check [`NomtProverStorage::should_check_dbs_sync`] for more details.
     pub fn create(
         state_session_builder: NomtSessionBuilder<S::Hasher, K>,
         historical_state: HistoricalStateReader,
         accessory: AccessoryDb,
-        with_witness: bool,
+        strict_with_witness: bool,
         pinned_cache: Option<PinnedCache>,
     ) -> Self {
         Self {
             state_session_builder,
             historical_state,
             accessory,
-            with_witness,
+            strict_with_witness,
             pinned_cache,
         }
     }
@@ -101,7 +102,7 @@ where
     /// Allows changing strict mode for the existing storage.
     #[cfg(feature = "test-utils")]
     pub fn change_strict_mode(&mut self, use_strict_mode: bool) {
-        self.with_witness = use_strict_mode;
+        self.strict_with_witness = use_strict_mode;
     }
 
     /// Returns a double option: The outer option is `None` if there is no reasonable version to use,
@@ -136,7 +137,7 @@ where
     /// not the latest known to this storage.
     fn should_check_dbs_sync(&self, version_to_use: SlotNumber) -> bool {
         cfg!(debug_assertions) &&
-            self.with_witness
+            self.strict_with_witness
             // latest version can be equal to genesis in 2 cases: pre-genesis and at genesis.
             // Since genesis is a special case and not covered by normal stf transition,
             // we exclude this case for simpler testing.
@@ -400,7 +401,7 @@ where
         state_db: NomtSessionBuilder<S::Hasher, K>,
         historical_state: HistoricalStateReader,
         accessory_db: AccessoryDb,
-        with_witness: bool,
+        strict_with_witness: bool,
         pinned_cache: Option<Box<(dyn Any + Send + Sync)>>,
     ) -> Self {
         let pinned_cache: Option<PinnedCache> = pinned_cache.map(|c| *c.downcast().expect("Failed to downcast the pinned_cache argument to `NomtProverStorage`. This is a bug. Please report it."));
@@ -408,7 +409,7 @@ where
             state_db,
             historical_state,
             accessory_db,
-            with_witness,
+            strict_with_witness,
             pinned_cache,
         )
     }
@@ -473,7 +474,7 @@ where
     ) -> Option<SlotValue> {
         match self.read_value::<N>(key, None) {
             Ok(val) => {
-                if self.with_witness {
+                if self.strict_with_witness {
                     witness.add_hint(&val);
                 }
                 val
@@ -510,7 +511,7 @@ where
             kernel: kernel_session,
         } = self
             .state_session_builder
-            .begin_both_sessions(self.with_witness)?;
+            .begin_both_sessions(self.strict_with_witness)?;
         let starting_session_time = start.elapsed();
         tracing::debug!(%prev_state_root, %next_version, sesssion_starting_time = ?starting_session_time, "computing state update, sessions are live");
 
@@ -519,7 +520,7 @@ where
         let current_prev_root = StorageRoot::new(current_prev_user_root, current_prev_kernel_root);
 
         // Check staleness, pre-computation:
-        if self.with_witness && current_prev_root != prev_state_root {
+        if self.strict_with_witness && current_prev_root != prev_state_root {
             anyhow::bail!("stale storage on next_version={}, passed prev_state_root {} does not match the current prev_state_root {}",
                 next_version,
                 prev_state_root,
@@ -533,7 +534,7 @@ where
                 user_session,
                 &state_accesses.user,
                 witness,
-                self.with_witness,
+                self.strict_with_witness,
             )
             .context("user state")?
         };
@@ -544,7 +545,7 @@ where
                 kernel_session,
                 &state_accesses.kernel,
                 witness,
-                self.with_witness,
+                self.strict_with_witness,
             )
             .context("kernel state")?
         };
@@ -558,7 +559,7 @@ where
         );
 
         // Check staleness, post-computation. This should check if storage became stale during the computation.
-        if self.with_witness && prev_state_root != finished_session_prev_root {
+        if self.strict_with_witness && prev_state_root != finished_session_prev_root {
             anyhow::bail!("stale storage on next_version={}, passed prev_state_root {} does not match the current prev_state_root {}",
                 next_version,
                 prev_state_root,

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -361,6 +361,7 @@ fn compute_state_update_namespace<S: MerkleProofSpec>(
     session: NomtSession<S::Hasher>,
     accesses: &OrderedReadsAndWrites,
     witness: &S::Witness,
+    write_witness: bool,
 ) -> anyhow::Result<FinishedSession> {
     tracing::trace!(
         reads = accesses.ordered_reads.len(),
@@ -369,22 +370,24 @@ fn compute_state_update_namespace<S: MerkleProofSpec>(
     );
     let nomt_accesses = to_nomt_accesses::<S>(&session, accesses)?;
     let mut finished = session.finish(nomt_accesses)?;
-    let nomt_witness = finished.take_witness().expect("Witness cannot be missing");
-    let nomt::Witness {
-        path_proofs,
-        operations: nomt::WitnessedOperations { .. },
-    } = nomt_witness;
-    // Note, we discard `p.path`, but maybe there's a way to use to have more efficient verification?
-    let mut path_proofs_inner = path_proofs.into_iter().map(|p| p.inner).collect::<Vec<_>>();
+    if write_witness {
+        let nomt_witness = finished.take_witness().expect("Witness cannot be missing");
+        let nomt::Witness {
+            path_proofs,
+            operations: nomt::WitnessedOperations { .. },
+        } = nomt_witness;
+        // Note, we discard `p.path`, but maybe there's a way to use to have more efficient verification?
+        let mut path_proofs_inner = path_proofs.into_iter().map(|p| p.inner).collect::<Vec<_>>();
 
-    // Sort them as required by
-    // Note that the path proofs produced within a crate::witness::Witness are not guaranteed to be ordered,
-    // so the input should be sorted lexicographically by the terminal path prior to calling this function.
-    // https://github.com/thrumdev/nomt/issues/904
-    path_proofs_inner.sort_by(|a, b| a.terminal.path().cmp(b.terminal.path()));
+        // Sort them as required by
+        // Note that the path proofs produced within a crate::witness::Witness are not guaranteed to be ordered,
+        // so the input should be sorted lexicographically by the terminal path prior to calling this function.
+        // https://github.com/thrumdev/nomt/issues/904
+        path_proofs_inner.sort_by(|a, b| a.terminal.path().cmp(b.terminal.path()));
 
-    let multi_proof = MultiProof::from_path_proofs(path_proofs_inner);
-    witness.add_hint(&multi_proof);
+        let multi_proof = MultiProof::from_path_proofs(path_proofs_inner);
+        witness.add_hint(&multi_proof);
+    }
     Ok(finished)
 }
 
@@ -502,7 +505,9 @@ where
         let SessionsContainer {
             user: user_session,
             kernel: kernel_session,
-        } = self.state_session_builder.begin_both_sessions()?;
+        } = self
+            .state_session_builder
+            .begin_both_sessions(self.is_strict_mode)?;
         let starting_session_time = start.elapsed();
         tracing::debug!(%prev_state_root, %next_version, sesssion_starting_time = ?starting_session_time, "computing state update, sessions are live");
 
@@ -521,14 +526,24 @@ where
 
         let user_finished_session = {
             let _span = tracing::debug_span!("compute_state_update", namespace = "user").entered();
-            compute_state_update_namespace::<S>(user_session, &state_accesses.user, witness)
-                .context("user state")?
+            compute_state_update_namespace::<S>(
+                user_session,
+                &state_accesses.user,
+                witness,
+                self.is_strict_mode,
+            )
+            .context("user state")?
         };
         let kernel_finished_session = {
             let _span =
                 tracing::debug_span!("compute_state_update", namespace = "kernel").entered();
-            compute_state_update_namespace::<S>(kernel_session, &state_accesses.kernel, witness)
-                .context("kernel state")?
+            compute_state_update_namespace::<S>(
+                kernel_session,
+                &state_accesses.kernel,
+                witness,
+                self.is_strict_mode,
+            )
+            .context("kernel state")?
         };
 
         // Additional self-check that the finished session has the same previous root hash as passed prev_state_root.
@@ -700,7 +715,7 @@ where
         .unwrap_or(self.latest_version());
         let storage_root_historical = self.get_root_hash_unbound(version_to_use)?;
         if self.should_check_dbs_sync(version_to_use) {
-            let session_container = self.state_session_builder.begin_both_sessions()?;
+            let session_container = self.state_session_builder.begin_both_sessions(false)?;
             let user_root = session_container.user.prev_root();
             let kernel_root = session_container.kernel.prev_root();
             drop(session_container);

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -472,7 +472,9 @@ where
     ) -> Option<SlotValue> {
         match self.read_value::<N>(key, None) {
             Ok(val) => {
-                witness.add_hint(&val);
+                if self.is_strict_mode {
+                    witness.add_hint(&val);
+                }
                 val
             }
             Err(e) => {


### PR DESCRIPTION
# Description

Sequencer computes state update only to get user-space root hash. But NomtProverStorage will collect witness anyway, which will be thrown away.

This PR repurposes `is_strict_mode` which was set only for node storage, so only node will collect witness, so prover logic remains unchanged.
The flag is renamed to `with_witness`. All consistency checks remains.

Changes:

* nomt::Session is initialized with default params if flag is not passed, which is `WitnessMode::disabled`
* All read value are not added to our own `ArrayWitness`

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existing tests are passing

## Docs
Updated doc for state_db_nomt
