### PR TITLE
Add `NodeRole::DbElected` mode that enables automatic leader election.

### DIFF
--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -141,6 +141,12 @@ pub enum NodeRole {
     /// It receives transactions exclusively through the DA layer.
     /// Use this mode when you want replica behavior without accepting transactions from the Leader only from the DA.
     ReplicaNoLeaderSync,
+    /// The node initially starts as a `Replica` and attempts to register itself as the `Leader`
+    /// by sending a request to the Db to acquire leadership.
+    /// If successful, it becomes the `Leader`` and all other nodes remain Replicas.
+    /// If the Leader goes down and fails to refresh its entry in the `Leader` table,
+    /// one of the `Replicas` will take over and assume the Leader role.
+    DbElected,
 }
 
 /// Postgres DB config.

--- a/crates/full-node/sov-sequencer/src/common.rs
+++ b/crates/full-node/sov-sequencer/src/common.rs
@@ -188,6 +188,9 @@ pub trait Sequencer: Clone + Send + Sync + 'static {
     ) -> Option<tokio::sync::broadcast::Receiver<StateUpdateNotification>> {
         None
     }
+
+    /// Returns the current sequencer role.
+    async fn sequencer_role(&self) -> crate::SequencerRole;
 }
 
 /// A transaction that has been accepted by the batch builder.

--- a/crates/full-node/sov-sequencer/src/lib.rs
+++ b/crates/full-node/sov-sequencer/src/lib.rs
@@ -18,8 +18,8 @@ use axum::async_trait;
 #[cfg(feature = "test-utils")]
 pub use common::StateUpdateNotification;
 pub use common::{react_to_state_updates, Sequencer};
-pub use preferred::SequencerRole;
 pub use config::{SeqConfigExtension, SequencerConfig, SequencerKindConfig, SovRateLimiterConfig};
+pub use preferred::SequencerRole;
 pub use rest_api::SequencerApis;
 use serde::Serialize;
 use sov_modules_api::capabilities::RollupHeight;

--- a/crates/full-node/sov-sequencer/src/lib.rs
+++ b/crates/full-node/sov-sequencer/src/lib.rs
@@ -18,6 +18,7 @@ use axum::async_trait;
 #[cfg(feature = "test-utils")]
 pub use common::StateUpdateNotification;
 pub use common::{react_to_state_updates, Sequencer};
+pub use preferred::SequencerRole;
 pub use config::{SeqConfigExtension, SequencerConfig, SequencerKindConfig, SovRateLimiterConfig};
 pub use rest_api::SequencerApis;
 use serde::Serialize;

