### PR TITLE
Enabling `arbitrary` or `native` feature in some crates brings unwanted dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,7 +2727,6 @@ version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "arbitrary",
  "iana-time-zone",
  "num-traits",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,6 +2727,7 @@ version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
+ "arbitrary",
  "iana-time-zone",
  "num-traits",
  "serde",

--- a/crates/adapters/mock-da/Cargo.toml
+++ b/crates/adapters/mock-da/Cargo.toml
@@ -79,12 +79,13 @@ testcontainers-modules = { workspace = true, features = ["postgres"] }
 [features]
 default = []
 arbitrary = [
-    "dep:arbitrary",
-    "dep:proptest",
-    "dep:proptest-derive",
-    "sov-mock-da/arbitrary",
-    "sov-rollup-interface/arbitrary",
-    "sov-test-utils/arbitrary"
+	"dep:arbitrary",
+	"dep:proptest",
+	"dep:proptest-derive",
+	"sov-mock-da/arbitrary",
+	"sov-rollup-interface/arbitrary",
+	"sov-test-utils/arbitrary",
+	"chrono?/arbitrary"
 ]
 native = [
     "dep:chrono",

--- a/crates/adapters/mock-da/Cargo.toml
+++ b/crates/adapters/mock-da/Cargo.toml
@@ -80,7 +80,6 @@ testcontainers-modules = { workspace = true, features = ["postgres"] }
 default = []
 arbitrary = [
     "dep:arbitrary",
-    "chrono?/arbitrary",
     "dep:proptest",
     "dep:proptest-derive",
     "sov-mock-da/arbitrary",

--- a/crates/module-system/hyperlane/Cargo.toml
+++ b/crates/module-system/hyperlane/Cargo.toml
@@ -62,28 +62,28 @@ tracing = { workspace = true }
 
 [features]
 default = []
-evm = ["sov-address/evm"]
+evm = ["dep:sov-address", "sov-address?/evm"]
 arbitrary = [
   "dep:proptest-derive",
   "dep:arbitrary",
   "dep:proptest",
-  "sov-address/arbitrary",
+  "sov-address?/arbitrary",
   "sov-bank/arbitrary",
   "sov-hyperlane-integration/arbitrary",
   "sov-modules-api/arbitrary",
   "sov-state/arbitrary",
-  "sov-test-utils/arbitrary",
+  "sov-test-utils?/arbitrary",
   "ruint/arbitrary",
-  "sov-mock-da/arbitrary",
+  "sov-mock-da?/arbitrary",
 ]
 test-utils = ["arbitrary"]
 native = [
   "sov-modules-api/native",
   "sov-value-setter/native",
   "sov-state/native",
-  "sov-address/native",
+  "sov-address?/native",
   "sov-bank/native",
   "sov-hyperlane-integration/native",
-  "sov-mock-da/native",
+  "sov-mock-da?/native",
   "sov-metrics/native",
 ]

--- a/crates/module-system/hyperlane/Cargo.toml
+++ b/crates/module-system/hyperlane/Cargo.toml
@@ -64,15 +64,17 @@ tracing = { workspace = true }
 default = []
 evm = ["dep:sov-address", "sov-address?/evm"]
 arbitrary = [
-    "dep:proptest-derive",
-    "dep:arbitrary",
-    "dep:proptest",
-    "sov-address?/arbitrary",
-    "sov-bank/arbitrary",
-    "sov-hyperlane-integration/arbitrary",
-    "sov-modules-api/arbitrary",
-    "sov-state/arbitrary",
-    "ruint/arbitrary",
+	"dep:proptest-derive",
+	"dep:arbitrary",
+	"dep:proptest",
+	"sov-address?/arbitrary",
+	"sov-bank/arbitrary",
+	"sov-hyperlane-integration/arbitrary",
+	"sov-modules-api/arbitrary",
+	"sov-state/arbitrary",
+	"ruint/arbitrary",
+	"sov-mock-da/arbitrary",
+	"sov-test-utils/arbitrary"
 ]
 test-utils = ["arbitrary"]
 native = [
@@ -84,4 +86,5 @@ native = [
 	"sov-hyperlane-integration/native",
 	"dep:sov-metrics",
 	"sov-metrics/native",
+	"sov-mock-da/native"
 ]

--- a/crates/module-system/hyperlane/Cargo.toml
+++ b/crates/module-system/hyperlane/Cargo.toml
@@ -18,11 +18,11 @@ workspace = true
 sov-address = { workspace = true }
 sov-api-spec = { workspace = true }
 sov-hyperlane-integration = { path = ".", features = ["test-utils", "native"] }
-sov-mock-da = { workspace = true }
+sov-mock-da = { workspace = true, features = ["native"] }
 sov-modules-api = { workspace = true, features = ["native"] }
 sov-sequencer = { workspace = true }
 sov-state = { workspace = true, features = ["native"] }
-sov-test-utils = { workspace = true, features = ["arbitrary"] }
+sov-test-utils = { workspace = true }
 sov-value-setter = { workspace = true, features = ["native"] }
 secp256k1 = { workspace = true, features = ["rand"] }
 
@@ -64,26 +64,27 @@ tracing = { workspace = true }
 default = []
 evm = ["dep:sov-address", "sov-address?/evm"]
 arbitrary = [
-  "dep:proptest-derive",
-  "dep:arbitrary",
-  "dep:proptest",
-  "sov-address?/arbitrary",
-  "sov-bank/arbitrary",
-  "sov-hyperlane-integration/arbitrary",
-  "sov-modules-api/arbitrary",
-  "sov-state/arbitrary",
-  "sov-test-utils/arbitrary",
-  "ruint/arbitrary",
-  "sov-mock-da?/arbitrary",
+    "dep:proptest-derive",
+    "dep:arbitrary",
+    "dep:proptest",
+    "sov-address?/arbitrary",
+    "sov-bank/arbitrary",
+    "sov-hyperlane-integration/arbitrary",
+    "sov-modules-api/arbitrary",
+    "sov-state/arbitrary",
+    "sov-test-utils/arbitrary",
+    "ruint/arbitrary",
+    "sov-mock-da/arbitrary",
 ]
 test-utils = ["arbitrary"]
 native = [
-  "sov-modules-api/native",
-  "sov-value-setter/native",
-  "sov-state/native",
-  "sov-address?/native",
-  "sov-bank/native",
-  "sov-hyperlane-integration/native",
-  "sov-mock-da?/native",
-  "sov-metrics/native",
+	"sov-modules-api/native",
+	"sov-value-setter/native",
+	"sov-state/native",
+	"sov-address?/native",
+	"sov-bank/native",
+	"sov-hyperlane-integration/native",
+	"dep:sov-metrics",
+	"sov-metrics/native",
+	"sov-mock-da/native"
 ]

--- a/crates/module-system/hyperlane/Cargo.toml
+++ b/crates/module-system/hyperlane/Cargo.toml
@@ -17,12 +17,12 @@ workspace = true
 [dev-dependencies]
 sov-address = { workspace = true }
 sov-api-spec = { workspace = true }
-sov-hyperlane-integration = { path = ".", features = ["test-utils", "native"] }
-sov-mock-da = { workspace = true, features = ["native"] }
+sov-hyperlane-integration = { path = ".", features = ["test-utils", "native", "arbitrary"] }
+sov-mock-da = { workspace = true, features = ["native", "arbitrary"] }
 sov-modules-api = { workspace = true, features = ["native"] }
 sov-sequencer = { workspace = true }
 sov-state = { workspace = true, features = ["native"] }
-sov-test-utils = { workspace = true }
+sov-test-utils = { workspace = true, features = ["arbitrary"] }
 sov-value-setter = { workspace = true, features = ["native"] }
 secp256k1 = { workspace = true, features = ["rand"] }
 
@@ -72,9 +72,7 @@ arbitrary = [
     "sov-hyperlane-integration/arbitrary",
     "sov-modules-api/arbitrary",
     "sov-state/arbitrary",
-    "sov-test-utils/arbitrary",
     "ruint/arbitrary",
-    "sov-mock-da/arbitrary",
 ]
 test-utils = ["arbitrary"]
 native = [
@@ -86,5 +84,4 @@ native = [
 	"sov-hyperlane-integration/native",
 	"dep:sov-metrics",
 	"sov-metrics/native",
-	"sov-mock-da/native"
 ]

--- a/crates/module-system/hyperlane/Cargo.toml
+++ b/crates/module-system/hyperlane/Cargo.toml
@@ -72,7 +72,7 @@ arbitrary = [
   "sov-hyperlane-integration/arbitrary",
   "sov-modules-api/arbitrary",
   "sov-state/arbitrary",
-  "sov-test-utils?/arbitrary",
+  "sov-test-utils/arbitrary",
   "ruint/arbitrary",
   "sov-mock-da?/arbitrary",
 ]

--- a/crates/module-system/hyperlane/Cargo.toml
+++ b/crates/module-system/hyperlane/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dev-dependencies]
 sov-address = { workspace = true }
 sov-api-spec = { workspace = true }
-sov-hyperlane-integration = { path = ".", features = ["test-utils", "native"] }
+sov-hyperlane-integration = { path = ".", features = ["test-utils", "native", "arbitrary"] }
 sov-mock-da = { workspace = true, features = ["native"] }
 sov-modules-api = { workspace = true, features = ["native"] }
 sov-sequencer = { workspace = true }
@@ -76,7 +76,7 @@ arbitrary = [
 	"sov-mock-da/arbitrary",
 	"sov-test-utils/arbitrary"
 ]
-test-utils = ["arbitrary"]
+test-utils = []
 native = [
 	"sov-modules-api/native",
 	"sov-value-setter/native",

--- a/crates/module-system/hyperlane/Cargo.toml
+++ b/crates/module-system/hyperlane/Cargo.toml
@@ -17,8 +17,8 @@ workspace = true
 [dev-dependencies]
 sov-address = { workspace = true }
 sov-api-spec = { workspace = true }
-sov-hyperlane-integration = { path = ".", features = ["test-utils", "native", "arbitrary"] }
-sov-mock-da = { workspace = true, features = ["native", "arbitrary"] }
+sov-hyperlane-integration = { path = ".", features = ["test-utils", "native"] }
+sov-mock-da = { workspace = true, features = ["native"] }
 sov-modules-api = { workspace = true, features = ["native"] }
 sov-sequencer = { workspace = true }
 sov-state = { workspace = true, features = ["native"] }

--- a/crates/module-system/sov-modules-api/Cargo.toml
+++ b/crates/module-system/sov-modules-api/Cargo.toml
@@ -86,7 +86,7 @@ arbitrary = [
 	"sov-db?/arbitrary",
 	"sov-mock-zkvm/arbitrary",
 	"sov-modules-api/arbitrary",
-	"sov-rest-utils/arbitrary",
+	"sov-rest-utils?/arbitrary",
 	"sov-rollup-interface/arbitrary",
 	"sov-state/arbitrary",
 	"sov-sequencer-registry/arbitrary",

--- a/crates/module-system/sov-state/Cargo.toml
+++ b/crates/module-system/sov-state/Cargo.toml
@@ -52,7 +52,7 @@ arbitrary = [
     "sov-modules-macros?/arbitrary",
     "sov-db-types/arbitrary",
 ]
-bench = ["sov-modules-macros/bench"]
+bench = ["dep:sov-modules-macros", "sov-modules-macros/bench"]
 default = []
 native = [
     "sov-db",


### PR DESCRIPTION
# Description

This PR fixes this. In some cases I've changed dep and feature to be more explicit, so it is easier to understand, which feature actually needs dependency:


It was:

```toml
[dependencies]
my-crate = { version = "1", optional = true }

[features]
foo = ["my-crate/foo"]
# many other features
```

and now:

```toml
[dependencies]
my-crate = { version = "1", optional = true }

[features]
foo = ["dep:my-crate", "my-crate/foo"]
# many other features
```

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Existing tests are passing

## Docs
No updates
