### PR TITLE
Improve websocket behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12119,7 +12119,6 @@ dependencies = [
  "jsonrpsee",
  "mini-moka",
  "openapiv3",
- "pin-project",
  "proptest",
  "proptest-derive 0.5.1",
  "reltester",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11945,10 +11945,13 @@ dependencies = [
  "test-strategy",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
+ "tokio-tungstenite 0.28.0",
  "tower",
  "tower-http 0.5.2",
  "tower-request-id",
  "tracing",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -12116,6 +12119,7 @@ dependencies = [
  "jsonrpsee",
  "mini-moka",
  "openapiv3",
+ "pin-project",
  "proptest",
  "proptest-derive 0.5.1",
  "reltester",

--- a/crates/full-node/sov-sequencer/src/common.rs
+++ b/crates/full-node/sov-sequencer/src/common.rs
@@ -32,24 +32,64 @@ use crate::{SequencerNotReadyDetails, SlotNumber, TxHash, TxStatus, TxStatusMana
 
 #[derive(Debug, Error, Clone, serde::Serialize, serde::Deserialize)]
 pub enum SubscriptionStreamError {
-    #[error("Subscription data was produced faster than it could be sent. Try again later.")]
-    Lagged,
+    /// The receiver fell behind and some messages were skipped.
+    #[error("Subscription data was produced faster than it could be sent. {skipped} messages were skipped.")]
+    Lagged {
+        /// The number of messages that were skipped due to lag.
+        skipped: u64,
+        /// The identifier of the last successfully sent message before lag occurred.
+        /// `None` if no messages were sent before the lag or if the stream doesn't support identifiers.
+        disconnected_at: Option<u64>,
+        /// The identifier of the next message that will be sent after resuming.
+        /// `None` if the identifier couldn't be determined or if the stream doesn't support identifiers.
+        resumed_at: Option<u64>,
+    },
     #[error("Requested future data. The next available item is {next_available}")]
     RequestedFutureData { next_available: u64 },
     #[error("Internal server error")]
     Internal,
 }
 
+impl SubscriptionStreamError {
+    /// Creates a lag error for streams that don't track sequential identifiers.
+    pub fn lagged_without_identifiers(skipped: u64) -> Self {
+        Self::Lagged {
+            skipped,
+            disconnected_at: None,
+            resumed_at: None,
+        }
+    }
+}
+
 impl ReportableWsError for SubscriptionStreamError {
     fn to_json(&self) -> String {
-        serde_json::to_string(&match self {
-            SubscriptionStreamError::Lagged => {
-                json_obj!({
-                    "error": "LAGGED",
-                    "description": "Subscription data was produced faster than it could be sent. Try again later.",
-                    "details": {},
-                })
-            },
+        let obj = match self {
+            SubscriptionStreamError::Lagged {
+                skipped,
+                disconnected_at,
+                resumed_at,
+            } => {
+                // Use detailed format with identifiers when available, otherwise standard format
+                let has_identifiers = disconnected_at.is_some() || resumed_at.is_some();
+                if has_identifiers {
+                    json_obj!({
+                        "message": "lagged",
+                        "details": {
+                            "disconnected_at": *disconnected_at,
+                            "resumed_at": *resumed_at,
+                        },
+                    })
+                } else {
+                    json_obj!({
+                        "status": 200,
+                        "message": "Messages skipped due to lag",
+                        "details": {
+                            "skipped": *skipped,
+                            "reason": "lag",
+                        },
+                    })
+                }
+            }
             SubscriptionStreamError::RequestedFutureData { next_available } => {
                 json_obj!({
                     "error": "REQUESTED_FUTURE_DATA",
@@ -58,15 +98,21 @@ impl ReportableWsError for SubscriptionStreamError {
                         "next_available": *next_available,
                     },
                 })
-            },
+            }
             SubscriptionStreamError::Internal => {
                 json_obj!({
                     "error": "INTERNAL_SERVER_ERROR",
                     "description": "An internal server error occurred.",
                     "details": {},
                 })
-            },
-        }).expect("Failed to serialize SubscriptionStreamError literal to JSON. This is a bug, please report it.")
+            }
+        };
+        serde_json::to_string(&obj)
+            .expect("Failed to serialize SubscriptionStreamError to JSON. This is a bug.")
+    }
+
+    fn is_recoverable(&self) -> bool {
+        matches!(self, SubscriptionStreamError::Lagged { .. })
     }
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -785,22 +785,7 @@ where
     }
 
     async fn subscribe_events(&self) -> Option<SequencerEventStream<Self::Rt>> {
-        use futures::StreamExt;
-
-        let tx_stream = self.transaction_cache.subscribe();
-
-        let event_stream: SequencerEventStream<Self::Rt> =
-            Box::pin(tx_stream.flat_map(|tx| match tx {
-                Ok(tx) => Box::pin(futures::stream::iter(
-                    tx.confirmation.events.into_iter().map(Ok),
-                )),
-                Err(e) => {
-                    let output: SequencerEventStream<Self::Rt> =
-                        Box::pin(futures::stream::once(async { Err(e) }));
-                    output
-                }
-            }));
-        Some(event_stream)
+        Some(self.transaction_cache.subscribe_events())
     }
 
     async fn get_tx(

--- a/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
@@ -264,7 +264,8 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
         }))
     }
 
-    pub fn subscribe(&self) -> SequencerTxStream<Confirmation<S, Rt>> {
+    /// Subscribe to transactions with tx number tracking for lag notifications.  
+    pub fn subscribe_txs(&self) -> SequencerTxStream<Confirmation<S, Rt>> {
         let broadcast_stream = BroadcastStream::new(self.tx_response_receiver.resubscribe());
 
         let mut last_tx_number: Option<u64> = None;
@@ -278,7 +279,11 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
                     Err(SubscriptionStreamError::Lagged {
                         skipped,
                         disconnected_at: last_tx_number,
-                        resumed_at: last_tx_number.map(|id| id + skipped + 1),
+                        resumed_at: last_tx_number.map(|id| {
+                            id.checked_add(skipped)
+                                .and_then(|id| id.checked_add(1))
+                                .expect("Overflow when adding tx number and skipped count")
+                        }),
                     })
                 }
             })
@@ -298,15 +303,8 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
                 match result {
                     Ok(tx) => {
                         // Update last_event_number for each event as we collect them
-                        let events: Vec<_> = tx
-                            .confirmation
-                            .events
-                            .into_iter()
-                            .map(|e| {
-                                last_event_number = Some(e.number);
-                                Ok(e)
-                            })
-                            .collect();
+                        last_event_number = tx.confirmation.events.last().map(|e| e.number);
+                        let events = tx.confirmation.events.into_iter().map(|e| Ok(e));
                         futures::stream::iter(events).left_stream()
                     }
                     Err(BroadcastStreamRecvError::Lagged(skipped)) => {
@@ -330,7 +328,7 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
         starting_from: Option<u64>,
     ) -> Result<SequencerTxStream<Confirmation<S, Rt>>, SubscriptionStreamError> {
         let Some(starting_from) = starting_from else {
-            return Ok(self.subscribe());
+            return Ok(self.subscribe_txs());
         };
         let transaction_cache = self.inner.read().await;
         let next_tx_number = transaction_cache.next_tx_number;
@@ -342,7 +340,7 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
 
         // If the caller is starting from the next tx number, we can just return the broadcast stream
         if starting_from == transaction_cache.next_tx_number {
-            return Ok(self.subscribe());
+            return Ok(self.subscribe_txs());
         }
 
         let stream = AcceptedTxStream {
@@ -491,7 +489,11 @@ impl<S: Spec, Rt: Runtime<S>> AcceptedTxStream<S, Rt> {
                             SubscriptionStreamError::Lagged {
                                 skipped: n,
                                 disconnected_at: last_sent_id,
-                                resumed_at: last_sent_id.map(|id| id + n + 1),
+                                resumed_at: last_sent_id.map(|id| {
+                                    id.checked_add(n)
+                                        .and_then(|id| id.checked_add(1))
+                                        .expect("Overflow when adding tx number and skipped count")
+                                }),
                             }
                         })
                 })
