### PR TITLE
`max_fee` validation for EVM transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2026-01-14
+- #2326 **Breaking Change** Add `max_fee` validation to the EVM authenticator. This is a breaking change, as transactions that were valid before may no longer be accepted.
+The check can be disabled by sending a special EVM admin message to turn off the validation.
+
 # 2026-01-09
 - #2266 **Breaking Change** Replaces `is_replica` with the `NodeRole` enum. Users must update the `PostgreSQL` sections in `rollup_config.toml` to specify node_role.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2026-01-14
-- #2326 **Breaking Change** Add `max_fee` validation to the EVM authenticator. This is a breaking change: transactions that were previously valid may now be rejected. Set `EVM_MAX_FEE_CHECK_HEIGHT` to mitigate this.
-The validation can be disabled by sending a special EVM admin message.
+- #2326 Add `max_fee` validation to the EVM authenticator. Introduce `EVM_MAX_FEE_CHECK_HEIGHT` in `constants.toml` to specify the block height after which the max-fee check becomes active.
+This validation can be disabled by sending an `UpdateRuntimeConfig::empty` EVM admin message.
 
 # 2026-01-09
 - #2266 **Breaking Change** Replaces `is_replica` with the `NodeRole` enum. Users must update the `PostgreSQL` sections in `rollup_config.toml` to specify node_role.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2026-01-14
-- #2326 **Breaking Change** Add `max_fee` validation to the EVM authenticator. This is a breaking change, as transactions that were valid before may no longer be accepted.
-The check can be disabled by sending a special EVM admin message to turn off the validation.
+- #2326 **Breaking Change** Add `max_fee` validation to the EVM authenticator. This is a breaking change: transactions that were previously valid may now be rejected. Set `EVM_MAX_FEE_CHECK_HEIGHT` to mitigate this.
+The validation can be disabled by sending a special EVM admin message.
 
 # 2026-01-09
 - #2266 **Breaking Change** Replaces `is_replica` with the `NodeRole` enum. Users must update the `PostgreSQL` sections in `rollup_config.toml` to specify node_role.

--- a/constants.testing.toml
+++ b/constants.testing.toml
@@ -13,6 +13,8 @@ CHAIN_NAME = "TestChain"
 EVM_BLOCK_PRUNING_THRESHOLD = 10000
 # Rollup for production and EVM for benchmarks
 EVM_GAS_METERING_MODE = "Rollup"
+# After this evm block height, the max_fee check will be enforced, i64::MAX by default.
+EVM_MAX_FEE_CHECK_HEIGHT = 9223372036854775807
 # How many rollup blocks to wait before terminating setup mode. While setup mode is enabled,
 # the rollup does not charge gas. This is useful when initializing the rollup with a bridged gas token.
 SETUP_MODE_TERMINATION_HEIGHT = 0 # Disable setup mode entirely by default.

--- a/constants.testing.toml
+++ b/constants.testing.toml
@@ -13,8 +13,8 @@ CHAIN_NAME = "TestChain"
 EVM_BLOCK_PRUNING_THRESHOLD = 10000
 # Rollup for production and EVM for benchmarks
 EVM_GAS_METERING_MODE = "Rollup"
-# After this evm block height, the max_fee check will be enforced, i64::MAX by default.
-EVM_MAX_FEE_CHECK_HEIGHT = 9223372036854775807
+# After this evm block height, the max_fee check will be enforced.
+EVM_MAX_FEE_CHECK_HEIGHT = 0
 # How many rollup blocks to wait before terminating setup mode. While setup mode is enabled,
 # the rollup does not charge gas. This is useful when initializing the rollup with a bridged gas token.
 SETUP_MODE_TERMINATION_HEIGHT = 0 # Disable setup mode entirely by default.

--- a/constants.toml
+++ b/constants.toml
@@ -26,8 +26,8 @@ PROOF_NAMESPACE = { hex = "0x736f762d746573742d70" }
 EVM_BLOCK_PRUNING_THRESHOLD = 10000
 # Rollup for production and EVM for benchmarks
 EVM_GAS_METERING_MODE = "Rollup"
-# After this evm block height, the max_fee check will be enforced, i64::MAX by default.
-EVM_MAX_FEE_CHECK_HEIGHT = 9223372036854775807
+# After this evm block height, the max_fee check will be enforced.
+EVM_MAX_FEE_CHECK_HEIGHT = 0
 # How many rollup blocks to wait before terminating setup mode. While setup mode is enabled,
 # the rollup does not charge gas. This is useful when initializing the rollup with a bridged gas token.
 SETUP_MODE_TERMINATION_HEIGHT = 0 # Disable setup mode entirely by default.

--- a/constants.toml
+++ b/constants.toml
@@ -26,6 +26,8 @@ PROOF_NAMESPACE = { hex = "0x736f762d746573742d70" }
 EVM_BLOCK_PRUNING_THRESHOLD = 10000
 # Rollup for production and EVM for benchmarks
 EVM_GAS_METERING_MODE = "Rollup"
+# After this evm block height, the max_fee check will be enforced, i64::MAX by default.
+EVM_MAX_FEE_CHECK_HEIGHT = 9223372036854775807
 # How many rollup blocks to wait before terminating setup mode. While setup mode is enabled,
 # the rollup does not charge gas. This is useful when initializing the rollup with a bridged gas token.
 SETUP_MODE_TERMINATION_HEIGHT = 0 # Disable setup mode entirely by default.

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -1,5 +1,9 @@
 use std::marker::PhantomData;
 
+use crate::conversions::RlpConversionError;
+use crate::Evm;
+use crate::TransactionSigned;
+use crate::{call, CallMessage, RlpEvmTransaction};
 use alloy_consensus::{transaction::SignerRecoverable, Transaction};
 use alloy_eips::eip2718::{Decodable2718, EIP1559_TX_TYPE_ID};
 use alloy_primitives::Address;
@@ -15,15 +19,12 @@ use sov_modules_api::runtime::capabilities::AuthenticationError;
 use sov_modules_api::transaction::{
     AuthenticatedTransactionAndRawHash, Credentials, PriorityFeeBips, TxDetails,
 };
+use sov_modules_api::StateReader;
 use sov_modules_api::{
     DispatchCall, FullyBakedTx, Gas, GetGasPrice, ProvableStateReader, RawTx, Runtime, Spec,
 };
 use sov_rollup_interface::TxHash;
 use sov_state::User;
-
-use crate::conversions::RlpConversionError;
-use crate::TransactionSigned;
-use crate::{call, CallMessage, RlpEvmTransaction};
 
 #[cfg(feature = "native")]
 use sov_modules_api::capabilities::{SignatureVerificationCache, DEFAULT_SIGNATURE_CACHE_SIZE};
