### PR TITLE
EVM: EIP-1898 block-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 2026-01-16 
+# 2026-01-20
+- #2379 EVM: Add EIP-1898 BlockId support for JSON-RPC endpoints.
+
+# 2026-01-16
 - #2342 EVM: Populate the `gas_limit` for pending block.
 - #2338 **Infra only breaking change**: Removes `da_total_timeout_secs` from runner section in `rollup_config.toml`
 - #2349 Adds optional celestia params: `api_request_timeout_secs`, `tx_status_polling_millis` and `background_stat_polling_interval_secs`

--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -1,6 +1,8 @@
 mod get_logs;
 mod subscribe;
 #[cfg(feature = "local")]
+use alloy_eips::BlockId;
+#[cfg(feature = "local")]
 use alloy_eips::Encodable2718;
 #[cfg(feature = "local")]
 use alloy_primitives::Address;
@@ -217,7 +219,7 @@ where
 
             let estimated_gas = evm.eth_estimate_gas(
                 transaction_request.clone(),
-                Some("pending".to_string()),
+                Some(BlockId::pending()),
                 &mut state,
             )?;
             transaction_request.gas = Some(estimated_gas.to::<u64>());

--- a/crates/full-node/sov-ethereum/src/signer.rs
+++ b/crates/full-node/sov-ethereum/src/signer.rs
@@ -1,3 +1,4 @@
+use alloy_eips::BlockId;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::RpcModule;
 use reth_primitives::{TxKind, U256};
@@ -124,7 +125,7 @@ where
             max_fee_per_blob_gas: None,
             ..Default::default()
         },
-        Some("pending".to_string()),
+        Some(BlockId::pending()),
         state,
     )?;
 

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -1,6 +1,7 @@
 use crate::error::into_rpc_error;
 use crate::rpc::error::ensure_success;
 use alloy_consensus::ReceiptEnvelope;
+use alloy_eips::BlockId;
 use alloy_primitives::{Address, U64};
 use alloy_primitives::{Bytes, B256, U256};
 use alloy_rpc_types::{
@@ -65,14 +66,17 @@ where
             "EVM module JSON-RPC request"
         );
 
-        let block_number_hex = self
+        let block_number = self
             .block_hash_to_number
             .get(&block_hash, state)
-            .unwrap_infallible()
-            .map(|number| hex::encode(number.to_be_bytes()));
+            .unwrap_infallible();
         let kind = details.unwrap_or_default().into();