@@ -510,18 +512,21 @@ impl<S: Spec, Rt: Runtime<S>> Stream for AcceptedTxStream<S, Rt> {
         mut self: Pin<&mut Self>,
         cx: &mut futures::task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        // Serve cached transactions first
+        // Step 1: Drain any buffered historical transactions from the last fetch.
+        // These come from cache/DB and must be served before switching to live data.
         if let Some(tx) = self.next_chunk.pop_front() {
             self.last_sent_id = Some(tx.confirmation.tx_number);
             return Poll::Ready(Some(Ok(tx)));
         }
 
-        // If backfill cache is drained, use the subscription
+        // Step 2: Check if we have alreaady have a live subscription from the previous iteration of this function.
+        // If so, that means we're done with backfill. Simply poll the subscription for the next transaction.
         if self.maybe_subscription.is_some() {
             return self.poll_subscription(cx);
         }
 
-        // Need to fetch the next chunk from cache/db
+        // Step 3: If we don't have a live subscription (checked above) we need to fetch the next chunk of historical
+        // transactions from cache/DB. This call will return a subscription if this chunk brings us up to date.
         let mut pending = self.pending_get_next_chunk.take().unwrap_or_else(|| {
             Box::pin(Self::get_next_chunk(
                 self.starting_from,
@@ -532,6 +537,8 @@ impl<S: Spec, Rt: Runtime<S>> Stream for AcceptedTxStream<S, Rt> {
 
         match pending.poll_unpin(cx) {
             Poll::Ready(Ok((txs, maybe_subscription))) => {
+                // Store results. If maybe_subscription is Some, the next poll will send these transaction first
+                // (Step 1) before serving data from the subscription (Step 2).
                 self.starting_from += txs.len() as u64;
                 self.next_chunk = txs.into();
                 self.maybe_subscription = maybe_subscription;
@@ -697,7 +704,7 @@ mod tests {
         let writer = cache.write_handle();
 
         // Subscribe first (broadcast channel only sends new messages to subscribers)
-        let mut stream = cache.subscribe();
+        let mut stream = cache.subscribe_txs();
 
         // Insert transactions and receive them to update the tracked identifier
         for i in 0..3 {

--- a/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
@@ -304,7 +304,7 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
                     Ok(tx) => {
                         // Update last_event_number for each event as we collect them
                         last_event_number = tx.confirmation.events.last().map(|e| e.number);
-                        let events = tx.confirmation.events.into_iter().map(|e| Ok(e));
+                        let events = tx.confirmation.events.into_iter().map(Ok);
                         futures::stream::iter(events).left_stream()
                     }
                     Err(BroadcastStreamRecvError::Lagged(skipped)) => {

--- a/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/transaction_subscriptions.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use futures::task::Poll;
-use futures::{Future, FutureExt, Stream, StreamExt, TryStreamExt};
+use futures::{Future, FutureExt, Stream, StreamExt};
 use sov_db::ledger_db::LedgerDb;
 use sov_modules_api::{HexString, Runtime, RuntimeEventResponse, Spec, TxHash};
 use sov_rollup_interface::node::ledger_api::{EventIdentifier, LedgerStateProvider, QueryMode};
@@ -265,13 +265,64 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
     }
 
     pub fn subscribe(&self) -> SequencerTxStream<Confirmation<S, Rt>> {
-        BroadcastStream::new(
-            // chain an empty stream::iter to make the types match
-            self.tx_response_receiver.resubscribe(),
-        )
-        .map(|tx| tx.map(|tx| tx.into()))
-        .map_err(|_: BroadcastStreamRecvError| SubscriptionStreamError::Lagged) // Put an explicit type check to ensure we catch this if the set of errors expands.
-        .boxed()
+        let broadcast_stream = BroadcastStream::new(self.tx_response_receiver.resubscribe());
+
+        let mut last_tx_number: Option<u64> = None;
+        broadcast_stream
+            .map(move |result| match result {
+                Ok(tx) => {
+                    last_tx_number = Some(tx.confirmation.tx_number);
+                    Ok(tx.into())
+                }
+                Err(BroadcastStreamRecvError::Lagged(skipped)) => {
+                    Err(SubscriptionStreamError::Lagged {
+                        skipped,
+                        disconnected_at: last_tx_number,
+                        resumed_at: last_tx_number.map(|id| id + skipped + 1),
+                    })
+                }
+            })
+            .boxed()
+    }
+
+    /// Subscribe to events with event number tracking for lag notifications.
+    pub fn subscribe_events(&self) -> crate::common::SequencerEventStream<Rt> {
+        let broadcast_stream = BroadcastStream::new(self.tx_response_receiver.resubscribe());
+
+        // Track the last event number seen. Option<u64> is Copy, so it can be
+        // captured by the inner `async move` block without moving out of the closure.
+        let mut last_event_number: Option<u64> = None;
+
+        broadcast_stream
+            .flat_map(move |result| {
+                match result {
+                    Ok(tx) => {
+                        // Update last_event_number for each event as we collect them
+                        let events: Vec<_> = tx
+                            .confirmation
+                            .events
+                            .into_iter()
+                            .map(|e| {
+                                last_event_number = Some(e.number);
+                                Ok(e)
+                            })
+                            .collect();
+                        futures::stream::iter(events).left_stream()
+                    }
+                    Err(BroadcastStreamRecvError::Lagged(skipped)) => {
+                        // last_event_number is Copy, so this captures a copy
+                        futures::stream::once(async move {
+                            Err(SubscriptionStreamError::Lagged {
+                                skipped,
+                                disconnected_at: last_event_number,
+                                resumed_at: None, // Unknown until next event arrives
+                            })
+                        })
+                        .right_stream()
+                    }
+                }
+            })
+            .boxed()
     }
 
     pub async fn subscribe_starting_from_tx_number(
@@ -301,6 +352,7 @@ impl<S: Spec, Rt: Runtime<S>> TransactionCache<S, Rt> {
             next_chunk: VecDeque::new(),
             maybe_subscription: None,
             pending_get_next_chunk: None,
+            last_sent_id: None,
         };
         Ok(Box::pin(stream))
     }
@@ -313,6 +365,8 @@ struct AcceptedTxStream<S: Spec, Rt: Runtime<S>> {
     next_chunk: VecDeque<ApiAcceptedTx<Confirmation<S, Rt>>>,
     maybe_subscription: Option<BroadcastStream<AcceptedTx<Confirmation<S, Rt>>>>,
     pending_get_next_chunk: Option<GetNextChunkFuture<S, Rt>>,
+    /// Tracks the last tx_number that was successfully yielded, for lag error reporting.
+    last_sent_id: Option<u64>,
 }
 
 impl<S: Spec, Rt: Runtime<S>> AcceptedTxStream<S, Rt> {
@@ -421,71 +475,83 @@ impl<S: Spec, Rt: Runtime<S>> AcceptedTxStream<S, Rt> {
     }
 
     fn poll_subscription(
-        subscription: &mut BroadcastStream<AcceptedTx<Confirmation<S, Rt>>>,
+        &mut self,
         cx: &mut futures::task::Context<'_>,
     ) -> Poll<Option<TxStreamItem<S, Rt>>> {
-        let subscription = Pin::new(subscription);
-        match subscription.poll_next(cx) {
-            Poll::Ready(Some(e)) => Poll::Ready(Some(
-                e.map(|tx| tx.into())
-                    .map_err(|_: BroadcastStreamRecvError| SubscriptionStreamError::Lagged),
-            )),
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+        let Some(subscription) = self.maybe_subscription.as_mut() else {
+            return Poll::Pending;
+        };
+        let last_sent_id = self.last_sent_id;
+        let result: Poll<Option<TxStreamItem<S, Rt>>> =
+            Pin::new(subscription).poll_next(cx).map(|opt| {
+                opt.map(|result| {
+                    result
+                        .map(|tx| tx.into())
+                        .map_err(|BroadcastStreamRecvError::Lagged(n)| {
+                            SubscriptionStreamError::Lagged {
+                                skipped: n,
+                                disconnected_at: last_sent_id,
+                                resumed_at: last_sent_id.map(|id| id + n + 1),
+                            }
+                        })
+                })
+            });
+        if let Poll::Ready(Some(Ok(ref tx))) = result {
+            self.last_sent_id = Some(tx.confirmation.tx_number);
         }
+        result
     }
 }
 
 impl<S: Spec, Rt: Runtime<S>> Stream for AcceptedTxStream<S, Rt> {
     type Item = Result<ApiAcceptedTx<Confirmation<S, Rt>>, SubscriptionStreamError>;
 
-    // TODO: Verify that the delegated `poll` calls register this task for wakeup
     fn poll_next(
         mut self: Pin<&mut Self>,
         cx: &mut futures::task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        // If we have txs already cached, serve one of those
+        // Serve cached transactions first
         if let Some(tx) = self.next_chunk.pop_front() {
+            self.last_sent_id = Some(tx.confirmation.tx_number);
             return Poll::Ready(Some(Ok(tx)));
         }
-        // If we have a subscription to the broadcast channel set up, then we're ready to start using that as our source instead
-        // (since we've just checked that the local backfill cache has been drained)
-        if let Some(subscription) = self.maybe_subscription.as_mut() {
-            return Self::poll_subscription(subscription, cx);
+
+        // If backfill cache is drained, use the subscription
+        if self.maybe_subscription.is_some() {
+            return self.poll_subscription(cx);
         }
-        // If we have no subscription and no backfill txs, we need to get the next chunk from the cache/db.
-        let mut pending_get_next_chunk = match self.pending_get_next_chunk.take() {
-            Some(pending_get_next_chunk) => pending_get_next_chunk,
-            None => Box::pin(Self::get_next_chunk(
+
+        // Need to fetch the next chunk from cache/db
+        let mut pending = self.pending_get_next_chunk.take().unwrap_or_else(|| {
+            Box::pin(Self::get_next_chunk(
                 self.starting_from,
                 self.inner.clone(),
                 self.ledger_db.clone(),
-            )),
-        };
-        let next_chunk_poll_result = pending_get_next_chunk.poll_unpin(cx);
-        self.pending_get_next_chunk = Some(pending_get_next_chunk);
-        match next_chunk_poll_result {
+            ))
+        });
+
+        match pending.poll_unpin(cx) {
             Poll::Ready(Ok((txs, maybe_subscription))) => {
-                // If the next chunk task is ready, it will return at either some txs from the cache or a fresh subscription to the broadcast channel, or both.
-                //
-                // We'll need to store the results, then check both sources (in order) and return the first one that is ready
                 self.starting_from += txs.len() as u64;
                 self.next_chunk = txs.into();
                 self.maybe_subscription = maybe_subscription;
-                self.pending_get_next_chunk = None;
+
                 if let Some(tx) = self.next_chunk.pop_front() {
+                    self.last_sent_id = Some(tx.confirmation.tx_number);
                     return Poll::Ready(Some(Ok(tx)));
                 }
-                if let Some(subscription) = self.maybe_subscription.as_mut() {
-                    return Self::poll_subscription(subscription, cx);
+                if self.maybe_subscription.is_some() {
+                    return self.poll_subscription(cx);
                 }
-                unreachable!("AcceptedTxStream::get_next_chunk must return an active subscription, a non-empty chunk of txs, or an error");
+                unreachable!(
+                    "get_next_chunk must return a subscription, transactions, or an error"
+                );
             }
-            Poll::Ready(Err(e)) => {
-                self.pending_get_next_chunk = None;
-                Poll::Ready(Some(Err(e)))
+            Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
+            Poll::Pending => {
+                self.pending_get_next_chunk = Some(pending);
+                Poll::Pending
             }
-            Poll::Pending => Poll::Pending,
         }
     }
 }
@@ -619,6 +685,61 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(next_tx.confirmation.tx_number, num_txs);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_subscribe_reports_correct_identifier_on_lag() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
+        let ledger_db = LedgerDb::with_reader(storage_manager.create_ledger_storage()).unwrap();
+        // Use a small channel size to easily trigger lag
+        let cache = TransactionCache::<S, TestRuntime<S>>::new(ledger_db, 0, 4);
+        let writer = cache.write_handle();
+
+        // Subscribe first (broadcast channel only sends new messages to subscribers)
+        let mut stream = cache.subscribe();
+
+        // Insert transactions and receive them to update the tracked identifier
+        for i in 0..3 {
+            writer.insert(build_mock_confirmation(i)).await;
+            let item = tokio::time::timeout(std::time::Duration::from_millis(100), stream.next())
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+            assert_eq!(item.confirmation.tx_number, i);
+        }
+
+        // Now insert more transactions than the channel can hold WITHOUT reading them.
+        // This will cause the subscriber to lag.
+        // Channel size is 4, so inserting 6 more should cause lag.
+        for i in 3..9 {
+            writer.insert(build_mock_confirmation(i)).await;
+        }
+
+        // The next item should be a lag error with disconnected_at = 2 (last received tx)
+        let item = tokio::time::timeout(std::time::Duration::from_millis(100), stream.next())
+            .await
+            .unwrap()
+            .unwrap();
+
+        match item {
+            Err(SubscriptionStreamError::Lagged {
+                disconnected_at,
+                resumed_at,
+                skipped,
+            }) => {
+                assert_eq!(
+                    disconnected_at,
+                    Some(2),
+                    "disconnected_at should be the last successfully received tx_number"
+                );
+                // resumed_at should be disconnected_at + skipped + 1
+                assert_eq!(resumed_at, Some(2 + skipped + 1));
+            }
+            Ok(_) => panic!("Expected Lagged error, got Ok"),
+            Err(other) => panic!("Expected Lagged error, got {other:?}"),
+        }
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -264,7 +264,11 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             drop(outbound_tx);
             // Wait up to 5 seconds for any remaining in-flight txs to return responses, forwarding them to the client.
             while let Ok(Some(msg)) = tokio::time::timeout(std::time::Duration::from_secs(5), outbound_rx.recv()).await {
-                if let Err(err) = send_json(&mut socket, msg).await {
+                let send_result = match msg {
+                    Ok(m) => send_json(&mut socket, m).await,
+                    Err(m) => send_json(&mut socket, m).await,
+                };
+                if let Err(err) = send_result {
                     tracing::warn!(?err, ip_addr=%ip_addr, "Error sending ws message to client");
                     break;
                 }

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -32,6 +32,26 @@ use tokio_stream::wrappers::BroadcastStream;
 use crate::common::{error_not_fully_synced, AcceptedTx, Sequencer, SubscriptionStreamError};
 use crate::TxStatus;
 
+/// Converts an optional broadcast receiver into a subscription stream.
+/// Returns an empty stream if the receiver is None.
+#[cfg(feature = "test-utils")]
+fn broadcast_to_subscription_stream<T>(
+    receiver: Option<tokio::sync::broadcast::Receiver<T>>,
+) -> std::pin::Pin<Box<dyn futures::Stream<Item = Result<T, SubscriptionStreamError>> + Send>>
+where
+    T: Clone + Send + 'static,
+{
+    receiver
+        .map(|rx| {
+            BroadcastStream::new(rx)
+                .map_err(|BroadcastStreamRecvError::Lagged(n)| {
+                    SubscriptionStreamError::lagged_without_identifiers(n)
+                })
+                .boxed()
+        })
+        .unwrap_or_else(|| futures::stream::empty().boxed())
+}
+
 /// [`StartFrom`] is used as a query parameter for the txs subscription
 #[derive(
     Debug,
@@ -223,24 +243,16 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
                     }
                     // We have an outbound message ready to send
                     outbound_msg = outbound_rx.recv() => {
-                        match outbound_msg {
-                            Some(msg) => {
-                                match msg {
-                                    Ok(msg) => {
-                                        if let Err(err) = send_json(&mut socket, msg).await {
-                                            tracing::warn!(?err, ip_addr=%ip_addr, "Error sending ws message to client");
-                                            break;
-                                        }
-                                    }
-                                    Err(msg) => {
-                                        if let Err(err) = send_json(&mut socket, msg).await {
-                                            tracing::warn!(?err, ip_addr=%ip_addr, "Error sending ws message to client");
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-                            None => break,
+                        let Some(msg) = outbound_msg else {
+                            break;
+                        };
+                        let send_result = match msg {
+                            Ok(m) => send_json(&mut socket, m).await,
+                            Err(m) => send_json(&mut socket, m).await,
+                        };
+                        if let Err(err) = send_result {
+                            tracing::warn!(?err, ip_addr=%ip_addr, "Error sending ws message to client");
+                            break;
                         }
                     }
                     _ = shutdown_receiver.changed() => break,
@@ -301,8 +313,10 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
                     id: tx_hash.0,
                     status,
                 })
-                // Put an explicit type check to ensure we catch this if the set of errors expands.
-                .map_err(|_: BroadcastStreamRecvError| SubscriptionStreamError::Lagged)
+                // Tx status subscriptions don't have sequential identifiers
+                .map_err(|BroadcastStreamRecvError::Lagged(n)| {
+                    SubscriptionStreamError::lagged_without_identifiers(n)
+                })
             })
             .boxed();
 
@@ -454,16 +468,9 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
         ws: WebSocketUpgrade,
     ) -> impl IntoResponse {
         ws.on_upgrade(|socket| async move {
-            let stream = state
-                .sequencer
-                .subscribe_blobs_from_blob_sender()
-                .await
-                .map(|receiver| {
-                    BroadcastStream::new(receiver)
-                        .map_err(|_| SubscriptionStreamError::Lagged) // Put an explicit type check to ensure we catch this if the set of errors expands.
-                        .boxed()
-                })
-                .unwrap_or_else(|| futures::stream::empty().boxed());
+            let stream = broadcast_to_subscription_stream(
+                state.sequencer.subscribe_blobs_from_blob_sender().await,
+            );
             serve_generic_ws_subscription(socket, stream, state.shutdown_receiver.clone()).await;
         })
     }
@@ -483,44 +490,28 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
         Ok(().into())
     }
 
-    /// Subscribe to state updates. Note that notifications may be delivered out of order.
     #[cfg(feature = "test-utils")]
     async fn subscribe_to_state_updates_unstable(
         State(state): State<Self>,
         ws: WebSocketUpgrade,
     ) -> impl IntoResponse {
         ws.on_upgrade(|socket| async move {
-            let stream = state
-                .sequencer
-                .subscribe_state_updates_unstable()
-                .await
-                .map(|receiver| {
-                    BroadcastStream::new(receiver)
-                        .map_err(|_: BroadcastStreamRecvError| SubscriptionStreamError::Lagged) // Put an explicit type check to ensure we catch this if the set of errors expands.
-                        .boxed()
-                })
-                .unwrap_or_else(|| futures::stream::empty().boxed());
+            let stream = broadcast_to_subscription_stream(
+                state.sequencer.subscribe_state_updates_unstable().await,
+            );
             serve_generic_ws_subscription(socket, stream, state.shutdown_receiver.clone()).await;
         })
     }
 
-    /// Subscribe to forced batch notifications. Note that notifications may be delivered out of order.
     #[cfg(feature = "test-utils")]
     async fn subscribe_to_forced_tx_batches_unstable(
         State(state): State<Self>,
         ws: WebSocketUpgrade,
     ) -> impl IntoResponse {
         ws.on_upgrade(|socket| async move {
-            let stream = state
-                .sequencer
-                .subscribe_forced_tx_batches_unstable()
-                .await
-                .map(|receiver| {
-                    BroadcastStream::new(receiver)
-                        .map_err(|_: BroadcastStreamRecvError| SubscriptionStreamError::Lagged)
-                        .boxed()
-                })
-                .unwrap_or_else(|| futures::stream::empty().boxed());
+            let stream = broadcast_to_subscription_stream(
+                state.sequencer.subscribe_forced_tx_batches_unstable().await,
+            );
             serve_generic_ws_subscription(socket, stream, state.shutdown_receiver.clone()).await;
         })
     }

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1789,7 +1789,14 @@ async fn sequencer_back_pressure() {
     test_rollup.produce_enough_finalized_slots().await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
+    let (slot_tx, mut slot_rx) = tokio::sync::mpsc::channel(100);
+    // Keep receiving from the slot subscription in the background to avoid timeouts
     let mut slot_subscription = test_rollup.client.client.subscribe_slots().await.unwrap();
+    tokio::spawn(async move {
+        while let Some(slot) = slot_subscription.next().await {
+            slot_tx.send(slot).await.unwrap();
+        }
+    });
     let client = test_rollup.api_client().clone();
 
     let mut generation = 0;
@@ -1850,7 +1857,7 @@ async fn sequencer_back_pressure() {
     }
 
     for _ in 0..(end_padding_blocks - 10) {
-        let _slot = slot_subscription.next().await.unwrap().unwrap();
+        let _slot = slot_rx.recv().await.unwrap().unwrap();
     }
 
     test_rollup.wait_for_node_synced().await.unwrap();

--- a/crates/utils/sov-rest-utils/Cargo.toml
+++ b/crates/utils/sov-rest-utils/Cargo.toml
@@ -31,6 +31,10 @@ tracing = { workspace = true }
 sov-rest-utils = { path = ".", features = ["arbitrary"] }
 serde_urlencoded = "0.7"
 test-strategy = { workspace = true }
+tokio-tungstenite = { version = "0.28.0", default-features = false, features = ["connect"] }
+tokio-stream = { workspace = true }
+tungstenite = "0.28.0"
+axum = { workspace = true, features = ["query", "ws", "json", "original-uri", "tokio", "http1"] }
 
 [features]
 arbitrary = ["proptest", "proptest-derive", "sov-rest-utils/arbitrary"]

--- a/crates/utils/sov-rest-utils/src/lib.rs
+++ b/crates/utils/sov-rest-utils/src/lib.rs
@@ -215,7 +215,7 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
         tokio::time::interval_at(tokio::time::Instant::now() + PING_INTERVAL, PING_INTERVAL);
     ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut awaiting_pong: Option<[u8; 8]> = None;
-    let mut last_pong_time = Instant::now();
+    let mut ping_sent_time = Instant::now();
     let mut ping_counter: u64 = 0;
 
     'outer: loop {
@@ -238,7 +238,6 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
                         // Client responded to our ping - verify it matches what we sent
                         if awaiting_pong.is_some_and(|expected| data == expected) {
                             awaiting_pong = None;
-                            last_pong_time = Instant::now();
                             trace!("Received valid pong from client");
                         } else {
                             trace!("Received pong with unexpected data; ignoring");
@@ -318,7 +317,7 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
             _ = ping_interval.tick() => {
                 // Check if we're still waiting for a pong from a previous ping
                 if awaiting_pong.is_some() {
-                    let elapsed = last_pong_time.elapsed();
+                    let elapsed = ping_sent_time.elapsed();
                     if elapsed > PONG_TIMEOUT {
                         warn!("No pong received within timeout ({:?}) - disconnecting client", PONG_TIMEOUT);
                         break;
@@ -332,6 +331,7 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
                     warn!(?err, "Failed to send ping - disconnecting client");
                     break;
                 }
+                ping_sent_time = Instant::now();
                 awaiting_pong = Some(ping_data);
                 trace!("Sent ping to client");
             },

--- a/crates/utils/sov-rest-utils/src/lib.rs
+++ b/crates/utils/sov-rest-utils/src/lib.rs
@@ -210,7 +210,9 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
     let mut chunked_subscription = subscription.ready_chunks(MAX_BATCH_SIZE);
 
     // Ping/pong state for keepalive
-    let mut ping_interval = tokio::time::interval(PING_INTERVAL);
+    // Use interval_at to delay the first ping until after a full interval of inactivity
+    let mut ping_interval =
+        tokio::time::interval_at(tokio::time::Instant::now() + PING_INTERVAL, PING_INTERVAL);
     ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut awaiting_pong: Option<[u8; 8]> = None;
     let mut last_pong_time = Instant::now();

--- a/crates/utils/sov-rest-utils/src/lib.rs
+++ b/crates/utils/sov-rest-utils/src/lib.rs
@@ -32,6 +32,9 @@ pub mod errors;
 #[doc(hidden)]
 #[cfg(test)]
 pub mod test_utils;
+
+#[cfg(test)]
+mod ws_tests;
 use axum::body::Body;
 use axum::extract::ws::WebSocket;
 use axum::extract::Request;
@@ -177,8 +180,20 @@ pub fn cors_layer_opt(
 
 const MAX_BATCH_SIZE: usize = 128;
 
+/// Interval between ping frames sent to the client for keepalive.
+const PING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Maximum time to wait for a pong response before considering the connection dead.
+const PONG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// A utility function for serving some data inside a [`futures::Stream`] over a
 /// WebSocket connection.
+///
+/// This function handles:
+/// - Sending data from the subscription stream to the client
+/// - Periodic ping/pong keepalive to detect dead connections
+/// - Graceful shutdown on server shutdown signal
+/// - Proper handling of client disconnection and half-closed connections
 pub async fn serve_generic_ws_subscription<S, M, E>(
     mut socket: WebSocket,
     subscription: S,
@@ -188,11 +203,24 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
     E: ReportableWsError,
     M: Clone + serde::Serialize + Send + Sync + 'static,
 {
+    use axum::extract::ws::Message;
+    use std::time::Instant;
+
     // Use ready_chunks to automatically batch items that are immediately available
     let mut chunked_subscription = subscription.ready_chunks(MAX_BATCH_SIZE);
 
+    // Ping/pong state for keepalive
+    let mut ping_interval = tokio::time::interval(PING_INTERVAL);
+    ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    let mut awaiting_pong: Option<[u8; 8]> = None;
+    let mut last_pong_time = Instant::now();
+    let mut ping_counter: u64 = 0;
+
     'outer: loop {
         tokio::select! {
+            // Biased ensures we check recv first to handle Close frames promptly
+            biased;
+
             msg = socket.recv() => {
                 match msg {
                     Some(Err(error)) => {
@@ -200,12 +228,43 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
                         break;
                     },
                     None => {
-                        // The client disconnected.
+                        // The client disconnected (received Close frame or connection closed).
+                        trace!("WebSocket connection closed by client");
+                        break;
+                    },
+                    Some(Ok(Message::Pong(data))) => {
+                        // Client responded to our ping - verify it matches what we sent
+                        if awaiting_pong.is_some_and(|expected| data == expected) {
+                            awaiting_pong = None;
+                            last_pong_time = Instant::now();
+                            trace!("Received valid pong from client");
+                        } else {
+                            trace!("Received pong with unexpected data; ignoring");
+                        }
+                    },
+                    Some(Ok(Message::Ping(data))) => {
+                        // Respond to client pings (though clients typically don't send pings)
+                        if let Err(err) = socket.send(Message::Pong(data)).await {
+                            warn!(?err, "Failed to send pong - disconnecting client");
+                            break;
+                        }
+                    },
+                    Some(Ok(Message::Close(_))) => {
+                        // Client initiated close - acknowledge and exit
+                        trace!("Received close frame from client");
                         break;
                     },
                     Some(Ok(_)) => {
-                        // Ignore incoming messages.
-                        trace!("Incoming WebSocket message but none was expected; ignoring");
+                        // Client sent an unexpected message - notify them it was ignored
+                        trace!("Incoming WebSocket message but none was expected; notifying client");
+                        if let Err(err) = send_json(&mut socket, &ErrorObject {
+                            status: StatusCode::BAD_REQUEST,
+                            message: "This subscription does not accept incoming messages".to_string(),
+                            details: JsonObject::new(),
+                        }).await {
+                            warn!(?err, "Failed to send error response - disconnecting client");
+                            break;
+                        }
                     },
                 }
             },
@@ -223,16 +282,18 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
                                         }
                                     };
                                     if let Err(err) = socket.feed(serialized.into()).await {
-                                        warn!(?err, "WebSocket error while sending data");
-                                        // Keep the loop going.
+                                        warn!(?err, "WebSocket send error - disconnecting client");
+                                        break 'outer;
                                     }
                                 }
                                 Err(err) => {
-                                    // Convert error to ErrorObject and send it to the client
-                                     if let Err(send_err) = socket.send(err.to_json().into()).await {
-                                        warn!(err=?send_err, "WebSocket error while sending error");
-                                        // keep the loop going.
+                                    // Send error notification to the client
+                                    if let Err(send_err) = socket.send(err.to_json().into()).await {
+                                        warn!(err=?send_err, "WebSocket send error - disconnecting client");
+                                        break 'outer;
                                     }
+                                    // For recoverable errors (e.g., lag), continue streaming
+                                    // For non-recoverable errors, disconnect
                                     if !err.is_recoverable() {
                                         break 'outer;
                                     }
@@ -240,15 +301,38 @@ pub async fn serve_generic_ws_subscription<S, M, E>(
                             }
                         }
                         if let Err(err) = socket.flush().await {
-                            trace!(?err, "Failed to flush the socket");
+                            warn!(?err, "WebSocket flush error - disconnecting client");
+                            break 'outer;
                         }
+                        // Successfully sent data proves connection is alive; reset ping timer
+                        ping_interval.reset();
                     },
                     None => {
                         // No more data to send.
                         break;
                     },
                 }
-            }
+            },
+            _ = ping_interval.tick() => {
+                // Check if we're still waiting for a pong from a previous ping
+                if awaiting_pong.is_some() {
+                    let elapsed = last_pong_time.elapsed();
+                    if elapsed > PONG_TIMEOUT {
+                        warn!("No pong received within timeout ({:?}) - disconnecting client", PONG_TIMEOUT);
+                        break;
+                    }
+                }
+
+                // Send a ping to check if the client is still alive
+                ping_counter = ping_counter.wrapping_add(1);
+                let ping_data = ping_counter.to_le_bytes();
+                if let Err(err) = socket.send(Message::Ping(ping_data.to_vec())).await {
+                    warn!(?err, "Failed to send ping - disconnecting client");
+                    break;
+                }
+                awaiting_pong = Some(ping_data);
+                trace!("Sent ping to client");
+            },
             _ = shutdown_receiver.changed() => break,
         }
     }

--- a/crates/utils/sov-rest-utils/src/ws_tests.rs
+++ b/crates/utils/sov-rest-utils/src/ws_tests.rs
@@ -1,0 +1,498 @@
+//! Integration tests for WebSocket functionality.
+//!
+//! These tests verify:
+//! 1. Socket errors (feed/flush) cause immediate disconnect
+//! 2. BroadcastStream lag sends skip notification and resumes (not disconnect)
+//! 3. Ping/pong keepalive detects dead connections
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use axum::extract::ws::WebSocketUpgrade;
+    use axum::extract::State;
+    use axum::response::IntoResponse;
+    use axum::routing::get;
+    use axum::Router;
+    use futures::StreamExt;
+    use tokio::net::TcpListener;
+    use tokio::sync::{broadcast, watch};
+    use tokio::time::timeout;
+    use tokio_stream::wrappers::BroadcastStream;
+
+    use crate::errors::ReportableWsError;
+    use crate::serve_generic_ws_subscription;
+
+    /// Error type matching the real SubscriptionStreamError pattern.
+    #[derive(Debug, Clone)]
+    enum TestSubscriptionError {
+        Lagged {
+            skipped: u64,
+            disconnected_at: Option<u64>,
+            resumed_at: Option<u64>,
+        },
+    }
+
+    impl ReportableWsError for TestSubscriptionError {
+        fn to_json(&self) -> String {
+            match self {
+                TestSubscriptionError::Lagged {
+                    skipped,
+                    disconnected_at,
+                    resumed_at,
+                } => {
+                    // If we have identifier information, use the detailed format
+                    if disconnected_at.is_some() || resumed_at.is_some() {
+                        format!(
+                            r#"{{"message": "lagged", "details": {{"disconnected_at": {}, "resumed_at": {}}}}}"#,
+                            disconnected_at
+                                .map(|v| v.to_string())
+                                .unwrap_or_else(|| "null".to_string()),
+                            resumed_at
+                                .map(|v| v.to_string())
+                                .unwrap_or_else(|| "null".to_string())
+                        )
+                    } else {
+                        // Otherwise, use the standard format with skip count
+                        format!(
+                            r#"{{"status": 200, "message": "Messages skipped due to lag", "details": {{"skipped": {skipped}, "reason": "lag"}}}}"#
+                        )
+                    }
+                }
+            }
+        }
+
+        fn is_recoverable(&self) -> bool {
+            // Lagged IS recoverable - we skip and continue
+            match self {
+                TestSubscriptionError::Lagged { .. } => true,
+            }
+        }
+    }
+
+    /// State shared between test handlers.
+    #[derive(Clone)]
+    struct TestState {
+        shutdown_tx: watch::Sender<()>,
+        shutdown_rx: watch::Receiver<()>,
+        /// Tracks how many messages were sent to the broadcast channel.
+        messages_produced: Arc<AtomicUsize>,
+        /// Tracks how many messages the stream attempted to yield.
+        messages_yielded: Arc<AtomicUsize>,
+    }
+
+    impl TestState {
+        fn new() -> Self {
+            let (shutdown_tx, shutdown_rx) = watch::channel(());
+            Self {
+                shutdown_tx,
+                shutdown_rx,
+                messages_produced: Arc::new(AtomicUsize::new(0)),
+                messages_yielded: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    type BoxedStream<T, E> = Pin<Box<dyn futures::Stream<Item = Result<T, E>> + Send>>;
+
+    /// Creates a stream backed by a broadcast channel.
+    /// Maps Lagged errors to include identifier tracking.
+    fn broadcast_message_stream(
+        buffer_size: usize,
+        messages_yielded: Arc<AtomicUsize>,
+    ) -> (
+        BoxedStream<String, TestSubscriptionError>,
+        broadcast::Sender<String>,
+    ) {
+        use std::sync::atomic::AtomicU64;
+        use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
+
+        let (tx, rx) = broadcast::channel::<String>(buffer_size);
+        let last_id = Arc::new(AtomicU64::new(0));
+        let stream = BroadcastStream::new(rx).map(move |result| {
+            messages_yielded.fetch_add(1, Ordering::SeqCst);
+            match result {
+                Ok(msg) => {
+                    // Extract message number from "message-N" format
+                    let id = msg
+                        .strip_prefix("message-")
+                        .or_else(|| msg.strip_prefix("slow-message-"))
+                        .and_then(|n| n.parse::<u64>().ok())
+                        .unwrap_or(0);
+                    last_id.store(id, Ordering::SeqCst);
+                    Ok(msg)
+                }
+                Err(BroadcastStreamRecvError::Lagged(count)) => {
+                    let disconnected = last_id.load(Ordering::SeqCst);
+                    Err(TestSubscriptionError::Lagged {
+                        skipped: count,
+                        disconnected_at: Some(disconnected),
+                        resumed_at: Some(disconnected + count + 1),
+                    })
+                }
+            }
+        });
+        (Box::pin(stream), tx)
+    }
+
+    /// Handler that uses a broadcast channel with small buffer to trigger lag.
+    async fn broadcast_handler(
+        ws: WebSocketUpgrade,
+        State(state): State<TestState>,
+    ) -> impl IntoResponse {
+        ws.on_upgrade(move |socket| async move {
+            // Small buffer size (4) to easily trigger lag when client is slow
+            let (stream, tx) = broadcast_message_stream(4, state.messages_yielded.clone());
+
+            // Spawn a task to rapidly produce messages
+            let messages_produced = state.messages_produced.clone();
+            let producer = tokio::spawn(async move {
+                for i in 0..1000 {
+                    if tx.send(format!("message-{i}")).is_err() {
+                        break;
+                    }
+                    messages_produced.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_micros(100)).await;
+                }
+            });
+
+            serve_generic_ws_subscription(socket, stream, state.shutdown_rx.clone()).await;
+            producer.abort();
+        })
+    }
+
+    /// Handler with larger buffer and slower production for disconnect tests.
+    async fn slow_broadcast_handler(
+        ws: WebSocketUpgrade,
+        State(state): State<TestState>,
+    ) -> impl IntoResponse {
+        ws.on_upgrade(move |socket| async move {
+            let (stream, tx) = broadcast_message_stream(100, state.messages_yielded.clone());
+
+            let messages_produced = state.messages_produced.clone();
+            let producer = tokio::spawn(async move {
+                for i in 0..100 {
+                    if tx.send(format!("slow-message-{i}")).is_err() {
+                        break;
+                    }
+                    messages_produced.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+            });
+
+            serve_generic_ws_subscription(socket, stream, state.shutdown_rx.clone()).await;
+            producer.abort();
+        })
+    }
+
+    /// Starts a test server and returns the address.
+    async fn start_test_server(state: TestState) -> SocketAddr {
+        let app = Router::new()
+            .route("/broadcast", get(broadcast_handler))
+            .route("/slow", get(slow_broadcast_handler))
+            .with_state(state);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        addr
+    }
+
+    // =========================================================================
+    // Socket Error Tests - Should disconnect
+    // =========================================================================
+
+    /// Test: When a client disconnects, the server should detect it and stop.
+    #[tokio::test]
+    async fn test_client_disconnect_stops_server() {
+        let state = TestState::new();
+        let addr = start_test_server(state.clone()).await;
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/slow"))
+            .await
+            .unwrap();
+
+        // Receive 2 text messages then close (skip ping/pong frames)
+        let mut text_count = 0;
+        while text_count < 2 {
+            let msg = ws.next().await.unwrap().unwrap();
+            match msg {
+                tungstenite::Message::Text(_) => text_count += 1,
+                tungstenite::Message::Ping(_) | tungstenite::Message::Pong(_) => continue,
+                _ => panic!("Unexpected message type: {msg:?}"),
+            }
+        }
+
+        ws.close(None).await.ok();
+        drop(ws);
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let produced = state.messages_produced.load(Ordering::SeqCst);
+        assert!(
+            produced < 20,
+            "Server produced {produced} messages but should have stopped after client disconnect."
+        );
+    }
+
+    /// Test: Server should not hang when client reads slowly.
+    ///
+    /// When socket.feed()/flush() fails due to backpressure, the server
+    /// should disconnect, not hang forever.
+    #[tokio::test]
+    async fn test_slow_reader_causes_disconnect() {
+        let state = TestState::new();
+        let addr = start_test_server(state.clone()).await;
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/broadcast"))
+            .await
+            .unwrap();
+
+        let _msg = ws.next().await.unwrap().unwrap();
+
+        let mut message_count = 0;
+
+        let result = timeout(Duration::from_secs(2), async {
+            loop {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+
+                match ws.next().await {
+                    Some(Ok(tungstenite::Message::Text(_))) => {
+                        message_count += 1;
+                    }
+                    Some(Ok(tungstenite::Message::Close(_))) | None => {
+                        return "closed";
+                    }
+                    Some(Err(_)) => {
+                        return "error";
+                    }
+                    _ => {}
+                }
+            }
+        })
+        .await;
+
+        let produced = state.messages_produced.load(Ordering::SeqCst);
+
+        match result {
+            Ok("closed") | Ok("error") => {
+                // Good - server disconnected as expected
+            }
+            Ok(_) => {
+                panic!("Unexpected result");
+            }
+            Err(e) => {
+                // Check if this is actually a problem - if server produced all messages
+                // and client received some, TCP buffering worked fine
+                if produced >= 900 {
+                    // Server finished sending all messages - TCP handled the buffering
+                    // This is actually fine behavior, not a bug
+                    eprintln!(
+                        "Note: Server produced {produced} messages, client received {message_count}. \
+                         TCP buffering handled the load without errors."
+                    );
+                    return; // Test passes - no hang occurred
+                }
+                panic!(
+                    "Error: {e:?}.\nTIMEOUT: Server produced {produced} messages, client received {message_count}. \
+                     Server may be hanging."
+                );
+            }
+        }
+
+        state.shutdown_tx.send(()).ok();
+    }
+
+    // =========================================================================
+    // BroadcastStream Lag Tests - Should skip and resume, NOT disconnect
+    // =========================================================================
+
+    /// Test: When a recoverable error occurs, server should send error notification
+    /// and continue streaming (not disconnect).
+    ///
+    /// Note: Actual BroadcastStream lag is hard to trigger in tests because:
+    /// 1. The server consumes from the stream as fast as possible
+    /// 2. TCP buffers handle the output without backpressure
+    /// 3. The BroadcastStream receiver never falls behind
+    ///
+    /// This test verifies the code path works by checking that:
+    /// 1. Server completes without hanging
+    /// 2. Messages are received
+    /// 3. When recoverable errors DO occur, they don't cause disconnect
+    #[tokio::test]
+    async fn test_recoverable_errors_continue_streaming() {
+        let state = TestState::new();
+        let addr = start_test_server(state.clone()).await;
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/broadcast"))
+            .await
+            .unwrap();
+
+        // Read messages until stream completes or connection closes
+        let mut message_count = 0;
+        let mut skip_notifications = 0;
+
+        let result = timeout(Duration::from_secs(3), async {
+            loop {
+                match ws.next().await {
+                    Some(Ok(tungstenite::Message::Text(t))) => {
+                        let text = t.to_string();
+
+                        // Check if this is a lag notification
+                        if text.contains("lagged") && text.contains("disconnected_at") {
+                            skip_notifications += 1;
+                            continue;
+                        }
+
+                        message_count += 1;
+                    }
+                    Some(Ok(tungstenite::Message::Close(_))) | None => {
+                        return "closed";
+                    }
+                    Some(Err(_)) => {
+                        return "error";
+                    }
+                    _ => {}
+                }
+            }
+        })
+        .await;
+
+        let produced = state.messages_produced.load(Ordering::SeqCst);
+
+        match result {
+            Ok("closed") | Ok("error") => {
+                // Connection closed normally - server completed or disconnected
+                eprintln!(
+                    "Server produced {produced} messages, client received {message_count}, skip notifications: {skip_notifications}"
+                );
+                // As long as we received some messages and didn't hang, the test passes
+                assert!(
+                    message_count > 0,
+                    "Expected to receive at least some messages"
+                );
+            }
+            Ok(_) => {
+                panic!("Unexpected result");
+            }
+            Err(_) => {
+                // Timeout - check if server completed its work
+                if produced >= 900 {
+                    // Server finished, client just didn't receive all messages yet
+                    eprintln!(
+                        "Server produced {produced} messages (completed), client received {message_count}"
+                    );
+                    return; // OK - server didn't hang
+                }
+                panic!(
+                    "Timeout. Server produced {produced} messages, client received {message_count}. \
+                     Server may be hanging."
+                );
+            }
+        }
+
+        state.shutdown_tx.send(()).ok();
+    }
+
+    // =========================================================================
+    // Ping/Pong Keepalive Tests
+    // =========================================================================
+
+    /// Test: Server should send periodic ping frames.
+    #[tokio::test]
+    async fn test_server_sends_pings() {
+        let state = TestState::new();
+        let addr = start_test_server(state.clone()).await;
+
+        let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/slow"))
+            .await
+            .unwrap();
+
+        // Wait for a ping (first tick is immediate, then every PING_INTERVAL seconds)
+        let ping_received = timeout(Duration::from_secs(5), async {
+            loop {
+                match ws.next().await {
+                    Some(Ok(tungstenite::Message::Ping(_))) => return true,
+                    Some(Ok(_)) => continue,
+                    _ => return false,
+                }
+            }
+        })
+        .await;
+
+        assert!(
+            ping_received.unwrap_or(false),
+            "Server should send ping frames for keepalive"
+        );
+
+        state.shutdown_tx.send(()).ok();
+    }
+
+    /// Test: Server should disconnect if pong is not received within timeout.
+    ///
+    /// Note: tokio-tungstenite automatically responds to pings with pongs,
+    /// so we use a raw TCP connection to test timeout behavior.
+    ///
+    /// This test is ignored by default because it takes ~40 seconds (PING_INTERVAL + PONG_TIMEOUT).
+    /// Run with `cargo test --ignored` to include it.
+    #[tokio::test]
+    #[ignore = "Takes ~40 seconds due to ping/pong timeout"]
+    async fn test_pong_timeout_disconnects() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
+        let state = TestState::new();
+        let addr = start_test_server(state.clone()).await;
+
+        // Connect via raw TCP and perform WebSocket handshake manually
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+
+        // Send WebSocket upgrade request
+        let request = format!(
+            "GET /slow HTTP/1.1\r\n\
+             Host: {addr}\r\n\
+             Upgrade: websocket\r\n\
+             Connection: Upgrade\r\n\
+             Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+             Sec-WebSocket-Version: 13\r\n\
+             \r\n"
+        );
+        stream.write_all(request.as_bytes()).await.unwrap();
+
+        // Read the HTTP response (we don't need to parse it fully for this test)
+        let mut response = vec![0u8; 1024];
+        let _ = stream.read(&mut response).await.unwrap();
+
+        // Now we have a WebSocket connection but we won't respond to pings
+        // The server should disconnect after PING_INTERVAL + PONG_TIMEOUT (30 + 10 = 40s)
+        // We wait a bit longer to be safe
+
+        let disconnect_time = timeout(Duration::from_secs(50), async {
+            let mut buf = vec![0u8; 1024];
+            loop {
+                match stream.read(&mut buf).await {
+                    Ok(0) => return true,  // Connection closed
+                    Ok(_) => continue,     // Got some data, keep reading
+                    Err(_) => return true, // Error = connection closed
+                }
+            }
+        })
+        .await;
+
+        assert!(
+            disconnect_time.unwrap_or(false),
+            "Server should disconnect after pong timeout"
+        );
+
+        state.shutdown_tx.send(()).ok();
+    }
+}

--- a/crates/utils/sov-rest-utils/src/ws_tests.rs
+++ b/crates/utils/sov-rest-utils/src/ws_tests.rs
@@ -189,11 +189,24 @@ mod tests {
         })
     }
 
+    /// Handler that sends no data - used for testing ping/pong keepalive in isolation.
+    async fn idle_handler(
+        ws: WebSocketUpgrade,
+        State(state): State<TestState>,
+    ) -> impl IntoResponse {
+        ws.on_upgrade(move |socket| async move {
+            // Create a stream that never yields any items (just stays pending)
+            let stream = futures::stream::pending::<Result<String, TestSubscriptionError>>();
+            serve_generic_ws_subscription(socket, stream, state.shutdown_rx.clone()).await;
+        })
+    }
+
     /// Starts a test server and returns the address.
     async fn start_test_server(state: TestState) -> SocketAddr {
         let app = Router::new()
             .route("/broadcast", get(broadcast_handler))
             .route("/slow", get(slow_broadcast_handler))
+            .route("/idle", get(idle_handler))
             .with_state(state);
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -261,7 +274,7 @@ mod tests {
 
         let mut message_count = 0;
 
-        let result = timeout(Duration::from_secs(2), async {
+        let closed = timeout(Duration::from_secs(2), async {
             loop {
                 tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -269,12 +282,8 @@ mod tests {
                     Some(Ok(tungstenite::Message::Text(_))) => {
                         message_count += 1;
                     }
-                    Some(Ok(tungstenite::Message::Close(_))) | None => {
-                        return "closed";
-                    }
-                    Some(Err(_)) => {
-                        return "error";
-                    }
+                    // Connection closed or errored - server disconnected as expected
+                    Some(Ok(tungstenite::Message::Close(_))) | None | Some(Err(_)) => return,
                     _ => {}
                 }
             }
@@ -283,30 +292,19 @@ mod tests {
 
         let produced = state.messages_produced.load(Ordering::SeqCst);
 
-        match result {
-            Ok("closed") | Ok("error") => {
-                // Good - server disconnected as expected
-            }
-            Ok(_) => {
-                panic!("Unexpected result");
-            }
-            Err(e) => {
-                // Check if this is actually a problem - if server produced all messages
-                // and client received some, TCP buffering worked fine
-                if produced >= 900 {
-                    // Server finished sending all messages - TCP handled the buffering
-                    // This is actually fine behavior, not a bug
-                    eprintln!(
-                        "Note: Server produced {produced} messages, client received {message_count}. \
-                         TCP buffering handled the load without errors."
-                    );
-                    return; // Test passes - no hang occurred
-                }
-                panic!(
-                    "Error: {e:?}.\nTIMEOUT: Server produced {produced} messages, client received {message_count}. \
-                     Server may be hanging."
+        if closed.is_err() {
+            // Timeout - check if server completed its work (TCP buffering handled it)
+            if produced >= 900 {
+                eprintln!(
+                    "Note: Server produced {produced} messages, client received {message_count}. \
+                     TCP buffering handled the load without errors."
                 );
+                return;
             }
+            panic!(
+                "TIMEOUT: Server produced {produced} messages, client received {message_count}. \
+                 Server may be hanging."
+            );
         }
 
         state.shutdown_tx.send(()).ok();
@@ -341,7 +339,7 @@ mod tests {
         let mut message_count = 0;
         let mut skip_notifications = 0;
 
-        let result = timeout(Duration::from_secs(3), async {
+        let closed = timeout(Duration::from_secs(3), async {
             loop {
                 match ws.next().await {
                     Some(Ok(tungstenite::Message::Text(t))) => {
@@ -355,12 +353,8 @@ mod tests {
 
                         message_count += 1;
                     }
-                    Some(Ok(tungstenite::Message::Close(_))) | None => {
-                        return "closed";
-                    }
-                    Some(Err(_)) => {
-                        return "error";
-                    }
+                    // Connection closed or errored
+                    Some(Ok(tungstenite::Message::Close(_))) | None | Some(Err(_)) => return,
                     _ => {}
                 }
             }
@@ -369,35 +363,27 @@ mod tests {
 
         let produced = state.messages_produced.load(Ordering::SeqCst);
 
-        match result {
-            Ok("closed") | Ok("error") => {
-                // Connection closed normally - server completed or disconnected
+        if closed.is_ok() {
+            // Connection closed normally - server completed or disconnected
+            eprintln!(
+                "Server produced {produced} messages, client received {message_count}, skip notifications: {skip_notifications}"
+            );
+            assert!(
+                message_count > 0,
+                "Expected to receive at least some messages"
+            );
+        } else {
+            // Timeout - check if server completed its work
+            if produced >= 900 {
                 eprintln!(
-                    "Server produced {produced} messages, client received {message_count}, skip notifications: {skip_notifications}"
+                    "Server produced {produced} messages (completed), client received {message_count}"
                 );
-                // As long as we received some messages and didn't hang, the test passes
-                assert!(
-                    message_count > 0,
-                    "Expected to receive at least some messages"
-                );
+                return;
             }
-            Ok(_) => {
-                panic!("Unexpected result");
-            }
-            Err(_) => {
-                // Timeout - check if server completed its work
-                if produced >= 900 {
-                    // Server finished, client just didn't receive all messages yet
-                    eprintln!(
-                        "Server produced {produced} messages (completed), client received {message_count}"
-                    );
-                    return; // OK - server didn't hang
-                }
-                panic!(
-                    "Timeout. Server produced {produced} messages, client received {message_count}. \
-                     Server may be hanging."
-                );
-            }
+            panic!(
+                "Timeout. Server produced {produced} messages, client received {message_count}. \
+                 Server may be hanging."
+            );
         }
 
         state.shutdown_tx.send(()).ok();
@@ -407,18 +393,24 @@ mod tests {
     // Ping/Pong Keepalive Tests
     // =========================================================================
 
-    /// Test: Server should send periodic ping frames.
+    /// Test: Server should send periodic ping frames when idle.
+    ///
+    /// Uses the /idle endpoint which sends no data, so ping keepalive is the only activity.
+    /// The first ping is sent after PING_INTERVAL (30s) of inactivity.
+    ///
+    /// This test is ignored by default because it takes ~30 seconds (PING_INTERVAL).
+    /// Run with `cargo test --ignored` to include it.
     #[tokio::test]
     async fn test_server_sends_pings() {
         let state = TestState::new();
         let addr = start_test_server(state.clone()).await;
 
-        let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/slow"))
+        let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/idle"))
             .await
             .unwrap();
 
-        // Wait for a ping (first tick is immediate, then every PING_INTERVAL seconds)
-        let ping_received = timeout(Duration::from_secs(5), async {
+        // Wait for a ping (sent after PING_INTERVAL of inactivity)
+        let ping_received = timeout(Duration::from_secs(35), async {
             loop {
                 match ws.next().await {
                     Some(Ok(tungstenite::Message::Ping(_))) => return true,
@@ -442,10 +434,11 @@ mod tests {
     /// Note: tokio-tungstenite automatically responds to pings with pongs,
     /// so we use a raw TCP connection to test timeout behavior.
     ///
+    /// Uses the /idle endpoint which sends no data, allowing ping/pong to be the only activity.
+    ///
     /// This test is ignored by default because it takes ~40 seconds (PING_INTERVAL + PONG_TIMEOUT).
     /// Run with `cargo test --ignored` to include it.
     #[tokio::test]
-    #[ignore = "Takes ~40 seconds due to ping/pong timeout"]
     async fn test_pong_timeout_disconnects() {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         use tokio::net::TcpStream;
@@ -456,9 +449,9 @@ mod tests {
         // Connect via raw TCP and perform WebSocket handshake manually
         let mut stream = TcpStream::connect(addr).await.unwrap();
 
-        // Send WebSocket upgrade request
+        // Send WebSocket upgrade request to /idle (no data, only ping/pong)
         let request = format!(
-            "GET /slow HTTP/1.1\r\n\
+            "GET /idle HTTP/1.1\r\n\
              Host: {addr}\r\n\
              Upgrade: websocket\r\n\
              Connection: Upgrade\r\n\
@@ -473,10 +466,13 @@ mod tests {
         let _ = stream.read(&mut response).await.unwrap();
 
         // Now we have a WebSocket connection but we won't respond to pings
-        // The server should disconnect after PING_INTERVAL + PONG_TIMEOUT (30 + 10 = 40s)
-        // We wait a bit longer to be safe
+        // The timeout check only runs when the ping interval ticks, so:
+        // - First ping sent at PING_INTERVAL (30s)
+        // - Timeout check runs at next tick (60s), sees no pong received, disconnects
+        // We wait a bit longer than 2*PING_INTERVAL to be safe
 
-        let disconnect_time = timeout(Duration::from_secs(50), async {
+        let start = std::time::Instant::now();
+        let disconnect_result = timeout(Duration::from_secs(70), async {
             let mut buf = vec![0u8; 1024];
             loop {
                 match stream.read(&mut buf).await {
@@ -487,9 +483,11 @@ mod tests {
             }
         })
         .await;
+        let elapsed = start.elapsed();
+        eprintln!("Connection closed after {elapsed:?}");
 
         assert!(
-            disconnect_time.unwrap_or(false),
+            disconnect_result.unwrap_or(false),
             "Server should disconnect after pong timeout"
         );
 

--- a/crates/utils/sov-rest-utils/src/ws_tests.rs
+++ b/crates/utils/sov-rest-utils/src/ws_tests.rs
@@ -236,6 +236,11 @@ mod tests {
 
         // Receive 2 text messages then close (skip ping/pong frames)
         let mut text_count = 0;
+        // Verify the server detected the disconnect and stopped producing.
+        // The slow_broadcast_handler produces messages every 50ms, so if it kept
+        // running for the full 500ms wait, it would produce ~10 messages.
+        // We use < 20 as a loose bound to account for timing variance.
+        // If disconnect detection failed, the producer would continue toward 100 messages.
         while text_count < 2 {
             let msg = ws.next().await.unwrap().unwrap();
             match msg {
@@ -410,7 +415,7 @@ mod tests {
             .unwrap();
 
         // Wait for a ping (sent after PING_INTERVAL of inactivity)
-        let ping_received = timeout(Duration::from_secs(35), async {
+        let ping_received = timeout(Duration::from_secs(50), async {
             loop {
                 match ws.next().await {
                     Some(Ok(tungstenite::Message::Ping(_))) => return true,


### PR DESCRIPTION
# Description

This PR makes improvements to the websocket handling of lag (we notify about where we lagged, when possible and do not disconnect), inbound messages (we accept pings and pongs and send helpful errors on other messages), and keepalive. 

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2408">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
