### PR TITLE
Building nomt actuals before starting the session.

### DIFF
--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -270,7 +270,6 @@ where
 }
 
 fn to_nomt_accesses<S: MerkleProofSpec>(
-    session: &NomtSession<S::Hasher>,
     sov_accesses: &OrderedReadsAndWrites,
 ) -> anyhow::Result<Vec<(nomt::trie::KeyPath, nomt::KeyReadWrite)>> {
     let mut merged_accesses: BTreeMap<nomt::trie::KeyPath, nomt::KeyReadWrite> = BTreeMap::new();
@@ -284,11 +283,6 @@ fn to_nomt_accesses<S: MerkleProofSpec>(
     for (key, read_node_leaf) in ordered_reads {
         // Reads are warmed up during normal `get/get_leaf`
         let key_hash: nomt::trie::KeyPath = S::Hasher::digest(key.as_ref()).into();
-        // From documentation:
-        // > This should be called for every logical write within the session, as well as every
-        // > logical read if you expect to generate a merkle proof for the session.
-        // So warming up all reads.
-        session.warm_up(key_hash);
 
         let combined_hash_and_size =
             read_node_leaf.map(|node_leaf| node_leaf.combine_val_hash_and_size());
@@ -303,7 +297,6 @@ fn to_nomt_accesses<S: MerkleProofSpec>(
     // Writes
     for (key, original_write) in ordered_writes {
         let key_hash: nomt::trie::KeyPath = S::Hasher::digest(key.as_ref()).into();
-        session.warm_up(key_hash);
 
         let authenticated_write = original_write
             .as_ref()
@@ -312,7 +305,6 @@ fn to_nomt_accesses<S: MerkleProofSpec>(
         match merged_accesses.entry(key_hash) {
             Entry::Vacant(vacant) => {
                 // Also warming up all writes. `ReadThenWrite` has been warmed up during reads collection.
-                session.warm_up(key_hash);
                 vacant.insert(nomt::KeyReadWrite::Write(authenticated_write));
             }
             Entry::Occupied(occupied) => match occupied.remove() {
@@ -334,17 +326,12 @@ fn to_nomt_accesses<S: MerkleProofSpec>(
 
 fn compute_state_update_namespace<S: MerkleProofSpec>(
     session: NomtSession<S::Hasher>,
-    accesses: &OrderedReadsAndWrites,
+    accesses: Vec<(nomt::trie::KeyPath, nomt::KeyReadWrite)>,
     witness: &S::Witness,
     write_witness: bool,
 ) -> anyhow::Result<FinishedSession> {
-    tracing::trace!(
-        reads = accesses.ordered_reads.len(),
-        writes = accesses.ordered_writes.len(),
-        "compute state update"
-    );
-    let nomt_accesses = to_nomt_accesses::<S>(&session, accesses)?;
-    let mut finished = session.finish(nomt_accesses)?;
+    tracing::trace!(accesses = accesses.len(), "compute state update");
+    let mut finished = session.finish(accesses)?;
     if write_witness {
         let nomt_witness = finished.take_witness().expect("Witness cannot be missing");
         let nomt::Witness {
@@ -477,7 +464,13 @@ where
         pinned_cache: Option<PinnedCache>,
     ) -> anyhow::Result<(Self::Root, Self::StateUpdate)> {
         let start = std::time::Instant::now();
+        let nomt_accesses_user = to_nomt_accesses::<S>(&state_accesses.user)?;
+        let nomt_accesses_kernel = to_nomt_accesses::<S>(&state_accesses.kernel)?;
+        let accesses_build_time = start.elapsed();
+        tracing::trace!(time = ?accesses_build_time, "Nomt accesses are computed");
+
         let next_version = self.historical_state.get_next_version();
+        let start_session = std::time::Instant::now();
         // Open 2 sessions at the same time
         let SessionsContainer {
             user: user_session,
@@ -485,7 +478,7 @@ where
         } = self
             .state_session_builder
             .begin_both_sessions(self.strict_with_witness)?;
-        let starting_session_time = start.elapsed();
+        let starting_session_time = start_session.elapsed();
         tracing::debug!(%prev_state_root, %next_version, sesssion_starting_time = ?starting_session_time, "computing state update, sessions are live");
 
         let current_prev_user_root = user_session.prev_root().into_inner();
@@ -501,11 +494,12 @@ where
             );
         }
 
+        let sessions_start = std::time::Instant::now();
         let user_finished_session = {
             let _span = tracing::debug_span!("compute_state_update", namespace = "user").entered();
             compute_state_update_namespace::<S>(
                 user_session,
-                &state_accesses.user,
+                nomt_accesses_user,
                 witness,
                 self.strict_with_witness,
             )
@@ -516,12 +510,13 @@ where
                 tracing::debug_span!("compute_state_update", namespace = "kernel").entered();
             compute_state_update_namespace::<S>(
                 kernel_session,
-                &state_accesses.kernel,
+                nomt_accesses_kernel,
                 witness,
                 self.strict_with_witness,
             )
             .context("kernel state")?
         };
+        let finishing_session_time = sessions_start.elapsed();
 
         let user_reads = state_accesses.user.ordered_reads.len();
         let user_writes = state_accesses.user.ordered_writes.len();
@@ -559,7 +554,7 @@ where
         let kernel_root = kernel_finished_session.root();
         let root = StorageRoot::new(user_root.into_inner(), kernel_root.into_inner());
 
-        tracing::debug!(state_root = %root, %next_version, time = ?start.elapsed(), "computed next state root");
+        tracing::debug!(state_root = %root, %next_version, time = ?start.elapsed(), ?accesses_build_time, ?finishing_session_time, "computed next state root");
 
         let state_update = NomtStateUpdate {
             user: user_finished_session,


### PR DESCRIPTION
# Summary

This increases sequencer/node parallelism.

Before we've been starting the session and then building actuals, because we've been warming up the keys. Our belief is that warming up the keys that close to closing the session does not bring performance benefits.

Change in this PR allows node and sequencer doing the work of converting state accesses into nomt format before starting the session, so commit in the node will wait less.


## Detailed info

Inspired by this graph:

<img width="3814" height="1712" alt="image" src="https://github.com/user-attachments/assets/d46b86d5-0942-4210-a125-1442a04bf2f4" />

Main prediction: better p99/max for HTTP requests.

*(!) Note: When I've started soak on the branch with the same number of workers (500) TPS was lower. TBD: Why??

I've bumped number of workers to 600 to saturate the work. It is visible on TPS and other graphs.

## Summary of the metrics

* Improvement on HTTP response time across all percentiles
  * P99 on average from 320ms => 186ms
  * Max on average from 517ms => 338ms
  * Median on average from from 5.31ms => 5.71ms (slight increase)
* Faster node process (almost no lagging behind the chain)
* Looks like sequencer is busier, but I cannot pin-point exact places where

Both runs on the same dashboard: http://37.27.235.101:3000/d/felyiwu9uwao0d/sovereign-rollup-node-dashboard?var-agg_interval=$__auto&orgId=1&from=2025-12-30T19:40:00.000Z&to=2025-12-30T22:10:00.000Z&timezone=utc&var-DS=febnee4svq96of&var-LOKI_DS=del27k3a8i328f&var-bucket=sov-dev&var-host=i-0f89149356774d460&var-agg_func=p99

## Future work

* There's potential to improving building actuals for NOMT, but it will require adding metrics first:
  * trade memory for CPU: switch from Btree into Vec to Vec with .sort
  * Rewamp https://github.com/Sovereign-Labs/sovereign-sdk/pull/1761 and use more aggressive parallelization

## HTTP p99

**Before (dev)**

<img width="1902" height="850" alt="HTTP-p99-Before" src="https://github.com/user-attachments/assets/2ff71854-ed89-44e3-b041-630ca8e3a6f6" />

**After (this branch)**
<img width="1907" height="850" alt="HTTP-p99-After" src="https://github.com/user-attachments/assets/c7107d0b-e36b-42e7-aed7-4d70a8f7fdab" />

## HTTP Max

**Before (dev)**

<img width="1908" height="858" alt="HTTP-max-Before" src="https://github.com/user-attachments/assets/ecad5676-efb4-4559-af4e-185177c5f229" />

**After (this branch)**

<img width="1902" height="855" alt="HTTP-max-After" src="https://github.com/user-attachments/assets/e1a0b0eb-730b-4cb6-8f7c-b30f2ec9c7a0" />

## Commit time of storage manager

**Before (dev)**
<img width="1907" height="857" alt="Commit-Before" src="https://github.com/user-attachments/assets/5749ef84-49d1-40fd-9803-0b978cbaed5f" />

**After (this branch)**

<img width="1906" height="853" alt="Commit-After" src="https://github.com/user-attachments/assets/745c9643-56a6-4ded-a9c4-15195fed5984" />


## Other metrics (same graph)

<img width="1906" height="845" alt="TPS-Together" src="https://github.com/user-attachments/assets/1f1c8a46-9c50-43ba-8f5c-bf8f5037a5bd" />

<img width="636" height="385" alt="RunnerLoop-Together" src="https://github.com/user-attachments/assets/362351ca-aef1-4228-a784-502f2a617e9c" />

<img width="479" height="306" alt="SyncDistance-Together" src="https://github.com/user-attachments/assets/5eed99a1-f11b-45ca-9dfc-fe316c365ae1" />

<img width="958" height="385" alt="ComputeStateUpdate-Together" src="https://github.com/user-attachments/assets/a472798d-ba43-4a7c-9213-a6716a41796b" />

-----


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
Existing tests are passing

## Docs
No updates