@@ -32,6 +33,51 @@ use sov_modules_api::capabilities::{SignatureVerificationCache, DEFAULT_SIGNATUR
 #[cfg(feature = "native")]
 static SIGNATURE_CACHE: std::sync::LazyLock<SignatureVerificationCache<Address>> =
     std::sync::LazyLock::new(|| SignatureVerificationCache::new(DEFAULT_SIGNATURE_CACHE_SIZE));
+
+impl<S: Spec> Evm<S> {
+    /// Validates the user's max fee per gas against the rollup's base fee and returns a gas multiplier.
+    ///
+    /// The max fee check is only enforced when:
+    /// - The current block number exceeds `EVM_MAX_FEE_CHECK_HEIGHT`
+    /// - The check has not been disabled via an admin `UpdateRuntimeConfig` message
+    ///
+    /// Returns:
+    /// - `Ok(1)` if the fee check passes (user fee >= rollup base fee)
+    /// - `Ok(100)` if the fee check is skipped (before height threshold or disabled)
+    /// - `Err(InsufficientMaxFeePerGas)` if the user's fee is below the rollup base fee
+    fn validate_fee_and_calculate_multiplayer<Accessor: StateReader<User>>(
+        &self,
+        user_max_fee_per_gas: u128,
+        rollup_base_fee: u128,
+        tx_hash: TxHash,
+        state: &mut Accessor,
+    ) -> Result<u64, AuthenticationError> {
+        let is_max_fee_check_disabled = self.is_max_fee_check_disabled(state).map_err(|e| {
+            AuthenticationError::OutOfGas(format!("validate_fee_and_calculate_multiplayer: {e}"))
+        })?;
+
+        let apply_max_fee_check_after_height: u64 = config_value!("EVM_MAX_FEE_CHECK_HEIGHT");
+        let env = self.block_env(state).map_err(|e| {
+            AuthenticationError::OutOfGas(format!("validate_fee_and_calculate_multiplayer: {e}"))
+        })?;
+
+        let block_number: u64 = env.number.to::<u64>();
+
+        if block_number > apply_max_fee_check_after_height && !is_max_fee_check_disabled {
+            if user_max_fee_per_gas < rollup_base_fee {
+                let err = FatalError::InsufficientMaxFeePerGas {
+                    user_max_fee_per_gas,
+                    rollup_base_fee,
+                };
+                return Err(AuthenticationError::FatalError(err, tx_hash));
+            }
+
+            Ok(1)
+        } else {
+            Ok(100)
+        }
+    }
+}
 
 /// Recovers the signer from an EVM transaction.
 fn recover_evm_signer(
@@ -64,7 +110,7 @@ fn create_auth_tx_and_hash<
 >(
     tx: &TransactionSigned,
     gas_price: <<S as Spec>::Gas as Gas>::Price,
-    _state: &mut Accessor,
+    state: &mut Accessor,
 ) -> Result<AuthenticatedTransactionAndRawHash<S>, AuthenticationError> {
     let tx_hash = TxHash::new(**tx.hash());
     let tx_chain_id = validate_chain_id(tx.chain_id(), tx_hash)?;
@@ -72,15 +118,15 @@ fn create_auth_tx_and_hash<
     let user_max_fee_per_gas = tx.max_fee_per_gas();
     let rollup_base_fee = gas_price.as_ref()[0].0;
 
-    if user_max_fee_per_gas < rollup_base_fee {
-        let err = FatalError::InsufficientMaxFeePerGas {
-            user_max_fee_per_gas,
-            rollup_base_fee,
-        };
-        return Err(AuthenticationError::FatalError(err, tx_hash));
-    }
+    let evm = Evm::<S>::default();
+    let multiplayer = evm.validate_fee_and_calculate_multiplayer(
+        user_max_fee_per_gas,
+        rollup_base_fee,
+        tx_hash,
+        state,
+    )?;
 
-    let gas_limit = tx.gas_limit().saturating_mul(100);
+    let gas_limit = tx.gas_limit().saturating_mul(multiplayer);
     let gas_limit: <S as Spec>::Gas = [gas_limit, gas_limit].into();
 
     let max_fee = gas_limit

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -58,9 +58,13 @@ fn recover_evm_signer(
 }
 
 /// Creates the transaction details and tx hash for an EVM transaction.
-fn create_auth_tx_and_hash<S: Spec>(
+fn create_auth_tx_and_hash<
+    Accessor: ProvableStateReader<User, Spec = S> + GetGasPrice<Spec = S>,
+    S: Spec,
+>(
     tx: &TransactionSigned,
     gas_price: <<S as Spec>::Gas as Gas>::Price,
+    _state: &mut Accessor,
 ) -> Result<AuthenticatedTransactionAndRawHash<S>, AuthenticationError> {
     let tx_hash = TxHash::new(**tx.hash());
     let tx_chain_id = validate_chain_id(tx.chain_id(), tx_hash)?;
@@ -165,7 +169,7 @@ where
         .map_err(|e| fatal_deserialization_error::<Accessor, S, _>(raw_tx, e, state))?;
 
     let gas_price = state.gas_price();
-    let tx_and_raw_hash = create_auth_tx_and_hash(&tx, gas_price)?;
+    let tx_and_raw_hash = create_auth_tx_and_hash(&tx, gas_price, state)?;
 
     let signer = recover_evm_signer(&tx, tx_and_raw_hash.raw_tx_hash)?;
 

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -45,7 +45,7 @@ impl<S: Spec> Evm<S> {
     /// - `Ok(1)` if the fee check passes (user fee >= rollup base fee)
     /// - `Ok(100)` if the fee check is skipped (before height threshold or disabled)
     /// - `Err(InsufficientMaxFeePerGas)` if the user's fee is below the rollup base fee
-    fn validate_fee_and_calculate_multiplayer<Accessor: StateReader<User>>(
+    fn validate_fee_and_calculate_multiplier<Accessor: StateReader<User>>(
         &self,
         user_max_fee_per_gas: u128,
         rollup_base_fee: u128,
@@ -53,12 +53,12 @@ impl<S: Spec> Evm<S> {
         state: &mut Accessor,
     ) -> Result<u64, AuthenticationError> {
         let is_max_fee_check_disabled = self.is_max_fee_check_disabled(state).map_err(|e| {
-            AuthenticationError::OutOfGas(format!("validate_fee_and_calculate_multiplayer: {e}"))
+            AuthenticationError::OutOfGas(format!("validate_fee_and_calculate_multiplier: {e}"))
         })?;
 
         let apply_max_fee_check_after_height: u64 = config_value!("EVM_MAX_FEE_CHECK_HEIGHT");
         let env = self.block_env(state).map_err(|e| {
-            AuthenticationError::OutOfGas(format!("validate_fee_and_calculate_multiplayer: {e}"))
+            AuthenticationError::OutOfGas(format!("validate_fee_and_calculate_multiplier: {e}"))
         })?;
 
         let block_number: u64 = env.number.to::<u64>();
@@ -119,14 +119,14 @@ fn create_auth_tx_and_hash<
     let rollup_base_fee = gas_price.as_ref()[0].0;
 
     let evm = Evm::<S>::default();
-    let multiplayer = evm.validate_fee_and_calculate_multiplayer(
+    let multiplier = evm.validate_fee_and_calculate_multiplier(
         user_max_fee_per_gas,
         rollup_base_fee,
         tx_hash,
         state,
     )?;
 
-    let gas_limit = tx.gas_limit().saturating_mul(multiplayer);
+    let gas_limit = tx.gas_limit().saturating_mul(multiplier);
     let gas_limit: <S as Spec>::Gas = [gas_limit, gas_limit].into();
 
     let max_fee = gas_limit

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -111,6 +111,12 @@ where
             "Only the admin can update the runtime configuration. Got {} but expected {admin}",
             context.sender()
         );
+        // Check if all fields are None - this is the signal to disable max fee check
+        if update.is_empty() {
+            self.disable_max_fee_check.set(&true, state)?;
+            return Ok(());
+        }
+
         let mut cfg = self.cfg(state)?;
 
         let EvmRuntimeConfigUpdate {

--- a/crates/module-system/module-implementations/sov-evm/src/config.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/config.rs
@@ -172,6 +172,24 @@ pub struct EvmRuntimeConfigUpdate<S: Spec> {
     pub new_admin: Option<S::Address>,
 }
 
+impl<S: Spec> EvmRuntimeConfigUpdate<S> {
+    /// Creates an empty config update with all fields set to None.
+    /// Sending this as an UpdateRuntimeConfig message disables the max fee check.
+    pub fn empty() -> Self {
+        Self {
+            new_hardfork: None,
+            new_contract_creation_policy: None,
+            chain_spec_update: None,
+            new_admin: None,
+        }
+    }
+
+    /// Returns true if all fields are None, indicating no actual config changes.
+    pub fn is_empty(&self) -> bool {
+        *self == Self::empty()
+    }
+}
+
 #[derive(
     Debug,
     Clone,

--- a/crates/module-system/module-implementations/sov-evm/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/genesis.rs
@@ -55,6 +55,7 @@ where
 
         self.cfg.set(&chain_cfg, state)?;
         self.head.set(&block, state)?;
+        self.disable_max_fee_check.set(&false, state)?;
 
         let block_env = create_block_env(
             0,

--- a/crates/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/lib.rs
@@ -119,11 +119,6 @@ pub struct Evm<S: Spec> {
     #[state]
     pub(crate) head: StateValue<Block, BcsCodec>,
 
-    /// When true, the max fee check in the authenticator is disabled.
-    /// This is set to true when an EvmRuntimeConfigUpdate with all fields None is received.
-    #[state]
-    pub(crate) disable_max_fee_check: StateValue<bool, BcsCodec>,
-
     /// Used only by the RPC. This represents the head of the chain and is set in two distinct stages:
     ///  1. `end_rollup_block_hook`: the pending head is populated with data from pending_transactions.
     ///  2. `finalize_hook` the `root_hash` is populated.
@@ -171,6 +166,11 @@ pub struct Evm<S: Spec> {
 
     #[phantom]
     phantom: core::marker::PhantomData<S>,
+
+    /// When true, the max fee check in the authenticator is disabled.
+    /// This is set to true when an EvmRuntimeConfigUpdate with all fields None is received.
+    #[state]
+    pub(crate) disable_max_fee_check: StateValue<bool, BcsCodec>,
 }
 
 /// The top-level error type for all EVM module operations.

--- a/crates/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/lib.rs
@@ -119,6 +119,11 @@ pub struct Evm<S: Spec> {
     #[state]
     pub(crate) head: StateValue<Block, BcsCodec>,
 
+    /// When true, the max fee check in the authenticator is disabled.
+    /// This is set to true when an EvmRuntimeConfigUpdate with all fields None is received.
+    #[state]
+    pub(crate) disable_max_fee_check: StateValue<bool, BcsCodec>,
+
     /// Used only by the RPC. This represents the head of the chain and is set in two distinct stages:
     ///  1. `end_rollup_block_hook`: the pending head is populated with data from pending_transactions.
     ///  2. `finalize_hook` the `root_hash` is populated.

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -294,7 +294,7 @@ where
         trace!(method = "eth_estimateGas", "EVM module JSON-RPC request");
 
         // Add 1,000 bytes to account for all other data in the Transaction structure, apart from call data.
-        let call_data_len = request.input.input().as_ref().map(|i| i.len()).unwrap_or(0) + 1000;
+        let tx_size = request.input.input().as_ref().map(|i| i.len()).unwrap_or(0) + 1000;
 
         let ResultAndState {
             result,
@@ -326,10 +326,10 @@ where
             .try_as_basic_gas_meter()
             .expect("ApiState has BasicGasMeter");
 
-        sov_modules_api::gas::charge_gas_for_sig(gas_meter, call_data_len)
+        sov_modules_api::gas::charge_gas_for_sig(gas_meter, tx_size)
             .expect("Gas meter is initialized with INF");
 
-        sov_modules_api::transaction::charge_tx_deserialization(gas_meter, call_data_len)
+        sov_modules_api::transaction::charge_tx_deserialization(gas_meter, tx_size)
             .expect("Gas meter is initialized with INF");
 
         gas_meter

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -292,6 +292,10 @@ where
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<U64> {
         trace!(method = "eth_estimateGas", "EVM module JSON-RPC request");
+
+        // Add 1,000 bytes to account for all other data in the Transaction structure, apart from call data.
+        let call_data_len = request.input.input().as_ref().map(|i| i.len()).unwrap_or(0) + 1000;
+
         let ResultAndState {
             result,
             state: changes,
@@ -317,14 +321,24 @@ where
             logs_size as u32,
         )
         .map_err(into_rpc_error)?;
+
         let gas_meter = state
             .try_as_basic_gas_meter()
             .expect("ApiState has BasicGasMeter");
+
+        sov_modules_api::gas::charge_gas_for_sig(gas_meter, call_data_len)
+            .expect("Gas meter is initialized with INF");
+
+        sov_modules_api::transaction::charge_tx_deserialization(gas_meter, call_data_len)
+            .expect("Gas meter is initialized with INF");
+
         gas_meter
             .charge_linear_gas(<S as GasSpec>::gas_to_charge_per_evm_gas(), gas_used as u32)
             .expect("Gas meter is initialized with INF");
+
         let total_gas_used =
             gas_meter.initial_gas.as_ref()[0] - gas_meter.remaining_gas.as_ref()[0];
+
         Ok(U64::from(apply_margins(total_gas_used)?))
     }
 

--- a/crates/module-system/module-implementations/sov-evm/src/state_access.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/state_access.rs
@@ -123,10 +123,7 @@ impl<S: Spec> Evm<S> {
         &self,
         state: &mut Accessor,
     ) -> Result<bool, Accessor::Error> {
-        Ok(self
-            .disable_max_fee_check
-            .get(state)?
-            .expect("disable_max_fee_check should be set in genesis"))
+        Ok(self.disable_max_fee_check.get(state)?.unwrap_or(false))
     }
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/state_access.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/state_access.rs
@@ -117,6 +117,17 @@ impl<S: Spec> Evm<S> {
         let cfg = self.cfg.get(state)?;
         Ok(cfg.expect("EVM config must be set in genesis"))
     }
+
+    /// Check if the max fee check is disabled.
+    pub fn is_max_fee_check_disabled<Accessor: StateReader<User>>(
+        &self,
+        state: &mut Accessor,
+    ) -> Result<bool, Accessor::Error> {
+        Ok(self
+            .disable_max_fee_check
+            .get(state)?
+            .expect("disable_max_fee_check should be set in genesis"))
+    }
 }
 
 /// Accessory state reads

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/archival_state.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/archival_state.rs
@@ -5,7 +5,7 @@ use crate::runtime::S;
 
 #[test]
 fn test_state_at_different_depth_is_accessible() {
-    let (mut runner, from, to) = setup();
+    let (mut runner, from, to, _) = setup();
 
     let evm = Evm::<S>::default();
     for tx_idx in 0..=1 {

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/config.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/config.rs
@@ -1,10 +1,9 @@
 use std::str::FromStr;
 
-use crate::runtime::GenesisConfig;
-use crate::runtime::TestRuntime;
-use crate::runtime::RT;
-use crate::runtime::S;
 use alloy_primitives::Address;
+
+use crate::helpers::setup;
+use crate::runtime::{RT, S};
 use sov_address::EthereumAddress;
 use sov_address::MultiAddress;
 use sov_evm::BorshSpecId;
@@ -13,56 +12,17 @@ use sov_evm::ChainSpecUpdate;
 use sov_evm::ContractCreationPolicy;
 use sov_evm::ContractCreationPolicyUpdate;
 use sov_evm::Evm;
-use sov_evm::EvmChainSpec;
-use sov_evm::EvmGenesisConfig;
 use sov_evm::EvmRuntimeConfigUpdate;
 use sov_evm::SpecId;
 use sov_modules_api::HexString;
 use sov_modules_api::SafeVec;
 use sov_modules_api::TxEffect;
-use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
-use sov_test_utils::runtime::TestRunner;
 use sov_test_utils::AsUser;
-use sov_test_utils::TestUser;
 use sov_test_utils::TransactionTestCase;
-
-pub(crate) fn setup() -> (TestRunner<RT, S>, TestUser<S>) {
-    let genesis_config =
-        HighLevelOptimisticGenesisConfig::generate().add_accounts_with_default_balance(1);
-    let admin = genesis_config
-        .additional_accounts()
-        .first()
-        .unwrap()
-        .clone();
-
-    let mut evm_config = EvmGenesisConfig {
-        accounts: vec![],
-        chain_spec: EvmChainSpec {
-            limit_contract_code_size: None,
-            coinbase: Address::ZERO,
-            block_gas_limit: 1_000_000_000,
-            tx_gas_limit: Some(30_000_000),
-            hardforks: vec![(0, SpecId::CANCUN)],
-        },
-        contract_creation_policy: ContractCreationPolicy::Everyone,
-        initial_base_fee: 0,
-        genesis_timestamp: 0,
-        admin: admin.address(),
-    };
-
-    evm_config.chain_spec.hardforks = vec![(0, SpecId::CANCUN)];
-
-    let genesis = GenesisConfig::from_minimal_config(genesis_config.into(), evm_config);
-
-    let runner =
-        TestRunner::new_with_genesis(genesis.into_genesis_params(), TestRuntime::default());
-
-    (runner, admin)
-}
 
 #[test]
 fn test_empty_config_update_is_noop() {
-    let (mut runner, admin) = setup();
+    let (mut runner, _, _, admin) = setup();
 
     let evm = Evm::<S>::default();
     // Send an empty config update and verify that the config is unchanged
@@ -95,7 +55,7 @@ fn test_empty_config_update_is_noop() {
 
 #[test]
 fn test_update_hardfork() {
-    let (mut runner, admin) = setup();
+    let (mut runner, _, _, admin) = setup();
 
     let evm = Evm::<S>::default();
     let admin_address = admin.address();
@@ -171,7 +131,7 @@ fn test_update_hardfork() {
 
 #[test]
 fn test_update_contract_creation_policy() {
-    let (mut runner, admin) = setup();
+    let (mut runner, _, _, admin) = setup();
 
     let evm = Evm::<S>::default();
     let admin_address = admin.address();
@@ -282,7 +242,7 @@ fn test_update_contract_creation_policy() {
 
 #[test]
 fn test_update_admin() {
-    let (mut runner, admin) = setup();
+    let (mut runner, _, _, admin) = setup();
 
     let evm = Evm::<S>::default();
     let new_admin_address = "0x0123456789012345678901234567890123456789";
@@ -337,7 +297,7 @@ fn test_update_admin() {
 
 #[test]
 fn test_update_chain_spec() {
-    let (mut runner, admin) = setup();
+    let (mut runner, _, _, admin) = setup();
 
     let evm = Evm::<S>::default();
     let admin_address = admin.address();
@@ -423,6 +383,63 @@ fn test_update_chain_spec() {
                     .chain_spec
                     .tx_gas_limit,
                 Some(20_000_000)
+            );
+        }),
+    });
+}
+
+#[test]
+fn test_disable_max_fee_check() {
+    let (mut runner, _, _, admin) = setup();
+
+    let evm = Evm::<S>::default();
+
+    // Verify that disable_max_fee_check is false by default
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Evm<S>>(CallMessage::UpdateRuntimeConfig(
+            EvmRuntimeConfigUpdate {
+                new_hardfork: None,
+                new_contract_creation_policy: Some(ContractCreationPolicyUpdate::Everyone),
+                chain_spec_update: None,
+                new_admin: None,
+            },
+        )),
+        assert: Box::new(move |ctx, state| {
+            assert!(ctx.tx_receipt.is_successful());
+            assert!(
+                !evm.is_max_fee_check_disabled(state).unwrap(),
+                "disable_max_fee_check should be false by default"
+            );
+        }),
+    });
+
+    let evm = Evm::<S>::default();
+    let admin_address = admin.address();
+
+    // Send an empty config update (all fields None) and verify that disable_max_fee_check is set to true
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Evm<S>>(CallMessage::UpdateRuntimeConfig(
+            EvmRuntimeConfigUpdate {
+                new_hardfork: None,
+                new_contract_creation_policy: None,
+                chain_spec_update: None,
+                new_admin: None,
+            },
+        )),
+        assert: Box::new(move |ctx, state| {
+            assert!(ctx.tx_receipt.is_successful());
+            // Verify that disable_max_fee_check is now true
+            assert!(
+                evm.is_max_fee_check_disabled(state).unwrap(),
+                "disable_max_fee_check should be true after empty config update"
+            );
+            // Verify that other config fields are unchanged
+            assert_eq!(evm.admin(state).unwrap(), admin_address);
+            let cfg = evm.cfg(state).unwrap();
+            assert_eq!(cfg.hardforks, vec![(0, SpecId::CANCUN)]);
+            assert_eq!(
+                cfg.contract_creation_policy,
+                ContractCreationPolicy::Everyone
             );
         }),
     });

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/contracts.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/contracts.rs
@@ -14,7 +14,7 @@ use crate::runtime::{RT, S};
 
 #[test]
 fn test_invalid_contract_execution() {
-    let (mut runner, account, _) = setup();
+    let (mut runner, account, _, _) = setup();
     let contract = LegacySimpleStorage::default();
     let contract_addr = account.address().create(0);
     let tx_request = TypedTransaction::Eip1559(TxEip1559 {
@@ -58,7 +58,7 @@ fn test_invalid_contract_execution() {
 
 #[test]
 fn test_get_empty_code() {
-    let (runner, account, _) = setup();
+    let (runner, account, _, _) = setup();
     let address_without_code = account.address();
 
     runner.query_visible_state(|state| {

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/genesis.rs
@@ -87,7 +87,7 @@ fn test_cfg_missing_specs() {
 
 #[test]
 fn test_genesis_block() {
-    let (runner, _, _) = setup();
+    let (runner, _, _, _) = setup();
     let beneficiary = Address::new([0u8; 20]);
 
     runner.query_visible_state(move |state| {

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use crate::runtime::{GenesisConfig, TestRuntime, RT, S};
 use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_consensus::crypto::secp256k1::public_key_to_address;
@@ -10,9 +8,10 @@ use alloy_primitives::B256;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 use secp256k1::rand::SeedableRng as _;
 use secp256k1::{PublicKey, SecretKey};
-use sov_address::MultiAddress;
-use sov_address::{EthereumAddress, FromVmAddress};
+use sov_address::{EthereumAddress, MultiAddress};
 use sov_eth_dev_signer::Signer;
+use sov_evm::ContractCreationPolicy;
+use sov_evm::EvmChainSpec;
 use sov_evm::{
     AccountData, EthereumAuthenticator, EvmGenesisConfig, RlpEvmTransaction, SpecId,
     TransactionSigned,
@@ -21,7 +20,16 @@ use sov_evm_test_utils::LegacySimpleStorage;
 use sov_modules_api::macros::config_value;
 use sov_modules_api::RawTx;
 use sov_test_utils::runtime::{genesis::optimistic::HighLevelOptimisticGenesisConfig, TestRunner};
-use sov_test_utils::{TransactionType, TEST_DEFAULT_USER_BALANCE};
+use sov_test_utils::{TestUser, TransactionType, TEST_DEFAULT_USER_BALANCE};
+
+/// Sets the block height after which max fee check becomes active.
+pub(crate) fn set_max_fee_check_height(height: u64) {
+    std::env::set_var(
+        "SOV_TEST_CONST_OVERRIDE_EVM_MAX_FEE_CHECK_HEIGHT",
+        height.to_string(),
+    );
+}
+
 pub(crate) struct EvmAccount(SecretKey);
 
 impl EvmAccount {
@@ -47,35 +55,47 @@ impl EvmAccount {
     }
 }
 
-pub(crate) fn setup() -> (TestRunner<RT, S>, EvmAccount, EvmAccount) {
+/// Setup with EVM accounts and an admin TestUser for config updates.
+/// Returns (runner, funded_account, no_balance_account, admin).
+pub(crate) fn setup() -> (TestRunner<RT, S>, EvmAccount, EvmAccount, TestUser<S>) {
     let evm_account = EvmAccount::generate();
     let no_balance_account = EvmAccount::generate();
 
-    let genesis_config = HighLevelOptimisticGenesisConfig::generate();
+    let genesis_config =
+        HighLevelOptimisticGenesisConfig::generate().add_accounts_with_default_balance(1);
+    let admin = genesis_config
+        .additional_accounts()
+        .first()
+        .unwrap()
+        .clone();
 
-    let mut evm_config = EvmGenesisConfig {
-        accounts: vec![
-            AccountData {
-                address: evm_account.address(),
-                code_hash: KECCAK_EMPTY,
-                code: Default::default(),
-            },
-            AccountData {
-                address: no_balance_account.address(),
-                code_hash: KECCAK_EMPTY,
-                code: Default::default(),
-            },
-        ],
-        chain_spec: Default::default(),
-        contract_creation_policy: Default::default(),
+    let accounts = vec![
+        AccountData {
+            address: evm_account.address(),
+            code_hash: KECCAK_EMPTY,
+            code: Default::default(),
+        },
+        AccountData {
+            address: no_balance_account.address(),
+            code_hash: KECCAK_EMPTY,
+            code: Default::default(),
+        },
+    ];
+
+    let evm_config = EvmGenesisConfig {
+        accounts,
+        chain_spec: EvmChainSpec {
+            limit_contract_code_size: None,
+            coinbase: Address::ZERO,
+            block_gas_limit: 1_000_000_000,
+            tx_gas_limit: Some(30_000_000),
+            hardforks: vec![(0, SpecId::CANCUN)],
+        },
+        contract_creation_policy: ContractCreationPolicy::Everyone,
         initial_base_fee: 0,
         genesis_timestamp: 0,
-        admin: MultiAddress::from_vm_address(
-            EthereumAddress::from_str("0x0123456789012345678901234567890123456789").unwrap(),
-        ),
+        admin: admin.address(),
     };
-
-    evm_config.chain_spec.hardforks = vec![(0, SpecId::CANCUN)];
 
     let mut genesis = GenesisConfig::from_minimal_config(genesis_config.into(), evm_config);
 
@@ -89,7 +109,7 @@ pub(crate) fn setup() -> (TestRunner<RT, S>, EvmAccount, EvmAccount) {
     let runner =
         TestRunner::new_with_genesis(genesis.into_genesis_params(), TestRuntime::default());
 
-    (runner, evm_account, no_balance_account)
+    (runner, evm_account, no_balance_account, admin)
 }
 
 pub(crate) fn create_transfer_tx(
@@ -193,4 +213,26 @@ fn create_tx(account: &EvmAccount, tx: TxEip1559) -> TxWithNonceAndHash {
         hash: *tx_env.hash(),
         tx: TransactionType::PreAuthenticated(RT::encode_with_ethereum_auth(raw_tx)),
     }
+}
+
+/// Create a transfer transaction with a specific max_fee_per_gas.
+pub(crate) fn create_transfer_tx_with_max_fee(
+    nonce: u64,
+    from: &EvmAccount,
+    to: Address,
+    max_fee_per_gas: u128,
+) -> TransactionType<RT, S> {
+    let tx = TxEip1559 {
+        to: TxKind::Call(to),
+        value: U256::from(1),
+        nonce,
+        gas_limit: 1_000_000,
+        max_fee_per_gas,
+        chain_id: config_value!("CHAIN_ID"),
+        ..Default::default()
+    };
+    let (signed_eth_tx, _) = from.sign(TypedTransaction::Eip1559(tx));
+    let data = borsh::to_vec(&signed_eth_tx).unwrap();
+    let raw_tx = RawTx { data };
+    TransactionType::PreAuthenticated(RT::encode_with_ethereum_auth(raw_tx))
 }

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/main.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod contracts;
 mod genesis;
 mod helpers;
+mod max_fee;
 mod pruning;
 mod runtime;
 mod state;

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/max_fee.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/max_fee.rs
@@ -1,0 +1,116 @@
+use std::str::FromStr;
+
+use alloy_primitives::Address;
+use sov_evm::{CallMessage, Evm, EvmRuntimeConfigUpdate};
+use sov_test_utils::runtime::TestRunner;
+use sov_test_utils::TransactionType;
+use sov_test_utils::{AsUser, TestUser, TransactionTestCase};
+
+use crate::helpers::{create_transfer_tx_with_max_fee, set_max_fee_check_height, setup};
+use crate::runtime::{RT, S};
+
+/// Test that EVM_MAX_FEE_CHECK_HEIGHT is respected:
+/// - Before the height threshold, transactions with insufficient max_fee pass.
+/// - After the height threshold, transactions with insufficient max_fee fail.
+/// - After disabling the check via UpdateRuntimeConfig, transactions pass again.
+#[test]
+fn test_max_fee_check_height_is_respected() {
+    // Set the max fee check to activate after block 3
+    set_max_fee_check_height(3);
+
+    let (mut runner, evm_account, _, admin) = setup();
+    let to_address = Address::from_str("0x0123456789012345678901234567890123456789").unwrap();
+    let mut nonce = 0u64;
+
+    let very_low_fee = 1u128;
+
+    // Block 1: Transaction with low fee should PASS.
+    let low_fee_tx = create_transfer_tx_with_max_fee(nonce, &evm_account, to_address, very_low_fee);
+    nonce += 1;
+    execute_tx_expect_success(
+        &mut runner,
+        low_fee_tx,
+        "Transaction should pass before height threshold",
+    );
+
+    runner.advance_slots(3);
+
+    // Block 5: Transaction with low fee should FAIL.
+    // Note: We don't increment nonce because this transaction will fail/be skipped
+    let low_fee_tx = create_transfer_tx_with_max_fee(nonce, &evm_account, to_address, very_low_fee);
+    execute_tx_expect_failure(
+        &mut runner,
+        low_fee_tx,
+        "Transaction should fail after height threshold",
+    );
+
+    let high_fee_tx = create_transfer_tx_with_max_fee(nonce, &evm_account, to_address, 99);
+    execute_tx_expect_success(&mut runner, high_fee_tx, "Transaction should succeed");
+    nonce += 1;
+
+    // Block 6: Disable the max fee check via empty config update
+    disable_max_fee_check(&mut runner, &admin);
+
+    // Block 7: Transaction with low fee should PASS.
+    let low_fee_tx = create_transfer_tx_with_max_fee(nonce, &evm_account, to_address, very_low_fee);
+    execute_tx_expect_success(
+        &mut runner,
+        low_fee_tx,
+        "Transaction should pass after disabling max fee check",
+    );
+}
+
+/// Execute a transaction and assert it succeeds.
+fn execute_tx_expect_success(
+    runner: &mut TestRunner<RT, S>,
+    input: TransactionType<RT, S>,
+    error_msg: &'static str,
+) {
+    runner.execute_transaction(TransactionTestCase {
+        input,
+        assert: Box::new(move |ctx, _state| {
+            assert!(
+                ctx.tx_receipt.is_successful(),
+                "{}: {:?}",
+                error_msg,
+                ctx.tx_receipt
+            );
+        }),
+    });
+}
+
+/// Execute a transaction and assert it fails.
+fn execute_tx_expect_failure(
+    runner: &mut TestRunner<RT, S>,
+    input: TransactionType<RT, S>,
+    error_msg: &'static str,
+) {
+    runner.execute_transaction(TransactionTestCase {
+        input,
+        assert: Box::new(move |ctx, _state| {
+            assert!(
+                !ctx.tx_receipt.is_successful(),
+                "{}: {:?}",
+                error_msg,
+                ctx.tx_receipt
+            );
+        }),
+    });
+}
+
+/// Disable the max fee check by sending an empty EvmRuntimeConfigUpdate.
+fn disable_max_fee_check(runner: &mut TestRunner<RT, S>, admin: &TestUser<S>) {
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Evm<S>>(CallMessage::UpdateRuntimeConfig(
+            EvmRuntimeConfigUpdate::empty(),
+        )),
+        assert: Box::new(move |ctx, state| {
+            assert!(ctx.tx_receipt.is_successful());
+            let evm = Evm::<S>::default();
+            assert!(
+                evm.is_max_fee_check_disabled(state).unwrap(),
+                "disable_max_fee_check should be true after empty config update"
+            );
+        }),
+    });
+}

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/max_fee.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/max_fee.rs
@@ -33,7 +33,7 @@ fn test_max_fee_check_height_is_respected() {
         "Transaction should pass before height threshold",
     );
 
-    runner.advance_slots(3);
+    runner.advance_slots(2);
 
     // Block 5: Transaction with low fee should FAIL.
     // Note: We don't increment nonce because this transaction will fail/be skipped

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/pruning.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/pruning.rs
@@ -36,7 +36,7 @@ fn test_pruning() {
     std::env::set_var("SOV_TEST_CONST_OVERRIDE_EVM_BLOCK_PRUNING_THRESHOLD", "5");
     let block_pruning_threshold = config_value!("EVM_BLOCK_PRUNING_THRESHOLD");
 
-    let (mut runner, from, to) = setup();
+    let (mut runner, from, to, _) = setup();
     let value = 1;
     let mut nonce = 0;
 

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/state.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/state.rs
@@ -13,7 +13,7 @@ use crate::runtime::{RT, S};
 
 #[test]
 fn test_block_updates() {
-    let (mut runner, account, _) = setup();
+    let (mut runner, account, _, _) = setup();
     let contract = LegacySimpleStorage::default();
     let create_contract_tx_request = TypedTransaction::Eip1559(TxEip1559 {
         chain_id: config_value!("CHAIN_ID"),

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/trace.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/trace.rs
@@ -10,7 +10,7 @@ use sov_test_utils::BatchTestCase;
 
 #[test]
 fn test_tracing() {
-    let (mut runner, account, _) = setup();
+    let (mut runner, account, _, _) = setup();
     let contract = LegacySimpleStorage::default();
     let contract_addr = account.address().create(0);
 

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
@@ -15,7 +15,7 @@ use sov_test_utils::{TransactionTestCase, TEST_DEFAULT_USER_BALANCE};
 
 #[test]
 fn test_simple_transfer() {
-    let (mut runner, from, to) = setup();
+    let (mut runner, from, to, _) = setup();
 
     let value = 1;
     let transfer_tx = create_transfer_tx(0, &from, &to, value).tx;
@@ -39,7 +39,7 @@ fn test_simple_transfer() {
 
 #[test]
 fn test_simple_transfer_balance_larger_than_allowed() {
-    let (mut runner, from, to) = setup();
+    let (mut runner, from, to, _) = setup();
 
     let transfer_tx = create_transfer_tx(
         0,
@@ -73,7 +73,7 @@ fn test_evm_gas_usage() {
         "[2, 0]",
     );
     let gas_used_with_evm_metering = {
-        let (mut runner, from, _) = setup();
+        let (mut runner, from, _, _) = setup();
         let contract = LegacySimpleStorage::default();
         let contract_addr = from.address().create(0);
         runner.execute(create_deploy_tx(0, &contract, &from).tx);
@@ -86,7 +86,7 @@ fn test_evm_gas_usage() {
         "[1, 0]",
     );
     let gas_used_without_evm_metering = {
-        let (mut runner, from, _) = setup();
+        let (mut runner, from, _, _) = setup();
         let contract = LegacySimpleStorage::default();
         let contract_addr = from.address().create(0);
         runner.execute(create_deploy_tx(0, &contract, &from).tx);
@@ -105,7 +105,7 @@ fn test_evm_gas_usage() {
 
 #[test]
 fn test_executing_eth_transactions() {
-    let (mut runner, account, _) = setup();
+    let (mut runner, account, _, _) = setup();
     let contract = LegacySimpleStorage::default();
     let contract_addr = account.address().create(0);
 
@@ -166,7 +166,7 @@ fn test_executing_eth_transactions() {
 
 #[test]
 fn test_executing_eth_transactions_several_blocks() {
-    let (mut runner, from, to) = setup();
+    let (mut runner, from, to, _) = setup();
 
     let nb_of_transfers: u64 = 200;
     let batch_size: usize = 10;
@@ -221,7 +221,7 @@ fn test_executing_eth_transactions_several_blocks() {
 
 #[test]
 fn test_failed_tx_doesnt_update_evm_module_state() {
-    let (mut runner, _, no_balance_account) = setup();
+    let (mut runner, _, no_balance_account, _) = setup();
     let contract = LegacySimpleStorage::default();
     let create_contract_tx = create_deploy_tx(0, &contract, &no_balance_account).tx;
 
@@ -238,7 +238,7 @@ fn test_failed_tx_doesnt_update_evm_module_state() {
 
 #[test]
 fn test_account_nonce() {
-    let (mut runner, from, to) = setup();
+    let (mut runner, from, to, _) = setup();
 
     let from_addr = from.address();
     let value = 1;
@@ -270,7 +270,7 @@ fn test_account_nonce() {
 // Check that if the same account deploys two contracts, each deployment results in a unique contract address
 #[test]
 fn test_deploy_many_contracts() {
-    let (mut runner, account, _) = setup();
+    let (mut runner, account, _, _) = setup();
     let contract = LegacySimpleStorage::default();
     let contract_addr_1 = account.address().create(0);
 
@@ -323,7 +323,7 @@ fn test_deploy_many_contracts() {
 
 #[test]
 fn test_evm_logs() {
-    let (mut runner, account, _) = setup();
+    let (mut runner, account, _, _) = setup();
     let contract = LegacySimpleStorage::default();
     let contract_addr = account.address().create(0);
     let address_bytes: [u8; 32] = account.address().into_word().into();

--- a/crates/module-system/module-implementations/sov-test-modules/src/access_pattern/mod.rs
+++ b/crates/module-system/module-implementations/sov-test-modules/src/access_pattern/mod.rs
@@ -26,14 +26,6 @@ pub const MAX_STR_LEN_BENCH: usize = 1_024;
 pub struct MeteredBorshDeserializeString(pub String);
 
 impl<S: Spec> MeteredBorshDeserialize<S> for MeteredBorshDeserializeString {
-    fn bias_borsh_deserialization() -> <S as Spec>::Gas {
-        <S as GasSpec>::string_bias_borsh_deserialization()
-    }
-
-    fn gas_to_charge_per_byte_borsh_deserialization() -> <S as Spec>::Gas {
-        <S as GasSpec>::string_gas_to_charge_per_byte_borsh_deserialization()
-    }
-
     fn deserialize(
         buf: &mut &[u8],
         meter: &mut impl sov_modules_api::GasMeter<Spec = S>,
@@ -41,7 +33,12 @@ impl<S: Spec> MeteredBorshDeserialize<S> for MeteredBorshDeserializeString {
         Self,
         sov_modules_api::MeteredBorshDeserializeError<<S as sov_modules_api::GasSpec>::Gas>,
     > {
-        Self::charge_gas_to_deserialize(buf, meter)?;
+        sov_modules_api::charge_gas_to_deserialize(
+            <S as GasSpec>::string_bias_borsh_deserialization(),
+            <S as GasSpec>::string_gas_to_charge_per_byte_borsh_deserialization(),
+            buf.len(),
+            meter,
+        )?;
 
         <MeteredBorshDeserializeString as BorshDeserialize>::deserialize(buf)
             .map_err(MeteredBorshDeserializeError::IOError)

--- a/crates/module-system/sov-modules-api/src/gas/metered_utils.rs
+++ b/crates/module-system/sov-modules-api/src/gas/metered_utils.rs
@@ -143,33 +143,12 @@ impl<GU: Gas, Sign: Signature> MeteredSignature<GU, Sign> {
         meter: &mut Meter,
         msg_len: usize,
     ) -> Result<(), MeteredSigVerificationError<GU>> {
-        meter
-            .charge_gas(self.fixed_gas_to_charge_per_verification)
-            .map_err(MeteredSigVerificationError::GasError)?;
-
-        meter
-            .charge_linear_gas(
-                self.gas_to_charge_per_byte_for_verification,
-                as_u32_or_panic(msg_len),
-            )
-            .map_err(MeteredSigVerificationError::GasError)?;
-
-        meter
-            .charge_gas(<Meter::Spec as GasSpec>::gas_to_charge_hash_update())
-            .map_err(MeteredSigVerificationError::GasError)?;
-
-        meter
-            .charge_linear_gas(
-                <Meter::Spec as GasSpec>::gas_to_charge_per_byte_hash_update(),
-                msg_len.try_into().map_err(|e: TryFromIntError| {
-                    MeteredSigVerificationError::GasError(MeteringError::<Meter>::Overflow(
-                        e.to_string(),
-                    ))
-                })?,
-            )
-            .map_err(MeteredSigVerificationError::GasError)?;
-
-        Ok(())
+        charge_gas_for_sig_inner(
+            meter,
+            msg_len,
+            self.fixed_gas_to_charge_per_verification,
+            self.gas_to_charge_per_byte_for_verification,
+        )
     }
 
     /// Verifies a signature with the provided gas meter. This method is a wrapper around [`Signature::verify`].
@@ -190,6 +169,54 @@ impl<GU: Gas, Sign: Signature> MeteredSignature<GU, Sign> {
     }
 }
 
+/// Charge gas for transaction signature verification.
+pub fn charge_gas_for_sig<S: Spec, Meter: GasMeter<Spec = S>>(
+    meter: &mut Meter,
+    msg_len: usize,
+) -> Result<(), MeteredSigVerificationError<S::Gas>> {
+    charge_gas_for_sig_inner(
+        meter,
+        msg_len,
+        S::fixed_gas_to_charge_per_signature_verification(),
+        S::gas_to_charge_per_byte_signature_verification(),
+    )
+}
+
+fn charge_gas_for_sig_inner<GU: Gas, Meter: GasMeter<Spec: Spec<Gas = GU>>>(
+    meter: &mut Meter,
+    msg_len: usize,
+    fixed_gas_to_charge_per_signature: GU,
+    gas_to_charge_per_byte_for_signature: GU,
+) -> Result<(), MeteredSigVerificationError<GU>> {
+    meter
+        .charge_gas(fixed_gas_to_charge_per_signature)
+        .map_err(MeteredSigVerificationError::GasError)?;
+
+    meter
+        .charge_linear_gas(
+            gas_to_charge_per_byte_for_signature,
+            as_u32_or_panic(msg_len),
+        )
+        .map_err(MeteredSigVerificationError::GasError)?;
+
+    meter
+        .charge_gas(<Meter::Spec as GasSpec>::gas_to_charge_hash_update())
+        .map_err(MeteredSigVerificationError::GasError)?;
+
+    meter
+        .charge_linear_gas(
+            <Meter::Spec as GasSpec>::gas_to_charge_per_byte_hash_update(),
+            msg_len.try_into().map_err(|e: TryFromIntError| {
+                MeteredSigVerificationError::GasError(MeteringError::<Meter>::Overflow(
+                    e.to_string(),
+                ))
+            })?,
+        )
+        .map_err(MeteredSigVerificationError::GasError)?;
+
+    Ok(())
+}
+
 /// Representation of a metered borsh deserialization error.
 #[derive(Debug, Error)]
 pub enum MeteredBorshDeserializeError<GU: Gas> {
@@ -203,46 +230,6 @@ pub enum MeteredBorshDeserializeError<GU: Gas> {
 
 /// Charges gas for deserialization.
 pub trait MeteredBorshDeserialize<S: Spec>: Sized {
-    /// The gas cost bias to deserialize this data structure.
-    fn bias_borsh_deserialization() -> <S as Spec>::Gas;
-
-    /// The linear gas cost to deserialize this data structure.
-    fn gas_to_charge_per_byte_borsh_deserialization() -> <S as Spec>::Gas;
-
-    /// Computes the cost to deserialize the given buffer, in `Gas`, and charges it to the provided
-    /// `GasMeter`.
-    ///
-    /// # Errors
-    /// Returns an error if charging the gas for the deserialization operation fails.
-    fn charge_gas_to_deserialize(
-        buf: &[u8],
-        meter: &mut impl GasMeter<Spec = S>,
-    ) -> Result<(), MeteredBorshDeserializeError<<S as GasSpec>::Gas>> {
-        // This is safe to cast here. We won't have data bigger than 4GB.
-        let buf_len: u32 = as_u32_or_panic(buf.len());
-
-        // Custom gas costs to deserialize this data structure.
-        meter
-            .charge_gas(Self::bias_borsh_deserialization())
-            .map_err(MeteredBorshDeserializeError::GasError)?;
-
-        meter
-            .charge_linear_gas(
-                Self::gas_to_charge_per_byte_borsh_deserialization(),
-                buf_len,
-            )
-            .map_err(MeteredBorshDeserializeError::GasError)?;
-
-        // Common gas costs to deserialize this data structure.
-        meter
-            .charge_gas(S::bias_borsh_deserialization())
-            .map_err(MeteredBorshDeserializeError::GasError)?;
-
-        meter
-            .charge_linear_gas(S::gas_to_charge_per_byte_borsh_deserialization(), buf_len)
-            .map_err(MeteredBorshDeserializeError::GasError)
-    }
-
     /// Deserializes a type from a byte slice with the provided gas meter. Charge the [`GasSpec::gas_to_charge_per_byte_borsh_deserialization`]
     /// amount of gas for each byte of the struct to deserialize.
     fn deserialize(
@@ -255,6 +242,39 @@ pub trait MeteredBorshDeserialize<S: Spec>: Sized {
     fn unmetered_deserialize(
         buf: &mut &[u8],
     ) -> Result<Self, MeteredBorshDeserializeError<<S as GasSpec>::Gas>>;
+}
+
+/// Computes the cost to deserialize the given buffer, in `Gas`, and charges it to the provided
+/// `GasMeter`.
+///
+/// # Errors
+/// Returns an error if charging the gas for the deserialization operation fails.
+pub fn charge_gas_to_deserialize<S: Spec>(
+    bias_borsh_deserialization: <S as Spec>::Gas,
+    gas_to_charge_per_byte_borsh_deserialization: <S as Spec>::Gas,
+    buf_len: usize,
+    meter: &mut impl GasMeter<Spec = S>,
+) -> Result<(), MeteredBorshDeserializeError<<S as GasSpec>::Gas>> {
+    // This is safe to cast here. We won't have data bigger than 4GB.
+    let buf_len: u32 = as_u32_or_panic(buf_len);
+
+    // Custom gas costs to deserialize this data structure.
+    meter
+        .charge_gas(bias_borsh_deserialization)
+        .map_err(MeteredBorshDeserializeError::GasError)?;
+
+    meter
+        .charge_linear_gas(gas_to_charge_per_byte_borsh_deserialization, buf_len)
+        .map_err(MeteredBorshDeserializeError::GasError)?;
+
+    // Common gas costs to deserialize this data structure.
+    meter
+        .charge_gas(S::bias_borsh_deserialization())
+        .map_err(MeteredBorshDeserializeError::GasError)?;
+
+    meter
+        .charge_linear_gas(S::gas_to_charge_per_byte_borsh_deserialization(), buf_len)
+        .map_err(MeteredBorshDeserializeError::GasError)
 }
 
 /// Computes the cost to deserialize the given JSON buffer, in `Gas`, and charges it to the provided

--- a/crates/module-system/sov-modules-api/src/gas/mod.rs
+++ b/crates/module-system/sov-modules-api/src/gas/mod.rs
@@ -11,9 +11,11 @@ mod tests;
 
 pub use error::GasMeteringError;
 pub(crate) use impl_macros::*;
+pub use metered_utils::charge_gas_for_sig;
 pub use metered_utils::{
-    charge_gas_to_deserialize_json, metered_credential, MeteredBorshDeserialize,
-    MeteredBorshDeserializeError, MeteredHasher, MeteredSigVerificationError, MeteredSignature,
+    charge_gas_to_deserialize, charge_gas_to_deserialize_json, metered_credential,
+    MeteredBorshDeserialize, MeteredBorshDeserializeError, MeteredHasher,
+    MeteredSigVerificationError, MeteredSignature,
 };
 pub use meters::*;
 pub use price::*;

--- a/crates/module-system/sov-modules-api/src/gas/tests/metered_utils.rs
+++ b/crates/module-system/sov-modules-api/src/gas/tests/metered_utils.rs
@@ -160,7 +160,12 @@ impl MeteredBorshDeserialize<S> for BorshTestStruct {
         buf: &mut &[u8],
         meter: &mut impl GasMeter<Spec = S>,
     ) -> Result<Self, MeteredBorshDeserializeError<<S as Spec>::Gas>> {
-        crate::charge_gas_to_deserialize(buf, meter)?;
+        crate::charge_gas_to_deserialize(
+            <S as Spec>::Gas::zero(),
+            <S as Spec>::Gas::zero(),
+            buf.len(),
+            meter,
+        )?;
 
         <Self as borsh::BorshDeserialize>::deserialize(buf)
             .map_err(MeteredBorshDeserializeError::IOError)

--- a/crates/module-system/sov-modules-api/src/gas/tests/metered_utils.rs
+++ b/crates/module-system/sov-modules-api/src/gas/tests/metered_utils.rs
@@ -156,19 +156,11 @@ pub struct BorshTestStruct {
 }
 
 impl MeteredBorshDeserialize<S> for BorshTestStruct {
-    fn bias_borsh_deserialization() -> <S as Spec>::Gas {
-        <S as Spec>::Gas::zero()
-    }
-
-    fn gas_to_charge_per_byte_borsh_deserialization() -> <S as Spec>::Gas {
-        <S as Spec>::Gas::zero()
-    }
-
     fn deserialize(
         buf: &mut &[u8],
         meter: &mut impl GasMeter<Spec = S>,
     ) -> Result<Self, MeteredBorshDeserializeError<<S as Spec>::Gas>> {
-        Self::charge_gas_to_deserialize(buf, meter)?;
+        crate::charge_gas_to_deserialize(buf, meter)?;
 
         <Self as borsh::BorshDeserialize>::deserialize(buf)
             .map_err(MeteredBorshDeserializeError::IOError)

--- a/crates/module-system/sov-modules-api/src/proof_metadata.rs
+++ b/crates/module-system/sov-modules-api/src/proof_metadata.rs
@@ -57,14 +57,6 @@ impl<S: Spec> SerializeProofWithDetails<S> {
 }
 
 impl<S: Spec> MeteredBorshDeserialize<S> for SerializeProofWithDetails<S> {
-    fn bias_borsh_deserialization() -> <S as Spec>::Gas {
-        S::proof_bias_borsh_deserialization()
-    }
-
-    fn gas_to_charge_per_byte_borsh_deserialization() -> <S as Spec>::Gas {
-        S::proof_gas_to_charge_per_byte_borsh_deserialization()
-    }
-
     #[cfg_attr(feature = "bench", crate::cycle_tracker)]
     #[cfg_attr(
         all(feature = "gas-constant-estimation", feature = "native"),
@@ -74,7 +66,12 @@ impl<S: Spec> MeteredBorshDeserialize<S> for SerializeProofWithDetails<S> {
         buf: &mut &[u8],
         meter: &mut impl GasMeter<Spec = S>,
     ) -> Result<Self, MeteredBorshDeserializeError<<S as GasSpec>::Gas>> {
-        Self::charge_gas_to_deserialize(buf, meter)?;
+        crate::charge_gas_to_deserialize(
+            S::proof_bias_borsh_deserialization(),
+            S::proof_gas_to_charge_per_byte_borsh_deserialization(),
+            buf.len(),
+            meter,
+        )?;
 
         SerializeProofWithDetails::<S>::unmetered_deserialize_inner(buf)
             .map_err(MeteredBorshDeserializeError::IOError)

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -55,7 +55,9 @@ pub trait TransactionAuthenticator<S: Spec> {
     /// For rollups running a preferred sequencer it is expected that implementations cache signature
     /// checks during native execution, and the preferred sequencer will attempt to pre-populate this
     /// cache to parallelise signature checks.
-    fn authenticate<Accessor: ProvableStateReader<User, Spec = S> + GetGasPrice<Spec = S>>(
+    fn authenticate<
+        Accessor: ProvableStateReader<User, Spec = S> + GetGasPrice<Spec = S> + crate::StateMetricsProvider,
+    >(
         tx: &FullyBakedTx,
         state: &mut Accessor,
     ) -> Result<AuthenticationOutput<S, Self::Decodable>, AuthenticationError>;

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -952,3 +952,9 @@ impl<S: Spec> GetGasPrice for MeteredApiStateAccessor<S> {
         self.api_state_accessor.gas_meter.gas_price
     }
 }
+
+impl<S: Spec> crate::state::accessors::StateMetricsProvider for MeteredApiStateAccessor<S> {
+    fn metrics(&mut self) -> &mut StateMetrics {
+        &mut self.api_state_accessor.metrics
+    }
+}

--- a/crates/module-system/sov-modules-api/src/state/traits.rs
+++ b/crates/module-system/sov-modules-api/src/state/traits.rs
@@ -313,7 +313,7 @@ pub trait AccessoryStateReader: UniversalStateAccessor + StateMetricsProvider {}
 /// A trait wrapper that replicates the functionality of [`StateReader`] but with a gas metering interface.
 /// This allows a storage reader to charge gas for read operations.
 pub trait ProvableStateReader<N: ProvableCompileTimeNamespace>:
-    UniversalStateAccessor + GasMeter
+    UniversalStateAccessor + GasMeter + StateMetricsProvider
 {
 }
 
@@ -399,11 +399,11 @@ macro_rules! blanket_impl_metered_state_reader {
     };
 }
 
-impl<T: ProvableStateReader<Kernel> + StateMetricsProvider> StateReader<Kernel> for T {
+impl<T: ProvableStateReader<Kernel>> StateReader<Kernel> for T {
     blanket_impl_metered_state_reader!(Kernel);
 }
 
-impl<T: ProvableStateReader<User> + StateMetricsProvider> StateReader<User> for T {
+impl<T: ProvableStateReader<User>> StateReader<User> for T {
     blanket_impl_metered_state_reader!(User);
 }
 

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -123,17 +123,22 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
     }
 }
 
+/// Charge gas for deserializing a transaction.
+pub fn charge_tx_deserialization<S: Spec>(
+    meter: &mut impl GasMeter<Spec = S>,
+    len: usize,
+) -> Result<(), MeteredBorshDeserializeError<<S as GasSpec>::Gas>> {
+    crate::charge_gas_to_deserialize(
+        S::tx_bias_borsh_deserialization(),
+        S::tx_gas_to_charge_per_byte_borsh_deserialization(),
+        len,
+        meter,
+    )
+}
+
 impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> MeteredBorshDeserialize<S>
     for Transaction<R, S, C>
 {
-    fn bias_borsh_deserialization() -> <S as Spec>::Gas {
-        S::tx_bias_borsh_deserialization()
-    }
-
-    fn gas_to_charge_per_byte_borsh_deserialization() -> <S as Spec>::Gas {
-        S::tx_gas_to_charge_per_byte_borsh_deserialization()
-    }
-
     #[cfg_attr(feature = "bench", crate::cycle_tracker)]
     #[cfg_attr(
         all(feature = "gas-constant-estimation", feature = "native"),
@@ -143,7 +148,7 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> MeteredBorshDeserialize<
         buf: &mut &[u8],
         meter: &mut impl GasMeter<Spec = S>,
     ) -> Result<Self, MeteredBorshDeserializeError<<S as GasSpec>::Gas>> {
-        Self::charge_gas_to_deserialize(buf, meter)?;
+        charge_tx_deserialization(meter, buf.len())?;
 
         Transaction::<R, S, C>::unmetered_deserialize_inner(buf)
             .map_err(MeteredBorshDeserializeError::IOError)

--- a/examples/demo-rollup/tests/evm/evm_gas_estimation.rs
+++ b/examples/demo-rollup/tests/evm/evm_gas_estimation.rs
@@ -6,26 +6,6 @@ use alloy_primitives::{Address, U256};
 use sov_evm_test_utils::SimpleStorage;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn simple_transfer() -> anyhow::Result<()> {
-    let (_, test_client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
-
-    let simple_transfer = test_client.make_tx(Some(Address::ZERO), None);
-    let gas_estimation = test_client.eth_estimate_gas(simple_transfer).await;
-    assert_eq!(gas_estimation, (14_810 / 2) * 3 + 100_000);
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn contract_deploy() -> anyhow::Result<()> {
-    let (_, test_client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
-
-    let deploy_tx = test_client.make_tx(None, Some(test_client.contract.byte_code()));
-    let gas_estimation = test_client.eth_estimate_gas(deploy_tx).await;
-    assert_eq!(gas_estimation, (248_136 / 2) * 3 + 100_000);
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn big_accessory_state_writes() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     rollup.wait_for_next_blocks(1).await;

--- a/examples/demo-rollup/tests/evm/evm_gas_estimation.rs
+++ b/examples/demo-rollup/tests/evm/evm_gas_estimation.rs
@@ -1,8 +1,7 @@
 use crate::evm::evm_test_helper::alloy_client;
 use crate::evm::evm_test_helper::setup_test_rollup;
-use crate::evm::evm_test_helper::setup_with_simple_storage;
 use crate::evm::evm_test_helper::EVM_EXTENSION;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::U256;
 use sov_evm_test_utils::SimpleStorage;
 
 #[tokio::test(flavor = "multi_thread")]

--- a/examples/demo-rollup/tests/evm/evm_max_fee_validation.rs
+++ b/examples/demo-rollup/tests/evm/evm_max_fee_validation.rs
@@ -4,6 +4,7 @@ use alloy::rpc::types::TransactionRequest;
 use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::{Address, U256};
 use alloy_provider::DynProvider;
+use alloy_rpc_types_eth::TransactionInput;
 use demo_stf::runtime::{Runtime, RuntimeCall};
 use sov_demo_rollup::MockDemoRollup;
 use sov_evm::{CallMessage, EvmRuntimeConfigUpdate};
@@ -111,6 +112,23 @@ async fn test_max_fee_check_height_is_respected() -> anyhow::Result<()> {
         "High fee should pass after height threshold.",
     )
     .await;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_big_call_data() -> anyhow::Result<()> {
+    let (rollup, client) = setup().await;
+    rollup.wait_for_next_blocks(1).await;
+    let mut tx = TransactionRequest::default().with_to(Address::ZERO);
+
+    tx.input = TransactionInput {
+        input: Some(vec![1; 1000_000].into()),
+        data: None,
+    };
+
+    let pending = client.send_transaction(tx).await.unwrap();
+    _ = pending.watch().await.unwrap();
 
     Ok(())
 }

--- a/examples/demo-rollup/tests/evm/evm_max_fee_validation.rs
+++ b/examples/demo-rollup/tests/evm/evm_max_fee_validation.rs
@@ -117,7 +117,7 @@ async fn test_max_fee_check_height_is_respected() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_big_call_data() -> anyhow::Result<()> {
+async fn test_big_call_data() {
     let (rollup, client) = setup().await;
     rollup.wait_for_next_blocks(1).await;
     let mut tx = TransactionRequest::default().with_to(Address::ZERO);
@@ -129,8 +129,6 @@ async fn test_big_call_data() -> anyhow::Result<()> {
 
     let pending = client.send_transaction(tx).await.unwrap();
     _ = pending.watch().await.unwrap();
-
-    Ok(())
 }
 
 /// Helper to create a simple ETH transfer transaction with the given max fee per gas

--- a/examples/demo-rollup/tests/evm/evm_max_fee_validation.rs
+++ b/examples/demo-rollup/tests/evm/evm_max_fee_validation.rs
@@ -4,23 +4,115 @@ use alloy::rpc::types::TransactionRequest;
 use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::{Address, U256};
 use alloy_provider::DynProvider;
+use demo_stf::runtime::{Runtime, RuntimeCall};
 use sov_demo_rollup::MockDemoRollup;
+use sov_evm::{CallMessage, EvmRuntimeConfigUpdate};
 use sov_modules_api::execution_mode::Native;
-use sov_test_utils::test_rollup::TestRollup;
+use sov_modules_api::transaction::Transaction;
+use sov_test_utils::default_test_signed_transaction;
+use sov_test_utils::test_rollup::{read_private_key, TestRollup};
 
 use crate::evm::evm_test_helper::{
     alloy_client_with_signer, setup_test_rollup, EVM_EXTENSION, SENDER_PRIV_KEY,
 };
+use crate::test_helpers::{DemoRollupSpec, CHAIN_HASH};
 
-const GAS_LIMIT: u64 = 21000;
+const GAS_LIMIT: u64 = 100_000;
 
 /// Sets up a test rollup and client, waiting for initial blocks and pausing batches
-async fn setup_paused_rollup() -> (TestRollup<MockDemoRollup<Native>>, DynProvider) {
+async fn setup() -> (TestRollup<MockDemoRollup<Native>>, DynProvider) {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client_with_signer(rollup.http_addr, SENDER_PRIV_KEY);
-    rollup.wait_for_next_blocks(1).await;
-    rollup.pause_preferred_batches().await;
+    rollup.wait_for_sequencer_ready().await.unwrap();
     (rollup, client)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_disable_max_fee_check() -> anyhow::Result<()> {
+    std::env::set_var("SOV_TEST_CONST_OVERRIDE_EVM_MAX_FEE_CHECK_HEIGHT", "0");
+    let (rollup, client) = setup().await;
+
+    let low_fee = 1;
+    let high_fee = 1_000_000;
+
+    // Verify low fee fails and high fee passes with max fee check enabled
+    send_tx_expect_failure(
+        &client,
+        low_fee,
+        "Low fee should fail before disable_max_fee_check message.",
+    )
+    .await;
+
+    send_tx_expect_success(
+        &client,
+        high_fee,
+        "High fee should pass before disable_max_fee_check message.",
+    )
+    .await;
+
+    // Disable the max fee check via admin config update
+    disable_max_fee_check(&rollup).await?;
+
+    // Now both low and high fee transactions should succeed
+    send_tx_expect_success(
+        &client,
+        low_fee,
+        "Low fee should pass after disable_max_fee_check message.",
+    )
+    .await;
+
+    send_tx_expect_success(
+        &client,
+        high_fee,
+        "High fee should pass after disable_max_fee_check message.",
+    )
+    .await;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_max_fee_check_height_is_respected() -> anyhow::Result<()> {
+    // Set a higher threshold so we can test before/after behavior
+    std::env::set_var("SOV_TEST_CONST_OVERRIDE_EVM_MAX_FEE_CHECK_HEIGHT", "15");
+
+    let (rollup, client) = setup().await;
+
+    let low_fee = 1;
+    let high_fee = 1_000_000;
+
+    // Before threshold: both low and high fee should pass
+    send_tx_expect_success(
+        &client,
+        low_fee,
+        "Low fee should pass before height threshold.",
+    )
+    .await;
+    send_tx_expect_success(
+        &client,
+        high_fee,
+        "High fee should pass before height threshold.",
+    )
+    .await;
+
+    // Advance past the threshold (height 15)
+    rollup.wait_for_next_blocks(20).await;
+
+    // After threshold: low fee should fail, high fee should pass
+    send_tx_expect_failure(
+        &client,
+        low_fee,
+        "Low fee should fail after height threshold.",
+    )
+    .await;
+    send_tx_expect_success(
+        &client,
+        high_fee,
+        "High fee should pass after height threshold.",
+    )
+    .await;
+
+    Ok(())
 }
 
 /// Helper to create a simple ETH transfer transaction with the given max fee per gas
@@ -40,44 +132,41 @@ async fn create_tx_request(
         .with_gas_limit(GAS_LIMIT))
 }
 
-/// Helper to send a transaction and wait for it to be mined
-async fn send_and_mine_tx(
-    rollup: &TestRollup<MockDemoRollup<Native>>,
-    client: &DynProvider,
-    max_fee_per_gas: u128,
-) -> anyhow::Result<alloy::rpc::types::TransactionReceipt> {
-    let tx_request = create_tx_request(client, max_fee_per_gas).await?;
-    let pending_tx = client.send_transaction(tx_request).await?;
-
-    rollup.resume_preferred_batches().await;
-    rollup.wait_for_next_blocks(1).await;
-
-    Ok(pending_tx.get_receipt().await?)
+/// Sends a transaction and asserts it succeeds
+async fn send_tx_expect_success(client: &DynProvider, fee: u128, msg: &str) {
+    let tx_request = create_tx_request(client, fee).await.unwrap();
+    let pending_tx = client.send_transaction(tx_request).await.unwrap();
+    let receipt = pending_tx.get_receipt().await.unwrap();
+    assert!(receipt.status(), "{msg}");
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_insufficient_max_fee_per_gas() -> anyhow::Result<()> {
-    let (_rollup, client) = setup_paused_rollup().await;
-
-    let user_max_fee = 1u128;
-    let tx_request = create_tx_request(&client, user_max_fee).await?;
-    let result = client.send_transaction(tx_request).await;
-
-    let err_msg = result.unwrap_err().to_string();
+/// Sends a transaction and asserts it fails with "Insufficient max_fee_per_gas"
+async fn send_tx_expect_failure(client: &DynProvider, fee: u128, msg: &str) {
+    let tx_request = create_tx_request(client, fee).await.unwrap();
+    let err = client.send_transaction(tx_request).await.unwrap_err();
+    let err_msg = err.to_string();
     assert!(
-        err_msg.contains("Insufficient max_fee_per_gas: user specified 1, but current base fee is"),
-        "Expected insufficient max_fee_per_gas error, got: {err_msg}"
+        err_msg.contains("Insufficient max_fee_per_gas"),
+        "{msg}: got {err_msg}"
     );
-
-    Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_sufficient_max_fee_per_gas() -> anyhow::Result<()> {
-    let (rollup, client) = setup_paused_rollup().await;
+/// Sends an empty EvmRuntimeConfigUpdate to disable the max fee check.
+async fn disable_max_fee_check(rollup: &TestRollup<MockDemoRollup<Native>>) -> anyhow::Result<()> {
+    let key_and_address = read_private_key::<DemoRollupSpec>("token_deployer_private_key.json");
+    let admin_key = key_and_address.private_key;
 
-    let receipt = send_and_mine_tx(&rollup, &client, 1_000_000_000).await?;
-    assert!(receipt.status());
+    let update = EvmRuntimeConfigUpdate::<DemoRollupSpec>::empty();
+    let msg = RuntimeCall::<DemoRollupSpec>::Evm(CallMessage::UpdateRuntimeConfig(update));
+
+    let tx: Transaction<Runtime<DemoRollupSpec>, DemoRollupSpec> =
+        default_test_signed_transaction(&admin_key, &msg, 0, &CHAIN_HASH);
+
+    rollup
+        .client
+        .client
+        .send_tx_to_sequencer_with_retry(&tx)
+        .await?;
 
     Ok(())
 }

--- a/examples/demo-rollup/tests/evm/evm_max_fee_validation.rs
+++ b/examples/demo-rollup/tests/evm/evm_max_fee_validation.rs
@@ -123,7 +123,7 @@ async fn test_big_call_data() {
     let mut tx = TransactionRequest::default().with_to(Address::ZERO);
 
     tx.input = TransactionInput {
-        input: Some(vec![1; 1000_000].into()),
+        input: Some(vec![1; 1_000_000].into()),
         data: None,
     };
 

--- a/examples/demo-rollup/tests/evm/evm_test_helper.rs
+++ b/examples/demo-rollup/tests/evm/evm_test_helper.rs
@@ -22,8 +22,9 @@ use sov_risc0_adapter::Risc0;
 use sov_sequencer::SeqConfigExtension;
 use sov_sequencer::SovRateLimiterConfig;
 use sov_stf_runner::processes::RollupProverConfig;
-use sov_test_utils::test_rollup::get_appropriate_rollup_prover_config;
-use sov_test_utils::test_rollup::{RollupBuilder, TestRollup};
+use sov_test_utils::test_rollup::{
+    get_appropriate_rollup_prover_config, RollupBuilder, TestRollup,
+};
 
 pub(crate) const SENDER_PRIV_KEY: &str =
     "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";

--- a/examples/test-data/genesis/integration-tests/evm.json
+++ b/examples/test-data/genesis/integration-tests/evm.json
@@ -39,5 +39,5 @@
     },
     "hardforks": [[0, "CANCUN"]]
   },
-  "admin": "0xAeb37910f93486C85A1F8F994b67E8187554d664"
+  "admin": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
 }


### PR DESCRIPTION
# Description

This PR introduces the following updates:
1. Adds the `Evm::validate_fee_and_calculate_multiplier` method to handle fee validation for the evm transactions.
2. Introduces the `EVM_MAX_FEE_CHECK_HEIGHT`  in `constants.toml` , after which the max fee check becomes active.
3. Allows disabling the max fee check via the `CallMessage::UpdateRuntimeConfig(empty)` message.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

