### PR TITLE
Rate Limiter: cleanup `SovRateLimiterConfig` config.

### DIFF
--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -178,11 +178,10 @@ pub fn from_toml_path<P: AsRef<Path>, R: DeserializeOwned>(path: P) -> anyhow::R
 
 #[cfg(test)]
 mod tests {
+    use super::RollupConfig;
     use sov_metrics::MonitoringConfig;
     use sov_mock_da::MockDaService;
     use sov_modules_api::Address;
-
-    use super::RollupConfig;
 
     #[test]
     fn test_correct_config() {
@@ -270,6 +269,66 @@ mod tests {
             postgres_connection_string = "postgresql://postgres:pass@localhost:5432/db"
             node_id = "node_1"
             time_till_leader_update_allowed_ms = 1000
+        "#;
+
+        let config =
+            toml::from_str::<RollupConfig<Address, MockDaService, MonitoringConfig>>(config_s)
+                .unwrap();
+
+        insta::assert_json_snapshot!(config);
+    }
+
+    #[test]
+    fn test_correct_config_with_rate_limiter() {
+        let config_s = r#"
+            [da]
+            connection_string = "sqlite:///tmp/mockda.sqlite?mode=rwc"
+            sender_address = "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f"
+            [da.block_producing.periodic]
+            block_time_ms = 1_000
+            [storage]
+            path = "/tmp"
+            [runner]
+            da_polling_interval_ms = 10000
+            concurrent_sync_tasks = 18
+            [runner.http_config]
+            bind_host = "127.0.0.1"
+            bind_port = 12346
+            public_address = "https://rollup.sovereign.xyz"
+            cors = "restrictive"
+            [monitoring]
+            telegraf_address = "udp://192.168.4.5:8543"
+            max_datagram_size = 1024
+            max_pending_metrics = 2560
+            [proof_manager]
+            aggregated_proof_block_jump = 22
+            prover_address = "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
+            max_number_of_transitions_in_db = 1025
+            max_number_of_transitions_in_memory = 768
+            [sequencer]
+            blob_processing_timeout_secs = 60
+            max_batch_size_bytes = 1048576
+            max_concurrent_blobs = 16
+            max_allowed_node_distance_behind = 5
+            rollup_address = "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
+            [sequencer.preferred]
+            disable_state_root_consistency_checks = true
+            recovery_strategy = "TryToSave"
+            batch_execution_time_limit_millis = 2000 
+            num_cache_warmup_workers = 0
+            ideal_lag_behind_finalized_slot = 3
+            is_replica = false
+            [sequencer.preferred.postgres_config]
+            postgres_connection_string = "postgresql://postgres:pass@localhost:5432/db"
+            node_id = "node_1"
+            time_till_leader_update_allowed_ms = 1000
+            [sequencer.preferred.rate_limiter]
+            address_custom_limits = []
+            max_requests_per_second = 1000000
+            ip_custom_limits = [["157.180.14.244", { max_user_bursts_per_batch = 200, refill_rate = 2}]]
+            [sequencer.preferred.rate_limiter.default_limits]
+            max_user_bursts_per_batch = 5
+            refill_rate = 2
         "#;
 
         let config =

--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -325,9 +325,9 @@ mod tests {
             [sequencer.preferred.rate_limiter]
             address_custom_limits = []
             max_requests_per_second = 1000000
-            ip_custom_limits = [["157.180.14.244", { max_user_bursts_per_batch = 200, refill_rate = 2}]]
+            ip_custom_limits = [["157.180.14.244", { batch_execution_time_limit_millis = 200, refill_rate = 2}]]
             [sequencer.preferred.rate_limiter.default_limits]
-            max_user_bursts_per_batch = 5
+            resources_per_bucket = 5
             refill_rate = 2
         "#;
 

--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -325,7 +325,7 @@ mod tests {
             [sequencer.preferred.rate_limiter]
             address_custom_limits = []
             max_requests_per_second = 1000000
-            ip_custom_limits = [["157.180.14.244", { batch_execution_time_limit_millis = 200, refill_rate = 2}]]
+            ip_custom_limits = [["157.180.14.244", { resources_per_bucket = 10, batch_execution_time_limit_millis = 200, refill_rate = 2}]]
             [sequencer.preferred.rate_limiter.default_limits]
             resources_per_bucket = 5
             refill_rate = 2

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -278,6 +278,9 @@ pub struct TimingOracleConfig {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
 pub struct SovRateLimiterConfig<Address: Copy> {
+    /// The maximum number of requests allowed per second.
+    pub max_requests_per_second: u64,
+    /// Default limits.
     pub default_limits: Limits,
     pub address_custom_limits: Vec<(Address, Limits)>,
     pub ip_custom_limits: Vec<(IpAddr, Limits)>,
@@ -289,18 +292,16 @@ pub struct Limits {
     /// This value is used as follows:
     ///
     /// MAX_THRESHOLD_PER_KEY =
-    ///     MAX_BATCH_RESOURCE_CAPACITY / max_threshold_per_key_to_batch_capacity_ratio
+    ///     MAX_BATCH_RESOURCE_CAPACITY * max_threshold_max_user_bursts
     ///
-    /// For example, setting max_threshold_per_key_to_batch_capacity_ratio to 200
+    /// For example, setting max_user_bursts_per_batch to 5
     /// means that MAX_THRESHOLD_PER_KEY will be 0.5% of MAX_BATCH_RESOURCE_CAPACITY.
-    pub max_threshold_per_key_to_batch_capacity_ratio: u64,
+    pub max_user_bursts_per_batch: u64,
     /// Determines how quickly tokens are refilled in the token-bucket algorithm.
     /// Each user can consume, on average, only a certain percentage of the batch resources (MAX_THRESHOLD_PER_KEY).
     /// Over time, users send requests that draw from their available resources, while a
     /// constant stream of tokens refilling those resources.
-    /// At refill_rate = 1, tokens regenerate at MAX_THRESHOLD_PER_KEY/100 per millisecond.
-    /// Values between 1 and 20 are recommended starting points.
+    /// At refill_rate = 1, tokens regenerate at MAX_THRESHOLD_PER_KEY/batch_execution_time_limit_millis.
+    /// Values between 10 and 200 are recommended starting points.
     pub refill_rate: u64,
-    /// The maximum number of requests allowed per batch.
-    pub max_requests_per_batch: u64,
 }

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -289,19 +289,9 @@ pub struct SovRateLimiterConfig<Address: Copy> {
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
 pub struct Limits {
     /// Determines the threshold for rate-limiting requests.
-    /// This value is used as follows:
-    ///
-    /// MAX_THRESHOLD_PER_KEY =
-    ///     MAX_BATCH_RESOURCE_CAPACITY * max_threshold_max_user_bursts
-    ///
-    /// For example, setting max_user_bursts_per_batch to 5
-    /// means that MAX_THRESHOLD_PER_KEY will be 0.5% of MAX_BATCH_RESOURCE_CAPACITY.
-    pub max_user_bursts_per_batch: u64,
-    /// Determines how quickly tokens are refilled in the token-bucket algorithm.
-    /// Each user can consume, on average, only a certain percentage of the batch resources (MAX_THRESHOLD_PER_KEY).
-    /// Over time, users send requests that draw from their available resources, while a
-    /// constant stream of tokens refilling those resources.
-    /// At refill_rate = 1, tokens regenerate at MAX_THRESHOLD_PER_KEY/batch_execution_time_limit_millis.
+    /// The resources allocated per user per rate-limiting bucket, defined in units of 1/1000th of a full batch. E.g. resources_per_bucket = 10 would mean each bucket allows the user to use 1% of a full batch capacity.
+    pub resources_per_bucket: u64,
+    /// The refill rate of buckets. E.g. if refill_rate = 5, the user's rate limiting bucket will be refilled up to five times every batch.
     /// Values between 1 and 20 are recommended starting points.
     pub refill_rate: u64,
 }

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -302,6 +302,6 @@ pub struct Limits {
     /// Over time, users send requests that draw from their available resources, while a
     /// constant stream of tokens refilling those resources.
     /// At refill_rate = 1, tokens regenerate at MAX_THRESHOLD_PER_KEY/batch_execution_time_limit_millis.
-    /// Values between 10 and 200 are recommended starting points.
+    /// Values between 1 and 20 are recommended starting points.
     pub refill_rate: u64,
 }

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
@@ -83,7 +83,7 @@ expression: config
           [
             "157.180.14.244",
             {
-              "resources_per_bucket": 200,
+              "resources_per_bucket": 10,
               "refill_rate": 2
             }
           ]

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
@@ -75,7 +75,7 @@ expression: config
       "rate_limiter": {
         "max_requests_per_second": 1000000,
         "default_limits": {
-          "max_user_bursts_per_batch": 5,
+          "resources_per_bucket": 5,
           "refill_rate": 2
         },
         "address_custom_limits": [],
@@ -83,7 +83,7 @@ expression: config
           [
             "157.180.14.244",
             {
-              "max_user_bursts_per_batch": 200,
+              "resources_per_bucket": 200,
               "refill_rate": 2
             }
           ]

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
@@ -1,0 +1,106 @@
+---
+source: crates/full-node/full-node-configs/src/runner.rs
+expression: config
+---
+{
+  "storage": {
+    "path": "/tmp",
+    "state_cache_size": null,
+    "user_commit_concurrency": null,
+    "user_hashtable_buckets": null,
+    "user_preallocate_ht": null,
+    "user_page_cache_size": null,
+    "user_leaf_cache_size": null,
+    "kernel_commit_concurrency": null,
+    "kernel_hashtable_buckets": null,
+    "kernel_preallocate_ht": null,
+    "kernel_page_cache_size": null,
+    "kernel_leaf_cache_size": null,
+    "pruner_block_interval": null,
+    "pruner_versions_to_keep": null,
+    "pruner_max_batch_size": null,
+    "separate_archival_state": false
+  },
+  "runner": {
+    "da_polling_interval_ms": 10000,
+    "da_total_timeout_secs": 600,
+    "http_config": {
+      "bind_host": "127.0.0.1",
+      "bind_port": 12346,
+      "public_address": "https://rollup.sovereign.xyz",
+      "cors": "restrictive"
+    },
+    "concurrent_sync_tasks": 18,
+    "pre_fetched_blocks_capacity": 20,
+    "save_tx_bodies": false
+  },
+  "da": {
+    "connection_string": "sqlite:///tmp/mockda.sqlite?mode=rwc",
+    "sender_address": "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f",
+    "finalization_blocks": 0,
+    "block_producing": {
+      "periodic": {
+        "block_time_ms": 1000
+      }
+    },
+    "randomization": null
+  },
+  "proof_manager": {
+    "aggregated_proof_block_jump": 22,
+    "prover_address": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
+    "max_number_of_transitions_in_db": 1025,
+    "max_number_of_transitions_in_memory": 768
+  },
+  "sequencer": {
+    "automatic_batch_production": true,
+    "max_allowed_node_distance_behind": 5,
+    "dropped_tx_ttl_secs": 60,
+    "rollup_address": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
+    "admin_addresses": [],
+    "preferred": {
+      "minimum_profit_per_tx": 0,
+      "events_channel_size": 10000,
+      "postgres_config": {
+        "postgres_connection_string": "postgresql://postgres:pass@localhost:5432/db",
+        "node_id": "node_1"
+      },
+      "disable_state_root_consistency_checks": true,
+      "ideal_lag_behind_finalized_slot": 3,
+      "db_event_channel_size": 10000,
+      "recovery_strategy": "TryToSave",
+      "batch_execution_time_limit_millis": 2000,
+      "is_replica": false,
+      "num_cache_warmup_workers": 0,
+      "timing_oracle": null,
+      "rate_limiter": {
+        "max_requests_per_second": 1000000,
+        "default_limits": {
+          "max_user_bursts_per_batch": 5,
+          "refill_rate": 2
+        },
+        "address_custom_limits": [],
+        "ip_custom_limits": [
+          [
+            "157.180.14.244",
+            {
+              "max_user_bursts_per_batch": 200,
+              "refill_rate": 2
+            }
+          ]
+        ]
+      },
+      "maximum_future_nonce_delta": 100,
+      "future_nonce_transaction_timeout_millis": 2000
+    },
+    "max_batch_size_bytes": 1048576,
+    "max_concurrent_blobs": 16,
+    "blob_processing_timeout_secs": 60,
+    "extension": null
+  },
+  "monitoring": {
+    "telegraf_address": "udp://192.168.4.5:8543",
+    "max_datagram_size": 1024,
+    "max_pending_metrics": 2560,
+    "tokio_runtime_metrics_interval_millis": 500
+  }
+}

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -1107,7 +1107,7 @@ where
 fn rate_limit_error<S: Spec>(err: ResourceLimitExceededError<S>) -> ErrorObject {
     ErrorObject {
         status: StatusCode::SERVICE_UNAVAILABLE,
-        message: format!("The sender was rate-limited by the sequencer: {err:?}"),
+        message: format!("The sender was rate-limited by the sequencer: {err}"),
         details: Default::default(),
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
@@ -89,7 +89,7 @@ impl<S: Spec> SovRateLimiterInner<S> {
 
 const TTL_MULTIPLIER: u64 = 20;
 
-fn clculate_limits<S: Spec>(
+fn calculate_limits<S: Spec>(
     limits: Limits,
     max_requests_per_second: u64,
     batch_execution_time_limit_millis: u64,
@@ -100,7 +100,7 @@ fn clculate_limits<S: Spec>(
     let max_resources_per_batch = Resource {
         req_counter: max_requests_per_second
             .checked_mul(batch_execution_time_limit_millis)
-            .expect("Unable to covert max_requests_per_second to req_counter"),
+            .expect("Overflow converting max_requests_per_second to max requests per batch"),
         // The expect is justified because we will never have batches larger than u64::MAX bytes.
         space_in_bytes: max_batch_size_bytes
             .try_into()
@@ -146,7 +146,7 @@ fn to_limiter_config_map<K: Eq + Hash, S: Spec>(
         .map(|(key, limits)| {
             (
                 key,
-                clculate_limits::<S>(
+                calculate_limits::<S>(
                     limits,
                     max_requests_per_second,
                     batch_execution_time_limit_millis,
@@ -167,7 +167,7 @@ fn limits<S: Spec>(
     HashMap<S::Address, RateLimiterConfig<S>>,
     HashMap<IpAddr, RateLimiterConfig<S>>,
 ) {
-    let default_config = clculate_limits::<S>(
+    let default_config = calculate_limits::<S>(
         sov_config.default_limits,
         sov_config.max_requests_per_second,
         batch_execution_time_limit_millis,
@@ -244,7 +244,7 @@ mod tests {
     type Gas = <TestSpec as Spec>::Gas;
 
     #[test]
-    fn test_clculate_limits() {
+    fn test_calculate_limits() {
         let limits = Limits {
             resources_per_bucket: 5,
             refill_rate: 1,
@@ -252,7 +252,7 @@ mod tests {
 
         let max_batch_exec_time = 6000;
         let rate_limiter_config =
-            clculate_limits::<TestSpec>(limits, 10000, max_batch_exec_time, 6000000);
+            calculate_limits::<TestSpec>(limits, 10000, max_batch_exec_time, 6000000);
 
         let max_allowed_resources_per_key = rate_limiter_config.max_allowed_resources;
 

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
@@ -25,12 +25,12 @@ pub(crate) struct LimiterToken<S: Spec> {
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum ResourceLimitExceededError<S: Spec> {
-    #[error("Resource limit exceeded for address: {address:?}, {reason:?}")]
+    #[error("Resource limit exceeded for address: {address}, {reason:?}")]
     Address {
         address: S::Address,
         reason: LimitExceeded<S::Gas>,
     },
-    #[error("Resource limit exceeded for IP: {ip:?}, {reason:?}")]
+    #[error("Resource limit exceeded for IP: {ip}, {reason:?}")]
     Ip {
         ip: IpAddr,
         reason: LimitExceeded<S::Gas>,
@@ -91,13 +91,16 @@ const TTL_MULTIPLIER: u64 = 20;
 
 fn clculate_limits<S: Spec>(
     limits: Limits,
+    max_requests_per_second: u64,
     batch_execution_time_limit_millis: u64,
     max_batch_size_bytes: usize,
 ) -> RateLimiterConfig<S> {
     let max_gas = comfortable_gas_limit::<S>();
 
     let max_resources_per_batch = Resource {
-        req_counter: limits.max_requests_per_batch,
+        req_counter: max_requests_per_second
+            .checked_mul(batch_execution_time_limit_millis)
+            .expect("Unable to covert max_requests_per_second to req_counter"),
         // The expect is justified because we will never have batches larger than u64::MAX bytes.
         space_in_bytes: max_batch_size_bytes
             .try_into()
@@ -110,13 +113,14 @@ fn clculate_limits<S: Spec>(
     };
 
     // A single sender is limited to 1/max_threshold_per_key_to_batch_capacity_ratio of resources of a single batch.
-    let max_per_key =
-        max_resources_per_batch.div_by_scalar(limits.max_threshold_per_key_to_batch_capacity_ratio);
+    let max_per_key = max_resources_per_batch
+        .saturating_mul_by_scalar(limits.max_user_bursts_per_batch)
+        .div_by_scalar(1000);
 
     // The refill rate is defined as 0.1% of max_per_key. After one second, the system refills max_per_key tokens.
     let refill_rate = max_per_key
         .saturating_mul_by_scalar(limits.refill_rate)
-        .div_by_scalar(1000);
+        .div_by_scalar(batch_execution_time_limit_millis);
 
     RateLimiterConfig {
         max_allowed_resources: TotalResources { inner: max_per_key },
@@ -133,6 +137,7 @@ pub(crate) struct SovRateLimiter<S: Spec> {
 }
 
 fn to_limiter_config_map<K: Eq + Hash, S: Spec>(
+    max_requests_per_second: u64,
     batch_execution_time_limit_millis: u64,
     max_batch_size_bytes: usize,
     v: Vec<(K, Limits)>,
@@ -143,6 +148,7 @@ fn to_limiter_config_map<K: Eq + Hash, S: Spec>(
                 key,
                 clculate_limits::<S>(
                     limits,
+                    max_requests_per_second,
                     batch_execution_time_limit_millis,
                     max_batch_size_bytes,
                 ),
@@ -163,18 +169,21 @@ fn limits<S: Spec>(
 ) {
     let default_config = clculate_limits::<S>(
         sov_config.default_limits,
+        sov_config.max_requests_per_second,
         batch_execution_time_limit_millis,
         max_batch_size_bytes,
     );
 
     let addrs = to_limiter_config_map::<S::Address, S>(
         batch_execution_time_limit_millis,
+        sov_config.max_requests_per_second,
         max_batch_size_bytes,
         sov_config.address_custom_limits,
     );
 
     let ips = to_limiter_config_map::<IpAddr, S>(
         batch_execution_time_limit_millis,
+        sov_config.max_requests_per_second,
         max_batch_size_bytes,
         sov_config.ip_custom_limits,
     );
@@ -237,12 +246,13 @@ mod tests {
     #[test]
     fn test_clculate_limits() {
         let limits = Limits {
-            max_threshold_per_key_to_batch_capacity_ratio: 200,
-            max_requests_per_batch: 234000000,
+            max_user_bursts_per_batch: 5,
             refill_rate: 1,
         };
 
-        let rate_limiter_config = clculate_limits::<TestSpec>(limits, 1_000_000_000, 1000000);
+        let max_batch_exec_time = 6000;
+        let rate_limiter_config =
+            clculate_limits::<TestSpec>(limits, 10000, max_batch_exec_time, 6000000);
 
         let max_allowed_resources_per_key = rate_limiter_config.max_allowed_resources;
 
@@ -250,9 +260,12 @@ mod tests {
         let refilled = rate_limiter_config
             .refill_rate
             .token_resource_per_ms
-            .saturating_mul_by_scalar(1000);
+            .saturating_mul_by_scalar(max_batch_exec_time);
 
-        assert_eq!(max_allowed_resources_per_key.inner, refilled);
+        assert_eq!(
+            max_allowed_resources_per_key.inner.space_in_bytes,
+            refilled.space_in_bytes
+        );
     }
 
     #[test]

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
@@ -114,7 +114,7 @@ fn clculate_limits<S: Spec>(
 
     // A single sender is limited to 1/max_threshold_per_key_to_batch_capacity_ratio of resources of a single batch.
     let max_per_key = max_resources_per_batch
-        .saturating_mul_by_scalar(limits.max_user_bursts_per_batch)
+        .saturating_mul_by_scalar(limits.resources_per_bucket)
         .div_by_scalar(1000);
 
     // The refill rate is defined as 0.1% of max_per_key. After one second, the system refills max_per_key tokens.
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn test_clculate_limits() {
         let limits = Limits {
-            max_user_bursts_per_batch: 5,
+            resources_per_bucket: 5,
             refill_rate: 1,
         };
 

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -28,6 +28,7 @@ use crate::{SequencerNotReadyDetails, TxHash};
 use sov_blob_sender::BlobInternalId;
 use sov_blob_storage::SequenceNumber;
 use sov_modules_api::capabilities::RollupHeight;
+use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::{
     FullyBakedTx, Runtime, Spec, StateCheckpoint, StateUpdateInfo, VersionReader,
 };
@@ -810,8 +811,7 @@ where
                 &ip_and_credential.credential_id,
                 checkpoint,
             )
-            // StateCheckpoint uses a no-op gas meter, which makes the expect safe.
-            .expect("Impossible happend StateCheckpoint run out of gas");
+            .unwrap_infallible();
 
         let token = inner
             .rate_limiter

--- a/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
@@ -92,10 +92,10 @@ async fn create_test_rollup(
 async fn test_rate_limiting() {
     let sov_config = SovRateLimiterConfig {
         default_limits: Limits {
-            max_threshold_per_key_to_batch_capacity_ratio: 200,
-            max_requests_per_batch: 1_000_000,
-            refill_rate: 10,
+            max_user_bursts_per_batch: 5,
+            refill_rate: 100,
         },
+        max_requests_per_second: 1_000_000,
         address_custom_limits: Vec::default(),
         ip_custom_limits: Vec::default(),
     };
@@ -146,10 +146,10 @@ async fn test_rate_limiting() {
 async fn test_correct_ip() {
     let sov_config = SovRateLimiterConfig {
         default_limits: Limits {
-            max_threshold_per_key_to_batch_capacity_ratio: 200,
-            max_requests_per_batch: 0,
+            max_user_bursts_per_batch: 5,
             refill_rate: 0,
         },
+        max_requests_per_second: 0,
         address_custom_limits: Vec::default(),
         ip_custom_limits: Vec::default(),
     };
@@ -203,9 +203,10 @@ async fn test_correct_ip() {
         let err = resp.bytes().await.unwrap();
         let err_str = std::str::from_utf8(&err).unwrap().to_string();
 
+        println!("err_str: {err_str}");
         // Check that the correct IP was rate limmited.
         assert!(err_str
-            .contains("The sender was rate-limited by the sequencer: Ip { ip: 123.123.123.123"));
+            .contains("The sender was rate-limited by the sequencer: Resource limit exceeded for IP: 123.123.123.123"));
     }
 }
 

--- a/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
@@ -203,7 +203,6 @@ async fn test_correct_ip() {
         let err = resp.bytes().await.unwrap();
         let err_str = std::str::from_utf8(&err).unwrap().to_string();
 
-        println!("err_str: {err_str}");
         // Check that the correct IP was rate limmited.
         assert!(err_str
             .contains("The sender was rate-limited by the sequencer: Resource limit exceeded for IP: 123.123.123.123"));

--- a/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
@@ -92,7 +92,7 @@ async fn create_test_rollup(
 async fn test_rate_limiting() {
     let sov_config = SovRateLimiterConfig {
         default_limits: Limits {
-            max_user_bursts_per_batch: 5,
+            resources_per_bucket: 5,
             refill_rate: 100,
         },
         max_requests_per_second: 1_000_000,
@@ -146,7 +146,7 @@ async fn test_rate_limiting() {
 async fn test_correct_ip() {
     let sov_config = SovRateLimiterConfig {
         default_limits: Limits {
-            max_user_bursts_per_batch: 5,
+            resources_per_bucket: 5,
             refill_rate: 0,
         },
         max_requests_per_second: 0,

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -215,12 +215,12 @@
     "Limits": {
       "type": "object",
       "required": [
-        "max_user_bursts_per_batch",
+        "resources_per_bucket",
         "refill_rate"
       ],
       "properties": {
-        "max_user_bursts_per_batch": {
-          "description": "Determines the threshold for rate-limiting requests. This value is used as follows:\n\nMAX_THRESHOLD_PER_KEY = MAX_BATCH_RESOURCE_CAPACITY * max_threshold_max_user_bursts\n\nFor example, setting max_user_bursts_per_batch to 5 means that MAX_THRESHOLD_PER_KEY will be 0.5% of MAX_BATCH_RESOURCE_CAPACITY.",
+        "resources_per_bucket": {
+          "description": "Determines the threshold for rate-limiting requests. This value is used as follows:\n\nMAX_THRESHOLD_PER_KEY = MAX_BATCH_RESOURCE_CAPACITY * max_threshold_max_user_bursts\n\nFor example, setting resources_per_bucket to 5 means that MAX_THRESHOLD_PER_KEY will be 0.5% of MAX_BATCH_RESOURCE_CAPACITY.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -215,18 +215,18 @@
     "Limits": {
       "type": "object",
       "required": [
-        "resources_per_bucket",
-        "refill_rate"
+        "refill_rate",
+        "resources_per_bucket"
       ],
       "properties": {
-        "resources_per_bucket": {
-          "description": "Determines the threshold for rate-limiting requests. This value is used as follows:\n\nMAX_THRESHOLD_PER_KEY = MAX_BATCH_RESOURCE_CAPACITY * max_threshold_max_user_bursts\n\nFor example, setting resources_per_bucket to 5 means that MAX_THRESHOLD_PER_KEY will be 0.5% of MAX_BATCH_RESOURCE_CAPACITY.",
+        "refill_rate": {
+          "description": "The refill rate of buckets. E.g. if refill_rate = 5, the user's rate limiting bucket will be refilled up to five times every batch. Values between 1 and 20 are recommended starting points.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
         },
-        "refill_rate": {
-          "description": "Determines how quickly tokens are refilled in the token-bucket algorithm. Each user can consume, on average, only a certain percentage of the batch resources (MAX_THRESHOLD_PER_KEY). Over time, users send requests that draw from their available resources, while a constant stream of tokens refilling those resources. At refill_rate = 1, tokens regenerate at MAX_THRESHOLD_PER_KEY/batch_execution_time_limit_millis. Values between 5 and 20 are recommended starting points.",
+        "resources_per_bucket": {
+          "description": "Determines the threshold for rate-limiting requests. The resources allocated per user per rate-limiting bucket, defined in units of 1/1000th of a full batch. E.g. resources_per_bucket = 10 would mean each bucket allows the user to use 1% of a full batch capacity.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -215,25 +215,18 @@
     "Limits": {
       "type": "object",
       "required": [
-        "max_requests_per_batch",
-        "max_threshold_per_key_to_batch_capacity_ratio",
+        "max_user_bursts_per_batch",
         "refill_rate"
       ],
       "properties": {
-        "max_requests_per_batch": {
-          "description": "The maximum number of requests allowed per batch.",
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        },
-        "max_threshold_per_key_to_batch_capacity_ratio": {
-          "description": "Determines the threshold for rate-limiting requests. This value is used as follows:\n\nMAX_THRESHOLD_PER_KEY = MAX_BATCH_RESOURCE_CAPACITY / max_threshold_per_key_to_batch_capacity_ratio\n\nFor example, setting max_threshold_per_key_to_batch_capacity_ratio to 200 means that MAX_THRESHOLD_PER_KEY will be 0.5% of MAX_BATCH_RESOURCE_CAPACITY.",
+        "max_user_bursts_per_batch": {
+          "description": "Determines the threshold for rate-limiting requests. This value is used as follows:\n\nMAX_THRESHOLD_PER_KEY = MAX_BATCH_RESOURCE_CAPACITY * max_threshold_max_user_bursts\n\nFor example, setting max_user_bursts_per_batch to 5 means that MAX_THRESHOLD_PER_KEY will be 0.5% of MAX_BATCH_RESOURCE_CAPACITY.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
         },
         "refill_rate": {
-          "description": "Determines how quickly tokens are refilled in the token-bucket algorithm. Each user can consume, on average, only a certain percentage of the batch resources (MAX_THRESHOLD_PER_KEY). Over time, users send requests that draw from their available resources, while a constant stream of tokens refilling those resources. At refill_rate = 1, tokens regenerate at MAX_THRESHOLD_PER_KEY/100 per millisecond. Values between 1 and 20 are recommended starting points.",
+          "description": "Determines how quickly tokens are refilled in the token-bucket algorithm. Each user can consume, on average, only a certain percentage of the batch resources (MAX_THRESHOLD_PER_KEY). Over time, users send requests that draw from their available resources, while a constant stream of tokens refilling those resources. At refill_rate = 1, tokens regenerate at MAX_THRESHOLD_PER_KEY/batch_execution_time_limit_millis. Values between 5 and 20 are recommended starting points.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
@@ -981,7 +974,8 @@
       "required": [
         "address_custom_limits",
         "default_limits",
-        "ip_custom_limits"
+        "ip_custom_limits",
+        "max_requests_per_second"
       ],
       "properties": {
         "address_custom_limits": {
@@ -1001,7 +995,12 @@
           }
         },
         "default_limits": {
-          "$ref": "#/definitions/Limits"
+          "description": "Default limits.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Limits"
+            }
+          ]
         },
         "ip_custom_limits": {
           "type": "array",
@@ -1019,6 +1018,12 @@
             "maxItems": 2,
             "minItems": 2
           }
+        },
+        "max_requests_per_second": {
+          "description": "The maximum number of requests allowed per second.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         }
       }
     },

--- a/examples/demo-rollup/tests/evm/evm_rate_limit.rs
+++ b/examples/demo-rollup/tests/evm/evm_rate_limit.rs
@@ -45,7 +45,7 @@ async fn setup_test_rollup(
 async fn evm_test_rate_limit() -> anyhow::Result<()> {
     let rate_limiter = SovRateLimiterConfig {
         default_limits: Limits {
-            max_user_bursts_per_batch: 5,
+            resources_per_bucket: 5,
             refill_rate: 0,
         },
         max_requests_per_second: 0,

--- a/examples/demo-rollup/tests/evm/evm_rate_limit.rs
+++ b/examples/demo-rollup/tests/evm/evm_rate_limit.rs
@@ -45,10 +45,10 @@ async fn setup_test_rollup(
 async fn evm_test_rate_limit() -> anyhow::Result<()> {
     let rate_limiter = SovRateLimiterConfig {
         default_limits: Limits {
-            max_threshold_per_key_to_batch_capacity_ratio: 200,
-            max_requests_per_batch: 0,
+            max_user_bursts_per_batch: 5,
             refill_rate: 0,
         },
+        max_requests_per_second: 0,
         address_custom_limits: Vec::default(),
         ip_custom_limits: Vec::default(),
     };


### PR DESCRIPTION
# Description

This PR introduces a renaming in `SovRateLimiterConfig`.
The key change is replacing `max_threshold_per_key_to_batch_capacity_ratio` with `max_user_bursts_per_batch`.
The relationship between the two is:

`max_user_bursts_per_batch = 1 / max_threshold_per_key_to_batch_capacity_ratio`
This is not a breaking change as the config is used only in tests.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2173 
