### PR TITLE
EVM: BaseFee fix 1: pass it to TransactionResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-02-10
+- #2462 EVM: Include `base_fee` in Transaction RPC response.
+
 # 2026-02-03
 - #2433 Updates tests in sov-demo-rollup.
 # 2026-02-02

--- a/crates/module-system/module-implementations/sov-evm/src/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/helpers.rs
@@ -55,6 +55,7 @@ pub(crate) fn from_recovered_with_block_context(
     block_hash: Option<B256>,
     block_number: BlockNumber,
     tx_index: u64,
+    base_fee: Option<u64>,
 ) -> alloy_rpc_types::Transaction {
     let tx_info = TransactionInfo {
         block_hash,
@@ -62,14 +63,16 @@ pub(crate) fn from_recovered_with_block_context(
         index: Some(tx_index),
         // Default values
         hash: None,
-        base_fee: None,
+        base_fee,
     };
     alloy_rpc_types::Transaction::from_transaction(tx.convert(), tx_info)
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, U256};
+    use alloy_consensus::{EthereumTxEnvelope, Signed, TxEip1559};
+    use alloy_primitives::Signature;
+    use alloy_primitives::{Address, B256, U256};
     use revm::context::TransactTo;
 
     use super::*;
@@ -116,5 +119,32 @@ mod tests {
         assert_eq!(tx_env.chain_id, expected.chain_id);
         assert_eq!(tx_env.nonce, expected.nonce);
         assert_eq!(tx_env.access_list, expected.access_list);
+    }
+
+    #[test]
+    fn from_recovered_with_block_context_uses_base_fee_for_effective_gas_price() {
+        let tx = TxEip1559 {
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 2,
+            ..Default::default()
+        };
+        let recovered = Recovered::new_unchecked(
+            EthereumTxEnvelope::Eip1559(Signed::new_unchecked(
+                tx,
+                Signature::test_signature(),
+                Default::default(),
+            )),
+            Address::ZERO,
+        );
+
+        let with_base_fee =
+            from_recovered_with_block_context(recovered.clone(), Some(B256::ZERO), 1, 0, Some(10));
+        // min(max_priority_fee_per_gas, max_fee_per_gas - base_fee) + base_fee
+        assert_eq!(with_base_fee.effective_gas_price, Some(12));
+
+        let without_base_fee =
+            from_recovered_with_block_context(recovered, Some(B256::ZERO), 1, 0, None);
+        // Fallback behavior when base fee is unavailable.
+        assert_eq!(without_base_fee.effective_gas_price, Some(100));
     }
 }

--- a/crates/module-system/module-implementations/sov-evm/src/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/helpers.rs
@@ -58,12 +58,12 @@ pub(crate) fn from_recovered_with_block_context(
     base_fee: Option<u64>,
 ) -> alloy_rpc_types::Transaction {
     let tx_info = TransactionInfo {
+        base_fee,
         block_hash,
         block_number: Some(block_number),
         index: Some(tx_index),
-        // Default values
+        // Default value. Why hash is None? Where does it actually set?
         hash: None,
-        base_fee,
     };
     alloy_rpc_types::Transaction::from_transaction(tx.convert(), tx_info)
 }

--- a/crates/module-system/module-implementations/sov-evm/src/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/helpers.rs
@@ -62,7 +62,7 @@ pub(crate) fn from_recovered_with_block_context(
         block_hash,
         block_number: Some(block_number),
         index: Some(tx_index),
-        // Default value. Why hash is None? Where does it actually set?
+        // Default value, because hash is in the tx.
         hash: None,
     };
     alloy_rpc_types::Transaction::from_transaction(tx.convert(), tx_info)

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -154,6 +154,7 @@ where
                             Some(block.header.hash()),
                             block.number,
                             pos as u64,
+                            block.header.base_fee_per_gas,
                         ))
                     })
                     .collect::<Result<Vec<_>, _>>()?;
@@ -210,6 +211,7 @@ where
                                     Some(header.hash),
                                     header.number,
                                     tx_idx as u64,
+                                    header.base_fee_per_gas,
                                 )
                             })
                             .collect(),
@@ -278,7 +280,13 @@ where
         let tx = self.transaction(tx_number, state)?;
         let block = self.get_maybe_sealed_block(tx.block_number, state)?;
         let index = tx_number - block.transactions_start();
