### PR TITLE
`chain-state`: Do not allow zero base fee with denominator `== 1`

### DIFF
--- a/crates/module-system/module-implementations/sov-chain-state/src/gas.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/gas.rs
@@ -117,8 +117,9 @@ impl<S: Spec> ChainState<S> {
         assert!((Self::config_base_fee_change_denominator().get() as u64).checked_mul(gas_target).is_some(), "Misconfiguration: The product of gas_target * baseconfig_base_fee_change_denominator must not excueed u64::MAX");
 
         if gas_used == gas_target {
-            // We reached the gas target, so we don't need to update the base fee
-            base_fee_per_gas
+            // We reached the gas target, so we don't need to update the base fee.
+            // However, we still enforce a minimum of 1 to prevent zero-fee transactions.
+            max(base_fee_per_gas, Amount(1))
         } else {
             // We need to update the base fee because we didn't reach the gas target.
 
@@ -184,9 +185,13 @@ impl<S: Spec> ChainState<S> {
 
                 base_fee_per_gas
             } else {
-                // Although unlikely, the `base_fee_per_gas` can reach zero. We cannot have a negative value for gas price
-                // so we saturate at zero.
-                base_fee_per_gas.saturating_sub(Amount::from(base_fee_per_gas_delta_normalized))
+                // Although unlikely, the `base_fee_per_gas` can reach zero.
+                // We cannot have a zero value for gas price so we saturate at 1.
+                std::cmp::max(
+                    base_fee_per_gas
+                        .saturating_sub(Amount::from(base_fee_per_gas_delta_normalized)),
+                    Amount(1),
+                )
             }
         }
     }

--- a/crates/module-system/module-implementations/sov-chain-state/src/tests/gas_elasticity_unidimensional.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/tests/gas_elasticity_unidimensional.rs
@@ -260,3 +260,24 @@ fn base_fee_decreases_if_gas_used_is_half_target() {
         "The base fee per gas should increase by `base_fee_per_gas * 1/(2*config_base_fee_change_denominator)` if the gas used is half the target. The new base fee should not depend on the value of the gas used",
     );
 }
+
+#[test]
+fn base_fee_does_not_drop_below_one_with_override_constants() {
+    std::env::set_var("SOV_TEST_CONST_OVERRIDE_BASE_FEE_MAX_CHANGE_DENOMINATOR", "1");
+    // optional: keep elasticity=2 (default); explicit override if desired
+    // std::env::set_var("SOV_TEST_CONST_OVERRIDE_ELASTICITY_MULTIPLIER", "2");
+
+    // Choose gas_limit so gas_target = 1 (with elasticity = 2)
+    let gas_limit = 2u64;
+    let gas_used = 0u64;
+    let base_fee = Amount::from(1u128);
+
+    let updated = ChainState::<TestSpec>::compute_base_fee_per_gas_unidimensional(
+        gas_limit,
+        gas_used,
+        base_fee,
+    );
+
+    // Expected: EIP‑1559 min clamp -> 1
+    assert!(updated >= Amount::from(1u128), "Base fee should never drop below 1");
+}

--- a/crates/module-system/module-implementations/sov-chain-state/src/tests/gas_elasticity_unidimensional.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/tests/gas_elasticity_unidimensional.rs
@@ -28,17 +28,17 @@ fn assert_correct_gas_update(
     );
 }
 
-/// The base fee per gas should remain to zero if the gas used is below the target
+/// The base fee per gas should be clamped to 1 if it would otherwise be zero
 #[test]
-fn test_zero_base_fee_gas_below_target() {
+fn test_zero_base_fee_is_clamped_to_one() {
     assert_correct_gas_update(
         BaseFeeUpdateConfig {
             gas_limit: 0,
             gas_used: 0,
             base_fee_per_gas: Amount::ZERO,
         },
-        Amount::ZERO,
-        "When the base fee per gas is zero, it should remain to zero if the gas used is below the target",
+        Amount::new(1),
+        "When the base fee per gas is zero, it should be clamped to 1",
     );
 }
 
@@ -263,7 +263,10 @@ fn base_fee_decreases_if_gas_used_is_half_target() {
 
 #[test]
 fn base_fee_does_not_drop_below_one_with_override_constants() {
-    std::env::set_var("SOV_TEST_CONST_OVERRIDE_BASE_FEE_MAX_CHANGE_DENOMINATOR", "1");
+    std::env::set_var(
+        "SOV_TEST_CONST_OVERRIDE_BASE_FEE_MAX_CHANGE_DENOMINATOR",
+        "1",
+    );
     // optional: keep elasticity=2 (default); explicit override if desired
     // std::env::set_var("SOV_TEST_CONST_OVERRIDE_ELASTICITY_MULTIPLIER", "2");
 
@@ -273,11 +276,12 @@ fn base_fee_does_not_drop_below_one_with_override_constants() {
     let base_fee = Amount::from(1u128);
 
     let updated = ChainState::<TestSpec>::compute_base_fee_per_gas_unidimensional(
-        gas_limit,
-        gas_used,
-        base_fee,
+        gas_limit, gas_used, base_fee,
     );
 
     // Expected: EIP‑1559 min clamp -> 1
-    assert!(updated >= Amount::from(1u128), "Base fee should never drop below 1");
+    assert!(
+        updated >= Amount::from(1u128),
+        "Base fee should never drop below 1"
+    );
 }


### PR DESCRIPTION
# Description

The claim that "EIP-1559 forbids base fee going to zero" was incorrect. The spec doesn't mandate a minimum - it only ensures increases are at least 1 wei. Implementations like ethereumjs settled on a practical floor (~7
  wei) through experience, not spec mandate.

## Implications of zero base fee:

1. Fee market degrades to pre-1559 auction — pure priority fee bidding returns, losing the predictability benefit
2. No burn — the deflationary/burn mechanism stops entirely when base_fee * gas_used = 0
3. Spam vulnerability — base fee is the primary spam deterrent during low-demand periods; at zero, only priority fees gate inclusion
4. Validator incentive shift — with no base fee to manipulate, MEV dynamics change; validators can't play games with base fee since there's nothing to game
5. Recovery behavior — when demand returns, base fee must climb from zero. With denominator = 1, it can double per block (100% increase when full), but starting from 0: 0 * anything = 0. You'd need special handling to bootstrap back up.

---

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
