### PR TITLE
Add `RootHashCheckMetric` in cluster-service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11929,6 +11929,7 @@ dependencies = [
  "async-trait",
  "reqwest",
  "serde",
+ "sov-metrics",
  "sqlx",
  "time",
  "tokio",

--- a/crates/utils/sov-proxy-utils/Cargo.toml
+++ b/crates/utils/sov-proxy-utils/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 
 
 [dependencies]
+sov-metrics = { workspace = true, features = ["native"] }
 anyhow = { workspace = true }
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls-ring-webpki", "postgres", "derive", "time"], default-features = false }
 time = { version = "0.3", default-features = false, features = ["formatting", "parsing"] }

--- a/crates/utils/sov-proxy-utils/src/cluster_info_service.rs
+++ b/crates/utils/sov-proxy-utils/src/cluster_info_service.rs
@@ -5,8 +5,6 @@ use crate::node_discovery::NodeDiscoveryTask;
 use crate::root_hash_checker::ClusterRootHashChecker;
 use crate::root_hash_checker::ClusterRootHashCheckerTask;
 use anyhow::{Context, Result};
-use sov_metrics::init_metrics_tracker;
-use sov_metrics::MonitoringConfig;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -14,7 +12,6 @@ use std::time::Duration;
 pub struct ClusterInfoService {
     pub node_discovery_task: NodeDiscoveryTask,
     pub root_hash_checker_task: ClusterRootHashCheckerTask,
-    metrics_shutdown_sender: tokio::sync::watch::Sender<()>,
 }
 
 impl ClusterInfoService {
@@ -25,12 +22,6 @@ impl ClusterInfoService {
         path: PathBuf,
         notifier: Option<Box<dyn ClusterUpdateNotifier>>,
     ) -> Result<Self> {
-        let (metrics_shutdown_sender, mut metrics_shutdown_receiver) =
-            tokio::sync::watch::channel(());
-        metrics_shutdown_receiver.mark_unchanged();
-        let monitoring_config = MonitoringConfig::standard();
-        init_metrics_tracker(&monitoring_config, metrics_shutdown_receiver.clone());
-
         let node_discovery =
             NodeDiscovery::connect(connection_string, max_age, path, notifier).await?;
         let root_hash_checker = ClusterRootHashChecker::new(node_discovery.receiver.clone())?;
@@ -41,7 +32,6 @@ impl ClusterInfoService {
         Ok(Self {
             node_discovery_task,
             root_hash_checker_task,
-            metrics_shutdown_sender,
         })
     }
 
@@ -63,14 +53,12 @@ impl ClusterInfoService {
     pub fn shutdown(self) {
         self.root_hash_checker_task.abort();
         self.node_discovery_task.abort();
-        let _ = self.metrics_shutdown_sender.send(());
     }
 
     // Waits for the background cluster-info tasks to finish.
     pub async fn join(self) -> anyhow::Result<()> {
         self.root_hash_checker_task.handle.await?;
         self.node_discovery_task.handle.await??;
-        let _ = self.metrics_shutdown_sender.send(());
         Ok(())
     }
 }

--- a/crates/utils/sov-proxy-utils/src/cluster_info_service.rs
+++ b/crates/utils/sov-proxy-utils/src/cluster_info_service.rs
@@ -5,6 +5,8 @@ use crate::node_discovery::NodeDiscoveryTask;
 use crate::root_hash_checker::ClusterRootHashChecker;
 use crate::root_hash_checker::ClusterRootHashCheckerTask;
 use anyhow::{Context, Result};
+use sov_metrics::init_metrics_tracker;
+use sov_metrics::MonitoringConfig;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -12,6 +14,7 @@ use std::time::Duration;
 pub struct ClusterInfoService {
     pub node_discovery_task: NodeDiscoveryTask,
     pub root_hash_checker_task: ClusterRootHashCheckerTask,
+    metrics_shutdown_sender: tokio::sync::watch::Sender<()>,
 }
 
 impl ClusterInfoService {
@@ -22,6 +25,12 @@ impl ClusterInfoService {
         path: PathBuf,
         notifier: Option<Box<dyn ClusterUpdateNotifier>>,
     ) -> Result<Self> {
+        let (metrics_shutdown_sender, mut metrics_shutdown_receiver) =
+            tokio::sync::watch::channel(());
+        metrics_shutdown_receiver.mark_unchanged();
+        let monitoring_config = MonitoringConfig::standard();
+        init_metrics_tracker(&monitoring_config, metrics_shutdown_receiver.clone());
+
         let node_discovery =
             NodeDiscovery::connect(connection_string, max_age, path, notifier).await?;
         let root_hash_checker = ClusterRootHashChecker::new(node_discovery.receiver.clone())?;
@@ -32,6 +41,7 @@ impl ClusterInfoService {
         Ok(Self {
             node_discovery_task,
             root_hash_checker_task,
+            metrics_shutdown_sender,
         })
     }
 
@@ -51,6 +61,7 @@ impl ClusterInfoService {
 
     /// Stops the background cluster-info task.
     pub fn shutdown(self) {
+        self.metrics_shutdown_sender.send(()).unwrap();
         self.root_hash_checker_task.abort();
         self.node_discovery_task.abort();
     }

--- a/crates/utils/sov-proxy-utils/src/cluster_info_service.rs
+++ b/crates/utils/sov-proxy-utils/src/cluster_info_service.rs
@@ -61,15 +61,16 @@ impl ClusterInfoService {
 
     /// Stops the background cluster-info task.
     pub fn shutdown(self) {
-        self.metrics_shutdown_sender.send(()).unwrap();
         self.root_hash_checker_task.abort();
         self.node_discovery_task.abort();
+        let _ = self.metrics_shutdown_sender.send(());
     }
 
     // Waits for the background cluster-info tasks to finish.
     pub async fn join(self) -> anyhow::Result<()> {
         self.root_hash_checker_task.handle.await?;
         self.node_discovery_task.handle.await??;
+        let _ = self.metrics_shutdown_sender.send(());
         Ok(())
     }
 }

--- a/crates/utils/sov-proxy-utils/src/lib.rs
+++ b/crates/utils/sov-proxy-utils/src/lib.rs
@@ -1,7 +1,9 @@
 mod cluster_info_service;
 mod file_writer;
 mod node_discovery;
+mod root_hash_check_metric;
 mod root_hash_checker;
 pub use cluster_info_service::*;
 pub use node_discovery::*;
+pub use root_hash_check_metric::*;
 pub use root_hash_checker::*;

--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -281,13 +281,13 @@ impl NodeDiscovery {
         write_to_file_atomically(&self.path, &content).await?;
         tracing::info!(?self.path, content, "Cluster info file updated");
 
-        self.prev_followers = followers;
-        self.prev_leader_id = leader_id;
-
         // Notify watchers that the cluster was updated.
         if let Some(notifier) = &mut self.notifier {
             notifier.on_cluster_update(&info).await?;
         }
+
+        self.prev_followers = followers;
+        self.prev_leader_id = leader_id;
         let _ = self.sender.send(info);
 
         Ok(())

--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -101,7 +101,7 @@ impl NodeInfo {
 #[async_trait]
 pub trait ClusterUpdateNotifier: Send + Sync + 'static {
     /// Called when cluster membership or leadership changes.
-    async fn on_cluster_update(&mut self, cluster_info: &ClusterInfo);
+    async fn on_cluster_update(&mut self, cluster_info: &ClusterInfo) -> anyhow::Result<()>;
 }
 
 /// Handle returned when subscribing to cluster updates.
@@ -286,7 +286,7 @@ impl NodeDiscovery {
 
         // Notify watchers that the cluster was updated.
         if let Some(notifier) = &mut self.notifier {
-            notifier.on_cluster_update(&info).await;
+            notifier.on_cluster_update(&info).await?;
         }
         let _ = self.sender.send(info);
 

--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -101,7 +101,7 @@ impl NodeInfo {
 #[async_trait]
 pub trait ClusterUpdateNotifier: Send + Sync + 'static {
     /// Called when cluster membership or leadership changes.
-    async fn on_cluster_update(&self, cluster_info: &ClusterInfo);
+    async fn on_cluster_update(&mut self, cluster_info: &ClusterInfo);
 }
 
 /// Handle returned when subscribing to cluster updates.
@@ -285,7 +285,7 @@ impl NodeDiscovery {
         self.prev_leader_id = leader_id;
 
         // Notify watchers that the cluster was updated.
-        if let Some(notifier) = &self.notifier {
+        if let Some(notifier) = &mut self.notifier {
             notifier.on_cluster_update(&info).await;
         }
         let _ = self.sender.send(info);

--- a/crates/utils/sov-proxy-utils/src/root_hash_check_metric.rs
+++ b/crates/utils/sov-proxy-utils/src/root_hash_check_metric.rs
@@ -1,0 +1,56 @@
+use crate::root_hash_checker::RootHashCheck;
+use crate::root_hash_checker::RootHashConsistency;
+use std::collections::BTreeSet;
+use std::io::Write;
+
+#[derive(Debug)]
+pub struct RootHashCheckMetric {
+    pub outcome: RootHashConsistency,
+    pub slot_number: u64,
+    pub nodes_ok: u64,
+    pub nodes_failed: u64,
+    pub unique_state_roots: u64,
+}
+
+impl RootHashCheckMetric {
+    pub fn from_check(check: &RootHashCheck, outcome: RootHashConsistency) -> Self {
+        let nodes_ok = check.node_results.len() as u64;
+        let nodes_failed = check.failed_nodes.len() as u64;
+        let unique_state_roots = check.node_results.values().collect::<BTreeSet<_>>().len() as u64;
+
+        Self {
+            outcome,
+            slot_number: check.slot_number,
+            nodes_ok,
+            nodes_failed,
+            unique_state_roots,
+        }
+    }
+
+    fn outcome_tag(&self) -> &'static str {
+        match self.outcome {
+            RootHashConsistency::AllMatch => "all_match",
+            RootHashConsistency::Mismatch => "mismatch",
+            RootHashConsistency::NoData => "no_data",
+        }
+    }
+}
+
+impl sov_metrics::Metric for RootHashCheckMetric {
+    fn measurement_name(&self) -> &'static str {
+        "sov_proxy_root_hash_check"
+    }
+
+    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        write!(
+            buffer,
+            "{},outcome={} slot_number={},nodes_ok={},nodes_failed={},unique_state_roots={}",
+            self.measurement_name(),
+            self.outcome_tag(),
+            self.slot_number,
+            self.nodes_ok,
+            self.nodes_failed,
+            self.unique_state_roots,
+        )
+    }
+}

--- a/crates/utils/sov-proxy-utils/src/root_hash_checker.rs
+++ b/crates/utils/sov-proxy-utils/src/root_hash_checker.rs
@@ -1,5 +1,6 @@
 use crate::node_discovery::ClusterInfo;
 use crate::node_discovery::NodeInfo;
+use crate::root_hash_check_metric::RootHashCheckMetric;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -147,8 +148,15 @@ impl ClusterRootHashChecker {
                     );
                 }
 
-                // TODO: Add a metric for root hash consistency check.
-                match root_hash_check.check_consistency() {
+                let consistency = root_hash_check.check_consistency();
+                sov_metrics::track_metrics(|tracker| {
+                    tracker.submit(RootHashCheckMetric::from_check(
+                        &root_hash_check,
+                        consistency,
+                    ));
+                });
+
+                match consistency {
                     RootHashConsistency::AllMatch => {
                         tracing::debug!(
                             slot_number = root_hash_check.slot_number,


### PR DESCRIPTION
# Description

This PR adds metrics to track the cluster view of the state root hash for a given slot.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to:
    - https://github.com/Sovereign-Labs/sov-rollup-cdk-starter/pull/71 
    - https://github.com/Sovereign-Labs/ubuntu-evm-starter-script/pull/28
    - https://github.com/Sovereign-Labs/rollup-starter/pull/124