### PR TITLE
Dont run rust job for ts & py paths

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,11 @@ on:
     types: ["checks_requested"]
   push:
     branches: ["nightly", "stable", "dev"]
-  pull_request: {}
+    paths-ignore: &ignore-paths
+      - "typescript/**"
+      - "python/**"
+  pull_request:
+    paths-ignore: *ignore-paths
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/typescript.release.yml
+++ b/.github/workflows/typescript.release.yml
@@ -2,7 +2,7 @@ name: Release (TypeScript)
 
 on:
   push:
-    branches: ["nightly"]
+    branches: ["dev"]
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
# Description

Prevents Rust job running for typescript & python paths

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
