### PR TITLE
Failover: Improve database error details

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -36,19 +36,19 @@ use crate::preferred::{exit_rollup, track_in_progress_batch_size};
 #[derive(Debug)]
 pub(crate) enum DbReadOutcome<T> {
     Success(T),
-    AbortedBecauseReplica { db_replica: Option<String> },
+    AbortedBecauseReplica { db_leader: Option<String> },
 }
 
 #[derive(Debug, PartialEq, strum::Display)]
-pub(crate) enum Operation {
+pub(crate) enum FailedOperation {
     BeginBlock,
     BatchAddTxs,
     AddTx,
     EndBlock,
-    Prune { db_replica: Option<String> },
+    Prune { db_leader: Option<String> },
     ReadBatch,
     AddProof,
-    CurrentData { db_replica: Option<String> },
+    CurrentData { db_leader: Option<String> },
 }
 
 #[derive(Debug)]
@@ -56,7 +56,7 @@ pub(crate) enum DbError {
     Database(anyhow::Error),
     ReplicaDisallowed {
         self_node_id: String,
-        operation: Operation,
+        operation: FailedOperation,
     },
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -39,10 +39,25 @@ pub(crate) enum DbReadOutcome<T> {
     AbortedBecauseReplica,
 }
 
+#[derive(Debug, PartialEq, strum::Display)]
+pub(crate) enum Operation {
+    BeginBlock,
+    BatchAddTxs,
+    AddTx,
+    EndBlock,
+    Prune,
+    ReadBatch,
+    AddProof,
+    CurrentData,
+}
+
 #[derive(Debug)]
 pub(crate) enum DbError {
     Database(anyhow::Error),
-    Replica,
+    ReplicaDisallowed {
+        self_node_id: String,
+        operation: Operation,
+    },
 }
 
 impl<T: Into<anyhow::Error>> From<T> for DbError {
@@ -470,9 +485,14 @@ impl PreferredSequencerDb {
                     ))
                 }
                 Err(DbError::Database(err)) => Err(err),
-                Err(DbError::Replica) => {
+                Err(DbError::ReplicaDisallowed {
+                    self_node_id,
+                    operation,
+                }) => {
                     tracing::error!(
-                        "initial_data: The primary has become a replica. Shutting down."
+                        %self_node_id,
+                        %operation,
+                        "The primary has become a replica. Shutting down.",
                     );
                     exit_rollup(&self.shutdown_sender).await;
                     unreachable!()
@@ -551,8 +571,15 @@ impl PreferredSequencerDb {
     async fn check_replica_err(&self, err: DbError) -> anyhow::Error {
         match err {
             DbError::Database(err) => err,
-            DbError::Replica => {
-                tracing::error!("The primary has become a replica. Shutting down.");
+            DbError::ReplicaDisallowed {
+                self_node_id,
+                operation,
+            } => {
+                tracing::error!(
+                    %self_node_id,
+                    %operation,
+                    "The primary has become a replica. Shutting down.",
+                );
                 exit_rollup(&self.shutdown_sender).await;
                 unreachable!()
             }

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -36,7 +36,7 @@ use crate::preferred::{exit_rollup, track_in_progress_batch_size};
 #[derive(Debug)]
 pub(crate) enum DbReadOutcome<T> {
     Success(T),
-    AbortedBecauseReplica,
+    AbortedBecauseReplica { db_replica: Option<String> },
 }
 
 #[derive(Debug, PartialEq, strum::Display)]
@@ -45,10 +45,10 @@ pub(crate) enum Operation {
     BatchAddTxs,
     AddTx,
     EndBlock,
-    Prune,
+    Prune { db_replica: Option<String> },
     ReadBatch,
     AddProof,
-    CurrentData,
+    CurrentData { db_replica: Option<String> },
 }
 
 #[derive(Debug)]

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -622,8 +622,8 @@ mod tests {
             let leader_2 = db_2.maybe_update_leader().await;
             assert!(leader_2.is_none());
 
-            let leader = db_2.get_sequencer_leader().await.unwrap().unwrap();
-            assert_eq!(updated_leader_1, leader);
+            let leader_node_id = db_2.get_sequencer_leader().await.unwrap().unwrap();
+            assert_eq!(updated_leader_1.node_id, leader_node_id);
         }
 
         {
@@ -771,10 +771,22 @@ mod tests {
         assert_err(err, &db_replica.node_id, &Operation::EndBlock);
 
         let err = db_replica.as_mut().prune(2).await.unwrap_err();
-        assert_err(err, &db_replica.node_id, &Operation::Prune);
+        assert_err(
+            err,
+            &db_replica.node_id,
+            &Operation::Prune {
+                db_replica: Some(db_leader.node_id.clone()),
+            },
+        );
 
         let err = db_replica.as_mut().current_data().await.unwrap_err();
-        assert_err(err, &db_replica.node_id, &Operation::CurrentData);
+        assert_err(
+            err,
+            &db_replica.node_id,
+            &Operation::CurrentData {
+                db_replica: Some(db_leader.node_id.clone()),
+            },
+        );
     }
 
     fn assert_err(err: DbError, expected_node_id: &String, expected_operation: &Operation) {
@@ -832,9 +844,7 @@ mod tests {
             self.backend.try_update_leader().await.unwrap()
         }
 
-        pub(crate) async fn get_sequencer_leader(
-            &self,
-        ) -> Result<Option<SequencerLeader>, sqlx::Error> {
+        pub(crate) async fn get_sequencer_leader(&self) -> Result<Option<String>, sqlx::Error> {
             let mut tx = self.backend.pool.begin().await?;
             let res = self.backend.get_sequencer_leader_inner(&mut tx).await?;
             tx.commit().await?;

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -206,8 +206,10 @@ impl PostgresBackend {
         let mut tx = self.pool.begin().await?;
         let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
 
-        if !self.is_leader(maybe_leader) {
-            return Ok(DbReadOutcome::AbortedBecauseReplica);
+        if !self.is_leader(&maybe_leader) {
+            return Ok(DbReadOutcome::AbortedBecauseReplica {
+                db_replica: maybe_leader,
+            });
         }
 
         let completed_blobs_metadata: Vec<(i64, Vec<u8>)> =
@@ -271,7 +273,10 @@ impl PostgresBackend {
         Ok(res)
     }
 
-    async fn prune_inner(&self, prune_up_to_including: SequenceNumber) -> anyhow::Result<bool> {
+    async fn prune_inner(
+        &self,
+        prune_up_to_including: SequenceNumber,
+    ) -> anyhow::Result<DbReadOutcome<()>> {
         let mut tx = self.pool.begin().await?;
         let prune_up_to_including: i64 = prune_up_to_including.saturating_add(1).try_into()?;
 
@@ -290,28 +295,34 @@ impl PostgresBackend {
 
         if result.rows_affected() == 0 {
             let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
-            return Ok(self.is_leader(maybe_leader));
+            if self.is_leader(&maybe_leader) {
+                return Ok(DbReadOutcome::AbortedBecauseReplica {
+                    db_replica: maybe_leader,
+                });
+            }
         }
         tx.commit().await?;
-        Ok(true)
+        Ok(DbReadOutcome::Success(()))
     }
 
     async fn get_sequencer_leader_inner(
         &self,
         connection: &mut PgConnection,
-    ) -> Result<Option<SequencerLeader>, sqlx::Error> {
-        sqlx::query_as::<_, SequencerLeader>(
+    ) -> Result<Option<String>, sqlx::Error> {
+        let maybe_leader: Option<SequencerLeader> = sqlx::query_as::<_, SequencerLeader>(
             "SELECT node_id, last_updated
                 FROM sequencer_leader
                 WHERE singleton = 1",
         )
         .fetch_optional(connection)
-        .await
+        .await?;
+
+        Ok(maybe_leader.map(|l| l.node_id))
     }
 
-    fn is_leader(&self, maybe_leader: Option<SequencerLeader>) -> bool {
-        match maybe_leader {
-            Some(leader) => leader.node_id == self.node_id,
+    fn is_leader(&self, maybe_node_id: &Option<String>) -> bool {
+        match maybe_node_id {
+            Some(node_id) => node_id == &self.node_id,
             None => false,
         }
     }
@@ -482,16 +493,16 @@ impl DbBackend for PostgresBackend {
     }
 
     async fn prune(&mut self, up_to_including: SequenceNumber) -> Result<(), DbError> {
-        let is_leader = run_with_retries!(
+        let outcome = run_with_retries!(
             &self.backoff_policy,
             self.prune_inner(up_to_including),
             "postgres_db_backend_prune"
         )?;
 
-        if !is_leader {
+        if let DbReadOutcome::AbortedBecauseReplica { db_replica } = outcome {
             return Err(DbError::ReplicaDisallowed {
                 self_node_id: self.node_id.clone(),
-                operation: Operation::Prune,
+                operation: Operation::Prune { db_replica },
             });
         }
 
@@ -500,7 +511,8 @@ impl DbBackend for PostgresBackend {
     async fn read_in_progress_batch(&self) -> anyhow::Result<Option<InProgressBatch>, DbError> {
         let mut tx = self.pool.begin().await?;
         let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
-        if !self.is_leader(maybe_leader) {
+
+        if !self.is_leader(&maybe_leader) {
             return Err(DbError::ReplicaDisallowed {
                 self_node_id: self.node_id.clone(),
                 operation: Operation::ReadBatch,
@@ -564,10 +576,10 @@ impl DbBackend for PostgresBackend {
 
         match res {
             DbReadOutcome::Success(data) => Ok(data),
-            DbReadOutcome::AbortedBecauseReplica => {
+            DbReadOutcome::AbortedBecauseReplica { db_replica } => {
                 return Err(DbError::ReplicaDisallowed {
                     self_node_id: self.node_id.clone(),
-                    operation: Operation::CurrentData,
+                    operation: Operation::CurrentData { db_replica },
                 });
             }
         }

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -765,7 +765,7 @@ mod tests {
         assert_err(err, &db_replica.node_id, &Operation::CurrentData);
     }
 
-    fn assert_err(err: DbError, expected_node_id: &String, expected_operation: &Operation) -> () {
+    fn assert_err(err: DbError, expected_node_id: &String, expected_operation: &Operation) {
         match &err {
             DbError::ReplicaDisallowed {
                 self_node_id,

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -295,7 +295,7 @@ impl PostgresBackend {
 
         if result.rows_affected() == 0 {
             let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
-            if self.is_leader(&maybe_leader) {
+            if !self.is_leader(&maybe_leader) {
                 return Ok(DbReadOutcome::AbortedBecauseReplica {
                     db_replica: maybe_leader,
                 });

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use crate::preferred::db::Operation;
+use crate::preferred::db::FailedOperation;
 use anyhow::{anyhow, Result};
 use std::sync::Arc;
 use std::time::Duration;
@@ -208,7 +208,7 @@ impl PostgresBackend {
 
         if !self.is_leader(&maybe_leader) {
             return Ok(DbReadOutcome::AbortedBecauseReplica {
-                db_replica: maybe_leader,
+                db_leader: maybe_leader,
             });
         }
 
@@ -297,7 +297,7 @@ impl PostgresBackend {
             let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
             if !self.is_leader(&maybe_leader) {
                 return Ok(DbReadOutcome::AbortedBecauseReplica {
-                    db_replica: maybe_leader,
+                    db_leader: maybe_leader,
                 });
             }
         }
@@ -320,9 +320,9 @@ impl PostgresBackend {
         Ok(maybe_leader.map(|l| l.node_id))
     }
 
-    fn is_leader(&self, maybe_node_id: &Option<String>) -> bool {
-        match maybe_node_id {
-            Some(node_id) => node_id == &self.node_id,
+    fn is_leader(&self, maybe_leader_id: &Option<String>) -> bool {
+        match maybe_leader_id {
+            Some(leader_id) => leader_id == &self.node_id,
             None => false,
         }
     }
@@ -363,7 +363,7 @@ impl DbBackend for PostgresBackend {
         if result.rows_affected() == 0 {
             return Err(DbError::ReplicaDisallowed {
                 self_node_id: self.node_id.clone(),
-                operation: Operation::BeginBlock,
+                operation: FailedOperation::BeginBlock,
             });
         }
 
@@ -416,7 +416,7 @@ impl DbBackend for PostgresBackend {
         if result.rows_affected() == 0 {
             return Err(DbError::ReplicaDisallowed {
                 self_node_id: self.node_id.clone(),
-                operation: Operation::BatchAddTxs,
+                operation: FailedOperation::BatchAddTxs,
             });
         }
 
@@ -451,7 +451,7 @@ impl DbBackend for PostgresBackend {
         if result.rows_affected() == 0 {
             return Err(DbError::ReplicaDisallowed {
                 self_node_id: self.node_id.clone(),
-                operation: Operation::AddTx,
+                operation: FailedOperation::AddTx,
             });
         }
 
@@ -485,7 +485,7 @@ impl DbBackend for PostgresBackend {
         if result.rows_affected() == 0 {
             return Err(DbError::ReplicaDisallowed {
                 self_node_id: self.node_id.clone(),
-                operation: Operation::EndBlock,
+                operation: FailedOperation::EndBlock,
             });
         }
 
@@ -499,10 +499,10 @@ impl DbBackend for PostgresBackend {
             "postgres_db_backend_prune"
         )?;
 
-        if let DbReadOutcome::AbortedBecauseReplica { db_replica } = outcome {
+        if let DbReadOutcome::AbortedBecauseReplica { db_leader } = outcome {
             return Err(DbError::ReplicaDisallowed {
                 self_node_id: self.node_id.clone(),
-                operation: Operation::Prune { db_replica },
+                operation: FailedOperation::Prune { db_leader },
             });
         }
 
@@ -515,7 +515,7 @@ impl DbBackend for PostgresBackend {
         if !self.is_leader(&maybe_leader) {
             return Err(DbError::ReplicaDisallowed {
                 self_node_id: self.node_id.clone(),
-                operation: Operation::ReadBatch,
+                operation: FailedOperation::ReadBatch,
             });
         }
 
@@ -560,7 +560,7 @@ impl DbBackend for PostgresBackend {
         if result.rows_affected() == 0 {
             return Err(DbError::ReplicaDisallowed {
                 self_node_id: self.node_id.clone(),
-                operation: Operation::AddProof,
+                operation: FailedOperation::AddProof,
             });
         }
 
@@ -576,10 +576,10 @@ impl DbBackend for PostgresBackend {
 
         match res {
             DbReadOutcome::Success(data) => Ok(data),
-            DbReadOutcome::AbortedBecauseReplica { db_replica } => {
+            DbReadOutcome::AbortedBecauseReplica { db_leader } => {
                 return Err(DbError::ReplicaDisallowed {
                     self_node_id: self.node_id.clone(),
-                    operation: Operation::CurrentData { db_replica },
+                    operation: FailedOperation::CurrentData { db_leader },
                 });
             }
         }
@@ -727,7 +727,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_err(err, &db_replica.node_id, &Operation::BeginBlock);
+        assert_err(err, &db_replica.node_id, &FailedOperation::BeginBlock);
 
         let err = db_replica
             .as_mut()
@@ -740,7 +740,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_err(err, &db_replica.node_id, &Operation::AddTx);
+        assert_err(err, &db_replica.node_id, &FailedOperation::AddTx);
 
         let err = db_replica
             .as_mut()
@@ -752,7 +752,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_err(err, &db_replica.node_id, &Operation::BatchAddTxs);
+        assert_err(err, &db_replica.node_id, &FailedOperation::BatchAddTxs);
 
         let err = db_replica
             .as_mut()
@@ -760,7 +760,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_err(err, &db_replica.node_id, &Operation::AddProof);
+        assert_err(err, &db_replica.node_id, &FailedOperation::AddProof);
 
         let err = db_replica
             .as_mut()
@@ -768,14 +768,14 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_err(err, &db_replica.node_id, &Operation::EndBlock);
+        assert_err(err, &db_replica.node_id, &FailedOperation::EndBlock);
 
         let err = db_replica.as_mut().prune(2).await.unwrap_err();
         assert_err(
             err,
             &db_replica.node_id,
-            &Operation::Prune {
-                db_replica: Some(db_leader.node_id.clone()),
+            &FailedOperation::Prune {
+                db_leader: Some(db_leader.node_id.clone()),
             },
         );
 
@@ -783,13 +783,13 @@ mod tests {
         assert_err(
             err,
             &db_replica.node_id,
-            &Operation::CurrentData {
-                db_replica: Some(db_leader.node_id.clone()),
+            &FailedOperation::CurrentData {
+                db_leader: Some(db_leader.node_id.clone()),
             },
         );
     }
 
-    fn assert_err(err: DbError, expected_node_id: &String, expected_operation: &Operation) {
+    fn assert_err(err: DbError, expected_node_id: &String, expected_operation: &FailedOperation) {
         match &err {
             DbError::ReplicaDisallowed {
                 self_node_id,

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+use crate::preferred::db::Operation;
 use anyhow::{anyhow, Result};
 use std::sync::Arc;
 use std::time::Duration;
@@ -349,8 +350,12 @@ impl DbBackend for PostgresBackend {
         )?;
 
         if result.rows_affected() == 0 {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::BeginBlock,
+            });
         }
+
         Ok(())
     }
 
@@ -398,7 +403,10 @@ impl DbBackend for PostgresBackend {
         )?;
 
         if result.rows_affected() == 0 {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::BatchAddTxs,
+            });
         }
 
         Ok(())
@@ -430,7 +438,10 @@ impl DbBackend for PostgresBackend {
         )?;
 
         if result.rows_affected() == 0 {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::AddTx,
+            });
         }
 
         Ok(())
@@ -461,7 +472,10 @@ impl DbBackend for PostgresBackend {
         )?;
 
         if result.rows_affected() == 0 {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::EndBlock,
+            });
         }
 
         Ok(())
@@ -475,7 +489,10 @@ impl DbBackend for PostgresBackend {
         )?;
 
         if !is_leader {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::Prune,
+            });
         }
 
         Ok(())
@@ -484,7 +501,10 @@ impl DbBackend for PostgresBackend {
         let mut tx = self.pool.begin().await?;
         let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
         if !self.is_leader(maybe_leader) {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::ReadBatch,
+            });
         }
 
         let res = self
@@ -507,20 +527,29 @@ impl DbBackend for PostgresBackend {
         let result = run_with_retries!(
             &self.backoff_policy,
             sqlx::query(
-                "WITH blob_insert AS (
-                    INSERT INTO proof_blobs (sequence_number, borsh_value) VALUES ($1, $2)
-             )
-             INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data) 
-             SELECT $1, 'new_proof', NULL, NULL, NULL",
+                "
+                WITH blob_insert AS (
+                    INSERT INTO proof_blobs (sequence_number, borsh_value)
+                    SELECT $1, $2
+                    WHERE is_leader($3)
+                    RETURNING sequence_number
+                )
+                INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data)
+                SELECT bi.sequence_number, 'new_proof', NULL, NULL, NULL
+                FROM blob_insert bi",
             )
             .bind(i64::try_from(sequence_number)?)
             .bind::<&[u8]>(blob_data.as_ref())
+            .bind(&self.node_id)
             .execute(&self.pool),
             "postgres_db_backend_add_proof_blob"
         )?;
 
         if result.rows_affected() == 0 {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::AddProof,
+            });
         }
 
         Ok(())
@@ -535,7 +564,12 @@ impl DbBackend for PostgresBackend {
 
         match res {
             DbReadOutcome::Success(data) => Ok(data),
-            DbReadOutcome::AbortedBecauseReplica => Err(DbError::Replica),
+            DbReadOutcome::AbortedBecauseReplica => {
+                return Err(DbError::ReplicaDisallowed {
+                    self_node_id: self.node_id.clone(),
+                    operation: Operation::CurrentData,
+                });
+            }
         }
     }
 }
@@ -640,6 +674,11 @@ mod tests {
             .await
             .unwrap();
 
+        db.as_mut()
+            .add_proof_blob(sequence_number, 3, Arc::new([1, 2, 3]))
+            .await
+            .unwrap();
+
         db.as_mut().end_rollup_block(batch_to_store).await.unwrap();
 
         let data = db.as_mut().current_data().await.unwrap();
@@ -670,10 +709,15 @@ mod tests {
 
         db_leader.maybe_update_leader().await.unwrap();
 
-        let res = db_replica.as_mut().begin_rollup_block(batch_to_store).await;
-        assert!(matches!(res, Err(DbError::Replica)));
+        let err = db_replica
+            .as_mut()
+            .begin_rollup_block(batch_to_store)
+            .await
+            .unwrap_err();
 
-        let res = db_replica
+        assert_err(err, &db_replica.node_id, &Operation::BeginBlock);
+
+        let err = db_replica
             .as_mut()
             .add_tx(
                 sequence_number,
@@ -681,28 +725,57 @@ mod tests {
                 FullyBakedTx::new(vec![1, 2, 3]),
                 TxHash::new([1; 32]),
             )
-            .await;
+            .await
+            .unwrap_err();
 
-        assert!(matches!(res, Err(DbError::Replica)));
+        assert_err(err, &db_replica.node_id, &Operation::AddTx);
 
-        let res = db_replica
+        let err = db_replica
             .as_mut()
             .batch_add_txs(
                 sequence_number,
                 2,
                 &[(FullyBakedTx::new(vec![4, 5, 6]), TxHash::new([1; 32]))],
             )
-            .await;
-        assert!(matches!(res, Err(DbError::Replica)));
+            .await
+            .unwrap_err();
 
-        let res = db_replica.as_mut().end_rollup_block(batch_to_store).await;
-        assert!(matches!(res, Err(DbError::Replica)));
+        assert_err(err, &db_replica.node_id, &Operation::BatchAddTxs);
 
-        let res = db_replica.as_mut().prune(2).await;
-        assert!(matches!(res, Err(DbError::Replica)));
+        let err = db_replica
+            .as_mut()
+            .add_proof_blob(sequence_number, 3, Arc::new([1, 2, 3]))
+            .await
+            .unwrap_err();
 
-        let res = db_replica.as_mut().current_data().await;
-        assert!(matches!(res, Err(DbError::Replica)));
+        assert_err(err, &db_replica.node_id, &Operation::AddProof);
+
+        let err = db_replica
+            .as_mut()
+            .end_rollup_block(batch_to_store)
+            .await
+            .unwrap_err();
+
+        assert_err(err, &db_replica.node_id, &Operation::EndBlock);
+
+        let err = db_replica.as_mut().prune(2).await.unwrap_err();
+        assert_err(err, &db_replica.node_id, &Operation::Prune);
+
+        let err = db_replica.as_mut().current_data().await.unwrap_err();
+        assert_err(err, &db_replica.node_id, &Operation::CurrentData);
+    }
+
+    fn assert_err(err: DbError, expected_node_id: &String, expected_operation: &Operation) -> () {
+        match &err {
+            DbError::ReplicaDisallowed {
+                self_node_id,
+                operation,
+            } => {
+                assert_eq!(self_node_id, expected_node_id);
+                assert_eq!(operation, expected_operation);
+            }
+            DbError::Database(err) => unreachable!("DbError::Database not allowed in test {err:?}"),
+        }
     }
 
     struct DB {


### PR DESCRIPTION
# Description

This PR adds more context to PostgreSQL database errors by including the current leader in the error messages for the `Prune` and `CurrentData` operations. This additional detail is intentionally omitted for other operations, as they may be executed in tight loops and we want to avoid adding complexity or overhead to their SQL queries.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 
