### PR TITLE
Replica: Skip `state_update` when a DA batch arrives before the PostgreSQL notification

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -208,6 +208,7 @@ where
         handles.push(nonce_buffer_task);
 
         let seq = PreferredSequencer(Arc::new(PreferredSequencerFields {
+            seq_role,
             synchronized_state_updator: synchronized_state_updator.clone(),
             tx_status_manager: tx_status_manager.clone(),
             transaction_cache: cached_txs,

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -113,6 +113,7 @@ where
     Rt: Runtime<S>,
     Da: DaService<Spec = S::Da>,
 {
+    seq_role: SequencerRole,
     synchronized_state_updator: Arc<SequencerStateUpdator<S, Rt>>,
     tx_status_manager: TxStatusManager<S::Da>,
     blobs_sender_channel: Option<broadcast::Sender<BlobExecutionStatus<Da::Spec>>>,

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
@@ -9,6 +9,7 @@ use crate::preferred::rate_limiter::ResourceLimitExceededError;
 use crate::preferred::rate_limiter::SovRateLimiter;
 use crate::preferred::replica::event_handler::ReplicaError;
 use crate::preferred::replica::event_receiver::EventReceiverStartNotifier;
+use crate::preferred::update_state::SequenceNumberMismatchError;
 use crate::preferred::AcceptedTx;
 use crate::preferred::BatchCreationError;
 use crate::preferred::Confirmation;
@@ -75,7 +76,7 @@ pub(super) enum Message<S: Spec, Rt: Runtime<S>> {
     },
 
     FinalCatchup {
-        resp: oneshot::Sender<anyhow::Result<ProcessFinalCatchupData>>,
+        resp: oneshot::Sender<Result<ProcessFinalCatchupData, SequenceNumberMismatchError>>,
         info: StateUpdateInfo<S::Storage>,
         db_event_subscription: mpsc::Receiver<DbEvent>,
         executor: Box<RollupBlockExecutor<S, Rt>>,

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -11,6 +11,7 @@ use crate::preferred::sync_sequencer_state::conditions_table::{
 use crate::preferred::sync_sequencer_state::ConditionsTable;
 use crate::preferred::sync_sequencer_state::{InitialStatus, Message};
 use crate::preferred::update_state::do_next_event;
+use crate::preferred::update_state::SequenceNumberMismatchError;
 use crate::preferred::AcceptTxError;
 use crate::preferred::DoNewTxError;
 use crate::preferred::Inner;
@@ -602,8 +603,13 @@ where
         node_state_root: <S::Storage as Storage>::Root,
         mut data: ProcessFinalCatchupData,
         reason: &'static str,
-    ) -> anyhow::Result<ProcessFinalCatchupData> {
+    ) -> Result<ProcessFinalCatchupData, SequenceNumberMismatchError> {
         let mut inner = self.get_inner_with_timing(reason).await;
+
+        let mut rt = Rt::default();
+        let next_sequence_number_according_to_node =
+            get_next_sequence_number_according_to_node(&info, &mut rt);
+
         // Some events might come in while we're waiting to grab the lock.
         // Replay them.
         while let Ok(event) = db_event_subscription.try_recv() {
@@ -613,6 +619,8 @@ where
             }
 
             do_next_event(
+                inner.seq_role,
+                next_sequence_number_according_to_node,
                 &mut executor,
                 event,
                 &mut data.batches_count,

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/updator.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/updator.rs
@@ -3,6 +3,7 @@ use crate::preferred::db::BatchToStore;
 use crate::preferred::rate_limiter::IpAndCredentialId;
 use crate::preferred::replica::event_handler::ReplicaError;
 use crate::preferred::sync_sequencer_state::Message;
+use crate::preferred::update_state::SequenceNumberMismatchError;
 use crate::preferred::AcceptTxError;
 use crate::preferred::AcceptedTx;
 use crate::preferred::Confirmation;
@@ -155,8 +156,13 @@ where
         node_state_root: <S::Storage as Storage>::Root,
         data: ProcessFinalCatchupData,
         reason: &'static str,
-    ) -> Result<(anyhow::Result<ProcessFinalCatchupData>, Duration), SequencerStateUpdatorError>
-    {
+    ) -> Result<
+        (
+            Result<ProcessFinalCatchupData, SequenceNumberMismatchError>,
+            Duration,
+        ),
+        SequencerStateUpdatorError,
+    > {
         let start_time = std::time::Instant::now();
         let (resp, recv) = oneshot::channel();
         self.send(Message::FinalCatchup {

--- a/crates/full-node/sov-sequencer/src/preferred/update_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/update_state.rs
@@ -10,6 +10,8 @@ use crate::preferred::{
     PreferredBatchToReplay, PreferredSequencer, ProcessFinalCatchupData, RollupBlockExecutor,
     StateUpdateInfo,
 };
+use crate::SequencerRole;
+use tracing::error;
 
 impl<S, Rt, Da> PreferredSequencer<S, Rt, Da>
 where
@@ -122,6 +124,22 @@ where
         // Replay the in-progress batch if it exists.
         let mut batch_is_in_progress = false;
         if let Some(batch) = in_progress_batch {
+            let seq_nr_in_of_in_progress_batch = batch.sequence_number;
+
+            if seq_nr_in_of_in_progress_batch < next_sequence_number {
+                if self.seq_role == SequencerRole::Replica {
+                    error!(seq_nr_in_of_in_progress_batch, next_sequence_number, "The replica has an in-progress batch whose sequence number is lower than the next_sequence_number expected by the node. 
+                    This may indicate that Postgres notifications are delayed. In this case, the update from the node is ignored. 
+                    If this error occurs repeatedly, investigate the database stack in the deployment.");
+                    return Ok(());
+                } else {
+                    error!(
+                        seq_role,
+                        seq_nr_in_of_in_progress_batch, next_sequence_number, "TODO"
+                    )
+                }
+            }
+
             batches_count += 1;
             transactions_count += batch.txs.len();
             batch_is_in_progress = true;

--- a/crates/full-node/sov-sequencer/src/preferred/update_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/update_state.rs
@@ -264,8 +264,7 @@ fn validate_seq_nr_from_node(
             SequencerRole::Replica => {
                 // If this occurs on replicas, we log the error and skip `update_state` for the batch received from the node.
                 // If the database slowdown is temporary, the issue will be resolved when the next `update_state` call succeeds.
-                // If the situation persists, the replica will eventually enter sync mode in that case that the database
-                // setup needs to be examined.
+                // If the situation persists, the replica will eventually enter sync mode in that case that the database setup needs to be examined.
                 error!(seq_nr_of_in_progress_batch, next_sequence_number_according_to_node, "The replica has an in-progress batch whose sequence number is lower than the next_sequence_number expected by the node. 
                     This indicate that Postgres notifications are delayed. In this case, the update from the node is ignored. 
                     If this error occurs repeatedly, investigate the database stack in the deployment.");

--- a/crates/full-node/sov-sequencer/src/preferred/update_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/update_state.rs
@@ -1,8 +1,7 @@
-use std::time::Instant;
-
 use sov_modules_api::{Runtime, Spec};
 use sov_rollup_interface::node::da::DaService;
 use sov_state::{NativeStorage, Storage};
+use std::time::Instant;
 
 use crate::metrics::PreferredSequencerUpdateStateMetrics;
 use crate::preferred::{
@@ -124,19 +123,14 @@ where
         // Replay the in-progress batch if it exists.
         let mut batch_is_in_progress = false;
         if let Some(batch) = in_progress_batch {
-            let seq_nr_in_of_in_progress_batch = batch.sequence_number;
-
-            if seq_nr_in_of_in_progress_batch < next_sequence_number {
-                if self.seq_role == SequencerRole::Replica {
-                    error!(seq_nr_in_of_in_progress_batch, next_sequence_number, "The replica has an in-progress batch whose sequence number is lower than the next_sequence_number expected by the node. 
-                    This may indicate that Postgres notifications are delayed. In this case, the update from the node is ignored. 
-                    If this error occurs repeatedly, investigate the database stack in the deployment.");
-                    return Ok(());
-                } else {
-                    error!(
-                        seq_role,
-                        seq_nr_in_of_in_progress_batch, next_sequence_number, "TODO"
-                    )
+            if let Err(err) = validate_seq_nr_from_node(
+                batch.sequence_number,
+                next_sequence_number,
+                self.seq_role,
+            ) {
+                match err {
+                    SequenceNumberMismatchError::SkipStateUpdate => return Ok(()),
+                    SequenceNumberMismatchError::Other(err) => return Err(err),
                 }
             }
 
@@ -164,7 +158,9 @@ where
                 return Ok(());
             }
             let event = db_event_subscription.try_recv().unwrap();
-            do_next_event(
+            if let Err(err) = do_next_event(
+                self.seq_role,
+                next_sequence_number,
                 &mut executor,
                 event,
                 &mut batches_count,
@@ -172,7 +168,13 @@ where
                 &node_state_root,
                 &mut batch_is_in_progress,
             )
-            .await?;
+            .await
+            {
+                match err {
+                    SequenceNumberMismatchError::SkipStateUpdate => return Ok(()),
+                    SequenceNumberMismatchError::Other(err) => return Err(err),
+                }
+            }
         }
 
         let (maybe_data, message_processing_duration) = self
@@ -192,7 +194,11 @@ where
             .await
             .map_err(|e| e.into_state_update_error())?;
 
-        let data = maybe_data?;
+        let data = match maybe_data {
+            Ok(data) => data,
+            Err(SequenceNumberMismatchError::SkipStateUpdate) => return Ok(()),
+            Err(SequenceNumberMismatchError::Other(e)) => return Err(e),
+        };
 
         total_message_processing_duration += message_processing_duration;
 
@@ -240,32 +246,88 @@ where
     }
 }
 
+/// The sequencer number and node sequence number do not match.
+pub enum SequenceNumberMismatchError {
+    /// The sequence number mismatch can be resolved by skipping the `state_update`.
+    SkipStateUpdate,
+    /// The error cannot be resolved locally and must be propagated to the caller.
+    Other(anyhow::Error),
+}
+
+fn validate_seq_nr_from_node(
+    seq_nr_of_in_progress_batch: u64,
+    next_sequence_number_according_to_node: u64,
+    seq_role: SequencerRole,
+) -> Result<(), SequenceNumberMismatchError> {
+    if seq_nr_of_in_progress_batch < next_sequence_number_according_to_node {
+        match seq_role {
+            SequencerRole::Replica => {
+                // If this occurs on replicas, we log the error and skip `update_state` for the batch received from the node.
+                // If the database slowdown is temporary, the issue will be resolved when the next `update_state` call succeeds.
+                // If the situation persists, the replica will eventually enter sync mode in that case that the database
+                // setup needs to be examined.
+                error!(seq_nr_of_in_progress_batch, next_sequence_number_according_to_node, "The replica has an in-progress batch whose sequence number is lower than the next_sequence_number expected by the node. 
+                    This indicate that Postgres notifications are delayed. In this case, the update from the node is ignored. 
+                    If this error occurs repeatedly, investigate the database stack in the deployment.");
+                return Err(SequenceNumberMismatchError::SkipStateUpdate);
+            }
+            SequencerRole::Leader | SequencerRole::ReplicaNoLeaderSync => {
+                // For roles other than replicas, we should never observe in-progress batches with sequence numbers lower than what the node expects (ReplicaNoLeaderSync don't create batches).
+                let err = anyhow::anyhow!(
+                    "sequencer_role: {seq_role:?},
+                    seq_nr_of_in_progress_batch: {seq_nr_of_in_progress_batch}, 
+                    next_sequence_number_according_to_node: {next_sequence_number_according_to_node},
+                    The sequencer has an in-progress batch whose sequence number is lower than the next_sequence_number expected by the node.
+                    This is a bug, please report it."
+                );
+
+                return Err(SequenceNumberMismatchError::Other(err));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Replay an event on the executor.
 #[tracing::instrument(skip_all, level = "warn", name = "update_state::do_next_event")]
 pub(crate) async fn do_next_event<S: Spec, Rt: Runtime<S>>(
+    seq_role: SequencerRole,
+    next_sequence_number_according_to_node: u64,
     executor: &mut RollupBlockExecutor<S, Rt>,
     event: DbEvent,
     batches_count: &mut u64,
     transactions_count: &mut usize,
     node_state_root: &<S::Storage as Storage>::Root,
     batch_is_in_progress: &mut bool,
-) -> anyhow::Result<()> {
+) -> Result<(), SequenceNumberMismatchError> {
     match event {
         DbEvent::TxAccepted(tx, hash) => {
             executor.replay_tx(hash, tx).await;
             *transactions_count += 1;
             *batch_is_in_progress = true;
         }
-        DbEvent::BatchClosed(_) => {
+        DbEvent::BatchClosed(sequence_number) => {
+            validate_seq_nr_from_node(
+                sequence_number,
+                next_sequence_number_according_to_node,
+                seq_role,
+            )?;
+
             tracing::trace!("Done replaying txs");
             executor.end_rollup_block().await;
             *batch_is_in_progress = false;
         }
         DbEvent::BatchStarted {
-            sequence_number: _,
+            sequence_number,
             visible_slot_number_after_increase,
             visible_slots_to_advance,
         } => {
+            validate_seq_nr_from_node(
+                sequence_number,
+                next_sequence_number_according_to_node,
+                seq_role,
+            )?;
+
             *batches_count += 1;
             executor
                 .start_rollup_block_for_replay(


### PR DESCRIPTION
# Description
The replica receives batches from the master via PostgreSQL notifications and via DA. Under normal conditions, PostgreSQL notifications are faster than DA, so after the initial sync, the replica stays ahead of DA.

However, when database performance degrades, the replica may receive a batch via DA first and only later receive the same batch via PostgreSQL. In this case, we will get the `visible slot number calculation was incorrect` error. 

This PR fixes the issue by skipping the problematic `update_state` call.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
