### PR TITLE
Prevent background poller from filling finalized header cache during sync

### DIFF
--- a/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
+++ b/crates/full-node/sov-stf-runner/src/da/finalized_headers_cache.rs
@@ -169,6 +169,15 @@ impl<Da: DaService> DaServiceWithCachedFinalizedHeaders<Da> {
     pub fn insert_header(&self, header: <Da::Spec as DaSpec>::BlockHeader) {
         self.headers_cache.insert_new_header(header);
     }
+
+    /// Removes all cached headers strictly below the given height.
+    ///
+    /// Called after a block is fully processed to evict headers that will never
+    /// be looked up again. This prevents stale sync-height entries from
+    /// accumulating and blocking the background poller from inserting.
+    pub fn remove_headers_below(&self, height: u64) {
+        self.headers_cache.remove_headers_below(height);
+    }
 }
 
 #[derive(Debug)]
@@ -200,6 +209,40 @@ impl<Da: DaService> FinalizedDaHeadersCacheContainer<Da> {
             }
             tracing::trace!(finalized_height = %height, "Updated cached recent headers");
         }
+    }
+
+    /// Inserts a header from the background poller, but only if the height gap
+    /// between this header and the lowest cached entry doesn't exceed the cache size.
+    /// This prevents tip-height entries from evicting sync-height entries during
+    /// initial sync, where `pop_first()` would always target the lower sync entries.
+    fn try_insert_background_header(&self, header: <Da::Spec as DaSpec>::BlockHeader) {
+        let height = header.height();
+        let max_size = self.max_size.load(Ordering::Relaxed);
+        let mut cache = self.recent_headers.write().expect(RECENT_HEADERS_POISONED);
+        if let Some((&lowest_height, _)) = cache.first_key_value() {
+            if height.saturating_sub(lowest_height) > max_size as u64 {
+                tracing::trace!(
+                    height,
+                    lowest_height,
+                    max_size,
+                    "Skipping background header insertion: height gap exceeds cache size"
+                );
+                return;
+            }
+        }
+        if let std::collections::btree_map::Entry::Vacant(e) = cache.entry(height) {
+            e.insert(header);
+            if cache.len() > max_size {
+                cache.pop_first();
+            }
+        }
+    }
+
+    fn remove_headers_below(&self, height: u64) {
+        let mut cache = self.recent_headers.write().expect(RECENT_HEADERS_POISONED);
+        // `split_off` returns everything >= height, leaving everything < height behind.
+        // We keep the right half and drop the left.
+        *cache = cache.split_off(&height);
     }
 
     fn get_block_header_at(&self, height: u64) -> Option<<Da::Spec as DaSpec>::BlockHeader> {
@@ -241,7 +284,7 @@ async fn background_header_fetch_task<Da: DaService>(
                             tracing::info!("All DA header receivers dropped, shutting down");
                             break;
                         }
-                        recent_headers.insert_new_header(finalized_header);
+                        recent_headers.try_insert_background_header(finalized_header);
                     }
                     FutureOrShutdownOutput::Output(Err(error)) => {
                         // DaService should do all retries, so we just stop and fail.
@@ -331,7 +374,7 @@ mod tests {
         let da_service = StorableMockDaService::new_in_memory(Default::default(), 0).await;
 
         // Produce more blocks than MAX_RECENT_HEADERS
-        for _ in 0..40 {
+        for _ in 0..110 {
             da_service.send_transaction(&[1; 32]).await.await??;
         }
 
@@ -485,6 +528,49 @@ mod tests {
         );
 
         let _ = sender.send(());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_background_header_skipped_when_gap_exceeds_cache_size() -> anyhow::Result<()> {
+        let container = FinalizedDaHeadersCacheContainer::<StorableMockDaService>::new();
+        // Override max_size to a small value for testing
+        container.max_size.store(5, Ordering::Relaxed);
+
+        let da_service = StorableMockDaService::new_in_memory(Default::default(), 0).await;
+        // Produce blocks so we have headers at heights 0..20
+        for _ in 0..20 {
+            da_service.send_transaction(&[1; 32]).await.await??;
+        }
+
+        // Insert a sync-height header at height 3
+        let sync_header = da_service.get_block_header_at(3).await?;
+        container.insert_new_header(sync_header);
+
+        // Try to insert a background header far away (height 15, gap = 12 > max_size 5)
+        let far_header = da_service.get_block_header_at(15).await?;
+        container.try_insert_background_header(far_header);
+
+        // The far header should NOT have been inserted
+        assert!(
+            container.get_block_header_at(15).is_none(),
+            "Background header with gap exceeding cache size should not be inserted"
+        );
+        // The sync header should still be there
+        assert!(
+            container.get_block_header_at(3).is_some(),
+            "Sync header should be preserved"
+        );
+
+        // Insert a background header within range (height 7, gap = 4 <= max_size 5)
+        let near_header = da_service.get_block_header_at(7).await?;
+        container.try_insert_background_header(near_header);
+
+        assert!(
+            container.get_block_header_at(7).is_some(),
+            "Background header within range should be inserted"
+        );
+
         Ok(())
     }
 }

--- a/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
@@ -455,6 +455,16 @@ where
             "All finalized transitions are marked as finalized"
         );
 
+        // Evict all cached headers at or below the finalized height — they
+        // will never be looked up again and removing them prevents stale
+        // sync-height entries from accumulating and blocking the background
+        // poller.
+        self.finalized_headers_provider.remove_headers_below(
+            self.last_processed_finalized_header
+                .height()
+                .saturating_add(1),
+        );
+
         let sending_to_prover_start = std::time::Instant::now();
         if let Some(stf_info_sender) = &mut self.stf_info_sender {
             // Notify `StateTransitionInfo` consumers that the data is saved in the Db.

--- a/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
@@ -455,15 +455,15 @@ where
             "All finalized transitions are marked as finalized"
         );
 
-        // Evict all cached headers at or below the finalized height — they
-        // will never be looked up again and removing them prevents stale
+        // Evict all cached headers below the finalized height — they will
+        // never be looked up again and removing them prevents stale
         // sync-height entries from accumulating and blocking the background
-        // poller.
-        self.finalized_headers_provider.remove_headers_below(
-            self.last_processed_finalized_header
-                .height()
-                .saturating_add(1),
-        );
+        // poller. We keep the entry at the finalized height itself so that
+        // the cache is never empty while the bulk fetcher is running, which
+        // ensures the background poller's gap check has a sentinel entry to
+        // compare against.
+        self.finalized_headers_provider
+            .remove_headers_below(self.last_processed_finalized_header.height());
 
         let sending_to_prover_start = std::time::Instant::now();
         if let Some(stf_info_sender) = &mut self.stf_info_sender {


### PR DESCRIPTION
# Description

This PR adds a heuristic to prevent the background task which watches for finalized headers from filling up the finalized headers cache with blocks that are far from the current sync site. If there are any old blocks in cache ("old" meaning, "more than max_cache_size from the chain tip"), the background task won't insert into the cache. 

Previously, the background task would fill up the cache within a few minutes, prevent the bulk fetcher from caching any headers. This made the cache useless after the first few minutes of sync, which would slow sync from 60-100 blocks/sec to 3-4. 

Note that the new heuristic only looks at the cache, so we must ensure that the bulk fetcher always keeps at least one header in cache while it's running - otherwise the heuristic won't detect that we're syncing and the cache will fill up again. 
