### PR TITLE
Replication:  Replica nodes register in `Nodes` table.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/leadership_election.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/leadership_election.rs
@@ -13,7 +13,7 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
-use super::postgres::PostgresBackend;
+use super::postgres::{PostgresBackend, LEADER_TIMEOUT};
 use crate::preferred::exit_rollup;
 
 /// How often replicas attempt to acquire leadership.
@@ -31,16 +31,13 @@ pub struct LeadershipElectionTask {
 }
 
 impl LeadershipElectionTask {
-    /// Creates a new leadership election task.
-    ///
-    /// Connects to PostgreSQL without claiming leadership - the caller should
-    /// call `try_acquire_leadership()` to attempt to become leader.
+    /// Creates a new leadership election task. And attempts to acquire leadership.
     pub async fn new(
         postgres_config: &PostgresConfig,
         shutdown_sender: watch::Sender<()>,
         bind_addr: SocketAddr,
     ) -> Result<Self> {
-        let backend = PostgresBackend::connect(postgres_config, bind_addr).await?;
+        let (backend, _) = PostgresBackend::connect(postgres_config, bind_addr).await?;
         let shutdown_receiver = shutdown_sender.subscribe();
 
         Ok(Self {
@@ -59,7 +56,11 @@ impl LeadershipElectionTask {
     /// This method always registers the node in the nodes table, regardless of
     /// whether leadership was acquired.
     pub async fn try_acquire_leadership(&self) -> Result<bool> {
-        match self.backend.try_update_leader_and_register_node().await? {
+        match self
+            .backend
+            .try_update_leader_and_register_node(LEADER_TIMEOUT)
+            .await?
+        {
             Some(leader) => Ok(leader.node_id == self.node_id),
             None => Ok(false),
         }

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -445,20 +445,28 @@ impl PreferredSequencerDb {
         let (backend, role): (Option<Box<dyn DbBackend>>, _) = {
             if let Some(postgres_config) = &postgres_config {
                 match postgres_config.node_role {
-                    NodeRole::ReplicaNoLeaderSync => (None, SequencerRole::ReplicaNoLeaderSync),
-                    NodeRole::Replica => (None, SequencerRole::Replica),
-                    NodeRole::Leader => (
-                        Some(Box::new(
-                            PostgresBackend::connect(postgres_config, bind_addr).await?,
-                        )),
-                        SequencerRole::Leader,
-                    ),
+                    NodeRole::ReplicaNoLeaderSync => {
+                        // Connect and register the node without attempting leader election.
+                        // The backend is dropped after registration since replicas don't need it.
+                        PostgresBackend::connect_as_replica(postgres_config, bind_addr).await?;
+                        (None, SequencerRole::ReplicaNoLeaderSync)
+                    }
+                    NodeRole::Replica => {
+                        // Connect and register the node without attempting leader election.
+                        // The backend is dropped after registration since replicas don't need it.
+                        PostgresBackend::connect_as_replica(postgres_config, bind_addr).await?;
+                        (None, SequencerRole::Replica)
+                    }
+                    NodeRole::Leader => {
+                        let (backend, _) =
+                            PostgresBackend::connect(postgres_config, bind_addr).await?;
+                        (Some(Box::new(backend)), SequencerRole::Leader)
+                    }
                     NodeRole::DbElected => {
-                        // Connect without claiming leadership, then try to acquire it
-                        let backend = PostgresBackend::connect(postgres_config, bind_addr).await?;
+                        // Connect and attempt to acquire leadership
+                        let (backend, maybe_leader) =
+                            PostgresBackend::connect(postgres_config, bind_addr).await?;
 
-                        // Try to become leader and register node
-                        let maybe_leader = backend.try_update_leader_and_register_node().await?;
                         let is_leader = maybe_leader
                             .map(|leader| leader.node_id == postgres_config.node_id)
                             .unwrap_or(false);

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -348,7 +348,7 @@ impl PostgresBackend {
 
     /// Registers this node in the nodes table with the maximum possible timestamp.
     /// Used by Replica nodes that need to be visible in the cluster but don't participate in leader election.
-    /// The infinity timestamp ensures that the replica nodes won't be pruned form the nodes table.
+    /// The infinity timestamp ensures that the replica nodes won't be pruned from the nodes table.
     async fn upsert_node_registration_max_timestamp(&self) -> anyhow::Result<()> {
         sqlx::query(
             "INSERT INTO nodes (node_id, address, last_updated)

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -19,8 +19,8 @@ use sqlx::FromRow;
 use sqlx::{PgConnection, Postgres};
 use time::OffsetDateTime;
 
-// The leader timeout.
-const LEADER_TIMEOUT: Duration = Duration::from_millis(500);
+/// The leader timeout used for leader election.
+pub(crate) const LEADER_TIMEOUT: Duration = Duration::from_millis(500);
 
 #[derive(Debug, FromRow, PartialEq)]
 pub(crate) struct SequencerLeader {
@@ -31,7 +31,6 @@ pub(crate) struct SequencerLeader {
 pub struct PostgresBackend {
     pool: PgPool,
     backoff_policy: ExponentialBuilder,
-    leader_timeout: Duration,
     node_id: String,
     pub(crate) node_address: String,
 }
@@ -64,22 +63,39 @@ macro_rules! run_with_retries {
 }
 
 impl PostgresBackend {
-    pub async fn connect(config: &PostgresConfig, bind_addr: SocketAddr) -> Result<Self> {
+    /// Connects to Postgres and attempts to acquire leadership.
+    /// Returns the backend and optionally the leader info if this node became leader.
+    /// The node is always registered in the nodes table regardless of leadership outcome.
+    pub async fn connect(
+        config: &PostgresConfig,
+        bind_addr: SocketAddr,
+    ) -> Result<(Self, Option<SequencerLeader>)> {
         // Compute node address for registration
         let node_address = node_address(bind_addr)?;
 
-        let backend =
-            Self::connect_with_leader_timeout(config, LEADER_TIMEOUT, node_address).await?;
+        let backend = Self::connect_internal(config, node_address).await?;
 
-        backend.try_update_leader_and_register_node().await?;
+        let maybe_leader = backend
+            .try_update_leader_and_register_node(LEADER_TIMEOUT)
+            .await?;
+
+        Ok((backend, maybe_leader))
+    }
+
+    /// Connects to Postgres and registers this node without attempting leader election.
+    /// Used by Replica nodes that need to be visible in the cluster but should never
+    /// become leader.
+    pub async fn connect_as_replica(
+        config: &PostgresConfig,
+        bind_addr: SocketAddr,
+    ) -> Result<Self> {
+        let node_address = node_address(bind_addr)?;
+        let backend = Self::connect_internal(config, node_address).await?;
+        backend.upsert_node_registration_max_timestamp().await?;
         Ok(backend)
     }
 
-    async fn connect_with_leader_timeout(
-        config: &PostgresConfig,
-        leader_timeout: Duration,
-        node_address: String,
-    ) -> Result<Self> {
+    async fn connect_internal(config: &PostgresConfig, node_address: String) -> Result<Self> {
         let connection_string = &config.postgres_connection_string;
         // This backoff policy should usually terminate in a second.
         // Running the numbers... We do 8 retries, doubling the sleep each time that yields 256ms max delay and an average delay of ~50ms
@@ -106,7 +122,6 @@ impl PostgresBackend {
         Ok(Self {
             pool,
             backoff_policy,
-            leader_timeout,
             node_id: config.node_id.clone(),
             node_address,
         })
@@ -258,19 +273,23 @@ impl PostgresBackend {
     /// the active leader and hasn't timed out yet. The node is always registered regardless.
     pub(crate) async fn try_update_leader_and_register_node(
         &self,
+        leader_timeout: Duration,
     ) -> anyhow::Result<Option<SequencerLeader>> {
         run_with_retries!(
             &self.backoff_policy,
-            self.try_update_leader_and_register_node_in_tx(),
+            self.try_update_leader_and_register_node_in_tx(leader_timeout),
             "postgres_db_backend_try_update_leader_and_register_node"
         )
     }
 
     async fn try_update_leader_and_register_node_in_tx(
         &self,
+        leader_timeout: Duration,
     ) -> anyhow::Result<Option<SequencerLeader>> {
         let mut tx: sqlx::Transaction<'_, Postgres> = self.pool.begin().await?;
-        let result = self.try_update_leader_inner(&mut tx).await?;
+        let result = self
+            .try_update_leader_inner(&mut tx, leader_timeout)
+            .await?;
         self.upsert_node_registration_inner(&mut tx).await?;
         tx.commit().await?;
         Ok(result)
@@ -279,9 +298,9 @@ impl PostgresBackend {
     async fn try_update_leader_inner(
         &self,
         conn: &mut PgConnection,
+        leader_timeout: Duration,
     ) -> anyhow::Result<Option<SequencerLeader>> {
-        let leader_timeout: i64 = self
-            .leader_timeout
+        let leader_timeout: i64 = leader_timeout
             .as_millis()
             .try_into()
             // It is ok to `expect` as leader_timeout should be much smaller than i64::MAX
@@ -323,6 +342,24 @@ impl PostgresBackend {
         .bind(&self.node_id)
         .bind(&self.node_address)
         .execute(&mut *conn)
+        .await?;
+        Ok(())
+    }
+
+    /// Registers this node in the nodes table with the maximum possible timestamp.
+    /// Used by Replica nodes that need to be visible in the cluster but don't participate in leader election.
+    /// The infinity timestamp ensures that the replica nodes won't be pruned form the nodes table.
+    async fn upsert_node_registration_max_timestamp(&self) -> anyhow::Result<()> {
+        sqlx::query(
+            "INSERT INTO nodes (node_id, address, last_updated)
+             VALUES ($1, $2, 'infinity'::TIMESTAMPTZ)
+             ON CONFLICT (node_id) DO UPDATE
+             SET address = EXCLUDED.address,
+                 last_updated = 'infinity'::TIMESTAMPTZ",
+        )
+        .bind(&self.node_id)
+        .bind(&self.node_address)
+        .execute(&self.pool)
         .await?;
         Ok(())
     }
@@ -904,6 +941,7 @@ mod tests {
     struct DB {
         backend: PostgresBackend,
         node_id: String,
+        leader_timeout: Duration,
     }
 
     impl AsRef<PostgresBackend> for DB {
@@ -929,24 +967,25 @@ mod tests {
                 config_from_postgres_container(postgres, node_id.clone(), node_role)
                     .await
                     .unwrap();
-            let backend = PostgresBackend::connect_with_leader_timeout(
-                &postgres_config,
-                leader_timeout,
-                format!("{node_id}_address"),
-            )
-            .await
-            .unwrap();
+            let backend =
+                PostgresBackend::connect_internal(&postgres_config, format!("{node_id}_address"))
+                    .await
+                    .unwrap();
 
-            Self { backend, node_id }
+            Self {
+                backend,
+                node_id,
+                leader_timeout,
+            }
         }
 
         fn override_leader_timeout(&mut self, leader_timeout: Duration) {
-            self.backend.leader_timeout = leader_timeout;
+            self.leader_timeout = leader_timeout;
         }
 
         async fn maybe_update_leader(&self) -> Option<SequencerLeader> {
             self.backend
-                .try_update_leader_and_register_node()
+                .try_update_leader_and_register_node(self.leader_timeout)
                 .await
                 .unwrap()
         }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -392,7 +392,7 @@ mod tests {
                 .unwrap();
 
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
-        let db = PostgresBackend::connect(&postgres_config, addr)
+        let (db, _) = PostgresBackend::connect(&postgres_config, addr)
             .await
             .unwrap();
 

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -153,6 +153,16 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
         self
     }
 
+    /// Sets the node role to Leader for the Postgres configuration.
+    /// Used when a replica node needs to transition to leader role.
+    pub fn set_as_leader(&mut self) {
+        if let SequencerKindConfig::Preferred(ref mut config) = &mut self.config.sequencer_config {
+            if let Some(c) = config.postgres_config.as_mut() {
+                c.node_role = NodeRole::Leader;
+            }
+        }
+    }
+
     /// See [`PreferredSequencerConfig::minimum_profit_per_tx`].
     pub fn with_preferred_seq_min_profit_per_tx(mut self, minimum_profit_per_tx: u128) -> Self {
         if let SequencerKindConfig::Preferred(ref mut config) = &mut self.config.sequencer_config {

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -32,6 +32,7 @@ use tokio::time::Duration;
 
 mod db_elected;
 mod replica_gets_txs_from_master;
+mod replica_registers_in_db;
 mod start_stop;
 
 type S = <ExternalMockDemoRollup<Native> as RollupBlueprint<Native>>::Spec;

--- a/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
+++ b/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
@@ -1,0 +1,115 @@
+use super::*;
+use sov_proxy_utils::{ClusterInfo, NodeDiscovery};
+
+type Rollup = ExternalMockDemoRollup<Native>;
+
+/// Test setup for replica registration tests.
+/// Handles common setup: postgres, DA service, leader node, and node discovery.
+struct ReplicaRegistrationTestSetup {
+    postgres: Arc<PostgresData>,
+    da_addr: SocketAddr,
+    node_discovery: NodeDiscovery,
+    da_shutdown: watch::Sender<()>,
+    // Keep file_watcher alive to prevent channel closure
+    _file_watcher: watch::Receiver<()>,
+}
+
+impl ReplicaRegistrationTestSetup {
+    /// Creates a new test setup with postgres, DA service, and a leader node.
+    /// Returns None if Docker is not supported.
+    async fn new() -> Option<Self> {
+        let postgres = match PostgresData::create_postgres().await {
+            Ok(pg) => pg,
+            Err(CreatePostgresError::DockerNotSupported) => return None,
+            Err(CreatePostgresError::DockerError(e)) => {
+                panic!("Failed to create Postgres container: {e}");
+            }
+        };
+
+        let (_, da_shutdown, da_addr) = create_da_service_periodic().await;
+
+        // Create NodeDiscovery to query the nodes table
+        let (node_discovery, _file_watcher) = NodeDiscovery::new(postgres.connection_string())
+            .await
+            .expect("Failed to create NodeDiscovery");
+
+        Some(Self {
+            postgres,
+            da_addr,
+            node_discovery,
+            da_shutdown,
+            _file_watcher,
+        })
+    }
+
+    /// Starts a replica node with the given node_id and role.
+    async fn start_replica(&self, node_id: &str, role: NodeRole) -> TestRollup<Rollup> {
+        let replica = Some((self.postgres.clone(), node_id.into(), role));
+        let replica_rollup = start_rollup(self.da_addr, replica).await;
+        replica_rollup
+    }
+
+    /// Gets cluster info from the nodes table.
+    async fn get_cluster_info(&self) -> ClusterInfo {
+        self.node_discovery
+            .get_cluster_info()
+            .await
+            .expect("Failed to get cluster info")
+    }
+
+    /// Gets follower node IDs from the cluster info.
+    async fn get_follower_ids(&self) -> Vec<String> {
+        self.get_cluster_info()
+            .await
+            .followers
+            .iter()
+            .map(|f| f.node_id.clone())
+            .collect()
+    }
+
+    /// Shuts down the leader and DA service.
+    async fn shutdown(self) {
+        let _ = self.da_shutdown.send(());
+    }
+}
+
+/// Tests that replica nodes correctly register in the Postgres nodes table.
+///
+/// This test verifies:
+/// 1. Multiple replica nodes can register in the nodes table simultaneously
+/// 2. Replicas appear as followers in the cluster info
+/// 3. A replica can transition to leader role and be recognized as such after a restart.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_multiple_replicas_register_in_nodes_table() {
+    let Some(setup) = ReplicaRegistrationTestSetup::new().await else {
+        return;
+    };
+
+    let replica_then_leader = setup
+        .start_replica("replica_then_leader", NodeRole::Replica)
+        .await;
+
+    let replica_rollup = setup.start_replica("replica", NodeRole::Replica).await;
+
+    // Verify both replicas are present in followers
+    let follower_ids = setup.get_follower_ids().await;
+    assert_eq!(follower_ids.len(), 2);
+    assert!(follower_ids.contains(&"replica_then_leader".to_string()));
+    assert!(follower_ids.contains(&"replica".to_string()));
+
+    let mut builder = replica_then_leader.shutdown().await.unwrap();
+    // Upgrade to leader.
+    builder.set_as_leader();
+
+    let leader = builder.start_test_rollup().await.unwrap();
+    leader.wait_for_sequencer_ready().await.unwrap();
+
+    let cluster_info = setup.get_cluster_info().await;
+    let follower_ids = setup.get_follower_ids().await;
+
+    assert_eq!(cluster_info.leader.unwrap().node_id, "replica_then_leader");
+    assert!(follower_ids.contains(&"replica".to_string()));
+
+    let _ = replica_rollup.shutdown().await;
+    setup.shutdown().await;
+}


### PR DESCRIPTION
Previously, only leader nodes registered themselves in the `Postgres` nodes table. `Replica` nodes skipped all `Postgres` interaction entirely. This PR ensures replicas also register, making them visible for cluster discovery.

The key changes:

1. `Replica` and `ReplicaNoLeaderSync` roles now call a new `connect_as_replica()` method that registers the node without attempting leader election
2. `Replicas` use 'infinity' as their `last_updated` timestamp to prevent being pruned (since they don't send heartbeats)
3. `connect()` was refactored to return `(Self, Option<SequencerLeader>)` directly, combining connection with leader election
4. leader_timeout was moved from a struct field to a method parameter


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to  #1524