### PR TITLE
Switch from slot num to rollup height

### DIFF
--- a/crates/module-system/hyperlane/src/call.rs
+++ b/crates/module-system/hyperlane/src/call.rs
@@ -207,7 +207,7 @@ where
         }
 
         // Backwards compatibility. Don't activate the counter until the configured height
-        if state.current_visible_slot_number().get()
+        if state.rollup_height_to_access().get()
             > config_value!("HYPERLANE_METER_DELIVERY_COUNTER_AFTER_HEIGHT")
         {
             let mut count = self.deliveries_count.get(state)?.unwrap_or_default();


### PR DESCRIPTION
# Description

This 1-liner switches the trigger for hyperlane delivery counting from a visible slot number to a rollup height. This is much more consistent with our other config options. 