### PR TITLE
EVM: Fee history input params validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 2026-01-16 
+# 2026-01-20
+- #2380 EVM: Validate `eth_feeHistory` input parameters.
+
+# 2026-01-16
 - #2342 EVM: Populate the `gas_limit` for pending block.
 - #2338 **Infra only breaking change**: Removes `da_total_timeout_secs` from runner section in `rollup_config.toml`
 - #2349 Adds optional celestia params: `api_request_timeout_secs`, `tx_status_polling_millis` and `background_stat_polling_interval_secs`

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/fee_history.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/fee_history.rs
@@ -1,5 +1,7 @@
 use alloy_eips::BlockNumberOrTag;
 use alloy_rpc_types::FeeHistory;
+use jsonrpsee::types::error::INVALID_PARAMS_CODE;
+use jsonrpsee::types::ErrorObjectOwned;
 use sov_address::{EthereumAddress, FromVmAddress};
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::{ApiStateAccessor, Spec};
@@ -21,9 +23,24 @@ where
         state: &mut ApiStateAccessor<S>,
     ) -> Result<FeeHistory, EthApiError> {
         if block_count == 0 {
-            return Err(EthApiError::other(into_rpc_error(anyhow::anyhow!(
-                "block_count must be greater than 0"
-            ))));
+            return Err(EthApiError::other(ErrorObjectOwned::owned(
+                INVALID_PARAMS_CODE,
+                "block_count must be greater than 0",
+                None::<()>,
+            )));
+        }
+
+        // Validate reward percentiles
+        if let Some(percentiles) = reward_percentiles {
+            for &p in percentiles {
+                if !(0.0..=100.0).contains(&p) {
+                    return Err(EthApiError::InvalidRewardPercentile(p));
+                }
+            }
+            // Check monotonic increasing
+            if !percentiles.windows(2).all(|w| w[0] <= w[1]) {
+                return Err(EthApiError::RewardPercentilesMustBeMonotonic);
+            }
         }
 
         let block_count = block_count.min(1024);

--- a/crates/utils/sov-rpc-eth-types/src/eth_api_error.rs
+++ b/crates/utils/sov-rpc-eth-types/src/eth_api_error.rs
@@ -74,6 +74,12 @@ pub enum EthApiError {
     /// Error encountered when converting a transaction type
     #[error("Transaction conversion error")]
     TransactionConversionError,
+    /// Invalid reward percentile value (must be between 0 and 100)
+    #[error("invalid reward percentile: {0} not in [0, 100]")]
+    InvalidRewardPercentile(f64),
+    /// Reward percentiles must be monotonically increasing
+    #[error("reward percentiles must be monotonically increasing")]
+    RewardPercentilesMustBeMonotonic,
     /// Any other error
     #[error("{0}")]
     Other(Box<dyn ToRpcError>),
@@ -96,7 +102,11 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             | EthApiError::InvalidTracerConfig
             | EthApiError::ApiStateAccess(_)
             | EthApiError::InvalidBlockNumber(_, _)
-            | EthApiError::TransactionConversionError => invalid_params_rpc_err(error.to_string()),
+            | EthApiError::TransactionConversionError
+            | EthApiError::InvalidRewardPercentile(_)
+            | EthApiError::RewardPercentilesMustBeMonotonic => {
+                invalid_params_rpc_err(error.to_string())
+            }
             EthApiError::InvalidTransaction(err) => err.into(),
             EthApiError::InvalidHeader(_) | EthApiError::EvmCustom(_) => {
                 internal_rpc_err(error.to_string())


### PR DESCRIPTION
# Description

Added `eth_feeHistory` reward percentile validation:
- Values must be in range `[0, 100]`
- Values must be monotonically increasing
- Returns `-32602` with descriptive error messages


Spin off 
* https://github.com/Sovereign-Labs/sovereign-sdk/pull/2374

Blocked by 
* https://github.com/Sovereign-Labs/sovereign-sdk/pull/2378

-------

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2271 

## Testing
All existing tests are passing


## Docs
No updates
