### PR TITLE
Add tx submission via ws

### DIFF
--- a/crates/full-node/sov-api-spec/src/client.rs
+++ b/crates/full-node/sov-api-spec/src/client.rs
@@ -10,19 +10,51 @@ use backon::{ExponentialBuilder, Retryable};
 use base64::prelude::*;
 use borsh::BorshSerialize;
 use futures::stream::BoxStream;
+use futures::stream::SplitSink;
+use futures::SinkExt;
 use futures::StreamExt;
 use sov_modules_api::RawTx;
 use sov_rollup_interface::crypto::CredentialId;
 use sov_rollup_interface::node::ledger_api::{FinalityStatus, IncludeChildren};
 use sov_rollup_interface::zk::aggregated_proof;
 use sov_rollup_interface::TxHash;
-use tokio_tungstenite::connect_async;
+use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::{Error as WsError, Message};
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 use types::TxInfoWithConfirmation;
 
 pub extern crate tokio_tungstenite;
 
 pub type WsSubscription<T> = Result<BoxStream<'static, anyhow::Result<T>>, WsError>;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WsMessage<T> {
+    pub id: u64,
+    pub contents: T,
+}
+
+pub struct TxWsSender {
+    sink: SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>,
+    id: u64,
+}
+
+impl TxWsSender {
+    pub async fn send(&mut self, tx: &RawTx) -> Result<(), WsError> {
+        let message = WsMessage {
+            id: self.id,
+            contents: types::AcceptTxBody {
+                body: BASE64_STANDARD.encode(tx),
+            },
+        };
+        self.id += 1;
+        self.sink
+            .send(Message::Text(
+                serde_json::to_string(&message).unwrap().into(),
+            ))
+            .await?;
+        Ok(())
+    }
+}
 
 progenitor::generate_api!(
     spec = "./openapi-v3.yaml",
@@ -219,6 +251,76 @@ impl Client {
                 }
             })
             .boxed())
