### PR TITLE
Replace "Pending" block with the synthetic "latest" block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-01-24
+- #2397: Major rework of "pending" block handling. Now we treat each new EVM transaction as creating a new head block (rather than a pending block) and then getting reorged when the next tx is added. 
+
 # 2026-01-20
 - #2379 EVM: Add EIP-1898 BlockId support for JSON-RPC endpoints.
 - #2380 EVM: Validate `eth_feeHistory` input parameters.

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
@@ -9,7 +9,6 @@ use alloy_consensus::BlockHeader;
 use alloy_consensus::TxReceipt;
 use alloy_eips::eip1898::ParseBlockNumberError;
 use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::BlockHash;
 use alloy_primitives::BlockNumber;
 use alloy_primitives::B256;
 use alloy_rpc_types::eth::Filter;

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
@@ -130,8 +130,13 @@ where
     }
 
     fn by_hash(mut self, block_hash: B256) -> Result<LogsWithMaybeCursor> {
-        let block_height = self.resolve_block_hash(block_hash)?;
-        let maybe_cursor = self.scan_block_range(block_height..=block_height)?;
+        let block = self
+            .evm
+            .get_maybe_sealed_block_by_id(block_hash.into(), &mut self.state)
+            .map_err(|_| Error::BlockHashNotFound(block_hash))?
+            .ok_or(Error::BlockHashNotFound(block_hash))?;
+        let maybe_cursor = self.scan_block(block)?;
+
         Ok(LogsWithMaybeCursor::new(
             self.logs,
             maybe_cursor.map(|c| c.pack()),
@@ -326,14 +331,6 @@ where
             return Err(Error::BlockPruned(number));
         };
         Ok(block)
-    }
-
-    fn resolve_block_hash(&mut self, block_hash: BlockHash) -> Result<u64> {
-        let Some(block_height) = self.evm.block_height(&block_hash, &mut self.state) else {
-            tracing::warn!(block_hash = %block_hash, "Block with hash not found");
-            return Err(Error::BlockHashNotFound(block_hash));
-        };
-        Ok(block_height)
     }
 
     fn get_block_nr(&mut self, block_nr_or_tag: Option<BlockNumberOrTag>) -> Result<BlockNumber> {

--- a/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/get_logs/service.rs
@@ -165,8 +165,10 @@ where
         let range = self.apply_block_level_cursor(range)?;
         for block_number in range {
             let block = self.get_block(block_number)?;
-            if !self.filter.matches_bloom(block.header().logs_bloom()) {
-                continue;
+            if let Some(header) = block.header_if_sealed() {
+                if !self.filter.matches_bloom(header.logs_bloom()) {
+                    continue;
+                }
             }
             if let Some(cursor) = self.scan_block(block)? {
                 return Ok(Some(cursor));
@@ -248,18 +250,17 @@ where
         block: &MaybeSealedBlock,
         time: Time,
     ) -> Result<Option<Cursor>> {
-        let header = block.header();
         let logs = receipt.receipt.logs;
         let log_range = 0_u32..(logs.len() as u32);
         let logs_iter = logs.into_iter().enumerate();
         let skipped_logs =
-            self.apply_log_level_cursor(log_range, tx_index_absolute, header.number())?;
+            self.apply_log_level_cursor(log_range, tx_index_absolute, block.number())?;
 
         // As logs iter is pre-enumerated - we keep correct indices
         for (idx, log) in logs_iter.skip(skipped_logs as usize) {
             if self.logs.len() >= *self.max_logs {
                 return Ok(Some(Cursor {
-                    block_height: header.number(),
+                    block_height: block.number(),
                     tx_index_absolute,
                     log_index_in_tx: idx as u32,
                 }));
@@ -283,7 +284,7 @@ where
             let log_size = serialized_size(&rpc_log);
             if self.logs_serialized_size + log_size >= *self.response_size_limit {
                 return Ok(Some(Cursor {
-                    block_height: header.number(),
+                    block_height: block.number(),
                     tx_index_absolute,
                     log_index_in_tx: idx as u32,
                 }));

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe.rs
@@ -50,7 +50,7 @@ where
 
     tokio::spawn(async move {
         match request {
-            SubscriptionRequest::Heads => streamer.blocks().await,
+            SubscriptionRequest::Heads => streamer.new_heads().await,
             SubscriptionRequest::Logs(filter) => streamer.logs(filter).await,
         }
     });

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -120,7 +120,7 @@ impl SyntheticBlockWatermark {
         if synthetic_block.num_transactions() != 0
             && self
                 .tx_index_of_last_notification_if_known
-                .map_or(true, |idx| idx < synthetic_block.last_tx_index())
+                .is_none_or(|idx| idx < synthetic_block.last_tx_index())
         {
             return self.advance_and_emit_synthetic_block_notification(synthetic_block);
         }
@@ -143,7 +143,7 @@ impl SyntheticBlockWatermark {
         if synthetic_block.num_transactions() != 0
             && self
                 .tx_index_of_last_notification_if_known
-                .map_or(true, |idx| idx < synthetic_block.last_tx_index())
+                .is_none_or(|idx| idx < synthetic_block.last_tx_index())
         {
             return SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock;
         }
@@ -257,7 +257,7 @@ where
                     // Send all of the notifications for new real blocks.
                     while let SyntheticBlockWatermarkAdvanceResult::NewRealBlock(block_number) = watermark.peek(&pending_block) {
                         let sealed = self.evm.blocks.get(&block_number, &mut state).unwrap_infallible().expect("Block was notified but did not exist. This is a bug!");
-                        let rpc_header = Header::from_consensus(sealed.header.into(), None, Some(U256::from(sealed.rlp_size)));
+                        let rpc_header = Header::from_consensus(sealed.header, None, Some(U256::from(sealed.rlp_size)));
                         self.send(&rpc_header).await?;
                         watermark.advance(&pending_block);
                         sent = true;
@@ -396,8 +396,10 @@ mod tests {
         tx_start: u64,
         tx_end: u64,
     ) -> SyntheticBlockWithoutRootsAndBloom {
-        let mut header = Header::default();
-        header.number = block_number;
+        let header = Header {
+            number: block_number,
+            ..Default::default()
+        };
         SyntheticBlockWithoutRootsAndBloom::new(header, tx_start..tx_end)
     }
 

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -21,6 +21,9 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use thiserror::Error;
 
+/// Don't send new heads notifcations for synthetic blocks more frequently than this.
+const SYNTHETIC_NEW_HEADS_MAX_FREQUENCY_MS: u64 = 200;
+
 #[derive(Error, Debug)]
 pub enum Error {
     #[error("Block does not exist")]
@@ -43,6 +46,67 @@ where
     evm: Evm<S>,
 }
 
+struct SyntheticBlockWatermark {
+    block_number_of_last_notification: u64,
+    // The tx index of the last notification, if known. 
+    // It's not known to use when we send a notification for a *real* block, 
+    // so we have special handling in that case
+    tx_index_of_last_notification_if_known: Option<u64>,
+}
+
+enum SyntheticBlockWatermarkAdvanceResult {
+    NewRealBlock(u64),
+    NewSyntheticBlock,
+    NoChange,
+}
+
+impl SyntheticBlockWatermark {
+    fn from_synthetic_block(synthetic_block: &SyntheticBlockWithoutRootsAndBloom) -> Self {
+        Self {
+            block_number_of_last_notification: synthetic_block.header.number,
+            tx_index_of_last_notification_if_known: synthetic_block.transactions.end,
+        }
+    }
+
+    fn advance_and_emit_synthetic_block_notification(&mut self, synthetic_block: &SyntheticBlockWithoutRootsAndBloom) -> SyntheticBlockWatermarkAdvanceResult {
+        self.block_number_of_last_notification = synthetic_block.header.number;
+        self.tx_index_of_last_notification_if_known = synthetic_block.transactions.end.saturating_sub(1);
+        SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock
+    }
+
+
+    fn advance_and_emit_real_block_notification(&mut self) -> SyntheticBlockWatermarkAdvanceResult {
+        // Per https://www.quicknode.com/docs/ethereum/eth_subscribe - we should send a notification each time a new header is appended
+        // Even if that means sending multiple notifications in succession. This means that we should increment the block number by one
+        // rather than jumping to the height of the synthetic block.
+        self.block_number_of_last_notification += 1;
+        // There's no guaranteed relationship between the first tx index of the synthetic block and the last tx index of the *current* real block that we need to notify for.
+        // We might have missed some synthetic block notifications due to tokio's nondeterminism. That's fine; just set it to None to reflect that we don't know for sure.
+        self.tx_index_of_last_notification_if_known = None;
+        SyntheticBlockWatermarkAdvanceResult::NewRealBlock(self.block_number_of_last_notification)
+    }
+    
+
+    // We want to send a notification if...
+    // There's been a new real block
+    // There's been a new synthetic block *and* it's been more than 200ms since the last notification
+    fn advance(&mut self, synthetic_block: &SyntheticBlockWithoutRootsAndBloom) -> SyntheticBlockWatermarkAdvanceResult {
+        if self.block_number_of_last_notification < synthetic_block.header.number {
+            return self.advance_and_emit_real_block_notification();
+        }
+
+        // If the synthetic block is empty, don't notify. 
+        // Similarly if we've already sent a notification for this synthetic block, don't notify again.
+        if synthetic_block.num_transactions() != 0 && || self.tx_index_of_last_notification_if_known.unwrap_or(0) < synthetic_block.last_tx_index() {
+            return self.advance_and_emit_synthetic_block_notification(synthetic_block);
+        }
+
+        SyntheticBlockWatermarkAdvanceResult::NoChange
+    }
+
+}
+
+// TODO: Refactor this into a long-running background task to reduce overhead. Right now, we do duplicate fetching for each subscription.
 impl<S, Seq> Streamer<S, Seq>
 where
     S: Spec,
@@ -61,7 +125,8 @@ where
     /// Stream new logs matching the provided filter to the subscriber.
     pub async fn logs(&self, filter: Box<Filter>) -> Result<(), Error> {
         let mut state = self.ethereum.api_state_accessor();
-        let pending_block = self.evm.pending_block(&mut state);
+        let pending_block = self.evm.pending_block(None, &mut state);
+        let synthetic_block_watermark = SyntheticBlockWatermark::from_synthetic_block(pending_block);
         let mut tx_watermark = Watermark::new(..pending_block.transactions.end);
 
         // Fetch the initial block. If it's stale, it will be replaced below.
@@ -79,7 +144,7 @@ where
                     }
 
                     let mut state = self.ethereum.api_state_accessor();
-                    let pending_block = self.evm.pending_block(&mut state);
+                    let pending_block = self.evm.pending_block(None, &mut state);
 
                     for tx_idx in tx_watermark.advance(..pending_block.transactions.end) {
                         let (receipt, time) = self.get_receipt(tx_idx, &mut state)?;
@@ -101,14 +166,18 @@ where
     }
 
     /// Stream new block headers to the subscriber.
-    pub async fn blocks(&self) -> Result<(), Error> {
+    pub async fn new_heads(&self) -> Result<(), Error> {
+        // Pick up here
+        // Long term todo: Refactor this into a long-running background task 
+
         let mut state = self.ethereum.api_state_accessor();
-        let latest_block = self.evm.latest_block(&mut state);
-        let mut block_watermark = Watermark::new(..latest_block.header.number + 1);
+        let pending_block = self.evm.pending_block(None, &mut state);
+        let mut watermark = SyntheticBlockWatermark::from_synthetic_block(&pending_block);
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
         let mut shutdown_receiver = self.ethereum.shutdown_receiver.clone();
 
+        let mut last_send_time = Instant::now();
         loop {
             tokio::select! {
                 result = state_updates.changed() => {
@@ -117,13 +186,20 @@ where
                         break;
                     }
 
+                    // TODO(@preston-evans98) - I think this checkpoint change notification might be problematic on resync/restart. Figure that out.
+                    // TODO: Wait - if it's been less than 200ms since the last update, skip the pending block check.
                     let mut state = self.ethereum.api_state_accessor();
                     let latest_block = self.evm.latest_block(&mut state);
 
+                    let mut sent = false;
                     for block_number in block_watermark.advance(..latest_block.header.number + 1) {
                         let block = self.get_block(block_number, &mut state)?;
-                        let rpc_header = self.evm.get_rpc_header(block)?;
+                        let rpc_header = self.evm.get_rpc_header(block, &mut state)?;
+                        sent = true;
                         self.send(&rpc_header).await?;
+                    }
+                    if sent {
+                        last_update_time = Instant::now();
                     }
                 }
                 _ = shutdown_receiver.changed() => {

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -1,6 +1,7 @@
 use super::watermark::Watermark;
 use crate::Ethereum;
-use alloy_rpc_types::Filter;
+use alloy_primitives::U256;
+use alloy_rpc_types::{Filter, Header};
 use jsonrpsee::DisconnectError;
 use jsonrpsee::SubscriptionMessage;
 use jsonrpsee::SubscriptionSink;
@@ -10,13 +11,16 @@ pub use sov_evm::EthereumAuthenticator;
 use sov_evm::Evm;
 use sov_evm::MaybeSealedBlock;
 use sov_evm::Receipt;
+use sov_evm::SyntheticBlockWithoutRootsAndBloom;
 use sov_modules_api::capabilities::HasKernel;
 use sov_modules_api::da::Time;
 use sov_modules_api::ApiStateAccessor;
 use sov_modules_api::Spec;
+use sov_modules_api::prelude::UnwrapInfallible;
 use sov_rpc_eth_types::EthApiError;
 use sov_rpc_eth_types::LogWithExecutionTimestamp;
 use sov_sequencer::Sequencer;
+use std::time::Duration;
 use std::fmt::Debug;
 use std::sync::Arc;
 use thiserror::Error;
@@ -46,14 +50,16 @@ where
     evm: Evm<S>,
 }
 
+#[derive(Debug, Clone)]
 struct SyntheticBlockWatermark {
     block_number_of_last_notification: u64,
-    // The tx index of the last notification, if known. 
-    // It's not known to use when we send a notification for a *real* block, 
+    // The tx index of the last notification, if known.
+    // It's not known to use when we send a notification for a *real* block,
     // so we have special handling in that case
     tx_index_of_last_notification_if_known: Option<u64>,
 }
 
+#[derive(Debug, PartialEq, Clone)]
 enum SyntheticBlockWatermarkAdvanceResult {
     NewRealBlock(u64),
     NewSyntheticBlock,
@@ -63,14 +69,14 @@ enum SyntheticBlockWatermarkAdvanceResult {
 impl SyntheticBlockWatermark {
     fn from_synthetic_block(synthetic_block: &SyntheticBlockWithoutRootsAndBloom) -> Self {
         Self {
-            block_number_of_last_notification: synthetic_block.header.number,
-            tx_index_of_last_notification_if_known: synthetic_block.transactions.end,
+            block_number_of_last_notification: synthetic_block.header().number,
+            tx_index_of_last_notification_if_known: Some(synthetic_block.last_tx_index()),
         }
     }
 
     fn advance_and_emit_synthetic_block_notification(&mut self, synthetic_block: &SyntheticBlockWithoutRootsAndBloom) -> SyntheticBlockWatermarkAdvanceResult {
-        self.block_number_of_last_notification = synthetic_block.header.number;
-        self.tx_index_of_last_notification_if_known = synthetic_block.transactions.end.saturating_sub(1);
+        self.block_number_of_last_notification = synthetic_block.header().number;
+        self.tx_index_of_last_notification_if_known = Some(synthetic_block.last_tx_index());
         SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock
     }
 
@@ -91,19 +97,31 @@ impl SyntheticBlockWatermark {
     // There's been a new real block
     // There's been a new synthetic block *and* it's been more than 200ms since the last notification
     fn advance(&mut self, synthetic_block: &SyntheticBlockWithoutRootsAndBloom) -> SyntheticBlockWatermarkAdvanceResult {
-        if self.block_number_of_last_notification < synthetic_block.header.number {
+        if self.block_number_of_last_notification < synthetic_block.header().number.saturating_sub(1) {
             return self.advance_and_emit_real_block_notification();
         }
 
-        // If the synthetic block is empty, don't notify. 
+        // If the synthetic block is empty, don't notify.
         // Similarly if we've already sent a notification for this synthetic block, don't notify again.
-        if synthetic_block.num_transactions() != 0 && || self.tx_index_of_last_notification_if_known.unwrap_or(0) < synthetic_block.last_tx_index() {
+        if synthetic_block.num_transactions() != 0 && self.tx_index_of_last_notification_if_known.map_or(true, |idx| idx < synthetic_block.last_tx_index()) {
             return self.advance_and_emit_synthetic_block_notification(synthetic_block);
         }
 
         SyntheticBlockWatermarkAdvanceResult::NoChange
     }
 
+    fn peek(&self, synthetic_block: &SyntheticBlockWithoutRootsAndBloom) -> SyntheticBlockWatermarkAdvanceResult {
+        if self.block_number_of_last_notification < synthetic_block.header().number.saturating_sub(1) {
+            return SyntheticBlockWatermarkAdvanceResult::NewRealBlock(self.block_number_of_last_notification + 1)
+        }
+
+        if synthetic_block.num_transactions() != 0 && self.tx_index_of_last_notification_if_known.map_or(true, |idx| idx < synthetic_block.last_tx_index()) {
+            return SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock
+        }
+
+        SyntheticBlockWatermarkAdvanceResult::NoChange
+    }
+        
 }
 
 // TODO: Refactor this into a long-running background task to reduce overhead. Right now, we do duplicate fetching for each subscription.
@@ -126,11 +144,10 @@ where
     pub async fn logs(&self, filter: Box<Filter>) -> Result<(), Error> {
         let mut state = self.ethereum.api_state_accessor();
         let pending_block = self.evm.pending_block(None, &mut state);
-        let synthetic_block_watermark = SyntheticBlockWatermark::from_synthetic_block(pending_block);
         let mut tx_watermark = Watermark::new(..pending_block.transactions.end);
 
         // Fetch the initial block. If it's stale, it will be replaced below.
-        let mut block = self.get_block(pending_block.header.number - 1, &mut state)?;
+        let mut block = self.get_block(pending_block.block_number() - 1, &mut state)?;
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
         let mut shutdown_receiver = self.ethereum.shutdown_receiver.clone();
@@ -166,40 +183,92 @@ where
     }
 
     /// Stream new block headers to the subscriber.
+    /// 
+    /// This method streams every real block as it comes in (i.e. each time a "slot" is computed on the DA layer). 
+    /// We also manufacture "synthetic" blocks with which to notify the subscriber each time a new transaction is added,
+    /// but we only notify for synthetic blocks at most once every few hundred milliseconds. 
+    /// 
+    /// We use synthetic blocks because...
+    /// - Rollup transactions are instantly confirmed 
+    /// - Most wallet software and tooling waits for the tx to be included in the "latest" (i.e. non-pending)
+    /// - We want tooling to recognize that transactions are confirmed instantly. 
+    /// 
+    /// By making up these sythetic blocks, we can simulate behavior where the tx is accepted instantly and then the chain experiences a reorg of depth 1.
+    /// Tooling that *doesn't* handle reorgs works fine, because the "reorg" simply appends new transactions - so previous tx results are unchanged.
+    /// Tolling that *does* handle reorgs will see breif instability at the chain head, but the block will settle after the next DA block is computed (i.e in about 6 seconds)
+    /// 
+    /// Unfortunately, this approach means that we have a *lot* of new_heads notifications (one per tx, plus one per DA block. We expect that receivers will not be able
+    /// to cope with notifications at a pace of several hundred per second, so we impose a throttle - we never notify more than once per 200ms. 
     pub async fn new_heads(&self) -> Result<(), Error> {
         // Pick up here
         // Long term todo: Refactor this into a long-running background task 
 
         let mut state = self.ethereum.api_state_accessor();
-        let pending_block = self.evm.pending_block(None, &mut state);
-        let mut watermark = SyntheticBlockWatermark::from_synthetic_block(&pending_block);
+        let mut watermark = SyntheticBlockWatermark::from_synthetic_block(&self.evm.pending_block(None, &mut state));
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
         let mut shutdown_receiver = self.ethereum.shutdown_receiver.clone();
-
-        let mut last_send_time = Instant::now();
+        let mut last_send_time = std::time::Instant::now();
+        let (wakeup_sender, mut wakeup_receiver) = tokio::sync::watch::channel(());
         loop {
             tokio::select! {
+                // Case 1: we just received a new state update. Notify for any new blocks
                 result = state_updates.changed() => {
                     if result.is_err() {
                         tracing::debug!("Subscription state updates channel closed, terminating blocks subscription");
                         break;
                     }
 
-                    // TODO(@preston-evans98) - I think this checkpoint change notification might be problematic on resync/restart. Figure that out.
-                    // TODO: Wait - if it's been less than 200ms since the last update, skip the pending block check.
                     let mut state = self.ethereum.api_state_accessor();
-                    let latest_block = self.evm.latest_block(&mut state);
-
+                    let pending_block = self.evm.pending_block(None, &mut state);
                     let mut sent = false;
-                    for block_number in block_watermark.advance(..latest_block.header.number + 1) {
-                        let block = self.get_block(block_number, &mut state)?;
-                        let rpc_header = self.evm.get_rpc_header(block, &mut state)?;
-                        sent = true;
+
+                    // Send all of the notifications for new real blocks.
+                    while let SyntheticBlockWatermarkAdvanceResult::NewRealBlock(block_number) = watermark.peek(&pending_block) {
+                        watermark.advance(&pending_block);
+                        let sealed = self.evm.blocks.get(&block_number, &mut state).unwrap_infallible().expect("Block was notified but did not exist. This is a bug!");
+                        let rpc_header = Header::from_consensus(sealed.header.into(), None, Some(U256::from(sealed.rlp_size)));
                         self.send(&rpc_header).await?;
+                        sent = true;
                     }
+
+                    // If the state change only created a synthetic block, send it only if we haven't sent one too recently
+                    if let SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock = watermark.peek(&pending_block) {
+                        if last_send_time.elapsed() >= Duration::from_millis(SYNTHETIC_NEW_HEADS_MAX_FREQUENCY_MS) {
+                            watermark.advance(&pending_block);
+                            let (rpc_header, _txs) = self.evm.get_synthetic_block_contents_slow(pending_block, &mut state)?;
+                            self.send(&rpc_header).await?;
+                            sent = true;
+                        } else {
+                            // If we don't send the notification now, scheudle a wakeup to try again later. This handles the edge case
+                            // where we have a bunch of new synethitic blocks in rapid succession followed by a gap; in that case, 
+                            // we'd never notify for the newer txs.
+                            // Spawn a wakeup for later to handle the edge case. Note that we don't try to dedup wakeups; duplicates are handled in the wakeup_receiver case.
+                            let wakeup_sender = wakeup_sender.clone();
+                            tokio::spawn(async move {
+                                tokio::time::sleep(Duration::from_millis(SYNTHETIC_NEW_HEADS_MAX_FREQUENCY_MS) ).await;
+                                let _ = wakeup_sender.send(());
+                            });
+                        }
+                    }
+                    
                     if sent {
-                        last_update_time = Instant::now();
+                        last_send_time = std::time::Instant::now();
+                    }
+                    // In the SyntheticBlockWatermarkAdvanceResult::None case, do nothing.
+                }
+                _ = wakeup_receiver.changed() => {
+                    // If we've sent a notification too recently, ignore the wakeup. Either we've sent all notifications already or - we'll get woken up again in no more than 200ms
+                    if last_send_time.elapsed() >= Duration::from_millis(SYNTHETIC_NEW_HEADS_MAX_FREQUENCY_MS) {
+                        let mut state = self.ethereum.api_state_accessor();
+                        let pending_block = self.evm.pending_block(None, &mut state);
+                        // Only send the notification if it's for a synthetic block. Real blocks are guaranteed to be handeld by the main state_change watcher.
+                        if let SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock = watermark.peek(&pending_block) {
+                            watermark.advance(&pending_block);
+                            let (rpc_header, _txs) = self.evm.get_synthetic_block_contents_slow(pending_block, &mut state)?;
+                            self.send(&rpc_header).await?;
+                            last_send_time = std::time::Instant::now();
+                        } 
                     }
                 }
                 _ = shutdown_receiver.changed() => {
@@ -210,6 +279,7 @@ where
         }
         Ok(())
     }
+    
 }
 
 // Helper methods
@@ -278,5 +348,107 @@ where
         self.sink.send(msg).await.inspect_err(|err| {
             tracing::debug!(%err, "The subscription client disconnected from the server.");
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+
+    fn make_synthetic_block(block_number: u64, tx_start: u64, tx_end: u64) -> SyntheticBlockWithoutRootsAndBloom {
+        let mut header = Header::default();
+        header.number = block_number;
+        SyntheticBlockWithoutRootsAndBloom::new(header, tx_start..tx_end)
+    }
+
+    /// Helper to verify peek and advance return the same result variant.
+    fn assert_peek_equals_and_advance(
+        watermark: &mut SyntheticBlockWatermark,
+        block: &SyntheticBlockWithoutRootsAndBloom,
+    ) -> SyntheticBlockWatermarkAdvanceResult {
+        let peek_result = watermark.peek(block);
+        let advance_result = watermark.advance(block);
+        assert_eq!(
+            peek_result, advance_result,
+            "peek and advance should return the same result"
+        );
+        peek_result
+    }
+    
+
+    #[test]
+    fn peek_and_advance_match_for_new_real_block() {
+        // Watermark at block 5, synthetic block is at block 7
+        // Should return NewRealBlock(6) - incrementing by 1
+        // Then NewSyntheticBlock
+        let mut watermark = SyntheticBlockWatermark {
+            block_number_of_last_notification: 4,
+            tx_index_of_last_notification_if_known: Some(100),
+        };
+        let block = make_synthetic_block(7, 100, 150);
+
+        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NewRealBlock(5)));
+        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NewRealBlock(6)));
+        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock));
+        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NoChange));
+    }
+
+    #[test]
+    fn peek_and_advance_match_for_new_synthetic_block() {
+        // Watermark and block at same block number, but block has newer transactions
+        let mut watermark = SyntheticBlockWatermark {
+            block_number_of_last_notification: 10,
+            tx_index_of_last_notification_if_known: Some(50),
+        };
+        let block = make_synthetic_block(10, 0, 100); // last_tx_index is 99, > 50
+
+        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock));
+        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NoChange));
+    }
+
+    #[test]
+    fn peek_and_advance_match_for_no_change() {
+        // Watermark already caught up with the block
+        let mut watermark = SyntheticBlockWatermark {
+            block_number_of_last_notification: 10,
+            tx_index_of_last_notification_if_known: Some(99),
+        };
+        let block = make_synthetic_block(10, 0, 100); // last_tx_index is 99, matches watermark
+
+        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NoChange));
+    }
+
+    #[test]
+    fn peek_and_advance_match_for_empty_block() {
+        // Block with no transactions should result in NoChange
+        let mut watermark = SyntheticBlockWatermark {
+            block_number_of_last_notification: 10,
+            tx_index_of_last_notification_if_known: None,
+        };
+        let block = make_synthetic_block(10, 0, 0); // empty block
+
+        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NoChange));
+    }
+
+    #[test]
+    fn peek_and_advance_match_when_tx_index_unknown() {
+        // When tx_index_of_last_notification_if_known is None, should trigger NewSyntheticBlock
+        // if there are transactions
+        let mut watermark = SyntheticBlockWatermark {
+            block_number_of_last_notification: 10,
+            tx_index_of_last_notification_if_known: None,
+        };
+        let block = make_synthetic_block(10, 0, 50);
+
+        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock));
+    }
+    #[test]
+    fn from_synthetic_block_initializes_correctly() {
+        let block = make_synthetic_block(10, 50, 100);
+        let watermark = SyntheticBlockWatermark::from_synthetic_block(&block);
+
+        assert_eq!(watermark.block_number_of_last_notification, 10);
+        assert_eq!(watermark.tx_index_of_last_notification_if_known, Some(99)); // last_tx_index = end - 1
     }
 }

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -69,7 +69,7 @@ enum SyntheticBlockWatermarkAdvanceResult {
 impl SyntheticBlockWatermark {
     fn from_synthetic_block(synthetic_block: &SyntheticBlockWithoutRootsAndBloom) -> Self {
         Self {
-            block_number_of_last_notification: synthetic_block.header().number,
+            block_number_of_last_notification: synthetic_block.partial_header().number,
             tx_index_of_last_notification_if_known: Some(synthetic_block.last_tx_index()),
         }
     }
@@ -78,7 +78,7 @@ impl SyntheticBlockWatermark {
         &mut self,
         synthetic_block: &SyntheticBlockWithoutRootsAndBloom,
     ) -> SyntheticBlockWatermarkAdvanceResult {
-        self.block_number_of_last_notification = synthetic_block.header().number;
+        self.block_number_of_last_notification = synthetic_block.partial_header().number;
         self.tx_index_of_last_notification_if_known = Some(synthetic_block.last_tx_index());
         SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock
     }
@@ -102,7 +102,7 @@ impl SyntheticBlockWatermark {
         synthetic_block: &SyntheticBlockWithoutRootsAndBloom,
     ) -> SyntheticBlockWatermarkAdvanceResult {
         if self.block_number_of_last_notification
-            < synthetic_block.header().number.saturating_sub(1)
+            < synthetic_block.partial_header().number.saturating_sub(1)
         {
             return self.advance_and_emit_real_block_notification();
         }
@@ -125,7 +125,7 @@ impl SyntheticBlockWatermark {
         synthetic_block: &SyntheticBlockWithoutRootsAndBloom,
     ) -> SyntheticBlockWatermarkAdvanceResult {
         if self.block_number_of_last_notification
-            < synthetic_block.header().number.saturating_sub(1)
+            < synthetic_block.partial_header().number.saturating_sub(1)
         {
             return SyntheticBlockWatermarkAdvanceResult::NewRealBlock(
                 self.block_number_of_last_notification + 1,
@@ -144,7 +144,7 @@ impl SyntheticBlockWatermark {
     }
 }
 
-// TODO: Refactor this into a long-running background task to reduce overhead. Right now, we do duplicate fetching for each subscription.
+// TODO(long term, not an immediate issue): Refactor this into a long-running background task to reduce overhead. Right now, we do duplicate fetching for each subscription.
 impl<S, Seq> Streamer<S, Seq>
 where
     S: Spec,

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -21,6 +21,8 @@ use sov_rpc_eth_types::EthApiError;
 use sov_rpc_eth_types::LogWithExecutionTimestamp;
 use sov_sequencer::Sequencer;
 use std::fmt::Debug;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
@@ -50,11 +52,12 @@ where
     evm: Evm<S>,
 }
 
+/// Tracks what we've already notified subscribers about, so we don't send duplicate notifications
 #[derive(Debug, Clone)]
 struct SyntheticBlockWatermark {
     block_number_of_last_notification: u64,
     // The tx index of the last notification, if known.
-    // It's not known to use when we send a notification for a *real* block,
+    // It's not known to us when we send a notification for a *real* block,
     // so we have special handling in that case
     tx_index_of_last_notification_if_known: Option<u64>,
 }
@@ -70,7 +73,9 @@ impl SyntheticBlockWatermark {
     fn from_synthetic_block(synthetic_block: &SyntheticBlockWithoutRootsAndBloom) -> Self {
         Self {
             block_number_of_last_notification: synthetic_block.partial_header().number,
-            tx_index_of_last_notification_if_known: Some(synthetic_block.last_tx_index()),
+            // The last tx index is the index of the last transaction in the synthetic block. If the end item is zero (at genesis) then
+            // we want to notify, so set this to None
+            tx_index_of_last_notification_if_known: synthetic_block.transactions.end.checked_sub(1),
         }
     }
 
@@ -101,6 +106,9 @@ impl SyntheticBlockWatermark {
         &mut self,
         synthetic_block: &SyntheticBlockWithoutRootsAndBloom,
     ) -> SyntheticBlockWatermarkAdvanceResult {
+        // The synthetic block number is always one greater than the sealed block number,
+        // so if the last notified block number is less than the synthetic block number - 1,
+        // we need to advance and emit real block notification.
         if self.block_number_of_last_notification
             < synthetic_block.partial_header().number.saturating_sub(1)
         {
@@ -231,6 +239,7 @@ where
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
         let mut shutdown_receiver = self.ethereum.shutdown_receiver.clone();
         let mut last_send_time = std::time::Instant::now();
+        let has_waker_task = Arc::new(AtomicBool::new(false));
         let (wakeup_sender, mut wakeup_receiver) = tokio::sync::watch::channel(());
         loop {
             tokio::select! {
@@ -247,11 +256,15 @@ where
 
                     // Send all of the notifications for new real blocks.
                     while let SyntheticBlockWatermarkAdvanceResult::NewRealBlock(block_number) = watermark.peek(&pending_block) {
-                        watermark.advance(&pending_block);
                         let sealed = self.evm.blocks.get(&block_number, &mut state).unwrap_infallible().expect("Block was notified but did not exist. This is a bug!");
                         let rpc_header = Header::from_consensus(sealed.header.into(), None, Some(U256::from(sealed.rlp_size)));
                         self.send(&rpc_header).await?;
+                        watermark.advance(&pending_block);
                         sent = true;
+                    }
+
+                    if sent {
+                        last_send_time = std::time::Instant::now();
                     }
 
                     // If the state change only created a synthetic block, send it only if we haven't sent one too recently
@@ -260,23 +273,24 @@ where
                             watermark.advance(&pending_block);
                             let (rpc_header, _txs) = self.evm.get_synthetic_block_contents_slow(pending_block, &mut state)?;
                             self.send(&rpc_header).await?;
-                            sent = true;
+                            last_send_time = std::time::Instant::now();
                         } else {
-                            // If we don't send the notification now, scheudle a wakeup to try again later. This handles the edge case
-                            // where we have a bunch of new synethitic blocks in rapid succession followed by a gap; in that case,
+                            // If we don't send the notification now, schedule a wakeup to try again later. This handles the edge case
+                            // where we have a bunch of new synthetic blocks in rapid succession followed by a gap; in that case,
                             // we'd never notify for the newer txs.
-                            // Spawn a wakeup for later to handle the edge case. Note that we don't try to dedup wakeups; duplicates are handled in the wakeup_receiver case.
-                            let wakeup_sender = wakeup_sender.clone();
-                            tokio::spawn(async move {
-                                tokio::time::sleep(Duration::from_millis(SYNTHETIC_NEW_HEADS_MAX_FREQUENCY_MS) ).await;
-                                let _ = wakeup_sender.send(());
-                            });
+                            // Spawn a wakeup for later to handle the edge case. Note that we schedule at most one wakeup every 200ms
+                            if !has_waker_task.swap(true, Ordering::SeqCst) {
+                                let has_waker_task = has_waker_task.clone();
+                                let wakeup_sender = wakeup_sender.clone();
+                                tokio::spawn(async move {
+                                    tokio::time::sleep(Duration::from_millis(SYNTHETIC_NEW_HEADS_MAX_FREQUENCY_MS) ).await;
+                                    has_waker_task.store(false, Ordering::SeqCst);
+                                    let _ = wakeup_sender.send(());
+                                });
+                            }
                         }
                     }
 
-                    if sent {
-                        last_send_time = std::time::Instant::now();
-                    }
                     // In the SyntheticBlockWatermarkAdvanceResult::None case, do nothing.
                 }
                 _ = wakeup_receiver.changed() => {

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -14,15 +14,15 @@ use sov_evm::Receipt;
 use sov_evm::SyntheticBlockWithoutRootsAndBloom;
 use sov_modules_api::capabilities::HasKernel;
 use sov_modules_api::da::Time;
+use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::ApiStateAccessor;
 use sov_modules_api::Spec;
-use sov_modules_api::prelude::UnwrapInfallible;
 use sov_rpc_eth_types::EthApiError;
 use sov_rpc_eth_types::LogWithExecutionTimestamp;
 use sov_sequencer::Sequencer;
-use std::time::Duration;
 use std::fmt::Debug;
 use std::sync::Arc;
+use std::time::Duration;
 use thiserror::Error;
 
 /// Don't send new heads notifcations for synthetic blocks more frequently than this.
@@ -74,12 +74,14 @@ impl SyntheticBlockWatermark {
         }
     }
 
-    fn advance_and_emit_synthetic_block_notification(&mut self, synthetic_block: &SyntheticBlockWithoutRootsAndBloom) -> SyntheticBlockWatermarkAdvanceResult {
+    fn advance_and_emit_synthetic_block_notification(
+        &mut self,
+        synthetic_block: &SyntheticBlockWithoutRootsAndBloom,
+    ) -> SyntheticBlockWatermarkAdvanceResult {
         self.block_number_of_last_notification = synthetic_block.header().number;
         self.tx_index_of_last_notification_if_known = Some(synthetic_block.last_tx_index());
         SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock
     }
-
 
     fn advance_and_emit_real_block_notification(&mut self) -> SyntheticBlockWatermarkAdvanceResult {
         // Per https://www.quicknode.com/docs/ethereum/eth_subscribe - we should send a notification each time a new header is appended
@@ -91,37 +93,55 @@ impl SyntheticBlockWatermark {
         self.tx_index_of_last_notification_if_known = None;
         SyntheticBlockWatermarkAdvanceResult::NewRealBlock(self.block_number_of_last_notification)
     }
-    
 
     // We want to send a notification if...
     // There's been a new real block
     // There's been a new synthetic block *and* it's been more than 200ms since the last notification
-    fn advance(&mut self, synthetic_block: &SyntheticBlockWithoutRootsAndBloom) -> SyntheticBlockWatermarkAdvanceResult {
-        if self.block_number_of_last_notification < synthetic_block.header().number.saturating_sub(1) {
+    fn advance(
+        &mut self,
+        synthetic_block: &SyntheticBlockWithoutRootsAndBloom,
+    ) -> SyntheticBlockWatermarkAdvanceResult {
+        if self.block_number_of_last_notification
+            < synthetic_block.header().number.saturating_sub(1)
+        {
             return self.advance_and_emit_real_block_notification();
         }
 
         // If the synthetic block is empty, don't notify.
         // Similarly if we've already sent a notification for this synthetic block, don't notify again.
-        if synthetic_block.num_transactions() != 0 && self.tx_index_of_last_notification_if_known.map_or(true, |idx| idx < synthetic_block.last_tx_index()) {
+        if synthetic_block.num_transactions() != 0
+            && self
+                .tx_index_of_last_notification_if_known
+                .map_or(true, |idx| idx < synthetic_block.last_tx_index())
+        {
             return self.advance_and_emit_synthetic_block_notification(synthetic_block);
         }
 
         SyntheticBlockWatermarkAdvanceResult::NoChange
     }
 
-    fn peek(&self, synthetic_block: &SyntheticBlockWithoutRootsAndBloom) -> SyntheticBlockWatermarkAdvanceResult {
-        if self.block_number_of_last_notification < synthetic_block.header().number.saturating_sub(1) {
-            return SyntheticBlockWatermarkAdvanceResult::NewRealBlock(self.block_number_of_last_notification + 1)
+    fn peek(
+        &self,
+        synthetic_block: &SyntheticBlockWithoutRootsAndBloom,
+    ) -> SyntheticBlockWatermarkAdvanceResult {
+        if self.block_number_of_last_notification
+            < synthetic_block.header().number.saturating_sub(1)
+        {
+            return SyntheticBlockWatermarkAdvanceResult::NewRealBlock(
+                self.block_number_of_last_notification + 1,
+            );
         }
 
-        if synthetic_block.num_transactions() != 0 && self.tx_index_of_last_notification_if_known.map_or(true, |idx| idx < synthetic_block.last_tx_index()) {
-            return SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock
+        if synthetic_block.num_transactions() != 0
+            && self
+                .tx_index_of_last_notification_if_known
+                .map_or(true, |idx| idx < synthetic_block.last_tx_index())
+        {
+            return SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock;
         }
 
         SyntheticBlockWatermarkAdvanceResult::NoChange
     }
-        
 }
 
 // TODO: Refactor this into a long-running background task to reduce overhead. Right now, we do duplicate fetching for each subscription.
@@ -183,28 +203,30 @@ where
     }
 
     /// Stream new block headers to the subscriber.
-    /// 
-    /// This method streams every real block as it comes in (i.e. each time a "slot" is computed on the DA layer). 
+    ///
+    /// This method streams every real block as it comes in (i.e. each time a "slot" is computed on the DA layer).
     /// We also manufacture "synthetic" blocks with which to notify the subscriber each time a new transaction is added,
-    /// but we only notify for synthetic blocks at most once every few hundred milliseconds. 
-    /// 
+    /// but we only notify for synthetic blocks at most once every few hundred milliseconds.
+    ///
     /// We use synthetic blocks because...
-    /// - Rollup transactions are instantly confirmed 
+    /// - Rollup transactions are instantly confirmed
     /// - Most wallet software and tooling waits for the tx to be included in the "latest" (i.e. non-pending)
-    /// - We want tooling to recognize that transactions are confirmed instantly. 
-    /// 
+    /// - We want tooling to recognize that transactions are confirmed instantly.
+    ///
     /// By making up these sythetic blocks, we can simulate behavior where the tx is accepted instantly and then the chain experiences a reorg of depth 1.
     /// Tooling that *doesn't* handle reorgs works fine, because the "reorg" simply appends new transactions - so previous tx results are unchanged.
     /// Tolling that *does* handle reorgs will see breif instability at the chain head, but the block will settle after the next DA block is computed (i.e in about 6 seconds)
-    /// 
+    ///
     /// Unfortunately, this approach means that we have a *lot* of new_heads notifications (one per tx, plus one per DA block. We expect that receivers will not be able
-    /// to cope with notifications at a pace of several hundred per second, so we impose a throttle - we never notify more than once per 200ms. 
+    /// to cope with notifications at a pace of several hundred per second, so we impose a throttle - we never notify more than once per 200ms.
     pub async fn new_heads(&self) -> Result<(), Error> {
         // Pick up here
-        // Long term todo: Refactor this into a long-running background task 
+        // Long term todo: Refactor this into a long-running background task
 
         let mut state = self.ethereum.api_state_accessor();
-        let mut watermark = SyntheticBlockWatermark::from_synthetic_block(&self.evm.pending_block(None, &mut state));
+        let mut watermark = SyntheticBlockWatermark::from_synthetic_block(
+            &self.evm.pending_block(None, &mut state),
+        );
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
         let mut shutdown_receiver = self.ethereum.shutdown_receiver.clone();
@@ -241,7 +263,7 @@ where
                             sent = true;
                         } else {
                             // If we don't send the notification now, scheudle a wakeup to try again later. This handles the edge case
-                            // where we have a bunch of new synethitic blocks in rapid succession followed by a gap; in that case, 
+                            // where we have a bunch of new synethitic blocks in rapid succession followed by a gap; in that case,
                             // we'd never notify for the newer txs.
                             // Spawn a wakeup for later to handle the edge case. Note that we don't try to dedup wakeups; duplicates are handled in the wakeup_receiver case.
                             let wakeup_sender = wakeup_sender.clone();
@@ -251,7 +273,7 @@ where
                             });
                         }
                     }
-                    
+
                     if sent {
                         last_send_time = std::time::Instant::now();
                     }
@@ -268,7 +290,7 @@ where
                             let (rpc_header, _txs) = self.evm.get_synthetic_block_contents_slow(pending_block, &mut state)?;
                             self.send(&rpc_header).await?;
                             last_send_time = std::time::Instant::now();
-                        } 
+                        }
                     }
                 }
                 _ = shutdown_receiver.changed() => {
@@ -279,7 +301,6 @@ where
         }
         Ok(())
     }
-    
 }
 
 // Helper methods
@@ -356,7 +377,11 @@ mod tests {
     use super::*;
     use alloy_consensus::Header;
 
-    fn make_synthetic_block(block_number: u64, tx_start: u64, tx_end: u64) -> SyntheticBlockWithoutRootsAndBloom {
+    fn make_synthetic_block(
+        block_number: u64,
+        tx_start: u64,
+        tx_end: u64,
+    ) -> SyntheticBlockWithoutRootsAndBloom {
         let mut header = Header::default();
         header.number = block_number;
         SyntheticBlockWithoutRootsAndBloom::new(header, tx_start..tx_end)
@@ -375,7 +400,6 @@ mod tests {
         );
         peek_result
     }
-    
 
     #[test]
     fn peek_and_advance_match_for_new_real_block() {
@@ -388,10 +412,22 @@ mod tests {
         };
         let block = make_synthetic_block(7, 100, 150);
 
-        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NewRealBlock(5)));
-        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NewRealBlock(6)));
-        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock));
-        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NoChange));
+        assert!(matches!(
+            assert_peek_equals_and_advance(&mut watermark, &block),
+            SyntheticBlockWatermarkAdvanceResult::NewRealBlock(5)
+        ));
+        assert!(matches!(
+            assert_peek_equals_and_advance(&mut watermark, &block),
+            SyntheticBlockWatermarkAdvanceResult::NewRealBlock(6)
+        ));
+        assert!(matches!(
+            assert_peek_equals_and_advance(&mut watermark, &block),
+            SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock
+        ));
+        assert!(matches!(
+            assert_peek_equals_and_advance(&mut watermark, &block),
+            SyntheticBlockWatermarkAdvanceResult::NoChange
+        ));
     }
 
     #[test]
@@ -403,8 +439,14 @@ mod tests {
         };
         let block = make_synthetic_block(10, 0, 100); // last_tx_index is 99, > 50
 
-        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock));
-        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NoChange));
+        assert!(matches!(
+            assert_peek_equals_and_advance(&mut watermark, &block),
+            SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock
+        ));
+        assert!(matches!(
+            assert_peek_equals_and_advance(&mut watermark, &block),
+            SyntheticBlockWatermarkAdvanceResult::NoChange
+        ));
     }
 
     #[test]