--- a/crates/full-node/sov-sequencer/src/preferred/db/leadership_election.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/leadership_election.rs
@@ -111,11 +111,6 @@ impl LeadershipElectionTask {
     ///
     /// This task periodically attempts to acquire leadership. If leadership is
     /// acquired, it will transition the node from replica to leader.
-    ///
-    /// # Note
-    ///
-    /// The replica-to-leader transition is currently not implemented and will
-    /// trigger a `todo!()` panic when leadership is acquired.
     pub fn spawn_replica_election_task(self) -> JoinHandle<()> {
         tokio::spawn(async move {
             info!(node_id = %self.node_id, "Starting replica election task");

--- a/crates/full-node/sov-sequencer/src/preferred/db/leadership_election.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/leadership_election.rs
@@ -133,9 +133,9 @@ impl LeadershipElectionTask {
                     Ok(true) => {
                         info!(
                             node_id = %self.node_id,
-                            "Replica acquired leadership!"
+                            "Replica acquired leadership! Restarting the node."
                         );
-                        todo!("Transition replica to leader at runtime - this requires recreating leader components (BlobSender, etc.)")
+                        exit_rollup(&self.shutdown_sender).await;
                     }
                     Ok(false) => {
                         // Another node is still leader, keep trying

--- a/crates/full-node/sov-sequencer/src/preferred/db/leadership_election.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/leadership_election.rs
@@ -1,0 +1,155 @@
+//! Leadership election and heartbeat tasks for DbElected nodes.
+//!
+//! DbElected nodes attempt to acquire leadership at startup. If successful, they
+//! run as leaders with a heartbeat task. If not, they run as replicas while
+//! continuously attempting to acquire leadership.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use sov_full_node_configs::sequencer::PostgresConfig;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use tracing::{error, info, warn};
+
+use super::postgres::PostgresBackend;
+use crate::preferred::exit_rollup;
+
+/// How often replicas attempt to acquire leadership.
+const ELECTION_INTERVAL: Duration = Duration::from_millis(200);
+
+/// How often leaders refresh their leadership heartbeat.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Manages leadership election and heartbeat for DbElected nodes.
+pub struct LeadershipElectionTask {
+    backend: PostgresBackend,
+    node_id: String,
+    shutdown_sender: watch::Sender<()>,
+    shutdown_receiver: watch::Receiver<()>,
+}
+
+impl LeadershipElectionTask {
+    /// Creates a new leadership election task.
+    ///
+    /// Connects to PostgreSQL without claiming leadership - the caller should
+    /// call `try_acquire_leadership()` to attempt to become leader.
+    pub async fn new(
+        postgres_config: &PostgresConfig,
+        shutdown_sender: watch::Sender<()>,
+    ) -> Result<Self> {
+        let backend = PostgresBackend::connect_without_leadership(postgres_config).await?;
+        let shutdown_receiver = shutdown_sender.subscribe();
+        Ok(Self {
+            backend,
+            node_id: postgres_config.node_id.clone(),
+            shutdown_sender,
+            shutdown_receiver,
+        })
+    }
+
+    /// Attempts to acquire leadership.
+    ///
+    /// Returns `true` if this node successfully became the leader.
+    /// Returns `false` if another node is the leader.
+    pub async fn try_acquire_leadership(&self) -> Result<bool> {
+        match self.backend.try_update_leader().await? {
+            Some(leader) => Ok(leader.node_id == self.node_id),
+            None => Ok(false),
+        }
+    }
+
+    /// Spawns the leader heartbeat task.
+    ///
+    /// This task periodically refreshes leadership. If leadership is lost
+    /// (another node took over or heartbeat failed), it triggers a graceful
+    /// shutdown of the node.
+    ///
+    /// This method consumes `self` and should only be called after successfully
+    /// acquiring leadership via `try_acquire_leadership()`.
+    pub fn spawn_leader_heartbeat_task(self) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            info!(node_id = %self.node_id, "Starting leader heartbeat task");
+            let mut interval = tokio::time::interval(HEARTBEAT_INTERVAL);
+
+            loop {
+                interval.tick().await;
+
+                if self.shutdown_receiver.has_changed().unwrap_or(true) {
+                    info!("Shutdown signal received, stopping heartbeat task");
+                    return;
+                }
+
+                match self.try_acquire_leadership().await {
+                    Ok(true) => {
+                        // Successfully refreshed leadership
+                        tracing::trace!("Leadership heartbeat successful");
+                    }
+                    Ok(false) => {
+                        error!(
+                            node_id = %self.node_id,
+                            "Leadership lost! Another node has taken over. Initiating graceful shutdown."
+                        );
+                        exit_rollup(&self.shutdown_sender).await;
+                        return;
+                    }
+                    Err(e) => {
+                        error!(
+                            node_id = %self.node_id,
+                            error = ?e,
+                            "Heartbeat error! Unable to communicate with database. Initiating graceful shutdown."
+                        );
+                        exit_rollup(&self.shutdown_sender).await;
+                        return;
+                    }
+                }
+            }
+        })
+    }
+
+    /// Spawns the replica election task.
+    ///
+    /// This task periodically attempts to acquire leadership. If leadership is
+    /// acquired, it will transition the node from replica to leader.
+    ///
+    /// # Note
+    ///
+    /// The replica-to-leader transition is currently not implemented and will
+    /// trigger a `todo!()` panic when leadership is acquired.
+    pub fn spawn_replica_election_task(self) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            info!(node_id = %self.node_id, "Starting replica election task");
+            let mut interval = tokio::time::interval(ELECTION_INTERVAL);
+
+            loop {
+                interval.tick().await;
+
+                if self.shutdown_receiver.has_changed().unwrap_or(true) {
+                    info!("Shutdown signal received, stopping election task");
+                    return;
+                }
+
+                match self.try_acquire_leadership().await {
+                    Ok(true) => {
+                        info!(
+                            node_id = %self.node_id,
+                            "Replica acquired leadership!"
+                        );
+                        todo!("Transition replica to leader at runtime - this requires recreating leader components (BlobSender, etc.)")
+                    }
+                    Ok(false) => {
+                        // Another node is still leader, keep trying
+                        tracing::trace!("Leadership acquisition failed, another node is leader");
+                    }
+                    Err(e) => {
+                        warn!(
+                            node_id = %self.node_id,
+                            error = ?e,
+                            "Election attempt failed, will retry"
+                        );
+                    }
+                }
+            }
+        })
+    }
+}

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -418,10 +418,14 @@ impl From<BatchToStore> for StoredBlob {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub(crate) enum SequencerRole {
+/// The role of the sequencer in a distributed setup.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum SequencerRole {
+    /// Replica that does not sync with the leader.
     ReplicaNoLeaderSync,
+    /// Replica that syncs with the leader via PostgreSQL.
     Replica,
+    /// Leader node that accepts transactions and produces batches.
     Leader,
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -9,6 +9,7 @@
 //! invariants and we'd rather have an application crash due to broken
 //! invariants than to have bugs that result in subtle state inconsistencies.
 
+pub mod leadership_election;
 pub mod postgres;
 pub mod rocksdb;
 use crate::preferred::PostgresBackend;
@@ -445,7 +446,29 @@ impl PreferredSequencerDb {
                         SequencerRole::Leader,
                     ),
                     NodeRole::DbElected => {
-                        todo!()
+                        // Connect without claiming leadership, then try to acquire it
+                        let backend =
+                            PostgresBackend::connect_without_leadership(postgres_config).await?;
+
+                        // Try to become leader
+                        let maybe_leader = backend.try_update_leader().await?;
+                        let is_leader = maybe_leader
+                            .map(|leader| leader.node_id == postgres_config.node_id)
+                            .unwrap_or(false);
+
+                        if is_leader {
+                            tracing::info!(
+                                node_id = %postgres_config.node_id,
+                                "DbElected node acquired leadership, running as Leader"
+                            );
+                            (Some(Box::new(backend)), SequencerRole::Leader)
+                        } else {
+                            tracing::info!(
+                                node_id = %postgres_config.node_id,
+                                "DbElected node did not acquire leadership, running as Replica"
+                            );
+                            (None, SequencerRole::Replica)
+                        }
                     }
                 }
             } else {

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -444,6 +444,9 @@ impl PreferredSequencerDb {
                         Some(Box::new(PostgresBackend::connect(postgres_config).await?)),
                         SequencerRole::Leader,
                     ),
+                    NodeRole::DbElected => {
+                        todo!()
+                    }
                 }
             } else {
                 (

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -22,8 +22,8 @@ const LEADER_TIMEOUT: Duration = Duration::from_millis(500);
 
 #[derive(Debug, FromRow, PartialEq)]
 pub(crate) struct SequencerLeader {
-    node_id: String,
-    last_updated: OffsetDateTime,
+    pub node_id: String,
+    pub last_updated: OffsetDateTime,
 }
 
 pub struct PostgresBackend {
@@ -65,6 +65,12 @@ impl PostgresBackend {
         let backend = Self::connect_with_leader_timeout(config, LEADER_TIMEOUT).await?;
         backend.try_update_leader().await?;
         Ok(backend)
+    }
+
+    /// Connect without immediately claiming leadership.
+    /// Used by DbElected nodes during the election phase.
+    pub async fn connect_without_leadership(config: &PostgresConfig) -> Result<Self> {
+        Self::connect_with_leader_timeout(config, LEADER_TIMEOUT).await
     }
 
     async fn connect_with_leader_timeout(

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -22,8 +22,8 @@ const LEADER_TIMEOUT: Duration = Duration::from_millis(500);
 
 #[derive(Debug, FromRow, PartialEq)]
 pub(crate) struct SequencerLeader {
-    pub node_id: String,
-    pub last_updated: OffsetDateTime,
+    pub(crate) node_id: String,
+    pub(crate) last_updated: OffsetDateTime,
 }
 
 pub struct PostgresBackend {

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -1,3 +1,4 @@
+use crate::preferred::db::leadership_election::LeadershipElectionTask;
 use crate::preferred::db::SequencerRole;
 
 use super::*;
@@ -228,6 +229,21 @@ where
                     .await;
                 handles.push(replica_task_handle.data_fetcher_handle);
                 handles.push(replica_task_handle.sync_task_handle);
+            }
+        }
+
+        // Launch leadership task for DbElected nodes
+        if let Some(postgres_config) = &preferred_config.postgres_config {
+            if postgres_config.node_role == NodeRole::DbElected {
+                let election_task =
+                    LeadershipElectionTask::new(postgres_config, shutdown_sender.clone()).await?;
+
+                let leadership_handle = match seq_role {
+                    SequencerRole::Leader => election_task.spawn_leader_heartbeat_task(),
+                    SequencerRole::Replica => election_task.spawn_replica_election_task(),
+                    _ => unreachable!("DbElected should only result in Leader or Replica role"),
+                };
+                handles.push(leadership_handle);
             }
         }
 

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -29,6 +29,7 @@ use async_trait::async_trait;
 use batch_size_tracker::BatchSizeTracker;
 use db::postgres::PostgresBackend;
 use db::rocksdb::RocksDbBackend;
+pub use db::SequencerRole;
 use db::{PreferredSequencerDb, ReadBatch, ReadBlob};
 use derive_more::Deref;
 use futures::Stream;
@@ -159,6 +160,14 @@ where
                 stop_at_rollup_height,
             )
             .await
+    }
+
+    /// Returns the current sequencer role.
+    pub async fn sequencer_role(&self) -> Result<db::SequencerRole, anyhow::Error> {
+        self.synchronized_state_updator
+            .sequencer_role_msg("get_sequencer_role")
+            .await
+            .map_err(|e| e.into_state_update_error())
     }
 
     /// Returns a range to allow hysteresis during catchup. The first (lower) value will be the
@@ -721,7 +730,8 @@ where
     async fn is_ready(&self) -> Result<(), SequencerNotReadyDetails> {
         // We don't actually care about the `inner`, we just want to reuse the
         // same logic.
-        self.synchronized_state_updator
+        let res = self
+            .synchronized_state_updator
             .check_readiness_msg(
                 self.config.max_concurrent_blobs,
                 self.stop_at_rollup_height,
@@ -729,7 +739,9 @@ where
             )
             .await
             .map_err(|_| SequencerNotReadyDetails::Shutdown)?
-            .map(|_| ())
+            .map(|_| ());
+
+        res
     }
 
     fn api_state(&self) -> ApiState<Self::Spec> {
@@ -849,6 +861,13 @@ where
         // way that facilitates random access to tx status information. That
         // means the sequencer only relies on the cache. FIXME(@neysofu).
         Ok(TxStatus::Unknown)
+    }
+
+    async fn sequencer_role(&self) -> SequencerRole {
+        self.synchronized_state_updator
+            .sequencer_role_msg("get_sequencer_role")
+            .await
+            .unwrap_or(SequencerRole::Leader)
     }
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
@@ -127,6 +127,10 @@ pub(super) enum Message<S: Spec, Rt: Runtime<S>> {
         batch_from_master: BatchToStore,
         reason: &'static str,
     },
+    GetSequencerRole {
+        resp: oneshot::Sender<SequencerRole>,
+        reason: &'static str,
+    },
 }
 
 impl<S: Spec, Rt: Runtime<S>> Message<S, Rt> {

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -369,6 +369,12 @@ where
                 self.send_response(resp, ret, "process_do_batch_start_replica")
                     .await;
             }
