### PR TITLE
Add `max_age` filtering to NodeDiscovery and simplify PostgresBackend API.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -444,30 +444,25 @@ impl PreferredSequencerDb {
     ) -> anyhow::Result<(Self, SequencerRole)> {
         let (backend, role): (Option<Box<dyn DbBackend>>, _) = {
             if let Some(postgres_config) = &postgres_config {
+                let backend = PostgresBackend::connect(postgres_config, bind_addr).await?;
+
                 match postgres_config.node_role {
                     ConfiguredNodeRole::ReplicaNoLeaderSync => {
-                        // Connect and register the node without attempting leader election.
-                        // The backend is dropped after registration since replicas don't need it.
-                        PostgresBackend::connect_as_replica(postgres_config, bind_addr).await?;
+                        PostgresBackend::connect(postgres_config, bind_addr).await?;
                         (None, SequencerRole::DaOnlyReplica)
                     }
                     ConfiguredNodeRole::Replica => {
-                        // Connect and register the node without attempting leader election.
-                        // The backend is dropped after registration since replicas don't need it.
-                        PostgresBackend::connect_as_replica(postgres_config, bind_addr).await?;
+                        PostgresBackend::connect(postgres_config, bind_addr).await?;
                         (None, SequencerRole::PgSyncReplica)
                     }
                     ConfiguredNodeRole::Leader => {
-                        let (backend, _) =
-                            PostgresBackend::connect_as_maybe_leader(postgres_config, bind_addr)
-                                .await?;
+                        let backend = PostgresBackend::connect(postgres_config, bind_addr).await?;
                         (Some(Box::new(backend)), SequencerRole::BatchProducer)
                     }
                     ConfiguredNodeRole::DbElected => {
-                        // Connect and attempt to acquire leadership
-                        let (backend, maybe_leader) =
-                            PostgresBackend::connect_as_maybe_leader(postgres_config, bind_addr)
-                                .await?;
+                        let maybe_leader = backend
+                            .heartbeat(Some(postgres_config.leader_election))
+                            .await?;
 
                         let is_leader = maybe_leader
                             .map(|leader| leader.node_id == postgres_config.node_id)

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -444,22 +444,19 @@ impl PreferredSequencerDb {
     ) -> anyhow::Result<(Self, SequencerRole)> {
         let (backend, role): (Option<Box<dyn DbBackend>>, _) = {
             if let Some(postgres_config) = &postgres_config {
-                let backend = PostgresBackend::connect(postgres_config, bind_addr).await?;
-
                 match postgres_config.node_role {
-                    ConfiguredNodeRole::ReplicaNoLeaderSync => {
-                        PostgresBackend::connect(postgres_config, bind_addr).await?;
-                        (None, SequencerRole::DaOnlyReplica)
-                    }
-                    ConfiguredNodeRole::Replica => {
-                        PostgresBackend::connect(postgres_config, bind_addr).await?;
-                        (None, SequencerRole::PgSyncReplica)
-                    }
+                    ConfiguredNodeRole::ReplicaNoLeaderSync => (None, SequencerRole::DaOnlyReplica),
+                    ConfiguredNodeRole::Replica => (None, SequencerRole::PgSyncReplica),
                     ConfiguredNodeRole::Leader => {
                         let backend = PostgresBackend::connect(postgres_config, bind_addr).await?;
+                        let _ = backend
+                            .heartbeat(Some(postgres_config.leader_election))
+                            .await?;
+
                         (Some(Box::new(backend)), SequencerRole::BatchProducer)
                     }
                     ConfiguredNodeRole::DbElected => {
+                        let backend = PostgresBackend::connect(postgres_config, bind_addr).await?;
                         let maybe_leader = backend
                             .heartbeat(Some(postgres_config.leader_election))
                             .await?;

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -66,32 +66,6 @@ macro_rules! run_with_retries {
 }
 
 impl PostgresBackend {
-    /// Connects to Postgres and competes for leadership.
-    ///
-    /// Returns the backend and `Some(leader)` if this node became leader,
-    /// or `None` if another node is the active leader.
-    /// The node is always registered in the cluster regardless of leadership outcome.
-    pub async fn connect_as_maybe_leader(
-        config: &PostgresConfig,
-        bind_addr: SocketAddr,
-    ) -> Result<(Self, Option<SequencerLeader>)> {
-        let backend = Self::connect(config, bind_addr).await?;
-        let maybe_leader = backend.heartbeat(Some(config.leader_election)).await?;
-        Ok((backend, maybe_leader))
-    }
-
-    /// Connects to Postgres as a replica without competing for leadership.
-    ///
-    /// Registers the node in the cluster but never attempts to become leader
-    pub async fn connect_as_replica(
-        config: &PostgresConfig,
-        bind_addr: SocketAddr,
-    ) -> Result<Self> {
-        let backend = Self::connect(config, bind_addr).await?;
-        let _maybe_leader = backend.heartbeat(None).await?;
-        Ok(backend)
-    }
-
     /// Connects to Postgres db.
     pub async fn connect(config: &PostgresConfig, bind_addr: SocketAddr) -> Result<Self> {
         // Compute node address for registration

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -399,9 +399,10 @@ mod tests {
             .await
             .unwrap();
 
-        let _ = backend
+        let _ = db
             .heartbeat(Some(postgres_config.leader_election))
-            .await?;
+            .await
+            .unwrap();
 
         let (shutdown_snd, _shutdown_rcv) = watch::channel(());
         let (mut sync_task, start_replica_task_notifier) =

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -395,9 +395,13 @@ mod tests {
         .unwrap();
 
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
-        let (db, _) = PostgresBackend::connect_as_maybe_leader(&postgres_config, addr)
+        let db = PostgresBackend::connect(&postgres_config, addr)
             .await
             .unwrap();
+
+        let _ = backend
+            .heartbeat(Some(postgres_config.leader_election))
+            .await?;
 
         let (shutdown_snd, _shutdown_rcv) = watch::channel(());
         let (mut sync_task, start_replica_task_notifier) =

--- a/crates/utils/sov-proxy-utils/src/lib.rs
+++ b/crates/utils/sov-proxy-utils/src/lib.rs
@@ -16,6 +16,8 @@ use tokio::sync::watch;
 
 const MAX_DB_ERRORS_ALLOWED: u32 = 10;
 
+const MAX_AGE: Duration = Duration::from_secs(10);
+
 /// Information about a registered node.
 #[derive(Debug, Clone, FromRow, PartialEq, Eq)]
 pub struct NodeInfo {
@@ -111,17 +113,32 @@ impl NodeInfo {
 
 /// Client for querying cluster information from the database.
 pub struct NodeDiscovery {
+    max_age: Duration,
     pool: PgPool,
     connection_string: String,
     file_saved_sender: watch::Sender<()>,
 }
 
 impl NodeDiscovery {
-    /// Creates a new NodeDiscovery with a connection pool.
+    /// Creates a new NodeDiscovery with a connection pool and default max_age.
     ///
     /// Returns the NodeDiscovery instance and a receiver that gets notified
     /// whenever the cluster info file is successfully saved.
     pub async fn new(connection_string: &str) -> Result<(Self, watch::Receiver<()>)> {
+        Self::new_with_max_age(connection_string, MAX_AGE).await
+    }
+
+    /// Creates a new NodeDiscovery with a connection pool and custom max_age.
+    ///
+    /// The `max_age` parameter controls how long a node can go without updating
+    /// its heartbeat before being filtered out of the cluster info.
+    ///
+    /// Returns the NodeDiscovery instance and a receiver that gets notified
+    /// whenever the cluster info file is successfully saved.
+    pub async fn new_with_max_age(
+        connection_string: &str,
+        max_age: Duration,
+    ) -> Result<(Self, watch::Receiver<()>)> {
         tracing::info!("Connecting to database.");
         let pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(5)
@@ -132,6 +149,7 @@ impl NodeDiscovery {
 
         Ok((
             Self {
+                max_age,
                 pool,
                 connection_string: connection_string.to_string(),
                 file_saved_sender,
@@ -140,11 +158,12 @@ impl NodeDiscovery {
         ))
     }
 
-    /// Fetches cluster info atomically using a single transaction.
-    ///
-    /// # Returns
-    /// A `ClusterInfo` struct containing the leader and all followers.
-    pub async fn get_cluster_info(&self) -> anyhow::Result<ClusterInfo> {
+    // Fetches cluster info atomically using a single transaction.
+    // Only nodes whose `last_updated` timestamp is within `max_age` are returned.
+    //
+    // # Returns
+    // A `ClusterInfo` struct containing the leader and all followers.
+    async fn get_cluster_info(&self) -> anyhow::Result<ClusterInfo> {
         let (leader_id, all_nodes) = self.get_cluster_info_from_db().await?;
         Self::cluster(leader_id, all_nodes)
     }
@@ -268,21 +287,30 @@ impl NodeDiscovery {
     async fn get_cluster_info_from_db(
         &self,
     ) -> Result<(Option<String>, Vec<(String, String, OffsetDateTime)>)> {
-        let mut tx = self.pool.begin().await?;
+        let max_age_secs = self.max_age.as_secs() as i64;
 
-        // Fetch leader within transaction
-        let leader_id: Option<String> =
-            sqlx::query_scalar("SELECT node_id FROM sequencer_leader WHERE singleton = 1")
-                .fetch_optional(&mut *tx)
-                .await?;
+        // Fetch nodes updated within max_age, always including the leader regardless of age.
+        // The leader_id is included in each row via LEFT JOIN, allowing us to get it from the results.
+        let rows: Vec<(String, String, OffsetDateTime, Option<String>)> = sqlx::query_as(
+            "SELECT n.node_id, n.address, n.last_updated, l.node_id as leader_id \
+             FROM nodes n \
+             LEFT JOIN sequencer_leader l ON l.singleton = 1 \
+             WHERE n.last_updated > NOW() - $1 * INTERVAL '1 second' \
+                OR n.node_id = l.node_id \
+             ORDER BY n.node_id",
+        )
+        .bind(max_age_secs)
+        .fetch_all(&self.pool)
+        .await?;
 
-        // Fetch all nodes within same transaction
-        let all_nodes: Vec<(String, String, OffsetDateTime)> =
-            sqlx::query_as("SELECT node_id, address, last_updated FROM nodes ORDER BY node_id")
-                .fetch_all(&mut *tx)
-                .await?;
+        // Extract leader_id from first row (same in all rows due to LEFT JOIN)
+        let leader_id = rows.first().and_then(|(_, _, _, lid)| lid.clone());
 
-        tx.commit().await?;
+        // Convert to the expected format without leader_id column
+        let all_nodes = rows
+            .into_iter()
+            .map(|(node_id, address, last_updated, _)| (node_id, address, last_updated))
+            .collect();
 
         Ok((leader_id, all_nodes))
     }

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -196,10 +196,18 @@ struct NodeDiscoveryTestSetup {
     cluster_info_subscription: ClusterInfoSubscription,
 }
 
+const MAX_AGE: Duration = Duration::from_secs(10);
+
 impl NodeDiscoveryTestSetup {
-    /// Creates a new test setup with two DbElected nodes.
+    /// Creates a new test setup with default max_age.
     /// Returns None if Docker is not supported.
     async fn new() -> Option<Self> {
+        Self::new_with_max_age(MAX_AGE).await
+    }
+
+    /// Creates a new test setup with custom max_age for NodeDiscovery.
+    /// Returns None if Docker is not supported.
+    async fn new_with_max_age(max_age: Duration) -> Option<Self> {
         let postgres = match PostgresData::create_postgres().await {
             Ok(pg) => pg,
             Err(CreatePostgresError::DockerNotSupported) => return None,
@@ -211,9 +219,10 @@ impl NodeDiscoveryTestSetup {
         let (_, da_shutdown, da_addr) = create_da_service_periodic().await;
 
         // Create NodeDiscovery to query the nodes table
-        let (node_discovery, file_watcher) = NodeDiscovery::new(postgres.connection_string())
-            .await
-            .expect("Failed to create NodeDiscovery");
+        let (node_discovery, file_watcher) =
+            NodeDiscovery::new_with_max_age(postgres.connection_string(), max_age)
+                .await
+                .expect("Failed to create NodeDiscovery");
 
         let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir.path().join("cluster_info.txt");
@@ -237,8 +246,6 @@ impl NodeDiscoveryTestSetup {
             postgres,
             da_shutdown,
             da_addr,
-            //node_discovery,
-            //_file_watcher,
             cluster_info_subscription,
         })
     }

--- a/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
+++ b/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
@@ -64,3 +64,67 @@ async fn test_multiple_replicas_register_in_nodes_table() {
     let _ = replica_rollup.shutdown().await;
     setup.shutdown().await;
 }
+
+/// Tests that stale nodes are filtered out from cluster info based on max_age.
+///
+/// This test verifies the recent NodeDiscovery changes:
+/// 1. Nodes whose `last_updated` timestamp exceeds `max_age` are filtered out
+/// 2. The leader is always included regardless of its age
+/// 3. Active nodes continue to appear in the cluster info
+#[tokio::test(flavor = "multi_thread")]
+async fn test_stale_nodes_are_filtered_from_cluster_info() {
+    // Use a short max_age (2 seconds) to speed up the test.
+    let max_age = Duration::from_secs(2);
+    let Some(mut setup) = NodeDiscoveryTestSetup::new_with_max_age(max_age).await else {
+        return;
+    };
+
+    // Start a leader node that will keep sending heartbeats.
+    let leader = setup.start_node("leader", ConfiguredNodeRole::Leader).await;
+
+    leader.wait_for_sequencer_ready().await.unwrap();
+
+    // Start a replica node.
+    let replica = setup
+        .start_node("replica", ConfiguredNodeRole::Replica)
+        .await;
+
+    // Wait for both nodes to appear in cluster info.
+    let cluster_info = setup.cluster_info_subscription.wait_for_change().await;
+    assert!(
+        cluster_info.has_leader("leader"),
+        "Leader should be present"
+    );
+    assert!(
+        cluster_info.has_follower("replica"),
+        "Replica should be present as follower"
+    );
+
+    // Shut down the replica - it will stop sending heartbeats.
+    let _ = replica.shutdown().await;
+
+    // Wait for the replica to become stale and be filtered out.
+    // The leader's heartbeat updates will trigger notifications.
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let cluster_info = setup.cluster_info_subscription.wait_for_change().await;
+
+            // Leader should always be present (never filtered regardless of age).
+            assert!(
+                cluster_info.has_leader("leader"),
+                "Leader should always be present in cluster info"
+            );
+
+            // Check if the stale replica has been filtered out.
+            if !cluster_info.has_follower("replica") {
+                // Success - the stale replica was filtered out.
+                break;
+            }
+        }
+    })
+    .await
+    .expect("Timeout waiting for stale replica to be filtered out");
+
+    let _ = leader.shutdown().await;
+    setup.shutdown().await;
+}


### PR DESCRIPTION
# Description

This PR introduces the following changes:
1. Simplifies the Postgres connection API by removing `connect_as_replica()` and `connect_as_maybe_leader() `helper methods. Callers now use `connect()` directly and call heartbeat() separately when needed. 
2. Adds stale node filtering to `NodeDiscovery` so that nodes whose `last_updated` timestamp exceeds a configurable max_age are filtered out of cluster info (except the leader, who is always included).
                                                                                                                                                        

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1524 