### PR TITLE
Ensure replicas shut down gracefully when stop height is reached

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_handler.rs
@@ -70,6 +70,17 @@ where
             Err(ReplicaError::NotReady(_sequencer_not_ready_details, db_data_rejected)) => {
                 return Err(DBDataRejected::ExecutorBehind(*db_data_rejected))
             }
+            Err(ReplicaError::Creation(BatchCreationError::PreferredSequencerAtStopHeight {
+                current_height,
+                height_to_stop_at,
+            })) => {
+                tracing::info!(
+                    current_height = %current_height,
+                    height_to_stop_at = %height_to_stop_at,
+                    "Replica reached stop height, stopping event processing"
+                );
+                return Err(DBDataRejected::StopHeightReached);
+            }
             Err(ReplicaError::Creation(batch_creation_error)) => {
                 panic!("Replica failed to create a new batch. Error: {batch_creation_error:?}");
             }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -162,7 +162,14 @@ impl ReplicaSyncTask {
                                     break 'outer;
                                 }
                                 FutureOrShutdownOutput::Output(Some(_)) => {
-                                    // Discard - past stop height
+                                    // Discard - past stop height.
+                                    // As mentioned above, this assumes that we will always shut
+                                    // down after reaching the stop height. The node will process
+                                    // the on-disk state up to the stop height and shut down
+                                    // immediately, so these events only affect the in-memory state
+                                    // of the sequencer. Therefore they are useless to this version
+                                    // of the rollup, and the next version will catch up on startup
+                                    // using the normal mechanisms.
                                 }
                             }
                         }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -17,6 +17,8 @@ const PAGE_SIZE: usize = 2000;
 pub(crate) enum DBDataRejected {
     ExecutorBehind(DbData),
     ExecutorAhead(u64),
+    /// The replica reached the configured stop height for a rollup upgrade.
+    StopHeightReached,
 }
 
 #[async_trait]
@@ -136,6 +138,34 @@ impl ReplicaSyncTask {
                         data = db_data;
                         tokio::time::sleep(Duration::from_millis(100)).await;
                         continue 'inner;
+                    }
+
+                    Err(DBDataRejected::StopHeightReached) => {
+                        // Stop height reached: drain events until shutdown.
+                        //
+                        // We've reached the configured stop height for this rollup upgrade.
+                        // Rather than exiting (which the task monitor would treat as a bug),
+                        // we drain events from the channel until shutdown. This keeps the
+                        // task alive and prevents buffer filling while the runner completes
+                        // processing DA blocks and triggers graceful shutdown.
+                        //
+                        // INVARIANT: This assumes that once the stop height is reached, we are
+                        // guaranteed to shut down soon. If we ever add an API to live-edit the
+                        // stop height, this will need to be taken into account for replicas.
+                        tracing::info!("Replica reached stop height, stopping event processing. Draining db events until node shutdown.");
+                        loop {
+                            let fut =
+                                future_or_shutdown(db_data_receiver.recv(), &shutdown_receiver);
+                            match fut.await {
+                                FutureOrShutdownOutput::Shutdown
+                                | FutureOrShutdownOutput::Output(None) => {
+                                    break 'outer;
+                                }
+                                FutureOrShutdownOutput::Output(Some(_)) => {
+                                    // Discard - past stop height
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
# Description

When `--stop-at-rollup-height` is passed to a rollup, replicas mostly work correctly, except that there was no explicit handling in the replica event handler. So if the master sequencer finished the upgrade and opened a batch at a new version, replicas would process the pg event and also try to open a batch, then panic because of the `BatchCreationError`.

This adds logic to make the replica loop a no-op while waiting for the node to shut down the process, avoiding the panic. An alternative way of handling this would be by sending a signal to stop the event receiver task and unsubscribe from postgres, but that would add another channel or adding a complex type and extra semantics to the `ready_to_process_db_events_recv`, and IMO is not worth the plumbing.

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [ ] ~~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
