### PR TITLE
Rate limiting: Add `SovRateLimiter` to the sequencer

### DIFF
--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -274,7 +274,8 @@ pub struct SovRateLimiterConfig {
     /// Determines how quickly tokens are refilled in the token-bucket algorithm.
     /// Each user can consume, on average, only a certain percentage of the batch resources.
     /// Over time, users send requests that draw from their available resources, while a
-    /// constant stream of tokens refilling those resources. The higher the value of `refill_rate`,
-    /// the faster the user’s resources are refilled.
+    /// constant stream of tokens refilling those resources.
+    /// At refill_rate = 1, tokens regenerate at 0.0005% × BatchCapacity per millisecond.
+    /// Values between 1 and 20 are recommended starting points.
     pub refill_rate: u64,
 }

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -176,6 +176,9 @@ pub struct PreferredSequencerConfig {
     /// Configuration for the timing oracle.
     #[serde(default)]
     pub timing_oracle: Option<TimingOracleConfig>,
+    /// Configuration for the reate limiting the sequencer.
+    #[serde(default)]
+    pub rate_limiter: Option<SovRateLimiterConfig>,
     /// The fartherst nonce into the future that the sequencer will accept and queue. This directly
     /// impacts the maximum "batch" of transactions that can be simultaneously sent to the
     /// sequencer out of order.
@@ -207,6 +210,7 @@ impl Default for PreferredSequencerConfig {
             future_nonce_transaction_timeout_millis:
                 default_future_nonce_transaction_timeout_millis(),
             timing_oracle: None,
+            rate_limiter: None,
         }
     }
 }
@@ -254,13 +258,20 @@ pub struct StdSequencerConfig {
 pub struct TimingOracleConfig {
     /// The priority fee percentage that the sequencer will pay for the timestamp oracle update tx.
     pub priority_fee_percentage: u8,
-
     /// The maximum fee that the sequencer will pay for the timestamp oracle update tx.
     pub max_fee: u64,
-
     /// The interval in milliseconds at which the timestamp oracle update tx is submitted.
     pub interval_millis: u64,
-
     /// The private key to use to sign timestamp oracle txs. If none is provided, an ephemeral key will be generated.
     pub private_key_hex: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
+pub struct SovRateLimiterConfig {
+    pub ttl_in_milis: u64,
+    pub refill_rate: u8,
+    pub max_req_counter_per_batch: u64,
+    pub max_space_in_bytes_per_batch: u64,
+    pub max_execution_time_micros_per_batch: u64,
+    pub max_gas_used_per_batch: [u64; 2],
 }

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 /// See [`SequencerConfig::sequencer_kind_config`].
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
 pub enum SequencerKindConfig {
     /// A "Standard" sequencer, which can post transactions to the rollup but not give soft confirmations.
     Standard(StdSequencerConfig),
@@ -176,7 +177,7 @@ pub struct PreferredSequencerConfig {
     /// Configuration for the timing oracle.
     #[serde(default)]
     pub timing_oracle: Option<TimingOracleConfig>,
-    /// Configuration for the reate limiting the sequencer.
+    /// Configuration for rate-limiting the sequencer.
     #[serde(default)]
     pub rate_limiter: Option<SovRateLimiterConfig>,
     /// The fartherst nonce into the future that the sequencer will accept and queue. This directly
@@ -266,12 +267,14 @@ pub struct TimingOracleConfig {
     pub private_key_hex: Option<String>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
 pub struct SovRateLimiterConfig {
-    pub ttl_in_milis: u64,
-    pub refill_rate: u8,
-    pub max_req_counter_per_batch: u64,
-    pub max_space_in_bytes_per_batch: u64,
-    pub max_execution_time_micros_per_batch: u64,
-    pub max_gas_used_per_batch: [u64; 2],
+    /// The maximum number of requests allowed per batch.
+    pub max_requests_per_batch: u64,
+    /// Determines how quickly tokens are refilled in the token-bucket algorithm.
+    /// Each user can consume, on average, only a certain percentage of the batch resources.
+    /// Over time, users send requests that draw from their available resources, while a
+    /// constant stream of tokens refilling those resources. The higher the value of `refill_rate`,
+    /// the faster the user’s resources are refilled.
+    pub refill_rate: u64,
 }

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
@@ -72,6 +72,7 @@ expression: config
       "is_replica": false,
       "num_cache_warmup_workers": 0,
       "timing_oracle": null,
+      "rate_limiter": null,
       "maximum_future_nonce_delta": 100,
       "future_nonce_transaction_timeout_millis": 2000
     },

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -19,6 +19,7 @@ mod update_state;
 
 use crate::preferred::block_executor::RollupBlockExecutorConfig;
 use crate::preferred::cache_warm_up_executor::CacheWarmUpExecutor;
+use crate::preferred::rate_limiter::ResourceLimitExceededError;
 use crate::preferred::replica::replica_sync_task::ReplicaSyncTask;
 use crate::preferred::timestamp::{update_timestamp_task, TimingOracleConfigWithPrivateKey};
 use crate::preferred::tx_nonce_queue::TxNonceQueues;
@@ -749,6 +750,7 @@ where
                     }
                 },
                 AcceptTxError::ReplicaMode => return Err(replica_mode_error()),
+                AcceptTxError::RateLimiter(err) => return Err(rate_limit_error(err)),
             },
         }
     }
@@ -1091,6 +1093,14 @@ where
     }
 }
 
