### PR TITLE
Adding metrics and timeout to `CelestiaAdapter::get_proofs_inner`

### DIFF
--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -3,8 +3,8 @@ mod tests;
 
 pub use crate::config::CelestiaConfig;
 use crate::metrics::client::{
-    GetBlockHeaderMeasurement, GetChainHeadMeasurement, GetNamespaceDataMeasurement,
-    SubmitPayForBlob,
+    BlobGetAllMeasurement, GetBlockHeaderMeasurement, GetChainHeadMeasurement,
+    GetNamespaceDataMeasurement, SubmitPayForBlob,
 };
 use crate::metrics::full::{
     BlobSubmitMeasurement, CelestiaAdapterStateMeasurement, GetBlockMeasurement,
@@ -364,17 +364,31 @@ impl CelestiaService {
         &self,
         height: u64,
     ) -> Result<Vec<Vec<u8>>, MaybeRetryable<anyhow::Error>> {
-        // TODO: follow up: timeout here
-        // TODO: follow up: metrics here
-        self.client
-            .blob()
-            .get_all(height, &[self.rollup_proof_namespace])
-            .await
-            .map_err(into_transient_with_context)
-            .map(|blobs| match blobs {
-                Some(blobs) => blobs.into_iter().map(|blob| blob.data).collect(),
-                None => vec![],
-            })
+        tracing::trace!(height, "Making call to blob.GetAll for proofs");
+        let start = std::time::Instant::now();
+        let result = tokio::time::timeout(
+            self.request_timeout,
+            self.client
+                .blob()
+                .get_all(height, &[self.rollup_proof_namespace]),
+        )
+        .await;
+        let response_time = start.elapsed();
+        let is_success = matches!(result, Ok(Ok(_)));
+        tracing::trace!(
+            is_success,
+            ?response_time,
+            height,
+            "Call to blob.GetAll is completed"
+        );
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit(BlobGetAllMeasurement::new(response_time, is_success));
+        });
+
+        let blobs = flatten_timeout(result)?
+            .map(|blobs| blobs.into_iter().map(|blob| blob.data).collect())
+            .unwrap_or_default();
+        Ok(blobs)
     }
 
     /// Subscribe to finalized headers as they are finalized.
@@ -388,12 +402,6 @@ impl CelestiaService {
             .map(|res| res.map(CelestiaHeader::from).map_err(|e| e.into()))
             .boxed())
     }
-}
-
-fn into_transient_with_context(error: celestia_client::Error) -> MaybeRetryable<anyhow::Error> {
-    // TODO: Follow up: Can be improved on when to retry or not
-    let error = anyhow::anyhow!("Celestia RPC node returned an error: {:?}", error);
-    MaybeRetryable::Transient(error)
 }
 
 #[async_trait]

--- a/crates/adapters/celestia/src/metrics/client.rs
+++ b/crates/adapters/celestia/src/metrics/client.rs
@@ -24,6 +24,8 @@ pub(crate) struct HeaderNetworkHead;
 pub(crate) struct ShareGetNamespaceData;
 #[derive(Debug)]
 pub(crate) struct StateSubmitPayForBlob;
+#[derive(Debug)]
+pub(crate) struct BlobGetAll;
 
 impl ApiCall for HeaderGetByHeight {
     fn measurement_name() -> &'static str {
@@ -46,6 +48,12 @@ impl ApiCall for ShareGetNamespaceData {
 impl ApiCall for StateSubmitPayForBlob {
     fn measurement_name() -> &'static str {
         "sov_celestia_adapter_state_submit_pay_for_blob"
+    }
+}
+
+impl ApiCall for BlobGetAll {
+    fn measurement_name() -> &'static str {
+        "sov_celestia_adapter_blob_get_all"
     }
 }
 
@@ -129,3 +137,4 @@ pub(crate) type GetBlockHeaderMeasurement = MeasuredApiCall<HeaderGetByHeight>;
 pub(crate) type GetChainHeadMeasurement = MeasuredApiCall<HeaderNetworkHead>;
 pub(crate) type GetNamespaceDataMeasurement = MeasuredApiCallWithNamespace<ShareGetNamespaceData>;
 pub(crate) type SubmitPayForBlob = MeasuredApiCallWithNamespace<StateSubmitPayForBlob>;
+pub(crate) type BlobGetAllMeasurement = MeasuredApiCall<BlobGetAll>;


### PR DESCRIPTION
# Description

The last API call not covered by timeout and measurement


- [x] Internal change ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1630 

## Testing
All existing tests are passing.


## Docs
No updates
