### PR TITLE
Prevent requests when rate limit is zero

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
@@ -108,21 +108,23 @@ impl<G: Gas> Resource<G> {
     }
 
     pub(crate) fn err_if_exceeding(&self, other: &Self) -> Result<(), LimitExceeded<G>> {
-        if self.req_counter > other.req_counter {
+        // Error if the total accumulated is greater than or equal to the max allowed. 
+        // Using >= instead of > to ensure that a rate limit of zero prevents all requests.
+        if self.req_counter >= other.req_counter {
             return Err(LimitExceeded::RequestCount {
                 total_accumulated: self.req_counter,
                 max_allowed: other.req_counter,
             });
         }
 
-        if self.space_in_bytes > other.space_in_bytes {
+        if self.space_in_bytes >= other.space_in_bytes {
             return Err(LimitExceeded::Space {
                 total_accumulated: self.space_in_bytes,
                 max_allowed: other.space_in_bytes,
             });
         }
 
-        if self.execution_time_micros > other.execution_time_micros {
+        if self.execution_time_micros >= other.execution_time_micros {
             return Err(LimitExceeded::ExecutionTime {
                 total_accumulated: self.execution_time_micros,
                 max_allowed: other.execution_time_micros,

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
@@ -228,7 +228,7 @@ mod tests {
         {
             let r1 = Resource::new(5, 5, 7, Gas::from([8, 9]));
             let r2 = Resource { ..r1 };
-            assert!(r2.err_if_exceeding(&r1).is_ok());
+            assert!(r2.err_if_exceeding(&r2).is_err());
         }
 
         {
@@ -248,10 +248,7 @@ mod tests {
 
         {
             let r1 = Resource::new(100, 101, 102, Gas::from([103, 104]));
-            let r2 = Resource {
-                space_in_bytes: 1,
-                ..r1
-            };
+            let r2 = Resource::new(101, 101, 103, Gas::from([104, 105])); // Set space in bytes exactly equal
             assert_eq!(
                 r1.err_if_exceeding(&r2),
                 Err(LimitExceeded::Space {
@@ -263,10 +260,7 @@ mod tests {
 
         {
             let r1 = Resource::new(100, 101, 102, Gas::from([103, 104]));
-            let r2 = Resource {
-                execution_time_micros: 1,
-                ..r1
-            };
+            let r2 = Resource::new(101, 102, 102, Gas::from([104, 105])); // Set execution time micros exactly equal
             assert_eq!(
                 r1.err_if_exceeding(&r2),
                 Err(LimitExceeded::ExecutionTime {

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
@@ -108,7 +108,7 @@ impl<G: Gas> Resource<G> {
     }
 
     pub(crate) fn err_if_exceeding(&self, other: &Self) -> Result<(), LimitExceeded<G>> {
-        // Error if the total accumulated is greater than or equal to the max allowed. 
+        // Error if the total accumulated is greater than or equal to the max allowed.
         // Using >= instead of > to ensure that a rate limit of zero prevents all requests.
         if self.req_counter >= other.req_counter {
             return Err(LimitExceeded::RequestCount {


### PR DESCRIPTION
# Description

This PR changes `err_if_exceeding` to ensure that requests which exactly exhaust the budget are rejected. This ensures that setting the rate limit to zero prevents all requests.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
