### PR TITLE
Fix hyperlane-monorepo dependency version

### DIFF
--- a/crates/module-system/module-implementations/extern/hyperlane-solana-register/solana/Cargo.lock
+++ b/crates/module-system/module-implementations/extern/hyperlane-solana-register/solana/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "access-control"
 version = "0.1.0"
-source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?branch=sovereign-rust-integration#7bfff9cad79b5d8c50871a88eab6bddb6da25ed4"
+source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec"
 dependencies = [
  "solana-program",
 ]
@@ -23,7 +23,7 @@ dependencies = [
 [[package]]
 name = "account-utils"
 version = "0.1.0"
-source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?branch=sovereign-rust-integration#7bfff9cad79b5d8c50871a88eab6bddb6da25ed4"
+source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec"
 dependencies = [
  "borsh",
  "solana-program",
@@ -1629,8 +1629,8 @@ dependencies = [
 
 [[package]]
 name = "hyperlane-application"
-version = "1.7.0"
-source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?branch=sovereign-rust-integration#7bfff9cad79b5d8c50871a88eab6bddb6da25ed4"
+version = "2.0.0"
+source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec"
 dependencies = [
  "serde",
  "serde_json",
@@ -1639,8 +1639,8 @@ dependencies = [
 
 [[package]]
 name = "hyperlane-core"
-version = "1.7.0"
-source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?branch=sovereign-rust-integration#7bfff9cad79b5d8c50871a88eab6bddb6da25ed4"
+version = "2.0.0"
+source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec"
 dependencies = [
  "async-rwlock",
  "async-trait",
@@ -1678,7 +1678,7 @@ dependencies = [
 [[package]]
 name = "hyperlane-sealevel-connection-client"
 version = "0.1.0"
-source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?branch=sovereign-rust-integration#7bfff9cad79b5d8c50871a88eab6bddb6da25ed4"
+source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec"
 dependencies = [
  "access-control",
  "borsh",
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "hyperlane-sealevel-igp"
 version = "0.1.0"
-source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?branch=sovereign-rust-integration#7bfff9cad79b5d8c50871a88eab6bddb6da25ed4"
+source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec"
 dependencies = [
  "access-control",
  "account-utils",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "hyperlane-sealevel-interchain-security-module-interface"
 version = "0.1.0"
-source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?branch=sovereign-rust-integration#7bfff9cad79b5d8c50871a88eab6bddb6da25ed4"
+source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec"
 dependencies = [
  "borsh",
  "solana-program",
@@ -1718,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "hyperlane-sealevel-mailbox"
 version = "0.1.0"
-source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?branch=sovereign-rust-integration#7bfff9cad79b5d8c50871a88eab6bddb6da25ed4"
+source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec"
 dependencies = [
  "access-control",
  "account-utils",
@@ -1740,7 +1740,7 @@ dependencies = [
 [[package]]
 name = "hyperlane-sealevel-message-recipient-interface"
 version = "0.1.0"
-source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?branch=sovereign-rust-integration#7bfff9cad79b5d8c50871a88eab6bddb6da25ed4"
+source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec"
 dependencies = [
  "borsh",
  "getrandom 0.2.15",
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "hyperlane-sealevel-test-ism"
 version = "0.1.0"
-source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?branch=sovereign-rust-integration#7bfff9cad79b5d8c50871a88eab6bddb6da25ed4"
+source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec"
 dependencies = [
  "account-utils",
  "borsh",
@@ -1805,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "hyperlane-test-transaction-utils"
 version = "0.1.0"
-source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?branch=sovereign-rust-integration#7bfff9cad79b5d8c50871a88eab6bddb6da25ed4"
+source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec"
 dependencies = [
  "solana-program",
  "solana-program-test",
@@ -1815,7 +1815,7 @@ dependencies = [
 [[package]]
 name = "hyperlane-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?branch=sovereign-rust-integration#7bfff9cad79b5d8c50871a88eab6bddb6da25ed4"
+source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec"
 dependencies = [
  "borsh",
  "hyperlane-core",
@@ -3385,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "serializable-account-meta"
 version = "0.1.0"
-source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?branch=sovereign-rust-integration#7bfff9cad79b5d8c50871a88eab6bddb6da25ed4"
+source = "git+https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec"
 dependencies = [
  "borsh",
  "solana-program",

--- a/crates/module-system/module-implementations/extern/hyperlane-solana-register/solana/Cargo.toml
+++ b/crates/module-system/module-implementations/extern/hyperlane-solana-register/solana/Cargo.toml
@@ -17,16 +17,16 @@ solana-program = "=1.14.13"
 solana-program-test = "=1.14.13"
 solana-client = "=1.14.13"
 spl-noop = { version = "=0.1.3", features = ["no-entrypoint"] }
-hyperlane-sealevel-mailbox = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", branch = "sovereign-rust-integration", features = [
+hyperlane-sealevel-mailbox = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", rev = "99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec", features = [
   "no-entrypoint",
 ] }
-hyperlane-sealevel-igp = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", branch = "sovereign-rust-integration", features = [
+hyperlane-sealevel-igp = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", rev = "99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec", features = [
   "no-entrypoint",
 ] }
-account-utils = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", branch = "sovereign-rust-integration" }
-hyperlane-core = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", branch = "sovereign-rust-integration" }
-hyperlane-sealevel-connection-client = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", branch = "sovereign-rust-integration" }
-hyperlane-sealevel-test-ism = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", branch = "sovereign-rust-integration" }
+account-utils = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", rev = "99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec" }
+hyperlane-core = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", rev = "99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec" }
+hyperlane-sealevel-connection-client = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", rev = "99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec" }
+hyperlane-sealevel-test-ism = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", rev = "99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec" }
 
 tokio = { version = "1.37", features = ["parking_lot", "tracing"] }
 

--- a/crates/module-system/module-implementations/extern/hyperlane-solana-register/solana/program-tests/Cargo.toml
+++ b/crates/module-system/module-implementations/extern/hyperlane-solana-register/solana/program-tests/Cargo.toml
@@ -30,7 +30,7 @@ hyperlane-core.workspace = true
 hyperlane-sealevel-connection-client.workspace = true
 hyperlane-sealevel-mailbox = { workspace = true, features = ["no-entrypoint"] }
 hyperlane-sealevel-igp = { workspace = true, features = ["no-entrypoint"] }
-hyperlane-test-utils = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", branch = "sovereign-rust-integration" }
+hyperlane-test-utils = { git = "https://github.com/Sovereign-Labs/hyperlane-monorepo.git", rev = "99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec" }
 hyperlane-sealevel-test-ism.workspace = true
 
 [lib]


### PR DESCRIPTION
# Description

Fixes hyperlane-monorepo fork version. I squashed some commits/force pushed our integration branch so the commit in the lockfile no longer existed.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
