### PR TITLE
Remove `sov-mock-da` dependency from `sov-soak-testing-lib`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12184,7 +12184,6 @@ dependencies = [
  "serde",
  "sov-api-spec",
  "sov-bank",
- "sov-mock-da",
  "sov-modules-api",
  "sov-synthetic-load",
  "sov-test-state-consistency",

--- a/crates/utils/sov-soak-testing-lib/Cargo.toml
+++ b/crates/utils/sov-soak-testing-lib/Cargo.toml
@@ -25,7 +25,6 @@ sov-api-spec = { workspace = true }
 sov-transaction-generator = { workspace = true }
 sov-modules-api = { workspace = true }
 sov-test-utils = { workspace = true, features = ["arbitrary"] }
-sov-mock-da = { workspace = true, features = ["arbitrary", "native"] }
 # modules
 sov-value-setter = { workspace = true }
 sov-bank = { workspace = true, features = ["native", "arbitrary"] }

--- a/crates/utils/sov-soak-testing-lib/src/lib.rs
+++ b/crates/utils/sov-soak-testing-lib/src/lib.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use rand::Rng;
 use sov_bank::Bank;
 use sov_bank::CallMessageDiscriminants::Transfer;
-use sov_mock_da::BlockProducingConfig;
 use sov_modules_api::capabilities::config_chain_id;
 use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::arbitrary::{self, Unstructured};
@@ -47,13 +46,6 @@ fn is_stop_height_error(err: &sov_api_spec::Error<sov_api_spec::types::ApiError>
     }
     false
 }
-
-pub const DEFAULT_BLOCK_TIME_MS: u64 = 200;
-pub const DEFAULT_BLOCK_PRODUCING_CONFIG: BlockProducingConfig = BlockProducingConfig::Periodic {
-    block_time_ms: DEFAULT_BLOCK_TIME_MS,
-};
-
-pub const DEFAULT_FINALIZATION_BLOCKS: u32 = 5;
 
 pub const BUFFER_SIZE: usize = 100_000;
 // The minimum randomness needed to guarantee successful transaction generation

--- a/examples/demo-rollup/sov-soak-testing/src/lib.rs
+++ b/examples/demo-rollup/sov-soak-testing/src/lib.rs
@@ -129,8 +129,8 @@ pub async fn setup_rollup(
 
     let rollup_builder = TestRollupBuilder::new_with_storage_path(
         GenesisSource::CustomParams(setup.genesis_config.clone().into_genesis_params()),
-        sov_soak_testing_lib::DEFAULT_BLOCK_PRODUCING_CONFIG,
-        sov_soak_testing_lib::DEFAULT_FINALIZATION_BLOCKS,
+        DEFAULT_BLOCK_PRODUCING_CONFIG,
+        DEFAULT_FINALIZATION_BLOCKS,
         StoragePath::Buf(storage_path),
         false,
     )


### PR DESCRIPTION
# Description

Because it does not use it. 

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Existing tests are passing

## Docs
No updates
