### PR TITLE
Standardize EVMs JSON-RPC error codes

### DIFF
--- a/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs.rs
@@ -1,4 +1,4 @@
-use crate::handlers::ETH_RPC_ERROR;
+use crate::rpc_limit_exceeded;
 use crate::Ethereum;
 use crate::EthereumAddress;
 use crate::EthereumAuthenticator;
@@ -46,10 +46,8 @@ where
         let LogsWithMaybeCursor { logs, cursor } = service.logs_for_filter().await?;
 
         if cursor.is_some() {
-            return Err(ErrorObjectOwned::owned(
-                jsonrpsee::types::error::UNKNOWN_ERROR_CODE,
-                ETH_RPC_ERROR,
-                Some("Response size exceeds limit. Use eth_getLogsWithCursor or reduce the number of logs requested"),
+            return Err(rpc_limit_exceeded(
+                "Response size exceeds limit. Use eth_getLogsWithCursor or reduce the number of logs requested",
             ));
         }
 

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs/cursor.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs/cursor.rs
@@ -1,7 +1,7 @@
 use hex::{decode, encode};
 use jsonrpsee::types::ErrorObjectOwned;
 
-use crate::{handlers::ETH_RPC_ERROR, to_jsonrpsee_error_object};
+use crate::rpc_invalid_params;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 /// Cursor indicating where to start processing.
@@ -29,15 +29,14 @@ impl Cursor {
     /// Unpacks a 40-character (or "0x"-prefixed) hex string into `Self`.
     pub fn unpack(hex_str: &str) -> Result<Self, ErrorObjectOwned> {
         let s = hex_str.strip_prefix("0x").unwrap_or(hex_str);
-        let bytes = decode(s)
-            .map_err(|_| to_jsonrpsee_error_object("Invalid hex string", ETH_RPC_ERROR))?;
+        let bytes = decode(s).map_err(|_| rpc_invalid_params("Invalid hex string"))?;
 
         if bytes.len() != 20 {
             let msg = format!(
                 "Invalid decoded length expected 20 bytes, got {}",
                 bytes.len()
             );
-            return Err(to_jsonrpsee_error_object(msg, ETH_RPC_ERROR));
+            return Err(rpc_invalid_params(msg));
         }
 
         let block_height = u64::from_be_bytes(bytes[0..8].try_into().unwrap());

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
@@ -22,6 +22,7 @@ use sov_modules_api::ApiStateAccessor;
 use sov_modules_api::Spec;
 use sov_rpc_eth_types::LogWithExecutionTimestamp;
 use sov_rpc_eth_types::LogsWithMaybeCursor;
+use sov_rpc_eth_types::rpc_error_with_code;
 use std::marker::PhantomData;
 use std::ops::Range;
 use std::ops::RangeInclusive;
@@ -60,15 +61,16 @@ type Result<T> = std::result::Result<T, Error>;
 impl From<Error> for ErrorObjectOwned {
     fn from(err: Error) -> ErrorObjectOwned {
         match err {
-            Error::ReceiptPruned(_)
-            | Error::BlockPruned(_)
-            | Error::BlockHashNotFound(_)
-            | Error::InvalidCursorTxIdx { .. } => rpc_resource_not_found(err.to_string()),
+            Error::ReceiptPruned(_) | Error::BlockPruned(_) => {
+                rpc_error_with_code(4444, err.to_string())
+            }
+            Error::BlockHashNotFound(_)
+            | Error::InvalidCursorBlockNumber { .. }
+            | Error::InvalidCursorTxIdx { .. }
+            | Error::InvalidCursorLogIdx { .. } => rpc_resource_not_found(err.to_string()),
             Error::TooManyLogsInBlock(_, _) => rpc_limit_exceeded(err.to_string()),
             Error::PendingBlock
             | Error::InvalidBlock(_)
-            | Error::InvalidCursorBlockNumber { .. }
-            | Error::InvalidCursorLogIdx { .. }
             | Error::ParseBlockNumber(_) => rpc_invalid_params(err.to_string()),
         }
     }

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
@@ -20,9 +20,9 @@ use sov_evm::{Evm, MaybeSealedBlock, Receipt};
 use sov_modules_api::da::Time;
 use sov_modules_api::ApiStateAccessor;
 use sov_modules_api::Spec;
+use sov_rpc_eth_types::rpc_error_with_code;
 use sov_rpc_eth_types::LogWithExecutionTimestamp;
 use sov_rpc_eth_types::LogsWithMaybeCursor;
-use sov_rpc_eth_types::rpc_error_with_code;
 use std::marker::PhantomData;
 use std::ops::Range;
 use std::ops::RangeInclusive;
@@ -69,9 +69,9 @@ impl From<Error> for ErrorObjectOwned {
             | Error::InvalidCursorTxIdx { .. }
             | Error::InvalidCursorLogIdx { .. } => rpc_resource_not_found(err.to_string()),
             Error::TooManyLogsInBlock(_, _) => rpc_limit_exceeded(err.to_string()),
-            Error::PendingBlock
-            | Error::InvalidBlock(_)
-            | Error::ParseBlockNumber(_) => rpc_invalid_params(err.to_string()),
+            Error::PendingBlock | Error::InvalidBlock(_) | Error::ParseBlockNumber(_) => {
+                rpc_invalid_params(err.to_string())
+            }
         }
     }
 }

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
@@ -1,11 +1,10 @@
 use super::cursor::Cursor;
-use crate::handlers::ETH_RPC_ERROR;
-use crate::to_jsonrpsee_error_object;
 use crate::EthereumAddress;
 use crate::EthereumAuthenticator;
 use crate::FromVmAddress;
 use crate::HasKernel;
 use crate::Sequencer;
+use crate::{rpc_invalid_params, rpc_limit_exceeded, rpc_resource_not_found};
 use alloy_consensus::BlockHeader;
 use alloy_consensus::TxReceipt;
 use alloy_eips::eip1898::ParseBlockNumberError;
@@ -60,7 +59,18 @@ type Result<T> = std::result::Result<T, Error>;
 
 impl From<Error> for ErrorObjectOwned {
     fn from(err: Error) -> ErrorObjectOwned {
-        to_jsonrpsee_error_object(err.to_string(), ETH_RPC_ERROR)
+        match err {
+            Error::ReceiptPruned(_) | Error::BlockPruned(_) | Error::BlockHashNotFound(_) => {
+                rpc_resource_not_found(err.to_string())
+            }
+            Error::TooManyLogsInBlock(_, _) => rpc_limit_exceeded(err.to_string()),
+            Error::PendingBlock
+            | Error::InvalidBlock(_)
+            | Error::InvalidCursorBlockNumber { .. }
+            | Error::InvalidCursorTxIdx { .. }
+            | Error::InvalidCursorLogIdx { .. }
+            | Error::ParseBlockNumber(_) => rpc_invalid_params(err.to_string()),
+        }
     }
 }
 

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
@@ -60,14 +60,14 @@ type Result<T> = std::result::Result<T, Error>;
 impl From<Error> for ErrorObjectOwned {
     fn from(err: Error) -> ErrorObjectOwned {
         match err {
-            Error::ReceiptPruned(_) | Error::BlockPruned(_) | Error::BlockHashNotFound(_) => {
-                rpc_resource_not_found(err.to_string())
-            }
+            Error::ReceiptPruned(_)
+            | Error::BlockPruned(_)
+            | Error::BlockHashNotFound(_)
+            | Error::InvalidCursorTxIdx { .. } => rpc_resource_not_found(err.to_string()),
             Error::TooManyLogsInBlock(_, _) => rpc_limit_exceeded(err.to_string()),
             Error::PendingBlock
             | Error::InvalidBlock(_)
             | Error::InvalidCursorBlockNumber { .. }
-            | Error::InvalidCursorTxIdx { .. }
             | Error::InvalidCursorLogIdx { .. }
             | Error::ParseBlockNumber(_) => rpc_invalid_params(err.to_string()),
         }

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -42,10 +42,9 @@ use std::time::Instant;
 pub use subscribe::eth_subscribe;
 use tokio::time::timeout;
 
-use crate::to_jsonrpsee_error_object;
 use crate::Ethereum;
+use crate::{rpc_internal_error, rpc_invalid_input, rpc_invalid_params, rpc_tx_rejected};
 
-const ETH_RPC_ERROR: &str = "ETH_RPC_ERROR";
 const TIMEOUT_CODE: i32 = 4;
 
 type Receipt = TransactionReceipt<ReceiptEnvelope<LogWithExecutionTimestamp>>;
@@ -89,10 +88,9 @@ where
         let data: Bytes = params.next()?;
         let timeout_ms = params.optional_next::<u64>()?.unwrap_or(MAX_TIMEOUT);
         if timeout_ms > MAX_TIMEOUT {
-            return Err(to_jsonrpsee_error_object(
-                format!("Max allowed timeout is: {MAX_TIMEOUT}"),
-                ETH_RPC_ERROR,
-            ));
+            return Err(rpc_invalid_params(format!(
+                "Max allowed timeout is: {MAX_TIMEOUT}"
+            )));
         }
         let addr = get_peer_ip_addr(extensions)?;
 
@@ -150,12 +148,9 @@ where
         Self::authenticate_tx(&tx, &ethereum)?;
 
         let seq = ethereum.sequencer.clone();
-        seq.accept_tx(tx, ip_addr).await.map_err(|e| {
-            to_jsonrpsee_error_object(
-                format!("{} - '{}' ({:?})", e.status, e.message, e.details),
-                ETH_RPC_ERROR,
-            )
-        })?;
+        seq.accept_tx(tx, ip_addr)
+            .await
+            .map_err(|e| rpc_tx_rejected(format!("{} - '{}' ({:?})", e.status, e.message, e.details)))?;
 
         on_success(tx_hash, ethereum)
     }
@@ -168,9 +163,8 @@ where
     // This will also be moved into the sequencer, but for now is kept here.
     fn authenticate_tx(tx: &FullyBakedTx, ethereum: &Arc<Ethereum<S, Seq>>) -> RpcResult<()> {
         let mut state = ethereum.api_state_accessor().to_provable_reader();
-        let _ = <Seq::Rt as Runtime<S>>::Auth::authenticate(tx, &mut state).map_err(|e| {
-            to_jsonrpsee_error_object(format!("Authentication failed: {e}"), ETH_RPC_ERROR)
-        })?;
+        let _ = <Seq::Rt as Runtime<S>>::Auth::authenticate(tx, &mut state)
+            .map_err(|e| rpc_invalid_input(format!("Authentication failed: {e}")))?;
         Ok(())
     }
 
@@ -197,14 +191,11 @@ where
         // get from, return error if none
         let from = transaction_request
             .from
-            .ok_or(to_jsonrpsee_error_object("No from address", ETH_RPC_ERROR))?;
+            .ok_or_else(|| rpc_invalid_params("No from address"))?;
 
         // return error if not in signers
         if !ethereum.eth_signer.addresses().contains(&from) {
-            return Err(to_jsonrpsee_error_object(
-                "From address not in signers",
-                ETH_RPC_ERROR,
-            ));
+            return Err(rpc_invalid_params("From address not in signers"));
         }
 
         let raw_evm_tx = {
@@ -246,15 +237,13 @@ where
             let signed_tx = ethereum
                 .eth_signer
                 .sign_transaction(transaction, &from)
-                .map_err(|e| to_jsonrpsee_error_object(e, ETH_RPC_ERROR))?;
+                .map_err(rpc_internal_error)?;
 
             RlpEvmTransaction {
                 rlp: signed_tx.encoded_2718(),
             }
         };
-        let (tx_hash, raw_message) = ethereum
-            .make_raw_tx(raw_evm_tx)
-            .map_err(|e| to_jsonrpsee_error_object(e, ETH_RPC_ERROR))?;
+        let (tx_hash, raw_message) = ethereum.make_raw_tx(raw_evm_tx)?;
 
         let tx = Seq::Rt::encode_with_ethereum_auth(RawTx::new(raw_message));
 
@@ -263,10 +252,7 @@ where
             .accept_tx(tx, ip_addr)
             .await
             .map_err(|e| {
-                to_jsonrpsee_error_object(
-                    format!("{} - '{}' ({:?})", e.status, e.message, e.details),
-                    ETH_RPC_ERROR,
-                )
+                rpc_tx_rejected(format!("{} - '{}' ({:?})", e.status, e.message, e.details))
             })?;
 
         Ok(tx_hash)
@@ -292,14 +278,14 @@ fn get_peer_ip_addr(extensions: Extensions) -> Result<IpAddr, ErrorObjectOwned> 
     // The `SocketAddr`` was injected into the request extensions by specific middleware in `axum::serve`.
     let ip_result = extensions.get::<GetIPResult>().ok_or_else(|| {
         tracing::error!("Axum Extensions map does not contain GetIPResult");
-        to_jsonrpsee_error_object(IP_ADDRESS_ERROR, ETH_RPC_ERROR)
+        rpc_internal_error(IP_ADDRESS_ERROR)
     })?;
 
     match ip_result.maybe_ip.as_ref() {
         Ok(ok) => Ok(*ok),
         Err(err) => {
             let err_msg = format!("IP address error: {err:?}");
-            Err(to_jsonrpsee_error_object(err_msg, ETH_RPC_ERROR))
+            Err(rpc_internal_error(err_msg))
         }
     }
 }

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -148,9 +148,9 @@ where
         Self::authenticate_tx(&tx, &ethereum)?;
 
         let seq = ethereum.sequencer.clone();
-        seq.accept_tx(tx, ip_addr)
-            .await
-            .map_err(|e| rpc_tx_rejected(format!("{} - '{}' ({:?})", e.status, e.message, e.details)))?;
+        seq.accept_tx(tx, ip_addr).await.map_err(|e| {
+            rpc_tx_rejected(format!("{} - '{}' ({:?})", e.status, e.message, e.details))
+        })?;
 
         on_success(tx_hash, ethereum)
     }

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -43,7 +43,7 @@ pub use subscribe::eth_subscribe;
 use tokio::time::timeout;
 
 use crate::Ethereum;
-use crate::{rpc_internal_error, rpc_invalid_input, rpc_invalid_params, rpc_tx_rejected};
+use crate::{rpc_internal_error, rpc_invalid_params, rpc_tx_rejected};
 
 const TIMEOUT_CODE: i32 = 4;
 
@@ -164,7 +164,7 @@ where
     fn authenticate_tx(tx: &FullyBakedTx, ethereum: &Arc<Ethereum<S, Seq>>) -> RpcResult<()> {
         let mut state = ethereum.api_state_accessor().to_provable_reader();
         let _ = <Seq::Rt as Runtime<S>>::Auth::authenticate(tx, &mut state)
-            .map_err(|e| rpc_invalid_input(format!("Authentication failed: {e}")))?;
+            .map_err(|e| rpc_invalid_params(format!("Authentication failed: {e}")))?;
         Ok(())
     }
 

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/params.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/params.rs
@@ -1,6 +1,5 @@
 use crate::handlers::subscribe::SubscriptionRequest;
-use crate::handlers::ETH_RPC_ERROR;
-use crate::to_jsonrpsee_error_object;
+use crate::rpc_invalid_params;
 use alloy_rpc_types::pubsub::Params;
 use alloy_rpc_types::pubsub::SubscriptionKind;
 use alloy_rpc_types::BlockNumberOrTag;
@@ -23,7 +22,7 @@ pub enum Error {
 
 impl From<Error> for ErrorObjectOwned {
     fn from(err: Error) -> Self {
-        to_jsonrpsee_error_object(err, ETH_RPC_ERROR)
+        rpc_invalid_params(err)
     }
 }
 

--- a/crates/full-node/sov-ethereum/src/lib.rs
+++ b/crates/full-node/sov-ethereum/src/lib.rs
@@ -3,9 +3,6 @@ mod handlers;
 use std::convert::Infallible;
 
 use alloy_primitives::{B256, U256};
-use jsonrpsee::types::error::{
-    CALL_EXECUTION_FAILED_CODE, INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE,
-};
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::RpcModule;
 use sov_address::{EthereumAddress, FromVmAddress};
@@ -15,7 +12,9 @@ pub use sov_evm::EthereumAuthenticator;
 use sov_evm::{convert_to_tx_signed, RlpEvmTransaction};
 use sov_modules_api::capabilities::HasKernel;
 use sov_modules_api::{ApiStateAccessor, Spec};
-use sov_rpc_eth_types::EthApiError;
+use sov_rpc_eth_types::{
+    internal_rpc_err, invalid_params_rpc_err, rpc_error_with_code, EthApiError,
+};
 use sov_sequencer::{SeqConfigExtension, Sequencer};
 use std::future::ready;
 
@@ -143,30 +142,22 @@ where
     }
 }
 
-fn rpc_error_with_data(code: i32, message: &'static str, err: impl ToString) -> ErrorObjectOwned {
-    ErrorObjectOwned::owned(code, message, Some(err.to_string()))
-}
-
 pub(crate) fn rpc_invalid_params(err: impl ToString) -> ErrorObjectOwned {
-    rpc_error_with_data(INVALID_PARAMS_CODE, "Invalid params", err)
-}
-
-pub(crate) fn rpc_invalid_input(err: impl ToString) -> ErrorObjectOwned {
-    rpc_error_with_data(CALL_EXECUTION_FAILED_CODE, "Invalid input", err)
+    invalid_params_rpc_err(err.to_string())
 }
 
 pub(crate) fn rpc_internal_error(err: impl ToString) -> ErrorObjectOwned {
-    rpc_error_with_data(INTERNAL_ERROR_CODE, "Internal error", err)
+    internal_rpc_err(err.to_string())
 }
 
 pub(crate) fn rpc_limit_exceeded(err: impl ToString) -> ErrorObjectOwned {
-    rpc_error_with_data(LIMIT_EXCEEDED_CODE, "Limit exceeded", err)
+    rpc_error_with_code(LIMIT_EXCEEDED_CODE, err.to_string())
 }
 
 pub(crate) fn rpc_tx_rejected(err: impl ToString) -> ErrorObjectOwned {
-    rpc_error_with_data(TX_REJECTED_CODE, "Transaction rejected", err)
+    rpc_error_with_code(TX_REJECTED_CODE, err.to_string())
 }
 
 pub(crate) fn rpc_resource_not_found(err: impl ToString) -> ErrorObjectOwned {
-    rpc_error_with_data(RESOURCE_NOT_FOUND_CODE, "Resource not found", err)
+    rpc_error_with_code(RESOURCE_NOT_FOUND_CODE, err.to_string())
 }

--- a/crates/full-node/sov-ethereum/src/lib.rs
+++ b/crates/full-node/sov-ethereum/src/lib.rs
@@ -3,7 +3,9 @@ mod handlers;
 use std::convert::Infallible;
 
 use alloy_primitives::{B256, U256};
-use jsonrpsee::types::error::UNKNOWN_ERROR_CODE;
+use jsonrpsee::types::error::{
+    CALL_EXECUTION_FAILED_CODE, INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE,
+};
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::RpcModule;
 use sov_address::{EthereumAddress, FromVmAddress};
@@ -13,6 +15,7 @@ pub use sov_evm::EthereumAuthenticator;
 use sov_evm::{convert_to_tx_signed, RlpEvmTransaction};
 use sov_modules_api::capabilities::HasKernel;
 use sov_modules_api::{ApiStateAccessor, Spec};
+use sov_rpc_eth_types::EthApiError;
 use sov_sequencer::{SeqConfigExtension, Sequencer};
 use std::future::ready;
 
@@ -28,6 +31,10 @@ pub struct EthRpcConfig {
     /// Shutdown signal receiver for graceful termination
     pub shutdown_receiver: tokio::sync::watch::Receiver<()>,
 }
+
+const LIMIT_EXCEEDED_CODE: i32 = -32005;
+const RESOURCE_NOT_FOUND_CODE: i32 = -32001;
+const TX_REJECTED_CODE: i32 = -32003;
 
 pub fn get_ethereum_rpc<S, Seq>(eth_rpc_config: EthRpcConfig, sequencer: Seq) -> RpcModule<()>
 where
@@ -120,9 +127,8 @@ where
 {
     fn make_raw_tx(&self, raw_tx: RlpEvmTransaction) -> Result<(B256, Vec<u8>), ErrorObjectOwned> {
         let message = borsh::to_vec(&raw_tx).expect("Failed to serialize raw tx");
-        let signed_transaction = convert_to_tx_signed(raw_tx).map_err(|err| {
-            ErrorObjectOwned::owned(UNKNOWN_ERROR_CODE, err.to_string(), None::<()>)
-        })?;
+        let signed_transaction = convert_to_tx_signed(raw_tx)
+            .map_err(|err| ErrorObjectOwned::from(EthApiError::from(err)))?;
 
         let tx_hash = signed_transaction.hash();
 
@@ -137,6 +143,30 @@ where
     }
 }
 
-pub(crate) fn to_jsonrpsee_error_object(err: impl ToString, message: &str) -> ErrorObjectOwned {
-    ErrorObjectOwned::owned(UNKNOWN_ERROR_CODE, message, Some(err.to_string()))
+fn rpc_error_with_data(code: i32, message: &'static str, err: impl ToString) -> ErrorObjectOwned {
+    ErrorObjectOwned::owned(code, message, Some(err.to_string()))
+}
+
+pub(crate) fn rpc_invalid_params(err: impl ToString) -> ErrorObjectOwned {
+    rpc_error_with_data(INVALID_PARAMS_CODE, "Invalid params", err)
+}
+
+pub(crate) fn rpc_invalid_input(err: impl ToString) -> ErrorObjectOwned {
+    rpc_error_with_data(CALL_EXECUTION_FAILED_CODE, "Invalid input", err)
+}
+
+pub(crate) fn rpc_internal_error(err: impl ToString) -> ErrorObjectOwned {
+    rpc_error_with_data(INTERNAL_ERROR_CODE, "Internal error", err)
+}
+
+pub(crate) fn rpc_limit_exceeded(err: impl ToString) -> ErrorObjectOwned {
+    rpc_error_with_data(LIMIT_EXCEEDED_CODE, "Limit exceeded", err)
+}
+
+pub(crate) fn rpc_tx_rejected(err: impl ToString) -> ErrorObjectOwned {
+    rpc_error_with_data(TX_REJECTED_CODE, "Transaction rejected", err)
+}
+
+pub(crate) fn rpc_resource_not_found(err: impl ToString) -> ErrorObjectOwned {
+    rpc_error_with_data(RESOURCE_NOT_FOUND_CODE, "Resource not found", err)
 }

--- a/crates/full-node/sov-ethereum/src/signer.rs
+++ b/crates/full-node/sov-ethereum/src/signer.rs
@@ -9,7 +9,7 @@ use sov_modules_api::{ApiStateAccessor, RawTx, Spec};
 use sov_rpc_eth_types::EthApiError;
 use sov_sequencer::Sequencer;
 
-use crate::{to_jsonrpsee_error_object, Ethereum, ETH_RPC_ERROR};
+use crate::{rpc_internal_error, rpc_invalid_params, rpc_tx_rejected, Ethereum};
 
 fn config_chain_id() -> u64 {
     config_value!("CHAIN_ID")
@@ -38,14 +38,11 @@ where
             // get from, return error if none
             let from = transaction_request
                 .from
-                .ok_or(to_jsonrpsee_error_object("No from address", ETH_RPC_ERROR))?;
+                .ok_or_else(|| rpc_invalid_params("No from address"))?;
 
             // return error if not in signers
             if !ethereum.eth_signer.addresses().contains(&from) {
-                return Err(to_jsonrpsee_error_object(
-                    "From address not in signers",
-                    ETH_RPC_ERROR,
-                ));
+                return Err(rpc_invalid_params("From address not in signers"));
             }
 
             let raw_evm_tx = {
@@ -67,24 +64,21 @@ where
                 let signed_tx = ethereum
                     .eth_signer
                     .sign_transaction(transaction, &from)
-                    .map_err(|e| to_jsonrpsee_error_object(e, ETH_RPC_ERROR))?;
+                    .map_err(rpc_internal_error)?;
 
                 RlpEvmTransaction {
                     rlp: signed_tx.envelope_encoded().to_vec(),
                 }
             };
-            let (tx_hash, raw_message) = ethereum
-                .make_raw_tx(raw_evm_tx)
-                .map_err(|e| to_jsonrpsee_error_object(e, ETH_RPC_ERROR))?;
+            let (tx_hash, raw_message) = ethereum.make_raw_tx(raw_evm_tx)?;
 
             let tx = Seq::Rt::encode_with_ethereum_auth(RawTx::new(raw_message));
 
-            ethereum.sequencer.accept_tx(tx).await.map_err(|e| {
-                to_jsonrpsee_error_object(
-                    format!("{} - '{}' ({:?})", e.status, e.message, e.details),
-                    ETH_RPC_ERROR,
-                )
-            })?;
+            ethereum
+                .sequencer
+                .accept_tx(tx)
+                .await
+                .map_err(|e| rpc_tx_rejected(format!("{} - '{}' ({:?})", e.status, e.message, e.details)))?;
 
             Ok::<_, ErrorObjectOwned>(tx_hash)
         },
@@ -109,7 +103,7 @@ where
     let gas_price = transaction_request.gas_price.unwrap_or_default();
 
     if transaction_request.from.is_none() {
-        return Err(to_jsonrpsee_error_object("No from address", ETH_RPC_ERROR));
+        return Err(rpc_invalid_params("No from address"));
     }
 
     let estimated_gas = evm.eth_estimate_gas(

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/error.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/error.rs
@@ -3,7 +3,8 @@
 use std::fmt::Display;
 
 use alloy_primitives::Bytes;
-use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
+use jsonrpsee::types::error::INTERNAL_ERROR_CODE;
+use jsonrpsee::types::ErrorObjectOwned;
 use revm::context::result::{ExecutionResult, HaltReason};
 use sov_modules_api::StateAccessor;
 use sov_rpc_eth_types::{EthApiError, EthResult, RevertError, RpcInvalidTransactionError};
@@ -44,5 +45,5 @@ impl<Ws: StateAccessor> From<crate::db::Error<Ws>> for EthApiError {
 
 /// Converts internal error into rpc error
 pub fn into_rpc_error(err: impl Display) -> ErrorObjectOwned {
-    ErrorObject::owned(500, format!("{err}"), None::<()>)
+    ErrorObjectOwned::owned(INTERNAL_ERROR_CODE, err.to_string(), None::<()>)
 }

--- a/crates/utils/sov-rpc-eth-types/src/lib.rs
+++ b/crates/utils/sov-rpc-eth-types/src/lib.rs
@@ -10,6 +10,7 @@ pub use filter_with_cursor::{FilterWithCursor, LogsWithMaybeCursor};
 pub use revert_error::RevertError;
 pub use rpc_invalid_transaction_error::RpcInvalidTransactionError;
 pub use to_rpc_error::ToRpcError;
+pub use utils::{internal_rpc_err, invalid_params_rpc_err, rpc_error_with_code};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
 pub struct LogWithExecutionTimestamp<L = alloy_rpc_types::Log> {

--- a/examples/demo-rollup/tests/evm/evm_contract_creation_allowlist.rs
+++ b/examples/demo-rollup/tests/evm/evm_contract_creation_allowlist.rs
@@ -22,6 +22,6 @@ async fn denied() -> anyhow::Result<()> {
     let client = alloy_client_with_signer(rollup.http_addr, SECONDARY_SENDER_PRIV_KEY);
 
     let err = SimpleStorage::deploy(client).await.unwrap_err();
-    assert_eq!(err.to_string(), "server returned an error response: error code 500: Contract creation is only allowed from allowed addresses. 0x3FE0233e6cf3c9753fcB7449987EC49C88aDDE71 is not on the list");
+    assert_eq!(err.to_string(), "server returned an error response: error code -32603: Contract creation is only allowed from allowed addresses. 0x3FE0233e6cf3c9753fcB7449987EC49C88aDDE71 is not on the list");
     Ok(())
 }

--- a/examples/demo-rollup/tests/evm/evm_rate_limit.rs
+++ b/examples/demo-rollup/tests/evm/evm_rate_limit.rs
@@ -86,7 +86,7 @@ fn assert_err(err: RpcError<TransportErrorKind>) {
     let payload = err.as_error_resp().unwrap();
     assert!(
         payload.message.as_ref().contains(X_FORWARDED_FOR),
-        "expected error message to include IP: {}",
-        X_FORWARDED_FOR
+        "expected error message to include IP: {X_FORWARDED_FOR}, but it was: {}",
+        payload.message,
     );
 }

--- a/examples/demo-rollup/tests/evm/evm_rate_limit.rs
+++ b/examples/demo-rollup/tests/evm/evm_rate_limit.rs
@@ -83,13 +83,10 @@ async fn evm_test_rate_limit() -> anyhow::Result<()> {
 }
 
 fn assert_err(err: RpcError<TransportErrorKind>) {
-    let err_str = err
-        .as_error_resp()
-        .unwrap()
-        .data
-        .as_ref()
-        .unwrap()
-        .to_string();
-
-    err_str.contains("X_FORWARDED_FOR");
+    let payload = err.as_error_resp().unwrap();
+    assert!(
+        payload.message.as_ref().contains(X_FORWARDED_FOR),
+        "expected error message to include IP: {}",
+        X_FORWARDED_FOR
+    );
 }

--- a/examples/demo-rollup/tests/evm/evm_subscribe.rs
+++ b/examples/demo-rollup/tests/evm/evm_subscribe.rs
@@ -132,8 +132,10 @@ async fn evm_test_log_subscription_with_block_range_returns_an_error() -> anyhow
     let RpcError::ErrorResp(payload) = err else {
         panic!("Expected subscription error")
     };
-    let data = payload.data.unwrap();
-    assert_eq!(data.get(), "\"Block Option parameters are not supported in LOG subscriptions. Please use eth_getLogs or eth_getLogsWithCursor\"");
+    assert_eq!(
+        payload.message.as_ref(),
+        "Block Option parameters are not supported in LOG subscriptions. Please use eth_getLogs or eth_getLogsWithCursor"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
# Description

Spin off https://github.com/Sovereign-Labs/sovereign-sdk/pull/2374

### Error Code Standardization

Replaced non-standard error codes with proper JSON-RPC codes:
- `-32602` (Invalid params) for validation errors
- `-32603` (Internal error) for server errors  
- `-32000` (Invalid input) for call execution failures
- `-32001` (Resource not found) for missing blocks/receipts
- `-32003` (Transaction rejected) for sequencer rejections
- `-32004` (Method not supported) for unsupported methods
- `-32005` (Limit exceeded) for response size limits

Removed generic `ETH_RPC_ERROR` message and `UNKNOWN_ERROR_CODE` usage throughout.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2271

## Testing
Manually checked by Codex

## Docs
No updates
