### PR TITLE
Leader failover: Add `test_db_elected_leader_failover`

### DIFF
--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -143,7 +143,7 @@ pub enum NodeRole {
     ReplicaNoLeaderSync,
     /// The node initially starts as a `Replica` and attempts to register itself as the `Leader`
     /// by sending a request to the Db to acquire leadership.
-    /// If successful, it becomes the `Leader`` and all other nodes remain Replicas.
+    /// If successful, it becomes the `Leader` and all other nodes remain Replicas.
     /// If the Leader goes down and fails to refresh its entry in the `Leader` table,
     /// one of the `Replicas` will take over and assume the Leader role.
     DbElected,

--- a/crates/full-node/sov-sequencer/src/preferred/db/leadership_election.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/leadership_election.rs
@@ -91,7 +91,7 @@ impl LeadershipElectionTask {
                             "Leadership lost! Another node has taken over. Initiating graceful shutdown."
                         );
                         exit_rollup(&self.shutdown_sender).await;
-                        return;
+                        unreachable!();
                     }
                     Err(e) => {
                         error!(
@@ -128,9 +128,9 @@ impl LeadershipElectionTask {
                     Ok(true) => {
                         info!(
                             node_id = %self.node_id,
-                            "Replica acquired leadership! Restarting the node."
+                            "Replica acquired leadership! Exiting to restart as leader."
                         );
-                        exit_rollup(&self.shutdown_sender).await;
+                        self.shutdown_sender.send(());
                     }
                     Ok(false) => {
                         // Another node is still leader, keep trying

--- a/crates/full-node/sov-sequencer/src/preferred/db/leadership_election.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/leadership_election.rs
@@ -130,7 +130,7 @@ impl LeadershipElectionTask {
                             node_id = %self.node_id,
                             "Replica acquired leadership! Exiting to restart as leader."
                         );
-                        self.shutdown_sender.send(());
+                        let _ = self.shutdown_sender.send(());
                     }
                     Ok(false) => {
                         // Another node is still leader, keep trying

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -730,8 +730,7 @@ where
     async fn is_ready(&self) -> Result<(), SequencerNotReadyDetails> {
         // We don't actually care about the `inner`, we just want to reuse the
         // same logic.
-        let res = self
-            .synchronized_state_updator
+        self.synchronized_state_updator
             .check_readiness_msg(
                 self.config.max_concurrent_blobs,
                 self.stop_at_rollup_height,
@@ -739,9 +738,7 @@ where
             )
             .await
             .map_err(|_| SequencerNotReadyDetails::Shutdown)?
-            .map(|_| ());
-
-        res
+            .map(|_| ())
     }
 
     fn api_state(&self) -> ApiState<Self::Spec> {

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -357,7 +357,7 @@
           ]
         },
         {
-          "description": "The node initially starts as a `Replica` and attempts to register itself as the `Leader` by sending a request to the Db to acquire leadership. If successful, it becomes the `Leader`` and all other nodes remain Replicas. If the Leader goes down and fails to refresh its entry in the `Leader` table, one of the `Replicas` will take over and assume the Leader role.",
+          "description": "The node initially starts as a `Replica` and attempts to register itself as the `Leader` by sending a request to the Db to acquire leadership. If successful, it becomes the `Leader` and all other nodes remain Replicas. If the Leader goes down and fails to refresh its entry in the `Leader` table, one of the `Replicas` will take over and assume the Leader role.",
           "type": "string",
           "enum": [
             "DbElected"

--- a/examples/demo-rollup/tests/replica/db_elected.rs
+++ b/examples/demo-rollup/tests/replica/db_elected.rs
@@ -110,7 +110,7 @@ async fn test_db_elected_leader_failover() {
     };
 
     let DbElectedTestSetup {
-        postgres,
+        postgres: _postgres,
         leader,
         replica,
         da_shutdown,
@@ -143,10 +143,9 @@ async fn test_db_elected_leader_failover() {
     assert_eq!(
         new_role,
         SequencerRole::Leader,
-        "Expected restarted node to be Leader, got {new_rolegit:?}",
+        "Expected restarted node to be Leader, got {new_role:?}",
     );
 
     let _ = restarted_rollup.shutdown().await;
     let _ = da_shutdown.send(());
-    drop(postgres);
 }

--- a/examples/demo-rollup/tests/replica/db_elected.rs
+++ b/examples/demo-rollup/tests/replica/db_elected.rs
@@ -3,49 +3,83 @@ use super::*;
 use sov_sequencer::SequencerRole;
 use tokio::time::Duration;
 
+type Rollup = ExternalMockDemoRollup<Native>;
+
+/// Test setup for DbElected tests with two nodes (leader and replica).
+struct DbElectedTestSetup {
+    postgres: Arc<PostgresData>,
+    leader: TestRollup<Rollup>,
+    replica: TestRollup<Rollup>,
+    da_shutdown: watch::Sender<()>,
+}
+
+impl DbElectedTestSetup {
+    /// Creates a new test setup with two DbElected nodes.
+    /// Returns None if Docker is not supported.
+    async fn new() -> Option<Self> {
+        let postgres = match PostgresData::create_postgres().await {
+            Ok(pg) => pg,
+            Err(CreatePostgresError::DockerNotSupported) => return None,
+            Err(CreatePostgresError::DockerError(e)) => {
+                panic!("Failed to create Postgres container: {e}");
+            }
+        };
+
+        let (_, da_shutdown, addr) = create_da_service_periodic().await;
+
+        // Start both DbElected nodes
+        let node1 = Some((postgres.clone(), "node1".into(), NodeRole::DbElected));
+        let rollup1 = start_rollup(addr, node1).await;
+
+        let node2 = Some((postgres.clone(), "node2".into(), NodeRole::DbElected));
+        let rollup2 = start_rollup(addr, node2).await;
+
+        // Wait for both nodes to be ready
+        rollup1.wait_for_sequencer_ready().await.unwrap();
+        rollup2.wait_for_sequencer_ready().await.unwrap();
+
+        // Discover roles via the /sequencer/role endpoint
+        let role1 = rollup1.sequencer_role().await.unwrap();
+        let role2 = rollup2.sequencer_role().await.unwrap();
+
+        // Determine which node is the leader and which is the replica
+        let (leader, replica) = match (role1, role2) {
+            (SequencerRole::Leader, SequencerRole::Replica) => (rollup1, rollup2),
+            (SequencerRole::Replica, SequencerRole::Leader) => (rollup2, rollup1),
+            _ => panic!(
+                "Expected one Leader and one Replica, got {:?} and {:?}",
+                role1, role2
+            ),
+        };
+
+        Some(Self {
+            postgres,
+            leader,
+            replica,
+            da_shutdown,
+        })
+    }
+
+    async fn shutdown(self) {
+        let _ = self.leader.shutdown().await;
+        let _ = self.replica.shutdown().await;
+        let _ = self.da_shutdown.send(());
+    }
+}
+
 /// Test that when two DbElected nodes start, one becomes leader and the other becomes replica.
 /// The leader can process transactions while the replica receives them via PostgreSQL sync.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_db_elected_two_nodes_leader_and_replica() {
-    let postgres = PostgresData::create_postgres().await;
-
-    let postgres = match postgres {
-        Ok(pg) => Some(pg),
-        Err(CreatePostgresError::DockerNotSupported) => return,
-        Err(CreatePostgresError::DockerError(e)) => {
-            panic!("Failed to create Postgres container: {e}");
-        }
+    let Some(setup) = DbElectedTestSetup::new().await else {
+        return;
     };
 
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
-    let (_, da_shutdown, addr) = create_da_service_periodic().await;
-
-    // Start both DbElected nodes
-    let node1 = postgres
-        .clone()
-        .map(|pg| (pg, "node1".into(), NodeRole::DbElected));
-    let rollup1 = start_rollup(addr, node1).await;
-
-    let node2 = postgres.map(|pg| (pg, "node2".into(), NodeRole::DbElected));
-    let rollup2 = start_rollup(addr, node2).await;
-
-    // Wait for both nodes to be ready
-    rollup1.wait_for_sequencer_ready().await.unwrap();
-    rollup2.wait_for_sequencer_ready().await.unwrap();
-
-    // Discover roles via the /sequencer/role endpoint
-    let role1 = rollup1.sequencer_role().await.unwrap();
-    let role2 = rollup2.sequencer_role().await.unwrap();
-
-    // Determine which node is the leader and which is the replica
-    let (leader_rollup, replica_rollup) = match (role1, role2) {
-        (SequencerRole::Leader, SequencerRole::Replica) => (&rollup1, &rollup2),
-        (SequencerRole::Replica, SequencerRole::Leader) => (&rollup2, &rollup1),
-        _ => panic!("Expected one Leader and one Replica, got {role1:?} and {role2:?}",),
-    };
 
     // Subscribe to events on the replica
-    let mut event_subscription = replica_rollup
+    let mut event_subscription = setup
+        .replica
         .api_client()
         .subscribe_to_events_with_filter("Bank/*")
         .await
@@ -63,12 +97,60 @@ async fn test_db_elected_two_nodes_leader_and_replica() {
         0,
     );
 
-    leader_rollup.send_tx_to_sequencer(&tx).await.unwrap();
+    setup.leader.send_tx_to_sequencer(&tx).await.unwrap();
 
     // Wait for the event on the replica (proves it received the tx via PostgreSQL sync)
     wait_for_all_events_with_timeout(Duration::from_millis(500), 1, &mut event_subscription).await;
 
-    let _ = rollup1.shutdown().await;
-    let _ = rollup2.shutdown().await;
+    setup.shutdown().await;
+}
+
+/// Test that when the leader dies, the replica acquires leadership and becomes the new leader.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_db_elected_leader_failover() {
+    let Some(setup) = DbElectedTestSetup::new().await else {
+        return;
+    };
+
+    let DbElectedTestSetup {
+        postgres,
+        leader,
+        replica,
+        da_shutdown,
+    } = setup;
+
+    // Kill the leader
+    let _ = leader.shutdown().await;
+
+    // Wait for replica to shutdown (it will acquire leadership and call exit_rollup)
+    let timeout_duration = Duration::from_secs(15);
+    let start = std::time::Instant::now();
+
+    while !replica.is_rollup_crashed() {
+        if start.elapsed() > timeout_duration {
+            panic!("Timeout waiting for replica to acquire leadership and shutdown");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Get the builder from the replica (task already finished due to exit_rollup)
+    let replica_builder = replica.shutdown().await.unwrap();
+
+    // Restart the former replica
+    let restarted_rollup = replica_builder.start_test_rollup().await.unwrap();
+    restarted_rollup.wait_for_sequencer_ready().await.unwrap();
+
+    // Verify the restarted node is now the leader
+    let new_role = restarted_rollup.sequencer_role().await.unwrap();
+
+    assert_eq!(
+        new_role,
+        SequencerRole::Leader,
+        "Expected restarted node to be Leader, got {:?}",
+        new_role
+    );
+
+    let _ = restarted_rollup.shutdown().await;
     let _ = da_shutdown.send(());
+    drop(postgres);
 }

--- a/examples/demo-rollup/tests/replica/db_elected.rs
+++ b/examples/demo-rollup/tests/replica/db_elected.rs
@@ -46,10 +46,7 @@ impl DbElectedTestSetup {
         let (leader, replica) = match (role1, role2) {
             (SequencerRole::Leader, SequencerRole::Replica) => (rollup1, rollup2),
             (SequencerRole::Replica, SequencerRole::Leader) => (rollup2, rollup1),
-            _ => panic!(
-                "Expected one Leader and one Replica, got {:?} and {:?}",
-                role1, role2
-            ),
+            _ => panic!("Expected one Leader and one Replica, got {role1:?} and {role2:?}"),
         };
 
         Some(Self {
@@ -146,8 +143,7 @@ async fn test_db_elected_leader_failover() {
     assert_eq!(
         new_role,
         SequencerRole::Leader,
-        "Expected restarted node to be Leader, got {:?}",
-        new_role
+        "Expected restarted node to be Leader, got {new_rolegit:?}",
     );
 
     let _ = restarted_rollup.shutdown().await;


### PR DESCRIPTION
# Description

This PR adds another failover test and fixses todos from #2332.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