+    }
+
+    pub async fn connect_txs_ws(
+        &self,
+    ) -> Result<
+        (
+            TxWsSender,
+            BoxStream<'static, anyhow::Result<WsMessage<types::ApiAcceptedTx>>>,
+        ),
+        anyhow::Error,
+    > {
+        let (sink, stream) = self.connect_to_ws("/sequencer/txs/submit/ws").await?;
+        Ok((TxWsSender { sink, id: 0 }, stream))
+    }
+
+    pub async fn connect_to_ws<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+    ) -> Result<
+        (
+            SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>,
+            BoxStream<'static, anyhow::Result<T>>,
+        ),
+        anyhow::Error,
+    > {
+        // The base URL can't be used for WebSocket connections; we need to
+        // change the protocol.
+        let url = format!("{}{}", self.baseurl(), path).replace("http://", "ws://");
+
+        let (ws, _) = connect_async(url).await?;
+        let (write, read) = ws.split();
+
+        Ok((
+            write,
+            read.filter_map(|msg| async {
+                match msg {
+                    Ok(Message::Text(text)) => match serde_json::from_str(&text) {
+                        Ok(tx_status) => Some(Ok(tx_status)),
+                        Err(err) => Some(Err(anyhow::anyhow!(
+                            "failed to deserialize JSON {} into type: {}",
+                            text,
+                            err
+                        ))),
+                    },
+                    Ok(Message::Binary(data)) => {
+                        // Parse binary frame as UTF-8 JSON
+                        match std::str::from_utf8(&data) {
+                            Ok(text) => match serde_json::from_str(text) {
+                                Ok(tx_status) => Some(Ok(tx_status)),
+                                Err(err) => Some(Err(anyhow::anyhow!(
+                                    "failed to deserialize JSON from binary frame: {}",
+                                    err
+                                ))),
+                            },
+                            Err(err) => Some(Err(anyhow::anyhow!(
+                                "invalid UTF-8 in binary WebSocket frame: {}",
+                                err
+                            ))),
+                        }
+                    }
+                    // All other kinds of messages are ignored because
+                    // `tokio-tungstenite` ought to handle all
+                    // meta-communication messages (ping, pong, clonse) for us anyway.
+                    Ok(_) => None,
+                    // Errors are not handled here but passed to the caller.
+                    Err(err) => Some(Err(anyhow::anyhow!("{}", err))),
+                }
+            })
+            .boxed(),
+        ))
     }
 
     pub async fn get_next_nonce(&self, credential_id: &CredentialId) -> anyhow::Result<u64> {

--- a/crates/full-node/sov-api-spec/src/client.rs
+++ b/crates/full-node/sov-api-spec/src/client.rs
@@ -29,24 +29,22 @@ pub type WsSubscription<T> = Result<BoxStream<'static, anyhow::Result<T>>, WsErr
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct WsMessage<T> {
-    pub id: u64,
+    pub id: String,
     pub contents: T,
 }
 
 pub struct TxWsSender {
     sink: SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>,
-    id: u64,
 }
 
 impl TxWsSender {
-    pub async fn send(&mut self, tx: &RawTx) -> Result<(), WsError> {
+    pub async fn send(&mut self, tx: &RawTx, id: String) -> Result<(), WsError> {
         let message = WsMessage {
-            id: self.id,
+            id: id.clone(),
             contents: types::AcceptTxBody {
                 body: BASE64_STANDARD.encode(tx),
             },
         };
-        self.id += 1;
         self.sink
             .send(Message::Text(
                 serde_json::to_string(&message).unwrap().into(),
@@ -263,7 +261,7 @@ impl Client {
         anyhow::Error,
     > {
         let (sink, stream) = self.connect_to_ws("/sequencer/txs/submit/ws").await?;
-        Ok((TxWsSender { sink, id: 0 }, stream))
+        Ok((TxWsSender { sink }, stream))
     }
 
     pub async fn connect_to_ws<T: serde::de::DeserializeOwned>(

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -15,11 +15,13 @@ use serde_with::serde_as;
 use sov_modules_api::capabilities::TransactionAuthenticator;
 use sov_modules_api::runtime::Runtime;
 use sov_modules_api::{FullyBakedTx, RawTx, RuntimeEventProcessor, RuntimeEventResponse};
-use sov_rest_utils::get_client_ip;
+use sov_rest_utils::handle_bad_ws_request;
+use sov_rest_utils::send_json;
 use sov_rest_utils::{
     errors, preconfigured_router_layers, serve_generic_ws_subscription, ApiResult, FilterQuery,
     PageSelection, PaginatedResponse, Pagination, Path, Query,
 };
+use sov_rest_utils::{get_client_ip, WsMessage};
 use sov_rollup_interface::da::{DaBlobHash, DaSpec};
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::TxHash;
@@ -87,6 +89,10 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
                 axum::routing::get(Self::subscribe_to_transactions),
             )
             .route(
+                "/sequencer/txs/submit/ws",
+                axum::routing::get(Self::axum_ws_submit_tx),
+            )
+            .route(
                 "/sequencer/unstable/events/:eventId",
                 axum::routing::get(Self::axum_get_event),
             )
@@ -128,6 +134,125 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
         socket.send(ws_msg).await?;
 
         Ok(())
+    }
+
+    async fn axum_ws_submit_tx(
+        connect_info: ConnectInfo<SocketAddr>,
+        state: State<Self>,
+        headers: axum::http::HeaderMap,
+        ws: ws::WebSocketUpgrade,
+    ) -> Result<impl IntoResponse, axum::response::Response> {
+        let ip_addr = get_client_ip(headers, Some(&connect_info))
+            .map_err(|e| IntoResponse::into_response(e.to_error_object()))?;
+
+        Ok(ws.on_upgrade(move |mut socket| async move {
+            let mut shutdown_receiver = state.shutdown_receiver.clone();
+            let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel(10);
+            loop {
+                tokio::select! {
+                    // The client sent us a message
+                    inbound_msg = socket.recv() => {
+                        match inbound_msg {
+                            // Try to deserialize the message as a WsMessage<AcceptTx>. On success, spawn a task to handle it.
+                            Some(Ok(ws::Message::Text(text))) => {
+                                match serde_json::from_str::<WsMessage<AcceptTx>>(&text) {
+                                    Ok(WsMessage { id, contents }) => {
+                                        let sender = outbound_tx.clone();
+                                        let state = state.clone();
+                                        // Spawn a task to handle the transaction submission and forward the response back to the main handler loop for this subscription
+                                        tokio::spawn(async move {
+                                            let raw_tx = RawTx::new(contents.body.blob);
+                                            let baked_tx = <<Seq::Rt as Runtime<Seq::Spec>>::Auth as TransactionAuthenticator<
+                                                Seq::Spec,
+                                            >>::encode_with_standard_auth(raw_tx);
+
+                                            let response = match state
+                                                .sequencer
+                                                .accept_tx(baked_tx, ip_addr)
+                                                .await {
+                                                    Ok(tx_with_hash) => {
+                                                        Ok(WsMessage {
+                                                            id,
+                                                            contents: TxInfoWithConfirmation {
+                                                                id: tx_with_hash.tx_hash,
+                                                                confirmation: tx_with_hash.confirmation,
+                                                                status: TxStatus::<DaBlobHash<<Seq::Da as DaService>::Spec>>::Submitted,
+                                                            }
+                                                        })
+                                                    }
+                                                    Err(e) => {
+                                                        if e.status.is_server_error() {
+                                                            tracing::error!(error = ?e, "Error accepting transaction");
+                                                        }
+                                                        Err(WsMessage {
+                                                            id,
+                                                            contents: e,
+                                                        })
+                                                    }
+                                                };
+                                            if let Err(e) = sender.send(response).await {
+                                                tracing::warn!(?e, "Error sending response to client. Could not respond because outbound ws channel was dropped. This usually means the seqeuncer is shutting down.");
+                                            };
+                                        });
+                                    }
+                                    Err(e) => {
+                                        if handle_bad_ws_request(&mut socket, ip_addr, e).await.is_err() {
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            // If the client disconnected
+                            None => break,
+                            Some(Err(error)) => {
+                                if handle_bad_ws_request(&mut socket, ip_addr, error).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Some(_) => {
+                                if handle_bad_ws_request(&mut socket, ip_addr, "Invalid websocket message: only text messages are supported").await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    // We have an outbound message ready to send
+                    outbound_msg = outbound_rx.recv() => {
+                        match outbound_msg {
+                            Some(msg) => {
+                                match msg {
+                                    Ok(msg) => {
+                                        if let Err(err) = send_json(&mut socket, msg).await {
+                                            tracing::warn!(?err, ip_addr=%ip_addr, "Error sending ws message to client");
+                                            break;
+                                        }
+                                    }
+                                    Err(msg) => {
+                                        if let Err(err) = send_json(&mut socket, msg).await {
+                                            tracing::warn!(?err, ip_addr=%ip_addr, "Error sending ws message to client");
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            None => break,
+                        }
+                    }
+                    _ = shutdown_receiver.changed() => break,
+                }
+            }
+
+            // Drop the local handle to the channel for outbound messages.
+            // This guarantees that the channel will be closed as soon as all in-flight tasks have resolved.
+            drop(outbound_tx);
+            // Wait up to 5 seconds for any remaining in-flight txs to return responses, forwarding them to the client.
+            while let Ok(Some(msg)) = tokio::time::timeout(std::time::Duration::from_secs(5), outbound_rx.recv()).await {
+                if let Err(err) = send_json(&mut socket, msg).await {
+                    tracing::warn!(?err, ip_addr=%ip_addr, "Error sending ws message to client");
+                    break;
+                }
+            }
+        }) )
     }
 
     async fn axum_get_tx_ws(

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -511,13 +511,14 @@ async fn test_tx_ws_submission() {
 
     for i in 0..3 {
         let tx = tx_set_value(&admin.private_key, i, i);
-        writer.send(&tx).await.unwrap();
+        writer.send(&tx, i.to_string()).await.unwrap();
     }
     let mut received_ids = [false, false, false];
     for _ in 0..3 {
         let msg = reader.next().await.unwrap().unwrap();
-        assert!(!received_ids[msg.id as usize]);
-        received_ids[msg.id as usize] = true;
+        let id: usize = msg.id.parse().unwrap();
+        assert!(!received_ids[id]);
+        received_ids[id] = true;
         assert_eq!(msg.contents.events.len(), 1);
         for event in msg.contents.events {
             assert!(
@@ -527,7 +528,7 @@ async fn test_tx_ws_submission() {
             );
             assert_eq!(
                 event.value.get("new_value").unwrap().as_u64().unwrap(),
-                msg.id,
+                id as u64,
                 "Unexpected event value: {:?}",
                 event.value
             );

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -492,6 +492,50 @@ async fn txs_below_min_fee_are_rejected() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_tx_ws_submission() {
+    let (test_rollup, admin) = create_test_rollup(
+        0,
+        TEST_MAX_BATCH_SIZE,
+        TEST_BLOB_PROCESSING_TIMEOUT,
+        MAX_BATCH_EXECUTION_TIME_MILLIS,
+        TEST_FINALIZATION_BLOCKS,
+        BlockProducingConfig::Manual,
+    )
+    .await;
+
+    test_rollup.produce_enough_finalized_slots().await;
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
+
+    let client = test_rollup.api_client().clone();
+    let (mut writer, mut reader) = client.connect_txs_ws().await.unwrap();
+
+    for i in 0..3 {
+        let tx = tx_set_value(&admin.private_key, i, i);
+        writer.send(&tx).await.unwrap();
+    }
+    let mut received_ids = [false, false, false];
+    for _ in 0..3 {
+        let msg = reader.next().await.unwrap().unwrap();
+        assert!(!received_ids[msg.id as usize]);
+        received_ids[msg.id as usize] = true;
+        assert_eq!(msg.contents.events.len(), 1);
+        for event in msg.contents.events {
+            assert!(
+                event.key.starts_with("ValueSetter/NewValue"),
+                "Unexpected event key: {}",
+                event.key
+            );
+            assert_eq!(
+                event.value.get("new_value").unwrap().as_u64().unwrap(),
+                msg.id,
+                "Unexpected event value: {:?}",
+                event.value
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "This test covers pruning behavior, which is only relevant for NOMT. Enable it when we switch to NOMT for the sequencer tests."]
 async fn test_archival_state_with_pruning() {
     let (test_rollup, admin) = create_test_rollup(

--- a/crates/utils/sov-rest-utils/src/lib.rs
+++ b/crates/utils/sov-rest-utils/src/lib.rs
@@ -261,7 +261,7 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub struct WsMessage<Contents> {
     /// The message id.
-    pub id: u64,
+    pub id: String,
     /// The contents of the message.
     pub contents: Contents,
 }

--- a/crates/utils/sov-rest-utils/src/lib.rs
+++ b/crates/utils/sov-rest-utils/src/lib.rs
@@ -37,7 +37,7 @@ use axum::extract::ws::WebSocket;
 use axum::extract::Request;
 use axum::http::{HeaderName, StatusCode};
 use axum::response::{IntoResponse, Response};
-use axum::{Json, Router};
+use axum::{Error, Json, Router};
 pub use axum_extractors::{Path, Query};
 pub use filter::{Filter, FilterError, FilterQuery};
 use futures::{SinkExt, StreamExt};
@@ -255,6 +255,58 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
 
     tracing::trace!("Closing websocket subscription");
     socket.close().await.ok();
+}
+
+/// A message that can be received via websocket.
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct WsMessage<Contents> {
+    /// The message id.
+    pub id: u64,
+    /// The contents of the message.
+    pub contents: Contents,
+}
+
+/// Sends a JSON message over a WebSocket, panicing on serialization failure
+pub async fn send_json<Json: Serialize>(socket: &mut WebSocket, json: Json) -> Result<(), Error> {
+    let serialized = match serde_json::to_string(&json) {
+        Ok(serialized) => serialized,
+        Err(err) => {
+            error!(
+                ?err,
+                "Failed to serialize data for WebSocket; this is a bug, please report it"
+            );
+            panic!("Failed to serialize data for WebSocket; this is a bug, please report it");
+        }
+    };
+    socket.send(serialized.into()).await
+}
+
+#[derive(Debug, Clone, Copy)]
+/// An error that indicates that the client should be disconnected and the connection should be closed.
+pub struct UnrecoverableWsError;
+
+/// Sends a bad request error to the client and returns an UnrecoverableWsError if the message cannot be sent.
+pub async fn handle_bad_ws_request(
+    socket: &mut WebSocket,
+    ip_addr: std::net::IpAddr,
+    error: impl ToString,
+) -> Result<(), UnrecoverableWsError> {
+    if let Err(err) = send_json(
+        socket,
+        &ErrorObject {
+            status: StatusCode::BAD_REQUEST,
+            message: "Invalid websocket message".to_string(),
+            details: json_obj!({
+                "error": error.to_string(),
+            }),
+        },
+    )
+    .await
+    {
+        tracing::warn!(?err, ip_addr=%ip_addr, "Error sending ws message to client");
+        return Err(UnrecoverableWsError);
+    }
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

This PR adds a new `/sequencer/txs/submit/ws` to which customers can connect to stream tx submissions.

## Request Format
```
{
  "id": 1,
  "contents": {"body": <BASE64_RAW_TX>}
}
```
## Response Format
```
{ 
  "id": 1,
  "contents": { 
     "tx_hash": ...,
     "receipt", ...
     "events: [...], 
     ...
   } 
}
```

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
