### PR TITLE
`StorageManager`: Simplify state root validation.

### DIFF
--- a/crates/full-node/sov-db/src/commit_flag.rs
+++ b/crates/full-node/sov-db/src/commit_flag.rs
@@ -11,13 +11,12 @@ const FLAG_FILE_NAME: &str = "commit_status.flag";
 #[derive(Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Clone, Copy)]
 pub enum CommitStatus {
     /// A commit of **kernel state** is in progress.
-    /// Stores the previous `kernel` root hash before the commit began.
-    CommittingKernelNomt([u8; 32]),
+    CommittingKernelNomt,
     /// A commit of **user state** is in progress.
     /// Stores the previous `user` root hash before the commit began.
-    CommittingUserNomt([u8; 32]),
+    CommittingUserNomt,
     /// /// A commit of **LedgerDB** is in progress.
-    CommittingLedger([u8; 64]),
+    CommittingLedger,
     /// A commit of **archival user and kernel state** in the flat-db is in progress.
     CommittingArchivalUserAndKernel,
     /// A commit of **live user and kernel state** in the flat-db is in progress.

--- a/crates/full-node/sov-db/src/state_db_nomt.rs
+++ b/crates/full-node/sov-db/src/state_db_nomt.rs
@@ -58,9 +58,7 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
 
         // 1.
         let flag_mid_start = std::time::Instant::now();
-        commit_flag.save_commit_status(&CommitStatus::CommittingKernelNomt(
-            self.kernel.root().into_inner(),
-        ))?;
+        commit_flag.save_commit_status(&CommitStatus::CommittingKernelNomt)?;
         let flag_mid = flag_mid_start.elapsed();
 
         #[cfg(feature = "test-utils")]
@@ -75,9 +73,7 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
         // 3.
         let flag_finish_start = std::time::Instant::now();
 
-        commit_flag.save_commit_status(&CommitStatus::CommittingUserNomt(
-            self.user.root().into_inner(),
-        ))?;
+        commit_flag.save_commit_status(&CommitStatus::CommittingUserNomt)?;
         let flag_finish = flag_finish_start.elapsed();
 
         #[cfg(feature = "test-utils")]
@@ -134,8 +130,8 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
 
     pub(crate) fn get_root_hashes(&self) -> StateRootHashes {
         StateRootHashes {
-            user: self.user.root(),
-            kernel: self.kernel.root(),
+            user: self.user.root().into_inner(),
+            kernel: self.kernel.root().into_inner(),
         }
     }
 
@@ -151,39 +147,8 @@ impl<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync> NomtSta
 
 #[derive(Debug)]
 pub(crate) struct StateRootHashes {
-    pub(crate) user: nomt::Root,
-    pub(crate) kernel: nomt::Root,
-}
-
-impl StateRootHashes {
-    // It is known that historical root hash is a concatenation of 2 root hashes,
-    // but we don't want to duplicate logic between `sov_state` and here.
-    // So just the simple inclusion of 2 root hashes is enough.
-    // This is based on an assumption that serialized root hash is stored as is, without any permutation.
-    pub(crate) fn included_in_raw(
-        &self,
-        combined_historical_root: &rockbound::SchemaValue,
-    ) -> bool {
-        if combined_historical_root.len() < 64 {
-            tracing::warn!(
-                "Combined historical root is too short to contain 2 root hashes: {}",
-                combined_historical_root.len()
-            );
-            return false;
-        }
-        let user_needle: &[u8] = self.user.as_ref();
-        let kernel_needle: &[u8] = self.kernel.as_ref();
-        assert_eq!(user_needle.len(), 32);
-        assert_eq!(kernel_needle.len(), 32);
-
-        let user_found = combined_historical_root
-            .windows(32)
-            .any(|window| window == user_needle);
-        let kernel_found = combined_historical_root
-            .windows(32)
-            .any(|window| window == kernel_needle);
-        user_found && kernel_found
-    }
+    pub(crate) user: [u8; 32],
+    pub(crate) kernel: [u8; 32],
 }
 
 /// Combination of [`Overlay`] for user and kernel namespaces.

--- a/crates/full-node/sov-db/src/storage_manager/delta_reader_based/tests.rs
+++ b/crates/full-node/sov-db/src/storage_manager/delta_reader_based/tests.rs
@@ -31,7 +31,7 @@ impl TestableStorage for TestNativeStorage {
         self,
         items: &[(Vec<u8>, Option<Vec<u8>>)],
         _version: u64,
-    ) -> Self::ChangeSet {
+    ) -> (Self::ChangeSet, [u8; 64]) {
         let mut preimages = Vec::with_capacity(items.len());
         let mut batch = Vec::with_capacity(items.len());
         let mut accessory_batch = Vec::with_capacity(items.len());
@@ -72,10 +72,13 @@ impl TestableStorage for TestNativeStorage {
         let accessory_change_set =
             AccessoryDb::materialize_values(accessory_batch, SlotNumber::GENESIS).unwrap();
 
-        NativeChangeSet {
-            state_change_set,
-            accessory_change_set,
-        }
+        (
+            NativeChangeSet {
+                state_change_set,
+                accessory_change_set,
+            },
+            [0; 64],
+        )
     }
 
     fn get_value(&self, key: &[u8]) -> Option<Vec<u8>> {
@@ -235,7 +238,7 @@ fn test_fork_keeps_reference_to_snapshot_after_finalization() {
 
     let stf_changes = storage.materialize_from_key_value(key.to_vec(), Some(value_1.to_vec()), 0);
     storage_manager
-        .save_change_set(&block_a, stf_changes, SchemaBatch::default())
+        .save_change_set(&block_a, stf_changes.0, SchemaBatch::default())
         .unwrap();
 
     let (stf_reader_b, _) = storage_manager.create_state_for(&block_b).unwrap();
@@ -250,7 +253,7 @@ fn test_fork_keeps_reference_to_snapshot_after_finalization() {
     let stf_changes =
         stf_reader_b.materialize_from_key_value(key.to_vec(), Some(value_2.to_vec()), 1);
     storage_manager
-        .save_change_set(&block_b, stf_changes, SchemaBatch::default())
+        .save_change_set(&block_b, stf_changes.0, SchemaBatch::default())
         .unwrap();
 
     storage_manager.finalize(&block_a).unwrap();

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -194,7 +194,7 @@ where
             CommitStatus::Success => {}
         }
 
-        let state_roots = AllDBsStateRoots::from_dbs(&merkelized_state, ledger_db, flat_state_db)?;
+        let state_roots = AllDBsStateRoots::from_dbs(merkelized_state, ledger_db, flat_state_db)?;
         state_roots.validate_all();
 
         Ok(())
@@ -550,27 +550,27 @@ impl AllDBsStateRoots {
 
     fn validate_all(&self) {
         assert_eq!(
-            hex::encode(&self.root_hash_nomt.user),
+            hex::encode(self.root_hash_nomt.user),
             hex::encode(&self.root_hash_from_live_db[0..32])
         );
 
         assert_eq!(
-            hex::encode(&self.root_hash_nomt.kernel),
+            hex::encode(self.root_hash_nomt.kernel),
             hex::encode(&self.root_hash_from_live_db[32..])
         );
 
         assert_eq!(
             hex::encode(&self.root_hash_from_ledger_db),
-            hex::encode(&self.root_hash_from_live_db)
+            hex::encode(self.root_hash_from_live_db)
         );
     }
 
     fn warning_on_rollback(&self, commit_status: &CommitStatus) {
         tracing::warn!(
-            live_db_kernel_root_hash = hex::encode(&self.root_hash_from_live_db),
-            root_hash_ledger_db = hex::encode(&self.root_hash_from_ledger_db),
-            user_nomt_db_root_hash = hex::encode(&self.root_hash_nomt.user),
-            kernel_nomt_db_root_hash = hex::encode(&self.root_hash_nomt.kernel),
+            live_db_kernel_root_hash = hex::encode(self.root_hash_from_live_db),
+            root_hash_ledger_db = hex::encode(self.root_hash_from_ledger_db),
+            user_nomt_db_root_hash = hex::encode(self.root_hash_nomt.user),
+            kernel_nomt_db_root_hash = hex::encode(self.root_hash_nomt.kernel),
             ?commit_status,
             "Detected in-progress commit. Rolling back DBs"
         );

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -562,7 +562,7 @@ impl AllDBsStateRoots {
         );
 
         assert_eq!(
-            hex::encode(&self.root_hash_from_ledger_db),
+            hex::encode(self.root_hash_from_ledger_db),
             hex::encode(self.root_hash_from_live_db)
         );
     }

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -23,7 +23,7 @@ use crate::namespaces::{KernelNamespace, UserNamespace};
 use crate::pruner::Pruner;
 use crate::schema::namespace::NomtStateValues;
 use crate::schema::tables::ModuleAccessoryState;
-use crate::state_db_nomt::{NomtSessionBuilder, NomtStateDb, StateOverlay};
+use crate::state_db_nomt::{NomtSessionBuilder, NomtStateDb, StateOverlay, StateRootHashes};
 use crate::storage_manager::{update_ledger_finalized_height, InitializableNativeNomtStorage};
 
 const GIGABYTE: usize = 1024 * 1024 * 1024;
@@ -31,6 +31,74 @@ const GIGABYTE: usize = 1024 * 1024 * 1024;
 // 300 thousand keys * 32 bytes is about 10 MB. This should be a large enough batch size to keep up with state growth,
 // without consuming excessive memory.
 pub(crate) const DEFAULT_MAX_PRUNING_BATCH_SIZE: usize = 300_000;
+
+struct AllDBsStateRoots {
+    root_hash_from_live_db: [u8; 64],
+    root_hash_from_ledger_db: [u8; 64],
+    root_hash_nomt: StateRootHashes,
+}
+
+impl AllDBsStateRoots {
+    fn from_dbs<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync>(
+        merkelized_state: Arc<NomtStateDb<H>>,
+        ledger_db: Arc<rockbound::DB>,
+        flat_state_db: &FlatStateDb,
+    ) -> anyhow::Result<AllDBsStateRoots> {
+        let root_hash_from_live_db =
+            root_hash_from_life_db(flat_state_db)?.unwrap_or_else(|| pre_genesis_root());
+
+        let root_hash_from_ledger_db =
+            LedgerDb::get_head_root_hash(ledger_db.clone())?.unwrap_or_else(|| pre_genesis_root());
+
+        let root_hash_nomt = merkelized_state.get_root_hashes();
+
+        Ok(AllDBsStateRoots {
+            root_hash_from_live_db,
+            root_hash_from_ledger_db,
+            root_hash_nomt,
+        })
+    }
+
+    fn is_kerner_nomt_root_newer(&self) -> bool {
+        self.root_hash_nomt.kernel != self.root_hash_from_live_db[32..]
+    }
+
+    fn is_user_nomt_root_newer(&self) -> bool {
+        self.root_hash_nomt.user != self.root_hash_from_live_db[0..32]
+    }
+
+    fn is_ledger_db_root_newer(&self) -> bool {
+        self.root_hash_from_ledger_db != self.root_hash_from_live_db
+    }
+
+    fn validate_all(&self) {
+        assert_eq!(
+            hex(&self.root_hash_nomt.user),
+            hex(&self.root_hash_from_live_db[0..32])
+        );
+
+        assert_eq!(
+            hex(&self.root_hash_nomt.kernel),
+            hex(&self.root_hash_from_live_db[32..])
+        );
+
+        assert_eq!(
+            hex(&self.root_hash_from_ledger_db),
+            hex(&self.root_hash_from_live_db)
+        );
+    }
+
+    fn warning_on_rollback(&self, commit_status: &CommitStatus) {
+        tracing::warn!(
+            live_db_kernel_root_hash = hex(&self.root_hash_from_live_db),
+            root_hash_ledger_db = hex(&self.root_hash_from_ledger_db),
+            user_nomt_db_root_hash = hex(&self.root_hash_nomt.user),
+            kernel_nomt_db_root_hash = hex(&self.root_hash_nomt.kernel),
+            ?commit_status,
+            "Detected in-progress commit. Rolling back DBs"
+        );
+    }
+}
 
 pub(crate) struct DbGroup<H, K> {
     commit_flag: CommitFlag,
@@ -65,8 +133,6 @@ where
             &flat_state,
         )?;
 
-        // Validate root hashes.
-        Self::are_root_hashes_match(&merklized_state, &flat_state)?;
         commit_flag.save_commit_status(&CommitStatus::Success)?;
 
         let accessory_rocksdb =
@@ -100,12 +166,8 @@ where
         #[cfg(feature = "test-utils")]
         crate::test_utils::CrashLocation::BeforeSavingLedger.crash_if_env_set();
 
-        // Immediately after genesis, the ledger contains no entries, and the root hash is initialized to [0; 64].
-        let root_hash = LedgerDb::get_head_root_hash(self.ledger.clone())?
-            .unwrap_or_else(|| Self::pre_genesis_root());
-
         self.commit_flag
-            .save_commit_status(&CommitStatus::CommittingLedger(root_hash))?;
+            .save_commit_status(&CommitStatus::CommittingLedger)?;
 
         #[cfg(feature = "test-utils")]
         crate::test_utils::CrashLocation::BeforeCommittingLedger.crash_if_env_set();
@@ -147,66 +209,39 @@ where
         ledger_db: Arc<rockbound::DB>,
         flat_state_db: &FlatStateDb,
     ) -> anyhow::Result<()> {
-        let root_hash_from_life_db = Self::root_hash_from_life_db(flat_state_db)?
-            .unwrap_or_else(|| Self::pre_genesis_root());
-
-        let root_hash_from_life_db_kernel = &root_hash_from_life_db[32..];
-        let root_hash_from_life_db_user = &root_hash_from_life_db[..31];
+        let state_roots =
+            AllDBsStateRoots::from_dbs(merkelized_state.clone(), ledger_db.clone(), flat_state_db)?;
 
         let commit_status = commit_flag.read_status()?;
 
         match commit_status {
-            CommitStatus::CommittingKernelNomt(_) => {
-                let mut current_kernel_root_hash = merkelized_state.kernel.root().into_inner();
-
+            CommitStatus::CommittingKernelNomt => {
                 // Kernel commit was successful but later commits failed. We rollback only the kernel.
-                if root_hash_from_life_db_kernel != current_kernel_root_hash {
-                    tracing::warn!(
-                        flag_kernel_root_hash = hex::encode(root_hash_from_life_db_kernel),
-                        db_kernel_root_hash = hex::encode(current_kernel_root_hash),
-                        ?commit_status,
-                        "Detected in-progress commit. Rolling back kernel DB."
-                    );
-
+                if state_roots.is_kerner_nomt_root_newer() {
+                    state_roots.warning_on_rollback(&commit_status);
                     merkelized_state.kernel.rollback(1)?;
-                    current_kernel_root_hash = merkelized_state.kernel.root().into_inner();
-                    assert_eq!(root_hash_from_life_db_kernel, current_kernel_root_hash)
                 }
             }
-            CommitStatus::CommittingUserNomt(_) => {
-                let current_user_root_hash = merkelized_state.user.root().into_inner();
-
+            CommitStatus::CommittingUserNomt => {
+                state_roots.warning_on_rollback(&commit_status);
                 // User & Kernel commit was successful but later commits failed. We rollback both.
-                if root_hash_from_life_db_user != current_user_root_hash {
-                    tracing::warn!(
-                        flag_user_root_hash = hex::encode(root_hash_from_life_db_user),
-                        db_user_root_hash = hex::encode(current_user_root_hash),
-                        ?commit_status,
-                        "Detected in-progress commit. Rolling back kernel DB."
-                    );
+                if state_roots.is_user_nomt_root_newer() {
                     merkelized_state.kernel.rollback(1)?;
                     merkelized_state.user.rollback(1)?;
                 } else
                 // Only Kernel commit was successful. We rollback only the kernel.
                 {
-                    tracing::warn!(
-                        ?commit_status,
-                        "Detected in-progress commit. Rolling back kernel & user DBs."
-                    );
                     merkelized_state.kernel.rollback(1)?;
                 }
             }
 
-            CommitStatus::CommittingLedger(_) => {
-                let current_root_hash = LedgerDb::get_head_root_hash(ledger_db.clone())?
-                    // This can be empty only during genesis startup; when that happens, we initialize CommitStatus to Succes.
-                    .expect("Error: The ledger database does not contain the state root hash.");
-
+            CommitStatus::CommittingLedger => {
+                state_roots.warning_on_rollback(&commit_status);
                 // User, Kernel & LedgerDb commit was successful but later commits failed. We rollback all of them.
-                if current_root_hash != root_hash_from_life_db {
+                if state_roots.is_ledger_db_root_newer() {
                     merkelized_state.kernel.rollback(1)?;
                     merkelized_state.user.rollback(1)?;
-                    LedgerDb::rollback_head_slot(ledger_db)?;
+                    LedgerDb::rollback_head_slot(ledger_db.clone())?;
                 } else
                 // We rollback kernel & user.
                 {
@@ -226,6 +261,10 @@ where
             }
             CommitStatus::Success => {}
         }
+
+        let state_roots =
+            AllDBsStateRoots::from_dbs(merkelized_state.clone(), ledger_db, flat_state_db)?;
+        state_roots.validate_all();
 
         Ok(())
     }
@@ -447,85 +486,7 @@ where
             accessory_state,
         }
     }
-
-    fn root_hash_from_life_db(flat_state: &FlatStateDb) -> anyhow::Result<Option<[u8; 64]>> {
-        let historical_state_delta_reader =
-            DeltaReader::new(flat_state.live_db.clone(), Vec::new());
-
-        let Some(last_version) =
-            HistoricalStateReader::last_version_from_reader(&historical_state_delta_reader)?
-        else {
-            return Ok(None);
-        };
-
-        let state_root_hash = HistoricalStateReader::get_serialized_root_hash_from_reader(
-            &historical_state_delta_reader,
-            last_version,
-        )?
-        .unwrap_or_else(|| {
-            // If `last_version`` is persent we must always have root hash.
-            panic!(
-                "Root hash missing for the latest LiveDB version {}",
-                last_version
-            );
-        });
-
-        Ok(Some(state_root_hash.try_into().unwrap()))
-    }
-
-    fn are_root_hashes_match(
-        merklized_state: &NomtStateDb<H>,
-        flat_state: &FlatStateDb,
-    ) -> anyhow::Result<bool> {
-        let historical_state_delta_reader =
-            DeltaReader::new(flat_state.live_db.clone(), Vec::new());
-
-        let nomt_root_hashes = merklized_state.get_root_hashes();
-        let last_version =
-            HistoricalStateReader::last_version_from_reader(&historical_state_delta_reader)?;
-
-        match last_version {
-            None => {
-                let is_kernel_empty = nomt_root_hashes.kernel.is_empty();
-                let is_user_empty = nomt_root_hashes.user.is_empty();
-                tracing::trace!(
-                    ?is_kernel_empty,
-                    ?is_user_empty,
-                    "Historical root hash is empty, user and kernel must be too"
-                );
-                Ok(is_kernel_empty && is_user_empty)
-            }
-            Some(latest_version) => {
-                let Some(state_root_rocksdb) =
-                    HistoricalStateReader::get_serialized_root_hash_from_reader(
-                        &historical_state_delta_reader,
-                        latest_version,
-                    )?
-                else {
-                    anyhow::bail!(
-                        "Missing root hash for the latest version {}",
-                        latest_version
-                    );
-                };
-                tracing::trace!(
-                    histrocial_root_hash = %hex::encode(&state_root_rocksdb),
-                    nomt_state_roots = ?nomt_root_hashes,
-                    %latest_version,
-                    "Historical root hash is not empty");
-                Ok(nomt_root_hashes.included_in_raw(&state_root_rocksdb))
-            }
-        }
-    }
-
-    // Root hash for empty nomt state.
-    fn pre_genesis_root() -> [u8; 64] {
-        let mut pre_genesis_root = [0u8; 64];
-        pre_genesis_root[..32].copy_from_slice(&nomt::trie::TERMINATOR);
-        pre_genesis_root[32..].copy_from_slice(&nomt::trie::TERMINATOR);
-        pre_genesis_root
-    }
 }
-
 pub(crate) struct SnapshotGroup {
     pub(crate) historical_state: StateChanges,
     pub(crate) accessory: Arc<SchemaBatch>,
@@ -586,4 +547,40 @@ impl PrunerJob {
             accessory: accessory_state,
         })
     }
+}
+
+fn root_hash_from_life_db(flat_state: &FlatStateDb) -> anyhow::Result<Option<[u8; 64]>> {
+    let historical_state_delta_reader = DeltaReader::new(flat_state.live_db.clone(), Vec::new());
+
+    let Some(last_version) =
+        HistoricalStateReader::last_version_from_reader(&historical_state_delta_reader)?
+    else {
+        return Ok(None);
+    };
+
+    let state_root_hash = HistoricalStateReader::get_serialized_root_hash_from_reader(
+        &historical_state_delta_reader,
+        last_version,
+    )?
+    .unwrap_or_else(|| {
+        // If `last_version`` is persent we must always have root hash.
+        panic!(
+            "Root hash missing for the latest LiveDB version {}",
+            last_version
+        );
+    });
+
+    Ok(Some(state_root_hash.try_into().unwrap()))
+}
+
+// Root hash for empty nomt state.
+fn pre_genesis_root() -> [u8; 64] {
+    let mut pre_genesis_root = [0u8; 64];
+    pre_genesis_root[..32].copy_from_slice(&nomt::trie::TERMINATOR);
+    pre_genesis_root[32..].copy_from_slice(&nomt::trie::TERMINATOR);
+    pre_genesis_root
+}
+
+fn hex(data: &[u8]) -> String {
+    hex::encode(data)
 }

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -564,10 +564,7 @@ fn root_hash_from_life_db(flat_state: &FlatStateDb) -> anyhow::Result<Option<[u8
     )?
     .unwrap_or_else(|| {
         // If `last_version`` is persent we must always have root hash.
-        panic!(
-            "Root hash missing for the latest LiveDB version {}",
-            last_version
-        );
+        panic!("Root hash missing for the latest LiveDB version {last_version}",);
     });
 
     Ok(Some(state_root_hash.try_into().unwrap()))

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -62,6 +62,7 @@ where
             &commit_flag,
             merklized_state.clone(),
             ledger_rocksdb.clone(),
+            &flat_state,
         )?;
 
         // Validate root hashes.
@@ -144,31 +145,41 @@ where
         commit_flag: &CommitFlag,
         merkelized_state: Arc<NomtStateDb<H>>,
         ledger_db: Arc<rockbound::DB>,
+        flat_state_db: &FlatStateDb,
     ) -> anyhow::Result<()> {
+        let root_hash_from_life_db = Self::root_hash_from_life_db(flat_state_db)?
+            .unwrap_or_else(|| Self::pre_genesis_root());
+
+        let root_hash_from_life_db_kernel = &root_hash_from_life_db[32..];
+        let root_hash_from_life_db_user = &root_hash_from_life_db[..31];
+
         let commit_status = commit_flag.read_status()?;
+
         match commit_status {
-            CommitStatus::CommittingKernelNomt(saved_hash) => {
-                let current_kernel_root_hash = merkelized_state.kernel.root().into_inner();
+            CommitStatus::CommittingKernelNomt(_) => {
+                let mut current_kernel_root_hash = merkelized_state.kernel.root().into_inner();
 
                 // Kernel commit was successful but later commits failed. We rollback only the kernel.
-                if saved_hash != current_kernel_root_hash {
+                if root_hash_from_life_db_kernel != current_kernel_root_hash {
                     tracing::warn!(
-                        flag_kernel_root_hash = hex::encode(saved_hash),
+                        flag_kernel_root_hash = hex::encode(root_hash_from_life_db_kernel),
                         db_kernel_root_hash = hex::encode(current_kernel_root_hash),
                         ?commit_status,
                         "Detected in-progress commit. Rolling back kernel DB."
                     );
 
                     merkelized_state.kernel.rollback(1)?;
+                    current_kernel_root_hash = merkelized_state.kernel.root().into_inner();
+                    assert_eq!(root_hash_from_life_db_kernel, current_kernel_root_hash)
                 }
             }
-            CommitStatus::CommittingUserNomt(saved_hash) => {
+            CommitStatus::CommittingUserNomt(_) => {
                 let current_user_root_hash = merkelized_state.user.root().into_inner();
 
                 // User & Kernel commit was successful but later commits failed. We rollback both.
-                if saved_hash != current_user_root_hash {
+                if root_hash_from_life_db_user != current_user_root_hash {
                     tracing::warn!(
-                        flag_user_root_hash = hex::encode(saved_hash),
+                        flag_user_root_hash = hex::encode(root_hash_from_life_db_user),
                         db_user_root_hash = hex::encode(current_user_root_hash),
                         ?commit_status,
                         "Detected in-progress commit. Rolling back kernel DB."
@@ -186,13 +197,13 @@ where
                 }
             }
 
-            CommitStatus::CommittingLedger(ledger_root_hash) => {
+            CommitStatus::CommittingLedger(_) => {
                 let current_root_hash = LedgerDb::get_head_root_hash(ledger_db.clone())?
                     // This can be empty only during genesis startup; when that happens, we initialize CommitStatus to Succes.
                     .expect("Error: The ledger database does not contain the state root hash.");
 
                 // User, Kernel & LedgerDb commit was successful but later commits failed. We rollback all of them.
-                if current_root_hash != ledger_root_hash {
+                if current_root_hash != root_hash_from_life_db {
                     merkelized_state.kernel.rollback(1)?;
                     merkelized_state.user.rollback(1)?;
                     LedgerDb::rollback_head_slot(ledger_db)?;
@@ -435,6 +446,31 @@ where
             historical_state,
             accessory_state,
         }
+    }
+
+    fn root_hash_from_life_db(flat_state: &FlatStateDb) -> anyhow::Result<Option<[u8; 64]>> {
+        let historical_state_delta_reader =
+            DeltaReader::new(flat_state.live_db.clone(), Vec::new());
+
+        let Some(last_version) =
+            HistoricalStateReader::last_version_from_reader(&historical_state_delta_reader)?
+        else {
+            return Ok(None);
+        };
+
+        let state_root_hash = HistoricalStateReader::get_serialized_root_hash_from_reader(
+            &historical_state_delta_reader,
+            last_version,
+        )?
+        .unwrap_or_else(|| {
+            // If `last_version`` is persent we must always have root hash.
+            panic!(
+                "Root hash missing for the latest LiveDB version {}",
+                last_version
+            );
+        });
+
+        Ok(Some(state_root_hash.try_into().unwrap()))
     }
 
     fn are_root_hashes_match(

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -510,6 +510,8 @@ fn pre_genesis_root() -> [u8; 64] {
 }
 
 struct AllDBsStateRoots {
+    // The `live_db` is committed last. We can use `root_hash_from_live_db` to verify
+    // whether all other databases were committed in the previous run.
     root_hash_from_live_db: [u8; 64],
     root_hash_from_ledger_db: [u8; 64],
     root_hash_nomt: StateRootHashes,

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -45,10 +45,10 @@ impl AllDBsStateRoots {
         flat_state_db: &FlatStateDb,
     ) -> anyhow::Result<AllDBsStateRoots> {
         let root_hash_from_live_db =
-            root_hash_from_life_db(flat_state_db)?.unwrap_or_else(|| pre_genesis_root());
+            root_hash_from_life_db(flat_state_db)?.unwrap_or_else(pre_genesis_root);
 
         let root_hash_from_ledger_db =
-            LedgerDb::get_head_root_hash(ledger_db.clone())?.unwrap_or_else(|| pre_genesis_root());
+            LedgerDb::get_head_root_hash(ledger_db.clone())?.unwrap_or_else(pre_genesis_root);
 
         let root_hash_nomt = merkelized_state.get_root_hashes();
 

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -60,7 +60,7 @@ where
         // Validate the commit state.
         Self::validate_commit_flag_and_rollback_if_necessesary(
             &commit_flag,
-            merklized_state.clone(),
+            &merklized_state,
             ledger_rocksdb.clone(),
             &flat_state,
         )?;
@@ -137,12 +137,12 @@ where
 
     fn validate_commit_flag_and_rollback_if_necessesary(
         commit_flag: &CommitFlag,
-        merkelized_state: Arc<NomtStateDb<H>>,
+        merkelized_state: &NomtStateDb<H>,
         ledger_db: Arc<rockbound::DB>,
         flat_state_db: &FlatStateDb,
     ) -> anyhow::Result<()> {
         let state_roots =
-            AllDBsStateRoots::from_dbs(merkelized_state.clone(), ledger_db.clone(), flat_state_db)?;
+            AllDBsStateRoots::from_dbs(merkelized_state, ledger_db.clone(), flat_state_db)?;
 
         let commit_status = commit_flag.read_status()?;
 
@@ -194,8 +194,7 @@ where
             CommitStatus::Success => {}
         }
 
-        let state_roots =
-            AllDBsStateRoots::from_dbs(merkelized_state.clone(), ledger_db, flat_state_db)?;
+        let state_roots = AllDBsStateRoots::from_dbs(&merkelized_state, ledger_db, flat_state_db)?;
         state_roots.validate_all();
 
         Ok(())
@@ -518,7 +517,7 @@ struct AllDBsStateRoots {
 
 impl AllDBsStateRoots {
     fn from_dbs<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync>(
-        merkelized_state: Arc<NomtStateDb<H>>,
+        merkelized_state: &NomtStateDb<H>,
         ledger_db: Arc<rockbound::DB>,
         flat_state_db: &FlatStateDb,
     ) -> anyhow::Result<AllDBsStateRoots> {
@@ -568,10 +567,10 @@ impl AllDBsStateRoots {
 
     fn warning_on_rollback(&self, commit_status: &CommitStatus) {
         tracing::warn!(
-            live_db_kernel_root_hash = hex(&self.root_hash_from_live_db),
-            root_hash_ledger_db = hex(&self.root_hash_from_ledger_db),
-            user_nomt_db_root_hash = hex(&self.root_hash_nomt.user),
-            kernel_nomt_db_root_hash = hex(&self.root_hash_nomt.kernel),
+            live_db_kernel_root_hash = hex::encode(&self.root_hash_from_live_db),
+            root_hash_ledger_db = hex::encode(&self.root_hash_from_ledger_db),
+            user_nomt_db_root_hash = hex::encode(&self.root_hash_nomt.user),
+            kernel_nomt_db_root_hash = hex::encode(&self.root_hash_nomt.kernel),
             ?commit_status,
             "Detected in-progress commit. Rolling back DBs"
         );

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -32,74 +32,6 @@ const GIGABYTE: usize = 1024 * 1024 * 1024;
 // without consuming excessive memory.
 pub(crate) const DEFAULT_MAX_PRUNING_BATCH_SIZE: usize = 300_000;
 
-struct AllDBsStateRoots {
-    root_hash_from_live_db: [u8; 64],
-    root_hash_from_ledger_db: [u8; 64],
-    root_hash_nomt: StateRootHashes,
-}
-
-impl AllDBsStateRoots {
-    fn from_dbs<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync>(
-        merkelized_state: Arc<NomtStateDb<H>>,
-        ledger_db: Arc<rockbound::DB>,
-        flat_state_db: &FlatStateDb,
-    ) -> anyhow::Result<AllDBsStateRoots> {
-        let root_hash_from_live_db =
-            root_hash_from_life_db(flat_state_db)?.unwrap_or_else(pre_genesis_root);
-
-        let root_hash_from_ledger_db =
-            LedgerDb::get_head_root_hash(ledger_db.clone())?.unwrap_or_else(pre_genesis_root);
-
-        let root_hash_nomt = merkelized_state.get_root_hashes();
-
-        Ok(AllDBsStateRoots {
-            root_hash_from_live_db,
-            root_hash_from_ledger_db,
-            root_hash_nomt,
-        })
-    }
-
-    fn is_kerner_nomt_root_newer(&self) -> bool {
-        self.root_hash_nomt.kernel != self.root_hash_from_live_db[32..]
-    }
-
-    fn is_user_nomt_root_newer(&self) -> bool {
-        self.root_hash_nomt.user != self.root_hash_from_live_db[0..32]
-    }
-
-    fn is_ledger_db_root_newer(&self) -> bool {
-        self.root_hash_from_ledger_db != self.root_hash_from_live_db
-    }
-
-    fn validate_all(&self) {
-        assert_eq!(
-            hex(&self.root_hash_nomt.user),
-            hex(&self.root_hash_from_live_db[0..32])
-        );
-
-        assert_eq!(
-            hex(&self.root_hash_nomt.kernel),
-            hex(&self.root_hash_from_live_db[32..])
-        );
-
-        assert_eq!(
-            hex(&self.root_hash_from_ledger_db),
-            hex(&self.root_hash_from_live_db)
-        );
-    }
-
-    fn warning_on_rollback(&self, commit_status: &CommitStatus) {
-        tracing::warn!(
-            live_db_kernel_root_hash = hex(&self.root_hash_from_live_db),
-            root_hash_ledger_db = hex(&self.root_hash_from_ledger_db),
-            user_nomt_db_root_hash = hex(&self.root_hash_nomt.user),
-            kernel_nomt_db_root_hash = hex(&self.root_hash_nomt.kernel),
-            ?commit_status,
-            "Detected in-progress commit. Rolling back DBs"
-        );
-    }
-}
-
 pub(crate) struct DbGroup<H, K> {
     commit_flag: CommitFlag,
     merklized_state: Arc<NomtStateDb<H>>,
@@ -563,7 +495,7 @@ fn root_hash_from_life_db(flat_state: &FlatStateDb) -> anyhow::Result<Option<[u8
         last_version,
     )?
     .unwrap_or_else(|| {
-        // If `last_version`` is persent we must always have root hash.
+        // If `last_version` is present we must always have root hash.
         panic!("Root hash missing for the latest LiveDB version {last_version}",);
     });
 
@@ -578,6 +510,70 @@ fn pre_genesis_root() -> [u8; 64] {
     pre_genesis_root
 }
 
-fn hex(data: &[u8]) -> String {
-    hex::encode(data)
+struct AllDBsStateRoots {
+    root_hash_from_live_db: [u8; 64],
+    root_hash_from_ledger_db: [u8; 64],
+    root_hash_nomt: StateRootHashes,
+}
+
+impl AllDBsStateRoots {
+    fn from_dbs<H: digest::Digest<OutputSize = digest::typenum::U32> + Send + Sync>(
+        merkelized_state: Arc<NomtStateDb<H>>,
+        ledger_db: Arc<rockbound::DB>,
+        flat_state_db: &FlatStateDb,
+    ) -> anyhow::Result<AllDBsStateRoots> {
+        let root_hash_from_live_db =
+            root_hash_from_life_db(flat_state_db)?.unwrap_or_else(pre_genesis_root);
+
+        let root_hash_from_ledger_db =
+            LedgerDb::get_head_root_hash(ledger_db.clone())?.unwrap_or_else(pre_genesis_root);
+
+        let root_hash_nomt = merkelized_state.get_root_hashes();
+
+        Ok(AllDBsStateRoots {
+            root_hash_from_live_db,
+            root_hash_from_ledger_db,
+            root_hash_nomt,
+        })
+    }
+
+    fn is_kerner_nomt_root_newer(&self) -> bool {
+        self.root_hash_nomt.kernel != self.root_hash_from_live_db[32..]
+    }
+
+    fn is_user_nomt_root_newer(&self) -> bool {
+        self.root_hash_nomt.user != self.root_hash_from_live_db[0..32]
+    }
+
+    fn is_ledger_db_root_newer(&self) -> bool {
+        self.root_hash_from_ledger_db != self.root_hash_from_live_db
+    }
+
+    fn validate_all(&self) {
+        assert_eq!(
+            hex::encode(&self.root_hash_nomt.user),
+            hex::encode(&self.root_hash_from_live_db[0..32])
+        );
+
+        assert_eq!(
+            hex::encode(&self.root_hash_nomt.kernel),
+            hex::encode(&self.root_hash_from_live_db[32..])
+        );
+
+        assert_eq!(
+            hex::encode(&self.root_hash_from_ledger_db),
+            hex::encode(&self.root_hash_from_live_db)
+        );
+    }
+
+    fn warning_on_rollback(&self, commit_status: &CommitStatus) {
+        tracing::warn!(
+            live_db_kernel_root_hash = hex(&self.root_hash_from_live_db),
+            root_hash_ledger_db = hex(&self.root_hash_from_ledger_db),
+            user_nomt_db_root_hash = hex(&self.root_hash_nomt.user),
+            kernel_nomt_db_root_hash = hex(&self.root_hash_nomt.kernel),
+            ?commit_status,
+            "Detected in-progress commit. Rolling back DBs"
+        );
+    }
 }

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/tests.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/tests.rs
@@ -40,7 +40,7 @@ impl TestableStorage for TestNomtStorage {
         self,
         items: &[(Vec<u8>, Option<Vec<u8>>)],
         version: u64,
-    ) -> Self::ChangeSet {
+    ) -> (Self::ChangeSet, [u8; 64]) {
         let TestNomtStorage {
             state_session_builder,
             historical_state: _,
@@ -86,20 +86,25 @@ impl TestableStorage for TestNomtStorage {
                 .iter()
                 .map(|(k, v)| (SlotKey::from_slice(k), v.as_ref().map(|v| v.clone().into()))),
             // Not used at the moment,
-            root_hash,
+            root_hash.clone(),
             SlotNumber::new(version),
         )
         .unwrap();
 
-        NomtChangeSet {
-            state: StateFinishedSession {
-                user: user_finished_session,
-                kernel: kernel_finished_session,
+        let root_hash = root_hash.try_into().unwrap();
+
+        (
+            NomtChangeSet {
+                state: StateFinishedSession {
+                    user: user_finished_session,
+                    kernel: kernel_finished_session,
+                },
+                historical_state: historical_change_set,
+                accessory: accessory_change_set,
+                pinned_cache: None,
             },
-            historical_state: historical_change_set,
-            accessory: accessory_change_set,
-            pinned_cache: None,
-        }
+            root_hash,
+        )
     }
 
     fn get_value(&self, key: &[u8]) -> Option<Vec<u8>> {
@@ -343,7 +348,7 @@ async fn test_historical_state_with_pruning() {
         let ledger_changes = SchemaBatch::default();
         // Save the change set
         storage_manager
-            .save_change_set(&da_header, stf_changes, ledger_changes)
+            .save_change_set(&da_header, stf_changes.0, ledger_changes)
             .unwrap();
         storage_manager.finalize(&da_header).unwrap();
     }

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/tests.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/tests.rs
@@ -342,13 +342,13 @@ async fn test_historical_state_with_pruning() {
             let value = height.to_be_bytes().to_vec();
             values.push((user_key, Some(value)));
         }
-        let stf_changes = stf_storage.materialize_from_key_values(&values, height);
+        let (stf_changes, _) = stf_storage.materialize_from_key_values(&values, height);
 
         // Does not matter in this test
         let ledger_changes = SchemaBatch::default();
         // Save the change set
         storage_manager
-            .save_change_set(&da_header, stf_changes.0, ledger_changes)
+            .save_change_set(&da_header, stf_changes, ledger_changes)
             .unwrap();
         storage_manager.finalize(&da_header).unwrap();
     }

--- a/crates/full-node/sov-db/src/storage_manager/tests/generic_tests.rs
+++ b/crates/full-node/sov-db/src/storage_manager/tests/generic_tests.rs
@@ -29,6 +29,7 @@ pub trait TestableStorage: Sized {
         let height = da_header.height().to_be_bytes().to_vec();
         let hash_bytes = da_header.hash().0.to_vec();
         self.materialize_from_key_value(height, Some(hash_bytes), da_header.height() - 1)
+            .0
     }
 
     fn materialize_from_key_value(
@@ -36,7 +37,7 @@ pub trait TestableStorage: Sized {
         key: Vec<u8>,
         value: Option<Vec<u8>>,
         version: u64,
-    ) -> Self::ChangeSet {
+    ) -> (Self::ChangeSet, [u8; 64]) {
         let items = [(key, value)];
         self.materialize_from_key_values(&items, version)
     }
@@ -44,7 +45,8 @@ pub trait TestableStorage: Sized {
         self,
         items: &[(Vec<u8>, Option<Vec<u8>>)],
         version: u64,
-    ) -> Self::ChangeSet;
+    ) -> (Self::ChangeSet, [u8; 64]);
+
     fn get_value(&self, key: &[u8]) -> Option<Vec<u8>>;
     fn get_value_without_consistency_checks(&self, key: &[u8]) -> Option<Vec<u8>>;
 }
@@ -716,7 +718,7 @@ where
     let (storage, _) = storage_manager.create_state_for(&block_a).unwrap();
     let stf_changes = storage.materialize_from_key_value(key.to_vec(), Some(value_1.to_vec()), 0);
     storage_manager
-        .save_change_set(&block_a, stf_changes, SchemaBatch::default())
+        .save_change_set(&block_a, stf_changes.0, SchemaBatch::default())
         .unwrap();
     storage_manager.finalize(&block_a).unwrap();
     assert!(storage_manager.is_empty());
@@ -734,7 +736,7 @@ where
     let stf_changes =
         stf_reader_b.materialize_from_key_value(key.to_vec(), Some(value_2.to_vec()), 1);
     storage_manager
-        .save_change_set(&block_b, stf_changes, SchemaBatch::default())
+        .save_change_set(&block_b, stf_changes.0, SchemaBatch::default())
         .unwrap();
     assert!(!storage_manager.is_empty());
 
@@ -788,7 +790,7 @@ where
         let stf_changes = stf_storage.materialize_from_key_values(&expected_values, height - 1);
 
         storage_manager
-            .save_change_set(&da_header, stf_changes, SchemaBatch::default())
+            .save_change_set(&da_header, stf_changes.0, SchemaBatch::default())
             .unwrap();
     }
 
@@ -817,7 +819,8 @@ where
         let da_header = MockBlockHeader::from_height(height);
 
         let (stf_state, ledger_reader) = storage_manager.create_state_for(&da_header).unwrap();
-        let changes = {
+
+        let (changes, state_root) = {
             let height = da_header.height().to_be_bytes().to_vec();
             let hash_bytes = da_header.hash().0.to_vec();
             stf_state.materialize_from_key_value(height, Some(hash_bytes), da_header.height())
@@ -831,7 +834,7 @@ where
 
         let slot_to_store = StoredSlot {
             hash: da_header.hash().into(),
-            state_root: [0u8; 64].to_vec().into(),
+            state_root: state_root.to_vec().into(),
             extra_data: vec![].into(),
             batches: BatchNumber(0)..BatchNumber(0),
             discarded_blobs: DiscardedBlobNumber(0)..DiscardedBlobNumber(0),

--- a/crates/full-node/sov-db/src/storage_manager/tests/generic_tests.rs
+++ b/crates/full-node/sov-db/src/storage_manager/tests/generic_tests.rs
@@ -787,10 +787,11 @@ where
 
         let (stf_storage, _) = storage_manager.create_state_for(&da_header).unwrap();
 
-        let stf_changes = stf_storage.materialize_from_key_values(&expected_values, height - 1);
+        let (stf_changes, _) =
+            stf_storage.materialize_from_key_values(&expected_values, height - 1);
 
         storage_manager
-            .save_change_set(&da_header, stf_changes.0, SchemaBatch::default())
+            .save_change_set(&da_header, stf_changes, SchemaBatch::default())
             .unwrap();
     }
 


### PR DESCRIPTION
# Description

This PR introduces the following changes:

1. Removes `RootHash` from `CommitState`, as this information was redundant—it already exists in the `live_db`, which is committed as the last database.

2. Adds `AllDBsStateRoots`, used for validating state root hashes across different databases. This change replaces the `are_root_hashes_match` method.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2267
