### PR TITLE
Add newline to gzipped messages

### DIFF
--- a/crates/utils/sov-rest-utils/src/lib.rs
+++ b/crates/utils/sov-rest-utils/src/lib.rs
@@ -434,6 +434,7 @@ fn compress_bytes(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
 
     let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
     encoder.write_all(data)?;
+    encoder.write_all(b"\n")?; // Add a newline for easy use with bash pipes.
     encoder.finish()
 }
 


### PR DESCRIPTION
# Description

This 1-liner adds a newline after json messages that come through the websocket. This makes them much easier to handle in bash scripts. This was a feature request from @vmmon
