### PR TITLE
Add defensive check into `CelestiaService::get_block_at`

### DIFF
--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -252,6 +252,12 @@ impl CelestiaService {
             tracker.submit(GetBlockHeaderMeasurement::new(response_time, is_success));
         });
         let extended_header = flatten_timeout(result)?;
+        if extended_header.header.height.value() != height {
+            return Err(MaybeRetryable::Transient(anyhow::anyhow!(
+                "Received wrong height {}, when requested {height}",
+                extended_header.header.height.value()
+            )));
+        }
         Ok(extended_header.into())
     }
 


### PR DESCRIPTION
# Description

Error locally if connected API is faulty

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1630 

## Testing
All existing tests are passing

## Docs
No updates
