### PR TITLE
Performance Improvement: use `Arc<ProvableStorageCache>` in `ApiStateAccessor` rather than cloning

### DIFF
--- a/crates/module-system/module-implementations/sov-attester-incentives/src/query.rs
+++ b/crates/module-system/module-implementations/sov-attester-incentives/src/query.rs
@@ -1,6 +1,7 @@
 //! Defines the query methods for the attester incentives module
 
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use sov_bank::Amount;
@@ -155,7 +156,7 @@ where
         let checkpoint = StateCheckpoint::new(storage, &kernel.kernel(), None);
 
         let mut state = ApiStateAccessor::<S>::new_with_true_slot_number_dangerous(
-            &checkpoint,
+            Arc::new(checkpoint),
             kernel.kernel_with_slot_mapping(),
             slot_number,
         )

--- a/crates/module-system/sov-modules-api/src/rest/mod.rs
+++ b/crates/module-system/sov-modules-api/src/rest/mod.rs
@@ -241,8 +241,7 @@ impl<S: Spec, T> ApiState<S, T> {
         tracing::trace!(?height_param, "Building an API state accessor");
         let state = match height_param {
             Some(HeightParam::RollupHeight(height)) => {
-                let mut state =
-                    ApiStateAccessor::new_archival(checkpoint, kernel.clone(), height)?;
+                let mut state = ApiStateAccessor::new_archival(checkpoint, kernel.clone(), height)?;
                 // This is not a security isse and this code runs offchain.
                 // TODO: Move this inside the constructor
                 // <https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/2244>

--- a/crates/module-system/sov-modules-api/src/rest/mod.rs
+++ b/crates/module-system/sov-modules-api/src/rest/mod.rs
@@ -242,7 +242,7 @@ impl<S: Spec, T> ApiState<S, T> {
         let state = match height_param {
             Some(HeightParam::RollupHeight(height)) => {
                 let mut state =
-                    ApiStateAccessor::new_archival(&checkpoint, kernel.clone(), height)?;
+                    ApiStateAccessor::new_archival(checkpoint, kernel.clone(), height)?;
                 // This is not a security isse and this code runs offchain.
                 // TODO: Move this inside the constructor
                 // <https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/2244>
@@ -260,14 +260,14 @@ impl<S: Spec, T> ApiState<S, T> {
             Some(HeightParam::SlotNumber(slot_number)) => {
                 // This constructor sets the gas price correctly, so we don't need to do it manually.
                 ApiStateAccessor::new_archival_with_true_slot_number(
-                    &checkpoint,
+                    checkpoint,
                     kernel.clone(),
                     slot_number,
                 )?
             }
             None => {
                 let height = checkpoint.rollup_height_to_access();
-                let mut state = ApiStateAccessor::new(&checkpoint, kernel.clone());
+                let mut state = ApiStateAccessor::new(checkpoint, kernel.clone());
                 // This is not a security isse and this code runs offchain.
                 // TODO: Move this inside the constructor
                 // <https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/2244>

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -39,12 +39,101 @@ fn get_slot_number(visible_slot_number: Option<VisibleSlotNumber>) -> Option<Slo
     }
 }
 
+impl<S: Spec> ApiStateAccessor<S> {
+    fn get_from_user_storage(&mut self, key: &SlotKey) -> Option<SlotValue> {
+        if let MaybePresentValue::Present(entry) = self.user_cache.get_from_cache(key) {
+            return entry
+        }
+
+        if let MaybePresentValue::Present(entry) = self.checkpoint.delta.user_cache.get_from_cache(key) {
+            return entry
+        }
+
+        if let Some(changes) = self.uncomitted_changes.as_ref() {
+            if let MaybePresentValue::Present(entry) = changes.get(Namespace::User, key) {
+                return entry
+            }
+        }
+        
+        self.checkpoint.storage().get::<namespaces::User>(key, &self.witness)
+
+    }
+
+    fn get_from_kernel_storage(&mut self, key: &SlotKey) -> Option<SlotValue> {
+        if let MaybePresentValue::Present(entry) = self.kernel_cache.get_from_cache(key) {
+            return entry
+        }
+
+        if let MaybePresentValue::Present(entry) = self.checkpoint.delta.kernel_cache.get_from_cache(key) {
+            return entry
+        }
+
+        if let Some(changes) = self.uncomitted_changes.as_ref() {
+            if let MaybePresentValue::Present(entry) = changes.get(Namespace::Kernel, key) {
+                return entry
+            }
+        }
+        
+        self.checkpoint.storage().get::<namespaces::Kernel>(key, &self.witness)
+    }
+
+    fn get_from_accessory_storage(&mut self, key: &SlotKey) -> Option<SlotValue> {
+        if let Some(write) = self.accessory_writes.get(key) {
+            return write.value.clone()
+        }
+
+        if let Some(write) = self.checkpoint.delta.accessory_writes.get(key) {
+            return write.value.clone()
+        }
+
+        if let Some(changes) = self.uncomitted_changes.as_ref() {
+            if let MaybePresentValue::Present(entry) = changes.get(Namespace::Accessory, key) {
+                return entry
+            }
+        }
+
+        self.checkpoint.storage().get_accessory(key)
+    }
+
+    fn get_archival_from_user_storage(&mut self, key: &SlotKey, version: Option<SlotNumber>) -> anyhow::Result<Option<SlotValue>> {
+        // First, check if the user has written this value. This allows users to write during eth_call even if they're reading historical state.
+        // IMPORTANT: Note that we do *not* empty the statecheckpoint passed by the caller who creates the API state accessor (we can't because it's Arc'd)
+        // so it is imperative that we do *not* read from it during archival queries - it might have random data from the current state.
+        if let MaybePresentValue::Present(entry) = self.user_cache.get_from_cache(key) {
+            return Ok(entry)
+        }
+        // If not, read it from storage
+        self.checkpoint.storage().get_historical::<namespaces::User>(key, version, &self.witness, )
+    }
+
+    fn get_archival_from_kernel_storage(&mut self, key: &SlotKey, version: Option<SlotNumber>) -> anyhow::Result<Option<SlotValue>> {
+        // First, check if the kernel has written this value. This allows users to write during eth_call even if they're reading historical state.
+        // IMPORTANT: Note that we do *not* empty the statecheckpoint passed by the caller who creates the API state accessor (we can't because it's Arc'd)
+        // so it is imperative that we do *not* read from it during archival queries - it might have random data from the current state.
+        if let MaybePresentValue::Present(entry) = self.kernel_cache.get_from_cache(key) {
+            return Ok(entry)
+        }
+        // If not, read it from storage
+        self.checkpoint.storage().get_historical::<namespaces::Kernel>(key, version, &self.witness, )
+    }
+
+    fn get_archival_from_accessory_storage(&mut self, key: &SlotKey, version: Option<SlotNumber>) -> anyhow::Result<Option<SlotValue>> {
+        // First, check if the accessory has written this value. This allows users to write during eth_call even if they're reading historical state.
+        if let Some(write) = self.accessory_writes.get(key) {
+            return Ok(write.value.clone())
+        }
+        // If not, read it from storage
+        self.checkpoint.storage().get_accessory_historical(key, version)
+    }
+}
+
+
 impl<S: Spec> UniversalStateAccessor for ApiStateAccessor<S> {
     fn get_size(
         &mut self,
         namespace: sov_state::Namespace,
         key: &SlotKey,
-        metric: &mut StateAccessMetric,
+        _metric: &mut StateAccessMetric,
     ) -> Option<u32> {
         let is_archival_query = self.safe_true_slot_number_to_use.is_some();
 
@@ -52,73 +141,33 @@ impl<S: Spec> UniversalStateAccessor for ApiStateAccessor<S> {
             Namespace::User => {
                 if let Some(number) = self.safe_true_slot_number_to_use {
                     // If we're doing an archival query, we can just use the historical storage API on `ProvableStorageCache`
-                    self.user_cache.get_size_or_fetch_historical(
-                        key,
-                        &self.storage,
-                        &self.witness,
-                        Some(number),
-                        metric,
-                    )
+                    self.get_archival_from_user_storage(key, Some(number)).map(|v| v.map(|v|v.size()))
                 } else {
                     // Otherwise we're doing a `current_state` query, so we need to use the API which is also aware of the intermediate state
                     // generated by the sequencer.
-                    Ok(self.user_cache.get_size_or_fetch(
-                        &self.uncomitted_changes,
-                        key,
-                        &self.storage,
-                        &self.witness,
-                        metric,
-                    ))
+                    Ok(self.get_from_user_storage(key).map(|v| v.size()))
                 }
             }
             Namespace::Kernel => {
                 if is_archival_query {
                     // If we're doing an archival query, we can just use the historical storage API on `ProvableStorageCache`
-                    self.kernel_cache.get_size_or_fetch_historical(
-                        key,
-                        &self.storage,
-                        &self.witness,
-                        get_slot_number(self.visible_slot_number),
-                        metric,
-                    )
+                    self.get_archival_from_kernel_storage(key, get_slot_number(self.visible_slot_number)).map(|v| v.map(|v|v.size()))
+
                 } else {
                     // Otherwise we're doing a `current_state` query, so we need to use the API which is also aware of the intermediate state
                     // generated by the sequencer.
-                    Ok(self.kernel_cache.get_size_or_fetch(
-                        &self.uncomitted_changes,
-                        key,
-                        &self.storage,
-                        &self.witness,
-                        metric,
-                    ))
+                    Ok(self.get_from_kernel_storage(key).map(|v| v.size()))
                 }
             }
             Namespace::Accessory => match self.accessory_writes.get(key).cloned() {
                 Some(write) => Ok(write.value.as_ref().map(|v| v.size())),
                 None => {
-                    let val = if is_archival_query {
+                    if is_archival_query {
                         // For archival queries, we always use the storage API
-                        self.storage
-                            .get_accessory_historical(key, self.safe_true_slot_number_to_use)
+                        self.get_archival_from_accessory_storage(key, self.safe_true_slot_number_to_use).map(|v| v.map(|v|v.size()))
                     } else {
-                        // For current state queries, we use the intermediate state if it's available
-                        if let Some(uncomitted_changes) = self.uncomitted_changes.as_ref() {
-                            if let MaybePresentValue::Present(value) =
-                                uncomitted_changes.get(Namespace::Accessory, key)
-                            {
-                                Ok(value)
-                            } else {
-                                self.storage.get_accessory_historical(
-                                    key,
-                                    self.safe_true_slot_number_to_use,
-                                )
-                            }
-                        } else {
-                            self.storage
-                                .get_accessory_historical(key, self.safe_true_slot_number_to_use)
-                        }
-                    };
-                    val.map(|opt| opt.map(|v| v.size()))
+                        Ok(self.get_from_accessory_storage(key).map(|v| v.size()))
+                    }
                 }
             },
         };
@@ -136,7 +185,7 @@ impl<S: Spec> UniversalStateAccessor for ApiStateAccessor<S> {
         &mut self,
         namespace: sov_state::Namespace,
         key: &SlotKey,
-        metric: &mut StateAccessMetric,
+        _metric: &mut StateAccessMetric,
     ) -> Option<SlotValue> {
         let is_archival_query = self.safe_true_slot_number_to_use.is_some();
         // For the user state, we use the self.safe_true_slot_number_to_use canary to determine if we're doing an archival query
@@ -144,46 +193,22 @@ impl<S: Spec> UniversalStateAccessor for ApiStateAccessor<S> {
         let result = match namespace {
             Namespace::User => {
                 if let Some(number) = self.safe_true_slot_number_to_use {
-                    self.user_cache.get_or_fetch_historical(
-                        key,
-                        &self.storage,
-                        &self.witness,
-                        Some(number),
-                        metric,
-                    )
+                   self.get_archival_from_user_storage(key, Some(number))
                 } else {
                     // Otherwise we're doing a `current_state` query, so we need to use the API which is also aware of the intermediate state
                     // generated by the sequencer.
-                    Ok(self.user_cache.get_or_fetch(
-                        &self.uncomitted_changes,
-                        key,
-                        &self.storage,
-                        &self.witness,
-                        metric,
-                    ))
+                    Ok(self.get_from_user_storage(key))
                 }
             }
             // For the kernel state, we also use the self.safe_true_slot_number_to_use canary to determine if we're doing an archival query
             // If so, use the appropriate API on `ProvableStorageCache`
             Namespace::Kernel => {
                 if is_archival_query {
-                    self.kernel_cache.get_or_fetch_historical(
-                        key,
-                        &self.storage,
-                        &self.witness,
-                        get_slot_number(self.visible_slot_number),
-                        metric,
-                    )
+                    self.get_archival_from_kernel_storage(key, get_slot_number(self.visible_slot_number))
                 } else {
                     // Otherwise we're doing a `current_state` query, so we need to use the API which is also aware of the intermediate state
                     // generated by the sequencer.
-                    Ok(self.kernel_cache.get_or_fetch(
-                        &self.uncomitted_changes,
-                        key,
-                        &self.storage,
-                        &self.witness,
-                        metric,
-                    ))
+                    Ok(self.get_from_kernel_storage(key))
                 }
             }
             Namespace::Accessory => match self.accessory_writes.get(key).cloned() {
@@ -191,25 +216,10 @@ impl<S: Spec> UniversalStateAccessor for ApiStateAccessor<S> {
                 None => {
                     // For archival queries, we always use the storage API
                     if is_archival_query {
-                        self.storage
-                            .get_accessory_historical(key, self.safe_true_slot_number_to_use)
+                        self.get_archival_from_accessory_storage(key, self.safe_true_slot_number_to_use)
                     } else {
                         // For current state queries, we use the intermediate state if it's available
-                        if let Some(uncomitted_changes) = self.uncomitted_changes.as_ref() {
-                            if let MaybePresentValue::Present(value) =
-                                uncomitted_changes.get(Namespace::Accessory, key)
-                            {
-                                Ok(value)
-                            } else {
-                                self.storage.get_accessory_historical(
-                                    key,
-                                    self.safe_true_slot_number_to_use,
-                                )
-                            }
-                        } else {
-                            self.storage
-                                .get_accessory_historical(key, self.safe_true_slot_number_to_use)
-                        }
+                        Ok(self.get_from_accessory_storage(key))
                     }
                 }
             },
@@ -262,14 +272,22 @@ pub(crate) enum StateToAccess {
 /// A [`crate::StateReaderAndWriter`] designed for use within REST APIs and JSON-RPC.
 ///
 /// It can read and write accessory data as well as "user" and "kernel" data.
+/// 
+// An API State accessor contains...
+//  - An `Arc` state checkpoint containing the latest state from the sequencer.
+//  - User, kernel, and accessory caches which contain...
+//     - Any writes done by the current accessor
+//     - Cached read values from whenever we had to fall back to storage.
+
 #[derive(derive_more::Debug)]
 pub struct ApiStateAccessor<S: Spec> {
-    #[debug(skip)]
-    storage: S::Storage,
+    // #[debug(skip)]
+    // storage: S::Storage,
     #[debug(skip)]
     witness: <<S as Spec>::Storage as Storage>::Witness,
     events: Vec<TypeErasedEvent>,
     gas_meter: BasicGasMeter<S>,
+    checkpoint: Arc<StateCheckpoint<S>>,
     kernel_cache: ProvableStorageCache<namespaces::Kernel>,
     user_cache: ProvableStorageCache<namespaces::User>,
     accessory_writes: HashMap<SlotKey, AccessoryWrite>,
@@ -328,7 +346,7 @@ impl<S: Spec> PinnedCacheAccessor<S> for ApiStateAccessor<S> {
         self.user_cache.pinned_cache_mut()
     }
     fn storage(&self) -> &S::Storage {
-        &self.storage
+        self.checkpoint.storage()
     }
 }
 
@@ -365,7 +383,7 @@ const _: () = {
             self.safe_true_slot_number_to_use = safe_true_slot_number_to_use;
             let slot_num = slot_num?;
 
-            match self.storage.get_with_proof::<N>(key, Some(slot_num)) {
+            match self.storage().get_with_proof::<N>(key, Some(slot_num)) {
                 Ok(storage_proof) => Some(storage_proof),
                 Err(err) => {
                     tracing::debug!(error = ?err, "Error requesting storage proof");
@@ -427,13 +445,14 @@ pub enum ApiStateAccessorError {
 impl<S: Spec + 'static> ApiStateAccessor<S> {
     /// Creates a new [`ApiStateAccessor`] from a [`StateCheckpoint`] with a gas price of zero at the [`StateCheckpoint::rollup_height_to_access`].
     pub fn new(
-        state_checkpoint: &StateCheckpoint<S>,
+        state_checkpoint: Arc<StateCheckpoint<S>>,
         kernel: Arc<dyn KernelWithSlotMapping<S>>,
     ) -> Self {
+        let height = state_checkpoint.rollup_height_to_access();
         Self::new_with_price_and_state_to_access(
             state_checkpoint,
             kernel,
-            StateToAccess::RollupHeight(state_checkpoint.rollup_height_to_access()),
+            StateToAccess::RollupHeight(height),
             <S::Gas as Gas>::Price::ZEROED,
         )
         .expect("Creating an ApiStateCheckpoint without specifying a height is infallible")
@@ -441,17 +460,18 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
 
     /// Creates a new [`ApiStateAccessor`] which queries all state at the provided slot number.
     pub fn new_archival_with_true_slot_number(
-        state_checkpoint: &StateCheckpoint<S>,
+        state_checkpoint: Arc<StateCheckpoint<S>>,
         kernel: Arc<dyn KernelWithSlotMapping<S>>,
         slot_number: SlotNumber,
     ) -> Result<Self, ApiStateAccessorError> {
+        let uncomitted_changes = state_checkpoint
+            .delta
+            .uncomitted_changes
+            .as_ref()
+            .map(|c| c.box_clone());
         Self::build_archival_state(
-            state_checkpoint.delta.inner.clone(),
-            state_checkpoint
-                .delta
-                .uncomitted_changes
-                .as_ref()
-                .map(|c| c.box_clone()),
+            state_checkpoint,
+            uncomitted_changes,
             kernel,
             StateToAccess::TrueSlotNumber(slot_number, None),
         )
@@ -464,17 +484,18 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
     /// Note that archival state is only available *after* the requested height has been processed by the node. In other words,
     /// state that is *only* soft-confirmed is not available for archival queries.
     pub fn new_archival(
-        state_checkpoint: &StateCheckpoint<S>,
+        state_checkpoint: Arc<StateCheckpoint<S>>,
         kernel: Arc<dyn KernelWithSlotMapping<S>>,
         height: RollupHeight,
     ) -> Result<Self, ApiStateAccessorError> {
+        let uncomitted_changes = state_checkpoint
+            .delta
+            .uncomitted_changes
+            .as_ref()
+            .map(|c| c.box_clone());
         Self::build_archival_state(
-            state_checkpoint.delta.inner.clone(),
-            state_checkpoint
-                .delta
-                .uncomitted_changes
-                .as_ref()
-                .map(|c| c.box_clone()),
+            state_checkpoint,
+            uncomitted_changes,
             kernel,
             StateToAccess::RollupHeight(height),
         )
@@ -482,7 +503,7 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
 
     /// Creates a new [`ApiStateAccessor`] from a [`StateCheckpoint`] with a gas price of zero at the [`StateCheckpoint::rollup_height_to_access`].
     pub fn new_with_true_slot_number_dangerous(
-        state_checkpoint: &StateCheckpoint<S>,
+        state_checkpoint: Arc<StateCheckpoint<S>>,
         kernel: Arc<dyn KernelWithSlotMapping<S>>,
         slot_number: SlotNumber,
     ) -> Result<Self, ApiStateAccessorError> {
@@ -508,7 +529,7 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
     /// our tests are written assuming that all assertions will execute during this miniscule instant of time, so we have to accommodate it for now.
     #[cfg(feature = "test-utils")]
     pub fn new_with_price_and_heights(
-        state_checkpoint: &StateCheckpoint<S>,
+        state_checkpoint: Arc<StateCheckpoint<S>>,
         kernel: Arc<dyn KernelWithSlotMapping<S>>,
         rollup_height: RollupHeight,
         visible_slot_number: VisibleSlotNumber,
@@ -527,7 +548,7 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
     /// Creates a new [`ApiStateAccessor`] that *queries all state at the provided slot number, regardless of whether that slot number is visible*. This should only be used
     /// when the semantics of the call necessitate it. If you're unsure, use [`ApiStateAccessor::new_archival`] and provide a rollup height instead.
     pub fn new_with_price_and_slot_number_dangerous(
-        state_checkpoint: &StateCheckpoint<S>,
+        state_checkpoint: Arc<StateCheckpoint<S>>,
         kernel: Arc<dyn KernelWithSlotMapping<S>>,
         slot_number: SlotNumber,
         gas_price: <S::Gas as Gas>::Price,
@@ -542,7 +563,7 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
 
     /// Creates a new [`ApiStateAccessor`] from a [`StateCheckpoint`] with the provided gas price.
     fn new_with_price_and_state_to_access(
-        state_checkpoint: &StateCheckpoint<S>,
+        state_checkpoint: Arc<StateCheckpoint<S>>,
         kernel: Arc<dyn KernelWithSlotMapping<S>>,
         state_to_access: StateToAccess,
         gas_price: <S::Gas as Gas>::Price,
@@ -551,15 +572,15 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
         let gas_meter = BasicGasMeter::new_api(gas_price);
 
         let mut out = Self {
-            storage: delta.inner.clone(),
+            checkpoint: state_checkpoint.clone(),
             uncomitted_changes: delta.uncomitted_changes.as_ref().map(|g| g.box_clone()),
             witness: Default::default(),
             gas_meter,
             events: Vec::new(),
             temp_cache: TempCache::new(),
-            kernel_cache: delta.kernel_cache.clone_without_pinned_cache(),
-            user_cache: delta.user_cache.clone_without_pinned_cache(),
-            accessory_writes: delta.accessory_writes.clone(),
+            kernel_cache: Default::default(),
+            user_cache: Default::default(),
+            accessory_writes: HashMap::new(),
             kernel: kernel.clone(),
             state_to_access,
             visible_slot_number: None,
@@ -596,15 +617,16 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
     }
 
     fn get_uninitialized_empty_accessor(
-        storage: S::Storage,
+        checkpoint: Arc<StateCheckpoint<S>>,
         kernel: Arc<dyn KernelWithSlotMapping<S>>,
         state_to_access: StateToAccess,
     ) -> Self {
         let gas_meter = BasicGasMeter::new_api(<S::Gas as Gas>::Price::ZEROED);
+
         Self {
+            checkpoint,
             events: Vec::new(),
             gas_meter,
-            storage,
             uncomitted_changes: None,
             witness: Default::default(),
             kernel_cache: Default::default(),
@@ -647,14 +669,14 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
     }
 
     fn build_archival_state(
-        storage: S::Storage,
+        checkpoint: Arc<StateCheckpoint<S>>,
         uncommitted_changes: Option<Box<dyn StateGetter>>,
         kernel: Arc<dyn KernelWithSlotMapping<S>>,
         height: StateToAccess,
     ) -> Result<Self, ApiStateAccessorError> {
-        let latest_true_slot_number = storage.latest_version();
+        let latest_true_slot_number = checkpoint.storage().latest_version();
         let mut state =
-            ApiStateAccessor::get_uninitialized_empty_accessor(storage, kernel.clone(), height);
+            ApiStateAccessor::get_uninitialized_empty_accessor(checkpoint, kernel.clone(), height);
         state.uncomitted_changes = uncommitted_changes;
         let true_slot_number = match height {
             // If the caller provided a rollup height, find the associated true slot number.
@@ -748,7 +770,7 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
         height: RollupHeight,
     ) -> Result<ApiStateAccessor<S>, ApiStateAccessorError> {
         Self::build_archival_state(
-            self.storage.clone(),
+            self.checkpoint.clone(),
             self.uncomitted_changes.as_ref().map(|c| c.box_clone()),
             self.kernel.clone(),
             StateToAccess::RollupHeight(height),

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -334,8 +334,6 @@ pub(crate) enum StateToAccess {
 
 #[derive(derive_more::Debug)]
 pub struct ApiStateAccessor<S: Spec> {
-    // #[debug(skip)]
-    // storage: S::Storage,
     #[debug(skip)]
     witness: <<S as Spec>::Storage as Storage>::Witness,
     events: Vec<TypeErasedEvent>,

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -9,8 +9,8 @@ use sov_state::pinned_cache::PinnedCache;
 use sov_state::sequencer_state::MaybePresentValue;
 use sov_state::StateGetter;
 use sov_state::{
-    namespaces, CompileTimeNamespace, EventContainer, Namespace, NativeStorage,
-    ProvableStorageCache, SlotKey, SlotValue, Storage, TypeErasedEvent,
+    namespaces, CompileTimeNamespace, EventContainer, Namespace, NativeStorage, SlotKey, SlotValue,
+    Storage, TypeErasedEvent,
 };
 
 use super::temp_cache::{CacheLookup, TempCache};
@@ -41,92 +41,122 @@ fn get_slot_number(visible_slot_number: Option<VisibleSlotNumber>) -> Option<Slo
 
 impl<S: Spec> ApiStateAccessor<S> {
     fn get_from_user_storage(&mut self, key: &SlotKey) -> Option<SlotValue> {
-        if let MaybePresentValue::Present(entry) = self.user_cache.get_from_cache(key) {
-            return entry
+        if let Some(entry) = self.local_user_writes.get(key) {
+            return entry.clone();
         }
 
-        if let MaybePresentValue::Present(entry) = self.checkpoint.delta.user_cache.get_from_cache(key) {
-            return entry
+        if let MaybePresentValue::Present(entry) = self
+            .latest_state_checkpoint
+            .delta
+            .user_cache
+            .get_from_cache(key)
+        {
+            return entry;
         }
 
         if let Some(changes) = self.uncomitted_changes.as_ref() {
             if let MaybePresentValue::Present(entry) = changes.get(Namespace::User, key) {
-                return entry
+                return entry;
             }
         }
-        
-        self.checkpoint.storage().get::<namespaces::User>(key, &self.witness)
 
+        self.latest_state_checkpoint
+            .storage()
+            .get::<namespaces::User>(key, &self.witness)
     }
 
     fn get_from_kernel_storage(&mut self, key: &SlotKey) -> Option<SlotValue> {
-        if let MaybePresentValue::Present(entry) = self.kernel_cache.get_from_cache(key) {
-            return entry
+        if let Some(entry) = self.local_kernel_writes.get(key) {
+            return entry.clone();
         }
 
-        if let MaybePresentValue::Present(entry) = self.checkpoint.delta.kernel_cache.get_from_cache(key) {
-            return entry
+        if let MaybePresentValue::Present(entry) = self
+            .latest_state_checkpoint
+            .delta
+            .kernel_cache
+            .get_from_cache(key)
+        {
+            return entry;
         }
 
         if let Some(changes) = self.uncomitted_changes.as_ref() {
             if let MaybePresentValue::Present(entry) = changes.get(Namespace::Kernel, key) {
-                return entry
+                return entry;
             }
         }
-        
-        self.checkpoint.storage().get::<namespaces::Kernel>(key, &self.witness)
+
+        self.latest_state_checkpoint
+            .storage()
+            .get::<namespaces::Kernel>(key, &self.witness)
     }
 
     fn get_from_accessory_storage(&mut self, key: &SlotKey) -> Option<SlotValue> {
-        if let Some(write) = self.accessory_writes.get(key) {
-            return write.value.clone()
+        if let Some(write) = self.local_accessory_writes.get(key) {
+            return write.value.clone();
         }
 
-        if let Some(write) = self.checkpoint.delta.accessory_writes.get(key) {
-            return write.value.clone()
+        if let Some(write) = self.latest_state_checkpoint.delta.accessory_writes.get(key) {
+            return write.value.clone();
         }
 
         if let Some(changes) = self.uncomitted_changes.as_ref() {
             if let MaybePresentValue::Present(entry) = changes.get(Namespace::Accessory, key) {
-                return entry
+                return entry;
             }
         }
 
-        self.checkpoint.storage().get_accessory(key)
+        self.latest_state_checkpoint.storage().get_accessory(key)
     }
 
-    fn get_archival_from_user_storage(&mut self, key: &SlotKey, version: Option<SlotNumber>) -> anyhow::Result<Option<SlotValue>> {
+    fn get_archival_from_user_storage(
+        &mut self,
+        key: &SlotKey,
+        version: Option<SlotNumber>,
+    ) -> anyhow::Result<Option<SlotValue>> {
         // First, check if the user has written this value. This allows users to write during eth_call even if they're reading historical state.
         // IMPORTANT: Note that we do *not* empty the statecheckpoint passed by the caller who creates the API state accessor (we can't because it's Arc'd)
         // so it is imperative that we do *not* read from it during archival queries - it might have random data from the current state.
-        if let MaybePresentValue::Present(entry) = self.user_cache.get_from_cache(key) {
-            return Ok(entry)
+        if let Some(entry) = self.local_user_writes.get(key) {
+            return Ok(entry.clone());
         }
         // If not, read it from storage
-        self.checkpoint.storage().get_historical::<namespaces::User>(key, version, &self.witness, )
+        self.latest_state_checkpoint
+            .storage()
+            .get_historical::<namespaces::User>(key, version, &self.witness)
     }
 
-    fn get_archival_from_kernel_storage(&mut self, key: &SlotKey, version: Option<SlotNumber>) -> anyhow::Result<Option<SlotValue>> {
+    fn get_archival_from_kernel_storage(
+        &mut self,
+        key: &SlotKey,
+        version: Option<SlotNumber>,
+    ) -> anyhow::Result<Option<SlotValue>> {
         // First, check if the kernel has written this value. This allows users to write during eth_call even if they're reading historical state.
         // IMPORTANT: Note that we do *not* empty the statecheckpoint passed by the caller who creates the API state accessor (we can't because it's Arc'd)
         // so it is imperative that we do *not* read from it during archival queries - it might have random data from the current state.
-        if let MaybePresentValue::Present(entry) = self.kernel_cache.get_from_cache(key) {
-            return Ok(entry)
+        if let Some(entry) = self.local_kernel_writes.get(key) {
+            return Ok(entry.clone());
         }
         // If not, read it from storage
-        self.checkpoint.storage().get_historical::<namespaces::Kernel>(key, version, &self.witness, )
+        self.latest_state_checkpoint
+            .storage()
+            .get_historical::<namespaces::Kernel>(key, version, &self.witness)
     }
 
-    fn get_archival_from_accessory_storage(&mut self, key: &SlotKey, version: Option<SlotNumber>) -> anyhow::Result<Option<SlotValue>> {
+    fn get_archival_from_accessory_storage(
+        &mut self,
+        key: &SlotKey,
+        version: Option<SlotNumber>,
+    ) -> anyhow::Result<Option<SlotValue>> {
         // First, check if the accessory has written this value. This allows users to write during eth_call even if they're reading historical state.
-        if let Some(write) = self.accessory_writes.get(key) {
-            return Ok(write.value.clone())
+        if let Some(write) = self.local_accessory_writes.get(key) {
+            return Ok(write.value.clone());
         }
         // If not, read it from storage
-        self.checkpoint.storage().get_accessory_historical(key, version)
+        self.latest_state_checkpoint
+            .storage()
+            .get_accessory_historical(key, version)
     }
 }
-
 
 impl<S: Spec> UniversalStateAccessor for ApiStateAccessor<S> {
     fn get_size(
@@ -141,7 +171,8 @@ impl<S: Spec> UniversalStateAccessor for ApiStateAccessor<S> {
             Namespace::User => {
                 if let Some(number) = self.safe_true_slot_number_to_use {
                     // If we're doing an archival query, we can just use the historical storage API on `ProvableStorageCache`
-                    self.get_archival_from_user_storage(key, Some(number)).map(|v| v.map(|v|v.size()))
+                    self.get_archival_from_user_storage(key, Some(number))
+                        .map(|v| v.map(|v| v.size()))
                 } else {
                     // Otherwise we're doing a `current_state` query, so we need to use the API which is also aware of the intermediate state
                     // generated by the sequencer.
@@ -151,20 +182,27 @@ impl<S: Spec> UniversalStateAccessor for ApiStateAccessor<S> {
             Namespace::Kernel => {
                 if is_archival_query {
                     // If we're doing an archival query, we can just use the historical storage API on `ProvableStorageCache`
-                    self.get_archival_from_kernel_storage(key, get_slot_number(self.visible_slot_number)).map(|v| v.map(|v|v.size()))
-
+                    self.get_archival_from_kernel_storage(
+                        key,
+                        get_slot_number(self.visible_slot_number),
+                    )
+                    .map(|v| v.map(|v| v.size()))
                 } else {
                     // Otherwise we're doing a `current_state` query, so we need to use the API which is also aware of the intermediate state
                     // generated by the sequencer.
                     Ok(self.get_from_kernel_storage(key).map(|v| v.size()))
                 }
             }
-            Namespace::Accessory => match self.accessory_writes.get(key).cloned() {
+            Namespace::Accessory => match self.local_accessory_writes.get(key).cloned() {
                 Some(write) => Ok(write.value.as_ref().map(|v| v.size())),
                 None => {
                     if is_archival_query {
                         // For archival queries, we always use the storage API
-                        self.get_archival_from_accessory_storage(key, self.safe_true_slot_number_to_use).map(|v| v.map(|v|v.size()))
+                        self.get_archival_from_accessory_storage(
+                            key,
+                            self.safe_true_slot_number_to_use,
+                        )
+                        .map(|v| v.map(|v| v.size()))
                     } else {
                         Ok(self.get_from_accessory_storage(key).map(|v| v.size()))
                     }
@@ -193,7 +231,7 @@ impl<S: Spec> UniversalStateAccessor for ApiStateAccessor<S> {
         let result = match namespace {
             Namespace::User => {
                 if let Some(number) = self.safe_true_slot_number_to_use {
-                   self.get_archival_from_user_storage(key, Some(number))
+                    self.get_archival_from_user_storage(key, Some(number))
                 } else {
                     // Otherwise we're doing a `current_state` query, so we need to use the API which is also aware of the intermediate state
                     // generated by the sequencer.
@@ -204,19 +242,25 @@ impl<S: Spec> UniversalStateAccessor for ApiStateAccessor<S> {
             // If so, use the appropriate API on `ProvableStorageCache`
             Namespace::Kernel => {
                 if is_archival_query {
-                    self.get_archival_from_kernel_storage(key, get_slot_number(self.visible_slot_number))
+                    self.get_archival_from_kernel_storage(
+                        key,
+                        get_slot_number(self.visible_slot_number),
+                    )
                 } else {
                     // Otherwise we're doing a `current_state` query, so we need to use the API which is also aware of the intermediate state
                     // generated by the sequencer.
                     Ok(self.get_from_kernel_storage(key))
                 }
             }
-            Namespace::Accessory => match self.accessory_writes.get(key).cloned() {
+            Namespace::Accessory => match self.local_accessory_writes.get(key).cloned() {
                 Some(write) => Ok(write.value),
                 None => {
                     // For archival queries, we always use the storage API
                     if is_archival_query {
-                        self.get_archival_from_accessory_storage(key, self.safe_true_slot_number_to_use)
+                        self.get_archival_from_accessory_storage(
+                            key,
+                            self.safe_true_slot_number_to_use,
+                        )
                     } else {
                         // For current state queries, we use the intermediate state if it's available
                         Ok(self.get_from_accessory_storage(key))
@@ -237,10 +281,14 @@ impl<S: Spec> UniversalStateAccessor for ApiStateAccessor<S> {
     fn set_value(&mut self, namespace: sov_state::Namespace, key: &SlotKey, value: SlotValue) {
         // The rollup height is only used for pruning the sequencer state checkpoint - which is irrelelvant for the API. So we use a dummy value.
         match namespace {
-            Namespace::User => self.user_cache.set(key, value),
-            Namespace::Kernel => self.kernel_cache.set(key, value),
+            Namespace::User => {
+                self.local_user_writes.insert(key.clone(), Some(value));
+            }
+            Namespace::Kernel => {
+                self.local_kernel_writes.insert(key.clone(), Some(value));
+            }
             Namespace::Accessory => {
-                self.accessory_writes
+                self.local_accessory_writes
                     .insert(key.clone(), AccessoryWrite::new(Some(value)));
             }
         }
@@ -249,10 +297,15 @@ impl<S: Spec> UniversalStateAccessor for ApiStateAccessor<S> {
     fn delete_value(&mut self, namespace: sov_state::Namespace, key: &SlotKey) {
         // The rollup height is only used for pruning the sequencer state checkpoint - which is irrelelvant for the API. So we use a dummy value.
         match namespace {
-            Namespace::User => self.user_cache.delete(key),
-            Namespace::Kernel => self.kernel_cache.delete(key),
+            Namespace::User => {
+                self.local_user_writes.insert(key.clone(), None);
+            }
+            Namespace::Kernel => {
+                self.local_kernel_writes.insert(key.clone(), None);
+            }
             Namespace::Accessory => {
-                self.accessory_writes.remove(key);
+                self.local_accessory_writes
+                    .insert(key.clone(), AccessoryWrite::new(None));
             }
         }
     }
@@ -272,7 +325,7 @@ pub(crate) enum StateToAccess {
 /// A [`crate::StateReaderAndWriter`] designed for use within REST APIs and JSON-RPC.
 ///
 /// It can read and write accessory data as well as "user" and "kernel" data.
-/// 
+///
 // An API State accessor contains...
 //  - An `Arc` state checkpoint containing the latest state from the sequencer.
 //  - User, kernel, and accessory caches which contain...
@@ -287,10 +340,10 @@ pub struct ApiStateAccessor<S: Spec> {
     witness: <<S as Spec>::Storage as Storage>::Witness,
     events: Vec<TypeErasedEvent>,
     gas_meter: BasicGasMeter<S>,
-    checkpoint: Arc<StateCheckpoint<S>>,
-    kernel_cache: ProvableStorageCache<namespaces::Kernel>,
-    user_cache: ProvableStorageCache<namespaces::User>,
-    accessory_writes: HashMap<SlotKey, AccessoryWrite>,
+    latest_state_checkpoint: Arc<StateCheckpoint<S>>,
+    local_kernel_writes: HashMap<SlotKey, Option<SlotValue>>,
+    local_user_writes: HashMap<SlotKey, Option<SlotValue>>,
+    local_accessory_writes: HashMap<SlotKey, AccessoryWrite>,
     uncomitted_changes: Option<Box<dyn StateGetter>>,
     temp_cache: TempCache,
     #[debug(skip)]
@@ -343,10 +396,10 @@ impl<S: Spec> PerBlockCache for ApiStateAccessor<S> {
 
 impl<S: Spec> PinnedCacheAccessor<S> for ApiStateAccessor<S> {
     fn pinned_cache_mut(&mut self) -> Option<&mut PinnedCache> {
-        self.user_cache.pinned_cache_mut()
+        None
     }
     fn storage(&self) -> &S::Storage {
-        self.checkpoint.storage()
+        self.latest_state_checkpoint.storage()
     }
 }
 
@@ -572,15 +625,15 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
         let gas_meter = BasicGasMeter::new_api(gas_price);
 
         let mut out = Self {
-            checkpoint: state_checkpoint.clone(),
+            latest_state_checkpoint: state_checkpoint.clone(),
             uncomitted_changes: delta.uncomitted_changes.as_ref().map(|g| g.box_clone()),
             witness: Default::default(),
             gas_meter,
             events: Vec::new(),
             temp_cache: TempCache::new(),
-            kernel_cache: Default::default(),
-            user_cache: Default::default(),
-            accessory_writes: HashMap::new(),
+            local_kernel_writes: Default::default(),
+            local_user_writes: Default::default(),
+            local_accessory_writes: HashMap::new(),
             kernel: kernel.clone(),
             state_to_access,
             visible_slot_number: None,
@@ -624,14 +677,14 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
         let gas_meter = BasicGasMeter::new_api(<S::Gas as Gas>::Price::ZEROED);
 
         Self {
-            checkpoint,
+            latest_state_checkpoint: checkpoint,
             events: Vec::new(),
             gas_meter,
             uncomitted_changes: None,
             witness: Default::default(),
-            kernel_cache: Default::default(),
-            user_cache: Default::default(),
-            accessory_writes: HashMap::new(),
+            local_kernel_writes: Default::default(),
+            local_user_writes: Default::default(),
+            local_accessory_writes: HashMap::new(),
             temp_cache: TempCache::new(),
             kernel: kernel.clone(),
             state_to_access,
@@ -658,9 +711,9 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
     }
 
     fn clear_caches(&mut self) {
-        self.kernel_cache = Default::default();
-        self.user_cache = Default::default();
-        self.accessory_writes = HashMap::new();
+        self.local_kernel_writes = Default::default();
+        self.local_user_writes = Default::default();
+        self.local_accessory_writes = HashMap::new();
     }
 
     /// Sets the gas price for the accessor.
@@ -770,7 +823,7 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
         height: RollupHeight,
     ) -> Result<ApiStateAccessor<S>, ApiStateAccessorError> {
         Self::build_archival_state(
-            self.checkpoint.clone(),
+            self.latest_state_checkpoint.clone(),
             self.uncomitted_changes.as_ref().map(|c| c.box_clone()),
             self.kernel.clone(),
             StateToAccess::RollupHeight(height),

--- a/crates/module-system/sov-modules-api/tests/integration/proof_tests.rs
+++ b/crates/module-system/sov-modules-api/tests/integration/proof_tests.rs
@@ -39,7 +39,7 @@ fn make_user_map_proof(
     let storage = storage_manager.create_storage();
 
     let state_checkpoint = StateCheckpoint::new(storage, &kernel, None);
-    let mut state = ApiStateAccessor::new(&state_checkpoint, Arc::new(kernel));
+    let mut state = ApiStateAccessor::new(Arc::new(state_checkpoint), Arc::new(kernel));
 
     let proof = map.get_with_proof(&1, &mut state).unwrap();
     (root, proof, map)
@@ -73,7 +73,7 @@ fn make_user_value_proof(
     let storage = storage_manager.create_storage();
 
     let state_checkpoint = StateCheckpoint::new(storage, &kernel, None);
-    let mut state = ApiStateAccessor::new(&state_checkpoint, Arc::new(kernel));
+    let mut state = ApiStateAccessor::new(Arc::new(state_checkpoint), Arc::new(kernel));
 
     let proof = state_val.get_with_proof(&mut state).unwrap();
     (root, proof, state_val)
@@ -206,7 +206,7 @@ fn test_archival_proof_gen() {
     let storage = storage_manager.create_storage();
     // Generate a proof at each archival state and validate it against the root
     let state_checkpoint = StateCheckpoint::new(storage.clone(), &kernel, None);
-    let mut api_state_accessor = ApiStateAccessor::new(&state_checkpoint, Arc::new(kernel));
+    let mut api_state_accessor = ApiStateAccessor::new(Arc::new(state_checkpoint), Arc::new(kernel));
     for iter in 0..NUM_ITER {
         let mut archival_accessor = api_state_accessor
             .get_archival_state(RollupHeight::new(iter))

--- a/crates/module-system/sov-modules-api/tests/integration/proof_tests.rs
+++ b/crates/module-system/sov-modules-api/tests/integration/proof_tests.rs
@@ -206,7 +206,8 @@ fn test_archival_proof_gen() {
     let storage = storage_manager.create_storage();
     // Generate a proof at each archival state and validate it against the root
     let state_checkpoint = StateCheckpoint::new(storage.clone(), &kernel, None);
-    let mut api_state_accessor = ApiStateAccessor::new(Arc::new(state_checkpoint), Arc::new(kernel));
+    let mut api_state_accessor =
+        ApiStateAccessor::new(Arc::new(state_checkpoint), Arc::new(kernel));
     for iter in 0..NUM_ITER {
         let mut archival_accessor = api_state_accessor
             .get_archival_state(RollupHeight::new(iter))

--- a/crates/module-system/sov-modules-api/tests/integration/state_tests/archival.rs
+++ b/crates/module-system/sov-modules-api/tests/integration/state_tests/archival.rs
@@ -34,7 +34,8 @@ where
     for current_height in 0..100 {
         let (storage, prev_root) = storage_manager.create_storage_with_root();
         let state_checkpoint = StateCheckpoint::new(storage.clone(), &kernel, None);
-        let api_accessor = ApiStateAccessor::new(Arc::new(state_checkpoint), Arc::new(kernel.clone()));
+        let api_accessor =
+            ApiStateAccessor::new(Arc::new(state_checkpoint), Arc::new(kernel.clone()));
 
         for past_height in 0..current_height {
             let mut archival_api_accessor = api_accessor
@@ -55,7 +56,8 @@ where
         );
         let storage = storage_manager.create_prover_storage();
         let state_checkpoint = StateCheckpoint::new(storage, &kernel, None);
-        let api_accessor = ApiStateAccessor::new(Arc::new(state_checkpoint), Arc::new(kernel.clone()));
+        let api_accessor =
+            ApiStateAccessor::new(Arc::new(state_checkpoint), Arc::new(kernel.clone()));
 
         for another_past_height in 0..=current_height {
             let mut archival_api_accessor = api_accessor

--- a/crates/module-system/sov-modules-api/tests/integration/state_tests/archival.rs
+++ b/crates/module-system/sov-modules-api/tests/integration/state_tests/archival.rs
@@ -34,7 +34,7 @@ where
     for current_height in 0..100 {
         let (storage, prev_root) = storage_manager.create_storage_with_root();
         let state_checkpoint = StateCheckpoint::new(storage.clone(), &kernel, None);
-        let api_accessor = ApiStateAccessor::new(&state_checkpoint, Arc::new(kernel.clone()));
+        let api_accessor = ApiStateAccessor::new(Arc::new(state_checkpoint), Arc::new(kernel.clone()));
 
         for past_height in 0..current_height {
             let mut archival_api_accessor = api_accessor
@@ -55,7 +55,7 @@ where
         );
         let storage = storage_manager.create_prover_storage();
         let state_checkpoint = StateCheckpoint::new(storage, &kernel, None);
-        let api_accessor = ApiStateAccessor::new(&state_checkpoint, Arc::new(kernel.clone()));
+        let api_accessor = ApiStateAccessor::new(Arc::new(state_checkpoint), Arc::new(kernel.clone()));
 
         for another_past_height in 0..=current_height {
             let mut archival_api_accessor = api_accessor

--- a/crates/utils/sov-test-utils/src/runtime/mod.rs
+++ b/crates/utils/sov-test-utils/src/runtime/mod.rs
@@ -346,14 +346,16 @@ where
         let base_fee_per_gas = RT::default()
             .chain_state()
             .base_fee_per_gas(&mut state_checkpoint).expect("Impossible to get the base fee per gas for the current slot. This is a bug. Please report it");
+        let rollup_height = state_checkpoint.rollup_height_to_access();
+        let visible_slot_number = state_checkpoint.current_visible_slot_number();
 
         ApiStateAccessor::<S>::new_with_price_and_heights(
-            &state_checkpoint,
+            Arc::new(state_checkpoint),
             RT::default().kernel_with_slot_mapping(),
-            state_checkpoint.rollup_height_to_access(),
-            state_checkpoint.current_visible_slot_number(),
+            rollup_height,
+            visible_slot_number,
             base_fee_per_gas,
-        ).unwrap_or_else(|_| panic!("ApiStateAccessor creation failed but the requested block height {} or visible height {} is accessible. This is a bug. Please report it.", state_checkpoint.rollup_height_to_access(), state_checkpoint.current_visible_slot_number()))
+        ).unwrap_or_else(|_| panic!("ApiStateAccessor creation failed but the requested block height {rollup_height} or visible height {visible_slot_number} is accessible. This is a bug. Please report it."))
     }
 
     /// Returns the state of the rollup at the most recent version of the rollup.
@@ -369,7 +371,7 @@ where
             .base_fee_per_gas(&mut state_checkpoint).expect("Impossible to get the base fee per gas for the current slot. This is a bug. Please report it");
 
         ApiStateAccessor::<S>::new_with_price_and_slot_number_dangerous(
-            &state_checkpoint,
+            Arc::new(state_checkpoint),
             RT::default().kernel_with_slot_mapping(),
             self.true_slot_number(),
             base_fee_per_gas,


### PR DESCRIPTION
# Description

This PR changes the internals of `ApiStateAccessor` to hold an `Arc` of the sequencer state checkpoint rather than cloning it internally. This makes creating an ApiStateAccessor significantly faster and restores the throughput of the nonce queue. 

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


