### PR TITLE
Failover: Replace `is_replica` with `NodeRole` and add `ReplicaNoLeaderSync` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2026-01-09
-- #2266 **Breaking Change, Chain Hash Change** Replaces `is_replica` with the `NodeRole` enum. Users must update the `PostgreSQL` sections in `rollup_config.toml` to specify node_role.
+- #2266 **Breaking Change** Replaces `is_replica` with the `NodeRole` enum. Users must update the `PostgreSQL` sections in `rollup_config.toml` to specify node_role.
 
 # 2026-01-08
 - #2312 Implements `eth_feeHistory` RPC endpoint to expose rollup's EIP-1559 base fee history for wallets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2026-01-09
-- #2266 **EVM Breaking Change, Chain Hash Change** Replaces `is_replica` with the `NodeRole` enum. Users must update the `PostgreSQL` sections in `rollup_config.toml` to specify node_role.
+- #2266 **Breaking Change, Chain Hash Change** Replaces `is_replica` with the `NodeRole` enum. Users must update the `PostgreSQL` sections in `rollup_config.toml` to specify node_role.
 
 # 2026-01-08
 - #2312 Implements `eth_feeHistory` RPC endpoint to expose rollup's EIP-1559 base fee history for wallets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-01-09
+- #2266 **EVM Breaking Change, Chain Hash Change** Replaces `is_replica` with the `NodeRole` enum. Users must update the `PostgreSQL` sections in `rollup_config.toml` to specify node_role.
+
 # 2026-01-08
 - #2312 Implements `eth_feeHistory` RPC endpoint to expose rollup's EIP-1559 base fee history for wallets.
 

