### PR TITLE
Set memory limit on EVM as fallback if gas limit is raised

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-evm/Cargo.toml
@@ -63,6 +63,7 @@ revm = { workspace = true, features = [
 	"optional_eip3607",
 	"optional_no_base_fee",
 	"optional_balance_check",
+	"memory_limit",
 	"std",
 ] }
 revm-database-interface = { workspace = true }

--- a/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -30,6 +30,7 @@ pub(crate) fn get_cfg_env(
 ) -> CfgEnv {
     let mut cfg_env = template_cfg.unwrap_or_default();
     cfg_env.chain_id = config_value!("CHAIN_ID");
+    cfg_env.memory_limit = 50 * 1024 * 1024; // 50MB
     cfg_env.limit_contract_code_size = Some(
         cfg.chain_spec
             .limit_contract_code_size

--- a/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -133,6 +133,7 @@ mod tests {
         expected_cfg_env.disable_base_fee = true;
         expected_cfg_env.limit_contract_code_size = Some(100);
         expected_cfg_env.spec = SpecId::CANCUN;
+        expected_cfg_env.memory_limit = 50 * 1024 * 1024; // 50MB
 
         assert_eq!(expected_cfg_env, cfg_env);
     }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -196,7 +196,7 @@ where
         block_number: Option<String>,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<ResultAndState, EthApiError> {
-        let block_env = self.resolve_block_env_for_call(block_number, state)?;
+        let block_env = self.resolve_block_env(block_number, state)?;
         let tx_env = prepare_call_env(&block_env, request.clone())?;
         let caller = tx_env.caller;
         let cfg = self.cfg_infallible(state);
@@ -363,21 +363,19 @@ where
         }
     }
 
-    fn resolve_block_env_for_call(
+    fn resolve_block_env(
         &self,
         block_number: Option<String>,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<BlockEnv, EthApiError> {
-        let maybe_block = self
+        let maybe_blcok = self
             .get_sealed_block_by_number(block_number, state)?
             .ok_or(EthApiError::UnknownBlock)?;
-        let mut block_env = match maybe_block {
+
+        Ok(match maybe_blcok {
             MaybeSealedBlock::Pending(_) => self.block_env(state).unwrap_infallible(),
             MaybeSealedBlock::Sealed(sealed_block) => BlockEnv::from(sealed_block),
-        };
-        // Set the base fee to zero for evm execution. Gas is paid for by the sov gas meter instead
-        block_env.basefee = 0;
-        Ok(block_env)
+        })
     }
 }
 
@@ -390,6 +388,7 @@ fn get_cfg_env_template() -> CfgEnv {
     cfg_env.disable_base_fee = true;
     cfg_env.chain_id = config_value!("CHAIN_ID");
     cfg_env.limit_contract_code_size = None;
+    cfg_env.memory_limit = 50 * 1024 * 1024; // 50MB
     cfg_env
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -196,7 +196,7 @@ where
         block_number: Option<String>,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<ResultAndState, EthApiError> {
-        let block_env = self.resolve_block_env(block_number, state)?;
+        let block_env = self.resolve_block_env_for_call(block_number, state)?;
         let tx_env = prepare_call_env(&block_env, request.clone())?;
         let caller = tx_env.caller;
         let cfg = self.cfg_infallible(state);
@@ -363,19 +363,22 @@ where
         }
     }
 
-    fn resolve_block_env(
+    fn resolve_block_env_for_call(
         &self,
         block_number: Option<String>,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<BlockEnv, EthApiError> {
-        let maybe_blcok = self
+        let maybe_block = self
             .get_sealed_block_by_number(block_number, state)?
             .ok_or(EthApiError::UnknownBlock)?;
 
-        Ok(match maybe_blcok {
+        let mut block_env = match maybe_block {
             MaybeSealedBlock::Pending(_) => self.block_env(state).unwrap_infallible(),
             MaybeSealedBlock::Sealed(sealed_block) => BlockEnv::from(sealed_block),
-        })
+        };
+        // Set the base fee to zero for evm execution. Gas is paid for by the sov gas meter instead
+        block_env.basefee = 0;
+        Ok(block_env)
     }
 }
 


### PR DESCRIPTION
# Description

This PR sets a reasonable memory limit on the EVM in case the tx gas limit is raised significantly. This addresses an audit finding.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

