### PR TITLE
Celestia configurational improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2026-01-16 
 - #2342 EVM: Populate the `gas_limit` for pending block.
 - #2338 **Infra only breaking change**: Removes `da_total_timeout_secs` from runner section in `rollup_config.toml`
+- #2349 Adds optional celestia params: `api_request_timeout_secs`, `tx_status_polling_millis` and `background_stat_polling_interval_secs`
 
 # 2026-01-14
 - #2326 Add `max_fee` validation to the EVM authenticator. Introduce `EVM_MAX_FEE_CHECK_HEIGHT` in `constants.toml` to specify the block height after which the max-fee check becomes active.

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -37,12 +37,27 @@ pub struct CelestiaConfig {
     /// `cel-key export key-name --unarmored-hex --unsafe --node.type light --p2p.network=mocha`
     #[serde(default = "default_signer_private_key")]
     pub signer_private_key: Option<String>,
-    /// The timeout for a Celestia RPC request, in seconds.
+    /// High-level timeout for Celestia RPC operations that may include multiple requests (in seconds).
+    /// Default: 38 (6 blocks × 6 seconds + 2 seconds polling buffer).
     #[serde(
         default = "default_request_timeout_seconds",
         alias = "celestia_rpc_timeout_seconds"
     )]
     pub request_timeout_secs: NonZero<u64>,
+    /// Timeout for individual API requests to the Celestia node (in seconds).
+    /// This is passed to the underlying celestia-client for each API call.
+    /// Default: 6 (one block time).
+    #[serde(default = "default_api_request_timeout_secs")]
+    pub api_request_timeout_secs: NonZero<u64>,
+    /// Interval for polling transaction status confirmation (in milliseconds).
+    /// Default: 2000.
+    #[serde(default = "default_tx_status_polling_millis")]
+    pub tx_status_polling_millis: u64,
+    /// Interval for background statistics collection (in seconds).
+    /// Set to 0 to disable the background stat collection task.
+    /// Default: 30.
+    #[serde(default = "default_background_stat_polling_interval_secs")]
+    pub background_stat_polling_interval_secs: u64,
     /// See [`sov_rollup_interface::node::da::DaService::safe_lead_time`].
     #[serde(default = "default_safe_lead_time_ms")]
     pub safe_lead_time_ms: u64,
@@ -86,6 +101,12 @@ impl fmt::Debug for CelestiaConfig {
                 &self.signer_private_key.as_ref().map(|_| "REDACTED"),
             )
             .field("request_timeout_secs", &self.request_timeout_secs)
+            .field("api_request_timeout_secs", &self.api_request_timeout_secs)
+            .field("tx_status_polling_millis", &self.tx_status_polling_millis)
+            .field(
+                "background_stat_polling_interval_secs",
+                &self.background_stat_polling_interval_secs,
+            )
             .field("safe_lead_time_ms", &self.safe_lead_time_ms)
             .field("tx_priority", &self.tx_priority)
             .field("backoff_min_delay_ms", &self.backoff_min_delay_ms)
