### PR TITLE
 cleanup: remove dead code and fix lint warnings  

### DIFF
--- a/crates/adapters/celestia/src/shares.rs
+++ b/crates/adapters/celestia/src/shares.rs
@@ -5,20 +5,6 @@ use sov_rollup_interface::Bytes;
 
 const PARITY_SHARE_PANIC: &str = "Attempted to read the payload of a parity share, but only data shares have payloads. Parity shares should never be read by the adapter - this is a bug, please report it.";
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub(crate) enum VersionedStartShare {
-    Zero(celestia_types::Share),
-    One(celestia_types::Share),
-}
-
-impl AsRef<[u8]> for VersionedStartShare {
-    fn as_ref(&self) -> &[u8] {
-        match self {
-            VersionedStartShare::Zero(inner) | VersionedStartShare::One(inner) => inner.as_ref(),
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub enum ShareError {
     NotAStartShare,

--- a/crates/full-node/sov-db/src/state_db.rs
+++ b/crates/full-node/sov-db/src/state_db.rs
@@ -46,7 +46,7 @@ impl StateDb {
     }
 
     /// Returns the associated JMT handler for a given namespace
-    pub fn get_jmt_handler<N: Namespace>(&self) -> JmtHandler<N> {
+    pub fn get_jmt_handler<N: Namespace>(&self) -> JmtHandler<'_, N> {
         JmtHandler {
             state_db: self,
             phantom: Default::default(),

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -54,7 +54,7 @@ pub struct NomtChangeSet {
     pub accessory: SchemaBatch,
     /// Use type erasure because the `pinned_cache` type is defined in sov-state, which depends on this crate.
     /// No type other than `PinnedCache` makes sense here.
-    pub pinned_cache: Option<Box<(dyn Any + Send + Sync)>>,
+    pub pinned_cache: Option<Box<dyn Any + Send + Sync>>,
 }
 
 #[cfg(test)]
@@ -94,7 +94,7 @@ where
         historical_state: HistoricalStateReader,
         accessory_db: AccessoryDb,
         strict_with_witness: bool,
-        pinned_cache: Option<Box<(dyn Any + Send + Sync)>>,
+        pinned_cache: Option<Box<dyn Any + Send + Sync>>,
     ) -> Self;
 }
 
@@ -108,7 +108,7 @@ pub struct NomtStorageManager<Da: DaSpec, H, S: InitializableNativeNomtStorage<H
 
     rockbound_snapshots: HashMap<Da::SlotHash, SnapshotGroup>,
     nomt_snapshots: Arc<RwLock<HashMap<Da::SlotHash, StateOverlay>>>,
-    pinned_caches: HashMap<Da::SlotHash, Box<(dyn Any + Send + Sync)>>,
+    pinned_caches: HashMap<Da::SlotHash, Box<dyn Any + Send + Sync>>,
 
     db_group: DbGroup<H, Da::SlotHash>,
 
@@ -161,7 +161,7 @@ where
         &self,
         block_hash: Da::SlotHash,
         with_witness: bool,
-        pinned_cache: Option<Box<(dyn Any + Send + Sync)>>,
+        pinned_cache: Option<Box<dyn Any + Send + Sync>>,
     ) -> anyhow::Result<(S, DeltaReader)> {
         tracing::trace!(%block_hash, "Creating storage up to block hash");
         // References are in reversed chronological order,

--- a/crates/full-node/sov-db/src/test_utils.rs
+++ b/crates/full-node/sov-db/src/test_utils.rs
@@ -77,7 +77,7 @@ impl crate::storage_manager::InitializableNativeNomtStorage<H, SlotHash> for Tes
         historical_state: crate::historical_state::HistoricalStateReader,
         accessory_db: AccessoryDb,
         _with_witness: bool,
-        _pinned_cache: Option<Box<(dyn Any + Send + Sync)>>,
+        _pinned_cache: Option<Box<dyn Any + Send + Sync>>,
     ) -> Self {
         TestNomtStorage {
             state_session_builder,

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -36,7 +36,6 @@ use futures::Stream;
 pub use initialization::Builder;
 use nonce_buffer_task::{NonceBufferInputSender, NonceBufferTask, SequencerTxExecutionBackend};
 use preferred_blob_sender::PreferredBlobSender;
-use serde_with::serde_as;
 use side_effects::SideEffectsTask;
 use sov_blob_sender::{new_blob_id, BlobExecutionStatus};
 use sov_blob_storage::{PreferredBatchData, SequenceNumber};
@@ -915,6 +914,7 @@ where
 
 #[serde_with::serde_as]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[allow(dead_code)]
 struct TxBody(#[serde_as(as = "serde_with::base64::Base64")] Vec<u8>);
 
 /// Transaction confirmation data of [`PreferredSequencer`].

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -912,11 +912,6 @@ where
     }
 }
 
-#[serde_with::serde_as]
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[allow(dead_code)]
-struct TxBody(#[serde_as(as = "serde_with::base64::Base64")] Vec<u8>);
-
 /// Transaction confirmation data of [`PreferredSequencer`].
 #[derive(derivative::Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(Clone(bound = ""), Debug(bound = "S: Spec, Rt: Runtime<S>"))]

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -382,7 +382,7 @@ where
     }
 
     #[tracing::instrument(skip_all, level = "debug")]
-    async fn get_inner_with_timing(&mut self, reason: &'static str) -> InnerGuard<S, Rt> {
+    async fn get_inner_with_timing(&mut self, reason: &'static str) -> InnerGuard<'_, S, Rt> {
         let channel_size = self.channel_size.fetch_sub(1, Ordering::Relaxed);
         InnerGuard::new(&mut self.inner, reason, channel_size)
     }

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -38,7 +38,7 @@ use thiserror::Error;
 use tokio::sync::{watch, Mutex};
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, trace, warn};
 
 struct Inner<S, Rt, Da>
 where

--- a/crates/full-node/sov-sequencer/tests/integration/pinned_cache.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/pinned_cache.rs
@@ -178,8 +178,6 @@ async fn test_nomt_basic_pinning_with_writes() {
     let mut da_layer = DaLayerWithSubscription::new(&test_rollup).await;
     da_layer.produce_and_wait_for_n_slots(nb_of_blocks).await;
     let client = test_rollup.api_client().clone();
-    let mut off_by_one_address = PINNED_ADDRESS;
-    off_by_one_address.0[31] += 1;
 
     for i in 0..8 {
         let tx = tx_write_pinned_cache(

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -19,7 +19,6 @@ use sov_rollup_interface::node::{
 };
 use sov_rollup_interface::stf::{
     ExecutionContext, ProofOutcome, ProofReceipt, ProofReceiptContents, StateTransitionFunction,
-    StoredEvent,
 };
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
@@ -64,16 +63,6 @@ where
     save_tx_bodies: bool,
     finalized_headers_provider: DaServiceWithCachedFinalizedHeaders<Da>,
     axum_tcp: Option<TcpListener>,
-}
-
-#[allow(dead_code)]
-struct DiscardEvents;
-impl TryFrom<(u64, &StoredEvent)> for DiscardEvents {
-    type Error = anyhow::Error;
-
-    fn try_from(_value: (u64, &StoredEvent)) -> Result<Self, Self::Error> {
-        Ok(Self)
-    }
 }
 
 /// Initializes rollup genesis.

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -66,6 +66,7 @@ where
     axum_tcp: Option<TcpListener>,
 }
 
+#[allow(dead_code)]
 struct DiscardEvents;
 impl TryFrom<(u64, &StoredEvent)> for DiscardEvents {
     type Error = anyhow::Error;

--- a/crates/module-system/hyperlane/tests/integration/warp/runtime.rs
+++ b/crates/module-system/hyperlane/tests/integration/warp/runtime.rs
@@ -30,10 +30,6 @@ generate_runtime! {
     auth_type: sov_modules_api::capabilities::RollupAuthenticator<S, TestRuntime<S>>,
     auth_call_wrapper: |call| call,
 }
-/// The input for the runtime's authenticator functionality.
-#[derive(std::fmt::Debug, Clone, borsh::BorshDeserialize, borsh::BorshSerialize)]
-#[allow(dead_code)]
-pub struct AuthenticatorInput(sov_modules_api::RawTx);
 
 pub const CONFIGURED_DOMAIN: u32 = 1;
 pub const CONFIGURED_REMOTE_ROUTER_ADDRESS: HexHash = HexString([1; 32]);

--- a/crates/module-system/hyperlane/tests/integration/warp/runtime.rs
+++ b/crates/module-system/hyperlane/tests/integration/warp/runtime.rs
@@ -32,6 +32,7 @@ generate_runtime! {
 }
 /// The input for the runtime's authenticator functionality.
 #[derive(std::fmt::Debug, Clone, borsh::BorshDeserialize, borsh::BorshSerialize)]
+#[allow(dead_code)]
 pub struct AuthenticatorInput(sov_modules_api::RawTx);
 
 pub const CONFIGURED_DOMAIN: u32 = 1;

--- a/crates/module-system/module-implementations/sov-attester-incentives/src/call.rs
+++ b/crates/module-system/module-implementations/sov-attester-incentives/src/call.rs
@@ -4,7 +4,6 @@ use std::fmt::Debug;
 use derivative::Derivative;
 use sov_modules_api::macros::{serialize, UniversalWallet};
 use thiserror::Error;
-use tracing::error;
 
 use crate::Amount;
 

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/event.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/event.rs
@@ -35,16 +35,6 @@ pub enum SlashingReason {
     IncorrectFinalSlotHash,
 }
 
-#[derive(Debug, PartialEq, Clone)]
-#[serialize(Borsh, Serde)]
-#[serde(rename_all = "snake_case")]
-#[allow(dead_code)]
-/// The reasons for penalizing a prover
-pub enum PenalizationReason {
-    /// We penalize the prover for submitting a proof for transitions that have already been processed
-    ProofAlreadyProcessed,
-}
-
 #[derive(Debug, PartialEq, Clone, schemars::JsonSchema)]
 #[serialize(Borsh, Serde)]
 #[serde(rename_all = "snake_case")]

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/event.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/event.rs
@@ -38,6 +38,7 @@ pub enum SlashingReason {
 #[derive(Debug, PartialEq, Clone)]
 #[serialize(Borsh, Serde)]
 #[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
 /// The reasons for penalizing a prover
 pub enum PenalizationReason {
     /// We penalize the prover for submitting a proof for transitions that have already been processed

--- a/crates/module-system/sov-modules-api/src/containers/map.rs
+++ b/crates/module-system/sov-modules-api/src/containers/map.rs
@@ -237,7 +237,7 @@ where
         &self,
         key: &Kq,
         state: &mut Reader,
-    ) -> Result<Borrowed<Option<V>, Self>, Reader::Error>
+    ) -> Result<Borrowed<'_, Option<V>, Self>, Reader::Error>
     where
         Codec::KeyCodec: EncodeLike<Kq, K>,
         Kq: ?Sized,
@@ -255,7 +255,7 @@ where
         &mut self,
         key: &Kq,
         state: &mut Reader,
-    ) -> Result<BorrowedMut<Option<V>, Self>, Reader::Error>
+    ) -> Result<BorrowedMut<'_, Option<V>, Self>, Reader::Error>
     where
         Codec::KeyCodec: EncodeLike<Kq, K>,
         Kq: ?Sized,

--- a/crates/module-system/sov-modules-api/src/containers/value.rs
+++ b/crates/module-system/sov-modules-api/src/containers/value.rs
@@ -116,7 +116,7 @@ where
     pub fn borrow<Reader>(
         &self,
         state: &mut Reader,
-    ) -> Result<Borrowed<Option<V>, Self>, Reader::Error>
+    ) -> Result<Borrowed<'_, Option<V>, Self>, Reader::Error>
     where
         Reader: StateReader<N>,
     {
@@ -130,7 +130,7 @@ where
     pub fn borrow_mut<Reader>(
         &mut self,
         state: &mut Reader,
-    ) -> Result<BorrowedMut<Option<V>, Self>, Reader::Error>
+    ) -> Result<BorrowedMut<'_, Option<V>, Self>, Reader::Error>
     where
         Reader: StateReader<N>,
     {

--- a/crates/module-system/sov-modules-api/src/lib.rs
+++ b/crates/module-system/sov-modules-api/src/lib.rs
@@ -262,7 +262,7 @@ impl<'a, S: Spec> ModuleVisitor<'a, S> {
     fn visit_module(
         &mut self,
         module: &'a dyn ModuleInfo<Spec = S>,
-        module_map: &HashMap<&'a ModuleId, &'a (dyn ModuleInfo<Spec = S>)>,
+        module_map: &HashMap<&'a ModuleId, &'a dyn ModuleInfo<Spec = S>>,
     ) -> anyhow::Result<()> {
         let id = module.id();
 

--- a/crates/module-system/sov-modules-api/src/state/accessors/checkpoints.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/checkpoints.rs
@@ -414,7 +414,7 @@ pub mod native {
         ///
         /// You can use this method when calling getters and setters on accessory
         /// state containers, like AccessoryStateMap.
-        pub fn accessory_state(&mut self) -> AccessoryStateCheckpoint<S> {
+        pub fn accessory_state(&mut self) -> AccessoryStateCheckpoint<'_, S> {
             AccessoryStateCheckpoint { checkpoint: self }
         }
     }

--- a/crates/module-system/sov-modules-api/src/state/accessors/genesis.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/genesis.rs
@@ -25,7 +25,7 @@ impl<S: Spec> StateCheckpoint<S> {
         &mut self,
         // This argument prevents this method from being called outside of genesis.
         _config: &G::Config,
-    ) -> GenesisStateAccessor<S> {
+    ) -> GenesisStateAccessor<'_, S> {
         GenesisStateAccessor {
             checkpoint: self,
             events: Vec::default(),

--- a/crates/module-system/sov-modules-api/src/state/accessors/temp_cache.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/temp_cache.rs
@@ -16,7 +16,7 @@ const MAX_EXPECTED_CACHE_ITEMS: usize = 100;
 /// This is used to warn if the cache is getting too large.
 const MAX_EXPECTED_CACHE_BYTES: usize = 10_000_000; // 10MB
 
-type Value = Option<(Box<(dyn Any + Send + Sync + 'static)>, usize)>;
+type Value = Option<(Box<dyn Any + Send + Sync + 'static>, usize)>;
 
 /// The result of a cache lookup.
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/module-system/sov-modules-api/src/state/traits.rs
+++ b/crates/module-system/sov-modules-api/src/state/traits.rs
@@ -41,7 +41,7 @@ use crate::{Gas, GasMeter, GasMeteringError, GasSpec, RevertableTxState, Spec};
 pub trait StateAccessor: StateReaderAndWriter<User> {
     /// Converts this accessor into an [`UnmeteredStateWrapper`]. This method should only be used either in tests or in the `EVM` module.
     #[cfg(any(feature = "test-utils", feature = "evm"))]
-    fn to_unmetered(&mut self) -> UnmeteredStateWrapper<Self>
+    fn to_unmetered(&mut self) -> UnmeteredStateWrapper<'_, Self>
     where
         Self: Sized,
     {
@@ -114,7 +114,7 @@ pub trait TxState<S: Spec>:
     /// Converts this state accessor into a [`RevertableTxState`].
     ///
     /// You *MUST* call .commit() to save the changes from the resulting accessor if you want them to be persisted
-    fn to_revertable(&mut self) -> RevertableTxState<S, Self> {
+    fn to_revertable(&mut self) -> RevertableTxState<'_, S, Self> {
         RevertableTxState::new(self)
     }
 }

--- a/crates/module-system/sov-modules-macros/tests/integration/dispatch.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/dispatch.rs
@@ -258,6 +258,7 @@ pub mod third_test_module {
 mod custom_attributes {
     use super::*;
     #[derive(Default, Genesis, DispatchCall, Event, MessageCodec)]
+    #[allow(dead_code)]
     struct Runtime<S: Spec> {
         pub chain_state: first_test_module::FirstTestStruct<S>,
         pub second: second_test_module::SecondTestStruct<S>,
@@ -275,6 +276,7 @@ mod derive_event {
 
     use super::*;
     #[derive(Default, Genesis, DispatchCall, Event, MessageCodec)]
+    #[allow(dead_code)]
     struct Runtime<S: Spec> {
         pub chain_state: first_test_module::FirstTestStruct<S>,
         pub second: second_test_module::SecondTestStruct<S>,

--- a/crates/module-system/sov-modules-macros/tests/integration/hygienic_module_info.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/hygienic_module_info.rs
@@ -4,6 +4,7 @@
 use sov_modules_api::{ModuleId, ModuleInfo, Spec, StateMap};
 
 #[derive(Clone, ModuleInfo)]
+#[allow(dead_code)]
 struct Module1<SpecWithWeirdNameForTesting: Spec> {
     #[id]
     pub id: ModuleId,
@@ -14,6 +15,7 @@ struct Module1<SpecWithWeirdNameForTesting: Spec> {
 }
 
 #[derive(Clone, ModuleInfo)]
+#[allow(dead_code)]
 struct Module2<SpecWithWeirdNameForTesting: Spec> {
     #[id]
     pub id: ModuleId,

--- a/crates/module-system/sov-modules-macros/tests/integration/regression_tests/derive_rpc_without_working_set_deny_missing_docs.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/regression_tests/derive_rpc_without_working_set_deny_missing_docs.rs
@@ -4,6 +4,7 @@ use sov_modules_api::macros::rpc_gen;
 use sov_modules_api::{ModuleId, Spec};
 
 #[derive(sov_modules_api::ModuleInfo, Clone)]
+#[allow(dead_code)]
 pub struct TestStruct<S: Spec> {
     #[id]
     pub(crate) id: ModuleId,

--- a/crates/module-system/sov-modules-macros/tests/integration/regression_tests/use_address_trait.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/regression_tests/use_address_trait.rs
@@ -5,6 +5,7 @@
 use sov_modules_api::{BasicAddress, ModuleId, ModuleInfo, Spec};
 
 #[derive(Clone, ModuleInfo)]
+#[allow(dead_code)]
 struct TestModule<S: Spec> {
     #[id]
     id: ModuleId,

--- a/crates/module-system/sov-modules-macros/tests/integration/regression_tests/versioned_state_items_are_compatible_with_module_rest_api_macro.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/regression_tests/versioned_state_items_are_compatible_with_module_rest_api_macro.rs
@@ -5,6 +5,7 @@
 use sov_modules_api::{Module, ModuleId, ModuleInfo, ModuleRestApi, Spec, VersionedStateValue};
 
 #[derive(Clone, ModuleInfo, ModuleRestApi)]
+#[allow(dead_code)]
 struct TestModule<S: Spec> {
     #[id]
     id: ModuleId,

--- a/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/misc.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/misc.rs
@@ -109,6 +109,7 @@ where
 
 #[derive(Default, DispatchCall)]
 #[expose_rpc]
+#[allow(dead_code)]
 pub struct TestRuntime<S: Spec> {
     module: MyModule<S, u32>,
 }

--- a/crates/module-system/sov-modules-macros/tests/integration/unrecognized_state_attributes_are_ignored.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/unrecognized_state_attributes_are_ignored.rs
@@ -1,6 +1,7 @@
 use sov_modules_api::{ModuleId, ModuleInfo, Spec, StateMap};
 
 #[derive(Clone, ModuleInfo)]
+#[allow(dead_code)]
 struct TestStruct<S: Spec> {
     #[id]
     id: ModuleId,

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/proof_sender.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/proof_sender.rs
@@ -119,6 +119,7 @@ fn make_details<S: Spec>(max_fee: Amount) -> TxDetails<S> {
 }
 
 #[derive(Debug, PartialEq, Clone, BorshDeserialize, BorshSerialize)]
+#[allow(dead_code)]
 struct PreferredProofData {
     sequence_number: u64,
     data: Vec<u8>,

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -362,7 +362,7 @@ where
         historical_state: HistoricalStateReader,
         accessory_db: AccessoryDb,
         strict_with_witness: bool,
-        pinned_cache: Option<Box<(dyn Any + Send + Sync)>>,
+        pinned_cache: Option<Box<dyn Any + Send + Sync>>,
     ) -> Self {
         let pinned_cache: Option<PinnedCache> = pinned_cache.map(|c| *c.downcast().expect("Failed to downcast the pinned_cache argument to `NomtProverStorage`. This is a bug. Please report it."));
         Self::create(
@@ -607,7 +607,7 @@ where
         )
         .expect("accessory db materialization must succeed");
         // Erase the type of the pinned cache since the storage manager isn't aware of it.
-        let pinned_cache = pinned_cache.map(|c| Box::new(c) as Box<(dyn Any + Send + Sync)>);
+        let pinned_cache = pinned_cache.map(|c| Box::new(c) as Box<dyn Any + Send + Sync>);
         NomtChangeSet {
             state: StateFinishedSession::new(user, kernel),
             historical_state: historical_schema_batch,

--- a/crates/rollup-interface/src/node/da.rs
+++ b/crates/rollup-interface/src/node/da.rs
@@ -8,7 +8,6 @@ use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
-use tracing::error;
 
 use crate::common::HexHash;
 use crate::da::{BlockHeaderTrait, DaSpec, DaVerifier, RelevantBlobs, RelevantProofs, Time};

--- a/crates/universal-wallet/schema/tests/integration/schema.rs
+++ b/crates/universal-wallet/schema/tests/integration/schema.rs
@@ -370,6 +370,7 @@ pub enum SimpleEnumWithTemplate {
     BorshDeserialize,
 )]
 #[sov_wallet(template_inherit)]
+#[allow(dead_code)]
 pub enum SimplerEnumWithTemplate {
     One(SimpleStructWithTemplate),
 }
@@ -794,12 +795,14 @@ impl UniversalWallet for SchemalessStringWrapper {
 
 #[derive(Debug, PartialEq, Eq, Clone, UniversalWallet)]
 #[cfg_attr(test, derive(BorshSerialize, BorshDeserialize))]
+#[allow(dead_code)]
 pub struct VecOfThing {
     memo: Vec<StringWrapper>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, UniversalWallet)]
 #[cfg_attr(test, derive(BorshSerialize, BorshDeserialize))]
+#[allow(dead_code)]
 pub struct VecOfWrapper {
     memo: Vec<SchemalessStringWrapper>,
 }
@@ -1181,6 +1184,7 @@ pub enum EnumWithStruct {
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 #[cfg_attr(test, derive(UniversalWallet, BorshSerialize, BorshDeserialize))]
+#[allow(dead_code)]
 pub enum EnumWithTwoStructs {
     Foo {
         first_field: u64,

--- a/crates/utils/transaction-generator/src/generators/access_pattern/http.rs
+++ b/crates/utils/transaction-generator/src/generators/access_pattern/http.rs
@@ -12,6 +12,7 @@ pub struct HttpStorageAccessClient {
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
+#[allow(dead_code)]
 struct LenResponse {
     length: u64,
 }

--- a/crates/utils/transaction-generator/src/generators/access_pattern/http.rs
+++ b/crates/utils/transaction-generator/src/generators/access_pattern/http.rs
@@ -11,12 +11,6 @@ pub struct HttpStorageAccessClient {
     rollup_height: Option<u64>,
 }
 
-#[derive(serde::Deserialize, serde::Serialize)]
-#[allow(dead_code)]
-struct LenResponse {
-    length: u64,
-}
-
 #[derive(Debug, Deserialize)]
 struct MapResponse<T> {
     #[allow(unused)]

--- a/crates/utils/transaction-generator/src/interface/mod.rs
+++ b/crates/utils/transaction-generator/src/interface/mod.rs
@@ -268,7 +268,7 @@ impl<T> Distribution<T> {
     }
 
     /// Maps the values inside the distribution using the mapping function
-    pub fn map_values<U>(self, map_fn: &mut impl (FnMut(T) -> U)) -> Distribution<U> {
+    pub fn map_values<U>(self, map_fn: &mut impl FnMut(T) -> U) -> Distribution<U> {
         Distribution {
             weights_and_values: self
                 .weights_and_values


### PR DESCRIPTION
# Description

This PR contains only code cleanup and removes unused code, with no functional impact.

  Unused imports removed:                                                                                                                                                                                                                                      
  - crates/rollup-interface/src/node/da.rs: Removed use tracing::error                                                                                                                                                                                         
  - crates/module-system/module-implementations/sov-attester-incentives/src/call.rs: Removed use tracing::error                                                                                                                                                
  - crates/full-node/sov-sequencer/src/preferred/mod.rs: Removed use serde_with::serde_as                                                                                                                                                                      
  - crates/full-node/sov-sequencer/src/standard/mod.rs: Removed error from tracing imports                                                                                                                                                                     
                                                                                                                                                                                                                                                               
  Unnecessary parentheses around types removed (from Box<(dyn Any + Send + Sync)> to Box<dyn Any + Send + Sync>):                                                                                                                                              
  - crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs (4 locations)                                                                                                                                                                                
  - crates/full-node/sov-db/src/test_utils.rs                                                                                                                                                                                                                  
  - crates/module-system/sov-state/src/nomt/prover_storage.rs (2 locations)                                                                                                                                                                                    
  - crates/module-system/sov-modules-api/src/state/accessors/temp_cache.rs                                                                                                                                                                                     
  - crates/module-system/sov-modules-api/src/lib.rs                                                                                                                                                                                                            
  - crates/utils/transaction-generator/src/interface/mod.rs                                                                                                                                                                                                    
                                                                                                                                                                                                                                                               
  Hidden lifetime warnings fixed (added '_ to make elided lifetimes explicit):                                                                                                                                                                                 
  - crates/full-node/sov-db/src/state_db.rs: JmtHandler<'_, N>                                                                                                                                                                                                 
  - crates/module-system/sov-modules-api/src/containers/map.rs: Borrowed<'_, ...> and BorrowedMut<'_, ...>                                                                                                                                                     
  - crates/module-system/sov-modules-api/src/containers/value.rs: same                                                                                                                                                                                         
  - crates/module-system/sov-modules-api/src/state/traits.rs: RevertableTxState<'_, S, Self> and UnmeteredStateWrapper<'_, Self>                                                                                                                               
  - crates/module-system/sov-modules-api/src/state/accessors/checkpoints.rs: AccessoryStateCheckpoint<'_, S>                                                                                                                                                   
  - crates/module-system/sov-modules-api/src/state/accessors/genesis.rs: GenesisStateAccessor<'_, S>                                                                                                                                                           
  - crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs: InnerGuard<'_, S, Rt>                                                                                                                                                     
                                                                                                                                                                                                                                                               
  Dead code warnings fixed (added #[allow(dead_code)]):                                                                                                                                                                                                        
  - crates/full-node/sov-stf-runner/src/runner.rs: DiscardEvents                                                                                                                                                                                               
  - crates/module-system/module-implementations/sov-prover-incentives/src/event.rs: PenalizationReason                                                                                                                                                         
  - crates/full-node/sov-sequencer/src/preferred/mod.rs: TxBody                                                                                                                                                                                                
  - crates/module-system/sov-modules-rollup-blueprint/src/native_only/proof_sender.rs: PreferredProofData                                                                                                                                                      
  - crates/utils/transaction-generator/src/generators/access_pattern/http.rs: LenResponse                                                                                                                                                                      
  - Multiple test files with macro-generated structs                                                                                                                                                                                                           
                                                                                                                                                                                                                                                               
  Unused variable removed:                                                                                                                                                                                                                                     
  - crates/full-node/sov-sequencer/tests/integration/pinned_cache.rs: Removed unused off_by_one_address variable 

Unused code is removed in commit #[f903ce6](https://github.com/Sovereign-Labs/sovereign-sdk/pull/2409/commits/f903ce69f1b5a19f5e82edb34da1377fe24fdd93)
