### PR TITLE
Use range delete when doing LedgerDb rollback

### DIFF
--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -725,6 +725,12 @@ impl LedgerDb {
                     ) {
                         let event_range_start = first_tx.events.start;
                         let event_range_end = last_tx.events.end;
+                        debug_assert!(
+                            event_range_start <= event_range_end,
+                            "Event range inverted: start={:?} end={:?}",
+                            event_range_start,
+                            event_range_end
+                        );
 
                         // Delete hash-indexed entries by iterating through txs
                         // (we need tx_number to delete EventByKey, and tx.hash to delete TxByHash)
@@ -750,7 +756,8 @@ impl LedgerDb {
                             }
                         }
 
-                        // Range delete EventByNumber (reduces tombstones)
+                        // Range delete EventByNumber (reduces tombstones).
+                        // If there are no events in this slot, the range is empty and we skip it.
                         if event_range_start < event_range_end {
                             schema_batch.delete_range::<EventByNumber>(
                                 &event_range_start,

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -702,6 +702,7 @@ impl LedgerDb {
         }
 
         // Delete all batches, transactions, and events in this slot.
+        // Missing batch/tx/event entries are treated as DB corruption and cause rollback to fail.
         // We use range deletes for number-indexed tables (TxByNumber, EventByNumber)
         // and individual deletes for hash-indexed tables (TxByHash, EventByKey, BatchByHash).
         if head_slot.batches.start < head_slot.batches.end {
@@ -709,64 +710,136 @@ impl LedgerDb {
             let last_batch_num = BatchNumber(head_slot.batches.end.0.saturating_sub(1));
 
             // Get first and last batches to determine the overall tx range
-            if let (Some(first_batch), Some(last_batch)) = (
-                db.get::<BatchByNumber>(&first_batch_num)?,
-                db.get::<BatchByNumber>(&last_batch_num)?,
-            ) {
-                let tx_range_start = first_batch.txs.start;
-                let tx_range_end = last_batch.txs.end;
-
-                // Process transactions and events if there are any
-                if tx_range_start < tx_range_end {
-                    // Get first and last txs to determine overall event range
-                    if let (Some(first_tx), Some(last_tx)) = (
-                        db.get::<TxByNumber>(&tx_range_start)?,
-                        db.get::<TxByNumber>(&TxNumber(tx_range_end.0.saturating_sub(1)))?,
-                    ) {
-                        let event_range_start = first_tx.events.start;
-                        let event_range_end = last_tx.events.end;
-                        debug_assert!(
-                            event_range_start <= event_range_end,
-                            "Event range inverted: start={event_range_start:?} end={event_range_end:?}",
-                        );
-
-                        // Delete hash-indexed entries by iterating through txs
-                        // (we need tx_number to delete EventByKey, and tx.hash to delete TxByHash)
-                        for current_tx_number in tx_range_start.0..tx_range_end.0 {
-                            let current_tx_number = TxNumber(current_tx_number);
-
-                            if let Some(tx) = db.get::<TxByNumber>(&current_tx_number)? {
-                                // Delete EventByKey entries for this tx's events
-                                for current_event_number in tx.events.start.0..tx.events.end.0 {
-                                    let current_event_number = EventNumber(current_event_number);
-                                    if let Some(event) =
-                                        db.get::<EventByNumber>(&current_event_number)?
-                                    {
-                                        schema_batch.delete::<EventByKey>(&(
-                                            event.key().clone(),
-                                            current_tx_number,
-                                            current_event_number,
-                                        ))?;
-                                    }
-                                }
-                                // Delete TxByHash entry
-                                schema_batch.delete::<TxByHash>(&(tx.hash, current_tx_number))?;
-                            }
-                        }
-
-                        // Range delete EventByNumber (reduces tombstones).
-                        // If there are no events in this slot, the range is empty and we skip it.
-                        if event_range_start < event_range_end {
-                            schema_batch.delete_range::<EventByNumber>(
-                                &event_range_start,
-                                &event_range_end,
-                            )?;
-                        }
-                    }
-
-                    // Range delete TxByNumber (reduces tombstones)
-                    schema_batch.delete_range::<TxByNumber>(&tx_range_start, &tx_range_end)?;
+            let first_batch = db.get::<BatchByNumber>(&first_batch_num)?;
+            let last_batch = db.get::<BatchByNumber>(&last_batch_num)?;
+            let (first_batch, last_batch) = match (first_batch, last_batch) {
+                (Some(first_batch), Some(last_batch)) => (first_batch, last_batch),
+                (None, None) => {
+                    anyhow::bail!(
+                        "Ledger DB corruption during rollback: missing first and last batch entries for slot {:?} (expected batch range {:?}..{:?})",
+                        head_slot_number,
+                        head_slot.batches.start,
+                        head_slot.batches.end,
+                    );
                 }
+                (None, Some(_)) => {
+                    anyhow::bail!(
+                        "Ledger DB corruption during rollback: missing first batch {:?} for slot {:?} (expected batch range {:?}..{:?})",
+                        first_batch_num,
+                        head_slot_number,
+                        head_slot.batches.start,
+                        head_slot.batches.end,
+                    );
+                }
+                (Some(_), None) => {
+                    anyhow::bail!(
+                        "Ledger DB corruption during rollback: missing last batch {:?} for slot {:?} (expected batch range {:?}..{:?})",
+                        last_batch_num,
+                        head_slot_number,
+                        head_slot.batches.start,
+                        head_slot.batches.end,
+                    );
+                }
+            };
+
+            let tx_range_start = first_batch.txs.start;
+            let tx_range_end = last_batch.txs.end;
+
+            // Process transactions and events if there are any
+            if tx_range_start < tx_range_end {
+                // Get first and last txs to determine overall event range
+                let first_tx = db.get::<TxByNumber>(&tx_range_start)?;
+                let last_tx = db.get::<TxByNumber>(&TxNumber(tx_range_end.0.saturating_sub(1)))?;
+                let (first_tx, last_tx) = match (first_tx, last_tx) {
+                    (Some(first_tx), Some(last_tx)) => (first_tx, last_tx),
+                    (None, None) => {
+                        anyhow::bail!(
+                            "Ledger DB corruption during rollback: missing first and last tx entries for slot {:?} (expected tx range {:?}..{:?})",
+                            head_slot_number,
+                            tx_range_start,
+                            tx_range_end,
+                        );
+                    }
+                    (None, Some(_)) => {
+                        anyhow::bail!(
+                            "Ledger DB corruption during rollback: missing first tx {:?} for slot {:?} (expected tx range {:?}..{:?})",
+                            tx_range_start,
+                            head_slot_number,
+                            tx_range_start,
+                            tx_range_end,
+                        );
+                    }
+                    (Some(_), None) => {
+                        anyhow::bail!(
+                            "Ledger DB corruption during rollback: missing last tx {:?} for slot {:?} (expected tx range {:?}..{:?})",
+                            TxNumber(tx_range_end.0.saturating_sub(1)),
+                            head_slot_number,
+                            tx_range_start,
+                            tx_range_end,
+                        );
+                    }
+                };
+
+                let event_range_start = first_tx.events.start;
+                let event_range_end = last_tx.events.end;
+                debug_assert!(
+                    event_range_start <= event_range_end,
+                    "Event range inverted: start={event_range_start:?} end={event_range_end:?}",
+                );
+
+                // Delete hash-indexed entries by iterating through txs
+                // (we need tx_number to delete EventByKey, and tx.hash to delete TxByHash)
+                for current_tx_number in tx_range_start.0..tx_range_end.0 {
+                    let current_tx_number = TxNumber(current_tx_number);
+
+                    let tx = match db.get::<TxByNumber>(&current_tx_number)? {
+                        Some(tx) => tx,
+                        None => {
+                            anyhow::bail!(
+                                "Ledger DB corruption during rollback: missing tx {:?} for slot {:?} (expected tx range {:?}..{:?})",
+                                current_tx_number,
+                                head_slot_number,
+                                tx_range_start,
+                                tx_range_end,
+                            );
+                        }
+                    };
+
+                    // Delete EventByKey entries for this tx's events
+                    for current_event_number in tx.events.start.0..tx.events.end.0 {
+                        let current_event_number = EventNumber(current_event_number);
+                        let event = match db.get::<EventByNumber>(&current_event_number)? {
+                            Some(event) => event,
+                            None => {
+                                anyhow::bail!(
+                                    "Ledger DB corruption during rollback: missing event {:?} for slot {:?} (tx {:?}, expected event range {:?}..{:?})",
+                                    current_event_number,
+                                    head_slot_number,
+                                    current_tx_number,
+                                    tx.events.start,
+                                    tx.events.end,
+                                );
+                            }
+                        };
+                        schema_batch.delete::<EventByKey>(&(
+                            event.key().clone(),
+                            current_tx_number,
+                            current_event_number,
+                        ))?;
+                    }
+                    // Delete TxByHash entry
+                    schema_batch.delete::<TxByHash>(&(tx.hash, current_tx_number))?;
+                }
+
+                // Range delete EventByNumber (reduces tombstones).
+                // If there are no events in this slot, the range is empty and we skip it.
+                if event_range_start < event_range_end {
+                    schema_batch
+                        .delete_range::<EventByNumber>(&event_range_start, &event_range_end)?;
+                }
+
+                // Range delete TxByNumber (reduces tombstones)
+                schema_batch.delete_range::<TxByNumber>(&tx_range_start, &tx_range_end)?;
             }
 
             // Delete BatchByHash individually (hash-indexed)

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -701,35 +701,79 @@ impl LedgerDb {
             }
         }
 
-        // Delete all batches in this slot
-        for current_batch_number in head_slot.batches.start.0..head_slot.batches.end.0 {
-            let current_batch_number = BatchNumber(current_batch_number);
+        // Delete all batches, transactions, and events in this slot.
+        // We use range deletes for number-indexed tables (TxByNumber, EventByNumber)
+        // and individual deletes for hash-indexed tables (TxByHash, EventByKey, BatchByHash).
+        if head_slot.batches.start < head_slot.batches.end {
+            let first_batch_num = head_slot.batches.start;
+            let last_batch_num = BatchNumber(head_slot.batches.end.0.saturating_sub(1));
 
-            if let Some(batch) = db.get::<BatchByNumber>(&current_batch_number)? {
-                // Delete all transactions in this batch
-                for current_tx_number in batch.txs.start.0..batch.txs.end.0 {
-                    let current_tx_number = TxNumber(current_tx_number);
+            // Get first and last batches to determine the overall tx range
+            if let (Some(first_batch), Some(last_batch)) = (
+                db.get::<BatchByNumber>(&first_batch_num)?,
+                db.get::<BatchByNumber>(&last_batch_num)?,
+            ) {
+                let tx_range_start = first_batch.txs.start;
+                let tx_range_end = last_batch.txs.end;
 
-                    if let Some(tx) = db.get::<TxByNumber>(&current_tx_number)? {
-                        // Delete all events in this transaction
-                        for current_event_number in tx.events.start.0..tx.events.end.0 {
-                            let current_event_number = EventNumber(current_event_number);
+                // Process transactions and events if there are any
+                if tx_range_start < tx_range_end {
+                    // Get first and last txs to determine overall event range
+                    if let (Some(first_tx), Some(last_tx)) = (
+                        db.get::<TxByNumber>(&tx_range_start)?,
+                        db.get::<TxByNumber>(&TxNumber(tx_range_end.0.saturating_sub(1)))?,
+                    ) {
+                        let event_range_start = first_tx.events.start;
+                        let event_range_end = last_tx.events.end;
 
-                            if let Some(event) = db.get::<EventByNumber>(&current_event_number)? {
-                                Self::delete_event(
-                                    &mut schema_batch,
-                                    current_tx_number,
-                                    &event,
-                                    current_event_number,
-                                )?;
+                        // Delete hash-indexed entries by iterating through txs
+                        // (we need tx_number to delete EventByKey, and tx.hash to delete TxByHash)
+                        for current_tx_number in tx_range_start.0..tx_range_end.0 {
+                            let current_tx_number = TxNumber(current_tx_number);
+
+                            if let Some(tx) = db.get::<TxByNumber>(&current_tx_number)? {
+                                // Delete EventByKey entries for this tx's events
+                                for current_event_number in tx.events.start.0..tx.events.end.0 {
+                                    let current_event_number = EventNumber(current_event_number);
+                                    if let Some(event) =
+                                        db.get::<EventByNumber>(&current_event_number)?
+                                    {
+                                        schema_batch.delete::<EventByKey>(&(
+                                            event.key().clone(),
+                                            current_tx_number,
+                                            current_event_number,
+                                        ))?;
+                                    }
+                                }
+                                // Delete TxByHash entry
+                                schema_batch.delete::<TxByHash>(&(tx.hash, current_tx_number))?;
                             }
                         }
-                        Self::delete_tx(&mut schema_batch, &tx, current_tx_number)?;
-                    }
-                }
 
-                Self::delete_batch(&mut schema_batch, &batch, &current_batch_number)?;
+                        // Range delete EventByNumber (reduces tombstones)
+                        if event_range_start < event_range_end {
+                            schema_batch.delete_range::<EventByNumber>(
+                                &event_range_start,
+                                &event_range_end,
+                            )?;
+                        }
+                    }
+
+                    // Range delete TxByNumber (reduces tombstones)
+                    schema_batch.delete_range::<TxByNumber>(&tx_range_start, &tx_range_end)?;
+                }
             }
+
+            // Delete BatchByHash individually (hash-indexed)
+            for current_batch_number in head_slot.batches.start.0..head_slot.batches.end.0 {
+                if let Some(batch) = db.get::<BatchByNumber>(&BatchNumber(current_batch_number))? {
+                    schema_batch.delete::<BatchByHash>(&batch.hash)?;
+                }
+            }
+
+            // Range delete BatchByNumber (reduces tombstones)
+            schema_batch
+                .delete_range::<BatchByNumber>(&head_slot.batches.start, &head_slot.batches.end)?;
         }
 
         Self::delete_slot(&mut schema_batch, &head_slot, &head_slot_number)?;
@@ -757,37 +801,6 @@ impl LedgerDb {
         }
 
         Ok(schema_batch)
-    }
-
-    fn delete_event(
-        schema_batch: &mut SchemaBatch,
-        tx_number: TxNumber,
-        event: &StoredEvent,
-        event_number: EventNumber,
-    ) -> anyhow::Result<()> {
-        schema_batch.delete::<EventByNumber>(&event_number)?;
-        schema_batch.delete::<EventByKey>(&(event.key().clone(), tx_number, event_number))?;
-        Ok(())
-    }
-
-    fn delete_tx(
-        schema_batch: &mut SchemaBatch,
-        tx: &StoredTransaction,
-        tx_number: TxNumber,
-    ) -> anyhow::Result<()> {
-        schema_batch.delete::<TxByNumber>(&tx_number)?;
-        schema_batch.delete::<TxByHash>(&(tx.hash, tx_number))?;
-        Ok(())
-    }
-
-    fn delete_batch(
-        schema_batch: &mut SchemaBatch,
-        batch: &StoredBatch,
-        batch_number: &BatchNumber,
-    ) -> anyhow::Result<()> {
-        schema_batch.delete::<BatchByNumber>(batch_number)?;
-        schema_batch.delete::<BatchByHash>(&batch.hash)?;
-        Ok(())
     }
 
     fn delete_discarded_blob(

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -727,9 +727,7 @@ impl LedgerDb {
                         let event_range_end = last_tx.events.end;
                         debug_assert!(
                             event_range_start <= event_range_end,
-                            "Event range inverted: start={:?} end={:?}",
-                            event_range_start,
-                            event_range_end
+                            "Event range inverted: start={event_range_start:?} end={event_range_end:?}",
                         );
 
                         // Delete hash-indexed entries by iterating through txs


### PR DESCRIPTION
# Description

To reduce number of thumbstones in rocksdb and maintain decent performance over long run.

First mentioned in the comment https://github.com/Sovereign-Labs/sovereign-sdk/issues/2267#issuecomment-3705233210

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2267 

## Testing
Existing tests are passing

## Docs
No updates

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
