### PR TITLE
Check all resync conditions before recovery in update_state.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/conditions_table.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/conditions_table.rs
@@ -51,16 +51,6 @@ pub(crate) async fn operation_for_master<S: Spec, Rt: Runtime<S>>(
             });
             PreferredSeqOperation::WaitForNodeResyncWithAllowedSlack
         }
-        (false, true, false, _, _) => {
-            error!(
-                    slot_number_according_to_node=%info.slot_number,
-                    %current_visible_slot_number,
-                    deferred_slots = %config_value!("DEFERRED_SLOTS_COUNT"),
-                    "Sequencer has detected that it is past, or very close to, having the visible_slot_number lag behind the deferred_slots_count threshold. Normal operation will be suspended until this can be remedied.");
-            inner.trigger_recovery(info).await;
-
-            PreferredSeqOperation::RecoverAndCatchUp
-        }
         // Node is out of sync and doesn't know it. This is a rare edge case after a DB wipe.
         (_, _, _, _, true) => {
             // Check for this condition after all of the normal "out-of-sync" conditions have been checked, because it may be possible for other unsynced conditions to trip this check
@@ -71,6 +61,16 @@ pub(crate) async fn operation_for_master<S: Spec, Rt: Runtime<S>>(
                 synced_da_height: sync_status.synced_da_height(),
             });
             PreferredSeqOperation::WaitForNodeResyncToTip
+        }
+        (false, true, false, _, _) => {
+            error!(
+                    slot_number_according_to_node=%info.slot_number,
+                    %current_visible_slot_number,
+                    deferred_slots = %config_value!("DEFERRED_SLOTS_COUNT"),
+                    "Sequencer has detected that it is past, or very close to, having the visible_slot_number lag behind the deferred_slots_count threshold. Normal operation will be suspended until this can be remedied.");
+            inner.trigger_recovery(info).await;
+
+            PreferredSeqOperation::RecoverAndCatchUp
         }
         (false, false, false, _, _) => {
             reply_soft_confirmations(info, inner, initial_status, time_spent_fetching_batches).await


### PR DESCRIPTION
# Description

Recovery should only trigger once we are at the chain tip - it's incorrect to use old data to decide whether to recover or not. This was mostly already the case but `condition_node_is_unsynced_and_doesnt_know_it` was being checked after the recovery conditions. This commit moved the match branch for this up so that if the condition is true we avoid triggering recovery based on stale information.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
