### PR TITLE
Rename` SequencerRole` and `NodeRole` enums for clarity.

### DIFF
--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -130,7 +130,7 @@ pub enum RecoveryStrategy {
 }
 
 #[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
-pub enum NodeStartingRole {
+pub enum ConfiguredNodeRole {
     /// This node runs as the leader. The leader is responsible for producing new batches.
     Leader,
     /// This node runs as a replica, syncing its state from the leader.
@@ -157,7 +157,7 @@ pub struct PostgresConfig {
     /// Id of the node.
     pub node_id: String,
     #[allow(missing_docs)]
-    pub node_role: NodeStartingRole,
+    pub node_role: ConfiguredNodeRole,
 }
 
 /// Configuration for [`PreferredSequencer`].

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -130,7 +130,7 @@ pub enum RecoveryStrategy {
 }
 
 #[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, JsonSchema)]
-pub enum NodeRole {
+pub enum NodeStartingRole {
     /// This node runs as the leader. The leader is responsible for producing new batches.
     Leader,
     /// This node runs as a replica, syncing its state from the leader.
@@ -157,7 +157,7 @@ pub struct PostgresConfig {
     /// Id of the node.
     pub node_id: String,
     #[allow(missing_docs)]
-    pub node_role: NodeRole,
+    pub node_role: NodeStartingRole,
 }
 
 /// Configuration for [`PreferredSequencer`].

--- a/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/cache_warm_up_executor.rs
@@ -154,7 +154,7 @@ impl<S: Spec> CacheWarmUpExecutor<S> {
         seq_config: SequencerConfig<S::Address, PreferredSequencerConfig<S::Address>>,
         seq_role: SequencerRole,
     ) -> (Self, Vec<JoinHandle<()>>) {
-        if seq_role != SequencerRole::Leader {
+        if seq_role != SequencerRole::BatchProducer {
             return (Self { inner: None }, vec![]);
         }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -422,12 +422,12 @@ impl From<BatchToStore> for StoredBlob {
 /// The role of the sequencer in a distributed setup.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum SequencerRole {
-    /// Replica that does not sync with the leader.
-    ReplicaNoLeaderSync,
-    /// Replica that syncs with the leader via PostgreSQL.
-    Replica,
-    /// Leader node that accepts transactions and produces batches.
-    Leader,
+    /// Node that does not sync with the `BatchProducer` and relies on DA for updates.
+    DaOnlyReplica,
+    /// Node that syncs with the `BatchProducer`` via PostgreSQL.
+    PgSyncReplica,
+    /// Node that accepts transactions and produces batches.
+    BatchProducer,
 }
 
 pub struct PreferredSequencerDb {
@@ -449,18 +449,18 @@ impl PreferredSequencerDb {
                         // Connect and register the node without attempting leader election.
                         // The backend is dropped after registration since replicas don't need it.
                         PostgresBackend::connect_as_replica(postgres_config, bind_addr).await?;
-                        (None, SequencerRole::ReplicaNoLeaderSync)
+                        (None, SequencerRole::DaOnlyReplica)
                     }
                     NodeRole::Replica => {
                         // Connect and register the node without attempting leader election.
                         // The backend is dropped after registration since replicas don't need it.
                         PostgresBackend::connect_as_replica(postgres_config, bind_addr).await?;
-                        (None, SequencerRole::Replica)
+                        (None, SequencerRole::PgSyncReplica)
                     }
                     NodeRole::Leader => {
                         let (backend, _) =
                             PostgresBackend::connect(postgres_config, bind_addr).await?;
-                        (Some(Box::new(backend)), SequencerRole::Leader)
+                        (Some(Box::new(backend)), SequencerRole::BatchProducer)
                     }
                     NodeRole::DbElected => {
                         // Connect and attempt to acquire leadership
@@ -474,22 +474,22 @@ impl PreferredSequencerDb {
                         if is_leader {
                             tracing::info!(
                                 node_id = %postgres_config.node_id,
-                                "DbElected node acquired leadership, running as Leader"
+                                "DbElected node acquired leadership, running as BatchProducer"
                             );
-                            (Some(Box::new(backend)), SequencerRole::Leader)
+                            (Some(Box::new(backend)), SequencerRole::BatchProducer)
                         } else {
                             tracing::info!(
                                 node_id = %postgres_config.node_id,
-                                "DbElected node did not acquire leadership, running as Replica"
+                                "DbElected node did not acquire leadership, running as PgSyncReplica"
                             );
-                            (None, SequencerRole::Replica)
+                            (None, SequencerRole::PgSyncReplica)
                         }
                     }
                 }
             } else {
                 (
                     Some(Box::new(RocksDbBackend::new(storage_path).await?)),
-                    SequencerRole::Leader,
+                    SequencerRole::BatchProducer,
                 )
             }
         };

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -19,7 +19,7 @@ use axum::async_trait;
 use borsh::{BorshDeserialize, BorshSerialize};
 use sov_blob_sender::{new_blob_id, BlobInternalId};
 use sov_blob_storage::{PreferredBatchData, SequenceNumber};
-use sov_full_node_configs::sequencer::NodeStartingRole;
+use sov_full_node_configs::sequencer::ConfiguredNodeRole;
 use sov_full_node_configs::sequencer::PostgresConfig;
 use sov_modules_api::capabilities::BlobSelector;
 use sov_modules_api::{
@@ -445,24 +445,24 @@ impl PreferredSequencerDb {
         let (backend, role): (Option<Box<dyn DbBackend>>, _) = {
             if let Some(postgres_config) = &postgres_config {
                 match postgres_config.node_role {
-                    NodeStartingRole::ReplicaNoLeaderSync => {
+                    ConfiguredNodeRole::ReplicaNoLeaderSync => {
                         // Connect and register the node without attempting leader election.
                         // The backend is dropped after registration since replicas don't need it.
                         PostgresBackend::connect_as_replica(postgres_config, bind_addr).await?;
                         (None, SequencerRole::DaOnlyReplica)
                     }
-                    NodeStartingRole::Replica => {
+                    ConfiguredNodeRole::Replica => {
                         // Connect and register the node without attempting leader election.
                         // The backend is dropped after registration since replicas don't need it.
                         PostgresBackend::connect_as_replica(postgres_config, bind_addr).await?;
                         (None, SequencerRole::PgSyncReplica)
                     }
-                    NodeStartingRole::Leader => {
+                    ConfiguredNodeRole::Leader => {
                         let (backend, _) =
                             PostgresBackend::connect(postgres_config, bind_addr).await?;
                         (Some(Box::new(backend)), SequencerRole::BatchProducer)
                     }
-                    NodeStartingRole::DbElected => {
+                    ConfiguredNodeRole::DbElected => {
                         // Connect and attempt to acquire leadership
                         let (backend, maybe_leader) =
                             PostgresBackend::connect(postgres_config, bind_addr).await?;

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -19,7 +19,7 @@ use axum::async_trait;
 use borsh::{BorshDeserialize, BorshSerialize};
 use sov_blob_sender::{new_blob_id, BlobInternalId};
 use sov_blob_storage::{PreferredBatchData, SequenceNumber};
-use sov_full_node_configs::sequencer::NodeRole;
+use sov_full_node_configs::sequencer::NodeStartingRole;
 use sov_full_node_configs::sequencer::PostgresConfig;
 use sov_modules_api::capabilities::BlobSelector;
 use sov_modules_api::{
@@ -445,24 +445,24 @@ impl PreferredSequencerDb {
         let (backend, role): (Option<Box<dyn DbBackend>>, _) = {
             if let Some(postgres_config) = &postgres_config {
                 match postgres_config.node_role {
-                    NodeRole::ReplicaNoLeaderSync => {
+                    NodeStartingRole::ReplicaNoLeaderSync => {
                         // Connect and register the node without attempting leader election.
                         // The backend is dropped after registration since replicas don't need it.
                         PostgresBackend::connect_as_replica(postgres_config, bind_addr).await?;
                         (None, SequencerRole::DaOnlyReplica)
                     }
-                    NodeRole::Replica => {
+                    NodeStartingRole::Replica => {
                         // Connect and register the node without attempting leader election.
                         // The backend is dropped after registration since replicas don't need it.
                         PostgresBackend::connect_as_replica(postgres_config, bind_addr).await?;
                         (None, SequencerRole::PgSyncReplica)
                     }
-                    NodeRole::Leader => {
+                    NodeStartingRole::Leader => {
                         let (backend, _) =
                             PostgresBackend::connect(postgres_config, bind_addr).await?;
                         (Some(Box::new(backend)), SequencerRole::BatchProducer)
                     }
-                    NodeRole::DbElected => {
+                    NodeStartingRole::DbElected => {
                         // Connect and attempt to acquire leadership
                         let (backend, maybe_leader) =
                             PostgresBackend::connect(postgres_config, bind_addr).await?;

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -424,7 +424,7 @@ impl From<BatchToStore> for StoredBlob {
 pub enum SequencerRole {
     /// Node that does not sync with the `BatchProducer` and relies on DA for updates.
     DaOnlyReplica,
-    /// Node that syncs with the `BatchProducer`` via PostgreSQL.
+    /// Node that syncs with the `BatchProducer` via PostgreSQL.
     PgSyncReplica,
     /// Node that accepts transactions and produces batches.
     BatchProducer,

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -723,7 +723,7 @@ fn get_local_ip(ip: IpAddr) -> Result<std::net::IpAddr> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sov_full_node_configs::sequencer::NodeStartingRole;
+    use sov_full_node_configs::sequencer::ConfiguredNodeRole;
     use sov_modules_api::VisibleSlotNumber;
     use sov_test_utils::postgres::{
         config_from_postgres_container, create_postgres_container, CreatePostgresError,
@@ -744,13 +744,13 @@ mod tests {
         let db_1 = &mut DB::new(
             &postgres,
             String::from("node_id_1"),
-            NodeStartingRole::Leader,
+            ConfiguredNodeRole::Leader,
         )
         .await;
         let db_2 = &mut DB::new(
             &postgres,
             String::from("node_id_2"),
-            NodeStartingRole::Replica,
+            ConfiguredNodeRole::Replica,
         )
         .await;
 
@@ -804,7 +804,7 @@ mod tests {
         let db = &mut DB::new(
             &postgres,
             String::from("node_id_1"),
-            NodeStartingRole::Leader,
+            ConfiguredNodeRole::Leader,
         )
         .await;
         db.maybe_update_leader().await.unwrap();
@@ -866,13 +866,13 @@ mod tests {
         let db_leader = &mut DB::new(
             &postgres,
             String::from("node_id_1"),
-            NodeStartingRole::Leader,
+            ConfiguredNodeRole::Leader,
         )
         .await;
         let db_replica = &mut DB::new(
             &postgres,
             String::from("node_id_2"),
-            NodeStartingRole::Replica,
+            ConfiguredNodeRole::Replica,
         )
         .await;
 
@@ -984,7 +984,7 @@ mod tests {
         async fn new(
             postgres: &sov_test_utils::postgres::ContainerAsync<sov_test_utils::postgres::Postgres>,
             node_id: String,
-            node_role: NodeStartingRole,
+            node_role: ConfiguredNodeRole,
         ) -> Self {
             let leader_timeout = Duration::from_millis(100_000);
             let postgres_config =
@@ -1042,7 +1042,7 @@ mod tests {
             }
         };
 
-        let db = DB::new(&postgres, String::from("node_1"), NodeStartingRole::Leader).await;
+        let db = DB::new(&postgres, String::from("node_1"), ConfiguredNodeRole::Leader).await;
 
         let mut listener = sqlx::postgres::PgListener::connect_with(&db.backend.pool)
             .await
@@ -1086,8 +1086,8 @@ mod tests {
             }
         };
 
-        let db_1 = &mut DB::new(&postgres, String::from("node_1"), NodeStartingRole::Leader).await;
-        let db_2 = &mut DB::new(&postgres, String::from("node_2"), NodeStartingRole::Replica).await;
+        let db_1 = &mut DB::new(&postgres, String::from("node_1"), ConfiguredNodeRole::Leader).await;
+        let db_2 = &mut DB::new(&postgres, String::from("node_2"), ConfiguredNodeRole::Replica).await;
 
         // Node 1 becomes leader
         db_1.maybe_update_leader().await.unwrap();

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -741,8 +741,18 @@ mod tests {
             }
         };
 
-        let db_1 = &mut DB::new(&postgres, String::from("node_id_1"), NodeStartingRole::Leader).await;
-        let db_2 = &mut DB::new(&postgres, String::from("node_id_2"), NodeStartingRole::Replica).await;
+        let db_1 = &mut DB::new(
+            &postgres,
+            String::from("node_id_1"),
+            NodeStartingRole::Leader,
+        )
+        .await;
+        let db_2 = &mut DB::new(
+            &postgres,
+            String::from("node_id_2"),
+            NodeStartingRole::Replica,
+        )
+        .await;
 
         {
             // Updating the same node_id should change the last updated time in the db.
@@ -791,7 +801,12 @@ mod tests {
             }
         };
 
-        let db = &mut DB::new(&postgres, String::from("node_id_1"), NodeStartingRole::Leader).await;
+        let db = &mut DB::new(
+            &postgres,
+            String::from("node_id_1"),
+            NodeStartingRole::Leader,
+        )
+        .await;
         db.maybe_update_leader().await.unwrap();
 
         let sequence_number = 1;
@@ -848,9 +863,18 @@ mod tests {
                 panic!("Failed to create Postgres container: {e}");
             }
         };
-        let db_leader = &mut DB::new(&postgres, String::from("node_id_1"), NodeStartingRole::Leader).await;
-        let db_replica =
-            &mut DB::new(&postgres, String::from("node_id_2"), NodeStartingRole::Replica).await;
+        let db_leader = &mut DB::new(
+            &postgres,
+            String::from("node_id_1"),
+            NodeStartingRole::Leader,
+        )
+        .await;
+        let db_replica = &mut DB::new(
+            &postgres,
+            String::from("node_id_2"),
+            NodeStartingRole::Replica,
+        )
+        .await;
 
         let sequence_number = 1;
         let batch_to_store = batch_to_store(sequence_number);

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -723,7 +723,7 @@ fn get_local_ip(ip: IpAddr) -> Result<std::net::IpAddr> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sov_full_node_configs::sequencer::NodeRole;
+    use sov_full_node_configs::sequencer::NodeStartingRole;
     use sov_modules_api::VisibleSlotNumber;
     use sov_test_utils::postgres::{
         config_from_postgres_container, create_postgres_container, CreatePostgresError,
@@ -741,8 +741,8 @@ mod tests {
             }
         };
 
-        let db_1 = &mut DB::new(&postgres, String::from("node_id_1"), NodeRole::Leader).await;
-        let db_2 = &mut DB::new(&postgres, String::from("node_id_2"), NodeRole::Replica).await;
+        let db_1 = &mut DB::new(&postgres, String::from("node_id_1"), NodeStartingRole::Leader).await;
+        let db_2 = &mut DB::new(&postgres, String::from("node_id_2"), NodeStartingRole::Replica).await;
 
         {
             // Updating the same node_id should change the last updated time in the db.
@@ -791,7 +791,7 @@ mod tests {
             }
         };
 
-        let db = &mut DB::new(&postgres, String::from("node_id_1"), NodeRole::Leader).await;
+        let db = &mut DB::new(&postgres, String::from("node_id_1"), NodeStartingRole::Leader).await;
         db.maybe_update_leader().await.unwrap();
 
         let sequence_number = 1;
@@ -848,9 +848,9 @@ mod tests {
                 panic!("Failed to create Postgres container: {e}");
             }
         };
-        let db_leader = &mut DB::new(&postgres, String::from("node_id_1"), NodeRole::Leader).await;
+        let db_leader = &mut DB::new(&postgres, String::from("node_id_1"), NodeStartingRole::Leader).await;
         let db_replica =
-            &mut DB::new(&postgres, String::from("node_id_2"), NodeRole::Replica).await;
+            &mut DB::new(&postgres, String::from("node_id_2"), NodeStartingRole::Replica).await;
 
         let sequence_number = 1;
         let batch_to_store = batch_to_store(sequence_number);
@@ -960,7 +960,7 @@ mod tests {
         async fn new(
             postgres: &sov_test_utils::postgres::ContainerAsync<sov_test_utils::postgres::Postgres>,
             node_id: String,
-            node_role: NodeRole,
+            node_role: NodeStartingRole,
         ) -> Self {
             let leader_timeout = Duration::from_millis(100_000);
             let postgres_config =
@@ -1018,7 +1018,7 @@ mod tests {
             }
         };
 
-        let db = DB::new(&postgres, String::from("node_1"), NodeRole::Leader).await;
+        let db = DB::new(&postgres, String::from("node_1"), NodeStartingRole::Leader).await;
 
         let mut listener = sqlx::postgres::PgListener::connect_with(&db.backend.pool)
             .await
@@ -1062,8 +1062,8 @@ mod tests {
             }
         };
 
-        let db_1 = &mut DB::new(&postgres, String::from("node_1"), NodeRole::Leader).await;
-        let db_2 = &mut DB::new(&postgres, String::from("node_2"), NodeRole::Replica).await;
+        let db_1 = &mut DB::new(&postgres, String::from("node_1"), NodeStartingRole::Leader).await;
+        let db_2 = &mut DB::new(&postgres, String::from("node_2"), NodeStartingRole::Replica).await;
 
         // Node 1 becomes leader
         db_1.maybe_update_leader().await.unwrap();

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -1042,7 +1042,12 @@ mod tests {
             }
         };
 
-        let db = DB::new(&postgres, String::from("node_1"), ConfiguredNodeRole::Leader).await;
+        let db = DB::new(
+            &postgres,
+            String::from("node_1"),
+            ConfiguredNodeRole::Leader,
+        )
+        .await;
 
         let mut listener = sqlx::postgres::PgListener::connect_with(&db.backend.pool)
             .await
@@ -1086,8 +1091,18 @@ mod tests {
             }
         };
 
-        let db_1 = &mut DB::new(&postgres, String::from("node_1"), ConfiguredNodeRole::Leader).await;
-        let db_2 = &mut DB::new(&postgres, String::from("node_2"), ConfiguredNodeRole::Replica).await;
+        let db_1 = &mut DB::new(
+            &postgres,
+            String::from("node_1"),
+            ConfiguredNodeRole::Leader,
+        )
+        .await;
+        let db_2 = &mut DB::new(
+            &postgres,
+            String::from("node_2"),
+            ConfiguredNodeRole::Replica,
+        )
+        .await;
 
         // Node 1 becomes leader
         db_1.maybe_update_leader().await.unwrap();

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -242,7 +242,7 @@ where
 
         // Launch leadership task for DbElected nodes
         if let Some(postgres_config) = &preferred_config.postgres_config {
-            if postgres_config.node_role == NodeRole::DbElected {
+            if postgres_config.node_role == NodeStartingRole::DbElected {
                 let election_task = LeadershipElectionTask::new(
                     postgres_config,
                     shutdown_sender.clone(),

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -242,7 +242,7 @@ where
 
         // Launch leadership task for DbElected nodes
         if let Some(postgres_config) = &preferred_config.postgres_config {
-            if postgres_config.node_role == NodeStartingRole::DbElected {
+            if postgres_config.node_role == ConfiguredNodeRole::DbElected {
                 let election_task = LeadershipElectionTask::new(
                     postgres_config,
                     shutdown_sender.clone(),

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -230,7 +230,7 @@ where
         }));
 
         // Launch replica sync task only for replicas.
-        if let SequencerRole::Replica = seq_role {
+        if let SequencerRole::PgSyncReplica = seq_role {
             if let Some(postgres_config) = &preferred_config.postgres_config {
                 let replica_task_handle = replica_task
                     .start(synchronized_state_updator, postgres_config)
@@ -251,9 +251,11 @@ where
                 .await?;
 
                 let leadership_handle = match seq_role {
-                    SequencerRole::Leader => election_task.spawn_leader_heartbeat_task(),
-                    SequencerRole::Replica => election_task.spawn_replica_election_task(),
-                    _ => unreachable!("DbElected should only result in Leader or Replica role"),
+                    SequencerRole::BatchProducer => election_task.spawn_leader_heartbeat_task(),
+                    SequencerRole::PgSyncReplica => election_task.spawn_replica_election_task(),
+                    _ => unreachable!(
+                        "DbElected should only result in BatchProducer or PgSyncReplica role"
+                    ),
                 };
                 handles.push(leadership_handle);
             }
@@ -281,7 +283,7 @@ where
         }));
 
         if let Some(oracle_config) = maybe_oracle_config {
-            if let SequencerRole::Leader = seq_role {
+            if let SequencerRole::BatchProducer = seq_role {
                 if Rt::default().maybe_set_oracle_timestamp(0).is_some() {
                     match update_timestamp_task(seq.clone(), oracle_config, shutdown_receiver) {
                         Ok(handle) => handles.push(handle),

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -41,7 +41,8 @@ use sov_blob_sender::{new_blob_id, BlobExecutionStatus};
 use sov_blob_storage::{PreferredBatchData, SequenceNumber};
 use sov_db::ledger_db::LedgerDb;
 pub use sov_full_node_configs::sequencer::{
-    NodeStartingRole, PostgresConfig, PreferredSequencerConfig, RecoveryStrategy, TimingOracleConfig,
+    NodeStartingRole, PostgresConfig, PreferredSequencerConfig, RecoveryStrategy,
+    TimingOracleConfig,
 };
 use sov_modules_api::capabilities::{
     BlobSelector, RollupHeight, TransactionAuthenticator, UniquenessData,

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -41,7 +41,7 @@ use sov_blob_sender::{new_blob_id, BlobExecutionStatus};
 use sov_blob_storage::{PreferredBatchData, SequenceNumber};
 use sov_db::ledger_db::LedgerDb;
 pub use sov_full_node_configs::sequencer::{
-    NodeRole, PostgresConfig, PreferredSequencerConfig, RecoveryStrategy, TimingOracleConfig,
+    NodeStartingRole, PostgresConfig, PreferredSequencerConfig, RecoveryStrategy, TimingOracleConfig,
 };
 use sov_modules_api::capabilities::{
     BlobSelector, RollupHeight, TransactionAuthenticator, UniquenessData,

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -41,7 +41,7 @@ use sov_blob_sender::{new_blob_id, BlobExecutionStatus};
 use sov_blob_storage::{PreferredBatchData, SequenceNumber};
 use sov_db::ledger_db::LedgerDb;
 pub use sov_full_node_configs::sequencer::{
-    NodeStartingRole, PostgresConfig, PreferredSequencerConfig, RecoveryStrategy,
+    ConfiguredNodeRole, PostgresConfig, PreferredSequencerConfig, RecoveryStrategy,
     TimingOracleConfig,
 };
 use sov_modules_api::capabilities::{

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -879,7 +879,7 @@ where
         self.synchronized_state_updator
             .sequencer_role_msg("get_sequencer_role")
             .await
-            .unwrap_or(SequencerRole::Leader)
+            .unwrap_or(SequencerRole::BatchProducer)
     }
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
@@ -38,14 +38,14 @@ impl<Da: DaService> PreferredBlobSender<Da> {
     ) -> anyhow::Result<(Self, Option<JoinHandle<()>>)> {
         let nb_of_concurrent_blob_submissions = Arc::new(AtomicUsize::new(0));
         match seq_role {
-            SequencerRole::Replica | SequencerRole::ReplicaNoLeaderSync => Ok((
+            SequencerRole::PgSyncReplica | SequencerRole::DaOnlyReplica => Ok((
                 Self {
                     inner: None,
                     nb_of_concurrent_blob_submissions,
                 },
                 None,
             )),
-            SequencerRole::Leader => {
+            SequencerRole::BatchProducer => {
                 // It's possible that sov-blob-sender's DB might miss some blob data at
                 // node startup due to:
                 //  1. Disk failure (the sequencer can use Postgres so it's durable).

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -55,7 +55,7 @@ impl EventReceiverStartNotifier {
     /// This method only has an effect when called on a replica sequencer, since the leader produces
     /// the DB events rather than consuming them.
     pub(crate) fn notify(&self) {
-        if self.seq_role == SequencerRole::Leader {
+        if self.seq_role == SequencerRole::BatchProducer {
             return;
         }
 
@@ -68,7 +68,7 @@ impl EventReceiverStartNotifier {
     pub(crate) fn check_replica_status_or_ok_for_leader(
         &self,
     ) -> Result<(), SequencerNotReadyDetails> {
-        if self.seq_role == SequencerRole::Leader {
+        if self.seq_role == SequencerRole::BatchProducer {
             return Ok(());
         }
 
@@ -82,12 +82,12 @@ impl EventReceiverStartNotifier {
     /// Marks that the replica has successfully processed its first batch of events.
     ///
     /// # Panics
-    /// Panics if this method is called on a leader sequencer.
+    /// Panics if this method is called on a batch-producing sequencer.
     pub(crate) fn set_replica_processed_first_batch(&mut self) {
         assert_eq!(
             self.seq_role,
-            SequencerRole::Replica,
-            "set_replica_processed_first_batch can only be called on a Replica sequencer"
+            SequencerRole::PgSyncReplica,
+            "set_replica_processed_first_batch can only be called on a PgSyncReplica sequencer"
         );
         self.replica_processed_first_batch = true;
     }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -186,7 +186,7 @@ mod tests {
     use crate::preferred::db::postgres::PostgresBackend;
     use crate::preferred::db::BatchToStore;
     use crate::preferred::db::DbBackend;
-    use sov_full_node_configs::sequencer::NodeRole;
+    use sov_full_node_configs::sequencer::NodeStartingRole;
     use sov_modules_api::FullyBakedTx;
     use sov_modules_api::TxHash;
     use sov_modules_api::VisibleSlotNumber;
@@ -387,7 +387,7 @@ mod tests {
         };
 
         let postgres_config =
-            config_from_postgres_container(&postgres, "Replica".into(), NodeRole::Replica)
+            config_from_postgres_container(&postgres, "Replica".into(), NodeStartingRole::Replica)
                 .await
                 .unwrap();
 

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -386,10 +386,13 @@ mod tests {
             }
         };
 
-        let postgres_config =
-            config_from_postgres_container(&postgres, "Replica".into(), ConfiguredNodeRole::Replica)
-                .await
-                .unwrap();
+        let postgres_config = config_from_postgres_container(
+            &postgres,
+            "Replica".into(),
+            ConfiguredNodeRole::Replica,
+        )
+        .await
+        .unwrap();
 
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
         let (db, _) = PostgresBackend::connect(&postgres_config, addr)

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -186,7 +186,7 @@ mod tests {
     use crate::preferred::db::postgres::PostgresBackend;
     use crate::preferred::db::BatchToStore;
     use crate::preferred::db::DbBackend;
-    use sov_full_node_configs::sequencer::NodeStartingRole;
+    use sov_full_node_configs::sequencer::ConfiguredNodeRole;
     use sov_modules_api::FullyBakedTx;
     use sov_modules_api::TxHash;
     use sov_modules_api::VisibleSlotNumber;
@@ -387,7 +387,7 @@ mod tests {
         };
 
         let postgres_config =
-            config_from_postgres_container(&postgres, "Replica".into(), NodeStartingRole::Replica)
+            config_from_postgres_container(&postgres, "Replica".into(), ConfiguredNodeRole::Replica)
                 .await
                 .unwrap();
 

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -398,7 +398,7 @@ mod tests {
 
         let (shutdown_snd, _shutdown_rcv) = watch::channel(());
         let (mut sync_task, start_replica_task_notifier) =
-            ReplicaSyncTask::new_with_page_size(shutdown_snd, 8, SequencerRole::Replica)
+            ReplicaSyncTask::new_with_page_size(shutdown_snd, 8, SequencerRole::PgSyncReplica)
                 .await
                 .unwrap();
 

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -449,7 +449,7 @@ where
     }
 
     pub(crate) fn is_replica_role(&self) -> bool {
-        self.seq_role == SequencerRole::Replica
+        self.seq_role == SequencerRole::PgSyncReplica
     }
 
     pub(crate) async fn update_api_ledger(&self, info: &StateUpdateInfo<S::Storage>) {

--- a/crates/full-node/sov-sequencer/src/preferred/update_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/update_state.rs
@@ -264,7 +264,7 @@ fn validate_seq_nr_from_node(
 ) -> Result<(), SequenceNumberMismatchError> {
     if seq_nr_of_in_progress_batch < next_sequence_number_according_to_node {
         match seq_role {
-            SequencerRole::Replica => {
+            SequencerRole::PgSyncReplica => {
                 // If this occurs on replicas, we log the error and skip `update_state` for the batch received from the node.
                 // If the database slowdown is temporary, the issue will be resolved when the next `update_state` call succeeds.
                 // If the situation persists, the replica will eventually enter sync mode in that case that the database setup needs to be examined.
@@ -273,8 +273,8 @@ fn validate_seq_nr_from_node(
                     If this error occurs repeatedly, investigate the database stack in the deployment.");
                 return Err(SequenceNumberMismatchError::SkipStateUpdate);
             }
-            SequencerRole::Leader | SequencerRole::ReplicaNoLeaderSync => {
-                // For roles other than replicas, we should never observe in-progress batches with sequence numbers lower than what the node expects (ReplicaNoLeaderSync don't create batches).
+            SequencerRole::BatchProducer | SequencerRole::DaOnlyReplica => {
+                // For roles other than PgSyncReplica, we should never observe in-progress batches with sequence numbers lower than what the node expects (DaOnlyReplica doesn't create batches).
                 let err = anyhow::anyhow!(
                     "sequencer_role: {seq_role:?},
                     seq_nr_of_in_progress_batch: {seq_nr_of_in_progress_batch}, 

--- a/crates/full-node/sov-sequencer/src/standard/mod.rs
+++ b/crates/full-node/sov-sequencer/src/standard/mod.rs
@@ -739,7 +739,7 @@ where
     }
 
     async fn sequencer_role(&self) -> crate::SequencerRole {
-        crate::SequencerRole::Leader
+        crate::SequencerRole::BatchProducer
     }
 }
 

--- a/crates/full-node/sov-sequencer/src/test_stateless.rs
+++ b/crates/full-node/sov-sequencer/src/test_stateless.rs
@@ -246,6 +246,6 @@ where
     }
 
     async fn sequencer_role(&self) -> crate::SequencerRole {
-        crate::SequencerRole::Leader
+        crate::SequencerRole::BatchProducer
     }
 }

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -442,7 +442,7 @@
         }
       }
     },
-    "NodeStartingRole": {
+    "ConfiguredNodeRole": {
       "oneOf": [
         {
           "description": "This node runs as the leader. The leader is responsible for producing new batches.",
@@ -488,7 +488,7 @@
           "type": "string"
         },
         "node_role": {
-          "$ref": "#/definitions/NodeStartingRole"
+          "$ref": "#/definitions/ConfiguredNodeRole"
         },
         "postgres_connection_string": {
           "description": "Connection string.",

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -152,6 +152,38 @@
         }
       ]
     },
+    "ConfiguredNodeRole": {
+      "oneOf": [
+        {
+          "description": "This node runs as the leader. The leader is responsible for producing new batches.",
+          "type": "string",
+          "enum": [
+            "Leader"
+          ]
+        },
+        {
+          "description": "This node runs as a replica, syncing its state from the leader. Replicas do not publish blobs to the DA layer, do not accept transactions via the API, and do not issue soft confirmations.",
+          "type": "string",
+          "enum": [
+            "Replica"
+          ]
+        },
+        {
+          "description": "This node runs in replica mode with Postgres-based synchronization from the leader disabled. It receives transactions exclusively through the DA layer. Use this mode when you want replica behavior without accepting transactions from the Leader only from the DA.",
+          "type": "string",
+          "enum": [
+            "ReplicaNoLeaderSync"
+          ]
+        },
+        {
+          "description": "The node initially starts as a `Replica` and attempts to register itself as the `Leader` by sending a request to the Db to acquire leadership. If successful, it becomes the `Leader` and all other nodes remain Replicas. If the Leader goes down and fails to refresh its entry in the `Leader` table, one of the `Replicas` will take over and assume the Leader role.",
+          "type": "string",
+          "enum": [
+            "DbElected"
+          ]
+        }
+      ]
+    },
     "CorsConfiguration": {
       "description": "See [`HttpServerConfig::cors`].\n\n# Default\n\nCross-origin resource sharing (CORS) makes local development easier, so it's enabled by default\n\nIn production, one may want to disable it and let your reverse proxy handle CORS instead. Security note: Allowing CORS in production allows making requests to rollup node any website on the Internet.",
       "oneOf": [
@@ -441,38 +473,6 @@
           "minimum": 0.0
         }
       }
-    },
-    "ConfiguredNodeRole": {
-      "oneOf": [
-        {
-          "description": "This node runs as the leader. The leader is responsible for producing new batches.",
-          "type": "string",
-          "enum": [
-            "Leader"
-          ]
-        },
-        {
-          "description": "This node runs as a replica, syncing its state from the leader. Replicas do not publish blobs to the DA layer, do not accept transactions via the API, and do not issue soft confirmations.",
-          "type": "string",
-          "enum": [
-            "Replica"
-          ]
-        },
-        {
-          "description": "This node runs in replica mode with Postgres-based synchronization from the leader disabled. It receives transactions exclusively through the DA layer. Use this mode when you want replica behavior without accepting transactions from the Leader only from the DA.",
-          "type": "string",
-          "enum": [
-            "ReplicaNoLeaderSync"
-          ]
-        },
-        {
-          "description": "The node initially starts as a `Replica` and attempts to register itself as the `Leader` by sending a request to the Db to acquire leadership. If successful, it becomes the `Leader` and all other nodes remain Replicas. If the Leader goes down and fails to refresh its entry in the `Leader` table, one of the `Replicas` will take over and assume the Leader role.",
-          "type": "string",
-          "enum": [
-            "DbElected"
-          ]
-        }
-      ]
     },
     "PostgresConfig": {
       "description": "Postgres DB config.",

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -442,7 +442,7 @@
         }
       }
     },
-    "NodeRole": {
+    "NodeStartingRole": {
       "oneOf": [
         {
           "description": "This node runs as the leader. The leader is responsible for producing new batches.",
@@ -488,7 +488,7 @@
           "type": "string"
         },
         "node_role": {
-          "$ref": "#/definitions/NodeRole"
+          "$ref": "#/definitions/NodeStartingRole"
         },
         "postgres_connection_string": {
           "description": "Connection string.",

--- a/crates/utils/sov-test-utils/src/postgres.rs
+++ b/crates/utils/sov-test-utils/src/postgres.rs
@@ -1,4 +1,4 @@
-use sov_sequencer::preferred::{NodeStartingRole, PostgresConfig};
+use sov_sequencer::preferred::{ConfiguredNodeRole, PostgresConfig};
 use testcontainers::runners::AsyncRunner;
 pub use testcontainers::{ContainerAsync, ImageExt};
 pub use testcontainers_modules::postgres::Postgres;
@@ -66,7 +66,7 @@ pub async fn connection_string_from_postgres_container(
 pub async fn config_from_postgres_container(
     container: &ContainerAsync<Postgres>,
     node_id: String,
-    node_role: NodeStartingRole,
+    node_role: ConfiguredNodeRole,
 ) -> anyhow::Result<PostgresConfig> {
     let postgres_connection_string = connection_string_from_postgres_container(container).await?;
     Ok(PostgresConfig {

--- a/crates/utils/sov-test-utils/src/postgres.rs
+++ b/crates/utils/sov-test-utils/src/postgres.rs
@@ -1,4 +1,4 @@
-use sov_sequencer::preferred::{NodeRole, PostgresConfig};
+use sov_sequencer::preferred::{NodeStartingRole, PostgresConfig};
 use testcontainers::runners::AsyncRunner;
 pub use testcontainers::{ContainerAsync, ImageExt};
 pub use testcontainers_modules::postgres::Postgres;
@@ -66,7 +66,7 @@ pub async fn connection_string_from_postgres_container(
 pub async fn config_from_postgres_container(
     container: &ContainerAsync<Postgres>,
     node_id: String,
-    node_role: NodeRole,
+    node_role: NodeStartingRole,
 ) -> anyhow::Result<PostgresConfig> {
     let postgres_connection_string = connection_string_from_postgres_container(container).await?;
     Ok(PostgresConfig {

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -46,7 +46,7 @@ use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::ZkvmHost;
 use sov_rollup_interface::StateUpdateInfo;
 use sov_sequencer::preferred::{
-    NodeStartingRole, PostgresConfig, PreferredSequencerConfig, TimingOracleConfig,
+    ConfiguredNodeRole, PostgresConfig, PreferredSequencerConfig, TimingOracleConfig,
 };
 use sov_sequencer::test_stateless::TestStatelessSequencer;
 use sov_sequencer::SeqConfigExtension;
@@ -158,7 +158,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
     pub fn set_as_leader(&mut self) {
         if let SequencerKindConfig::Preferred(ref mut config) = &mut self.config.sequencer_config {
             if let Some(c) = config.postgres_config.as_mut() {
-                c.node_role = NodeStartingRole::Leader;
+                c.node_role = ConfiguredNodeRole::Leader;
             }
         }
     }
@@ -471,7 +471,7 @@ where
     pub async fn new_with_external_da(
         genesis: GenesisSource<R::Spec, R::Runtime>,
         da_config: MockDaClientConfig,
-        postgres: Option<(Arc<PostgresData>, String, NodeStartingRole)>,
+        postgres: Option<(Arc<PostgresData>, String, ConfiguredNodeRole)>,
     ) -> Self {
         let storage_path = StoragePath::Tmp(Arc::new(tempfile::tempdir().unwrap()));
 

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -46,7 +46,7 @@ use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::ZkvmHost;
 use sov_rollup_interface::StateUpdateInfo;
 use sov_sequencer::preferred::{
-    NodeRole, PostgresConfig, PreferredSequencerConfig, TimingOracleConfig,
+    NodeStartingRole, PostgresConfig, PreferredSequencerConfig, TimingOracleConfig,
 };
 use sov_sequencer::test_stateless::TestStatelessSequencer;
 use sov_sequencer::SeqConfigExtension;
@@ -158,7 +158,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
     pub fn set_as_leader(&mut self) {
         if let SequencerKindConfig::Preferred(ref mut config) = &mut self.config.sequencer_config {
             if let Some(c) = config.postgres_config.as_mut() {
-                c.node_role = NodeRole::Leader;
+                c.node_role = NodeStartingRole::Leader;
             }
         }
     }
@@ -471,7 +471,7 @@ where
     pub async fn new_with_external_da(
         genesis: GenesisSource<R::Spec, R::Runtime>,
         da_config: MockDaClientConfig,
-        postgres: Option<(Arc<PostgresData>, String, NodeRole)>,
+        postgres: Option<(Arc<PostgresData>, String, NodeStartingRole)>,
     ) -> Self {
         let storage_path = StoragePath::Tmp(Arc::new(tempfile::tempdir().unwrap()));
 

--- a/examples/demo-rollup/sov-soak-testing/src/lib.rs
+++ b/examples/demo-rollup/sov-soak-testing/src/lib.rs
@@ -9,7 +9,7 @@ use sov_paymaster::{
     SafeVec,
 };
 use sov_rollup_interface::execution_mode::Native;
-use sov_sequencer::preferred::{NodeRole, PostgresConfig, PreferredSequencerConfig};
+use sov_sequencer::preferred::{NodeStartingRole, PostgresConfig, PreferredSequencerConfig};
 use sov_sequencer::SequencerKindConfig;
 pub use sov_soak_testing_lib::*;
 use sov_synthetic_load::SyntheticLoad;
@@ -125,7 +125,7 @@ pub async fn setup_rollup(
     let postgres_config = db_connection_url.map(|url| PostgresConfig {
         postgres_connection_string: url,
         node_id: "Primary".to_string(),
-        node_role: NodeRole::Leader,
+        node_role: NodeStartingRole::Leader,
     });
 
     let rollup_builder = TestRollupBuilder::new_with_storage_path(

--- a/examples/demo-rollup/sov-soak-testing/src/lib.rs
+++ b/examples/demo-rollup/sov-soak-testing/src/lib.rs
@@ -9,7 +9,7 @@ use sov_paymaster::{
     SafeVec,
 };
 use sov_rollup_interface::execution_mode::Native;
-use sov_sequencer::preferred::{NodeStartingRole, PostgresConfig, PreferredSequencerConfig};
+use sov_sequencer::preferred::{ConfiguredNodeRole, PostgresConfig, PreferredSequencerConfig};
 use sov_sequencer::SequencerKindConfig;
 pub use sov_soak_testing_lib::*;
 use sov_synthetic_load::SyntheticLoad;
@@ -125,7 +125,7 @@ pub async fn setup_rollup(
     let postgres_config = db_connection_url.map(|url| PostgresConfig {
         postgres_connection_string: url,
         node_id: "Primary".to_string(),
-        node_role: NodeStartingRole::Leader,
+        node_role: ConfiguredNodeRole::Leader,
     });
 
     let rollup_builder = TestRollupBuilder::new_with_storage_path(

--- a/examples/demo-rollup/tests/replica/db_elected.rs
+++ b/examples/demo-rollup/tests/replica/db_elected.rs
@@ -45,9 +45,11 @@ impl DbElectedTestSetup {
 
         // Determine which node is the leader and which is the replica
         let (leader, replica) = match (role1, role2) {
-            (SequencerRole::Leader, SequencerRole::Replica) => (rollup1, rollup2),
-            (SequencerRole::Replica, SequencerRole::Leader) => (rollup2, rollup1),
-            _ => panic!("Expected one Leader and one Replica, got {role1:?} and {role2:?}"),
+            (SequencerRole::BatchProducer, SequencerRole::PgSyncReplica) => (rollup1, rollup2),
+            (SequencerRole::PgSyncReplica, SequencerRole::BatchProducer) => (rollup2, rollup1),
+            _ => panic!(
+                "Expected one BatchProducer and one PgSyncReplica, got {role1:?} and {role2:?}"
+            ),
         };
 
         Some(Self {
@@ -127,7 +129,7 @@ async fn test_db_elected_leader_failover() {
         .expect("Failed to get cluster info");
 
     tracing::info!(
-        "Initial cluster state - Leader: {:?}, Followers: {:?}",
+        "Initial cluster state - BatchProducer: {:?}, Followers: {:?}",
         cluster_info.leader,
         cluster_info.followers
     );
@@ -149,12 +151,12 @@ async fn test_db_elected_leader_failover() {
 
     assert_ne!(
         initial_leader.node_id, initial_follower.node_id,
-        "Leader and follower should have different node_ids"
+        "BatchProducer and follower should have different node_ids"
     );
 
     assert_ne!(
         initial_leader.address, initial_follower.address,
-        "Leader and follower should have different addresses"
+        "BatchProducer and follower should have different addresses"
     );
 
     // Remember the follower's node_id - this should become the new leader after failover
@@ -186,8 +188,8 @@ async fn test_db_elected_leader_failover() {
 
     assert_eq!(
         new_role,
-        SequencerRole::Leader,
-        "Expected restarted node to be Leader, got {new_role:?}",
+        SequencerRole::BatchProducer,
+        "Expected restarted node to be BatchProducer, got {new_role:?}",
     );
 
     // Check final cluster state after failover

--- a/examples/demo-rollup/tests/replica/db_elected.rs
+++ b/examples/demo-rollup/tests/replica/db_elected.rs
@@ -29,10 +29,18 @@ impl DbElectedTestSetup {
         let (_, da_shutdown, addr) = create_da_service_periodic().await;
 
         // Start both DbElected nodes
-        let node1 = Some((postgres.clone(), "node1".into(), NodeStartingRole::DbElected));
+        let node1 = Some((
+            postgres.clone(),
+            "node1".into(),
+            NodeStartingRole::DbElected,
+        ));
         let rollup1 = start_rollup(addr, node1).await;
 
-        let node2 = Some((postgres.clone(), "node2".into(), NodeStartingRole::DbElected));
+        let node2 = Some((
+            postgres.clone(),
+            "node2".into(),
+            NodeStartingRole::DbElected,
+        ));
         let rollup2 = start_rollup(addr, node2).await;
 
         // Wait for both nodes to be ready
@@ -241,7 +249,11 @@ async fn test_subscribe_cluster_info_receives_notifications() {
     let (_, da_shutdown, addr) = create_da_service_periodic().await;
 
     // Start first node - it will become leader and trigger notifications
-    let node1 = Some((postgres.clone(), "node1".into(), NodeStartingRole::DbElected));
+    let node1 = Some((
+        postgres.clone(),
+        "node1".into(),
+        NodeStartingRole::DbElected,
+    ));
     let rollup1 = start_rollup(addr, node1).await;
     rollup1.wait_for_sequencer_ready().await.unwrap();
 
@@ -249,7 +261,11 @@ async fn test_subscribe_cluster_info_receives_notifications() {
     let file_content1 = wait_for_file_change(&cluster_info_path, &mut file_watcher).await;
 
     // Start second node - it will become follower and trigger another notification
-    let node2 = Some((postgres.clone(), "node2".into(), NodeStartingRole::DbElected));
+    let node2 = Some((
+        postgres.clone(),
+        "node2".into(),
+        NodeStartingRole::DbElected,
+    ));
     let rollup2 = start_rollup(addr, node2).await;
     rollup2.wait_for_sequencer_ready().await.unwrap();
 

--- a/examples/demo-rollup/tests/replica/db_elected.rs
+++ b/examples/demo-rollup/tests/replica/db_elected.rs
@@ -32,14 +32,14 @@ impl DbElectedTestSetup {
         let node1 = Some((
             postgres.clone(),
             "node1".into(),
-            NodeStartingRole::DbElected,
+            ConfiguredNodeRole::DbElected,
         ));
         let rollup1 = start_rollup(addr, node1).await;
 
         let node2 = Some((
             postgres.clone(),
             "node2".into(),
-            NodeStartingRole::DbElected,
+            ConfiguredNodeRole::DbElected,
         ));
         let rollup2 = start_rollup(addr, node2).await;
 
@@ -252,7 +252,7 @@ async fn test_subscribe_cluster_info_receives_notifications() {
     let node1 = Some((
         postgres.clone(),
         "node1".into(),
-        NodeStartingRole::DbElected,
+        ConfiguredNodeRole::DbElected,
     ));
     let rollup1 = start_rollup(addr, node1).await;
     rollup1.wait_for_sequencer_ready().await.unwrap();
@@ -264,7 +264,7 @@ async fn test_subscribe_cluster_info_receives_notifications() {
     let node2 = Some((
         postgres.clone(),
         "node2".into(),
-        NodeStartingRole::DbElected,
+        ConfiguredNodeRole::DbElected,
     ));
     let rollup2 = start_rollup(addr, node2).await;
     rollup2.wait_for_sequencer_ready().await.unwrap();

--- a/examples/demo-rollup/tests/replica/db_elected.rs
+++ b/examples/demo-rollup/tests/replica/db_elected.rs
@@ -29,10 +29,10 @@ impl DbElectedTestSetup {
         let (_, da_shutdown, addr) = create_da_service_periodic().await;
 
         // Start both DbElected nodes
-        let node1 = Some((postgres.clone(), "node1".into(), NodeRole::DbElected));
+        let node1 = Some((postgres.clone(), "node1".into(), NodeStartingRole::DbElected));
         let rollup1 = start_rollup(addr, node1).await;
 
-        let node2 = Some((postgres.clone(), "node2".into(), NodeRole::DbElected));
+        let node2 = Some((postgres.clone(), "node2".into(), NodeStartingRole::DbElected));
         let rollup2 = start_rollup(addr, node2).await;
 
         // Wait for both nodes to be ready
@@ -241,7 +241,7 @@ async fn test_subscribe_cluster_info_receives_notifications() {
     let (_, da_shutdown, addr) = create_da_service_periodic().await;
 
     // Start first node - it will become leader and trigger notifications
-    let node1 = Some((postgres.clone(), "node1".into(), NodeRole::DbElected));
+    let node1 = Some((postgres.clone(), "node1".into(), NodeStartingRole::DbElected));
     let rollup1 = start_rollup(addr, node1).await;
     rollup1.wait_for_sequencer_ready().await.unwrap();
 
@@ -249,7 +249,7 @@ async fn test_subscribe_cluster_info_receives_notifications() {
     let file_content1 = wait_for_file_change(&cluster_info_path, &mut file_watcher).await;
 
     // Start second node - it will become follower and trigger another notification
-    let node2 = Some((postgres.clone(), "node2".into(), NodeRole::DbElected));
+    let node2 = Some((postgres.clone(), "node2".into(), NodeStartingRole::DbElected));
     let rollup2 = start_rollup(addr, node2).await;
     rollup2.wait_for_sequencer_ready().await.unwrap();
 

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -18,7 +18,7 @@ use sov_modules_api::PrivateKey;
 use sov_modules_api::PublicKey;
 use sov_modules_api::Spec;
 use sov_modules_rollup_blueprint::RollupBlueprint;
-use sov_sequencer::preferred::NodeRole;
+use sov_sequencer::preferred::NodeStartingRole;
 use sov_test_utils::postgres::CreatePostgresError;
 use sov_test_utils::test_rollup::read_private_key;
 use sov_test_utils::test_rollup::PostgresData;
@@ -73,7 +73,7 @@ async fn create_da_service_periodic() -> (StorableMockDaService, watch::Sender<(
 
 async fn start_rollup(
     addr: SocketAddr,
-    postgres: Option<(Arc<PostgresData>, String, NodeRole)>,
+    postgres: Option<(Arc<PostgresData>, String, NodeStartingRole)>,
 ) -> TestRollup<ExternalMockDemoRollup<Native>> {
     let genesis = test_genesis_source(OperatingMode::Operator);
     RollupBuilder::new_with_external_da(

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -18,7 +18,7 @@ use sov_modules_api::PrivateKey;
 use sov_modules_api::PublicKey;
 use sov_modules_api::Spec;
 use sov_modules_rollup_blueprint::RollupBlueprint;
-use sov_sequencer::preferred::NodeStartingRole;
+use sov_sequencer::preferred::ConfiguredNodeRole;
 use sov_test_utils::postgres::CreatePostgresError;
 use sov_test_utils::test_rollup::read_private_key;
 use sov_test_utils::test_rollup::PostgresData;
@@ -73,7 +73,7 @@ async fn create_da_service_periodic() -> (StorableMockDaService, watch::Sender<(
 
 async fn start_rollup(
     addr: SocketAddr,
-    postgres: Option<(Arc<PostgresData>, String, NodeStartingRole)>,
+    postgres: Option<(Arc<PostgresData>, String, ConfiguredNodeRole)>,
 ) -> TestRollup<ExternalMockDemoRollup<Native>> {
     let genesis = test_genesis_source(OperatingMode::Operator);
     RollupBuilder::new_with_external_da(

--- a/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
+++ b/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
@@ -17,12 +17,12 @@ async fn test_replica_receives_txs_from_da() {
 
     let replica = postgres
         .clone()
-        .map(|pg| (pg, "replica".into(), NodeRole::ReplicaNoLeaderSync));
+        .map(|pg| (pg, "replica".into(), NodeStartingRole::ReplicaNoLeaderSync));
     let replica_test_rollup = start_rollup(addr, replica).await;
 
     let primary = postgres
         .clone()
-        .map(|pg| (pg, "primary".into(), NodeRole::Leader));
+        .map(|pg| (pg, "primary".into(), NodeStartingRole::Leader));
     let test_rollup = start_rollup(addr, primary).await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
@@ -73,12 +73,12 @@ async fn test_replica_receives_txs_from_postgres() {
 
     let replica = postgres
         .clone()
-        .map(|pg| (pg, "replica".into(), NodeRole::Replica));
+        .map(|pg| (pg, "replica".into(), NodeStartingRole::Replica));
     let replica_test_rollup = start_rollup(addr, replica).await;
 
     let primary = postgres
         .clone()
-        .map(|pg| (pg, "primary".into(), NodeRole::Leader));
+        .map(|pg| (pg, "primary".into(), NodeStartingRole::Leader));
     let test_rollup = start_rollup(addr, primary).await;
 
     for _ in 0..20 {

--- a/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
+++ b/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
@@ -15,9 +15,13 @@ async fn test_replica_receives_txs_from_da() {
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
     let (_, da_shutdown, addr) = create_da_service_periodic().await;
 
-    let replica = postgres
-        .clone()
-        .map(|pg| (pg, "replica".into(), ConfiguredNodeRole::ReplicaNoLeaderSync));
+    let replica = postgres.clone().map(|pg| {
+        (
+            pg,
+            "replica".into(),
+            ConfiguredNodeRole::ReplicaNoLeaderSync,
+        )
+    });
     let replica_test_rollup = start_rollup(addr, replica).await;
 
     let primary = postgres

--- a/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
+++ b/examples/demo-rollup/tests/replica/replica_gets_txs_from_master.rs
@@ -17,12 +17,12 @@ async fn test_replica_receives_txs_from_da() {
 
     let replica = postgres
         .clone()
-        .map(|pg| (pg, "replica".into(), NodeStartingRole::ReplicaNoLeaderSync));
+        .map(|pg| (pg, "replica".into(), ConfiguredNodeRole::ReplicaNoLeaderSync));
     let replica_test_rollup = start_rollup(addr, replica).await;
 
     let primary = postgres
         .clone()
-        .map(|pg| (pg, "primary".into(), NodeStartingRole::Leader));
+        .map(|pg| (pg, "primary".into(), ConfiguredNodeRole::Leader));
     let test_rollup = start_rollup(addr, primary).await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
@@ -73,12 +73,12 @@ async fn test_replica_receives_txs_from_postgres() {
 
     let replica = postgres
         .clone()
-        .map(|pg| (pg, "replica".into(), NodeStartingRole::Replica));
+        .map(|pg| (pg, "replica".into(), ConfiguredNodeRole::Replica));
     let replica_test_rollup = start_rollup(addr, replica).await;
 
     let primary = postgres
         .clone()
-        .map(|pg| (pg, "primary".into(), NodeStartingRole::Leader));
+        .map(|pg| (pg, "primary".into(), ConfiguredNodeRole::Leader));
     let test_rollup = start_rollup(addr, primary).await;
 
     for _ in 0..20 {

--- a/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
+++ b/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
@@ -43,7 +43,7 @@ impl ReplicaRegistrationTestSetup {
     }
 
     /// Starts a replica node with the given node_id and role.
-    async fn start_replica(&self, node_id: &str, role: NodeStartingRole) -> TestRollup<Rollup> {
+    async fn start_replica(&self, node_id: &str, role: ConfiguredNodeRole) -> TestRollup<Rollup> {
         let replica = Some((self.postgres.clone(), node_id.into(), role));
         let replica_rollup = start_rollup(self.da_addr, replica).await;
         replica_rollup
@@ -86,11 +86,11 @@ async fn test_multiple_replicas_register_in_nodes_table() {
     };
 
     let replica_then_leader = setup
-        .start_replica("replica_then_leader", NodeStartingRole::Replica)
+        .start_replica("replica_then_leader", ConfiguredNodeRole::Replica)
         .await;
 
     let replica_rollup = setup
-        .start_replica("replica", NodeStartingRole::Replica)
+        .start_replica("replica", ConfiguredNodeRole::Replica)
         .await;
 
     // Verify both replicas are present in followers

--- a/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
+++ b/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
@@ -43,7 +43,7 @@ impl ReplicaRegistrationTestSetup {
     }
 
     /// Starts a replica node with the given node_id and role.
-    async fn start_replica(&self, node_id: &str, role: NodeRole) -> TestRollup<Rollup> {
+    async fn start_replica(&self, node_id: &str, role: NodeStartingRole) -> TestRollup<Rollup> {
         let replica = Some((self.postgres.clone(), node_id.into(), role));
         let replica_rollup = start_rollup(self.da_addr, replica).await;
         replica_rollup
@@ -86,10 +86,10 @@ async fn test_multiple_replicas_register_in_nodes_table() {
     };
 
     let replica_then_leader = setup
-        .start_replica("replica_then_leader", NodeRole::Replica)
+        .start_replica("replica_then_leader", NodeStartingRole::Replica)
         .await;
 
-    let replica_rollup = setup.start_replica("replica", NodeRole::Replica).await;
+    let replica_rollup = setup.start_replica("replica", NodeStartingRole::Replica).await;
 
     // Verify both replicas are present in followers
     let follower_ids = setup.get_follower_ids().await;

--- a/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
+++ b/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
@@ -89,7 +89,9 @@ async fn test_multiple_replicas_register_in_nodes_table() {
         .start_replica("replica_then_leader", NodeStartingRole::Replica)
         .await;
 
-    let replica_rollup = setup.start_replica("replica", NodeStartingRole::Replica).await;
+    let replica_rollup = setup
+        .start_replica("replica", NodeStartingRole::Replica)
+        .await;
 
     // Verify both replicas are present in followers
     let follower_ids = setup.get_follower_ids().await;

--- a/examples/demo-rollup/tests/replica/start_stop.rs
+++ b/examples/demo-rollup/tests/replica/start_stop.rs
@@ -23,12 +23,12 @@ async fn test_replica_start_stop() {
 
     let replica = postgres
         .clone()
-        .map(|pg| (pg, "replica".into(), NodeRole::Replica));
+        .map(|pg| (pg, "replica".into(), NodeStartingRole::Replica));
     let replica_test_rollup = start_rollup(addr, replica).await;
 
     let primary = postgres
         .clone()
-        .map(|pg| (pg, "primary".into(), NodeRole::Leader));
+        .map(|pg| (pg, "primary".into(), NodeStartingRole::Leader));
     let test_rollup = start_rollup(addr, primary).await;
 
     replica_test_rollup
@@ -259,13 +259,13 @@ async fn test_replica_start_stop_many_times() {
 
     let primary = postgres
         .clone()
-        .map(|pg| (pg, "primary".into(), NodeRole::Leader));
+        .map(|pg| (pg, "primary".into(), NodeStartingRole::Leader));
     let test_rollup = start_rollup(addr, primary).await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     let replica = postgres
         .clone()
-        .map(|pg| (pg, "replica".into(), NodeRole::Replica));
+        .map(|pg| (pg, "replica".into(), NodeStartingRole::Replica));
     let mut replica_test_rollup = start_rollup(addr, replica).await;
 
     let nb_of_txs = 50;

--- a/examples/demo-rollup/tests/replica/start_stop.rs
+++ b/examples/demo-rollup/tests/replica/start_stop.rs
@@ -23,12 +23,12 @@ async fn test_replica_start_stop() {
 
     let replica = postgres
         .clone()
-        .map(|pg| (pg, "replica".into(), NodeStartingRole::Replica));
+        .map(|pg| (pg, "replica".into(), ConfiguredNodeRole::Replica));
     let replica_test_rollup = start_rollup(addr, replica).await;
 
     let primary = postgres
         .clone()
-        .map(|pg| (pg, "primary".into(), NodeStartingRole::Leader));
+        .map(|pg| (pg, "primary".into(), ConfiguredNodeRole::Leader));
     let test_rollup = start_rollup(addr, primary).await;
 
     replica_test_rollup
@@ -259,13 +259,13 @@ async fn test_replica_start_stop_many_times() {
 
     let primary = postgres
         .clone()
-        .map(|pg| (pg, "primary".into(), NodeStartingRole::Leader));
+        .map(|pg| (pg, "primary".into(), ConfiguredNodeRole::Leader));
     let test_rollup = start_rollup(addr, primary).await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     let replica = postgres
         .clone()
-        .map(|pg| (pg, "replica".into(), NodeStartingRole::Replica));
+        .map(|pg| (pg, "replica".into(), ConfiguredNodeRole::Replica));
     let mut replica_test_rollup = start_rollup(addr, replica).await;
 
     let nb_of_txs = 50;


### PR DESCRIPTION
# Description

1. Renamed `SequencerRole` variants to `BatchProducer, PgSyncReplica, and DaOnlyReplica`, updating logic, logs, and tests accordingly.
2. Renamed `NodeRole` to `NodeStartingRole` across configs, schemas, and tests while keeping node_role field and enum string values unchanged in rollup_config.toml.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1524
