### PR TITLE
Add address calculation for multisigs in web3

### DIFF
--- a/typescript/.changeset/seven-ghosts-trade.md
+++ b/typescript/.changeset/seven-ghosts-trade.md
@@ -1,0 +1,5 @@
+---
+"@sovereign-sdk/multisig": minor
+---
+
+Adds a method to retrieve the address/credential id associated with the multisig.

--- a/typescript/packages/multisig/package.json
+++ b/typescript/packages/multisig/package.json
@@ -38,7 +38,9 @@
     "access": "public"
   },
   "dependencies": {
+    "@noble/hashes": "^1.5.0",
     "@sovereign-sdk/signers": "workspace:^",
-    "@sovereign-sdk/utils": "workspace:^"
+    "@sovereign-sdk/utils": "workspace:^",
+    "borsh": "0.7.0"
   }
 }

--- a/typescript/packages/multisig/src/index.test.ts
+++ b/typescript/packages/multisig/src/index.test.ts
@@ -4,6 +4,7 @@ import type {
   TransactionV1,
   UnsignedTransaction,
 } from "@sovereign-sdk/types";
+import { bytesToHex } from "@sovereign-sdk/utils";
 import { describe, expect, it } from "vitest";
 import {
   InvalidMultisigParameterError,
@@ -240,6 +241,23 @@ describe("MultisigTransaction", () => {
 
       expect(() => multisig.addSignature("sig2", "pubkey1")).toThrow(
         InvalidMultisigParameterError,
+      );
+    });
+  });
+
+  describe("getMultisigAddress", () => {
+    it("should match Rust implementation output for known test vector", () => {
+      const multisig = MultisigTransaction.empty(createUnsignedTx(), 2, [
+        "33dd646d7c43830b52289c4f277d3a5a26b3ab0a10ee05c871cb654bc046e545",
+        "8c7788ad88084f12ce1556703b33e673c5e450eec793c1e8e1a55b1140b4dfb8",
+        "74fc1e9c39b21173ef47c1cdfb37158764486c8b8ba81d8f29c6dd77800cd57f",
+      ]);
+
+      const address = multisig.getMultisigAddress();
+      const addressHex = bytesToHex(address);
+
+      expect(addressHex).toBe(
+        "814394e81dd2a682efad0fc2082272cde35a172ba7e0e2240b0a0e9d68af23ee",
       );
     });
   });

--- a/typescript/packages/multisig/src/index.ts
+++ b/typescript/packages/multisig/src/index.ts
@@ -1,3 +1,4 @@
+import { sha256 } from "@noble/hashes/sha2";
 import type {
   SignatureAndPubKey,
   Transaction,
@@ -5,6 +6,8 @@ import type {
   UnsignedTransaction,
 } from "@sovereign-sdk/types";
 import type { HexString } from "@sovereign-sdk/utils";
+import { bytesToHex, hexToBytes } from "@sovereign-sdk/utils";
+import * as borsh from "borsh";
 
 /**
  * Base error class for multisig-related errors.
@@ -221,6 +224,34 @@ export class MultisigTransaction {
    */
   get threshold(): number {
     return this.minSigners;
+  }
+
+  /**
+   * Calculates the multisig address (credential ID) by hashing the threshold and sorted public keys.
+   * This matches the Rust implementation: hash(threshold || borsh(sorted_pubkeys))
+   * @param hasher - The hash algorithm to use (currently only 'sha256' is supported)
+   * @returns The 32-byte multisig address as a Uint8Array
+   */
+  getMultisigAddress(hasher: "sha256" = "sha256"): Uint8Array {
+    if (hasher !== "sha256") {
+      throw new Error(`Unsupported hasher: ${hasher}`);
+    }
+
+    // Collect all public keys (signatures + unused)
+    const allPubKeys = [
+      ...this.signatures.map((s) => s.pub_key),
+      ...Array.from(this.unusedPubKeys),
+    ];
+    const sortedPubKeys = allPubKeys.sort();
+    const pubKeyBytes = sortedPubKeys.map((pk) => Array.from(hexToBytes(pk)));
+    const buffer = new borsh.BinaryWriter();
+
+    buffer.writeU8(this.minSigners);
+    buffer.writeArray(pubKeyBytes, (pkBytes: number[]) => {
+      buffer.writeFixedArray(new Uint8Array(pkBytes));
+    });
+
+    return sha256(buffer.toArray());
   }
 
   /**

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -163,12 +163,18 @@ importers:
 
   packages/multisig:
     dependencies:
+      '@noble/hashes':
+        specifier: ^1.5.0
+        version: 1.8.0
       '@sovereign-sdk/signers':
         specifier: workspace:^
         version: link:../signers
       '@sovereign-sdk/utils':
         specifier: workspace:^
         version: link:../utils
+      borsh:
+        specifier: 0.7.0
+        version: 0.7.0
     devDependencies:
       '@sovereign-sdk/types':
         specifier: workspace:^


### PR DESCRIPTION
# Description

Adds a method to calculate the credential id that will be used by the multisig configuration to web3 js

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
