### PR TITLE
 Isolate `start_at` test cases to fix flakiness 

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -65,9 +65,17 @@ async fn test_start_at_immediate_finality() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_start_at() {
+async fn test_start_at_before_test_finalized_blocks() {
     check_start_at(TEST_FINALIZATION_BLOCKS - 1).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_start_at_test_finalized_blocks() {
     check_start_at(TEST_FINALIZATION_BLOCKS).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_start_at_after_test_finalized_blocks() {
     check_start_at(TEST_FINALIZATION_BLOCKS + 1).await;
 }
 

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -65,17 +65,17 @@ async fn test_start_at_immediate_finality() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_start_at_before_test_finalized_blocks() {
+async fn test_start_below_finalization_threshold() {
     check_start_at(TEST_FINALIZATION_BLOCKS - 1).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_start_at_test_finalized_blocks() {
+async fn test_start_at_finalization_threshold() {
     check_start_at(TEST_FINALIZATION_BLOCKS).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_start_at_after_test_finalized_blocks() {
+async fn test_start_above_finalization_threshold() {
     check_start_at(TEST_FINALIZATION_BLOCKS + 1).await;
 }
 

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -65,7 +65,7 @@ async fn test_start_at_immediate_finality() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_start_below_finalization_threshold() {
+async fn test_start_at_finalization_minus_one() {
     check_start_at(TEST_FINALIZATION_BLOCKS - 1).await;
 }
 
@@ -75,7 +75,7 @@ async fn test_start_at_finalization_threshold() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_start_above_finalization_threshold() {
+async fn test_start_at_finalization_plus_one() {
     check_start_at(TEST_FINALIZATION_BLOCKS + 1).await;
 }
 


### PR DESCRIPTION
# Description

  - Split `test_start_at` into three isolated tests to fix flakiness                                                                                                                                                                                             
  - Each test now covers a single case: below, at, and above the finalization threshold

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
