### PR TITLE
Add `serde(deny_unknown_fields)` for rollup configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2025-12-14 
 - #2229 **Breaking DB change**: ow, BasicAddress is required to implement Copy, ensuring that duplicating an address is a cheap operation.
+- #2232 **No breaking, but important**: rollup_config.toml now will panic if there's an unknown field, preventing accidental misconfiguration.
 
 # 2025-12-09
 - #2203 Code breaking change. CelestiaService now require `shutdown_sender` on constructor. Rollup.rs needs update

--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -13,6 +13,7 @@ pub const DEFAULT_CONCURRENT_SYNC_TASKS: u8 = 5;
 
 /// Configuration for StateTransitionRunner.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct RunnerConfig {
     /// Polling interval for the DA service to check the sync status (in milliseconds).
     pub da_polling_interval_ms: u64,
@@ -136,6 +137,7 @@ pub struct ProofManagerConfig<Address> {
     bound = "Address: JsonSchema, Da: DaService, M: JsonSchema",
     rename = "RollupConfig"
 )]
+#[serde(deny_unknown_fields)]
 pub struct RollupConfig<Address: Copy, Da: DaService, M> {
     /// Currently rollup config runner only supports storage path parameter
     pub storage: RollupDbConfig,

--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -195,7 +195,6 @@ mod tests {
             [storage]
             path = "/tmp"
             [runner]
-            genesis_height = 31337
             da_polling_interval_ms = 10000
             concurrent_sync_tasks = 18
             [runner.http_config]
@@ -217,7 +216,6 @@ mod tests {
             max_batch_size_bytes = 1048576
             max_concurrent_blobs = 16
             max_allowed_node_distance_behind = 5
-            num_cache_warmup_workers = 5
             rollup_address = "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
             [sequencer.standard]
         "#;
@@ -239,7 +237,6 @@ mod tests {
             [storage]
             path = "/tmp"
             [runner]
-            genesis_height = 31337
             da_polling_interval_ms = 10000
             concurrent_sync_tasks = 18
             [runner.http_config]
@@ -261,7 +258,6 @@ mod tests {
             max_batch_size_bytes = 1048576
             max_concurrent_blobs = 16
             max_allowed_node_distance_behind = 5
-            num_cache_warmup_workers = 5
             rollup_address = "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
             [sequencer.preferred]
             disable_state_root_consistency_checks = true

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -38,6 +38,7 @@ fn default_response_size_limit() -> usize {
 /// Sequencer configuration.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[schemars(rename = "SequencerConfig")]
+#[serde(deny_unknown_fields)]
 pub struct SequencerConfig<Address: Copy, Sc = SequencerKindConfig<Address>> {
     /// When enabled, submitted transactions are periodically assembled into
     /// batches and automatically posted to the DA layer. When disabled, the
@@ -139,6 +140,7 @@ pub struct PostgresConfig {
 
 /// Configuration for [`PreferredSequencer`].
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct PreferredSequencerConfig<Address: Copy> {
     /// The minimum fee that the preferred sequencer is willing to accept, denominated in rollup tokens. Defaults to zero.
     /// Sequencers should set this to a non-zero value if they wish to cover their DA costs.
@@ -251,6 +253,7 @@ fn default_db_event_channel_size() -> usize {
 
 /// Configuration for [`StdSequencer`].
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct StdSequencerConfig {
     /// Maximum number of transactions in mempool. Once this limit is reached,
     /// the batch builder will evict older transactions.

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -61,6 +61,7 @@
       ]
     }
   },
+  "additionalProperties": false,
   "definitions": {
     "Address": {
       "description": "Address",
@@ -476,7 +477,8 @@
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "ProofManagerConfig_for_Address": {
       "description": "Prover service configuration.",
@@ -846,7 +848,8 @@
           "default": false,
           "type": "boolean"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "SeqConfigExtension": {
       "description": "Configuration data used by sequencer extensions, such as EVM endpoints.",
@@ -970,7 +973,8 @@
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     },
     "SovRateLimiterConfig_for_Address": {
       "type": "object",
@@ -1040,7 +1044,8 @@
           "format": "uint",
           "minimum": 1.0
         }
-      }
+      },
+      "additionalProperties": false
     },
     "TelegrafSocketConfig": {
       "description": "Config of receiving `inputs.socket_listener` <https://www.influxdata.com/blog/telegraf-socket-listener-input-plugin/>",


### PR DESCRIPTION
# Description

To prevent silent fall-backs to unwanted configuration: for example for sequencer on rocksdb

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
All existing tests are passing

## Docs
No updates
