### PR TITLE
Add test for money printing vuln. Fix panic at genesis

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -86,6 +86,7 @@ where
         state: &mut impl TxState<S>,
     ) -> anyhow::Result<()> {
         start_timer!(total);
+        // Note: This does *not* verify the signature
         let tx = convert_to_tx_signed(message.rlp)?;
 
         if matches!(tx, alloy_consensus::EthereumTxEnvelope::Eip4844(_)) {
@@ -202,10 +203,7 @@ where
         let gas_meter = state
             .try_as_basic_gas_meter()
             .expect("TxState should have BasicGasMeter");
-        let funds = gas_meter
-            .remaining_funds
-            .expect("TxState gas meter has funds set")
-            .0;
+        let funds = gas_meter.remaining_funds.map(|funds| funds.0).unwrap_or(0);
         let gas = gas_meter.remaining_gas.as_ref()[0];
         let price = gas_meter.gas_price.as_ref()[0].0;
         match (funds, gas) {
@@ -493,6 +491,8 @@ fn on_error<S: Spec>(
         "EVM transaction error"
     );
 
+    println!("On error: {:?}", err);
+
     anyhow::bail!("EVM transaction error: {:?}", err);
 }
 
@@ -520,6 +520,7 @@ fn on_revert<S: Spec>(
         publish = %preferred_sequencer_publish_reverted_txs,
         "EVM execution error"
     );
+    println!("On revert: {:?}", result);
     // Revert the sovereign SDK transaction only if
     // 1. We're in the sequencer
     // 2. The submitter of this transaction is the preferred sequencer

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -491,8 +491,6 @@ fn on_error<S: Spec>(
         "EVM transaction error"
     );
 
-    println!("On error: {:?}", err);
-
     anyhow::bail!("EVM transaction error: {:?}", err);
 }
 
@@ -520,7 +518,6 @@ fn on_revert<S: Spec>(
         publish = %preferred_sequencer_publish_reverted_txs,
         "EVM execution error"
     );
-    println!("On revert: {:?}", result);
     // Revert the sovereign SDK transaction only if
     // 1. We're in the sequencer
     // 2. The submitter of this transaction is the preferred sequencer

--- a/crates/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -2,6 +2,7 @@ use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_consensus::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
 use alloy_primitives::{Address, Bloom, B256, B64, U256};
 use alloy_primitives::{BlockNumber, Bytes};
+use anyhow::bail;
 use revm::primitives::hardfork::SpecId;
 use revm::state::AccountInfo;
 use sov_address::{EthereumAddress, FromVmAddress};
@@ -141,7 +142,7 @@ fn init_spec(config: &EvmGenesisConfig) -> anyhow::Result<Vec<(BlockNumber, Spec
     if spec.is_empty() {
         spec.push((0, SpecId::CANCUN));
     } else if spec[0].0 != 0u64 {
-        anyhow::bail!("EVM spec must start from block 0");
+        bail!("EVM spec must start from block 0");
     };
 
     Ok(spec)

--- a/crates/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -141,7 +141,7 @@ fn init_spec(config: &EvmGenesisConfig) -> anyhow::Result<Vec<(BlockNumber, Spec
     if spec.is_empty() {
         spec.push((0, SpecId::CANCUN));
     } else if spec[0].0 != 0u64 {
-        panic!("EVM spec must start from block 0");
+        anyhow::bail!("EVM spec must start from block 0");
     };
 
     Ok(spec)

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
@@ -53,7 +53,6 @@ fn test_simple_transfer_balance_larger_than_allowed() {
     runner.execute_transaction(TransactionTestCase {
         input: transfer_tx,
         assert: Box::new(move |ctx, state| {
-            // assert!(!ctx.tx_receipt.is_successful(), "Transaction should not be successful: {:?}", ctx.tx_receipt);
             let mut db = evm.db(state);
             let from_acc = db.basic(from.address()).unwrap().unwrap();
             let to_acc = db.basic(to.address()).unwrap().unwrap();

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
@@ -38,6 +38,36 @@ fn test_simple_transfer() {
 }
 
 #[test]
+fn test_simple_transfer_balance_larger_than_allowed() {
+    let (mut runner, from, to) = setup();
+
+    let transfer_tx = create_transfer_tx(
+        0,
+        &from,
+        &to,
+        TEST_DEFAULT_USER_BALANCE.0.checked_add(1).unwrap(),
+    )
+    .tx;
+
+    let evm = Evm::<S>::default();
+    runner.execute_transaction(TransactionTestCase {
+        input: transfer_tx,
+        assert: Box::new(move |ctx, state| {
+            // assert!(!ctx.tx_receipt.is_successful(), "Transaction should not be successful: {:?}", ctx.tx_receipt);
+            let mut db = evm.db(state);
+            let from_acc = db.basic(from.address()).unwrap().unwrap();
+            let to_acc = db.basic(to.address()).unwrap().unwrap();
+            // The only balance changes should be from the transfer itself and not from gas as it's disabled in SovEvm
+            assert_eq!(to_acc.balance, 0);
+            assert_eq!(
+                from_acc.balance,
+                TEST_DEFAULT_USER_BALANCE.0 - ctx.gas_value_used.0
+            );
+        }),
+    });
+}
+
+#[test]
 fn test_evm_gas_usage() {
     std::env::set_var(
         "SOV_TEST_CONST_OVERRIDE_DEFAULT_GAS_TO_CHARGE_PER_EVM_GAS",


### PR DESCRIPTION
# Description

This PR adds a test which catches a potential misconfiguration which causes REVM to allow money-printing. This bug has never been present in our codebase, but only because another change (apparently accidentally) removes the default trait implementation that uses this config. 

The PR also makes a tiny change to return an error rather than panicking when bad data is provided at genesis.