+            Message::GetSequencerRole { resp, reason } => {
+                let inner = self.get_inner_with_timing(reason).await;
+                let role = inner.seq_role;
+                drop(inner);
+                self.send_response(resp, role, "get_sequencer_role").await;
+            }
         }
 
         Ok(())

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/updator.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/updator.rs
@@ -319,4 +319,14 @@ where
         self.recv(recv).await??;
         Ok(())
     }
+
+    pub(crate) async fn sequencer_role_msg(
+        &self,
+        reason: &'static str,
+    ) -> Result<crate::preferred::db::SequencerRole, SequencerStateUpdatorError> {
+        let (resp, recv) = oneshot::channel();
+        self.send(Message::GetSequencerRole { resp, reason })
+            .await?;
+        self.recv(recv).await
+    }
 }

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -100,10 +100,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
                 "/sequencer/unstable/events",
                 axum::routing::get(Self::axum_list_events),
             )
-            .route(
-                "/sequencer/role",
-                axum::routing::get(Self::axum_get_role),
-            );
+            .route("/sequencer/role", axum::routing::get(Self::axum_get_role));
 
         #[cfg(feature = "test-utils")]
         let router = router

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -99,6 +99,10 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             .route(
                 "/sequencer/unstable/events",
                 axum::routing::get(Self::axum_list_events),
+            )
+            .route(
+                "/sequencer/role",
+                axum::routing::get(Self::axum_get_role),
             );
 
         #[cfg(feature = "test-utils")]
