### PR TITLE
Rate Limiter: Limit number of concurrent users.

### DIFF
--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -323,8 +323,9 @@ mod tests {
             node_id = "node_1"
             time_till_leader_update_allowed_ms = 1000
             [sequencer.preferred.rate_limiter]
-            address_custom_limits = []
+            max_nb_of_concurrent_users_in_rate_limiter = 100000
             max_requests_per_second = 1000000
+            address_custom_limits = []
             ip_custom_limits = [["157.180.14.244", { resources_per_bucket = 10, batch_execution_time_limit_millis = 200, refill_rate = 2}]]
             [sequencer.preferred.rate_limiter.default_limits]
             resources_per_bucket = 5

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -278,6 +278,7 @@ pub struct TimingOracleConfig {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
 pub struct SovRateLimiterConfig<Address: Copy> {
+    pub max_nb_of_concurrent_users_in_rate_limiter: u64,
     /// The maximum number of requests allowed per second.
     pub max_requests_per_second: u64,
     /// Default limits.

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -278,6 +278,7 @@ pub struct TimingOracleConfig {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
 pub struct SovRateLimiterConfig<Address: Copy> {
+    /// The cache size for the rate limiter.
     pub max_nb_of_concurrent_users_in_rate_limiter: u64,
     /// The maximum number of requests allowed per second.
     pub max_requests_per_second: u64,

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
@@ -73,6 +73,7 @@ expression: config
       "num_cache_warmup_workers": 0,
       "timing_oracle": null,
       "rate_limiter": {
+        "max_nb_of_concurrent_users_in_rate_limiter": 100000,
         "max_requests_per_second": 1000000,
         "default_limits": {
           "resources_per_bucket": 5,

--- a/crates/full-node/sov-metrics/src/influxdb/mod.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/mod.rs
@@ -15,9 +15,9 @@ pub use config::{MonitoringConfig, TelegrafSocketConfig};
 pub use gas_constant_estimation::{GasConstantTracker, GAS_CONSTANTS};
 pub use tracker::{
     init_metrics_tracker, spawn_tokio_runtime_metrics_task, timestamp, BatchMetrics, BatchOutcome,
-    HttpMetrics, RpcMetrics, RunnerMetrics, RunnerProcessStfChangesMetrics, SlotProcessingMetrics,
-    TransactionEffect, TransactionProcessingMetrics, UserSpaceSlotProcessingMetrics, ZkCircuit,
-    ZkProvingTime, ZkVmExecutionChunk,
+    HttpMetrics, RateLimiterMetrics, RpcMetrics, RunnerMetrics, RunnerProcessStfChangesMetrics,
+    SlotProcessingMetrics, TransactionEffect, TransactionProcessingMetrics,
+    UserSpaceSlotProcessingMetrics, ZkCircuit, ZkProvingTime, ZkVmExecutionChunk,
 };
 
 pub(crate) type SerializableMetric = Box<dyn Metric>;

--- a/crates/full-node/sov-metrics/src/influxdb/tracker.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/tracker.rs
@@ -795,3 +795,30 @@ pub fn spawn_tokio_runtime_metrics_task(
         }
     })
 }
+
+/// Metrics for rate limiter.
+#[derive(Debug)]
+pub struct RateLimiterMetrics {
+    /// Type of the limiter
+    pub limiter_type: &'static str,
+    /// Total number of items stored in the cache.
+    pub value: u64,
+}
+
+impl Metric for RateLimiterMetrics {
+    fn measurement_name(&self) -> &'static str {
+        "sov_rollup_rate_limiter"
+    }
+
+    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        write!(
+            buffer,
+            "{},limiter_type={:?} value={}",
+            self.measurement_name(),
+            self.limiter_type,
+            self.value,
+        )?;
+
+        Ok(())
+    }
+}

--- a/crates/full-node/sov-metrics/src/lib.rs
+++ b/crates/full-node/sov-metrics/src/lib.rs
@@ -16,9 +16,10 @@ pub use influx_db_nonnative::{
 pub use influxdb::{
     init_metrics_tracker, safe_telegraf_string, spawn_tokio_runtime_metrics_task, timestamp,
     track_metrics, BatchMetrics, BatchOutcome, HttpMetrics, Metric, MetricsTracker,
-    MonitoringConfig, RpcMetrics, RunnerMetrics, RunnerProcessStfChangesMetrics,
-    SlotProcessingMetrics, TelegrafSocketConfig, TransactionEffect, TransactionProcessingMetrics,
-    UserSpaceSlotProcessingMetrics, ZkCircuit, ZkProvingTime, ZkVmExecutionChunk,
+    MonitoringConfig, RateLimiterMetrics, RpcMetrics, RunnerMetrics,
+    RunnerProcessStfChangesMetrics, SlotProcessingMetrics, TelegrafSocketConfig, TransactionEffect,
+    TransactionProcessingMetrics, UserSpaceSlotProcessingMetrics, ZkCircuit, ZkProvingTime,
+    ZkVmExecutionChunk,
 };
 #[cfg(all(feature = "native", feature = "gas-constant-estimation"))]
 pub use influxdb::{GasConstantTracker, GAS_CONSTANTS};

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
@@ -277,6 +277,8 @@ impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
         });
 
         if entry_count >= self.max_nb_of_concurrent_users {
+            // data.entry_count() returns only approximate number of entries in this cache.
+            // Once we hit the limit we sync to get the exact number of entries.
             self.data.sync();
             let entry_count = self.data.entry_count();
             if entry_count >= self.max_nb_of_concurrent_users {

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
@@ -1,6 +1,8 @@
 use crate::preferred::rate_limiter::resource::LimitExceeded;
 use crate::preferred::rate_limiter::resource::Resource;
 use mini_moka::sync::Cache;
+use mini_moka::sync::ConcurrentCacheExt;
+use sov_metrics::RateLimiterMetrics;
 use sov_modules_api::Gas;
 use sov_modules_api::Spec;
 use std::collections::HashMap;
@@ -247,7 +249,7 @@ impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
         default_config: RateLimiterConfig<S>,
         special_configs: HashMap<K, RateLimiterConfig<S>>,
     ) -> Self {
-        let data = Cache::builder()
+        let data: Cache<K, Throttler<<S as Spec>::Gas>> = Cache::builder()
             .time_to_live(Duration::from_millis(ttl_in_millis))
             .build();
 
@@ -263,14 +265,26 @@ impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
         &mut self,
         now: Instant,
         key: &K,
+        limiter_type: &'static str,
     ) -> Result<Throttler<S::Gas>, LimitExceeded<S::Gas>> {
         let entry_count = self.data.entry_count();
 
-        if entry_count > self.max_nb_of_concurrent_users {
-            return Err(LimitExceeded::TooManyConcurrentUsers {
-                nb_of_users: entry_count,
-                max_allowed: self.max_nb_of_concurrent_users,
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit(RateLimiterMetrics {
+                value: entry_count,
+                limiter_type,
             });
+        });
+
+        if entry_count >= self.max_nb_of_concurrent_users {
+            self.data.sync();
+            let entry_count = self.data.entry_count();
+            if entry_count >= self.max_nb_of_concurrent_users {
+                return Err(LimitExceeded::TooManyConcurrentUsers {
+                    nb_of_users: entry_count,
+                    max_allowed: self.max_nb_of_concurrent_users,
+                });
+            }
         }
 
         match self.data.get(key) {
@@ -308,6 +322,7 @@ impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use sov_modules_api::Spec;
     use sov_test_utils::TestSpec;
     use std::thread::sleep;
@@ -318,6 +333,7 @@ mod tests {
     const MAX_SPACE_IN_BYTES: u64 = 100_0000;
     const MAX_EXECUTION_TIME_MICROS: u64 = 1_000_000;
     const TTL_IN_MILLIS: u64 = 1_000_000;
+    const MAX_NB_OF_CONCURRENT_USERS: u64 = 10_000;
 
     #[test]
     fn test_rate_limiter_happy_path() {
@@ -331,6 +347,7 @@ mod tests {
         };
 
         let mut rollup_simulator = Simulator::new(
+            MAX_NB_OF_CONCURRENT_USERS,
             TTL_IN_MILLIS,
             config,
             resource_used_per_run,
@@ -403,6 +420,7 @@ mod tests {
         )]);
 
         let mut rollup_simulator = Simulator::new(
+            MAX_NB_OF_CONCURRENT_USERS,
             TTL_IN_MILLIS,
             default_config,
             resource_used_per_run,
@@ -447,6 +465,7 @@ mod tests {
         };
 
         let mut rollup_simulator = Simulator::new(
+            MAX_NB_OF_CONCURRENT_USERS,
             TTL_IN_MILLIS,
             config,
             resource_used_per_run,
@@ -526,8 +545,13 @@ mod tests {
             refill_rate,
         };
 
-        let mut rollup_simulator =
-            Simulator::new(2, config, resource_used_per_run, Default::default());
+        let mut rollup_simulator = Simulator::new(
+            MAX_NB_OF_CONCURRENT_USERS,
+            2,
+            config,
+            resource_used_per_run,
+            Default::default(),
+        );
 
         let addr = <TestSpec as Spec>::Address::from([1; 28]);
         let now = Instant::now();
@@ -544,6 +568,58 @@ mod tests {
         assert!(throttler.is_none());
     }
 
+    #[test]
+    fn test_rate_limiter_max_concurrent_users() {
+        let resource_used_per_run = big_resource_used_per_run();
+        let max_allowed_resources = max_allowed_resources();
+        let refill_rate = refill_rate();
+
+        let config = RateLimiterConfig::<TestSpec> {
+            max_allowed_resources,
+            refill_rate,
+        };
+
+        let max_nb_of_concurrent_users = 5;
+        let ttl_in_millis = 50;
+
+        let mut rollup_simulator = Simulator::new(
+            max_nb_of_concurrent_users,
+            2,
+            config,
+            resource_used_per_run,
+            Default::default(),
+        );
+
+        // Attempt to insert 20 entries into the rate limiter.
+        for i in 0..20 {
+            let addr = <TestSpec as Spec>::Address::from([i; 28]);
+            let now = Instant::now();
+
+            let res = rollup_simulator.run_and_assert_limits(
+                now,
+                &addr,
+                rollup_simulator.resource_used_per_run,
+            );
+
+            // mini-mocka does not track the exact number of entries. After about five entries, we should encounter a rate limiter error.
+            if let Err(err) = res {
+                if matches!(err, LimitExceeded::TooManyConcurrentUsers { .. }) {
+                    // Wait for some entries to expire. At this point, we should be able to insert another entry.
+                    sleep(Duration::from_millis(5 * ttl_in_millis));
+                    rollup_simulator
+                        .run_and_assert_limits(now, &addr, rollup_simulator.resource_used_per_run)
+                        .unwrap();
+
+                    return;
+                }
+            }
+        }
+
+        panic!(
+            "Test failed: The rate limiter did not apply the max_nb_of_concurrent_users parameter."
+        );
+    }
+
     struct Simulator {
         rate_limiter: RateLimiter<<TestSpec as Spec>::Address, TestSpec>,
         resource_used_per_run: ResourceUsed<Gas>,
@@ -551,12 +627,18 @@ mod tests {
 
     impl Simulator {
         fn new(
+            max_nb_of_concurrent_users: u64,
             ttl_in_millis: u64,
             config: RateLimiterConfig<TestSpec>,
             resource_used_per_run: ResourceUsed<Gas>,
             special_configs: HashMap<<TestSpec as Spec>::Address, RateLimiterConfig<TestSpec>>,
         ) -> Self {
-            let rate_limiter = RateLimiter::new(1000, ttl_in_millis, config, special_configs);
+            let rate_limiter = RateLimiter::new(
+                max_nb_of_concurrent_users,
+                ttl_in_millis,
+                config,
+                special_configs,
+            );
             Self {
                 rate_limiter,
                 resource_used_per_run,
@@ -569,7 +651,7 @@ mod tests {
             addr: &<TestSpec as Spec>::Address,
             resource_used_so_far: ResourceUsed<Gas>,
         ) -> Result<(), LimitExceeded<Gas>> {
-            let throttler = self.rate_limiter.allow(now, addr)?;
+            let throttler = self.rate_limiter.allow(now, addr, "by_addr")?;
 
             let throttler = self
                 .rate_limiter
@@ -655,7 +737,7 @@ mod tests {
     }
 
     impl RefillRatePerMillis<Gas> {
-        fn zero() -> Self {
+        pub(crate) fn zero() -> Self {
             Self {
                 token_resource_per_ms: Resource::zero(),
             }

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
@@ -236,6 +236,7 @@ impl<G: Gas> Throttler<G> {
 /// update:
 ///   total_resource_used = 3 micros
 pub(crate) struct RateLimiter<K, S: Spec> {
+    limiter_type: &'static str,
     max_nb_of_concurrent_users: u64,
     data: Cache<K, Throttler<S::Gas>>,
     default_config: RateLimiterConfig<S>,
@@ -244,6 +245,7 @@ pub(crate) struct RateLimiter<K, S: Spec> {
 
 impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
     pub(crate) fn new(
+        limiter_type: &'static str,
         max_nb_of_concurrent_users: u64,
         ttl_in_millis: u64,
         default_config: RateLimiterConfig<S>,
@@ -254,6 +256,7 @@ impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
             .build();
 
         Self {
+            limiter_type,
             max_nb_of_concurrent_users,
             data,
             default_config,
@@ -265,9 +268,9 @@ impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
         &mut self,
         now: Instant,
         key: &K,
-        limiter_type: &'static str,
     ) -> Result<Throttler<S::Gas>, LimitExceeded<S::Gas>> {
         let entry_count = self.data.entry_count();
+        let limiter_type = self.limiter_type;
 
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(RateLimiterMetrics {
@@ -636,6 +639,7 @@ mod tests {
             special_configs: HashMap<<TestSpec as Spec>::Address, RateLimiterConfig<TestSpec>>,
         ) -> Self {
             let rate_limiter = RateLimiter::new(
+                "by_addr",
                 max_nb_of_concurrent_users,
                 ttl_in_millis,
                 config,
@@ -653,7 +657,7 @@ mod tests {
             addr: &<TestSpec as Spec>::Address,
             resource_used_so_far: ResourceUsed<Gas>,
         ) -> Result<(), LimitExceeded<Gas>> {
-            let throttler = self.rate_limiter.allow(now, addr, "by_addr")?;
+            let throttler = self.rate_limiter.allow(now, addr)?;
 
             let throttler = self
                 .rate_limiter

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
@@ -234,6 +234,7 @@ impl<G: Gas> Throttler<G> {
 /// update:
 ///   total_resource_used = 3 micros
 pub(crate) struct RateLimiter<K, S: Spec> {
+    max_nb_of_concurrent_users: u64,
     data: Cache<K, Throttler<S::Gas>>,
     default_config: RateLimiterConfig<S>,
     special_configs: HashMap<K, RateLimiterConfig<S>>,
@@ -241,6 +242,7 @@ pub(crate) struct RateLimiter<K, S: Spec> {
 
 impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
     pub(crate) fn new(
+        max_nb_of_concurrent_users: u64,
         ttl_in_millis: u64,
         default_config: RateLimiterConfig<S>,
         special_configs: HashMap<K, RateLimiterConfig<S>>,
@@ -250,6 +252,7 @@ impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
             .build();
 
         Self {
+            max_nb_of_concurrent_users,
             data,
             default_config,
             special_configs,
@@ -261,6 +264,15 @@ impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
         now: Instant,
         key: &K,
     ) -> Result<Throttler<S::Gas>, LimitExceeded<S::Gas>> {
+        let entry_count = self.data.entry_count();
+
+        if entry_count > self.max_nb_of_concurrent_users {
+            return Err(LimitExceeded::TooManyConcurrentUsers {
+                nb_of_users: entry_count,
+                max_allowed: self.max_nb_of_concurrent_users,
+            });
+        }
+
         match self.data.get(key) {
             Some(throttler) => {
                 let config = self.get_config(key);
@@ -544,7 +556,7 @@ mod tests {
             resource_used_per_run: ResourceUsed<Gas>,
             special_configs: HashMap<<TestSpec as Spec>::Address, RateLimiterConfig<TestSpec>>,
         ) -> Self {
-            let rate_limiter = RateLimiter::new(ttl_in_millis, config, special_configs);
+            let rate_limiter = RateLimiter::new(1000, ttl_in_millis, config, special_configs);
             Self {
                 rate_limiter,
                 resource_used_per_run,

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
@@ -52,12 +52,14 @@ impl<S: Spec> SovRateLimiterInner<S> {
     ) -> Self {
         Self {
             by_addr_rate_limiter: RateLimiter::new(
+                "limiter_by_addr",
                 max_nb_of_concurrent_users_in_rate_limiter,
                 ttl_in_millis,
                 config.clone(),
                 addrs,
             ),
             by_ip_rate_limiter: RateLimiter::new(
+                "limiter_by_ip",
                 max_nb_of_concurrent_users_in_rate_limiter,
                 ttl_in_millis,
                 config,
@@ -73,18 +75,14 @@ impl<S: Spec> SovRateLimiterInner<S> {
     ) -> Result<LimiterToken<S>, ResourceLimitExceededError<S>> {
         let now = Instant::now();
 
-        let throttler_for_addr =
-            match self
-                .by_addr_rate_limiter
-                .allow(now, &address, "limiter_by_addr")
-            {
-                Ok(ok) => ok,
-                Err(reason) => return Err(ResourceLimitExceededError::Address { address, reason }),
-            };
+        let throttler_for_addr = match self.by_addr_rate_limiter.allow(now, &address) {
+            Ok(ok) => ok,
+            Err(reason) => return Err(ResourceLimitExceededError::Address { address, reason }),
+        };
 
         let throttler_for_ip = self
             .by_ip_rate_limiter
-            .allow(now, &ip, "limiter_by_ip")
+            .allow(now, &ip)
             .map_err(|reason| ResourceLimitExceededError::Ip { ip, reason })?;
 
         Ok(LimiterToken {

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
@@ -44,14 +44,25 @@ struct SovRateLimiterInner<S: Spec> {
 
 impl<S: Spec> SovRateLimiterInner<S> {
     fn new(
+        max_nb_of_concurrent_users_in_rate_limiter: u64,
         ttl_in_millis: u64,
         config: RateLimiterConfig<S>,
         addrs: HashMap<S::Address, RateLimiterConfig<S>>,
         ips: HashMap<IpAddr, RateLimiterConfig<S>>,
     ) -> Self {
         Self {
-            by_addr_rate_limiter: RateLimiter::new(ttl_in_millis, config.clone(), addrs),
-            by_ip_rate_limiter: RateLimiter::new(ttl_in_millis, config, ips),
+            by_addr_rate_limiter: RateLimiter::new(
+                max_nb_of_concurrent_users_in_rate_limiter,
+                ttl_in_millis,
+                config.clone(),
+                addrs,
+            ),
+            by_ip_rate_limiter: RateLimiter::new(
+                max_nb_of_concurrent_users_in_rate_limiter,
+                ttl_in_millis,
+                config,
+                ips,
+            ),
         }
     }
 
@@ -200,13 +211,21 @@ impl<S: Spec> SovRateLimiter<S> {
         let inner = config.map(|sov_config| {
             // All entries older than this value are evicted from the rate limiter.
             let ttl_in_millis = batch_execution_time_limit_millis * TTL_MULTIPLIER;
+            let max_nb_of_concurrent_users_in_rate_limiter =
+                sov_config.max_nb_of_concurrent_users_in_rate_limiter;
 
             let (config, addrs, ips) = limits(
                 sov_config,
                 batch_execution_time_limit_millis,
                 max_batch_size_bytes,
             );
-            SovRateLimiterInner::new(ttl_in_millis, config, addrs, ips)
+            SovRateLimiterInner::new(
+                max_nb_of_concurrent_users_in_rate_limiter,
+                ttl_in_millis,
+                config,
+                addrs,
+                ips,
+            )
         });
         Self { inner }
     }
@@ -341,7 +360,13 @@ mod tests {
     impl<S: Spec> SovRateLimiter<S> {
         fn new_for_test(ttl_in_millis: u64, config: Option<RateLimiterConfig<S>>) -> Self {
             let inner = config.map(|c| {
-                SovRateLimiterInner::new(ttl_in_millis, c, Default::default(), Default::default())
+                SovRateLimiterInner::new(
+                    1000,
+                    ttl_in_millis,
+                    c,
+                    Default::default(),
+                    Default::default(),
+                )
             });
             Self { inner }
         }

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
@@ -72,14 +72,19 @@ impl<S: Spec> SovRateLimiterInner<S> {
         address: S::Address,
     ) -> Result<LimiterToken<S>, ResourceLimitExceededError<S>> {
         let now = Instant::now();
-        let throttler_for_addr = match self.by_addr_rate_limiter.allow(now, &address) {
-            Ok(ok) => ok,
-            Err(reason) => return Err(ResourceLimitExceededError::Address { address, reason }),
-        };
+
+        let throttler_for_addr =
+            match self
+                .by_addr_rate_limiter
+                .allow(now, &address, "limiter_by_addr")
+            {
+                Ok(ok) => ok,
+                Err(reason) => return Err(ResourceLimitExceededError::Address { address, reason }),
+            };
 
         let throttler_for_ip = self
             .by_ip_rate_limiter
-            .allow(now, &ip)
+            .allow(now, &ip, "limiter_by_ip")
             .map_err(|reason| ResourceLimitExceededError::Ip { ip, reason })?;
 
         Ok(LimiterToken {
@@ -98,7 +103,7 @@ impl<S: Spec> SovRateLimiterInner<S> {
     }
 }
 
-const TTL_MULTIPLIER: u64 = 20;
+const TTL_MULTIPLIER: u64 = 5;
 
 fn calculate_limits<S: Spec>(
     limits: Limits,
@@ -235,10 +240,17 @@ impl<S: Spec> SovRateLimiter<S> {
         ip: IpAddr,
         address: S::Address,
     ) -> Result<Option<LimiterToken<S>>, ResourceLimitExceededError<S>> {
-        self.inner
+        let res = self
+            .inner
             .as_mut()
             .map(|inner| inner.allow(ip, address))
-            .transpose()
+            .transpose();
+
+        if let Err(err) = &res {
+            tracing::debug!(ip = %ip, address = %address, %err, "Transaction not allowed.");
+        }
+
+        res
     }
 
     pub(crate) fn update(
@@ -329,7 +341,7 @@ mod tests {
         let ip1 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
         let ip2 = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
 
-        let mut rate_limiter = SovRateLimiter::new_for_test(1_000_000, Some(config));
+        let mut rate_limiter = SovRateLimiter::new_for_test(1000, 1000000, Some(config));
 
         // Update rate limiter for (ip1, cred1)
         {
@@ -358,10 +370,14 @@ mod tests {
     }
 
     impl<S: Spec> SovRateLimiter<S> {
-        fn new_for_test(ttl_in_millis: u64, config: Option<RateLimiterConfig<S>>) -> Self {
+        fn new_for_test(
+            max_nb_of_concurrent_users: u64,
+            ttl_in_millis: u64,
+            config: Option<RateLimiterConfig<S>>,
+        ) -> Self {
             let inner = config.map(|c| {
                 SovRateLimiterInner::new(
-                    1000,
+                    max_nb_of_concurrent_users,
                     ttl_in_millis,
                     c,
                     Default::default(),

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
@@ -19,6 +19,10 @@ pub(crate) enum LimitExceeded<G: Gas> {
         total_accumulated: G,
         max_allowed: G,
     },
+    TooManyConcurrentUsers {
+        nb_of_users: u64,
+        max_allowed: u64,
+    },
 }
 
 // Represents a resource that requires rate limiting.

--- a/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
@@ -91,6 +91,7 @@ async fn create_test_rollup(
 #[tokio::test(flavor = "multi_thread")]
 async fn test_rate_limiting() {
     let sov_config = SovRateLimiterConfig {
+        max_nb_of_concurrent_users_in_rate_limiter: 1000,
         default_limits: Limits {
             resources_per_bucket: 5,
             refill_rate: 100,
@@ -149,6 +150,7 @@ async fn test_correct_ip() {
             resources_per_bucket: 5,
             refill_rate: 0,
         },
+        max_nb_of_concurrent_users_in_rate_limiter: 1000,
         max_requests_per_second: 0,
         address_custom_limits: Vec::default(),
         ip_custom_limits: Vec::default(),

--- a/crates/module-system/module-implementations/sov-accounts/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-accounts/src/capabilities.rs
@@ -1,4 +1,4 @@
-use sov_modules_api::{CredentialId, Spec, StateAccessor, StateWriter};
+use sov_modules_api::{CredentialId, Spec, StateAccessor, StateReader, StateWriter};
 use sov_state::User;
 
 use crate::{Account, Accounts};
@@ -26,6 +26,22 @@ impl<S: Spec> Accounts<S> {
 
                 Ok(*default_address)
             }
+        }
+    }
+
+    /// Resolve the sender's public key to an address.
+    /// If the sender is not registered, but a fallback address if provided, immediately registers
+    /// the credential to the fallback and then returns it.
+    pub fn resolve_sender_address_read_only<ST: StateReader<User>>(
+        &mut self,
+        default_address: &S::Address,
+        credential_id: &CredentialId,
+        state: &mut ST,
+    ) -> Result<S::Address, ST::Error> {
+        let maybe_address = self.accounts.get(credential_id, state)?.map(|a| a.addr);
+        match maybe_address {
+            Some(address) => Ok(address),
+            None => Ok(*default_address),
         }
     }
 }

--- a/crates/module-system/module-implementations/sov-accounts/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-accounts/src/capabilities.rs
@@ -30,8 +30,6 @@ impl<S: Spec> Accounts<S> {
     }
 
     /// Resolve the sender's public key to an address.
-    /// If the sender is not registered, but a fallback address if provided, immediately registers
-    /// the credential to the fallback and then returns it.
     pub fn resolve_sender_address_read_only<ST: StateReader<User>>(
         &mut self,
         default_address: &S::Address,

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -975,6 +975,7 @@
         "address_custom_limits",
         "default_limits",
         "ip_custom_limits",
+        "max_nb_of_concurrent_users_in_rate_limiter",
         "max_requests_per_second"
       ],
       "properties": {
@@ -1018,6 +1019,11 @@
             "maxItems": 2,
             "minItems": 2
           }
+        },
+        "max_nb_of_concurrent_users_in_rate_limiter": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         },
         "max_requests_per_second": {
           "description": "The maximum number of requests allowed per second.",

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -1021,6 +1021,7 @@
           }
         },
         "max_nb_of_concurrent_users_in_rate_limiter": {
+          "description": "The cache size for the rate limiter.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0

--- a/crates/module-system/sov-modules-api/src/runtime/mod.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/mod.rs
@@ -11,15 +11,17 @@ use serde::{Deserialize, Serialize};
 use sov_rollup_interface::stf::GenesisParams;
 #[cfg(feature = "native")]
 use sov_state::pinned_cache::PinnedCache;
+#[cfg(feature = "native")]
+use sov_state::User;
 
 #[cfg(feature = "native")]
 use crate::hooks::FinalizeHook;
 use crate::hooks::{BlockHooks, TxHooks};
 use crate::transaction::TransactionCallable;
 use crate::Context;
-#[cfg(feature = "native")]
-use crate::FullyBakedTx;
 use crate::{DispatchCall, Genesis, RuntimeEventProcessor, Spec};
+#[cfg(feature = "native")]
+use crate::{FullyBakedTx, StateReader};
 
 /// Flag indicating what mode the rollup is operating in.
 #[derive(
@@ -168,12 +170,12 @@ pub trait Runtime<S: Spec>:
     }
 
     /// Resolve CredentialId to address.
-    fn resolve_address<ST: crate::StateAccessor>(
+    fn resolve_address<ST: StateReader<User>>(
         &mut self,
         default_address: &S::Address,
         credential_id: &crate::CredentialId,
         state: &mut ST,
-    ) -> Result<S::Address, <ST as crate::StateWriter<crate::User>>::Error>;
+    ) -> Result<S::Address, ST::Error>;
 }
 
 #[cfg(feature = "native")]

--- a/crates/utils/sov-test-utils/src/runtime/macros.rs
+++ b/crates/utils/sov-test-utils/src/runtime/macros.rs
@@ -165,13 +165,13 @@ macro_rules! generate_runtime_without_capabilities {
                 }
             }
 
-            fn resolve_address<ST: ::sov_modules_api::StateAccessor>(
+            fn resolve_address<ST: ::sov_modules_api::StateReader<::sov_modules_api::User>>(
                 &mut self,
                 default_address: &S::Address,
                 credential_id: &::sov_modules_api::CredentialId,
                 state: &mut ST,
-            ) -> ::std::result::Result<S::Address, <ST as ::sov_modules_api::StateWriter<::sov_modules_api::User>>::Error>{
-                self.accounts.resolve_sender_address(default_address, credential_id, state)
+            ) -> ::std::result::Result<S::Address, ST::Error>{
+                self.accounts.resolve_sender_address_read_only(default_address, credential_id, state)
             }
 
             fn genesis_config(_input: &Self::GenesisInput) -> ::sov_modules_api::prelude::anyhow::Result<Self::GenesisConfig> {

--- a/examples/demo-rollup/configs/mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/mock_rollup_config.toml
@@ -117,7 +117,7 @@ is_replica = false
 #postgres_connection_string = "postgresql://user:pass@host/db" # HIGHLY RECOMMENDED: Use Postgres instead of RocksDB to soft confirmed transactions
 
 # [sequencer.preferred.rate_limiter] # Setting related to rate limiter.
-# max_nb_of_concurrent_users_in_rate_limiter = 100000 # Limit on how many concurrent users can the rate limiter handl.
+# max_nb_of_concurrent_users_in_rate_limiter = 100000 # Limit on how many concurrent users the rate limiter can handle.
 # max_requests_per_second = 10000 # Limit on requests per second.
 # address_custom_limits = [] 
 # ip_custom_limits = []

--- a/examples/demo-rollup/configs/mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/mock_rollup_config.toml
@@ -63,7 +63,7 @@ bind_port = 12346
 # cors = "permissive" # CORS configuration: "permissive" or "restrictive"
 
 [monitoring]
-telegraf_address = "udp://127.0.0.1:8094"
+telegraf_address = "udp://127.0.0.1:9094"
 tokio_runtime_metrics_interval_millis = 500
 # Defines how many measurements a rollup node will accumulate before sending it to the Telegraf.
 # It is expected from the rollup node to produce metrics all the time,
@@ -116,6 +116,14 @@ is_replica = false
 #[sequencer.preferred.postgres_config]
 #postgres_connection_string = "postgresql://user:pass@host/db" # HIGHLY RECOMMENDED: Use Postgres instead of RocksDB to soft confirmed transactions
 
+# [sequencer.preferred.rate_limiter] # Setting related to rate limiter.
+# max_nb_of_concurrent_users_in_rate_limiter = 100000 # Limit on how many concurrent users can the rate limiter handl.
+# max_requests_per_second = 10000 # Limit on requests per second.
+# address_custom_limits = [] 
+# ip_custom_limits = []
+# [sequencer.preferred.rate_limiter.default_limits]
+# resources_per_bucket = 20 # The resources allocated per user per rate-limiting bucket, defined in units of 1/1000th of a full batch. E.g. resources_per_bucket = 10 would mean each bucket allows the user to use 1% of a full batch capacity.
+# refill_rate = 5 # The refill rate of buckets. E.g. if refill_rate = 5, the user's rate limiting bucket will be refilled up to five times every batch.
 
 # Alternative configuration for non-preferred sequencer. This is mutually exclusive with the preferred sequencer configuration:
 # [sequencer.standard]

--- a/examples/demo-rollup/configs/mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/mock_rollup_config.toml
@@ -63,7 +63,7 @@ bind_port = 12346
 # cors = "permissive" # CORS configuration: "permissive" or "restrictive"
 
 [monitoring]
-telegraf_address = "udp://127.0.0.1:9094"
+telegraf_address = "udp://127.0.0.1:8094"
 tokio_runtime_metrics_interval_millis = 500
 # Defines how many measurements a rollup node will accumulate before sending it to the Telegraf.
 # It is expected from the rollup node to produce metrics all the time,

--- a/examples/demo-rollup/stf/src/runtime.rs
+++ b/examples/demo-rollup/stf/src/runtime.rs
@@ -138,15 +138,14 @@ where
     }
 
     #[cfg(feature = "native")]
-    fn resolve_address<ST: sov_modules_api::StateAccessor>(
+    fn resolve_address<ST: sov_modules_api::StateReader<User>>(
         &mut self,
         default_address: &S::Address,
         credential_id: &sov_modules_api::CredentialId,
         state: &mut ST,
-    ) -> Result<S::Address, <ST as sov_modules_api::StateWriter<sov_modules_api::User>>::Error>
-    {
+    ) -> Result<S::Address, ST::Error> {
         self.accounts
-            .resolve_sender_address(default_address, credential_id, state)
+            .resolve_sender_address_read_only(default_address, credential_id, state)
     }
 
     #[cfg(feature = "native")]

--- a/examples/demo-rollup/stf/src/runtime.rs
+++ b/examples/demo-rollup/stf/src/runtime.rs
@@ -138,7 +138,7 @@ where
     }
 
     #[cfg(feature = "native")]
-    fn resolve_address<ST: sov_modules_api::StateReader<User>>(
+    fn resolve_address<ST: sov_modules_api::StateReader<sov_modules_api::User>>(
         &mut self,
         default_address: &S::Address,
         credential_id: &sov_modules_api::CredentialId,

--- a/examples/demo-rollup/tests/evm/evm_rate_limit.rs
+++ b/examples/demo-rollup/tests/evm/evm_rate_limit.rs
@@ -48,6 +48,7 @@ async fn evm_test_rate_limit() -> anyhow::Result<()> {
             resources_per_bucket: 5,
             refill_rate: 0,
         },
+        max_nb_of_concurrent_users_in_rate_limiter: 1000,
         max_requests_per_second: 0,
         address_custom_limits: Vec::default(),
         ip_custom_limits: Vec::default(),


### PR DESCRIPTION
# Description

This PR introduces the following changes:
1. Adds a limit on the number of concurrent users that can be tracked by the rate limiter
2. Introduces `RateLimiterMetrics`
3. Performs general cleanup and refactoring

This is not a breaking change, as the rate limiter configuration is currently used only in tests.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2173 
