### PR TITLE
Move address resolution off critical path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2025-12-17
+- #2250 Moves address resolution for rate limiting off the critical path
+
 # 2025-12-16
 - #2239 Updates the internals of the API state for improved performance. 
 

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -44,6 +44,7 @@ use sov_modules_api::capabilities::{
     BlobSelector, RollupHeight, TransactionAuthenticator, UniquenessData,
 };
 use sov_modules_api::macros::config_value;
+use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::rest::utils::ErrorObject;
 use sov_modules_api::rest::{ApiState, StateUpdateReceiver};
 use sov_modules_api::{
@@ -646,9 +647,18 @@ where
             let call = Rt::wrap_call(call);
             let delay_ms = self.runtime.get_transaction_delay_ms(&call);
             let uniqueness = auth_data.uniqueness;
+            let mut state = state.api_state_accessor;
+            let address = self
+                .runtime
+                .resolve_address(
+                    &auth_data.default_address,
+                    &auth_data.credential_id,
+                    &mut state,
+                )
+                .unwrap_infallible();
             (
                 IpAndCredentialId {
-                    default_address: auth_data.default_address,
+                    address,
                     ip_addr,
                     credential_id: auth_data.credential_id,
                 },

--- a/crates/full-node/sov-sequencer/src/preferred/nonce_buffer_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/nonce_buffer_task.rs
@@ -814,7 +814,7 @@ mod tests {
             },
             tx_hash: TxHash::from(hash),
             ip_addr_and_credential: IpAndCredentialId {
-                default_address: <TestSpec as Spec>::Address::from([1; 28]),
+                address: <TestSpec as Spec>::Address::from([1; 28]),
                 credential_id: CredentialId::from([1u8; 32]),
                 ip_addr: std::net::IpAddr::V4(Ipv4Addr::LOCALHOST),
             },
@@ -1188,7 +1188,7 @@ mod tests {
                     to_queue.tx_hash,
                     nonce.into(),
                     IpAndCredentialId {
-                        default_address: <TestSpec as Spec>::Address::from([1; 28]),
+                        address: <TestSpec as Spec>::Address::from([1; 28]),
                         credential_id: CredentialId::from([1u8; 32]),
                         ip_addr: std::net::IpAddr::V4(Ipv4Addr::LOCALHOST),
                     },

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
@@ -389,7 +389,7 @@ mod tests {
 
 #[derive(Clone, Copy, Debug)]
 pub struct IpAndCredentialId<Address: BasicAddress> {
-    pub default_address: Address,
+    pub address: Address,
     pub credential_id: CredentialId,
     pub ip_addr: IpAddr,
 }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -802,20 +802,9 @@ where
             });
         };
 
-        let checkpoint = &mut inner.executor.checkpoint;
-        let mut rt = Rt::default();
-
-        let address = rt
-            .resolve_address(
-                &ip_and_credential.default_address,
-                &ip_and_credential.credential_id,
-                checkpoint,
-            )
-            .unwrap_infallible();
-
         let token = inner
             .rate_limiter
-            .allow(ip_and_credential.ip_addr, address)
+            .allow(ip_and_credential.ip_addr, ip_and_credential.address)
             .map_err(|err| AcceptTxError::RateLimiter(err))?;
 
         let (res, resource_used) = inner.do_new_tx(tx_hash, baked_tx).await;

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -28,7 +28,6 @@ use crate::{SequencerNotReadyDetails, TxHash};
 use sov_blob_sender::BlobInternalId;
 use sov_blob_storage::SequenceNumber;
 use sov_modules_api::capabilities::RollupHeight;
-use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::{
     FullyBakedTx, Runtime, Spec, StateCheckpoint, StateUpdateInfo, VersionReader,
 };

--- a/crates/module-system/module-implementations/sov-accounts/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-accounts/src/capabilities.rs
@@ -31,7 +31,7 @@ impl<S: Spec> Accounts<S> {
 
     /// Resolve the sender's public key to an address.
     pub fn resolve_sender_address_read_only<ST: StateReader<User>>(
-        &mut self,
+        &self,
         default_address: &S::Address,
         credential_id: &CredentialId,
         state: &mut ST,

--- a/crates/module-system/sov-modules-api/src/runtime/mod.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/mod.rs
@@ -171,7 +171,7 @@ pub trait Runtime<S: Spec>:
 
     /// Resolve CredentialId to address.
     fn resolve_address<ST: StateReader<User>>(
-        &mut self,
+        &self,
         default_address: &S::Address,
         credential_id: &crate::CredentialId,
         state: &mut ST,

--- a/crates/utils/sov-test-utils/src/runtime/macros.rs
+++ b/crates/utils/sov-test-utils/src/runtime/macros.rs
@@ -166,7 +166,7 @@ macro_rules! generate_runtime_without_capabilities {
             }
 
             fn resolve_address<ST: ::sov_modules_api::StateReader<::sov_modules_api::User>>(
-                &mut self,
+                &self,
                 default_address: &S::Address,
                 credential_id: &::sov_modules_api::CredentialId,
                 state: &mut ST,

--- a/examples/demo-rollup/stf/src/runtime.rs
+++ b/examples/demo-rollup/stf/src/runtime.rs
@@ -139,7 +139,7 @@ where
 
     #[cfg(feature = "native")]
     fn resolve_address<ST: sov_modules_api::StateReader<sov_modules_api::User>>(
-        &mut self,
+        &self,
         default_address: &S::Address,
         credential_id: &sov_modules_api::CredentialId,
         state: &mut ST,


### PR DESCRIPTION
# Description

This tiny PR moves address resolution for rate limiting from the sequencer `Inner` (the single threaded part) into accept tx. This clears the way for removing the `Inner` state altogether at the expense of rate limiting occasionally seeing slightly stale state from the API.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
