### PR TITLE
Fix `chain_name` in web3 solana-signable-rollup

### DIFF
--- a/typescript/.changeset/fast-timers-sniff.md
+++ b/typescript/.changeset/fast-timers-sniff.md
@@ -1,0 +1,5 @@
+---
+"@sovereign-sdk/web3": patch
+---
+
+Fixed type issue in SolanaSignableRollup

--- a/typescript/packages/web3/src/rollup/solana-signable-rollup.test.ts
+++ b/typescript/packages/web3/src/rollup/solana-signable-rollup.test.ts
@@ -1,8 +1,10 @@
 import SovereignClient from "@sovereign-sdk/client";
+import { JsSerializer } from "@sovereign-sdk/serializers";
 import type { Signer } from "@sovereign-sdk/signers";
 import { Ed25519Signer } from "@sovereign-sdk/signers";
 import { LedgerSolanaSigner } from "@sovereign-sdk/signers/ledger-solana";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import demoRollupSchema from "../../../__fixtures__/demo-rollup-schema.json";
 import {
   SolanaSignableRollup,
   createSolanaPreamble,
@@ -17,11 +19,17 @@ function createMockClient(overrides?: {
 }) {
   const mockClient = new SovereignClient({ fetch: vi.fn() });
   const chainId = overrides?.chainId || 1;
+  const chainName = overrides?.chainName ?? "";
 
   mockClient.rollup = {
     constants: vi.fn().mockResolvedValue({ chain_id: chainId }),
     schema: vi.fn().mockResolvedValue({
-      schema: overrides?.chainName ? { chain_name: overrides.chainName } : {},
+      schema: {
+        chain_data: {
+          chain_id: chainId,
+          chain_name: chainName,
+        },
+      },
       chain_hash:
         overrides?.chainHash ||
         "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -134,7 +142,9 @@ describe("SolanaSignableRollup", () => {
       {
         client: mockClient,
         getSerializer: () =>
-          createMockSerializer({ schema: { chain_name: "TestChain" } }),
+          createMockSerializer({
+            schema: { chain_data: { chain_id: 1, chain_name: "TestChain" } },
+          }),
       },
       customEndpoint,
     );
@@ -159,6 +169,61 @@ describe("SolanaSignableRollup", () => {
 
     expect(capturedEndpoint).toBe(customEndpoint);
     expect(capturedPayload).toHaveProperty("body");
+  });
+
+  it("should read chain_name from schema.chain_data in fixture schema", async () => {
+    const fixtureChainId = demoRollupSchema.chain_data.chain_id;
+    const mockClient = createMockClient({ chainId: fixtureChainId });
+
+    // Capture the payload sent to the client
+    let capturedPayload: any;
+    mockClient.post = vi
+      .fn()
+      .mockImplementation((path: string, options: any) => {
+        capturedPayload = options;
+        return Promise.resolve({ id: "test-tx-hash" });
+      });
+
+    mockClient.rollup.schema = vi.fn().mockResolvedValue({
+      schema: demoRollupSchema,
+      chain_hash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+    });
+
+    const rollup = await createSolanaSignableRollup({
+      client: mockClient,
+      getSerializer: (schema: any) => new JsSerializer(schema),
+    });
+
+    await rollup.signAndSubmitTransaction(
+      {
+        runtime_call: { test: "call" },
+        uniqueness: { generation: 123 },
+        details: {
+          max_priority_fee_bips: 0,
+          max_fee: "1000",
+          gas_limit: null,
+          chain_id: fixtureChainId,
+        },
+      } as any,
+      {
+        signer: createMockSigner(),
+        authenticator: "solanaSimple",
+      },
+    );
+
+    const bodyJson = JSON.parse(JSON.stringify(capturedPayload));
+    const decodedBody = Buffer.from(bodyJson.body, "base64");
+    const view = new DataView(
+      decodedBody.buffer,
+      decodedBody.byteOffset,
+      decodedBody.byteLength,
+    );
+    const messageLength = view.getUint32(0, true);
+    const jsonBytes = decodedBody.slice(4, 4 + messageLength);
+    const message = JSON.parse(new TextDecoder().decode(jsonBytes));
+
+    expect(message.chain_name).toBe(demoRollupSchema.chain_data.chain_name);
   });
 
   describe("byte-level compatibility with Rust implementation", () => {
@@ -337,7 +402,9 @@ describe("SolanaSignableRollup", () => {
       const rollup = await createSolanaSignableRollup({
         client: mockClient,
         getSerializer: () =>
-          createMockSerializer({ schema: { chain_name: "TestChain" } }),
+          createMockSerializer({
+            schema: { chain_data: { chain_id: 1, chain_name: "TestChain" } },
+          }),
       });
 
       // Create a real LedgerSolanaSigner instance and mock its methods
@@ -388,7 +455,9 @@ describe("SolanaSignableRollup", () => {
       const rollup = await createSolanaSignableRollup({
         client: mockClient,
         getSerializer: () =>
-          createMockSerializer({ schema: { chain_name: "TestChain" } }),
+          createMockSerializer({
+            schema: { chain_data: { chain_id: 1, chain_name: "TestChain" } },
+          }),
       });
 
       // Create a regular Ed25519Signer

--- a/typescript/packages/web3/src/rollup/solana-signable-rollup.ts
+++ b/typescript/packages/web3/src/rollup/solana-signable-rollup.ts
@@ -13,17 +13,10 @@ import {
   standardTypeBuilder,
 } from "./standard-rollup";
 
-export type SolanaOffchainUnsignedTransaction<RuntimeCall> = {
-  runtime_call: RuntimeCall;
-  uniqueness: { nonce: number } | { generation: number };
-  details: {
-    max_priority_fee_bips: number;
-    max_fee: string;
-    gas_limit: number[] | null;
-    chain_id: number;
+export type SolanaOffchainUnsignedTransaction<RuntimeCall> =
+  UnsignedTransaction<RuntimeCall> & {
+    chain_name: string;
   };
-  chain_name: string;
-};
 
 export type SolanaOffchainSimpleMessage = {
   signed_message: Uint8Array;
@@ -197,7 +190,7 @@ export class SolanaSignableRollup<RuntimeCall> {
   ): Promise<Uint8Array> {
     const serializer = await this.inner.serializer();
     const schema = serializer.schema;
-    const chainName = schema.chain_name || "";
+    const chainName = schema.chain_data.chain_name || "";
 
     const solanaUnsignedTx: SolanaOffchainUnsignedTransaction<RuntimeCall> = {
       runtime_call: unsignedTx.runtime_call,


### PR DESCRIPTION
# Description

Fixed type issue with solana-signable-rollup. Simplified transaction type. Added test using demo-rollup schema to ensure type compatibility.

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~ Changeset
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
