### PR TITLE
Add method to bank for token meta

### DIFF
--- a/crates/module-system/module-implementations/sov-bank/src/token.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/token.rs
@@ -194,7 +194,7 @@ impl std::fmt::Display for Coins {
 }
 
 /// This struct represents a token in the sov-bank module.
-#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone)]
+#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Token<S: Spec> {
     /// Name of the token.
     pub(crate) name: String,

--- a/crates/module-system/module-implementations/sov-bank/src/token.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/token.rs
@@ -194,7 +194,9 @@ impl std::fmt::Display for Coins {
 }
 
 /// This struct represents a token in the sov-bank module.
-#[derive(borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone, serde::Serialize)]
+#[derive(
+    borsh::BorshDeserialize, borsh::BorshSerialize, Debug, PartialEq, Clone, serde::Serialize,
+)]
 pub struct Token<S: Spec> {
     /// Name of the token.
     pub(crate) name: String,

--- a/typescript/.changeset/lucky-olives-sparkle.md
+++ b/typescript/.changeset/lucky-olives-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@sovereign-sdk/modules": minor
+---
+
+Adds a method to fetch the tokens metadata. Removes the old totalSupply method as it is redundant; the token metadata contains the total supply

--- a/typescript/packages/modules/package.json
+++ b/typescript/packages/modules/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@sovereign-sdk/web3": "workspace:^",
-    "@sovereign-sdk/utils": "workspace:^"
+    "@sovereign-sdk/utils": "workspace:^",
+    "bech32": "^2.0.0"
   }
 }

--- a/typescript/packages/modules/src/bank.test.ts
+++ b/typescript/packages/modules/src/bank.test.ts
@@ -1,4 +1,5 @@
 import { SovereignClient } from "@sovereign-sdk/web3";
+import { bech32m } from "bech32";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Bank } from "./bank";
 
@@ -139,45 +140,76 @@ describe("Bank", () => {
     });
   });
 
