### PR TITLE
Add backwards compatible mode for Hyperlane delivery counting

### DIFF
--- a/constants.testing.toml
+++ b/constants.testing.toml
@@ -136,6 +136,7 @@ ELASTICITY_MULTIPLIER = 2
 
 # --- Hyperlane constants ---
 HYPERLANE_BRIDGE_DOMAIN = 5555
+HYPERLANE_METER_DELIVERY_COUNTER_AFTER_HEIGHT = 0
 # --- End Hyperlane constants ---
 
 CONST_TOKEN_ID = { const = { bech32 = "token_1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnfxkwm", type = "MyTokenId" } }

--- a/constants.toml
+++ b/constants.toml
@@ -156,6 +156,7 @@ ELASTICITY_MULTIPLIER = 2
 
 # --- Hyperlane constants ---
 HYPERLANE_BRIDGE_DOMAIN = 5555
+HYPERLANE_METER_DELIVERY_COUNTER_AFTER_HEIGHT = 0
 # --- End Hyperlane constants ---
 
 

--- a/crates/module-system/hyperlane/src/call.rs
+++ b/crates/module-system/hyperlane/src/call.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use sov_bank::Amount;
 use sov_modules_api::macros::{config_value, UniversalWallet};
 use sov_modules_api::{
-    Context, EventEmitter, GasMeter, HexHash, HexString, SafeVec, Spec, StateAccessor, TxState
+    Context, EventEmitter, GasMeter, HexHash, HexString, SafeVec, Spec, TxState,
 };
 use strum::{EnumDiscriminants, EnumIs, VariantArray};
 
@@ -207,12 +207,14 @@ where
         }
 
         // Backwards compatibility. Don't activate the counter until the configured height
-        if state.current_visible_slot_number().get() > config_value!("HYPERLANE_METER_DELIVERY_COUNTER_AFTER_HEIGHT") {
+        if state.current_visible_slot_number().get()
+            > config_value!("HYPERLANE_METER_DELIVERY_COUNTER_AFTER_HEIGHT")
+        {
             let mut count = self.deliveries_count.get(state)?.unwrap_or_default();
             count += 1;
             self.deliveries_count.set(&count, state)?;
         }
-       
+
         self.deliveries.set(
             &message_id,
             &Delivery {

--- a/crates/module-system/hyperlane/src/call.rs
+++ b/crates/module-system/hyperlane/src/call.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use sov_bank::Amount;
 use sov_modules_api::macros::{config_value, UniversalWallet};
 use sov_modules_api::{
-    Context, EventEmitter, GasMeter, HexHash, HexString, SafeVec, Spec, TxState,
+    Context, EventEmitter, GasMeter, HexHash, HexString, SafeVec, Spec, StateAccessor, TxState
 };
 use strum::{EnumDiscriminants, EnumIs, VariantArray};
 
@@ -206,9 +206,13 @@ where
             return Err(anyhow::anyhow!("Message {} already processed", message_id));
         }
 
-        let mut count = self.deliveries_count.get(state)?.unwrap_or_default();
-        count += 1;
-        self.deliveries_count.set(&count, state)?;
+        // Backwards compatibility. Don't activate the counter until the configured height
+        if state.current_visible_slot_number().get() > config_value!("HYPERLANE_METER_DELIVERY_COUNTER_AFTER_HEIGHT") {
+            let mut count = self.deliveries_count.get(state)?.unwrap_or_default();
+            count += 1;
+            self.deliveries_count.set(&count, state)?;
+        }
+       
         self.deliveries.set(
             &message_id,
             &Delivery {


### PR DESCRIPTION
# Description

This PR adds a constant to disable the new delivery tracking introduced in #2340 before a specified height. This allows chains to update to the new behavior without breaking resync.
