### PR TITLE
Add rollup-height endpoint

### DIFF
--- a/crates/full-node/sov-api-spec/openapi-v3.yaml
+++ b/crates/full-node/sov-api-spec/openapi-v3.yaml
@@ -481,6 +481,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SyncStatus"
+  /sequencer/rollup-height:
+    get:
+      tags:
+        - Sequencer
+      summary: Get the current rollup height
+      description: Returns the current rollup height that the sequencer is operating at.
+      operationId: get_rollup_height
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RollupHeightResponse"
 components:
   parameters:
     pageType:
@@ -1302,3 +1316,13 @@ components:
         - value
         - key
         - module
+    RollupHeightResponse:
+      type: object
+      description: Response containing the current rollup height
+      properties:
+        rollup_height:
+          type: integer
+          format: uint64
+          description: The current rollup height
+      required:
+        - rollup_height

--- a/crates/full-node/sov-sequencer/src/lib.rs
+++ b/crates/full-node/sov-sequencer/src/lib.rs
@@ -22,7 +22,7 @@ pub use common::StateUpdateNotification;
 pub use common::{react_to_state_updates, Sequencer};
 pub use config::{SeqConfigExtension, SequencerConfig, SequencerKindConfig, SovRateLimiterConfig};
 pub use preferred::SequencerRole;
-pub use rest_api::SequencerApis;
+pub use rest_api::{RollupHeightResponse, SequencerApis};
 use serde::Serialize;
 use sov_modules_api::capabilities::RollupHeight;
 use sov_rollup_interface::common::SlotNumber;

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -155,7 +155,11 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
                 "/sequencer/unstable/events",
                 axum::routing::get(Self::axum_list_events),
             )
-            .route("/sequencer/role", axum::routing::get(Self::axum_get_role));
+            .route("/sequencer/role", axum::routing::get(Self::axum_get_role))
+            .route(
+                "/sequencer/rollup-height",
+                axum::routing::get(Self::axum_get_rollup_height),
+            );
 
         #[cfg(feature = "test-utils")]
         let router = router
@@ -436,6 +440,17 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
 
     async fn axum_get_role(state: State<Self>) -> ApiResult<crate::SequencerRole> {
         Ok(state.sequencer.sequencer_role().await.into())
+    }
+
+    async fn axum_get_rollup_height(state: State<Self>) -> ApiResult<RollupHeightResponse> {
+        let api_state = state.sequencer.api_state();
+        let receiver = api_state.checkpoint_receiver();
+        let checkpoint = receiver.borrow();
+        let height = checkpoint.rollup_height_to_access();
+        Ok(RollupHeightResponse {
+            rollup_height: height.get(),
+        }
+        .into())
     }
 
     async fn axum_get_tx_status(
@@ -720,6 +735,13 @@ pub struct TxInfoWithConfirmation<DaTransactionId, Confirmation> {
     pub confirmation: Confirmation,
     #[serde(flatten)]
     pub status: TxStatus<DaTransactionId>,
+}
+
+/// The response for the /sequencer/rollup-height endpoint.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RollupHeightResponse {
+    /// The current rollup height.
+    pub rollup_height: u64,
 }
 
 /// An accepted transaction, with the transaction body and confirmation data.


### PR DESCRIPTION
# Description

This tiny PR adds a new endpoint to fetch the latest rollup-height from the sequencer

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