@@ -316,6 +320,10 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             Ok(()) => Ok(().into()),
             Err(details) => Err(error_not_fully_synced(details).into_response()),
         }
+    }
+
+    async fn axum_get_role(state: State<Self>) -> ApiResult<crate::SequencerRole> {
+        Ok(state.sequencer.sequencer_role().await.into())
     }
 
     async fn axum_get_tx_status(

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -737,6 +737,10 @@ where
             Ok(TxStatus::Unknown)
         }
     }
+
+    async fn sequencer_role(&self) -> crate::SequencerRole {
+        crate::SequencerRole::Leader
+    }
 }
 
 #[async_trait]

--- a/crates/full-node/sov-sequencer/src/test_stateless.rs
+++ b/crates/full-node/sov-sequencer/src/test_stateless.rs
@@ -244,4 +244,8 @@ where
     ) -> Result<AcceptedTx<Self::Confirmation>, ErrorObject> {
         Ok(self.accept_encoded_tx(tx).await)
     }
+
+    async fn sequencer_role(&self) -> crate::SequencerRole {
+        crate::SequencerRole::Leader
+    }
 }

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -355,6 +355,13 @@
           "enum": [
             "ReplicaNoLeaderSync"
           ]
+        },
+        {
+          "description": "The node initially starts as a `Replica` and attempts to register itself as the `Leader` by sending a request to the Db to acquire leadership. If successful, it becomes the `Leader`` and all other nodes remain Replicas. If the Leader goes down and fails to refresh its entry in the `Leader` table, one of the `Replicas` will take over and assume the Leader role.",
+          "type": "string",
+          "enum": [
+            "DbElected"
+          ]
         }
       ]
     },

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -51,7 +51,7 @@ use sov_sequencer::preferred::{
 use sov_sequencer::test_stateless::TestStatelessSequencer;
 use sov_sequencer::SeqConfigExtension;
 use sov_sequencer::{
-    SequencerApis, SequencerConfig, SequencerKindConfig, SovRateLimiterConfig,
+    SequencerApis, SequencerConfig, SequencerKindConfig, SequencerRole, SovRateLimiterConfig,
     StateUpdateNotification,
 };
 pub use sov_stf_runner::processes::RollupProverConfig;
@@ -818,6 +818,11 @@ where
                 false
             }
         }