-  describe("totalSupply", () => {
-    const mockTokenId = "token_123";
-    const mockGasTokenId = "gas_token_456";
+  describe("tokenMetadata", () => {
+    // Valid bech32m token ID with decimals = 89 (last byte)
+    const mockTokenId =
+      "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7";
+
+    // Create a gas token ID with 6 decimals
+    const gasTokenBytes = new Uint8Array(32);
+    gasTokenBytes[31] = 6;
+    const mockGasTokenId = bech32m.encode(
+      "token_",
+      bech32m.toWords(gasTokenBytes),
+    );
 
     beforeEach(() => {
       // Mock gasTokenId method
       vi.spyOn(bank, "gasTokenId").mockResolvedValue(mockGasTokenId);
     });
 
-    it("should return total supply for a specific token", async () => {
+    it("should return token metadata for a specific token", async () => {
       const mockResponse = {
-        amount: "1000000000000000000000000",
-        token_id: mockTokenId,
+        key: mockTokenId,
+        value: {
+          name: "Test Token",
+          total_supply: "1000000000000000000000000",
+          supply_cap: "2000000000000000000000000",
+          admins: [{ user: "sov1abc123" }, { module: "sov1mod456" }],
+        },
       };
 
       mockClient.get.mockResolvedValue(mockResponse);
 
-      const result = await bank.totalSupply(mockTokenId);
+      const result = await bank.tokenMetadata(mockTokenId);
 
       expect(mockClient.get).toHaveBeenCalledWith(
-        `/modules/bank/tokens/${mockTokenId}/total-supply`,
+        `/modules/bank/state/tokens/items/${mockTokenId}`,
       );
-      expect(result).toBe(BigInt("1000000000000000000000000"));
+      expect(result).toEqual({
+        name: "Test Token",
+        decimals: 89,
+        totalSupply: BigInt("1000000000000000000000000"),
+        supplyCap: BigInt("2000000000000000000000000"),
+        admins: ["sov1abc123", "sov1mod456"],
+      });
     });
 
-    it("should return total supply for gas token when no tokenId provided", async () => {
+    it("should return token metadata for gas token when no tokenId provided", async () => {
       const mockResponse = {
-        amount: "500000000000000000000000",
-        token_id: mockGasTokenId,
+        key: mockGasTokenId,
+        value: {
+          name: "Gas Token",
+          total_supply: "500000000000000000000000",
+          supply_cap: "1000000000000000000000000",
+          admins: [{ derived: "sov1derived789" }],
+        },
       };
 
       mockClient.get.mockResolvedValue(mockResponse);
 
-      const result = await bank.totalSupply();
+      const result = await bank.tokenMetadata();
 
       expect(mockClient.get).toHaveBeenCalledWith(
-        `/modules/bank/tokens/${mockGasTokenId}/total-supply`,
+        `/modules/bank/state/tokens/items/${mockGasTokenId}`,
       );
-      expect(result).toBe(BigInt("500000000000000000000000"));
+      expect(result).toEqual({
+        name: "Gas Token",
+        decimals: 6,
+        totalSupply: BigInt("500000000000000000000000"),
+        supplyCap: BigInt("1000000000000000000000000"),
+        admins: ["sov1derived789"],
+      });
     });
 
     it("should throw error when API request fails", async () => {
@@ -194,7 +226,7 @@ describe("Bank", () => {
 
       mockClient.get.mockRejectedValue(apiError);
 
-      await expect(bank.totalSupply(mockTokenId)).rejects.toEqual(apiError);
+      await expect(bank.tokenMetadata(mockTokenId)).rejects.toEqual(apiError);
     });
   });
 

--- a/typescript/packages/modules/src/bank.test.ts
+++ b/typescript/packages/modules/src/bank.test.ts
@@ -1,5 +1,4 @@
 import { SovereignClient } from "@sovereign-sdk/web3";
-import { bech32m } from "bech32";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Bank } from "./bank";
 
@@ -145,17 +144,9 @@ describe("Bank", () => {
     const mockTokenId =
       "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7";
 
-    // Create a gas token ID with 6 decimals
-    const gasTokenBytes = new Uint8Array(32);
-    gasTokenBytes[31] = 6;
-    const mockGasTokenId = bech32m.encode(
-      "token_",
-      bech32m.toWords(gasTokenBytes),
-    );
-
     beforeEach(() => {
       // Mock gasTokenId method
-      vi.spyOn(bank, "gasTokenId").mockResolvedValue(mockGasTokenId);
+      vi.spyOn(bank, "gasTokenId").mockResolvedValue(mockTokenId);
     });
 
     it("should return token metadata for a specific token", async () => {
@@ -187,7 +178,7 @@ describe("Bank", () => {
 
     it("should return token metadata for gas token when no tokenId provided", async () => {
       const mockResponse = {
-        key: mockGasTokenId,
+        key: mockTokenId,
         value: {
           name: "Gas Token",
           total_supply: "500000000000000000000000",
@@ -201,11 +192,11 @@ describe("Bank", () => {
       const result = await bank.tokenMetadata();
 
       expect(mockClient.get).toHaveBeenCalledWith(
-        `/modules/bank/state/tokens/items/${mockGasTokenId}`,
+        `/modules/bank/state/tokens/items/${mockTokenId}`,
       );
       expect(result).toEqual({
         name: "Gas Token",
-        decimals: 6,
+        decimals: 89,
         totalSupply: BigInt("500000000000000000000000"),
         supplyCap: BigInt("1000000000000000000000000"),
         admins: ["sov1derived789"],

--- a/typescript/packages/modules/src/bank.ts
+++ b/typescript/packages/modules/src/bank.ts
@@ -41,11 +41,6 @@ type BalancePayload = {
   token_id: string;
 };
 
-type TotalSupplyPayload = {
-  amount: string;
-  token_id: string;
-};
-
 /**
  * Bank class for interacting with the Sovereign SDK Bank module.
  */
@@ -97,32 +92,6 @@ export class Bank {
 
       throw err;
     }
-  }
-
-  /**
-   * Gets the total supply of a specific token.
-   *
-   * If no token ID is provided, returns the total supply of the gas token.
-   *
-   * @param tokenId - Optional token ID. If not provided, uses the gas token
-   * @returns Promise resolving to the total supply as a bigint
-   * @throws {SovereignClient.APIError} When the request fails
-   * @example
-   * ```typescript
-   * const bank = new Bank(rollup);
-   * const totalSupply = await bank.totalSupply();
-   * console.log(`Total gas token supply: ${totalSupply}`);
-   *
-   * // Query specific token supply
-   * const tokenSupply = await bank.totalSupply("token_123");
-   * ```
-   */
-  async totalSupply(tokenId?: string): Promise<bigint> {
-    const token = await this.tokenIdOrElseGasTokenId(tokenId);
-    const response: TotalSupplyPayload = await this.rollup.http.get(
-      `/modules/bank/tokens/${token}/total-supply`,
-    );
-    return BigInt(response.amount);
   }
 
   /**

--- a/typescript/packages/modules/src/bank.ts
+++ b/typescript/packages/modules/src/bank.ts
@@ -1,5 +1,36 @@
 import { type Rollup, SovereignClient } from "@sovereign-sdk/web3";
+import { bech32m } from "bech32";
 import type { ErrorResponse } from "./types";
+
+// TokenHolder is an enum: { user: string } | { module: string } | { derived: string }
+type TokenHolderPayload =
+  | { user: string }
+  | { module: string }
+  | { derived: string };
+
+type TokenStatePayload = {
+  key: string;
+  value: {
+    name: string;
+    total_supply: string;
+    supply_cap: string;
+    admins: TokenHolderPayload[];
+  };
+};
+
+export type TokenMetadata = {
+  name: string;
+  decimals: number;
+  totalSupply: bigint;
+  supplyCap: bigint;
+  admins: string[];
+};
+
+function getHolderAddress(holder: TokenHolderPayload): string {
+  if ("user" in holder) return holder.user;
+  if ("module" in holder) return holder.module;
+  return holder.derived;
+}
 
 type GasTokenIdPayload = {
   token_id: string;
@@ -92,6 +123,44 @@ export class Bank {
       `/modules/bank/tokens/${token}/total-supply`,
     );
     return BigInt(response.amount);
+  }
+
+  /**
+   * Gets the metadata of a specific token.
+   *
+   * If no token ID is provided, returns the metadata of the gas token.
+   *
+   * @param tokenId - Optional token ID. If not provided, uses the gas token
+   * @returns Promise resolving to the token metadata
+   * @throws {SovereignClient.APIError} When the request fails
+   * @example
+   * ```typescript
+   * const bank = new Bank(rollup);
+   * const metadata = await bank.tokenMetadata();
+   * console.log(`Token name: ${metadata.name}, decimals: ${metadata.decimals}`);
+   *
+   * // Query specific token metadata
+   * const tokenMeta = await bank.tokenMetadata("token_123");
+   * ```
+   */
+  async tokenMetadata(tokenId?: string): Promise<TokenMetadata> {
+    const token = await this.tokenIdOrElseGasTokenId(tokenId);
+    const response: TokenStatePayload = await this.rollup.http.get(
+      `/modules/bank/state/tokens/items/${token}`,
+    );
+
+    // Decimals are encoded in the last byte of the token ID (byte 31 of the 32-byte hash)
+    const decoded = bech32m.decode(token);
+    const bytes = bech32m.fromWords(decoded.words);
+    const decimals = bytes[31];
+
+    return {
+      name: response.value.name,
+      decimals,
+      totalSupply: BigInt(response.value.total_supply),
+      supplyCap: BigInt(response.value.supply_cap),
+      admins: response.value.admins.map(getHolderAddress),
+    };
   }
 
   /**

--- a/typescript/packages/modules/tests/bank.integration-test.ts
+++ b/typescript/packages/modules/tests/bank.integration-test.ts
@@ -72,17 +72,4 @@ describe("bank", async () => {
       );
     });
   });
-
-  describe("totalSupply()", async () => {
-    it("should return the expected total supply", async () => {
-      const bank = new Bank(rollup);
-      const actual = await bank.totalSupply();
-      expect(actual).toBe(BigInt("10030000000000000"));
-    });
-    it("should use the tokenId parameter if it is supplied", async () => {
-      const bank = new Bank(rollup);
-      const actual = await bank.totalSupply(createdTokenId);
-      expect(actual).toBe(BigInt(createdTokenInitBalance));
-    });
-  });
 });

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       '@sovereign-sdk/web3':
         specifier: workspace:^
         version: link:../web3
+      bech32:
+        specifier: ^2.0.0
+        version: 2.0.0
     devDependencies:
       '@sovereign-sdk/signers':
         specifier: workspace:^


### PR DESCRIPTION
# Description

Add a method to the bank typescript class to retrieve token metadata.
Adds serde serialize to the `Token` struct so the auto-generated state endpoint for `tokens` is generated.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
