### PR TITLE
Error on finalized headers going backwards

### DIFF
--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -241,9 +241,11 @@ async fn background_header_fetch_task<Da: DaService>(
                                     last_seen = %previously_seen_finalized_header.display(),
                                     "Critical error in DaService, finalized header when backwards");
                             }
+                        } else {
+                            // Preventing adding rolled back finalized header
+                            last_seen_finalized_header = Some(finalized_header.clone());
+                            recent_headers.insert_new_header(finalized_header);
                         }
-                        last_seen_finalized_header = Some(finalized_header.clone());
-                        recent_headers.insert_new_header(finalized_header);
                     }
                     FutureOrShutdownOutput::Output(Err(error)) => {
                         // DaService should do all retries, so we just stop and fail.

--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -231,10 +231,10 @@ async fn background_header_fetch_task<Da: DaService>(
                             None => true,
                             Some(prev_seen) => {
                                 if finalized_header.height() < prev_seen.height() {
-                                    tracing::error!(
+                                    tracing::warn!(
                                     received = %finalized_header.display(),
                                     last_seen = %prev_seen.display(),
-                                    "Critical error in DaService, finalized header when backwards");
+                                    "finalized header when backwards in DaService. This update won't be propagated to consumers of `DaServiceWithCachedFinalizedHeaders`");
                                     false
                                 } else {
                                     true

--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -227,17 +227,22 @@ async fn background_header_fetch_task<Da: DaService>(
                         break;
                     }
                     FutureOrShutdownOutput::Output(Ok(finalized_header)) => {
-                        if let Some(previously_seen_finalized_header) =
-                            last_seen_finalized_header.as_ref()
-                        {
-                            if finalized_header.height() < previously_seen_finalized_header.height()
-                            {
-                                tracing::error!(
+                        // TODO: SOME BUG HERE
+                        let is_received_header_valid = match last_seen_finalized_header.as_ref() {
+                            None => true,
+                            Some(prev_seen) => {
+                                if finalized_header.height() < prev_seen.height() {
+                                    tracing::error!(
                                     received = %finalized_header.display(),
-                                    last_seen = %previously_seen_finalized_header.display(),
+                                    last_seen = %prev_seen.display(),
                                     "Critical error in DaService, finalized header when backwards");
+                                    false
+                                } else {
+                                    true
+                                }
                             }
-                        } else {
+                        };
+                        if is_received_header_valid {
                             // Preventing adding rolled back finalized header
                             if finalized_sender.send(finalized_header.clone()).is_err() {
                                 tracing::info!("All DA header receivers dropped, shutting down");

--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -227,7 +227,8 @@ async fn background_header_fetch_task<Da: DaService>(
                         break;
                     }
                     FutureOrShutdownOutput::Output(Ok(finalized_header)) => {
-                        let is_received_header_valid = match highest_seen_finalized_header.as_ref() {
+                        let is_received_header_valid = match highest_seen_finalized_header.as_ref()
+                        {
                             None => true,
                             Some(highest_seen) => {
                                 if finalized_header.height() < highest_seen.height() {
@@ -251,7 +252,6 @@ async fn background_header_fetch_task<Da: DaService>(
                             // Only update seen headers in case if it is valid (that is, higher).
                             highest_seen_finalized_header = Some(finalized_header);
                         }
-
                     }
                     FutureOrShutdownOutput::Output(Err(error)) => {
                         // DaService should do all retries, so we just stop and fail.

--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -227,10 +227,6 @@ async fn background_header_fetch_task<Da: DaService>(
                         break;
                     }
                     FutureOrShutdownOutput::Output(Ok(finalized_header)) => {
-                        if finalized_sender.send(finalized_header.clone()).is_err() {
-                            tracing::info!("All DA header receivers dropped, shutting down");
-                            break;
-                        }
                         if let Some(previously_seen_finalized_header) =
                             last_seen_finalized_header.as_ref()
                         {
@@ -243,9 +239,13 @@ async fn background_header_fetch_task<Da: DaService>(
                             }
                         } else {
                             // Preventing adding rolled back finalized header
-                            last_seen_finalized_header = Some(finalized_header.clone());
-                            recent_headers.insert_new_header(finalized_header);
+                            if finalized_sender.send(finalized_header.clone()).is_err() {
+                                tracing::info!("All DA header receivers dropped, shutting down");
+                                break;
+                            }
+                            recent_headers.insert_new_header(finalized_header.clone());
                         }
+                        last_seen_finalized_header = Some(finalized_header);
                     }
                     FutureOrShutdownOutput::Output(Err(error)) => {
                         // DaService should do all retries, so we just stop and fail.

--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -208,7 +208,7 @@ async fn background_header_fetch_task<Da: DaService>(
     tracing::info!(?interval, "Starting background fetcher task");
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-    let mut last_seen_finalized_header: Option<<Da::Spec as DaSpec>::BlockHeader> = None;
+    let mut highest_seen_finalized_header: Option<<Da::Spec as DaSpec>::BlockHeader> = None;
 
     loop {
         // Wait for the next tick or shutdown
@@ -227,13 +227,13 @@ async fn background_header_fetch_task<Da: DaService>(
                         break;
                     }
                     FutureOrShutdownOutput::Output(Ok(finalized_header)) => {
-                        let is_received_header_valid = match last_seen_finalized_header.as_ref() {
+                        let is_received_header_valid = match highest_seen_finalized_header.as_ref() {
                             None => true,
-                            Some(prev_seen) => {
-                                if finalized_header.height() < prev_seen.height() {
+                            Some(highest_seen) => {
+                                if finalized_header.height() < highest_seen.height() {
                                     tracing::warn!(
                                     received = %finalized_header.display(),
-                                    last_seen = %prev_seen.display(),
+                                    last_seen = %highest_seen.display(),
                                     "finalized header when backwards in DaService. This update won't be propagated to consumers of `DaServiceWithCachedFinalizedHeaders`");
                                     false
                                 } else {
@@ -248,8 +248,10 @@ async fn background_header_fetch_task<Da: DaService>(
                                 break;
                             }
                             recent_headers.insert_new_header(finalized_header.clone());
+                            // Only update seen headers in case if it is valid (that is, higher).
+                            highest_seen_finalized_header = Some(finalized_header);
                         }
-                        last_seen_finalized_header = Some(finalized_header);
+
                     }
                     FutureOrShutdownOutput::Output(Err(error)) => {
                         // DaService should do all retries, so we just stop and fail.

--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -208,6 +208,8 @@ async fn background_header_fetch_task<Da: DaService>(
     tracing::info!(?interval, "Starting background fetcher task");
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+    let mut last_seen_finalized_header: Option<<Da::Spec as DaSpec>::BlockHeader> = None;
+
     loop {
         // Wait for the next tick or shutdown
         match future_or_shutdown(interval.tick(), &shutdown_rx).await {
@@ -229,6 +231,18 @@ async fn background_header_fetch_task<Da: DaService>(
                             tracing::info!("All DA header receivers dropped, shutting down");
                             break;
                         }
+                        if let Some(previously_seen_finalized_header) =
+                            last_seen_finalized_header.as_ref()
+                        {
+                            if finalized_header.height() < previously_seen_finalized_header.height()
+                            {
+                                tracing::error!(
+                                    received = %finalized_header.display(),
+                                    last_seen = %previously_seen_finalized_header.display(),
+                                    "Critical error in DaService, finalized header when backwards");
+                            }
+                        }
+                        last_seen_finalized_header = Some(finalized_header.clone());
                         recent_headers.insert_new_header(finalized_header);
                     }
                     FutureOrShutdownOutput::Output(Err(error)) => {

--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -234,7 +234,7 @@ async fn background_header_fetch_task<Da: DaService>(
                                 if finalized_header.height() < highest_seen.height() {
                                     tracing::warn!(
                                     received = %finalized_header.display(),
-                                    last_seen = %highest_seen.display(),
+                                    highest_seen = %highest_seen.display(),
                                     "finalized header when backwards in DaService. This update won't be propagated to consumers of `DaServiceWithCachedFinalizedHeaders`");
                                     false
                                 } else {

--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -227,7 +227,6 @@ async fn background_header_fetch_task<Da: DaService>(
                         break;
                     }
                     FutureOrShutdownOutput::Output(Ok(finalized_header)) => {
-                        // TODO: SOME BUG HERE
                         let is_received_header_valid = match last_seen_finalized_header.as_ref() {
                             None => true,
                             Some(prev_seen) => {

--- a/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
@@ -581,6 +581,7 @@ where
             .expect("Choosing fork point only possible if some transitions have been seen");
 
         let mut head = da_service.get_head_block_header().await?;
+        let last_finalized_header = self.finalized_headers_provider.get_last_finalized_block_header()?;
 
         for attempt in 0..MAX_REORG_FINDING_ATTEMPTS {
             match self
@@ -602,6 +603,9 @@ where
                     return Ok(fork_point);
                 }
                 ForkPointSearchResult::HeadChanged(new_head) => {
+                    if new_head.height() < last_finalized_header.height() {
+                        anyhow::bail!("New head (height={}) went below last finalized height {}", new_head.height(), last_finalized_header.height());
+                    }
                     tracing::warn!(
                         old_head = %head.display(),
                         new_head = %new_head.display(),

--- a/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
@@ -581,7 +581,9 @@ where
             .expect("Choosing fork point only possible if some transitions have been seen");
 
         let mut head = da_service.get_head_block_header().await?;
-        let last_finalized_header = self.finalized_headers_provider.get_last_finalized_block_header()?;
+        let last_finalized_header = self
+            .finalized_headers_provider
+            .get_last_finalized_block_header()?;
 
         for attempt in 0..MAX_REORG_FINDING_ATTEMPTS {
             match self
@@ -604,7 +606,11 @@ where
                 }
                 ForkPointSearchResult::HeadChanged(new_head) => {
                     if new_head.height() < last_finalized_header.height() {
-                        anyhow::bail!("New head (height={}) went below last finalized height {}", new_head.height(), last_finalized_header.height());
+                        anyhow::bail!(
+                            "New head (height={}) went below last finalized height {}",
+                            new_head.height(),
+                            last_finalized_header.height()
+                        );
                     }
                     tracing::warn!(
                         old_head = %head.display(),


### PR DESCRIPTION
# Description

Runner state manager is going to check if new head during reorg went below last finalized header.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
All existing tests are passing

## Docs
No updates