+    }
+
+    /// Returns the current sequencer role.
+    pub async fn sequencer_role(&self) -> anyhow::Result<SequencerRole> {
+        self.client.query_rest_endpoint("/sequencer/role").await
     }
 
     /// Polls the sequencer until is_ready() returns Err(). Useful when you expect the sequencer to

--- a/examples/demo-rollup/tests/replica/db_elected.rs
+++ b/examples/demo-rollup/tests/replica/db_elected.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+use sov_sequencer::SequencerRole;
+use tokio::time::Duration;
+
+/// Test that when two DbElected nodes start, one becomes leader and the other becomes replica.
+/// The leader can process transactions while the replica receives them via PostgreSQL sync.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_db_elected_two_nodes_leader_and_replica() {
+    let postgres = PostgresData::create_postgres().await;
+
+    let postgres = match postgres {
+        Ok(pg) => Some(pg),
+        Err(CreatePostgresError::DockerNotSupported) => return,
+        Err(CreatePostgresError::DockerError(e)) => {
+            panic!("Failed to create Postgres container: {e}");
+        }
+    };
+
+    let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
+    let (_, da_shutdown, addr) = create_da_service_periodic().await;
+
+    // Start both DbElected nodes
+    let node1 = postgres
+        .clone()
+        .map(|pg| (pg, "node1".into(), NodeRole::DbElected));
+    let rollup1 = start_rollup(addr, node1).await;
+
+    let node2 = postgres.map(|pg| (pg, "node2".into(), NodeRole::DbElected));
+    let rollup2 = start_rollup(addr, node2).await;
+
+    // Wait for both nodes to be ready
+    rollup1.wait_for_sequencer_ready().await.unwrap();
+    rollup2.wait_for_sequencer_ready().await.unwrap();
+
+    // Discover roles via the /sequencer/role endpoint
+    let role1 = rollup1.sequencer_role().await.unwrap();
+    let role2 = rollup2.sequencer_role().await.unwrap();
+
+    // Determine which node is the leader and which is the replica
+    let (leader_rollup, replica_rollup) = match (role1, role2) {
+        (SequencerRole::Leader, SequencerRole::Replica) => (&rollup1, &rollup2),
+        (SequencerRole::Replica, SequencerRole::Leader) => (&rollup2, &rollup1),
+        _ => panic!(
+            "Expected one Leader and one Replica, got {:?} and {:?}",
+            role1, role2
+        ),
+    };
+
+    // Subscribe to events on the replica
+    let mut event_subscription = replica_rollup
+        .api_client()
+        .subscribe_to_events_with_filter("Bank/*")
+        .await
+        .unwrap();
+
+    // Send transaction to the leader
+    let token_id = config_gas_token_id();
+    let receiver_addr = random_address();
+
+    let tx = build_transfer_token_tx::<S>(
+        &key_and_address.private_key,
+        token_id,
+        receiver_addr,
+        AMOUNT,
+        0,
+    );
+
+    leader_rollup.send_tx_to_sequencer(&tx).await.unwrap();
+
+    // Wait for the event on the replica (proves it received the tx via PostgreSQL sync)
+    wait_for_all_events_with_timeout(Duration::from_millis(500), 1, &mut event_subscription).await;
+
+    let _ = rollup1.shutdown().await;
+    let _ = rollup2.shutdown().await;
+    let _ = da_shutdown.send(());
+}

