### PR TITLE
Notify events websocket after a response has been sent to the tx submitter

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
@@ -135,10 +135,6 @@ where
 
                 let mut oneshot_and_txs = Vec::with_capacity(txs_to_insert.len());
                 for contents in txs_to_insert {
-                    self.transaction_cache
-                        .insert(contents.accepted_tx.clone())
-                        .await;
-                    // If the receiver is no longer listening, just don't send the confirmation.
                     // Apply all updates in a single batch
                     checkpoint_ref.apply_tx_changes(contents.tx_changes);
                     oneshot_and_txs.push((contents.oneshot_sender, contents.accepted_tx));
@@ -146,9 +142,13 @@ where
                 // Send a notification that the checkpoint has been updated. The inner value is already concurrency safe, this just ensures that anyone
                 // relying on change notifications get one. Note, however, that change notifications are not in sync with the actual changes.
                 self.checkpoint_sender.send_modify(|_| {});
-                // Send tx confirmations after API state is updated
+                // Send tx confirmations after API state is updated, then broadcast to WebSocket.
+                // HTTP callers receive their response before WebSocket subscribers are notified.
+                // We yield after sending to the oneshot to give the HTTP handler a chance to
+                // process the response before we broadcast to WebSocket subscribers.
                 for (oneshot, tx) in oneshot_and_txs {
-                    let _ = oneshot.send(tx);
+                    let _ = oneshot.send(tx.clone());
+                    self.transaction_cache.insert(tx).await;
                 }
             }
             ExecutorEvent::CloseBatch {


### PR DESCRIPTION
# Description

Previously, we updated the tx cache (causing websocket subscribers to be notified of a new event) before updating API state and sending a confirmation to the tx submitter. This caused a noticeable lag between the ws event emission and the user's confirmation. This PR fixes the issue and makes them much more nearly concurrent (note that exact timing depends on tokio's scheduler).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2428">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