-        Ok(match block_number_hex {
-            Some(block_number_hex) => self.get_block(Some(block_number_hex), kind, state)?,
+        Ok(match block_number {
+            Some(number) => self.get_block(
+                Some(BlockId::Number(BlockNumberOrTag::Number(number))),
+                kind,
+                state,
+            )?,
             None => None,
         })
     }
@@ -81,17 +85,17 @@ where
     #[rpc_method(name = "eth_getBlockByNumber")]
     pub fn get_block_by_number(
         &self,
-        block_number: Option<String>,
+        block_id: Option<BlockId>,
         details: Option<bool>,
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<Option<Block>> {
         trace!(
-            block_number,
+            ?block_id,
             method = "eth_getBlockByNumber",
             "EVM module JSON-RPC request"
         );
         let kind = details.unwrap_or_default().into();
-        Ok(self.get_block(block_number, kind, state)?)
+        Ok(self.get_block(block_id, kind, state)?)
     }
 
     /// Handler for: `eth_getBalance`
@@ -99,10 +103,10 @@ where
     pub fn get_balance(
         &self,
         address: Address,
-        block_number: Option<String>,
+        block_id: Option<BlockId>,
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<U256> {
-        let mut state = self.resolve_state(block_number, state)?;
+        let mut state = self.resolve_state_for_block_id(block_id, state)?;
         let balance = self
             .db(state.deref_mut())
             .basic(address)
@@ -126,12 +130,12 @@ where
         &self,
         address: Address,
         index: U256,
-        block_number: Option<String>,
+        block_id: Option<BlockId>,
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<U256> {
-        trace!(method = "eth_getStorageAt", ?block_number, %address, %index, "EVM module JSON-RPC request");
+        trace!(method = "eth_getStorageAt", ?block_id, %address, %index, "EVM module JSON-RPC request");
 
-        let mut state = self.resolve_state(block_number, state)?;
+        let mut state = self.resolve_state_for_block_id(block_id, state)?;
         let storage_slot = self
             .account_storage
             .get(&(&address, &index), state.deref_mut())
@@ -146,10 +150,10 @@ where
     pub fn get_transaction_count(
         &self,
         address: Address,
-        block_number: Option<String>,
+        block_id: Option<BlockId>,
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<U64> {
-        let mut state = self.resolve_state(block_number, state)?;
+        let mut state = self.resolve_state_for_block_id(block_id, state)?;
 
         let ethereum_address: EthereumAddress = address.into();
         let credential_id = ethereum_address.as_credential_id();
@@ -168,11 +172,11 @@ where
     pub fn get_code(
         &self,
         address: Address,
-        block_number: Option<String>,
+        block_id: Option<BlockId>,
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<Bytes> {
-        trace!(method = "eth_getCode", %address, ?block_number, "EVM module JSON-RPC request");
-        let state = self.resolve_state(block_number, state)?;
+        trace!(method = "eth_getCode", %address, ?block_id, "EVM module JSON-RPC request");
+        let state = self.resolve_state_for_block_id(block_id, state)?;
         Ok(self.get_contract_code(address, state).unwrap_or_default())
     }
 
@@ -227,16 +231,16 @@ where
     #[rpc_method(name = "eth_getBlockReceipts")]
     pub fn get_block_receipts(
         &self,
-        block_number: Option<String>,
+        block_id: Option<BlockId>,
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<Option<Vec<TransactionReceipt<ReceiptEnvelope<LogWithExecutionTimestamp>>>>>
     {
         trace!(
-            block_number,
+            ?block_id,
             method = "eth_getBlockReceipts",
             "EVM module JSON-RPC request"
         );
-        Ok(self.get_receipts(block_number, state)?)
+        Ok(self.get_receipts(block_id, state)?)
     }
 
     /// Handler for: `eth_getTransactionReceipt`
@@ -260,17 +264,17 @@ where
     pub fn eth_call(
         &self,
         request: TransactionRequest,
-        block_number: Option<String>,
+        block_id: Option<BlockId>,
         _state_overrides: Option<StateOverride>,
         _block_overrides: Option<Box<BlockOverrides>>,
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<Bytes> {
         trace!(
             method = "eth_call",
-            ?block_number,
+            ?block_id,
             "EVM module JSON-RPC request"
         );
-        let result = self.call(request, block_number, state)?.result;
+        let result = self.call(request, block_id, state)?.result;
         Ok(ensure_success(result)?)
     }
 
@@ -288,10 +292,14 @@ where
     pub fn eth_estimate_gas(
         &self,
         request: TransactionRequest,
-        block_number: Option<String>,
+        block_id: Option<BlockId>,
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<U64> {
-        trace!(method = "eth_estimateGas", "EVM module JSON-RPC request");
+        trace!(
+            ?block_id,
+            method = "eth_estimateGas",
+            "EVM module JSON-RPC request"
+        );
 
         // Add 1,000 bytes to account for all other data in the Transaction structure, apart from call data.
         let tx_size = request.input.input().as_ref().map(|i| i.len()).unwrap_or(0) + 1000;
@@ -299,7 +307,7 @@ where
         let ResultAndState {
             result,
             state: changes,
-        } = self.call(request, block_number, state)?;
+        } = self.call(request, block_id, state)?;
         self.db(state)
             .try_commit(changes)
             .expect("Gas meter is initialized with INF");

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -10,7 +10,7 @@ pub use crate::primitive_types::MaybeSealedBlock;
 use crate::{verify_contract_creation_allowlist, Evm, SealedBlock};
 use alloy_consensus::{transaction::Recovered, Transaction as TransactionTrait, TxReceipt};
 use alloy_consensus::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
-use alloy_eips::BlockNumberOrTag;
+use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, BlockNumber, Bloom, B64};
 use alloy_primitives::{Bytes, TxKind, B256, U256};
 use alloy_rpc_types::{
@@ -109,11 +109,12 @@ where
 
     fn get_block(
         &self,
-        block_number: Option<String>,
+        block_id: Option<BlockId>,
         kind: BlockTransactionsKind,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<Option<Block>, EthApiError> {
-        let Some(block) = self.get_sealed_block_by_number(block_number, state)? else {
+        let block_id = block_id.unwrap_or_else(BlockId::latest);
+        let Some(block) = self.get_maybe_sealed_block_by_id(block_id, state)? else {
             return Ok(None);
         };
         let transactions = self.get_block_transactions(&block, kind, state)?;
@@ -172,13 +173,14 @@ where
 
     fn get_receipts(
         &self,
-        block_number: Option<String>,
+        block_id: Option<BlockId>,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<
         Option<Vec<TransactionReceipt<ReceiptEnvelope<LogWithExecutionTimestamp>>>>,
         EthApiError,
     > {
-        let Some(block) = self.get_sealed_block_by_number(block_number, state)? else {
+        let block_id = block_id.unwrap_or_else(BlockId::latest);
+        let Some(block) = self.get_maybe_sealed_block_by_id(block_id, state)? else {
             return Ok(None);
         };
         let Some(receipts) = block
@@ -194,10 +196,10 @@ where
     fn call(
         &self,
         request: TransactionRequest,
-        block_number: Option<String>,
+        block_id: Option<BlockId>,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<ResultAndState, EthApiError> {
-        let block_env = self.resolve_block_env_for_call(block_number, state)?;
+        let block_env = self.resolve_block_env_for_call(block_id, state)?;
         let tx_env = prepare_call_env(&block_env, request.clone())?;
         let caller = tx_env.caller;
         let cfg = self.cfg_infallible(state);
@@ -228,21 +230,38 @@ where
         None
     }
 
-    /// Convert string to block nr.
-    pub fn str_to_block_nr(
+    fn block_tag_to_pending_or_block(
         &self,
-        block_number: Option<String>,
+        block: BlockNumberOrTag,
+        state: &mut ApiStateAccessor<S>,
+    ) -> PendingOrBlock {
+        let block_numbers = self.block_numbers(state);
+        match block {
+            BlockNumberOrTag::Earliest => PendingOrBlock::Number(*block_numbers.start()),
+            // We treat latest and pending the same to avoid foundry issues
+            BlockNumberOrTag::Latest | BlockNumberOrTag::Pending => PendingOrBlock::Pending,
+            BlockNumberOrTag::Finalized | BlockNumberOrTag::Safe => {
+                PendingOrBlock::Number(*block_numbers.end())
+            }
+            BlockNumberOrTag::Number(number) => PendingOrBlock::Number(number),
+        }
+    }
+
+    fn block_id_to_pending_or_block(
+        &self,
+        block_id: BlockId,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<PendingOrBlock, EthApiError> {
-        let block_number_str = block_number.unwrap_or_else(|| "latest".into());
-
-        Ok(match block_number_str.as_str() {
-            "earliest" => PendingOrBlock::Number(*self.block_numbers(state).start()),
-            // We treat latest and pending the same to avoid foundry issues
-            "latest" | "pending" => PendingOrBlock::Pending,
-            number => {
-                let number = u64::from_str_radix(number.trim_start_matches("0x"), 16)
-                    .map_err(|e| EthApiError::InvalidBlockNumber(block_number_str, e))?;
+        Ok(match block_id {
+            BlockId::Number(tag) => self.block_tag_to_pending_or_block(tag, state),
+            BlockId::Hash(hash) => {
+                let Some(number) = self
+                    .block_hash_to_number
+                    .get(&hash.block_hash, state)
+                    .unwrap_infallible()
+                else {
+                    return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash)));
+                };
                 PendingOrBlock::Number(number)
             }
         })
@@ -268,10 +287,10 @@ where
     /// Retrieves a sealed block by number.
     pub fn get_sealed_block_by_number(
         &self,
-        block_number: Option<String>,
+        block_number: BlockNumberOrTag,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<Option<MaybeSealedBlock>, EthApiError> {
-        let pending_or_block_nr = self.str_to_block_nr(block_number, state)?;
+        let pending_or_block_nr = self.block_tag_to_pending_or_block(block_number, state);
 
         Ok(match pending_or_block_nr {
             PendingOrBlock::Number(nr) => self.get_maybe_sealed_block(nr, state),
@@ -279,6 +298,29 @@ where
                 let pending_block = self.pending_block(state);
                 Some(MaybeSealedBlock::Pending(pending_block))
             }
+        })
+    }
+
+    fn get_maybe_sealed_block_by_id(
+        &self,
+        block_id: BlockId,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Result<Option<MaybeSealedBlock>, EthApiError> {
+        Ok(match block_id {
+            BlockId::Number(tag) => {
+                let pending_or_block = self.block_tag_to_pending_or_block(tag, state);
+                match pending_or_block {
+                    PendingOrBlock::Number(number) => self.get_maybe_sealed_block(number, state),
+                    PendingOrBlock::Pending => {
+                        Some(MaybeSealedBlock::Pending(self.pending_block(state)))
+                    }
+                }
+            }
+            BlockId::Hash(hash) => self
+                .block_hash_to_number
+                .get(&hash.block_hash, state)
+                .unwrap_infallible()
+                .and_then(|number| self.get_maybe_sealed_block(number, state)),
         })
     }
 
@@ -344,12 +386,13 @@ where
         }
     }
 
-    fn resolve_state<'a>(
+    fn resolve_state_for_block_id<'a>(
         &self,
-        block_number: Option<String>,
+        block_id: Option<BlockId>,
         state: &'a mut ApiStateAccessor<S>,
     ) -> Result<MaybeArchivalState<'a, S>, EthApiError> {
-        let pending_or_block_nr = self.str_to_block_nr(block_number, state)?;
+        let block_id = block_id.unwrap_or_else(BlockId::latest);
+        let pending_or_block_nr = self.block_id_to_pending_or_block(block_id, state)?;
         match pending_or_block_nr {
             PendingOrBlock::Pending => Ok(MaybeArchivalState::Current(state)),
             PendingOrBlock::Number(number) => {
@@ -366,11 +409,12 @@ where
 
     fn resolve_block_env_for_call(
         &self,
-        block_number: Option<String>,
+        block_id: Option<BlockId>,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<BlockEnv, EthApiError> {
+        let block_id = block_id.unwrap_or_else(BlockId::latest);
         let maybe_block = self
-            .get_sealed_block_by_number(block_number, state)?
+            .get_maybe_sealed_block_by_id(block_id, state)?
             .ok_or(EthApiError::UnknownBlock)?;
 
         let mut block_env = match maybe_block {

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -284,23 +284,6 @@ where
         block_number
     }
 
-    /// Retrieves a sealed block by number.
-    pub fn get_sealed_block_by_number(
-        &self,
-        block_number: BlockNumberOrTag,
-        state: &mut ApiStateAccessor<S>,
-    ) -> Result<Option<MaybeSealedBlock>, EthApiError> {
-        let pending_or_block_nr = self.block_tag_to_pending_or_block(block_number, state);
-
-        Ok(match pending_or_block_nr {
-            PendingOrBlock::Number(nr) => self.get_maybe_sealed_block(nr, state),
-            PendingOrBlock::Pending => {
-                let pending_block = self.pending_block(state);
-                Some(MaybeSealedBlock::Pending(pending_block))
-            }
-        })
-    }
-
     fn get_maybe_sealed_block_by_id(
         &self,
         block_id: BlockId,

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/archival_state.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/archival_state.rs
@@ -1,7 +1,25 @@
+use alloy_eips::BlockId;
+use alloy_rpc_types::BlockNumberOrTag;
 use sov_evm::Evm;
 
 use crate::helpers::{create_transfer_tx, setup};
 use crate::runtime::S;
+
+/// Helper to convert string block identifiers to BlockId
+fn parse_block_id(s: &str) -> BlockId {
+    match s {
+        "latest" => BlockId::Number(BlockNumberOrTag::Latest),
+        "pending" => BlockId::Number(BlockNumberOrTag::Pending),
+        "earliest" => BlockId::Number(BlockNumberOrTag::Earliest),
+        "safe" => BlockId::Number(BlockNumberOrTag::Safe),
+        "finalized" => BlockId::Number(BlockNumberOrTag::Finalized),
+        hex if hex.starts_with("0x") => {
+            let num = u64::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap();
+            BlockId::Number(BlockNumberOrTag::Number(num))
+        }
+        _ => panic!("Invalid block identifier: {s}"),
+    }
+}
 
 #[test]
 fn test_state_at_different_depth_is_accessible() {
@@ -14,7 +32,7 @@ fn test_state_at_different_depth_is_accessible() {
     }
     runner.query_visible_state(|state| {
         let mut balance = |block: Option<&str>| {
-            evm.get_balance(to.address(), block.map(Into::into), state)
+            evm.get_balance(to.address(), block.map(parse_block_id), state)
                 .unwrap()
         };
         assert_eq!(balance(None), 2);

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/archival_state.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/archival_state.rs
@@ -1,25 +1,8 @@
 use alloy_eips::BlockId;
-use alloy_rpc_types::BlockNumberOrTag;
 use sov_evm::Evm;
 
 use crate::helpers::{create_transfer_tx, setup};
 use crate::runtime::S;
-
-/// Helper to convert string block identifiers to BlockId
-fn parse_block_id(s: &str) -> BlockId {
-    match s {
-        "latest" => BlockId::Number(BlockNumberOrTag::Latest),
-        "pending" => BlockId::Number(BlockNumberOrTag::Pending),
-        "earliest" => BlockId::Number(BlockNumberOrTag::Earliest),
-        "safe" => BlockId::Number(BlockNumberOrTag::Safe),
-        "finalized" => BlockId::Number(BlockNumberOrTag::Finalized),
-        hex if hex.starts_with("0x") => {
-            let num = u64::from_str_radix(hex.trim_start_matches("0x"), 16).unwrap();
-            BlockId::Number(BlockNumberOrTag::Number(num))
-        }
-        _ => panic!("Invalid block identifier: {s}"),
-    }
-}
 
 #[test]
 fn test_state_at_different_depth_is_accessible() {
@@ -32,8 +15,12 @@ fn test_state_at_different_depth_is_accessible() {
     }
     runner.query_visible_state(|state| {
         let mut balance = |block: Option<&str>| {
-            evm.get_balance(to.address(), block.map(parse_block_id), state)
-                .unwrap()
+            evm.get_balance(
+                to.address(),
+                block.map(|s| s.parse::<BlockId>().unwrap()),
+                state,
+            )
+            .unwrap()
         };
         assert_eq!(balance(None), 2);
         assert_eq!(balance(Some("latest")), 2);

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
@@ -1,6 +1,7 @@
 use crate::helpers::*;
 use crate::runtime::RT;
 use crate::runtime::S;
+use alloy_eips::BlockId;
 use alloy_primitives::FixedBytes;
 use alloy_primitives::Log;
 use alloy_primitives::U256;
@@ -182,7 +183,7 @@ fn test_executing_eth_transactions_several_blocks() {
             assert: Box::new(move |_result, state| {
                 assert_eq!(block.nr, evm.block_number(state).unwrap().to::<u64>());
                 let block_from_evm = evm
-                    .get_block_by_number(Some(format!("{:x}", block.nr)), None, state)
+                    .get_block_by_number(Some(BlockId::number(block.nr)), None, state)
                     .unwrap()
                     .unwrap();
 

--- a/examples/demo-rollup/tests/evm/evm_tx.rs
+++ b/examples/demo-rollup/tests/evm/evm_tx.rs
@@ -107,8 +107,8 @@ async fn execute_evm_tests(
     // TODO: reenable this check by figuring out a way to get finer grained control over preferred batch production.
     //evm_test_helper::gas_check(client, da_service, contract_address).await?;
 
-    let first_block = client.eth_get_block_by_number(Some("0".to_owned())).await;
-    let second_block = client.eth_get_block_by_number(Some("1".to_owned())).await;
+    let first_block = client.eth_get_block_by_number(Some("0x0".to_owned())).await;
+    let second_block = client.eth_get_block_by_number(Some("0x1".to_owned())).await;
 
     // assert parent hash works correctly
     assert_eq!(


### PR DESCRIPTION
# Description



Changed all block identifier parameters from `String` to `BlockId`, enabling:
- Block tags: `"latest"`, `"pending"`, `"earliest"`, `"safe"`, `"finalized"`
- Block number objects: `{"blockNumber": "0x1"}`
- Block hash objects: `{"blockHash": "0x..."}`

Affected methods: `eth_getBlockByNumber`, `eth_getBalance`, `eth_getStorageAt`, `eth_getTransactionCount`, `eth_getCode`, `eth_call`, `eth_estimateGas`, `eth_getBlockReceipts`


Spin off
* https://github.com/Sovereign-Labs/sovereign-sdk/pull/2374

Blocked by 
* https://github.com/Sovereign-Labs/sovereign-sdk/pull/2378
* https://github.com/Sovereign-Labs/sovereign-sdk/pull/2380

----

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2271

## Testing
Existing test are passing. Other cases were manually checked by codex

## Docs
No updates