### PR TITLE
Add support for `ArchivalDb::rollback`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-01-05
+- #2297 **Breaking change**: Removes the `separate_archival_state` flag. After this change, `livedb` and `archivaldb` are always stored in separate locations. Users should remove this flag from their configurations. If it was previously set to false, the node will need to be resynced from genesis.
+
 # 2026-01-01
 - #2256 Enforce the EVM block gas limit and introduce the EVM tx gas limit in config.
 - #2279 Propagates fee information to ethereum block responses

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9538,7 +9538,7 @@ dependencies = [
 [[package]]
 name = "rockbound"
 version = "0.1.0"
-source = "git+https://github.com/sovereign-labs/rockbound?rev=e8d1cfa7402a3ab90369d664bd88a52394cd40e6#e8d1cfa7402a3ab90369d664bd88a52394cd40e6"
+source = "git+https://github.com/sovereign-labs/rockbound?rev=e8a6d930a0b16de889dbbe675010fddd044a42cd#e8a6d930a0b16de889dbbe675010fddd044a42cd"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9538,7 +9538,7 @@ dependencies = [
 [[package]]
 name = "rockbound"
 version = "0.1.0"
-source = "git+https://github.com/sovereign-labs/rockbound?rev=e8a6d930a0b16de889dbbe675010fddd044a42cd#e8a6d930a0b16de889dbbe675010fddd044a42cd"
+source = "git+https://github.com/sovereign-labs/rockbound?rev=e6a1af46e500a5d3ec5c949d14f56f1440231c4d#e6a1af46e500a5d3ec5c949d14f56f1440231c4d"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ nearly-linear = { path = "crates/utils/nearly-linear", version = "0.3" }
 # Dependencies maintained by Sovereign
 jmt = { version = "0.12.0", default-features = false }
 reltester = { git = "https://github.com/sovereign-labs/reltester.git", rev = "d6209abff72929f5ba41614f5cea3e4a748428c3" }
-rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "e8d1cfa7402a3ab90369d664bd88a52394cd40e6" }
+rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "e8a6d930a0b16de889dbbe675010fddd044a42cd" }
 nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
 nomt-core = { version = "1.0.3", default-features = false, features = ["borsh", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ nearly-linear = { path = "crates/utils/nearly-linear", version = "0.3" }
 # Dependencies maintained by Sovereign
 jmt = { version = "0.12.0", default-features = false }
 reltester = { git = "https://github.com/sovereign-labs/reltester.git", rev = "d6209abff72929f5ba41614f5cea3e4a748428c3" }
-rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "e8a6d930a0b16de889dbbe675010fddd044a42cd" }
+rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "e6a1af46e500a5d3ec5c949d14f56f1440231c4d" }
 nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
 nomt-core = { version = "1.0.3", default-features = false, features = ["borsh", "serde"] }

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/full-node/full-node-configs/src/runner.rs
-assertion_line: 226
 expression: config
 ---
 {
@@ -19,8 +18,7 @@ expression: config
     "kernel_leaf_cache_size": null,
     "pruner_block_interval": null,
     "pruner_versions_to_keep": null,
-    "pruner_max_batch_size": null,
-    "separate_archival_state": false
+    "pruner_max_batch_size": null
   },
   "runner": {
     "da_polling_interval_ms": 10000,

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
@@ -18,8 +18,7 @@ expression: config
     "kernel_leaf_cache_size": null,
     "pruner_block_interval": null,
     "pruner_versions_to_keep": null,
-    "pruner_max_batch_size": null,
-    "separate_archival_state": false
+    "pruner_max_batch_size": null
   },
   "runner": {
     "da_polling_interval_ms": 10000,

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
@@ -18,8 +18,7 @@ expression: config
     "kernel_leaf_cache_size": null,
     "pruner_block_interval": null,
     "pruner_versions_to_keep": null,
-    "pruner_max_batch_size": null,
-    "separate_archival_state": false
+    "pruner_max_batch_size": null
   },
   "runner": {
     "da_polling_interval_ms": 10000,

--- a/crates/full-node/sov-db/src/config.rs
+++ b/crates/full-node/sov-db/src/config.rs
@@ -54,10 +54,6 @@ pub struct RollupDbConfig {
     pub pruner_versions_to_keep: Option<usize>,
     /// Maximum number of keys to prune in a single batch.
     pub pruner_max_batch_size: Option<usize>,
-
-    /// Whether to use a separate db for archival state.
-    #[serde(default)]
-    pub separate_archival_state: bool,
 }
 
 impl RollupDbConfig {
@@ -92,7 +88,6 @@ impl RollupDbConfig {
             pruner_block_interval: Some(100),
             pruner_versions_to_keep: Some(20),
             pruner_max_batch_size: None,
-            separate_archival_state: false,
         }
     }
 

--- a/crates/full-node/sov-db/src/flat_db.rs
+++ b/crates/full-node/sov-db/src/flat_db.rs
@@ -524,7 +524,7 @@ mod tests {
         test_rollback(CrashLocation::BeforeCommittingLive, 1)
     }
 
-    // This test commits data for version 0 of the rollup state and panics at various points during the commit.
+    // This test commits data for version 0 of the rollup state and panics at various points during the commit for version 1.
     // Afterward, it checks whether the rollback logic correctly reverted the archival state.
     fn test_rollback(crash_location: CrashLocation, archival_version: u64) -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir().unwrap();

--- a/crates/full-node/sov-db/src/flat_db.rs
+++ b/crates/full-node/sov-db/src/flat_db.rs
@@ -2,6 +2,7 @@
 //! used by NOMT.
 
 use crate::commit_flag::{CommitFlag, CommitStatus};
+use crate::historical_state::{HistoricalStateReader, STATE_ROOT_HASH_SINGLETON};
 use crate::metrics::nomt::FlatStateCommitMetric;
 use crate::{
     historical_state::StateChanges,
@@ -11,12 +12,14 @@ use crate::{
 };
 use parking_lot::{MappedRwLockReadGuard, MappedRwLockWriteGuard, RwLock};
 use parking_lot::{RwLockReadGuard, RwLockWriteGuard};
+use rockbound::cache::delta_reader::DeltaReader;
 use rockbound::versioned_db::CacheForVersionedDB;
 use rockbound::versioned_db::SchemaWithVersion;
 use rockbound::{
     default_cf_descriptor, rocksdb::ColumnFamilyDescriptor, versioned_db::VersionedDB,
 };
-use rockbound::{rocksdb, DB};
+use rockbound::{rocksdb, SchemaBatch, DB};
+use sov_rollup_interface::common::SlotNumber;
 use std::sync::Arc;
 
 /// A database to store the flat state of the rollup (i.e. the raw key-value pairs)
@@ -41,6 +44,7 @@ impl FlatStateDb {
     ) -> anyhow::Result<Self> {
         let mut columns: Vec<ColumnFamilyDescriptor> =
             vec![default_cf_descriptor(StateRootHashes::table_name())];
+
         VersionedDB::<NomtStateValues<UserNamespace>, DbCache>::add_column_families(
             &mut columns,
             separate_archival,
@@ -55,6 +59,7 @@ impl FlatStateDb {
         let archival_db = if separate_archival {
             let archival_path = path.join(Self::ARCHIVAL_DB_PATH_SUFFIX);
             let archival_columns = vec![
+                default_cf_descriptor(StateRootHashes::table_name()),
                 default_cf_descriptor(
                     NomtStateValues::<UserNamespace>::HISTORICAL_COLUMN_FAMILY_NAME,
                 ),
@@ -114,6 +119,83 @@ impl FlatStateDb {
         })
     }
 
+    pub(crate) fn root_hash_from_live_db(&self) -> anyhow::Result<Option<[u8; 64]>> {
+        let Some((delta_reader, version)) = Self::latest_reader_and_version(self.live_db.clone())?
+        else {
+            return Ok(None);
+        };
+
+        Self::root_hash_from_db(&delta_reader, version)
+    }
+
+    pub(crate) fn root_hash_from_archival_db(&self) -> anyhow::Result<Option<[u8; 64]>> {
+        let Some((delta_reader, version)) =
+            Self::latest_reader_and_version(self.archival_db.clone())?
+        else {
+            return Ok(None);
+        };
+
+        Self::root_hash_from_db(&delta_reader, version)
+    }
+
+    /// Latest state root hash from live db
+    pub fn latest_version_and_root_hash_live_db(&self) -> anyhow::Result<Option<(u64, [u8; 64])>> {
+        let Some((delta_reader, version)) = Self::latest_reader_and_version(self.live_db.clone())?
+        else {
+            return Ok(None);
+        };
+        let root_hash = Self::root_hash_from_db(&delta_reader, version)?.unwrap();
+        Ok(Some((version.get(), root_hash)))
+    }
+
+    /// Latest state root hash from archival db.
+    pub fn latest_version_and_root_hash_archival_db(
+        &self,
+    ) -> anyhow::Result<Option<(u64, [u8; 64])>> {
+        let Some((delta_reader, version)) =
+            Self::latest_reader_and_version(self.archival_db.clone())?
+        else {
+            return Ok(None);
+        };
+        let root_hash = Self::root_hash_from_db(&delta_reader, version)?.unwrap();
+        Ok(Some((version.get(), root_hash)))
+    }
+
+    /// Historical state root hash from archival db.
+    pub(crate) fn root_hash_from_archival_db_for_version(
+        &self,
+        version: SlotNumber,
+    ) -> anyhow::Result<Option<[u8; 64]>> {
+        let Some((delta_reader, _)) = Self::latest_reader_and_version(self.archival_db.clone())?
+        else {
+            return Ok(None);
+        };
+
+        Self::root_hash_from_db(&delta_reader, version)
+    }
+
+    fn root_hash_from_db(
+        delta_reader: &DeltaReader,
+        version: SlotNumber,
+    ) -> anyhow::Result<Option<[u8; 64]>> {
+        let state_root_hash =
+            HistoricalStateReader::get_serialized_root_hash_from_reader(delta_reader, version)?
+                .unwrap_or_else(|| {
+                    // If `last_version` is present we must always have root hash.
+                    panic!("Root hash missing for the latest DB version {version}",);
+                });
+
+        Ok(Some(state_root_hash.try_into().unwrap()))
+    }
+
+    fn latest_reader_and_version(
+        db: Arc<rockbound::DB>,
+    ) -> anyhow::Result<Option<(DeltaReader, SlotNumber)>> {
+        let delta_reader = DeltaReader::new(db, Vec::new());
+        let last_version = HistoricalStateReader::last_version_from_reader(&delta_reader)?;
+        Ok(last_version.map(|v| (delta_reader, v)))
+    }
+
     /// Get the underlying [`rockbound::DB`] for the historical state. Used for testing only.
     pub fn get_db(&self) -> Arc<rockbound::DB> {
         self.live_db.clone()
@@ -140,28 +222,29 @@ impl FlatStateDb {
         }
     }
 
-    /// Coalesce all the changes into a single schema batch and write it atomically.
+    /// Commit the `state_changes`.
     pub fn commit(
         &self,
-        state: StateChanges,
-        commit_flag: &CommitFlag,
+        state_changes: StateChanges,
+        commit_flag: Option<&CommitFlag>,
+    ) -> anyhow::Result<FlatStateCommitMetric> {
+        self.commit_internal(state_changes, commit_flag, true)
+    }
+
+    fn commit_internal(
+        &self,
+        state_changes: StateChanges,
+        commit_flag: Option<&CommitFlag>,
+        commit_live_db: bool,
     ) -> anyhow::Result<FlatStateCommitMetric> {
         let start_prepare = std::time::Instant::now();
         let prepare = start_prepare.elapsed();
         let start_write = std::time::Instant::now();
+
         let version = self
-            .kernel
-            .get_committed_version()?
-            .and_then(|v| v.checked_add(1))
+            .latest_version_and_root_hash_live_db()?
+            .and_then(|(v, _)| v.checked_add(1))
             .unwrap_or(0);
-        if cfg!(debug_assertions) {
-            let user_version = self
-                .user
-                .get_committed_version()?
-                .and_then(|v| v.checked_add(1))
-                .unwrap_or(0);
-            assert_eq!(user_version, version);
-        }
 
         let mut live_db_batch = rocksdb::WriteBatch::default();
         let mut archival_db_batch = rocksdb::WriteBatch::default();
@@ -176,7 +259,7 @@ impl FlatStateDb {
         let metrics_kernel = VersionedDB::<_, DbCache>::update_versioned_db_batch(
             &mut live_db_batch,
             &mut archival_db_batch,
-            &state.kernel,
+            &state_changes.kernel,
             version,
             kernel_cache,
             &self.live_db,
@@ -190,7 +273,7 @@ impl FlatStateDb {
         let metrics_user = VersionedDB::<_, DbCache>::update_versioned_db_batch(
             &mut live_db_batch,
             &mut archival_db_batch,
-            &state.user,
+            &state_changes.user,
             version,
             user_cache,
             &self.live_db,
@@ -203,20 +286,45 @@ impl FlatStateDb {
 
         // 4.Update root hash.
         DB::update_db_batch_with_schema_data(
+            &mut archival_db_batch,
+            &state_changes.root_hash_batch,
+            &self.archival_db,
+        )?;
+
+        DB::update_db_batch_with_schema_data(
             &mut live_db_batch,
-            &state.root_hash_batch,
+            &state_changes.root_hash_batch,
             &self.live_db,
         )?;
 
+        #[cfg(feature = "test-utils")]
+        crate::test_utils::CrashLocation::BeforeSavingArchival.crash_if_env_set();
+
         // Write archival db batches.
-        commit_flag.save_commit_status(&CommitStatus::CommittingArchivalUserAndKernel)?;
+        if let Some(commit_flag) = commit_flag {
+            commit_flag.save_commit_status(&CommitStatus::CommittingArchivalUserAndKernel)?;
+        }
+
+        #[cfg(feature = "test-utils")]
+        crate::test_utils::CrashLocation::BeforeCommittingArchival.crash_if_env_set();
         self.archival_db.write_db_batch(archival_db_batch)?;
+
         // rockbound requirement:  `store_committed_archival_version` has to be called before before writing `live_db_batch`.
         self.kernel.store_committed_archival_version(version);
         self.user.store_committed_archival_version(version);
         // Write live db batch.
-        commit_flag.save_commit_status(&CommitStatus::CommittingLiveUserAndKernel)?;
-        self.live_db.write_db_batch(live_db_batch)?;
+
+        if commit_live_db {
+            #[cfg(feature = "test-utils")]
+            crate::test_utils::CrashLocation::BeforeSavingLive.crash_if_env_set();
+            if let Some(commit_flag) = commit_flag {
+                commit_flag.save_commit_status(&CommitStatus::CommittingLiveUserAndKernel)?;
+            }
+
+            #[cfg(feature = "test-utils")]
+            crate::test_utils::CrashLocation::BeforeCommittingLive.crash_if_env_set();
+            self.live_db.write_db_batch(live_db_batch)?;
+        }
 
         // 5. Release caches.
         drop(inner);
@@ -237,6 +345,106 @@ impl FlatStateDb {
         let write = start_write.elapsed();
         Ok(FlatStateCommitMetric { prepare, write })
     }
+
+    /// Validate consistency between live and archival DBs, rollback archival changes if necessary.
+    pub fn validate_and_rollback_archival(&self) -> anyhow::Result<()> {
+        let live_version_and_root_hash = self.latest_version_and_root_hash_live_db()?;
+
+        let Some((current_version_archival, root_hash_archival)) =
+            self.latest_version_and_root_hash_archival_db()?
+        else {
+            assert!(live_version_and_root_hash.is_none());
+            tracing::info!("Roolup Archival & Live DBs are empty, nothing to rollback");
+            return Ok(());
+        };
+
+        let Some((current_version_live, root_hash_live)) = live_version_and_root_hash else {
+            assert_eq!(current_version_archival, 0);
+            anyhow::bail!("The Live DB is empty; please remove the Archival DB manually.")
+        };
+
+        if current_version_archival == current_version_live {
+            assert_eq!(root_hash_archival, root_hash_live);
+            return Ok(());
+        }
+
+        assert_eq!(current_version_archival, current_version_live + 1);
+
+        let prev_root_hash_archival = self
+            .root_hash_from_archival_db_for_version(SlotNumber::new(current_version_live))?
+            .unwrap_or_else(|| {
+                panic!("Missing archival root hash for version {current_version_live}")
+            });
+
+        assert_eq!(prev_root_hash_archival, root_hash_live);
+
+        self.rollback_archival(
+            current_version_archival,
+            current_version_live,
+            root_hash_live,
+        )
+    }
+
+    fn rollback_archival(
+        &self,
+        current_version_archival: u64,
+        current_version_live: u64,
+        root_hash_live: [u8; 64],
+    ) -> anyhow::Result<()> {
+        let user_changes = keys_and_values_for_rollback(&self.user, current_version_archival)?;
+        let kernel_changes = keys_and_values_for_rollback(&self.kernel, current_version_archival)?;
+
+        let mut state_changes = HistoricalStateReader::materialize_values(
+            user_changes,
+            kernel_changes,
+            root_hash_live.to_vec(),
+            SlotNumber::new(current_version_live),
+        )?;
+
+        // Remove the most recent (current_version_archival) root hash from the `StateRootHashes` table.
+        let mut root_hash_batch = SchemaBatch::default();
+        root_hash_batch.merge(state_changes.root_hash_batch.as_ref().clone());
+        root_hash_batch.delete(&(
+            SlotNumber::new(current_version_archival),
+            STATE_ROOT_HASH_SINGLETON,
+        ))?;
+
+        state_changes.root_hash_batch = Arc::new(root_hash_batch);
+        // We rollback only archival db.
+        self.commit_internal(state_changes, None, false)?;
+
+        Ok(())
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn keys_and_values_for_rollback<V, C>(
+    db: &VersionedDB<V, C>,
+    version_to_rollback: u64,
+) -> anyhow::Result<Vec<(V::Key, Option<V::Value>)>>
+where
+    C: CacheForVersionedDB<V>,
+    V::Key: Ord + Clone + std::hash::Hash + AsRef<[u8]>,
+    V::Value: Clone + AsRef<[u8]>,
+    V: SchemaWithVersion + Ord,
+{
+    // Get all keys committed at `version_to_rollback`.
+    // Then retrieve the values for those keys from the previous state version.
+    // Values that changed between `version_to_rollback` and `version_to_rollback - 1` are overridden.
+    // Values that were inserted at `version_to_rollback` are deleted.
+    // Values that were deleted at `version_to_rollback` are reinserted.
+    let prunable_keys = db.iter_pruning_keys_at_version(version_to_rollback)?;
+    let mut data_to_materialize = Vec::new();
+
+    for key in prunable_keys {
+        let (version, key) = key.version_and_key();
+        assert_eq!(version, version_to_rollback);
+
+        let value = db.get_historical_value(&key, version_to_rollback - 1)?;
+        data_to_materialize.push((key, value));
+    }
+
+    Ok(data_to_materialize)
 }
 
 struct Inner {
@@ -294,5 +502,360 @@ impl CacheForVersionedDB<NomtStateValues<KernelNamespace>> for DbCache {
     > {
         let lock = self.inner.try_read()?;
         Some(RwLockReadGuard::map(lock, |c: &Inner| &c.kernel_cache))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::CrashLocation;
+    use sov_db_types::{SlotKey, SlotValue};
+    use std::{collections::HashMap, panic::AssertUnwindSafe, vec};
+    use tempfile::TempDir;
+
+    type Changes = Vec<(SlotKey, Option<SlotValue>)>;
+
+    #[test]
+    fn test_rollback_crash_before_saving_archival() -> anyhow::Result<()> {
+        test_rollback(CrashLocation::BeforeSavingArchival, 0)
+    }
+
+    #[test]
+    fn test_rollback_crash_before_commiting_archival() -> anyhow::Result<()> {
+        test_rollback(CrashLocation::BeforeCommittingArchival, 0)
+    }
+
+    #[test]
+    fn test_rollback_crash_before_saving_live() -> anyhow::Result<()> {
+        test_rollback(CrashLocation::BeforeSavingLive, 1)
+    }
+
+    #[test]
+    fn test_rollback_crash_before_comitting_live() -> anyhow::Result<()> {
+        test_rollback(CrashLocation::BeforeCommittingLive, 1)
+    }
+
+    // This test commits data for version 0 of the rollup state and panics at various points during the commit.
+    // Afterward, it checks whether the rollback logic correctly reverted the archival state.
+    fn test_rollback(crash_location: CrashLocation, archival_version: u64) -> anyhow::Result<()> {
+        let separate_archival = true;
+        let tempdir = tempfile::tempdir().unwrap();
+        let db_path = tempdir.path();
+        let data = data_to_insert_per_verson();
+
+        // Commit version 0.
+        {
+            let version = 0;
+            let flat_db =
+                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+
+            let state_changes = data.change_set(version);
+            flat_db.commit(state_changes, None).unwrap();
+            assert_flat_state(version, version, &flat_db);
+        }
+
+        unlock_dbs(&tempdir);
+        crash_location.set_crash_env();
+
+        // Crash during commit of version 1.
+        {
+            let version = 1;
+            let flat_db =
+                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+
+            let state_changes = data.change_set(version);
+            let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                flat_db.commit(state_changes, None).unwrap();
+            }));
+
+            assert!(res.is_err());
+            assert_flat_state(0, archival_version, &flat_db);
+        }
+
+        // Rollback to version 0.
+        {
+            let flat_db =
+                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+
+            flat_db.validate_and_rollback_archival().unwrap();
+            assert_flat_state(0, 0, &flat_db);
+
+            // After rollback, the latest archival state must match version 0.
+            for (k, v) in data.get_user_data_for_version(0).iter() {
+                let value_from_archival_db = flat_db.user.get_historical_value(k, 99).unwrap();
+                assert_eq!(v, &value_from_archival_db);
+            }
+
+            for (k, v) in data.get_kernel_data_for_version(0).iter() {
+                let value_from_archival_db = flat_db.kernel.get_historical_value(k, 99).unwrap();
+                assert_eq!(v, &value_from_archival_db);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// This test rolls back the archival state regardless of the version of the live state.
+    #[test]
+    fn test_rollback_skip_validation() -> anyhow::Result<()> {
+        let separate_archival = true;
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let db_path = tempdir.path();
+
+        let data = data_to_insert_per_verson();
+
+        {
+            let version = 0;
+            let flat_db =
+                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+
+            let state_changes = data.change_set(version);
+            flat_db.commit(state_changes, None).unwrap();
+            assert_flat_state(version, version, &flat_db);
+        }
+
+        unlock_dbs(&tempdir);
+
+        {
+            let version = 1;
+            let flat_db =
+                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+
+            let state_changes = data.change_set(version);
+            flat_db.commit(state_changes, None).unwrap();
+
+            assert_flat_state(version, version, &flat_db);
+        }
+
+        unlock_dbs(&tempdir);
+
+        {
+            let version = 2;
+            let flat_db =
+                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+
+            let state_changes = data.change_set(version);
+            flat_db.commit(state_changes, None).unwrap();
+
+            assert_flat_state(version, version, &flat_db);
+        }
+
+        unlock_dbs(&tempdir);
+
+        // Rollbacks
+
+        {
+            let flat_db =
+                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+
+            flat_db.rollback_archival_one_slot().unwrap();
+
+            let version = 2;
+            assert_flat_state(version, version - 1, &flat_db);
+        }
+
+        unlock_dbs(&tempdir);
+
+        {
+            let flat_db =
+                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+            flat_db.rollback_archival_one_slot().unwrap();
+
+            let version = 2;
+            assert_flat_state(version, version - 2, &flat_db);
+
+            for (k, v) in data.get_user_data_for_version(0).iter() {
+                let value_from_archival_db = flat_db.user.get_historical_value(k, 99).unwrap();
+                assert_eq!(v, &value_from_archival_db);
+            }
+
+            for (k, v) in data.get_kernel_data_for_version(0).iter() {
+                let value_from_archival_db = flat_db.kernel.get_historical_value(k, 99).unwrap();
+                assert_eq!(v, &value_from_archival_db);
+            }
+        }
+
+        Ok(())
+    }
+
+    impl FlatStateDb {
+        fn rollback_archival_one_slot(&self) -> anyhow::Result<()> {
+            let (current_version_archival, _) =
+                self.latest_version_and_root_hash_archival_db()?.unwrap();
+
+            let prev_root_hash_archival = self
+                .root_hash_from_archival_db_for_version(SlotNumber::new(
+                    current_version_archival - 1,
+                ))?
+                .unwrap();
+
+            self.rollback_archival(
+                current_version_archival,
+                current_version_archival - 1,
+                prev_root_hash_archival,
+            )
+        }
+    }
+
+    fn assert_flat_state(live_db_version: u64, archival_db_version: u64, flat_db: &FlatStateDb) {
+        let expected_root_hash_live_db = [live_db_version as u8; 64].to_vec();
+        let root_hash_from_live_db = flat_db.root_hash_from_live_db().unwrap().unwrap();
+        let root_hash_from_archival_db = flat_db.root_hash_from_archival_db().unwrap().unwrap();
+
+        assert_eq!(expected_root_hash_live_db, root_hash_from_live_db);
+
+        let expected_root_hash_archival_db = [archival_db_version as u8; 64].to_vec();
+        assert_eq!(expected_root_hash_archival_db, root_hash_from_archival_db);
+
+        assert_eq!(
+            live_db_version,
+            flat_db
+                .latest_version_and_root_hash_live_db()
+                .unwrap()
+                .unwrap()
+                .0
+        );
+        assert_eq!(
+            archival_db_version,
+            flat_db
+                .latest_version_and_root_hash_archival_db()
+                .unwrap()
+                .unwrap()
+                .0
+        );
+    }
+
+    struct TestData {
+        data: HashMap<u64, (Changes, Changes)>,
+    }
+
+    impl TestData {
+        fn new() -> Self {
+            Self {
+                data: HashMap::new(),
+            }
+        }
+
+        fn insert(
+            &mut self,
+            version: u64,
+            op_user: Vec<OperationType>,
+            op_kernel: Vec<OperationType>,
+        ) {
+            let user = make_data(op_user, version);
+            let kernel = make_data(op_kernel, version);
+            self.data.insert(version, (user, kernel));
+        }
+
+        fn get_user_data_for_version(&self, version: u64) -> Changes {
+            self.data.get(&version).unwrap().0.clone()
+        }
+
+        fn get_kernel_data_for_version(&self, version: u64) -> Changes {
+            self.data.get(&version).unwrap().1.clone()
+        }
+
+        fn change_set(&self, version: u64) -> StateChanges {
+            make_change_set(
+                self.get_user_data_for_version(version),
+                self.get_kernel_data_for_version(version),
+                version,
+            )
+        }
+    }
+
+    fn data_to_insert_per_verson() -> TestData {
+        let mut data = TestData::new();
+        data.insert(
+            0,
+            vec![
+                OperationType::Insert("user_key1"),
+                OperationType::Insert("user_key2"),
+                OperationType::Insert("user_key3"),
+            ],
+            vec![
+                OperationType::Insert("kernel_key1"),
+                OperationType::Insert("kernel_key2"),
+                OperationType::Insert("kernel_key3"),
+            ],
+        );
+
+        data.insert(
+            1,
+            vec![
+                OperationType::Insert("user_key1"),
+                OperationType::Insert("user_key2"),
+            ],
+            vec![OperationType::Insert("kernel_key4")],
+        );
+
+        data.insert(
+            2,
+            vec![
+                OperationType::Delete("user_key1"),
+                OperationType::Insert("user_key2"),
+            ],
+            vec![
+                OperationType::Delete("kernel_key3"),
+                OperationType::Insert("kernel_key11"),
+            ],
+        );
+
+        data
+    }
+
+    enum OperationType {
+        Insert(&'static str),
+        Delete(&'static str),
+    }
+
+    fn make_key(key: &str) -> SlotKey {
+        SlotKey::from_slice(key.as_bytes())
+    }
+
+    fn make_value(key_str: &str, version: u64) -> SlotValue {
+        SlotValue::from(format!("{key_str}_value_{version}").as_str())
+    }
+
+    fn make_data(ops: Vec<OperationType>, version: u64) -> Changes {
+        let mut data = Vec::new();
+
+        for op in ops {
+            match op {
+                OperationType::Insert(key_str) => {
+                    let key = make_key(key_str);
+                    let value = make_value(key_str, version);
+                    data.push((key, Some(value)));
+                }
+                OperationType::Delete(key) => {
+                    let key = make_key(key);
+                    data.push((key, None));
+                }
+            }
+        }
+
+        data
+    }
+
+    fn make_change_set(
+        user_changes: Changes,
+        kernel_changes: Changes,
+        version: u64,
+    ) -> StateChanges {
+        let root_hash = [version as u8; 64].to_vec();
+        let version = SlotNumber::new(version);
+        HistoricalStateReader::materialize_values(user_changes, kernel_changes, root_hash, version)
+            .unwrap()
+    }
+
+    fn unlock_dbs(temp_dir: &TempDir) {
+        let lock_files = ["LOCK", "LOG", "LOG.old"];
+        let dbs = ["state-db", "archival-state-db", "accessory", "blob_sender"];
+        for lock_file in &lock_files {
+            for db in &dbs {
+                let _ = std::fs::remove_file(temp_dir.path().join(db).join(lock_file));
+            }
+        }
     }
 }

--- a/crates/full-node/sov-db/src/flat_db.rs
+++ b/crates/full-node/sov-db/src/flat_db.rs
@@ -301,8 +301,8 @@ impl FlatStateDb {
         // rockbound requirement:  `store_committed_archival_version` has to be called before before writing `live_db_batch`.
         self.kernel.store_committed_archival_version(version);
         self.user.store_committed_archival_version(version);
-        // Write live db batch.
 
+        // Write live db batch.
         if commit_live_db {
             #[cfg(feature = "test-utils")]
             crate::test_utils::CrashLocation::BeforeSavingLive.crash_if_env_set();
@@ -343,7 +343,7 @@ impl FlatStateDb {
             self.latest_version_and_root_hash_archival_db()?
         else {
             assert!(live_version_and_root_hash.is_none());
-            tracing::info!("Roolup Archival & Live DBs are empty, nothing to rollback");
+            tracing::info!("Rollup Archival & Live DBs are empty, nothing to rollback");
             return Ok(());
         };
 
@@ -357,7 +357,11 @@ impl FlatStateDb {
             return Ok(());
         }
 
-        assert_eq!(current_version_archival, current_version_live + 1);
+        assert_eq!(
+            current_version_archival,
+            current_version_live + 1,
+            "Live and Archival DBs are in unrecoverable state."
+        );
 
         let prev_root_hash_archival = self
             .root_hash_from_archival_db_for_version(SlotNumber::new(current_version_live))?
@@ -520,7 +524,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rollback_crash_before_comitting_live() -> anyhow::Result<()> {
+    fn test_rollback_crash_before_committing_live() -> anyhow::Result<()> {
         test_rollback(CrashLocation::BeforeCommittingLive, 1)
     }
 
@@ -529,7 +533,7 @@ mod tests {
     fn test_rollback(crash_location: CrashLocation, archival_version: u64) -> anyhow::Result<()> {
         let tempdir = tempfile::tempdir().unwrap();
         let db_path = tempdir.path();
-        let data = data_to_insert_per_verson();
+        let data = data_to_insert_per_version();
 
         // Commit version 0.
         {
@@ -586,7 +590,7 @@ mod tests {
         let tempdir = tempfile::tempdir().unwrap();
         let db_path = tempdir.path();
 
-        let data = data_to_insert_per_verson();
+        let data = data_to_insert_per_version();
 
         {
             let version = 0;
@@ -743,7 +747,7 @@ mod tests {
         }
     }
 
-    fn data_to_insert_per_verson() -> TestData {
+    fn data_to_insert_per_version() -> TestData {
         let mut data = TestData::new();
         data.insert(
             0,

--- a/crates/full-node/sov-db/src/flat_db.rs
+++ b/crates/full-node/sov-db/src/flat_db.rs
@@ -37,50 +37,39 @@ impl FlatStateDb {
     const ARCHIVAL_DB_PATH_SUFFIX: &'static str = "archival-state-db";
 
     /// Create a new [`FlatStateDb`] from a path.
-    pub fn new(
-        path: std::path::PathBuf,
-        cache_size: usize,
-        separate_archival: bool,
-    ) -> anyhow::Result<Self> {
-        let mut columns: Vec<ColumnFamilyDescriptor> =
-            vec![default_cf_descriptor(StateRootHashes::table_name())];
+    pub fn new(path: std::path::PathBuf, cache_size: usize) -> anyhow::Result<Self> {
+        let live_db = {
+            let mut live_columns = vec![default_cf_descriptor(StateRootHashes::table_name())];
 
-        VersionedDB::<NomtStateValues<UserNamespace>, DbCache>::add_column_families(
-            &mut columns,
-            separate_archival,
-        )?;
-        VersionedDB::<NomtStateValues<KernelNamespace>, DbCache>::add_column_families(
-            &mut columns,
-            separate_archival,
-        )?;
-        let live_db = Self::get_rockbound_options(columns)
-            .setup_db_in_path_with_column_descriptors(path.clone())?;
-        let live_db = Arc::new(live_db);
-        let archival_db = if separate_archival {
+            VersionedDB::<NomtStateValues<UserNamespace>, DbCache>::add_live_db_column_families(
+                &mut live_columns,
+            )?;
+            VersionedDB::<NomtStateValues<KernelNamespace>, DbCache>::add_live_db_column_families(
+                &mut live_columns,
+            )?;
+
+            let live = Self::get_rockbound_options(live_columns)
+                .setup_db_in_path_with_column_descriptors(path.clone())?;
+            Arc::new(live)
+        };
+
+        let archival_db = {
             let archival_path = path.join(Self::ARCHIVAL_DB_PATH_SUFFIX);
-            let archival_columns = vec![
-                default_cf_descriptor(StateRootHashes::table_name()),
-                default_cf_descriptor(
-                    NomtStateValues::<UserNamespace>::HISTORICAL_COLUMN_FAMILY_NAME,
-                ),
-                default_cf_descriptor(
-                    NomtStateValues::<KernelNamespace>::HISTORICAL_COLUMN_FAMILY_NAME,
-                ),
-                default_cf_descriptor(NomtStateValues::<UserNamespace>::PRUNING_COLUMN_FAMILY_NAME),
-                default_cf_descriptor(
-                    NomtStateValues::<KernelNamespace>::PRUNING_COLUMN_FAMILY_NAME,
-                ),
-                default_cf_descriptor(
-                    NomtStateValues::<UserNamespace>::VERSION_METADATA_COLUMN_FAMILY_NAME,
-                ),
-                default_cf_descriptor(
-                    NomtStateValues::<KernelNamespace>::VERSION_METADATA_COLUMN_FAMILY_NAME,
-                ),
-            ];
-            let archival = Self::get_rockbound_options(archival_columns);
-            Arc::new(archival.setup_db_in_path_with_column_descriptors(archival_path)?)
-        } else {
-            live_db.clone()
+
+            let mut archival_columns = vec![default_cf_descriptor(StateRootHashes::table_name())];
+
+            VersionedDB::<NomtStateValues<UserNamespace>, DbCache>::add_archival_db_column_families(
+                &mut archival_columns,
+            )?;
+
+            VersionedDB::<NomtStateValues<KernelNamespace>, DbCache>::add_archival_db_column_families(
+                &mut archival_columns,
+            )?;
+
+            let archival = Self::get_rockbound_options(archival_columns)
+                .setup_db_in_path_with_column_descriptors(archival_path)?;
+
+            Arc::new(archival)
         };
 
         let inner = Arc::new(RwLock::new(Inner {
@@ -538,7 +527,6 @@ mod tests {
     // This test commits data for version 0 of the rollup state and panics at various points during the commit.
     // Afterward, it checks whether the rollback logic correctly reverted the archival state.
     fn test_rollback(crash_location: CrashLocation, archival_version: u64) -> anyhow::Result<()> {
-        let separate_archival = true;
         let tempdir = tempfile::tempdir().unwrap();
         let db_path = tempdir.path();
         let data = data_to_insert_per_verson();
@@ -546,8 +534,7 @@ mod tests {
         // Commit version 0.
         {
             let version = 0;
-            let flat_db =
-                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+            let flat_db = FlatStateDb::new(db_path.to_path_buf(), 1_000_000).unwrap();
 
             let state_changes = data.change_set(version);
             flat_db.commit(state_changes, None).unwrap();
@@ -560,8 +547,7 @@ mod tests {
         // Crash during commit of version 1.
         {
             let version = 1;
-            let flat_db =
-                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+            let flat_db = FlatStateDb::new(db_path.to_path_buf(), 1_000_000).unwrap();
 
             let state_changes = data.change_set(version);
             let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
@@ -574,8 +560,7 @@ mod tests {
 
         // Rollback to version 0.
         {
-            let flat_db =
-                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+            let flat_db = FlatStateDb::new(db_path.to_path_buf(), 1_000_000).unwrap();
 
             flat_db.validate_and_rollback_archival().unwrap();
             assert_flat_state(0, 0, &flat_db);
@@ -607,8 +592,7 @@ mod tests {
 
         {
             let version = 0;
-            let flat_db =
-                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+            let flat_db = FlatStateDb::new(db_path.to_path_buf(), 1_000_000).unwrap();
 
             let state_changes = data.change_set(version);
             flat_db.commit(state_changes, None).unwrap();
@@ -619,8 +603,7 @@ mod tests {
 
         {
             let version = 1;
-            let flat_db =
-                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+            let flat_db = FlatStateDb::new(db_path.to_path_buf(), 1_000_000).unwrap();
 
             let state_changes = data.change_set(version);
             flat_db.commit(state_changes, None).unwrap();
@@ -632,8 +615,7 @@ mod tests {
 
         {
             let version = 2;
-            let flat_db =
-                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+            let flat_db = FlatStateDb::new(db_path.to_path_buf(), 1_000_000).unwrap();
 
             let state_changes = data.change_set(version);
             flat_db.commit(state_changes, None).unwrap();
@@ -646,8 +628,7 @@ mod tests {
         // Rollbacks
 
         {
-            let flat_db =
-                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+            let flat_db = FlatStateDb::new(db_path.to_path_buf(), 1_000_000).unwrap();
 
             flat_db.rollback_archival_one_slot().unwrap();
 
@@ -658,8 +639,7 @@ mod tests {
         unlock_dbs(&tempdir);
 
         {
-            let flat_db =
-                FlatStateDb::new(db_path.to_path_buf(), 1_000_000, separate_archival).unwrap();
+            let flat_db = FlatStateDb::new(db_path.to_path_buf(), 1_000_000).unwrap();
             flat_db.rollback_archival_one_slot().unwrap();
 
             let version = 2;

--- a/crates/full-node/sov-db/src/flat_db.rs
+++ b/crates/full-node/sov-db/src/flat_db.rs
@@ -583,8 +583,6 @@ mod tests {
     /// This test rolls back the archival state regardless of the version of the live state.
     #[test]
     fn test_rollback_skip_validation() -> anyhow::Result<()> {
-        let separate_archival = true;
-
         let tempdir = tempfile::tempdir().unwrap();
         let db_path = tempdir.path();
 

--- a/crates/full-node/sov-db/src/historical_state.rs
+++ b/crates/full-node/sov-db/src/historical_state.rs
@@ -285,7 +285,7 @@ mod tests {
         let tempdir = tempfile::tempdir().unwrap();
         let db_path = tempdir.path();
         let commit_flag = CommitFlag::new(db_path);
-        let rocksdb = FlatStateDb::new(db_path.to_path_buf(), 1_000_000, true).unwrap(); // Use a 1MB state cache for tests
+        let rocksdb = FlatStateDb::new(db_path.to_path_buf(), 1_000_000).unwrap(); // Use a 1MB state cache for tests
 
         let key1 = b"AAA";
         let key2 = b"BBB";
@@ -321,7 +321,7 @@ mod tests {
         let db_path = tempdir.path();
         let commit_flag = CommitFlag::new(db_path);
 
-        let rocksdb = FlatStateDb::new(db_path.to_path_buf(), 1_000_000, true).unwrap(); // Use a 1MB state cache for tests
+        let rocksdb = FlatStateDb::new(db_path.to_path_buf(), 1_000_000).unwrap(); // Use a 1MB state cache for tests
 
         // Create two independent readers on the same database.
         let reader1 = HistoricalStateReader::new_empty(&rocksdb);
@@ -401,7 +401,7 @@ mod tests {
         let db_path = tempdir.path();
         let commit_flag = CommitFlag::new(db_path);
 
-        let rocksdb = FlatStateDb::new(db_path.to_path_buf(), 1_000_000, true).unwrap(); // Use a 1MB state cache for tests
+        let rocksdb = FlatStateDb::new(db_path.to_path_buf(), 1_000_000).unwrap(); // Use a 1MB state cache for tests
 
         let reader1 = HistoricalStateReader::new_empty(&rocksdb);
         let reader2 = HistoricalStateReader::new_empty(&rocksdb);

--- a/crates/full-node/sov-db/src/historical_state.rs
+++ b/crates/full-node/sov-db/src/historical_state.rs
@@ -14,7 +14,7 @@ use crate::schema::tables::StateRootHashes;
 use crate::schema::types::slot_key::{SlotKey, SlotValue};
 use crate::schema::types::StateRootHashId;
 
-const STATE_ROOT_HASH_SINGLETON: StateRootHashId = StateRootHashId(0);
+pub(crate) const STATE_ROOT_HASH_SINGLETON: StateRootHashId = StateRootHashId(0);
 
 type KvPair = (SlotKey, Option<SlotValue>);
 
@@ -34,7 +34,7 @@ pub struct HistoricalStateReader {
 }
 
 /// A collection of changes to the state db. Includes versioned changes to user/kernel state, and a plain schema batch of changes to any other columns.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct StateChanges {
     pub(crate) user: Arc<VersionedSchemaBatch<NomtStateValues<UserNamespace>>>,
     pub(crate) kernel: Arc<VersionedSchemaBatch<NomtStateValues<KernelNamespace>>>,
@@ -45,16 +45,14 @@ impl HistoricalStateReader {
     // Used for testing only.
     #[cfg(test)]
     fn new_empty(flat_state: &crate::storage_manager::FlatStateDb) -> Self {
-        let kernel_version = flat_state.get_kernel_db().get_committed_version().unwrap();
-        let user_version = flat_state.get_user_db().get_committed_version().unwrap();
-        assert_eq!(
-            kernel_version, user_version,
-            "Kernel and user should always have the same latest version"
-        );
-        let kernel =
-            VersionedDeltaReader::new(flat_state.get_kernel_db().clone(), kernel_version, vec![]);
-        let user =
-            VersionedDeltaReader::new(flat_state.get_user_db().clone(), user_version, vec![]);
+        let version = flat_state
+            .latest_version_and_root_hash_live_db()
+            .unwrap()
+            .map(|(v, _)| v);
+
+        let kernel = VersionedDeltaReader::new(flat_state.get_kernel_db().clone(), version, vec![]);
+        let user = VersionedDeltaReader::new(flat_state.get_user_db().clone(), version, vec![]);
+
         let root_hash_reader = DeltaReader::new(flat_state.get_db(), vec![]);
         let next_version = match user.latest_version() {
             Some(latest_version) => SlotNumber::new(
@@ -260,6 +258,7 @@ impl HistoricalStateReader {
             root_hash = %hex::encode(&root_hash),
             "Materialized root hash"
         );
+
         root_hash_batch
             .put::<StateRootHashes>(&(version, STATE_ROOT_HASH_SINGLETON), &root_hash)?;
 
@@ -303,7 +302,7 @@ mod tests {
             assert_eq!(slot_number.checked_sub(1), historical_state.last_version());
             assert_eq!(slot_number, historical_state.get_next_version());
 
-            let root_hash = idx.to_be_bytes().to_vec();
+            let root_hash = [idx as u8; 64].to_vec();
 
             let changes = HistoricalStateReader::materialize_values(
                 vec![],
@@ -312,7 +311,7 @@ mod tests {
                 slot_number,
             )
             .unwrap();
-            rocksdb.commit(changes, &commit_flag).unwrap();
+            rocksdb.commit(changes, Some(&commit_flag)).unwrap();
         }
     }
 
@@ -333,7 +332,7 @@ mod tests {
         assert_eq!(reader1.get_next_version(), version0);
         assert_eq!(reader2.get_next_version(), version0);
 
-        let root_hash0 = vec![1; 32];
+        let root_hash0 = vec![1; 64];
         let changes0 = HistoricalStateReader::materialize_values(
             vec![],
             vec![(
@@ -344,7 +343,7 @@ mod tests {
             version0,
         )
         .unwrap();
-        rocksdb.commit(changes0, &commit_flag).unwrap();
+        rocksdb.commit(changes0, Some(&commit_flag)).unwrap();
         assert_eq!(reader1.get_next_version(), version0);
         assert_eq!(reader2.get_next_version(), version0);
 
@@ -360,7 +359,7 @@ mod tests {
 
         // --- Second set of changes (version 1) ---
         let version1 = SlotNumber::new(1);
-        let root_hash1 = vec![2; 32];
+        let root_hash1 = vec![2; 64];
         let changes1 = HistoricalStateReader::materialize_values(
             vec![],
             vec![(
@@ -371,7 +370,7 @@ mod tests {
             version1,
         )
         .unwrap();
-        rocksdb.commit(changes1, &commit_flag).unwrap();
+        rocksdb.commit(changes1, Some(&commit_flag)).unwrap();
         assert_eq!(reader1.get_next_version(), version0);
         assert_eq!(reader2.get_next_version(), version0);
 
@@ -421,11 +420,11 @@ mod tests {
                 SlotKey::from_slice(b"key1"),
                 Some(b"value1".to_vec().into()),
             )],
-            vec![1; 32],
+            vec![1; 64],
             version0,
         )
         .unwrap();
-        rocksdb.commit(changes0, &commit_flag).unwrap();
+        rocksdb.commit(changes0, Some(&commit_flag)).unwrap();
 
         // Reader1's bound version stays the same, but unbound sees the update
         assert_eq!(reader1.last_version(), None);
@@ -443,11 +442,11 @@ mod tests {
                 SlotKey::from_slice(b"key2"),
                 Some(b"value2".to_vec().into()),
             )],
-            vec![2; 32],
+            vec![2; 64],
             version1,
         )
         .unwrap();
-        rocksdb.commit(changes1, &commit_flag).unwrap();
+        rocksdb.commit(changes1, Some(&commit_flag)).unwrap();
 
         // Both readers see the latest version through unbound
         assert_eq!(reader1.last_version_unbound().unwrap(), version1);

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -105,12 +105,9 @@ where
         crate::test_utils::CrashLocation::BeforeCommittingLedger.crash_if_env_set();
         let ledger_commit = self.commit_ledger(&ledger)?;
 
-        #[cfg(feature = "test-utils")]
-        crate::test_utils::CrashLocation::BeforeSavingArchival.crash_if_env_set();
-
         let flat_metrics = self
             .flat_state
-            .commit(historical_state, &self.commit_flag)?;
+            .commit(historical_state, Some(&self.commit_flag))?;
 
         self.commit_flag
             .save_commit_status(&CommitStatus::Success)?;
@@ -145,57 +142,47 @@ where
             AllDBsStateRoots::from_dbs(merkelized_state, ledger_db.clone(), flat_state_db)?;
 
         let commit_status = commit_flag.read_status()?;
+        state_roots.info(&commit_status, "before validation");
 
         match commit_status {
             CommitStatus::CommittingKernelNomt => {
                 // Kernel commit was successful but later commits failed. We rollback only the kernel.
                 if state_roots.is_kerner_nomt_root_newer() {
-                    state_roots.warning_on_rollback(&commit_status);
                     merkelized_state.kernel.rollback(1)?;
                 }
             }
             CommitStatus::CommittingUserNomt => {
-                state_roots.warning_on_rollback(&commit_status);
-                // User & Kernel commit was successful but later commits failed. We rollback both.
+                merkelized_state.kernel.rollback(1)?;
                 if state_roots.is_user_nomt_root_newer() {
-                    merkelized_state.kernel.rollback(1)?;
                     merkelized_state.user.rollback(1)?;
-                } else
-                // Only Kernel commit was successful. We rollback only the kernel.
-                {
-                    merkelized_state.kernel.rollback(1)?;
                 }
             }
 
             CommitStatus::CommittingLedger => {
-                state_roots.warning_on_rollback(&commit_status);
-                // User, Kernel & LedgerDb commit was successful but later commits failed. We rollback all of them.
+                merkelized_state.kernel.rollback(1)?;
+                merkelized_state.user.rollback(1)?;
+
                 if state_roots.is_ledger_db_root_newer() {
-                    merkelized_state.kernel.rollback(1)?;
-                    merkelized_state.user.rollback(1)?;
                     LedgerDb::rollback_head_slot(ledger_db.clone())?;
-                } else
-                // We rollback kernel & user.
-                {
-                    merkelized_state.kernel.rollback(1)?;
-                    merkelized_state.user.rollback(1)?;
                 }
             }
 
             CommitStatus::CommittingArchivalUserAndKernel
             | CommitStatus::CommittingLiveUserAndKernel => {
-                tracing::warn!(
-                    ?commit_status,
-                    "Detected in-progress commit. Rolling back kernel & user DBs."
-                );
-                // TODO: Requires careful consideration.
-                todo!("Rollback is not yet supported for archival and LiveDB.")
+                merkelized_state.kernel.rollback(1)?;
+                merkelized_state.user.rollback(1)?;
+                LedgerDb::rollback_head_slot(ledger_db.clone())?;
+
+                if state_roots.is_archival_db_root_newer() {
+                    flat_state_db.validate_and_rollback_archival()?;
+                }
             }
             CommitStatus::Success => {}
         }
 
         let state_roots = AllDBsStateRoots::from_dbs(merkelized_state, ledger_db, flat_state_db)?;
-        state_roots.validate_all();
+        state_roots.info(&commit_status, "after validation");
+        state_roots.check_all();
 
         Ok(())
     }
@@ -230,7 +217,7 @@ where
         relevant_snapshot_refs: Vec<K>,
         rockbound_snapshots: &HashMap<K, SnapshotGroup>,
         nomt_snapshots: Arc<RwLock<HashMap<K, StateOverlay>>>,
-        pinned_cache: Option<Box<(dyn Any + Send + Sync)>>,
+        pinned_cache: Option<Box<dyn Any + Send + Sync>>,
         with_witness: bool,
     ) -> anyhow::Result<(S, DeltaReader)> {
         let mut historical_state_snapshots = Vec::with_capacity(relevant_snapshot_refs.len());
@@ -260,7 +247,10 @@ where
         );
         let historical_state_reader =
             DeltaReader::new(self.flat_state.live_db.clone(), historical_state_snapshots);
-        let version = self.flat_state.get_kernel_db().get_committed_version()?;
+        let version = self
+            .flat_state
+            .latest_version_and_root_hash_live_db()?
+            .map(|(v, _)| v);
 
         let user_state_reader =
             VersionedDeltaReader::<NomtStateValues<UserNamespace>, DbCache>::new(
@@ -274,6 +264,7 @@ where
                 version,
                 kernel_state_snapshots,
             );
+
         let historical_state_mapper = HistoricalStateReader::new(
             user_state_reader,
             kernel_state_reader,
@@ -480,27 +471,6 @@ impl PrunerJob {
     }
 }
 
-fn root_hash_from_life_db(flat_state: &FlatStateDb) -> anyhow::Result<Option<[u8; 64]>> {
-    let historical_state_delta_reader = DeltaReader::new(flat_state.live_db.clone(), Vec::new());
-
-    let Some(last_version) =
-        HistoricalStateReader::last_version_from_reader(&historical_state_delta_reader)?
-    else {
-        return Ok(None);
-    };
-
-    let state_root_hash = HistoricalStateReader::get_serialized_root_hash_from_reader(
-        &historical_state_delta_reader,
-        last_version,
-    )?
-    .unwrap_or_else(|| {
-        // If `last_version` is present we must always have root hash.
-        panic!("Root hash missing for the latest LiveDB version {last_version}",);
-    });
-
-    Ok(Some(state_root_hash.try_into().unwrap()))
-}
-
 // Root hash for empty nomt state.
 fn pre_genesis_root() -> [u8; 64] {
     let mut pre_genesis_root = [0u8; 64];
@@ -513,6 +483,7 @@ struct AllDBsStateRoots {
     // The `live_db` is committed last. We can use `root_hash_from_live_db` to verify
     // whether all other databases were committed in the previous run.
     root_hash_from_live_db: [u8; 64],
+    root_hash_from_archival_db: [u8; 64],
     root_hash_from_ledger_db: [u8; 64],
     root_hash_nomt: StateRootHashes,
 }
@@ -523,8 +494,13 @@ impl AllDBsStateRoots {
         ledger_db: Arc<rockbound::DB>,
         flat_state_db: &FlatStateDb,
     ) -> anyhow::Result<AllDBsStateRoots> {
-        let root_hash_from_live_db =
-            root_hash_from_life_db(flat_state_db)?.unwrap_or_else(pre_genesis_root);
+        let root_hash_from_archival_db = flat_state_db
+            .root_hash_from_archival_db()?
+            .unwrap_or_else(pre_genesis_root);
+
+        let root_hash_from_live_db = flat_state_db
+            .root_hash_from_live_db()?
+            .unwrap_or_else(pre_genesis_root);
 
         let root_hash_from_ledger_db =
             LedgerDb::get_head_root_hash(ledger_db.clone())?.unwrap_or_else(pre_genesis_root);
@@ -533,6 +509,7 @@ impl AllDBsStateRoots {
 
         Ok(AllDBsStateRoots {
             root_hash_from_live_db,
+            root_hash_from_archival_db,
             root_hash_from_ledger_db,
             root_hash_nomt,
         })
@@ -550,7 +527,16 @@ impl AllDBsStateRoots {
         self.root_hash_from_ledger_db != self.root_hash_from_live_db
     }
 
-    fn validate_all(&self) {
+    fn is_archival_db_root_newer(&self) -> bool {
+        self.root_hash_from_archival_db != self.root_hash_from_live_db
+    }
+
+    fn check_all(&self) {
+        assert_eq!(
+            hex::encode(self.root_hash_from_ledger_db),
+            hex::encode(self.root_hash_from_live_db)
+        );
+
         assert_eq!(
             hex::encode(self.root_hash_nomt.user),
             hex::encode(&self.root_hash_from_live_db[0..32])
@@ -560,21 +546,17 @@ impl AllDBsStateRoots {
             hex::encode(self.root_hash_nomt.kernel),
             hex::encode(&self.root_hash_from_live_db[32..])
         );
-
-        assert_eq!(
-            hex::encode(self.root_hash_from_ledger_db),
-            hex::encode(self.root_hash_from_live_db)
-        );
     }
 
-    fn warning_on_rollback(&self, commit_status: &CommitStatus) {
-        tracing::warn!(
-            live_db_kernel_root_hash = hex::encode(self.root_hash_from_live_db),
-            root_hash_ledger_db = hex::encode(self.root_hash_from_ledger_db),
-            user_nomt_db_root_hash = hex::encode(self.root_hash_nomt.user),
-            kernel_nomt_db_root_hash = hex::encode(self.root_hash_nomt.kernel),
+    fn info(&self, commit_status: &CommitStatus, msg: &str) {
+        tracing::info!(
+            root_hash_from_live_db = hex::encode(self.root_hash_from_live_db),
+            root_hash_from_archival_db = hex::encode(self.root_hash_from_archival_db),
+            root_hash_from_ledger_db = hex::encode(self.root_hash_from_ledger_db),
+            root_hash_nomt_user = hex::encode(self.root_hash_nomt.user),
+            root_hash_nomt_kernel = hex::encode(self.root_hash_nomt.kernel),
             ?commit_status,
-            "Detected in-progress commit. Rolling back DBs"
+            "State roots on startup {msg}"
         );
     }
 }

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -137,11 +137,16 @@ where
         ledger_db: Arc<rockbound::DB>,
         flat_state_db: &FlatStateDb,
     ) -> anyhow::Result<()> {
-        let state_roots =
-            AllDBsStateRoots::from_dbs(merkelized_state, ledger_db.clone(), flat_state_db)?;
-
         let commit_status = commit_flag.read_status()?;
-        state_roots.info(&commit_status, "before validation");
+
+        let state_roots = AllDBsStateRoots::from_dbs(
+            merkelized_state,
+            ledger_db.clone(),
+            flat_state_db,
+            commit_status,
+        )?;
+
+        state_roots.info("before validation");
 
         match commit_status {
             CommitStatus::CommittingKernelNomt => {
@@ -179,8 +184,9 @@ where
             CommitStatus::Success => {}
         }
 
-        let state_roots = AllDBsStateRoots::from_dbs(merkelized_state, ledger_db, flat_state_db)?;
-        state_roots.info(&commit_status, "after validation");
+        let state_roots =
+            AllDBsStateRoots::from_dbs(merkelized_state, ledger_db, flat_state_db, commit_status)?;
+        state_roots.info("after validation");
         state_roots.check_all();
 
         Ok(())
@@ -485,6 +491,7 @@ struct AllDBsStateRoots {
     root_hash_from_archival_db: [u8; 64],
     root_hash_from_ledger_db: [u8; 64],
     root_hash_nomt: StateRootHashes,
+    commit_status: CommitStatus,
 }
 
 impl AllDBsStateRoots {
@@ -492,10 +499,28 @@ impl AllDBsStateRoots {
         merkelized_state: &NomtStateDb<H>,
         ledger_db: Arc<rockbound::DB>,
         flat_state_db: &FlatStateDb,
+        commit_status: CommitStatus,
     ) -> anyhow::Result<AllDBsStateRoots> {
-        let root_hash_from_live_db = flat_state_db
-            .root_hash_from_live_db()?
-            .unwrap_or_else(pre_genesis_root);
+        let root_hash_from_live_db = match flat_state_db.root_hash_from_live_db()? {
+            Some(root_hash_from_live_db) => root_hash_from_live_db,
+            None => {
+                // root_hash_from_live_db is None.
+                if commit_status == CommitStatus::Success {
+                    // Missing `root_hash_from_live_db` and the commit status is Success, which indicates that the rollup is being run for the first time.
+                    pre_genesis_root()
+                } else {
+                    // The commit status is not Success. This means that the rollup ran before for the first time but crashed before saving the live DB.
+                    //
+                    // In this case, we should manually remove all databases and start again.
+                    // This happens only in the following scenario:
+                    // 1. The rollup started from genesis.
+                    // 2. It crashed before finishing the first commit, and the live DB was not saved.
+                    //
+                    // In this case, it is safe to delete all the databases.
+                    anyhow::bail!("Live db not found. Commit status: {commit_status:?}. Delete the rollup databses and start again.");
+                }
+            }
+        };
 
         let root_hash_from_archival_db = flat_state_db
             .root_hash_from_archival_db()?
@@ -511,6 +536,7 @@ impl AllDBsStateRoots {
             root_hash_from_archival_db,
             root_hash_from_ledger_db,
             root_hash_nomt,
+            commit_status,
         })
     }
 
@@ -547,14 +573,14 @@ impl AllDBsStateRoots {
         );
     }
 
-    fn info(&self, commit_status: &CommitStatus, msg: &str) {
+    fn info(&self, msg: &str) {
         tracing::info!(
             root_hash_from_live_db = hex::encode(self.root_hash_from_live_db),
             root_hash_from_archival_db = hex::encode(self.root_hash_from_archival_db),
             root_hash_from_ledger_db = hex::encode(self.root_hash_from_ledger_db),
             root_hash_nomt_user = hex::encode(self.root_hash_nomt.user),
             root_hash_nomt_kernel = hex::encode(self.root_hash_nomt.kernel),
-            ?commit_status,
+            ?self.commit_status,
             "State roots on startup {msg}"
         );
     }

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -493,12 +493,12 @@ impl AllDBsStateRoots {
         ledger_db: Arc<rockbound::DB>,
         flat_state_db: &FlatStateDb,
     ) -> anyhow::Result<AllDBsStateRoots> {
-        let root_hash_from_archival_db = flat_state_db
-            .root_hash_from_archival_db()?
-            .unwrap_or_else(pre_genesis_root);
-
         let root_hash_from_live_db = flat_state_db
             .root_hash_from_live_db()?
+            .unwrap_or_else(pre_genesis_root);
+
+        let root_hash_from_archival_db = flat_state_db
+            .root_hash_from_archival_db()?
             .unwrap_or_else(pre_genesis_root);
 
         let root_hash_from_ledger_db =

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -517,6 +517,10 @@ impl AllDBsStateRoots {
                     // 2. It crashed before finishing the first commit, and the live DB was not saved.
                     //
                     // In this case, it is safe to delete all the databases.
+                    tracing::error!(
+                        ?commit_status,
+                        "Rollup instantiation error: Delete the rollup databases and start again."
+                    );
                     anyhow::bail!("Live db not found. Commit status: {commit_status:?}. Delete the rollup databses and start again.");
                 }
             }

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -49,11 +49,10 @@ where
     pub(crate) fn new(config: RollupDbConfig) -> anyhow::Result<Self> {
         let path = config.path.clone();
         let state_cache_size = config.state_cache_size.unwrap_or(GIGABYTE);
-        let separate_archival_state = config.separate_archival_state;
 
         let commit_flag = CommitFlag::new(&config.path);
         let merklized_state = Arc::new(NomtStateDb::<H>::new(config)?);
-        let flat_state = FlatStateDb::new(path.clone(), state_cache_size, separate_archival_state)?;
+        let flat_state = FlatStateDb::new(path.clone(), state_cache_size)?;
         let ledger_rocksdb =
             Arc::new(LedgerDb::get_rockbound_options().default_setup_db_in_path(&path)?);
 

--- a/crates/full-node/sov-db/src/test_utils.rs
+++ b/crates/full-node/sov-db/src/test_utils.rs
@@ -313,6 +313,12 @@ pub enum CrashLocation {
     BeforeCommittingLedger,
     /// Rollup crashes before saving the `CommittingArchival` flag.
     BeforeSavingArchival,
+    /// Rollup crashes before committing the the archival db.
+    BeforeCommittingArchival,
+    /// Rollup crashes before saving the `CommittingLive` flag.
+    BeforeSavingLive,
+    /// Rollup crashes before committing the the live db.
+    BeforeCommittingLive,
 }
 
 impl CrashLocation {

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -494,7 +494,6 @@ where
         // Once we're this close to `deferred_slots_count`, we risk crossing the
         // `deferred_slots_count` threshold before the next call to
         // `update_state`. That's no good.
-
         let current_visible_slot_number =
             current_visible_slot_number_according_to_node::<S, Rt>(info);
         let too_close_to_deferred_slots_count_for_comfort =

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -494,6 +494,7 @@ where
         // Once we're this close to `deferred_slots_count`, we risk crossing the
         // `deferred_slots_count` threshold before the next call to
         // `update_state`. That's no good.
+
         let current_visible_slot_number =
             current_visible_slot_number_according_to_node::<S, Rt>(info);
         let too_close_to_deferred_slots_count_for_comfort =

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -734,11 +734,6 @@
           "format": "uint",
           "minimum": 0.0
         },
-        "separate_archival_state": {
-          "description": "Whether to use a separate db for archival state.",
-          "default": false,
-          "type": "boolean"
-        },
         "state_cache_size": {
           "description": "The size of the cache which holds hot key-value pairs in the flat state database. Default is 1GB. A larger cache size can improve execution speed at the cost of more memory usage.",
           "type": [

--- a/crates/utils/sov-test-utils/src/storage.rs
+++ b/crates/utils/sov-test-utils/src/storage.rs
@@ -253,7 +253,7 @@ impl<S: MerkleProofSpec> SimpleNomtStorageManager<S> {
         self.accessory.write_schemas(&accessory).unwrap();
         tracing::trace!("Committed accessory changes to disk");
         self.historical_state
-            .commit(historical_state, &self.commit_flag)
+            .commit(historical_state, Some(&self.commit_flag))
             .unwrap();
 
         *self.pinned_cache.lock().unwrap() = pinned_cache.map(|c| *c.downcast().expect("Failed to downcast the pinned_cache argument to `NomtProverStorage`. This is a bug. Please report it."));

--- a/crates/utils/sov-test-utils/src/storage.rs
+++ b/crates/utils/sov-test-utils/src/storage.rs
@@ -177,7 +177,7 @@ impl<S: MerkleProofSpec> SimpleNomtStorageManager<S> {
         let commit_flag = CommitFlag::new(&config.path);
         let state_db = sov_db::state_db_nomt::NomtStateDb::new(config)
             .expect("Failed to initialize StateDb for NOMT");
-        let historical_state = FlatStateDb::new(dir.path().to_path_buf(), 1_000_000, true).unwrap(); // Use a 1MB state cache for tests
+        let historical_state = FlatStateDb::new(dir.path().to_path_buf(), 1_000_000).unwrap(); // Use a 1MB state cache for tests
         let accessory_rocksdb = AccessoryDb::get_rockbound_options()
             .default_setup_db_in_path(dir.path())
             .unwrap();

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -117,7 +117,6 @@ pub struct RollupBuilderConfig<S: Spec> {
     pub start_at_rollup_height: Option<RollupHeight>,
     pub stop_at_rollup_height: Option<RollupHeight>,
     pub extension: Option<SeqConfigExtension>,
-    pub separate_archival_db: bool,
 }
 
 /// A one-stop shop for building entire rollups and starting them in the
@@ -350,11 +349,8 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
     }
 
     pub fn rollup_config(&self) -> RollupConfig<<R::Spec as Spec>::Address, R::DaService> {
-        let mut rollup_db_config =
+        let rollup_db_config =
             RollupDbConfig::default_in_path(self.config.storage.path().to_path_buf());
-        if self.config.separate_archival_db {
-            rollup_db_config.separate_archival_state = true;
-        }
 
         RollupConfig {
             storage: rollup_db_config,
@@ -436,7 +432,6 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                 max_log_limit: 20000,
                 response_size_limit: (1024 * 1024) - (1024 * 30), // Limit our response size to 1MB, leaving 30kb for headers, overhead, and misestimation.
             }),
-            separate_archival_db: true,
         }
     }
 }

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -72,7 +72,6 @@ backoff_max_times = 10
 # The path to the rollup's data directory. Paths that do not begin with `/` are interpreted as relative paths.
 path = "demo_data"
 state_cache_size = 4294967296 # 4GB. Default is 1GB.
-separate_archival_state = true
 
 [runner]
 # 3 times per regular celestia block

--- a/examples/demo-rollup/configs/mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/mock_rollup_config.toml
@@ -30,7 +30,6 @@ block_time_ms = 1_000
 # The path to the rollup's data directory. Paths that do not begin with `/` are interpreted as relative paths.
 path = "demo_data"
 state_cache_size = 4294967296 # 4GB. Default is 1GB.
-separate_archival_state = true
 # user_commit_concurrency = 4 # Number of concurrent commit workers for user state
 # user_hashtable_buckets = 15000000 # Expected state size, cannot be changed after creation
 # user_preallocate_ht = false # Whether to preallocate hashtable file for user db

--- a/examples/demo-rollup/tests/restart/crash.rs
+++ b/examples/demo-rollup/tests/restart/crash.rs
@@ -296,10 +296,8 @@ async fn send_txs(
         // It's fine not to check the result here — it will be verified later via subscription.
         let res = api_client.send_tx_to_sequencer(&tx).await;
 
-        if res.is_err() {
-            if std::env::var(CRASH_ENV_NAME).is_ok() {
-                return;
-            }
+        if res.is_err() && std::env::var(CRASH_ENV_NAME).is_ok() {
+            return;
         }
 
         // Send transactions continuously every 100ms to maintain steady TX traffic during the test.

--- a/examples/demo-rollup/tests/restart/crash.rs
+++ b/examples/demo-rollup/tests/restart/crash.rs
@@ -296,7 +296,7 @@ async fn send_txs(
             return;
         }
 
-        // Send transactions continuously every 100ms to maintain steady TX traffic during the test.
+        // Send transactions continuously every 50ms to maintain steady TX traffic during the test.
         tokio::time::sleep(Duration::from_millis(50)).await;
         nb_of_txs += 1;
 

--- a/examples/demo-rollup/tests/restart/crash.rs
+++ b/examples/demo-rollup/tests/restart/crash.rs
@@ -30,7 +30,7 @@ async fn start_node(location: Arc<TempDir>) -> TestRollup<MockNomtDemoRollup<Nat
     RollupBuilder::new(
         test_genesis_source(sov_modules_api::OperatingMode::Zk),
         BlockProducingConfig::Periodic {
-            block_time_ms: 1_000,
+            block_time_ms: 1000,
         },
         0,
     )
@@ -55,7 +55,7 @@ async fn start_node(location: Arc<TempDir>) -> TestRollup<MockNomtDemoRollup<Nat
 #[tokio::test(flavor = "multi_thread")]
 async fn test_crash_before_saving_kernel_nomt() -> anyhow::Result<()> {
     tokio::time::timeout(
-        Duration::from_secs(30),
+        Duration::from_secs(120),
         test_start_stop_with_crash(CrashLocation::BeforeSavingKernelNomt),
     )
     .await
@@ -122,6 +122,36 @@ async fn test_crash_before_saving_archival() -> anyhow::Result<()> {
     .unwrap()
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_crash_before_comitting_archival() -> anyhow::Result<()> {
+    tokio::time::timeout(
+        Duration::from_secs(120),
+        test_start_stop_with_crash(CrashLocation::BeforeCommittingArchival),
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_crash_before_saving_live() -> anyhow::Result<()> {
+    tokio::time::timeout(
+        Duration::from_secs(120),
+        test_start_stop_with_crash(CrashLocation::BeforeSavingLive),
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_crash_before_comitting_live() -> anyhow::Result<()> {
+    tokio::time::timeout(
+        Duration::from_secs(120),
+        test_start_stop_with_crash(CrashLocation::BeforeCommittingLive),
+    )
+    .await
+    .unwrap()
+}
+
 // This test checks whether rollp can recover from different kinds of crashes, see `CrashLocation` enum.
 async fn test_start_stop_with_crash(crash_moment: CrashLocation) -> anyhow::Result<()> {
     let temp_dir = Arc::new(tempfile::tempdir()?);
@@ -137,7 +167,9 @@ async fn test_start_stop_with_crash(crash_moment: CrashLocation) -> anyhow::Resu
         let client = test_rollup.client.clone();
 
         let mut event_subscription = subscribe_to_bank_events(&test_rollup).await;
-        let max_nb_of_txs = 200;
+        let max_nb_of_txs = 500;
+
+        println!("START1 =================");
 
         send_txs_in_background(
             0,
@@ -150,8 +182,8 @@ async fn test_start_stop_with_crash(crash_moment: CrashLocation) -> anyhow::Resu
 
         let mut nb_of_events = 0;
         loop {
-            // Crash the node after 5 txs.
-            if nb_of_events == 5 {
+            // Crash the node after 100 txs.
+            if nb_of_events == 100 {
                 crash_moment.set_crash_env();
             }
 
@@ -181,10 +213,12 @@ async fn test_start_stop_with_crash(crash_moment: CrashLocation) -> anyhow::Resu
         test_rollup.wait_for_sequencer_ready().await.unwrap();
         test_rollup.wait_for_next_blocks(10).await;
 
+        println!("START2 =================");
+
         let client = test_rollup.client.clone();
         let mut event_subscription = subscribe_to_bank_events(&test_rollup).await;
 
-        let max_nb_of_txs = 100;
+        let max_nb_of_txs = 500;
         let start_generation = 1000;
 
         // Keep sending txs in the bacground.
@@ -198,7 +232,7 @@ async fn test_start_stop_with_crash(crash_moment: CrashLocation) -> anyhow::Resu
         .await;
 
         // Check if transactions are coming through.
-        for _ in 0..10 {
+        for _ in 0..40 {
             let _ = event_subscription.next().await.unwrap().unwrap();
         }
         test_rollup.shutdown().await.unwrap();
@@ -260,10 +294,16 @@ async fn send_txs(
         );
 
         // It's fine not to check the result here — it will be verified later via subscription.
-        let _ = api_client.send_tx_to_sequencer(&tx).await;
+        let res = api_client.send_tx_to_sequencer(&tx).await;
+
+        if res.is_err() {
+            if std::env::var(CRASH_ENV_NAME).is_ok() {
+                return;
+            }
+        }
 
         // Send transactions continuously every 100ms to maintain steady TX traffic during the test.
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
         nb_of_txs += 1;
 
         assert!(nb_of_txs < max_nb_of_txs);

--- a/examples/demo-rollup/tests/restart/crash.rs
+++ b/examples/demo-rollup/tests/restart/crash.rs
@@ -30,7 +30,7 @@ async fn start_node(location: Arc<TempDir>) -> TestRollup<MockNomtDemoRollup<Nat
     RollupBuilder::new(
         test_genesis_source(sov_modules_api::OperatingMode::Zk),
         BlockProducingConfig::Periodic {
-            block_time_ms: 1000,
+            block_time_ms: 1_000,
         },
         0,
     )
@@ -169,8 +169,6 @@ async fn test_start_stop_with_crash(crash_moment: CrashLocation) -> anyhow::Resu
         let mut event_subscription = subscribe_to_bank_events(&test_rollup).await;
         let max_nb_of_txs = 500;
 
-        println!("START1 =================");
-
         send_txs_in_background(
             0,
             receiver_addr,
@@ -212,8 +210,6 @@ async fn test_start_stop_with_crash(crash_moment: CrashLocation) -> anyhow::Resu
         let test_rollup = start_node(temp_dir).await;
         test_rollup.wait_for_sequencer_ready().await.unwrap();
         test_rollup.wait_for_next_blocks(10).await;
-
-        println!("START2 =================");
 
         let client = test_rollup.client.clone();
         let mut event_subscription = subscribe_to_bank_events(&test_rollup).await;


### PR DESCRIPTION
# Description

See relevant update in https://github.com/Sovereign-Labs/rockbound/pull/43

This PR introduces the following changes:
1. Removes the `separate_archival_state` flag; the archival and live Dbs are now always created in separate locations.
2. Adds a rollback mechanism to ArchivalDb.
3. Adds a test that crashes the rollup during an archival commit and verifies database consistency after restart.

Accesorry state rollback will be implemented in the next PR.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2267
