### PR TITLE
Simple sync speedup: insert prefetched blocks into finalized header cache

### DIFF
--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -157,6 +157,18 @@ impl<Da: DaService> DaServiceWithCachedFinalizedHeaders<Da> {
     ) -> Result<<Da::Spec as DaSpec>::BlockHeader, Da::Error> {
         self.da_service.get_head_block_header().await
     }
+
+    /// Inserts a block header into the recent headers cache.
+    ///
+    /// This allows external callers (e.g., sync_fetcher) to populate the cache
+    /// with headers they've already fetched, avoiding redundant network calls
+    /// when `get_block_header_at` is later called for the same height.
+    ///
+    /// The header is only inserted if it's not already present in the cache.
+    /// If the cache is full, the oldest entry is evicted.
+    pub fn insert_header(&self, header: <Da::Spec as DaSpec>::BlockHeader) {
+        self.headers_cache.insert_new_header(header);
+    }
 }
 
 #[derive(Debug)]
@@ -398,6 +410,47 @@ mod tests {
         // Request a header that's not in cache - should fall back to DA service
         let header_0 = cache.get_block_header_at(0).await?;
         assert_eq!(header_0.height(), 0);
+
+        sender.send(())?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_externally_inserted_header_is_cached() -> anyhow::Result<()> {
+        let da_service = StorableMockDaService::new_in_memory(Default::default(), 0).await;
+
+        for _ in 0..5 {
+            da_service.send_transaction(&[1; 32]).await.await??;
+        }
+
+        let (sender, receiver) = tokio::sync::watch::channel(());
+        let da_service = Arc::new(da_service);
+        let cache = DaServiceWithCachedFinalizedHeaders::new(
+            da_service.clone(),
+            receiver,
+            Duration::from_millis(100),
+        )
+        .await?;
+
+        // Get a header from the DA service directly
+        let header = da_service.get_block_header_at(3).await?;
+
+        // Verify the header is NOT in the internal cache before insertion
+        assert!(
+            cache.headers_cache.get_block_header_at(3).is_none(),
+            "Header should not be in cache before insert_header is called"
+        );
+
+        // Insert it into the cache
+        cache.insert_header(header.clone());
+
+        // Verify the header IS in the internal cache after insertion
+        let cached = cache
+            .headers_cache
+            .get_block_header_at(3)
+            .expect("Header should be in cache after insert_header");
+        assert_eq!(cached.height(), 3);
+        assert_eq!(cached.hash(), header.hash());
 
         sender.send(())?;
         Ok(())

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -485,8 +485,13 @@ where
         let get_block_start = std::time::Instant::now();
         let filtered_block = if next_da_height <= self.sync_fetcher.last_finalized_height {
             // no reorg will happen for this height; it is safe to just pull it from the fetcher,
-            // which could have this block fetcher already
-            self.sync_fetcher.get_block_at(next_da_height).await?
+            // which could have this block fetched already
+            let block = self.sync_fetcher.get_block_at(next_da_height).await?;
+            // Pre-populate the finalized headers cache with this header to avoid
+            // a redundant network call in get_effective_finalized_header
+            self.finalized_headers_provider
+                .insert_header(block.header().clone());
+            block
         } else {
             // Requests height might re-org
             // It never returns a future height for requested


### PR DESCRIPTION
# Description

This PR raises the sync rate from ~3 to ~60 blocks/sec on the dev box by removing a network access on the hot loop during initial sync. We do this by populating the "finalized headers cache" from the block prefetcher. Note that this does *not* change the assumptions made by sync - the prefetcher only pulls blocks below the finalized height, so we already assume that these blocks are correct.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

