### PR TITLE
Remove hot tracing logs

### DIFF
--- a/crates/full-node/sov-metrics/src/influxdb/publisher.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/publisher.rs
@@ -139,7 +139,6 @@ pub(crate) async fn metrics_publisher_task(
                         if let Err(err) = measurement.write_to_csv(csv_writers) {
                             tracing::warn!(?err, "Failed to write metrics to CSV file");
                         }
-                        tracing::trace!(?measurement, "Received measurement");
                         process_measurement(&mut buffer, measurement, &mut publisher, max_buffer_size)
                             .await;
                     }
@@ -221,10 +220,8 @@ async fn process_measurement(
             ?measurement,
             "Failed to format measurement, skipping"
         );
-    } else {
-        // We know that telegraf format is string-based, so for debugging we can print strings:
-        tracing::trace!(buffer = ?String::from_utf8_lossy(buffer), "Serialized measurement into buffer");
     };
+
     // Exceed max size, need to submit the packet first.
     if buffer.len() > max_buffer_size {
         if let Err(error) = publisher.publish(buffer).await {

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -192,11 +192,7 @@ where
                 let version_to_check = resolved_version.unwrap_or(self.latest_version());
                 if self.should_check_dbs_sync(version_to_check) {
                     let key_path = S::Hasher::digest(&key_vec).into();
-                    tracing::trace!(
-                        %key,
-                        key_path = hex::encode(key_path),
-                        "Reading from user namespace",
-                    );
+
                     let nomt_session = self
                         .state_session_builder
                         .begin_user_session_without_witness()
@@ -222,11 +218,6 @@ where
                 let version_to_check = resolved_version.unwrap_or(self.latest_version());
                 if self.should_check_dbs_sync(version_to_check) {
                     let key_path = S::Hasher::digest(&key_vec).into();
-                    tracing::trace!(
-                        %key,
-                        key_path = hex::encode(key_path),
-                        "Reading from kernel namespace",
-                    );
                     let nomt_session = self
                         .state_session_builder
                         .begin_kernel_session_without_witness()
@@ -325,16 +316,6 @@ fn to_nomt_accesses<S: MerkleProofSpec>(
         let authenticated_write = original_write
             .as_ref()
             .map(|v| v.combine_val_hash_and_size::<S::Hasher>());
-
-        tracing::trace!(
-            %key,
-            key_path = hex::encode(key_hash),
-            original_write = ?original_write
-                .as_ref()
-                .map(|v| String::from_utf8_lossy(v.value())),
-            authenticated_write = ?authenticated_write.as_ref().map(hex::encode),
-            "state update write",
-        );
 
         match merged_accesses.entry(key_hash) {
             Entry::Vacant(vacant) => {


### PR DESCRIPTION
# Description
This tiny PR removes some trace level logs that were showing up as allocation hotspots even when `trace` logs weren't enabled.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
