### PR TITLE
Allow urls in evm soak test

### DIFF
--- a/crates/utils/sov-evm-soak-testing/src/logs.rs
+++ b/crates/utils/sov-evm-soak-testing/src/logs.rs
@@ -7,10 +7,10 @@ use alloy_primitives::U256;
 use alloy_pubsub::Subscription;
 use anyhow::Result;
 use futures::future::try_join_all;
+use reqwest::Url;
 use sov_eth_client::LogsWithCursorProvider;
 use sov_evm_test_utils::SimpleStorage;
 use sov_evm_test_utils::Submit;
-use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 use tokio::time::timeout;
 use tokio::try_join;
@@ -21,7 +21,7 @@ use crate::{alloy_ws_client, derive_worker_key};
 
 /// Spawns multiple log test workers, runs them, and retrieves all generated logs.
 pub async fn run_logs_test(
-    rpc_addr: SocketAddr,
+    rpc_url: &Url,
     private_key: &str,
     tx_count: usize,
     logs_per_tx: usize,
@@ -31,7 +31,7 @@ pub async fn run_logs_test(
     validate_worker_count(num_workers)?;
     // Set up root account and fund workers
     let root_signer: PrivateKeySigner = private_key.parse()?;
-    let root_client = alloy_ws_client(rpc_addr, root_signer.clone()).await?;
+    let root_client = alloy_ws_client(rpc_url, root_signer.clone()).await?;
     fund_worker_accounts(&root_client, &root_signer, private_key, num_workers).await?;
 
     let ((logs_count, logs_time), (stream_count, stream_time)) = match mode {
@@ -42,14 +42,14 @@ pub async fn run_logs_test(
                 .await?;
             let expected_count = tx_count * logs_per_tx * num_workers;
             try_join!(
-                produce_logs(rpc_addr, private_key, num_workers, tx_count, logs_per_tx),
+                produce_logs(rpc_url, private_key, num_workers, tx_count, logs_per_tx),
                 stream_logs(subscription, expected_count)
             )
         }
         LogsRetrievalMode::WithCursor => {
             let from_block = root_client.get_block_number().await?;
             try_join!(
-                produce_logs(rpc_addr, private_key, num_workers, tx_count, logs_per_tx),
+                produce_logs(rpc_url, private_key, num_workers, tx_count, logs_per_tx),
                 retrieve_logs(root_client, from_block)
             )
         }
@@ -61,7 +61,7 @@ pub async fn run_logs_test(
 }
 
 async fn produce_logs(
-    rpc_addr: SocketAddr,
+    rpc_url: &Url,
     private_key: &str,
     num_workers: usize,
     tx_count: usize,
@@ -71,7 +71,7 @@ async fn produce_logs(
     let mut handles = Vec::with_capacity(num_workers);
     for worker_idx in 0..num_workers {
         let signer: PrivateKeySigner = derive_worker_key(private_key, worker_idx)?.parse()?;
-        let client = alloy_client(rpc_addr, signer.clone())?;
+        let client = alloy_client(rpc_url, signer.clone())?;
 
         handles.push(tokio::spawn(async move {
             match LogsSoakTest::new(client, worker_idx).await {

--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -9,7 +9,6 @@ use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};
 use futures::future::try_join_all;
 use reqwest::Url;
-use std::net::SocketAddr;
 use tracing::warn;
 use tracing_subscriber::EnvFilter;
 
@@ -25,9 +24,9 @@ const MAX_WORKERS: usize = 255;
 #[command(name = "sov-evm-soak-testing")]
 #[command(about = "EVM soak testing tool", long_about = None)]
 struct Args {
-    /// RPC address
-    #[arg(short, long, default_value = "127.0.0.1:12346")]
-    rpc_addr: SocketAddr,
+    /// RPC URL (e.g., http://127.0.0.1:12346/rpc or https://example.com/rpc)
+    #[arg(short, long, default_value = "http://127.0.0.1:12346/rpc")]
+    rpc_url: Url,
 
     /// Private key for signing transactions
     #[arg(
@@ -100,22 +99,33 @@ fn derive_worker_key(root_key: &str, worker_idx: usize) -> Result<String> {
 }
 
 /// Creates an Alloy HTTP client connected to the specified RPC server.
-pub(crate) fn alloy_client(rpc_addr: SocketAddr, signer: PrivateKeySigner) -> Result<DynProvider> {
-    let url = Url::parse(&format!("http://{rpc_addr}/rpc"))?;
+pub(crate) fn alloy_client(rpc_url: &Url, signer: PrivateKeySigner) -> Result<DynProvider> {
     let client = ProviderBuilder::new()
         .wallet(signer)
-        .connect_http(url)
+        .connect_http(rpc_url.clone())
         .erased();
     Ok(client)
 }
 
+/// Converts an HTTP(S) URL to its WebSocket equivalent (ws/wss).
+fn http_to_ws_url(url: &Url) -> Result<Url> {
+    let mut ws_url = url.clone();
+    let new_scheme = match url.scheme() {
+        "http" => "ws",
+        "https" => "wss",
+        "ws" | "wss" => return Ok(ws_url),
+        scheme => return Err(anyhow!("Unsupported URL scheme: {scheme}")),
+    };
+    ws_url
+        .set_scheme(new_scheme)
+        .map_err(|_| anyhow!("Failed to set WebSocket scheme"))?;
+    Ok(ws_url)
+}
+
 /// Creates an Alloy WS client connected to the specified RPC server.
-pub(crate) async fn alloy_ws_client(
-    rpc_addr: SocketAddr,
-    signer: PrivateKeySigner,
-) -> Result<DynProvider> {
-    let url = Url::parse(&format!("ws://{rpc_addr}/rpc"))?;
-    let ws = WsConnect::new(url);
+pub(crate) async fn alloy_ws_client(rpc_url: &Url, signer: PrivateKeySigner) -> Result<DynProvider> {
+    let ws_url = http_to_ws_url(rpc_url)?;
+    let ws = WsConnect::new(ws_url);
     let client = ProviderBuilder::new()
         .wallet(signer)
         .connect_ws(ws)
@@ -137,7 +147,7 @@ fn validate_worker_count(num_workers: usize) -> Result<()> {
 
 /// Spawns multiple Uniswap test workers and waits for them to complete.
 async fn run_uniswap_test(
-    rpc_addr: SocketAddr,
+    rpc_url: &Url,
     private_key: &str,
     count: usize,
     num_workers: usize,
@@ -147,7 +157,7 @@ async fn run_uniswap_test(
     let mut handles = Vec::with_capacity(num_workers);
     for worker_idx in 0..num_workers {
         let signer: PrivateKeySigner = derive_worker_key(private_key, worker_idx)?.parse()?;
-        let client = alloy_client(rpc_addr, signer.clone())?;
+        let client = alloy_client(rpc_url, signer.clone())?;
 
         handles.push(tokio::spawn(async move {
             match UniSoakTest::new(client, signer.address()).await {
@@ -196,9 +206,9 @@ async fn fund_worker_accounts(
 }
 
 /// Runs the SimpleStorage soak test.
-async fn run_simple_storage_test(rpc_addr: SocketAddr, private_key: &str) -> Result<()> {
+async fn run_simple_storage_test(rpc_url: &Url, private_key: &str) -> Result<()> {
     let signer: PrivateKeySigner = private_key.parse()?;
-    let client = alloy_client(rpc_addr, signer)?;
+    let client = alloy_client(rpc_url, signer)?;
     simple_storage::run(client).await
 }
 
@@ -210,10 +220,10 @@ async fn main() -> Result<()> {
 
     match args.test {
         TestType::Uniswap { count, num_workers } => {
-            run_uniswap_test(args.rpc_addr, &args.private_key, count, num_workers).await?;
+            run_uniswap_test(&args.rpc_url, &args.private_key, count, num_workers).await?;
         }
         TestType::SimpleStorage => {
-            run_simple_storage_test(args.rpc_addr, &args.private_key).await?;
+            run_simple_storage_test(&args.rpc_url, &args.private_key).await?;
         }
         TestType::Logs {
             tx_count,
@@ -222,7 +232,7 @@ async fn main() -> Result<()> {
             mode,
         } => {
             run_logs_test(
-                args.rpc_addr,
+                &args.rpc_url,
                 &args.private_key,
                 tx_count,
                 logs_per_tx,

--- a/crates/utils/sov-evm-soak-testing/src/main.rs
+++ b/crates/utils/sov-evm-soak-testing/src/main.rs
@@ -123,7 +123,10 @@ fn http_to_ws_url(url: &Url) -> Result<Url> {
 }
 
 /// Creates an Alloy WS client connected to the specified RPC server.
-pub(crate) async fn alloy_ws_client(rpc_url: &Url, signer: PrivateKeySigner) -> Result<DynProvider> {
+pub(crate) async fn alloy_ws_client(
+    rpc_url: &Url,
+    signer: PrivateKeySigner,
+) -> Result<DynProvider> {
     let ws_url = http_to_ws_url(rpc_url)?;
     let ws = WsConnect::new(ws_url);
     let client = ProviderBuilder::new()


### PR DESCRIPTION
# Description

Previously, the evm soak test only accepted IP addresses as arguments. This made it impossible to use on many targets. This PR fixes the issue.