-        let tx = from_recovered_with_block_context(tx.into(), block.hash(), block.number(), index);
+        let tx = from_recovered_with_block_context(
+            tx.into(),
+            block.hash(),
+            block.number(),
+            index,
+            block.maybe_partial_header().base_fee_per_gas,
+        );
         Some(tx)
     }
 

--- a/examples/demo-rollup/tests/evm/evm_effective_gas_price.rs
+++ b/examples/demo-rollup/tests/evm/evm_effective_gas_price.rs
@@ -1,0 +1,69 @@
+use alloy_primitives::U256;
+use alloy_rpc_types_eth::{Block, BlockTransactions};
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::rpc_params;
+
+use crate::evm::evm_test_helper::{
+    create_simple_storage_client, setup_test_rollup, EVM_EXTENSION, SENDER_PRIV_KEY,
+};
+
+const HIGH_MAX_FEE_PER_GAS: u128 = 1_000_000_000_000;
+const HIGH_PRIORITY_FEE_PER_GAS: u128 = 1;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn eip1559_tx_gas_price_matches_receipt_effective_gas_price() -> anyhow::Result<()> {
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    rollup.wait_for_next_blocks(2).await;
+
+    let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
+
+    let mut tx = client.make_tx(Some(client.address()), None);
+    tx = tx
+        .value(U256::from(1u64))
+        .max_fee_per_gas(HIGH_MAX_FEE_PER_GAS)
+        .max_priority_fee_per_gas(HIGH_PRIORITY_FEE_PER_GAS);
+
+    let receipt = client
+        .send_tx_and_wait_finalized(tx)
+        .await
+        .map_err(|err| anyhow::anyhow!(err.to_string()))?;
+
+    let tx_hash = receipt.transaction_hash;
+    let tx_response = client
+        .transaction(tx_hash)
+        .await
+        .ok_or_else(|| anyhow::anyhow!("missing transaction response for {tx_hash:?}"))?;
+
+    assert_eq!(
+        tx_response.effective_gas_price,
+        Some(receipt.effective_gas_price),
+        "eth_getTransactionByHash gasPrice should match receipt.effectiveGasPrice"
+    );
+
+    let block_number = receipt
+        .block_number
+        .ok_or_else(|| anyhow::anyhow!("finalized receipt should include block_number"))?;
+    let block_id = format!("0x{block_number:x}");
+    let full_block: Block = client
+        .ws
+        .request("eth_getBlockByNumber", rpc_params![Some(block_id), true])
+        .await?;
+
+    let block_tx = match full_block.transactions {
+        BlockTransactions::Full(txs) => txs
+            .into_iter()
+            .find(|tx| *tx.inner.hash() == tx_hash)
+            .ok_or_else(|| anyhow::anyhow!("tx {tx_hash:?} not found in full block response"))?,
+        BlockTransactions::Hashes(_) | BlockTransactions::Uncle => {
+            anyhow::bail!("expected full tx objects from eth_getBlockByNumber(..., true)")
+        }
+    };
+
+    assert_eq!(
+        block_tx.effective_gas_price,
+        Some(receipt.effective_gas_price),
+        "eth_getBlockByNumber(full) tx gasPrice should match receipt.effectiveGasPrice"
+    );
+
+    Ok(())
+}

--- a/examples/demo-rollup/tests/evm/mod.rs
+++ b/examples/demo-rollup/tests/evm/mod.rs
@@ -3,6 +3,7 @@ mod evm_balances;
 mod evm_block_hash;
 mod evm_block_number;
 mod evm_contract_creation_allowlist;
+mod evm_effective_gas_price;
 mod evm_fee_history;
 mod evm_gas_estimation;
 mod evm_logs;


### PR DESCRIPTION
# Description

> Prior to this PR, receipts already computed effective_gas_price correctly using block.maybe_partial_header().base_fee_per_gas at, but the transaction response from from_recovered_with_block_context always passed base_fee: None in TransactionInfo. When base_fee is None, alloy's from_transaction falls back to using max_fee_per_gas as the effective gas price, which would disagree with the receipt's value for any EIP-1559 transaction where max_fee_per_gas > base_fee + max_priority_fee_per_gas. This PR fixes that inconsistency. The new integration test eip1559_tx_gas_price_matches_receipt_effective_gas_price explicitly validates that both paths now agree.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2237

## Testing
Added new tests

## Docs
No updates
