### PR TITLE
Make submodules shallow to reduce cloning traffic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,16 @@
 [submodule "crates/module-system/sov-test-utils/lib/openzeppelin-contracts"]
 	path = crates/module-system/sov-test-utils/lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts.git
+	shallow = true
 [submodule "crates/module-system/sov-test-utils/lib/solidity-lib"]
 	path = crates/module-system/sov-test-utils/lib/solidity-lib
 	url = https://github.com/ethereum/solidity.git
+	shallow = true
 [submodule "crates/module-system/sov-test-utils/lib/v2-core"]
 	path = crates/module-system/sov-test-utils/lib/v2-core
 	url = https://github.com/Uniswap/v2-core.git
+	shallow = true
 [submodule "crates/module-system/sov-test-utils/lib/v2-periphery"]
 	path = crates/module-system/sov-test-utils/lib/v2-periphery
 	url = https://github.com/Uniswap/v2-periphery.git
+	shallow = true


### PR DESCRIPTION
# Description

This won't solve cloning for speed when building starter, but improve CI at least and we can experiment with other flags

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
