### PR TITLE
Add tokenMetadata method to TypeScript Bank class

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,6 +25,11 @@ priority = 90                                                        # try to ru
 threads-required = 3
 
 [[profile.default.overrides]]
+filter = 'package(sov-sequencer) & test(/flaky_test_archival_state_is_immediately_available/)'
+priority = 95
+threads-required = 3
+
+[[profile.default.overrides]]
 filter = 'package(sov-demo-rollup) & test(/replica::/)'
 priority = 90                                                        # try to run it first, so it doesn't add up at the end
 threads-required = 3

--- a/typescript/.changeset/fix-eip712-high-s-signatures.md
+++ b/typescript/.changeset/fix-eip712-high-s-signatures.md
@@ -1,0 +1,5 @@
+---
+"@sovereign-sdk/signers": patch
+---
+
+Fix EIP-712 signature verification failures by normalizing high-s signatures to low-s. Migrated from ethers to viem for better signature handling. Removed ethers dependency.

--- a/typescript/.changeset/fix-eip712-high-s-signatures.md
+++ b/typescript/.changeset/fix-eip712-high-s-signatures.md
@@ -1,5 +1,0 @@
----
-"@sovereign-sdk/signers": patch
----
-
-Fix EIP-712 signature verification failures by normalizing high-s signatures to low-s. Migrated from ethers to viem for better signature handling. Removed ethers dependency.

--- a/typescript/apps/indexer/CHANGELOG.md
+++ b/typescript/apps/indexer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sovereign-sdk/indexer
 
+## 0.4.17
+
+### Patch Changes
+
+-   @sovereign-sdk/web3@0.12.4
+
 ## 0.4.16
 
 ### Patch Changes

