### PR TITLE
`Proxy` tool: Save the leader and followers to a file after receiving a notification from `Postgres`.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use super::{DbBackend, ReadBlob, SnapshotData, StoredBlob};
 use crate::preferred::db::DbError;
 use crate::preferred::db::{BatchToStore, DbReadOutcome, InProgressBatch};
+use anyhow::Context;
 use axum::async_trait;
 use backon::{BackoffBuilder, ExponentialBuilder};
 use sov_blob_sender::BlobInternalId;
@@ -658,15 +659,28 @@ fn node_address(bind_addr: SocketAddr) -> Result<String> {
 fn get_local_ip(ip: IpAddr) -> Result<std::net::IpAddr> {
     // This is a classic networking trick to figure out your machine’s local IP address,
     // without actually sending any data.
-    if ip.is_ipv6() {
-        let socket = std::net::UdpSocket::bind("[::]:0")?;
-        socket.connect("[2001:4860:4860::8888]:80")?;
-        Ok(socket.local_addr()?.ip())
+    let addr = if ip.is_ipv6() {
+        let socket = std::net::UdpSocket::bind("[::]:0").with_context(|| {
+            format!("Failed to bind UDP socket for local IPv6 address discovery: {ip}")
+        })?;
+        socket
+            .connect("[2001:4860:4860::8888]:80")
+            .context("Failed to connect UDP socket for local IPv6 address discovery")?;
+        socket
     } else {
-        let socket = std::net::UdpSocket::bind("0.0.0.0:0")?;
-        socket.connect("8.8.8.8:80")?;
-        Ok(socket.local_addr()?.ip())
+        let socket = std::net::UdpSocket::bind("0.0.0.0:0").with_context(|| {
+            format!("Failed to bind UDP socket for local IPv4 address discovery: {ip}")
+        })?;
+        socket
+            .connect("8.8.8.8:80")
+            .context("Failed to connect UDP socket for local IPv4 address discovery.")?;
+
+        socket
     }
+    .local_addr()
+    .context("Failed to retrieve local address from UDP socket.")?;
+
+    Ok(addr.ip())
 }
 
 #[cfg(test)]

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -1,6 +1,6 @@
 use crate::preferred::db::FailedOperation;
 use anyhow::{anyhow, Result};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -643,7 +643,30 @@ impl DbBackend for PostgresBackend {
 fn node_address(bind_addr: SocketAddr) -> Result<String> {
     let bind_port = bind_addr.port();
     let ip = bind_addr.ip();
-    Ok(format!("{ip}:{bind_port}"))
+
+    let effective_ip = if ip.is_unspecified() {
+        get_local_ip(ip)?
+    } else {
+        ip
+    };
+
+    let effective_addr = SocketAddr::new(effective_ip, bind_port);
+    Ok(effective_addr.to_string())
+}
+
+/// Gets the local IP address by creating a UDP socket and checking its local address.
+fn get_local_ip(ip: IpAddr) -> Result<std::net::IpAddr> {
+    // This is a classic networking trick to figure out your machine’s local IP address,
+    // without actually sending any data.
+    if ip.is_ipv6() {
+        let socket = std::net::UdpSocket::bind("[::]:0")?;
+        socket.connect("[2001:4860:4860::8888]:80")?;
+        Ok(socket.local_addr()?.ip())
+    } else {
+        let socket = std::net::UdpSocket::bind("0.0.0.0:0")?;
+        socket.connect("8.8.8.8:80")?;
+        Ok(socket.local_addr()?.ip())
+    }
 }
 
 #[cfg(test)]

--- a/crates/utils/sov-proxy-utils/Cargo.toml
+++ b/crates/utils/sov-proxy-utils/Cargo.toml
@@ -8,10 +8,11 @@ homepage.workspace = true
 publish = false
 repository.workspace = true
 
+
 [dependencies]
 anyhow = { workspace = true }
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres"] }
-tokio = { workspace = true }
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls-ring-webpki", "postgres"] }
+tokio = { workspace = true, features = ["time", "sync"] }
 tracing = { workspace = true }
 
 [lints]

--- a/crates/utils/sov-proxy-utils/Cargo.toml
+++ b/crates/utils/sov-proxy-utils/Cargo.toml
@@ -11,9 +11,10 @@ repository.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls-ring-webpki", "postgres"] }
-tokio = { workspace = true, features = ["time", "sync"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls-ring-webpki", "postgres", "derive"], default-features = false }
+tokio = { workspace = true, features = ["time", "sync"], default-features = false }
 tracing = { workspace = true }
+
 
 [lints]
 workspace = true

--- a/crates/utils/sov-proxy-utils/src/lib.rs
+++ b/crates/utils/sov-proxy-utils/src/lib.rs
@@ -156,7 +156,7 @@ impl NodeDiscovery {
         match self.get_cluster_info().await {
             Ok(info) => {
                 if let Err(error) = write_to_file(path, info.to_file_content()).await {
-                    tracing::warn!(?error, "Failed to update the cluster info file.");
+                    tracing::warn!(?error, ?path, "Failed to update the cluster info file.");
                 } else {
                     // Notify watchers that the file was saved successfully.
                     let _ = self.file_saved_sender.send(());

--- a/crates/utils/sov-proxy-utils/src/lib.rs
+++ b/crates/utils/sov-proxy-utils/src/lib.rs
@@ -3,11 +3,16 @@
 //! This crate provides the [`Proxy`] struct to retrieve leader and follower
 //! IP addresses from the PostgreSQL database atomically.
 
+use std::collections::HashSet;
 use std::net::SocketAddr;
+use std::time::Duration;
 
-use anyhow::Result;
-use sqlx::postgres::PgPool;
+use anyhow::{Context, Result};
+use sqlx::postgres::{PgListener, PgPool};
 use sqlx::FromRow;
+use tokio::sync::watch;
+
+const MAX_DB_ERRORS_ALLOWED: u32 = 10;
 
 /// Information about a registered node.
 #[derive(Debug, Clone, FromRow, PartialEq, Eq)]
@@ -16,6 +21,12 @@ pub struct NodeInfo {
     pub node_id: String,
     /// The address (ip:port) where the node can be reached.
     pub address: SocketAddr,
+}
+
+impl NodeInfo {
+    fn str(&self, role: &str) -> String {
+        format!("{role}={}", self.address)
+    }
 }
 
 /// Result of querying cluster node information.
@@ -27,33 +38,78 @@ pub struct ClusterInfo {
     pub followers: Vec<NodeInfo>,
 }
 
+impl ClusterInfo {
+    /// Formats the cluster info as a string suitable for writing to a file.
+    /// Each node is written on a separate line in the format `role=address`.
+    pub fn to_file_content(&self) -> String {
+        let mut lines = Vec::new();
+
+        if let Some(leader) = &self.leader {
+            lines.push(leader.str("leader"));
+        }
+
+        for follower in &self.followers {
+            lines.push(follower.str("follower"));
+        }
+
+        lines.join("\n")
+    }
+}
+
 /// Client for querying cluster information from the database.
 pub struct NodeDiscovery {
     pool: PgPool,
+    connection_string: String,
+    file_saved_sender: watch::Sender<()>,
 }
 
 impl NodeDiscovery {
     /// Creates a new NodeDiscovery with a connection pool.
-    pub async fn new(connection_string: &str) -> Result<Self> {
+    ///
+    /// Returns the NodeDiscovery instance and a receiver that gets notified
+    /// whenever the cluster info file is successfully saved.
+    pub async fn new(connection_string: &str) -> Result<(Self, watch::Receiver<()>)> {
+        tracing::info!("Connecting to database.");
         let pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(5)
             .connect(connection_string)
             .await?;
-        Ok(Self { pool })
+        tracing::info!("DB connection established.");
+        let (file_saved_sender, file_saved_receiver) = watch::channel(());
+
+        Ok((
+            Self {
+                pool,
+                connection_string: connection_string.to_string(),
+                file_saved_sender,
+            },
+            file_saved_receiver,
+        ))
     }
 
     /// Fetches cluster info atomically using a single transaction.
     ///
     /// # Returns
     /// A `ClusterInfo` struct containing the leader and all followers.
-    pub async fn get_cluster_info(&self) -> Result<ClusterInfo> {
+    pub async fn get_cluster_info(&self) -> anyhow::Result<ClusterInfo> {
         let (leader_id, all_nodes) = self.get_cluster_info_from_db().await?;
+        Self::cluster(leader_id, all_nodes)
+    }
 
+    fn cluster(
+        leader_id: Option<String>,
+        all_nodes: Vec<(String, String)>,
+    ) -> anyhow::Result<ClusterInfo> {
+        let cap = all_nodes.capacity();
         let mut leader = None;
-        let mut followers = Vec::new();
+        let mut followers = Vec::with_capacity(cap);
+        let mut seen_node_ids = HashSet::with_capacity(cap);
         for (node_id, address) in all_nodes {
-            let address: SocketAddr = address.parse()?;
+            if !seen_node_ids.insert(node_id.clone()) {
+                anyhow::bail!("Duplicate node id found in Nodes table: {node_id}");
+            }
 
+            let address: SocketAddr = address.parse()?;
             let node = NodeInfo { node_id, address };
 
             if Some(&node.node_id) == leader_id.as_ref() {
@@ -63,7 +119,93 @@ impl NodeDiscovery {
             }
         }
 
+        if followers.is_empty() {
+            if let Some(leader) = &leader {
+                followers.push(leader.clone());
+            }
+        }
+
+        if let Some(leader_id) = &leader_id {
+            if leader.is_none() {
+                anyhow::bail!("Leader is missing from the Nodes table. leader_id: {leader_id}");
+            }
+        }
+
         Ok(ClusterInfo { leader, followers })
+    }
+
+    /// Subscribes to PostgreSQL notifications for cluster changes and writes
+    /// cluster info to a file whenever the cluster state changes.
+    ///
+    /// Listens on `nodes_changes` and `leader_changes` channels.
+    pub async fn subscribe_cluster_info_loop(
+        &self,
+        path: impl AsRef<std::path::Path>,
+    ) -> anyhow::Result<()> {
+        let path = path.as_ref();
+
+        let mut listener = PgListener::connect(&self.connection_string).await?;
+
+        listener
+            .listen_all(["nodes_changes", "leader_changes"])
+            .await?;
+
+        tracing::info!("Subscribed to nodes_changes and leader_changes channels");
+
+        // Fetch initial cluster info.
+        match self.get_cluster_info().await {
+            Ok(info) => {
+                if let Err(error) = write_to_file(path, info.to_file_content()).await {
+                    tracing::warn!(?error, "Failed to update the cluster info file.");
+                } else {
+                    // Notify watchers that the file was saved successfully.
+                    let _ = self.file_saved_sender.send(());
+                }
+            }
+            Err(error) => {
+                tracing::warn!(?error, "Failed to fetch initial cluster info");
+            }
+        }
+
+        let mut consecutive_errors: u32 = 0;
+
+        loop {
+            match self.handle_cluster_update(&mut listener, path).await {
+                Ok(()) => consecutive_errors = 0,
+                Err(error) => {
+                    tracing::warn!(?error, "Cluster update failed");
+                    consecutive_errors += 1;
+                    // In case of an error, wait a little before querying the database again.
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+
+            if consecutive_errors >= MAX_DB_ERRORS_ALLOWED {
+                tracing::error!(
+                    consecutive_errors,
+                    "Too many consecutive errors, exiting the node discovery loop."
+                );
+                anyhow::bail!("Node discovery failed.");
+            }
+        }
+    }
+
+    async fn handle_cluster_update(
+        &self,
+        listener: &mut PgListener,
+        path: &std::path::Path,
+    ) -> anyhow::Result<()> {
+        // Wait for at least one notification.
+        listener.recv().await?;
+
+        // Drain any additional pending notifications.
+        while let Some(_) = listener.next_buffered() {}
+
+        let info = self.get_cluster_info().await?;
+        write_to_file(path, info.to_file_content()).await?;
+        // Notify watchers that the file was saved successfully.
+        let _ = self.file_saved_sender.send(());
+        Ok(())
     }
 
     async fn get_cluster_info_from_db(&self) -> Result<(Option<String>, Vec<(String, String)>)> {
@@ -82,6 +224,106 @@ impl NodeDiscovery {
                 .await?;
 
         tx.commit().await?;
+
         Ok((leader_id, all_nodes))
+    }
+}
+
+async fn write_to_file(path: impl AsRef<std::path::Path>, content: String) -> anyhow::Result<()> {
+    tokio::fs::write(path, content)
+        .await
+        .context("Failed to write cluster info to file")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cluster_with_leader_and_followers() {
+        let info = NodeDiscovery::cluster(
+            Some("node1".to_string()),
+            vec![
+                ("node1".to_string(), "127.0.0.1:8000".to_string()),
+                ("node2".to_string(), "127.0.0.1:8001".to_string()),
+                ("node3".to_string(), "127.0.0.1:8002".to_string()),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            &info.to_file_content(),
+            "leader=127.0.0.1:8000\nfollower=127.0.0.1:8001\nfollower=127.0.0.1:8002",
+        );
+    }
+
+    #[test]
+    fn cluster_with_only_leader_adds_leader_to_followers() {
+        let info = NodeDiscovery::cluster(
+            Some("node1".to_string()),
+            vec![("node1".to_string(), "127.0.0.1:8000".to_string())],
+        )
+        .unwrap();
+
+        assert_eq!(
+            &info.to_file_content(),
+            "leader=127.0.0.1:8000\nfollower=127.0.0.1:8000",
+        );
+    }
+
+    #[test]
+    fn cluster_with_no_leader() {
+        let info = NodeDiscovery::cluster(
+            None,
+            vec![
+                ("node1".to_string(), "127.0.0.1:8000".to_string()),
+                ("node2".to_string(), "127.0.0.1:8001".to_string()),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            &info.to_file_content(),
+            "follower=127.0.0.1:8000\nfollower=127.0.0.1:8001",
+        );
+    }
+
+    #[test]
+    fn cluster_empty() {
+        let info = NodeDiscovery::cluster(None, vec![]).unwrap();
+        assert_eq!(info.to_file_content(), "");
+    }
+
+    #[test]
+    fn cluster_errors_on_duplicate_node_id() {
+        let result = NodeDiscovery::cluster(
+            None,
+            vec![
+                ("node1".to_string(), "127.0.0.1:8000".to_string()),
+                ("node1".to_string(), "127.0.0.1:8001".to_string()),
+            ],
+        );
+
+        let err = result.unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Duplicate node id found in Nodes table: node1"));
+    }
+
+    #[test]
+    fn cluster_errors_when_leader_not_in_nodes() {
+        let result = NodeDiscovery::cluster(
+            Some("missing_leader".to_string()),
+            vec![
+                ("node1".to_string(), "127.0.0.1:8000".to_string()),
+                ("node2".to_string(), "127.0.0.1:8001".to_string()),
+            ],
+        );
+
+        let err = result.unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Leader is missing from the Nodes table."));
     }
 }

--- a/crates/utils/sov-proxy-utils/src/lib.rs
+++ b/crates/utils/sov-proxy-utils/src/lib.rs
@@ -199,7 +199,7 @@ impl NodeDiscovery {
         listener.recv().await?;
 
         // Drain any additional pending notifications.
-        while let Some(_) = listener.next_buffered() {}
+        while listener.next_buffered().is_some() {}
 
         let info = self.get_cluster_info().await?;
         write_to_file(path, info.to_file_content()).await?;

--- a/crates/utils/sov-proxy-utils/src/lib.rs
+++ b/crates/utils/sov-proxy-utils/src/lib.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashSet;
 use std::net::SocketAddr;
+use std::path::Path;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -229,10 +230,11 @@ impl NodeDiscovery {
     }
 }
 
-async fn write_to_file(path: impl AsRef<std::path::Path>, content: String) -> anyhow::Result<()> {
+async fn write_to_file(path: &Path, content: String) -> anyhow::Result<()> {
     tokio::fs::write(path, content)
         .await
-        .context("Failed to write cluster info to file")?;
+        .with_context(|| format!("Failed to write cluster info to file at {path:?}"))?;
+
     Ok(())
 }
 

--- a/examples/demo-rollup/tests/replica/db_elected.rs
+++ b/examples/demo-rollup/tests/replica/db_elected.rs
@@ -1,7 +1,7 @@
 use super::*;
-
 use sov_proxy_utils::NodeDiscovery;
 use sov_sequencer::SequencerRole;
+use std::path::Path;
 use tokio::time::Duration;
 
 type Rollup = ExternalMockDemoRollup<Native>;
@@ -117,7 +117,7 @@ async fn test_db_elected_leader_failover() {
         da_shutdown,
     } = setup;
 
-    let node_discovery = NodeDiscovery::new(postgres.connection_string())
+    let (node_discovery, _file_watcher) = NodeDiscovery::new(postgres.connection_string())
         .await
         .expect("Failed to create proxy");
 
@@ -206,4 +206,97 @@ async fn test_db_elected_leader_failover() {
 
     let _ = restarted_rollup.shutdown().await;
     let _ = da_shutdown.send(());
+}
+
+/// Test that `subscribe_cluster_info_loop` receives PostgreSQL notifications
+/// and writes updated cluster info to file when nodes register and leadership changes.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscribe_cluster_info_receives_notifications() {
+    let postgres = match PostgresData::create_postgres().await {
+        Ok(pg) => pg,
+        Err(CreatePostgresError::DockerNotSupported) => return,
+        Err(CreatePostgresError::DockerError(e)) => {
+            panic!("Failed to create Postgres container: {e}");
+        }
+    };
+
+    // Create NodeDiscovery and spawn subscribe_cluster_info_loop
+    let (node_discovery, mut file_watcher) = NodeDiscovery::new(postgres.connection_string())
+        .await
+        .expect("Failed to create NodeDiscovery");
+
+    // Create temp file for cluster info output
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cluster_info_path = temp_dir.path().join("cluster_info.txt");
+    let cluster_info_path_clone = cluster_info_path.clone();
+    let subscription_handle = tokio::spawn(async move {
+        node_discovery
+            .subscribe_cluster_info_loop(cluster_info_path_clone)
+            .await
+            .unwrap();
+    });
+
+    let (_, da_shutdown, addr) = create_da_service_periodic().await;
+
+    // Start first node - it will become leader and trigger notifications
+    let node1 = Some((postgres.clone(), "node1".into(), NodeRole::DbElected));
+    let rollup1 = start_rollup(addr, node1).await;
+    rollup1.wait_for_sequencer_ready().await.unwrap();
+
+    // Wait for file to be updated with leader info.
+    let file_content1 = wait_for_file_change(&cluster_info_path, &mut file_watcher).await;
+
+    // Start second node - it will become follower and trigger another notification
+    let node2 = Some((postgres.clone(), "node2".into(), NodeRole::DbElected));
+    let rollup2 = start_rollup(addr, node2).await;
+    rollup2.wait_for_sequencer_ready().await.unwrap();
+
+    // Wait for file to be updated with follower info.
+    let file_content2 = wait_for_file_change(&cluster_info_path, &mut file_watcher).await;
+
+    // After replica joined, the leader didn't change.
+    assert_eq!(
+        file_content1.leader.as_ref().unwrap(),
+        file_content2.leader.as_ref().unwrap()
+    );
+
+    // The followers are updated.
+    assert!(file_content1.followers[0] != file_content2.followers[0]);
+
+    // Cleanup
+    subscription_handle.abort();
+    let _ = rollup1.shutdown().await;
+    let _ = rollup2.shutdown().await;
+    let _ = da_shutdown.send(());
+}
+
+async fn wait_for_file_change(path: &Path, file_watcher: &mut watch::Receiver<()>) -> FileContent {
+    tokio::time::timeout(Duration::from_secs(2), file_watcher.changed())
+        .await
+        .unwrap()
+        .unwrap();
+
+    let content = std::fs::read_to_string(path).expect("Failed to read file content");
+    FileContent::parse(&content)
+}
+
+struct FileContent {
+    leader: Option<String>,
+    followers: Vec<String>,
+}
+
+impl FileContent {
+    fn parse(content: &str) -> FileContent {
+        let mut leader = None;
+        let mut followers = Vec::new();
+
+        for line in content.lines() {
+            if let Some(addr) = line.strip_prefix("leader=") {
+                leader = Some(addr.parse().expect("Invalid leader address"));
+            } else if let Some(addr) = line.strip_prefix("follower=") {
+                followers.push(addr.parse().expect("Invalid follower address"));
+            }
+        }
+        FileContent { leader, followers }
+    }
 }


### PR DESCRIPTION
# Description

This PR adds a node-discovery subscription system that allows external services (such as a load-balancing proxy) to receive real-time updates on sequencer cluster membership: 

1. Add `subscribe_cluster_info_loop` to `NodeDiscovery` that listens for PostgreSQL notifications and writes cluster info to a file                                                                                                                           
2. Fix node address resolution when binding to `0.0.0.0` by detecting the actual local IP                                                                                                                                                                     
3. Add validation and error handling for cluster info parsing   

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1524
