### PR TITLE
Print error from DA service as Debug to avoid swallowing information

### DIFF
--- a/crates/rollup-interface/src/node/da.rs
+++ b/crates/rollup-interface/src/node/da.rs
@@ -259,7 +259,7 @@ pub async fn run_maybe_retryable_async_fn_with_retries<F, Fut, T, E>(
 where
     F: Fn() -> Fut,
     Fut: std::future::Future<Output = Result<T, MaybeRetryable<E>>>,
-    E: std::fmt::Display,
+    E: std::fmt::Display + std::fmt::Debug,
 {
     fxn.retry(backoff_policy)
         .notify(|err: &MaybeRetryable<E>, dur: Duration| {

--- a/crates/rollup-interface/src/node/da.rs
+++ b/crates/rollup-interface/src/node/da.rs
@@ -69,7 +69,7 @@ pub enum MaybeRetryable<E> {
     Transient(E),
 }
 
-impl<E: std::fmt::Display> MaybeRetryable<E> {
+impl<E: std::fmt::Debug> MaybeRetryable<E> {
     fn is_retryable(&self) -> bool {
         matches!(self, Self::Transient(_))
     }
@@ -259,7 +259,7 @@ pub async fn run_maybe_retryable_async_fn_with_retries<F, Fut, T, E>(
 where
     F: Fn() -> Fut,
     Fut: std::future::Future<Output = Result<T, MaybeRetryable<E>>>,
-    E: std::fmt::Display + std::fmt::Debug,
+    E: std::fmt::Debug,
 {
     fxn.retry(backoff_policy)
         .notify(|err: &MaybeRetryable<E>, dur: Duration| {

--- a/crates/rollup-interface/src/node/da.rs
+++ b/crates/rollup-interface/src/node/da.rs
@@ -264,7 +264,7 @@ where
     fxn.retry(backoff_policy)
         .notify(|err: &MaybeRetryable<E>, dur: Duration| {
             tracing::warn!(
-                method_name = da_method_name, error = %err, duration = ?dur,
+                method_name = da_method_name, error = ?err, duration = ?dur,
                 "Error in DA Service, will retry in specified duration."
             );
         })


### PR DESCRIPTION
# Description

Because adding a single `.context` from anyhow will erase all info about actual error

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
