### PR TITLE
Add `rollback` to LedgerDb

### DIFF
--- a/crates/full-node/sov-db/src/commit_flag.rs
+++ b/crates/full-node/sov-db/src/commit_flag.rs
@@ -16,6 +16,8 @@ pub enum CommitStatus {
     /// A commit of **user state** is in progress.
     /// Stores the previous `user` root hash before the commit began.
     CommittingUserNomt([u8; 32]),
+    /// Ledger db commit in progress.
+    CommittingLedgerDb,
     /// A commit of **archival user and kernel state** in the flat-db is in progress.
     CommittingArchivalUserAndKernel,
     /// A commit of **live user and kernel state** in the flat-db is in progress.

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -676,10 +676,10 @@ impl LedgerDb {
 
         Self::delete_slot(&mut schema_batch, &head_slot, &head_slot_number)?;
 
-        // Check if we need to update the finalized slot
+        // Check if we need to update the finalized slot.
         if let Some(finalized_slot) = db.get::<FinalizedSlots>(&LatestFinalizedSlotSingleton)? {
             if finalized_slot >= head_slot_number {
-                // Find the previous slot number (if any)
+                // Find the previous slot number.
                 let new_finalized_slot = if head_slot_number > SlotNumber::GENESIS {
                     // Get the previous slot
                     let mut prev_slot = head_slot_number;

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -621,16 +621,17 @@ impl LedgerDb {
 
     /// Rolls back the last committed slot from the ledger database.
     /// If there are no slots in the database, this method returns `Ok(())` without doing anything.
-    pub fn rollback_last_slot(&self, ledger_db: &Arc<rockbound::DB>) -> anyhow::Result<()> {
-        let schema_batch = self.create_schema_batch_for_rollback()?;
+    pub fn rollback_last_slot(ledger_db: Arc<rockbound::DB>) -> anyhow::Result<()> {
+        let schema_batch = Self::create_schema_batch_for_rollback(ledger_db.clone())?;
         ledger_db.write_schemas(&schema_batch)?;
         Ok(())
     }
 
-    fn create_schema_batch_for_rollback(&self) -> anyhow::Result<SchemaBatch> {
+    fn create_schema_batch_for_rollback(db: Arc<rockbound::DB>) -> anyhow::Result<SchemaBatch> {
         // Hold the same lock for the entire duration of this method.
-        let db = self.db.read().expect(DB_LOCK_POISONED).clone();
+
         let mut schema_batch = SchemaBatch::new();
+        let db = DeltaReader::new(db, Vec::new());
 
         // Get the current head slot
         let Some((head_slot_number, head_slot)) = db.get_largest::<SlotByNumber>()? else {

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -643,38 +643,35 @@ impl LedgerDb {
             "Rolling back last slot from ledger database"
         );
 
-        let mut current_batch_number = head_slot.batches.start;
-
         // Delete all batches in this slot
-        while current_batch_number < head_slot.batches.end {
+        for current_batch_number in head_slot.batches.start.0..head_slot.batches.end.0 {
+            let current_batch_number = BatchNumber(current_batch_number);
+
             if let Some(batch) = db.get::<BatchByNumber>(&current_batch_number)? {
                 // Delete all transactions in this batch
-                let mut current_tx = batch.txs.start;
+                for current_tx_number in batch.txs.start.0..batch.txs.end.0 {
+                    let current_tx_number = TxNumber(current_tx_number);
 
-                while current_tx < batch.txs.end {
-                    if let Some(tx) = db.get::<TxByNumber>(&current_tx)? {
+                    if let Some(tx) = db.get::<TxByNumber>(&current_tx_number)? {
                         // Delete all events in this transaction
-                        let mut current_event_number = tx.events.start;
+                        for current_event_number in tx.events.start.0..tx.events.end.0 {
+                            let current_event_number = EventNumber(current_event_number);
 
-                        while current_event_number < tx.events.end {
                             if let Some(event) = db.get::<EventByNumber>(&current_event_number)? {
                                 Self::delete_event(
                                     &mut schema_batch,
-                                    current_tx,
+                                    current_tx_number,
                                     &event,
                                     current_event_number,
                                 )?;
                             }
-                            current_event_number = EventNumber(current_event_number.0 + 1);
                         }
-                        Self::delete_tx(&mut schema_batch, &tx, current_tx)?;
+                        Self::delete_tx(&mut schema_batch, &tx, current_tx_number)?;
                     }
-                    current_tx = TxNumber(current_tx.0 + 1);
                 }
 
                 Self::delete_batch(&mut schema_batch, &batch, &current_batch_number)?;
             }
-            current_batch_number = BatchNumber(current_batch_number.0 + 1);
         }
 
         Self::delete_slot(&mut schema_batch, &head_slot, &head_slot_number)?;

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -620,25 +620,22 @@ impl LedgerDb {
     }
 
     /// Rolls back the last committed slot from the ledger database.
-    ///
-    /// This method deletes the most recent slot and all its associated data
-    /// (batches, transactions, events, and discarded blobs).
-    ///
-    /// # Arguments
-    ///
-    /// * `ledger_db` - The underlying RocksDB database to write the rollback changes to.
-    ///
-    /// # Returns
-    ///
-    /// Returns `Ok(())` if the rollback was successful, or an error if any database operation failed.
     /// If there are no slots in the database, this method returns `Ok(())` without doing anything.
     pub fn rollback_last_slot(&self, ledger_db: &Arc<rockbound::DB>) -> anyhow::Result<()> {
+        let schema_batch = self.create_schema_batch_for_rollback()?;
+        ledger_db.write_schemas(&schema_batch)?;
+        Ok(())
+    }
+
+    fn create_schema_batch_for_rollback(&self) -> anyhow::Result<SchemaBatch> {
+        // Hold the same lock for the entire duration of this method.
         let db = self.db.read().expect(DB_LOCK_POISONED).clone();
+        let mut schema_batch = SchemaBatch::new();
 
         // Get the current head slot
         let Some((head_slot_number, head_slot)) = db.get_largest::<SlotByNumber>()? else {
             tracing::debug!("No slots in database, nothing to rollback");
-            return Ok(());
+            return Ok(schema_batch);
         };
 
         tracing::info!(
@@ -646,58 +643,41 @@ impl LedgerDb {
             "Rolling back last slot from ledger database"
         );
 
-        let mut schema_batch = SchemaBatch::new();
-        let mut batches_deleted = 0;
-        let mut txs_deleted = 0;
-        let mut events_deleted = 0;
+        let mut current_batch_number = head_slot.batches.start;
 
         // Delete all batches in this slot
-        let mut current_batch = head_slot.batches.start;
-        while current_batch < head_slot.batches.end {
-            if let Some(batch) = db.get::<BatchByNumber>(&current_batch)? {
+        while current_batch_number < head_slot.batches.end {
+            if let Some(batch) = db.get::<BatchByNumber>(&current_batch_number)? {
                 // Delete all transactions in this batch
                 let mut current_tx = batch.txs.start;
+
                 while current_tx < batch.txs.end {
                     if let Some(tx) = db.get::<TxByNumber>(&current_tx)? {
                         // Delete all events in this transaction
-                        let mut current_event = tx.events.start;
-                        while current_event < tx.events.end {
-                            if let Some(event) = db.get::<EventByNumber>(&current_event)? {
-                                // Delete event by number
-                                schema_batch.delete::<EventByNumber>(&current_event)?;
-                                // Delete event by key
-                                schema_batch.delete::<EventByKey>(&(
-                                    event.key().clone(),
-                                    current_tx,
-                                    current_event,
-                                ))?;
-                                events_deleted += 1;
-                            }
-                            current_event = EventNumber(current_event.0 + 1);
-                        }
+                        let mut current_event_number = tx.events.start;
 
-                        // Delete transaction by number
-                        schema_batch.delete::<TxByNumber>(&current_tx)?;
-                        // Delete transaction by hash
-                        schema_batch.delete::<TxByHash>(&(tx.hash, current_tx))?;
-                        txs_deleted += 1;
+                        while current_event_number < tx.events.end {
+                            if let Some(event) = db.get::<EventByNumber>(&current_event_number)? {
+                                Self::delete_event(
+                                    &mut schema_batch,
+                                    current_tx,
+                                    &event,
+                                    current_event_number,
+                                )?;
+                            }
+                            current_event_number = EventNumber(current_event_number.0 + 1);
+                        }
+                        Self::delete_tx(&mut schema_batch, &tx, current_tx)?;
                     }
                     current_tx = TxNumber(current_tx.0 + 1);
                 }
 
-                // Delete batch by number
-                schema_batch.delete::<BatchByNumber>(&current_batch)?;
-                // Delete batch by hash
-                schema_batch.delete::<BatchByHash>(&batch.hash)?;
-                batches_deleted += 1;
+                Self::delete_batch(&mut schema_batch, &batch, &current_batch_number)?;
             }
-            current_batch = BatchNumber(current_batch.0 + 1);
+            current_batch_number = BatchNumber(current_batch_number.0 + 1);
         }
 
-        // Delete slot by number
-        schema_batch.delete::<SlotByNumber>(&head_slot_number)?;
-        // Delete slot by hash
-        schema_batch.delete::<SlotByHash>(&head_slot.hash)?;
+        Self::delete_slot(&mut schema_batch, &head_slot, &head_slot_number)?;
 
         // Check if we need to update the finalized slot
         if let Some(finalized_slot) = db.get::<FinalizedSlots>(&LatestFinalizedSlotSingleton)? {
@@ -721,18 +701,51 @@ impl LedgerDb {
             }
         }
 
-        // Commit the deletions
-        drop(db);
-        ledger_db.write_schemas(&schema_batch)?;
+        Ok(schema_batch)
+    }
 
-        tracing::info!(
-            slot_number = %head_slot_number,
-            batches_deleted = %batches_deleted,
-            txs_deleted = %txs_deleted,
-            events_deleted = %events_deleted,
-            "Ledger database rollback completed"
-        );
+    fn delete_event(
+        schema_batch: &mut SchemaBatch,
+        current_tx: TxNumber,
+        event: &StoredEvent,
+        current_event_number: EventNumber,
+    ) -> anyhow::Result<()> {
+        schema_batch.delete::<EventByNumber>(&current_event_number)?;
+        schema_batch.delete::<EventByKey>(&(
+            event.key().clone(),
+            current_tx,
+            current_event_number,
+        ))?;
+        Ok(())
+    }
 
+    fn delete_tx(
+        schema_batch: &mut SchemaBatch,
+        tx: &StoredTransaction,
+        current_tx: TxNumber,
+    ) -> anyhow::Result<()> {
+        schema_batch.delete::<TxByNumber>(&current_tx)?;
+        schema_batch.delete::<TxByHash>(&(tx.hash, current_tx))?;
+        Ok(())
+    }
+
+    fn delete_batch(
+        schema_batch: &mut SchemaBatch,
+        batch: &StoredBatch,
+        current_batch_number: &BatchNumber,
+    ) -> anyhow::Result<()> {
+        schema_batch.delete::<BatchByNumber>(current_batch_number)?;
+        schema_batch.delete::<BatchByHash>(&batch.hash)?;
+        Ok(())
+    }
+
+    fn delete_slot(
+        schema_batch: &mut SchemaBatch,
+        slot: &StoredSlot,
+        slot_number: &SlotNumber,
+    ) -> anyhow::Result<()> {
+        schema_batch.delete::<SlotByNumber>(slot_number)?;
+        schema_batch.delete::<SlotByHash>(&slot.hash)?;
         Ok(())
     }
 }

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -716,7 +716,8 @@ impl LedgerDb {
                     new_finalized_slot = %new_finalized_slot,
                     "Updating finalized slot during rollback"
                 );
-                schema_batch.put::<FinalizedSlots>(&LatestFinalizedSlotSingleton, &new_finalized_slot)?;
+                schema_batch
+                    .put::<FinalizedSlots>(&LatestFinalizedSlotSingleton, &new_finalized_slot)?;
             }
         }
 

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -641,6 +641,16 @@ impl LedgerDb {
         db.get_async::<DiscardedBlobByHash>(&blob_hash.0).await
     }
 
+    /// TODO
+    pub fn get_head_root_hast(db: Arc<rockbound::DB>) -> anyhow::Result<Option<[u8; 64]>> {
+        let db = DeltaReader::new(db, Vec::new());
+        Ok(db.get_largest::<SlotByNumber>()?.map(|s| {
+            let r = s.1.state_root.as_ref().to_vec();
+            let arr: [u8; 64] = r.try_into().expect("Slice must be exactly 64 bytes");
+            arr
+        }))
+    }
+
     /// Rolls back the last committed slot from the ledger database.
     /// If there are no slots in the database, this method returns `Ok(())` without doing anything.
     pub fn rollback_last_slot(ledger_db: Arc<rockbound::DB>) -> anyhow::Result<()> {

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -10,15 +10,16 @@ use sov_rollup_interface::node::ledger_api::AggregatedProofResponse;
 use sov_rollup_interface::stf::{BatchReceipt, DiscardedBlob, StoredEvent, TxReceiptContents};
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
 
+use crate::schema::tables::DiscardedBlobHahsByNumber;
 use crate::schema::tables::{
     BatchByHash, BatchByNumber, DiscardedBlobByHash, EventByKey, EventByNumber, FinalizedSlots,
     ProofByUniqueId, SlotByHash, SlotByNumber, StfInfoByNumber, StfInfoMetadata, TxByHash,
     TxByNumber, LEDGER_TABLES,
 };
 use crate::schema::types::{
-    split_tx_for_storage, BatchNumber, EventNumber, LatestFinalizedSlotSingleton, ProofUniqueId,
-    StfInfoUniqueId, StoredBatch, StoredDiscardedBlob, StoredSlot, StoredStfInfo,
-    StoredTransaction, TxNumber,
+    split_tx_for_storage, BatchNumber, DiscardedBlobNumber, EventNumber,
+    LatestFinalizedSlotSingleton, ProofUniqueId, StfInfoUniqueId, StoredBatch, StoredDiscardedBlob,
+    StoredSlot, StoredStfInfo, StoredTransaction, TxNumber,
 };
 use crate::DbOptions;
 
@@ -38,6 +39,8 @@ pub struct ItemNumbers {
     pub slot_number: SlotNumber,
     /// The batch number
     pub batch_number: u64,
+    /// The discarded batch number
+    pub discarded_batch_number: u64,
     /// The transaction number
     pub tx_number: u64,
     /// The event number
@@ -327,6 +330,9 @@ impl LedgerDb {
             batch_number: Self::last_version_written(&db, BatchByNumber)?
                 .map(|x| x.0 + 1)
                 .unwrap_or_default(),
+            discarded_batch_number: Self::last_version_written(&db, DiscardedBlobHahsByNumber)?
+                .map(|x| x.0 + 1)
+                .unwrap_or_default(),
             tx_number: Self::last_version_written(&db, TxByNumber)?
                 .map(|x| x.0 + 1)
                 .unwrap_or_default(),
@@ -359,8 +365,13 @@ impl LedgerDb {
     fn put_discarded_blob(
         &self,
         blob: StoredDiscardedBlob,
+        discarded_batch_number: DiscardedBlobNumber,
         schema_batch: &mut SchemaBatch,
     ) -> anyhow::Result<()> {
+        schema_batch.put::<DiscardedBlobHahsByNumber>(
+            &discarded_batch_number,
+            &blob.discarded_blob.hash.0,
+        )?;
         schema_batch.put::<DiscardedBlobByHash>(&blob.discarded_blob.hash.0, &blob)
     }
 
@@ -440,12 +451,21 @@ impl LedgerDb {
             current_item_numbers.batch_number += 1;
         }
 
-        for discarded_blob in data_to_commit.discarded_blobs.into_iter() {
+        let first_discarded_blob_number = current_item_numbers.discarded_batch_number;
+
+        let last_discarded_blob_number =
+            first_discarded_blob_number + data_to_commit.discarded_blobs.len() as u64;
+
+        for (discarded_blob_index, discarded_blob) in
+            data_to_commit.discarded_blobs.into_iter().enumerate()
+        {
+            let discarded_blob_index = discarded_blob_index as u64;
             self.put_discarded_blob(
                 StoredDiscardedBlob {
                     discarded_blob,
                     slot_number,
                 },
+                DiscardedBlobNumber(first_discarded_blob_number + discarded_blob_index),
                 &mut schema_batch,
             )?;
         }
@@ -457,6 +477,8 @@ impl LedgerDb {
             // TODO: Add a method to the slot data trait allowing additional data to be stored
             extra_data: vec![].into(),
             batches: BatchNumber(first_batch_number)..BatchNumber(last_batch_number),
+            discarded_blobs: DiscardedBlobNumber(first_discarded_blob_number)
+                ..DiscardedBlobNumber(last_discarded_blob_number),
             timestamp: data_to_commit.slot_data.timestamp(),
         };
         self.put_slot(&slot_to_store, &slot_number, &mut schema_batch)?;
@@ -644,6 +666,22 @@ impl LedgerDb {
             "Rolling back last slot from ledger database"
         );
 
+        // Delete all discarded blobs
+        for current_discarded_blob_number in
+            head_slot.discarded_blobs.start.0..head_slot.discarded_blobs.end.0
+        {
+            let current_discarded_blob_number = DiscardedBlobNumber(current_discarded_blob_number);
+            if let Some(discarded_blob_hash) =
+                db.get::<DiscardedBlobHahsByNumber>(&current_discarded_blob_number)?
+            {
+                Self::delete_discarded_blob(
+                    &mut schema_batch,
+                    discarded_blob_hash,
+                    &current_discarded_blob_number,
+                )?;
+            }
+        }
+
         // Delete all batches in this slot
         for current_batch_number in head_slot.batches.start.0..head_slot.batches.end.0 {
             let current_batch_number = BatchNumber(current_batch_number);
@@ -704,36 +742,42 @@ impl LedgerDb {
 
     fn delete_event(
         schema_batch: &mut SchemaBatch,
-        current_tx: TxNumber,
+        tx_number: TxNumber,
         event: &StoredEvent,
-        current_event_number: EventNumber,
+        event_number: EventNumber,
     ) -> anyhow::Result<()> {
-        schema_batch.delete::<EventByNumber>(&current_event_number)?;
-        schema_batch.delete::<EventByKey>(&(
-            event.key().clone(),
-            current_tx,
-            current_event_number,
-        ))?;
+        schema_batch.delete::<EventByNumber>(&event_number)?;
+        schema_batch.delete::<EventByKey>(&(event.key().clone(), tx_number, event_number))?;
         Ok(())
     }
 
     fn delete_tx(
         schema_batch: &mut SchemaBatch,
         tx: &StoredTransaction,
-        current_tx: TxNumber,
+        tx_number: TxNumber,
     ) -> anyhow::Result<()> {
-        schema_batch.delete::<TxByNumber>(&current_tx)?;
-        schema_batch.delete::<TxByHash>(&(tx.hash, current_tx))?;
+        schema_batch.delete::<TxByNumber>(&tx_number)?;
+        schema_batch.delete::<TxByHash>(&(tx.hash, tx_number))?;
         Ok(())
     }
 
     fn delete_batch(
         schema_batch: &mut SchemaBatch,
         batch: &StoredBatch,
-        current_batch_number: &BatchNumber,
+        batch_number: &BatchNumber,
     ) -> anyhow::Result<()> {
-        schema_batch.delete::<BatchByNumber>(current_batch_number)?;
+        schema_batch.delete::<BatchByNumber>(batch_number)?;
         schema_batch.delete::<BatchByHash>(&batch.hash)?;
+        Ok(())
+    }
+
+    fn delete_discarded_blob(
+        schema_batch: &mut SchemaBatch,
+        discarded_blob_hash: [u8; 32],
+        discarded_blob_number: &DiscardedBlobNumber,
+    ) -> anyhow::Result<()> {
+        schema_batch.delete::<DiscardedBlobHahsByNumber>(discarded_blob_number)?;
+        schema_batch.delete::<DiscardedBlobByHash>(&discarded_blob_hash)?;
         Ok(())
     }
 

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -618,4 +618,120 @@ impl LedgerDb {
         let db = self.db.read().expect(DB_LOCK_POISONED).clone();
         db.get_async::<DiscardedBlobByHash>(&blob_hash.0).await
     }
+
+    /// Rolls back the last committed slot from the ledger database.
+    ///
+    /// This method deletes the most recent slot and all its associated data
+    /// (batches, transactions, events, and discarded blobs).
+    ///
+    /// # Arguments
+    ///
+    /// * `ledger_db` - The underlying RocksDB database to write the rollback changes to.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the rollback was successful, or an error if any database operation failed.
+    /// If there are no slots in the database, this method returns `Ok(())` without doing anything.
+    pub fn rollback_last_slot(&self, ledger_db: &Arc<rockbound::DB>) -> anyhow::Result<()> {
+        let db = self.db.read().expect(DB_LOCK_POISONED).clone();
+
+        // Get the current head slot
+        let Some((head_slot_number, head_slot)) = db.get_largest::<SlotByNumber>()? else {
+            tracing::debug!("No slots in database, nothing to rollback");
+            return Ok(());
+        };
+
+        tracing::info!(
+            slot_number = %head_slot_number,
+            "Rolling back last slot from ledger database"
+        );
+
+        let mut schema_batch = SchemaBatch::new();
+        let mut batches_deleted = 0;
+        let mut txs_deleted = 0;
+        let mut events_deleted = 0;
+
+        // Delete all batches in this slot
+        let mut current_batch = head_slot.batches.start;
+        while current_batch < head_slot.batches.end {
+            if let Some(batch) = db.get::<BatchByNumber>(&current_batch)? {
+                // Delete all transactions in this batch
+                let mut current_tx = batch.txs.start;
+                while current_tx < batch.txs.end {
+                    if let Some(tx) = db.get::<TxByNumber>(&current_tx)? {
+                        // Delete all events in this transaction
+                        let mut current_event = tx.events.start;
+                        while current_event < tx.events.end {
+                            if let Some(event) = db.get::<EventByNumber>(&current_event)? {
+                                // Delete event by number
+                                schema_batch.delete::<EventByNumber>(&current_event)?;
+                                // Delete event by key
+                                schema_batch.delete::<EventByKey>(&(
+                                    event.key().clone(),
+                                    current_tx,
+                                    current_event,
+                                ))?;
+                                events_deleted += 1;
+                            }
+                            current_event = EventNumber(current_event.0 + 1);
+                        }
+
+                        // Delete transaction by number
+                        schema_batch.delete::<TxByNumber>(&current_tx)?;
+                        // Delete transaction by hash
+                        schema_batch.delete::<TxByHash>(&(tx.hash, current_tx))?;
+                        txs_deleted += 1;
+                    }
+                    current_tx = TxNumber(current_tx.0 + 1);
+                }
+
+                // Delete batch by number
+                schema_batch.delete::<BatchByNumber>(&current_batch)?;
+                // Delete batch by hash
+                schema_batch.delete::<BatchByHash>(&batch.hash)?;
+                batches_deleted += 1;
+            }
+            current_batch = BatchNumber(current_batch.0 + 1);
+        }
+
+        // Delete slot by number
+        schema_batch.delete::<SlotByNumber>(&head_slot_number)?;
+        // Delete slot by hash
+        schema_batch.delete::<SlotByHash>(&head_slot.hash)?;
+
+        // Check if we need to update the finalized slot
+        if let Some(finalized_slot) = db.get::<FinalizedSlots>(&LatestFinalizedSlotSingleton)? {
+            if finalized_slot >= head_slot_number {
+                // Find the previous slot number (if any)
+                let new_finalized_slot = if head_slot_number > SlotNumber::GENESIS {
+                    // Get the previous slot
+                    let mut prev_slot = head_slot_number;
+                    prev_slot.decr();
+                    prev_slot
+                } else {
+                    SlotNumber::GENESIS
+                };
+                tracing::info!(
+                    old_finalized_slot = %finalized_slot,
+                    new_finalized_slot = %new_finalized_slot,
+                    "Updating finalized slot during rollback"
+                );
+                schema_batch.put::<FinalizedSlots>(&LatestFinalizedSlotSingleton, &new_finalized_slot)?;
+            }
+        }
+
+        // Commit the deletions
+        drop(db);
+        ledger_db.write_schemas(&schema_batch)?;
+
+        tracing::info!(
+            slot_number = %head_slot_number,
+            batches_deleted = %batches_deleted,
+            txs_deleted = %txs_deleted,
+            events_deleted = %events_deleted,
+            "Ledger database rollback completed"
+        );
+
+        Ok(())
+    }
 }

--- a/crates/full-node/sov-db/src/schema/tables.rs
+++ b/crates/full-node/sov-db/src/schema/tables.rs
@@ -40,7 +40,7 @@ use super::types::{
     LatestFinalizedSlotSingleton, ProofUniqueId, StateRootHashId, StfInfoUniqueId, StoredBatch,
     StoredSlot, StoredStfInfo, StoredTransaction, TxNumber,
 };
-use crate::schema::types::StoredDiscardedBlob;
+use crate::schema::types::{DiscardedBlobNumber, StoredDiscardedBlob};
 
 /* Other tables used by the Rollup */
 
@@ -50,8 +50,9 @@ pub const LEDGER_TABLES: &[ColumnFamilyName] = &[
     SlotByNumber::table_name(),
     SlotByHash::table_name(),
     BatchByHash::table_name(),
-    DiscardedBlobByHash::table_name(),
     BatchByNumber::table_name(),
+    DiscardedBlobByHash::table_name(),
+    DiscardedBlobHahsByNumber::table_name(),
     TxByHash::table_name(),
     TxByNumber::table_name(),
     EventByKey::table_name(),
@@ -236,14 +237,19 @@ define_table_with_seek_key_codec!(
     (BatchByNumber) BatchNumber => StoredBatch
 );
 
-define_table_with_seek_key_codec!(
-    /// The primary source for discarded blobs
-    (DiscardedBlobByHash) DbHash => StoredDiscardedBlob
-);
-
 define_table_with_default_codec!(
     /// A "secondary index" for batch data by hash
     (BatchByHash) DbHash => BatchNumber
+);
+
+define_table_with_seek_key_codec!(
+    /// The primary source for batch data
+    (DiscardedBlobHahsByNumber) DiscardedBlobNumber => DbHash
+);
+
+define_table_with_seek_key_codec!(
+    /// The primary source for discarded blobs
+    (DiscardedBlobByHash) DbHash => StoredDiscardedBlob
 );
 
 define_table_with_seek_key_codec!(

--- a/crates/full-node/sov-db/src/schema/types.rs
+++ b/crates/full-node/sov-db/src/schema/types.rs
@@ -77,6 +77,8 @@ pub struct StoredSlot {
     pub extra_data: DbBytes,
     /// The range of batches which occurred in this slot.
     pub batches: std::ops::Range<BatchNumber>,
+    /// TODO
+    pub discarded_blobs: std::ops::Range<DiscardedBlobNumber>,
     /// The timestamp of the slot.
     pub timestamp: Time,
 }
@@ -270,6 +272,7 @@ macro_rules! u64_wrapper {
 
 u64_wrapper!(TxIncrId);
 u64_wrapper!(BatchNumber);
+u64_wrapper!(DiscardedBlobNumber);
 u64_wrapper!(TxNumber);
 u64_wrapper!(EventNumber);
 u64_wrapper!(ProofUniqueId);

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -84,6 +84,9 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
                     self.kernel.rollback(1)?;
                 }
             }
+            CommitStatus::CommittingLedgerDb => {
+                todo!()
+            }
 
             CommitStatus::CommittingArchivalUserAndKernel
             | CommitStatus::CommittingLiveUserAndKernel => {

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -91,6 +91,11 @@ where
 
         let merklized_commit = self.merklized_state.commit(state, &self.commit_flag)?;
 
+        self.commit_flag
+            .save_commit_status(&CommitStatus::CommittingLedgerDb)?;
+
+        let ledger_commit = self.commit_ledger(&ledger)?;
+
         let flat_metrics = self
             .flat_state
             .commit(historical_state, &self.commit_flag)?;
@@ -99,7 +104,6 @@ where
             .save_commit_status(&CommitStatus::Success)?;
 
         let accessory_commit = self.commit_accessory(&accessory)?;
-        let ledger_commit = self.commit_ledger(&ledger)?;
 
         let merklized_commit_from_caller = merklized_commit.total;
         let commit_detailed_metrics = CommitDetailedMetric {

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -89,12 +89,33 @@ where
                 },
         } = group;
 
+        {
+            println!("---");
+            println!("");
+            let nomt_root_hashes = self.merklized_state.get_root_hashes();
+            println!("nomt_root_hashes before {:?}", nomt_root_hashes);
+        }
         let merklized_commit = self.merklized_state.commit(state, &self.commit_flag)?;
+
+        {
+            let nomt_root_hashes = self.merklized_state.get_root_hashes();
+            println!("nomt_root_hashes after {:?}", nomt_root_hashes);
+        }
+
+        {
+            let root_hash = LedgerDb::get_head_root_hast(self.ledger.clone())?;
+            println!("root_hash before {:?}", root_hash);
+        }
 
         self.commit_flag
             .save_commit_status(&CommitStatus::CommittingLedgerDb)?;
 
         let ledger_commit = self.commit_ledger(&ledger)?;
+
+        {
+            let root_hash = LedgerDb::get_head_root_hast(self.ledger.clone())?;
+            println!("root_hash after {:?}", root_hash);
+        }
 
         let flat_metrics = self
             .flat_state

--- a/crates/full-node/sov-db/src/storage_manager/tests/generic_tests.rs
+++ b/crates/full-node/sov-db/src/storage_manager/tests/generic_tests.rs
@@ -17,7 +17,7 @@ use super::data_helpers::{
     get_expected_chain_values, materialize_ledger_changes, verify_ledger_storage,
 };
 use crate::ledger_db::LedgerDb;
-use crate::schema::types::{BatchNumber, StoredSlot};
+use crate::schema::types::{BatchNumber, DiscardedBlobNumber, StoredSlot};
 use crate::storage_manager::tests::arbitrary::{get_block_hash, ForkDescription, ForkMap};
 
 pub trait TestableStorage: Sized {
@@ -834,6 +834,7 @@ where
             state_root: Default::default(),
             extra_data: vec![].into(),
             batches: BatchNumber(0)..BatchNumber(0),
+            discarded_blobs: DiscardedBlobNumber(0)..DiscardedBlobNumber(0),
             timestamp: da_header.time(),
         };
 

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -162,49 +162,45 @@ async fn test_rollback() {
     let db = storage_manager.get_db();
     let ledger_db = LedgerDb::with_reader(ledger_storage).unwrap();
 
-    // Initially, there should be no slots
-    assert!(ledger_db.get_head_slot().unwrap().is_none());
-
     // Add a few slots
     for i in 0..3 {
         let mut block = MockBlock::default();
         block.header.height = i;
         let slot_commit = SlotCommit::<_, MockBlob, ()>::new(block, Default::default());
-        let schema_batch = ledger_db
-            .materialize_slot(slot_commit, b"state-root")
+        let mut schema_batch = ledger_db
+            .materialize_slot(slot_commit, &i.to_be_bytes())
             .unwrap();
+
+        let finalized_slot_number = ledger_db
+            .materialize_latest_finalize_slot(SlotNumber::new(i), SlotNumber::new(i))
+            .unwrap();
+
+        schema_batch.merge(finalized_slot_number);
         storage_manager.commit(&schema_batch);
     }
 
     // Verify we have 3 slots (slots 0, 1, 2)
+    assert_slot_numbers(2, &ledger_db).await;
 
-    let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
-    assert_eq!(head_slot_number.get(), 2);
-
+    // Rollback slot 2
     {
         LedgerDb::rollback_last_slot(db.clone()).unwrap();
-
         // Verify the head slot is now slot 1
-        let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
-        assert_eq!(head_slot_number.get(), 1);
+        assert_slot_numbers(1, &ledger_db).await;
     }
 
     // Rollback another slot (slot 1)
     {
         LedgerDb::rollback_last_slot(db.clone()).unwrap();
-
         // Verify the head slot is now slot 0
-        let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
-        assert_eq!(head_slot_number.get(), 0);
+        assert_slot_numbers(0, &ledger_db).await;
     }
 
     // Rollback the last slot (slot 0)
     {
         LedgerDb::rollback_last_slot(db.clone()).unwrap();
-
         // Verify there are no more slots
         assert!(ledger_db.get_head_slot().unwrap().is_none());
-
         // Try to rollback when there are no slots (should succeed without error)
         LedgerDb::rollback_last_slot(db.clone()).unwrap();
     }
@@ -401,4 +397,13 @@ async fn test_rollback_with_data() {
     assert_eq!(item_numbers_after_second_rollback.batch_number, 2);
     assert_eq!(item_numbers_after_second_rollback.tx_number, 6);
     assert_eq!(item_numbers_after_second_rollback.event_number, 12);
+}
+
+async fn assert_slot_numbers(n: u64, ledger_db: &LedgerDb) {
+    let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
+    assert_eq!(head_slot_number.get(), n);
+    assert_eq!(
+        head_slot_number,
+        ledger_db.get_latest_finalized_slot_number().await.unwrap()
+    );
 }

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -210,3 +210,191 @@ async fn test_rollback() {
         .rollback_last_slot(storage_manager.get_db())
         .unwrap();
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rollback_with_data() {
+    use sov_rollup_interface::common::IntoSlotNumber;
+    use sov_rollup_interface::stf::{BatchReceipt, TransactionReceipt, TxEffect};
+    use sov_rollup_interface::TxHash;
+    use sov_test_utils::TestTxReceiptContents;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
+    let ledger_storage = storage_manager.create_ledger_storage();
+    let ledger_db = LedgerDb::with_reader(ledger_storage).unwrap();
+
+    // Create slots with actual data (batches, transactions, events)
+    for slot_num in 0..3 {
+        let mut block = MockBlock::default();
+        block.header.height = slot_num;
+        let mut slot_commit = SlotCommit::<_, i32, TestTxReceiptContents>::new(block, vec![]);
+
+        // Add 2 batches per slot
+        for batch_num in 0..2 {
+            let mut tx_receipts = vec![];
+
+            // Add 3 transactions per batch
+            for tx_num in 0..3 {
+                let tx_hash = TxHash::new([
+                    (slot_num * 100 + batch_num * 10 + tx_num) as u8,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ]);
+
+                let events = vec![
+                    sov_rollup_interface::stf::StoredEvent::new(
+                        format!("event_key_slot{}_batch{}_tx{}_evt0", slot_num, batch_num, tx_num)
+                            .as_bytes(),
+                        format!("event_value_{}_{}_{}_0", slot_num, batch_num, tx_num).as_bytes(),
+                        [0u8; 32],
+                    ),
+                    sov_rollup_interface::stf::StoredEvent::new(
+                        format!("event_key_slot{}_batch{}_tx{}_evt1", slot_num, batch_num, tx_num)
+                            .as_bytes(),
+                        format!("event_value_{}_{}_{}_1", slot_num, batch_num, tx_num).as_bytes(),
+                        [0u8; 32],
+                    ),
+                ];
+
+                tx_receipts.push(TransactionReceipt {
+                    tx_hash,
+                    body_to_save: None,
+                    events,
+                    receipt: TxEffect::Successful((slot_num * 100 + batch_num * 10 + tx_num) as u32),
+                });
+            }
+
+            let batch_receipt = BatchReceipt {
+                batch_hash: [
+                    (slot_num * 100 + batch_num * 10) as u8,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ],
+                tx_receipts,
+                ignored_tx_receipts: vec![],
+                inner: batch_num as i32,
+            };
+
+            slot_commit.add_batch(batch_receipt);
+        }
+
+        let schema_batch = ledger_db
+            .materialize_slot(slot_commit, b"state-root")
+            .unwrap();
+        storage_manager.commit(&schema_batch);
+    }
+
+    // Verify we have 3 slots with data
+    let (head_slot_number, head_slot) = ledger_db.get_head_slot().unwrap().unwrap();
+    assert_eq!(head_slot_number, 2.to_slot_number());
+    assert_eq!(head_slot.batches.start.0, 4); // Slots 0 and 1 each have 2 batches
+    assert_eq!(head_slot.batches.end.0, 6); // Slot 2 has batches 4 and 5
+
+    // Verify item numbers before rollback
+    let item_numbers_before_rollback = ledger_db.get_next_items_numbers().unwrap();
+    assert_eq!(item_numbers_before_rollback.slot_number, 3.to_slot_number());
+    assert_eq!(item_numbers_before_rollback.batch_number, 6); // 3 slots × 2 batches
+    assert_eq!(item_numbers_before_rollback.tx_number, 18); // 6 batches × 3 txs
+    assert_eq!(item_numbers_before_rollback.event_number, 36); // 18 txs × 2 events
+
+    // Rollback slot 2
+    ledger_db
+        .rollback_last_slot(storage_manager.get_db())
+        .unwrap();
+
+    // Verify slot 2 is gone
+    let (head_slot_number, head_slot) = ledger_db.get_head_slot().unwrap().unwrap();
+    assert_eq!(head_slot_number, 1.to_slot_number());
+    assert_eq!(head_slot.batches.start.0, 2); // Slot 1 starts at batch 2
+    assert_eq!(head_slot.batches.end.0, 4); // Slot 1 ends at batch 4
+
+    // Verify the item numbers reflect the rollback
+    let item_numbers_after_rollback = ledger_db.get_next_items_numbers().unwrap();
+    assert_eq!(item_numbers_after_rollback.slot_number, 2.to_slot_number());
+    assert_eq!(item_numbers_after_rollback.batch_number, 4); // 2 slots × 2 batches
+    assert_eq!(item_numbers_after_rollback.tx_number, 12); // 4 batches × 3 txs
+    assert_eq!(item_numbers_after_rollback.event_number, 24); // 12 txs × 2 events
+
+    // Verify slot 1 data is intact by checking item numbers
+    let item_numbers_slot_1 = ledger_db.get_next_items_numbers().unwrap();
+    assert_eq!(item_numbers_slot_1.slot_number, 2.to_slot_number());
+    assert_eq!(item_numbers_slot_1.batch_number, 4); // 2 slots × 2 batches
+
+    // Rollback slot 1
+    ledger_db
+        .rollback_last_slot(storage_manager.get_db())
+        .unwrap();
+
+    // Verify slot 1 is gone but slot 0 remains
+    let (head_slot_number, head_slot) = ledger_db.get_head_slot().unwrap().unwrap();
+    assert_eq!(head_slot_number, 0.to_slot_number());
+    assert_eq!(head_slot.batches.start.0, 0);
+    assert_eq!(head_slot.batches.end.0, 2);
+
+    let item_numbers_after_second_rollback = ledger_db.get_next_items_numbers().unwrap();
+    assert_eq!(
+        item_numbers_after_second_rollback.slot_number,
+        1.to_slot_number()
+    );
+    assert_eq!(item_numbers_after_second_rollback.batch_number, 2);
+    assert_eq!(item_numbers_after_second_rollback.tx_number, 6);
+    assert_eq!(item_numbers_after_second_rollback.event_number, 12);
+}

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -159,6 +159,7 @@ async fn test_rollback() {
     let temp_dir = tempfile::tempdir().unwrap();
     let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
     let ledger_storage = storage_manager.create_ledger_storage();
+    let db = storage_manager.get_db();
     let ledger_db = LedgerDb::with_reader(ledger_storage).unwrap();
 
     // Initially, there should be no slots
@@ -180,35 +181,27 @@ async fn test_rollback() {
     assert_eq!(head_slot_number, 2.to_slot_number());
 
     // Rollback the last slot (slot 2)
-    ledger_db
-        .rollback_last_slot(storage_manager.get_db())
-        .unwrap();
+    LedgerDb::rollback_last_slot(db.clone()).unwrap();
 
     // Verify the head slot is now slot 1
     let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
     assert_eq!(head_slot_number, 1.to_slot_number());
 
     // Rollback another slot (slot 1)
-    ledger_db
-        .rollback_last_slot(storage_manager.get_db())
-        .unwrap();
+    LedgerDb::rollback_last_slot(db.clone()).unwrap();
 
     // Verify the head slot is now slot 0
     let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
     assert_eq!(head_slot_number, 0.to_slot_number());
 
     // Rollback the last slot (slot 0)
-    ledger_db
-        .rollback_last_slot(storage_manager.get_db())
-        .unwrap();
+    LedgerDb::rollback_last_slot(db.clone()).unwrap();
 
     // Verify there are no more slots
     assert!(ledger_db.get_head_slot().unwrap().is_none());
 
     // Try to rollback when there are no slots (should succeed without error)
-    ledger_db
-        .rollback_last_slot(storage_manager.get_db())
-        .unwrap();
+    LedgerDb::rollback_last_slot(db.clone()).unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -221,6 +214,7 @@ async fn test_rollback_with_data() {
     let temp_dir = tempfile::tempdir().unwrap();
     let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
     let ledger_storage = storage_manager.create_ledger_storage();
+    let db = storage_manager.get_db();
     let ledger_db = LedgerDb::with_reader(ledger_storage).unwrap();
 
     // Create slots with actual data (batches, transactions, events)
@@ -364,9 +358,7 @@ async fn test_rollback_with_data() {
     assert_eq!(item_numbers_before_rollback.event_number, 36); // 18 txs × 2 events
 
     // Rollback slot 2
-    ledger_db
-        .rollback_last_slot(storage_manager.get_db())
-        .unwrap();
+    LedgerDb::rollback_last_slot(db.clone()).unwrap();
 
     // Verify slot 2 is gone
     let (head_slot_number, head_slot) = ledger_db.get_head_slot().unwrap().unwrap();
@@ -387,9 +379,7 @@ async fn test_rollback_with_data() {
     assert_eq!(item_numbers_slot_1.batch_number, 4); // 2 slots × 2 batches
 
     // Rollback slot 1
-    ledger_db
-        .rollback_last_slot(storage_manager.get_db())
-        .unwrap();
+    LedgerDb::rollback_last_slot(db.clone()).unwrap();
 
     // Verify slot 1 is gone but slot 0 remains
     let (head_slot_number, head_slot) = ledger_db.get_head_slot().unwrap().unwrap();

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -1,4 +1,5 @@
 use futures::StreamExt;
+use rockbound::SchemaBatch;
 use sov_db::ledger_db::{LedgerDb, SlotCommit};
 use sov_db::schema::types::StoredStfInfo;
 use sov_mock_da::{MockAddress, MockBlob, MockBlock, MockDaSpec, MockHash};
@@ -220,64 +221,23 @@ async fn test_rollback_with_data() {
 
     // Create slots with actual data (batches, transactions, events)
     for slot_num in 0..3 {
-        let mut block = MockBlock::default();
-        block.header.height = slot_num;
-        let mut slot_commit = SlotCommit::<_, i32, TestTxReceiptContents>::new(block, vec![]);
-
-        // Add 2 batches per slot
-        for batch_num in 0..2 {
-            let mut tx_receipts = vec![];
-
-            // Add 3 transactions per batch
-            for tx_num in 0..3 {
-                let mut out = [0u8; 32];
-                out[..8].copy_from_slice(&u64::to_le_bytes(10 * batch_num + tx_num));
-                let tx_hash = TxHash::new(out);
-
-                let events = vec![
-                    StoredEvent::new("k1".as_bytes(), "v1".as_bytes(), tx_hash.0),
-                    StoredEvent::new("k2".as_bytes(), "v2".as_bytes(), tx_hash.0),
-                ];
-
-                tx_receipts.push(TransactionReceipt {
-                    tx_hash,
-                    body_to_save: None,
-                    events,
-                    receipt: TxEffect::Successful(0),
-                });
-            }
-
-            let mut batch_hash: [u8; 32] = [0u8; 32];
-            batch_hash[..8].copy_from_slice(&u64::to_le_bytes(10 * slot_num + batch_num));
-
-            let batch_receipt = BatchReceipt {
-                batch_hash,
-                tx_receipts,
-                ignored_tx_receipts: vec![],
-                inner: batch_num as i32,
-            };
-
-            slot_commit.add_batch(batch_receipt);
-        }
-
-        let schema_batch = ledger_db
-            .materialize_slot(slot_commit, b"state-root")
-            .unwrap();
+        let schema_batch = create_slot_schema_batch(slot_num, &ledger_db);
         storage_manager.commit(&schema_batch);
     }
 
     // Verify we have 3 slots with data
     let (head_slot_number, head_slot) = ledger_db.get_head_slot().unwrap().unwrap();
     assert_eq!(head_slot_number, 2.to_slot_number());
-    assert_eq!(head_slot.batches.start.0, 4); // Slots 0 and 1 each have 2 batches
-    assert_eq!(head_slot.batches.end.0, 6); // Slot 2 has batches 4 and 5
 
+    assert_eq!(head_slot.batches.end.0 - head_slot.batches.start.0, 2);
+
+    let n = 3;
     // Verify item numbers before rollback
     let item_numbers_before_rollback = ledger_db.get_next_items_numbers().unwrap();
-    assert_eq!(item_numbers_before_rollback.slot_number, 3.to_slot_number());
-    assert_eq!(item_numbers_before_rollback.batch_number, 6); // 3 slots × 2 batches
-    assert_eq!(item_numbers_before_rollback.tx_number, 18); // 6 batches × 3 txs
-    assert_eq!(item_numbers_before_rollback.event_number, 36); // 18 txs × 2 events
+    assert_eq!(item_numbers_before_rollback.slot_number.get(), n);
+    assert_eq!(item_numbers_before_rollback.batch_number, n * 2); // n slots × 2 batches
+    assert_eq!(item_numbers_before_rollback.tx_number, n * 6); // batch_number × 3 txs
+    assert_eq!(item_numbers_before_rollback.event_number, 36); // tx_number × 2 events
 
     // Rollback slot 2
     LedgerDb::rollback_last_slot(db.clone()).unwrap();
@@ -326,4 +286,52 @@ async fn assert_slot_numbers(n: u64, ledger_db: &LedgerDb) {
         head_slot_number,
         ledger_db.get_latest_finalized_slot_number().await.unwrap()
     );
+}
+
+fn create_slot_schema_batch(slot_num: u64, ledger_db: &LedgerDb) -> SchemaBatch {
+    let mut block = MockBlock::default();
+    block.header.height = slot_num;
+    let mut slot_commit = SlotCommit::<_, i32, TestTxReceiptContents>::new(block, vec![]);
+
+    // Add 2 batches per slot
+    for batch_num in 0..2 {
+        let mut tx_receipts = vec![];
+
+        // Add 3 transactions per batch
+        for tx_num in 0..3 {
+            let mut out = [0u8; 32];
+            out[..8].copy_from_slice(&u64::to_le_bytes(10 * batch_num + tx_num));
+            let tx_hash = TxHash::new(out);
+
+            let events = vec![
+                StoredEvent::new("k1".as_bytes(), "v1".as_bytes(), tx_hash.0),
+                StoredEvent::new("k2".as_bytes(), "v2".as_bytes(), tx_hash.0),
+            ];
+
+            tx_receipts.push(TransactionReceipt {
+                tx_hash,
+                body_to_save: None,
+                events,
+                receipt: TxEffect::Successful(0),
+            });
+        }
+
+        let mut batch_hash: [u8; 32] = [0u8; 32];
+        batch_hash[..8].copy_from_slice(&u64::to_le_bytes(10 * slot_num + batch_num));
+
+        let batch_receipt = BatchReceipt {
+            batch_hash,
+            tx_receipts,
+            ignored_tx_receipts: vec![],
+            inner: batch_num as i32,
+        };
+
+        slot_commit.add_batch(batch_receipt);
+    }
+
+    let schema_batch = ledger_db
+        .materialize_slot(slot_commit, b"state-root")
+        .unwrap();
+
+    schema_batch
 }

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -177,31 +177,37 @@ async fn test_rollback() {
     }
 
     // Verify we have 3 slots (slots 0, 1, 2)
-    let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
-    assert_eq!(head_slot_number, 2.to_slot_number());
 
-    // Rollback the last slot (slot 2)
-    LedgerDb::rollback_last_slot(db.clone()).unwrap();
-
-    // Verify the head slot is now slot 1
     let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
-    assert_eq!(head_slot_number, 1.to_slot_number());
+    assert_eq!(head_slot_number.get(), 2);
+
+    {
+        LedgerDb::rollback_last_slot(db.clone()).unwrap();
+
+        // Verify the head slot is now slot 1
+        let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
+        assert_eq!(head_slot_number.get(), 1);
+    }
 
     // Rollback another slot (slot 1)
-    LedgerDb::rollback_last_slot(db.clone()).unwrap();
+    {
+        LedgerDb::rollback_last_slot(db.clone()).unwrap();
 
-    // Verify the head slot is now slot 0
-    let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
-    assert_eq!(head_slot_number, 0.to_slot_number());
+        // Verify the head slot is now slot 0
+        let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
+        assert_eq!(head_slot_number.get(), 0);
+    }
 
     // Rollback the last slot (slot 0)
-    LedgerDb::rollback_last_slot(db.clone()).unwrap();
+    {
+        LedgerDb::rollback_last_slot(db.clone()).unwrap();
 
-    // Verify there are no more slots
-    assert!(ledger_db.get_head_slot().unwrap().is_none());
+        // Verify there are no more slots
+        assert!(ledger_db.get_head_slot().unwrap().is_none());
 
-    // Try to rollback when there are no slots (should succeed without error)
-    LedgerDb::rollback_last_slot(db.clone()).unwrap();
+        // Try to rollback when there are no slots (should succeed without error)
+        LedgerDb::rollback_last_slot(db.clone()).unwrap();
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -272,14 +272,20 @@ async fn test_rollback_with_data() {
 
                 let events = vec![
                     sov_rollup_interface::stf::StoredEvent::new(
-                        format!("event_key_slot{}_batch{}_tx{}_evt0", slot_num, batch_num, tx_num)
-                            .as_bytes(),
+                        format!(
+                            "event_key_slot{}_batch{}_tx{}_evt0",
+                            slot_num, batch_num, tx_num
+                        )
+                        .as_bytes(),
                         format!("event_value_{}_{}_{}_0", slot_num, batch_num, tx_num).as_bytes(),
                         [0u8; 32],
                     ),
                     sov_rollup_interface::stf::StoredEvent::new(
-                        format!("event_key_slot{}_batch{}_tx{}_evt1", slot_num, batch_num, tx_num)
-                            .as_bytes(),
+                        format!(
+                            "event_key_slot{}_batch{}_tx{}_evt1",
+                            slot_num, batch_num, tx_num
+                        )
+                        .as_bytes(),
                         format!("event_value_{}_{}_{}_1", slot_num, batch_num, tx_num).as_bytes(),
                         [0u8; 32],
                     ),
@@ -289,7 +295,9 @@ async fn test_rollback_with_data() {
                     tx_hash,
                     body_to_save: None,
                     events,
-                    receipt: TxEffect::Successful((slot_num * 100 + batch_num * 10 + tx_num) as u32),
+                    receipt: TxEffect::Successful(
+                        (slot_num * 100 + batch_num * 10 + tx_num) as u32,
+                    ),
                 });
             }
 

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -4,10 +4,10 @@ use sov_db::ledger_db::{LedgerDb, SlotCommit};
 use sov_db::schema::types::StoredStfInfo;
 use sov_mock_da::{MockAddress, MockBlob, MockBlock, MockDaSpec, MockHash};
 use sov_mock_zkvm::MockZkvmHost;
-use sov_rollup_interface::common::{IntoSlotNumber, SlotNumber};
+use sov_rollup_interface::common::{HexHash, IntoSlotNumber, SlotNumber};
 use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
-use sov_rollup_interface::stf::StoredEvent;
-use sov_rollup_interface::stf::{BatchReceipt, TransactionReceipt, TxEffect};
+use sov_rollup_interface::stf::{BatchReceipt, BlobDiscardReason, TransactionReceipt, TxEffect};
+use sov_rollup_interface::stf::{DiscardedBlob, StoredEvent};
 use sov_rollup_interface::zk::aggregated_proof::{
     AggregatedProofPublicData, CodeCommitment, SerializedAggregatedProof,
 };
@@ -280,6 +280,12 @@ fn assert_next_items_numbers(slot_number: u64, ledger_db: &LedgerDb) {
         item_numbers_before_rollback.batch_number,
         next_slot_number * 2
     ); // n slots × 2 batches
+
+    assert_eq!(
+        item_numbers_before_rollback.discarded_batch_number,
+        next_slot_number * 3
+    );
+
     assert_eq!(item_numbers_before_rollback.tx_number, next_slot_number * 6); // batch_number × 3 txs
     assert_eq!(
         item_numbers_before_rollback.event_number,
@@ -290,7 +296,18 @@ fn assert_next_items_numbers(slot_number: u64, ledger_db: &LedgerDb) {
 fn create_slot_schema_batch(slot_num: u64, ledger_db: &LedgerDb) -> SchemaBatch {
     let mut block = MockBlock::default();
     block.header.height = slot_num;
-    let mut slot_commit = SlotCommit::<_, i32, TestTxReceiptContents>::new(block, vec![]);
+
+    let mut discarded_blobs = Vec::new();
+
+    for i in 0..3 {
+        let discarded_blob = DiscardedBlob {
+            hash: HexHash::new([(slot_num + i) as u8; 32]),
+            reason: BlobDiscardReason::OutOfCapacity,
+        };
+        discarded_blobs.push(discarded_blob);
+    }
+
+    let mut slot_commit = SlotCommit::<_, i32, TestTxReceiptContents>::new(block, discarded_blobs);
 
     // Add 2 batches per slot
     for batch_num in 0..2 {

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -225,58 +225,38 @@ async fn test_rollback_with_data() {
         storage_manager.commit(&schema_batch);
     }
 
-    // Verify we have 3 slots with data
-    let (head_slot_number, head_slot) = ledger_db.get_head_slot().unwrap().unwrap();
-    assert_eq!(head_slot_number, 2.to_slot_number());
-
-    assert_eq!(head_slot.batches.end.0 - head_slot.batches.start.0, 2);
-
-    let n = 3;
     // Verify item numbers before rollback
-    let item_numbers_before_rollback = ledger_db.get_next_items_numbers().unwrap();
-    assert_eq!(item_numbers_before_rollback.slot_number.get(), n);
-    assert_eq!(item_numbers_before_rollback.batch_number, n * 2); // n slots × 2 batches
-    assert_eq!(item_numbers_before_rollback.tx_number, n * 6); // batch_number × 3 txs
-    assert_eq!(item_numbers_before_rollback.event_number, 36); // tx_number × 2 events
+    {
+        let expected_slot_number = 2;
+        let (head_slot_number, head_slot) = ledger_db.get_head_slot().unwrap().unwrap();
+        assert_eq!(head_slot_number.get(), expected_slot_number);
+        assert_eq!(head_slot.batches.end.0 - head_slot.batches.start.0, 2);
+        assert_next_items_numbers(expected_slot_number, &ledger_db);
+    }
 
     // Rollback slot 2
-    LedgerDb::rollback_last_slot(db.clone()).unwrap();
+    {
+        LedgerDb::rollback_last_slot(db.clone()).unwrap();
+        let expected_slot_number = 1;
 
-    // Verify slot 2 is gone
-    let (head_slot_number, head_slot) = ledger_db.get_head_slot().unwrap().unwrap();
-    assert_eq!(head_slot_number, 1.to_slot_number());
-    assert_eq!(head_slot.batches.start.0, 2); // Slot 1 starts at batch 2
-    assert_eq!(head_slot.batches.end.0, 4); // Slot 1 ends at batch 4
+        // Verify slot 2 is gone
+        let (head_slot_number, head_slot) = ledger_db.get_head_slot().unwrap().unwrap();
+        assert_eq!(head_slot_number.get(), expected_slot_number);
+        assert_eq!(head_slot.batches.end.0 - head_slot.batches.start.0, 2);
+        assert_next_items_numbers(expected_slot_number, &ledger_db);
+    }
 
-    // Verify the item numbers reflect the rollback
-    let item_numbers_after_rollback = ledger_db.get_next_items_numbers().unwrap();
-    assert_eq!(item_numbers_after_rollback.slot_number, 2.to_slot_number());
-    assert_eq!(item_numbers_after_rollback.batch_number, 4); // 2 slots × 2 batches
-    assert_eq!(item_numbers_after_rollback.tx_number, 12); // 4 batches × 3 txs
-    assert_eq!(item_numbers_after_rollback.event_number, 24); // 12 txs × 2 events
+    {
+        // Rollback slot 1
+        LedgerDb::rollback_last_slot(db.clone()).unwrap();
+        let expected_slot_number = 0;
 
-    // Verify slot 1 data is intact by checking item numbers
-    let item_numbers_slot_1 = ledger_db.get_next_items_numbers().unwrap();
-    assert_eq!(item_numbers_slot_1.slot_number, 2.to_slot_number());
-    assert_eq!(item_numbers_slot_1.batch_number, 4); // 2 slots × 2 batches
-
-    // Rollback slot 1
-    LedgerDb::rollback_last_slot(db.clone()).unwrap();
-
-    // Verify slot 1 is gone but slot 0 remains
-    let (head_slot_number, head_slot) = ledger_db.get_head_slot().unwrap().unwrap();
-    assert_eq!(head_slot_number, 0.to_slot_number());
-    assert_eq!(head_slot.batches.start.0, 0);
-    assert_eq!(head_slot.batches.end.0, 2);
-
-    let item_numbers_after_second_rollback = ledger_db.get_next_items_numbers().unwrap();
-    assert_eq!(
-        item_numbers_after_second_rollback.slot_number,
-        1.to_slot_number()
-    );
-    assert_eq!(item_numbers_after_second_rollback.batch_number, 2);
-    assert_eq!(item_numbers_after_second_rollback.tx_number, 6);
-    assert_eq!(item_numbers_after_second_rollback.event_number, 12);
+        // Verify slot 1 is gone but slot 0 remains
+        let (head_slot_number, head_slot) = ledger_db.get_head_slot().unwrap().unwrap();
+        assert_eq!(head_slot_number.get(), expected_slot_number);
+        assert_eq!(head_slot.batches.end.0 - head_slot.batches.start.0, 2);
+        assert_next_items_numbers(expected_slot_number, &ledger_db);
+    }
 }
 
 async fn assert_slot_numbers(n: u64, ledger_db: &LedgerDb) {
@@ -285,6 +265,25 @@ async fn assert_slot_numbers(n: u64, ledger_db: &LedgerDb) {
     assert_eq!(
         head_slot_number,
         ledger_db.get_latest_finalized_slot_number().await.unwrap()
+    );
+}
+
+fn assert_next_items_numbers(slot_number: u64, ledger_db: &LedgerDb) {
+    let next_slot_number = slot_number + 1;
+    // Verify item numbers before rollback
+    let item_numbers_before_rollback = ledger_db.get_next_items_numbers().unwrap();
+    assert_eq!(
+        item_numbers_before_rollback.slot_number.get(),
+        next_slot_number
+    );
+    assert_eq!(
+        item_numbers_before_rollback.batch_number,
+        next_slot_number * 2
+    ); // n slots × 2 batches
+    assert_eq!(item_numbers_before_rollback.tx_number, next_slot_number * 6); // batch_number × 3 txs
+    assert_eq!(
+        item_numbers_before_rollback.event_number,
+        next_slot_number * 12
     );
 }
 
@@ -329,9 +328,7 @@ fn create_slot_schema_batch(slot_num: u64, ledger_db: &LedgerDb) -> SchemaBatch 
         slot_commit.add_batch(batch_receipt);
     }
 
-    let schema_batch = ledger_db
+    ledger_db
         .materialize_slot(slot_commit, b"state-root")
-        .unwrap();
-
-    schema_batch
+        .unwrap()
 }

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -153,3 +153,60 @@ async fn next_slot_number_to_receive_is_none_at_startup() {
         .unwrap()
         .is_none());
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_rollback() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
+    let ledger_storage = storage_manager.create_ledger_storage();
+    let ledger_db = LedgerDb::with_reader(ledger_storage).unwrap();
+
+    // Initially, there should be no slots
+    assert!(ledger_db.get_head_slot().unwrap().is_none());
+
+    // Add a few slots
+    for i in 0..3 {
+        let mut block = MockBlock::default();
+        block.header.height = i;
+        let slot_commit = SlotCommit::<_, MockBlob, ()>::new(block, Default::default());
+        let schema_batch = ledger_db
+            .materialize_slot(slot_commit, b"state-root")
+            .unwrap();
+        storage_manager.commit(&schema_batch);
+    }
+
+    // Verify we have 3 slots (slots 0, 1, 2)
+    let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
+    assert_eq!(head_slot_number, 2.to_slot_number());
+
+    // Rollback the last slot (slot 2)
+    ledger_db
+        .rollback_last_slot(storage_manager.get_db())
+        .unwrap();
+
+    // Verify the head slot is now slot 1
+    let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
+    assert_eq!(head_slot_number, 1.to_slot_number());
+
+    // Rollback another slot (slot 1)
+    ledger_db
+        .rollback_last_slot(storage_manager.get_db())
+        .unwrap();
+
+    // Verify the head slot is now slot 0
+    let (head_slot_number, _) = ledger_db.get_head_slot().unwrap().unwrap();
+    assert_eq!(head_slot_number, 0.to_slot_number());
+
+    // Rollback the last slot (slot 0)
+    ledger_db
+        .rollback_last_slot(storage_manager.get_db())
+        .unwrap();
+
+    // Verify there are no more slots
+    assert!(ledger_db.get_head_slot().unwrap().is_none());
+
+    // Try to rollback when there are no slots (should succeed without error)
+    ledger_db
+        .rollback_last_slot(storage_manager.get_db())
+        .unwrap();
+}

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -5,12 +5,16 @@ use sov_mock_da::{MockAddress, MockBlob, MockBlock, MockDaSpec, MockHash};
 use sov_mock_zkvm::MockZkvmHost;
 use sov_rollup_interface::common::{IntoSlotNumber, SlotNumber};
 use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
+use sov_rollup_interface::stf::StoredEvent;
+use sov_rollup_interface::stf::{BatchReceipt, TransactionReceipt, TxEffect};
 use sov_rollup_interface::zk::aggregated_proof::{
     AggregatedProofPublicData, CodeCommitment, SerializedAggregatedProof,
 };
+use sov_rollup_interface::TxHash;
 use sov_test_utils::ledger_db::sov_api_spec::types::IntOrHash;
 use sov_test_utils::ledger_db::{LedgerTestService, LedgerTestServiceData};
 use sov_test_utils::storage::SimpleLedgerStorageManager;
+use sov_test_utils::TestTxReceiptContents;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_filtered_slot_events() {
@@ -208,11 +212,6 @@ async fn test_rollback() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_rollback_with_data() {
-    use sov_rollup_interface::common::IntoSlotNumber;
-    use sov_rollup_interface::stf::{BatchReceipt, TransactionReceipt, TxEffect};
-    use sov_rollup_interface::TxHash;
-    use sov_test_utils::TestTxReceiptContents;
-
     let temp_dir = tempfile::tempdir().unwrap();
     let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
     let ledger_storage = storage_manager.create_ledger_storage();
@@ -231,107 +230,28 @@ async fn test_rollback_with_data() {
 
             // Add 3 transactions per batch
             for tx_num in 0..3 {
-                let tx_hash = TxHash::new([
-                    (slot_num * 100 + batch_num * 10 + tx_num) as u8,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                ]);
+                let mut out = [0u8; 32];
+                out[..8].copy_from_slice(&u64::to_le_bytes(10 * batch_num + tx_num));
+                let tx_hash = TxHash::new(out);
 
                 let events = vec![
-                    sov_rollup_interface::stf::StoredEvent::new(
-                        format!(
-                            "event_key_slot{}_batch{}_tx{}_evt0",
-                            slot_num, batch_num, tx_num
-                        )
-                        .as_bytes(),
-                        format!("event_value_{}_{}_{}_0", slot_num, batch_num, tx_num).as_bytes(),
-                        [0u8; 32],
-                    ),
-                    sov_rollup_interface::stf::StoredEvent::new(
-                        format!(
-                            "event_key_slot{}_batch{}_tx{}_evt1",
-                            slot_num, batch_num, tx_num
-                        )
-                        .as_bytes(),
-                        format!("event_value_{}_{}_{}_1", slot_num, batch_num, tx_num).as_bytes(),
-                        [0u8; 32],
-                    ),
+                    StoredEvent::new("k1".as_bytes(), "v1".as_bytes(), tx_hash.0),
+                    StoredEvent::new("k2".as_bytes(), "v2".as_bytes(), tx_hash.0),
                 ];
 
                 tx_receipts.push(TransactionReceipt {
                     tx_hash,
                     body_to_save: None,
                     events,
-                    receipt: TxEffect::Successful(
-                        (slot_num * 100 + batch_num * 10 + tx_num) as u32,
-                    ),
+                    receipt: TxEffect::Successful(0),
                 });
             }
 
+            let mut batch_hash: [u8; 32] = [0u8; 32];
+            batch_hash[..8].copy_from_slice(&u64::to_le_bytes(10 * slot_num + batch_num));
+
             let batch_receipt = BatchReceipt {
-                batch_hash: [
-                    (slot_num * 100 + batch_num * 10) as u8,
-                    1,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                ],
+                batch_hash,
                 tx_receipts,
                 ignored_tx_receipts: vec![],
                 inner: batch_num as i32,

--- a/crates/utils/sov-test-utils/src/storage.rs
+++ b/crates/utils/sov-test-utils/src/storage.rs
@@ -147,6 +147,11 @@ impl SimpleLedgerStorageManager {
     pub fn commit(&mut self, ledger_change_set: &SchemaBatch) {
         self.db.write_schemas(ledger_change_set).unwrap();
     }
+
+    /// Get a reference to the underlying database
+    pub fn get_db(&self) -> &Arc<rockbound::DB> {
+        &self.db
+    }
 }
 
 /// Implementation of [`HierarchicalStorageManager`] that provides [`NomtProverStorage`]

--- a/crates/utils/sov-test-utils/src/storage.rs
+++ b/crates/utils/sov-test-utils/src/storage.rs
@@ -149,8 +149,8 @@ impl SimpleLedgerStorageManager {
     }
 
     /// Get a reference to the underlying database
-    pub fn get_db(&self) -> &Arc<rockbound::DB> {
-        &self.db
+    pub fn get_db(&self) -> Arc<rockbound::DB> {
+        self.db.clone()
     }
 }
 


### PR DESCRIPTION
# Description

This PR introduces the `LedgerDb::rollback` method along with its corresponding tests.
We chose not to reuse the existing `LedgerStateProvider::get_slots` logic because its complex generic signature would require adding intermediary types just to satisfy the API. Even with that in place, additional glue code would still be necessary to construct a SchemaBatch.


- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
