### PR TITLE
Adjust AGENTS.md based on recent learning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ make install-dev-tools      # Install all development dependencies
 
 Instead of running `make build` use `make lint` or `cargo check --all-features` for faster feedback loops.
 
-### Running Single Tests
+### Running Tests
 
 ```bash
 cargo nextest run <test_name>
@@ -27,7 +27,15 @@ cargo nextest run -p <package_name> <test_name>
 ```
 
 - Prefer running tests with `-p` to reduce rebuild times.
-- Tests must be ran with `nextest`.
+- Always use `cargo nextest` over regular `cargo test`. Cargo nextest runs each test in a separate process which gives isolation of environment variables.
+- This project has strict testing practices. It means that tests on base branch(`dev`) are always passing. 
+  Any consistent failure in the branch is certainly introduced in the branch.
+
+### Debugging
+
+- Logs: add `sov_test_utils::initialize_logging()` and run test like this. `RUST_LOG=debug cargo nextest run -p <pkg> <test>`. If there's too much information, adjust `RUST_LOG` to only emit logs from relevant modules.
+- For DB issues: Check `sov-db` traces with `RUST_LOG=sov_db=trace`
+- Feel free to add println! or logs if it helps. 
 
 ### Environment Variables
 
@@ -36,29 +44,24 @@ cargo nextest run -p <package_name> <test_name>
 - `SP1_SKIP_PROGRAM_BUILD=1` - Skip SP1 program builds during development
 - `SOV_TEST_SKIP_DOCKER=1` - Skip docker-based tests, useful for local development without docker
 
-Always use `SKIP_GUEST_BUILD=1` unless performing specific ZK related changes.
+Always use `SKIP_GUEST_BUILD=1` unless performing specific ZK related changes, because it massively speeds up compilation time.
 
 ## Architecture
 
+### Key Design Principles
+
+- **Modularity**: Pluggable DA(Data Availability) layers, storage backends, and ZK systems
+- **Type Safety**: Strong typing with Rust's type system, because it allows checking correctness at compile time.
+- **Determinism**: All operations deterministic for ZK proving. No HashMap/HashSet iteration order, no system time, no random. Breaks ZK proofs.
+- **Gas Metering**: Automatic tracking of compute and storage costs
+- **State Isolation**: Each module's state is namespaced. Modules cannot directly access other modules' state; use hooks or explicit dependencies / methods
+
 ### Four Major Layers
 
-1. **Module System** (`crates/module-system/`) - Framework for building rollups
-   - `sov-modules-api`: Core traits (Module, Spec, Context)
-   - `sov-state`: State management and storage accessors
-   - `sov-modules-macros`: Procedural macros for code generation
-
-2. **Full Node** (`crates/full-node/`) - Node components
-   - `sov-sequencer`: Transaction acceptance and soft-confirmation production
-   - `sov-db`: RocksDB-backed persistent storage
-   - `sov-stf-runner`: State transition function executor
-   - `sov-blob-sender`: Blob submission manager for DA layer publishing
-
-3. **Adapters** (`crates/adapters/`) - Pluggable integrations
-   - DA layers: Celestia, Mock DA
-   - zkVMs: Risc0, SP1, Mock ZkVM
-
-4. **Rollup Interface** (`crates/rollup-interface/`) - Core traits
-   - StateTransitionFunction, ZkVerifier, DaSpec traits
+1. **Rollup Interface** (`crates/rollup-interface/`) - Core traits defining rollup behavior
+2. **Module System** (`crates/module-system/`) - Framework for building modules
+3. **Adapters** (`crates/adapters/`) - DA and zkVM integrations
+4. **Full Node** (`crates/full-node/`) - Node infrastructure
 
 Delegate to subagents & CLAUDE.md in those directories for more details.
 
@@ -67,49 +70,23 @@ Delegate to subagents & CLAUDE.md in those directories for more details.
 - `./typescript/`: TypeScript bindings for serialization, transaction building, and RPC client
 - `./python/`: Python bindings for simple transaction building & serialization in python
 
