### PR TITLE
FlatStateDb: commit kernel and user changesets atomically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9509,7 +9509,7 @@ dependencies = [
 [[package]]
 name = "rockbound"
 version = "0.1.0"
-source = "git+https://github.com/sovereign-labs/rockbound?rev=a41ebf6396910ebac44d985fb89a6e67a80cb1a0#a41ebf6396910ebac44d985fb89a6e67a80cb1a0"
+source = "git+https://github.com/sovereign-labs/rockbound?rev=50ad963c84226038af2a30719f21c30738b00fd0#50ad963c84226038af2a30719f21c30738b00fd0"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -11018,6 +11018,7 @@ dependencies = [
  "hex",
  "jmt",
  "nomt",
+ "parking_lot",
  "proptest",
  "proptest-derive 0.5.1",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9509,7 +9509,7 @@ dependencies = [
 [[package]]
 name = "rockbound"
 version = "0.1.0"
-source = "git+https://github.com/sovereign-labs/rockbound?rev=50ad963c84226038af2a30719f21c30738b00fd0#50ad963c84226038af2a30719f21c30738b00fd0"
+source = "git+https://github.com/sovereign-labs/rockbound?rev=e8d1cfa7402a3ab90369d664bd88a52394cd40e6#e8d1cfa7402a3ab90369d664bd88a52394cd40e6"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ nearly-linear = { path = "crates/utils/nearly-linear", version = "0.3" }
 # Dependencies maintained by Sovereign
 jmt = { version = "0.12.0", default-features = false }
 reltester = { git = "https://github.com/sovereign-labs/reltester.git", rev = "d6209abff72929f5ba41614f5cea3e4a748428c3" }
-rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "278af530b39ed11b4839cd85bc7e896037153462" }
+rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "50ad963c84226038af2a30719f21c30738b00fd0" }
 nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
 nomt-core = { version = "1.0.3", default-features = false, features = ["borsh", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ nearly-linear = { path = "crates/utils/nearly-linear", version = "0.3" }
 # Dependencies maintained by Sovereign
 jmt = { version = "0.12.0", default-features = false }
 reltester = { git = "https://github.com/sovereign-labs/reltester.git", rev = "d6209abff72929f5ba41614f5cea3e4a748428c3" }
-rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "50ad963c84226038af2a30719f21c30738b00fd0" }
+rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "e8d1cfa7402a3ab90369d664bd88a52394cd40e6" }
 nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
 nomt-core = { version = "1.0.3", default-features = false, features = ["borsh", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ nearly-linear = { path = "crates/utils/nearly-linear", version = "0.3" }
 # Dependencies maintained by Sovereign
 jmt = { version = "0.12.0", default-features = false }
 reltester = { git = "https://github.com/sovereign-labs/reltester.git", rev = "d6209abff72929f5ba41614f5cea3e4a748428c3" }
-rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "a41ebf6396910ebac44d985fb89a6e67a80cb1a0" }
+rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "278af530b39ed11b4839cd85bc7e896037153462" }
 nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
 nomt-core = { version = "1.0.3", default-features = false, features = ["borsh", "serde"] }

--- a/crates/full-node/sov-db/Cargo.toml
+++ b/crates/full-node/sov-db/Cargo.toml
@@ -19,6 +19,7 @@ rockbound = { workspace = true }
 sov-rollup-interface = { workspace = true, features = ["native"] }
 nomt = { workspace = true }
 sov-metrics = { workspace = true, features = ["native"] }
+parking_lot = "0.12.4"
 
 # External
 anyhow = { workspace = true, default-features = true }

--- a/crates/full-node/sov-db/src/flat_db.rs
+++ b/crates/full-node/sov-db/src/flat_db.rs
@@ -168,7 +168,7 @@ impl FlatStateDb {
         let user_cache = &inner.user_cache;
 
         // 2. Update batches with kernel values.
-        let metrics_kernel = VersionedDB::<_, DbCache>::update_verioned_db_batch(
+        let metrics_kernel = VersionedDB::<_, DbCache>::update_versioned_db_batch(
             &mut live_db_batch,
             &mut archival_db_batch,
             &state.kernel,
@@ -182,7 +182,7 @@ impl FlatStateDb {
         let archival_serialized_size_kernel = archival_db_batch.size_in_bytes();
 
         // 3. Update batches with user values.
-        let metrics_user = VersionedDB::<_, DbCache>::update_verioned_db_batch(
+        let metrics_user = VersionedDB::<_, DbCache>::update_versioned_db_batch(
             &mut live_db_batch,
             &mut archival_db_batch,
             &state.user,

--- a/crates/full-node/sov-db/src/flat_db.rs
+++ b/crates/full-node/sov-db/src/flat_db.rs
@@ -1,12 +1,6 @@
 //! A database to store the flat state of the rollup (i.e. the raw key-value pairs)
 //! used by NOMT.
 
-use std::sync::Arc;
-
-use rockbound::{
-    default_cf_descriptor, rocksdb::ColumnFamilyDescriptor, versioned_db::VersionedDB,
-};
-
 use crate::metrics::nomt::FlatStateCommitMetric;
 use crate::{
     historical_state::StateChanges,
@@ -14,18 +8,23 @@ use crate::{
     schema::{namespace::NomtStateValues, tables::StateRootHashes},
     DbOptions,
 };
+use parking_lot::{MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock};
+use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
+use rockbound::versioned_db::CacheForVersionedDB;
 use rockbound::versioned_db::SchemaWithVersion;
+use rockbound::{
+    default_cf_descriptor, rocksdb::ColumnFamilyDescriptor, versioned_db::VersionedDB,
+};
+use rockbound::{rocksdb, DB};
+use std::sync::Arc;
 
 /// A database to store the flat state of the rollup (i.e. the raw key-value pairs)
 pub struct FlatStateDb {
-    pub(crate) user: Arc<VersionedDB<NomtStateValues<UserNamespace>>>,
-    pub(crate) kernel: Arc<VersionedDB<NomtStateValues<KernelNamespace>>>,
-    pub(crate) other: Arc<rockbound::DB>,
-    #[allow(dead_code)]
-    // We don't technically need to store the archival db here - it's only accessed through the user/kernel versioned DB wrappers.
-    // We keep it here so that the internal structure is more legible by glancing at this struct. Note that unless the user has set the config to separate out the archival db,
-    // this will point to the same rockbound::DB as the `other` field.
-    pub(crate) archival: Arc<rockbound::DB>,
+    pub(crate) user: Arc<VersionedDB<NomtStateValues<UserNamespace>, DbCache>>,
+    pub(crate) kernel: Arc<VersionedDB<NomtStateValues<KernelNamespace>, DbCache>>,
+    pub(crate) live_db: Arc<rockbound::DB>,
+    pub(crate) archival_db: Arc<rockbound::DB>,
+    db_cache: DbCache,
 }
 
 impl FlatStateDb {
@@ -41,18 +40,18 @@ impl FlatStateDb {
     ) -> anyhow::Result<Self> {
         let mut columns: Vec<ColumnFamilyDescriptor> =
             vec![default_cf_descriptor(StateRootHashes::table_name())];
-        VersionedDB::<NomtStateValues<UserNamespace>>::add_column_families(
+        VersionedDB::<NomtStateValues<UserNamespace>, DbCache>::add_column_families(
             &mut columns,
             separate_archival,
         )?;
-        VersionedDB::<NomtStateValues<KernelNamespace>>::add_column_families(
+        VersionedDB::<NomtStateValues<KernelNamespace>, DbCache>::add_column_families(
             &mut columns,
             separate_archival,
         )?;
-        let other = Self::get_rockbound_options(columns)
+        let live_db = Self::get_rockbound_options(columns)
             .setup_db_in_path_with_column_descriptors(path.clone())?;
-        let other = Arc::new(other);
-        let archival = if separate_archival {
+        let live_db = Arc::new(live_db);
+        let archival_db = if separate_archival {
             let archival_path = path.join(Self::ARCHIVAL_DB_PATH_SUFFIX);
             let archival_columns = vec![
                 default_cf_descriptor(
@@ -75,38 +74,57 @@ impl FlatStateDb {
             let archival = Self::get_rockbound_options(archival_columns);
             Arc::new(archival.setup_db_in_path_with_column_descriptors(archival_path)?)
         } else {
-            other.clone()
+            live_db.clone()
         };
-        let user = Arc::new(VersionedDB::<NomtStateValues<UserNamespace>>::from_dbs(
-            other.clone(),
-            archival.clone(),
-            cache_size,
-        )?);
-        let kernel = Arc::new(VersionedDB::<NomtStateValues<KernelNamespace>>::from_dbs(
-            other.clone(),
-            archival.clone(),
-            100_000,
-        )?);
+
+        let inner = Arc::new(RwLock::new(Inner {
+            user_cache: rockbound::new_cache_for_schema::<NomtStateValues<UserNamespace>>(
+                cache_size,
+            ),
+            kernel_cache: rockbound::new_cache_for_schema::<NomtStateValues<KernelNamespace>>(
+                100_000,
+            ),
+        }));
+
+        let db_cache = DbCache { inner };
+
+        let user = Arc::new(
+            VersionedDB::<NomtStateValues<UserNamespace>, DbCache>::from_dbs(
+                live_db.clone(),
+                archival_db.clone(),
+                db_cache.clone(),
+            )?,
+        );
+
+        let kernel = Arc::new(
+            VersionedDB::<NomtStateValues<KernelNamespace>, DbCache>::from_dbs(
+                live_db.clone(),
+                archival_db.clone(),
+                db_cache.clone(),
+            )?,
+        );
+
         Ok(Self {
+            db_cache,
             user,
             kernel,
-            other,
-            archival,
+            live_db,
+            archival_db,
         })
     }
 
     /// Get the underlying [`rockbound::DB`] for the historical state. Used for testing only.
     pub fn get_db(&self) -> Arc<rockbound::DB> {
-        self.other.clone()
+        self.live_db.clone()
     }
 
     /// Get the underlying [`VersionedDB`] for the user state.
-    pub fn get_user_db(&self) -> &Arc<VersionedDB<NomtStateValues<UserNamespace>>> {
+    pub fn get_user_db(&self) -> &Arc<VersionedDB<NomtStateValues<UserNamespace>, DbCache>> {
         &self.user
     }
 
     /// Get the underlying [`VersionedDB`] for the kernel state.
-    pub fn get_kernel_db(&self) -> &Arc<VersionedDB<NomtStateValues<KernelNamespace>>> {
+    pub fn get_kernel_db(&self) -> &Arc<VersionedDB<NomtStateValues<KernelNamespace>, DbCache>> {
         &self.kernel
     }
 
@@ -139,10 +157,133 @@ impl FlatStateDb {
                 .unwrap_or(0);
             assert_eq!(user_version, version);
         }
-        self.kernel.commit(&state.kernel, version)?;
-        self.user.commit(&state.user, version)?;
-        self.other.write_schemas(&state.other)?;
+
+        let mut live_db_batch = rocksdb::WriteBatch::default();
+        let mut archival_db_batch = rocksdb::WriteBatch::default();
+
+        // 1. Lock caches.
+        let inner = self.db_cache.inner.write();
+
+        let kernel_cache = &inner.kernel_cache;
+        let user_cache = &inner.user_cache;
+
+        // 2. Update batches with kernel values.
+        let metrics_kernel = VersionedDB::<_, DbCache>::update_verioned_db_batch(
+            &mut live_db_batch,
+            &mut archival_db_batch,
+            &state.kernel,
+            version,
+            kernel_cache,
+            &self.live_db,
+            &self.archival_db,
+        )?;
+
+        let serialized_size_kernel = live_db_batch.size_in_bytes();
+        let archival_serialized_size_kernel = archival_db_batch.size_in_bytes();
+
+        // 3. Update batches with user values.
+        let metrics_user = VersionedDB::<_, DbCache>::update_verioned_db_batch(
+            &mut live_db_batch,
+            &mut archival_db_batch,
+            &state.user,
+            version,
+            user_cache,
+            &self.live_db,
+            &self.archival_db,
+        )?;
+
+        let serialized_size_user = live_db_batch.size_in_bytes() - serialized_size_kernel;
+        let archival_serialized_size_user =
+            archival_db_batch.size_in_bytes() - archival_serialized_size_kernel;
+
+        // 4.Update root hash.
+        DB::update_db_batch_with_schema_data(
+            &mut live_db_batch,
+            &state.root_hash_batch,
+            &self.live_db,
+        )?;
+
+        // Write batches.
+        self.archival_db.write_db_batch(archival_db_batch)?;
+        self.kernel.store_committed_archival_version(version);
+        self.user.store_committed_archival_version(version);
+        self.live_db.write_db_batch(live_db_batch)?;
+
+        // 5. Release caches.
+        drop(inner);
+
+        // Update metrics once the cache lock is released.
+        self.kernel.update_metrics(
+            metrics_kernel,
+            serialized_size_kernel,
+            archival_serialized_size_kernel,
+        );
+
+        self.user.update_metrics(
+            metrics_user,
+            serialized_size_user,
+            archival_serialized_size_user,
+        );
+
         let write = start_write.elapsed();
         Ok(FlatStateCommitMetric { prepare, write })
+    }
+}
+
+struct Inner {
+    user_cache: rockbound::CacheForSchema<NomtStateValues<UserNamespace>>,
+    kernel_cache: rockbound::CacheForSchema<NomtStateValues<KernelNamespace>>,
+}
+
+/// Cache for the database.
+#[derive(Clone)]
+pub struct DbCache {
+    inner: Arc<RwLock<Inner>>,
+}
+
+impl CacheForVersionedDB<NomtStateValues<UserNamespace>> for DbCache {
+    fn write(
+        &self,
+    ) -> MappedRwLockWriteGuard<'_, rockbound::CacheForSchema<NomtStateValues<UserNamespace>>> {
+        RwLockWriteGuard::map(self.inner.write(), |c: &mut Inner| &mut c.user_cache)
+    }
+
+    fn read(
+        &self,
+    ) -> MappedRwLockReadGuard<'_, rockbound::CacheForSchema<NomtStateValues<UserNamespace>>> {
+        RwLockReadGuard::map(self.inner.read(), |c: &Inner| &c.user_cache)
+    }
+
+    fn try_read(
+        &self,
+    ) -> Option<MappedRwLockReadGuard<'_, rockbound::CacheForSchema<NomtStateValues<UserNamespace>>>>
+    {
+        let lock = self.inner.try_read()?;
+        Some(RwLockReadGuard::map(lock, |c: &Inner| &c.user_cache))
+    }
+}
+
+impl CacheForVersionedDB<NomtStateValues<KernelNamespace>> for DbCache {
+    fn write(
+        &self,
+    ) -> MappedRwLockWriteGuard<'_, rockbound::CacheForSchema<NomtStateValues<KernelNamespace>>>
+    {
+        RwLockWriteGuard::map(self.inner.write(), |c: &mut Inner| &mut c.kernel_cache)
+    }
+
+    fn read(
+        &self,
+    ) -> MappedRwLockReadGuard<'_, rockbound::CacheForSchema<NomtStateValues<KernelNamespace>>>
+    {
+        RwLockReadGuard::map(self.inner.read(), |c: &Inner| &c.kernel_cache)
+    }
+
+    fn try_read(
+        &self,
+    ) -> Option<
+        MappedRwLockReadGuard<'_, rockbound::CacheForSchema<NomtStateValues<KernelNamespace>>>,
+    > {
+        let lock = self.inner.try_read()?;
+        Some(RwLockReadGuard::map(lock, |c: &Inner| &c.kernel_cache))
     }
 }

--- a/crates/full-node/sov-db/src/historical_state.rs
+++ b/crates/full-node/sov-db/src/historical_state.rs
@@ -6,6 +6,7 @@ use rockbound::versioned_db::{VersionedDeltaReader, VersionedSchemaBatch};
 use rockbound::{SchemaBatch, SchemaValue};
 use sov_rollup_interface::common::SlotNumber;
 
+use crate::flat_db::DbCache;
 use crate::metrics::StateMaterializationMetrics;
 use crate::namespaces::{KernelNamespace, UserNamespace};
 use crate::schema::namespace::NomtStateValues;
@@ -18,13 +19,13 @@ const STATE_ROOT_HASH_SINGLETON: StateRootHashId = StateRootHashId(0);
 type KvPair = (SlotKey, Option<SlotValue>);
 
 /// A typed wrapper around the [`DeltaReader`] for reading materializing historical rollup state.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct HistoricalStateReader {
     /// The underlying [`DeltaReader`] correctly routes requests to previous snapshots and/or [`rockbound::DB`]
-    user: VersionedDeltaReader<NomtStateValues<UserNamespace>>,
+    user: VersionedDeltaReader<NomtStateValues<UserNamespace>, DbCache>,
     /// The underlying [`DeltaReader`] correctly routes requests to previous snapshots and/or [`rockbound::DB`]
-    kernel: VersionedDeltaReader<NomtStateValues<KernelNamespace>>,
-    other: DeltaReader,
+    kernel: VersionedDeltaReader<NomtStateValues<KernelNamespace>, DbCache>,
+    root_hash_reader: DeltaReader,
 
     /// The [`SlotNumber`] that will be used for the next batch of writes to the DB
     /// This [`SlotNumber`] is also used for querying data,
@@ -37,7 +38,7 @@ pub struct HistoricalStateReader {
 pub struct StateChanges {
     pub(crate) user: Arc<VersionedSchemaBatch<NomtStateValues<UserNamespace>>>,
     pub(crate) kernel: Arc<VersionedSchemaBatch<NomtStateValues<KernelNamespace>>>,
-    pub(crate) other: Arc<SchemaBatch>,
+    pub(crate) root_hash_batch: Arc<SchemaBatch>,
 }
 
 impl HistoricalStateReader {
@@ -54,7 +55,7 @@ impl HistoricalStateReader {
             VersionedDeltaReader::new(flat_state.get_kernel_db().clone(), kernel_version, vec![]);
         let user =
             VersionedDeltaReader::new(flat_state.get_user_db().clone(), user_version, vec![]);
-        let other = DeltaReader::new(flat_state.get_db(), vec![]);
+        let root_hash_reader = DeltaReader::new(flat_state.get_db(), vec![]);
         let next_version = match user.latest_version() {
             Some(latest_version) => SlotNumber::new(
                 latest_version
@@ -66,16 +67,16 @@ impl HistoricalStateReader {
         Self {
             user,
             kernel,
-            other,
+            root_hash_reader,
             next_version,
         }
     }
 
     /// Create a new instance of [`HistoricalStateReader`].
     pub fn new(
-        user: VersionedDeltaReader<NomtStateValues<UserNamespace>>,
-        kernel: VersionedDeltaReader<NomtStateValues<KernelNamespace>>,
-        other: DeltaReader,
+        user: VersionedDeltaReader<NomtStateValues<UserNamespace>, DbCache>,
+        kernel: VersionedDeltaReader<NomtStateValues<KernelNamespace>, DbCache>,
+        root_hash_reader: DeltaReader,
     ) -> Self {
         // Cross check the versions across all three dbs
         assert_eq!(
@@ -85,7 +86,7 @@ impl HistoricalStateReader {
         );
         assert_eq!(
             user.latest_version(),
-            Self::last_version_from_reader(&other)
+            Self::last_version_from_reader(&root_hash_reader)
                 .expect("Failed to get last version from db")
                 .map(|v| v.get()),
             "Other must have the same last version as user"
@@ -101,7 +102,7 @@ impl HistoricalStateReader {
         Self {
             user,
             kernel,
-            other,
+            root_hash_reader,
             next_version,
         }
     }
@@ -127,7 +128,8 @@ impl HistoricalStateReader {
     /// The last version committed to the database.
     /// Can differ from [`Self::last_version`] in case if a newer version has been written to the underlying database.
     pub fn last_version_unbound(&self) -> anyhow::Result<SlotNumber> {
-        Self::last_version_from_reader(&self.other).map(|v| v.unwrap_or(SlotNumber::GENESIS))
+        Self::last_version_from_reader(&self.root_hash_reader)
+            .map(|v| v.unwrap_or(SlotNumber::GENESIS))
     }
 
     /// Get an optional value from the database, given a version and a key hash.
@@ -208,7 +210,7 @@ impl HistoricalStateReader {
         &self,
         version: SlotNumber,
     ) -> anyhow::Result<Option<SchemaValue>> {
-        Self::get_serialized_root_hash_from_reader(&self.other, version)
+        Self::get_serialized_root_hash_from_reader(&self.root_hash_reader, version)
     }
 
     /// Collects a sequence of key-value pairs into [`SchemaBatch`].
@@ -218,7 +220,7 @@ impl HistoricalStateReader {
         root_hash: SchemaValue,
         version: SlotNumber,
     ) -> anyhow::Result<StateChanges> {
-        let mut batch = SchemaBatch::default();
+        let mut root_hash_batch = SchemaBatch::default();
         let mut has_kernel_been_updated = false;
         let mut has_user_been_updated = false;
         let mut metric = StateMaterializationMetrics::new();
@@ -258,7 +260,8 @@ impl HistoricalStateReader {
             root_hash = %hex::encode(&root_hash),
             "Materialized root hash"
         );
-        batch.put::<StateRootHashes>(&(version, STATE_ROOT_HASH_SINGLETON), &root_hash)?;
+        root_hash_batch
+            .put::<StateRootHashes>(&(version, STATE_ROOT_HASH_SINGLETON), &root_hash)?;
 
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(metric);
@@ -267,7 +270,7 @@ impl HistoricalStateReader {
         Ok(StateChanges {
             user: Arc::new(user_batch),
             kernel: Arc::new(kernel_batch),
-            other: Arc::new(batch),
+            root_hash_batch: Arc::new(root_hash_batch),
         })
     }
 }

--- a/crates/full-node/sov-db/src/lib.rs
+++ b/crates/full-node/sov-db/src/lib.rs
@@ -7,6 +7,7 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
+pub use flat_db::DbCache;
 use rockbound::rocksdb::ColumnFamilyDescriptor;
 use rockbound::{SchemaKey, SchemaValue};
 

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -1,3 +1,4 @@
+use crate::flat_db::DbCache;
 use std::any::Any;
 use std::collections::HashMap;
 use std::marker::PhantomData;
@@ -108,7 +109,7 @@ where
     // Flush pruning schema batches to disk.
     pub(crate) fn commit_pruning(&mut self, group: PruneGroup) -> anyhow::Result<()> {
         self.flat_state
-            .archival
+            .archival_db
             .write_schemas(&group.historical_state.pruning_batch)?;
         self.accessory
             .write_schemas(&group.accessory.pruning_batch)?;
@@ -135,7 +136,7 @@ where
         // (in normal chronological order).
         for snapshot_ref in relevant_snapshot_refs.iter().rev() {
             let snapshot = rockbound_snapshots.get(snapshot_ref).unwrap();
-            historical_state_snapshots.push(snapshot.historical_state.other.clone());
+            historical_state_snapshots.push(snapshot.historical_state.root_hash_batch.clone());
             user_state_snapshots.push(snapshot.historical_state.user.clone());
             kernel_state_snapshots.push(snapshot.historical_state.kernel.clone());
             accessory_snapshots.push(snapshot.accessory.clone());
@@ -150,19 +151,21 @@ where
             nomt_snapshots,
         );
         let historical_state_reader =
-            DeltaReader::new(self.flat_state.other.clone(), historical_state_snapshots);
+            DeltaReader::new(self.flat_state.live_db.clone(), historical_state_snapshots);
         let version = self.flat_state.get_kernel_db().get_committed_version()?;
 
-        let user_state_reader = VersionedDeltaReader::<NomtStateValues<UserNamespace>>::new(
-            self.flat_state.user.clone(),
-            version,
-            user_state_snapshots,
-        );
-        let kernel_state_reader = VersionedDeltaReader::<NomtStateValues<KernelNamespace>>::new(
-            self.flat_state.kernel.clone(),
-            version,
-            kernel_state_snapshots,
-        );
+        let user_state_reader =
+            VersionedDeltaReader::<NomtStateValues<UserNamespace>, DbCache>::new(
+                self.flat_state.user.clone(),
+                version,
+                user_state_snapshots,
+            );
+        let kernel_state_reader =
+            VersionedDeltaReader::<NomtStateValues<KernelNamespace>, DbCache>::new(
+                self.flat_state.kernel.clone(),
+                version,
+                kernel_state_snapshots,
+            );
         let historical_state_mapper = HistoricalStateReader::new(
             user_state_reader,
             kernel_state_reader,
@@ -309,7 +312,7 @@ where
 
     fn are_root_hashes_match(&self) -> anyhow::Result<bool> {
         let historical_state_delta_reader =
-            DeltaReader::new(self.flat_state.other.clone(), Vec::new());
+            DeltaReader::new(self.flat_state.live_db.clone(), Vec::new());
 
         let nomt_root_hashes = self.merklized_state.get_root_hashes();
         let last_version =

--- a/crates/utils/sov-test-utils/src/storage.rs
+++ b/crates/utils/sov-test-utils/src/storage.rs
@@ -19,6 +19,7 @@ use sov_db::storage_manager::{
 pub use sov_db::storage_manager::{
     NativeChangeSet, NativeStorageManager, NomtChangeSet, NomtStorageManager,
 };
+use sov_db::DbCache;
 use sov_mock_da::{MockBlockHeader, MockDaSpec};
 use sov_modules_api::digest;
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec};
@@ -196,16 +197,18 @@ impl<S: MerkleProofSpec> SimpleNomtStorageManager<S> {
         let version = HistoricalStateReader::last_version_from_reader(&other_data_reader)
             .unwrap()
             .map(|v| v.get());
-        let user_state_reader = VersionedDeltaReader::<NomtStateValues<UserNamespace>>::new(
-            flat_state.get_user_db().clone(),
-            version,
-            vec![],
-        );
-        let kernel_state_reader = VersionedDeltaReader::<NomtStateValues<KernelNamespace>>::new(
-            flat_state.get_kernel_db().clone(),
-            version,
-            vec![],
-        );
+        let user_state_reader =
+            VersionedDeltaReader::<NomtStateValues<UserNamespace>, DbCache>::new(
+                flat_state.get_user_db().clone(),
+                version,
+                vec![],
+            );
+        let kernel_state_reader =
+            VersionedDeltaReader::<NomtStateValues<KernelNamespace>, DbCache>::new(
+                flat_state.get_kernel_db().clone(),
+                version,
+                vec![],
+            );
 
         let state_session_builder = get_session_builder_from_committed(self.state.clone());
         let historical_state_reader =


### PR DESCRIPTION
# Description

rockbound update: https://github.com/Sovereign-Labs/rockbound/pull/41

This PR refactors the `FlatStateDb::commit` logic so that `kernel and user` data are now applied atomically to `live_db` and `archival_db`, instead of being updated separately.


The most significant change is in `FlatStateDb::commit`.
Now, the commit flow works as follows:

1. Create `live_db_batch: WriteBatch and archival_db_batch: WriteBatch`
2. Lock the common `kernel/user cache`
3. Apply `kernel` updates to `live_db_batch`
4. Apply `user` updates to `live_db_batch`
(steps 3 and 4 are repeated for `archival_db_batch`)
5. Atomically commit both `archival_db_batch` and `live_db_batch`

This required the following changes in `[rockbound](https://github.com/Sovereign-Labs/rockbound)`:

- Added `VersionedDB::<_, DbCache>::update_versioned_db_batch` method, which accepts a mutable reference to a `WriteBatch`

- The cache for both `kernel` and `user` is now protected by a single lock. As a result, the cache must be created outside of `rockbound::VersionedDB` This was achieved by abstracting the injected component via the `CacheForVersionedDB` trait.

From the above, it becomes clear that we should merge

```
pub(crate) user: Arc<VersionedDB<NomtStateValues<UserNamespace>, DbCache>>,
pub(crate) kernel: Arc<VersionedDB<NomtStateValues<KernelNamespace>, DbCache>>,
```
into a single object (something also briefly discussed with @preston-evans98). In fact, it looks like `FlatStateDb` has  turned into that unified object.

We could remove `live_db and archival_db from VersionedDB` and instead inject them as method parameters—similar to what we now do for cache injection. After additional cleanup and renaming, `FlatStateDb` could be moved to `rockbound`.

I initially attempted this refactor in this PR, but it required extensive changes across `rockbound` and the `sov-db` crate. Given the scope, I decided not to proceed further at this time. If this consolidation is still a priority, we should revisit it once the crash-consistency issue is resolved and all relevant unit tests are passing.


- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


see also https://github.com/Sovereign-Labs/rockbound/pull/41

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
