### PR TITLE
Exit soak worker without error when stop height is detected

### DIFF
--- a/crates/utils/sov-soak-testing-lib/src/lib.rs
+++ b/crates/utils/sov-soak-testing-lib/src/lib.rs
@@ -34,6 +34,20 @@ use sov_transaction_generator::interface::MessageValidity;
 use sov_transaction_generator::{Distribution, GeneratedMessage, Percent, State};
 use tokio::sync::watch::Receiver;
 
+/// The message substring that indicates the sequencer has reached its configured stop height.
+const STOP_HEIGHT_ERROR_MARKER: &str = "The preferred sequencer has reached the stop height ";
+
+/// Checks if an API error indicates the sequencer has reached its configured stop height.
+/// When a rollup is configured with a stop height, transactions are rejected once that height
+/// is reached. This is not a real error condition for soak tests.
+fn is_stop_height_error(err: &sov_api_spec::Error<sov_api_spec::types::ApiError>) -> bool {
+    if let sov_api_spec::Error::ErrorResponse(response) = err {
+        // ResponseValue<T> implements Deref<Target = T>, so we can access ApiError fields directly
+        return response.message.contains(STOP_HEIGHT_ERROR_MARKER);
+    }
+    false
+}
+
 pub const DEFAULT_BLOCK_TIME_MS: u64 = 200;
 pub const DEFAULT_BLOCK_PRODUCING_CONFIG: BlockProducingConfig = BlockProducingConfig::Periodic {
     block_time_ms: DEFAULT_BLOCK_TIME_MS,
@@ -411,14 +425,27 @@ async fn prepare_and_send_txs<R: Runtime<S> + Clone, S: Spec>(
         let start = std::time::Instant::now();
         for (tx, is_invalid) in &txns {
             if *is_invalid {
-                client
-                    .send_tx_to_sequencer(tx)
-                    .await
-                    .expect_err("Outdated transaction should have failed");
-            } else if use_retries {
-                client.send_tx_to_sequencer_with_retry(tx).await?;
+                if client.send_tx_to_sequencer(tx).await.is_ok() {
+                    anyhow::bail!("Outdated transaction should have failed");
+                }
             } else {
-                client.send_tx_to_sequencer(tx).await?;
+                // Always try a fail-fast call first to check for stop height error
+                match client.send_tx_to_sequencer(tx).await {
+                    Ok(_) => {}
+                    Err(err) if is_stop_height_error(&err) => {
+                        tracing::info!(
+                            "Sequencer reached stop height, gracefully stopping soak worker"
+                        );
+                        return Ok(());
+                    }
+                    Err(_) if use_retries => {
+                        // First attempt failed with a non-stop-height error, kick off retries
+                        client.send_tx_to_sequencer_with_retry(tx).await?;
+                    }
+                    Err(err) => {
+                        return Err(err.into());
+                    }
+                }
             }
             total_txns += 1;
         }


### PR DESCRIPTION
# Description

When a rollup reaches the stop height, e.g. during acceptance testing or upgrade testing, transaction submission failing is expected and is not an error case.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
