### PR TITLE
Failover: DB rejecting queries from replica.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 //! Database for sequencer-related data.
 //!
 //! TODO(@neysofu): Remove *all* blocking code inside async functions.
@@ -33,11 +31,6 @@ use tokio::sync::{mpsc, watch};
 
 use crate::common::WithCachedTxHashes;
 use crate::preferred::{exit_rollup, track_in_progress_batch_size};
-
-pub(crate) enum DbWriteOutcome {
-    Success,
-    AbortedBecauseReplica,
-}
 
 #[derive(Debug)]
 pub(crate) enum DbReadOutcome<T> {
@@ -127,6 +120,7 @@ pub struct DbSnapshotData {
 }
 
 impl DbSnapshotData {
+    #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.completed_blobs.is_empty() && self.in_progress_batch.is_none()
     }

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 //! Database for sequencer-related data.
 //!
 //! TODO(@neysofu): Remove *all* blocking code inside async functions.
@@ -32,12 +34,35 @@ use tokio::sync::{mpsc, watch};
 use crate::common::WithCachedTxHashes;
 use crate::preferred::{exit_rollup, track_in_progress_batch_size};
 
+pub(crate) enum DbWriteOutcome {
+    Success,
+    AbortedBecauseReplica,
+}
+
+#[derive(Debug)]
+pub(crate) enum DbReadOutcome<T> {
+    Success(T),
+    AbortedBecauseReplica,
+}
+
+#[derive(Debug)]
+pub(crate) enum DbError {
+    Database(anyhow::Error),
+    Replica,
+}
+
+impl<T: Into<anyhow::Error>> From<T> for DbError {
+    fn from(error: T) -> Self {
+        DbError::Database(error.into())
+    }
+}
+
 // Don’t prune the data from the database immediately — give the replica some time to read it before it is pruned.
 const PRUNING_LAG: u64 = 10;
 
 #[async_trait]
 pub trait PreferredSequencerDbBackend: Send + Sync + 'static {
-    async fn begin_rollup_block(&mut self, stored_batch: BatchToStore) -> anyhow::Result<()>;
+    async fn begin_rollup_block(&mut self, stored_batch: BatchToStore) -> Result<(), DbError>;
 
     /// Calls to this method MUST be "sandwiched" between
     /// [`PreferredSequencerDbBackend::begin_rollup_block`] and
@@ -48,14 +73,14 @@ pub trait PreferredSequencerDbBackend: Send + Sync + 'static {
         tx_idx_within_batch: u64,
         tx: FullyBakedTx,
         hash: TxHash,
-    ) -> anyhow::Result<()>;
+    ) -> anyhow::Result<(), DbError>;
 
     async fn batch_add_txs(
         &mut self,
         sequence_number_of_in_progress_batch: SequenceNumber,
         mut tx_idx_within_batch: u64,
         txs: &[(FullyBakedTx, TxHash)],
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<(), DbError> {
         for (tx, hash) in txs {
             self.add_tx(
                 sequence_number_of_in_progress_batch,
@@ -69,28 +94,28 @@ pub trait PreferredSequencerDbBackend: Send + Sync + 'static {
         Ok(())
     }
 
-    async fn end_rollup_block(&mut self, stored_batch: BatchToStore) -> anyhow::Result<()>;
+    async fn end_rollup_block(&mut self, stored_batch: BatchToStore) -> Result<(), DbError>;
 
-    async fn read_in_progress_batch(&self) -> anyhow::Result<Option<InProgressBatch>>;
+    async fn read_in_progress_batch(&self) -> Result<Option<InProgressBatch>, DbError>;
 
     /// Reads completed blobs, in-progress batch, and latest event_id.
     /// Bundling this as a single function allows the Postgres backend to do this atomically, which
     /// is necessary to support replica initialization in the presence of concurrent writes.
-    async fn current_data(&self) -> anyhow::Result<DbSnapshotData>;
+    async fn current_data(&self) -> anyhow::Result<DbSnapshotData, DbError>;
 
     async fn add_proof_blob(
         &mut self,
         sequence_number: SequenceNumber,
         blob_id: BlobInternalId,
         data: Arc<[u8]>,
-    ) -> anyhow::Result<()>;
+    ) -> anyhow::Result<(), DbError>;
 
     /// Instructs the database it MAY delete all data up to the given
     /// [`SequenceNumber`] (included).
     ///
     /// This method exists because the sequencer has no use for data that is
     /// already finalized.
-    async fn prune(&mut self, up_to_including: SequenceNumber) -> anyhow::Result<()>;
+    async fn prune(&mut self, up_to_including: SequenceNumber) -> Result<(), DbError>;
 }
 
 /// The return type of `PreferredSequencerDbBackend::current_data()`.
@@ -99,6 +124,12 @@ pub trait PreferredSequencerDbBackend: Send + Sync + 'static {
 pub struct DbSnapshotData {
     pub completed_blobs: Vec<PreferredSequencerReadBlob>,
     pub in_progress_batch: Option<InProgressBatch>,
+}
+
+impl DbSnapshotData {
+    pub fn is_empty(&self) -> bool {
+        self.completed_blobs.is_empty() && self.in_progress_batch.is_none()
+    }
 }
 
 /// See [`PreferredSequencerReadBlob::Batch`].
@@ -420,30 +451,41 @@ impl PreferredSequencerDb {
         &self,
     ) -> anyhow::Result<(SequenceNumber, PreferredSequencerCache)> {
         if let Some(backend) = &self.backend {
-            let DbSnapshotData {
-                completed_blobs,
-                in_progress_batch,
-            } = backend.current_data().await?;
-
-            let completed_blobs = VecDeque::from(completed_blobs);
-
-            let sequence_number_of_next_blob = match (completed_blobs.back(), &in_progress_batch) {
-                (Some(blob), None) => blob.sequence_number() + 1,
-                (None, Some(batch)) => batch.sequence_number + 1,
-                (Some(blob), Some(batch)) => {
-                    std::cmp::max(blob.sequence_number(), batch.sequence_number) + 1
-                }
-                (None, None) => 0,
-            };
-
-            Ok((
-                sequence_number_of_next_blob,
-                PreferredSequencerCache::new(
+            match backend.current_data().await {
+                Ok(DbSnapshotData {
                     completed_blobs,
                     in_progress_batch,
-                    self.shutdown_sender.clone(),
-                ),
-            ))
+                }) => {
+                    let completed_blobs = VecDeque::from(completed_blobs);
+
+                    let sequence_number_of_next_blob =
+                        match (completed_blobs.back(), &in_progress_batch) {
+                            (Some(blob), None) => blob.sequence_number() + 1,
+                            (None, Some(batch)) => batch.sequence_number + 1,
+                            (Some(blob), Some(batch)) => {
+                                std::cmp::max(blob.sequence_number(), batch.sequence_number) + 1
+                            }
+                            (None, None) => 0,
+                        };
+
+                    Ok((
+                        sequence_number_of_next_blob,
+                        PreferredSequencerCache::new(
+                            completed_blobs,
+                            in_progress_batch,
+                            self.shutdown_sender.clone(),
+                        ),
+                    ))
+                }
+                Err(DbError::Database(err)) => Err(err),
+                Err(DbError::Replica) => {
+                    tracing::error!(
+                        "initial_data: The primary has become a replica. Shutting down."
+                    );
+                    exit_rollup(&self.shutdown_sender).await;
+                    unreachable!()
+                }
+            }
         } else {
             Ok((
                 0, // TODO this will be revisited when we enable the replica sync task.
@@ -464,9 +506,12 @@ impl PreferredSequencerDb {
         tx_idx_within_batch: u64,
     ) -> anyhow::Result<()> {
         if let Some(backend) = &mut self.backend {
-            backend
+            if let Err(err) = backend
                 .batch_add_txs(sequence_number, tx_idx_within_batch, &txs)
-                .await?;
+                .await
+            {
+                return Err(self.check_replica_err(err).await);
+            }
         }
 
         Ok(())
@@ -479,7 +524,7 @@ impl PreferredSequencerDb {
         visible_slots_to_advance: NonZero<u8>,
         sequence_number: SequenceNumber,
         blob_id: BlobInternalId,
-    ) -> anyhow::Result<SequenceNumber> {
+    ) -> anyhow::Result<()> {
         if let Some(backend) = &mut self.backend {
             Self::debug_assert_in_progress_batch_is_none(
                 "Cached in-progress batch state (None) didn't match backend db state",
@@ -502,10 +547,24 @@ impl PreferredSequencerDb {
                 visible_slot_number_after_increase,
                 visible_slots_to_advance,
             };
-            backend.begin_rollup_block(batch_to_store).await?;
+
+            if let Err(err) = backend.begin_rollup_block(batch_to_store).await {
+                return Err(self.check_replica_err(err).await);
+            }
         }
 
-        Ok(sequence_number)
+        Ok(())
+    }
+
+    async fn check_replica_err(&self, err: DbError) -> anyhow::Error {
+        match err {
+            DbError::Database(err) => err,
+            DbError::Replica => {
+                tracing::error!("The primary has become a replica. Shutting down.");
+                exit_rollup(&self.shutdown_sender).await;
+                unreachable!()
+            }
+        }
     }
 
     #[tracing::instrument(skip_all, level = "info")]
@@ -514,20 +573,25 @@ impl PreferredSequencerDb {
         blob_id: BlobInternalId,
         data: Arc<[u8]>,
         sequence_number: SequenceNumber,
-    ) -> anyhow::Result<SequenceNumber> {
+    ) -> anyhow::Result<()> {
         if let Some(backend) = &mut self.backend {
-            backend
+            if let Err(err) = backend
                 .add_proof_blob(sequence_number, blob_id, data.clone())
-                .await?;
+                .await
+            {
+                return Err(self.check_replica_err(err).await);
+            };
         }
 
-        Ok(sequence_number)
+        Ok(())
     }
 
     #[tracing::instrument(skip_all, level = "info")]
     pub(crate) async fn terminate_batch(&mut self, batch: BatchToStore) -> anyhow::Result<()> {
         if let Some(backend) = &mut self.backend {
-            backend.end_rollup_block(batch).await?;
+            if let Err(err) = backend.end_rollup_block(batch).await {
+                return Err(self.check_replica_err(err).await);
+            };
             Self::debug_assert_in_progress_batch_is_none(
                 "Backend didn't remove in-progress batch from database when ending rollup block",
                 backend,
@@ -546,7 +610,9 @@ impl PreferredSequencerDb {
     ) -> anyhow::Result<()> {
         if let Some(backend) = &mut self.backend {
             if let Some(prune_up_to_including) = prune_up_to_including.checked_sub(PRUNING_LAG) {
-                backend.prune(prune_up_to_including).await?;
+                if let Err(err) = backend.prune(prune_up_to_including).await {
+                    return Err(self.check_replica_err(err).await);
+                }
             }
         }
         Ok(())
@@ -559,7 +625,7 @@ impl PreferredSequencerDb {
     ) {
         if cfg!(debug_assertions) {
             match backend.read_in_progress_batch().await {
-                Ok(None) => {}
+                Ok(_) => {}
                 other => {
                     tracing::error!("{msg}: {other:?}");
                     exit_rollup(shutdown_sender).await;

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -61,7 +61,9 @@ macro_rules! run_with_retries {
 
 impl PostgresBackend {
     pub async fn connect(config: &PostgresConfig) -> anyhow::Result<Self> {
-        Self::connect_with_leader_timeout(config, LEADER_TIMEOUT).await
+        let backend = Self::connect_with_leader_timeout(config, LEADER_TIMEOUT).await?;
+        backend.try_update_leader().await?;
+        Ok(backend)
     }
 
     async fn connect_with_leader_timeout(
@@ -727,7 +729,7 @@ mod tests {
             node_id: String,
         ) -> Self {
             let leader_timeout = Duration::from_millis(100_000);
-            let postgres_config = config_from_postgres_container(&postgres, node_id.clone())
+            let postgres_config = config_from_postgres_container(postgres, node_id.clone())
                 .await
                 .unwrap();
             let backend =

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -468,9 +468,10 @@ impl PreferredSequencerDbBackend for PostgresBackend {
             "postgres_db_backend_prune"
         )?;
 
+        /*
         if result.rows_affected() == 0 {
             return Err(DbError::Replica);
-        }
+        }*/
 
         Ok(())
     }

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::{DbSnapshotData, PreferredSequencerDbBackend, PreferredSequencerReadBlob, StoredBlob};
-use crate::preferred::db::{BatchToStore, InProgressBatch};
+use crate::preferred::db::DbError;
+use crate::preferred::db::{BatchToStore, DbReadOutcome, InProgressBatch};
 use axum::async_trait;
 use backon::{BackoffBuilder, ExponentialBuilder};
 use sov_blob_sender::BlobInternalId;
@@ -197,8 +198,13 @@ impl PostgresBackend {
     }
     /// Read all the current data as a single transaction. We have to attempt the whole transaction atomically,
     /// which is why this is wrapped in a helper function and any nested helpers have their retries disabled.
-    async fn current_data_transaction(&self) -> anyhow::Result<DbSnapshotData> {
+    async fn current_data_transaction(&self) -> anyhow::Result<DbReadOutcome<DbSnapshotData>> {
         let mut tx = self.pool.begin().await?;
+        let maybe_leader = self.get_sequencer_leader_inner().await?;
+
+        if !self.is_leader(maybe_leader) {
+            return Ok(DbReadOutcome::AbortedBecauseReplica);
+        }
 
         let completed_blobs_metadata: Vec<(i64, Vec<u8>)> =
             sqlx::query_as::<Postgres, _>(
@@ -224,10 +230,10 @@ impl PostgresBackend {
 
         tx.commit().await?;
 
-        Ok(DbSnapshotData {
+        Ok(DbReadOutcome::Success(DbSnapshotData {
             completed_blobs,
             in_progress_batch,
-        })
+        }))
     }
 
     pub(crate) async fn try_update_leader(&self) -> anyhow::Result<Option<SequencerLeader>> {
@@ -266,22 +272,34 @@ impl PostgresBackend {
     ) -> Result<Option<SequencerLeader>, sqlx::Error> {
         let res = run_with_retries!(
             &self.backoff_policy,
-            sqlx::query_as::<_, SequencerLeader>(
-                "SELECT node_id, last_updated
-                FROM sequencer_leader
-                WHERE singleton = 1",
-            )
-            .fetch_optional(&self.pool),
+            self.get_sequencer_leader_inner(),
             "postgres_db_get_sequencer_leader"
         )?;
 
         Ok(res)
     }
+
+    async fn get_sequencer_leader_inner(&self) -> Result<Option<SequencerLeader>, sqlx::Error> {
+        sqlx::query_as::<_, SequencerLeader>(
+            "SELECT node_id, last_updated
+                FROM sequencer_leader
+                WHERE singleton = 1",
+        )
+        .fetch_optional(&self.pool)
+        .await
+    }
+
+    fn is_leader(&self, maybe_leader: Option<SequencerLeader>) -> bool {
+        match maybe_leader {
+            Some(leader) => leader.node_id == self.node_id,
+            None => false,
+        }
+    }
 }
 
 #[async_trait]
 impl PreferredSequencerDbBackend for PostgresBackend {
-    async fn begin_rollup_block(&mut self, batch_to_store: BatchToStore) -> anyhow::Result<()> {
+    async fn begin_rollup_block(&mut self, batch_to_store: BatchToStore) -> Result<(), DbError> {
         let blob_data = borsh::to_vec(&StoredBlob::Batch {
             blob_id: batch_to_store.blob_id,
             visible_slot_number_after_increase: batch_to_store.visible_slot_number_after_increase,
@@ -289,21 +307,31 @@ impl PreferredSequencerDbBackend for PostgresBackend {
         })?;
 
         // Compound CTE statement to avoid multiple roundtrips
-        run_with_retries!(
+        let result = run_with_retries!(
             &self.backoff_policy,
             sqlx::query(
-                "WITH batch_insert AS (
-                    INSERT INTO in_progress_batch (sequence_number, borsh_value) VALUES ($1, $2)
-                )
-             INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data) 
-             SELECT $1, 'batch_start', NULL, NULL, $2",
+                "
+            WITH batch_insert AS (
+                INSERT INTO in_progress_batch (sequence_number, borsh_value)
+                SELECT $1, $2
+                WHERE is_leader($3)
+            RETURNING sequence_number
+            )
+            INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data)
+            SELECT bi.sequence_number, 'batch_start', NULL, NULL, $2
+            FROM batch_insert bi;
+            "
             )
             .bind(i64::try_from(batch_to_store.sequence_number)?)
             .bind::<&[u8]>(blob_data.as_ref())
+            .bind(&self.node_id)
             .execute(&self.pool),
             "postgres_db_backend_begin_rollup_block"
         )?;
 
+        if result.rows_affected() == 0 {
+            return Err(DbError::Replica);
+        }
         Ok(())
     }
 
@@ -312,7 +340,7 @@ impl PreferredSequencerDbBackend for PostgresBackend {
         sequence_number: SequenceNumber,
         tx_idx_within_batch: u64,
         txs: &[(FullyBakedTx, TxHash)],
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<(), DbError> {
         let start = i64::try_from(tx_idx_within_batch)?;
         let end = start + txs.len() as i64;
         let sequence_number = vec![i64::try_from(sequence_number)?; txs.len()];
@@ -325,20 +353,35 @@ impl PreferredSequencerDbBackend for PostgresBackend {
             .map(|(tx, _)| borsh::to_vec(tx).unwrap())
             .collect::<Vec<_>>();
         let txs_refs: Vec<&[u8]> = txs.iter().map(|t| t.as_slice()).collect();
-        run_with_retries!(
+
+        let result = run_with_retries!(
             &self.backoff_policy,
             sqlx::query::<Postgres>(
                 "INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data)
-                SELECT * FROM UNNEST($1::bigint[], $2::event_type[], $3::bigint[], $4::bytea[], $5::bytea[])"
+                SELECT *
+                    FROM UNNEST(
+                    $1::bigint[],
+                    $2::event_type[],
+                    $3::bigint[],
+                    $4::bytea[],
+                    $5::bytea[]
+                )
+                WHERE is_leader($6);"
             )
             .bind(&sequence_number[..])
             .bind(&event_types[..])
             .bind(&tx_indexes[..])
             .bind(&hashes[..])
             .bind(&txs_refs[..])
+            .bind(&self.node_id)
             .execute(&self.pool),
             "postgres_db_backend_add_tx"
         )?;
+
+        if result.rows_affected() == 0 {
+            return Err(DbError::Replica);
+        }
+
         Ok(())
     }
 
@@ -348,26 +391,33 @@ impl PreferredSequencerDbBackend for PostgresBackend {
         tx_index_within_batch: u64,
         tx: FullyBakedTx,
         hash: TxHash,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<(), DbError> {
         // Serialize the full FullyBakedTx (including sequencing_data) to preserve metadata
         let tx_serialized = borsh::to_vec(&tx)?;
-        run_with_retries!(
+        let result = run_with_retries!(
             &self.backoff_policy,
             sqlx::query::<Postgres>(
-                "INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data) VALUES ($1, 'transaction', $2, $3, $4)",
+                "INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data)
+                    SELECT $1, 'transaction', $2, $3, $4
+                WHERE is_leader($5);",
             )
             .bind(i64::try_from(sequence_number)?)
             .bind(i64::try_from(tx_index_within_batch)?)
             .bind::<&[u8]>(hash.as_ref())
             .bind(&tx_serialized)
+            .bind(&self.node_id)
             .execute(&self.pool),
             "postgres_db_backend_add_tx"
         )?;
 
+        if result.rows_affected() == 0 {
+            return Err(DbError::Replica);
+        }
+
         Ok(())
     }
 
-    async fn end_rollup_block(&mut self, cached: BatchToStore) -> anyhow::Result<()> {
+    async fn end_rollup_block(&mut self, cached: BatchToStore) -> Result<(), DbError> {
         let sequence_number = cached.sequence_number;
         let stored_blob: StoredBlob = cached.into();
         let blob_data = borsh::to_vec(&stored_blob)?;
@@ -378,46 +428,72 @@ impl PreferredSequencerDbBackend for PostgresBackend {
             sqlx::query(
                 "WITH batch_delete AS (
                     DELETE FROM in_progress_batch
-                RETURNING 1
-            )
-            INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data) 
-            SELECT $1, 'batch_end', NULL, NULL, $2
-            FROM batch_delete",
+                    WHERE is_leader($3)
+                    RETURNING 1)
+                INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data)
+                SELECT $1, 'batch_end', NULL, NULL, $2
+                FROM batch_delete",
             )
             .bind(i64::try_from(sequence_number)?)
             .bind::<&[u8]>(blob_data.as_ref())
+            .bind(&self.node_id)
             .execute(&self.pool),
             "postgres_db_backend_end_rollup_block"
         )?;
 
         if result.rows_affected() == 0 {
-            return Err(anyhow::anyhow!("No in-progress batch found to end"));
+            return Err(DbError::Replica);
         }
 
         Ok(())
     }
 
-    async fn prune(&mut self, up_to_including: SequenceNumber) -> anyhow::Result<()> {
+    async fn prune(&mut self, up_to_including: SequenceNumber) -> Result<(), DbError> {
         // Compound CTE statement to avoid multiple roundtrips
-        run_with_retries!(
+        let result = run_with_retries!(
             &self.backoff_policy,
             sqlx::query(
                 "WITH blobs_deleted AS (
-                    DELETE FROM proof_blobs WHERE sequence_number <= $1
-             )
-             DELETE FROM events WHERE sequence_number <= $1",
+                    DELETE FROM proof_blobs
+                    WHERE sequence_number <= $1
+                    AND is_leader($2))
+                DELETE FROM events
+                    WHERE sequence_number <= $1 AND is_leader($2);",
             )
             .bind(i64::try_from(up_to_including)?)
+            .bind(&self.node_id)
             .execute(&self.pool),
             "postgres_db_backend_prune"
         )?;
 
+        if result.rows_affected() == 0 {
+            return Err(DbError::Replica);
+        }
+
         Ok(())
     }
-    async fn read_in_progress_batch(&self) -> anyhow::Result<Option<InProgressBatch>> {
-        let mut conn = self.pool.acquire().await?;
-        self.read_in_progress_batch_with_connection(&mut conn, true)
-            .await
+    async fn read_in_progress_batch(&self) -> anyhow::Result<Option<InProgressBatch>, DbError> {
+        let mut tx = self.pool.begin().await?;
+        let maybe_leader = self.get_sequencer_leader().await?;
+
+        if !self.is_leader(maybe_leader) {
+            return Err(DbError::Replica);
+        }
+
+        let res: Result<
+            Option<
+                super::PreferredSequencerReadBatch<
+                    Vec<FullyBakedTx>,
+                    Vec<sov_modules_api::HexString<[u8; 32]>>,
+                >,
+            >,
+            anyhow::Error,
+        > = self
+            .read_in_progress_batch_with_connection(&mut tx, true)
+            .await;
+        tx.commit().await?;
+
+        Ok(res?)
     }
 
     async fn add_proof_blob(
@@ -425,11 +501,11 @@ impl PreferredSequencerDbBackend for PostgresBackend {
         sequence_number: SequenceNumber,
         blob_id: BlobInternalId,
         data: Arc<[u8]>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), DbError> {
         let blob_data = borsh::to_vec(&StoredBlob::Proof { data, blob_id })?;
 
         // Compound CTE statement to avoid multiple roundtrips
-        run_with_retries!(
+        let result = run_with_retries!(
             &self.backoff_policy,
             sqlx::query(
                 "WITH blob_insert AS (
@@ -444,30 +520,35 @@ impl PreferredSequencerDbBackend for PostgresBackend {
             "postgres_db_backend_add_proof_blob"
         )?;
 
+        if result.rows_affected() == 0 {
+            return Err(DbError::Replica);
+        }
+
         Ok(())
     }
 
-    async fn current_data(&self) -> anyhow::Result<DbSnapshotData> {
-        run_with_retries!(
+    async fn current_data(&self) -> anyhow::Result<DbSnapshotData, DbError> {
+        let res = run_with_retries!(
             &self.backoff_policy,
             self.current_data_transaction(),
             "postgres_db_backend_current_data"
-        )
+        )?;
+
+        match res {
+            DbReadOutcome::Success(data) => Ok(data),
+            DbReadOutcome::AbortedBecauseReplica => Err(DbError::Replica),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sov_modules_api::VisibleSlotNumber;
     use sov_test_utils::postgres::{
         config_from_postgres_container, create_postgres_container, CreatePostgresError,
     };
-
-    impl PostgresBackend {
-        async fn maybe_update_leader(&self) -> Option<SequencerLeader> {
-            self.try_update_leader().await.unwrap()
-        }
-    }
+    use std::num::NonZero;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_sequencer_leader_election() {
@@ -480,34 +561,15 @@ mod tests {
             }
         };
 
-        let node_id_1 = String::from("node_id_1");
-        let node_id_2 = String::from("node_id_2");
-
-        let postgres_config_1 = config_from_postgres_container(&postgres, node_id_1.clone())
-            .await
-            .unwrap();
-
-        let postgres_config_2 = config_from_postgres_container(&postgres, node_id_2.clone())
-            .await
-            .unwrap();
-
-        let leader_timeout = Duration::from_millis(1000);
-        let mut db_1 =
-            PostgresBackend::connect_with_leader_timeout(&postgres_config_1, leader_timeout)
-                .await
-                .unwrap();
-
-        let mut db_2 =
-            PostgresBackend::connect_with_leader_timeout(&postgres_config_2, leader_timeout)
-                .await
-                .unwrap();
+        let db_1 = &mut DB::new(&postgres, String::from("node_id_1")).await;
+        let db_2 = &mut DB::new(&postgres, String::from("node_id_2")).await;
 
         {
             // Updating the same node_id should change the last updated time in the db.
             let leader_1 = db_1.maybe_update_leader().await.unwrap();
             let updated_leader_1 = db_1.maybe_update_leader().await.unwrap();
 
-            assert_eq!(leader_1.node_id, node_id_1);
+            assert_eq!(leader_1.node_id, db_1.node_id);
             assert_eq!(leader_1.node_id, updated_leader_1.node_id);
             assert!(leader_1.last_updated < updated_leader_1.last_updated);
 
@@ -515,31 +577,31 @@ mod tests {
             let leader_2 = db_2.maybe_update_leader().await;
             assert!(leader_2.is_none());
 
-            let leader = db_2.get_sequencer_leader().await.unwrap().unwrap();
+            let leader = db_2.as_ref().get_sequencer_leader().await.unwrap().unwrap();
             assert_eq!(updated_leader_1, leader);
         }
 
         {
-            db_2.leader_timeout = Duration::ZERO;
+            db_2.override_leader_timeout(Duration::ZERO);
             // Now we should be able to update db as the leader_timeout is zero.
             let leader_2 = db_2.maybe_update_leader().await.unwrap();
-            assert_eq!(leader_2.node_id, node_id_2);
+            assert_eq!(leader_2.node_id, db_2.node_id);
         }
 
         {
-            db_1.leader_timeout = Duration::from_millis(100);
+            db_1.override_leader_timeout(Duration::from_millis(100));
             let leader_1 = db_1.maybe_update_leader().await;
             assert!(leader_1.is_none());
 
             // Wait for more than 100ms and update the leader.
             tokio::time::sleep(Duration::from_millis(200)).await;
             let leader_1 = db_1.maybe_update_leader().await.unwrap();
-            assert_eq!(leader_1.node_id, node_id_1);
+            assert_eq!(leader_1.node_id, db_1.node_id);
         }
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_foo() {
+    async fn test_db_operations_leader() {
         let postgres = create_postgres_container().await;
         let postgres = match postgres {
             Ok(pg) => pg,
@@ -549,9 +611,148 @@ mod tests {
             }
         };
 
-        let mut db_1 =
-            PostgresBackend::connect_with_leader_timeout(&postgres_config_1, leader_timeout)
+        let db = &mut DB::new(&postgres, String::from("node_id_1")).await;
+        db.maybe_update_leader().await.unwrap();
+
+        let sequence_number = 1;
+        let batch_to_store = batch_to_store(sequence_number);
+
+        db.as_mut()
+            .begin_rollup_block(batch_to_store)
+            .await
+            .unwrap();
+
+        db.as_mut()
+            .add_tx(
+                sequence_number,
+                1,
+                FullyBakedTx::new(vec![1, 2, 3]),
+                TxHash::new([1; 32]),
+            )
+            .await
+            .unwrap();
+
+        db.as_mut()
+            .batch_add_txs(
+                sequence_number,
+                2,
+                &[(FullyBakedTx::new(vec![4, 5, 6]), TxHash::new([1; 32]))],
+            )
+            .await
+            .unwrap();
+
+        db.as_mut().end_rollup_block(batch_to_store).await.unwrap();
+
+        let data = db.as_mut().current_data().await.unwrap();
+        assert!(!data.is_empty());
+
+        db.as_mut().prune(2).await.unwrap();
+        let data = db.as_mut().current_data().await.unwrap();
+        assert!(data.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_db_operations_replica() {
+        let postgres = create_postgres_container().await;
+        let postgres = match postgres {
+            Ok(pg) => pg,
+            Err(CreatePostgresError::DockerNotSupported) => return,
+            Err(CreatePostgresError::DockerError(e)) => {
+                panic!("Failed to create Postgres container: {e}");
+            }
+        };
+        let db_leader = &mut DB::new(&postgres, String::from("node_id_1")).await;
+        let db_replica = &mut DB::new(&postgres, String::from("node_id_2")).await;
+
+        let sequence_number = 1;
+        let batch_to_store = batch_to_store(sequence_number);
+
+        db_leader.maybe_update_leader().await.unwrap();
+
+        let res = db_replica.as_mut().begin_rollup_block(batch_to_store).await;
+        assert!(matches!(res, Err(DbError::Replica)));
+
+        let res = db_replica
+            .as_mut()
+            .add_tx(
+                sequence_number,
+                1,
+                FullyBakedTx::new(vec![1, 2, 3]),
+                TxHash::new([1; 32]),
+            )
+            .await;
+
+        assert!(matches!(res, Err(DbError::Replica)));
+
+        let res = db_replica
+            .as_mut()
+            .batch_add_txs(
+                sequence_number,
+                2,
+                &[(FullyBakedTx::new(vec![4, 5, 6]), TxHash::new([1; 32]))],
+            )
+            .await;
+        assert!(matches!(res, Err(DbError::Replica)));
+
+        let res = db_replica.as_mut().end_rollup_block(batch_to_store).await;
+        assert!(matches!(res, Err(DbError::Replica)));
+
+        let res = db_replica.as_mut().prune(2).await;
+        assert!(matches!(res, Err(DbError::Replica)));
+
+        let res = db_replica.as_mut().current_data().await;
+        assert!(matches!(res, Err(DbError::Replica)));
+    }
+
+    struct DB {
+        backend: PostgresBackend,
+        node_id: String,
+    }
+
+    impl AsRef<PostgresBackend> for DB {
+        fn as_ref(&self) -> &PostgresBackend {
+            &self.backend
+        }
+    }
+
+    impl AsMut<PostgresBackend> for DB {
+        fn as_mut(&mut self) -> &mut PostgresBackend {
+            &mut self.backend
+        }
+    }
+
+    impl DB {
+        async fn new(
+            postgres: &sov_test_utils::postgres::ContainerAsync<sov_test_utils::postgres::Postgres>,
+            node_id: String,
+        ) -> Self {
+            let leader_timeout = Duration::from_millis(100_000);
+            let postgres_config = config_from_postgres_container(&postgres, node_id.clone())
                 .await
                 .unwrap();
+            let backend =
+                PostgresBackend::connect_with_leader_timeout(&postgres_config, leader_timeout)
+                    .await
+                    .unwrap();
+
+            Self { backend, node_id }
+        }
+
+        fn override_leader_timeout(&mut self, leader_timeout: Duration) {
+            self.backend.leader_timeout = leader_timeout;
+        }
+
+        async fn maybe_update_leader(&self) -> Option<SequencerLeader> {
+            self.backend.try_update_leader().await.unwrap()
+        }
+    }
+
+    fn batch_to_store(sequence_number: SequenceNumber) -> BatchToStore {
+        BatchToStore {
+            blob_id: 1,
+            sequence_number,
+            visible_slot_number_after_increase: VisibleSlotNumber::new_dangerous(1),
+            visible_slots_to_advance: NonZero::new(1).unwrap(),
+        }
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -231,12 +231,12 @@ impl PostgresBackend {
     }
 
     pub(crate) async fn try_update_leader(&self) -> anyhow::Result<Option<SequencerLeader>> {
-        let time_delta: i64 = self
+        let leader_timeout: i64 = self
             .leader_timeout
             .as_millis()
             .try_into()
-            // It is ok to `expect` as time_delta should be much smaller than i64::MAX
-            .expect("PostgresBackend error: time_delta is bigger than i64::MAX");
+            // It is ok to `expect` as leader_timeout should be much smaller than i64::MAX
+            .expect("PostgresBackend error: leader_timeout is bigger than i64::MAX");
 
         let res = run_with_retries!(
             &self.backoff_policy,
@@ -253,7 +253,7 @@ impl PostgresBackend {
                             OR sequencer_leader.last_updated < EXCLUDED.last_updated - ($2 * INTERVAL '1 millisecond')
                         RETURNING node_id, last_updated",)
         .bind(&self.node_id)
-        .bind(time_delta)
+        .bind(leader_timeout)
         .fetch_optional(&self.pool),
             "postgres_db_backend_try_update_leader"
         )?;
@@ -521,7 +521,7 @@ mod tests {
 
         {
             db_2.leader_timeout = Duration::ZERO;
-            // Now we should be able to update db as the time_delta is zero.
+            // Now we should be able to update db as the leader_timeout is zero.
             let leader_2 = db_2.maybe_update_leader().await.unwrap();
             assert_eq!(leader_2.node_id, node_id_2);
         }
@@ -531,10 +531,27 @@ mod tests {
             let leader_1 = db_1.maybe_update_leader().await;
             assert!(leader_1.is_none());
 
-            // Wait for more than 10ms and update the leader.
+            // Wait for more than 100ms and update the leader.
             tokio::time::sleep(Duration::from_millis(200)).await;
             let leader_1 = db_1.maybe_update_leader().await.unwrap();
             assert_eq!(leader_1.node_id, node_id_1);
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_foo() {
+        let postgres = create_postgres_container().await;
+        let postgres = match postgres {
+            Ok(pg) => pg,
+            Err(CreatePostgresError::DockerNotSupported) => return,
+            Err(CreatePostgresError::DockerError(e)) => {
+                panic!("Failed to create Postgres container: {e}");
+            }
+        };
+
+        let mut db_1 =
+            PostgresBackend::connect_with_leader_timeout(&postgres_config_1, leader_timeout)
+                .await
+                .unwrap();
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -202,7 +202,7 @@ impl PostgresBackend {
     /// which is why this is wrapped in a helper function and any nested helpers have their retries disabled.
     async fn current_data_transaction(&self) -> anyhow::Result<DbReadOutcome<DbSnapshotData>> {
         let mut tx = self.pool.begin().await?;
-        let maybe_leader = self.get_sequencer_leader_inner().await?;
+        let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
 
         if !self.is_leader(maybe_leader) {
             return Ok(DbReadOutcome::AbortedBecauseReplica);
@@ -269,25 +269,41 @@ impl PostgresBackend {
         Ok(res)
     }
 
-    pub(crate) async fn get_sequencer_leader(
-        &self,
-    ) -> Result<Option<SequencerLeader>, sqlx::Error> {
-        let res = run_with_retries!(
-            &self.backoff_policy,
-            self.get_sequencer_leader_inner(),
-            "postgres_db_get_sequencer_leader"
-        )?;
+    async fn prune_inner(&self, prune_up_to_including: SequenceNumber) -> anyhow::Result<bool> {
+        let mut tx = self.pool.begin().await?;
+        let prune_up_to_including: i64 = prune_up_to_including.saturating_add(1).try_into()?;
 
-        Ok(res)
+        let result = sqlx::query(
+            "WITH blobs_deleted AS (
+                    DELETE FROM proof_blobs
+                    WHERE sequence_number <= $1
+                    AND is_leader($2))
+                DELETE FROM events
+                    WHERE sequence_number <= $1 AND is_leader($2);",
+        )
+        .bind(prune_up_to_including)
+        .bind(&self.node_id)
+        .execute(&mut *tx)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
+            return Ok(self.is_leader(maybe_leader));
+        }
+        tx.commit().await?;
+        Ok(true)
     }
 
-    async fn get_sequencer_leader_inner(&self) -> Result<Option<SequencerLeader>, sqlx::Error> {
+    async fn get_sequencer_leader_inner(
+        &self,
+        connection: &mut PgConnection,
+    ) -> Result<Option<SequencerLeader>, sqlx::Error> {
         sqlx::query_as::<_, SequencerLeader>(
             "SELECT node_id, last_updated
                 FROM sequencer_leader
                 WHERE singleton = 1",
         )
-        .fetch_optional(&self.pool)
+        .fetch_optional(connection)
         .await
     }
 
@@ -451,47 +467,26 @@ impl PreferredSequencerDbBackend for PostgresBackend {
     }
 
     async fn prune(&mut self, up_to_including: SequenceNumber) -> Result<(), DbError> {
-        // Compound CTE statement to avoid multiple roundtrips
-        let result = run_with_retries!(
+        let is_leader = run_with_retries!(
             &self.backoff_policy,
-            sqlx::query(
-                "WITH blobs_deleted AS (
-                    DELETE FROM proof_blobs
-                    WHERE sequence_number <= $1
-                    AND is_leader($2))
-                DELETE FROM events
-                    WHERE sequence_number <= $1 AND is_leader($2);",
-            )
-            .bind(i64::try_from(up_to_including)?)
-            .bind(&self.node_id)
-            .execute(&self.pool),
+            self.prune_inner(up_to_including),
             "postgres_db_backend_prune"
         )?;
 
-        /*
-        if result.rows_affected() == 0 {
+        if !is_leader {
             return Err(DbError::Replica);
-        }*/
+        }
 
         Ok(())
     }
     async fn read_in_progress_batch(&self) -> anyhow::Result<Option<InProgressBatch>, DbError> {
         let mut tx = self.pool.begin().await?;
-        let maybe_leader = self.get_sequencer_leader().await?;
-
+        let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
         if !self.is_leader(maybe_leader) {
             return Err(DbError::Replica);
         }
 
-        let res: Result<
-            Option<
-                super::PreferredSequencerReadBatch<
-                    Vec<FullyBakedTx>,
-                    Vec<sov_modules_api::HexString<[u8; 32]>>,
-                >,
-            >,
-            anyhow::Error,
-        > = self
+        let res = self
             .read_in_progress_batch_with_connection(&mut tx, true)
             .await;
         tx.commit().await?;
@@ -580,7 +575,7 @@ mod tests {
             let leader_2 = db_2.maybe_update_leader().await;
             assert!(leader_2.is_none());
 
-            let leader = db_2.as_ref().get_sequencer_leader().await.unwrap().unwrap();
+            let leader = db_2.get_sequencer_leader().await.unwrap().unwrap();
             assert_eq!(updated_leader_1, leader);
         }
 
@@ -652,6 +647,8 @@ mod tests {
         db.as_mut().prune(2).await.unwrap();
         let data = db.as_mut().current_data().await.unwrap();
         assert!(data.is_empty());
+
+        db.as_mut().prune(2).await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -747,6 +744,15 @@ mod tests {
 
         async fn maybe_update_leader(&self) -> Option<SequencerLeader> {
             self.backend.try_update_leader().await.unwrap()
+        }
+
+        pub(crate) async fn get_sequencer_leader(
+            &self,
+        ) -> Result<Option<SequencerLeader>, sqlx::Error> {
+            let mut tx = self.backend.pool.begin().await?;
+            let res = self.backend.get_sequencer_leader_inner(&mut tx).await?;
+            tx.commit().await?;
+            Ok(res)
         }
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/rocksdb.rs
@@ -8,7 +8,7 @@ use sov_blob_storage::SequenceNumber;
 use sov_modules_api::{FullyBakedTx, TxHash};
 
 use super::{DbSnapshotData, PreferredSequencerDbBackend, PreferredSequencerReadBlob, StoredBlob};
-use crate::preferred::db::{BatchToStore, InProgressBatch};
+use crate::preferred::db::{BatchToStore, DbError, InProgressBatch};
 
 #[derive(Debug)]
 pub struct RocksDbBackend {
@@ -20,10 +20,8 @@ pub struct RocksDbBackend {
     first_unpruned_sequence_number: SequenceNumber,
 }
 
-#[async_trait]
-impl PreferredSequencerDbBackend for RocksDbBackend {
-    #[tracing::instrument(skip_all, level = "trace")]
-    async fn read_in_progress_batch(&self) -> anyhow::Result<Option<InProgressBatch>> {
+impl RocksDbBackend {
+    async fn read_in_progress_batch_inner(&self) -> anyhow::Result<Option<InProgressBatch>> {
         let Some((sequence_number, stored_blob)) =
             self.db.get_async::<tables::InProgressBatch>(&()).await?
         else {
@@ -37,9 +35,18 @@ impl PreferredSequencerDbBackend for RocksDbBackend {
             _ => panic!("In-progress batch must be a batch but is a proof blob; this is a bug, please report it"),
         }
     }
+}
+
+#[async_trait]
+impl PreferredSequencerDbBackend for RocksDbBackend {
+    #[tracing::instrument(skip_all, level = "trace")]
+    async fn read_in_progress_batch(&self) -> anyhow::Result<Option<InProgressBatch>, DbError> {
+        let res = self.read_in_progress_batch_inner().await?;
+        Ok(res)
+    }
 
     #[tracing::instrument(skip_all, level = "trace")]
-    async fn begin_rollup_block(&mut self, batch_to_store: BatchToStore) -> anyhow::Result<()> {
+    async fn begin_rollup_block(&mut self, batch_to_store: BatchToStore) -> Result<(), DbError> {
         self.db
             .put_async::<tables::InProgressBatch>(
                 &(),
@@ -65,7 +72,7 @@ impl PreferredSequencerDbBackend for RocksDbBackend {
         tx_idx_within_batch: u64,
         tx: FullyBakedTx,
         hash: TxHash,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<(), DbError> {
         self.db
             .put_async::<tables::BatchContents>(
                 &(sequence_number, tx_idx_within_batch),
@@ -77,19 +84,21 @@ impl PreferredSequencerDbBackend for RocksDbBackend {
     }
 
     #[tracing::instrument(skip_all, level = "trace")]
-    async fn end_rollup_block(&mut self, stored_batch: BatchToStore) -> anyhow::Result<()> {
+    async fn end_rollup_block(&mut self, stored_batch: BatchToStore) -> Result<(), DbError> {
         let sequence_number = stored_batch.sequence_number;
         let stored_blob: StoredBlob = stored_batch.into();
         let mut s = SchemaBatch::new();
         s.delete::<tables::InProgressBatch>(&())?;
         s.put::<tables::CompletedBlobs>(&sequence_number, &stored_blob)?;
         self.db.write_schemas_async(&s).await?;
-
         Ok(())
     }
 
     #[tracing::instrument(skip_all, level = "trace")]
-    async fn prune(&mut self, prune_up_to_including: SequenceNumber) -> anyhow::Result<()> {
+    async fn prune(
+        &mut self,
+        prune_up_to_including: SequenceNumber,
+    ) -> anyhow::Result<(), DbError> {
         // We first delete blob data, and only then batch contents. We'd rather have orphaned
         // data (no harm in that, it'll just get pruned eventually) than batches
         // incorrectly marked as empty.
@@ -131,7 +140,7 @@ impl PreferredSequencerDbBackend for RocksDbBackend {
         sequence_number: SequenceNumber,
         blob_id: BlobInternalId,
         data: Arc<[u8]>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<(), DbError> {
         self.db
             .put_async::<tables::CompletedBlobs>(
                 &sequence_number,
@@ -141,10 +150,10 @@ impl PreferredSequencerDbBackend for RocksDbBackend {
         Ok(())
     }
 
-    async fn current_data(&self) -> anyhow::Result<DbSnapshotData> {
+    async fn current_data(&self) -> anyhow::Result<DbSnapshotData, DbError> {
         // RocksDB doesn't need atomicity, and doesn't track event_ids
         let completed_blobs = self.read_completed_blobs().await?;
-        let in_progress_batch = self.read_in_progress_batch().await?;
+        let in_progress_batch = self.read_in_progress_batch_inner().await?;
         Ok(DbSnapshotData {
             completed_blobs,
             in_progress_batch,

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -318,6 +318,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_notifications_start_event_id() {
+        //sov_test_utils::initialize_logging();
         let test_data = vec![
             TestCase::Transaction(6),
             TestCase::Transaction(6),

--- a/crates/utils/sov-test-utils/src/lib.rs
+++ b/crates/utils/sov-test-utils/src/lib.rs
@@ -32,6 +32,7 @@ use sov_rollup_interface::execution_mode::{Native, Zk};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 pub use sov_state::ProverStorage;
 use sov_state::{DefaultStorageSpec, StateAccesses, Storage};
+pub use testcontainers::ContainerAsync;
 pub use {
     sov_bank, sov_chain_state, sov_paymaster, sov_rollup_apis, sov_sequencer_registry,
     sov_universal_wallet,

--- a/crates/utils/sov-test-utils/src/postgres.rs
+++ b/crates/utils/sov-test-utils/src/postgres.rs
@@ -1,7 +1,7 @@
 use sov_sequencer::preferred::PostgresConfig;
 use testcontainers::runners::AsyncRunner;
-use testcontainers::{ContainerAsync, ImageExt};
-use testcontainers_modules::postgres::Postgres;
+pub use testcontainers::{ContainerAsync, ImageExt};
+pub use testcontainers_modules::postgres::Postgres;
 
 #[derive(Debug, thiserror::Error)]
 /// Error indicating problems when creating a Postgres container.


### PR DESCRIPTION
# Description

This PR introduces the following changes:
1. Updates the SQL statements to ensure the replica cannot modify the sequencer database.
2. If a rollup detects that it has transitioned from `Leader` to `Replica`, it shuts itself down.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