@@ -124,6 +145,9 @@ impl CelestiaConfig {
             grpc_auth_token: None,
             signer_private_key: None,
             request_timeout_secs: default_request_timeout_seconds(),
+            api_request_timeout_secs: default_api_request_timeout_secs(),
+            tx_status_polling_millis: default_tx_status_polling_millis(),
+            background_stat_polling_interval_secs: default_background_stat_polling_interval_secs(),
             safe_lead_time_ms: default_safe_lead_time_ms(),
             tx_priority: default_tx_priority(),
             backoff_min_delay_ms: default_min_delay_ms(),
@@ -152,10 +176,11 @@ impl CelestiaConfig {
     }
 
     pub(crate) async fn build_client(&self) -> anyhow::Result<celestia_client::Client> {
-        let request_timeout = std::time::Duration::from_secs(self.request_timeout_secs.get());
+        let api_request_timeout =
+            std::time::Duration::from_secs(self.api_request_timeout_secs.get());
         let mut builder = celestia_client::Client::builder()
             .rpc_url(&self.rpc_url)
-            .timeout(request_timeout);
+            .timeout(api_request_timeout);
         if let Some(rpc_auth_token) = &self.rpc_auth_token {
             builder = builder.rpc_auth_token(rpc_auth_token);
         }
@@ -232,6 +257,18 @@ pub(crate) fn default_factor() -> f32 {
 }
 
 pub(crate) fn default_request_timeout_seconds() -> NonZero<u64> {
-    // 6 blocks + 1 second for jitter
-    NonZero::new(37).unwrap()
+    // 6 blocks × 6 seconds + 2 seconds polling buffer
+    NonZero::new(38).unwrap()
+}
+
+pub(crate) fn default_api_request_timeout_secs() -> NonZero<u64> {
+    NonZero::new(6).unwrap()
+}
+
+pub(crate) fn default_tx_status_polling_millis() -> u64 {
+    2_000
+}
+
+pub(crate) fn default_background_stat_polling_interval_secs() -> u64 {
+    30
 }

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -262,7 +262,7 @@ pub(crate) fn default_request_timeout_seconds() -> NonZero<u64> {
 }
 
 pub(crate) fn default_api_request_timeout_secs() -> NonZero<u64> {
-    NonZero::new(6).unwrap()
+    NonZero::new(8).unwrap()
 }
 
 pub(crate) fn default_tx_status_polling_millis() -> u64 {

--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -51,6 +51,7 @@ pub struct CelestiaService {
     backoff_policy: ExponentialBuilder,
     request_timeout: Duration,
     tx_priority: celestia_client::tx::TxPriority,
+    tx_status_polling_millis: u64,
 }
 
 impl CelestiaService {
@@ -63,6 +64,7 @@ impl CelestiaService {
         backoff_policy: ExponentialBuilder,
         request_timeout: Duration,
         tx_priority: celestia_client::tx::TxPriority,
+        tx_status_polling_millis: u64,
     ) -> Self {
         Self {
             client: Arc::new(client),
@@ -73,6 +75,7 @@ impl CelestiaService {
             backoff_policy,
             request_timeout,
             tx_priority,
+            tx_status_polling_millis,
         }
     }
 
@@ -88,7 +91,9 @@ impl CelestiaService {
 
     fn get_tx_config(&self) -> celestia_client::tx::TxConfig {
         let mut tx_config = celestia_client::tx::TxConfig::default();
-        tx_config = tx_config.with_priority(self.tx_priority);
+        tx_config = tx_config
+            .with_priority(self.tx_priority)
+            .with_confirmation_interval_ms(self.tx_status_polling_millis);
         tx_config
     }
 
@@ -201,17 +206,26 @@ impl CelestiaService {
         }
 
         let tx_priority = config.tx_priority.clone().into();
-        if let Ok(signer) = client.address() {
-            let bg_client = config
-                .build_client()
-                .await
-                .expect("Failed to build celestia-client for background task");
-            tokio::spawn(stat_collection_task(
-                bg_client,
-                signer,
-                tx_priority,
-                shutdown_receiver,
-            ));
+        if config.background_stat_polling_interval_secs > 0 {
+            if let Ok(signer) = client.address() {
+                let bg_client = config
+                    .build_client()
+                    .await
+                    .expect("Failed to build celestia-client for background task");
+                let stat_polling_period =
+                    Duration::from_secs(config.background_stat_polling_interval_secs);
+                // Background stat collection timeout is 2x the individual API request timeout
+                let stat_request_timeout =
+                    Duration::from_secs(config.api_request_timeout_secs.get() * 2);
+                tokio::spawn(stat_collection_task(
+                    bg_client,
+                    signer,
+                    tx_priority,
+                    shutdown_receiver,
+                    stat_polling_period,
+                    stat_request_timeout,
+                ));
+            }
         }
 
         Self::with_client(
@@ -223,6 +237,7 @@ impl CelestiaService {
             backoff_policy,
             request_timeout,
             tx_priority,
+            config.tx_status_polling_millis,
         )
     }
 }
@@ -602,9 +617,10 @@ async fn stat_collection_task(
     signer: celestia_types::state::AccAddress,
     priority: celestia_client::tx::TxPriority,
     mut shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    period: Duration,
+    request_timeout: Duration,
 ) {
     let chain_id = client.chain_id();
-    let period = Duration::from_secs(30);
     tracing::info!(%chain_id, ?period, "Starting celestia stat collection task");
 
     let mut interval = tokio::time::interval(period);
@@ -616,7 +632,7 @@ async fn stat_collection_task(
                 return;
             }
             _ = interval.tick() => {
-                match gather_stat(&client, &signer, priority).await {
+                match gather_stat(&client, &signer, priority, request_timeout).await {
                     Ok(measurement) => {
                         sov_metrics::track_metrics(|tracker| {
                             tracker.submit(measurement);
@@ -638,10 +654,8 @@ async fn gather_stat(
     client: &celestia_client::Client,
     signer: &celestia_types::state::AccAddress,
     priority: celestia_client::tx::TxPriority,
+    request_timeout: Duration,
 ) -> anyhow::Result<CelestiaAdapterStateMeasurement> {
-    // TODO: timeout as param!!!
-    let request_timeout = std::time::Duration::from_secs(12);
-
     // Balance
     let balance_start = std::time::Instant::now();
     let balance_response =

--- a/crates/adapters/celestia/src/test_helper/docker.rs
+++ b/crates/adapters/celestia/src/test_helper/docker.rs
@@ -3,8 +3,10 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use crate::config::{
+    default_api_request_timeout_secs, default_background_stat_polling_interval_secs,
     default_factor, default_max_delay_ms, default_max_times, default_min_delay_ms,
     default_request_timeout_seconds, default_safe_lead_time_ms, default_tx_priority,
+    default_tx_status_polling_millis,
 };
 use crate::verifier::address::CelestiaAddress;
 use crate::{CelestiaConfig, CelestiaService};
@@ -280,6 +282,9 @@ impl CelestiaDevNode {
             grpc_auth_token: None,
             signer_private_key: Some(key_0),
             request_timeout_secs: default_request_timeout_seconds(),
+            api_request_timeout_secs: default_api_request_timeout_secs(),
+            tx_status_polling_millis: default_tx_status_polling_millis(),
+            background_stat_polling_interval_secs: default_background_stat_polling_interval_secs(),
             safe_lead_time_ms: default_safe_lead_time_ms(),
             tx_priority: default_tx_priority(),
             backoff_min_delay_ms: default_min_delay_ms(),

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -36,8 +36,8 @@ signer_private_key = "aec34bb1cfae6e906594dc106af4057a9046f769e2eeed67d040f0107e
 
 # Timeout for individual API requests to the Celestia node (in seconds).
 # This is passed to the underlying celestia-client for each API call.
-# Default: 6 (one block time)
-#api_request_timeout_secs = 6
+# Default: 8 (one block time plus 2 seconds of wiggle room)
+#api_request_timeout_secs = 8
 
 # Interval for polling transaction status confirmation (in milliseconds).
 # Default: 2000

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -30,9 +30,23 @@ grpc_url = "http://127.0.0.1:9090"
 # This one is from ../../docker/credentials/bridge-0.key
 signer_private_key = "aec34bb1cfae6e906594dc106af4057a9046f769e2eeed67d040f0107e15e167"
 
-# The maximum time to wait for a response to an RPC query against Celestia node.
-# Default: 37 seconds
-#request_timeout_secs = 37
+# High-level timeout for Celestia RPC operations that may include multiple requests (in seconds).
+# Default: 38 (6 blocks × 6 seconds + 2 seconds polling buffer)
+#request_timeout_secs = 38
+
+# Timeout for individual API requests to the Celestia node (in seconds).
+# This is passed to the underlying celestia-client for each API call.
+# Default: 6 (one block time)
+#api_request_timeout_secs = 6
+
+# Interval for polling transaction status confirmation (in milliseconds).
+# Default: 2000
+#tx_status_polling_millis = 2000
+
+# Interval for background statistics collection (in seconds).
+# Set to 0 to disable the background stat collection task.
+# Default: 30
+#background_stat_polling_interval_secs = 30
 
 # Options are "Low", "Medium" and "High"
 # Defines a priority of rollup blob transactions. Set it to "High" for faster inclusion.


### PR DESCRIPTION
# Description

Splits high level request timeout from individual API calls made to RPC gRPC. This allows to have more fine grained controls on errors. For instance, blobs will be resubmitted sooner.

Also adjusts tx-status polling to 2s (default in celestia-client is 500ms), allowing us to cut QuickNode cost almost 4x and reduce load on their nodes. 

Adds another optional config for changing how often background stat is collected, or completely disable it.

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2309

## Testing
All existing tests are passed, but several days soak is required and results will be posted in the comment

## Docs
Updated config docstring and reference toml
