### PR TITLE
Move Axum tcp listener binding earlier in rollup startup.

### DIFF
--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -114,6 +114,14 @@ impl HttpServerConfig {
             cors: CorsConfiguration::Permissive,
         }
     }
+
+    /// Creates socket address from this config.
+    pub fn socket_address(&self) -> anyhow::Result<std::net::SocketAddr> {
+        Ok(std::net::SocketAddr::new(
+            self.bind_host.parse()?,
+            self.bind_port,
+        ))
+    }
 }
 
 /// Prover service configuration.

--- a/crates/full-node/sov-stf-runner/src/http/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/http/mod.rs
@@ -75,14 +75,13 @@ where
 }
 
 pub(crate) async fn start_http_server(
-    listen_address_http: &SocketAddr,
+    axum_listener: TcpListener,
     router: axum::Router<()>,
     methods: RpcModule<()>,
     mut shutdown_receiver: watch::Receiver<()>,
     cors_configuration: CorsConfiguration,
-) -> anyhow::Result<(JoinHandle<anyhow::Result<()>>, SocketAddr)> {
-    let listener = TcpListener::bind(listen_address_http).await?;
-    let rest_address = listener.local_addr()?;
+) -> anyhow::Result<JoinHandle<anyhow::Result<()>>> {
+    let rest_address = axum_listener.local_addr()?;
     let (rpc_router, server_handle) = rpc_module_to_router(methods, cors_configuration);
 
     let handle = tokio::spawn(async move {
@@ -96,7 +95,7 @@ pub(crate) async fn start_http_server(
 
         // TODO: Is there a way to have max_connections and other params for axum::serve?
         let result = axum::serve(
-            listener,
+            axum_listener,
             ServiceExt::<axum::extract::Request>::into_make_service_with_connect_info::<SocketAddr>(
                 router,
             ),
@@ -117,7 +116,7 @@ pub(crate) async fn start_http_server(
 
         result
     });
-    Ok((handle, rest_address))
+    Ok(handle)
 }
 
 /// Build [`axum::Router`] from [`jsonrpsee::RpcModule`] with support of websocket.
@@ -288,8 +287,10 @@ mod tests {
         let axum_router = build_test_axum_router();
         let (shutdown_sender, mut shutdown_receiver) = watch::channel(());
         shutdown_receiver.mark_unchanged();
-        let (_join_handle, addr) = start_http_server(
-            &SocketAddr::from(([127, 0, 0, 1], 0)),
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _join_handle = start_http_server(
+            listener,
             axum_router,
             methods,
             shutdown_receiver,

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -31,6 +31,7 @@ use tracing::{debug, info, trace};
 use crate::da::{DaServiceWithCachedFinalizedHeaders, FinalizedBlocksBulkFetcher};
 use crate::processes::{new_stf_info_channel, Receiver};
 use crate::state_manager::StateManager;
+use tokio::net::TcpListener;
 
 type GenesisParams<ST, InnerVm, OuterVm, Da> =
     <ST as StateTransitionFunction<InnerVm, OuterVm, Da>>::GenesisParams;
@@ -53,7 +54,6 @@ where
     da_service: Arc<Da>,
     stf: Stf,
     state_manager: StateManager<Stf::StateRoot, Stf::Witness, Sm, Da>,
-    listen_address_http: SocketAddr,
     stf_info_receiver: Option<Receiver<Stf::StateRoot, Stf::Witness, Da::Spec>>,
     sync_state: Arc<DaSyncState>,
     sync_fetcher: FinalizedBlocksBulkFetcher<Da>,
@@ -64,6 +64,7 @@ where
     stop_at_rollup_height: Option<RollupHeight>,
     save_tx_bodies: bool,
     finalized_headers_provider: DaServiceWithCachedFinalizedHeaders<Da>,
+    axum_tcp: Option<TcpListener>,
 }
 
 struct DiscardEvents;
@@ -146,6 +147,7 @@ where
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     pub async fn new(
         runner_config: RunnerConfig,
+        axum_tcp: TcpListener,
         pm_config: Option<ProofManagerConfig<Stf::Address>>,
         da_service: Arc<Da>,
         ledger_db: LedgerDb,
@@ -169,11 +171,6 @@ where
         // But when REST and RPC handlers start, sender is used to get another subscription.
         let (secondary_shutdown_sender, mut secondary_shutdown_receiver) = watch::channel(());
         secondary_shutdown_receiver.mark_unchanged();
-
-        let axum_config = &runner_config.http_config;
-
-        let listen_address_http =
-            SocketAddr::new(axum_config.bind_host.parse()?, axum_config.bind_port);
 
         let first_unprocessed_height_at_startup = sync_state
             .synced_da_height
@@ -240,7 +237,6 @@ where
             da_service: da_service.clone(),
             stf,
             state_manager,
-            listen_address_http,
             sync_state,
             stf_info_receiver,
             sync_fetcher,
@@ -251,7 +247,21 @@ where
             stop_at_rollup_height,
             save_tx_bodies: runner_config.save_tx_bodies,
             finalized_headers_provider: da_service_with_cached_finalized_headers,
+            axum_tcp: Some(axum_tcp),
         })
+    }
+
+    /// Returns the socket address of the Axum server.
+    ///
+    /// This method must be called before [`StateTransitionRunner::run_in_process`], as the TCP listener
+    /// is consumed when the HTTP server starts. Calling this method after `run_in_process` will return
+    /// an error.
+    pub fn axum_socket_address(&self) -> anyhow::Result<SocketAddr> {
+        let axum_tcp = self
+            .axum_tcp
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("The axum tcp listener is not initialized."))?;
+        Ok(axum_tcp.local_addr()?)
     }
 
     /// Subscribes to this runner's [`StateUpdateInfo`] channel, if enabled.
@@ -275,9 +285,11 @@ where
         router: axum::Router<()>,
         methods: RpcModule<()>,
         cors_configuration: CorsConfiguration,
-    ) -> anyhow::Result<SocketAddr> {
-        let (http_task_handle, rest_address) = crate::http::start_http_server(
-            &self.listen_address_http,
+    ) -> anyhow::Result<()> {
+        let http_task_handle = crate::http::start_http_server(
+            self.axum_tcp
+                .take()
+                .ok_or_else(|| anyhow::anyhow!("HTTP server already started."))?,
             router,
             methods,
             self.secondary_shutdown_sender.subscribe(),
@@ -287,7 +299,7 @@ where
 
         self.background_handles.push(http_task_handle);
 
-        Ok(rest_address)
+        Ok(())
     }
 
     /// Spawn a [`tokio::task`] that updates the sync status every `polling_interval`.

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -42,6 +42,7 @@ use sov_test_utils::{
     TestSpec, TEST_BLOB_PROCESSING_TIMEOUT, TEST_MAX_BATCH_SIZE, TEST_MAX_CONCURRENT_BLOBS,
     TEST_MOCK_DA_POLLING_INTERVAL,
 };
+use tokio::net::TcpListener;
 use tokio::sync::broadcast::Receiver;
 use tokio::sync::watch;
 use tokio::task::JoinSet;
@@ -239,8 +240,18 @@ pub async fn initialize_runner(
         )
     });
 
+    let axum_socket_addr = rollup_config
+        .runner
+        .http_config
+        .socket_address()
+        .unwrap_or_else(|e| {
+            panic!("Unable to create socket from config: {e:?}");
+        });
+
+    let axum_tcp = TcpListener::bind(axum_socket_addr).await.unwrap();
     let mut runner = StateTransitionRunner::new(
         rollup_config.runner.clone(),
+        axum_tcp,
         if nb_of_prover_threads.is_some() {
             Some(rollup_config.proof_manager)
         } else {

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -28,6 +28,7 @@ use sov_stf_runner::{make_da_sync_state, DaServiceWithCachedFinalizedHeaders};
 use sov_test_utils::storage::SimpleStorageManager;
 use sov_test_utils::TEST_MOCK_DA_POLLING_INTERVAL;
 use tempfile::TempDir;
+use tokio::net::TcpListener;
 use tokio::sync::watch;
 
 type MockInitVariant = InitVariant<HashStf, MockZkvm, MockZkvm, MockDaService>;
@@ -97,8 +98,12 @@ async fn test_runner_with_background_da_service(
     let _ =
         sov_metrics::init_metrics_tracker(&MonitoringConfig::standard(), shutdown_receiver.clone());
 
+    let axum_socket_addr = rollup_config.runner.http_config.socket_address()?;
+    let axum_tcp = TcpListener::bind(axum_socket_addr).await.unwrap();
+
     let mut runner: HashStfRunner<StorableMockDaService> = StateTransitionRunner::new(
         rollup_config.runner.clone(),
+        axum_tcp,
         None,
         da_service.clone(),
         ledger_db.clone(),

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -3,9 +3,6 @@ pub mod logging;
 pub mod proof_sender;
 mod telemetry;
 mod wallet;
-use std::net::SocketAddr;
-use std::sync::Arc;
-
 use anyhow::Context;
 use async_trait::async_trait;
 pub use endpoints::*;
@@ -41,8 +38,10 @@ use sov_stf_runner::{
     StateTransitionRunner,
 };
 use sov_stf_runner::{make_da_sync_state, DaServiceWithCachedFinalizedHeaders};
+use std::sync::Arc;
+use tokio::net::TcpListener;
 use tokio::signal::unix::SignalKind;
-use tokio::sync::{oneshot, watch};
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::info;
 pub use wallet::*;
@@ -469,8 +468,12 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             MaximumProvableHeight::new(state_update_sender.subscribe(), Self::Runtime::default()),
         );
 
+        let axum_socket_addr = rollup_config.runner.http_config.socket_address()?;
+        let axum_tcp = TcpListener::bind(axum_socket_addr).await?;
+
         let mut runner = StateTransitionRunner::new(
             rollup_config.runner.clone(),
+            axum_tcp,
             if prover_config.is_some() {
                 Some(rollup_config.proof_manager)
             } else {
@@ -652,17 +655,9 @@ pub struct Rollup<S: FullNodeBlueprint<M>, M: ExecutionMode> {
 impl<S: FullNodeBlueprint<M>, M: ExecutionMode> Rollup<S, M> {
     /// Runs the rollup.
     pub async fn run(self) -> anyhow::Result<()> {
-        self.run_and_report_addr(None).await
-    }
-
-    /// Runs the rollup. Reports REST and RPC ports to the caller using the provided channel.
-    pub async fn run_and_report_addr(
-        self,
-        axum_addr_channel: Option<oneshot::Sender<SocketAddr>>,
-    ) -> anyhow::Result<()> {
         let mut runner = self.runner;
 
-        let axum_addr = runner
+        runner
             .start_http_server(
                 self.endpoints.inner.axum_router,
                 self.endpoints.inner.jsonrpsee_module,
@@ -670,11 +665,6 @@ impl<S: FullNodeBlueprint<M>, M: ExecutionMode> Rollup<S, M> {
             )
             .await
             .context("Failed to start Axum Server")?;
-        if let Some(sender) = axum_addr_channel {
-            sender
-                .send(axum_addr)
-                .map_err(|_| anyhow::anyhow!("Failed to send Axum address"))?;
-        }
 
         let monitoring_task =
             spawn_task_monitor(self.shutdown_sender.clone(), self.background_handles);

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -299,7 +299,6 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
             }
         };
 
-        let (rest_addr_tx, rest_addr_rx) = tokio::sync::oneshot::channel();
         let shutdown_sender = rollup.shutdown_sender.clone();
 
         let mut other_handles = Vec::new();
@@ -309,8 +308,9 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
             other_handles.push(handle);
         }
 
+        let rest_addr = rollup.runner.axum_socket_address()?;
         let rollup_task = tokio::spawn(async move {
-            match rollup.run_and_report_addr(Some(rest_addr_tx)).await {
+            match rollup.run().await {
                 Ok(()) => {
                     tracing::info!("Completed running a rollup");
                     Ok(())
@@ -321,8 +321,6 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                 }
             }
         });
-
-        let rest_addr = rest_addr_rx.await?;
 
         let rest_url = format!("http://{}:{}", rest_addr.ip(), rest_addr.port());
         let client = match NodeClient::new(&rest_url).await {


### PR DESCRIPTION
# Description

Problem: The sequencer currently cannot access the Axum server’s bound socket address, which is a requirement for the failover workstream.

This PR changes when the TCP listener is bound during rollup startup. Instead of creating the `TcpListener` inside `start_http_server`, it is now initialized earlier and passed to the runner.

This way, we will be able to pass the axum address to the sequencer  (to be implemented in a follow-up PR).


- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

Related issue #1524