--- a/examples/demo-rollup/tests/replica/db_elected.rs
+++ b/examples/demo-rollup/tests/replica/db_elected.rs
@@ -41,10 +41,7 @@ async fn test_db_elected_two_nodes_leader_and_replica() {
     let (leader_rollup, replica_rollup) = match (role1, role2) {
         (SequencerRole::Leader, SequencerRole::Replica) => (&rollup1, &rollup2),
         (SequencerRole::Replica, SequencerRole::Leader) => (&rollup2, &rollup1),
-        _ => panic!(
-            "Expected one Leader and one Replica, got {:?} and {:?}",
-            role1, role2
-        ),
+        _ => panic!("Expected one Leader and one Replica, got {role1:?} and {role2:?}",),
     };
 
     // Subscribe to events on the replica

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -30,6 +30,7 @@ use std::sync::Arc;
 use tokio::sync::watch;
 use tokio::time::Duration;
 
+mod db_elected;
 mod replica_gets_txs_from_master;
 mod start_stop;
 


### PR DESCRIPTION
# Description

Summary:

  Add `NodeRole::DbElected` mode that enables automatic leader election using PostgreSQL. When multiple nodes start with `DbElected` role, they compete for leadership via the database - one becomes the Leader and others become Replicas.

  Key features:
  - Automatic leader election at startup using PostgreSQL `sequencer_leader` table
  - Leader maintains heartbeat to retain leadership
  - Replicas monitor for leadership availability
  - New `/sequencer/role` REST endpoint to query the current node's role

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