--- a/typescript/apps/indexer/package.json
+++ b/typescript/apps/indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereign-sdk/indexer",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "A simple indexer for Sovereign SDK rollups",
   "scripts": {
     "build": "bun build ./src/cli.ts --compile --outfile bin/sov-indexer",

--- a/typescript/examples/soak-testing/CHANGELOG.md
+++ b/typescript/examples/soak-testing/CHANGELOG.md
@@ -1,5 +1,14 @@
 # soak-testing
 
+## 1.0.18
+
+### Patch Changes
+
+-   Updated dependencies [fc00847]
+    -   @sovereign-sdk/signers@0.5.2
+    -   @sovereign-sdk/test@0.1.18
+    -   @sovereign-sdk/web3@0.12.4
+
 ## 1.0.17
 
 ### Patch Changes

--- a/typescript/examples/soak-testing/package.json
+++ b/typescript/examples/soak-testing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "soak-testing",
   "private": true,
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "",
   "type": "module",
   "scripts": {

--- a/typescript/packages/modules/CHANGELOG.md
+++ b/typescript/packages/modules/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sovereign-sdk/modules
 
+## 0.1.12
+
+### Patch Changes
+
+-   @sovereign-sdk/web3@0.12.4
+
 ## 0.1.11
 
 ### Patch Changes

--- a/typescript/packages/modules/package.json
+++ b/typescript/packages/modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereign-sdk/modules",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "A package providing convenient helpers for interacting with core Sovereign SDK modules",
   "scripts": {
     "build": "tsup",

--- a/typescript/packages/multisig/CHANGELOG.md
+++ b/typescript/packages/multisig/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sovereign-sdk/multisig
 
+## 0.3.1
+
+### Patch Changes
+
+-   Updated dependencies [fc00847]
+    -   @sovereign-sdk/signers@0.5.2
+
 ## 0.3.0
 
 ### Minor Changes

--- a/typescript/packages/multisig/package.json
+++ b/typescript/packages/multisig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereign-sdk/multisig",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Multisig functionality for Sovereign SDK applications",
   "scripts": {
     "build": "tsup",

--- a/typescript/packages/signers/CHANGELOG.md
+++ b/typescript/packages/signers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sovereign-sdk/signers
 
+## 0.5.2
+
+### Patch Changes
+
+-   fc00847: Fix EIP-712 signature verification failures by normalizing high-s signatures to low-s. Migrated from ethers to viem for better signature handling. Removed ethers dependency.
+
 ## 0.5.1
 
 ### Patch Changes

--- a/typescript/packages/signers/package.json
+++ b/typescript/packages/signers/package.json
@@ -55,14 +55,14 @@
   "dependencies": {
     "@ledgerhq/hw-app-solana": "^7.5.2",
     "@ledgerhq/hw-transport": "^6.31.9",
+    "@ledgerhq/hw-transport-node-hid": "^6.29.10",
     "@ledgerhq/hw-transport-webhid": "^6.30.5",
     "@ledgerhq/hw-transport-webusb": "^6.29.9",
-    "@ledgerhq/hw-transport-node-hid": "^6.29.10",
     "@noble/ed25519": "^2.1.0",
     "@noble/hashes": "^1.5.0",
     "@noble/secp256k1": "^2.3.0",
     "@sovereign-sdk/universal-wallet-wasm": "workspace:^",
     "@sovereign-sdk/utils": "workspace:^",
-    "ethers": "^6.15.0"
+    "viem": "^2.44.4"
   }
 }

--- a/typescript/packages/signers/package.json
+++ b/typescript/packages/signers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereign-sdk/signers",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Signer interface and default implementations for use with Sovereign SDK applications",
   "scripts": {
     "build": "tsup",

--- a/typescript/packages/signers/src/privy.ts
+++ b/typescript/packages/signers/src/privy.ts
@@ -1,5 +1,6 @@
 import * as secp from "@noble/secp256k1";
-import { Signature, ethers } from "ethers";
+import { hexToBytes } from "@sovereign-sdk/utils";
+import { type Signature, keccak256, parseSignature } from "viem";
 import { SignerError } from "./errors";
 import type { Signer } from "./signer";
 
@@ -31,11 +32,19 @@ export class PrivySigner implements Signer {
   }
 
   async sign(message: Uint8Array): Promise<Uint8Array> {
-    const digest = ethers.keccak256(message);
+    const digest = keccak256(message);
     const signatureBytes = await this.signProvider(digest);
-    const signature = Signature.from(signatureBytes);
+    // Normalize to ensure 0x prefix
+    const normalizedHex = signatureBytes.startsWith("0x")
+      ? signatureBytes
+      : `0x${signatureBytes}`;
+    const signature = parseSignature(normalizedHex as `0x${string}`);
     this.cachePublicKey(digest, signature);
-    return ethers.getBytes(ethers.concat([signature.r, signature.s]));
+
+    // Return compact signature (r + s, 64 bytes)
+    const r = hexToBytes(signature.r.slice(2));
+    const s = hexToBytes(signature.s.slice(2));
+    return new Uint8Array([...r, ...s]);
   }
 
   /** Returns the public key in compressed form. */
@@ -52,11 +61,13 @@ export class PrivySigner implements Signer {
   private cachePublicKey(msgHash: string, signature: Signature) {
     if (this.cachedPublicKey) return;
 
-    let secpSig = secp.Signature.fromCompact(
-      ethers.getBytesCopy(ethers.concat([signature.r, signature.s])),
-    );
-    secpSig = secpSig.addRecoveryBit(signature.yParity);
-    const publicKey = secpSig.recoverPublicKey(ethers.getBytes(msgHash));
+    const r = hexToBytes(signature.r.slice(2));
+    const s = hexToBytes(signature.s.slice(2));
+    let secpSig = secp.Signature.fromCompact(new Uint8Array([...r, ...s]));
+    secpSig = secpSig.addRecoveryBit(signature.yParity ?? 0);
+
+    const msgHashBytes = hexToBytes(msgHash.slice(2));
+    const publicKey = secpSig.recoverPublicKey(msgHashBytes);
 
     this.cachedPublicKey = publicKey.toBytes(true);
   }

--- a/typescript/packages/signers/src/wasm/eip712.test.ts
+++ b/typescript/packages/signers/src/wasm/eip712.test.ts
@@ -1,23 +1,100 @@
+import * as secp from "@noble/secp256k1";
+import { KnownTypeId, Schema } from "@sovereign-sdk/universal-wallet-wasm";
+import { hexToBytes } from "@sovereign-sdk/utils";
+import { hashTypedData } from "viem";
+import { privateKeyToAccount, signTypedData } from "viem/accounts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import demoRollupSchema from "../../../__fixtures__/demo-rollup-schema.json";
 import { Eip712Signer } from "./eip712";
 
-describe("Eip712Signer", () => {
-  const mockProvider = {
-    request: vi.fn(),
-  };
+// Test private key (do not use in production)
+const TEST_PRIVATE_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const testAccount = privateKeyToAccount(TEST_PRIVATE_KEY);
+const TEST_PUBLIC_KEY = secp.getPublicKey(
+  hexToBytes(TEST_PRIVATE_KEY.slice(2)),
+  true,
+);
 
-  const mockSchema = {
-    types: [],
-    root_type_indices: [0, 1, 2],
-    chain_data: {
-      chain_id: 4321,
-      chain_name: "TestChain",
+const schema = Schema.fromJSON(JSON.stringify(demoRollupSchema));
+
+// Sample unsigned transaction for testing
+const sampleUnsignedTx = {
+  runtime_call: {
+    bank: {
+      transfer: {
+        to: {
+          Standard: "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
+        },
+        coins: {
+          amount: "1000",
+          token_id:
+            "token_1rwrh8gn2py0dl4vv65twgctmlwck6esm2as9dftumcw89kqqn3nqrduss6",
+        },
+      },
     },
-    templates: [],
-    serde_metadata: [],
-  };
+  },
+  generation: "12345",
+  details: {
+    max_priority_fee_bips: "1000",
+    max_fee: "10000",
+    gas_limit: null,
+    chain_id: "1",
+  },
+};
 
-  const testAddress = "0x1234567890123456789012345678901234567890";
+/**
+ * Creates the message that would be passed to signer.sign().
+ * This is what rollup.signTransaction() does - serialize unsigned tx and append chain hash.
+ */
+function createTestMessage(): Uint8Array {
+  const unsignedTxBorsh = schema.jsonToBorsh(
+    schema.knownTypeIndex(KnownTypeId.UnsignedTransaction),
+    JSON.stringify(sampleUnsignedTx),
+  );
+  return new Uint8Array([...unsignedTxBorsh, ...schema.chainHash]);
+}
+
+/**
+ * Parse typed data received by the mock provider and convert chainId for viem.
+ */
+function parseTypedDataForViem(typedDataJson: string) {
+  const typedData = JSON.parse(typedDataJson);
+  const { EIP712Domain: _, ...typesWithoutDomain } = typedData.types;
+  const chainId =
+    typeof typedData.domain.chainId === "string"
+      ? Number.parseInt(typedData.domain.chainId.replace("0x", ""), 16)
+      : typedData.domain.chainId;
+  return {
+    domain: { ...typedData.domain, chainId },
+    types: typesWithoutDomain,
+    primaryType: typedData.primaryType as "UnsignedTransaction",
+    message: typedData.message,
+  };
+}
+
+/**
+ * Creates a mock provider that signs whatever typed data the signer sends.
+ * The provider receives typed data from the signer (not pre-computed in tests).
+ */
+function createMockProvider() {
+  return {
+    request: vi.fn(
+      async ({ method, params }: { method: string; params?: unknown[] }) => {
+        if (method === "eth_signTypedData_v4") {
+          const [, typedDataJson] = params as [string, string];
+          const viemData = parseTypedDataForViem(typedDataJson);
+          return signTypedData({ privateKey: TEST_PRIVATE_KEY, ...viemData });
+        }
+        throw new Error(`Unsupported method: ${method}`);
+      },
+    ),
+  };
+}
+
+describe("Eip712Signer", () => {
+  const mockProvider = { request: vi.fn() };
+  const testAddress = testAccount.address;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -27,10 +104,9 @@ describe("Eip712Signer", () => {
     it("should create a signer instance with address", () => {
       const signer = new Eip712Signer(
         mockProvider as any,
-        mockSchema,
+        demoRollupSchema,
         testAddress,
       );
-
       expect(signer).toBeDefined();
       expect(signer.publicKey).toBeDefined();
       expect(signer.sign).toBeDefined();
@@ -38,8 +114,7 @@ describe("Eip712Signer", () => {
 
     it("should throw error if address is not provided", () => {
       expect(() => {
-        // @ts-expect-error Testing missing address parameter
-        new Eip712Signer(mockProvider as any, mockSchema);
+        new Eip712Signer(mockProvider as any, demoRollupSchema, "");
       }).toThrow("Address is required");
     });
   });
@@ -48,10 +123,9 @@ describe("Eip712Signer", () => {
     it("should throw error if public key not available before signing", async () => {
       const signer = new Eip712Signer(
         mockProvider as any,
-        mockSchema,
+        demoRollupSchema,
         testAddress,
       );
-
       await expect(signer.publicKey()).rejects.toThrow(
         "Public key was not available, you must call sign() first",
       );
@@ -62,14 +136,123 @@ describe("Eip712Signer", () => {
     it("should throw error if message is too short for chain hash", async () => {
       const signer = new Eip712Signer(
         mockProvider as any,
-        mockSchema,
+        demoRollupSchema,
         testAddress,
       );
-
-      const shortMessage = new Uint8Array([1, 2, 3]); // Less than 32 bytes
+      const shortMessage = new Uint8Array([1, 2, 3]);
       await expect(signer.sign(shortMessage)).rejects.toThrow(
         "Message too short, expected at least 32 bytes for chain hash",
       );
+    });
+
+    it("should sign and return 64-byte signature with correct public key", async () => {
+      const message = createTestMessage();
+      const provider = createMockProvider();
+      const signer = new Eip712Signer(
+        provider as any,
+        demoRollupSchema,
+        testAddress,
+      );
+
+      const signature = await signer.sign(message);
+
+      // Should return a 64-byte compact signature
+      expect(signature).toBeInstanceOf(Uint8Array);
+      expect(signature.length).toBe(64);
+
+      // Public key should be available and match expected
+      const publicKey = await signer.publicKey();
+      expect(publicKey).toEqual(TEST_PUBLIC_KEY);
+
+      // Verify signature using the typed data the signer sent to the provider
+      const [, typedDataJson] = provider.request.mock.calls[0][0].params as [
+        string,
+        string,
+      ];
+      const viemData = parseTypedDataForViem(typedDataJson);
+      const signingHash = hexToBytes(hashTypedData(viemData).slice(2));
+      expect(secp.verify(signature, signingHash, TEST_PUBLIC_KEY)).toBe(true);
+    });
+
+    it("should normalize high-s signatures to low-s", async () => {
+      // secp256k1 curve order (use BigInt() for ES2015 compatibility)
+      const N = BigInt(
+        "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+      );
+      const halfN = N / BigInt(2);
+      const message = createTestMessage();
+
+      // Mock provider that forces HIGH-S signature
+      const highSProvider = {
+        request: vi.fn(
+          async ({
+            method,
+            params,
+          }: { method: string; params?: unknown[] }) => {
+            if (method === "eth_signTypedData_v4") {
+              const [, typedDataJson] = params as [string, string];
+              const viemData = parseTypedDataForViem(typedDataJson);
+              const sig = await signTypedData({
+                privateKey: TEST_PRIVATE_KEY,
+                ...viemData,
+              });
+
+              // Parse and force high-s
+              const sigBytes = hexToBytes(sig.slice(2));
+              const r = sigBytes.slice(0, 32);
+              const s = sigBytes.slice(32, 64);
+              const v = sigBytes[64];
+
+              const sBigInt = BigInt(
+                `0x${Array.from(s)
+                  .map((b) => b.toString(16).padStart(2, "0"))
+                  .join("")}`,
+              );
+
+              // Only flip to high-s if currently low-s
+              // (N - s flips between high and low, so we only flip if s < N/2)
+              const isLowS = sBigInt <= halfN;
+              const newS = isLowS ? N - sBigInt : sBigInt;
+              // Only flip recovery bit if we flipped s
+              const newV = isLowS ? (v === 27 ? 28 : v === 28 ? 27 : v) : v;
+
+              const newSBytes = hexToBytes(newS.toString(16).padStart(64, "0"));
+              const highSSig = new Uint8Array(65);
+              highSSig.set(r, 0);
+              highSSig.set(newSBytes, 32);
+              highSSig[64] = newV;
+
+              return `0x${Array.from(highSSig)
+                .map((b) => b.toString(16).padStart(2, "0"))
+                .join("")}`;
+            }
+            throw new Error(`Unsupported method: ${method}`);
+          },
+        ),
+      };
+
+      const signer = new Eip712Signer(
+        highSProvider as any,
+        demoRollupSchema,
+        testAddress,
+      );
+      const signature = await signer.sign(message);
+
+      // Verify s is now low (s <= n/2)
+      const sBytes = signature.slice(32, 64);
+      const s = BigInt(
+        `0x${Array.from(sBytes)
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("")}`,
+      );
+      expect(s <= halfN).toBe(true);
+
+      // Verify signature is still valid after normalization
+      const [, typedDataJson] = highSProvider.request.mock.calls[0][0]
+        .params as [string, string];
+      const viemData = parseTypedDataForViem(typedDataJson);
+      const signingHash = hexToBytes(hashTypedData(viemData).slice(2));
+      expect(secp.verify(signature, signingHash, TEST_PUBLIC_KEY)).toBe(true);
     });
   });
 });

--- a/typescript/packages/signers/src/wasm/eip712.ts
+++ b/typescript/packages/signers/src/wasm/eip712.ts
@@ -2,9 +2,27 @@ import type { MetaMaskInpageProvider } from "@metamask/providers";
 import * as secp from "@noble/secp256k1";
 import { KnownTypeId, Schema } from "@sovereign-sdk/universal-wallet-wasm";
 import { hexToBytes } from "@sovereign-sdk/utils";
-import { Signature } from "ethers";
+import { type Signature, parseSignature } from "viem";
 import { SignerError } from "../errors";
 import type { Signer } from "../signer";
+
+/**
+ * Normalize a signature to low-s form if needed.
+ * MetaMask's eth_signTypedData_v4 may return high-s signatures (~50% of the time).
+ * The rollup server requires low-s signatures.
+ */
+function normalizeSignature(signature: Signature): Uint8Array {
+  const r = hexToBytes(signature.r.slice(2));
+  const s = hexToBytes(signature.s.slice(2));
+  let secpSig = secp.Signature.fromCompact(new Uint8Array([...r, ...s]));
+
+  // Normalize s if it's > n/2 (convert high-s to low-s)
+  if (secpSig.hasHighS()) {
+    secpSig = secpSig.normalizeS();
+  }
+
+  return secpSig.toCompactRawBytes();
+}
 
 /**
  * EIP-712 signer implementation that uses MetaMask's eth_signTypedData_v4 method.
@@ -36,17 +54,16 @@ export class Eip712Signer implements Signer {
 
   /**
    * Cache the public key recovered from a signature.
+   * Uses viem's parseSignature which accepts high-s signatures (unlike ethers).
    */
   private cachePublicKey(signingHash: Uint8Array, signature: Signature): void {
     if (this.cachedPublicKey) return;
 
-    let secpSig = secp.Signature.fromCompact(
-      new Uint8Array([
-        ...hexToBytes(signature.r.slice(2)),
-        ...hexToBytes(signature.s.slice(2)),
-      ]),
-    );
-    secpSig = secpSig.addRecoveryBit(signature.yParity);
+    const r = hexToBytes(signature.r.slice(2));
+    const s = hexToBytes(signature.s.slice(2));
+
+    let secpSig = secp.Signature.fromCompact(new Uint8Array([...r, ...s]));
+    secpSig = secpSig.addRecoveryBit(signature.yParity ?? 0);
     const publicKey = secpSig.recoverPublicKey(signingHash);
 
     this.cachedPublicKey = publicKey.toBytes(true); // compressed form
@@ -121,11 +138,17 @@ export class Eip712Signer implements Signer {
       );
     }
 
-    // Parse the signature for public key recovery
-    const signature = Signature.from(signatureHex);
+    // Parse the signature using viem (accepts high-s signatures unlike ethers)
+    // Normalize to ensure 0x prefix
+    const normalizedHex = signatureHex.startsWith("0x")
+      ? signatureHex
+      : `0x${signatureHex}`;
+    const signature = parseSignature(normalizedHex as `0x${string}`);
     this.cachePublicKey(signingHash, signature);
 
-    // Return the standard compact serialized signature (r + s, 64 bytes)
-    return hexToBytes(signature.compactSerialized.slice(2));
+    // Normalize to low-s form
+    // (EIP-2 low-s requirement only applies to transactions, not off-chain message signing,
+    // but the rollup server expects low-s signatures)
+    return normalizeSignature(signature);
   }
 }

--- a/typescript/packages/signers/tsup.config.ts
+++ b/typescript/packages/signers/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     "src/ledger-solana/node.ts",
   ],
   format: ["cjs", "esm"],
+  target: "es2020",
   splitting: false,
   sourcemap: true,
   clean: true,

--- a/typescript/packages/test/CHANGELOG.md
+++ b/typescript/packages/test/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @sovereign-sdk/test
 
+## 0.1.18
+
+### Patch Changes
+
+-   Updated dependencies [fc00847]
+    -   @sovereign-sdk/signers@0.5.2
+    -   @sovereign-sdk/web3@0.12.4
+
 ## 0.1.17
 
 ### Patch Changes

--- a/typescript/packages/test/package.json
+++ b/typescript/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereign-sdk/test",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "",
   "scripts": {
     "build": "pnpm typecheck && tsup",

--- a/typescript/packages/web3/CHANGELOG.md
+++ b/typescript/packages/web3/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sovereign-sdk/web3
 
+## 0.12.4
+
+### Patch Changes
+
+-   Updated dependencies [fc00847]
+    -   @sovereign-sdk/signers@0.5.2
+
 ## 0.12.3
 
 ### Patch Changes

--- a/typescript/packages/web3/package.json
+++ b/typescript/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sovereign-sdk/web3",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "scripts": {
     "build": "pnpm typecheck && tsup",
     "ci": "biome ci",

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.1(@types/react@19.1.8)
+        version: 1.3.6
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.7.42(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.6.3)
@@ -249,9 +249,9 @@ importers:
       '@sovereign-sdk/utils':
         specifier: workspace:^
         version: link:../utils
-      ethers:
-        specifier: ^6.15.0
-        version: 6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      viem:
+        specifier: ^2.44.4
+        version: 2.44.4(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10)
     devDependencies:
       '@metamask/providers':
         specifier: ^18.1.0
@@ -383,8 +383,8 @@ importers:
 
 packages:
 
-  '@adraffy/ens-normalize@1.10.1':
-    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@babel/helper-string-parser@7.25.9':
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
@@ -964,21 +964,22 @@ packages:
     resolution: {integrity: sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==}
     engines: {node: '>=16.0.0'}
 
-  '@noble/curves@1.2.0':
-    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/curves@1.4.2':
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
 
   '@noble/ed25519@2.1.0':
     resolution: {integrity: sha512-KM4qTyXPinyCgMzeYJH/UudpdL+paJXtY3CHtHYZQtBkS8MZoPr4rOikZllIutJe0d06QDQKisyn02gxZ8TcQA==}
 
   '@noble/ed25519@2.3.0':
     resolution: {integrity: sha512-M7dvXL2B92/M7dw9+gzuydL8qn/jiqNHaoR3Q+cb1q1GHV7uwE17WCyFMG+Y+TZb5izcaXk5TdJRrDUxHXL78A==}
-
-  '@noble/hashes@1.3.2':
-    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
-    engines: {node: '>= 16'}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -1199,11 +1200,20 @@ packages:
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
 
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
 
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
   '@scure/bip39@1.3.0':
     resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@shikijs/engine-oniguruma@3.4.0':
     resolution: {integrity: sha512-zwcWlZ4OQuJ/+1t32ClTtyTU1AiDkK1lhtviRWoq/hFqPjCNyLj22bIg9rB7BfoZKOEOfrsGz7No33BPCf+WlQ==}
@@ -1346,8 +1356,8 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@types/bun@1.3.1':
-    resolution: {integrity: sha512-4jNMk2/K9YJtfqwoAa28c8wK+T7nvJFOjxI4h/7sORWcypRNxBpr+TPNaCfVWq70tLCJsqoFwcf0oI0JU/fvMQ==}
+  '@types/bun@1.3.6':
+    resolution: {integrity: sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1390,9 +1400,6 @@ packages:
 
   '@types/pg@8.11.13':
     resolution: {integrity: sha512-6kXByGkvRvwXLuyaWzsebs2du6+XuAB2CuMsuzP7uaihQahshVgSmB22Pmh0vQMkQ1h5+PZU0d+Di1o+WpVWJg==}
-
-  '@types/react@19.1.8':
-    resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
 
   '@types/ssh2-streams@0.1.12':
     resolution: {integrity: sha512-Sy8tpEmCce4Tq0oSOYdfqaBpA3hDM8SoxoFh5vzFsu2oL+znzGz8oVWW7xb4K920yYMUY+PIG31qZnFMfPWNCg==}
@@ -1465,6 +1472,17 @@ packages:
   '@vitest/utils@4.0.7':
     resolution: {integrity: sha512-HNrg9CM/Z4ZWB6RuExhuC6FPmLipiShKVMnT9JlQvfhwR47JatWLChA6mtZqVHqypE6p/z6ofcjbyWpM7YLxPQ==}
 
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -1477,9 +1495,6 @@ packages:
     resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  aes-js@4.0.0-beta.5:
-    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
@@ -1614,6 +1629,7 @@ packages:
   binary-install@1.1.0:
     resolution: {integrity: sha512-rkwNGW+3aQVSZoD0/o3mfPN6Yxh3Id0R/xzTVBVVpGNlVz8EGwusksxRlbk/A5iKTZt9zkMn3qIqmAt3vpfbzg==}
     engines: {node: '>=10'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -1664,10 +1680,8 @@ packages:
     resolution: {integrity: sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==}
     engines: {node: '>=10.0.0'}
 
-  bun-types@1.3.1:
-    resolution: {integrity: sha512-NMrcy7smratanWJ2mMXdpatalovtxVggkj11bScuWuiOoXTiKIu2eVS1/7qbyI/4yHedtsn175n4Sm4JcdHLXw==}
-    peerDependencies:
-      '@types/react': ^19
+  bun-types@1.3.6:
+    resolution: {integrity: sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ==}
 
   bun@1.2.17:
     resolution: {integrity: sha512-lrUZTWS24eVy6v+Eph8VTwqFPcG7/XQ0rLBQEMNoQs2Vd7ctVdMGAzJKKGZRUQH+rgkD8rBeHGIVoWxX4vJLCA==}
@@ -1787,9 +1801,6 @@ packages:
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
-
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
@@ -1917,10 +1928,6 @@ packages:
 
   ethereum-cryptography@2.2.1:
     resolution: {integrity: sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==}
-
-  ethers@6.15.0:
-    resolution: {integrity: sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==}
-    engines: {node: '>=14.0.0'}
 
   event-target-polyfill@0.0.4:
     resolution: {integrity: sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==}
@@ -2177,6 +2184,11 @@ packages:
 
   isomorphic-ws@5.0.0:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
       ws: '*'
 
@@ -2437,6 +2449,14 @@ packages:
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
+  ox@0.11.3:
+    resolution: {integrity: sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -3130,6 +3150,14 @@ packages:
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
+  viem@2.44.4:
+    resolution: {integrity: sha512-sJDLVl2EsS5Fo7GSWZME5CXEV7QRYkUJPeBw7ac+4XI3D4ydvMw/gjulTsT5pgqcpu70BploFnOAC6DLpan1Yg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite-plugin-wasm@3.4.1:
     resolution: {integrity: sha512-ja3nSo2UCkVeitltJGkS3pfQHAanHv/DqGatdI39ja6McgABlpsZ5hVgl6wuR8Qx5etY3T5qgDQhOWzc5RReZA==}
     peerDependencies:
@@ -3273,8 +3301,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.17.1:
-    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+  ws@8.18.1:
+    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3285,8 +3313,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.18.1:
-    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3339,7 +3367,7 @@ packages:
 
 snapshots:
 
-  '@adraffy/ens-normalize@1.10.1': {}
+  '@adraffy/ens-normalize@1.11.1': {}
 
   '@babel/helper-string-parser@7.25.9': {}
 
@@ -3931,19 +3959,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@noble/curves@1.2.0':
-    dependencies:
-      '@noble/hashes': 1.3.2
+  '@noble/ciphers@1.3.0': {}
 
   '@noble/curves@1.4.2':
     dependencies:
       '@noble/hashes': 1.4.0
 
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/ed25519@2.1.0': {}
 
   '@noble/ed25519@2.3.0': {}
-
-  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.4.0': {}
 
@@ -4086,16 +4114,29 @@ snapshots:
 
   '@scure/base@1.1.9': {}
 
+  '@scure/base@1.2.6': {}
+
   '@scure/bip32@1.4.0':
     dependencies:
       '@noble/curves': 1.4.2
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.9
 
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
   '@scure/bip39@1.3.0':
     dependencies:
       '@noble/hashes': 1.4.0
       '@scure/base': 1.1.9
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@shikijs/engine-oniguruma@3.4.0':
     dependencies:
@@ -4240,11 +4281,9 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@types/bun@1.3.1(@types/react@19.1.8)':
+  '@types/bun@1.3.6':
     dependencies:
-      bun-types: 1.3.1(@types/react@19.1.8)
-    transitivePeerDependencies:
-      - '@types/react'
+      bun-types: 1.3.6
 
   '@types/chai@5.2.3':
     dependencies:
@@ -4297,10 +4336,6 @@ snapshots:
       '@types/node': 22.7.5
       pg-protocol: 1.8.0
       pg-types: 4.0.2
-
-  '@types/react@19.1.8':
-    dependencies:
-      csstype: 3.1.3
 
   '@types/ssh2-streams@0.1.12':
     dependencies:
@@ -4393,6 +4428,10 @@ snapshots:
       '@vitest/pretty-format': 4.0.7
       tinyrainbow: 3.0.3
 
+  abitype@1.2.3(typescript@5.6.3):
+    optionalDependencies:
+      typescript: 5.6.3
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -4402,8 +4441,6 @@ snapshots:
       acorn: 8.14.0
 
   acorn@8.14.0: {}
-
-  aes-js@4.0.0-beta.5: {}
 
   agentkeepalive@4.6.0:
     dependencies:
@@ -4598,10 +4635,9 @@ snapshots:
   buildcheck@0.0.6:
     optional: true
 
-  bun-types@1.3.1(@types/react@19.1.8):
+  bun-types@1.3.6:
     dependencies:
       '@types/node': 22.7.5
-      '@types/react': 19.1.8
 
   bun@1.2.17:
     optionalDependencies:
@@ -4729,8 +4765,6 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  csstype@3.1.3: {}
 
   debug@4.3.7:
     dependencies:
@@ -4885,19 +4919,6 @@ snapshots:
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
-
-  ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
-    dependencies:
-      '@adraffy/ens-normalize': 1.10.1
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@types/node': 22.7.5
-      aes-js: 4.0.0-beta.5
-      tslib: 2.7.0
-      ws: 8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   event-target-polyfill@0.0.4: {}
 
@@ -5121,6 +5142,10 @@ snapshots:
   isomorphic-ws@5.0.0(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+
+  isows@1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+    dependencies:
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -5367,6 +5392,21 @@ snapshots:
   os-tmpdir@1.0.2: {}
 
   outdent@0.5.0: {}
+
+  ox@0.11.3(typescript@5.6.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.6.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - zod
 
   p-filter@2.1.0:
     dependencies:
@@ -6083,6 +6123,23 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
+  viem@2.44.4(bufferutil@4.0.9)(typescript@5.6.3)(utf-8-validate@5.0.10):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.6.3)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ox: 0.11.3(typescript@5.6.3)
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite-plugin-wasm@3.4.1(vite@6.2.3(@types/node@22.7.5)(tsx@4.20.3)(yaml@2.7.1)):
     dependencies:
       vite: 6.2.3(@types/node@22.7.5)(tsx@4.20.3)(yaml@2.7.1)
@@ -6212,12 +6269,12 @@ snapshots:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
 
-  ws@8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+  ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
 
-  ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+  ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10

--- a/typescript/tsconfig.build.json
+++ b/typescript/tsconfig.build.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es2020", "dom"],
     "module": "esnext",
-    "target": "es6",
+    "target": "es2020",
     "moduleResolution": "bundler",
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- Add `serde::Serialize` to the Rust `Token` struct to enable the auto-generated state endpoint for token metadata
- Add `tokenMetadata()` method to the TypeScript Bank class that fetches token metadata including name, decimals, total supply, supply cap, and admin addresses
- Add bech32 dependency to decode token IDs and extract decimals from the last byte