### PR TITLE
Fix ism resoltuion for solana register module

### DIFF
--- a/crates/module-system/module-implementations/extern/hyperlane-solana-register/src/lib.rs
+++ b/crates/module-system/module-implementations/extern/hyperlane-solana-register/src/lib.rs
@@ -181,11 +181,7 @@ impl<S: Spec> Recipient<S> for SolanaRegistration<S>
 where
     S::Address: HyperlaneAddress,
 {
-    fn ism(
-        &self,
-        recipient: &HexHash,
-        state: &mut impl TxState<S>,
-    ) -> anyhow::Result<Option<Ism>> {
+    fn ism(&self, recipient: &HexHash, state: &mut impl TxState<S>) -> anyhow::Result<Option<Ism>> {
         if let Some(ism) = self.warp.ism(recipient, state)? {
             return Ok(Some(ism));
         }

--- a/crates/module-system/module-implementations/extern/hyperlane-solana-register/src/lib.rs
+++ b/crates/module-system/module-implementations/extern/hyperlane-solana-register/src/lib.rs
@@ -183,9 +183,12 @@ where
 {
     fn ism(
         &self,
-        _recipient: &HexHash,
+        recipient: &HexHash,
         state: &mut impl TxState<S>,
     ) -> anyhow::Result<Option<Ism>> {
+        if let Some(ism) = self.warp.ism(recipient, state)? {
+            return Ok(Some(ism));
+        }
         self.default_ism(state)
     }
 

--- a/crates/module-system/module-implementations/extern/hyperlane-solana-register/tests/integration/ism_resolution.rs
+++ b/crates/module-system/module-implementations/extern/hyperlane-solana-register/tests/integration/ism_resolution.rs
@@ -1,0 +1,47 @@
+use sov_hyperlane_integration::warp::TokenKind;
+use sov_hyperlane_integration::{Ism, Recipient};
+use sov_modules_api::{HexHash, HexString, SafeVec};
+
+use crate::setup::{register_warp_route_with_ism_and_token_source, setup, SetupParams};
+
+/// When a warp route has a dedicated ISM, `SolanaRegistration::ism(route_id)` should
+/// return that per-route ISM rather than the module-level default.
+#[test]
+fn test_ism_returns_warp_route_ism_over_default() {
+    let SetupParams {
+        mut runner,
+        admin,
+        ..
+    } = setup();
+
+    // The default ISM from genesis is AlwaysTrust.
+    // Register a warp route with a *different* ISM (MessageIdMultisig).
+    let route_ism = Ism::MessageIdMultisig {
+        validators: SafeVec::try_from(vec![HexString([0xAB; 20])]).unwrap(),
+        threshold: 1,
+    };
+
+    let route_id =
+        register_warp_route_with_ism_and_token_source(&mut runner, &admin, route_ism.clone(), TokenKind::Native);
+
+    runner.query_state(|state| {
+        let module = sov_hyperlane_register_module::SolanaRegistration::default();
+
+        // Querying with the route ID should return the warp route's ISM
+        let resolved = module.ism(&route_id, state).unwrap();
+        assert_eq!(
+            resolved,
+            Some(route_ism.clone()),
+            "ism() should return the warp route's per-route ISM, not the default"
+        );
+
+        // Querying with an unknown recipient should fall back to the default ISM
+        let unknown_recipient = HexHash::new([0xFF; 32]);
+        let fallback = module.ism(&unknown_recipient, state).unwrap();
+        assert_eq!(
+            fallback,
+            Some(Ism::AlwaysTrust),
+            "ism() should fall back to the default ISM for unknown recipients"
+        );
+    });
+}

--- a/crates/module-system/module-implementations/extern/hyperlane-solana-register/tests/integration/ism_resolution.rs
+++ b/crates/module-system/module-implementations/extern/hyperlane-solana-register/tests/integration/ism_resolution.rs
@@ -9,9 +9,7 @@ use crate::setup::{register_warp_route_with_ism_and_token_source, setup, SetupPa
 #[test]
 fn test_ism_returns_warp_route_ism_over_default() {
     let SetupParams {
-        mut runner,
-        admin,
-        ..
+        mut runner, admin, ..
     } = setup();
 
     // The default ISM from genesis is AlwaysTrust.
@@ -21,8 +19,12 @@ fn test_ism_returns_warp_route_ism_over_default() {
         threshold: 1,
     };
 
-    let route_id =
-        register_warp_route_with_ism_and_token_source(&mut runner, &admin, route_ism.clone(), TokenKind::Native);
+    let route_id = register_warp_route_with_ism_and_token_source(
+        &mut runner,
+        &admin,
+        route_ism.clone(),
+        TokenKind::Native,
+    );
 
     runner.query_state(|state| {
         let module = sov_hyperlane_register_module::SolanaRegistration::default();

--- a/crates/module-system/module-implementations/extern/hyperlane-solana-register/tests/integration/main.rs
+++ b/crates/module-system/module-implementations/extern/hyperlane-solana-register/tests/integration/main.rs
@@ -1,2 +1,3 @@
+mod ism_resolution;
 mod registration;
 pub(crate) mod setup;


### PR DESCRIPTION
# Description

SolanaRegistration module wraps the standard hyperlane warp route and defers to it. There was a deferral missing in the case of ISM which was causing the wrong ISM to be retrieved for warp transfers

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