--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -264,10 +264,10 @@ mod tests {
             batch_execution_time_limit_millis = 2000 
             num_cache_warmup_workers = 0
             ideal_lag_behind_finalized_slot = 3
-            is_replica = false
             [sequencer.preferred.postgres_config]
             postgres_connection_string = "postgresql://postgres:pass@localhost:5432/db"
             node_id = "node_1"
+            node_role = "Leader"
             time_till_leader_update_allowed_ms = 1000
         "#;
 
@@ -317,10 +317,10 @@ mod tests {
             batch_execution_time_limit_millis = 2000 
             num_cache_warmup_workers = 0
             ideal_lag_behind_finalized_slot = 3
-            is_replica = false
             [sequencer.preferred.postgres_config]
             postgres_connection_string = "postgresql://postgres:pass@localhost:5432/db"
             node_id = "node_1"
+            node_role = "Leader"
             time_till_leader_update_allowed_ms = 1000
             [sequencer.preferred.rate_limiter]
             max_nb_of_concurrent_users_in_rate_limiter = 100000

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -129,10 +129,14 @@ pub enum RecoveryStrategy {
     TryToSave,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
+#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
 pub enum NodeRole {
-    Replica,
+    /// The node is the leader.
     Leader,
+    /// The node is a replica and syncs from the leader.
+    Replica,
+    /// The node is a replica, but syncing from the leader via Postgres is disabled.
+    ReplicaNoLeaderSync,
 }
 
 /// Postgres DB config.
@@ -142,7 +146,7 @@ pub struct PostgresConfig {
     pub postgres_connection_string: String,
     /// Id of the node.
     pub node_id: String,
-    ///
+    /// The role of the node.
     pub node_role: NodeRole,
 }
 

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -129,6 +129,12 @@ pub enum RecoveryStrategy {
     TryToSave,
 }
 
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
+pub enum NodeRole {
+    Replica,
+    Leader,
+}
+
 /// Postgres DB config.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
 pub struct PostgresConfig {
@@ -136,6 +142,8 @@ pub struct PostgresConfig {
     pub postgres_connection_string: String,
     /// Id of the node.
     pub node_id: String,
+    ///
+    pub node_role: NodeRole,
 }
 
 /// Configuration for [`PreferredSequencer`].
@@ -171,10 +179,6 @@ pub struct PreferredSequencerConfig<Address: Copy> {
     pub recovery_strategy: RecoveryStrategy,
     /// Target time in milliseconds to spend executing all the txs in a single batch. Batches will be closed when they exceed this value.
     pub batch_execution_time_limit_millis: u64,
-    /// When enabled, the sequencer runs in replica mode and cannot accept transactions.
-    /// It will sync from the master sequencer's database but remain read-only.
-    #[serde(default)]
-    pub is_replica: Option<bool>,
     #[serde(default = "default_num_cache_warmup_workers")]
     /// The number of workers that warm up the main executor cache.
     pub num_cache_warmup_workers: usize,
@@ -207,7 +211,6 @@ impl<Address: Copy> Default for PreferredSequencerConfig<Address> {
             disable_state_root_consistency_checks: false,
             ideal_lag_behind_finalized_slot: default_ideal_lag_behind_finalized_slot(),
             recovery_strategy: RecoveryStrategy::None,
-            is_replica: Some(false),
             db_event_channel_size: default_db_event_channel_size(),
             batch_execution_time_limit_millis: 6_000, // 6 seconds
             num_cache_warmup_workers: default_num_cache_warmup_workers(),

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -133,11 +133,13 @@ pub enum RecoveryStrategy {
 pub enum NodeRole {
     /// This node runs as the leader. The leader is responsible for producing new batches.
     Leader,
-    /// This node runs as a replica, syncing state from the leader.
-    /// Replicas do not publish blobs to the DA layer.
+    /// This node runs as a replica, syncing its state from the leader.
+    /// Replicas do not publish blobs to the DA layer, do not accept transactions via the API,
+    /// and do not issue soft confirmations.
     Replica,
-    /// This node runs as a replica, but Postgres-based syncing from the leader is disabled.
-    /// It only receives transactions via the DA layer.
+    /// This node runs in replica mode with Postgres-based synchronization from the leader disabled.
+    /// It receives transactions exclusively through the DA layer.
+    /// Use this mode when you want replica behavior without accepting transactions from the Leader only from the DA.
     ReplicaNoLeaderSync,
 }
 

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -131,11 +131,13 @@ pub enum RecoveryStrategy {
 
 #[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
 pub enum NodeRole {
-    /// The node is the leader.
+    /// This node runs as the leader. The leader is responsible for producing new batches.
     Leader,
-    /// The node is a replica and syncs from the leader.
+    /// This node runs as a replica, syncing state from the leader.
+    /// Replicas do not publish blobs to the DA layer.
     Replica,
-    /// The node is a replica, but syncing from the leader via Postgres is disabled.
+    /// This node runs as a replica, but Postgres-based syncing from the leader is disabled.
+    /// It only receives transactions via the DA layer.
     ReplicaNoLeaderSync,
 }
 
@@ -146,7 +148,7 @@ pub struct PostgresConfig {
     pub postgres_connection_string: String,
     /// Id of the node.
     pub node_id: String,
-    /// The role of the node.
+    #[allow(missing_docs)]
     pub node_role: NodeRole,
 }
 

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
@@ -61,14 +61,14 @@ expression: config
       "events_channel_size": 10000,
       "postgres_config": {
         "postgres_connection_string": "postgresql://postgres:pass@localhost:5432/db",
-        "node_id": "node_1"
+        "node_id": "node_1",
+        "node_role": "Leader"
       },
       "disable_state_root_consistency_checks": true,
       "ideal_lag_behind_finalized_slot": 3,
       "db_event_channel_size": 10000,
       "recovery_strategy": "TryToSave",
       "batch_execution_time_limit_millis": 2000,
-      "is_replica": false,
       "num_cache_warmup_workers": 0,
       "timing_oracle": null,
       "rate_limiter": null,

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
@@ -61,14 +61,14 @@ expression: config
       "events_channel_size": 10000,
       "postgres_config": {
         "postgres_connection_string": "postgresql://postgres:pass@localhost:5432/db",
-        "node_id": "node_1"
+        "node_id": "node_1",
+        "node_role": "Leader"
       },
       "disable_state_root_consistency_checks": true,
       "ideal_lag_behind_finalized_slot": 3,
       "db_event_channel_size": 10000,
       "recovery_strategy": "TryToSave",
       "batch_execution_time_limit_millis": 2000,
-      "is_replica": false,
       "num_cache_warmup_workers": 0,
       "timing_oracle": null,
       "rate_limiter": {

--- a/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
@@ -154,7 +154,7 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
         seq_config: SequencerConfig<S::Address, PreferredSequencerConfig<S::Address>>,
         seq_role: SequencerRole,
     ) -> (Self, Vec<JoinHandle<()>>) {
-        if seq_role == SequencerRole::Replica {
+        if seq_role != SequencerRole::Leader {
             return (Self { inner: None }, vec![]);
         }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -18,6 +18,7 @@ use axum::async_trait;
 use borsh::{BorshDeserialize, BorshSerialize};
 use sov_blob_sender::{new_blob_id, BlobInternalId};
 use sov_blob_storage::{PreferredBatchData, SequenceNumber};
+use sov_full_node_configs::sequencer::NodeRole;
 use sov_full_node_configs::sequencer::PostgresConfig;
 use sov_modules_api::capabilities::BlobSelector;
 use sov_modules_api::{
@@ -430,26 +431,23 @@ pub struct PreferredSequencerDb {
 impl PreferredSequencerDb {
     pub(crate) async fn new(
         shutdown_sender: watch::Sender<()>,
-        is_replica: Option<bool>,
         storage_path: &Path,
         postgres_config: &Option<PostgresConfig>,
     ) -> anyhow::Result<(Self, SequencerRole)> {
-        let is_replica = is_replica.unwrap_or(false);
-        if is_replica {
-            return Ok((
-                Self {
-                    backend: None,
-                    shutdown_sender: shutdown_sender.clone(),
-                },
-                SequencerRole::Replica,
-            ));
-        }
-
-        let backend: Option<Box<dyn DbBackend>> = {
+        let (backend, role): (Option<Box<dyn DbBackend>>, _) = {
             if let Some(postgres_config) = &postgres_config {
-                Some(Box::new(PostgresBackend::connect(postgres_config).await?))
+                match postgres_config.node_role {
+                    NodeRole::Replica => (None, SequencerRole::Replica),
+                    NodeRole::Leader => (
+                        Some(Box::new(PostgresBackend::connect(postgres_config).await?)),
+                        SequencerRole::Leader,
+                    ),
+                }
             } else {
-                Some(Box::new(RocksDbBackend::new(storage_path).await?))
+                (
+                    Some(Box::new(RocksDbBackend::new(storage_path).await?)),
+                    SequencerRole::Leader,
+                )
             }
         };
 
@@ -458,7 +456,7 @@ impl PreferredSequencerDb {
                 backend,
                 shutdown_sender: shutdown_sender.clone(),
             },
-            SequencerRole::Leader,
+            role,
         ))
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -419,6 +419,7 @@ impl From<BatchToStore> for StoredBlob {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum SequencerRole {
+    ReplicaNoLeaderSync,
     Replica,
     Leader,
 }
@@ -437,6 +438,7 @@ impl PreferredSequencerDb {
         let (backend, role): (Option<Box<dyn DbBackend>>, _) = {
             if let Some(postgres_config) = &postgres_config {
                 match postgres_config.node_role {
+                    NodeRole::ReplicaNoLeaderSync => (None, SequencerRole::ReplicaNoLeaderSync),
                     NodeRole::Replica => (None, SequencerRole::Replica),
                     NodeRole::Leader => (
                         Some(Box::new(PostgresBackend::connect(postgres_config).await?)),
@@ -450,7 +452,6 @@ impl PreferredSequencerDb {
                 )
             }
         };
-
         Ok((
             Self {
                 backend,

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -588,6 +588,7 @@ impl DbBackend for PostgresBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sov_full_node_configs::sequencer::NodeRole;
     use sov_modules_api::VisibleSlotNumber;
     use sov_test_utils::postgres::{
         config_from_postgres_container, create_postgres_container, CreatePostgresError,
@@ -605,8 +606,8 @@ mod tests {
             }
         };
 
-        let db_1 = &mut DB::new(&postgres, String::from("node_id_1")).await;
-        let db_2 = &mut DB::new(&postgres, String::from("node_id_2")).await;
+        let db_1 = &mut DB::new(&postgres, String::from("node_id_1"), NodeRole::Leader).await;
+        let db_2 = &mut DB::new(&postgres, String::from("node_id_2"), NodeRole::Replica).await;
 
         {
             // Updating the same node_id should change the last updated time in the db.
@@ -655,7 +656,7 @@ mod tests {
             }
         };
 
-        let db = &mut DB::new(&postgres, String::from("node_id_1")).await;
+        let db = &mut DB::new(&postgres, String::from("node_id_1"), NodeRole::Leader).await;
         db.maybe_update_leader().await.unwrap();
 
         let sequence_number = 1;
@@ -712,8 +713,9 @@ mod tests {
                 panic!("Failed to create Postgres container: {e}");
             }
         };
-        let db_leader = &mut DB::new(&postgres, String::from("node_id_1")).await;
-        let db_replica = &mut DB::new(&postgres, String::from("node_id_2")).await;
+        let db_leader = &mut DB::new(&postgres, String::from("node_id_1"), NodeRole::Leader).await;
+        let db_replica =
+            &mut DB::new(&postgres, String::from("node_id_2"), NodeRole::Replica).await;
 
         let sequence_number = 1;
         let batch_to_store = batch_to_store(sequence_number);
@@ -822,11 +824,13 @@ mod tests {
         async fn new(
             postgres: &sov_test_utils::postgres::ContainerAsync<sov_test_utils::postgres::Postgres>,
             node_id: String,
+            node_role: NodeRole,
         ) -> Self {
             let leader_timeout = Duration::from_millis(100_000);
-            let postgres_config = config_from_postgres_container(postgres, node_id.clone())
-                .await
-                .unwrap();
+            let postgres_config =
+                config_from_postgres_container(postgres, node_id.clone(), node_role)
+                    .await
+                    .unwrap();
             let backend =
                 PostgresBackend::connect_with_leader_timeout(&postgres_config, leader_timeout)
                     .await

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -221,7 +221,6 @@ where
         }));
 
         // Launch replica sync task only for replicas.
-
         if let SequencerRole::Replica = seq_role {
             if let Some(postgres_config) = &preferred_config.postgres_config {
                 let replica_task_handle = replica_task

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -84,7 +84,6 @@ where
 
         let (db, seq_role) = PreferredSequencerDb::new(
             shutdown_sender.clone(),
-            preferred_config.is_replica,
             storage_path,
             &preferred_config.postgres_config,
         )

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -41,7 +41,7 @@ use sov_blob_sender::{new_blob_id, BlobExecutionStatus};
 use sov_blob_storage::{PreferredBatchData, SequenceNumber};
 use sov_db::ledger_db::LedgerDb;
 pub use sov_full_node_configs::sequencer::{
-    PostgresConfig, PreferredSequencerConfig, RecoveryStrategy, TimingOracleConfig,
+    NodeRole, PostgresConfig, PreferredSequencerConfig, RecoveryStrategy, TimingOracleConfig,
 };
 use sov_modules_api::capabilities::{
     BlobSelector, RollupHeight, TransactionAuthenticator, UniquenessData,

--- a/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
@@ -38,7 +38,7 @@ impl<Da: DaService> PreferredBlobSender<Da> {
     ) -> anyhow::Result<(Self, Option<JoinHandle<()>>)> {
         let nb_of_concurrent_blob_submissions = Arc::new(AtomicUsize::new(0));
         match seq_role {
-            SequencerRole::Replica => Ok((
+            SequencerRole::Replica | SequencerRole::ReplicaNoLeaderSync => Ok((
                 Self {
                     inner: None,
                     nb_of_concurrent_blob_submissions,

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -149,6 +149,7 @@ mod tests {
     use crate::preferred::db::postgres::PostgresBackend;
     use crate::preferred::db::BatchToStore;
     use crate::preferred::db::DbBackend;
+    use sov_full_node_configs::sequencer::NodeRole;
     use sov_modules_api::FullyBakedTx;
     use sov_modules_api::TxHash;
     use sov_modules_api::VisibleSlotNumber;
@@ -346,9 +347,10 @@ mod tests {
             }
         };
 
-        let postgres_config = config_from_postgres_container(&postgres, "Replica".into())
-            .await
-            .unwrap();
+        let postgres_config =
+            config_from_postgres_container(&postgres, "Replica".into(), NodeRole::Replica)
+                .await
+                .unwrap();
 
         let db = PostgresBackend::connect(&postgres_config).await.unwrap();
 

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -336,21 +336,21 @@
     "NodeRole": {
       "oneOf": [
         {
-          "description": "The node is the leader.",
+          "description": "This node runs as the leader. The leader is responsible for producing new batches.",
           "type": "string",
           "enum": [
             "Leader"
           ]
         },
         {
-          "description": "The node is a replica and syncs from the leader.",
+          "description": "This node runs as a replica, syncing its state from the leader. Replicas do not publish blobs to the DA layer, do not accept transactions via the API, and do not issue soft confirmations.",
           "type": "string",
           "enum": [
             "Replica"
           ]
         },
         {
-          "description": "The node is a replica, but syncing from the leader via Postgres is disabled.",
+          "description": "This node runs in replica mode with Postgres-based synchronization from the leader disabled. It receives transactions exclusively through the DA layer. Use this mode when you want replica behavior without accepting transactions from the Leader only from the DA.",
           "type": "string",
           "enum": [
             "ReplicaNoLeaderSync"
@@ -372,12 +372,7 @@
           "type": "string"
         },
         "node_role": {
-          "description": "The role of the node.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/NodeRole"
-            }
-          ]
+          "$ref": "#/definitions/NodeRole"
         },
         "postgres_connection_string": {
           "description": "Connection string.",

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -333,17 +333,51 @@
         }
       }
     },
+    "NodeRole": {
+      "oneOf": [
+        {
+          "description": "The node is the leader.",
+          "type": "string",
+          "enum": [
+            "Leader"
+          ]
+        },
+        {
+          "description": "The node is a replica and syncs from the leader.",
+          "type": "string",
+          "enum": [
+            "Replica"
+          ]
+        },
+        {
+          "description": "The node is a replica, but syncing from the leader via Postgres is disabled.",
+          "type": "string",
+          "enum": [
+            "ReplicaNoLeaderSync"
+          ]
+        }
+      ]
+    },
     "PostgresConfig": {
       "description": "Postgres DB config.",
       "type": "object",
       "required": [
         "node_id",
+        "node_role",
         "postgres_connection_string"
       ],
       "properties": {
         "node_id": {
           "description": "Id of the node.",
           "type": "string"
+        },
+        "node_role": {
+          "description": "The role of the node.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NodeRole"
+            }
+          ]
         },
         "postgres_connection_string": {
           "description": "Connection string.",
@@ -397,14 +431,6 @@
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
-        },
-        "is_replica": {
-          "description": "When enabled, the sequencer runs in replica mode and cannot accept transactions. It will sync from the master sequencer's database but remain read-only.",
-          "default": null,
-          "type": [
-            "boolean",
-            "null"
-          ]
         },
         "maximum_future_nonce_delta": {
           "description": "The fartherst nonce into the future that the sequencer will accept and queue. This directly impacts the maximum \"batch\" of transactions that can be simultaneously sent to the sequencer out of order.",

--- a/crates/utils/sov-test-utils/src/postgres.rs
+++ b/crates/utils/sov-test-utils/src/postgres.rs
@@ -1,4 +1,4 @@
-use sov_sequencer::preferred::PostgresConfig;
+use sov_sequencer::preferred::{NodeRole, PostgresConfig};
 use testcontainers::runners::AsyncRunner;
 pub use testcontainers::{ContainerAsync, ImageExt};
 pub use testcontainers_modules::postgres::Postgres;
@@ -66,10 +66,12 @@ pub async fn connection_string_from_postgres_container(
 pub async fn config_from_postgres_container(
     container: &ContainerAsync<Postgres>,
     node_id: String,
+    node_role: NodeRole,
 ) -> anyhow::Result<PostgresConfig> {
     let postgres_connection_string = connection_string_from_postgres_container(container).await?;
     Ok(PostgresConfig {
         postgres_connection_string,
         node_id,
+        node_role,
     })
 }

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -45,7 +45,9 @@ use sov_rollup_interface::node::{DaSyncState, SyncStatus};
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::ZkvmHost;
 use sov_rollup_interface::StateUpdateInfo;
-use sov_sequencer::preferred::{PostgresConfig, PreferredSequencerConfig, TimingOracleConfig};
+use sov_sequencer::preferred::{
+    NodeRole, PostgresConfig, PreferredSequencerConfig, TimingOracleConfig,
+};
 use sov_sequencer::test_stateless::TestStatelessSequencer;
 use sov_sequencer::SeqConfigExtension;
 use sov_sequencer::{
@@ -402,7 +404,6 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
     fn default_config(
         finalization_blocks: u32,
         storage_path: StoragePath,
-        is_replica: bool,
         postgres_config: Option<PostgresConfig>,
     ) -> RollupBuilderConfig<R::Spec> {
         RollupBuilderConfig {
@@ -413,7 +414,6 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
             max_infos_in_db: 250 + finalization_blocks as u64,
             automatic_batch_production: true,
             sequencer_config: SequencerKindConfig::Preferred(PreferredSequencerConfig {
-                is_replica: Some(is_replica),
                 postgres_config,
                 ..PreferredSequencerConfig::default()
             }),
@@ -457,26 +457,26 @@ where
     R: FullNodeBlueprint<Native, DaService = StorableMockDaClient> + Default + 'static,
 {
     pub async fn new_with_external_da(
-        is_replica: bool,
         genesis: GenesisSource<R::Spec, R::Runtime>,
         da_config: MockDaClientConfig,
-        postgres: Option<(Arc<PostgresData>, String)>,
+        postgres: Option<(Arc<PostgresData>, String, NodeRole)>,
     ) -> Self {
         let storage_path = StoragePath::Tmp(Arc::new(tempfile::tempdir().unwrap()));
 
         let postgres_container_opt: Option<Arc<PostgresData>> = postgres
             .as_ref()
-            .map(|(postgres_container, _)| postgres_container.clone());
+            .map(|(postgres_container, _, _)| postgres_container.clone());
 
         let post_config = postgres.as_ref().map(|p| PostgresConfig {
             postgres_connection_string: p.0.connection_string.clone(),
             node_id: p.1.clone(),
+            node_role: p.2,
         });
 
         Self {
             genesis,
             da_config,
-            config: Self::default_config(0, storage_path, is_replica, post_config),
+            config: Self::default_config(0, storage_path, post_config),
             postgres_container_opt,
             with_secondary_sequencer: None,
             exec_config: None,
@@ -556,7 +556,7 @@ where
             genesis,
             da_config,
             postgres_container_opt: None,
-            config: Self::default_config(finalization_blocks, storage_path, false, None),
+            config: Self::default_config(finalization_blocks, storage_path, None),
             with_secondary_sequencer: None,
             exec_config,
         }

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -126,7 +126,6 @@ batch_execution_time_limit_millis = 12000 # Do no more than 12 seconds worth of 
 # This warms up caches so the main transaction executor can run with ready-to-use data.
 # This variable determines the number of worker threads.
 
-is_replica = false
 num_cache_warmup_workers = 0
 [sequencer.extension]
 max_log_limit = 20000

--- a/examples/demo-rollup/configs/external_mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/external_mock_rollup_config.toml
@@ -82,12 +82,12 @@ num_cache_warmup_workers = 0
 
 ideal_lag_behind_finalized_slot = 3 # Ideal buffer of finalized slots to maintain. Larger values increase lag in seeing DA info on chain, but allow more buffering when the DA layer is unstable
 # db_event_channel_size = 10000 # Event buffer size while update_state is running
-is_replica = false
 
 
 [sequencer.preferred.postgres_config]
 postgres_connection_string = "postgresql://postgres:pass@localhost:5432/db" # HIGHLY RECOMMENDED: Use Postgres instead of RocksDB to soft confirmed transactions
 node_id = "node_1"
+node_role = "Leader"
 
 # Alternative configuration for non-preferred sequencer. This is mutually exclusive with the preferred sequencer configuration:
 # [sequencer.standard]

--- a/examples/demo-rollup/configs/mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/mock_rollup_config.toml
@@ -110,10 +110,13 @@ ideal_lag_behind_finalized_slot = 3 # Ideal buffer of finalized slots to maintai
 # db_event_channel_size = 10000 # Event buffer size while update_state is running
 
 
-is_replica = false
+
 
 #[sequencer.preferred.postgres_config]
 #postgres_connection_string = "postgresql://user:pass@host/db" # HIGHLY RECOMMENDED: Use Postgres instead of RocksDB to soft confirmed transactions
+#node_id = "node_1"
+#node_role = "Leader"
+
 
 # [sequencer.preferred.rate_limiter] # Setting related to rate limiter.
 # max_nb_of_concurrent_users_in_rate_limiter = 100000 # Limit on how many concurrent users the rate limiter can handle.

--- a/examples/demo-rollup/configs/mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/mock_rollup_config.toml
@@ -115,7 +115,7 @@ ideal_lag_behind_finalized_slot = 3 # Ideal buffer of finalized slots to maintai
 #[sequencer.preferred.postgres_config]
 #postgres_connection_string = "postgresql://user:pass@host/db" # HIGHLY RECOMMENDED: Use Postgres instead of RocksDB to soft confirmed transactions
 #node_id = "node_1"
-#node_role = "Leader"
+#node_role = "Leader" #Other options are "Replica" or "ReplicaNoLeaderSync".
 
 
 # [sequencer.preferred.rate_limiter] # Setting related to rate limiter.

--- a/examples/demo-rollup/configs/replica_external_mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/replica_external_mock_rollup_config.toml
@@ -83,10 +83,11 @@ num_cache_warmup_workers = 0
 
 ideal_lag_behind_finalized_slot = 3 # Ideal buffer of finalized slots to maintain. Larger values increase lag in seeing DA info on chain, but allow more buffering when the DA layer is unstable
 # db_event_channel_size = 10000 # Event buffer size while update_state is running
-is_replica = true # Run sequencer in read-only replica mode
+
 [sequencer.preferred.postgres_config]
 postgres_connection_string = "postgresql://postgres:pass@localhost:5432/db" # HIGHLY RECOMMENDED: Use Postgres instead of RocksDB to soft confirmed transactions
 node_id = "node_2"
+node_role = "Replica"
 
 # Alternative configuration for non-preferred sequencer. This is mutually exclusive with the preferred sequencer configuration:
 # [sequencer.standard]

--- a/examples/demo-rollup/sov-soak-testing/src/lib.rs
+++ b/examples/demo-rollup/sov-soak-testing/src/lib.rs
@@ -9,7 +9,7 @@ use sov_paymaster::{
     SafeVec,
 };
 use sov_rollup_interface::execution_mode::Native;
-use sov_sequencer::preferred::{PostgresConfig, PreferredSequencerConfig};
+use sov_sequencer::preferred::{NodeRole, PostgresConfig, PreferredSequencerConfig};
 use sov_sequencer::SequencerKindConfig;
 pub use sov_soak_testing_lib::*;
 use sov_synthetic_load::SyntheticLoad;
@@ -125,6 +125,7 @@ pub async fn setup_rollup(
     let postgres_config = db_connection_url.map(|url| PostgresConfig {
         postgres_connection_string: url,
         node_id: "Primary".to_string(),
+        node_role: NodeRole::Leader,
     });
 
     let rollup_builder = TestRollupBuilder::new_with_storage_path(

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -18,6 +18,7 @@ use sov_modules_api::PrivateKey;
 use sov_modules_api::PublicKey;
 use sov_modules_api::Spec;
 use sov_modules_rollup_blueprint::RollupBlueprint;
+use sov_sequencer::preferred::NodeRole;
 use sov_test_utils::postgres::CreatePostgresError;
 use sov_test_utils::test_rollup::read_private_key;
 use sov_test_utils::test_rollup::PostgresData;
@@ -69,13 +70,11 @@ async fn create_da_service_periodic() -> (StorableMockDaService, watch::Sender<(
 }
 
 async fn start_rollup(
-    is_replica: bool,
     addr: SocketAddr,
-    postgres: Option<(Arc<PostgresData>, String)>,
+    postgres: Option<(Arc<PostgresData>, String, NodeRole)>,
 ) -> TestRollup<ExternalMockDemoRollup<Native>> {
     let genesis = test_genesis_source(OperatingMode::Operator);
     RollupBuilder::new_with_external_da(
-        is_replica,
         genesis,
         MockDaClientConfig {
             url: format!("http://{addr}"),

--- a/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
+++ b/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
@@ -13,7 +13,7 @@ async fn test_replica_receives_txs_from_da() {
     };
 
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
-    da_service.wait_for_height(10).await.unwrap();
+    let (da_service, da_shutdown, addr) = create_da_service_periodic().await;
 
     let replica = postgres
         .clone()

--- a/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
+++ b/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
@@ -13,7 +13,7 @@ async fn test_replica_receives_txs_from_da() {
     };
 
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
-    let (da_service, da_shutdown, addr) = create_da_service_periodic().await;
+    let (_, da_shutdown, addr) = create_da_service_periodic().await;
 
     let replica = postgres
         .clone()

--- a/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
+++ b/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
@@ -14,7 +14,7 @@ async fn test_replica_receives_txs_from_da() {
 
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
     let (da_service, da_shutdown, addr) = create_da_service_periodic().await;
-    // Ideal lag and stuff
+    // Wait 10 blocks to satisfy the ideal lag requirement. The primary won’t create batches until the lag is large enough, so we pause here to allow batches to be produced.
     da_service.wait_for_height(10).await.unwrap();
 
     let replica = postgres

--- a/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
+++ b/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
@@ -2,15 +2,33 @@ use super::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_replica_receives_txs_from_da() {
-    let (_, shutdown_sender, addr) = create_da_service_periodic().await;
+    let postgres = PostgresData::create_postgres().await;
+
+    let postgres = match postgres {
+        Ok(pg) => Some(pg),
+        Err(CreatePostgresError::DockerNotSupported) => return,
+        Err(CreatePostgresError::DockerError(e)) => {
+            panic!("Failed to create Postgres container: {e}");
+        }
+    };
+
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
+    let (da_service, da_shutdown, addr) = create_da_service_periodic().await;
+    // Ideal lag and stuff
+    da_service.wait_for_height(10).await.unwrap();
 
-    let test_rollup = start_rollup(false, addr, None).await;
-    let replica_test_rollup = start_rollup(true, addr, None).await;
+    let replica = postgres
+        .clone()
+        .map(|pg| (pg, "replica".into(), NodeRole::ReplicaNoLeaderSync));
+    let replica_test_rollup = start_rollup(addr, replica).await;
 
-    let token_id = config_gas_token_id();
+    let primary = postgres
+        .clone()
+        .map(|pg| (pg, "primary".into(), NodeRole::Leader));
+    let test_rollup = start_rollup(addr, primary).await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
+    let token_id = config_gas_token_id();
     let receiver_addr = random_address();
 
     let tx = build_transfer_token_tx::<S>(
@@ -34,9 +52,10 @@ async fn test_replica_receives_txs_from_da() {
         .unwrap();
 
     assert_eq!(receiver_balance.0, AMOUNT);
+
     let _ = replica_test_rollup.shutdown().await;
     let _ = test_rollup.shutdown().await;
-    let _ = shutdown_sender.send(());
+    let _ = da_shutdown.send(());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -54,11 +73,15 @@ async fn test_replica_receives_txs_from_postgres() {
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
     let (da_service, addr) = create_da_service_manual().await;
 
-    let replica = postgres.clone().map(|pg| (pg, "replica".into()));
-    let replica_test_rollup = start_rollup(true, addr, replica).await;
+    let replica = postgres
+        .clone()
+        .map(|pg| (pg, "replica".into(), NodeRole::Replica));
+    let replica_test_rollup = start_rollup(addr, replica).await;
 
-    let primary = postgres.clone().map(|pg| (pg, "primary".into()));
-    let test_rollup = start_rollup(false, addr, primary).await;
+    let primary = postgres
+        .clone()
+        .map(|pg| (pg, "primary".into(), NodeRole::Leader));
+    let test_rollup = start_rollup(addr, primary).await;
 
     for _ in 0..20 {
         da_service.produce_block_now().await.unwrap();

--- a/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
+++ b/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
@@ -13,8 +13,6 @@ async fn test_replica_receives_txs_from_da() {
     };
 
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
-    let (da_service, da_shutdown, addr) = create_da_service_periodic().await;
-    // Wait 10 blocks to satisfy the ideal lag requirement. The primary won’t create batches until the lag is large enough, so we pause here to allow batches to be produced.
     da_service.wait_for_height(10).await.unwrap();
 
     let replica = postgres

--- a/examples/demo-rollup/tests/replica/start_stop.rs
+++ b/examples/demo-rollup/tests/replica/start_stop.rs
@@ -21,12 +21,15 @@ async fn test_replica_start_stop() {
 
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
 
-    // Why replica starts first?
-    let replica = postgres.clone().map(|pg| (pg, "replica".into()));
-    let replica_test_rollup = start_rollup(true, addr, replica).await;
+    let replica = postgres
+        .clone()
+        .map(|pg| (pg, "replica".into(), NodeRole::Replica));
+    let replica_test_rollup = start_rollup(addr, replica).await;
 
-    let primary = postgres.clone().map(|pg| (pg, "primary".into()));
-    let test_rollup = start_rollup(false, addr, primary).await;
+    let primary = postgres
+        .clone()
+        .map(|pg| (pg, "primary".into(), NodeRole::Leader));
+    let test_rollup = start_rollup(addr, primary).await;
 
     replica_test_rollup
         .wait_for_sequencer_ready()
@@ -254,12 +257,16 @@ async fn test_replica_start_stop_many_times() {
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
     let receiver_addr = random_address();
 
-    let primary = postgres.clone().map(|pg| (pg, "primary".into()));
-    let test_rollup = start_rollup(false, addr, primary).await;
+    let primary = postgres
+        .clone()
+        .map(|pg| (pg, "primary".into(), NodeRole::Leader));
+    let test_rollup = start_rollup(addr, primary).await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
-    let replica = postgres.clone().map(|pg| (pg, "replica".into()));
-    let mut replica_test_rollup = start_rollup(true, addr, replica).await;
+    let replica = postgres
+        .clone()
+        .map(|pg| (pg, "replica".into(), NodeRole::Replica));
+    let mut replica_test_rollup = start_rollup(addr, replica).await;
 
     let nb_of_txs = 300;
     for i in 0..3 {


### PR DESCRIPTION
# Description

This PR replaces the `is_replica` flag with a `NodeRole` enum.

We already have three distinct node role cases, and we may want to introduce additional roles in the future, so enum is more appropriate.

```
    /// The node is the leader.
    NodeRole::Leader,
    /// The node is a replica and syncs from the leader.
    NodeRole::Replica,
    /// The node is a replica, but syncing from the leader via Postgres is disabled.
    NodeRole::ReplicaNoLeaderSync,
```

We also moved this setting `PostgreSQL` configurations, since we don't have multi-sequencer setups for RocksDB sequencers.

Here are related PRs in other repos:

1. https://github.com/Sovereign-Labs/sov-rollup-cdk-starter/pull/52
2. https://github.com/Sovereign-Labs/rollup-starter-ansible/pull/51
3. https://github.com/Sovereign-Labs/rollup-starter/pull/92


- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

