### PR TITLE
Remove spurious error log from sequencer/ready/ endpoint

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -418,7 +418,6 @@ where
         // is AT LEAST 1. Meaning, as long as we're stuck at genesis, we can't
         // accept any transactions.
         if self.latest_info.latest_finalized_slot_number == SlotNumber::GENESIS {
-            tracing::error!("Timed out while waiting for the node to progress beyond genesis. The sequencer can't accept transactions until that happens");
             return Err(SequencerNotReadyDetails::WaitingOnDa {
                 finalized_slot_number: SlotNumber::GENESIS,
                 needed_finalized_slot_number: SlotNumber::new(1),


### PR DESCRIPTION
# Description

As far as I can tell `check_readiness()` is only called from the readiness API or from accept_tx(). Not being ready yet is not an error condition.

Removing this silences some logs when polling readiness on startup in tests (in particular in the rollup manager's upgrade tests)

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
