### PR TITLE
Gentler arbitrary in rollup-interface

### DIFF
--- a/crates/rollup-interface/Cargo.toml
+++ b/crates/rollup-interface/Cargo.toml
@@ -71,6 +71,6 @@ arbitrary = [
 	"proptest-derive",
 	"sov-rollup-interface/arbitrary",
 	"dep:sha2",
-	"rockbound/arbitrary"
+	"rockbound?/arbitrary"
 ]
 vec-compat = []


### PR DESCRIPTION
# Description

Enabling `arbitrary` feature in `sov-rollup-interface` forces `rockbound` compilation, even if `native` feature is not specified. This PR fixes this.

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
All existing tests are passing

## Docs
No updates
