### PR TITLE
Remove the key from the pruning table during rollback.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9538,7 +9538,7 @@ dependencies = [
 [[package]]
 name = "rockbound"
 version = "0.1.0"
-source = "git+https://github.com/sovereign-labs/rockbound?rev=b90a4ea44a914511eceed6ce08c4ff2a35c5ab58#b90a4ea44a914511eceed6ce08c4ff2a35c5ab58"
+source = "git+https://github.com/sovereign-labs/rockbound?rev=c0495b56687075e5d237a248679a69ad6f1d04b7#c0495b56687075e5d237a248679a69ad6f1d04b7"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9538,7 +9538,7 @@ dependencies = [
 [[package]]
 name = "rockbound"
 version = "0.1.0"
-source = "git+https://github.com/sovereign-labs/rockbound?rev=1cf58e2679600d87eb147ac786359503bac21898#1cf58e2679600d87eb147ac786359503bac21898"
+source = "git+https://github.com/sovereign-labs/rockbound?rev=b90a4ea44a914511eceed6ce08c4ff2a35c5ab58#b90a4ea44a914511eceed6ce08c4ff2a35c5ab58"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ nearly-linear = { path = "crates/utils/nearly-linear", version = "0.3" }
 # Dependencies maintained by Sovereign
 jmt = { version = "0.12.0", default-features = false }
 reltester = { git = "https://github.com/sovereign-labs/reltester.git", rev = "d6209abff72929f5ba41614f5cea3e4a748428c3" }
-rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "1cf58e2679600d87eb147ac786359503bac21898" }
+rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "b90a4ea44a914511eceed6ce08c4ff2a35c5ab58" }
 nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
 nomt-core = { version = "1.0.3", default-features = false, features = ["borsh", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ nearly-linear = { path = "crates/utils/nearly-linear", version = "0.3" }
 # Dependencies maintained by Sovereign
 jmt = { version = "0.12.0", default-features = false }
 reltester = { git = "https://github.com/sovereign-labs/reltester.git", rev = "d6209abff72929f5ba41614f5cea3e4a748428c3" }
-rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "b90a4ea44a914511eceed6ce08c4ff2a35c5ab58" }
+rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "c0495b56687075e5d237a248679a69ad6f1d04b7" }
 nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
 nomt-core = { version = "1.0.3", default-features = false, features = ["borsh", "serde"] }

--- a/crates/full-node/sov-db/src/flat_db.rs
+++ b/crates/full-node/sov-db/src/flat_db.rs
@@ -18,7 +18,7 @@ use rockbound::{
     default_cf_descriptor, rocksdb::ColumnFamilyDescriptor, versioned_db::VersionedDB,
 };
 use rockbound::{rocksdb, SchemaBatch, DB};
-use sov_rollup_interface::common::SlotNumber;
+use sov_rollup_interface::common::{IntoSlotNumber, SlotNumber};
 use std::sync::Arc;
 
 /// A database to store the flat state of the rollup (i.e. the raw key-value pairs)
