### PR TITLE
Implement eth_feeHistory RPC endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-01-08
+- #2312 Implements `eth_feeHistory` RPC endpoint to expose rollup's EIP-1559 base fee history for wallets.
+
 # 2026-01-02
 - #2292 **EVM Breaking Change, Chain Hash Change**. This PR Changes the borsh serialization of sov_evm::CallMessage by making it an enum. After upgrading, chains will not be able to deserialize transactions in the old format - so it will become impossible to sync from genesis if your chain pre-dates this change.
 # 2026-01-05

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/fee_history.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/fee_history.rs
@@ -1,0 +1,117 @@
+use alloy_eips::BlockNumberOrTag;
+use alloy_rpc_types::FeeHistory;
+use sov_address::{EthereumAddress, FromVmAddress};
+use sov_modules_api::prelude::UnwrapInfallible;
+use sov_modules_api::{ApiStateAccessor, Spec};
+use sov_rollup_interface::common::RollupHeight;
+use sov_rpc_eth_types::EthApiError;
+
+use crate::error::into_rpc_error;
+use crate::Evm;
+
+impl<S: Spec> Evm<S>
+where
+    S::Address: FromVmAddress<EthereumAddress>,
+{
+    pub(super) fn get_fee_history(
+        &self,
+        block_count: u64,
+        newest_block: BlockNumberOrTag,
+        reward_percentiles: Option<&[f64]>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Result<FeeHistory, EthApiError> {
+        if block_count == 0 {
+            return Err(EthApiError::other(into_rpc_error(anyhow::anyhow!(
+                "block_count must be greater than 0"
+            ))));
+        }
+
+        let block_count = block_count.min(1024);
+
+        let end_block_number = self.resolve_block_number(newest_block, state);
+        let start_block_number = end_block_number.saturating_sub(block_count - 1);
+
+        let base_fee_per_gas =
+            self.collect_base_fees(start_block_number, end_block_number, state)?;
+        let gas_used_ratio =
+            self.collect_gas_used_ratios(start_block_number, end_block_number, state);
+        let reward = Self::build_reward_percentiles(reward_percentiles, block_count);
+
+        Ok(FeeHistory {
+            base_fee_per_gas,
+            gas_used_ratio,
+            oldest_block: start_block_number,
+            reward,
+            blob_gas_used_ratio: vec![],
+            base_fee_per_blob_gas: vec![],
+        })
+    }
+
+    fn collect_base_fees(
+        &self,
+        start_block: u64,
+        end_block: u64,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Result<Vec<u128>, EthApiError> {
+        (start_block..=(end_block + 1))
+            .map(|block_num| self.get_base_fee_for_block(block_num, state))
+            .collect()
+    }
+
+    fn get_base_fee_for_block(
+        &self,
+        block_num: u64,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Result<u128, EthApiError> {
+        let rollup_height = RollupHeight::new(block_num);
+        let gas_price = self
+            .chain_state_module
+            .base_fee_per_gas_at(rollup_height, state)
+            .map_err(|e| {
+                EthApiError::other(into_rpc_error(anyhow::anyhow!(
+                    "Failed to get base fee: {e}"
+                )))
+            })?;
+
+        // Extract dimension 0 (execution gas) from multidimensional gas price
+        Ok(gas_price.map(|price| price.as_ref()[0].0).unwrap_or(0))
+    }
+
+    fn collect_gas_used_ratios(
+        &self,
+        start_block: u64,
+        end_block: u64,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Vec<f64> {
+        (start_block..=end_block)
+            .map(|block_num| self.get_gas_used_ratio_for_block(block_num, state))
+            .collect()
+    }
+
+    fn get_gas_used_ratio_for_block(&self, block_num: u64, state: &mut ApiStateAccessor<S>) -> f64 {
+        let rollup_height = RollupHeight::new(block_num);
+
+        let gas_info = self
+            .chain_state_module
+            .historical_gas_info_at(rollup_height, state)
+            .unwrap_infallible();
+
+        if let Some(info) = gas_info {
+            let gas_used = info.gas_used().as_ref()[0];
+            let gas_limit = info.gas_limit().as_ref()[0];
+            if gas_limit > 0 {
+                return (gas_used as f64) / (gas_limit as f64);
+            }
+        }
+
+        0.0
+    }
+
+    /// Returns zeros - the rollup uses a preferred sequencer model, not priority fees.
+    fn build_reward_percentiles(
+        percentiles: Option<&[f64]>,
+        block_count: u64,
+    ) -> Option<Vec<Vec<u128>>> {
+        percentiles.map(|p| vec![vec![0u128; p.len()]; block_count as usize])
+    }
+}

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/fee_history.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/fee_history.rs
@@ -100,6 +100,8 @@ where
             let gas_used = info.gas_used().as_ref()[0];
             let gas_limit = info.gas_limit().as_ref()[0];
             if gas_limit > 0 {
+                // Float arithmetic is safe here - RPC only, not consensus-critical
+                #[allow(clippy::float_arithmetic)]
                 return (gas_used as f64) / (gas_limit as f64);
             }
         }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -189,8 +189,9 @@ where
         reward_percentiles: Option<Vec<f64>>,
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<FeeHistory> {
+        let block_count = block_count.to::<u64>();
         trace!(
-            block_count = block_count.to::<u64>(),
+            block_count,
             ?newest_block,
             ?reward_percentiles,
             method = "eth_feeHistory",
@@ -198,7 +199,7 @@ where
         );
 
         Ok(self.get_fee_history(
-            block_count.to::<u64>(),
+            block_count,
             newest_block,
             reward_percentiles.as_deref(),
             state,

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -24,16 +24,6 @@ use tracing::trace;
 use crate::{apply_margins, Evm};
 use std::ops::DerefMut;
 
-const EMPTY_FEE_HISTORY: FeeHistory = FeeHistory {
-    base_fee_per_gas: vec![],
-    gas_used_ratio: vec![],
-    oldest_block: 0,
-    reward: None,
-    blob_gas_used_ratio: vec![],
-    // EIP-4844 related
-    base_fee_per_blob_gas: vec![],
-};
-
 #[rpc_gen(client, server)]
 impl<S: Spec> Evm<S>
 where
@@ -187,11 +177,32 @@ where
     }
 
     /// Handler for: `eth_feeHistory`
-    // TODO https://github.com/Sovereign-Labs/sovereign-sdk/issues/502
+    /// Returns historical gas price and usage data for recent blocks.
+    ///
+    /// This endpoint helps wallets and users determine appropriate gas prices
+    /// by exposing the rollup's EIP-1559 style base fee history.
     #[rpc_method(name = "eth_feeHistory")]
-    pub fn fee_history(&self) -> RpcResult<FeeHistory> {
-        trace!(method = "eth_feeHistory", "EVM module JSON-RPC request");
-        Ok(EMPTY_FEE_HISTORY)
+    pub fn fee_history(
+        &self,
+        block_count: U64,
+        newest_block: BlockNumberOrTag,
+        reward_percentiles: Option<Vec<f64>>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> RpcResult<FeeHistory> {
+        trace!(
+            block_count = block_count.to::<u64>(),
+            ?newest_block,
+            ?reward_percentiles,
+            method = "eth_feeHistory",
+            "EVM module JSON-RPC request"
+        );
+
+        Ok(self.get_fee_history(
+            block_count.to::<u64>(),
+            newest_block,
+            reward_percentiles.as_deref(),
+            state,
+        )?)
     }
 
     /// Handler for: `eth_getTransactionByHash`

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod error;
 pub(crate) mod handlers;
 pub(crate) mod maybe_archival_state;
 
+mod fee_history;
 mod trace;
 
 /// Result of String => BlockNr conversion

--- a/examples/demo-rollup/tests/evm/evm_fee_history.rs
+++ b/examples/demo-rollup/tests/evm/evm_fee_history.rs
@@ -10,11 +10,16 @@ async fn test_eth_fee_history_basic() -> anyhow::Result<()> {
     rollup.wait_for_next_blocks(3).await;
     rollup.pause_preferred_batches().await;
 
-    let fee_history = client.get_fee_history(3, BlockNumberOrTag::Latest, &[]).await?;
+    let fee_history = client
+        .get_fee_history(3, BlockNumberOrTag::Latest, &[])
+        .await?;
 
     assert_eq!(fee_history.base_fee_per_gas.len(), 4);
     assert_eq!(fee_history.gas_used_ratio.len(), 3);
-    assert!(fee_history.gas_used_ratio.iter().all(|&r| r >= 0.0 && r <= 1.0));
+    assert!(fee_history
+        .gas_used_ratio
+        .iter()
+        .all(|&r| r >= 0.0 && r <= 1.0));
 
     Ok(())
 }
@@ -26,7 +31,9 @@ async fn test_eth_fee_history_single_block() -> anyhow::Result<()> {
     rollup.wait_for_next_blocks(2).await;
     rollup.pause_preferred_batches().await;
 
-    let fee_history = client.get_fee_history(1, BlockNumberOrTag::Latest, &[]).await?;
+    let fee_history = client
+        .get_fee_history(1, BlockNumberOrTag::Latest, &[])
+        .await?;
 
     assert_eq!(fee_history.base_fee_per_gas.len(), 2);
     assert_eq!(fee_history.gas_used_ratio.len(), 1);
@@ -58,7 +65,9 @@ async fn test_eth_fee_history_zero_blocks() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
 
-    let result = client.get_fee_history(0, BlockNumberOrTag::Latest, &[]).await;
+    let result = client
+        .get_fee_history(0, BlockNumberOrTag::Latest, &[])
+        .await;
 
     assert!(result.is_err());
 
@@ -72,7 +81,9 @@ async fn test_eth_fee_history_specific_block() -> anyhow::Result<()> {
     rollup.wait_for_next_blocks(5).await;
     rollup.pause_preferred_batches().await;
 
-    let fee_history = client.get_fee_history(3, BlockNumberOrTag::Number(3), &[]).await?;
+    let fee_history = client
+        .get_fee_history(3, BlockNumberOrTag::Number(3), &[])
+        .await?;
 
     assert!(fee_history.oldest_block <= 3);
     assert_eq!(fee_history.base_fee_per_gas.len(), 4);
@@ -88,7 +99,9 @@ async fn test_eth_fee_history_large_count_capped() -> anyhow::Result<()> {
     rollup.wait_for_next_blocks(3).await;
     rollup.pause_preferred_batches().await;
 
-    let fee_history = client.get_fee_history(2000, BlockNumberOrTag::Latest, &[]).await?;
+    let fee_history = client
+        .get_fee_history(2000, BlockNumberOrTag::Latest, &[])
+        .await?;
 
     assert!(fee_history.base_fee_per_gas.len() > 0);
     assert!(fee_history.base_fee_per_gas.len() <= 1025);

--- a/examples/demo-rollup/tests/evm/evm_fee_history.rs
+++ b/examples/demo-rollup/tests/evm/evm_fee_history.rs
@@ -19,7 +19,7 @@ async fn test_eth_fee_history_basic() -> anyhow::Result<()> {
     assert!(fee_history
         .gas_used_ratio
         .iter()
-        .all(|&r| r >= 0.0 && r <= 1.0));
+        .all(|&r| (0.0..=1.0).contains(&r)));
 
     Ok(())
 }
@@ -103,7 +103,7 @@ async fn test_eth_fee_history_large_count_capped() -> anyhow::Result<()> {
         .get_fee_history(2000, BlockNumberOrTag::Latest, &[])
         .await?;
 
-    assert!(fee_history.base_fee_per_gas.len() > 0);
+    assert!(!fee_history.base_fee_per_gas.is_empty());
     assert!(fee_history.base_fee_per_gas.len() <= 1025);
 
     Ok(())

--- a/examples/demo-rollup/tests/evm/evm_fee_history.rs
+++ b/examples/demo-rollup/tests/evm/evm_fee_history.rs
@@ -1,0 +1,97 @@
+use alloy_provider::Provider;
+use alloy_rpc_types_eth::BlockNumberOrTag;
+
+use crate::evm::evm_test_helper::{alloy_client, setup_test_rollup, EVM_EXTENSION};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_fee_history_basic() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    let client = alloy_client(rollup.http_addr);
+    rollup.wait_for_next_blocks(3).await;
+    rollup.pause_preferred_batches().await;
+
+    let fee_history = client.get_fee_history(3, BlockNumberOrTag::Latest, &[]).await?;
+
+    assert_eq!(fee_history.base_fee_per_gas.len(), 4);
+    assert_eq!(fee_history.gas_used_ratio.len(), 3);
+    assert!(fee_history.gas_used_ratio.iter().all(|&r| r >= 0.0 && r <= 1.0));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_fee_history_single_block() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    let client = alloy_client(rollup.http_addr);
+    rollup.wait_for_next_blocks(2).await;
+    rollup.pause_preferred_batches().await;
+
+    let fee_history = client.get_fee_history(1, BlockNumberOrTag::Latest, &[]).await?;
+
+    assert_eq!(fee_history.base_fee_per_gas.len(), 2);
+    assert_eq!(fee_history.gas_used_ratio.len(), 1);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_fee_history_with_reward_percentiles() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    let client = alloy_client(rollup.http_addr);
+    rollup.wait_for_next_blocks(2).await;
+    rollup.pause_preferred_batches().await;
+
+    let fee_history = client
+        .get_fee_history(2, BlockNumberOrTag::Latest, &[25.0, 50.0, 75.0])
+        .await?;
+
+    let rewards = fee_history.reward.unwrap();
+    assert_eq!(rewards.len(), 2);
+    assert_eq!(rewards[0].len(), 3);
+    assert!(rewards.iter().all(|block| block.iter().all(|&r| r == 0)));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_fee_history_zero_blocks() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    let client = alloy_client(rollup.http_addr);
+
+    let result = client.get_fee_history(0, BlockNumberOrTag::Latest, &[]).await;
+
+    assert!(result.is_err());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_fee_history_specific_block() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    let client = alloy_client(rollup.http_addr);
+    rollup.wait_for_next_blocks(5).await;
+    rollup.pause_preferred_batches().await;
+
+    let fee_history = client.get_fee_history(3, BlockNumberOrTag::Number(3), &[]).await?;
+
+    assert!(fee_history.oldest_block <= 3);
+    assert_eq!(fee_history.base_fee_per_gas.len(), 4);
+    assert_eq!(fee_history.gas_used_ratio.len(), 3);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_eth_fee_history_large_count_capped() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    let client = alloy_client(rollup.http_addr);
+    rollup.wait_for_next_blocks(3).await;
+    rollup.pause_preferred_batches().await;
+
+    let fee_history = client.get_fee_history(2000, BlockNumberOrTag::Latest, &[]).await?;
+
+    assert!(fee_history.base_fee_per_gas.len() > 0);
+    assert!(fee_history.base_fee_per_gas.len() <= 1025);
+
+    Ok(())
+}

--- a/examples/demo-rollup/tests/evm/mod.rs
+++ b/examples/demo-rollup/tests/evm/mod.rs
@@ -2,6 +2,7 @@ mod evm_account_abstraction;
 mod evm_balances;
 mod evm_block_hash;
 mod evm_contract_creation_allowlist;
+mod evm_fee_history;
 mod evm_gas_estimation;
 mod evm_logs;
 mod evm_no_gas_limit;


### PR DESCRIPTION
Adds `eth_feeHistory` to expose the rollup's EIP-1559 base fee history, enabling wallets to query gas prices and set appropriate `max_fee_per_gas` values.

## Implementation

- New module: `sov-evm/src/rpc/fee_history.rs`
- Fetches rollup gas prices from ChainState, converts to EVM format (dimension 0)
- Returns N+1 base fees (N blocks + next) and N gas used ratios
- Caps at 1024 blocks, errors on 0 blocks
- Priority fees return zeros (preferred sequencer model)

## Testing

6 test cases covering basic usage, edge cases, and validation.

```bash
cargo nextest run fee_history
```

# Description

*Summary of the changes...*

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
