### PR TITLE
Add `debug-ci` claude skill

### DIFF
--- a/.claude/skills/debug-ci/SKILL.md
+++ b/.claude/skills/debug-ci/SKILL.md
@@ -7,6 +7,10 @@ description: Debug failed CI tests by fetching workflow logs from GitHub Actions
 
 Debug failed CI tests by fetching workflow logs and analyzing failures.
 
+## Prerequisites
+
+- `gh` CLI installed and authenticated (`gh auth login`)
+
 ## Instructions
 
 ### Step 1: Identify Current PR
@@ -40,7 +44,7 @@ Create directory and download all job logs, stripping ANSI color codes:
 mkdir -p ci-logs/pr-<PR_NUMBER>/
 # or: mkdir -p ci-logs/branch-<BRANCH_NAME>/
 
-gh run view --job <job-id> --log | sed 's/\x1b\[[0-9;]*m//g' > ci-logs/pr-<PR_NUMBER>/<job_name>_<job_id>.log
+gh run view --job <job-id> --log | perl -pe 's/\e\[[0-9;]*m//g' > ci-logs/pr-<PR_NUMBER>/<job_name>_<job_id>.log
 ```
 
 Sanitize job names for filenames (replace spaces/special chars with underscores).

--- a/.claude/skills/debug-ci/SKILL.md
+++ b/.claude/skills/debug-ci/SKILL.md
@@ -35,12 +35,12 @@ gh run view <run-id> --json jobs --jq '.jobs[] | {id: .databaseId, name: .name, 
 
 ### Step 4: Download Logs
 
-Create directory and download all job logs:
+Create directory and download all job logs, stripping ANSI color codes:
 ```bash
 mkdir -p ci-logs/pr-<PR_NUMBER>/
 # or: mkdir -p ci-logs/branch-<BRANCH_NAME>/
 
