### PR TITLE
Gate tokio console behind an env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-12-03
+ - #2148 Disables tokio console unless the `TOKIO_CONSOLE` environment variable is set to `1` or `true`. This significantly improves performance.
+
 # 2025-11-25
 - #2124 Allows configuring EVM contracts to pin their storage in RAM.
 

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/logging.rs
@@ -3,6 +3,7 @@
 use std::env;
 use std::str::FromStr;
 
+use crate::native_only::telemetry::should_init_tokio_console_subscriber;
 pub use crate::native_only::telemetry::{should_init_open_telemetry_exporter, OtelGuard};
 use crate::GIT_COMMIT_HASH;
 use sov_modules_api::ExecutionContext;
@@ -48,7 +49,7 @@ pub fn initialize_logging() -> Option<OtelGuard> {
         .with_filter(IgnoreSpan(ExecutionContext::SEQUENCER_WARM_UP))
         .boxed();
 
-    if cfg!(tokio_unstable) {
+    if cfg!(tokio_unstable) && should_init_tokio_console_subscriber() {
         layers = layers
             .and_then(
                 // See <https://github.com/tokio-rs/console?tab=readme-ov-file#using-it>.
@@ -114,7 +115,7 @@ fn log_info_about_logging(current_env_filter: &str) {
     );
 
     let tokio_console_info_url = "https://github.com/tokio-rs/console";
-    if cfg!(tokio_unstable) {
+    if cfg!(tokio_unstable) && should_init_tokio_console_subscriber() {
         info!(
             tokio_console_info_url,
             "The Tokio debugging console is available",

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/telemetry.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/telemetry.rs
@@ -142,17 +142,31 @@ pub fn should_init_open_telemetry_exporter() -> bool {
         "None of standard OTEL_ prefixed environment variables are set, checking.. {SOV_OTEL_ENV}"
     );
 
-    match std::env::var(SOV_OTEL_ENV).as_deref() {
+    check_and_log_truthiness(SOV_OTEL_ENV, "Open Telemetry exporter")
+}
+
+/// Helper function to ensure if open telemetry exporter should be enabled.
+pub fn should_init_tokio_console_subscriber() -> bool {
+    // logging in this function won't be printed originally, but on the second it will
+    let var_name: &'static str = "TOKIO_CONSOLE";
+
+    check_and_log_truthiness(var_name, "Tokio console subscriber")
+}
+
+fn check_and_log_truthiness(value: &str, item_to_enable: &str) -> bool {
+    match std::env::var(value).as_deref() {
         Ok("1") | Ok("true") => {
-            tracing::debug!("`{SOV_OTEL_ENV}` environment variable is set, Open Telemetry exporter will be enabled with default values");
+            tracing::debug!("`{value}` environment variable is set, {item_to_enable} will be enabled with default values");
             true
         }
         Ok(value) => {
-            tracing::info!(%value, "Value of environment variable `{SOV_OTEL_ENV}` suggests not enabling Open Telemetry exporter");
+            tracing::info!(%value, "Value of environment variable `{value}` suggests not enabling {item_to_enable}");
             false
         }
         Err(_) => {
-            tracing::trace!("Environment variable `{SOV_OTEL_ENV}` is not set, Open Telemetry exporter won't be enabled");
+            tracing::trace!(
+                "Environment variable `{value}` is not set, {item_to_enable} won't be enabled"
+            );
             false
         }
     }


### PR DESCRIPTION
# Description

This small PR gates tokio-console's tracing subscriber behind an env var. Without this change, tokio-console is a top-5 source of allocations. Disabling it improves throughput by 10-20%. 