+fn rate_limit_error<S: Spec>(err: ResourceLimitExceededError<S>) -> ErrorObject {
+    ErrorObject {
+        status: StatusCode::SERVICE_UNAVAILABLE,
+        message: format!("The sender was rate-limited by the sequencer: {err:?}"),
+        details: Default::default(),
+    }
+}
+
 fn replica_mode_error() -> ErrorObject {
     ErrorObject {
         status: StatusCode::SERVICE_UNAVAILABLE,
@@ -1156,6 +1166,21 @@ where
     events: Vec<RuntimeEventResponse<<Rt as RuntimeEventProcessor>::RuntimeEvent>>,
     receipt: ApiTxEffect<TxReceiptContents<S>>,
     tx_number: u64,
+}
+
+impl<S, Rt> Confirmation<S, Rt>
+where
+    S: Spec,
+    Rt: Runtime<S>,
+{
+    /// Gas used by the transaction
+    pub fn gas_used(&self) -> <S as Spec>::Gas {
+        match &self.receipt {
+            ApiTxEffect::Skipped { data } => data.gas_used,
+            ApiTxEffect::Reverted { data } => data.gas_used,
+            ApiTxEffect::Successful { data } => data.gas_used,
+        }
+    }
 }
 
 fn get_next_sequence_number_according_to_node<S, Rt>(

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
@@ -1,6 +1,6 @@
 use crate::preferred::rate_limiter::resource::LimitExceeded;
 use crate::preferred::rate_limiter::resource::Resource;
-use mini_moka::unsync::Cache;
+use mini_moka::sync::Cache;
 use sov_modules_api::Gas;
 use sov_modules_api::Spec;
 use std::fmt::Debug;
@@ -11,7 +11,7 @@ use std::time::Instant;
 /// Configuration for the rate limiter.
 #[derive(Debug, Clone)]
 pub(crate) struct RateLimiterConfig<S: Spec> {
-    pub(crate) ttl_in_milis: u64,
+    pub(crate) ttl_in_millis: u64,
     pub(crate) max_allowed_resources: TotalResources<S::Gas>,
     pub(crate) refill_rate: RefillRatePerMillis<S::Gas>,
 }
@@ -20,6 +20,33 @@ pub(crate) struct RateLimiterConfig<S: Spec> {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct ResourceUsed<G: Gas> {
     pub(crate) inner: Resource<G>,
+}
+
+impl<G: Gas> ResourceUsed<G> {
+    pub(crate) fn zero() -> Self {
+        Self {
+            inner: Resource::zero(),
+        }
+    }
+
+    pub(crate) fn new(
+        req_counter: u64,
+        tx_size_in_bytes: usize,
+        execution_time_micros: u64,
+        gas_used: G,
+    ) -> Self {
+        Self {
+            inner: Resource {
+                req_counter,
+                // This cast is safe because a single transaction can never use more than u64::MAX bytes.
+                space_in_bytes: tx_size_in_bytes
+                    .try_into()
+                    .expect("Alowed transactions size overflows u64::MAX"),
+                execution_time_micros,
+                gas_used,
+            },
+        }
+    }
 }
 
 /// [`RefillRatePerMillis`] determines how quickly used resources are refilled.
@@ -212,10 +239,10 @@ pub(crate) struct RateLimiter<K, S: Spec> {
     refill_rate: RefillRatePerMillis<S::Gas>,
 }
 
-impl<K: Hash + Eq + Debug, S: Spec> RateLimiter<K, S> {
+impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
     pub(crate) fn new(config: RateLimiterConfig<S>) -> Self {
         let data = Cache::builder()
-            .time_to_live(Duration::from_millis(config.ttl_in_milis))
+            .time_to_live(Duration::from_millis(config.ttl_in_millis))
             .build();
 
         Self {
@@ -230,7 +257,7 @@ impl<K: Hash + Eq + Debug, S: Spec> RateLimiter<K, S> {
         now: Instant,
         key: &K,
     ) -> Result<Throttler<S::Gas>, LimitExceeded<S::Gas>> {
-        match self.data.get(key).copied() {
+        match self.data.get(key) {
             Some(throttler) => Ok(throttler.allow_request_and_refill_resource_used(
                 now,
                 &self.max_allowed_resources,
@@ -275,7 +302,7 @@ mod tests {
         let refill_rate = refill_rate();
 
         let config = RateLimiterConfig::<TestSpec> {
-            ttl_in_milis: 1_000_000,
+            ttl_in_millis: 1_000_000,
             max_allowed_resources,
             refill_rate,
         };
@@ -334,7 +361,7 @@ mod tests {
         let refill_rate = refill_rate();
 
         let config = RateLimiterConfig::<TestSpec> {
-            ttl_in_milis: 1_000_000,
+            ttl_in_millis: 1_000_000,
             max_allowed_resources,
             refill_rate,
         };
@@ -410,7 +437,7 @@ mod tests {
         let refill_rate = refill_rate();
 
         let config = RateLimiterConfig::<TestSpec> {
-            ttl_in_milis: 2,
+            ttl_in_millis: 2,
             max_allowed_resources,
             refill_rate,
         };
@@ -474,12 +501,6 @@ mod tests {
                 .refill_rate
                 .token_resource_per_ms
                 .saturating_mul_by_scalar(time_passed_ms)
-        }
-    }
-
-    impl<K: Hash + Eq, S: Spec> RateLimiter<K, S> {
-        fn get_throtler(&mut self, key: &K) -> Option<&Throttler<S::Gas>> {
-            self.data.get(key)
         }
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
@@ -92,7 +92,7 @@ const TTL_MULTIPLIER: u64 = 20;
 // A single user is limited to 1/PER_KEY = 0.5% of resources of a single batch.
 const PER_KEY: u64 = 200;
 
-fn to_rate_limiter_config<S: Spec>(
+fn clculate_limits<S: Spec>(
     sov_config: SovRateLimiterConfig,
     batch_execution_time_limit_millis: u64,
     max_batch_size_bytes: usize,
@@ -144,7 +144,7 @@ impl<S: Spec> SovRateLimiter<S> {
         max_batch_size_bytes: usize,
     ) -> Self {
         let inner = config.map(|sov_config| {
-            let config = to_rate_limiter_config(
+            let config = clculate_limits(
                 sov_config,
                 batch_execution_time_limit_millis,
                 max_batch_size_bytes,
@@ -182,14 +182,13 @@ mod tests {
     type Gas = <TestSpec as Spec>::Gas;
 
     #[test]
-    fn test_to_rate_limiter_config() {
+    fn test_clculate_limits() {
         let sov_config = SovRateLimiterConfig {
             max_requests_per_batch: 234000000,
             refill_rate: 1,
         };
 
-        let rate_limiter_config =
-            to_rate_limiter_config::<TestSpec>(sov_config, 1_000_000_000, 1000000);
+        let rate_limiter_config = clculate_limits::<TestSpec>(sov_config, 1_000_000_000, 1000000);
 
         let max_allowed_resources_per_key = rate_limiter_config.max_allowed_resources;
 

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
@@ -2,14 +2,18 @@
 mod limiter;
 mod resource;
 
+pub(crate) use limiter::ResourceUsed;
 use limiter::*;
 use resource::*;
-use sov_modules_api::Spec;
+use sov_full_node_configs::sequencer::SovRateLimiterConfig;
+use sov_modules_api::{CredentialId, Spec};
 use std::{net::IpAddr, time::Instant};
+
+use crate::preferred::sync_sequencer_state::comfortable_gas_limit;
 
 #[derive(Debug)]
 pub(crate) struct Token<S: Spec> {
-    addr: S::Address,
+    credential_id: CredentialId,
     throttler_for_addr: Throttler<S::Gas>,
 
     ip: IpAddr,
@@ -18,9 +22,9 @@ pub(crate) struct Token<S: Spec> {
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum ResourceLimitExceededError<S: Spec> {
-    #[error("Resource limit exceeded for Address:{addr:?}, {reason:?}")]
-    Address {
-        addr: S::Address,
+    #[error("Resource limit exceeded for Credential_ID: {credential_id:?}, {reason:?}")]
+    CredentialId {
+        credential_id: CredentialId,
         reason: LimitExceeded<S::Gas>,
     },
     #[error("Resource limit exceeded for IP: {ip:?}, {reason:?}")]
@@ -31,7 +35,7 @@ pub(crate) enum ResourceLimitExceededError<S: Spec> {
 }
 
 struct SovRateLimiterInner<S: Spec> {
-    by_addr_rate_limiter: RateLimiter<S::Address, S>,
+    by_addr_rate_limiter: RateLimiter<CredentialId, S>,
     by_ip_rate_limiter: RateLimiter<IpAddr, S>,
 }
 
@@ -46,12 +50,17 @@ impl<S: Spec> SovRateLimiterInner<S> {
     fn allow(
         &mut self,
         ip: IpAddr,
-        addr: S::Address,
+        credential_id: CredentialId,
     ) -> Result<Token<S>, ResourceLimitExceededError<S>> {
         let now = Instant::now();
-        let throttler_for_addr = match self.by_addr_rate_limiter.allow(now, &addr) {
+        let throttler_for_addr = match self.by_addr_rate_limiter.allow(now, &credential_id) {
             Ok(ok) => ok,
-            Err(reason) => return Err(ResourceLimitExceededError::Address { addr, reason }),
+            Err(reason) => {
+                return Err(ResourceLimitExceededError::CredentialId {
+                    credential_id,
+                    reason,
+                })
+            }
         };
 
         let throttler_for_ip = self
@@ -60,7 +69,7 @@ impl<S: Spec> SovRateLimiterInner<S> {
             .map_err(|reason| ResourceLimitExceededError::Ip { ip, reason })?;
 
         Ok(Token {
-            addr,
+            credential_id,
             throttler_for_addr,
             ip,
             throttler_for_ip,
@@ -68,10 +77,57 @@ impl<S: Spec> SovRateLimiterInner<S> {
     }
 
     fn update(&mut self, token: Token<S>, resource_used: ResourceUsed<S::Gas>) {
-        self.by_addr_rate_limiter
-            .update(token.addr, token.throttler_for_addr, resource_used);
+        self.by_addr_rate_limiter.update(
+            token.credential_id,
+            token.throttler_for_addr,
+            resource_used,
+        );
         self.by_ip_rate_limiter
             .update(token.ip, token.throttler_for_ip, resource_used);
+    }
+}
+
+const TTL_MULTIPLIER: u64 = 20;
+
+// A single user is limited to 1/PER_KEY = 0.5% of resources of a single batch.
+const PER_KEY: u64 = 200;
+
+fn to_rate_limiter_config<S: Spec>(
+    sov_config: SovRateLimiterConfig,
+    batch_execution_time_limit_millis: u64,
+    max_batch_size_bytes: usize,
+) -> RateLimiterConfig<S> {
+    // All entries older than this value are evicted from the rate limiter.
+    let ttl_in_millis = batch_execution_time_limit_millis * TTL_MULTIPLIER;
+    let max_gas = comfortable_gas_limit::<S>();
+
+    let max_resources_per_batch = Resource {
+        req_counter: sov_config.max_requests_per_batch,
+        // The expect is justified because we will never have batches larger than u64::MAX bytes.
+        space_in_bytes: max_batch_size_bytes
+            .try_into()
+            .expect("Alowed batch size overflows u64::MAX"),
+        // The expect is justified because batches will never take longer than u64::MAX microseconds.
+        execution_time_micros: batch_execution_time_limit_millis.checked_mul(1000).expect(
+            "Converting batch_execution_time_limit_millis to microseconds would overflow u64::MAX.",
+        ),
+        gas_used: max_gas,
+    };
+
+    // A single sender is limited to 1/PER_KEY = 0.5% of resources of a single batch.
+    let max_per_key = max_resources_per_batch.div_by_scalar(PER_KEY);
+
+    // The refill rate is defined as 0.1% of max_per_key. After one second, the system refills max_per_key tokens.
+    let refill_rate = max_per_key
+        .saturating_mul_by_scalar(sov_config.refill_rate)
+        .div_by_scalar(1000);
+
+    RateLimiterConfig {
+        ttl_in_millis,
+        max_allowed_resources: TotalResources { inner: max_per_key },
+        refill_rate: RefillRatePerMillis {
+            token_resource_per_ms: refill_rate,
+        },
     }
 }
 
@@ -82,19 +138,30 @@ pub(crate) struct SovRateLimiter<S: Spec> {
 }
 
 impl<S: Spec> SovRateLimiter<S> {
-    pub(crate) fn new(config: Option<RateLimiterConfig<S>>) -> Self {
-        let inner = config.map(|c| SovRateLimiterInner::new(c));
+    pub(crate) fn new(
+        config: Option<SovRateLimiterConfig>,
+        batch_execution_time_limit_millis: u64,
+        max_batch_size_bytes: usize,
+    ) -> Self {
+        let inner = config.map(|sov_config| {
+            let config = to_rate_limiter_config(
+                sov_config,
+                batch_execution_time_limit_millis,
+                max_batch_size_bytes,
+            );
+            SovRateLimiterInner::new(config)
+        });
         Self { inner }
     }
 
     pub(crate) fn allow(
         &mut self,
         ip: IpAddr,
-        addr: S::Address,
+        credential_id: CredentialId,
     ) -> Result<Option<Token<S>>, ResourceLimitExceededError<S>> {
         self.inner
             .as_mut()
-            .map(|inner| inner.allow(ip, addr))
+            .map(|inner| inner.allow(ip, credential_id))
             .transpose()
     }
 
@@ -113,6 +180,27 @@ mod tests {
     use std::net::Ipv4Addr;
 
     type Gas = <TestSpec as Spec>::Gas;
+
+    #[test]
+    fn test_to_rate_limiter_config() {
+        let sov_config = SovRateLimiterConfig {
+            max_requests_per_batch: 234000000,
+            refill_rate: 1,
+        };
+
+        let rate_limiter_config =
+            to_rate_limiter_config::<TestSpec>(sov_config, 1_000_000_000, 1000000);
+
+        let max_allowed_resources_per_key = rate_limiter_config.max_allowed_resources;
+
+        // In one ms we refill max_allowed_resources_per_key tokens.
+        let refilled = rate_limiter_config
+            .refill_rate
+            .token_resource_per_ms
+            .saturating_mul_by_scalar(1000);
+
+        assert_eq!(max_allowed_resources_per_key.inner, refilled);
+    }
 
     #[test]
     fn test_sov_test_limiter() {
@@ -146,42 +234,49 @@ mod tests {
         };
 
         let config = RateLimiterConfig::<TestSpec> {
-            ttl_in_milis: 1_000_000,
+            ttl_in_millis: 1_000_000,
             max_allowed_resources,
             refill_rate,
         };
 
-        let addr1 = <TestSpec as Spec>::Address::from([1; 28]);
-        let addr2 = <TestSpec as Spec>::Address::from([2; 28]);
-        let addr3 = <TestSpec as Spec>::Address::from([3; 28]);
+        let cred1 = CredentialId::from_bytes([1; 32]);
+        let cred2 = CredentialId::from_bytes([2; 32]);
+        let cred3 = CredentialId::from_bytes([3; 32]);
         let ip1 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
         let ip2 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
 
-        let mut rate_limiter = SovRateLimiter::new(Some(config));
+        let mut rate_limiter = SovRateLimiter::new_for_test(Some(config));
 
-        // Update rate limiter for (ip1, addr1)
+        // Update rate limiter for (ip1, cred1)
         {
-            let token = rate_limiter.allow(ip1, addr1).unwrap();
+            let token = rate_limiter.allow(ip1, cred1).unwrap();
             rate_limiter.update(token, resource_used_per_run);
         }
 
-        // Update rate limiter for (ip1, addr2)
+        // Update rate limiter for (ip1, cred2)
         {
-            let token = rate_limiter.allow(ip1, addr2).unwrap();
+            let token = rate_limiter.allow(ip1, cred2).unwrap();
             rate_limiter.update(token, resource_used_per_run);
         }
 
-        // Update rate limiter for (ip1, addr3)
+        // Update rate limiter for (ip1, cred3)
         // Different addresses were sent from the same IP, and after two requests we exceeded the limit for that IP.
         {
-            let err = rate_limiter.allow(ip1, addr3).unwrap_err();
+            let err = rate_limiter.allow(ip1, cred3).unwrap_err();
             assert!(matches!(err, ResourceLimitExceededError::Ip { .. }));
         }
 
-        // Update the rate limiter for (ip2, addr3); this works because we're using a new IP.
+        // Update the rate limiter for (ip2, cred3); this works because we're using a new IP.
         {
-            let token = rate_limiter.allow(ip2, addr3).unwrap();
+            let token = rate_limiter.allow(ip2, cred3).unwrap();
             rate_limiter.update(token, resource_used_per_run);
+        }
+    }
+
+    impl<S: Spec> SovRateLimiter<S> {
+        fn new_for_test(config: Option<RateLimiterConfig<S>>) -> Self {
+            let inner = config.map(|c| SovRateLimiterInner::new(c));
+            Self { inner }
         }
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
@@ -91,6 +91,18 @@ impl<G: Gas> Resource<G> {
         }
     }
 
+    #[must_use]
+    pub(crate) fn div_by_scalar(&self, scalar: u64) -> Self {
+        let gas_used = self.gas_used.scalar_division(scalar);
+
+        Self {
+            req_counter: self.req_counter / scalar,
+            space_in_bytes: self.space_in_bytes / scalar,
+            execution_time_micros: self.execution_time_micros / scalar,
+            gas_used,
+        }
+    }
+
     pub(crate) fn err_if_exceeding(&self, other: &Self) -> Result<(), LimitExceeded<G>> {
         if self.req_counter > other.req_counter {
             return Err(LimitExceeded::RequestCount {

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -6,8 +6,11 @@ use crate::preferred::block_executor::{
 };
 use crate::preferred::block_executor::{RollupBlockExecutorErrorWithBudget, StartBlockData};
 use crate::preferred::cache_warm_up_executor::{CacheWarmUpExecutor, StartBlockNotification};
+use crate::preferred::comfortable_gas_limit;
 use crate::preferred::db::latest_finalized_sequence_number;
 use crate::preferred::executor_events::ExecutorEventsSender;
+use crate::preferred::rate_limiter::ResourceUsed;
+use crate::preferred::rate_limiter::SovRateLimiter;
 use crate::preferred::sync_sequencer_state::EventReceiverStartNotifier;
 use crate::preferred::AcceptedTx;
 use crate::preferred::BatchSizeTracker;
@@ -21,6 +24,7 @@ use crate::preferred::{
 use crate::{SequencerConfig, SequencerNotReadyDetails, SlotNumber, TxHash};
 use sov_blob_storage::SequenceNumber;
 use sov_modules_api::capabilities::RollupHeight;
+use sov_modules_api::Gas;
 use sov_modules_api::{
     FullyBakedTx, GasArray, GasSpec, Runtime, Spec, StateCheckpoint, StateUpdateInfo,
     VersionReader, VisibleSlotNumber,
@@ -40,11 +44,6 @@ use tracing::{debug, info, warn};
 const COMFORTABLE_SIZE_LIMIT_MULTIPLIER: u64 = 99;
 const COMFORTABLE_SIZE_LIMIT_DIVISOR: u64 = 100;
 
-/// These two constants are used to calculate the comfortable gas limit.
-/// Currently, this is 95% of the initial gas limit. After the comfortable limit is reached,
-/// the sequencer will close and publish the current batch.
-const COMFORTABLE_GAS_LIMIT_MULTIPLIER: u64 = 19;
-const COMFORTABLE_GAS_LIMIT_DIVISOR: u64 = 20;
 const COMFORTABLE_IN_FLIGHT_BLOBS: usize = 5;
 
 const METRICS_BATCH_SIZE: usize = 32;
@@ -97,6 +96,7 @@ where
     pub(crate) tx_cache_writer: TxResultWriter<S, Rt>,
     pub(crate) cache_warm_up_executor: CacheWarmUpExecutor<S>,
     pub(crate) start_replica_task_notifier: EventReceiverStartNotifier,
+    pub(crate) rate_limiter: SovRateLimiter<S>,
 }
 
 // We submit metrics when this guard is dropped.
@@ -314,16 +314,12 @@ where
         // Check if we're close to the gas limit and close the batch if we are.
         // We want to close when gas used is at least 95% of the initial gas limit.
         let initial_gas_limit = <S as GasSpec>::initial_gas_limit();
+        let comfortable_gas_limit = comfortable_gas_limit::<S>();
+
         let gas_used = initial_gas_limit
             .checked_sub(remaining_slot_gas)
             .expect("remaining_lot_gas is always smaller than initial_gas_limit");
-        let comfortable_gas_limit = initial_gas_limit
-            .scalar_division(COMFORTABLE_GAS_LIMIT_DIVISOR)
-            .checked_scalar_product(COMFORTABLE_GAS_LIMIT_MULTIPLIER).unwrap_or_else(|| {
-                panic!(
-                    "Cannot overflow after dividing by {COMFORTABLE_GAS_LIMIT_DIVISOR} and multiplying by {COMFORTABLE_GAS_LIMIT_MULTIPLIER}",
-                )
-            });
+
         let close_to_gas_limit = comfortable_gas_limit.dim_is_less_or_eq(gas_used);
         if close_to_gas_limit {
             tracing::debug!(%comfortable_gas_limit, %gas_used, "Closing and publishing current batch because we're close to the gas limit");
@@ -663,16 +659,22 @@ where
         &mut self,
         tx_hash: TxHash,
         baked_tx: FullyBakedTx,
-    ) -> Result<
-        (
-            oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>,
-            <S as Spec>::Gas,
-        ),
-        DoNewTxError<S>,
-    > {
+    ) -> (
+        Result<
+            (
+                oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>,
+                <S as Spec>::Gas,
+            ),
+            DoNewTxError<S>,
+        >,
+        ResourceUsed<S::Gas>,
+    ) {
+        // Even if this method return early it uses 1 request slot.
+        let request_used = ResourceUsed::new(1, 0, 0, <S as Spec>::Gas::zero());
+
         if self.shutdown_receiver.has_changed().unwrap_or(true) {
             tracing::info!("The sequencer is shutting down. Cannot accept transactions");
-            return Err(DoNewTxError::Shutdown);
+            return (Err(DoNewTxError::Shutdown), request_used);
         }
 
         if !self.executor.has_in_progress_batch() {
@@ -693,10 +695,13 @@ where
 
         let tx_len = baked_tx.data.len();
         if !batch_size_tracker.can_fit_tx_bytes(tx_len) {
-            return Err(DoNewTxError::TxTooBig {
-                current_batch_size: batch_size_tracker.current_batch_size,
-                max_batch_size: batch_size_tracker.max_batch_size,
-            });
+            return (
+                Err(DoNewTxError::TxTooBig {
+                    current_batch_size: batch_size_tracker.current_batch_size,
+                    max_batch_size: batch_size_tracker.max_batch_size,
+                }),
+                request_used,
+            );
         }
 
         let baked_tx = cache_warm_up_executor.send_tx(baked_tx.clone(), sequence_number);
@@ -717,18 +722,27 @@ where
                 );
                 res
             }
-            Err(RollupBlockExecutorErrorWithBudget { inner_err: err, .. }) => {
+            Err(RollupBlockExecutorErrorWithBudget {
+                inner_err: err,
+                execution_time_micros,
+                gas_used,
+            }) => {
                 tracing::debug!(%tx_hash, %err, "Transaction was dropped by the sequencer");
-                return Err(DoNewTxError::ExecutorError(err));
+
+                let resource_used = ResourceUsed::new(1, tx_len, execution_time_micros, gas_used);
+                return (Err(DoNewTxError::ExecutorError(err)), resource_used);
             }
         };
+
+        let gas_used = accepted_tx.confirmation.gas_used();
+        let resource_used = ResourceUsed::new(1, tx_len, execution_time_micros, gas_used);
 
         batch_size_tracker.add_tx(tx_len, execution_time_micros);
         let rx = executor_events_sender
             .send_accept_tx(accepted_tx, tx_changes, sequence_number)
             .await;
 
-        Ok((rx, remaining_slot_gas))
+        (Ok((rx, remaining_slot_gas)), resource_used)
     }
 
     /// Closes the current batch.

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
@@ -3,6 +3,8 @@ use crate::preferred::block_executor::RollupBlockExecutor;
 use crate::preferred::cache_warm_up_executor::CacheWarmUpExecutor;
 use crate::preferred::db::BatchToStore;
 use crate::preferred::executor_events::ExecutorEventsSender;
+use crate::preferred::rate_limiter::ResourceLimitExceededError;
+use crate::preferred::rate_limiter::SovRateLimiter;
 use crate::preferred::replica::event_handler::ReplicaError;
 use crate::preferred::replica::event_receiver::EventReceiverStartNotifier;
 use crate::preferred::AcceptedTx;
@@ -20,6 +22,8 @@ use sov_db::ledger_db::LedgerDb;
 use sov_full_node_configs::sequencer::{PreferredSequencerConfig, SequencerConfig};
 use sov_modules_api::capabilities::RollupHeight;
 use sov_modules_api::CredentialId;
+use sov_modules_api::GasArray;
+use sov_modules_api::GasSpec;
 use sov_modules_api::{FullyBakedTx, Runtime, Spec, StateUpdateInfo};
 use sov_state::Storage;
 use std::collections::BTreeMap;
@@ -30,8 +34,8 @@ pub(crate) use sync_state::*;
 use tokio::sync::broadcast;
 use tokio::sync::{mpsc, oneshot, watch};
 pub(crate) use updator::*;
-mod conditions_table;
 
+mod conditions_table;
 mod inner;
 mod sync_state;
 mod updator;
@@ -166,8 +170,15 @@ where
     Rt: Runtime<S>,
 {
     let (message_sender, message_receiver) = mpsc::channel(CHANNEL_SIZE);
-
     let is_ready = Err(SequencerNotReadyDetails::Startup);
+
+    let rate_limiter = SovRateLimiter::new(
+        seq_config.sequencer_kind_config.rate_limiter,
+        seq_config
+            .sequencer_kind_config
+            .batch_execution_time_limit_millis,
+        seq_config.max_batch_size_bytes,
+    );
 
     let inner = Inner {
         is_replica,
@@ -197,6 +208,7 @@ where
         tx_cache_writer,
         cache_warm_up_executor,
         start_replica_task_notifier,
+        rate_limiter,
     };
 
     let channel_size = Arc::new(AtomicU32::new(0));
@@ -230,6 +242,7 @@ pub(crate) enum AcceptTxError<S: Spec> {
     },
     NewTxError(DoNewTxError<S>),
     ReplicaMode,
+    RateLimiter(ResourceLimitExceededError<S>),
 }
 
 #[derive(Debug)]
@@ -263,4 +276,21 @@ impl InitialStatus {
     fn should_flush_tx_cache_and_pinned_cache(&self) -> bool {
         self.is_startup || self.is_resync || self.is_recover
     }
+}
+
+/// These two constants are used to calculate the comfortable gas limit.
+/// Currently, this is 95% of the initial gas limit. After the comfortable limit is reached,
+/// the sequencer will close and publish the current batch.
+const COMFORTABLE_GAS_LIMIT_MULTIPLIER: u64 = 19;
+const COMFORTABLE_GAS_LIMIT_DIVISOR: u64 = 20;
+
+pub(crate) fn comfortable_gas_limit<S: Spec>() -> <S as GasSpec>::Gas {
+    let initial_gas_limit = <S as GasSpec>::initial_gas_limit();
+    initial_gas_limit
+            .scalar_division(COMFORTABLE_GAS_LIMIT_DIVISOR)
+            .checked_scalar_product(COMFORTABLE_GAS_LIMIT_MULTIPLIER).unwrap_or_else(|| {
+                panic!(
+                    "Cannot overflow after dividing by {COMFORTABLE_GAS_LIMIT_DIVISOR} and multiplying by {COMFORTABLE_GAS_LIMIT_MULTIPLIER}",
+                )
+            })
 }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -762,8 +762,8 @@ where
         baked_tx: FullyBakedTx,
         tx_hash: TxHash,
         original_tx_queue_id: u64,
-        _credential_id: CredentialId,
-        _socket_addr: SocketAddr,
+        credential_id: CredentialId,
+        socket_addr: SocketAddr,
         reason: &'static str,
     ) -> Result<oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>, AcceptTxError<S>> {
         let mut inner = self.get_inner_with_timing(reason).await;
@@ -804,10 +804,18 @@ where
             });
         };
 
-        let (rx, remaining_slot_gas) = inner
-            .do_new_tx(tx_hash, baked_tx)
-            .await
-            .map_err(AcceptTxError::NewTxError)?;
+        let token = inner
+            .rate_limiter
+            .allow(socket_addr.ip(), credential_id)
+            .map_err(|err| AcceptTxError::RateLimiter(err))?;
+
+        let (res, resource_used) = inner.do_new_tx(tx_hash, baked_tx).await;
+
+        // Do not use `?` or return early here. We must always call `rate_limiter.update`
+        // to ensure the limits are updated even for unsuccessful transactions.
+        let res = res.map_err(AcceptTxError::NewTxError);
+        inner.rate_limiter.update(token, resource_used);
+        let (rx, remaining_slot_gas) = res?;
 
         inner.close_batch_if_nearly_full(remaining_slot_gas).await;
 
@@ -876,12 +884,8 @@ where
             seq_nr_from_master,
         )?;
 
-        let _ = inner
-            .do_new_tx(tx_hash, baked_tx)
-            .await
-            .map_err(ReplicaError::NewTx)?
-            .0
-            .await;
+        let (res, _) = inner.do_new_tx(tx_hash, baked_tx).await;
+        let _ = res.map_err(ReplicaError::NewTx)?.0.await;
 
         Ok(())
     }

--- a/crates/full-node/sov-sequencer/tests/integration/main.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/main.rs
@@ -3,6 +3,7 @@ mod preferred_blob_sender;
 mod preferred_end_to_end;
 mod preferred_tx_nonce_queue;
 mod preferred_with_reorgs;
+mod rate_limits;
 mod setup_mode;
 mod standard_sequencer;
 mod thin_sequencer;

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1,6 +1,7 @@
 //! Integration tests for the preferred sequencer that use [`RollupBuilder`] and
 //! thus test sequencer + node interactions.
 
+use crate::utils::encode_call;
 use crate::utils::{
     generate_paymaster_tx, generate_txs, new_test_rollup, pause_update_state,
     tempdir_inside_codebase_dir, tx_set_value_with_gas, ModuleWithVersionedStateAccessInSlotHook,
@@ -37,9 +38,9 @@ use sov_test_utils::test_rollup::FullNodeBlueprint;
 use sov_test_utils::test_rollup::StoragePath;
 use sov_test_utils::test_rollup::{GenesisSource, RollupBuilder, RollupProverConfig, TestRollup};
 use sov_test_utils::{
-    default_test_signed_transaction, generate_optimistic_runtime_with_kernel, RtAgnosticBlueprint,
-    TestSpec, TestUser, TEST_DEFAULT_MOCK_DA_ON_SUBMIT, TEST_FINALIZATION_BLOCKS,
-    TEST_MAX_BATCH_SIZE, TEST_MAX_CONCURRENT_BLOBS, TEST_NORMAL_SHUTDOWN_TIMEOUT,
+    generate_optimistic_runtime_with_kernel, RtAgnosticBlueprint, TestSpec, TestUser,
+    TEST_DEFAULT_MOCK_DA_ON_SUBMIT, TEST_FINALIZATION_BLOCKS, TEST_MAX_BATCH_SIZE,
+    TEST_MAX_CONCURRENT_BLOBS, TEST_NORMAL_SHUTDOWN_TIMEOUT,
 };
 use sov_value_setter::{ValueSetter, ValueSetterConfig};
 use std::collections::HashMap;
@@ -3338,14 +3339,14 @@ fn tx_delayed_call(key: &Ed25519PrivateKey, generation: u64) -> RawTx {
     let msg = <TestRuntime<TestSpec> as DispatchCall>::Decodable::HooksCount(
         sov_test_modules::hooks_count::CallMessage::DelayedCallMsg {},
     );
-    encode_call(key, generation, &msg)
+    encode_call::<TestRuntime<TestSpec>>(key, generation, &msg)
 }
 
 fn tx_set_many_values(key: &Ed25519PrivateKey, generation: u64, values_to_set: Vec<u8>) -> RawTx {
     let msg = <TestRuntime<TestSpec> as DispatchCall>::Decodable::ValueSetter(
         sov_value_setter::CallMessage::SetManyValues(values_to_set),
     );
-    encode_call(key, generation, &msg)
+    encode_call::<TestRuntime<TestSpec>>(key, generation, &msg)
 }
 
 fn tx_set_value_and_sleep(
@@ -3360,14 +3361,14 @@ fn tx_set_value_and_sleep(
             sleep_millis,
         },
     );
-    encode_call(key, generation, &msg)
+    encode_call::<TestRuntime<TestSpec>>(key, generation, &msg)
 }
 
 fn tx_panic(key: &Ed25519PrivateKey, nonce: u64) -> RawTx {
     let msg = <TestRuntime<TestSpec> as DispatchCall>::Decodable::ValueSetter(
         sov_value_setter::CallMessage::Panic,
     );
-    encode_call(key, nonce, &msg)
+    encode_call::<TestRuntime<TestSpec>>(key, nonce, &msg)
 }
 
 fn tx_assert_visible_slot_number(
@@ -3381,7 +3382,7 @@ fn tx_assert_visible_slot_number(
         },
     );
 
-    encode_call(key, nonce, &msg)
+    encode_call::<TestRuntime<TestSpec>>(key, nonce, &msg)
 }
 
 fn tx_assert_state_root(
@@ -3395,22 +3396,7 @@ fn tx_assert_state_root(
         },
     );
 
-    encode_call(key, nonce, &msg)
-}
-
-fn encode_call(
-    key: &Ed25519PrivateKey,
-    generation: u64,
-    call_message: &<TestRuntime<TestSpec> as DispatchCall>::Decodable,
-) -> RawTx {
-    let tx = default_test_signed_transaction::<TestRuntime<TestSpec>, TestSpec>(
-        key,
-        call_message,
-        generation,
-        &<TestRuntime<TestSpec> as Runtime<TestSpec>>::CHAIN_HASH,
-    );
-
-    RawTx::new(borsh::to_vec(&tx).unwrap())
+    encode_call::<TestRuntime<TestSpec>>(key, nonce, &msg)
 }
 
 mod tests_with_basic_kernel {

--- a/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
@@ -1,0 +1,144 @@
+use crate::utils::encode_call;
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
+use sov_api_spec::types as api_types;
+use sov_full_node_configs::sequencer::SovRateLimiterConfig;
+use sov_mock_da::BlockProducingConfig;
+use sov_mock_zkvm::crypto::private_key::Ed25519PrivateKey;
+use sov_modules_api::DispatchCall;
+use sov_modules_api::RawTx;
+use sov_modules_stf_blueprint::Runtime;
+use sov_sequencer::SequencerKindConfig;
+use sov_test_utils::generate_operator_runtime_with_kernel;
+use sov_test_utils::runtime::genesis::operator::HighLevelOperatorGenesisConfig;
+use sov_test_utils::runtime::GenesisParams;
+use sov_test_utils::runtime::SoftConfirmationsKernel;
+use sov_test_utils::test_rollup::GenesisSource;
+use sov_test_utils::test_rollup::RollupBuilder;
+use sov_test_utils::test_rollup::StoragePath;
+use sov_test_utils::test_rollup::TestRollup;
+use sov_test_utils::RtAgnosticBlueprint;
+use sov_test_utils::TestSpec;
+use sov_test_utils::TestUser;
+use sov_test_utils::TEST_DEFAULT_USER_BALANCE;
+use sov_value_setter::ValueSetter;
+use sov_value_setter::ValueSetterConfig;
+use std::sync::Arc;
+use std::time::Duration;
+
+generate_operator_runtime_with_kernel!(kernel_type: SoftConfirmationsKernel<'a, S>, TestRuntime <= value_setter: ValueSetter<S>);
+
+type RT = TestRuntime<TestSpec>;
+type TestBlueprint = RtAgnosticBlueprint<TestSpec, RT>;
+
+async fn create_test_rollup() -> (TestRollup<TestBlueprint>, TestUser<TestSpec>) {
+    let reward_user = TestUser::<TestSpec>::generate(TEST_DEFAULT_USER_BALANCE);
+
+    let genesis_config =
+        HighLevelOperatorGenesisConfig::<TestSpec>::generate_with_additional_accounts(
+            1,
+            reward_user,
+        );
+
+    let admin = genesis_config.additional_accounts()[0].clone();
+    let rt_genesis_config = <RT as Runtime<TestSpec>>::GenesisConfig::from_minimal_config(
+        genesis_config.into(),
+        ValueSetterConfig {
+            admin: admin.address(),
+        },
+    );
+
+    let genesis_params = GenesisParams {
+        runtime: rt_genesis_config.clone(),
+    };
+
+    let dir = Arc::new(tempfile::tempdir().unwrap());
+
+    let seq_da_address = genesis_params
+        .runtime
+        .sequencer_registry
+        .sequencer_config
+        .seq_da_address;
+
+    let builder = RollupBuilder::<RtAgnosticBlueprint<TestSpec, RT>>::new(
+        GenesisSource::CustomParams(genesis_params),
+        BlockProducingConfig::Manual,
+        0,
+    )
+    .set_config(|c| {
+        c.storage = StoragePath::Tmp(dir);
+        c.max_concurrent_blobs = 64;
+        if let SequencerKindConfig::Preferred(ref mut config) = &mut c.sequencer_config {
+            config.num_cache_warmup_workers = 0;
+            config.batch_execution_time_limit_millis = 3000;
+            config.rate_limiter = Some(SovRateLimiterConfig {
+                refill_rate: 10,
+                max_requests_per_batch: 1_000_000,
+            });
+        }
+    })
+    .set_da_config(|c| c.sender_address = seq_da_address)
+    .set_persistent_da()
+    .with_preferred_seq_recovery_strategy(sov_sequencer::preferred::RecoveryStrategy::TryToSave);
+
+    (builder.start().await.unwrap(), admin)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rate_limiting() {
+    let (test_rollup, admin) = create_test_rollup().await;
+    test_rollup.produce_enough_finalized_slots().await;
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
+
+    let client = test_rollup.api_client().clone();
+
+    // Send tx that takes 200ms but the limit for each sender is 3000*0.5% = 15ms
+    let tx = tx_set_value_and_sleep(&admin.private_key, 0, 99, 200);
+
+    // The transactions is accepted but the sender has been rate-limited after it is executed.
+    client
+        .accept_tx(&api_types::AcceptTxBody {
+            body: BASE64_STANDARD.encode(&tx),
+        })
+        .await
+        .unwrap();
+
+    // Another transactions fails.
+    let tx: RawTx = tx_set_value_and_sleep(&admin.private_key, 1, 100, 1);
+    let err = client
+        .accept_tx(&api_types::AcceptTxBody {
+            body: BASE64_STANDARD.encode(&tx),
+        })
+        .await
+        .unwrap_err();
+
+    let err_str = err.to_string();
+    assert!(err_str.contains("The sender was rate-limited by the sequencer:"));
+
+    // Unfortunately, the only way to test this is by waiting.
+    // The rate limits recover proportionally to the time elapsed since the last request.
+    // Wait long enough for the limits to reset.
+    tokio::time::sleep(Duration::from_millis(2000)).await;
+
+    client
+        .accept_tx(&api_types::AcceptTxBody {
+            body: BASE64_STANDARD.encode(&tx),
+        })
+        .await
+        .unwrap();
+}
+
+fn tx_set_value_and_sleep(
+    key: &Ed25519PrivateKey,
+    generation: u64,
+    value_to_set: u64,
+    sleep_millis: u64,
+) -> RawTx {
+    let msg = <TestRuntime<TestSpec> as DispatchCall>::Decodable::ValueSetter(
+        sov_value_setter::CallMessage::SetValueAndSleep {
+            value: value_to_set as u32,
+            sleep_millis,
+        },
+    );
+    encode_call::<RT>(key, generation, &msg)
+}

--- a/crates/full-node/sov-sequencer/tests/integration/utils.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/utils.rs
@@ -10,6 +10,7 @@ use sov_modules_api::capabilities::{RollupHeight, TransactionAuthenticator, Uniq
 use sov_modules_api::digest::Digest;
 use sov_modules_api::prelude::*;
 use sov_modules_api::rest::HasRestApi;
+use sov_modules_api::transaction::TransactionCallable;
 use sov_modules_api::transaction::{Transaction, TxDetails};
 use sov_modules_api::{
     Amount, BlockHooks, CryptoSpec, DispatchCall, FullyBakedTx, GasUnit, Module, ModuleId,
@@ -299,4 +300,21 @@ pub fn tx_set_value_with_gas<RT: Runtime<TestSpec> + EncodeCall<ValueSetter<Test
 // This allows for easily setting file sharing when using Docker Desktop.
 pub fn tempdir_inside_codebase_dir() -> Arc<tempfile::TempDir> {
     Arc::new(tempfile::tempdir_in(std::env!("CARGO_TARGET_TMPDIR")).unwrap())
+}
+
+pub(crate) fn encode_call<
+    RT: Runtime<TestSpec> + TransactionCallable<Call = <RT as DispatchCall>::Decodable>,
+>(
+    key: &Ed25519PrivateKey,
+    generation: u64,
+    call_message: &<RT as DispatchCall>::Decodable,
+) -> RawTx {
+    let tx = default_test_signed_transaction::<RT, TestSpec>(
+        key,
+        call_message,
+        generation,
+        &RT::CHAIN_HASH,
+    );
+
+    RawTx::new(borsh::to_vec(&tx).unwrap())
 }

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -959,7 +959,7 @@
           "minimum": 0.0
         },
         "refill_rate": {
-          "description": "Determines how quickly tokens are refilled in the token-bucket algorithm. Each user can consume, on average, only a certain percentage of the batch resources. Over time, users send requests that draw from their available resources, while a constant stream of tokens refilling those resources. The higher the value of `refill_rate`, the faster the user’s resources are refilled.",
+          "description": "Determines how quickly tokens are refilled in the token-bucket algorithm. Each user can consume, on average, only a certain percentage of the batch resources. Over time, users send requests that draw from their available resources, while a constant stream of tokens refilling those resources. At refill_rate = 1, tokens regenerate at 0.0005% × BatchCapacity per millisecond. Values between 1 and 20 are recommended starting points.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -417,6 +417,18 @@
             }
           ]
         },
+        "rate_limiter": {
+          "description": "Configuration for rate-limiting the sequencer.",
+          "default": null,
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SovRateLimiterConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "recovery_strategy": {
           "description": "Strategy for handling recovery scenarios in the preferred sequencer.",
           "allOf": [
@@ -930,6 +942,27 @@
               "$ref": "#/definitions/Address"
             }
           ]
+        }
+      }
+    },
+    "SovRateLimiterConfig": {
+      "type": "object",
+      "required": [
+        "max_requests_per_batch",
+        "refill_rate"
+      ],
+      "properties": {
+        "max_requests_per_batch": {
+          "description": "The maximum number of requests allowed per batch.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "refill_rate": {
+          "description": "Determines how quickly tokens are refilled in the token-bucket algorithm. Each user can consume, on average, only a certain percentage of the batch resources. Over time, users send requests that draw from their available resources, while a constant stream of tokens refilling those resources. The higher the value of `refill_rate`, the faster the user’s resources are refilled.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         }
       }
     },


### PR DESCRIPTION
# Description

This PR introduces the following changes:
- Adds an optional` SovRateLimiterConfig` to `SequencerConfig`.
- Adds `SovRateLimiter` to `Inner`. The limiter is currently configured as None in production (except in tests), so rate limiting will not take effect yet.
- Integrates rate limiting into the `process_accept_tx` method.

Configuration
Users only configure:
```
SovRateLimiterConfig {
    max_requests_per_batch: u64,
    refill_rate: u64,
}
```

All other parameters—such as `max_batch_size, batch_execution_time_limit_millis, etc`.—are derived from existing configuration values. Using these parameters, we can determine the maximum resource capacity of a batch. The RateLimiter uses this information to compute a threshold of resource usage above which any given user will be rate-limited.

Currently, this threshold is set to 0.5% of the batch’s total capacity.

Other changes
- The` RateLimiter` now operates on `CredentialId` instead of `Addresses`, since `CredentialId` is more readily accessible within the sequencer.
- The `RateLimiter` cache has been migrated from `mini_moka::unsync::Cache` to `mini_moka::sync::Cache,` as the unsynchronized version does not implement Send + Sync.


see #2173 for the next steps. 

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2173