-### Pre-built Modules (`crates/module-system/module-implementations/`)
-
-- `sov-bank`: Token creation and transfer
-- `sov-accounts`: Account management
-- `sov-evm`: EVM execution environment
-- `sov-sequencer-registry`: Sequencer registration
-
-These are some of the most important modules, but there are others as well.
-
-## Key Patterns
-
-### Generic Spec Pattern
-
-All modules are generic over `Spec`, abstracting cryptographic operations:
-```rust
-pub struct MyModule<S: sov_modules_api::Spec> {
-    #[id]
-    pub id: ModuleId,
-    #[state]
-    pub my_state: StateValue<S::Address, MyData>,
-}
-```
-
-### Dual-Mode Execution
-
-- **Native Mode**: Direct execution with `DefaultContext`
-- **ZK Mode**: Execution within zkVM with `ZkDefaultContext`
-- Code gated with `#[cfg(feature = "native")]` runs only in native mode
-
-### State Access Pattern
-
-Modules access state through `WorkingSet<S>` or `TxState<S>`:
-```rust
-pub fn operation(&self, param: Type, state: &mut impl StateReader<S>) -> Result<Output>
-```
 
 ## Code Quality Requirements
 
 Avoid over-engineering solutions. Prioritise clarity and maintainability. Don't prematurely add code or features that aren't needed.
 
+### Philosophy
+
+This codebase will outlive you. Avoid shortcuts that create long-term debt.
+- Validate the plan and downstream impact; small mistakes can propagate.
+- Take time to understand the question before changing code.
+- Keep docs/comments in sync with behavior.
+- Improve logging around changed areas if it helps future debugging.
+
 ### Non-Determinism
 
-- Always avoid non-deterministic code paths in modules and core logic. Because it will break consensus code and ZK proofs.
+- Always avoid non-deterministic code paths in modules and core logic, because non-determinism breaks consensus code and ZK proofs for the light clients.
+- For tests, avoid using `sleep`, prefer deterministic detection of expected changes.
 
 ### Safe Arithmetic
 
@@ -133,8 +110,14 @@ Avoid over-engineering solutions. Prioritise clarity and maintainability. Don't 
 - Always favour clear and concise over verbose. Add more detail when asked
 - Always state if you are guessing or making an assumption
 - Always link to relevant files, lines, or documentation when referencing code or answering questions
-    - Use style `[filename:line_number]` for inline references
-    - Use style `[filename]` for general references
+    - Prefer style `[filename:line_number]` for inline references
+    - Prefer style `[filename]` for general references
+
+## Code Review
+
+ - Base branch for this project is `dev`.
+ - Focus on business logic, correctness and code quality which has the highest business impact. Ignore untracked files.
+ - Ignore uncommitted changes in Cargo.toml, if it removes `default-members`. This is expected pattern with `cargo switcheroo`
 
 ## Toolchain
 

--- a/crates/module-system/AGENTS.md
+++ b/crates/module-system/AGENTS.md
@@ -1,0 +1,30 @@
+## Key Patterns
+
+### Generic Spec Pattern
+
+All modules are generic over `Spec`, abstracting cryptographic operations:
+```rust
+pub struct MyModule<S: sov_modules_api::Spec> {
+    #[id]
+    pub id: ModuleId,
+    #[state]
+    pub my_state: StateValue<S::Address, MyData>,
+}
+```
+
+### Dual-Mode Execution
+
+- **Native Mode**: Direct execution with `DefaultContext`
+- **ZK Mode**: Execution within zkVM with `ZkDefaultContext`
+- Code gated with `#[cfg(feature = "native")]` runs only in native mode
+
+### State Access Pattern
+
+Modules access state through `WorkingSet<S>` or `TxState<S>`:
+```rust
+impl<S: sov_modules_api::Spec> MyModule<S> {
+    pub fn operation(&self, param: Type, state: &mut impl StateReader<S>) -> Result<Output> {
+        unimplemented!()
+    }
+}
+```

--- a/crates/module-system/AGENTS.md
+++ b/crates/module-system/AGENTS.md
@@ -27,4 +27,3 @@ impl<S: sov_modules_api::Spec> MyModule<S> {
         unimplemented!()
     }
 }
-```


### PR DESCRIPTION
# Description


## Important changes

* Specified base branch, because both claude and codex often got messed up with review, because they tried to look into nighly
* Claude and Codex both keep running `cargo test` which can produce bad result because isolation won't work. Hihglighted importance of it.
* Added explicit ignore of changed `Cargo.toml` by switcheroo. Codex has been often threw off by it when doing reviews.

## Other changes

* Added more "why", because this give claude new imformation, "what"s he can discover pretty well
* Moved module-system specific example into module-system `AGENTS.md` file, so it does not pollute context when working on full-node or adapters.
* Removed some basic description of the crates, based on Claude's advice:
  > Claude can discover crate purposes from Cargo.toml descriptions and code. This duplicates information. Line 80 already says "Delegate to subagents & CLAUDE.md in those directories for more details."


----

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


