### PR TITLE
Mark `test_pinned_cache_after_fast_resync` as flaky.

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/pinned_cache.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/pinned_cache.rs
@@ -523,9 +523,10 @@ async fn test_pinned_cache_after_total_resync() {
     test_rollup.shutdown().await.unwrap();
 }
 
-/// Ensures that RAM pinning works again after the node falls out of sync
+/// Ensures that RAM pinning works again after the node falls out of sync.
+/// Marked as flaky, because it calls the manual produce_batch endpoint but sometimes there’s no open batch.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_pinned_cache_after_fast_resync() {
+async fn flaky_test_pinned_cache_after_fast_resync() {
     sov_test_utils::initialize_logging();
     let (test_rollup, admin) = create_test_nomt_rollup().await;
     // Finalise some blocks


### PR DESCRIPTION
# Description

To have greener CI faster

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
All existing tests are passing

## Docs
No updates
