### PR TITLE
Use hyperlane metrics to wait in tests

### DIFF
--- a/crates/module-system/hyperlane/tests/integration/with_agent/helpers/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/helpers/mod.rs
@@ -216,7 +216,7 @@ impl HyperlaneBuilder {
 
         // Current image is based on https://github.com/Sovereign-Labs/hyperlane-monorepo/tree/integration-2025-09-17-rebase branch
         let docker_image = docker_image
-            .unwrap_or_else(|_| "ghcr.io/ross-weir/hyperlane-agent:integration-8".into());
+            .unwrap_or_else(|_| "ghcr.io/ross-weir/hyperlane-agent:integration-lander-1".into());
         let (name, tag) = docker_image
             .split_once(':')
             .unwrap_or((&docker_image, "latest"));

--- a/crates/module-system/hyperlane/tests/integration/with_agent/helpers/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/helpers/mod.rs
@@ -214,7 +214,7 @@ impl HyperlaneBuilder {
         let docker_image = env::var("CUSTOM_HLP_DOCKER_IMAGE");
         let has_custom_image = !matches!(docker_image, Err(env::VarError::NotPresent));
 
-        // Current image is based on https://github.com/Sovereign-Labs/hyperlane-monorepo/tree/integration-2025-09-17-rebase branch
+        // Current image is based on https://github.com/Sovereign-Labs/hyperlane-monorepo/tree/sovereign-lander-integration
         let docker_image = docker_image
             .unwrap_or_else(|_| "ghcr.io/ross-weir/hyperlane-agent:integration-lander-1".into());
         let (name, tag) = docker_image

--- a/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
@@ -285,6 +285,20 @@ async fn test_process_message_from_evm_counterparty() {
     // finalize the block with a dispatched message
     hyperlane.mine_next_block_on_counterparty().await;
 
+    tracing::info!("Waiting for relayer to process inbound message...");
+    if let Err(err) = wait_for_messages_processed(
+        hyperlane.metrics(),
+        "ethtest",
+        "sovtest",
+        1,
+        RelayerWaitConfig::default(),
+    )
+    .await
+    {
+        hyperlane.print_stdout().await;
+        panic!("Relayer metrics check failed for inbound message: {err}");
+    }
+
     // look for `process` event
     for _ in 0..DEFAULT_FINALIZATION_BLOCKS * 15 {
         let events = next_slot_events(rollup.api_client(), &mut slot_subscription).await;
@@ -528,6 +542,21 @@ async fn test_warp_transfer_back_and_forth_with_evm_counterparty(
         )
         .await;
     hyperlane.mine_next_block_on_counterparty().await;
+
+    // Wait for the relayer to process the inbound EVM→Sovereign message
+    tracing::info!("Waiting for relayer to process inbound warp transfer...");
+    if let Err(err) = wait_for_messages_processed(
+        hyperlane.metrics(),
+        "ethtest",
+        "sovtest",
+        1,
+        RelayerWaitConfig::default(),
+    )
+    .await
+    {
+        hyperlane.print_stdout().await;
+        panic!("Relayer metrics check failed for inbound transfer: {err}");
+    }
 
     let mut transfer_received = false;
     for _ in 0..DEFAULT_FINALIZATION_BLOCKS * 15 {


### PR DESCRIPTION
# Description

Wait for hyperlane lander metrics in tests. Updates the docker image to one that implements lander for sovereign

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
