### PR TITLE
Call hooks in Runtime order, not dependency order

### DIFF
--- a/crates/module-system/sov-modules-macros/src/dispatch/hooks.rs
+++ b/crates/module-system/sov-modules-macros/src/dispatch/hooks.rs
@@ -231,14 +231,6 @@ impl HooksMacro {
             .iter()
             .map(|ArgWithType { ty, arg }| quote::quote! { #arg: #ty });
 
-        let idents = fields.iter().enumerate().map(|(i, field)| {
-            let ident = &field.ident;
-
-            quote::quote! {
-                (&mut self.#ident, #i)
-            }
-        });
-
         let method_generics = if method_generics.is_empty() {
             None
         } else {
@@ -251,18 +243,14 @@ impl HooksMacro {
             quote::quote! {()}
         };
 
-        let matches = fields.iter().enumerate().map(|(i, field)| {
+        let module_calls = fields.iter().map(|field| {
             let ident = &field.ident;
             let args_loop = args_names.clone();
 
-            let module_call = if is_faillible {
-                quote::quote! {(&mut self.#ident).#method(#(#args_loop),*)?}
+            if is_faillible {
+                quote::quote! {(&mut self.#ident).#method(#(#args_loop),*)?;}
             } else {
-                quote::quote! {(&mut self.#ident).#method(#(#args_loop),*)}
-            };
-
-            quote::quote! {
-                #i => #module_call,
+                quote::quote! {(&mut self.#ident).#method(#(#args_loop),*);}
             }
         });
 
@@ -274,16 +262,7 @@ impl HooksMacro {
 
         quote::quote! {
             fn #method #method_generics (&mut self, #(#args_with_types),*) -> #method_output_ty {
-                let modules: ::std::vec::Vec<(&dyn ::sov_modules_api::ModuleInfo<Spec = Self::Spec>, usize)> = ::std::vec![#(#idents),*];
-
-                let sorted_modules = ::sov_modules_api::sort_values_by_modules_dependencies(modules).expect("Sorting of modules failed");
-
-                for module in sorted_modules {
-                     match module {
-                         #(#matches)*
-                         _ => panic!("Module not found: {:?}", module),
-                     }
-                };
+                #(#module_calls)*
 
                 #output
             }


### PR DESCRIPTION
# Description

This PR changes the call order of tx hooks. Previously, they were called in the same order that genesis initialization runs. However, this was unnecessary; unlike genesis (which may depend on state from dependencies), tx hooks are not responsible for setting up state. 

sort_modules_by_dependencies was one of the largest allocators. If we ever wish to reintroduce ordering to hooks, we can cache the result of sorting on the first run and avoid it for all subsequent txs. However, that change is more complicated so I've gone with the simple option for now.

