### PR TITLE
`NodeDiscovery`: Update the cluster_info file only when cluster membership changes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11926,6 +11926,7 @@ name = "sov-proxy-utils"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "sqlx",
  "time",
  "tokio",

--- a/crates/utils/sov-proxy-utils/Cargo.toml
+++ b/crates/utils/sov-proxy-utils/Cargo.toml
@@ -15,6 +15,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls-ring-webpki",
 time = { version = "0.3", default-features = false, features = ["formatting", "parsing"] }
 tokio = { workspace = true, features = ["time", "sync"], default-features = false }
 tracing = { workspace = true }
+async-trait = { workspace = true }
 
 
 [lints]

--- a/crates/utils/sov-proxy-utils/src/lib.rs
+++ b/crates/utils/sov-proxy-utils/src/lib.rs
@@ -271,24 +271,12 @@ impl NodeDiscovery {
             .listen_all(["nodes_changes", "leader_changes"])
             .await?;
 
-        // Fetch initial cluster info.
-        match self.get_cluster_info().await {
-            Ok(info) => {
-                if let Err(error) = write_to_file_atomically(path, info.to_file_content()).await {
-                    tracing::warn!(?error, ?path, "Failed to update the cluster info file.");
-                } else {
-                    // Notify watchers that the file was saved successfully.
-                    self.notifier.on_cluster_update(&info).await;
-                }
-            }
-            Err(error) => {
-                tracing::warn!(?error, "Failed to fetch initial cluster info");
-            }
-        }
-
         tracing::info!("Subscribed to nodes_changes and leader_changes channels");
 
         let mut consecutive_errors: u32 = 0;
+
+        // On startup, write an empty file. If the cluster is not empty, the file will be populated on the first call to `handle_cluster_update`.
+        write_to_file_atomically(path, "".to_string()).await?;
 
         loop {
             match self.handle_cluster_update(&mut listener, path).await {
@@ -316,12 +304,6 @@ impl NodeDiscovery {
         listener: &mut PgListener,
         path: &std::path::Path,
     ) -> anyhow::Result<()> {
-        // Wait for at least one notification.
-        listener.recv().await?;
-
-        // Drain any additional pending notifications.
-        while listener.next_buffered().is_some() {}
-
         let info = self.get_cluster_info().await?;
         let leader_id = info.leader_id();
 
@@ -355,6 +337,12 @@ impl NodeDiscovery {
         }
 
         tracing::debug!(info = ?info, "Last cluster info");
+
+        // Wait for at least one notification.
+        listener.recv().await?;
+
+        // Drain any additional pending notifications.
+        while listener.next_buffered().is_some() {}
 
         Ok(())
     }

--- a/crates/utils/sov-proxy-utils/src/lib.rs
+++ b/crates/utils/sov-proxy-utils/src/lib.rs
@@ -336,7 +336,7 @@ impl NodeDiscovery {
             self.notifier.on_cluster_update(&info).await;
         }
 
-        tracing::debug!(info = ?info, "Last cluster info");
+        tracing::trace!(info = ?info, "Last cluster info");
 
         // Wait for at least one notification.
         listener.recv().await?;
@@ -387,7 +387,7 @@ async fn write_to_file_atomically(path: &Path, content: String) -> anyhow::Resul
     let dir = path.parent().context("Path has no parent directory")?;
 
     // Create temp file in same directory to ensure same filesystem for atomic rename.
-    let temp_path = dir.join(format!(".{}.tmp", std::process::id()));
+    let temp_path = dir.join(".tmp");
 
     // Write content to temp file.
     let mut file = tokio::fs::File::create(&temp_path)

--- a/crates/utils/sov-proxy-utils/src/lib.rs
+++ b/crates/utils/sov-proxy-utils/src/lib.rs
@@ -3,20 +3,19 @@
 //! This crate provides the [`Proxy`] struct to retrieve leader and follower
 //! IP addresses from the PostgreSQL database atomically.
 
-use std::collections::HashSet;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use sqlx::postgres::{PgListener, PgPool};
+use sqlx::FromRow;
+use std::collections::BTreeSet;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::time::Duration;
-
-use anyhow::{Context, Result};
-use sqlx::postgres::{PgListener, PgPool};
-use sqlx::FromRow;
 pub use time::OffsetDateTime;
+use tokio::io::AsyncWriteExt;
 use tokio::sync::watch;
 
 const MAX_DB_ERRORS_ALLOWED: u32 = 10;
-
-const MAX_AGE: Duration = Duration::from_secs(10);
 
 /// Information about a registered node.
 #[derive(Debug, Clone, FromRow, PartialEq, Eq)]
@@ -47,6 +46,8 @@ pub struct ClusterInfo {
     pub leader: Option<NodeInfo>,
     /// All follower nodes.
     pub followers: Vec<NodeInfo>,
+    /// Set of all node IDs in the cluster, used to detect membership changes.
+    members: BTreeSet<String>,
 }
 
 impl ClusterInfo {
@@ -81,16 +82,29 @@ impl ClusterInfo {
     pub fn parse(content: &str) -> Result<Self> {
         let mut leader = None;
         let mut followers = Vec::new();
+        let mut members = BTreeSet::new();
 
         for line in content.lines() {
             if let Some(rest) = line.strip_prefix("leader=") {
-                leader = Some(NodeInfo::parse(rest)?);
+                let node = NodeInfo::parse(rest)?;
+                members.insert(node.node_id.clone());
+                leader = Some(node);
             } else if let Some(rest) = line.strip_prefix("follower=") {
-                followers.push(NodeInfo::parse(rest)?);
+                let node = NodeInfo::parse(rest)?;
+                members.insert(node.node_id.clone());
+                followers.push(node);
             }
         }
 
-        Ok(ClusterInfo { leader, followers })
+        Ok(ClusterInfo {
+            leader,
+            followers,
+            members,
+        })
+    }
+
+    fn leader_id(&self) -> Option<String> {
+        self.leader.as_ref().map(|l| l.node_id.clone())
     }
 }
 
@@ -111,23 +125,51 @@ impl NodeInfo {
     }
 }
 
+/// Trait for receiving notifications when cluster state changes.
+///
+/// Implement this trait to define custom behavior when the cluster membership
+/// or leader changes. The notification is triggered after the cluster info file
+/// has been updated.
+#[async_trait]
+pub trait ClusterUpdateNotifier: Send + Sync + 'static {
+    /// Called when cluster membership or leadership changes.
+    async fn on_cluster_update(&self, cluster_info: &ClusterInfo);
+}
+
+/// A simple notifier that signals a watch channel when the cluster updates.
+///
+/// This is the default implementation of [`ClusterUpdateNotifier`] that uses
+/// a [`tokio::sync::watch`] channel to notify waiters of cluster changes.
+pub struct SimpleClusterUpdateNotifier {
+    sender: watch::Sender<()>,
+}
+
+impl SimpleClusterUpdateNotifier {
+    /// Creates a new notifier and its corresponding receiver.
+    pub fn new() -> (Self, watch::Receiver<()>) {
+        let (sender, receiver) = watch::channel(());
+        (Self { sender }, receiver)
+    }
+}
+
+#[async_trait]
+impl ClusterUpdateNotifier for SimpleClusterUpdateNotifier {
+    async fn on_cluster_update(&self, _cluster_info: &ClusterInfo) {
+        let _ = self.sender.send(());
+    }
+}
+
 /// Client for querying cluster information from the database.
 pub struct NodeDiscovery {
     max_age: Duration,
     pool: PgPool,
     connection_string: String,
-    file_saved_sender: watch::Sender<()>,
+    prev_members: BTreeSet<String>,
+    prev_leader_id: Option<String>,
+    notifier: Box<dyn ClusterUpdateNotifier>,
 }
 
 impl NodeDiscovery {
-    /// Creates a new NodeDiscovery with a connection pool and default max_age.
-    ///
-    /// Returns the NodeDiscovery instance and a receiver that gets notified
-    /// whenever the cluster info file is successfully saved.
-    pub async fn new(connection_string: &str) -> Result<(Self, watch::Receiver<()>)> {
-        Self::new_with_max_age(connection_string, MAX_AGE).await
-    }
-
     /// Creates a new NodeDiscovery with a connection pool and custom max_age.
     ///
     /// The `max_age` parameter controls how long a node can go without updating
@@ -135,27 +177,26 @@ impl NodeDiscovery {
     ///
     /// Returns the NodeDiscovery instance and a receiver that gets notified
     /// whenever the cluster info file is successfully saved.
-    pub async fn new_with_max_age(
+    pub async fn new(
         connection_string: &str,
         max_age: Duration,
-    ) -> Result<(Self, watch::Receiver<()>)> {
+        notifier: Box<dyn ClusterUpdateNotifier>,
+    ) -> Result<Self> {
         tracing::info!("Connecting to database.");
         let pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(5)
             .connect(connection_string)
             .await?;
         tracing::info!("DB connection established.");
-        let (file_saved_sender, file_saved_receiver) = watch::channel(());
 
-        Ok((
-            Self {
-                max_age,
-                pool,
-                connection_string: connection_string.to_string(),
-                file_saved_sender,
-            },
-            file_saved_receiver,
-        ))
+        Ok(Self {
+            max_age,
+            pool,
+            connection_string: connection_string.to_string(),
+            prev_members: BTreeSet::new(),
+            prev_leader_id: None,
+            notifier,
+        })
     }
 
     // Fetches cluster info atomically using a single transaction.
@@ -175,9 +216,9 @@ impl NodeDiscovery {
         let cap = all_nodes.capacity();
         let mut leader = None;
         let mut followers = Vec::with_capacity(cap);
-        let mut seen_node_ids: HashSet<String> = HashSet::with_capacity(cap);
+        let mut members = BTreeSet::new();
         for (node_id, address, last_updated) in all_nodes {
-            if !seen_node_ids.insert(node_id.clone()) {
+            if !members.insert(node_id.clone()) {
                 anyhow::bail!("Duplicate node id found in Nodes table: {node_id}");
             }
 
@@ -207,7 +248,11 @@ impl NodeDiscovery {
             }
         }
 
-        Ok(ClusterInfo { leader, followers })
+        Ok(ClusterInfo {
+            leader,
+            followers,
+            members,
+        })
     }
 
     /// Subscribes to PostgreSQL notifications for cluster changes and writes
@@ -215,7 +260,7 @@ impl NodeDiscovery {
     ///
     /// Listens on `nodes_changes` and `leader_changes` channels.
     pub async fn subscribe_cluster_info_loop(
-        &self,
+        &mut self,
         path: impl AsRef<std::path::Path>,
     ) -> anyhow::Result<()> {
         let path = path.as_ref();
@@ -226,22 +271,22 @@ impl NodeDiscovery {
             .listen_all(["nodes_changes", "leader_changes"])
             .await?;
 
-        tracing::info!("Subscribed to nodes_changes and leader_changes channels");
-
         // Fetch initial cluster info.
         match self.get_cluster_info().await {
             Ok(info) => {
-                if let Err(error) = write_to_file(path, info.to_file_content()).await {
+                if let Err(error) = write_to_file_atomically(path, info.to_file_content()).await {
                     tracing::warn!(?error, ?path, "Failed to update the cluster info file.");
                 } else {
                     // Notify watchers that the file was saved successfully.
-                    let _ = self.file_saved_sender.send(());
+                    self.notifier.on_cluster_update(&info).await;
                 }
             }
             Err(error) => {
                 tracing::warn!(?error, "Failed to fetch initial cluster info");
             }
         }
+
+        tracing::info!("Subscribed to nodes_changes and leader_changes channels");
 
         let mut consecutive_errors: u32 = 0;
 
@@ -267,7 +312,7 @@ impl NodeDiscovery {
     }
 
     async fn handle_cluster_update(
-        &self,
+        &mut self,
         listener: &mut PgListener,
         path: &std::path::Path,
     ) -> anyhow::Result<()> {
@@ -278,9 +323,39 @@ impl NodeDiscovery {
         while listener.next_buffered().is_some() {}
 
         let info = self.get_cluster_info().await?;
-        write_to_file(path, info.to_file_content()).await?;
-        // Notify watchers that the file was saved successfully.
-        let _ = self.file_saved_sender.send(());
+        let leader_id = info.leader_id();
+
+        let membership_changed = self.prev_members != info.members;
+        let leader_changed = self.prev_leader_id != leader_id;
+
+        if membership_changed || leader_changed {
+            // Log membership changes
+            for node_id in info.members.difference(&self.prev_members) {
+                tracing::info!(node_id, "Node joined the cluster");
+            }
+            for node_id in self.prev_members.difference(&info.members) {
+                tracing::info!(node_id, "Node left the cluster");
+            }
+
+            // Log leader change
+            if leader_changed {
+                tracing::info!(
+                    old_leader = ?self.prev_leader_id,
+                    new_leader = ?leader_id,
+                    "Leader changed"
+                );
+            }
+
+            write_to_file_atomically(path, info.to_file_content()).await?;
+            self.prev_members = info.members.clone();
+            self.prev_leader_id = leader_id;
+
+            // Notify watchers that the cluster was updated.
+            self.notifier.on_cluster_update(&info).await;
+        }
+
+        tracing::debug!(info = ?info, "Last cluster info");
+
         Ok(())
     }
 
@@ -316,10 +391,34 @@ impl NodeDiscovery {
     }
 }
 
-async fn write_to_file(path: &Path, content: String) -> anyhow::Result<()> {
-    tokio::fs::write(path, content)
+/// Atomically writes content to a file.
+///
+/// Uses write-to-temp-then-rename pattern to ensure the file is never
+/// partially written. The data is synced to disk before renaming.
+async fn write_to_file_atomically(path: &Path, content: String) -> anyhow::Result<()> {
+    let dir = path.parent().context("Path has no parent directory")?;
+
+    // Create temp file in same directory to ensure same filesystem for atomic rename.
+    let temp_path = dir.join(format!(".{}.tmp", std::process::id()));
+
+    // Write content to temp file.
+    let mut file = tokio::fs::File::create(&temp_path)
         .await
-        .with_context(|| format!("Failed to write cluster info to file at {path:?}"))?;
+        .with_context(|| format!("Failed to create temp file at {temp_path:?}"))?;
+
+    file.write_all(content.as_bytes())
+        .await
+        .with_context(|| format!("Failed to write to temp file at {temp_path:?}"))?;
+
+    // Sync to disk before renaming.
+    file.sync_all()
+        .await
+        .with_context(|| format!("Failed to sync temp file at {temp_path:?}"))?;
+
+    // Atomic rename.
+    tokio::fs::rename(&temp_path, path)
+        .await
+        .with_context(|| format!("Failed to rename {temp_path:?} to {path:?}"))?;
 
     Ok(())
 }
@@ -434,5 +533,27 @@ mod tests {
         assert!(err
             .to_string()
             .contains("Leader is missing from the Nodes table."));
+    }
+
+    #[test]
+    fn leader_change_detected_when_membership_unchanged() {
+        let ts = test_timestamp();
+        let nodes = vec![
+            ("node1".to_string(), "127.0.0.1:8000".to_string(), ts),
+            ("node2".to_string(), "127.0.0.1:8001".to_string(), ts),
+        ];
+
+        // Initial state: node1 is leader
+        let info1 = NodeDiscovery::cluster(Some("node1".to_string()), nodes.clone()).unwrap();
+
+        // New state: node2 becomes leader, same membership
+        let info2 = NodeDiscovery::cluster(Some("node2".to_string()), nodes).unwrap();
+
+        // Membership should be identical
+        assert_eq!(info1.members, info2.members, "Members should be unchanged");
+
+        // But leader_id should differ.
+        assert_eq!(info1.leader_id(), Some("node1".to_string()));
+        assert_eq!(info2.leader_id(), Some("node2".to_string()));
     }
 }

--- a/crates/utils/sov-proxy-utils/src/lib.rs
+++ b/crates/utils/sov-proxy-utils/src/lib.rs
@@ -276,7 +276,7 @@ impl NodeDiscovery {
         let mut consecutive_errors: u32 = 0;
 
         // On startup, write an empty file. If the cluster is not empty, the file will be populated on the first call to `handle_cluster_update`.
-        write_to_file_atomically(path, "".to_string()).await?;
+        write_to_file_atomically(path, "").await?;
 
         loop {
             match self.handle_cluster_update(&mut listener, path).await {
@@ -328,7 +328,10 @@ impl NodeDiscovery {
                 );
             }
 
-            write_to_file_atomically(path, info.to_file_content()).await?;
+            let content = info.to_file_content();
+            write_to_file_atomically(path, &content).await?;
+            tracing::info!(?path, content, "Cluster info file updated");
+
             self.prev_members = info.members.clone();
             self.prev_leader_id = leader_id;
 
@@ -383,7 +386,7 @@ impl NodeDiscovery {
 ///
 /// Uses write-to-temp-then-rename pattern to ensure the file is never
 /// partially written. The data is synced to disk before renaming.
-async fn write_to_file_atomically(path: &Path, content: String) -> anyhow::Result<()> {
+async fn write_to_file_atomically(path: &Path, content: &str) -> anyhow::Result<()> {
     let dir = path.parent().context("Path has no parent directory")?;
 
     // Create temp file in same directory to ensure same filesystem for atomic rename.

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -18,6 +18,7 @@ use sov_modules_api::PrivateKey;
 use sov_modules_api::PublicKey;
 use sov_modules_api::Spec;
 use sov_modules_rollup_blueprint::RollupBlueprint;
+use sov_proxy_utils::SimpleClusterUpdateNotifier;
 use sov_sequencer::preferred::ConfiguredNodeRole;
 use sov_test_utils::postgres::CreatePostgresError;
 use sov_test_utils::test_rollup::read_private_key;
@@ -26,7 +27,6 @@ use sov_test_utils::test_rollup::RollupBuilder;
 use sov_test_utils::test_rollup::TestRollup;
 use sov_test_utils::TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS;
 use std::net::SocketAddr;
-use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::watch;
@@ -158,16 +158,6 @@ async fn wait_for_all_events(
 use sov_proxy_utils::ClusterInfo;
 use sov_proxy_utils::NodeDiscovery;
 
-async fn wait_for_file_change(path: &Path, file_watcher: &mut watch::Receiver<()>) -> ClusterInfo {
-    tokio::time::timeout(Duration::from_secs(2), file_watcher.changed())
-        .await
-        .unwrap()
-        .unwrap();
-
-    let content = std::fs::read_to_string(path).expect("Failed to read file content");
-    ClusterInfo::parse(&content).expect("Failed to parse cluster info")
-}
-
 type Rollup = ExternalMockDemoRollup<Native>;
 
 /// Holds resources for a cluster info subscription.
@@ -180,7 +170,19 @@ struct ClusterInfoSubscription {
 
 impl ClusterInfoSubscription {
     async fn wait_for_change(&mut self) -> ClusterInfo {
-        wait_for_file_change(&self.path, &mut self.file_watcher).await
+        self.wait_for_change_with_timeout(Duration::from_secs(2))
+            .await
+    }
+
+    async fn wait_for_change_with_timeout(&mut self, timeout: Duration) -> ClusterInfo {
+        tokio::time::timeout(timeout, self.file_watcher.changed())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let content =
+            std::fs::read_to_string(self.path.clone()).expect("Failed to read file content");
+        ClusterInfo::parse(&content).expect("Failed to parse cluster info")
     }
 
     fn abort(self) {
@@ -218,9 +220,10 @@ impl NodeDiscoveryTestSetup {
 
         let (_, da_shutdown, da_addr) = create_da_service_periodic().await;
 
+        let (notifier, file_watcher) = SimpleClusterUpdateNotifier::new();
         // Create NodeDiscovery to query the nodes table
-        let (node_discovery, file_watcher) =
-            NodeDiscovery::new_with_max_age(postgres.connection_string(), max_age)
+        let mut node_discovery =
+            NodeDiscovery::new(postgres.connection_string(), max_age, Box::new(notifier))
                 .await
                 .expect("Failed to create NodeDiscovery");
 

--- a/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
+++ b/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
@@ -22,9 +22,16 @@ async fn test_multiple_replicas_register_in_nodes_table() {
 
     // Verify both replicas are present in followers
     let cluster_info = setup.cluster_info_subscription.wait_for_change().await;
+
     assert_eq!(cluster_info.followers.len(), 2);
     assert!(cluster_info.has_follower("replica_then_leader"));
     assert!(cluster_info.has_follower("replica"));
+
+    let old_follower = cluster_info
+        .followers
+        .iter()
+        .find(|f| f.node_id == "replica")
+        .unwrap();
 
     let mut builder = replica_then_leader.shutdown().await.unwrap();
     // Upgrade to leader.
@@ -33,32 +40,19 @@ async fn test_multiple_replicas_register_in_nodes_table() {
     let leader = builder.start_test_rollup().await.unwrap();
     leader.wait_for_sequencer_ready().await.unwrap();
 
-    let mut cluster_info = setup.cluster_info_subscription.wait_for_change().await;
+    let new_cluster_info = setup.cluster_info_subscription.wait_for_change().await;
 
-    assert!(cluster_info.has_leader("replica_then_leader"));
-    assert!(cluster_info.has_follower("replica"));
+    assert!(new_cluster_info.has_leader("replica_then_leader"));
+    assert!(new_cluster_info.has_follower("replica"));
 
     // Verify that nodes timestamps are increasing.
-    for _ in 0..3 {
-        let new_cluster_info = setup.cluster_info_subscription.wait_for_change().await;
-        assert!(
-            new_cluster_info.leader.as_ref().unwrap().last_updated
-                >= cluster_info.leader.as_ref().unwrap().last_updated
-        );
+    let new_follower = new_cluster_info
+        .followers
+        .iter()
+        .find(|f| f.node_id == "replica")
+        .unwrap();
 
-        // This is O(n^2), but it's we have only two nodes in this test.
-        for new_follower in &new_cluster_info.followers {
-            let follower = cluster_info
-                .followers
-                .iter()
-                .find(|f| f.node_id == new_follower.node_id)
-                .unwrap();
-
-            assert!(new_follower.last_updated >= follower.last_updated);
-        }
-
-        cluster_info = new_cluster_info;
-    }
+    assert!(new_follower.last_updated > old_follower.last_updated);
 
     let _ = leader.shutdown().await;
     let _ = replica_rollup.shutdown().await;
@@ -104,26 +98,21 @@ async fn test_stale_nodes_are_filtered_from_cluster_info() {
     let _ = replica.shutdown().await;
 
     // Wait for the replica to become stale and be filtered out.
-    // The leader's heartbeat updates will trigger notifications.
-    tokio::time::timeout(Duration::from_secs(10), async {
-        loop {
-            let cluster_info = setup.cluster_info_subscription.wait_for_change().await;
+    let cluster_info = setup
+        .cluster_info_subscription
+        .wait_for_change_with_timeout(Duration::from_secs(10))
+        .await;
 
-            // Leader should always be present (never filtered regardless of age).
-            assert!(
-                cluster_info.has_leader("leader"),
-                "Leader should always be present in cluster info"
-            );
+    // Leader should always be present (never filtered regardless of age).
+    assert!(
+        cluster_info.has_leader("leader"),
+        "Leader should always be present in cluster info"
+    );
 
-            // Check if the stale replica has been filtered out.
-            if !cluster_info.has_follower("replica") {
-                // Success - the stale replica was filtered out.
-                break;
-            }
-        }
-    })
-    .await
-    .expect("Timeout waiting for stale replica to be filtered out");
+    // When there are no other followers, the leader is added to the followers list
+    // so that clients always have at least one node to connect to for reads.
+    assert!(cluster_info.has_follower("leader"));
+    assert!(!cluster_info.has_follower("replica"));
 
     let _ = leader.shutdown().await;
     setup.shutdown().await;


### PR DESCRIPTION
# Description

This PR optimizes cluster state change detection in `NodeDiscovery`. Previously, every database notification (including heartbeat updates) triggered a file write and notified watchers. Now, the system tracks the previous state and only acts when membership or leadership actually changes.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1524 
- https://github.com/Sovereign-Labs/rollup-starter/pull/121
- https://github.com/Sovereign-Labs/sov-rollup-cdk-starter/pull/69
- https://github.com/Sovereign-Labs/ubuntu-evm-starter-script/pull/28
