### PR TITLE
Tweak nonce buffer integration tests to reduce failures on CI runners

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/preferred_tx_nonce_queue.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_tx_nonce_queue.rs
@@ -299,7 +299,7 @@ async fn test_zero_length_queue() {
     // Absolutely ensure all of the transactions have time to hit the queue (500 ms is very
     // generous) - while also absolutely making sure we don't hit the timeout case before sending
     // transaction 0 (so if they got queued, they would then execute, failing the test).
-    tokio::time::sleep(LONGISH_TIMEOUT / 4).await;
+    tokio::time::sleep(Duration::from_millis(LONGISH_TIMEOUT / 4)).await;
     // Send the 0 nonce transaction - if the above had gotten queued (which they shouldn't have),
     // this would let them succeed
     submit_tx_set_value(&client, &key, 0, true).await;
@@ -327,11 +327,11 @@ async fn test_zero_length_queue() {
 async fn test_repeated_timeouts_with_race_conditions() {
     // We have to bump the timeout since the queue doesn't check pre-reqs currently, so all txs
     // need to process before the timeout even on slow CI runners
-    const LONGER_TIMEOUT: u64 = 5000; 
+    const LONGER_TIMEOUT: u64 = 5000;
     const DELAY_BEFORE_NONCE_0: u64 = 500;
     const NUM_TXS: u64 = 100;
 
-    let (test_rollup, admin) = create_test_rollup(NUM_TXS + 10, SHORTENED_TIMEOUT).await;
+    let (test_rollup, admin) = create_test_rollup(NUM_TXS + 10, LONGER_TIMEOUT).await;
     let client = test_rollup.api_client().clone();
     let key = admin.private_key;
 

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_tx_nonce_queue.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_tx_nonce_queue.rs
@@ -289,14 +289,19 @@ async fn test_nonce_queue_timeout() {
 /// Test transaction rejection with a zero-length queue
 #[tokio::test(flavor = "multi_thread")]
 async fn test_zero_length_queue() {
-    let (test_rollup, admin) = create_test_rollup(0, DEFAULT_TIMEOUT).await;
+    const LONGISH_TIMEOUT: u64 = 2000;
+    let (test_rollup, admin) = create_test_rollup(0, LONGISH_TIMEOUT).await;
     let client = test_rollup.api_client().clone();
     let key = admin.private_key;
 
     // Spam some transactions with nonces above 0. Expect them to fail because queue size is 0.
     let handles = submit_parallel_txs(&client, &key, (1..5).collect(), false).await;
+    // Absolutely ensure all of the transactions have time to hit the queue (500 ms is very
+    // generous) - while also absolutely making sure we don't hit the timeout case before sending
+    // transaction 0 (so if they got queued, they would then execute, failing the test).
+    tokio::time::sleep(LONGISH_TIMEOUT / 4).await;
     // Send the 0 nonce transaction - if the above had gotten queued (which they shouldn't have),
-    // this would have let them succeed
+    // this would let them succeed
     submit_tx_set_value(&client, &key, 0, true).await;
 
     for handle in handles {
@@ -320,8 +325,10 @@ async fn test_zero_length_queue() {
 /// timeouts both locally and in CI, without observable flakiness (at the time of writing).
 #[tokio::test(flavor = "multi_thread")]
 async fn test_repeated_timeouts_with_race_conditions() {
-    const SHORTENED_TIMEOUT: u64 = 2000;
-    const DELAY_BEFORE_NONCE_0: u64 = SHORTENED_TIMEOUT - 400;
+    // We have to bump the timeout since the queue doesn't check pre-reqs currently, so all txs
+    // need to process before the timeout even on slow CI runners
+    const LONGER_TIMEOUT: u64 = 5000; 
+    const DELAY_BEFORE_NONCE_0: u64 = 500;
     const NUM_TXS: u64 = 100;
 
     let (test_rollup, admin) = create_test_rollup(NUM_TXS + 10, SHORTENED_TIMEOUT).await;


### PR DESCRIPTION
# Description

The integration tests rely on timing to ensure the transactions arrive in the correct order. This PR makes the timing more lenient to reduce the risk of flaking on slow and congested CI runners, while keeping the relative ordering of events the same to ensure they still test the correct behaviour.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
