### PR TITLE
Introduce `SequencerRole` and  enforce Replica-only checks

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use crate::preferred::block_executor::RollupBlockExecutorErrorWithBudget;
 use crate::preferred::block_executor::StartBlockData;
+use crate::preferred::db::SequencerRole;
 use crate::preferred::PreferredSequencerConfig;
 use crate::preferred::RollupBlockExecutor;
 use crate::preferred::RollupBlockExecutorConfig;
@@ -151,8 +152,9 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
         info: StateUpdateInfo<S::Storage>,
         exec_config: RollupBlockExecutorConfig<S>,
         seq_config: SequencerConfig<S::Address, PreferredSequencerConfig<S::Address>>,
+        seq_role: SequencerRole,
     ) -> (Self, Vec<JoinHandle<()>>) {
-        if seq_config.sequencer_kind_config.is_replica.unwrap_or(true) {
+        if seq_role == SequencerRole::Replica {
             return (Self { inner: None }, vec![]);
         }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -39,10 +39,25 @@ pub(crate) enum DbReadOutcome<T> {
     AbortedBecauseReplica,
 }
 
+#[derive(Debug, PartialEq, strum::Display)]
+pub(crate) enum Operation {
+    BeginBlock,
+    BatchAddTxs,
+    AddTx,
+    EndBlock,
+    Prune,
+    ReadBatch,
+    AddProof,
+    CurrentData,
+}
+
 #[derive(Debug)]
 pub(crate) enum DbError {
     Database(anyhow::Error),
-    Replica,
+    ReplicaDisallowed {
+        self_node_id: String,
+        operation: Operation,
+    },
 }
 
 impl<T: Into<anyhow::Error>> From<T> for DbError {
@@ -470,9 +485,14 @@ impl PreferredSequencerDb {
                     ))
                 }
                 Err(DbError::Database(err)) => Err(err),
-                Err(DbError::Replica) => {
+                Err(DbError::ReplicaDisallowed {
+                    self_node_id,
+                    operation,
+                }) => {
                     tracing::error!(
-                        "initial_data: The primary has become a replica. Shutting down."
+                        %self_node_id,
+                        %operation,
+                        "The primary has become a replica. Shutting down.",
                     );
                     exit_rollup(&self.shutdown_sender).await;
                     unreachable!()
@@ -551,8 +571,15 @@ impl PreferredSequencerDb {
     async fn check_replica_err(&self, err: DbError) -> anyhow::Error {
         match err {
             DbError::Database(err) => err,
-            DbError::Replica => {
-                tracing::error!("The primary has become a replica. Shutting down.");
+            DbError::ReplicaDisallowed {
+                self_node_id,
+                operation,
+            } => {
+                tracing::error!(
+                    %self_node_id,
+                    %operation,
+                    "The primary has become a replica. Shutting down.",
+                );
                 exit_rollup(&self.shutdown_sender).await;
                 unreachable!()
             }

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -416,6 +416,12 @@ impl From<BatchToStore> for StoredBlob {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SequencerRole {
+    Replica,
+    Leader,
+}
+
 pub struct PreferredSequencerDb {
     backend: Option<Box<dyn DbBackend>>,
     shutdown_sender: watch::Sender<()>,
@@ -427,7 +433,7 @@ impl PreferredSequencerDb {
         is_replica: Option<bool>,
         storage_path: &Path,
         postgres_config: &Option<PostgresConfig>,
-    ) -> anyhow::Result<(Self, bool)> {
+    ) -> anyhow::Result<(Self, SequencerRole)> {
         let is_replica = is_replica.unwrap_or(false);
         if is_replica {
             return Ok((
@@ -435,7 +441,7 @@ impl PreferredSequencerDb {
                     backend: None,
                     shutdown_sender: shutdown_sender.clone(),
                 },
-                is_replica,
+                SequencerRole::Replica,
             ));
         }
 
@@ -452,7 +458,7 @@ impl PreferredSequencerDb {
                 backend,
                 shutdown_sender: shutdown_sender.clone(),
             },
-            is_replica,
+            SequencerRole::Leader,
         ))
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -36,7 +36,7 @@ use crate::preferred::{exit_rollup, track_in_progress_batch_size};
 #[derive(Debug)]
 pub(crate) enum DbReadOutcome<T> {
     Success(T),
-    AbortedBecauseReplica,
+    AbortedBecauseReplica { db_replica: Option<String> },
 }
 
 #[derive(Debug, PartialEq, strum::Display)]
@@ -45,10 +45,10 @@ pub(crate) enum Operation {
     BatchAddTxs,
     AddTx,
     EndBlock,
-    Prune,
+    Prune { db_replica: Option<String> },
     ReadBatch,
     AddProof,
-    CurrentData,
+    CurrentData { db_replica: Option<String> },
 }
 
 #[derive(Debug)]

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -622,8 +622,8 @@ mod tests {
             let leader_2 = db_2.maybe_update_leader().await;
             assert!(leader_2.is_none());
 
-            let leader = db_2.get_sequencer_leader().await.unwrap().unwrap();
-            assert_eq!(updated_leader_1, leader);
+            let leader_node_id = db_2.get_sequencer_leader().await.unwrap().unwrap();
+            assert_eq!(updated_leader_1.node_id, leader_node_id);
         }
 
         {
@@ -771,10 +771,22 @@ mod tests {
         assert_err(err, &db_replica.node_id, &Operation::EndBlock);
 
         let err = db_replica.as_mut().prune(2).await.unwrap_err();
-        assert_err(err, &db_replica.node_id, &Operation::Prune);
+        assert_err(
+            err,
+            &db_replica.node_id,
+            &Operation::Prune {
+                db_replica: Some(db_leader.node_id.clone()),
+            },
+        );
 
         let err = db_replica.as_mut().current_data().await.unwrap_err();
-        assert_err(err, &db_replica.node_id, &Operation::CurrentData);
+        assert_err(
+            err,
+            &db_replica.node_id,
+            &Operation::CurrentData {
+                db_replica: Some(db_leader.node_id.clone()),
+            },
+        );
     }
 
     fn assert_err(err: DbError, expected_node_id: &String, expected_operation: &Operation) {
@@ -832,9 +844,7 @@ mod tests {
             self.backend.try_update_leader().await.unwrap()
         }
 
-        pub(crate) async fn get_sequencer_leader(
-            &self,
-        ) -> Result<Option<SequencerLeader>, sqlx::Error> {
+        pub(crate) async fn get_sequencer_leader(&self) -> Result<Option<String>, sqlx::Error> {
             let mut tx = self.backend.pool.begin().await?;
             let res = self.backend.get_sequencer_leader_inner(&mut tx).await?;
             tx.commit().await?;

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -206,8 +206,10 @@ impl PostgresBackend {
         let mut tx = self.pool.begin().await?;
         let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
 
-        if !self.is_leader(maybe_leader) {
-            return Ok(DbReadOutcome::AbortedBecauseReplica);
+        if !self.is_leader(&maybe_leader) {
+            return Ok(DbReadOutcome::AbortedBecauseReplica {
+                db_replica: maybe_leader,
+            });
         }
 
         let completed_blobs_metadata: Vec<(i64, Vec<u8>)> =
@@ -271,7 +273,10 @@ impl PostgresBackend {
         Ok(res)
     }
 
-    async fn prune_inner(&self, prune_up_to_including: SequenceNumber) -> anyhow::Result<bool> {
+    async fn prune_inner(
+        &self,
+        prune_up_to_including: SequenceNumber,
+    ) -> anyhow::Result<DbReadOutcome<()>> {
         let mut tx = self.pool.begin().await?;
         let prune_up_to_including: i64 = prune_up_to_including.saturating_add(1).try_into()?;
 
@@ -290,28 +295,34 @@ impl PostgresBackend {
 
         if result.rows_affected() == 0 {
             let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
-            return Ok(self.is_leader(maybe_leader));
+            if self.is_leader(&maybe_leader) {
+                return Ok(DbReadOutcome::AbortedBecauseReplica {
+                    db_replica: maybe_leader,
+                });
+            }
         }
         tx.commit().await?;
-        Ok(true)
+        Ok(DbReadOutcome::Success(()))
     }
 
     async fn get_sequencer_leader_inner(
         &self,
         connection: &mut PgConnection,
-    ) -> Result<Option<SequencerLeader>, sqlx::Error> {
-        sqlx::query_as::<_, SequencerLeader>(
+    ) -> Result<Option<String>, sqlx::Error> {
+        let maybe_leader: Option<SequencerLeader> = sqlx::query_as::<_, SequencerLeader>(
             "SELECT node_id, last_updated
                 FROM sequencer_leader
                 WHERE singleton = 1",
         )
         .fetch_optional(connection)
-        .await
+        .await?;
+
+        Ok(maybe_leader.map(|l| l.node_id))
     }
 
-    fn is_leader(&self, maybe_leader: Option<SequencerLeader>) -> bool {
-        match maybe_leader {
-            Some(leader) => leader.node_id == self.node_id,
+    fn is_leader(&self, maybe_node_id: &Option<String>) -> bool {
+        match maybe_node_id {
+            Some(node_id) => node_id == &self.node_id,
             None => false,
         }
     }
@@ -482,16 +493,16 @@ impl DbBackend for PostgresBackend {
     }
 
     async fn prune(&mut self, up_to_including: SequenceNumber) -> Result<(), DbError> {
-        let is_leader = run_with_retries!(
+        let outcome = run_with_retries!(
             &self.backoff_policy,
             self.prune_inner(up_to_including),
             "postgres_db_backend_prune"
         )?;
 
-        if !is_leader {
+        if let DbReadOutcome::AbortedBecauseReplica { db_replica } = outcome {
             return Err(DbError::ReplicaDisallowed {
                 self_node_id: self.node_id.clone(),
-                operation: Operation::Prune,
+                operation: Operation::Prune { db_replica },
             });
         }
 
@@ -500,7 +511,8 @@ impl DbBackend for PostgresBackend {
     async fn read_in_progress_batch(&self) -> anyhow::Result<Option<InProgressBatch>, DbError> {
         let mut tx = self.pool.begin().await?;
         let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
-        if !self.is_leader(maybe_leader) {
+
+        if !self.is_leader(&maybe_leader) {
             return Err(DbError::ReplicaDisallowed {
                 self_node_id: self.node_id.clone(),
                 operation: Operation::ReadBatch,
@@ -564,10 +576,10 @@ impl DbBackend for PostgresBackend {
 
         match res {
             DbReadOutcome::Success(data) => Ok(data),
-            DbReadOutcome::AbortedBecauseReplica => {
+            DbReadOutcome::AbortedBecauseReplica { db_replica } => {
                 return Err(DbError::ReplicaDisallowed {
                     self_node_id: self.node_id.clone(),
-                    operation: Operation::CurrentData,
+                    operation: Operation::CurrentData { db_replica },
                 });
             }
         }

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -765,7 +765,7 @@ mod tests {
         assert_err(err, &db_replica.node_id, &Operation::CurrentData);
     }
 
-    fn assert_err(err: DbError, expected_node_id: &String, expected_operation: &Operation) -> () {
+    fn assert_err(err: DbError, expected_node_id: &String, expected_operation: &Operation) {
         match &err {
             DbError::ReplicaDisallowed {
                 self_node_id,

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -295,7 +295,7 @@ impl PostgresBackend {
 
         if result.rows_affected() == 0 {
             let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
-            if self.is_leader(&maybe_leader) {
+            if !self.is_leader(&maybe_leader) {
                 return Ok(DbReadOutcome::AbortedBecauseReplica {
                     db_replica: maybe_leader,
                 });

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+use crate::preferred::db::Operation;
 use anyhow::{anyhow, Result};
 use std::sync::Arc;
 use std::time::Duration;
@@ -349,8 +350,12 @@ impl DbBackend for PostgresBackend {
         )?;
 
         if result.rows_affected() == 0 {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::BeginBlock,
+            });
         }
+
         Ok(())
     }
 
@@ -398,7 +403,10 @@ impl DbBackend for PostgresBackend {
         )?;
 
         if result.rows_affected() == 0 {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::BatchAddTxs,
+            });
         }
 
         Ok(())
@@ -430,7 +438,10 @@ impl DbBackend for PostgresBackend {
         )?;
 
         if result.rows_affected() == 0 {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::AddTx,
+            });
         }
 
         Ok(())
@@ -461,7 +472,10 @@ impl DbBackend for PostgresBackend {
         )?;
 
         if result.rows_affected() == 0 {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::EndBlock,
+            });
         }
 
         Ok(())
@@ -475,7 +489,10 @@ impl DbBackend for PostgresBackend {
         )?;
 
         if !is_leader {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::Prune,
+            });
         }
 
         Ok(())
@@ -484,7 +501,10 @@ impl DbBackend for PostgresBackend {
         let mut tx = self.pool.begin().await?;
         let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;
         if !self.is_leader(maybe_leader) {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::ReadBatch,
+            });
         }
 
         let res = self
@@ -507,20 +527,29 @@ impl DbBackend for PostgresBackend {
         let result = run_with_retries!(
             &self.backoff_policy,
             sqlx::query(
-                "WITH blob_insert AS (
-                    INSERT INTO proof_blobs (sequence_number, borsh_value) VALUES ($1, $2)
-             )
-             INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data) 
-             SELECT $1, 'new_proof', NULL, NULL, NULL",
+                "
+                WITH blob_insert AS (
+                    INSERT INTO proof_blobs (sequence_number, borsh_value)
+                    SELECT $1, $2
+                    WHERE is_leader($3)
+                    RETURNING sequence_number
+                )
+                INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data)
+                SELECT bi.sequence_number, 'new_proof', NULL, NULL, NULL
+                FROM blob_insert bi",
             )
             .bind(i64::try_from(sequence_number)?)
             .bind::<&[u8]>(blob_data.as_ref())
+            .bind(&self.node_id)
             .execute(&self.pool),
             "postgres_db_backend_add_proof_blob"
         )?;
 
         if result.rows_affected() == 0 {
-            return Err(DbError::Replica);
+            return Err(DbError::ReplicaDisallowed {
+                self_node_id: self.node_id.clone(),
+                operation: Operation::AddProof,
+            });
         }
 
         Ok(())
@@ -535,7 +564,12 @@ impl DbBackend for PostgresBackend {
 
         match res {
             DbReadOutcome::Success(data) => Ok(data),
-            DbReadOutcome::AbortedBecauseReplica => Err(DbError::Replica),
+            DbReadOutcome::AbortedBecauseReplica => {
+                return Err(DbError::ReplicaDisallowed {
+                    self_node_id: self.node_id.clone(),
+                    operation: Operation::CurrentData,
+                });
+            }
         }
     }
 }
@@ -640,6 +674,11 @@ mod tests {
             .await
             .unwrap();
 
+        db.as_mut()
+            .add_proof_blob(sequence_number, 3, Arc::new([1, 2, 3]))
+            .await
+            .unwrap();
+
         db.as_mut().end_rollup_block(batch_to_store).await.unwrap();
 
         let data = db.as_mut().current_data().await.unwrap();
@@ -670,10 +709,15 @@ mod tests {
 
         db_leader.maybe_update_leader().await.unwrap();
 
-        let res = db_replica.as_mut().begin_rollup_block(batch_to_store).await;
-        assert!(matches!(res, Err(DbError::Replica)));
+        let err = db_replica
+            .as_mut()
+            .begin_rollup_block(batch_to_store)
+            .await
+            .unwrap_err();
 
-        let res = db_replica
+        assert_err(err, &db_replica.node_id, &Operation::BeginBlock);
+
+        let err = db_replica
             .as_mut()
             .add_tx(
                 sequence_number,
@@ -681,28 +725,57 @@ mod tests {
                 FullyBakedTx::new(vec![1, 2, 3]),
                 TxHash::new([1; 32]),
             )
-            .await;
+            .await
+            .unwrap_err();
 
-        assert!(matches!(res, Err(DbError::Replica)));
+        assert_err(err, &db_replica.node_id, &Operation::AddTx);
 
-        let res = db_replica
+        let err = db_replica
             .as_mut()
             .batch_add_txs(
                 sequence_number,
                 2,
                 &[(FullyBakedTx::new(vec![4, 5, 6]), TxHash::new([1; 32]))],
             )
-            .await;
-        assert!(matches!(res, Err(DbError::Replica)));
+            .await
+            .unwrap_err();
 
-        let res = db_replica.as_mut().end_rollup_block(batch_to_store).await;
-        assert!(matches!(res, Err(DbError::Replica)));
+        assert_err(err, &db_replica.node_id, &Operation::BatchAddTxs);
 
-        let res = db_replica.as_mut().prune(2).await;
-        assert!(matches!(res, Err(DbError::Replica)));
+        let err = db_replica
+            .as_mut()
+            .add_proof_blob(sequence_number, 3, Arc::new([1, 2, 3]))
+            .await
+            .unwrap_err();
 
-        let res = db_replica.as_mut().current_data().await;
-        assert!(matches!(res, Err(DbError::Replica)));
+        assert_err(err, &db_replica.node_id, &Operation::AddProof);
+
+        let err = db_replica
+            .as_mut()
+            .end_rollup_block(batch_to_store)
+            .await
+            .unwrap_err();
+
+        assert_err(err, &db_replica.node_id, &Operation::EndBlock);
+
+        let err = db_replica.as_mut().prune(2).await.unwrap_err();
+        assert_err(err, &db_replica.node_id, &Operation::Prune);
+
+        let err = db_replica.as_mut().current_data().await.unwrap_err();
+        assert_err(err, &db_replica.node_id, &Operation::CurrentData);
+    }
+
+    fn assert_err(err: DbError, expected_node_id: &String, expected_operation: &Operation) -> () {
+        match &err {
+            DbError::ReplicaDisallowed {
+                self_node_id,
+                operation,
+            } => {
+                assert_eq!(self_node_id, expected_node_id);
+                assert_eq!(operation, expected_operation);
+            }
+            DbError::Database(err) => unreachable!("DbError::Database not allowed in test {err:?}"),
+        }
     }
 
     struct DB {

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -140,6 +140,7 @@ where
             latest_state_update.clone(),
             rollup_exec_config.clone(),
             config.clone(),
+            seq_role,
         )
         .await;
 

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -90,7 +90,25 @@ where
         let (next_sequence_number, db_cache) = db.initial_data().await?;
         let mut handles = vec![];
 
-        let blob_sender = if !is_replica_seq {
+        let (blob_sender, blob_sender_handle) = PreferredBlobSender::new(
+            self.da,
+            ledger_db.clone(),
+            db_cache.all_completed_blobs().clone(),
+            storage_path.into(),
+            tx_status_manager.clone(),
+            shutdown_sender.clone(),
+            Duration::from_secs(config.blob_processing_timeout_secs),
+            blobs_sender_channel.clone(),
+            is_replica_seq,
+        )
+        .await?;
+
+        if let Some(blob_sender_handle) = blob_sender_handle {
+            handles.push(blob_sender_handle);
+        }
+
+        /*
+
             let (blob_sender, handle) = PreferredBlobSender::new(
                 self.da,
                 ledger_db.clone(),
@@ -100,6 +118,7 @@ where
                 shutdown_sender.clone(),
                 Duration::from_secs(config.blob_processing_timeout_secs),
                 blobs_sender_channel.clone(),
+                is_replica_seq,
             )
             .await?;
             handles.push(handle);
@@ -107,6 +126,7 @@ where
         } else {
             None
         };
+        */
 
         let (block_executors_shutdown_notifier, block_executors_shutdown_rx) = mpsc::channel(1);
         let (state_root_handle, state_root_task) = StateRootTask::create::<Rt>(
@@ -123,10 +143,8 @@ where
 
         let (executor_events_sender, executor_events_receiver) =
             ExecutorEventsSender::new(shutdown_sender.clone(), db_cache);
-        let in_flight_blobs = blob_sender
-            .as_ref()
-            .map(|b| b.nb_of_in_flight_blobs())
-            .unwrap_or_default();
+
+        let in_flight_blobs = blob_sender.nb_of_in_flight_blobs();
 
         let rollup_exec_config = RollupBlockExecutorConfig {
             da_address,

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -149,7 +149,7 @@ where
         }
 
         let (mut replica_task, start_replica_task_notifier) =
-            ReplicaSyncTask::new(shutdown_sender.clone()).await?;
+            ReplicaSyncTask::new(shutdown_sender.clone(), seq_role).await?;
 
         let tx_queue_id = Arc::new(AtomicU64::new(0));
         let batch_execution_time_limit_micros =

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -1,3 +1,5 @@
+use crate::preferred::db::SequencerRole;
+
 use super::*;
 use anyhow::Context;
 use anyhow::Result;
@@ -68,6 +70,7 @@ where
 
         let mut config = self.config;
         let preferred_config = &config.sequencer_kind_config;
+
         let maybe_oracle_config =
             TimingOracleConfigWithPrivateKey::new(preferred_config.timing_oracle.clone())
                 .transpose()?;
@@ -79,7 +82,7 @@ where
 
         let (blobs_sender_channel, _) = broadcast::channel(preferred_config.events_channel_size);
 
-        let (db, is_replica_seq) = PreferredSequencerDb::new(
+        let (db, seq_role) = PreferredSequencerDb::new(
             shutdown_sender.clone(),
             preferred_config.is_replica,
             storage_path,
@@ -99,7 +102,7 @@ where
             shutdown_sender.clone(),
             Duration::from_secs(config.blob_processing_timeout_secs),
             blobs_sender_channel.clone(),
-            is_replica_seq,
+            seq_role,
         )
         .await?;
 
@@ -151,7 +154,7 @@ where
         let batch_execution_time_limit_micros =
             preferred_config.batch_execution_time_limit_millis * 1000;
         let (synchronized_state, synchronized_state_updator) = create(
-            is_replica_seq,
+            seq_role,
             api_ledger_db.clone(),
             latest_state_update.clone(),
             tx_queue_id.clone(),
@@ -218,7 +221,8 @@ where
         }));
 
         // Launch replica sync task only for replicas.
-        if is_replica_seq {
+
+        if let SequencerRole::Replica = seq_role {
             if let Some(postgres_config) = &preferred_config.postgres_config {
                 let replica_task_handle = replica_task
                     .start(synchronized_state_updator, postgres_config)
@@ -250,11 +254,13 @@ where
         }));
 
         if let Some(oracle_config) = maybe_oracle_config {
-            if Rt::default().maybe_set_oracle_timestamp(0).is_some() && !is_replica_seq {
-                match update_timestamp_task(seq.clone(), oracle_config, shutdown_receiver) {
-                    Ok(handle) => handles.push(handle),
-                    Err(e) => {
-                        error!(error = ?e, "Failed to start timestamp oracle task");
+            if let SequencerRole::Leader = seq_role {
+                if Rt::default().maybe_set_oracle_timestamp(0).is_some() {
+                    match update_timestamp_task(seq.clone(), oracle_config, shutdown_receiver) {
+                        Ok(handle) => handles.push(handle),
+                        Err(e) => {
+                            error!(error = ?e, "Failed to start timestamp oracle task");
+                        }
                     }
                 }
             }

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -107,27 +107,6 @@ where
             handles.push(blob_sender_handle);
         }
 
-        /*
-
-            let (blob_sender, handle) = PreferredBlobSender::new(
-                self.da,
-                ledger_db.clone(),
-                db_cache.all_completed_blobs().clone(),
-                storage_path.into(),
-                tx_status_manager.clone(),
-                shutdown_sender.clone(),
-                Duration::from_secs(config.blob_processing_timeout_secs),
-                blobs_sender_channel.clone(),
-                is_replica_seq,
-            )
-            .await?;
-            handles.push(handle);
-            Some(blob_sender)
-        } else {
-            None
-        };
-        */
-
         let (block_executors_shutdown_notifier, block_executors_shutdown_rx) = mpsc::channel(1);
         let (state_root_handle, state_root_task) = StateRootTask::create::<Rt>(
             block_executors_shutdown_rx,

--- a/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
@@ -15,6 +15,7 @@ use tokio::time::Duration;
 use tracing::debug;
 
 use super::db::{ReadBatch, ReadBlob};
+use crate::preferred::db::SequencerRole;
 use crate::{common::TxStatusBlobSenderHooks, TxStatusManager};
 
 /// Wrapper around [`BlobSender`] with preferred blob -specific logic.
@@ -33,45 +34,48 @@ impl<Da: DaService> PreferredBlobSender<Da> {
         shutdown_sender: watch::Sender<()>,
         blob_processing_timeout: Duration,
         blobs_sender_channel: broadcast::Sender<BlobExecutionStatus<Da::Spec>>,
-        is_replica: bool,
+        seq_role: SequencerRole,
     ) -> anyhow::Result<(Self, Option<JoinHandle<()>>)> {
         let nb_of_concurrent_blob_submissions = Arc::new(AtomicUsize::new(0));
-        if is_replica {
-            Ok((
-                Self {
-                    inner: None,
-                    nb_of_concurrent_blob_submissions,
-                },
-                None,
-            ))
-        } else {
-            // It's possible that sov-blob-sender's DB might miss some blob data at
-            // node startup due to:
-            //  1. Disk failure (the sequencer can use Postgres so it's durable).
-            //  2. DB corruption.
-            //  3. Node crash at an inconvenient time.
-            // Let's restore all missing blob data to make sure they land on the DA.
-            let blobs_to_send = create_blobs_to_send(all_completed_blobs)?;
-            let (inner, blob_sender_handle) = BlobSender::new(
-                da.clone(),
-                ledger_db,
-                storage_path.as_ref(),
-                TxStatusBlobSenderHooks::new(tx_status_manager.clone()),
-                shutdown_sender,
-                blob_processing_timeout,
-                Some(blobs_sender_channel),
-                blobs_to_send,
-                nb_of_concurrent_blob_submissions.clone(),
-            )
-            .await?;
+        match seq_role {
+            SequencerRole::Replica => {
+                return Ok((
+                    Self {
+                        inner: None,
+                        nb_of_concurrent_blob_submissions,
+                    },
+                    None,
+                ));
+            }
+            SequencerRole::Leader => {
+                // It's possible that sov-blob-sender's DB might miss some blob data at
+                // node startup due to:
+                //  1. Disk failure (the sequencer can use Postgres so it's durable).
+                //  2. DB corruption.
+                //  3. Node crash at an inconvenient time.
+                // Let's restore all missing blob data to make sure they land on the DA.
+                let blobs_to_send = create_blobs_to_send(all_completed_blobs)?;
+                let (inner, blob_sender_handle) = BlobSender::new(
+                    da.clone(),
+                    ledger_db,
+                    storage_path.as_ref(),
+                    TxStatusBlobSenderHooks::new(tx_status_manager.clone()),
+                    shutdown_sender,
+                    blob_processing_timeout,
+                    Some(blobs_sender_channel),
+                    blobs_to_send,
+                    nb_of_concurrent_blob_submissions.clone(),
+                )
+                .await?;
 
-            Ok((
-                Self {
-                    inner: Some(inner),
-                    nb_of_concurrent_blob_submissions,
-                },
-                Some(blob_sender_handle),
-            ))
+                Ok((
+                    Self {
+                        inner: Some(inner),
+                        nb_of_concurrent_blob_submissions,
+                    },
+                    Some(blob_sender_handle),
+                ))
+            }
         }
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
@@ -38,15 +38,13 @@ impl<Da: DaService> PreferredBlobSender<Da> {
     ) -> anyhow::Result<(Self, Option<JoinHandle<()>>)> {
         let nb_of_concurrent_blob_submissions = Arc::new(AtomicUsize::new(0));
         match seq_role {
-            SequencerRole::Replica => {
-                return Ok((
-                    Self {
-                        inner: None,
-                        nb_of_concurrent_blob_submissions,
-                    },
-                    None,
-                ));
-            }
+            SequencerRole::Replica => Ok((
+                Self {
+                    inner: None,
+                    nb_of_concurrent_blob_submissions,
+                },
+                None,
+            )),
             SequencerRole::Leader => {
                 // It's possible that sov-blob-sender's DB might miss some blob data at
                 // node startup due to:

--- a/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
@@ -19,7 +19,7 @@ use crate::{common::TxStatusBlobSenderHooks, TxStatusManager};
 
 /// Wrapper around [`BlobSender`] with preferred blob -specific logic.
 pub struct PreferredBlobSender<Da: DaService> {
-    inner: BlobSender<Da, TxStatusBlobSenderHooks<Da::Spec>, LedgerDb>,
+    inner: Option<BlobSender<Da, TxStatusBlobSenderHooks<Da::Spec>, LedgerDb>>,
     nb_of_concurrent_blob_submissions: Arc<AtomicUsize>,
 }
 
@@ -33,33 +33,46 @@ impl<Da: DaService> PreferredBlobSender<Da> {
         shutdown_sender: watch::Sender<()>,
         blob_processing_timeout: Duration,
         blobs_sender_channel: broadcast::Sender<BlobExecutionStatus<Da::Spec>>,
-    ) -> anyhow::Result<(Self, JoinHandle<()>)> {
+        is_replica: bool,
+    ) -> anyhow::Result<(Self, Option<JoinHandle<()>>)> {
         let nb_of_concurrent_blob_submissions = Arc::new(AtomicUsize::new(0));
-        // It's possible that sov-blob-sender's DB might miss some blob data at
-        // node startup due to:
-        //  1. Disk failure (the sequencer can use Postgres so it's durable).
-        //  2. DB corruption.
-        //  3. Node crash at an inconvenient time.
-        // Let's restore all missing blob data to make sure they land on the DA.
-        let blobs_to_send = create_blobs_to_send(all_completed_blobs)?;
-        let (inner, handle) = BlobSender::new(
-            da.clone(),
-            ledger_db,
-            storage_path.as_ref(),
-            TxStatusBlobSenderHooks::new(tx_status_manager.clone()),
-            shutdown_sender,
-            blob_processing_timeout,
-            Some(blobs_sender_channel),
-            blobs_to_send,
-            nb_of_concurrent_blob_submissions.clone(),
-        )
-        .await?;
+        if is_replica {
+            Ok((
+                Self {
+                    inner: None,
+                    nb_of_concurrent_blob_submissions,
+                },
+                None,
+            ))
+        } else {
+            // It's possible that sov-blob-sender's DB might miss some blob data at
+            // node startup due to:
+            //  1. Disk failure (the sequencer can use Postgres so it's durable).
+            //  2. DB corruption.
+            //  3. Node crash at an inconvenient time.
+            // Let's restore all missing blob data to make sure they land on the DA.
+            let blobs_to_send = create_blobs_to_send(all_completed_blobs)?;
+            let (inner, blob_sender_handle) = BlobSender::new(
+                da.clone(),
+                ledger_db,
+                storage_path.as_ref(),
+                TxStatusBlobSenderHooks::new(tx_status_manager.clone()),
+                shutdown_sender,
+                blob_processing_timeout,
+                Some(blobs_sender_channel),
+                blobs_to_send,
+                nb_of_concurrent_blob_submissions.clone(),
+            )
+            .await?;
 
-        let sender = Self {
-            inner,
-            nb_of_concurrent_blob_submissions,
-        };
-        Ok((sender, handle))
+            Ok((
+                Self {
+                    inner: Some(inner),
+                    nb_of_concurrent_blob_submissions,
+                },
+                Some(blob_sender_handle),
+            ))
+        }
     }
 
     pub(crate) async fn publish_proof(
@@ -68,6 +81,10 @@ impl<Da: DaService> PreferredBlobSender<Da> {
         sequence_number: u64,
         blob_id: BlobInternalId,
     ) -> anyhow::Result<()> {
+        let Some(ref mut inner) = self.inner else {
+            return Ok(());
+        };
+
         let blob_bytes = proof_bytes(&proof_data, sequence_number)?;
 
         debug!(
@@ -75,16 +92,20 @@ impl<Da: DaService> PreferredBlobSender<Da> {
             blob_id, "Dispatching proof blob for publishing"
         );
 
-        self.inner.publish_proof_blob(blob_bytes, blob_id).await?;
+        inner.publish_proof_blob(blob_bytes, blob_id).await?;
 
         Ok(())
     }
 
     pub(crate) async fn publish_batch(&mut self, batch: ReadBatch) -> anyhow::Result<()> {
+        let Some(ref mut inner) = self.inner else {
+            return Ok(());
+        };
+
         let blob_id = batch.blob_id;
         let data = batch_bytes(batch)?;
 
-        self.inner.publish_batch_blob(data, blob_id).await?;
+        inner.publish_batch_blob(data, blob_id).await?;
 
         Ok(())
     }
@@ -115,7 +136,11 @@ impl<Da: DaService> PreferredBlobSender<Da> {
     }
 
     pub(crate) async fn add_txs(&self, blob_id: BlobInternalId, tx_hashes: Arc<Vec<TxHash>>) {
-        self.inner.hooks().add_txs(blob_id, tx_hashes).await;
+        let Some(ref inner) = self.inner else {
+            return;
+        };
+
+        inner.hooks().add_txs(blob_id, tx_hashes).await;
     }
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -1,9 +1,11 @@
+use crate::preferred::db::SequencerRole;
 use crate::preferred::replica::db_data::row_to_event;
 use crate::preferred::replica::db_data::rows;
 use crate::preferred::replica::db_data::DbData;
 use crate::preferred::replica::db_data::EventType;
 use crate::preferred::replica::db_data::EventsNotificationPayload;
 use crate::preferred::replica::db_data::ParsingError;
+use crate::SequencerNotReadyDetails;
 use sov_rollup_interface::node::future_or_shutdown;
 use sov_rollup_interface::node::FutureOrShutdownOutput;
 use sqlx::postgres::{PgListener, PgPoolOptions};
@@ -32,30 +34,61 @@ pub(crate) enum EventReceiverError {
 pub(crate) struct EventReceiverStartNotifier {
     notify: watch::Sender<()>,
     replica_processed_first_batch: bool,
+    seq_role: SequencerRole,
 }
 
 impl EventReceiverStartNotifier {
-    pub(crate) fn new() -> (Self, watch::Receiver<()>) {
+    pub(crate) fn new(seq_role: SequencerRole) -> (Self, watch::Receiver<()>) {
         let (notify, mut receiver) = watch::channel(());
         receiver.borrow_and_update();
         (
             Self {
                 notify,
                 replica_processed_first_batch: false,
+                seq_role,
             },
             receiver,
         )
     }
 
+    /// Notifies the replica sync task that it’s time to start processing leader sequencer DB events.
+    /// This method only has an effect when called on a replica sequencer, since the leader produces
+    /// the DB events rather than consuming them.
     pub(crate) fn notify(&self) {
+        if self.seq_role == SequencerRole::Leader {
+            return;
+        }
+
         let _ = self.notify.send(());
     }
 
-    pub(crate) fn replica_processed_first_batch(&self) -> bool {
-        self.replica_processed_first_batch
+    /// If the sequencer is in replica mode, we check whether the replica sync task has processed
+    /// its first batch, which indicates that all services are up and running.
+    /// For the leader, this method always returns Ok(()).
+    pub(crate) fn check_replica_status_or_ok_for_leader(
+        &self,
+    ) -> Result<(), SequencerNotReadyDetails> {
+        if self.seq_role == SequencerRole::Leader {
+            return Ok(());
+        }
+
+        if self.replica_processed_first_batch {
+            return Ok(());
+        }
+
+        return Err(SequencerNotReadyDetails::ReplicaNotReady);
     }
 
+    /// Marks that the replica has successfully processed its first batch of events.
+    ///
+    /// # Panics
+    /// Panics if this method is called on a leader sequencer.
     pub(crate) fn set_replica_processed_first_batch(&mut self) {
+        assert_eq!(
+            self.seq_role,
+            SequencerRole::Replica,
+            "set_replica_processed_first_batch can only be called on a Replica sequencer"
+        );
         self.replica_processed_first_batch = true;
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -76,7 +76,7 @@ impl EventReceiverStartNotifier {
             return Ok(());
         }
 
-        return Err(SequencerNotReadyDetails::ReplicaNotReady);
+        Err(SequencerNotReadyDetails::ReplicaNotReady);
     }
 
     /// Marks that the replica has successfully processed its first batch of events.

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -76,7 +76,7 @@ impl EventReceiverStartNotifier {
             return Ok(());
         }
 
-        Err(SequencerNotReadyDetails::ReplicaNotReady);
+        Err(SequencerNotReadyDetails::ReplicaNotReady)
     }
 
     /// Marks that the replica has successfully processed its first batch of events.

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -1,3 +1,4 @@
+use crate::preferred::db::SequencerRole;
 use crate::preferred::replica::db_data::DbData;
 use crate::preferred::replica::event_receiver::EventReceiver;
 use crate::preferred::replica::event_receiver::EventReceiverStartNotifier;
@@ -37,16 +38,18 @@ pub(crate) struct ReplicaSyncTask {
 impl ReplicaSyncTask {
     pub(crate) async fn new(
         shutdown_sender: watch::Sender<()>,
+        seq_role: SequencerRole,
     ) -> anyhow::Result<(Self, EventReceiverStartNotifier)> {
-        Self::new_with_page_size(shutdown_sender, PAGE_SIZE).await
+        Self::new_with_page_size(shutdown_sender, PAGE_SIZE, seq_role).await
     }
 
     pub(crate) async fn new_with_page_size(
         shutdown_sender: watch::Sender<()>,
         page_size: usize,
+        seq_role: SequencerRole,
     ) -> anyhow::Result<(Self, EventReceiverStartNotifier)> {
         let (start_replica_task_notifier, start_replica_task_receiver) =
-            EventReceiverStartNotifier::new();
+            EventReceiverStartNotifier::new(seq_role);
         Ok((
             Self {
                 shutdown_sender,

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -354,7 +354,7 @@ mod tests {
 
         let (shutdown_snd, _shutdown_rcv) = watch::channel(());
         let (mut sync_task, start_replica_task_notifier) =
-            ReplicaSyncTask::new_with_page_size(shutdown_snd, 8)
+            ReplicaSyncTask::new_with_page_size(shutdown_snd, 8, SequencerRole::Replica)
                 .await
                 .unwrap();
 

--- a/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
@@ -27,7 +27,7 @@ where
     Da: DaService<Spec = S::Da>,
 {
     pub checkpoint_sender: watch::Sender<std::sync::Arc<ConcurrentStateCheckpoint<S>>>,
-    pub blob_sender: Option<PreferredBlobSender<Da>>,
+    pub blob_sender: PreferredBlobSender<Da>,
     pub db: PreferredSequencerDb,
     pub executor_events_receiver: mpsc::Receiver<ExecutorEvent<S, Rt>>,
     pub shutdown_sender: watch::Sender<()>,
@@ -64,10 +64,10 @@ where
         self.update_api_state(checkpoint);
 
         // Publish the batch.
-        if let Some(ref mut bs) = self.blob_sender {
-            bs.add_txs(batch.blob_id, batch.tx_hashes.clone()).await;
-            bs.publish_batch(batch).await?;
-        }
+        self.blob_sender
+            .add_txs(batch.blob_id, batch.tx_hashes.clone())
+            .await;
+        self.blob_sender.publish_batch(batch).await?;
 
         Ok(())
     }
@@ -82,9 +82,9 @@ where
                 RecoveryStrategy::TryToSave => {
                     // Flush our batches to try to save them if we can
                     warn!(num_batches_to_replay = batches_to_flush.len(), "TryToSave recovery strategy has been configured. The currently pending soft confirmations will be flushed to the node. This may save some of the transactions, but if any are no longer valid, the sequencer will be penalised.");
-                    if let Some(ref mut bs) = self.blob_sender {
-                        bs.publish_blobs_for_recovery(batches_to_flush).await?;
-                    }
+                    self.blob_sender
+                        .publish_blobs_for_recovery(batches_to_flush)
+                        .await?;
                 }
                 RecoveryStrategy::None => {
                     // Shut down
@@ -200,9 +200,9 @@ where
                 self.db
                     .insert_proof_blob(blob_id, data.clone(), sequence_number)
                     .await?;
-                if let Some(ref mut bs) = self.blob_sender {
-                    bs.publish_proof(data, sequence_number, blob_id).await?;
-                }
+                self.blob_sender
+                    .publish_proof(data, sequence_number, blob_id)
+                    .await?;
             }
             ExecutorEvent::ForceUpdateApiState(new_checkpoint) => {
                 self.update_api_state(new_checkpoint);

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -7,7 +7,7 @@ use crate::preferred::block_executor::{
 use crate::preferred::block_executor::{RollupBlockExecutorErrorWithBudget, StartBlockData};
 use crate::preferred::cache_warm_up_executor::{CacheWarmUpExecutor, StartBlockNotification};
 use crate::preferred::comfortable_gas_limit;
-use crate::preferred::db::latest_finalized_sequence_number;
+use crate::preferred::db::{latest_finalized_sequence_number, SequencerRole};
 use crate::preferred::executor_events::ExecutorEventsSender;
 use crate::preferred::rate_limiter::ResourceUsed;
 use crate::preferred::rate_limiter::SovRateLimiter;
@@ -66,7 +66,7 @@ where
     S: Spec,
     Rt: Runtime<S>,
 {
-    pub(crate) is_replica: bool,
+    pub(crate) seq_role: SequencerRole,
     // This ledgerdb is used specifically for REST API and websocket subscriptions.
     // The sequencer controls when it is updated to solve inconsistency issues,
     // See [`LedgerDb::with_shared_notifications`] for more details.
@@ -442,7 +442,7 @@ where
             }
         }
 
-        if self.is_replica()
+        if self.is_replica_role()
             && !self
                 .start_replica_task_notifier
                 .replica_processed_first_batch()
@@ -454,8 +454,8 @@ where
         Ok(())
     }
 
-    pub(crate) fn is_replica(&self) -> bool {
-        self.is_replica
+    pub(crate) fn is_replica_role(&self) -> bool {
+        self.seq_role == SequencerRole::Replica
     }
 
     pub(crate) async fn update_api_ledger(&self, info: &StateUpdateInfo<S::Storage>) {
@@ -613,7 +613,7 @@ where
             visible_increase,
             node_state_root: node_state_root.clone(),
             minimum_profit_per_tx: min_profit_per_tx,
-            is_responsible_for_gating_admins: !self.is_replica(),
+            is_responsible_for_gating_admins: !self.is_replica_role(),
         };
 
         let old_checkpoint = self

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -442,13 +442,8 @@ where
             }
         }
 
-        if self.is_replica_role()
-            && !self
-                .start_replica_task_notifier
-                .replica_processed_first_batch()
-        {
-            return Err(SequencerNotReadyDetails::ReplicaNotReady);
-        }
+        self.start_replica_task_notifier
+            .check_replica_status_or_ok_for_leader()?;
 
         self.is_ready.as_ref().map_err(|details| details.clone())?;
         Ok(())

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
@@ -2,6 +2,7 @@ use super::batch_size_tracker::BatchSizeTracker;
 use crate::preferred::block_executor::RollupBlockExecutor;
 use crate::preferred::cache_warm_up_executor::CacheWarmUpExecutor;
 use crate::preferred::db::BatchToStore;
+use crate::preferred::db::SequencerRole;
 use crate::preferred::executor_events::ExecutorEventsSender;
 use crate::preferred::rate_limiter::IpAndCredentialId;
 use crate::preferred::rate_limiter::ResourceLimitExceededError;
@@ -143,7 +144,7 @@ impl<S: Spec, Rt: Runtime<S>> Message<S, Rt> {
 }
 
 pub(crate) fn create<S, Rt>(
-    is_replica: bool,
+    seq_role: SequencerRole,
     api_ledger_db: LedgerDb,
     latest_info: StateUpdateInfo<S::Storage>,
     tx_queue_id: Arc<AtomicU64>,
@@ -179,7 +180,7 @@ where
     );
 
     let inner = Inner {
-        is_replica,
+        seq_role,
         api_ledger_db,
         executor: RollupBlockExecutor::new(
             &latest_info,

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -525,7 +525,7 @@ where
             is_recover,
         };
 
-        if inner.is_replica() {
+        if inner.is_replica_role() {
             operation_for_replica(
                 table,
                 info,
@@ -657,7 +657,7 @@ where
     async fn process_prune_sequencer_db(&mut self, reason: &'static str) {
         let start_prune = std::time::Instant::now();
         let mut inner = self.get_inner_with_timing(reason).await;
-        if !inner.is_replica() {
+        if !inner.is_replica_role() {
             inner.trigger_batch_production_if_convenient().await;
         }
         inner.prune_sequencer_db().await;
@@ -764,7 +764,7 @@ where
     ) -> Result<oneshot::Receiver<AcceptedTx<Confirmation<S, Rt>>>, AcceptTxError<S>> {
         let mut inner = self.get_inner_with_timing(reason).await;
 
-        if inner.is_replica() {
+        if inner.is_replica_role() {
             // The sequencer is running in replica mode and cannot accept transactions.
             return Err(AcceptTxError::ReplicaMode);
         }


### PR DESCRIPTION
# Description

This PR introduces the following changes:
1. Adds a `SequencerRole` enum, replacing the `is_replica` boolean in most parts of the sequencer. This enum is required because a follow-up PR will introduce a third variant to represent a system without predefined `leader/`replica roles, where the leader is elected by the database.

2. Adds role checks in `EventReceiverStartNotifier`, enforcing that some of its methods may only be called by a replica sequencer.

3. Makes `BlobSender` optional in `PreferredBlobSender`, simplifying the transition from Replica to Leader in a subsequent PR.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 