@@ -416,7 +458,10 @@ mod tests {
         };
         let block = make_synthetic_block(10, 0, 100); // last_tx_index is 99, matches watermark
 
-        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NoChange));
+        assert!(matches!(
+            assert_peek_equals_and_advance(&mut watermark, &block),
+            SyntheticBlockWatermarkAdvanceResult::NoChange
+        ));
     }
 
     #[test]
@@ -428,7 +473,10 @@ mod tests {
         };
         let block = make_synthetic_block(10, 0, 0); // empty block
 
-        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NoChange));
+        assert!(matches!(
+            assert_peek_equals_and_advance(&mut watermark, &block),
+            SyntheticBlockWatermarkAdvanceResult::NoChange
+        ));
     }
 
     #[test]
@@ -441,7 +489,10 @@ mod tests {
         };
         let block = make_synthetic_block(10, 0, 50);
 
-        assert!(matches!(assert_peek_equals_and_advance(&mut watermark, &block), SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock));
+        assert!(matches!(
+            assert_peek_equals_and_advance(&mut watermark, &block),
+            SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock
+        ));
     }
     #[test]
     fn from_synthetic_block_initializes_correctly() {

--- a/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/subscribe/service.rs
@@ -163,7 +163,7 @@ where
     /// Stream new logs matching the provided filter to the subscriber.
     pub async fn logs(&self, filter: Box<Filter>) -> Result<(), Error> {
         let mut state = self.ethereum.api_state_accessor();
-        let pending_block = self.evm.pending_block(None, &mut state);
+        let pending_block = self.evm.get_newest_synthetic_header(&mut state);
         let mut tx_watermark = Watermark::new(..pending_block.transactions.end);
 
         // Fetch the initial block. If it's stale, it will be replaced below.
@@ -181,7 +181,7 @@ where
                     }
 
                     let mut state = self.ethereum.api_state_accessor();
-                    let pending_block = self.evm.pending_block(None, &mut state);
+                    let pending_block = self.evm.get_newest_synthetic_header(&mut state);
 
                     for tx_idx in tx_watermark.advance(..pending_block.transactions.end) {
                         let (receipt, time) = self.get_receipt(tx_idx, &mut state)?;
@@ -225,7 +225,7 @@ where
 
         let mut state = self.ethereum.api_state_accessor();
         let mut watermark = SyntheticBlockWatermark::from_synthetic_block(
-            &self.evm.pending_block(None, &mut state),
+            &self.evm.get_newest_synthetic_header(&mut state),
         );
 
         let mut state_updates = self.ethereum.sequencer.api_state().checkpoint_receiver();
@@ -242,7 +242,7 @@ where
                     }
 
                     let mut state = self.ethereum.api_state_accessor();
-                    let pending_block = self.evm.pending_block(None, &mut state);
+                    let pending_block = self.evm.get_newest_synthetic_header(&mut state);
                     let mut sent = false;
 
                     // Send all of the notifications for new real blocks.
@@ -283,7 +283,7 @@ where
                     // If we've sent a notification too recently, ignore the wakeup. Either we've sent all notifications already or - we'll get woken up again in no more than 200ms
                     if last_send_time.elapsed() >= Duration::from_millis(SYNTHETIC_NEW_HEADS_MAX_FREQUENCY_MS) {
                         let mut state = self.ethereum.api_state_accessor();
-                        let pending_block = self.evm.pending_block(None, &mut state);
+                        let pending_block = self.evm.get_newest_synthetic_header(&mut state);
                         // Only send the notification if it's for a synthetic block. Real blocks are guaranteed to be handeld by the main state_change watcher.
                         if let SyntheticBlockWatermarkAdvanceResult::NewSyntheticBlock = watermark.peek(&pending_block) {
                             watermark.advance(&pending_block);

--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -12,7 +12,7 @@ use super::primitive_types::SealedBlock;
 #[cfg(feature = "native")]
 use crate::primitive_types::TxSignedAndRecovered;
 use crate::{
-    evm::primitive_types::TransactionSigned, RlpEvmTransaction, BLOB_GAS_PRICE, EXCESS_BLOB_GAS,
+    BLOB_GAS_PRICE, EXCESS_BLOB_GAS, RlpEvmTransaction, SyntheticBlockWithoutRootsAndBloom, evm::primitive_types::TransactionSigned
 };
 
 // BlockEnv from SealedBlock
@@ -25,6 +25,20 @@ impl From<SealedBlock> for BlockEnv {
             block.header.beneficiary,
             block.header.number,
             Some(block.header.mix_hash),
+        )
+    }
+}
+
+impl From<SyntheticBlockWithoutRootsAndBloom> for BlockEnv {
+    fn from(block: SyntheticBlockWithoutRootsAndBloom) -> Self {
+        let header = block.partial_header();
+        create_block_env(
+            header.base_fee_per_gas.expect("Synthetic blocks have their base fee set"),
+            header.gas_limit,
+            header.timestamp,
+            header.beneficiary,
+            header.number,
+            Some(header.mix_hash),
         )
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -12,7 +12,8 @@ use super::primitive_types::SealedBlock;
 #[cfg(feature = "native")]
 use crate::primitive_types::TxSignedAndRecovered;
 use crate::{
-    BLOB_GAS_PRICE, EXCESS_BLOB_GAS, RlpEvmTransaction, SyntheticBlockWithoutRootsAndBloom, evm::primitive_types::TransactionSigned
+    evm::primitive_types::TransactionSigned, RlpEvmTransaction, SyntheticBlockWithoutRootsAndBloom,
+    BLOB_GAS_PRICE, EXCESS_BLOB_GAS,
 };
 
 // BlockEnv from SealedBlock
@@ -33,7 +34,9 @@ impl From<SyntheticBlockWithoutRootsAndBloom> for BlockEnv {
     fn from(block: SyntheticBlockWithoutRootsAndBloom) -> Self {
         let header = block.partial_header();
         create_block_env(
-            header.base_fee_per_gas.expect("Synthetic blocks have their base fee set"),
+            header
+                .base_fee_per_gas
+                .expect("Synthetic blocks have their base fee set"),
             header.gas_limit,
             header.timestamp,
             header.beneficiary,

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -30,7 +30,9 @@ pub fn synthetic_block_hash_for(block_number: u64, num_txs: u32) -> B256 {
 }
 
 pub fn is_synthetic_block_hash(hash: &B256) -> bool {
-    hash.iter().take(20).eq(SYNTHETIC_BLOCK_HASH_PLACEHOLDER.iter().take(20))
+    hash.iter()
+        .take(20)
+        .eq(SYNTHETIC_BLOCK_HASH_PLACEHOLDER.iter().take(20))
 }
 
 pub fn parse_synthetic_block_hash(hash: &B256) -> Option<(u64, u32)> {
@@ -386,11 +388,11 @@ impl<'de> serde::Deserialize<'de> for SealedBlock {
 pub enum MaybeSealedBlock {
     /// SealedBlock
     Sealed(SealedBlock),
-    /// A synthetic block whose number matches the pending block number. It may be slightly older than the newest pending block 
+    /// A synthetic block whose number matches the pending block number. It may be slightly older than the newest pending block
     PendingSynthetic(SyntheticBlockWithoutRootsAndBloom),
     /// A synthetic block whose number is different from the pending block number.
     /// This block is either in the past, or it doesn't exist yet
-    PastSynthetic(SyntheticBlockWithoutRootsAndBloom)
+    PastSynthetic(SyntheticBlockWithoutRootsAndBloom),
 }
 
 #[cfg(feature = "native")]
@@ -474,7 +476,6 @@ impl MaybeSealedBlock {
         }
     }
 }
-
 
 /// TODO: Can we replace this with Reth type?
 #[serde_as]

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -154,6 +154,8 @@ impl Block {
 }
 
 
+/// A synthetic block header without the roots (txs, receipts) and bloom, and gas used.
+/// "synthetic" here means that the header has a fake hash which we can reverse engineer to identify which transaction are in the block.
 #[derive(Debug, PartialEq, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SyntheticBlockWithoutRootsAndBloom {
     /// The synthetic block header. All fields are set except for the roots (txs, receipts) and bloom, and gas used.
@@ -175,6 +177,7 @@ fn xor_hashes(a: B256, b: B256) -> B256 {
 
 
 impl SyntheticBlockWithoutRootsAndBloom {
+    /// Creates a new synthetic block header.
     pub fn new(mut header: Header, transactions: Range<u64>) -> Self {
         if header.state_root == EMPTY_ROOT_HASH {
             header.state_root = xor_hashes(header.parent_hash, header.transactions_root);
@@ -185,18 +188,35 @@ impl SyntheticBlockWithoutRootsAndBloom {
         }
     }
 
+    /// Returns the block number of the synthetic block.
+    pub fn block_number(&self) -> u64 {
+        self.header_without_roots_bloom_and_gas_used.number
+    }
+
+    /// Returns the synthetic block hash.
     pub fn hash(&self) -> B256 {
         synthetic_block_hash_for(self.header_without_roots_bloom_and_gas_used.number, (self.transactions.end - self.transactions.start).try_into().expect("Transactions range should be less than u32::MAX"))
     }
 
+    /// Returns the number of transactions in the synthetic block.
     pub fn num_transactions(&self) -> u64 {
         self.transactions.end - self.transactions.start
     }
 
+    /// Returns the index of the first transaction in the synthetic block.
     pub fn first_tx_index(&self) -> u64 {
         self.transactions.start
     }
 
+    /// Returns the index of the last transaction in the synthetic block. If the block is empty, returns the index of the last tx in the previous block.
+    pub fn last_tx_index(&self) -> u64 {
+        self.transactions.end.saturating_sub(1)
+    }
+
+    /// Returns the header of the synthetic block.
+    pub fn header(&self) -> &Header {
+        &self.header_without_roots_bloom_and_gas_used
+    }
 
     /// Finishes the synthetic block and seals it. Returns the sealed synthetic block and the transactions that were added to the block. 
     /// This function is relatively heavy, since it computes the tx and receipts roots.

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -29,6 +29,19 @@ pub fn synthetic_block_hash_for(block_number: u64, num_txs: u32) -> B256 {
     hash.into()
 }
 
+pub fn is_synthetic_block_hash(hash: &B256) -> bool {
+    hash.iter().take(20).eq(SYNTHETIC_BLOCK_HASH_PLACEHOLDER.iter().take(20))
+}
+
+pub fn parse_synthetic_block_hash(hash: &B256) -> Option<(u64, u32)> {
+    if !is_synthetic_block_hash(hash) {
+        return None;
+    }
+    let block_number = u64::from_be_bytes(hash[20..28].try_into().unwrap());
+    let num_txs = u32::from_be_bytes(hash[28..32].try_into().unwrap());
+    Some((block_number, num_txs))
+}
+
 /// Signed ethereum transaction
 pub type TransactionSigned = EthereumTxEnvelope<TxEip4844>;
 
@@ -218,7 +231,7 @@ impl SyntheticBlockWithoutRootsAndBloom {
     }
 
     /// Returns the header of the synthetic block.
-    pub fn header(&self) -> &Header {
+    pub fn partial_header(&self) -> &Header {
         &self.header_without_roots_bloom_and_gas_used
     }
 
@@ -369,12 +382,15 @@ impl<'de> serde::Deserialize<'de> for SealedBlock {
 
 #[cfg(feature = "native")]
 /// Sealed or pending block.
-#[derive(From, Debug)]
+#[derive(Debug)]
 pub enum MaybeSealedBlock {
     /// SealedBlock
     Sealed(SealedBlock),
-    /// Pending
-    PartialSynthetic(SyntheticBlockWithoutRootsAndBloom),
+    /// A synthetic block whose number matches the pending block number. It may be slightly older than the newest pending block 
+    PendingSynthetic(SyntheticBlockWithoutRootsAndBloom),
+    /// A synthetic block whose number is different from the pending block number.
+    /// This block is either in the past, or it doesn't exist yet
+    PastSynthetic(SyntheticBlockWithoutRootsAndBloom)
 }
 
 #[cfg(feature = "native")]
@@ -383,7 +399,8 @@ impl MaybeSealedBlock {
     pub fn hash(&self) -> Option<B256> {
         match self {
             Self::Sealed(block) => Some(block.header.hash()),
-            Self::PartialSynthetic(block) => Some(block.hash()),
+            Self::PendingSynthetic(block) => Some(block.hash()),
+            Self::PastSynthetic(block) => Some(block.hash()),
         }
     }
 
@@ -391,7 +408,8 @@ impl MaybeSealedBlock {
     pub fn number(&self) -> u64 {
         match self {
             Self::Sealed(block) => block.header.number,
-            Self::PartialSynthetic(block) => block.header_without_roots_bloom_and_gas_used.number,
+            Self::PendingSynthetic(block) => block.header_without_roots_bloom_and_gas_used.number,
+            Self::PastSynthetic(block) => block.header_without_roots_bloom_and_gas_used.number,
         }
     }
 
@@ -404,7 +422,8 @@ impl MaybeSealedBlock {
     pub fn transactions_start(&self) -> u64 {
         match self {
             Self::Sealed(block) => block.transactions.start,
-            Self::PartialSynthetic(block) => block.transactions.start,
+            Self::PendingSynthetic(block) => block.transactions.start,
+            Self::PastSynthetic(block) => block.transactions.start,
         }
     }
 
@@ -412,7 +431,8 @@ impl MaybeSealedBlock {
     pub fn transactions_end(&self) -> u64 {
         match self {
             Self::Sealed(block) => block.transactions.end,
-            Self::PartialSynthetic(block) => block.transactions.end,
+            Self::PendingSynthetic(block) => block.transactions.end,
+            Self::PastSynthetic(block) => block.transactions.end,
         }
     }
 
@@ -420,9 +440,10 @@ impl MaybeSealedBlock {
     pub fn timestamp(&self) -> u64 {
         match self {
             Self::Sealed(block) => block.header.timestamp,
-            Self::PartialSynthetic(block) => {
+            Self::PendingSynthetic(block) => {
                 block.header_without_roots_bloom_and_gas_used.timestamp
             }
+            Self::PastSynthetic(block) => block.header_without_roots_bloom_and_gas_used.timestamp,
         }
     }
 
@@ -430,7 +451,8 @@ impl MaybeSealedBlock {
     pub fn maybe_partial_header(&self) -> &Header {
         match self {
             Self::Sealed(block) => block.header.inner(),
-            Self::PartialSynthetic(block) => &block.header_without_roots_bloom_and_gas_used,
+            Self::PendingSynthetic(block) => &block.header_without_roots_bloom_and_gas_used,
+            Self::PastSynthetic(block) => &block.header_without_roots_bloom_and_gas_used,
         }
     }
 
@@ -438,7 +460,8 @@ impl MaybeSealedBlock {
     pub fn into_maybe_partial_header(self) -> Header {
         match self {
             Self::Sealed(block) => block.header.into_inner(),
-            Self::PartialSynthetic(block) => block.header_without_roots_bloom_and_gas_used,
+            Self::PendingSynthetic(block) => block.header_without_roots_bloom_and_gas_used,
+            Self::PastSynthetic(block) => block.header_without_roots_bloom_and_gas_used,
         }
     }
 
@@ -446,19 +469,12 @@ impl MaybeSealedBlock {
     pub fn header_if_sealed(&self) -> Option<&Header> {
         match self {
             Self::Sealed(block) => Some(block.header.inner()),
-            Self::PartialSynthetic(_) => None,
+            Self::PendingSynthetic(_) => None,
+            Self::PastSynthetic(_) => None,
         }
     }
 }
 
-// #[cfg(feature = "native")]
-// impl From<MaybeSealedBlock> for Sealed<Header> {
-//     fn from(block: MaybeSealedBlock) -> Sealed<Header> {
-//         let hash = block.hash().unwrap_or_default();
-//         let header = block.into_header();
-//         Sealed::new_unchecked(header, hash)
-//     }
-// }
 
 /// TODO: Can we replace this with Reth type?
 #[serde_as]
@@ -511,5 +527,13 @@ mod tests {
         let reth_tx: Recovered<TransactionSigned> = tx.into();
 
         assert_eq!(signer, reth_tx.signer());
+    }
+
+    #[test]
+    fn test_synthetic_block_hash() {
+        let hash = synthetic_block_hash_for(100, 10);
+        assert!(is_synthetic_block_hash(&hash));
+        assert_eq!(parse_synthetic_block_hash(&hash), Some((100, 10)));
+        assert!(!is_synthetic_block_hash(&B256::ZERO));
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -29,12 +29,14 @@ pub fn synthetic_block_hash_for(block_number: u64, num_txs: u32) -> B256 {
     hash.into()
 }
 
+#[cfg(feature = "native")]
 pub fn is_synthetic_block_hash(hash: &B256) -> bool {
     hash.iter()
         .take(20)
         .eq(SYNTHETIC_BLOCK_HASH_PLACEHOLDER.iter().take(20))
 }
 
+#[cfg(feature = "native")]
 pub fn parse_synthetic_block_hash(hash: &B256) -> Option<(u64, u32)> {
     if !is_synthetic_block_hash(hash) {
         return None;
@@ -82,7 +84,7 @@ pub struct TxSignedAndRecovered {
 
 impl Encodable2718 for TxSignedAndRecovered {
     fn encode_2718(&self, out: &mut dyn BufMut) {
-        self.signed_transaction.encode_2718(out)
+        self.signed_transaction.encode_2718(out);
     }
 
     fn encode_2718_len(&self) -> usize {
@@ -98,7 +100,7 @@ impl Typed2718 for TxSignedAndRecovered {
 
 impl Encodable for TxSignedAndRecovered {
     fn encode(&self, out: &mut dyn BufMut) {
-        self.signed_transaction.encode(out)
+        self.signed_transaction.encode(out);
     }
 }
 

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -1,16 +1,16 @@
 use std::ops::Range;
 
+use alloy_consensus::proofs::{calculate_receipt_root, calculate_transaction_root};
 use alloy_consensus::{
     serde_bincode_compat::Header as HeaderBincodeCompat,
     transaction::serde_bincode_compat::EthereumTxEnvelope as EthereumTxEnvelopeBincodeCompat,
     transaction::Recovered, Header,
 };
-use alloy_consensus::proofs::{calculate_receipt_root, calculate_transaction_root};
 use alloy_consensus::{EthereumTxEnvelope, TxEip4844, TxReceipt, EMPTY_ROOT_HASH};
 use alloy_eips::{Encodable2718, Typed2718};
-use alloy_primitives::{Bloom, TxHash};
-use alloy_primitives::{Address, Sealable, Sealed, B256};
 use alloy_primitives::private::alloy_rlp::Encodable;
+use alloy_primitives::{Address, Sealable, Sealed, B256};
+use alloy_primitives::{Bloom, TxHash};
 use bytes::BufMut;
 use derive_more::{Deref, DerefMut, From};
 use derive_new::new;
@@ -19,7 +19,8 @@ use serde_with::serde_as;
 use sov_modules_api::macros::UniversalWallet;
 use sov_rollup_interface::da::Time;
 
-const SYNTHETIC_BLOCK_HASH_PLACEHOLDER: &[u8;32] = b"synthetic_block_hash\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+const SYNTHETIC_BLOCK_HASH_PLACEHOLDER: &[u8; 32] =
+    b"synthetic_block_hash\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
 
 pub fn synthetic_block_hash_for(block_number: u64, num_txs: u32) -> B256 {
     let mut hash = *SYNTHETIC_BLOCK_HASH_PLACEHOLDER;
@@ -153,7 +154,6 @@ impl Block {
     }
 }
 
-
 /// A synthetic block header without the roots (txs, receipts) and bloom, and gas used.
 /// "synthetic" here means that the header has a fake hash which we can reverse engineer to identify which transaction are in the block.
 #[derive(Debug, PartialEq, Default, Clone, serde::Serialize, serde::Deserialize)]
@@ -175,7 +175,6 @@ fn xor_hashes(a: B256, b: B256) -> B256 {
     result
 }
 
-
 impl SyntheticBlockWithoutRootsAndBloom {
     /// Creates a new synthetic block header.
     pub fn new(mut header: Header, transactions: Range<u64>) -> Self {
@@ -195,7 +194,12 @@ impl SyntheticBlockWithoutRootsAndBloom {
 
     /// Returns the synthetic block hash.
     pub fn hash(&self) -> B256 {
-        synthetic_block_hash_for(self.header_without_roots_bloom_and_gas_used.number, (self.transactions.end - self.transactions.start).try_into().expect("Transactions range should be less than u32::MAX"))
+        synthetic_block_hash_for(
+            self.header_without_roots_bloom_and_gas_used.number,
+            (self.transactions.end - self.transactions.start)
+                .try_into()
+                .expect("Transactions range should be less than u32::MAX"),
+        )
     }
 
     /// Returns the number of transactions in the synthetic block.
@@ -218,22 +222,33 @@ impl SyntheticBlockWithoutRootsAndBloom {
         &self.header_without_roots_bloom_and_gas_used
     }
 
-    /// Finishes the synthetic block and seals it. Returns the sealed synthetic block and the transactions that were added to the block. 
+    /// Finishes the synthetic block and seals it. Returns the sealed synthetic block and the transactions that were added to the block.
     /// This function is relatively heavy, since it computes the tx and receipts roots.
-    /// 
+    ///
     /// We pass the transactions as an owned type and return it rather than using a referene since some reth helpers requrie constructing types
-    /// with Vec<Tx>. 
-    pub fn finish_and_seal(mut self, transactions: Vec<TxSignedAndRecovered>, receipts: &[reth_primitives::Receipt]) -> (SealedSynthetic, Vec<TxSignedAndRecovered>) {
-        assert_eq!(transactions.len(), receipts.len(), "Transactions and receipts must have the same length");
+    /// with Vec<Tx>.
+    pub fn finish_and_seal(
+        mut self,
+        transactions: Vec<TxSignedAndRecovered>,
+        receipts: &[reth_primitives::Receipt],
+    ) -> (SealedSynthetic, Vec<TxSignedAndRecovered>) {
+        assert_eq!(
+            transactions.len(),
+            receipts.len(),
+            "Transactions and receipts must have the same length"
+        );
         let gas_used = receipts.last().map_or(0, |r| r.cumulative_gas_used);
 
         let hash = self.hash();
         let tx_root = calculate_transaction_root(transactions.as_slice());
         let receipts_root = calculate_receipt_root(receipts);
-        let bloom = receipts.iter().fold(Bloom::ZERO, |bloom, r| bloom | r.bloom());
+        let bloom = receipts
+            .iter()
+            .fold(Bloom::ZERO, |bloom, r| bloom | r.bloom());
         self.header_without_roots_bloom_and_gas_used.logs_bloom = bloom;
         self.header_without_roots_bloom_and_gas_used.gas_used = gas_used;
-        self.header_without_roots_bloom_and_gas_used.transactions_root = tx_root;
+        self.header_without_roots_bloom_and_gas_used
+            .transactions_root = tx_root;
         self.header_without_roots_bloom_and_gas_used.receipts_root = receipts_root;
 
         let body = reth_primitives::BlockBody {
@@ -241,14 +256,20 @@ impl SyntheticBlockWithoutRootsAndBloom {
             ommers: vec![],
             withdrawals: None,
         };
-        let rlp_size = alloy_consensus::Block::rlp_length_for(&self.header_without_roots_bloom_and_gas_used, &body);
+        let rlp_size = alloy_consensus::Block::rlp_length_for(
+            &self.header_without_roots_bloom_and_gas_used,
+            &body,
+        );
         let txs = body.transactions;
-        
-        (SealedSynthetic {
-            header: Sealed::new_unchecked(self.header_without_roots_bloom_and_gas_used, hash),
-            transactions: self.transactions,
-            rlp_size,
-        }, txs)
+
+        (
+            SealedSynthetic {
+                header: Sealed::new_unchecked(self.header_without_roots_bloom_and_gas_used, hash),
+                transactions: self.transactions,
+                rlp_size,
+            },
+            txs,
+        )
     }
 }
 
@@ -262,7 +283,6 @@ pub struct SealedSynthetic {
     /// The RLP encoded size of the block (header + body).
     pub rlp_size: usize,
 }
-
 
 /// Block with sealed header.
 #[derive(Debug, PartialEq, Clone, Deref, DerefMut)]
@@ -357,7 +377,6 @@ pub enum MaybeSealedBlock {
     PartialSynthetic(SyntheticBlockWithoutRootsAndBloom),
 }
 
-
 #[cfg(feature = "native")]
 impl MaybeSealedBlock {
     /// Hash of the block.
@@ -401,7 +420,9 @@ impl MaybeSealedBlock {
     pub fn timestamp(&self) -> u64 {
         match self {
             Self::Sealed(block) => block.header.timestamp,
-            Self::PartialSynthetic(block) => block.header_without_roots_bloom_and_gas_used.timestamp,
+            Self::PartialSynthetic(block) => {
+                block.header_without_roots_bloom_and_gas_used.timestamp
+            }
         }
     }
 
@@ -418,6 +439,14 @@ impl MaybeSealedBlock {
         match self {
             Self::Sealed(block) => block.header.into_inner(),
             Self::PartialSynthetic(block) => block.header_without_roots_bloom_and_gas_used,
+        }
+    }
+
+    /// Returns the header if the block has been sealed. Returns None for synthetic blocks.
+    pub fn header_if_sealed(&self) -> Option<&Header> {
+        match self {
+            Self::Sealed(block) => Some(block.header.inner()),
+            Self::PartialSynthetic(_) => None,
         }
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -5,15 +5,28 @@ use alloy_consensus::{
     transaction::serde_bincode_compat::EthereumTxEnvelope as EthereumTxEnvelopeBincodeCompat,
     transaction::Recovered, Header,
 };
-use alloy_consensus::{EthereumTxEnvelope, TxEip4844};
-use alloy_primitives::TxHash;
+use alloy_consensus::proofs::{calculate_receipt_root, calculate_transaction_root};
+use alloy_consensus::{EthereumTxEnvelope, TxEip4844, TxReceipt, EMPTY_ROOT_HASH};
+use alloy_eips::{Encodable2718, Typed2718};
+use alloy_primitives::{Bloom, TxHash};
 use alloy_primitives::{Address, Sealable, Sealed, B256};
+use alloy_primitives::private::alloy_rlp::Encodable;
+use bytes::BufMut;
 use derive_more::{Deref, DerefMut, From};
 use derive_new::new;
 use reth_ethereum_primitives::serde_bincode_compat::Receipt as ReceiptBincodeCompat;
 use serde_with::serde_as;
 use sov_modules_api::macros::UniversalWallet;
 use sov_rollup_interface::da::Time;
+
+const SYNTHETIC_BLOCK_HASH_PLACEHOLDER: &[u8;32] = b"synthetic_block_hash\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+
+pub fn synthetic_block_hash_for(block_number: u64, num_txs: u32) -> B256 {
+    let mut hash = *SYNTHETIC_BLOCK_HASH_PLACEHOLDER;
+    hash[20..28].copy_from_slice(&block_number.to_be_bytes());
+    hash[28..32].copy_from_slice(&num_txs.to_be_bytes());
+    hash.into()
+}
 
 /// Signed ethereum transaction
 pub type TransactionSigned = EthereumTxEnvelope<TxEip4844>;
@@ -49,6 +62,28 @@ pub struct TxSignedAndRecovered {
     pub(crate) signed_transaction: TransactionSigned,
     /// Block the transaction was added to
     pub block_number: u64,
+}
+
+impl Encodable2718 for TxSignedAndRecovered {
+    fn encode_2718(&self, out: &mut dyn BufMut) {
+        self.signed_transaction.encode_2718(out)
+    }
+
+    fn encode_2718_len(&self) -> usize {
+        self.signed_transaction.encode_2718_len()
+    }
+}
+
+impl Typed2718 for TxSignedAndRecovered {
+    fn ty(&self) -> u8 {
+        self.signed_transaction.ty()
+    }
+}
+
+impl Encodable for TxSignedAndRecovered {
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.signed_transaction.encode(out)
+    }
 }
 
 impl TxSignedAndRecovered {
@@ -117,6 +152,97 @@ impl Block {
         alloy_consensus::Block::rlp_length_for(&self.header, &body)
     }
 }
+
+
+#[derive(Debug, PartialEq, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SyntheticBlockWithoutRootsAndBloom {
+    /// The synthetic block header. All fields are set except for the roots (txs, receipts) and bloom, and gas used.
+    /// Note that the state root is also synthetic;
+    /// https://reth.rs/docs/reth_primitives/serde_bincode_compat/index.html
+    header_without_roots_bloom_and_gas_used: Header,
+
+    /// Transactions in this synthetic block.
+    pub transactions: Range<u64>,
+}
+
+fn xor_hashes(a: B256, b: B256) -> B256 {
+    let mut result = B256::ZERO;
+    for ((a_byte, b_byte), result_byte) in a.iter().zip(b.iter()).zip(result.iter_mut()) {
+        *result_byte = a_byte ^ b_byte;
+    }
+    result
+}
+
+
+impl SyntheticBlockWithoutRootsAndBloom {
+    pub fn new(mut header: Header, transactions: Range<u64>) -> Self {
+        if header.state_root == EMPTY_ROOT_HASH {
+            header.state_root = xor_hashes(header.parent_hash, header.transactions_root);
+        }
+        Self {
+            header_without_roots_bloom_and_gas_used: header,
+            transactions,
+        }
+    }
+
+    pub fn hash(&self) -> B256 {
+        synthetic_block_hash_for(self.header_without_roots_bloom_and_gas_used.number, (self.transactions.end - self.transactions.start).try_into().expect("Transactions range should be less than u32::MAX"))
+    }
+
+    pub fn num_transactions(&self) -> u64 {
+        self.transactions.end - self.transactions.start
+    }
+
+    pub fn first_tx_index(&self) -> u64 {
+        self.transactions.start
+    }
+
+
+    /// Finishes the synthetic block and seals it. Returns the sealed synthetic block and the transactions that were added to the block. 
+    /// This function is relatively heavy, since it computes the tx and receipts roots.
+    /// 
+    /// We pass the transactions as an owned type and return it rather than using a referene since some reth helpers requrie constructing types
+    /// with Vec<Tx>. 
+    pub fn finish_and_seal(mut self, transactions: Vec<TxSignedAndRecovered>, receipts: &[reth_primitives::Receipt]) -> (SealedSynthetic, Vec<TxSignedAndRecovered>) {
+        assert_eq!(transactions.len(), receipts.len(), "Transactions and receipts must have the same length");
+        let gas_used = receipts.last().map_or(0, |r| r.cumulative_gas_used);
+
+        let hash = self.hash();
+        let tx_root = calculate_transaction_root(transactions.as_slice());
+        let receipts_root = calculate_receipt_root(receipts);
+        let bloom = receipts.iter().fold(Bloom::ZERO, |bloom, r| bloom | r.bloom());
+        self.header_without_roots_bloom_and_gas_used.logs_bloom = bloom;
+        self.header_without_roots_bloom_and_gas_used.gas_used = gas_used;
+        self.header_without_roots_bloom_and_gas_used.transactions_root = tx_root;
+        self.header_without_roots_bloom_and_gas_used.receipts_root = receipts_root;
+
+        let body = reth_primitives::BlockBody {
+            transactions,
+            ommers: vec![],
+            withdrawals: None,
+        };
+        let rlp_size = alloy_consensus::Block::rlp_length_for(&self.header_without_roots_bloom_and_gas_used, &body);
+        let txs = body.transactions;
+        
+        (SealedSynthetic {
+            header: Sealed::new_unchecked(self.header_without_roots_bloom_and_gas_used, hash),
+            transactions: self.transactions,
+            rlp_size,
+        }, txs)
+    }
+}
+
+#[serde_as]
+#[derive(Debug, PartialEq, Default, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SealedSynthetic {
+    // The synthetic block header. Contains real bloom, tx root, and receipts root but, but the block hash will be fake.
+    pub header: Sealed<Header>,
+    /// The transactions in the synthetic block.
+    pub transactions: Range<u64>,
+    /// The RLP encoded size of the block (header + body).
+    pub rlp_size: usize,
+}
+
 
 /// Block with sealed header.
 #[derive(Debug, PartialEq, Clone, Deref, DerefMut)]
@@ -208,8 +334,9 @@ pub enum MaybeSealedBlock {
     /// SealedBlock
     Sealed(SealedBlock),
     /// Pending
-    Pending(crate::Block),
+    PartialSynthetic(SyntheticBlockWithoutRootsAndBloom),
 }
+
 
 #[cfg(feature = "native")]
 impl MaybeSealedBlock {
@@ -217,7 +344,7 @@ impl MaybeSealedBlock {
     pub fn hash(&self) -> Option<B256> {
         match self {
             Self::Sealed(block) => Some(block.header.hash()),
-            Self::Pending { .. } => None,
+            Self::PartialSynthetic(block) => Some(block.hash()),
         }
     }
 
@@ -225,7 +352,7 @@ impl MaybeSealedBlock {
     pub fn number(&self) -> u64 {
         match self {
             Self::Sealed(block) => block.header.number,
-            Self::Pending(pending) => pending.header.number,
+            Self::PartialSynthetic(block) => block.header_without_roots_bloom_and_gas_used.number,
         }
     }
 
@@ -238,7 +365,7 @@ impl MaybeSealedBlock {
     pub fn transactions_start(&self) -> u64 {
         match self {
             Self::Sealed(block) => block.transactions.start,
-            Self::Pending(pending) => pending.transactions.start,
+            Self::PartialSynthetic(block) => block.transactions.start,
         }
     }
 
@@ -246,7 +373,7 @@ impl MaybeSealedBlock {
     pub fn transactions_end(&self) -> u64 {
         match self {
             Self::Sealed(block) => block.transactions.end,
-            Self::Pending(pending) => pending.transactions.end,
+            Self::PartialSynthetic(block) => block.transactions.end,
         }
     }
 
@@ -254,35 +381,35 @@ impl MaybeSealedBlock {
     pub fn timestamp(&self) -> u64 {
         match self {
             Self::Sealed(block) => block.header.timestamp,
-            Self::Pending(pending) => pending.header.timestamp,
+            Self::PartialSynthetic(block) => block.header_without_roots_bloom_and_gas_used.timestamp,
         }
     }
 
     /// The block header.
-    pub fn header(&self) -> &Header {
+    pub fn maybe_partial_header(&self) -> &Header {
         match self {
             Self::Sealed(block) => block.header.inner(),
-            Self::Pending(pending) => &pending.header,
+            Self::PartialSynthetic(block) => &block.header_without_roots_bloom_and_gas_used,
         }
     }
 
     /// The block header.
-    pub fn into_header(self) -> Header {
+    pub fn into_maybe_partial_header(self) -> Header {
         match self {
             Self::Sealed(block) => block.header.into_inner(),
-            Self::Pending(pending) => pending.header,
+            Self::PartialSynthetic(block) => block.header_without_roots_bloom_and_gas_used,
         }
     }
 }
 
-#[cfg(feature = "native")]
-impl From<MaybeSealedBlock> for Sealed<Header> {
-    fn from(block: MaybeSealedBlock) -> Sealed<Header> {
-        let hash = block.hash().unwrap_or_default();
-        let header = block.into_header();
-        Sealed::new_unchecked(header, hash)
-    }
-}
+// #[cfg(feature = "native")]
+// impl From<MaybeSealedBlock> for Sealed<Header> {
+//     fn from(block: MaybeSealedBlock) -> Sealed<Header> {
+//         let hash = block.hash().unwrap_or_default();
+//         let header = block.into_header();
+//         Sealed::new_unchecked(header, hash)
+//     }
+// }
 
 /// TODO: Can we replace this with Reth type?
 #[serde_as]

--- a/crates/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/lib.rs
@@ -58,7 +58,7 @@ use crate::db::DbAccount;
 pub use crate::evm::primitive_types::TransactionSigned;
 use crate::evm::primitive_types::{Block, PendingTransaction, TxSignedAndRecovered};
 
-pub use crate::evm::primitive_types::{Receipt, SealedBlock};
+pub use crate::evm::primitive_types::{Receipt, SealedBlock, SyntheticBlockWithoutRootsAndBloom};
 
 pub use conversions::convert_to_tx_signed;
 pub use conversions::create_tx_env;

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -65,20 +65,11 @@ where
             method = "eth_getBlockByHash",
             "EVM module JSON-RPC request"
         );
-
-        let block_number = self
-            .block_hash_to_number
-            .get(&block_hash, state)
-            .unwrap_infallible();
-        let kind = details.unwrap_or_default().into();
-        Ok(match block_number {
-            Some(number) => self.get_block(
-                Some(BlockId::Number(BlockNumberOrTag::Number(number))),
-                kind,
-                state,
-            )?,
-            None => None,
-        })
+        Ok(self.get_maybe_synthetic_block_for_rpc(
+            Some(BlockId::Hash(block_hash.into())),
+            details.unwrap_or_default().into(),
+            state,
+        )?)
     }
 
     /// Handler for: `eth_getBlockByNumber`
@@ -95,7 +86,7 @@ where
             "EVM module JSON-RPC request"
         );
         let kind = details.unwrap_or_default().into();
-        Ok(self.get_block(block_id, kind, state)?)
+        Ok(self.get_maybe_synthetic_block_for_rpc(block_id, kind, state)?)
     }
 
     /// Handler for: `eth_getBalance`
@@ -437,7 +428,7 @@ where
             method = "eth_getBlockTransactionCountByNumber",
             "EVM module JSON-RPC request"
         );
-        let block = self.get_block(block_id, false.into(), state)?;
+        let block = self.get_maybe_synthetic_block_for_rpc(block_id, false.into(), state)?;
         Ok(block.map(|b| U64::from(b.transactions.len())))
     }
 
@@ -460,7 +451,7 @@ where
             .unwrap_infallible();
         match block_number {
             Some(number) => {
-                let block = self.get_block(
+                let block = self.get_maybe_synthetic_block_for_rpc(
                     Some(BlockId::Number(BlockNumberOrTag::Number(number))),
                     false.into(),
                     state,

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/maybe_archival_state.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/maybe_archival_state.rs
@@ -1,12 +1,10 @@
-use derive_more::From;
 use sov_modules_api::{ApiStateAccessor, Spec};
 use std::ops::{Deref, DerefMut};
 
-#[derive(From)]
 pub(crate) enum MaybeArchivalState<'a, S: Spec> {
     Current(&'a mut ApiStateAccessor<S>),
     Archival(Box<ApiStateAccessor<S>>),
-    Synthetic(ApiStateAccessor<S>),
+    Synthetic(Box<ApiStateAccessor<S>>),
 }
 
 impl<'a, S: Spec> Deref for MaybeArchivalState<'a, S> {

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/maybe_archival_state.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/maybe_archival_state.rs
@@ -6,6 +6,7 @@ use std::ops::{Deref, DerefMut};
 pub(crate) enum MaybeArchivalState<'a, S: Spec> {
     Current(&'a mut ApiStateAccessor<S>),
     Archival(Box<ApiStateAccessor<S>>),
+    Synthetic(ApiStateAccessor<S>),
 }
 
 impl<'a, S: Spec> Deref for MaybeArchivalState<'a, S> {
@@ -14,6 +15,7 @@ impl<'a, S: Spec> Deref for MaybeArchivalState<'a, S> {
         match self {
             Self::Current(a) => a,
             Self::Archival(a) => a,
+            Self::Synthetic(a) => a,
         }
     }
 }
@@ -23,6 +25,7 @@ impl<'a, S: Spec> DerefMut for MaybeArchivalState<'a, S> {
         match self {
             Self::Current(a) => a,
             Self::Archival(a) => a,
+            Self::Synthetic(a) => a,
         }
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/maybe_archival_state.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/maybe_archival_state.rs
@@ -12,8 +12,7 @@ impl<'a, S: Spec> Deref for MaybeArchivalState<'a, S> {
     fn deref(&self) -> &Self::Target {
         match self {
             Self::Current(a) => a,
-            Self::Archival(a) => a,
-            Self::Synthetic(a) => a,
+            Self::Archival(a) | Self::Synthetic(a) => a,
         }
     }
 }
@@ -22,8 +21,7 @@ impl<'a, S: Spec> DerefMut for MaybeArchivalState<'a, S> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         match self {
             Self::Current(a) => a,
-            Self::Archival(a) => a,
-            Self::Synthetic(a) => a,
+            Self::Archival(a) | Self::Synthetic(a) => a,
         }
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -120,18 +120,7 @@ where
             }
             // For pending blocks, we would like to avoid fetching the whole block body for performance reasons
             MaybeSealedBlock::PartialSynthetic(block) =>  {
-                let len = block.transactions.end - block.transactions.start;
-                let mut txs = Vec::with_capacity(len as usize);
-                let mut receipts = Vec::with_capacity(len as usize);
-                for tx_idx in block.transactions.clone() {
-                    let tx = self.tx(tx_idx, state)?;
-                    txs.push(tx);
-                    let receipt = self.receipt(tx_idx, state).unwrap_or_else(|| panic!("Tx {tx_idx} exists but has no corresponding receipt. This is a bug, please report it."));
-                    let receipt = receipt.0.receipt;
-                    receipts.push(receipt);
-                }
-                let (synthetic_block, txs) = block.finish_and_seal(txs, &receipts);
-                let header = Header::from_consensus(synthetic_block.header, None, Some(U256::from(synthetic_block.rlp_size)));
+                let (header, txs) = self.get_synthetic_block_contents_slow(block, state)?;
                 let txs = match kind {
                     BlockTransactionsKind::Full => BlockTransactions::Full(txs.into_iter().enumerate().map(|(tx_idx, tx)| from_recovered_with_block_context(tx.into(), Some(header.hash), header.number, tx_idx as u64)).collect()),
                     BlockTransactionsKind::Hashes => BlockTransactions::Hashes(txs.into_iter().map(|tx| *tx.signed_transaction.hash()).collect()),
@@ -144,6 +133,29 @@ where
                 }))
             }
         }
+    }
+
+    /// Populates the header of a partial synthetic block and returns the transactions.
+    /// 
+    /// This function has to fetch all the transactions and receipts, so it's relatively slow - avoid when possible.
+    pub fn get_synthetic_block_contents_slow(
+        &self,
+        block: SyntheticBlockWithoutRootsAndBloom,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Result<(Header, Vec<TxSignedAndRecovered>), EthApiError> {
+            let len = block.transactions.end - block.transactions.start;
+                let mut txs = Vec::with_capacity(len as usize);
+                let mut receipts = Vec::with_capacity(len as usize);
+                for tx_idx in block.transactions.clone() {
+                    let tx = self.tx(tx_idx, state)?;
+                    txs.push(tx);
+                    let receipt = self.receipt(tx_idx, state).unwrap_or_else(|| panic!("Tx {tx_idx} exists but has no corresponding receipt. This is a bug, please report it."));
+                    let receipt = receipt.0.receipt;
+                    receipts.push(receipt);
+                }
+                let (synthetic_block, txs) = block.finish_and_seal(txs, &receipts);
+                let header = Header::from_consensus(synthetic_block.header, None, Some(U256::from(synthetic_block.rlp_size)));
+            Ok((header, txs))
        
     }
 

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -261,7 +261,8 @@ where
         let caller = tx_env.caller;
         let cfg = self.cfg_infallible(state);
         let cfg_env = get_cfg_env(&block_env, &cfg, Some(get_cfg_env_template()));
-        let mut evm_db: EvmDb<_, S> = self.db(state);
+        let mut maybe_archival_state = self.resolve_state_for_block_id(block_id, state)?;
+        let mut evm_db: EvmDb<_, S> = self.db(maybe_archival_state.deref_mut());
         let result = executor::transact(&mut evm_db, &block_env, tx_env, cfg_env)?;
         verify_contract_creation_allowlist(&result.state, &caller, &cfg, &mut evm_db)
             .map_err(|e| EthApiError::other(into_rpc_error(e)))?;
@@ -366,6 +367,7 @@ where
                     },
                 }
             }
+            // TODO: Handle synthetic blocks
             BlockId::Hash(hash) => self
                 .block_hash_to_number
                 .get(&hash.block_hash, state)
@@ -472,6 +474,7 @@ where
         state: &'a mut ApiStateAccessor<S>,
     ) -> Result<MaybeArchivalState<'a, S>, EthApiError> {
         let block_id = block_id.unwrap_or_else(BlockId::latest);
+        // TODO: Handle synthetic blocks
         let pending_or_block_nr = self.block_id_to_pending_or_block(block_id, state)?;
         match pending_or_block_nr {
             PendingOrBlock::Pending => Ok(MaybeArchivalState::Current(state)),

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -436,7 +436,8 @@ where
         block_number
     }
 
-    fn get_maybe_sealed_block_by_id(
+    /// Retrieve a block by its id.
+    pub fn get_maybe_sealed_block_by_id(
         &self,
         block_id: BlockId,
         state: &mut ApiStateAccessor<S>,

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -461,10 +461,24 @@ where
                 }
             }
             BlockId::Hash(hash) => {
-                // If the hash matches a synthetic block, handle that special case
+                // If the hash is synthetic, handle that special case
                 if let Some((block_number, num_txs)) = parse_synthetic_block_hash(&hash.into()) {
-                    let block_env = self.block_env(state).unwrap_infallible();
+                    // Prerequisite: Check that the synthetic block exists and is recent enough to still be saved.
+                    // This ensures that any calls to "getBlockByHash" will succeed only if "eth_call" would succeed given the same hash.
+                    {
+                        let Some(cache) = SAVED_SYNTHETIC_BLOCK_STATE_BY_HASH.get() else {
+                            return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
+                        };
+                        let lock = cache
+                            .read()
+                            .expect("Failed to read from synthetic blocks cache");
+                        if lock.get_state_by_hash::<S>(hash.into()).is_none() {
+                            return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
+                        }
+                    }
+
                     // Case 1: The synthetic block has the same block number as the pending block; that's a harder special case where we need to populate its fields from the pending block
+                    let block_env = self.block_env(state).unwrap_infallible();
                     if block_env.number == block_number {
                         let Some(mut newest_pending_block) =
                             self.pending_block(Some(block_env), state)
@@ -489,7 +503,7 @@ where
                         )));
                     }
 
-                    // Case 2: The synthetic block has a different block number. Then we can just populate the fields from the sealed block at that height.
+                    // Case 2: The synthetic block is not pending. We can just populate the fields from the sealed block at that height if one exists
                     return Ok(Some(MaybeSealedBlock::PastSynthetic(
                         self.past_synthetic_block(block_number, num_txs, state)?,
                     )));

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -408,7 +408,13 @@ where
             BlockNumberOrTag::Finalized | BlockNumberOrTag::Safe => *block_numbers.end(),
             BlockNumberOrTag::Number(nr) => nr,
             // We treat latest and pending the same to avoid foundry issues
-            BlockNumberOrTag::Latest | BlockNumberOrTag::Pending => *block_numbers.end() + 1,
+            BlockNumberOrTag::Latest | BlockNumberOrTag::Pending => {
+                if self.has_pending_block(state) {
+                    *block_numbers.end() + 1
+                } else {
+                    *block_numbers.end()
+                }
+            }
         };
         block_number
     }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -96,7 +96,7 @@ where
         };
         Ok(txs)
     }
-  
+
     fn get_block(
         &self,
         block_number: Option<String>,
@@ -107,10 +107,14 @@ where
             return Ok(None);
         };
         match block {
-            MaybeSealedBlock::Sealed(sealed) =>  {
+            MaybeSealedBlock::Sealed(sealed) => {
                 let block_size = sealed.rlp_size;
                 let transactions = self.get_block_transactions(&sealed, kind, state)?;
-                let header = Header::from_consensus(sealed.header.into(), None, Some(U256::from(block_size)));
+                let header = Header::from_consensus(
+                    sealed.header.into(),
+                    None,
+                    Some(U256::from(block_size)),
+                );
                 Ok(Some(Block {
                     header,
                     transactions,
@@ -119,11 +123,27 @@ where
                 }))
             }
             // For pending blocks, we would like to avoid fetching the whole block body for performance reasons
-            MaybeSealedBlock::PartialSynthetic(block) =>  {
+            MaybeSealedBlock::PartialSynthetic(block) => {
                 let (header, txs) = self.get_synthetic_block_contents_slow(block, state)?;
                 let txs = match kind {
-                    BlockTransactionsKind::Full => BlockTransactions::Full(txs.into_iter().enumerate().map(|(tx_idx, tx)| from_recovered_with_block_context(tx.into(), Some(header.hash), header.number, tx_idx as u64)).collect()),
-                    BlockTransactionsKind::Hashes => BlockTransactions::Hashes(txs.into_iter().map(|tx| *tx.signed_transaction.hash()).collect()),
+                    BlockTransactionsKind::Full => BlockTransactions::Full(
+                        txs.into_iter()
+                            .enumerate()
+                            .map(|(tx_idx, tx)| {
+                                from_recovered_with_block_context(
+                                    tx.into(),
+                                    Some(header.hash),
+                                    header.number,
+                                    tx_idx as u64,
+                                )
+                            })
+                            .collect(),
+                    ),
+                    BlockTransactionsKind::Hashes => BlockTransactions::Hashes(
+                        txs.into_iter()
+                            .map(|tx| *tx.signed_transaction.hash())
+                            .collect(),
+                    ),
                 };
                 Ok(Some(Block {
                     header,
@@ -136,27 +156,30 @@ where
     }
 
     /// Populates the header of a partial synthetic block and returns the transactions.
-    /// 
+    ///
     /// This function has to fetch all the transactions and receipts, so it's relatively slow - avoid when possible.
     pub fn get_synthetic_block_contents_slow(
         &self,
         block: SyntheticBlockWithoutRootsAndBloom,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<(Header, Vec<TxSignedAndRecovered>), EthApiError> {
-            let len = block.transactions.end - block.transactions.start;
-                let mut txs = Vec::with_capacity(len as usize);
-                let mut receipts = Vec::with_capacity(len as usize);
-                for tx_idx in block.transactions.clone() {
-                    let tx = self.tx(tx_idx, state)?;
-                    txs.push(tx);
-                    let receipt = self.receipt(tx_idx, state).unwrap_or_else(|| panic!("Tx {tx_idx} exists but has no corresponding receipt. This is a bug, please report it."));
-                    let receipt = receipt.0.receipt;
-                    receipts.push(receipt);
-                }
-                let (synthetic_block, txs) = block.finish_and_seal(txs, &receipts);
-                let header = Header::from_consensus(synthetic_block.header, None, Some(U256::from(synthetic_block.rlp_size)));
-            Ok((header, txs))
-       
+        let len = block.transactions.end - block.transactions.start;
+        let mut txs = Vec::with_capacity(len as usize);
+        let mut receipts = Vec::with_capacity(len as usize);
+        for tx_idx in block.transactions.clone() {
+            let tx = self.tx(tx_idx, state)?;
+            txs.push(tx);
+            let receipt = self.receipt(tx_idx, state).unwrap_or_else(|| panic!("Tx {tx_idx} exists but has no corresponding receipt. This is a bug, please report it."));
+            let receipt = receipt.0.receipt;
+            receipts.push(receipt);
+        }
+        let (synthetic_block, txs) = block.finish_and_seal(txs, &receipts);
+        let header = Header::from_consensus(
+            synthetic_block.header,
+            None,
+            Some(U256::from(synthetic_block.rlp_size)),
+        );
+        Ok((header, txs))
     }
 
     fn get_contract_code(
@@ -332,11 +355,15 @@ where
 
     /// Retrieves the pending block. We maintain the invariant that the pending block always has number
     /// latest_sealed_block.number + 1. (Both are updated during the finalize_hook, so they're atomic).
-    /// 
+    ///
     /// Note that values in the block_env (including the block number there!) are updated during the begin_rollup_block_hook, so the values here may be stale
     /// if this function is called while no rollup block is in progress. In that case, the number of transactions will be zero.
     // TODO: Have this function return None if no block is pending!
-    pub fn pending_block(&self, block_env: Option<BlockEnv>, state: &mut ApiStateAccessor<S>) -> SyntheticBlockWithoutRootsAndBloom {
+    pub fn pending_block(
+        &self,
+        block_env: Option<BlockEnv>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> SyntheticBlockWithoutRootsAndBloom {
         let block_numbers = self.block_numbers(state);
 
         let head_block = self
@@ -344,7 +371,8 @@ where
             .get(block_numbers.end(), state)
             .unwrap_infallible()
             .expect("Block should exist as index is inside block_numbers");
-        let current_block_env = block_env.unwrap_or_else(|| self.block_env(state).unwrap_infallible());
+        let current_block_env =
+            block_env.unwrap_or_else(|| self.block_env(state).unwrap_infallible());
 
         assert_eq!(&head_block.header.number, block_numbers.end());
 

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -285,7 +285,9 @@ where
 
         let block_env = self.block_env(state).unwrap_infallible();
         if block_env.number == block_number {
-            let pending = self.pending_block(Some(block_env), state);
+            let Some(pending) = self.pending_block(Some(block_env), state) else {
+                return Some(MaybeSealedBlock::Sealed(self.latest_block(state)));
+            };
             return Some(MaybeSealedBlock::PartialSynthetic(pending));
         }
 
@@ -356,9 +358,12 @@ where
                 let pending_or_block = self.block_tag_to_pending_or_block(tag, state);
                 match pending_or_block {
                     PendingOrBlock::Number(number) => self.get_maybe_sealed_block(number, state),
-                    PendingOrBlock::Pending => {
-                        Some(MaybeSealedBlock::PartialSynthetic(self.pending_block(None, state)))
-                    }
+                    PendingOrBlock::Pending => match self.pending_block(None, state) {
+                        Some(pending) => Some(MaybeSealedBlock::PartialSynthetic(pending)),
+                        None => {
+                            return Ok(Some(MaybeSealedBlock::Sealed(self.latest_block(state))))
+                        }
+                    },
                 }
             }
             BlockId::Hash(hash) => self
@@ -379,16 +384,25 @@ where
     }
 
     /// Retrieves the pending block. We maintain the invariant that the pending block always has number
-    /// latest_sealed_block.number + 1. (Both are updated during the finalize_hook, so they're atomic).
+    /// latest_sealed_block.number + 1. (Both are updated during the finalize_hook, so they're atomic). Returns None if there are no txs in the pending block.
+    /// In that case, we should use the latest sealed block instead.
     ///
     /// Note that values in the block_env (including the block number there!) are updated during the begin_rollup_block_hook, so the values here may be stale
     /// if this function is called while no rollup block is in progress. In that case, the number of transactions will be zero.
-    // TODO: Have this function return None if no block is pending!
     pub fn pending_block(
         &self,
         block_env: Option<BlockEnv>,
         state: &mut ApiStateAccessor<S>,
-    ) -> SyntheticBlockWithoutRootsAndBloom {
+    ) -> Option<SyntheticBlockWithoutRootsAndBloom> {
+        self.maybe_pending_block(false, block_env, state)
+    }
+
+    fn maybe_pending_block(
+        &self,
+        allow_empty: bool,
+        block_env: Option<BlockEnv>,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Option<SyntheticBlockWithoutRootsAndBloom> {
         let block_numbers = self.block_numbers(state);
 
         let head_block = self
@@ -402,6 +416,9 @@ where
         assert_eq!(&head_block.header.number, block_numbers.end());
 
         let pending_transactions_len = self.pending_transactions.len(state).unwrap_infallible();
+        if pending_transactions_len == 0 && !allow_empty {
+            return None;
+        }
 
         let start = head_block.transactions.end;
         let end = start + pending_transactions_len;
@@ -437,7 +454,16 @@ where
             requests_hash: None,
         };
 
-        SyntheticBlockWithoutRootsAndBloom::new(header, start..end)
+        Some(SyntheticBlockWithoutRootsAndBloom::new(header, start..end))
+    }
+
+    /// Returns the header of the newest synthetic block, even if it's empty.
+    pub fn get_newest_synthetic_header(
+        &self,
+        state: &mut ApiStateAccessor<S>,
+    ) -> SyntheticBlockWithoutRootsAndBloom {
+        self.maybe_pending_block(true, None, state)
+            .expect("Maybe pending block should never return None if allow_empty is true")
     }
 
     fn resolve_state_for_block_id<'a>(

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -40,6 +40,12 @@ use sov_rpc_eth_types::{EthApiError, LogWithExecutionTimestamp, RpcInvalidTransa
 // Prune synthetic blocks more than this number of blocks away from the latest block.
 const SYNTHETIC_BLOCKS_CACHE_PRUNE_INTERVAL: u64 = 20;
 
+/// Cache of synthetic block states by hash.
+/// 
+/// Currently, there's no way to recreate the state of a synthetic block once it's gone. This is because
+/// EVM state is shared with the sov-modles system, so any sov txs can impact the state of the synthetic block - but only
+/// EVM tx bodies are stored in the EVM module. This cache saves a copy of the API state accessor for each synthetic block we make,
+/// pruning them after some interval.
 #[cfg(feature = "native")]
 pub(crate) static SAVED_SYNTHETIC_BLOCK_STATE_BY_HASH: OnceLock<RwLock<SyntheticBlocksCache>> =
     OnceLock::new();
@@ -511,6 +517,9 @@ where
     ///
     /// Note that values in the block_env (including the block number there!) are updated during the begin_rollup_block_hook, so the values here may be stale
     /// if this function is called while no rollup block is in progress. In that case, the number of transactions will be zero.
+    /// 
+    /// This function also caches the API state at the time this pending block was created in `SYNTHETIC_BLOCKS_CACHE_BY_HASH`. This allows recreate the state
+    /// as of the synthetic block as long as it remains in cache, which would otherwise be impossible. See the docs on `SYNTHETIC_BLOCKS_CACHE_BY_HASH` for more details
     pub fn pending_block(
         &self,
         block_env: Option<BlockEnv>,

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -1,5 +1,12 @@
+use std::any::Any;
+#[cfg(feature = "native")]
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::ops::DerefMut;
+#[cfg(feature = "native")]
+use std::sync::{OnceLock, RwLock};
 
+use crate::primitive_types::parse_synthetic_block_hash;
 use crate::db::EvmDb;
 use crate::error::into_rpc_error;
 use crate::evm::executor;
@@ -7,10 +14,10 @@ use crate::evm::primitive_types::{Receipt, TransactionSigned, TxSignedAndRecover
 use crate::executor::get_cfg_env;
 use crate::helpers::{from_recovered_with_block_context, prepare_call_env};
 pub use crate::primitive_types::MaybeSealedBlock;
-use crate::primitive_types::SyntheticBlockWithoutRootsAndBloom;
+use crate::primitive_types::{SyntheticBlockWithoutRootsAndBloom, synthetic_block_hash_for};
 use crate::{verify_contract_creation_allowlist, Evm, SealedBlock};
 use alloy_consensus::{transaction::Recovered, Transaction as TransactionTrait, TxReceipt};
-use alloy_consensus::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
+use alloy_consensus::{BlockHeader, EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, BlockNumber, Bloom, B64};
 use alloy_primitives::{Bytes, TxKind, B256, U256};
@@ -30,6 +37,49 @@ use sov_modules_api::{ApiStateAccessor, Spec, VersionReader};
 use sov_rollup_interface::common::RollupHeight;
 use sov_rpc_eth_types::{EthApiError, LogWithExecutionTimestamp, RpcInvalidTransactionError};
 
+// Prune synthetic blocks more than this number of blocks away from the latest block.
+const SYNTHETIC_BLOCKS_CACHE_PRUNE_INTERVAL: u64 = 20;
+
+#[cfg(feature = "native")]
+pub(crate) static SAVED_SYNTHETIC_BLOCK_STATE_BY_HASH: OnceLock<RwLock<SyntheticBlocksCache>> = OnceLock::new();
+
+#[derive(Default)]
+pub(crate)struct SyntheticBlocksCache {
+    // Store ApiStateAccessor<S> by hash. We have to type erase because static variables can't store generic types.
+    state_by_hash: HashMap<B256, Box<dyn Any + Send + Sync>>,
+    // To allow for pruning, save a list of all synthetic block hashes for each block number
+    // When those blocks are old enough, we prune them all.
+    hashes_by_block_number: HashMap<u64, Vec<B256>>,
+    oldest_block_number: u64,
+}
+impl SyntheticBlocksCache {
+    fn insert_if_absent<S: Spec>(&mut self, block: &SyntheticBlockWithoutRootsAndBloom, state: &mut ApiStateAccessor<S>) {
+        if let Entry::Vacant(entry) = self.state_by_hash.entry(block.hash()) {
+            let state = state.clone_without_local_writes();
+            let state: Box<dyn Any + Send + Sync> = Box::new(state);
+            entry.insert(state);
+            self.hashes_by_block_number.entry(block.block_number()).or_insert(Vec::new()).push(block.hash());
+            if block.block_number() > self.oldest_block_number + SYNTHETIC_BLOCKS_CACHE_PRUNE_INTERVAL {
+                self.prune(block.block_number());
+            }
+        }
+    }
+
+    fn get_state_by_hash<S: Spec>(&self, hash: B256) -> Option<&ApiStateAccessor<S>> {
+        self.state_by_hash.get(&hash).map(|b| b.downcast_ref::<ApiStateAccessor<S>>().expect("Attempted to get the wrong type out of the SyntheticBlocksCache. This is impossible unless you request a different Spec than you put in. It's a bug, please report it."))
+    }
+    fn prune(&mut self, block_number: u64) {
+        let stop_at = block_number.saturating_sub(SYNTHETIC_BLOCKS_CACHE_PRUNE_INTERVAL);
+        for number in self.oldest_block_number..stop_at {
+            let hashes = self.hashes_by_block_number.remove(&number).unwrap_or_default();
+            for hash in hashes {
+                self.state_by_hash.remove(&hash);
+            }
+        }
+        self.oldest_block_number = stop_at;
+    }
+}
+
 pub(crate) mod error;
 pub(crate) mod handlers;
 pub(crate) mod maybe_archival_state;
@@ -44,6 +94,13 @@ pub enum PendingOrBlock {
     Pending,
     /// Block number.
     Number(u64),
+    /// A synthetic block which is not the current pending block.
+    PastSynthetic {
+        #[allow(missing_docs)]
+        block_number: u64,
+        #[allow(missing_docs)]
+        last_tx_idx: u32,
+    },
 }
 
 const ABSOLUTE_MARGIN: u64 = 100_000;
@@ -97,7 +154,8 @@ where
         Ok(txs)
     }
 
-    fn get_block(
+    /// Gets a block requested by hash or number by an external caller.
+    fn get_maybe_synthetic_block_for_rpc(
         &self,
         block_id: Option<BlockId>,
         kind: BlockTransactionsKind,
@@ -124,7 +182,7 @@ where
                 }))
             }
             // For pending blocks, we would like to avoid fetching the whole block body for performance reasons
-            MaybeSealedBlock::PartialSynthetic(block) => {
+            MaybeSealedBlock::PendingSynthetic(block)  | MaybeSealedBlock::PastSynthetic(block) => {
                 let (header, txs) = self.get_synthetic_block_contents_slow(block, state)?;
                 let txs = match kind {
                     BlockTransactionsKind::Full => BlockTransactions::Full(
@@ -289,7 +347,7 @@ where
             let Some(pending) = self.pending_block(Some(block_env), state) else {
                 return Some(MaybeSealedBlock::Sealed(self.latest_block(state)));
             };
-            return Some(MaybeSealedBlock::PartialSynthetic(pending));
+            return Some(MaybeSealedBlock::PendingSynthetic(pending));
         }
 
         None
@@ -320,6 +378,12 @@ where
         Ok(match block_id {
             BlockId::Number(tag) => self.block_tag_to_pending_or_block(tag, state),
             BlockId::Hash(hash) => {
+                if let Some((block_number, last_tx_idx)) = parse_synthetic_block_hash(&hash.into()) {
+                    return Ok(PendingOrBlock::PastSynthetic {
+                        block_number,
+                        last_tx_idx,
+                    });
+                }
                 let Some(number) = self
                     .block_hash_to_number
                     .get(&hash.block_hash, state)
@@ -360,19 +424,47 @@ where
                 match pending_or_block {
                     PendingOrBlock::Number(number) => self.get_maybe_sealed_block(number, state),
                     PendingOrBlock::Pending => match self.pending_block(None, state) {
-                        Some(pending) => Some(MaybeSealedBlock::PartialSynthetic(pending)),
+                        Some(pending) => Some(MaybeSealedBlock::PendingSynthetic(pending)),
                         None => {
                             return Ok(Some(MaybeSealedBlock::Sealed(self.latest_block(state))))
                         }
                     },
+                    PendingOrBlock::PastSynthetic { .. } => {
+                        unreachable!()
+                    }
                 }
             }
-            // TODO: Handle synthetic blocks
-            BlockId::Hash(hash) => self
-                .block_hash_to_number
-                .get(&hash.block_hash, state)
-                .unwrap_infallible()
-                .and_then(|number| self.get_maybe_sealed_block(number, state)),
+            BlockId::Hash(hash) => {
+                // If the hash matches a synthetic block, handle that special case
+                if let Some((block_number, num_txs)) = parse_synthetic_block_hash(&hash.into()) {
+
+                    let block_env = self.block_env(state).unwrap_infallible();
+                    // Case 1: The synthetic block has the same block number as the pending block; that's a harder special case where we need to populate its fields from the pending block
+                    if block_env.number == block_number {
+                        let Some(mut newest_pending_block) = self.pending_block(Some(block_env), state) else {
+                            return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
+                        };
+                        // Check that the number of txs requested is no more than the number of txs in the pending block. If not, this block doesn't exist - return early
+                        if num_txs as u64 > newest_pending_block.num_transactions() {
+                            return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
+                        } 
+                        // Check if the number of txs requested is exactly the same as the number of txs in the pending block. If so, this is the pending block! return it
+                        if num_txs as u64 == newest_pending_block.num_transactions() {
+                            return Ok(Some(MaybeSealedBlock::PendingSynthetic(newest_pending_block)));
+                        }
+                        // Otherwise, this is a the same as the pending block but with fewer txs - truncate the pending block to the number of txs requested
+                        newest_pending_block.transactions.end = newest_pending_block.transactions.start + num_txs as u64;
+                        return Ok(Some(MaybeSealedBlock::PendingSynthetic(newest_pending_block)));
+                    }
+
+                    // Case 2: The synthetic block has a different block number. Then we can just populate the fields from the sealed block at that height.
+                    return Ok(Some(MaybeSealedBlock::PastSynthetic(self.past_synthetic_block(block_number, num_txs, state)?)));
+                }
+                self
+                    .block_hash_to_number
+                    .get(&hash.block_hash, state)
+                    .unwrap_infallible()
+                    .and_then(|number| self.get_maybe_sealed_block(number, state))},
         })
     }
 
@@ -399,6 +491,61 @@ where
         self.maybe_pending_block(false, block_env, state)
     }
 
+    // Populates a synthetic block from a sealed block.
+    fn past_synthetic_block(
+        &self,
+        block_number: u64,
+        num_txs: u32,
+        state: &mut ApiStateAccessor<S>,
+    ) -> Result<SyntheticBlockWithoutRootsAndBloom, EthApiError> {
+
+        // Populate the header from the sealed block
+        let Some(block) = self
+            .blocks
+            .get(&block_number, state)
+            .unwrap_infallible() else {
+                return Err(EthApiError::HeaderNotFound(BlockId::Hash(synthetic_block_hash_for(block_number, num_txs).into())));
+        };
+
+        if block.transactions().end - block.transactions().start < num_txs as u64 {
+            return Err(EthApiError::HeaderNotFound(BlockId::Hash(synthetic_block_hash_for(block_number, num_txs).into())));
+        }
+        let first_tx_index = block.transactions().start;
+        let last_tx_index = first_tx_index.checked_add(num_txs as u64).expect("Number of transactions should fit in u64");
+
+        let header = alloy_consensus::Header {
+            parent_hash: block.header.parent_hash(),
+            number: block_number,
+            timestamp: block.header.timestamp,
+            excess_blob_gas: block.header.excess_blob_gas,
+            base_fee_per_gas: block.header.base_fee_per_gas,
+            gas_limit: block.header.gas_limit,
+
+            // Values that will be filled in later
+            gas_used: 0,
+            logs_bloom: Bloom::default(),
+            state_root: EMPTY_ROOT_HASH,
+            transactions_root: EMPTY_ROOT_HASH,
+            receipts_root: EMPTY_ROOT_HASH,
+
+            // Values that never need to be initailized
+            ommers_hash: EMPTY_OMMER_ROOT_HASH,
+            beneficiary: Address::ZERO,
+            difficulty: U256::ZERO,
+            extra_data: Bytes::default(),
+            mix_hash: B256::ZERO,
+            nonce: B64::ZERO,
+            withdrawals_root: None,
+            blob_gas_used: None,
+            parent_beacon_block_root: None,
+            requests_hash: None,
+        };
+
+        let block = SyntheticBlockWithoutRootsAndBloom::new(header, first_tx_index..last_tx_index);
+
+        Ok(block)
+    }
+
     fn maybe_pending_block(
         &self,
         allow_empty: bool,
@@ -421,6 +568,7 @@ where
         if pending_transactions_len == 0 && !allow_empty {
             return None;
         }
+        
 
         let start = head_block.transactions.end;
         let end = start + pending_transactions_len;
@@ -456,7 +604,15 @@ where
             requests_hash: None,
         };
 
-        Some(SyntheticBlockWithoutRootsAndBloom::new(header, start..end))
+        let block = SyntheticBlockWithoutRootsAndBloom::new(header, start..end);
+        #[cfg(feature = "native")]
+        {
+            let state_by_hash = SAVED_SYNTHETIC_BLOCK_STATE_BY_HASH.get_or_init(|| RwLock::new(Default::default()));
+            // TODO: Optimization, lower priority - move the rwlock inside the cache and "read" to check if the block is already in the cache before grabbing the write lock.
+            state_by_hash.write().expect("Failed to write to synthetic blocks cache").insert_if_absent(&block, state);
+        }
+
+        Some(block)
     }
 
     /// Returns the header of the newest synthetic block, even if it's empty.
@@ -474,7 +630,6 @@ where
         state: &'a mut ApiStateAccessor<S>,
     ) -> Result<MaybeArchivalState<'a, S>, EthApiError> {
         let block_id = block_id.unwrap_or_else(BlockId::latest);
-        // TODO: Handle synthetic blocks
         let pending_or_block_nr = self.block_id_to_pending_or_block(block_id, state)?;
         match pending_or_block_nr {
             PendingOrBlock::Pending => Ok(MaybeArchivalState::Current(state)),
@@ -486,6 +641,17 @@ where
                 }
                 let archival_state = state.get_archival_state(RollupHeight::new(number))?;
                 Ok(MaybeArchivalState::Archival(archival_state.into()))
+            }
+            PendingOrBlock::PastSynthetic { block_number, last_tx_idx } => {
+                let hash = synthetic_block_hash_for(block_number, last_tx_idx);
+                let Some(cache) = SAVED_SYNTHETIC_BLOCK_STATE_BY_HASH.get() else {
+                    return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
+                };
+                let lock = cache.read().expect("Failed to read from synthetic blocks cache");
+                let Some(state) = lock.get_state_by_hash(hash).map(|state| state.clone_without_local_writes()) else {
+                    return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
+                };
+                Ok(MaybeArchivalState::Synthetic(state))
             }
         }
     }
@@ -501,10 +667,10 @@ where
             .ok_or(EthApiError::UnknownBlock)?;
 
         let mut block_env = match maybe_block {
-            MaybeSealedBlock::PartialSynthetic(_) => self.block_env(state).unwrap_infallible(),
+            MaybeSealedBlock::PendingSynthetic(_) => self.block_env(state).unwrap_infallible(),
             MaybeSealedBlock::Sealed(sealed_block) => BlockEnv::from(sealed_block),
+            MaybeSealedBlock::PastSynthetic(synthetic_block) => BlockEnv::from(synthetic_block),
         };
-        // Set the base fee to zero for evm execution. Gas is paid for by the sov gas meter instead
         block_env.basefee = 0;
         Ok(block_env)
     }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -1,20 +1,20 @@
 use std::any::Any;
+use std::collections::hash_map::Entry;
 #[cfg(feature = "native")]
 use std::collections::HashMap;
-use std::collections::hash_map::Entry;
 use std::ops::DerefMut;
 #[cfg(feature = "native")]
 use std::sync::{OnceLock, RwLock};
 
-use crate::primitive_types::parse_synthetic_block_hash;
 use crate::db::EvmDb;
 use crate::error::into_rpc_error;
 use crate::evm::executor;
 use crate::evm::primitive_types::{Receipt, TransactionSigned, TxSignedAndRecovered};
 use crate::executor::get_cfg_env;
 use crate::helpers::{from_recovered_with_block_context, prepare_call_env};
+use crate::primitive_types::parse_synthetic_block_hash;
 pub use crate::primitive_types::MaybeSealedBlock;
-use crate::primitive_types::{SyntheticBlockWithoutRootsAndBloom, synthetic_block_hash_for};
+use crate::primitive_types::{synthetic_block_hash_for, SyntheticBlockWithoutRootsAndBloom};
 use crate::{verify_contract_creation_allowlist, Evm, SealedBlock};
 use alloy_consensus::{transaction::Recovered, Transaction as TransactionTrait, TxReceipt};
 use alloy_consensus::{BlockHeader, EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
@@ -41,10 +41,11 @@ use sov_rpc_eth_types::{EthApiError, LogWithExecutionTimestamp, RpcInvalidTransa
 const SYNTHETIC_BLOCKS_CACHE_PRUNE_INTERVAL: u64 = 20;
 
 #[cfg(feature = "native")]
-pub(crate) static SAVED_SYNTHETIC_BLOCK_STATE_BY_HASH: OnceLock<RwLock<SyntheticBlocksCache>> = OnceLock::new();
+pub(crate) static SAVED_SYNTHETIC_BLOCK_STATE_BY_HASH: OnceLock<RwLock<SyntheticBlocksCache>> =
+    OnceLock::new();
 
 #[derive(Default)]
-pub(crate)struct SyntheticBlocksCache {
+pub(crate) struct SyntheticBlocksCache {
     // Store ApiStateAccessor<S> by hash. We have to type erase because static variables can't store generic types.
     state_by_hash: HashMap<B256, Box<dyn Any + Send + Sync>>,
     // To allow for pruning, save a list of all synthetic block hashes for each block number
@@ -53,13 +54,22 @@ pub(crate)struct SyntheticBlocksCache {
     oldest_block_number: u64,
 }
 impl SyntheticBlocksCache {
-    fn insert_if_absent<S: Spec>(&mut self, block: &SyntheticBlockWithoutRootsAndBloom, state: &mut ApiStateAccessor<S>) {
+    fn insert_if_absent<S: Spec>(
+        &mut self,
+        block: &SyntheticBlockWithoutRootsAndBloom,
+        state: &mut ApiStateAccessor<S>,
+    ) {
         if let Entry::Vacant(entry) = self.state_by_hash.entry(block.hash()) {
             let state = state.clone_without_local_writes();
             let state: Box<dyn Any + Send + Sync> = Box::new(state);
             entry.insert(state);
-            self.hashes_by_block_number.entry(block.block_number()).or_insert(Vec::new()).push(block.hash());
-            if block.block_number() > self.oldest_block_number + SYNTHETIC_BLOCKS_CACHE_PRUNE_INTERVAL {
+            self.hashes_by_block_number
+                .entry(block.block_number())
+                .or_insert(Vec::new())
+                .push(block.hash());
+            if block.block_number()
+                > self.oldest_block_number + SYNTHETIC_BLOCKS_CACHE_PRUNE_INTERVAL
+            {
                 self.prune(block.block_number());
             }
         }
@@ -71,7 +81,10 @@ impl SyntheticBlocksCache {
     fn prune(&mut self, block_number: u64) {
         let stop_at = block_number.saturating_sub(SYNTHETIC_BLOCKS_CACHE_PRUNE_INTERVAL);
         for number in self.oldest_block_number..stop_at {
-            let hashes = self.hashes_by_block_number.remove(&number).unwrap_or_default();
+            let hashes = self
+                .hashes_by_block_number
+                .remove(&number)
+                .unwrap_or_default();
             for hash in hashes {
                 self.state_by_hash.remove(&hash);
             }
@@ -182,7 +195,7 @@ where
                 }))
             }
             // For pending blocks, we would like to avoid fetching the whole block body for performance reasons
-            MaybeSealedBlock::PendingSynthetic(block)  | MaybeSealedBlock::PastSynthetic(block) => {
+            MaybeSealedBlock::PendingSynthetic(block) | MaybeSealedBlock::PastSynthetic(block) => {
                 let (header, txs) = self.get_synthetic_block_contents_slow(block, state)?;
                 let txs = match kind {
                     BlockTransactionsKind::Full => BlockTransactions::Full(
@@ -378,7 +391,8 @@ where
         Ok(match block_id {
             BlockId::Number(tag) => self.block_tag_to_pending_or_block(tag, state),
             BlockId::Hash(hash) => {
-                if let Some((block_number, last_tx_idx)) = parse_synthetic_block_hash(&hash.into()) {
+                if let Some((block_number, last_tx_idx)) = parse_synthetic_block_hash(&hash.into())
+                {
                     return Ok(PendingOrBlock::PastSynthetic {
                         block_number,
                         last_tx_idx,
@@ -443,34 +457,42 @@ where
             BlockId::Hash(hash) => {
                 // If the hash matches a synthetic block, handle that special case
                 if let Some((block_number, num_txs)) = parse_synthetic_block_hash(&hash.into()) {
-
                     let block_env = self.block_env(state).unwrap_infallible();
                     // Case 1: The synthetic block has the same block number as the pending block; that's a harder special case where we need to populate its fields from the pending block
                     if block_env.number == block_number {
-                        let Some(mut newest_pending_block) = self.pending_block(Some(block_env), state) else {
+                        let Some(mut newest_pending_block) =
+                            self.pending_block(Some(block_env), state)
+                        else {
                             return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
                         };
                         // Check that the number of txs requested is no more than the number of txs in the pending block. If not, this block doesn't exist - return early
                         if num_txs as u64 > newest_pending_block.num_transactions() {
                             return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
-                        } 
+                        }
                         // Check if the number of txs requested is exactly the same as the number of txs in the pending block. If so, this is the pending block! return it
                         if num_txs as u64 == newest_pending_block.num_transactions() {
-                            return Ok(Some(MaybeSealedBlock::PendingSynthetic(newest_pending_block)));
+                            return Ok(Some(MaybeSealedBlock::PendingSynthetic(
+                                newest_pending_block,
+                            )));
                         }
                         // Otherwise, this is a the same as the pending block but with fewer txs - truncate the pending block to the number of txs requested
-                        newest_pending_block.transactions.end = newest_pending_block.transactions.start + num_txs as u64;
-                        return Ok(Some(MaybeSealedBlock::PendingSynthetic(newest_pending_block)));
+                        newest_pending_block.transactions.end =
+                            newest_pending_block.transactions.start + num_txs as u64;
+                        return Ok(Some(MaybeSealedBlock::PendingSynthetic(
+                            newest_pending_block,
+                        )));
                     }
 
                     // Case 2: The synthetic block has a different block number. Then we can just populate the fields from the sealed block at that height.
-                    return Ok(Some(MaybeSealedBlock::PastSynthetic(self.past_synthetic_block(block_number, num_txs, state)?)));
+                    return Ok(Some(MaybeSealedBlock::PastSynthetic(
+                        self.past_synthetic_block(block_number, num_txs, state)?,
+                    )));
                 }
-                self
-                    .block_hash_to_number
+                self.block_hash_to_number
                     .get(&hash.block_hash, state)
                     .unwrap_infallible()
-                    .and_then(|number| self.get_maybe_sealed_block(number, state))},
+                    .and_then(|number| self.get_maybe_sealed_block(number, state))
+            }
         })
     }
 
@@ -504,20 +526,22 @@ where
         num_txs: u32,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<SyntheticBlockWithoutRootsAndBloom, EthApiError> {
-
         // Populate the header from the sealed block
-        let Some(block) = self
-            .blocks
-            .get(&block_number, state)
-            .unwrap_infallible() else {
-                return Err(EthApiError::HeaderNotFound(BlockId::Hash(synthetic_block_hash_for(block_number, num_txs).into())));
+        let Some(block) = self.blocks.get(&block_number, state).unwrap_infallible() else {
+            return Err(EthApiError::HeaderNotFound(BlockId::Hash(
+                synthetic_block_hash_for(block_number, num_txs).into(),
+            )));
         };
 
         if block.transactions().end - block.transactions().start < num_txs as u64 {
-            return Err(EthApiError::HeaderNotFound(BlockId::Hash(synthetic_block_hash_for(block_number, num_txs).into())));
+            return Err(EthApiError::HeaderNotFound(BlockId::Hash(
+                synthetic_block_hash_for(block_number, num_txs).into(),
+            )));
         }
         let first_tx_index = block.transactions().start;
-        let last_tx_index = first_tx_index.checked_add(num_txs as u64).expect("Number of transactions should fit in u64");
+        let last_tx_index = first_tx_index
+            .checked_add(num_txs as u64)
+            .expect("Number of transactions should fit in u64");
 
         let header = alloy_consensus::Header {
             parent_hash: block.header.parent_hash(),
@@ -574,7 +598,6 @@ where
         if pending_transactions_len == 0 && !allow_empty {
             return None;
         }
-        
 
         let start = head_block.transactions.end;
         let end = start + pending_transactions_len;
@@ -613,9 +636,13 @@ where
         let block = SyntheticBlockWithoutRootsAndBloom::new(header, start..end);
         #[cfg(feature = "native")]
         {
-            let state_by_hash = SAVED_SYNTHETIC_BLOCK_STATE_BY_HASH.get_or_init(|| RwLock::new(Default::default()));
+            let state_by_hash =
+                SAVED_SYNTHETIC_BLOCK_STATE_BY_HASH.get_or_init(|| RwLock::new(Default::default()));
             // TODO: Optimization, lower priority - move the rwlock inside the cache and "read" to check if the block is already in the cache before grabbing the write lock.
-            state_by_hash.write().expect("Failed to write to synthetic blocks cache").insert_if_absent(&block, state);
+            state_by_hash
+                .write()
+                .expect("Failed to write to synthetic blocks cache")
+                .insert_if_absent(&block, state);
         }
 
         Some(block)
@@ -648,13 +675,21 @@ where
                 let archival_state = state.get_archival_state(RollupHeight::new(number))?;
                 Ok(MaybeArchivalState::Archival(archival_state.into()))
             }
-            PendingOrBlock::PastSynthetic { block_number, last_tx_idx } => {
+            PendingOrBlock::PastSynthetic {
+                block_number,
+                last_tx_idx,
+            } => {
                 let hash = synthetic_block_hash_for(block_number, last_tx_idx);
                 let Some(cache) = SAVED_SYNTHETIC_BLOCK_STATE_BY_HASH.get() else {
                     return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
                 };
-                let lock = cache.read().expect("Failed to read from synthetic blocks cache");
-                let Some(state) = lock.get_state_by_hash(hash).map(|state| state.clone_without_local_writes()) else {
+                let lock = cache
+                    .read()
+                    .expect("Failed to read from synthetic blocks cache");
+                let Some(state) = lock
+                    .get_state_by_hash(hash)
+                    .map(|state| state.clone_without_local_writes())
+                else {
                     return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
                 };
                 Ok(MaybeArchivalState::Synthetic(state))

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -41,7 +41,7 @@ use sov_rpc_eth_types::{EthApiError, LogWithExecutionTimestamp, RpcInvalidTransa
 const SYNTHETIC_BLOCKS_CACHE_PRUNE_INTERVAL: u64 = 20;
 
 /// Cache of synthetic block states by hash.
-/// 
+///
 /// Currently, there's no way to recreate the state of a synthetic block once it's gone. This is because
 /// EVM state is shared with the sov-modles system, so any sov txs can impact the state of the synthetic block - but only
 /// EVM tx bodies are stored in the EVM module. This cache saves a copy of the API state accessor for each synthetic block we make,
@@ -517,7 +517,7 @@ where
     ///
     /// Note that values in the block_env (including the block number there!) are updated during the begin_rollup_block_hook, so the values here may be stale
     /// if this function is called while no rollup block is in progress. In that case, the number of transactions will be zero.
-    /// 
+    ///
     /// This function also caches the API state at the time this pending block was created in `SYNTHETIC_BLOCKS_CACHE_BY_HASH`. This allows recreate the state
     /// as of the synthetic block as long as it remains in cache, which would otherwise be impossible. See the docs on `SYNTHETIC_BLOCKS_CACHE_BY_HASH` for more details
     pub fn pending_block(

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -71,7 +71,7 @@ impl SyntheticBlocksCache {
             entry.insert(state);
             self.hashes_by_block_number
                 .entry(block.block_number())
-                .or_insert(Vec::new())
+                .or_default()
                 .push(block.hash());
             if block.block_number()
                 > self.oldest_block_number + SYNTHETIC_BLOCKS_CACHE_PRUNE_INTERVAL
@@ -188,11 +188,8 @@ where
             MaybeSealedBlock::Sealed(sealed) => {
                 let block_size = sealed.rlp_size;
                 let transactions = self.get_block_transactions(&sealed, kind, state)?;
-                let header = Header::from_consensus(
-                    sealed.header.into(),
-                    None,
-                    Some(U256::from(block_size)),
-                );
+                let header =
+                    Header::from_consensus(sealed.header, None, Some(U256::from(block_size)));
                 Ok(Some(Block {
                     header,
                     transactions,
@@ -467,13 +464,13 @@ where
                     // This ensures that any calls to "getBlockByHash" will succeed only if "eth_call" would succeed given the same hash.
                     {
                         let Some(cache) = SAVED_SYNTHETIC_BLOCK_STATE_BY_HASH.get() else {
-                            return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
+                            return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash)));
                         };
                         let lock = cache
                             .read()
                             .expect("Failed to read from synthetic blocks cache");
                         if lock.get_state_by_hash::<S>(hash.into()).is_none() {
-                            return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
+                            return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash)));
                         }
                     }
 
@@ -483,11 +480,11 @@ where
                         let Some(mut newest_pending_block) =
                             self.pending_block(Some(block_env), state)
                         else {
-                            return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
+                            return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash)));
                         };
                         // Check that the number of txs requested is no more than the number of txs in the pending block. If not, this block doesn't exist - return early
                         if num_txs as u64 > newest_pending_block.num_transactions() {
-                            return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
+                            return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash)));
                         }
                         // Check if the number of txs requested is exactly the same as the number of txs in the pending block. If so, this is the pending block! return it
                         if num_txs as u64 == newest_pending_block.num_transactions() {
@@ -715,7 +712,7 @@ where
                 else {
                     return Err(EthApiError::HeaderNotFound(BlockId::Hash(hash.into())));
                 };
-                Ok(MaybeArchivalState::Synthetic(state))
+                Ok(MaybeArchivalState::Synthetic(Box::new(state)))
             }
         }
     }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -7,6 +7,7 @@ use crate::evm::primitive_types::{Receipt, TransactionSigned, TxSignedAndRecover
 use crate::executor::get_cfg_env;
 use crate::helpers::{from_recovered_with_block_context, prepare_call_env};
 pub use crate::primitive_types::MaybeSealedBlock;
+use crate::primitive_types::SyntheticBlockWithoutRootsAndBloom;
 use crate::{verify_contract_creation_allowlist, Evm, SealedBlock};
 use alloy_consensus::{transaction::Recovered, Transaction as TransactionTrait, TxReceipt};
 use alloy_consensus::{EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
@@ -60,22 +61,22 @@ where
 {
     fn get_block_transactions(
         &self,
-        block: &MaybeSealedBlock,
+        block: &SealedBlock,
         kind: BlockTransactionsKind,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<BlockTransactions<Transaction>, EthApiError> {
-        let tx_range = block.tx_range();
+        let tx_range = block.transactions.start..block.transactions.end;
         let txs = match kind {
             BlockTransactionsKind::Full => {
-                let txs = tx_range
+                let txs: Vec<Transaction> = tx_range
                     .into_iter()
                     .enumerate()
                     .map(|(pos, idx)| {
                         let tx = self.tx(idx, state)?;
                         Ok::<_, EthApiError>(from_recovered_with_block_context(
                             tx.into(),
-                            block.hash(),
-                            block.number(),
+                            Some(block.header.hash()),
+                            block.number,
                             pos as u64,
                         ))
                     })
@@ -95,18 +96,7 @@ where
         };
         Ok(txs)
     }
-
-    /// Gets RPC Block Header including the size
-    pub fn get_rpc_header(&self, block: MaybeSealedBlock) -> Result<Header, EthApiError> {
-        let block_size = match &block {
-            MaybeSealedBlock::Sealed(sealed) => sealed.rlp_size,
-            // For pending blocks, we would like to avoid fetching the whole block body for performance reasons
-            MaybeSealedBlock::Pending(_) => 0,
-        };
-        let header = Header::from_consensus(block.into(), None, Some(U256::from(block_size)));
-        Ok(header)
-    }
-
+  
     fn get_block(
         &self,
         block_number: Option<String>,
@@ -116,13 +106,45 @@ where
         let Some(block) = self.get_sealed_block_by_number(block_number, state)? else {
             return Ok(None);
         };
-        let transactions = self.get_block_transactions(&block, kind, state)?;
-        Ok(Some(Block {
-            header: self.get_rpc_header(block)?,
-            transactions,
-            uncles: vec![],
-            withdrawals: None,
-        }))
+        match block {
+            MaybeSealedBlock::Sealed(sealed) =>  {
+                let block_size = sealed.rlp_size;
+                let transactions = self.get_block_transactions(&sealed, kind, state)?;
+                let header = Header::from_consensus(sealed.header.into(), None, Some(U256::from(block_size)));
+                Ok(Some(Block {
+                    header,
+                    transactions,
+                    uncles: vec![],
+                    withdrawals: None,
+                }))
+            }
+            // For pending blocks, we would like to avoid fetching the whole block body for performance reasons
+            MaybeSealedBlock::PartialSynthetic(block) =>  {
+                let len = block.transactions.end - block.transactions.start;
+                let mut txs = Vec::with_capacity(len as usize);
+                let mut receipts = Vec::with_capacity(len as usize);
+                for tx_idx in block.transactions.clone() {
+                    let tx = self.tx(tx_idx, state)?;
+                    txs.push(tx);
+                    let receipt = self.receipt(tx_idx, state).unwrap_or_else(|| panic!("Tx {tx_idx} exists but has no corresponding receipt. This is a bug, please report it."));
+                    let receipt = receipt.0.receipt;
+                    receipts.push(receipt);
+                }
+                let (synthetic_block, txs) = block.finish_and_seal(txs, &receipts);
+                let header = Header::from_consensus(synthetic_block.header, None, Some(U256::from(synthetic_block.rlp_size)));
+                let txs = match kind {
+                    BlockTransactionsKind::Full => BlockTransactions::Full(txs.into_iter().enumerate().map(|(tx_idx, tx)| from_recovered_with_block_context(tx.into(), Some(header.hash), header.number, tx_idx as u64)).collect()),
+                    BlockTransactionsKind::Hashes => BlockTransactions::Hashes(txs.into_iter().map(|tx| *tx.signed_transaction.hash()).collect()),
+                };
+                Ok(Some(Block {
+                    header,
+                    transactions: txs,
+                    uncles: vec![],
+                    withdrawals: None,
+                }))
+            }
+        }
+       
     }
 
     fn get_contract_code(
@@ -215,14 +237,19 @@ where
         block_number: u64,
         state: &mut ApiStateAccessor<S>,
     ) -> Option<MaybeSealedBlock> {
+        // Check if the block is already sealed. Important: We must do this before checking the block env, because blocks are sealed in the finalize_hook.
+        // but the block env is set during the begin_rollup_block_hook.
+        // That means that if we call this function after the finalize hook but before the start of the next block, the "pending" block env corresponds to the same
+        // number and set of txs as the latest sealed block - in which case we want to return the sealed version of it rather than making up a synthetic one.
         let block = self.blocks.get(&block_number, state).unwrap_infallible();
         if let Some(block) = block {
             return Some(MaybeSealedBlock::Sealed(block));
         }
 
-        let pending = self.pending_block(state);
-        if block_number == pending.header.number {
-            return Some(MaybeSealedBlock::Pending(pending));
+        let block_env = self.block_env(state).unwrap_infallible();
+        if block_env.number == block_number {
+            let pending = self.pending_block(Some(block_env), state);
+            return Some(MaybeSealedBlock::PartialSynthetic(pending));
         }
 
         None
@@ -276,8 +303,8 @@ where
         Ok(match pending_or_block_nr {
             PendingOrBlock::Number(nr) => self.get_maybe_sealed_block(nr, state),
             PendingOrBlock::Pending => {
-                let pending_block = self.pending_block(state);
-                Some(MaybeSealedBlock::Pending(pending_block))
+                let pending_block = self.pending_block(None, state);
+                Some(MaybeSealedBlock::PartialSynthetic(pending_block))
             }
         })
     }
@@ -291,8 +318,13 @@ where
             .expect("Block should exist as index is inside block_numbers")
     }
 
-    /// Retrieves the pending block.
-    pub fn pending_block(&self, state: &mut ApiStateAccessor<S>) -> crate::Block {
+    /// Retrieves the pending block. We maintain the invariant that the pending block always has number
+    /// latest_sealed_block.number + 1. (Both are updated during the finalize_hook, so they're atomic).
+    /// 
+    /// Note that values in the block_env (including the block number there!) are updated during the begin_rollup_block_hook, so the values here may be stale
+    /// if this function is called while no rollup block is in progress. In that case, the number of transactions will be zero.
+    // TODO: Have this function return None if no block is pending!
+    pub fn pending_block(&self, block_env: Option<BlockEnv>, state: &mut ApiStateAccessor<S>) -> SyntheticBlockWithoutRootsAndBloom {
         let block_numbers = self.block_numbers(state);
 
         let head_block = self
@@ -300,7 +332,7 @@ where
             .get(block_numbers.end(), state)
             .unwrap_infallible()
             .expect("Block should exist as index is inside block_numbers");
-        let current_block_env = self.block_env(state).unwrap_infallible();
+        let current_block_env = block_env.unwrap_or_else(|| self.block_env(state).unwrap_infallible());
 
         assert_eq!(&head_block.header.number, block_numbers.end());
 
@@ -320,15 +352,17 @@ where
                 .map(|blob_gas| blob_gas.excess_blob_gas),
             base_fee_per_gas: Some(current_block_env.basefee),
             gas_limit: current_block_env.gas_limit,
-            // Default values
-            ommers_hash: EMPTY_OMMER_ROOT_HASH,
-            beneficiary: Address::ZERO,
+            // Values that will be filled in later
+            gas_used: 0,
+            logs_bloom: Bloom::default(),
             state_root: EMPTY_ROOT_HASH,
             transactions_root: EMPTY_ROOT_HASH,
             receipts_root: EMPTY_ROOT_HASH,
-            logs_bloom: Bloom::default(),
+
+            // Values that never need to be initailized
+            ommers_hash: EMPTY_OMMER_ROOT_HASH,
+            beneficiary: Address::ZERO,
             difficulty: U256::ZERO,
-            gas_used: 0,
             extra_data: Bytes::default(),
             mix_hash: B256::ZERO,
             nonce: B64::ZERO,
@@ -338,10 +372,7 @@ where
             requests_hash: None,
         };
 
-        crate::Block {
-            header,
-            transactions: start..end,
-        }
+        SyntheticBlockWithoutRootsAndBloom::new(header, start..end)
     }
 
     fn resolve_state<'a>(
@@ -374,7 +405,7 @@ where
             .ok_or(EthApiError::UnknownBlock)?;
 
         let mut block_env = match maybe_block {
-            MaybeSealedBlock::Pending(_) => self.block_env(state).unwrap_infallible(),
+            MaybeSealedBlock::PartialSynthetic(_) => self.block_env(state).unwrap_infallible(),
             MaybeSealedBlock::Sealed(sealed_block) => BlockEnv::from(sealed_block),
         };
         // Set the base fee to zero for evm execution. Gas is paid for by the sov gas meter instead

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
@@ -57,6 +57,7 @@ where
         EthApiError,
     > {
         // Get the block - could be pending or sealed
+        // TODO: Skip fetching the whole block; we just need the block number
         let maybe_block = self
             .get_maybe_sealed_block(block_number, state)
             .ok_or_else(|| EthApiError::HeaderNotFound(BlockId::number(block_number)))?;
@@ -64,7 +65,7 @@ where
         // Pre-load transactions to avoid borrow conflicts
         let transactions = self.preload_block_transactions(&maybe_block, state)?;
 
-        let is_pending = matches!(maybe_block, MaybeSealedBlock::Pending(_));
+        let is_pending = matches!(maybe_block, MaybeSealedBlock::PartialSynthetic(_));
 
         let mut maybe_archival_state: MaybeArchivalState<'a, S> = if is_pending {
             state.into()

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
@@ -57,7 +57,7 @@ where
         EthApiError,
     > {
         // Get the block - could be pending or sealed
-        // TODO: Skip fetching the whole block; we just need the block number
+        // TODO(low priority): Skip fetching the whole block; we just need the block number
         let maybe_block = self
             .get_maybe_sealed_block(block_number, state)
             .ok_or_else(|| EthApiError::HeaderNotFound(BlockId::number(block_number)))?;
@@ -68,10 +68,10 @@ where
         let is_pending = matches!(maybe_block, MaybeSealedBlock::PendingSynthetic(_));
 
         let mut maybe_archival_state: MaybeArchivalState<'a, S> = if is_pending {
-            state.into()
+            MaybeArchivalState::Current(state)
         } else {
             let archival = self.archival_state_pre_block(maybe_block.number(), state)?;
-            Box::new(archival).into()
+            MaybeArchivalState::Archival(Box::new(archival))
         };
         let state = maybe_archival_state.deref_mut();
 

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/trace.rs
@@ -65,7 +65,7 @@ where
         // Pre-load transactions to avoid borrow conflicts
         let transactions = self.preload_block_transactions(&maybe_block, state)?;
 
-        let is_pending = matches!(maybe_block, MaybeSealedBlock::PartialSynthetic(_));
+        let is_pending = matches!(maybe_block, MaybeSealedBlock::PendingSynthetic(_));
 
         let mut maybe_archival_state: MaybeArchivalState<'a, S> = if is_pending {
             state.into()

--- a/crates/module-system/module-implementations/sov-evm/src/state_access.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/state_access.rs
@@ -167,17 +167,6 @@ impl<S: Spec> Evm<S> {
             .unwrap_infallible()
     }
 
-    /// Lookup the height of an Ethereum block based on the supplied hash.
-    pub fn block_height<Accessor: AccessoryStateReader>(
-        &self,
-        block_hash: &B256,
-        state: &mut Accessor,
-    ) -> Option<u64> {
-        self.block_hash_to_number
-            .get(block_hash, state)
-            .unwrap_infallible()
-    }
-
     /// Get the currently pending head block.
     pub fn pending_head<Accessor: AccessoryStateReader>(
         &self,

--- a/crates/module-system/module-implementations/sov-evm/src/state_access.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/state_access.rs
@@ -198,6 +198,15 @@ impl<S: Spec> Evm<S> {
         block_numbers.expect("Block numbers must be set in genesis")
     }
 
+    /// Check if there are pending transactions.
+    #[cfg(feature = "native")]
+    pub fn has_pending_block(
+        &self,
+        state: &mut ApiStateAccessor<S>,
+    ) -> bool {
+        self.pending_transactions.len(state).unwrap_infallible() != 0
+    }
+
     /// Get the Evm chain config.
     pub fn cfg_infallible<Accessor: InfallibleStateAccessor>(
         &self,

--- a/crates/module-system/module-implementations/sov-evm/src/state_access.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/state_access.rs
@@ -100,7 +100,7 @@ impl<S: Spec> Evm<S> {
         self.account_storage.get(&(address, index), state)
     }
 
-    /// Get the current block env. This corresponds to the pending block (i.e. the one that's currently being built). 
+    /// Get the current block env. This corresponds to the pending block (i.e. the one that's currently being built).
     /// It is set in the begin_rollup_block_hook.
     pub fn block_env<Accessor: StateReader<User>>(
         &self,

--- a/crates/module-system/module-implementations/sov-evm/src/state_access.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/state_access.rs
@@ -100,7 +100,8 @@ impl<S: Spec> Evm<S> {
         self.account_storage.get(&(address, index), state)
     }
 
-    /// Get the current block env.
+    /// Get the current block env. This corresponds to the pending block (i.e. the one that's currently being built). 
+    /// It is set in the begin_rollup_block_hook.
     pub fn block_env<Accessor: StateReader<User>>(
         &self,
         state: &mut Accessor,

--- a/crates/module-system/module-implementations/sov-evm/src/state_access.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/state_access.rs
@@ -200,10 +200,7 @@ impl<S: Spec> Evm<S> {
 
     /// Check if there are pending transactions.
     #[cfg(feature = "native")]
-    pub fn has_pending_block(
-        &self,
-        state: &mut ApiStateAccessor<S>,
-    ) -> bool {
+    pub fn has_pending_block(&self, state: &mut ApiStateAccessor<S>) -> bool {
         self.pending_transactions.len(state).unwrap_infallible() != 0
     }
 

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/state.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/state.rs
@@ -52,7 +52,11 @@ fn test_block_updates() {
             let txs = current_block.transactions();
             assert_eq!(txs.start, 0);
             assert_eq!(txs.end, 1);
-            let block_height = evm.get_block_by_hash(current_block.header().hash(), None, state).unwrap().unwrap().number();
+            let block_height = evm
+                .get_block_by_hash(current_block.header().hash(), None, state)
+                .unwrap()
+                .unwrap()
+                .number();
             assert_eq!(block_height, 1);
         }),
     });

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/state.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/state.rs
@@ -52,8 +52,8 @@ fn test_block_updates() {
             let txs = current_block.transactions();
             assert_eq!(txs.start, 0);
             assert_eq!(txs.end, 1);
-            let block_height = evm.block_height(&current_block.header().hash(), state);
-            assert_eq!(block_height, Some(1));
+            let block_height = evm.get_block_by_hash(current_block.header().hash(), None, state).unwrap().unwrap().number();
+            assert_eq!(block_height, 1);
         }),
     });
 }

--- a/crates/module-system/sov-modules-api/src/module/mod.rs
+++ b/crates/module-system/sov-modules-api/src/module/mod.rs
@@ -170,7 +170,12 @@ pub trait EventEmitter: ModuleInfo {
     /// Execution context.
     type Spec: Spec;
     /// Module defined event resulting from a call method.
-    type Event: Debug + BorshSerialize + BorshDeserialize + 'static + core::marker::Send + core::marker::Sync;
+    type Event: Debug
+        + BorshSerialize
+        + BorshDeserialize
+        + 'static
+        + core::marker::Send
+        + core::marker::Sync;
 
     /// Emits an event with an auto-generated event key composed by the module
     /// of origin's name and the `enum` variant's name of the event.

--- a/crates/module-system/sov-modules-api/src/module/mod.rs
+++ b/crates/module-system/sov-modules-api/src/module/mod.rs
@@ -42,7 +42,8 @@ pub trait Module: Clone {
         + schemars::JsonSchema
         + 'static
         + core::marker::Send
-        + PartialEq;
+        + PartialEq
+        + core::marker::Sync;
 
     /// Error type returned by [`Module::call`].
     type Error: Debug + std::fmt::Display + Send + Sync + 'static;
@@ -169,7 +170,7 @@ pub trait EventEmitter: ModuleInfo {
     /// Execution context.
     type Spec: Spec;
     /// Module defined event resulting from a call method.
-    type Event: Debug + BorshSerialize + BorshDeserialize + 'static + core::marker::Send;
+    type Event: Debug + BorshSerialize + BorshDeserialize + 'static + core::marker::Send + core::marker::Sync;
 
     /// Emits an event with an auto-generated event key composed by the module
     /// of origin's name and the `enum` variant's name of the event.

--- a/crates/module-system/sov-modules-api/src/state/accessors/genesis.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/genesis.rs
@@ -116,7 +116,7 @@ impl<S: Spec> GenesisStateAccessor<'_, S> {
 }
 
 impl<S: Spec> EventContainer for GenesisStateAccessor<'_, S> {
-    fn add_event<E: 'static + core::marker::Send>(&mut self, event_key: &str, event: E) {
+    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(&mut self, event_key: &str, event: E) {
         self.events.push(TypeErasedEvent::new(event_key, event));
     }
 

--- a/crates/module-system/sov-modules-api/src/state/accessors/genesis.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/genesis.rs
@@ -116,7 +116,11 @@ impl<S: Spec> GenesisStateAccessor<'_, S> {
 }
 
 impl<S: Spec> EventContainer for GenesisStateAccessor<'_, S> {
-    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(&mut self, event_key: &str, event: E) {
+    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(
+        &mut self,
+        event_key: &str,
+        event: E,
+    ) {
         self.events.push(TypeErasedEvent::new(event_key, event));
     }
 

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -381,7 +381,11 @@ impl<S: Spec> GetGasPrice for ApiStateAccessor<S> {
 }
 
 impl<S: Spec> EventContainer for ApiStateAccessor<S> {
-    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(&mut self, event_key: &str, event: E) {
+    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(
+        &mut self,
+        event_key: &str,
+        event: E,
+    ) {
         self.events.push(TypeErasedEvent::new(event_key, event));
     }
 

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -205,11 +205,11 @@ pub(crate) enum StateToAccess {
     ),
 }
 
-#[derive(derive_more::Debug)]
+#[derive(derive_more::Debug, Clone)]
 struct CheckpointAndReadTxn<S: Spec> {
     // IMPORTANT: Do not re-order the checkpoint before the read_txn - otherwise the read_txn will potentially  be invalidated for a split second on drop.
     #[debug(skip)]
-    read_txn: HashMapReadTxn<'static, (SlotKey, Namespace), Option<SlotValue>>,
+    read_txn: Arc<HashMapReadTxn<'static, (SlotKey, Namespace), Option<SlotValue>>>,
     // IMPORTANT: Do not re-order the checkpoint before the read_txn - otherwise the read_txn will potentially  be invalidated for a split second on drop.
     // This is undefined behavior
     state_checkpoint: Arc<ConcurrentStateCheckpoint<S>>,
@@ -218,7 +218,7 @@ struct CheckpointAndReadTxn<S: Spec> {
 impl<S: Spec> CheckpointAndReadTxn<S> {
     pub fn new(state_checkpoint: Arc<ConcurrentStateCheckpoint<S>>) -> Self {
         Self {
-            read_txn: unsafe { Self::lengthen_lifetime(state_checkpoint.writes.read()) },
+            read_txn: Arc::new(unsafe { Self::lengthen_lifetime(state_checkpoint.writes.read()) }),
             state_checkpoint,
         }
     }
@@ -381,7 +381,7 @@ impl<S: Spec> GetGasPrice for ApiStateAccessor<S> {
 }
 
 impl<S: Spec> EventContainer for ApiStateAccessor<S> {
-    fn add_event<E: 'static + core::marker::Send>(&mut self, event_key: &str, event: E) {
+    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(&mut self, event_key: &str, event: E) {
         self.events.push(TypeErasedEvent::new(event_key, event));
     }
 
@@ -855,6 +855,27 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
         // the first accesses to those values since they would be incorrectly shown as cached.
         state.clear_caches();
         Ok(state)
+    }
+
+    /// Clones the accessor for use in RPC contexts, rese
+    pub fn clone_without_local_writes(&self) -> ApiStateAccessor<S> {
+        ApiStateAccessor {
+            witness: Default::default(),
+            events: Vec::new(),
+            gas_meter: self.gas_meter.clone(),
+            local_kernel_writes: HashMap::new(),
+            local_user_writes: HashMap::new(),
+            local_accessory_writes: HashMap::new(),
+            uncomitted_changes: self.uncomitted_changes.as_ref().map(|c| c.box_clone()),
+            temp_cache: TempCache::new(),
+            checkpoint_and_read_txn: self.checkpoint_and_read_txn.clone(),
+            kernel: self.kernel.clone(),
+            state_to_access: self.state_to_access.clone(),
+            visible_slot_number: self.visible_slot_number,
+            safe_true_slot_number_to_use: self.safe_true_slot_number_to_use,
+            encountered_pruning_error: None,
+            metrics: StateMetrics::default(),
+        }
     }
 
     /// Returns a new accessor which accesses the rollup at the specified `height`.

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -874,7 +874,7 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
             temp_cache: TempCache::new(),
             checkpoint_and_read_txn: self.checkpoint_and_read_txn.clone(),
             kernel: self.kernel.clone(),
-            state_to_access: self.state_to_access.clone(),
+            state_to_access: self.state_to_access,
             visible_slot_number: self.visible_slot_number,
             safe_true_slot_number_to_use: self.safe_true_slot_number_to_use,
             encountered_pruning_error: None,

--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/revertable_tx_state.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/revertable_tx_state.rs
@@ -183,7 +183,11 @@ impl<S: Spec, I: TxState<S>> AccessoryStateWriter for RevertableTxState<'_, S, I
 impl<S: Spec, I: TxState<S>> AccessoryStateReader for RevertableTxState<'_, S, I> {}
 
 impl<S: Spec, I: TxState<S>> EventContainer for RevertableTxState<'_, S, I> {
-    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(&mut self, event_key: &str, event: E) {
+    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(
+        &mut self,
+        event_key: &str,
+        event: E,
+    ) {
         self.events.push(TypeErasedEvent::new(event_key, event));
     }
 

--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/revertable_tx_state.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/revertable_tx_state.rs
@@ -183,7 +183,7 @@ impl<S: Spec, I: TxState<S>> AccessoryStateWriter for RevertableTxState<'_, S, I
 impl<S: Spec, I: TxState<S>> AccessoryStateReader for RevertableTxState<'_, S, I> {}
 
 impl<S: Spec, I: TxState<S>> EventContainer for RevertableTxState<'_, S, I> {
-    fn add_event<E: 'static + core::marker::Send>(&mut self, event_key: &str, event: E) {
+    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(&mut self, event_key: &str, event: E) {
         self.events.push(TypeErasedEvent::new(event_key, event));
     }
 

--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/working_set.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/working_set.rs
@@ -267,7 +267,7 @@ impl<S: Spec, I: StateProvider<S>> UniversalStateAccessor for WorkingSet<S, I> {
 }
 
 impl<S: Spec, I: StateProvider<S>> EventContainer for WorkingSet<S, I> {
-    fn add_event<E: 'static + core::marker::Send>(&mut self, event_key: &str, event: E) {
+    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(&mut self, event_key: &str, event: E) {
         self.events.push(TypeErasedEvent::new(event_key, event));
     }
 

--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/working_set.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/working_set.rs
@@ -267,7 +267,11 @@ impl<S: Spec, I: StateProvider<S>> UniversalStateAccessor for WorkingSet<S, I> {
 }
 
 impl<S: Spec, I: StateProvider<S>> EventContainer for WorkingSet<S, I> {
-    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(&mut self, event_key: &str, event: E) {
+    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(
+        &mut self,
+        event_key: &str,
+        event: E,
+    ) {
         self.events.push(TypeErasedEvent::new(event_key, event));
     }
 

--- a/crates/module-system/sov-state/src/event.rs
+++ b/crates/module-system/sov-state/src/event.rs
@@ -18,7 +18,10 @@ pub struct TypeErasedEvent {
 
 impl TypeErasedEvent {
     /// Created a Typed Event
-    pub fn new<E: 'static + core::marker::Send + core::marker::Sync>(event_key: &str, event: E) -> Self {
+    pub fn new<E: 'static + core::marker::Send + core::marker::Sync>(
+        event_key: &str,
+        event: E,
+    ) -> Self {
         TypeErasedEvent {
             event_key: event_key.as_bytes().to_vec(),
             type_id: event.type_id(),

--- a/crates/module-system/sov-state/src/event.rs
+++ b/crates/module-system/sov-state/src/event.rs
@@ -13,12 +13,12 @@ use std::any::Any;
 pub struct TypeErasedEvent {
     event_key: Vec<u8>,
     type_id: core::any::TypeId,
-    boxed_event: Box<dyn core::any::Any + core::marker::Send>,
+    boxed_event: Box<dyn core::any::Any + core::marker::Send + core::marker::Sync>,
 }
 
 impl TypeErasedEvent {
     /// Created a Typed Event
-    pub fn new<E: 'static + core::marker::Send>(event_key: &str, event: E) -> Self {
+    pub fn new<E: 'static + core::marker::Send + core::marker::Sync>(event_key: &str, event: E) -> Self {
         TypeErasedEvent {
             event_key: event_key.as_bytes().to_vec(),
             type_id: event.type_id(),

--- a/crates/module-system/sov-state/src/lib.rs
+++ b/crates/module-system/sov-state/src/lib.rs
@@ -69,7 +69,7 @@ impl<H: Digest<OutputSize = digest::typenum::U32> + Send + Sync> MerkleProofSpec
 /// Accepts events emitted by modules
 pub trait EventContainer {
     /// Adds a typed event to the working set.
-    fn add_event<E: 'static + core::marker::Send>(&mut self, event_key: &str, event: E);
+    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(&mut self, event_key: &str, event: E);
 
     /// Adds a type erased event to the working set.
     fn add_type_erased_event(&mut self, event: TypeErasedEvent);

--- a/crates/module-system/sov-state/src/lib.rs
+++ b/crates/module-system/sov-state/src/lib.rs
@@ -69,7 +69,11 @@ impl<H: Digest<OutputSize = digest::typenum::U32> + Send + Sync> MerkleProofSpec
 /// Accepts events emitted by modules
 pub trait EventContainer {
     /// Adds a typed event to the working set.
-    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(&mut self, event_key: &str, event: E);
+    fn add_event<E: 'static + core::marker::Send + core::marker::Sync>(
+        &mut self,
+        event_key: &str,
+        event: E,
+    );
 
     /// Adds a type erased event to the working set.
     fn add_type_erased_event(&mut self, event: TypeErasedEvent);

--- a/docs/ethereum-rpc-compliance-findings.md
+++ b/docs/ethereum-rpc-compliance-findings.md
@@ -1,0 +1,89 @@
+# Ethereum JSON-RPC Compliance Findings (sov-evm + sov-ethereum)
+
+Scope
+- Code review: sov-evm RPC handlers and error mapping, sov-ethereum RPC wrapper handlers.
+- Live probe: local RPC at http://localhost:12346/rpc (2025-02-14).
+
+Summary
+- Several common Ethereum RPC methods are missing.
+- Multiple paths return non-standard error codes (notably -32001 or 500) for common client errors.
+- Several parameter handling gaps diverge from standard JSON-RPC / execution-apis behavior.
+
+Live probe results (key examples)
+- web3_clientVersion -> -32601 Method not found (missing method).
+- eth_getBalance [] -> -32602 Invalid params (missing params handled by jsonrpsee).
+- eth_getBlockByNumber ["safe", false] -> -32602 invalid block number (string tag not supported).
+- eth_getBlockByNumber [{"blockNumber":"0x1"}, false] -> -32602 invalid type (EIP-1898 object not supported).
+- eth_sendRawTransaction ["0x"] -> -32001 Empty raw transaction (non-standard for invalid input).
+- eth_sendRawTransaction ["0x01"] -> -32001 Deserialization failed (non-standard for invalid input).
+- eth_feeHistory [0, "latest", []] -> code 500 (non-JSON-RPC), should be invalid params.
+- eth_sendTransaction [{}] -> -32001 ETH_RPC_ERROR "No from address" (non-standard).
+
+Missing methods (not implemented)
+- web3: web3_clientVersion, web3_sha3.
+- net: net_listening, net_peerCount.
+- eth status/fees: eth_protocolVersion, eth_syncing, eth_coinbase, eth_mining, eth_hashrate, eth_maxPriorityFeePerGas.
+- eth block/tx lookup: eth_getBlockTransactionCountByHash, eth_getBlockTransactionCountByNumber,
+  eth_getTransactionByBlockHashAndIndex, eth_getTransactionByBlockNumberAndIndex,
+  eth_getUncleCountByBlockHash, eth_getUncleCountByBlockNumber,
+  eth_getUncleByBlockHashAndIndex, eth_getUncleByBlockNumberAndIndex.
+- eth filters: eth_newFilter, eth_newBlockFilter, eth_newPendingTransactionFilter,
+  eth_uninstallFilter, eth_getFilterChanges, eth_getFilterLogs.
+- eth account/signing: eth_sign, eth_signTransaction, eth_signTypedData.
+- misc: eth_getProof, eth_createAccessList.
+- trace/debug/txpool: no trace_* APIs, no txpool_* APIs; debug only has debug_traceBlockByNumber/debug_traceTransaction.
+
+Non-standard error codes (common errors)
+- eth_sendRawTransaction invalid raw data -> -32001 (UNKNOWN_ERROR_CODE) instead of invalid input/params.
+  Paths: make_raw_tx() + convert_to_tx_signed() -> ErrorObjectOwned::owned(-32001, ...).
+  Files: crates/full-node/sov-ethereum/src/lib.rs, crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+- eth_sendTransaction missing from -> -32001 ETH_RPC_ERROR.
+  File: crates/full-node/sov-ethereum/src/handlers/mod.rs
+- eth_feeHistory block_count == 0 -> code 500 (not JSON-RPC).
+  File: crates/module-system/module-implementations/sov-evm/src/rpc/fee_history.rs and rpc/error.rs
+- Generic helper to_jsonrpsee_error_object always uses -32001 for many invalid-param cases
+  (auth failures, log cursor errors, subscribe parameter errors, response size limit).
+  Files: crates/full-node/sov-ethereum/src/lib.rs, handlers/mod.rs, handlers/get_logs.rs,
+  handlers/get_logs/service.rs, handlers/subscribe/params.rs
+
+Parameter handling gaps
+- String block tags:
+  - "safe" / "finalized" rejected by string parsing.
+  - "latest" treated as "pending".
+  File: crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+- EIP-1898 blockId objects not supported in string-based methods.
+  Affects: eth_getBlockByNumber, eth_getBalance, eth_getCode, eth_getStorageAt,
+  eth_getTransactionCount, eth_getBlockReceipts, eth_call, eth_estimateGas.
+  Files: crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+- eth_call ignores state_override and block_overrides; eth_estimateGas does not accept overrides.
+  File: crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+- eth_call / eth_estimateGas ignore fee fields and transaction type (always EIP-1559, zero fees).
+  File: crates/module-system/module-implementations/sov-evm/src/helpers.rs
+- Pending semantics:
+  - eth_getTransactionByHash and eth_getTransactionCount do not include pending txs even when
+    "pending" is requested.
+  Files: crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs, state_access.rs
+- eth_subscribe logs rejects valid block ranges; only allows default or pending->pending.
+  File: crates/full-node/sov-ethereum/src/handlers/subscribe/params.rs
+- eth_feeHistory does not validate reward_percentiles (range/order).
+  File: crates/module-system/module-implementations/sov-evm/src/rpc/fee_history.rs
+- eth_sendTransaction (local) overwrites user-supplied gas with estimate.
+  File: crates/full-node/sov-ethereum/src/handlers/mod.rs
+
+Notes on expected vs current error mapping
+- EthApiError maps several transaction/input errors to invalid params (-32602); typical clients
+  use -32000 (Invalid Input) or -32003 (Transaction rejected) depending on the case.
+  File: crates/utils/sov-rpc-eth-types/src/eth_api_error.rs
+- into_rpc_error hardcodes code 500 (non-JSON-RPC), which leaks into eth_feeHistory and
+  other EthApiError::other() call sites.
+  File: crates/module-system/module-implementations/sov-evm/src/rpc/error.rs
+
+Appendix: RPC methods present (non-exhaustive)
+- sov-evm: net_version, eth_chainId, eth_getBlockByHash, eth_getBlockByNumber, eth_getBalance,
+  eth_getStorageAt, eth_getTransactionCount, eth_getCode, eth_feeHistory,
+  eth_getTransactionByHash, eth_getBlockReceipts, eth_getTransactionReceipt, eth_call,
+  eth_blockNumber, eth_estimateGas, debug_traceBlockByNumber, debug_traceTransaction.
+- sov-ethereum wrapper: eth_gasPrice, eth_sendRawTransaction, eth_sendRawTransactionSync,
+  realtime_sendRawTransaction, eth_getLogs, eth_getLogsWithCursor, eth_subscribe,
+  (local) eth_accounts, eth_sendTransaction.
+

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -33,13 +33,6 @@ async fn get_log_from_pending_block() -> anyhow::Result<()> {
     let receipt_logs = receipt.inner.into_logs();
     assert_eq!(receipt_logs, logs);
     assert_eq!(receipt_logs.len(), 1);
-    assert_eq!(receipt_logs[0].block_hash, None);
-    assert_ne!(
-        receipt_logs[0]
-            .block_timestamp
-            .expect("block timestamp should be present"),
-        0
-    );
 
     Ok(())
 }
@@ -54,6 +47,8 @@ async fn evm_test_get_logs() {
         EVM_EXTENSION.response_size_limit,
     )
     .await;
+
+    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
 
     // Make sure all the txs are in the same blcok.
     rollup_and_client
@@ -352,6 +347,7 @@ async fn logs_resumed_from_the_middle_of_tx_have_correct_indices() {
 
     let rollup_and_client =
         RollupAndClient::new(max_log_limit, EVM_EXTENSION.response_size_limit).await;
+    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
 
     rollup_and_client
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, None)

--- a/examples/demo-rollup/tests/evm/evm_rpc.rs
+++ b/examples/demo-rollup/tests/evm/evm_rpc.rs
@@ -30,9 +30,9 @@ async fn eth_get_block_by_number() -> anyhow::Result<()> {
     rollup.pause_preferred_batches().await;
 
     assert_eq!(by_number(&client, Earliest).await?.unwrap().number, 0);
-    assert_eq!(by_number(&client, Latest).await?.unwrap().number, 1);
-    assert_eq!(by_number(&client, Pending).await?.unwrap().number, 1);
-    assert_eq!(by_number(&client, 1).await?.unwrap().number, 1);
+    assert_eq!(by_number(&client, Latest).await?.unwrap().number, 0);
+    assert_eq!(by_number(&client, Pending).await?.unwrap().number, 0);
+    assert_eq!(by_number(&client, 1).await?, None);
     assert_eq!(by_number(&client, 2).await?, None);
 
     rollup.resume_preferred_batches().await;
@@ -40,16 +40,16 @@ async fn eth_get_block_by_number() -> anyhow::Result<()> {
     rollup.pause_preferred_batches().await;
 
     assert_eq!(by_number(&client, Earliest).await?.unwrap().number, 0);
-    assert_eq!(by_number(&client, Latest).await?.unwrap().number, 2);
-    assert_eq!(by_number(&client, Pending).await?.unwrap().number, 2);
+    assert_eq!(by_number(&client, Latest).await?.unwrap().number, 1);
+    assert_eq!(by_number(&client, Pending).await?.unwrap().number, 1);
 
     assert_eq!(by_number(&client, 1).await?.unwrap().number, 1);
-    assert_eq!(by_number(&client, 2).await?.unwrap().number, 2);
+    assert_eq!(by_number(&client, 2).await?, None);
     assert_eq!(by_number(&client, 3).await?, None);
 
     assert_eq!(
-        by_number(&client, 2).await?.unwrap().parent_hash,
-        by_number(&client, 1).await?.unwrap().hash
+        by_number(&client, 1).await?.unwrap().parent_hash,
+        by_number(&client, 0).await?.unwrap().hash
     );
 
     Ok(())
@@ -67,18 +67,18 @@ async fn eth_get_block_by_hash() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
 
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_next_blocks(2).await;
     rollup.pause_preferred_batches().await;
 
-    let latest_hash = by_number(&client, Pending).await?.unwrap().parent_hash;
+    let latest_hash = by_number(&client, Latest).await?.unwrap().parent_hash;
     let latest = by_hash(&client, latest_hash).await?.unwrap();
     assert_eq!(latest.hash, latest_hash);
     assert_eq!(latest.number, 1);
 
-    let pending_hash = by_number(&client, Pending).await?.unwrap().hash;
-    assert_eq!(pending_hash, BlockHash::ZERO);
+    let pending_hash = by_number(&client, Latest).await?.unwrap().hash;
+    assert_ne!(pending_hash, BlockHash::ZERO);
     // Because the hash of the pending block is fake - it can't be fetched by hash
-    assert_eq!(by_hash(&client, pending_hash).await?, None);
+    assert_ne!(by_hash(&client, pending_hash).await?, None);
 
     Ok(())
 }

--- a/examples/demo-rollup/tests/evm/evm_soft_conf.rs
+++ b/examples/demo-rollup/tests/evm/evm_soft_conf.rs
@@ -40,8 +40,8 @@ async fn evm_test_soft_confirmations() -> anyhow::Result<()> {
             let rec = evm_client.receipt(tx_hash).await.unwrap();
             let tx = evm_client.transaction(tx_hash).await.unwrap();
 
-            assert!(rec.block_hash.is_none());
-            assert!(tx.block_hash.is_none());
+            assert!(rec.block_hash.is_some());
+            assert!(tx.block_hash.is_some());
 
             assert_eq!(rec.block_number.unwrap(), expected_block_nr);
             assert_eq!(tx.block_number.unwrap(), expected_block_nr);

--- a/examples/demo-rollup/tests/evm/evm_subscribe.rs
+++ b/examples/demo-rollup/tests/evm/evm_subscribe.rs
@@ -116,9 +116,7 @@ async fn evm_test_log_subscription_with_pending_blcok() {
 
     // Verify conditions for logs in the pending block.
     for log in logs_from_subscription {
-        assert!(log.block_hash.is_none());
         assert_eq!(log.block_number.unwrap(), block_nr);
-        assert_ne!(log.block_timestamp.unwrap(), 0);
     }
 }
 
@@ -184,9 +182,7 @@ async fn evm_test_log_subscription_with_pending_block_range_is_alllowed() {
 
     // Verify conditions for logs in the pending block.
     for log in logs_from_subscription {
-        assert!(log.block_hash.is_none());
         assert_eq!(log.block_number.unwrap(), block_nr);
-        assert_ne!(log.block_timestamp.unwrap(), 0);
     }
 }
 

--- a/examples/demo-rollup/tests/evm/evm_tx.rs
+++ b/examples/demo-rollup/tests/evm/evm_tx.rs
@@ -45,7 +45,7 @@ async fn sanity_checks(test_client: &SimpleStorageClient) {
         .await;
 
     assert_eq!(latest_block, pending_block);
-    assert_eq!(pending_block.header.hash, B256::ZERO);
+    assert_ne!(pending_block.header.hash, B256::ZERO);
     assert_eq!(earliest_block.header.number, 0);
     assert!(pending_block.header.number > earliest_block.header.number);
 

--- a/examples/demo-rollup/tests/evm/evm_ws_watch.rs
+++ b/examples/demo-rollup/tests/evm/evm_ws_watch.rs
@@ -2,7 +2,6 @@ use alloy::network::TransactionBuilder;
 use alloy::providers::Provider;
 use alloy::rpc::types::TransactionRequest;
 use alloy_primitives::{Address, B256};
-use alloy_rpc_types_eth::BlockNumberOrTag;
 use futures::StreamExt;
 use std::time::Duration;
 use tokio::time::timeout;

--- a/examples/demo-rollup/tests/evm/evm_ws_watch.rs
+++ b/examples/demo-rollup/tests/evm/evm_ws_watch.rs
@@ -70,38 +70,8 @@ async fn ws_subscribe_new_heads_sizes() -> anyhow::Result<()> {
     rollup.wait_for_next_blocks(1).await;
 
     let header = subscription.recv().await?;
-    assert_eq!(header.number, 1);
+    assert_eq!(header.number, 2);
     assert_eq!(header.size.unwrap().to::<u64>(), 511);
-
-    Ok(())
-}
-
-/// Tests that the newHeads subscription does not include the pending block.
-/// This test should be deleted if we decide to support pending blocks in the newHeads subscription again.
-#[tokio::test(flavor = "multi_thread")]
-async fn ws_subscribe_new_heads_does_not_include_pending() -> anyhow::Result<()> {
-    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    let client = alloy_ws_client(rollup.http_addr).await;
-    let mut subscription = client.subscribe_blocks().await?;
-    while let Ok(header) = subscription.try_recv() {
-        println!("Received header before starting test: {}", header.number);
-    }
-
-    rollup.wait_for_next_blocks(2).await;
-    // Send a transaction to ensure a pending block is created
-    let tx = TransactionRequest::default().with_to(Address::ZERO);
-    let _pending = client.send_transaction(tx).await?;
-
-    let header_1 = subscription.try_recv().unwrap();
-    let header_2 = subscription.try_recv().unwrap();
-    let pending_block = client
-        .get_block_by_number(BlockNumberOrTag::Pending)
-        .await?
-        .expect("Pending block should be available");
-    assert_eq!(pending_block.number(), header_2.number + 1);
-    assert!(subscription.try_recv().is_err(), "Pending is not supported");
-
-    assert_eq!(header_1.number + 1, header_2.number);
 
     Ok(())
 }


### PR DESCRIPTION
# Description

This PR makes a significant change to the way we handle the active block while the sequencer is accepting transactions for it. Previously, we treated the block as "pending", but this caused some standard tooling (notably foundry) to choke. Now, we treat the open block as being sealed by creating a fake ("synthetic") block header for it, and then doing a pretend reorg of depth one when a new tx is added. 

To avoid overwhelming subscribers, we notify `new_heads` subscribers about these synthetic blocks at most once every 200ms.

Synthetic blocks look exactly like real blocks except that their block hashes are special marker values: `[SENTINEL || BLOCK_NUMBER || NUM_TXS]`. Because the "hashes" contain all the information needed to reconstruct a synthetic block, we don't have to store these blocks anywhere and we can still serve requests for block by hash. 

However, there is one limitation to synthetic blocks. Because the EVM shares state with the sov-modules system, we can't reconstruct the rollup state as of a particular synthetic block just by replaying EVM txs. Since we don't store sov-modules tx bodies anywhere, this creates a problem - there's no way to go back to the state as of a particular synthetic block. To fix this issue, we create a cache of API State accessors which stores concread::ReadTxns for all of the recent states. 


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
I've manually tested with forge deploy to ensure this doesn't regress foundry support.

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