-gh run view --job <job-id> --log > ci-logs/pr-<PR_NUMBER>/<job_name>_<job_id>.log
+gh run view --job <job-id> --log | sed 's/\x1b\[[0-9;]*m//g' > ci-logs/pr-<PR_NUMBER>/<job_name>_<job_id>.log
 ```
 
 Sanitize job names for filenames (replace spaces/special chars with underscores).

--- a/.claude/skills/debug-ci/SKILL.md
+++ b/.claude/skills/debug-ci/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: debug-ci
+description: Debug failed CI tests by fetching workflow logs from GitHub Actions and analyzing failures. Use when the user mentions CI failures, test failures, or wants to understand why their PR's CI is failing.
+---
+
+# Debug CI
+
+Debug failed CI tests by fetching workflow logs and analyzing failures.
+
+## Instructions
+
+### Step 1: Identify Current PR
+
+Get PR info for current branch:
+```bash
+gh pr view --json number,title --jq '"\(.number) \(.title)"' 2>/dev/null || echo "no-pr"
+```
+
+If no PR exists, use branch name for the log directory.
+
+### Step 2: Get Latest Workflow Run
+
+Get latest "Rust" workflow run for current branch:
+```bash
+BRANCH=$(git branch --show-current)
+gh run list --workflow=Rust --branch=$BRANCH --limit=1 --json databaseId,conclusion,headSha,createdAt
+```
+
+### Step 3: Get Job Information
+
+List all jobs from the run:
+```bash
+gh run view <run-id> --json jobs --jq '.jobs[] | {id: .databaseId, name: .name, conclusion: .conclusion}'
+```
+
+### Step 4: Download Logs
+
+Create directory and download all job logs:
+```bash
+mkdir -p ci-logs/pr-<PR_NUMBER>/
+# or: mkdir -p ci-logs/branch-<BRANCH_NAME>/
+
+gh run view --job <job-id> --log > ci-logs/pr-<PR_NUMBER>/<job_name>_<job_id>.log
+```
+
+Sanitize job names for filenames (replace spaces/special chars with underscores).
+
+### Step 5: Analyze Failures
+
+1. Read downloaded log files
+2. Search for failure patterns: `FAILED`, `error[E`, `panicked at`, `assertion failed`
+3. Extract test names and error messages
+4. Read PR diff (`gh pr diff`) to correlate failures with changes
+5. Categorize failures:
+   - **Real failure**: Error in code touched by PR
+   - **Flaky test**: Known flaky or unrelated to changes
+   - **Infrastructure**: Network/timeout issues
+
+### Step 6: Report
+
+Provide summary:
+- PR number and title
+- Run status and commit SHA
+- List of downloaded log file paths
+- Categorized failures with file:line references
+- Recommendations for next steps
+
+## Notes
+
+- The `ci-logs/` directory should be in `.gitignore`
+- Focus on relevant log sections; files can be large

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ demo_data_1/
 demo_data_2/
 demo_data_replica/
 
+ci-logs/
+
 docker/observability
 
 .vscode/settings.json


### PR DESCRIPTION
# Description

CI fails? Let claude figure it out.

It require `gh` github cli installed and configured.

Bonus point: CI logs will be available on your machine, so you can tell codex other agent to take look.

Here is example how it worked for me in the https://github.com/Sovereign-Labs/sovereign-sdk/pull/2387:

```
❯ Can you identify why the most recent CI tests fail?

⏺ Skill(debug-ci)
  ⎿  Initializing…

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 Use skill "debug-ci"?
 Claude may use instructions, code, or files from this Skill.

   Debug failed CI tests by fetching workflow logs from GitHub Actions and analyzing failures. Use when the user mentions CI failures, test failures, or wants to understand why their
   PR's CI is failing.

 Do you want to proceed?
 ❯ 1. Yes
   2. Yes, and don't ask again for debug-ci in /Users/nikolai/workspace/sovereign/sovereign-sdk
   3. No

 Esc to cancel · Tab to add additional instructions
```


And then it just pulled the logs, looked at it and found correct reason:


```
 CI Failure Summary

  PR: #2387 - "EVM: JSON-RPC endpoints compatibility testing: part 1"
  Run ID: 21286887751
  Commit: 9d13a0a39

  Failed Jobs

  - nextest
  - nextest_all_features
  - coverage

  Root Cause

  Two tests are failing due to EVM gas value mismatches:
  ┌──────────────────────────────────┬──────────────────────────────────────────────┬────────────────┬────────────────┐
  │               Test               │                     File                     │    Expected    │     Actual     │
  ├──────────────────────────────────┼──────────────────────────────────────────────┼────────────────┼────────────────┤
  │ trace::test_tracing              │ sov-evm/tests/integration/trace.rs:49        │ gas_used: 5612 │ gas_used: 5634 │
  ├──────────────────────────────────┼──────────────────────────────────────────────┼────────────────┼────────────────┤
  │ transactions::test_evm_gas_usage │ sov-evm/tests/integration/transactions.rs:98 │ [5251, 0]      │ [5318, 0]      │
  └──────────────────────────────────┴──────────────────────────────────────────────┴────────────────┴────────────────┘
  Analysis

  The PR modifies SimpleStorage.sol by adding three new events:
  - FullTopicLog
  - DataOnlyLog
  - IndexedOnlyLog

  These additions change the compiled contract bytecode, which affects gas calculations. The integration tests have hardcoded expected gas values that were computed with the old contract
  bytecode.

  Recommendation

  Update the expected gas values in the test files to match the new bytecode:

  1. trace.rs:58: Change gas_used: U256::from(5_612) → gas_used: U256::from(5_634)
  2. transactions.rs:103: Change &[5_251, 0] → &[5_318, 0]

  Note: The commit "Ignored failing tests" (9d13a0a39) only ignored tests in examples/demo-rollup/tests/evm/, not the integration tests in sov-evm/tests/integration/.

✻ Sautéed for 1m 24s
```