### PR TITLE
Skip evm gas changes until constant height

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -20,6 +20,7 @@ use sov_modules_api::transaction::{
     AuthenticatedTransactionAndRawHash, Credentials, PriorityFeeBips, TxDetails,
 };
 use sov_modules_api::StateReader;
+use sov_modules_api::VersionReader;
 use sov_modules_api::{
     DispatchCall, FullyBakedTx, Gas, GetGasPrice, ProvableStateReader, RawTx, Runtime, Spec,
 };
@@ -45,25 +46,24 @@ impl<S: Spec> Evm<S> {
     /// - `Ok(1)` if the fee check passes (user fee >= rollup base fee)
     /// - `Ok(100)` if the fee check is skipped (before height threshold or disabled)
     /// - `Err(InsufficientMaxFeePerGas)` if the user's fee is below the rollup base fee
-    fn validate_fee_and_calculate_multiplier<Accessor: StateReader<User>>(
+    fn validate_fee_and_calculate_multiplier<Accessor: StateReader<User> + VersionReader>(
         &self,
         user_max_fee_per_gas: u128,
         rollup_base_fee: u128,
         tx_hash: TxHash,
         state: &mut Accessor,
     ) -> Result<u64, AuthenticationError> {
-        let is_max_fee_check_disabled = self.is_max_fee_check_disabled(state).map_err(|e| {
-            AuthenticationError::OutOfGas(format!("validate_fee_and_calculate_multiplier: {e}"))
-        })?;
-
         let apply_max_fee_check_after_height: u64 = config_value!("EVM_MAX_FEE_CHECK_HEIGHT");
-        let env = self.block_env(state).map_err(|e| {
-            AuthenticationError::OutOfGas(format!("validate_fee_and_calculate_multiplier: {e}"))
-        })?;
 
-        let block_number: u64 = env.number.to::<u64>();
+        let block_number: u64 = state.rollup_height_to_access().get();
 
-        if block_number > apply_max_fee_check_after_height && !is_max_fee_check_disabled {
+        if block_number > apply_max_fee_check_after_height {
+            let is_max_fee_check_disabled = self.is_max_fee_check_disabled(state).map_err(|e| {
+                AuthenticationError::OutOfGas(format!("validate_fee_and_calculate_multiplier: {e}"))
+            })?;
+            if is_max_fee_check_disabled {
+                return Ok(100);
+            }
             if user_max_fee_per_gas < rollup_base_fee {
                 let err = FatalError::InsufficientMaxFeePerGas {
                     user_max_fee_per_gas,
@@ -105,7 +105,7 @@ fn recover_evm_signer(
 
 /// Creates the transaction details and tx hash for an EVM transaction.
 fn create_auth_tx_and_hash<
-    Accessor: ProvableStateReader<User, Spec = S> + GetGasPrice<Spec = S>,
+    Accessor: ProvableStateReader<User, Spec = S> + GetGasPrice<Spec = S> + VersionReader,
     S: Spec,
 >(
     tx: &TransactionSigned,
@@ -200,7 +200,7 @@ where
 /// If the caller does plan to derive rollup addresses from evm addresses, they should be sure that their scheme for doing so is deterministic and
 /// collision resistant. You don't want someone to be able to pick a rollup address that someone else is already using!
 pub fn authenticate<
-    Accessor: ProvableStateReader<User, Spec = S> + GetGasPrice<Spec = S>,
+    Accessor: ProvableStateReader<User, Spec = S> + GetGasPrice<Spec = S> + VersionReader,
     S: Spec,
 >(
     raw_tx: &[u8],
@@ -316,7 +316,9 @@ where
         }
     }
 
-    fn authenticate<Accessor: ProvableStateReader<User, Spec = S> + GetGasPrice<Spec = S>>(
+    fn authenticate<
+        Accessor: ProvableStateReader<User, Spec = S> + GetGasPrice<Spec = S> + VersionReader,
+    >(
         tx: &FullyBakedTx,
         state: &mut Accessor,
     ) -> Result<

--- a/crates/module-system/sov-eip712-auth/src/lib.rs
+++ b/crates/module-system/sov-eip712-auth/src/lib.rs
@@ -13,7 +13,7 @@ use sov_modules_api::transaction::{
 };
 use sov_modules_api::{
     DispatchCall, FullyBakedTx, GasMeter, MeteredBorshDeserialize, MeteredBorshDeserializeError,
-    ProvableStateReader, RawTx, Runtime, Spec, TxHash,
+    ProvableStateReader, RawTx, Runtime, Spec, TxHash, VersionReader,
 };
 use sov_state::User;
 
@@ -112,7 +112,7 @@ where
         }
     }
 
-    fn authenticate<Accessor: ProvableStateReader<User, Spec = S>>(
+    fn authenticate<Accessor: ProvableStateReader<User, Spec = S> + VersionReader>(
         tx: &FullyBakedTx,
         state: &mut Accessor,
     ) -> Result<

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -21,7 +21,7 @@ use crate::GetGasPrice;
 use crate::{
     capabilities, CryptoSpec, DispatchCall, FullyBakedTx, GasMeter, GasMeteringError,
     MeteredBorshDeserialize, MeteredBorshDeserializeError, MeteredHasher, ProvableStateReader,
-    RawTx, Runtime, Spec,
+    RawTx, Runtime, Spec, VersionReader,
 };
 
 /// The chain ID of the rollup.
@@ -56,7 +56,10 @@ pub trait TransactionAuthenticator<S: Spec> {
     /// checks during native execution, and the preferred sequencer will attempt to pre-populate this
     /// cache to parallelise signature checks.
     fn authenticate<
-        Accessor: ProvableStateReader<User, Spec = S> + GetGasPrice<Spec = S> + crate::StateMetricsProvider,
+        Accessor: ProvableStateReader<User, Spec = S>
+            + GetGasPrice<Spec = S>
+            + crate::StateMetricsProvider
+            + VersionReader,
     >(
         tx: &FullyBakedTx,
         state: &mut Accessor,

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -917,6 +917,20 @@ impl<S: Spec> GasMeter for MeteredApiStateAccessor<S> {
     }
 }
 
+impl<S: Spec> VersionReader for MeteredApiStateAccessor<S> {
+    fn max_allowed_slot_number_to_access(&self) -> SlotNumber {
+        self.api_state_accessor.max_allowed_slot_number_to_access()
+    }
+
+    fn current_visible_slot_number(&self) -> VisibleSlotNumber {
+        self.api_state_accessor.current_visible_slot_number()
+    }
+
+    fn rollup_height_to_access(&self) -> RollupHeight {
+        self.api_state_accessor.rollup_height_to_access()
+    }
+}
+
 impl<S: Spec> UniversalStateAccessor for MeteredApiStateAccessor<S> {
     fn get_size(
         &mut self,

--- a/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/capabilities.rs
@@ -7,7 +7,9 @@ use sov_modules_api::capabilities::{
     BatchFromUnregisteredSequencer, TransactionAuthenticator, UnregisteredAuthenticationError,
 };
 use sov_modules_api::macros::config_value;
-use sov_modules_api::{DispatchCall, FullyBakedTx, ProvableStateReader, RawTx, Runtime, Spec};
+use sov_modules_api::{
+    DispatchCall, FullyBakedTx, ProvableStateReader, RawTx, Runtime, Spec, VersionReader,
+};
 
 /// Indicates that a runtime supports the `SolanaOffchain` transaction authenticator
 /// and provides suitable methods for encoding and decoding solana offchain message transactions.
@@ -68,7 +70,7 @@ where
         }
     }
 
-    fn authenticate<Accessor: ProvableStateReader<sov_state::User, Spec = S>>(
+    fn authenticate<Accessor: ProvableStateReader<sov_state::User, Spec = S> + VersionReader>(
         tx: &FullyBakedTx,
         state: &mut Accessor,
     ) -> Result<


### PR DESCRIPTION
# Description

This PR fixes an accidental breaking change introduced in #2339. In that PR, we added an extra check against the is_max_fee_disabled state variable. That extra check caused txs to consume more gas, which meant that resyncing over old transactions resulted in different state. This PR fixes the issue by moving that check *after* the check for the change's activation height.

