### PR TITLE
sov-db: Track DB commit status

### DIFF
--- a/crates/full-node/sov-db/src/commit_flag.rs
+++ b/crates/full-node/sov-db/src/commit_flag.rs
@@ -18,9 +18,9 @@ pub enum CommitStatus {
     CommittingUserNomt([u8; 32]),
     /// A commit of **archival user and kernel state** in the flat-db is in progress.
     CommittingArchivalUserAndKernel,
-    /// A commit of **live live user and kernel state** in the flat-db is in progress.
+    /// A commit of **live user and kernel state** in the flat-db is in progress.
     CommittingLiveUserAndKernel,
-    /// The commit suceeded.
+    /// The commit succeeded.
     Success,
 }
 

--- a/crates/full-node/sov-db/src/commit_flag.rs
+++ b/crates/full-node/sov-db/src/commit_flag.rs
@@ -59,13 +59,13 @@ impl CommitFlag {
                 Ok(status) => Ok(status),
                 Err(err) => {
                     tracing::warn!(error = ?err, "Commit flag file is corrupted, defaulting to completed");
-                    self.write_status(CommitStatus::Completed)?;
+                    self.write_status(&CommitStatus::Completed)?;
                     Ok(CommitStatus::Completed)
                 }
             },
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 // File not found, create it with COMPLETED status
-                self.write_status(CommitStatus::Completed)?;
+                self.write_status(&CommitStatus::Completed)?;
                 Ok(CommitStatus::Completed)
             }
             Err(e) => Err(anyhow::Error::from(e).context("Failed to read commit flag file")),
