### PR TITLE
Allow chainid 0 for compatibility with EIP7702

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -97,7 +97,7 @@ fn validate_chain_id(
     ))?;
 
     // Allow 0 chain id for compatibility with EIP7702
-    if tx_chain_id != rollup_chain_id  && tx_chain_id != 0 {
+    if tx_chain_id != rollup_chain_id && tx_chain_id != 0 {
         return Err(AuthenticationError::FatalError(
             FatalError::InvalidChainId {
                 expected: rollup_chain_id,

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -96,7 +96,8 @@ fn validate_chain_id(
         tx_hash,
     ))?;
 
-    if tx_chain_id != rollup_chain_id {
+    // Allow 0 chain id for compatibility with EIP7702
+    if tx_chain_id != rollup_chain_id  && tx_chain_id != 0 {
         return Err(AuthenticationError::FatalError(
             FatalError::InvalidChainId {
                 expected: rollup_chain_id,


### PR DESCRIPTION
# Description

This PR allows chain ID 0 in evm transactions for compatibility with EIP-7702. This addresses an audit finding.
