### PR TITLE
StorableMockDa: Bump logging and minor optimizations

### DIFF
--- a/crates/adapters/mock-da/src/storable/entity/blobs.rs
+++ b/crates/adapters/mock-da/src/storable/entity/blobs.rs
@@ -2,7 +2,7 @@
 use std::convert::TryInto;
 
 use sea_orm::entity::prelude::*;
-use sea_orm::Set;
+use sea_orm::{FromQueryResult, Set};
 
 use crate::storable::entity::{BATCH_NAMESPACE, PROOF_NAMESPACE};
 use crate::utils::hash_to_array;
@@ -25,6 +25,16 @@ pub struct Model {
     pub namespace: String,
     /// Who submitted it. Converted to `Vec<u8>` [`MockAddress`]
     pub sender: Vec<u8>,
+}
+
+/// Partial model excluding the large `data` field.
+/// Used to reduce IO when only metadata is needed.
+#[derive(Clone, Debug, FromQueryResult)]
+pub struct BlobHashData {
+    pub id: i32,
+    pub hash: Vec<u8>,
+    pub sender: Vec<u8>,
+    pub namespace: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -101,10 +101,11 @@ impl StorableMockDaLayer {
         &mut self,
         timestamp: sov_rollup_interface::da::Time,
     ) -> anyhow::Result<()> {
-        tracing::trace!(
+        let start = std::time::Instant::now();
+        tracing::debug!(
             next_height = self.next_height,
             ?timestamp,
-            "Start producing a new block at"
+            "Start producing a new block"
         );
         if self.next_height >= i32::MAX as u32 {
             anyhow::bail!("Due to database limitation cannot produce anymore blocks: {} is more than max supported height {}", self.next_height, i32::MAX);
@@ -150,11 +151,12 @@ impl StorableMockDaLayer {
         let block_model = block_headers::ActiveModel::from(new_head.clone());
         block_model.insert(&self.conn).await?;
         let _ = self.head_header_sender.send_replace(new_head);
-        tracing::trace!(
+        tracing::debug!(
             blobs_count,
             height = self.next_height,
             prev_hash = %HexHash::new(prev_block_hash),
             hash = %HexHash::new(this_block_hash),
+            producing_time = ?start.elapsed(),
             "New block has been produced"
         );
 
@@ -194,11 +196,12 @@ impl StorableMockDaLayer {
 
     /// Saves new block header into a database.
     pub async fn produce_block(&mut self) -> anyhow::Result<()> {
+        let timestamp = sov_rollup_interface::da::Time::now();
         tracing::trace!(
             next_height = self.next_height,
+            ?timestamp,
             "Produce block has been called"
         );
-        let timestamp = sov_rollup_interface::da::Time::now();
 
         // Temporarily remove the randomizer from `self` so it won't collide
         // with the &mut borrow needed in `produce_block`:
@@ -240,20 +243,22 @@ impl StorableMockDaLayer {
         batch_data: &[u8],
         sender: &MockAddress,
     ) -> anyhow::Result<MockHash> {
-        tracing::trace!(
+        tracing::debug!(
             batch_bytes = batch_data.len(),
             %sender,
             next_da_height = self.next_height,
             "Submitting batch is received"
         );
+        let start = std::time::Instant::now();
         let (blob, hash) = blobs::build_batch_blob(self.next_height as i32, batch_data, sender);
         blob.insert(&self.conn).await?;
         let include_at = self.next_height + self.delay_blobs_by;
-        tracing::trace!(
+        tracing::debug!(
             %hash,
             %sender,
             next_da_height = self.next_height,
             include_at = %include_at,
+            time = ?start.elapsed(),
             "Submitted batch is saved"
         );
         Ok(hash)
@@ -264,18 +269,20 @@ impl StorableMockDaLayer {
         proof_data: &[u8],
         sender: &MockAddress,
     ) -> anyhow::Result<MockHash> {
-        tracing::trace!(
+        tracing::debug!(
             proof_bytes = proof_data.len(),
             %sender,
             next_da_height = self.next_height,
             "Submitting proof is received"
         );
+        let start = std::time::Instant::now();
         let (blob, hash) = blobs::build_proof_blob(self.next_height as i32, proof_data, sender);
         blob.insert(&self.conn).await?;
         tracing::trace!(
             %hash,
             %sender,
             next_da_height = self.next_height,
+            time = ?start.elapsed(),
             "Submitted proof is saved"
         );
         Ok(hash)

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -6,7 +6,7 @@ use rand::prelude::{SliceRandom, SmallRng};
 use rand::{Rng, SeedableRng};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, Database, DatabaseConnection, EntityTrait, QueryFilter,
-    QueryOrder,
+    QueryOrder, QuerySelect,
 };
 use sha2::Digest;
 use sov_rollup_interface::common::{HexHash, HexString};
@@ -128,18 +128,25 @@ impl StorableMockDaLayer {
             GENESIS_HEADER.hash.0
         };
 
-        let blobs = Blobs::find()
+        let blobs_for_hash = Blobs::find()
             .filter(blobs::Column::BlockHeight.eq(self.next_height + self.delay_blobs_by))
+            .select_only()
+            .column(blobs::Column::Id)
+            .column(blobs::Column::Hash)
+            .column(blobs::Column::Sender)
+            .column(blobs::Column::Namespace)
+            .into_model::<blobs::BlobHashData>()
             .all(&self.conn)
             .await?;
-        let blobs_count = blobs.len();
+        let blobs_count = blobs_for_hash.len();
         tracing::trace!(
             blobs_count,
             height = self.next_height,
             "Extracted blobs for this block"
         );
 
-        let this_block_hash = self.calculate_block_hash(self.next_height, &prev_block_hash, &blobs);
+        let this_block_hash =
+            self.calculate_block_hash(self.next_height, &prev_block_hash, &blobs_for_hash);
 
         let new_head = MockBlockHeader {
             height: self.next_height as u64,
@@ -426,9 +433,15 @@ impl StorableMockDaLayer {
         );
 
         let start_reading = std::time::Instant::now();
-        // Query 1: Read a lot: all blobs data.
+        // Query 1: Read blob metadata (excluding large data field).
         let non_finalized_blobs = Blobs::find()
             .filter(blobs::Column::BlockHeight.gt(last_finalized_height))
+            .select_only()
+            .column(blobs::Column::Id)
+            .column(blobs::Column::Hash)
+            .column(blobs::Column::Sender)
+            .column(blobs::Column::Namespace)
+            .into_model::<blobs::BlobHashData>()
             .all(&self.conn)
             .await?;
         tracing::trace!(
@@ -456,7 +469,7 @@ impl StorableMockDaLayer {
 
         let updating_start = std::time::Instant::now();
         // This is going to be layout of new non-finalized blocks.
-        let mut new_non_finalised_order: Vec<Vec<blobs::Model>> = (last_finalized_height
+        let mut new_non_finalised_order: Vec<Vec<blobs::BlobHashData>> = (last_finalized_height
             ..self.next_height)
             .map(|_height| Vec::new())
             .collect();
@@ -566,7 +579,7 @@ impl StorableMockDaLayer {
         &self,
         height: u32,
         prev_block_hash: &[u8; 32],
-        blobs: &[blobs::Model],
+        blobs: &[blobs::BlobHashData],
     ) -> [u8; 32] {
         let mut hasher = sha2::Sha256::new();
 

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -102,7 +102,7 @@ impl StorableMockDaLayer {
         timestamp: sov_rollup_interface::da::Time,
     ) -> anyhow::Result<()> {
         let start = std::time::Instant::now();
-        tracing::debug!(
+        tracing::trace!(
             next_height = self.next_height,
             ?timestamp,
             "Start producing a new block"
@@ -250,8 +250,9 @@ impl StorableMockDaLayer {
         batch_data: &[u8],
         sender: &MockAddress,
     ) -> anyhow::Result<MockHash> {
-        tracing::debug!(
-            batch_bytes = batch_data.len(),
+        let bytes = batch_data.len();
+        tracing::trace!(
+            bytes,
             %sender,
             next_da_height = self.next_height,
             "Submitting batch is received"
@@ -265,6 +266,7 @@ impl StorableMockDaLayer {
             %sender,
             next_da_height = self.next_height,
             include_at = %include_at,
+            bytes,
             time = ?start.elapsed(),
             "Submitted batch is saved"
         );
@@ -276,8 +278,9 @@ impl StorableMockDaLayer {
         proof_data: &[u8],
         sender: &MockAddress,
     ) -> anyhow::Result<MockHash> {
-        tracing::debug!(
-            proof_bytes = proof_data.len(),
+        let bytes = proof_data.len();
+        tracing::trace!(
+            bytes,
             %sender,
             next_da_height = self.next_height,
             "Submitting proof is received"
@@ -289,6 +292,7 @@ impl StorableMockDaLayer {
             %hash,
             %sender,
             next_da_height = self.next_height,
+            bytes,
             time = ?start.elapsed(),
             "Submitted proof is saved"
         );


### PR DESCRIPTION
# Description

This PR promotes several log messages from trace to debug. These are happening once per DA block or per submitted blob, so log verbosity won't be huge.

Following messages are going to be printed.

* `New block has been produced` with `producing_time` and `blobs_count`. It does not include bytes.
* `Submitted batch is saved` and `Submitted proof is saved`. Those have bytes and insertion time.


**Produce block optimizaton**.

Stop querying blob data when new block is produced, because data is not used for block header hash calculation, saving I/O budget.

- [x] Internal change ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existing tests are passing

## Docs
No updates
