### PR TITLE
`EVM`: Populate the `gas_limit` for pending block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-01-16 
+- #2342 EVM: Populate the `gas_limit` for pending block.
+
 # 2026-01-14
 - #2326 Add `max_fee` validation to the EVM authenticator. Introduce `EVM_MAX_FEE_CHECK_HEIGHT` in `constants.toml` to specify the block height after which the max-fee check becomes active.
 This validation can be disabled by sending an `UpdateRuntimeConfig::empty` EVM admin message.

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -319,6 +319,7 @@ where
                 .blob_excess_gas_and_price
                 .map(|blob_gas| blob_gas.excess_blob_gas),
             base_fee_per_gas: Some(current_block_env.basefee),
+            gas_limit: current_block_env.gas_limit,
             // Default values
             ommers_hash: EMPTY_OMMER_ROOT_HASH,
             beneficiary: Address::ZERO,
@@ -327,7 +328,6 @@ where
             receipts_root: EMPTY_ROOT_HASH,
             logs_bloom: Bloom::default(),
             difficulty: U256::ZERO,
-            gas_limit: 0,
             gas_used: 0,
             extra_data: Bytes::default(),
             mix_hash: B256::ZERO,

--- a/examples/demo-rollup/tests/evm/evm_block_hash.rs
+++ b/examples/demo-rollup/tests/evm/evm_block_hash.rs
@@ -17,7 +17,6 @@ async fn block_hash() -> anyhow::Result<()> {
         .await?
         .unwrap()
         .number();
-
     let pending_block_hash = block_hash
         .block_hash(U256::from(pending_number))
         .block(BlockId::pending())

--- a/examples/demo-rollup/tests/evm/evm_block_hash.rs
+++ b/examples/demo-rollup/tests/evm/evm_block_hash.rs
@@ -17,6 +17,7 @@ async fn block_hash() -> anyhow::Result<()> {
         .await?
         .unwrap()
         .number();
+
     let pending_block_hash = block_hash
         .block_hash(U256::from(pending_number))
         .block(BlockId::pending())

--- a/examples/demo-rollup/tests/evm/evm_block_number.rs
+++ b/examples/demo-rollup/tests/evm/evm_block_number.rs
@@ -1,0 +1,25 @@
+use crate::evm::evm_test_helper::{alloy_client, setup_test_rollup, EVM_EXTENSION};
+use alloy_provider::Provider;
+use alloy_rpc_types_eth::BlockNumberOrTag;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pending_block_number() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    let client = alloy_client(rollup.http_addr);
+    rollup.wait_for_next_blocks(1).await;
+    rollup.pause_preferred_batches().await;
+
+    let pending_block = client
+        .get_block_by_number(BlockNumberOrTag::Pending)
+        .await?
+        .unwrap();
+
+    let pending_header = pending_block.header;
+    assert!(pending_header.gas_limit > 0);
+    assert!(pending_header.number > 0);
+    assert!(pending_header.timestamp > 0);
+    assert!(pending_header.base_fee_per_gas.unwrap() > 0);
+    assert_eq!(pending_header.gas_used, 0);
+
+    Ok(())
+}

--- a/examples/demo-rollup/tests/evm/mod.rs
+++ b/examples/demo-rollup/tests/evm/mod.rs
@@ -1,6 +1,7 @@
 mod evm_account_abstraction;
 mod evm_balances;
 mod evm_block_hash;
+mod evm_block_number;
 mod evm_contract_creation_allowlist;
 mod evm_fee_history;
 mod evm_gas_estimation;


### PR DESCRIPTION
# Description

This PR sets the `gas_limit` field in the pending evm block.  

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 