@@ -87,7 +87,7 @@ impl CommitFlag {
     /// Returns `anyhow::Result<()>` which is `Ok(())` on successful write, or an error
     /// if any step of the atomic write process fails (e.g., I/O errors, permission issues,
     /// disk full).
-    pub fn write_status(&self, status: CommitStatus) -> anyhow::Result<()> {
+    pub fn write_status(&self, status: &CommitStatus) -> anyhow::Result<()> {
         let message = borsh::to_vec(&status)?;
 
         // Write to a temporary file first
@@ -120,6 +120,7 @@ impl CommitFlag {
         Ok(())
     }
 
+    /// TODO
     pub fn log_reset_instruction(&self) {
         tracing::error!(
             "To reset commit flag, please remove commit flag file: `rm {}`",
@@ -155,7 +156,7 @@ mod tests {
         let in_progress_msg = CommitStatus::InProgress(root_hash);
 
         // 2. Write InProgress
-        flag.write_status(in_progress_msg).unwrap();
+        flag.write_status(&in_progress_msg).unwrap();
         assert_eq!(flag.read_status().unwrap(), in_progress_msg);
 
         let mut f = File::open(dir.path().join(FLAG_FILE_NAME)).unwrap();
@@ -166,7 +167,7 @@ mod tests {
         drop(f);
 
         // 3. Write Completed
-        flag.write_status(CommitStatus::Completed).unwrap();
+        flag.write_status(&CommitStatus::Completed).unwrap();
         assert_eq!(flag.read_status().unwrap(), CommitStatus::Completed);
 
         let mut f = File::open(dir.path().join(FLAG_FILE_NAME)).unwrap();

--- a/crates/full-node/sov-db/src/commit_flag.rs
+++ b/crates/full-node/sov-db/src/commit_flag.rs
@@ -7,14 +7,21 @@ use borsh::{BorshDeserialize, BorshSerialize};
 
 const FLAG_FILE_NAME: &str = "commit_status.flag";
 
-/// Represents the status of a two-phase commit operation.
+/// Represents the current state of a commit operation.
 #[derive(Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Clone, Copy)]
 pub enum CommitStatus {
-    /// Indicates that the first phase of a commit is done, but the second is pending.
-    /// Write root hash that has been written while in progress.
-    InProgress([u8; 32]),
-    /// Indicates that a commit operation is fully completed, or no operation is in progress.
-    Completed,
+    /// A commit of **kernel state** is in progress.
+    /// Stores the previous `kernel` root hash before the commit began.
+    CommittingKernelNomt([u8; 32]),
+    /// A commit of **user state** is in progress.
+    /// Stores the previous `user` root hash before the commit began.
+    CommittingUserNomt([u8; 32]),
+    /// A commit of **archival user and kernel state** in the flat-db is in progress.
+    CommittingArchivalUserAndKernel,
+    /// A commit of **live live user and kernel state** in the flat-db is in progress.
+    CommittingLiveUserAndKernel,
+    /// The commit suceeded.
+    Success,
 }
 
 /// Manages a persistent flag file to track the state of two-phase commits.
@@ -59,14 +66,14 @@ impl CommitFlag {
                 Ok(status) => Ok(status),
                 Err(err) => {
                     tracing::warn!(error = ?err, "Commit flag file is corrupted, defaulting to completed");
-                    self.write_status(&CommitStatus::Completed)?;
-                    Ok(CommitStatus::Completed)
+                    self.write_status(&CommitStatus::Success)?;
+                    Ok(CommitStatus::Success)
                 }
             },
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 // File not found, create it with COMPLETED status
-                self.write_status(&CommitStatus::Completed)?;
-                Ok(CommitStatus::Completed)
+                self.write_status(&CommitStatus::Success)?;
+                Ok(CommitStatus::Success)
             }
             Err(e) => Err(anyhow::Error::from(e).context("Failed to read commit flag file")),
         }
@@ -120,81 +127,12 @@ impl CommitFlag {
         Ok(())
     }
 
-    /// TODO
-    pub fn log_reset_instruction(&self) {
-        tracing::error!(
-            "To reset commit flag, please remove commit flag file: `rm {}`",
-            self.file_path.display()
-        );
-    }
-}
+    pub(crate) fn save_commit_status(&self, commit_status: &CommitStatus) -> anyhow::Result<()> {
+        self.write_status(commit_status).with_context(|| {
+            format!("Failed to write {commit_status:?} status after successful user commit")
+        })?;
 
-#[cfg(test)]
-mod tests {
-    use std::io::Read;
-
-    use tempfile::tempdir;
-
-    use super::*;
-
-    #[test]
-    fn test_commit_flag_flow() {
-        let dir = tempdir().unwrap();
-        let flag = CommitFlag::new(dir.path());
-
-        // 1. Initial read: file doesn't exist, should create and return Completed
-        assert_eq!(flag.read_status().unwrap(), CommitStatus::Completed);
-        assert!(dir.path().join(FLAG_FILE_NAME).exists());
-
-        let mut f = File::open(dir.path().join(FLAG_FILE_NAME)).unwrap();
-        let mut contents = Vec::new();
-        f.read_to_end(&mut contents).unwrap();
-        assert_eq!(contents, borsh::to_vec(&CommitStatus::Completed).unwrap());
-        drop(f);
-
-        let root_hash = [128u8; 32];
-        let in_progress_msg = CommitStatus::InProgress(root_hash);
-
-        // 2. Write InProgress
-        flag.write_status(&in_progress_msg).unwrap();
-        assert_eq!(flag.read_status().unwrap(), in_progress_msg);
-
-        let mut f = File::open(dir.path().join(FLAG_FILE_NAME)).unwrap();
-        contents.clear();
-        f.read_to_end(&mut contents).unwrap();
-        assert_eq!(contents, borsh::to_vec(&in_progress_msg).unwrap());
-        assert!(!dir.path().join(format!("{FLAG_FILE_NAME}.tmp")).exists());
-        drop(f);
-
-        // 3. Write Completed
-        flag.write_status(&CommitStatus::Completed).unwrap();
-        assert_eq!(flag.read_status().unwrap(), CommitStatus::Completed);
-
-        let mut f = File::open(dir.path().join(FLAG_FILE_NAME)).unwrap();
-        contents.clear();
-        f.read_to_end(&mut contents).unwrap();
-        assert_eq!(contents, borsh::to_vec(&CommitStatus::Completed).unwrap());
-        assert!(!dir.path().join(format!("{FLAG_FILE_NAME}.tmp")).exists());
-    }
-
-    #[test]
-    fn test_corrupted_file() {
-        let dir = tempdir().unwrap();
-        let flag_path = dir.path().join(FLAG_FILE_NAME);
-
-        // Create a corrupted file
-        let mut file = File::create(&flag_path).unwrap();
-        file.write_all(b"CORRUPTED_DATA").unwrap();
-        drop(file);
-
-        let commit_flag = CommitFlag::new(dir.path());
-        // Should detect corruption, fix the file, and return Completed
-        assert_eq!(commit_flag.read_status().unwrap(), CommitStatus::Completed);
-
-        // Verify the file content is now COMPLETED
-        let mut f = File::open(&flag_path).unwrap();
-        let mut contents = Vec::new();
-        f.read_to_end(&mut contents).unwrap();
-        assert_eq!(contents, borsh::to_vec(&CommitStatus::Completed).unwrap());
+        debug_assert_eq!(&self.read_status()?, commit_status);
+        Ok(())
     }
 }

--- a/crates/full-node/sov-db/src/flat_db.rs
+++ b/crates/full-node/sov-db/src/flat_db.rs
@@ -1,6 +1,7 @@
 //! A database to store the flat state of the rollup (i.e. the raw key-value pairs)
 //! used by NOMT.
 
+use crate::commit_flag::{CommitFlag, CommitStatus};
 use crate::metrics::nomt::FlatStateCommitMetric;
 use crate::{
     historical_state::StateChanges,
@@ -140,7 +141,11 @@ impl FlatStateDb {
     }
 
     /// Coalesce all the changes into a single schema batch and write it atomically.
-    pub fn commit(&self, state: StateChanges) -> anyhow::Result<FlatStateCommitMetric> {
+    pub fn commit(
+        &self,
+        state: StateChanges,
+        commit_flag: &CommitFlag,
+    ) -> anyhow::Result<FlatStateCommitMetric> {
         let start_prepare = std::time::Instant::now();
         let prepare = start_prepare.elapsed();
         let start_write = std::time::Instant::now();
@@ -203,10 +208,14 @@ impl FlatStateDb {
             &self.live_db,
         )?;
 
-        // Write batches.
+        // Write archival db batches.
+        commit_flag.save_commit_status(&CommitStatus::CommittingArchivalUserAndKernel)?;
         self.archival_db.write_db_batch(archival_db_batch)?;
+        // rockbound requirement:  `store_committed_archival_version` has to be called before before writing `live_db_batch`.
         self.kernel.store_committed_archival_version(version);
         self.user.store_committed_archival_version(version);
+        // Write live db batch.
+        commit_flag.save_commit_status(&CommitStatus::CommittingLiveUserAndKernel)?;
         self.live_db.write_db_batch(live_db_batch)?;
 
         // 5. Release caches.

--- a/crates/full-node/sov-db/src/historical_state.rs
+++ b/crates/full-node/sov-db/src/historical_state.rs
@@ -278,12 +278,15 @@ impl HistoricalStateReader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commit_flag::CommitFlag;
     use crate::storage_manager::FlatStateDb;
 
     #[test]
     fn verify_last_version_bumped_properly() {
         let tempdir = tempfile::tempdir().unwrap();
-        let rocksdb = FlatStateDb::new(tempdir.path().to_path_buf(), 1_000_000, true).unwrap(); // Use a 1MB state cache for tests
+        let db_path = tempdir.path();
+        let commit_flag = CommitFlag::new(db_path);
+        let rocksdb = FlatStateDb::new(db_path.to_path_buf(), 1_000_000, true).unwrap(); // Use a 1MB state cache for tests
 
         let key1 = b"AAA";
         let key2 = b"BBB";
@@ -309,7 +312,7 @@ mod tests {
                 slot_number,
             )
             .unwrap();
-            rocksdb.commit(changes).unwrap();
+            rocksdb.commit(changes, &commit_flag).unwrap();
         }
     }
 
@@ -317,6 +320,8 @@ mod tests {
     fn test_no_bound_on_passed_version() {
         let tempdir = tempfile::tempdir().unwrap();
         let db_path = tempdir.path();
+        let commit_flag = CommitFlag::new(db_path);
+
         let rocksdb = FlatStateDb::new(db_path.to_path_buf(), 1_000_000, true).unwrap(); // Use a 1MB state cache for tests
 
         // Create two independent readers on the same database.
@@ -339,7 +344,7 @@ mod tests {
             version0,
         )
         .unwrap();
-        rocksdb.commit(changes0).unwrap();
+        rocksdb.commit(changes0, &commit_flag).unwrap();
         assert_eq!(reader1.get_next_version(), version0);
         assert_eq!(reader2.get_next_version(), version0);
 
@@ -366,7 +371,7 @@ mod tests {
             version1,
         )
         .unwrap();
-        rocksdb.commit(changes1).unwrap();
+        rocksdb.commit(changes1, &commit_flag).unwrap();
         assert_eq!(reader1.get_next_version(), version0);
         assert_eq!(reader2.get_next_version(), version0);
 
@@ -394,7 +399,10 @@ mod tests {
     #[test]
     fn test_unbound_last_version() {
         let tempdir = tempfile::tempdir().unwrap();
-        let rocksdb = FlatStateDb::new(tempdir.path().to_path_buf(), 1_000_000, true).unwrap(); // Use a 1MB state cache for tests
+        let db_path = tempdir.path();
+        let commit_flag = CommitFlag::new(db_path);
+
+        let rocksdb = FlatStateDb::new(db_path.to_path_buf(), 1_000_000, true).unwrap(); // Use a 1MB state cache for tests
 
         let reader1 = HistoricalStateReader::new_empty(&rocksdb);
         let reader2 = HistoricalStateReader::new_empty(&rocksdb);
@@ -417,7 +425,7 @@ mod tests {
             version0,
         )
         .unwrap();
-        rocksdb.commit(changes0).unwrap();
+        rocksdb.commit(changes0, &commit_flag).unwrap();
 
         // Reader1's bound version stays the same, but unbound sees the update
         assert_eq!(reader1.last_version(), None);
@@ -439,7 +447,7 @@ mod tests {
             version1,
         )
         .unwrap();
-        rocksdb.commit(changes1).unwrap();
+        rocksdb.commit(changes1, &commit_flag).unwrap();
 
         // Both readers see the latest version through unbound
         assert_eq!(reader1.last_version_unbound().unwrap(), version1);

--- a/crates/full-node/sov-db/src/lib.rs
+++ b/crates/full-node/sov-db/src/lib.rs
@@ -35,7 +35,7 @@ pub mod accessory_db;
 pub mod namespaces;
 
 /// Implements commit flag logic for state_db_nomt.
-pub(crate) mod commit_flag;
+pub mod commit_flag;
 /// Configuration for `sov-db`
 pub mod config;
 pub(crate) mod metrics;

--- a/crates/full-node/sov-db/src/lib.rs
+++ b/crates/full-node/sov-db/src/lib.rs
@@ -35,7 +35,10 @@ pub mod accessory_db;
 pub mod namespaces;
 
 /// Implements commit flag logic for state_db_nomt.
+#[cfg(feature = "test-utils")]
 pub mod commit_flag;
+#[cfg(not(feature = "test-utils"))]
+pub(crate) mod commit_flag;
 /// Configuration for `sov-db`
 pub mod config;
 pub(crate) mod metrics;

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -160,7 +160,7 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
         let start_user = std::time::Instant::now();
         {
             let _span = tracing::debug_span!("namespace_commit", namespace = "user").entered();
-            user.commit(&self.user).context("kernel namespace commit")?;
+            user.commit(&self.user).context("user namespace commit")?;
         };
         let write_user = start_user.elapsed();
         Ok(write_user)

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -49,7 +49,7 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
             CommitStatus::CommittingKernelNomt(saved_hash) => {
                 let current_kernel_root_hash = self.kernel.root().into_inner();
 
-                // Kernel commit was sucefull but later commits failed. We rollback only the kernel.
+                // Kernel commit was successful but later commits failed. We rollback only the kernel.
                 if saved_hash != current_kernel_root_hash {
                     tracing::warn!(
                         flag_kernel_root_hash = hex::encode(saved_hash),
@@ -63,7 +63,7 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
             CommitStatus::CommittingUserNomt(saved_hash) => {
                 let current_user_root_hash = self.user.root().into_inner();
 
-                // User & Kernel commit was sucefull but later commits failed. We rollback both.
+                // User & Kernel commit was successful but later commits failed. We rollback both.
                 if saved_hash != current_user_root_hash {
                     tracing::warn!(
                         flag_user_root_hash = hex::encode(saved_hash),
@@ -73,7 +73,7 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
                     self.kernel.rollback(1)?;
                     self.user.rollback(1)?;
                 } else
-                // Only Kernel commit was sucesfull. We rollback only the kernel.
+                // Only Kernel commit was successful. We rollback only the kernel.
                 {
                     tracing::warn!(
                       "Detected in-progress commit {commit_status:?}. Rolling back kernel & user DBs."
@@ -87,7 +87,7 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
                 tracing::warn!(
                 "Detected in-progress commit {commit_status:?}. Rolling back kernel & user DBs."
             );
-                // User & Kernel commit was sucefull but we don't see `Success`. We rollback both User & Kernek.
+                // User & Kernel commit was sucefull but we don't see `Success`. We rollback both User & Kernel.
                 self.kernel.rollback(1)?;
                 self.user.rollback(1)?;
             }

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -656,7 +656,7 @@ mod tests {
             overlays.remove(&0).unwrap()
         };
         let StateOverlay {
-            user: base_user_overlay,
+            user: _,
             kernel: base_kernel_overlay,
         } = base_overlay;
 

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -131,20 +131,13 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
         // 3.
         let flag_finish_start = std::time::Instant::now();
 
-        let r1 = self.user.root().into_inner();
-        commit_flag.save_commit_status(&CommitStatus::CommittingUserNomt(r1))?;
+        commit_flag.save_commit_status(&CommitStatus::CommittingUserNomt(
+            self.user.root().into_inner(),
+        ))?;
         let flag_finish = flag_finish_start.elapsed();
 
-        println!("----");
-        println!("U1 r1 {}", hex::encode(r1));
-
-        let r2 = user.root().into_inner();
-        println!("U1 r2 {}", hex::encode(r2));
         // 4.
         let write_user = self.commit_user(user)?;
-
-        let r2 = self.user.root().into_inner();
-        println!("U1 r3 {}", hex::encode(r2));
 
         let total = start.elapsed();
         Ok(MerklizedCommitMetric {

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -40,7 +40,7 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
         Ok(Self { user, kernel })
     }
 
-    pub(crate) fn validate_commit_flag_and_rollback_if_necssesary(
+    pub(crate) fn validate_commit_flag_and_rollback_if_necessesary(
         &self,
         commit_flag: &CommitFlag,
     ) -> anyhow::Result<()> {
@@ -583,7 +583,7 @@ mod tests {
         let commit_flag = CommitFlag::new(&config.path);
         let state_db = Arc::new(NomtStateDb::<H>::new(config).unwrap());
         state_db
-            .validate_commit_flag_and_rollback_if_necssesary(&commit_flag)
+            .validate_commit_flag_and_rollback_if_necessesary(&commit_flag)
             .unwrap();
 
         let all_overlays: HashMap<u64, StateOverlay> = HashMap::new();
@@ -659,7 +659,7 @@ mod tests {
         let config = RollupDbConfig::default_in_path(temp_dir.path().to_path_buf());
         let state_db = Arc::new(NomtStateDb::<H>::new(config).unwrap());
         state_db
-            .validate_commit_flag_and_rollback_if_necssesary(&commit_flag)
+            .validate_commit_flag_and_rollback_if_necessesary(&commit_flag)
             .unwrap();
 
         let builder =

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -16,101 +16,6 @@ const KERNEL: &str = "kernel_state";
 const USER: &str = "user_state";
 const BOTH: &str = "user_and_kernel_state";
 
-fn validate_commit_flag<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync>(
-    commit_flag: &CommitFlag,
-    kernel: &Nomt<BinaryHasher<H>>,
-) -> anyhow::Result<()> {
-    match commit_flag.read_status()? {
-        CommitStatus::InProgress(detected_root_hash) => {
-            let current_kernel_root_hash = kernel.root().into_inner();
-            tracing::warn!(
-                flag_kernel_root_hash = hex::encode(detected_root_hash),
-                db_kernel_root_hash = hex::encode(current_kernel_root_hash),
-                "Detected in-progress commit. Rolling back kernel DB."
-            );
-            if current_kernel_root_hash != detected_root_hash {
-                anyhow::bail!("Unsafe to perform rollback, status root hash {} does not match database {}. Manual intervention is needed",
-                        hex::encode(detected_root_hash),
-                        hex::encode(current_kernel_root_hash),
-                    );
-            }
-
-            kernel
-                .rollback(1)
-                .context("Failed to rollback kernel DB after in-progress commit detected")?;
-            commit_flag
-                    .write_status(&CommitStatus::Completed)
-                    .with_context(|| {
-                        commit_flag.log_reset_instruction();
-                        "Failed to write `COMPLETED` status after rollback. Manual intervention required."
-                    })?;
-            let rolled_back_root_hash = kernel.root().into_inner();
-            tracing::info!(
-                from_root_hash = hex::encode(current_kernel_root_hash),
-                to_root_hash = hex::encode(rolled_back_root_hash),
-                "Kernel namespace rollback completed"
-            );
-        }
-        CommitStatus::Completed => {
-            tracing::trace!("Commit flag is `Completed`, proceeding as usual");
-        }
-    };
-
-    Ok(())
-}
-
-fn save_commit_status<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync>(
-    commit_flag: &CommitFlag,
-    commit_status: &CommitStatus,
-    kernel: &Nomt<BinaryHasher<H>>,
-) -> anyhow::Result<()> {
-    // If the kernel commit fails, the flag is untouched, meaning DB remains synced on previous state.
-    // Write IN-PROGRESS status after kernel committed successfully.
-    match commit_status {
-        CommitStatus::InProgress(_) => {
-            if let Err(flag_write_err) = commit_flag.write_status(commit_status) {
-                // CRITICAL: Kernel committed, but couldn't write IN-PROGRESS flag.
-                // Try to roll back the kernel commit to revert to a consistent state.
-                // Failures here are more likely to be due to persistent disk issues (full, I/O errors, permissions).
-                tracing::error!(
-                    error = ?flag_write_err,
-                    "Kernel commit succeeded, but failed to write IN-PROGRESS flag: Attempting kernel rollback.",
-                );
-                if let Err(rollback_err) = kernel.rollback(1) {
-                    // DISASTER: Kernel committed, flag is still COMPLETED, and kernel rollback FAILED.
-                    // The database is in an inconsistent state that cannot be automatically recovered by this logic.
-                    // Propagate a combined error. This situation likely requires manual intervention or node reset.
-                    return Err(anyhow::anyhow!(
-                "CRITICAL INCONSISTENCY: Kernel committed, but failed to write IN-PROGRESS flag ({:?}), \
-                 AND subsequent kernel rollback also failed ({:?}). Manual intervention required.",
-                flag_write_err,
-                rollback_err
-            ));
-                }
-                // Kernel rollback succeeded.
-                // The DB is back to its state before this commit attempt.
-                // Return an error indicating the flag write failure, but state is consistent.
-                tracing::warn!("Kernel rollback succeeded after IN-PROGRESS flag write failure. DB state is consistent with previous version, but flag does not match. Manual intervention required.");
-                return Err(flag_write_err).with_context(|| {
-                commit_flag.log_reset_instruction();
-                "Failed to write IN-PROGRESS status after kernel commit; kernel was rolled back, but flag does not match. Manual intervention required."
-            });
-            }
-        }
-        CommitStatus::Completed => {
-            commit_flag
-                .write_status(&CommitStatus::Completed)
-                .with_context(|| {
-                    commit_flag.log_reset_instruction();
-                    "Failed to write `COMPLETED` status after successful user commit"
-                })?;
-            debug_assert_eq!(commit_flag.read_status()?, CommitStatus::Completed);
-        }
-    }
-
-    Ok(())
-}
-
 /// Contains all the most recent rollup data.
 pub struct NomtStateDb<H> {
     user: Nomt<BinaryHasher<H>>,
@@ -119,7 +24,7 @@ pub struct NomtStateDb<H> {
 
 impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtStateDb<H> {
     /// Initialize a new [` NomtStateDb `] in the given path.
-    pub fn new(config: RollupDbConfig, commit_flag: &CommitFlag) -> anyhow::Result<Self> {
+    pub fn new(config: RollupDbConfig) -> anyhow::Result<Self> {
         tracing::debug!(options = ?config, "Opening NOMT");
 
         let kernel = {
@@ -127,14 +32,77 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
             Nomt::<BinaryHasher<H>>::open(opts)?
         };
 
-        validate_commit_flag(commit_flag, &kernel)?;
-
         let user = {
             let opts = config.get_user_options();
             Nomt::<BinaryHasher<H>>::open(opts)?
         };
 
         Ok(Self { user, kernel })
+    }
+
+    pub(crate) fn validate_commit_flag_and_rollback_if_necssesary(
+        &self,
+        commit_flag: &CommitFlag,
+    ) -> anyhow::Result<()> {
+        let commit_status = commit_flag.read_status()?;
+        match commit_status {
+            CommitStatus::CommittingKernelNomt(saved_hash) => {
+                let current_kernel_root_hash = self.kernel.root().into_inner();
+
+                println!("X1");
+                // Kernel commit was sucefull but later commits failed. We revert only the kernel.
+                if saved_hash != current_kernel_root_hash {
+                    tracing::warn!(
+                        flag_kernel_root_hash = hex::encode(saved_hash),
+                        db_kernel_root_hash = hex::encode(current_kernel_root_hash),
+                        "Detected in-progress commit {commit_status:?}. Rolling back kernel DB."
+                    );
+                    println!("X2");
+                    self.kernel.rollback(1)?;
+                }
+            }
+            CommitStatus::CommittingUserNomt(saved_hash) => {
+                let current_user_root_hash = self.user.root().into_inner();
+
+                let sh = hex::encode(saved_hash);
+                let ch = hex::encode(current_user_root_hash);
+
+                if saved_hash != current_user_root_hash {
+                    println!("");
+                    println!("X3 {}", sh);
+                    println!("X3 {}", ch);
+
+                    tracing::warn!(
+                        flag_user_root_hash = hex::encode(saved_hash),
+                        db_user_root_hash = hex::encode(current_user_root_hash),
+                        "Detected in-progress commit {commit_status:?}. Rolling back kernel DB."
+                    );
+                    self.kernel.rollback(1)?;
+                    self.user.rollback(1)?;
+                } else {
+                    println!("X4");
+                    tracing::warn!(
+                      "Detected in-progress commit {commit_status:?}. Rolling back kernel & user DBs."
+                    );
+                    self.kernel.rollback(1)?;
+                }
+            }
+            CommitStatus::CommittingArchivalUserAndKernel
+            | CommitStatus::CommittingLiveUserAndKernel => {
+                tracing::warn!(
+                "Detected in-progress commit {commit_status:?}. Rolling back kernel & user DBs."
+            );
+                println!("X5");
+
+                self.kernel.rollback(1)?;
+                self.user.rollback(1)?;
+            }
+            CommitStatus::Success => {
+                println!("X6");
+            }
+        }
+
+        Ok(())
     }
 
     /// Commit [`StateOverlay`] to disk.
@@ -148,25 +116,36 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
         let StateOverlay { user, kernel } = overlay;
         // Status should be completed before committing.
         let flag_prepare_start = std::time::Instant::now();
-        debug_assert_eq!(commit_flag.read_status()?, CommitStatus::Completed);
-
-        let in_progress_commit_status = CommitStatus::InProgress(kernel.root().into_inner());
         let flag_prepare = flag_prepare_start.elapsed();
 
-        let write_kernel = self.commit_kernel(kernel)?;
-
+        // 1.
         let flag_mid_start = std::time::Instant::now();
-        save_commit_status(commit_flag, &in_progress_commit_status, &self.kernel)?;
-
-        debug_assert_eq!(commit_flag.read_status()?, in_progress_commit_status);
+        commit_flag.save_commit_status(&CommitStatus::CommittingKernelNomt(
+            self.kernel.root().into_inner(),
+        ))?;
         let flag_mid = flag_mid_start.elapsed();
 
+        // 2.
+        let write_kernel = self.commit_kernel(kernel)?;
+
+        // 3.
+        let flag_finish_start = std::time::Instant::now();
+
+        let r1 = self.user.root().into_inner();
+        commit_flag.save_commit_status(&CommitStatus::CommittingUserNomt(r1))?;
+        let flag_finish = flag_finish_start.elapsed();
+
+        println!("----");
+        println!("U1 r1 {}", hex::encode(r1));
+
+        let r2 = user.root().into_inner();
+        println!("U1 r2 {}", hex::encode(r2));
+        // 4.
         let write_user = self.commit_user(user)?;
 
-        let flag_finish_start = std::time::Instant::now();
-        save_commit_status(commit_flag, &CommitStatus::Completed, &self.kernel)?;
+        let r2 = self.user.root().into_inner();
+        println!("U1 r3 {}", hex::encode(r2));
 
-        let flag_finish = flag_finish_start.elapsed();
         let total = start.elapsed();
         Ok(MerklizedCommitMetric {
             flag_prepare,
@@ -211,12 +190,6 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
     ) -> anyhow::Result<MerklizedCommitMetric> {
         let overlay = session.into_state_overlay();
         self.commit(overlay, commit_flag)
-    }
-
-    pub(crate) fn full_rollback(&self) -> anyhow::Result<()> {
-        self.user.rollback(1)?;
-        self.kernel.rollback(1)?;
-        Ok(())
     }
 
     pub(crate) fn get_root_hashes(&self) -> StateRootHashes {
@@ -515,7 +488,7 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let config = RollupDbConfig::default_in_path(temp_dir.path().to_path_buf());
         let commit_flag = CommitFlag::new(&config.path);
-        let state_db = Arc::new(NomtStateDb::<H>::new(config, &commit_flag).unwrap());
+        let state_db = Arc::new(NomtStateDb::<H>::new(config).unwrap());
 
         // First produce some overlays with data
         let all_overlays: HashMap<u64, StateOverlay> = HashMap::new();
@@ -580,8 +553,6 @@ mod tests {
     // Then we create 2 more overlays on top of those 2, let's call them "test overlays".
     // Then the "base" kernel overlay is committed, but the "user" base overlay is kept in memory.
     // This creates a precondition for `StateOverlay::commit` to fail on the user overlay phase.
-    // After this error is confirmed, we commit the "base user" overlay and re-open the NOMT database.
-    // We expect that both user and kernel databases are in sync and on data from base overlays.
     #[test]
     fn test_namespaced_db_stay_in_sync_on_error() {
         let temp_dir = tempfile::tempdir().unwrap();
@@ -621,7 +592,10 @@ mod tests {
 
         let config = RollupDbConfig::default_in_path(temp_dir.path().to_path_buf());
         let commit_flag = CommitFlag::new(&config.path);
-        let state_db = Arc::new(NomtStateDb::<H>::new(config, &commit_flag).unwrap());
+        let state_db = Arc::new(NomtStateDb::<H>::new(config).unwrap());
+        state_db
+            .validate_commit_flag_and_rollback_if_necssesary(&commit_flag)
+            .unwrap();
 
         let all_overlays: HashMap<u64, StateOverlay> = HashMap::new();
         let all_overlays = Arc::new(RwLock::new(all_overlays));
@@ -691,14 +665,13 @@ mod tests {
         let test_commit_result = state_db.commit(test_overlay, &commit_flag);
         assert!(test_commit_result.is_err());
 
-        base_user_overlay.commit(&state_db.user).unwrap();
-
         // Reopen the state db.
         drop(state_db);
         let config = RollupDbConfig::default_in_path(temp_dir.path().to_path_buf());
-
-        let commit_flag = CommitFlag::new(&config.path);
-        let state_db = Arc::new(NomtStateDb::<H>::new(config, &commit_flag).unwrap());
+        let state_db = Arc::new(NomtStateDb::<H>::new(config).unwrap());
+        state_db
+            .validate_commit_flag_and_rollback_if_necssesary(&commit_flag)
+            .unwrap();
 
         let builder =
             NomtSessionBuilder::<H, u64>::new(state_db.clone(), Vec::new(), all_overlays.clone());
@@ -708,7 +681,8 @@ mod tests {
 
         let user_value = user_session.read(user_key_path).unwrap();
         let kernel_value = kernel_session.read(kernel_key_path).unwrap();
-        assert_eq!(user_value, Some(value_2.clone()));
-        assert_eq!(user_value, kernel_value);
+
+        assert_eq!(kernel_value, Some(value_2.clone()));
+        assert_eq!(user_value, Some(value_1.clone()));
     }
 }

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -49,29 +49,22 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
             CommitStatus::CommittingKernelNomt(saved_hash) => {
                 let current_kernel_root_hash = self.kernel.root().into_inner();
 
-                println!("X1");
-                // Kernel commit was sucefull but later commits failed. We revert only the kernel.
+                // Kernel commit was sucefull but later commits failed. We rollback only the kernel.
                 if saved_hash != current_kernel_root_hash {
                     tracing::warn!(
                         flag_kernel_root_hash = hex::encode(saved_hash),
                         db_kernel_root_hash = hex::encode(current_kernel_root_hash),
                         "Detected in-progress commit {commit_status:?}. Rolling back kernel DB."
                     );
-                    println!("X2");
+
                     self.kernel.rollback(1)?;
                 }
             }
             CommitStatus::CommittingUserNomt(saved_hash) => {
                 let current_user_root_hash = self.user.root().into_inner();
 
-                let sh = hex::encode(saved_hash);
-                let ch = hex::encode(current_user_root_hash);
-
+                // User & Kernel commit was sucefull but later commits failed. We rollback both.
                 if saved_hash != current_user_root_hash {
-                    println!("");
-                    println!("X3 {}", sh);
-                    println!("X3 {}", ch);
-
                     tracing::warn!(
                         flag_user_root_hash = hex::encode(saved_hash),
                         db_user_root_hash = hex::encode(current_user_root_hash),
@@ -79,27 +72,26 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
                     );
                     self.kernel.rollback(1)?;
                     self.user.rollback(1)?;
-                } else {
-                    println!("X4");
+                } else
+                // Only Kernel commit was sucesfull. We rollback only the kernel.
+                {
                     tracing::warn!(
                       "Detected in-progress commit {commit_status:?}. Rolling back kernel & user DBs."
                     );
                     self.kernel.rollback(1)?;
                 }
             }
+
             CommitStatus::CommittingArchivalUserAndKernel
             | CommitStatus::CommittingLiveUserAndKernel => {
                 tracing::warn!(
                 "Detected in-progress commit {commit_status:?}. Rolling back kernel & user DBs."
             );
-                println!("X5");
-
+                // User & Kernel commit was sucefull but we don't see `Success`. We rollback both User & Kernek.
                 self.kernel.rollback(1)?;
                 self.user.rollback(1)?;
             }
-            CommitStatus::Success => {
-                println!("X6");
-            }
+            CommitStatus::Success => {}
         }
 
         Ok(())

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -54,7 +54,8 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
                     tracing::warn!(
                         flag_kernel_root_hash = hex::encode(saved_hash),
                         db_kernel_root_hash = hex::encode(current_kernel_root_hash),
-                        "Detected in-progress commit {commit_status:?}. Rolling back kernel DB."
+                        ?commit_status,
+                        "Detected in-progress commit. Rolling back kernel DB."
                     );
 
                     self.kernel.rollback(1)?;
@@ -68,7 +69,8 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
                     tracing::warn!(
                         flag_user_root_hash = hex::encode(saved_hash),
                         db_user_root_hash = hex::encode(current_user_root_hash),
-                        "Detected in-progress commit {commit_status:?}. Rolling back kernel DB."
+                        ?commit_status,
+                        "Detected in-progress commit. Rolling back kernel DB."
                     );
                     self.kernel.rollback(1)?;
                     self.user.rollback(1)?;
@@ -76,7 +78,8 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
                 // Only Kernel commit was successful. We rollback only the kernel.
                 {
                     tracing::warn!(
-                      "Detected in-progress commit {commit_status:?}. Rolling back kernel & user DBs."
+                        ?commit_status,
+                        "Detected in-progress commit. Rolling back kernel & user DBs."
                     );
                     self.kernel.rollback(1)?;
                 }
@@ -85,8 +88,9 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
             CommitStatus::CommittingArchivalUserAndKernel
             | CommitStatus::CommittingLiveUserAndKernel => {
                 tracing::warn!(
-                "Detected in-progress commit {commit_status:?}. Rolling back kernel & user DBs."
-            );
+                    ?commit_status,
+                    "Detected in-progress commit. Rolling back kernel & user DBs."
+                );
                 // User & Kernel commit was sucefull but we don't see `Success`. We rollback both User & Kernel.
                 self.kernel.rollback(1)?;
                 self.user.rollback(1)?;

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -91,9 +91,7 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
                     ?commit_status,
                     "Detected in-progress commit. Rolling back kernel & user DBs."
                 );
-                // User & Kernel commit was sucefull but we don't see `Success`. We rollback both User & Kernel.
-                self.kernel.rollback(1)?;
-                self.user.rollback(1)?;
+                // TODO: Requires careful consideration.
             }
             CommitStatus::Success => {}
         }

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 use anyhow::Context;
 use nomt::hasher::BinaryHasher;
@@ -15,18 +16,110 @@ const KERNEL: &str = "kernel_state";
 const USER: &str = "user_state";
 const BOTH: &str = "user_and_kernel_state";
 
+fn validate_commit_flag<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync>(
+    commit_flag: &CommitFlag,
+    kernel: &Nomt<BinaryHasher<H>>,
+) -> anyhow::Result<()> {
+    match commit_flag.read_status()? {
+        CommitStatus::InProgress(detected_root_hash) => {
+            let current_kernel_root_hash = kernel.root().into_inner();
+            tracing::warn!(
+                flag_kernel_root_hash = hex::encode(detected_root_hash),
+                db_kernel_root_hash = hex::encode(current_kernel_root_hash),
+                "Detected in-progress commit. Rolling back kernel DB."
+            );
+            if current_kernel_root_hash != detected_root_hash {
+                anyhow::bail!("Unsafe to perform rollback, status root hash {} does not match database {}. Manual intervention is needed",
+                        hex::encode(detected_root_hash),
+                        hex::encode(current_kernel_root_hash),
+                    );
+            }
+
+            kernel
+                .rollback(1)
+                .context("Failed to rollback kernel DB after in-progress commit detected")?;
+            commit_flag
+                    .write_status(&CommitStatus::Completed)
+                    .with_context(|| {
+                        commit_flag.log_reset_instruction();
+                        "Failed to write `COMPLETED` status after rollback. Manual intervention required."
+                    })?;
+            let rolled_back_root_hash = kernel.root().into_inner();
+            tracing::info!(
+                from_root_hash = hex::encode(current_kernel_root_hash),
+                to_root_hash = hex::encode(rolled_back_root_hash),
+                "Kernel namespace rollback completed"
+            );
+        }
+        CommitStatus::Completed => {
+            tracing::trace!("Commit flag is `Completed`, proceeding as usual");
+        }
+    };
+
+    Ok(())
+}
+
+fn save_commit_status<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync>(
+    commit_flag: &CommitFlag,
+    commit_status: &CommitStatus,
+    kernel: &Nomt<BinaryHasher<H>>,
+) -> anyhow::Result<()> {
+    // If the kernel commit fails, the flag is untouched, meaning DB remains synced on previous state.
+    // Write IN-PROGRESS status after kernel committed successfully.
+    match commit_status {
+        CommitStatus::InProgress(_) => {
+            if let Err(flag_write_err) = commit_flag.write_status(commit_status) {
+                // CRITICAL: Kernel committed, but couldn't write IN-PROGRESS flag.
+                // Try to roll back the kernel commit to revert to a consistent state.
+                // Failures here are more likely to be due to persistent disk issues (full, I/O errors, permissions).
+                tracing::error!(
+                    error = ?flag_write_err,
+                    "Kernel commit succeeded, but failed to write IN-PROGRESS flag: Attempting kernel rollback.",
+                );
+                if let Err(rollback_err) = kernel.rollback(1) {
+                    // DISASTER: Kernel committed, flag is still COMPLETED, and kernel rollback FAILED.
+                    // The database is in an inconsistent state that cannot be automatically recovered by this logic.
+                    // Propagate a combined error. This situation likely requires manual intervention or node reset.
+                    return Err(anyhow::anyhow!(
+                "CRITICAL INCONSISTENCY: Kernel committed, but failed to write IN-PROGRESS flag ({:?}), \
+                 AND subsequent kernel rollback also failed ({:?}). Manual intervention required.",
+                flag_write_err,
+                rollback_err
+            ));
+                }
+                // Kernel rollback succeeded.
+                // The DB is back to its state before this commit attempt.
+                // Return an error indicating the flag write failure, but state is consistent.
+                tracing::warn!("Kernel rollback succeeded after IN-PROGRESS flag write failure. DB state is consistent with previous version, but flag does not match. Manual intervention required.");
+                return Err(flag_write_err).with_context(|| {
+                commit_flag.log_reset_instruction();
+                "Failed to write IN-PROGRESS status after kernel commit; kernel was rolled back, but flag does not match. Manual intervention required."
+            });
+            }
+        }
+        CommitStatus::Completed => {
+            commit_flag
+                .write_status(&CommitStatus::Completed)
+                .with_context(|| {
+                    commit_flag.log_reset_instruction();
+                    "Failed to write `COMPLETED` status after successful user commit"
+                })?;
+            debug_assert_eq!(commit_flag.read_status()?, CommitStatus::Completed);
+        }
+    }
+
+    Ok(())
+}
+
 /// Contains all the most recent rollup data.
 pub struct NomtStateDb<H> {
     user: Nomt<BinaryHasher<H>>,
     kernel: Nomt<BinaryHasher<H>>,
-    commit_flag: CommitFlag,
 }
 
 impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtStateDb<H> {
     /// Initialize a new [` NomtStateDb `] in the given path.
-    pub fn new(config: RollupDbConfig) -> anyhow::Result<Self> {
-        let commit_flag = CommitFlag::new(&config.path);
-
+    pub fn new(config: RollupDbConfig, commit_flag: &CommitFlag) -> anyhow::Result<Self> {
         tracing::debug!(options = ?config, "Opening NOMT");
 
         let kernel = {
@@ -34,126 +127,45 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
             Nomt::<BinaryHasher<H>>::open(opts)?
         };
 
-        match commit_flag.read_status()? {
-            CommitStatus::InProgress(detected_root_hash) => {
-                let current_kernel_root_hash = kernel.root().into_inner();
-                tracing::warn!(
-                    flag_kernel_root_hash = hex::encode(detected_root_hash),
-                    db_kernel_root_hash = hex::encode(current_kernel_root_hash),
-                    "Detected in-progress commit. Rolling back kernel DB."
-                );
-                if current_kernel_root_hash != detected_root_hash {
-                    anyhow::bail!("Unsafe to perform rollback, status root hash {} does not match database {}. Manual intervention is needed",
-                        hex::encode(detected_root_hash),
-                        hex::encode(current_kernel_root_hash),
-                    );
-                }
-                kernel
-                    .rollback(1)
-                    .context("Failed to rollback kernel DB after in-progress commit detected")?;
-                commit_flag
-                    .write_status(CommitStatus::Completed)
-                    .with_context(|| {
-                        commit_flag.log_reset_instruction();
-                        "Failed to write `COMPLETED` status after rollback. Manual intervention required."
-                    })?;
-                let rolled_back_root_hash = kernel.root().into_inner();
-                tracing::info!(
-                    from_root_hash = hex::encode(current_kernel_root_hash),
-                    to_root_hash = hex::encode(rolled_back_root_hash),
-                    "Kernel namespace rollback completed"
-                );
-            }
-            CommitStatus::Completed => {
-                tracing::trace!("Commit flag is `Completed`, proceeding as usual");
-            }
-        }
+        validate_commit_flag(commit_flag, &kernel)?;
 
         let user = {
             let opts = config.get_user_options();
             Nomt::<BinaryHasher<H>>::open(opts)?
         };
 
-        Ok(Self {
-            user,
-            kernel,
-            commit_flag,
-        })
+        Ok(Self { user, kernel })
     }
 
     /// Commit [`StateOverlay`] to disk.
     #[tracing::instrument(skip_all)]
-    pub(crate) fn commit(&self, overlay: StateOverlay) -> anyhow::Result<MerklizedCommitMetric> {
+    pub(crate) fn commit(
+        &self,
+        overlay: StateOverlay,
+        commit_flag: &CommitFlag,
+    ) -> anyhow::Result<MerklizedCommitMetric> {
         let start = std::time::Instant::now();
         let StateOverlay { user, kernel } = overlay;
         // Status should be completed before committing.
         let flag_prepare_start = std::time::Instant::now();
-        debug_assert_eq!(self.commit_flag.read_status()?, CommitStatus::Completed);
+        debug_assert_eq!(commit_flag.read_status()?, CommitStatus::Completed);
 
         let in_progress_commit_status = CommitStatus::InProgress(kernel.root().into_inner());
         let flag_prepare = flag_prepare_start.elapsed();
 
-        let start_kernel = std::time::Instant::now();
-        {
-            let _span = tracing::debug_span!("namespace_commit", namespace = "kernel").entered();
-            kernel
-                .commit(&self.kernel)
-                .context("kernel namespace commit")?;
-        };
-        let write_kernel = start_kernel.elapsed();
-
-        // If the kernel commit fails, the flag is untouched, meaning DB remains synced on previous state.
-        // Write IN-PROGRESS status after kernel committed successfully.
+        let write_kernel = self.commit_kernel(kernel)?;
 
         let flag_mid_start = std::time::Instant::now();
-        // 2. Kernel commit succeeded. Try to set flag to IN-PROGRESS.
-        if let Err(flag_write_err) = self.commit_flag.write_status(in_progress_commit_status) {
-            // CRITICAL: Kernel committed, but couldn't write IN-PROGRESS flag.
-            // Try to roll back the kernel commit to revert to a consistent state.
-            // Failures here are more likely to be due to persistent disk issues (full, I/O errors, permissions).
-            tracing::error!(
-                error = ?flag_write_err,
-                "Kernel commit succeeded, but failed to write IN-PROGRESS flag: Attempting kernel rollback.",
-            );
-            if let Err(rollback_err) = self.kernel.rollback(1) {
-                // DISASTER: Kernel committed, flag is still COMPLETED, and kernel rollback FAILED.
-                // The database is in an inconsistent state that cannot be automatically recovered by this logic.
-                // Propagate a combined error. This situation likely requires manual intervention or node reset.
-                return Err(anyhow::anyhow!(
-                "CRITICAL INCONSISTENCY: Kernel committed, but failed to write IN-PROGRESS flag ({:?}), \
-                 AND subsequent kernel rollback also failed ({:?}). Manual intervention required.",
-                flag_write_err,
-                rollback_err
-            ));
-            }
-            // Kernel rollback succeeded.
-            // The DB is back to its state before this commit attempt.
-            // Return an error indicating the flag write failure, but state is consistent.
-            tracing::warn!("Kernel rollback succeeded after IN-PROGRESS flag write failure. DB state is consistent with previous version, but flag does not match. Manual intervention required.");
-            return Err(flag_write_err).with_context(|| {
-                self.commit_flag.log_reset_instruction();
-                "Failed to write IN-PROGRESS status after kernel commit; kernel was rolled back, but flag does not match. Manual intervention required."
-            });
-        }
+        save_commit_status(commit_flag, &in_progress_commit_status, &self.kernel)?;
 
-        debug_assert_eq!(self.commit_flag.read_status()?, in_progress_commit_status);
+        debug_assert_eq!(commit_flag.read_status()?, in_progress_commit_status);
         let flag_mid = flag_mid_start.elapsed();
 
-        let start_user = std::time::Instant::now();
-        {
-            let _span = tracing::debug_span!("namespace_commit", namespace = "user").entered();
-            user.commit(&self.user).context("user namespace commit")?;
-        };
-        let write_user = start_user.elapsed();
+        let write_user = self.commit_user(user)?;
 
         let flag_finish_start = std::time::Instant::now();
-        self.commit_flag
-            .write_status(CommitStatus::Completed)
-            .with_context(|| {
-                self.commit_flag.log_reset_instruction();
-                "Failed to write `COMPLETED` status after successful user commit"
-            })?;
-        debug_assert_eq!(self.commit_flag.read_status()?, CommitStatus::Completed);
+        save_commit_status(commit_flag, &CommitStatus::Completed, &self.kernel)?;
+
         let flag_finish = flag_finish_start.elapsed();
         let total = start.elapsed();
         Ok(MerklizedCommitMetric {
@@ -168,14 +180,37 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
         })
     }
 
+    fn commit_kernel(&self, kernel: Overlay) -> anyhow::Result<Duration> {
+        let start_kernel = std::time::Instant::now();
+        {
+            let _span = tracing::debug_span!("namespace_commit", namespace = "kernel").entered();
+            kernel
+                .commit(&self.kernel)
+                .context("kernel namespace commit")?;
+        };
+        let write_kernel = start_kernel.elapsed();
+        Ok(write_kernel)
+    }
+
+    fn commit_user(&self, user: Overlay) -> anyhow::Result<Duration> {
+        let start_user = std::time::Instant::now();
+        {
+            let _span = tracing::debug_span!("namespace_commit", namespace = "user").entered();
+            user.commit(&self.user).context("kernel namespace commit")?;
+        };
+        let write_user = start_user.elapsed();
+        Ok(write_user)
+    }
+
     /// Commit [`crate::storage_manager::StateFinishedSession`] to disk.
     #[cfg(feature = "test-utils")]
     pub fn commit_change_set(
         &self,
         session: crate::storage_manager::StateFinishedSession,
+        commit_flag: &CommitFlag,
     ) -> anyhow::Result<MerklizedCommitMetric> {
         let overlay = session.into_state_overlay();
-        self.commit(overlay)
+        self.commit(overlay, commit_flag)
     }
 
     pub(crate) fn full_rollback(&self) -> anyhow::Result<()> {
@@ -479,7 +514,8 @@ mod tests {
     fn test_session_can_be_built_while_finalized() {
         let temp_dir = tempfile::tempdir().unwrap();
         let config = RollupDbConfig::default_in_path(temp_dir.path().to_path_buf());
-        let state_db = Arc::new(NomtStateDb::<H>::new(config).unwrap());
+        let commit_flag = CommitFlag::new(&config.path);
+        let state_db = Arc::new(NomtStateDb::<H>::new(config, &commit_flag).unwrap());
 
         // First produce some overlays with data
         let all_overlays: HashMap<u64, StateOverlay> = HashMap::new();
@@ -532,7 +568,7 @@ mod tests {
             drop(kernel_session);
             let mut overlays = all_overlays.write().unwrap();
             let overlay = overlays.remove(&commiting_ref).unwrap();
-            state_db.commit(overlay).unwrap();
+            state_db.commit(overlay, &commit_flag).unwrap();
         }
     }
 
@@ -584,7 +620,8 @@ mod tests {
         )];
 
         let config = RollupDbConfig::default_in_path(temp_dir.path().to_path_buf());
-        let state_db = Arc::new(NomtStateDb::<H>::new(config).unwrap());
+        let commit_flag = CommitFlag::new(&config.path);
+        let state_db = Arc::new(NomtStateDb::<H>::new(config, &commit_flag).unwrap());
 
         let all_overlays: HashMap<u64, StateOverlay> = HashMap::new();
         let all_overlays = Arc::new(RwLock::new(all_overlays));
@@ -604,7 +641,7 @@ mod tests {
             let finished_kernel_session = kernel_session.finish(initial_kernel_writes).unwrap();
             let overlay = StateFinishedSession::new(finished_user_session, finished_kernel_session)
                 .into_state_overlay();
-            state_db.commit(overlay).unwrap();
+            state_db.commit(overlay, &commit_flag).unwrap();
         }
 
         // Base overlays
@@ -651,7 +688,7 @@ mod tests {
 
         base_kernel_overlay.commit(&state_db.kernel).unwrap();
 
-        let test_commit_result = state_db.commit(test_overlay);
+        let test_commit_result = state_db.commit(test_overlay, &commit_flag);
         assert!(test_commit_result.is_err());
 
         base_user_overlay.commit(&state_db.user).unwrap();
@@ -659,7 +696,9 @@ mod tests {
         // Reopen the state db.
         drop(state_db);
         let config = RollupDbConfig::default_in_path(temp_dir.path().to_path_buf());
-        let state_db = Arc::new(NomtStateDb::<H>::new(config).unwrap());
+
+        let commit_flag = CommitFlag::new(&config.path);
+        let state_db = Arc::new(NomtStateDb::<H>::new(config, &commit_flag).unwrap());
 
         let builder =
             NomtSessionBuilder::<H, u64>::new(state_db.clone(), Vec::new(), all_overlays.clone());

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -95,11 +95,11 @@ where
             .flat_state
             .commit(historical_state, &self.commit_flag)?;
 
-        let accessory_commit = self.commit_accessory(&accessory)?;
-        let ledger_commit = self.commit_ledger(&ledger)?;
-
         self.commit_flag
             .save_commit_status(&CommitStatus::Success)?;
+
+        let accessory_commit = self.commit_accessory(&accessory)?;
+        let ledger_commit = self.commit_ledger(&ledger)?;
 
         let merklized_commit_from_caller = merklized_commit.total;
         let commit_detailed_metrics = CommitDetailedMetric {
@@ -121,7 +121,7 @@ where
 
     fn commit_accessory(&self, accessory: &SchemaBatch) -> anyhow::Result<Duration> {
         let accessory_start = std::time::Instant::now();
-        self.accessory.write_schemas(&accessory)?;
+        self.accessory.write_schemas(accessory)?;
         Ok(accessory_start.elapsed())
     }
 
@@ -129,7 +129,7 @@ where
         let ledger_start = std::time::Instant::now();
         // Ledger goes after last, as its data is used during the start.
         // So if ledger save failed, state and accessory will be synced from DA
-        self.ledger.write_schemas(&ledger)?;
+        self.ledger.write_schemas(ledger)?;
         Ok(ledger_start.elapsed())
     }
 

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -1,4 +1,4 @@
-use crate::commit_flag::CommitFlag;
+use crate::commit_flag::{CommitFlag, CommitStatus};
 use crate::flat_db::DbCache;
 use std::any::Any;
 use std::collections::HashMap;
@@ -22,7 +22,6 @@ use crate::namespaces::{KernelNamespace, UserNamespace};
 use crate::pruner::Pruner;
 use crate::schema::namespace::NomtStateValues;
 use crate::schema::tables::ModuleAccessoryState;
-use crate::schema::tables::StateRootHashes;
 use crate::state_db_nomt::{NomtSessionBuilder, NomtStateDb, StateOverlay};
 use crate::storage_manager::{update_ledger_finalized_height, InitializableNativeNomtStorage};
 
@@ -52,19 +51,22 @@ where
         let separate_archival_state = config.separate_archival_state;
 
         let commit_flag = CommitFlag::new(&config.path);
-        let state_db = NomtStateDb::<H>::new(config, &commit_flag)?;
+        let merklized_state = NomtStateDb::<H>::new(config)?;
+        let flat_state = FlatStateDb::new(path.clone(), state_cache_size, separate_archival_state)?;
+
+        // Validate the commit state.
+        merklized_state.validate_commit_flag_and_rollback_if_necssesary(&commit_flag)?;
+
+        // Validate root hashes.
+        Self::are_root_hashes_match(&merklized_state, &flat_state)?;
+
         let accessory_rocksdb =
             AccessoryDb::get_rockbound_options().default_setup_db_in_path(&path)?;
         let ledger_rocksdb = LedgerDb::get_rockbound_options().default_setup_db_in_path(&path)?;
-        let flat_state = FlatStateDb::new(path, state_cache_size, separate_archival_state)?;
-
-        let root_hash_reader = DeltaReader::new(flat_state.get_db(), vec![]);
-        // TODO
-        let _last_root_hash = root_hash_reader.get_largest::<StateRootHashes>()?;
 
         Ok(Self {
             commit_flag,
-            merklized_state: Arc::new(state_db),
+            merklized_state: Arc::new(merklized_state),
             flat_state,
             accessory: Arc::new(accessory_rocksdb),
             ledger: Arc::new(ledger_rocksdb),
@@ -73,6 +75,8 @@ where
     }
 
     pub(crate) fn commit(&mut self, group: CommitGroup) -> anyhow::Result<()> {
+        // The last commit had to be successful.
+        debug_assert_eq!(&self.commit_flag.read_status()?, &CommitStatus::Success);
         let CommitGroup {
             nomt: state,
             rockbound:
@@ -84,13 +88,16 @@ where
         } = group;
 
         let merklized_start = std::time::Instant::now();
-        // Note: failure handling and data recovery will be implemented later.
 
         let merklized_commit = self.merklized_state.commit(state, &self.commit_flag)?;
         let merklized_commit_from_caller = merklized_start.elapsed();
         // Historical data is committed after merklized state, as in case of failure, it can be synced from the normal state,
         // as it duplicates the last written data to `self.state`.
-        let flat_metrics = self.flat_state.commit(historical_state)?;
+
+        let flat_metrics = self
+            .flat_state
+            .commit(historical_state, &self.commit_flag)?;
+
         let accessory_start = std::time::Instant::now();
         self.accessory.write_schemas(&accessory)?;
         let accessory_commit = accessory_start.elapsed();
@@ -100,6 +107,9 @@ where
         // So if ledger save failed, state and accessory will be synced from DA
         self.ledger.write_schemas(&ledger)?;
         let ledger_commit = ledger_start.elapsed();
+
+        self.commit_flag
+            .save_commit_status(&CommitStatus::Success)?;
 
         let commit_detailed_metrics = CommitDetailedMetric {
             merklized_commit,
@@ -322,11 +332,14 @@ where
         }
     }
 
-    fn are_root_hashes_match(&self) -> anyhow::Result<bool> {
+    fn are_root_hashes_match(
+        merklized_state: &NomtStateDb<H>,
+        flat_state: &FlatStateDb,
+    ) -> anyhow::Result<bool> {
         let historical_state_delta_reader =
-            DeltaReader::new(self.flat_state.live_db.clone(), Vec::new());
+            DeltaReader::new(flat_state.live_db.clone(), Vec::new());
 
-        let nomt_root_hashes = self.merklized_state.get_root_hashes();
+        let nomt_root_hashes = merklized_state.get_root_hashes();
         let last_version =
             HistoricalStateReader::last_version_from_reader(&historical_state_delta_reader)?;
 
@@ -361,20 +374,6 @@ where
                 Ok(nomt_root_hashes.included_in_raw(&state_root_rocksdb))
             }
         }
-    }
-
-    pub(crate) fn verify_and_fix_commited_root_hashes(&self) -> anyhow::Result<()> {
-        if !self.are_root_hashes_match()? {
-            tracing::warn!("Historical state root hashes are not equal to NOMT state root hashes, attempt to fix it");
-            self.merklized_state.full_rollback()?;
-            if !self.are_root_hashes_match()? {
-                return Err(anyhow::anyhow!("Fix didn't help, historical state root hashes are not equal to NOMT state root hashes. Manual intervention is required."));
-            }
-            tracing::info!(
-                "Historical state root hashes are equal to NOMT state root hashes, fix applied"
-            );
-        }
-        Ok(())
     }
 }
 

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -1,3 +1,4 @@
+use crate::commit_flag::CommitFlag;
 use crate::flat_db::DbCache;
 use std::any::Any;
 use std::collections::HashMap;
@@ -21,6 +22,7 @@ use crate::namespaces::{KernelNamespace, UserNamespace};
 use crate::pruner::Pruner;
 use crate::schema::namespace::NomtStateValues;
 use crate::schema::tables::ModuleAccessoryState;
+use crate::schema::tables::StateRootHashes;
 use crate::state_db_nomt::{NomtSessionBuilder, NomtStateDb, StateOverlay};
 use crate::storage_manager::{update_ledger_finalized_height, InitializableNativeNomtStorage};
 
@@ -31,6 +33,7 @@ const GIGABYTE: usize = 1024 * 1024 * 1024;
 pub(crate) const DEFAULT_MAX_PRUNING_BATCH_SIZE: usize = 300_000;
 
 pub(crate) struct DbGroup<H, K> {
+    commit_flag: CommitFlag,
     merklized_state: Arc<NomtStateDb<H>>,
     flat_state: FlatStateDb,
     accessory: Arc<rockbound::DB>,
@@ -47,12 +50,20 @@ where
         let path = config.path.clone();
         let state_cache_size = config.state_cache_size.unwrap_or(GIGABYTE);
         let separate_archival_state = config.separate_archival_state;
-        let state_db = NomtStateDb::<H>::new(config)?;
+
+        let commit_flag = CommitFlag::new(&config.path);
+        let state_db = NomtStateDb::<H>::new(config, &commit_flag)?;
         let accessory_rocksdb =
             AccessoryDb::get_rockbound_options().default_setup_db_in_path(&path)?;
         let ledger_rocksdb = LedgerDb::get_rockbound_options().default_setup_db_in_path(&path)?;
         let flat_state = FlatStateDb::new(path, state_cache_size, separate_archival_state)?;
+
+        let root_hash_reader = DeltaReader::new(flat_state.get_db(), vec![]);
+        // TODO
+        let _last_root_hash = root_hash_reader.get_largest::<StateRootHashes>()?;
+
         Ok(Self {
+            commit_flag,
             merklized_state: Arc::new(state_db),
             flat_state,
             accessory: Arc::new(accessory_rocksdb),
@@ -74,7 +85,8 @@ where
 
         let merklized_start = std::time::Instant::now();
         // Note: failure handling and data recovery will be implemented later.
-        let merklized_commit = self.merklized_state.commit(state)?;
+
+        let merklized_commit = self.merklized_state.commit(state, &self.commit_flag)?;
         let merklized_commit_from_caller = merklized_start.elapsed();
         // Historical data is committed after merklized state, as in case of failure, it can be synced from the normal state,
         // as it duplicates the last written data to `self.state`.

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -55,7 +55,7 @@ where
         let flat_state = FlatStateDb::new(path.clone(), state_cache_size, separate_archival_state)?;
 
         // Validate the commit state.
-        merklized_state.validate_commit_flag_and_rollback_if_necssesary(&commit_flag)?;
+        merklized_state.validate_commit_flag_and_rollback_if_necessesary(&commit_flag)?;
 
         // Validate root hashes.
         Self::are_root_hashes_match(&merklized_state, &flat_state)?;

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -59,6 +59,7 @@ where
 
         // Validate root hashes.
         Self::are_root_hashes_match(&merklized_state, &flat_state)?;
+        commit_flag.save_commit_status(&CommitStatus::Success)?;
 
         let accessory_rocksdb =
             AccessoryDb::get_rockbound_options().default_setup_db_in_path(&path)?;

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::{Arc, RwLock};
 use std::thread::JoinHandle;
+use std::time::Duration;
 
 use anyhow::Context;
 use rockbound::cache::delta_reader::DeltaReader;
@@ -88,28 +89,19 @@ where
                 },
         } = group;
 
-        let merklized_start = std::time::Instant::now();
-
         let merklized_commit = self.merklized_state.commit(state, &self.commit_flag)?;
-        let merklized_commit_from_caller = merklized_start.elapsed();
 
         let flat_metrics = self
             .flat_state
             .commit(historical_state, &self.commit_flag)?;
 
-        let accessory_start = std::time::Instant::now();
-        self.accessory.write_schemas(&accessory)?;
-        let accessory_commit = accessory_start.elapsed();
-
-        let ledger_start = std::time::Instant::now();
-        // Ledger goes after last, as its data is used during the start.
-        // So if ledger save failed, state and accessory will be synced from DA
-        self.ledger.write_schemas(&ledger)?;
-        let ledger_commit = ledger_start.elapsed();
+        let accessory_commit = self.commit_accessory(&accessory)?;
+        let ledger_commit = self.commit_ledger(&ledger)?;
 
         self.commit_flag
             .save_commit_status(&CommitStatus::Success)?;
 
+        let merklized_commit_from_caller = merklized_commit.total;
         let commit_detailed_metrics = CommitDetailedMetric {
             merklized_commit,
             merklized_commit_from_caller,
@@ -125,6 +117,20 @@ where
         self.merklized_state.send_metrics();
 
         Ok(())
+    }
+
+    fn commit_accessory(&self, accessory: &SchemaBatch) -> anyhow::Result<Duration> {
+        let accessory_start = std::time::Instant::now();
+        self.accessory.write_schemas(&accessory)?;
+        Ok(accessory_start.elapsed())
+    }
+
+    fn commit_ledger(&self, ledger: &SchemaBatch) -> anyhow::Result<Duration> {
+        let ledger_start = std::time::Instant::now();
+        // Ledger goes after last, as its data is used during the start.
+        // So if ledger save failed, state and accessory will be synced from DA
+        self.ledger.write_schemas(&ledger)?;
+        Ok(ledger_start.elapsed())
     }
 
     // Flush pruning schema batches to disk.

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -91,8 +91,6 @@ where
 
         let merklized_commit = self.merklized_state.commit(state, &self.commit_flag)?;
         let merklized_commit_from_caller = merklized_start.elapsed();
-        // Historical data is committed after merklized state, as in case of failure, it can be synced from the normal state,
-        // as it duplicates the last written data to `self.state`.
 
         let flat_metrics = self
             .flat_state

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -138,8 +138,6 @@ where
             "Pruner versions to keep should be at least 1, got {pruner_versions_to_keep}",
         );
         let db_group = DbGroup::new(config)?;
-
-        db_group.verify_and_fix_commited_root_hashes()?;
         db_group.update_ledger_finalized_height()?;
 
         Ok(Self {

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/tests.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/tests.rs
@@ -10,6 +10,7 @@ use sov_rollup_interface::storage::HierarchicalStorageManager;
 
 use super::{NomtChangeSet, NomtStorageManager, StateFinishedSession};
 use crate::accessory_db::AccessoryDb;
+use crate::commit_flag::CommitFlag;
 use crate::config::RollupDbConfig;
 use crate::historical_state::HistoricalStateReader;
 use crate::schema::types::slot_key::{SlotKey, SlotValue};
@@ -396,7 +397,8 @@ async fn test_root_hashes_match_after_crash() {
     // Writing extra data to NOMT, both namespaces.
     // Since changes for both namespaces are always provided.
     {
-        let nomt = Arc::new(NomtStateDb::<H>::new(config.clone()).unwrap());
+        let commit_flag = CommitFlag::new(&config.path);
+        let nomt = Arc::new(NomtStateDb::<H>::new(config.clone(), &commit_flag).unwrap());
 
         let the_last_block = MockBlockHeader::from_height(blocks);
 
@@ -418,7 +420,8 @@ async fn test_root_hashes_match_after_crash() {
 
         let state_finished_session =
             StateFinishedSession::new(finished_user_session, finished_kernel_session);
-        nomt.commit_change_set(state_finished_session).unwrap();
+        nomt.commit_change_set(state_finished_session, &commit_flag)
+            .unwrap();
     }
 
     let mut storage_manager =

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/tests.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/tests.rs
@@ -398,7 +398,7 @@ async fn test_root_hashes_match_after_crash() {
     // Since changes for both namespaces are always provided.
     {
         let commit_flag = CommitFlag::new(&config.path);
-        let nomt = Arc::new(NomtStateDb::<H>::new(config.clone(), &commit_flag).unwrap());
+        let nomt = Arc::new(NomtStateDb::<H>::new(config.clone()).unwrap());
 
         let the_last_block = MockBlockHeader::from_height(blocks);
 

--- a/crates/utils/sov-test-utils/src/storage.rs
+++ b/crates/utils/sov-test-utils/src/storage.rs
@@ -170,7 +170,7 @@ impl<S: MerkleProofSpec> SimpleNomtStorageManager<S> {
         let config = RollupDbConfig::default_in_path(dir.path().to_path_buf());
 
         let commit_flag = CommitFlag::new(&config.path);
-        let state_db = sov_db::state_db_nomt::NomtStateDb::new(config, &commit_flag)
+        let state_db = sov_db::state_db_nomt::NomtStateDb::new(config)
             .expect("Failed to initialize StateDb for NOMT");
         let historical_state = FlatStateDb::new(dir.path().to_path_buf(), 1_000_000, true).unwrap(); // Use a 1MB state cache for tests
         let accessory_rocksdb = AccessoryDb::get_rockbound_options()
@@ -247,7 +247,10 @@ impl<S: MerkleProofSpec> SimpleNomtStorageManager<S> {
         tracing::trace!("Committed state changes to disk");
         self.accessory.write_schemas(&accessory).unwrap();
         tracing::trace!("Committed accessory changes to disk");
-        self.historical_state.commit(historical_state).unwrap();
+        self.historical_state
+            .commit(historical_state, &self.commit_flag)
+            .unwrap();
+
         *self.pinned_cache.lock().unwrap() = pinned_cache.map(|c| *c.downcast().expect("Failed to downcast the pinned_cache argument to `NomtProverStorage`. This is a bug. Please report it."));
         tracing::trace!("Committed historical state changes to disk");
         tracing::trace!("Committed all changes to disk");

--- a/crates/utils/sov-test-utils/src/storage.rs
+++ b/crates/utils/sov-test-utils/src/storage.rs
@@ -6,6 +6,7 @@ use rockbound::cache::delta_reader::DeltaReader;
 use rockbound::versioned_db::VersionedDeltaReader;
 use rockbound::SchemaBatch;
 use sov_db::accessory_db::AccessoryDb;
+use sov_db::commit_flag::CommitFlag;
 use sov_db::config::RollupDbConfig;
 use sov_db::historical_state::HistoricalStateReader;
 use sov_db::ledger_db::LedgerDb;
@@ -159,6 +160,7 @@ pub struct SimpleNomtStorageManager<S: MerkleProofSpec> {
     root: StorageRoot<S>,
     is_strict_mode: bool,
     pinned_cache: Mutex<Option<PinnedCache>>,
+    commit_flag: CommitFlag,
 }
 
 impl<S: MerkleProofSpec> SimpleNomtStorageManager<S> {
@@ -166,7 +168,9 @@ impl<S: MerkleProofSpec> SimpleNomtStorageManager<S> {
     pub fn new() -> Self {
         let dir = tempfile::tempdir().unwrap();
         let config = RollupDbConfig::default_in_path(dir.path().to_path_buf());
-        let state_db = sov_db::state_db_nomt::NomtStateDb::new(config)
+
+        let commit_flag = CommitFlag::new(&config.path);
+        let state_db = sov_db::state_db_nomt::NomtStateDb::new(config, &commit_flag)
             .expect("Failed to initialize StateDb for NOMT");
         let historical_state = FlatStateDb::new(dir.path().to_path_buf(), 1_000_000, true).unwrap(); // Use a 1MB state cache for tests
         let accessory_rocksdb = AccessoryDb::get_rockbound_options()
@@ -181,6 +185,7 @@ impl<S: MerkleProofSpec> SimpleNomtStorageManager<S> {
             root: <NomtProverStorage<S, TestSlotHash> as Storage>::PRE_GENESIS_ROOT,
             is_strict_mode: true,
             pinned_cache: Mutex::new(None),
+            commit_flag,
         }
     }
 
@@ -236,7 +241,9 @@ impl<S: MerkleProofSpec> SimpleNomtStorageManager<S> {
             pinned_cache,
         } = stf_change_set;
 
-        self.state.commit_change_set(state).unwrap();
+        self.state
+            .commit_change_set(state, &self.commit_flag)
+            .unwrap();
         tracing::trace!("Committed state changes to disk");
         self.accessory.write_schemas(&accessory).unwrap();
         tracing::trace!("Committed accessory changes to disk");


### PR DESCRIPTION
# Description

This PR adds tracking for DB commit status.

Previously, the `CommitFlag` mechanism saved the `CommitStatus` to a file, but it had two major limitations:
1. It did not cover all possible database shutdown scenarios.
2. The flag was written after committing a specific DB. It is now written before the commit, which simplifies error handling.

The `CommitStatus` is now written to a file in the `DbGroup::commit` method, and recovery is performed in `NomtStateDb::`validate_commit_flag_and_rollback_if_necssesary.

Unit tests will be included in a follow-up PR.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)



## Linked Issues
- Related to #2267