### PR TITLE
Reduce num generations stored for timing oracle

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/timestamp.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/timestamp.rs
@@ -109,6 +109,8 @@ where
                 .try_into()
                 .expect("Converting unix timestamp to i64 number of milliseconds failed");
 
+            // Artificially inflate the generation number to reduce the number of tx hashes we need to store
+            let generation = timestamp.saturating_mul(100);
             let message = Rt::maybe_set_oracle_timestamp(&runtime, timestamp).expect(
                 "Oracle support must be checked before before spawning update_timestamp_task",
             );
@@ -122,7 +124,7 @@ where
 
             let unsigned_tx = UnsignedTransaction::<Rt, S>::new_with_details(
                 message,
-                UniquenessData::Generation(timestamp as u64),
+                UniquenessData::Generation(generation as u64),
                 details,
             );
 


### PR DESCRIPTION
# Description

Currently, the timing oracle can be a bottleneck due to very frequent tx submission using generation numbers. Since we store several seconds worth of tx history, the timing oracle accrues a very large account which takes hundreds of micros to deserialize. 

This PR reduces the number of generations that we'll store by artificially multiplying the generation number by 100. 

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
