### PR TITLE
Celestia adapter: measuring all API calls

### DIFF
--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -4,7 +4,8 @@ mod tests;
 pub use crate::config::CelestiaConfig;
 use crate::metrics::client::{
     BlobGetAllMeasurement, GetBlockHeaderMeasurement, GetChainHeadMeasurement,
-    GetNamespaceDataMeasurement, SubmitPayForBlob,
+    GetNamespaceDataMeasurement, HeaderSyncStateMeasurement, StateBalanceForAddressMeasurement,
+    StateEstimateGasPriceMeasurement, SubmitPayForBlob,
 };
 use crate::metrics::full::{
     BlobSubmitMeasurement, CelestiaAdapterStateMeasurement, GetBlockMeasurement,
@@ -626,23 +627,48 @@ async fn gather_stat(
     signer: &celestia_types::state::AccAddress,
     priority: celestia_client::tx::TxPriority,
 ) -> anyhow::Result<CelestiaAdapterStateMeasurement> {
-    let balance = client
-        .state()
-        .balance_for_address(signer)
-        .await
-        .context("state.BalanceForAddress")?;
+    // TODO: timeout as param!!!
+    let request_timeout = std::time::Duration::from_secs(12);
 
-    let sync_state = client
-        .header()
-        .sync_state()
-        .await
-        .context("header.SyncState")?;
+    // Balance
+    let balance_start = std::time::Instant::now();
+    let balance_response =
+        tokio::time::timeout(request_timeout, client.state().balance_for_address(signer)).await;
+    let response_time = balance_start.elapsed();
+    let is_success = matches!(balance_response, Ok(Ok(_)));
+    sov_metrics::track_metrics(|tracker| {
+        tracker.submit(StateBalanceForAddressMeasurement::new(
+            response_time,
+            is_success,
+        ));
+    });
+    let balance = flatten_timeout::<u64>(balance_response).context("state.BalanceForAddress")?;
+
+    // Sync state
+    let sync_state_start = std::time::Instant::now();
+    let sync_state_response =
+        tokio::time::timeout(request_timeout, client.header().sync_state()).await;
+    let response_time = sync_state_start.elapsed();
+    let is_success = matches!(sync_state_response, Ok(Ok(_)));
+    sov_metrics::track_metrics(|tracker| {
+        tracker.submit(HeaderSyncStateMeasurement::new(response_time, is_success));
+    });
+    let sync_state = flatten_timeout(sync_state_response).context("header.SyncState")?;
     let sync_distance = sync_state.to_height.saturating_sub(sync_state.from_height);
-    let gas_price = client
-        .state()
-        .estimate_gas_price(priority)
-        .await
-        .context("state.EstimateGasPrice")?;
+
+    // Gas price
+    let gas_price_start = std::time::Instant::now();
+    let gas_price_response =
+        tokio::time::timeout(request_timeout, client.state().estimate_gas_price(priority)).await;
+    let response_time = gas_price_start.elapsed();
+    let is_success = matches!(gas_price_response, Ok(Ok(_)));
+    sov_metrics::track_metrics(|tracker| {
+        tracker.submit(StateEstimateGasPriceMeasurement::new(
+            response_time,
+            is_success,
+        ));
+    });
+    let gas_price = flatten_timeout(gas_price_response).context("state.EstimateGasPrice")?;
 
     Ok(CelestiaAdapterStateMeasurement {
         balance,

--- a/crates/adapters/celestia/src/metrics/client.rs
+++ b/crates/adapters/celestia/src/metrics/client.rs
@@ -26,6 +26,12 @@ pub(crate) struct ShareGetNamespaceData;
 pub(crate) struct StateSubmitPayForBlob;
 #[derive(Debug)]
 pub(crate) struct BlobGetAll;
+#[derive(Debug)]
+pub(crate) struct StateBalanceForAddress;
+#[derive(Debug)]
+pub(crate) struct HeaderSyncState;
+#[derive(Debug)]
+pub(crate) struct StateEstimateGasPrice;
 
 impl ApiCall for HeaderGetByHeight {
     fn measurement_name() -> &'static str {
@@ -54,6 +60,24 @@ impl ApiCall for StateSubmitPayForBlob {
 impl ApiCall for BlobGetAll {
     fn measurement_name() -> &'static str {
         "sov_celestia_adapter_blob_get_all"
+    }
+}
+
+impl ApiCall for StateBalanceForAddress {
+    fn measurement_name() -> &'static str {
+        "sov_celestia_adapter_state_balance_for_address"
+    }
+}
+
+impl ApiCall for HeaderSyncState {
+    fn measurement_name() -> &'static str {
+        "sov_celestia_adapter_header_sync_state"
+    }
+}
+
+impl ApiCall for StateEstimateGasPrice {
+    fn measurement_name() -> &'static str {
+        "sov_celestia_adapter_state_estimate_gas_price"
     }
 }
 
@@ -138,3 +162,6 @@ pub(crate) type GetChainHeadMeasurement = MeasuredApiCall<HeaderNetworkHead>;
 pub(crate) type GetNamespaceDataMeasurement = MeasuredApiCallWithNamespace<ShareGetNamespaceData>;
 pub(crate) type SubmitPayForBlob = MeasuredApiCallWithNamespace<StateSubmitPayForBlob>;
 pub(crate) type BlobGetAllMeasurement = MeasuredApiCall<BlobGetAll>;
+pub(crate) type StateBalanceForAddressMeasurement = MeasuredApiCall<StateBalanceForAddress>;
+pub(crate) type HeaderSyncStateMeasurement = MeasuredApiCall<HeaderSyncState>;
+pub(crate) type StateEstimateGasPriceMeasurement = MeasuredApiCall<StateEstimateGasPrice>;


### PR DESCRIPTION
# Description

Adds measuring of background stats, so grafana dashabord can have a full view of interacting with celestia API

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1630

## Testing
All existing tests are passing

## Docs
No updates
