### PR TITLE
Remove duplicate sorting test case

### DIFF
--- a/crates/utils/sov-rest-utils/src/sorting.rs
+++ b/crates/utils/sov-rest-utils/src/sorting.rs
@@ -123,7 +123,6 @@ mod tests {
     fn ok_cases() {
         try_deserialize(&[("sort", "+100")]).unwrap();
         try_deserialize(&[("sort", "-100")]).unwrap();
-        try_deserialize(&[("sort", "+100")]).unwrap();
         try_deserialize(&[("sort", "--100")]).unwrap();
         try_deserialize(&[("sort", "+0")]).unwrap();
     }


### PR DESCRIPTION

This PR removes a duplicated `+100` case from `sorting::tests::ok_cases`, keeping the test set concise and focused on distinct inputs.