@@ -212,22 +212,23 @@ impl FlatStateDb {
 
     /// Commit the `state_changes`.
     pub fn commit(&self, state_changes: StateChanges) -> anyhow::Result<FlatStateCommitMetric> {
-        self.commit_internal(state_changes, true)
+        let version = self
+            .latest_version_and_root_hash_live_db()?
+            .and_then(|(v, _)| v.checked_add(1))
+            .unwrap_or(0);
+
+        self.commit_internal(state_changes, version, true)
     }
 
     fn commit_internal(
         &self,
         state_changes: StateChanges,
-        commit_live_db: bool,
+        version: u64,
+        is_commit: bool,
     ) -> anyhow::Result<FlatStateCommitMetric> {
         let start_prepare = std::time::Instant::now();
         let prepare = start_prepare.elapsed();
         let start_write = std::time::Instant::now();
-
-        let version = self
-            .latest_version_and_root_hash_live_db()?
-            .and_then(|(v, _)| v.checked_add(1))
-            .unwrap_or(0);
 
         let mut live_db_batch = rocksdb::WriteBatch::default();
         let mut archival_db_batch = rocksdb::WriteBatch::default();
@@ -247,6 +248,7 @@ impl FlatStateDb {
             kernel_cache,
             &self.live_db,
             &self.archival_db,
+            is_commit,
         )?;
 
         let serialized_size_kernel = live_db_batch.size_in_bytes();
@@ -261,6 +263,7 @@ impl FlatStateDb {
             user_cache,
             &self.live_db,
             &self.archival_db,
+            is_commit,
         )?;
 
         let serialized_size_user = live_db_batch.size_in_bytes() - serialized_size_kernel;
@@ -290,7 +293,7 @@ impl FlatStateDb {
         self.user.store_committed_archival_version(version);
 
         // Write live db batch.
-        if commit_live_db {
+        if is_commit {
             #[cfg(feature = "test-utils")]
             crate::test_utils::CrashLocation::BeforeCommittingLive.crash_if_env_set();
             self.live_db.write_db_batch(live_db_batch)?;
@@ -352,47 +355,39 @@ impl FlatStateDb {
 
         assert_eq!(prev_root_hash_archival, root_hash_live);
 
-        self.rollback_archival(
-            current_version_archival,
-            current_version_live,
-            root_hash_live,
-        )
+        self.rollback_archival(current_version_archival)
     }
 
-    fn rollback_archival(
-        &self,
-        current_version_archival: u64,
-        current_version_live: u64,
-        root_hash_live: [u8; 64],
-    ) -> anyhow::Result<()> {
-        let user_changes = keys_and_values_for_rollback(&self.user, current_version_archival)?;
-        let kernel_changes = keys_and_values_for_rollback(&self.kernel, current_version_archival)?;
+    fn rollback_archival(&self, current_version_archival: u64) -> anyhow::Result<()> {
+        let user_changes = keys_for_rollback(&self.user, current_version_archival)?;
+        let kernel_changes = keys_for_rollback(&self.kernel, current_version_archival)?;
 
-        let mut state_changes = HistoricalStateReader::materialize_values(
+        let (user_batch, kernel_batch) = HistoricalStateReader::materialize_user_and_kernel_values(
             user_changes,
             kernel_changes,
-            root_hash_live.to_vec(),
-            SlotNumber::new(current_version_live),
         )?;
 
-        // Remove the most recent (current_version_archival) root hash from the `StateRootHashes` table.
         let mut root_hash_batch = SchemaBatch::default();
-        root_hash_batch.merge(state_changes.root_hash_batch.as_ref().clone());
-        root_hash_batch.delete(&(
-            SlotNumber::new(current_version_archival),
+        root_hash_batch.delete::<StateRootHashes>(&(
+            current_version_archival.to_slot_number(),
             STATE_ROOT_HASH_SINGLETON,
         ))?;
 
-        state_changes.root_hash_batch = Arc::new(root_hash_batch);
+        let state_changes = StateChanges {
+            user: Arc::new(user_batch),
+            kernel: Arc::new(kernel_batch),
+            root_hash_batch: Arc::new(root_hash_batch),
+        };
+
         // We rollback only archival db.
-        self.commit_internal(state_changes, false)?;
+        self.commit_internal(state_changes, current_version_archival, false)?;
 
         Ok(())
     }
 }
 
 #[allow(clippy::type_complexity)]
-fn keys_and_values_for_rollback<V, C>(
+fn keys_for_rollback<V, C>(
     db: &VersionedDB<V, C>,
     version_to_rollback: u64,
 ) -> anyhow::Result<Vec<(V::Key, Option<V::Value>)>>
@@ -402,22 +397,15 @@ where
     V::Value: Clone + AsRef<[u8]>,
     V: SchemaWithVersion + Ord,
 {
-    // Get all keys committed at `version_to_rollback`.
-    // Then retrieve the values for those keys from the previous state version.
-    // Values that changed between `version_to_rollback` and `version_to_rollback - 1` are overridden.
-    // Values that were inserted at `version_to_rollback` are deleted.
-    // Values that were deleted at `version_to_rollback` are reinserted.
+    // Get all keys committed at `version_to_rollback` and delete them.
     let prunable_keys = db.iter_pruning_keys_at_version(version_to_rollback)?;
     let mut data_to_materialize = Vec::new();
 
     for key in prunable_keys {
         let (version, key) = key.version_and_key();
         assert_eq!(version, version_to_rollback);
-
-        let value = db.get_historical_value(&key, version_to_rollback - 1)?;
-        data_to_materialize.push((key, value));
+        data_to_materialize.push((key, None));
     }
-
     Ok(data_to_materialize)
 }
 
@@ -499,6 +487,25 @@ mod tests {
         test_rollback(CrashLocation::BeforeCommittingLive, 1)
     }
 
+    fn assert_key_value(
+        key: &SlotKey,
+        value: Option<SlotValue>,
+        version: u64,
+        flat_db: &FlatStateDb,
+    ) {
+        {
+            let key_version = flat_db
+                .kernel
+                .get_version_for_key(key, 99)
+                .unwrap()
+                .unwrap();
+            assert_eq!(key_version, version);
+
+            let value_from_fb = flat_db.kernel.get_historical_value(key, 99).unwrap();
+            assert_eq!(value_from_fb, value);
+        }
+    }
+
     // This test commits data for version 0 of the rollup state and panics at various points during the commit for version 1.
     // Afterward, it checks whether the rollback logic correctly reverted the archival state.
     fn test_rollback(crash_location: CrashLocation, archival_version: u64) -> anyhow::Result<()> {
@@ -506,14 +513,26 @@ mod tests {
         let db_path = tempdir.path();
         let data = data_to_insert_per_version();
 
+        // Key was inserted in version 0 and deleted in version 1
+        let kernel_key1 = &make_key("kernel_key1");
+
+        // Key was inserted in version 0 and overriden in version 1
+        let kernel_key2 = &make_key("kernel_key2");
+
         // Commit version 0.
         {
             let version = 0;
-            let flat_db = FlatStateDb::new(db_path.to_path_buf(), 1_000_000).unwrap();
+            let flat_db = FlatStateDb::new(db_path.to_path_buf(), 1_000_000)?;
 
             let state_changes = data.change_set(version);
             flat_db.commit(state_changes).unwrap();
             assert_flat_state(version, version, &flat_db);
+
+            let value_1 = make_value("kernel_key1", version);
+            let value_2 = make_value("kernel_key2", version);
+
+            assert_key_value(kernel_key1, Some(value_1), version, &flat_db);
+            assert_key_value(kernel_key2, Some(value_2), version, &flat_db);
         }
 
         unlock_dbs(&tempdir);
@@ -522,7 +541,7 @@ mod tests {
         // Crash during commit of version 1.
         {
             let version = 1;
-            let flat_db = FlatStateDb::new(db_path.to_path_buf(), 1_000_000).unwrap();
+            let flat_db = FlatStateDb::new(db_path.to_path_buf(), 1_000_000)?;
 
             let state_changes = data.change_set(version);
             let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
@@ -532,6 +551,8 @@ mod tests {
             assert!(res.is_err());
             assert_flat_state(0, archival_version, &flat_db);
         }
+
+        unlock_dbs(&tempdir);
 
         // Rollback to version 0.
         {
@@ -550,6 +571,12 @@ mod tests {
                 let value_from_archival_db = flat_db.kernel.get_historical_value(k, 99).unwrap();
                 assert_eq!(v, &value_from_archival_db);
             }
+
+            let value_1 = make_value("kernel_key1", 0);
+            let value_2 = make_value("kernel_key2", 0);
+
+            assert_key_value(kernel_key1, Some(value_1), 0, &flat_db);
+            assert_key_value(kernel_key2, Some(value_2), 0, &flat_db);
         }
 
         Ok(())
@@ -637,17 +664,13 @@ mod tests {
             let (current_version_archival, _) =
                 self.latest_version_and_root_hash_archival_db()?.unwrap();
 
-            let prev_root_hash_archival = self
+            let _prev_root_hash_archival = self
                 .root_hash_from_archival_db_for_version(SlotNumber::new(
                     current_version_archival - 1,
                 ))?
                 .unwrap();
 
-            self.rollback_archival(
-                current_version_archival,
-                current_version_archival - 1,
-                prev_root_hash_archival,
-            )
+            self.rollback_archival(current_version_archival)
         }
     }
 
@@ -730,17 +753,19 @@ mod tests {
             vec![
                 OperationType::Insert("kernel_key1"),
                 OperationType::Insert("kernel_key2"),
-                OperationType::Insert("kernel_key3"),
             ],
         );
 
         data.insert(
             1,
             vec![
-                OperationType::Insert("user_key1"),
+                OperationType::Delete("user_key1"),
                 OperationType::Insert("user_key2"),
             ],
-            vec![OperationType::Insert("kernel_key4")],
+            vec![
+                OperationType::Delete("kernel_key1"),
+                OperationType::Insert("kernel_key2"),
+            ],
         );
 
         data.insert(

--- a/crates/full-node/sov-db/src/historical_state.rs
+++ b/crates/full-node/sov-db/src/historical_state.rs
@@ -219,6 +219,35 @@ impl HistoricalStateReader {
         version: SlotNumber,
     ) -> anyhow::Result<StateChanges> {
         let mut root_hash_batch = SchemaBatch::default();
+
+        let (user_batch, kernel_batch) =
+            Self::materialize_user_and_kernel_values(user_changes, kernel_changes)?;
+
+        tracing::trace!(
+            %version,
+            root_hash = %hex::encode(&root_hash),
+            "Materialized root hash"
+        );
+
+        root_hash_batch
+            .put::<StateRootHashes>(&(version, STATE_ROOT_HASH_SINGLETON), &root_hash)?;
+
+        Ok(StateChanges {
+            user: Arc::new(user_batch),
+            kernel: Arc::new(kernel_batch),
+            root_hash_batch: Arc::new(root_hash_batch),
+        })
+    }
+
+    /// Collects a sequence of key-value pairs into [`SchemaBatch`] for user & kernel changes.
+    #[allow(clippy::type_complexity)]
+    pub fn materialize_user_and_kernel_values(
+        user_changes: impl IntoIterator<Item = (SlotKey, Option<SlotValue>)>,
+        kernel_changes: impl IntoIterator<Item = (SlotKey, Option<SlotValue>)>,
+    ) -> anyhow::Result<(
+        VersionedSchemaBatch<NomtStateValues<UserNamespace>>,
+        VersionedSchemaBatch<NomtStateValues<KernelNamespace>>,
+    )> {
         let mut has_kernel_been_updated = false;
         let mut has_user_been_updated = false;
         let mut metric = StateMaterializationMetrics::new();
@@ -253,24 +282,11 @@ impl HistoricalStateReader {
             );
         }
 
-        tracing::trace!(
-            %version,
-            root_hash = %hex::encode(&root_hash),
-            "Materialized root hash"
-        );
-
-        root_hash_batch
-            .put::<StateRootHashes>(&(version, STATE_ROOT_HASH_SINGLETON), &root_hash)?;
-
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(metric);
         });
 
-        Ok(StateChanges {
-            user: Arc::new(user_batch),
-            kernel: Arc::new(kernel_batch),
-            root_hash_batch: Arc::new(root_hash_batch),
-        })
+        Ok((user_batch, kernel_batch))
     }
 }
 

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -545,30 +545,44 @@ impl AllDBsStateRoots {
     }
 
     fn check_all(&self) {
-        assert_eq!(
-            hex::encode(self.root_hash_from_archival_db),
-            hex::encode(self.root_hash_from_live_db)
+        Self::check_hashes(
+            &self.root_hash_from_archival_db,
+            "root_hash_from_archival_db",
+            &self.root_hash_from_live_db,
         );
 
-        assert_eq!(
-            hex::encode(self.root_hash_from_accessory_db),
-            hex::encode(self.root_hash_from_live_db)
+        Self::check_hashes(
+            &self.root_hash_from_accessory_db,
+            "root_hash_from_accessory_db",
+            &self.root_hash_from_live_db,
         );
 
-        assert_eq!(
-            hex::encode(self.root_hash_from_ledger_db),
-            hex::encode(self.root_hash_from_live_db)
+        Self::check_hashes(
+            &self.root_hash_from_ledger_db,
+            "root_hash_from_ledger_db",
+            &self.root_hash_from_live_db,
         );
 
-        assert_eq!(
-            hex::encode(self.root_hash_nomt.user),
-            hex::encode(&self.root_hash_from_live_db[0..32])
+        Self::check_hashes(
+            &self.root_hash_nomt.user,
+            "self.root_hash_nomt.user",
+            &self.root_hash_from_live_db[0..32],
         );
 
-        assert_eq!(
-            hex::encode(self.root_hash_nomt.kernel),
-            hex::encode(&self.root_hash_from_live_db[32..])
+        Self::check_hashes(
+            &self.root_hash_nomt.kernel,
+            "self.root_hash_nomt.kernel",
+            &self.root_hash_from_live_db[0..32],
         );
+    }
+
+    fn check_hashes(root_hash: &[u8], root_hash_name: &str, root_hash_from_live_db: &[u8]) {
+        let root_hash = hex::encode(root_hash);
+        let root_hash_from_live_db = hex::encode(root_hash_from_live_db);
+
+        if root_hash != root_hash_from_live_db {
+            panic!("{root_hash_name}: root_hash dooes not match root_hash_from_live_db: {root_hash_from_live_db}");
+        }
     }
 
     fn info(&self, msg: &str) {

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -572,7 +572,7 @@ impl AllDBsStateRoots {
         Self::check_hashes(
             &self.root_hash_nomt.kernel,
             "self.root_hash_nomt.kernel",
-            &self.root_hash_from_live_db[0..32],
+            &self.root_hash_from_live_db[32..],
         );
     }
 
@@ -581,7 +581,7 @@ impl AllDBsStateRoots {
         let root_hash_from_live_db = hex::encode(root_hash_from_live_db);
 
         if root_hash != root_hash_from_live_db {
-            panic!("{root_hash_name}: root_hash dooes not match root_hash_from_live_db: {root_hash_from_live_db}");
+            panic!("{root_hash_name}: {root_hash} dooes not match root_hash_from_live_db: {root_hash_from_live_db}");
         }
     }
 


### PR DESCRIPTION
# Description

This PR updates the rollback process for the archival database. Previously, rollback did not remove keys from the pruning table. This change updates the rollup to the latest `rockbound` version and uses the new `rockbound` API for pruning.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to https://github.com/Sovereign-Labs/rockbound/pull/44 , #2267
