### PR TITLE
RateLimiter: Reduce frequency of `RateLimiterMetrics`

### DIFF
--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -325,8 +325,11 @@ mod tests {
             [sequencer.preferred.rate_limiter]
             max_nb_of_concurrent_users_in_rate_limiter = 100000
             max_requests_per_second = 1000000
-            address_custom_limits = []
-            ip_custom_limits = [["157.180.14.244", { resources_per_bucket = 10, batch_execution_time_limit_millis = 200, refill_rate = 2}]]
+            address_custom_limits = [["sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf", { resources_per_bucket = 10, refill_rate = 2}]]
+            ip_custom_limits = [
+                ["157.180.14.244", { resources_per_bucket = 10, refill_rate = 2}],
+                ["157.180.34.249", { resources_per_bucket = 8, refill_rate = 2}]
+            ]
             [sequencer.preferred.rate_limiter.default_limits]
             resources_per_bucket = 5
             refill_rate = 2

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
@@ -99,7 +99,7 @@ expression: config
           [
             "157.180.34.249",
             {
-              "resources_per_bucket": 10,
+              "resources_per_bucket": 8,
               "refill_rate": 2
             }
           ]

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
@@ -79,10 +79,25 @@ expression: config
           "resources_per_bucket": 5,
           "refill_rate": 2
         },
-        "address_custom_limits": [],
+        "address_custom_limits": [
+          [
+            "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
+            {
+              "resources_per_bucket": 10,
+              "refill_rate": 2
+            }
+          ]
+        ],
         "ip_custom_limits": [
           [
             "157.180.14.244",
+            {
+              "resources_per_bucket": 10,
+              "refill_rate": 2
+            }
+          ],
+          [
+            "157.180.34.249",
             {
               "resources_per_bucket": 10,
               "refill_rate": 2

--- a/crates/full-node/sov-metrics/src/influxdb/tracker.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/tracker.rs
@@ -818,7 +818,7 @@ pub struct RateLimiterMetrics {
     /// Type of the limiter
     pub limiter_type: &'static str,
     /// Total number of items stored in the cache.
-    pub value: u64,
+    pub count: u64,
 }
 
 impl Metric for RateLimiterMetrics {

--- a/crates/full-node/sov-metrics/src/influxdb/tracker.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/tracker.rs
@@ -829,10 +829,10 @@ impl Metric for RateLimiterMetrics {
     fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
         write!(
             buffer,
-            "{},limiter_type={:?} value={}",
+            "{},limiter_type={:?} count={}",
             self.measurement_name(),
             self.limiter_type,
-            self.value,
+            self.count,
         )?;
 
         Ok(())

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
@@ -279,7 +279,7 @@ impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
             // to reduce pressure on the observability stack.
             sov_metrics::track_metrics(|tracker| {
                 tracker.submit(RateLimiterMetrics {
-                    value: entry_count,
+                    count: entry_count,
                     limiter_type,
                 });
             });

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
@@ -241,6 +241,7 @@ pub(crate) struct RateLimiter<K, S: Spec> {
     data: Cache<K, Throttler<S::Gas>>,
     default_config: RateLimiterConfig<S>,
     special_configs: HashMap<K, RateLimiterConfig<S>>,
+    metric_counter: u64,
 }
 
 impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
@@ -261,6 +262,7 @@ impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
             data,
             default_config,
             special_configs,
+            metric_counter: 0,
         }
     }
 
@@ -272,12 +274,18 @@ impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
         let entry_count = self.data.entry_count();
         let limiter_type = self.limiter_type;
 
-        sov_metrics::track_metrics(|tracker| {
-            tracker.submit(RateLimiterMetrics {
-                value: entry_count,
-                limiter_type,
+        if self.metric_counter % 100 == 0 {
+            // We don’t need real-time values for this metric, so we emit it once every 100 events
+            // to reduce pressure on the observability stack.
+            sov_metrics::track_metrics(|tracker| {
+                tracker.submit(RateLimiterMetrics {
+                    value: entry_count,
+                    limiter_type,
+                });
             });
-        });
+        }
+
+        self.metric_counter += 1;
 
         if entry_count >= self.max_nb_of_concurrent_users {
             // data.entry_count() returns only approximate number of entries in this cache.

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
@@ -274,8 +274,8 @@ impl<K: Hash + Eq + Debug + Send + Sync + 'static, S: Spec> RateLimiter<K, S> {
         let entry_count = self.data.entry_count();
         let limiter_type = self.limiter_type;
 
-        if self.metric_counter % 100 == 0 {
-            // We don’t need real-time values for this metric, so we emit it once every 100 events
+        if self.metric_counter % 500 == 0 {
+            // We don’t need precise real-time values for this metric, so we emit it once every 500 events
             // to reduce pressure on the observability stack.
             sov_metrics::track_metrics(|tracker| {
                 tracker.submit(RateLimiterMetrics {


### PR DESCRIPTION
# Description

This PR introduces the following changes:
1. Reduces the emission frequency of `RateLimiterMetrics`.
2. Renames `RateLimiterMetrics{value…} to RateLimiterMetrics{count…}`.
3. Improves unit tests.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
