### PR TITLE
Pin `celestia-rpc` to prevent `sov-celestia-adapter` compilation failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10991,6 +10991,7 @@ dependencies = [
  "bincode",
  "borsh",
  "celestia-client",
+ "celestia-rpc",
  "celestia-types",
  "derive_more 1.0.0",
  "futures",

--- a/crates/adapters/celestia/Cargo.toml
+++ b/crates/adapters/celestia/Cargo.toml
@@ -21,6 +21,8 @@ prost = "0.13"
 
 # Upgrade with care. The new version might be incompatible and require a run of soak tests
 celestia-types = { version = "0.19.0", default-features = false }
+# This is for preventing breaking change in 0.16.2. Can be removed after upgrade above 0.4.1
+celestia-rpc = { version = "=0.16.1", default-features = false, optional = true }
 celestia-client = { version = "0.4.1", optional = true }
 tendermint = { version = "0.40.4", default-features = false }
 tendermint-proto = { version = "0.40.4" }
@@ -79,6 +81,7 @@ native = [
     "backon",
     "tendermint/default",
     "dep:celestia-client",
+    "dep:celestia-rpc",
     "dep:futures",
     "dep:tokio",
     "sov-celestia-adapter/native",


### PR DESCRIPTION
on fresh builds

There has been this issue:

```
This is a dependency-resolution break:

- sov-celestia-adapter uses celestia-client = "0.4.1" in crates/adapters/celestia/Cargo.toml:23.
- celestia-client 0.4.1 depends on:
  - celestia-types = "0.19.0"
  - celestia-rpc = "0.16.1" (caret range, so 0.16.2 is allowed)
    in /Users/nikolai/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/celestia-client-0.4.1/Cargo.toml.
- celestia-rpc 0.16.2 depends on celestia-types = "0.20.0" in /Users/nikolai/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/celestia-rpc-0.16.2/Cargo.toml.
- Result: celestia-client 0.4.1 pulls both celestia-types 0.19 and 0.20, causing the E0308 type mismatches.

The problematic semver break is celestia-rpc 0.16.2 (patch release) becoming incompatible with celestia-client 0.4.1 via celestia-types 0.20.
```

This PR ensures, that users don't have to manually pin:

```
cargo update -p celestia-rpc --precise 0.16.1
```

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
No

## Docs
No
