### PR TITLE
Fix; prevent serde from parsing one-element arrays as structs

### DIFF
--- a/crates/module-system/sov-modules-macros/src/compile_manifest_constants.rs
+++ b/crates/module-system/sov-modules-macros/src/compile_manifest_constants.rs
@@ -157,6 +157,16 @@ fn parse_constant_inner(value: &toml::Value, span: Span) -> syn::Result<AllowedT
 }
 
 fn parse_constant(value: &toml::Value, span: Span) -> syn::Result<ParsedConstant> {
+    // Arrays and non-table types should always be handled by parse_constant_inner directly.
+    // We only try struct deserialization for TOML tables, because the toml serde deserializer
+    // can spuriously unwrap single-element arrays into structs with one field.
+    if !value.is_table() {
+        return Ok(ParsedConstant {
+            value: parse_constant_inner(value, span)?,
+            make_const: false,
+        });
+    }
+
     // Is it a `{ const = ... }` value?
     if let Ok(with_custom_override) = value.clone().try_into::<TomlConstValue>() {
         Ok(ParsedConstant {


### PR DESCRIPTION
# Description

This PR fixes an issue where single-element arrays of CHAIN_HASH_OVERRIDES would fail to compile in release mode. The root cause is that serde's toml deserializer tries to deserialize single-element arrays into single-element structs as a fallback in some cases. This was causing the `CHAIN_HASH_OVERRIDES` array to mis-parse as a `TomlConstValue`. 

This bug was not triggered in testing since overriding the env var takes a different parsing path