### PR TITLE
Celestia background stat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-12-09
+- #2203 Code breaking change. CelestiaService now require `shutdown_sender` on constructor. Rollup.rs needs update
+
 # 2025-12-03
  - #2148 Disables tokio console unless the `TOKIO_CONSOLE` environment variable is set to `1` or `true`. This significantly improves performance.
 

--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -32,7 +32,6 @@ use sov_rollup_interface::da::{DaProof, DaSpec, RelevantBlobs, RelevantProofs};
 use sov_rollup_interface::node::da::{
     run_maybe_retryable_async_fn_with_retries, DaService, MaybeRetryable, SubmitBlobReceipt,
 };
-use sov_test_utils::ledger_db::sov_api_spec::tokio_tungstenite::tungstenite::client;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -178,7 +177,11 @@ impl CelestiaService {
 }
 
 impl CelestiaService {
-    pub async fn new(config: CelestiaConfig, chain_params: RollupParams) -> Self {
+    pub async fn new(
+        config: CelestiaConfig,
+        chain_params: RollupParams,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    ) -> Self {
         tracing::info!(?config, "Initializing Celestia Adapter");
         let request_timeout = Duration::from_secs(config.request_timeout_secs.get());
 
@@ -196,6 +199,20 @@ impl CelestiaService {
             );
         }
 
+        let tx_priority = config.tx_priority.clone().into();
+        if let Ok(signer) = client.address() {
+            let bg_client = config
+                .build_client()
+                .await
+                .expect("Failed to build celestia-client for background task");
+            tokio::spawn(stat_collection_task(
+                bg_client,
+                signer,
+                tx_priority,
+                shutdown_receiver,
+            ));
+        }
+
         Self::with_client(
             client,
             chain_params.rollup_batch_namespace,
@@ -204,7 +221,7 @@ impl CelestiaService {
             Duration::from_millis(config.safe_lead_time_ms),
             backoff_policy,
             request_timeout,
-            config.tx_priority.into(),
+            tx_priority,
         )
     }
 }
@@ -563,27 +580,36 @@ async fn stat_collection_task(
     client: celestia_client::Client,
     signer: celestia_types::state::AccAddress,
     priority: celestia_client::tx::TxPriority,
-    shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    mut shutdown_receiver: tokio::sync::watch::Receiver<()>,
 ) {
     let chain_id = client.chain_id();
-    let sleep_time = std::time::Duration::from_secs(30);
-    tracing::info!(%chain_id, period = ?sleep_time, "Starting celestia stat collection task");
+    let period = Duration::from_secs(30);
+    tracing::info!(%chain_id, ?period, "Starting celestia stat collection task");
+
+    let mut interval = tokio::time::interval(period);
 
     loop {
-        match gather_stat(&client, &signer, priority).await {
-            Ok(measurement) => {
-                sov_metrics::track_metrics(|tracker| {
-                    tracker.submit(measurement);
-                });
+        tokio::select! {
+            _ = shutdown_receiver.changed() => {
+                tracing::info!("Shutting down celestia stat collection task");
+                return;
             }
-            Err(error) => {
-                tracing::info!(
-                    ?error,
-                    "Error gathering background statistics for celestia adapter"
-                );
+            _ = interval.tick() => {
+                match gather_stat(&client, &signer, priority).await {
+                    Ok(measurement) => {
+                        sov_metrics::track_metrics(|tracker| {
+                            tracker.submit(measurement);
+                        });
+                    }
+                    Err(error) => {
+                        tracing::info!(
+                            ?error,
+                            "Error gathering background statistics for celestia adapter"
+                        );
+                    }
+                }
             }
         }
-        tokio::time::sleep(sleep_time).await;
     }
 }
 

--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -6,7 +6,10 @@ use crate::metrics::client::{
     GetBlockHeaderMeasurement, GetChainHeadMeasurement, GetNamespaceDataMeasurement,
     SubmitPayForBlob,
 };
-use crate::metrics::full::{BlobSubmitMeasurement, GetBlockMeasurement, NamespaceDataMetrics};
+use crate::metrics::full::{
+    BlobSubmitMeasurement, CelestiaAdapterStateMeasurement, GetBlockMeasurement,
+    NamespaceDataMetrics,
+};
 use crate::metrics::RollupNamespace;
 use crate::types::{
     BlobWithSender, FilteredCelestiaBlock, NamespaceBoundaryProof, NamespaceRelevantData, TmHash,
@@ -29,6 +32,7 @@ use sov_rollup_interface::da::{DaProof, DaSpec, RelevantBlobs, RelevantProofs};
 use sov_rollup_interface::node::da::{
     run_maybe_retryable_async_fn_with_retries, DaService, MaybeRetryable, SubmitBlobReceipt,
 };
+use sov_test_utils::ledger_db::sov_api_spec::tokio_tungstenite::tungstenite::client;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -553,4 +557,62 @@ fn flatten_timeout<T>(
         Ok(Err(e)) => Err(MaybeRetryable::Transient(e.into())),
         Err(_) => Err(MaybeRetryable::Transient(anyhow::anyhow!("await timeout"))),
     }
+}
+
+async fn stat_collection_task(
+    client: celestia_client::Client,
+    signer: celestia_types::state::AccAddress,
+    priority: celestia_client::tx::TxPriority,
+    shutdown_receiver: tokio::sync::watch::Receiver<()>,
+) {
+    let chain_id = client.chain_id();
+    let sleep_time = std::time::Duration::from_secs(30);
+    tracing::info!(%chain_id, period = ?sleep_time, "Starting celestia stat collection task");
+
+    loop {
+        match gather_stat(&client, &signer, priority).await {
+            Ok(measurement) => {
+                sov_metrics::track_metrics(|tracker| {
+                    tracker.submit(measurement);
+                });
+            }
+            Err(error) => {
+                tracing::info!(
+                    ?error,
+                    "Error gathering background statistics for celestia adapter"
+                );
+            }
+        }
+        tokio::time::sleep(sleep_time).await;
+    }
+}
+
+async fn gather_stat(
+    client: &celestia_client::Client,
+    signer: &celestia_types::state::AccAddress,
+    priority: celestia_client::tx::TxPriority,
+) -> anyhow::Result<CelestiaAdapterStateMeasurement> {
+    let balance = client
+        .state()
+        .balance_for_address(signer)
+        .await
+        .context("state.BalanceForAddress")?;
+
+    let sync_state = client
+        .header()
+        .sync_state()
+        .await
+        .context("header.SyncState")?;
+    let sync_distance = sync_state.to_height.saturating_sub(sync_state.from_height);
+    let gas_price = client
+        .state()
+        .estimate_gas_price(priority)
+        .await
+        .context("state.EstimateGasPrice")?;
+
+    Ok(CelestiaAdapterStateMeasurement {
+        balance,
+        gas_price,
+        sync_distance,
+    })
 }

--- a/crates/adapters/celestia/src/da_service/tests.rs
+++ b/crates/adapters/celestia/src/da_service/tests.rs
@@ -71,7 +71,8 @@ async fn test_submit_blob_correct() -> anyhow::Result<()> {
     let rollup_params = ROLLUP_PARAMS_DEV;
     let dev_node = crate::test_helper::docker::CelestiaDevNode::start().await?;
     let config = dev_node.get_config().await?;
-    let da_service = CelestiaService::new(config, rollup_params).await;
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+    let da_service = CelestiaService::new(config, rollup_params, shutdown_rx).await;
     let signer = da_service
         .get_signer()
         .await
@@ -96,7 +97,8 @@ async fn test_submit_blob_correct() -> anyhow::Result<()> {
 async fn test_submit_proof_correct() -> anyhow::Result<()> {
     let dev_node = crate::test_helper::docker::CelestiaDevNode::start().await?;
     let config = dev_node.get_config().await?;
-    let da_service = CelestiaService::new(config, ROLLUP_PARAMS_DEV).await;
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+    let da_service = CelestiaService::new(config, ROLLUP_PARAMS_DEV, shutdown_rx).await;
 
     let zk_proof: Vec<u8> = vec![1, 2, 3, 4, 5, 11, 12, 13, 14, 15];
     let signer = da_service
@@ -124,8 +126,9 @@ async fn test_submit_proof_correct() -> anyhow::Result<()> {
 async fn test_submit_blob_application_level_error() -> anyhow::Result<()> {
     let dev_node = crate::test_helper::docker::CelestiaDevNode::start().await?;
     let config = dev_node.get_config().await?;
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
     // TODO: disable retries
-    let da_service = CelestiaService::new(config, ROLLUP_PARAMS_DEV).await;
+    let da_service = CelestiaService::new(config, ROLLUP_PARAMS_DEV, shutdown_rx).await;
 
     let blob: Vec<u8> = vec![1, 2, 3, 4, 5, 11, 12, 13, 14, 15];
 
@@ -145,8 +148,9 @@ async fn test_submit_blob_application_level_error() -> anyhow::Result<()> {
 async fn test_submit_blob_internal_server_error() -> anyhow::Result<()> {
     let dev_node = crate::test_helper::docker::CelestiaDevNode::start().await?;
     let config = dev_node.get_config().await?;
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
     // TODO: disable retries
-    let da_service = CelestiaService::new(config, ROLLUP_PARAMS_DEV).await;
+    let da_service = CelestiaService::new(config, ROLLUP_PARAMS_DEV, shutdown_rx).await;
 
     let blob: Vec<u8> = vec![1, 2, 3, 4, 5, 11, 12, 13, 14, 15];
 
@@ -169,8 +173,9 @@ async fn test_submit_blob_internal_server_error() -> anyhow::Result<()> {
 async fn test_submit_blob_response_timeout() -> anyhow::Result<()> {
     let dev_node = crate::test_helper::docker::CelestiaDevNode::start().await?;
     let config = dev_node.get_config().await?;
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
     // TODO: disable retries
-    let da_service = CelestiaService::new(config, ROLLUP_PARAMS_DEV).await;
+    let da_service = CelestiaService::new(config, ROLLUP_PARAMS_DEV, shutdown_rx).await;
 
     let blob: Vec<u8> = vec![1, 2, 3, 4, 5, 11, 12, 13, 14, 15];
 

--- a/crates/adapters/celestia/src/metrics/full.rs
+++ b/crates/adapters/celestia/src/metrics/full.rs
@@ -84,3 +84,21 @@ impl Metric for BlobSubmitMeasurement {
         )
     }
 }
+
+
+#[derive(Debug)]
+pub struct CelestiaAdapterStateMeasurement {
+    pub balance: u64,
+    pub gas_price: f64,
+    pub sync_distance: u64,
+}
+
+impl Metric for CelestiaAdapterStateMeasurement {
+    fn measurement_name(&self) -> &'static str {
+        "sov_celestia_adapter_periodic_data"
+    }
+
+    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/adapters/celestia/src/metrics/full.rs
+++ b/crates/adapters/celestia/src/metrics/full.rs
@@ -102,9 +102,11 @@ impl Metric for CelestiaAdapterStateMeasurement {
         let balance = self.balance;
         let gas_price = self.gas_price;
         let sync_distance = self.sync_distance;
+        // Celestia minimum gas price can be 0.000001 utia, so 6 decimal places is sufficient.
+        // See: https://forum.celestia.org/t/cip-price-enforcement/1351/5
         write!(
             buffer,
-            "{name} balance={balance},gas_price={gas_price:?},sync_distance={sync_distance}"
+            "{name} balance={balance},gas_price={gas_price:.6},sync_distance={sync_distance}"
         )
     }
 }

--- a/crates/adapters/celestia/src/metrics/full.rs
+++ b/crates/adapters/celestia/src/metrics/full.rs
@@ -85,7 +85,6 @@ impl Metric for BlobSubmitMeasurement {
     }
 }
 
-
 #[derive(Debug)]
 pub struct CelestiaAdapterStateMeasurement {
     pub balance: u64,
@@ -99,6 +98,13 @@ impl Metric for CelestiaAdapterStateMeasurement {
     }
 
     fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
-        Ok(())
+        let name = self.measurement_name();
+        let balance = self.balance;
+        let gas_price = self.gas_price;
+        let sync_distance = self.sync_distance;
+        write!(
+            buffer,
+            "{name} balance={balance},gas_price={gas_price:?},sync_distance={sync_distance}"
+        )
     }
 }

--- a/crates/adapters/celestia/src/test_helper/docker.rs
+++ b/crates/adapters/celestia/src/test_helper/docker.rs
@@ -299,7 +299,9 @@ async fn test_service_starts() -> anyhow::Result<()> {
 
     let config = dev_node.get_config().await?;
     tracing::info!("CONFIG: {:?}", config);
-    let da_service = CelestiaService::new(config, crate::test_helper::ROLLUP_PARAMS_DEV).await;
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+    let da_service =
+        CelestiaService::new(config, crate::test_helper::ROLLUP_PARAMS_DEV, shutdown_rx).await;
     let signer = da_service.get_signer().await;
     assert_eq!(signer, Some(dev_node.get_signer_address(0).await?));
     let header_1 = da_service.get_head_block_header().await?;

--- a/examples/demo-rollup/src/celestia_nomt_rollup.rs
+++ b/examples/demo-rollup/src/celestia_nomt_rollup.rs
@@ -117,7 +117,7 @@ impl FullNodeBlueprint<Native> for CelestiaNomtDemoRollup<Native> {
     async fn create_da_service(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        _shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> Self::DaService {
         CelestiaService::new(
             rollup_config.da.clone(),
@@ -125,6 +125,7 @@ impl FullNodeBlueprint<Native> for CelestiaNomtDemoRollup<Native> {
                 rollup_batch_namespace: ROLLUP_BATCH_NAMESPACE,
                 rollup_proof_namespace: ROLLUP_PROOF_NAMESPACE,
             },
+            shutdown_receiver,
         )
         .await
     }

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -103,7 +103,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
     async fn create_da_service(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        _shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> Self::DaService {
         CelestiaService::new(
             rollup_config.da.clone(),
@@ -111,6 +111,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
                 rollup_batch_namespace: ROLLUP_BATCH_NAMESPACE,
                 rollup_proof_namespace: ROLLUP_PROOF_NAMESPACE,
             },
+            shutdown_receiver,
         )
         .await
     }

--- a/examples/demo-rollup/src/da_tester/demo_celestia_tester.rs
+++ b/examples/demo-rollup/src/da_tester/demo_celestia_tester.rs
@@ -37,14 +37,19 @@ async fn main() -> anyhow::Result<()> {
 
     tracing::info!("Rollup config: {:?}", rollup_config);
 
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::watch::channel(());
+    shutdown_rx.mark_unchanged();
     let da_service = CelestiaService::new(
         rollup_config.da.clone(),
         RollupParams {
             rollup_batch_namespace: ROLLUP_BATCH_NAMESPACE,
             rollup_proof_namespace: ROLLUP_PROOF_NAMESPACE,
         },
+        shutdown_rx,
     )
     .await;
 
-    sov_celestia_adapter::checker::check_da_service(&da_service, args.rounds).await
+    sov_celestia_adapter::checker::check_da_service(&da_service, args.rounds).await?;
+    shutdown_tx.send(())?;
+    Ok(())
 }


### PR DESCRIPTION
# Description

Celestia adapter now spins up the task, that collects some information every 30 seconds:

* Signer balance
* Gas Price
* Sync distance of the connected node.

This PR adds extra 6 API calls per minute, but in the future it will allow to build more comprehensive alerting

<img width="1914" height="861" alt="Screenshot 2025-12-09 at 14 29 59" src="https://github.com/user-attachments/assets/3dbf6d6f-0d6c-4eb7-af25-cccfc9354130" />


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1630 

## Testing
Dashboard updated and tested manually

## Docs
No updates
