### PR TITLE
feat: count deliveries in the mailbox

### DIFF
--- a/crates/module-system/hyperlane/src/api.rs
+++ b/crates/module-system/hyperlane/src/api.rs
@@ -62,6 +62,7 @@ impl<S: Spec, R: Recipient<S>> HasCustomRestApi for Mailbox<S, R> {
     fn custom_rest_api(&self, state: ApiState<S>) -> axum::Router<()> {
         axum::Router::new()
             .route("/nonce", get(Self::get_nonce))
+            .route("/deliveries", get(Self::get_deliveries))
             .route("/recipient-ism/:address", get(Self::get_recipient_ism))
             .route(
                 "/recipient-ism/:address/validators_and_threshold",
@@ -114,6 +115,18 @@ impl<S: Spec, R: Recipient<S>> Mailbox<S, R> {
             .map(|dispatch_state| dispatch_state.nonce)
             .unwrap_or_default();
         Json(json!({"nonce": nonce}))
+    }
+
+    async fn get_deliveries(
+        state: ApiState<S, Self>,
+        mut accessor: ApiStateAccessor<S>,
+    ) -> impl IntoResponse {
+        let deliveries = state
+            .delivery_count
+            .get(&mut accessor)
+            .unwrap_infallible()
+            .unwrap_or_default();
+        Json(json!({"count": deliveries}))
     }
 
     async fn get_recipient_ism(

--- a/crates/module-system/hyperlane/src/api.rs
+++ b/crates/module-system/hyperlane/src/api.rs
@@ -62,7 +62,6 @@ impl<S: Spec, R: Recipient<S>> HasCustomRestApi for Mailbox<S, R> {
     fn custom_rest_api(&self, state: ApiState<S>) -> axum::Router<()> {
         axum::Router::new()
             .route("/nonce", get(Self::get_nonce))
-            .route("/deliveries", get(Self::get_deliveries))
             .route("/recipient-ism/:address", get(Self::get_recipient_ism))
             .route(
                 "/recipient-ism/:address/validators_and_threshold",
@@ -115,18 +114,6 @@ impl<S: Spec, R: Recipient<S>> Mailbox<S, R> {
             .map(|dispatch_state| dispatch_state.nonce)
             .unwrap_or_default();
         Json(json!({"nonce": nonce}))
-    }
-
-    async fn get_deliveries(
-        state: ApiState<S, Self>,
-        mut accessor: ApiStateAccessor<S>,
-    ) -> impl IntoResponse {
-        let deliveries = state
-            .delivery_count
-            .get(&mut accessor)
-            .unwrap_infallible()
-            .unwrap_or_default();
-        Json(json!({"count": deliveries}))
     }
 
     async fn get_recipient_ism(

--- a/crates/module-system/hyperlane/src/call.rs
+++ b/crates/module-system/hyperlane/src/call.rs
@@ -206,9 +206,9 @@ where
             return Err(anyhow::anyhow!("Message {} already processed", message_id));
         }
 
-        let mut count = self.delivery_count.get(state)?.unwrap_or_default();
+        let mut count = self.deliveries_count.get(state)?.unwrap_or_default();
         count += 1;
-        self.delivery_count.set(&count, state)?;
+        self.deliveries_count.set(&count, state)?;
         self.deliveries.set(
             &message_id,
             &Delivery {

--- a/crates/module-system/hyperlane/src/call.rs
+++ b/crates/module-system/hyperlane/src/call.rs
@@ -205,6 +205,10 @@ where
         if delivery.is_some() {
             return Err(anyhow::anyhow!("Message {} already processed", message_id));
         }
+
+        let mut count = self.delivery_count.get(state)?.unwrap_or_default();
+        count += 1;
+        self.delivery_count.set(&count, state)?;
         self.deliveries.set(
             &message_id,
             &Delivery {

--- a/crates/module-system/hyperlane/src/lib.rs
+++ b/crates/module-system/hyperlane/src/lib.rs
@@ -85,10 +85,6 @@ pub struct Mailbox<S: Spec, R: Recipient<S>> {
     #[state]
     pub deliveries: StateMap<MessageId, Delivery>,
 
-    /// The number of successful deliveries.
-    #[state]
-    pub delivery_count: StateValue<u64>,
-
     /// A map of announced validator addresses to their signature locations.
     #[state]
     pub validators: StateMap<EthAddress, Vec<StorageLocation>>,
@@ -107,6 +103,10 @@ pub struct Mailbox<S: Spec, R: Recipient<S>> {
     /// A reference to the recipient module.
     #[module]
     pub recipients: R,
+
+    /// The number of successful deliveries.
+    #[state]
+    pub deliveries_count: StateValue<u64>,
 
     #[phantom]
     phantom: std::marker::PhantomData<S>,

--- a/crates/module-system/hyperlane/src/lib.rs
+++ b/crates/module-system/hyperlane/src/lib.rs
@@ -85,6 +85,10 @@ pub struct Mailbox<S: Spec, R: Recipient<S>> {
     #[state]
     pub deliveries: StateMap<MessageId, Delivery>,
 
+    /// The number of successful deliveries.
+    #[state]
+    pub delivery_count: StateValue<u64>,
+
     /// A map of announced validator addresses to their signature locations.
     #[state]
     pub validators: StateMap<EthAddress, Vec<StorageLocation>>,


### PR DESCRIPTION
# Description

Counts the number of inbound messages received.  This allows an indexer to use binary search to find all delivered messages in O(log(N)).  This makes Delivery indexing as fast as MerkleTree and Dispatch indexing.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
