### PR TITLE
Use helper for more stable test

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -2289,22 +2289,12 @@ async fn events_are_returned_in_tx_response() {
     )
     .await;
 
-    // Produce a few blocks to DA blocks to make sure there's a finalized slot after genesis.
-    test_rollup
-        .da_service
-        .produce_n_blocks_now(5)
-        .await
-        .unwrap();
-    sleep(Duration::from_millis(200)).await;
+    test_rollup.produce_enough_finalized_slots().await;
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     let client = test_rollup.api_client().clone();
     let tx = tx_set_value(&admin.private_key, 0, 7);
-    let response = client
-        .accept_tx(&api_types::AcceptTxBody {
-            body: BASE64_STANDARD.encode(&tx),
-        })
-        .await
-        .unwrap();
+    let response = client.send_raw_tx_to_sequencer(&tx).await.unwrap();
 
     assert_eq!(response.events.len(), 1);
 }


### PR DESCRIPTION
Fixes:

```
[8](https://github.com/Sovereign-Labs/sovereign-sdk/actions/runs/21864167379/job/63100817677?pr=2462#step:6:1279)
        FAIL [   0.690s] sov-sequencer::integration preferred_end_to_end::events_are_returned_in_tx_response
  stdout ───

    running 1 test
    test preferred_end_to_end::events_are_returned_in_tx_response ... FAILED

    failures:

    failures:
        preferred_end_to_end::events_are_returned_in_tx_response

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 86 filtered out; finished in 0.66s
    
  stderr ───

    thread 'preferred_end_to_end::events_are_returned_in_tx_response' panicked at crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs:2307:10:
    called `Result::unwrap()` on an `Err` value: Error Response: status: 503 Service Unavailable; headers: {"content-type": "application/json", "vary": "origin, access-control-request-method, access-control-request-headers", "access-control-allow-origin": "*", "access-control-expose-headers": "*", "content-length": "227", "date": "Tue, 10 Feb 2026 12:19:54 GMT"}; value: ApiError { details: {"WaitingOnDa": Object {"finalized_slot_number": Number(0), "needed_finalized_slot_number": Number(1)}}, message: "The sequencer is waiting for the DA to finalize more blocks; No new transactions can be accepted, try again later", status: 503 }
    stack backtrace:
```

observed here: https://github.com/Sovereign-Labs/sovereign-sdk/actions/runs/21864167379/job/63100817677?pr=2462