### PR TITLE
Don't retry TXs in acceptance tests, to reduce noise when the rollup is shutting down.

### DIFF
--- a/crates/utils/sov-soak-testing-lib/src/lib.rs
+++ b/crates/utils/sov-soak-testing-lib/src/lib.rs
@@ -107,6 +107,7 @@ impl ValidityProfile {
 #[derive(Default)]
 pub struct SoakTestRunner<R, S: Spec> {
     modules: Vec<BasicModuleRef<S, R>>,
+    use_retries: bool,
 }
 
 impl<R, S> SoakTestRunner<R, S>
@@ -118,7 +119,17 @@ where
     pub fn new() -> Self {
         Self {
             modules: Vec::new(),
+            use_retries: true,
         }
+    }
+
+    /// By default, all transactions that are intended to succeed are submitted with retries using
+    /// exponential backoff.
+    /// When opted out, transactions are sent using a single request and fail-fast if they're not
+    /// successful on the first try.
+    pub fn without_retries(mut self) -> Self {
+        self.use_retries = false;
+        self
     }
 
     /// Add Bank module to the soak test.
@@ -204,7 +215,8 @@ where
                         rx.clone(),
                         worker_id,
                         num_workers,
-                        validity.clone()
+                        validity.clone(),
+                        self.use_retries
                     ) => {
                         // If prepare_and_send_txs completes (likely an error), return immediately
                         return result;
@@ -225,6 +237,7 @@ where
                     worker_id,
                     num_workers,
                     validity.clone(),
+                    self.use_retries,
                 )
                 .await
             };
@@ -314,6 +327,7 @@ async fn prepare_and_send_txs<R: Runtime<S> + Clone, S: Spec>(
     worker_id: u128,
     num_workers: u32,
     validity: Distribution<MessageValidity>,
+    use_retries: bool,
 ) -> anyhow::Result<()> {
     let mut nonces: HashMap<<<S as Spec>::CryptoSpec as CryptoSpec>::PublicKey, u64> =
         Default::default();
@@ -401,6 +415,8 @@ async fn prepare_and_send_txs<R: Runtime<S> + Clone, S: Spec>(
                     .send_tx_to_sequencer(tx)
                     .await
                     .expect_err("Outdated transaction should have failed");
+            } else if use_retries {
+                client.send_tx_to_sequencer_with_retry(tx).await?;
             } else {
                 client.send_tx_to_sequencer(tx).await?;
             }

--- a/crates/utils/sov-soak-testing-lib/src/lib.rs
+++ b/crates/utils/sov-soak-testing-lib/src/lib.rs
@@ -402,7 +402,7 @@ async fn prepare_and_send_txs<R: Runtime<S> + Clone, S: Spec>(
                     .await
                     .expect_err("Outdated transaction should have failed");
             } else {
-                client.send_tx_to_sequencer_with_retry(tx).await?;
+                client.send_tx_to_sequencer(tx).await?;
             }
             total_txns += 1;
         }


### PR DESCRIPTION
# Description

This results in a lot of pollution in the logs of the acceptance tests, because the rollup is started with a `--stop-at-height` parameter, and when it's reached the sequencer gives out 503s. But each of the 20 or so workers then retries the transaction 30 times resulting in a couple of thousand of `ERROR`/`WARNING` logs lines from the rollup ("rejecting transaction") and the soak workers ("transaction failed, retrying"). This makes it very annoying to scroll up to see if there were any actual errors during the soak run.

In my experience on a correctly running rollup transaction inclusion is reliable and so retries are not needed. An alternative feature if we want to keep retries would be discriminating the retry logic to fail-fast on certain errors like "rollup shutting down".

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
