### PR TITLE
Celestia: Enable verification of each celestia block on fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2026-02-16
+- #2489 Non-breaking, but **important**: Celestia adapter now by default validates blocks fetched from RPC node.
+  This adds performance overhead. It can be disabled by setting `verify_on_fetch = false` in `da` section of rollup_config.toml. Do on your own risk.
+
 # 2026-02-09
 - #2459 Fixes in EVM RPC `eth_estimateGas` and `eth_getStorageAt`
 # 2026-01-29

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -59,6 +59,8 @@ pub struct CelestiaConfig {
     #[serde(default = "default_background_stat_polling_interval_secs")]
     pub background_stat_polling_interval_secs: u64,
     /// Whether to verify fetched namespace data against block DAH before returning from `get_block_at`.
+    /// Disable only if you explicitly want to skip this integrity check for performance reasons.
+    /// Disabling it might lead to silent consensus breaking fork if connected RPC node returns corrupted data.
     /// Default: true.
     #[serde(default = "default_verify_on_fetch")]
     pub verify_on_fetch: bool,

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -305,7 +305,6 @@ pub(crate) const fn default_verify_on_fetch() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::{validate_rpc_url, CelestiaConfig};
 
     const RPC_ENV_VAR: &str = "SOV_CELESTIA_RPC_URL";

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -58,6 +58,10 @@ pub struct CelestiaConfig {
     /// Default: 30.
     #[serde(default = "default_background_stat_polling_interval_secs")]
     pub background_stat_polling_interval_secs: u64,
+    /// Whether to verify fetched namespace data against block DAH before returning from `get_block_at`.
+    /// Default: true.
+    #[serde(default = "default_verify_on_fetch")]
+    pub verify_on_fetch: bool,
     /// See [`sov_rollup_interface::node::da::DaService::safe_lead_time`].
     #[serde(default = "default_safe_lead_time_ms")]
     pub safe_lead_time_ms: u64,
@@ -107,6 +111,7 @@ impl fmt::Debug for CelestiaConfig {
                 "background_stat_polling_interval_secs",
                 &self.background_stat_polling_interval_secs,
             )
+            .field("verify_on_fetch", &self.verify_on_fetch)
             .field("safe_lead_time_ms", &self.safe_lead_time_ms)
             .field("tx_priority", &self.tx_priority)
             .field("backoff_min_delay_ms", &self.backoff_min_delay_ms)
@@ -148,6 +153,7 @@ impl CelestiaConfig {
             api_request_timeout_secs: default_api_request_timeout_secs(),
             tx_status_polling_millis: default_tx_status_polling_millis(),
             background_stat_polling_interval_secs: default_background_stat_polling_interval_secs(),
+            verify_on_fetch: default_verify_on_fetch(),
             safe_lead_time_ms: default_safe_lead_time_ms(),
             tx_priority: default_tx_priority(),
             backoff_min_delay_ms: default_min_delay_ms(),
@@ -271,4 +277,26 @@ pub(crate) fn default_tx_status_polling_millis() -> u64 {
 
 pub(crate) fn default_background_stat_polling_interval_secs() -> u64 {
     30
+}
+
+pub(crate) const fn default_verify_on_fetch() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_on_fetch_defaults_to_true() {
+        let parsed: CelestiaConfig = serde_json::from_str("{}").expect("valid default config");
+        assert!(parsed.verify_on_fetch);
+    }
+
+    #[test]
+    fn verify_on_fetch_can_be_disabled() {
+        let parsed: CelestiaConfig =
+            serde_json::from_str(r#"{"verify_on_fetch":false}"#).expect("valid override config");
+        assert!(!parsed.verify_on_fetch);
+    }
 }

--- a/crates/adapters/celestia/src/da_service/mod.rs
+++ b/crates/adapters/celestia/src/da_service/mod.rs
@@ -29,7 +29,9 @@ use celestia_types::nmt::Namespace;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use sov_rollup_interface::common::HexHash;
-use sov_rollup_interface::da::{DaProof, DaSpec, RelevantBlobs, RelevantProofs};
+use sov_rollup_interface::da::{
+    BlobReaderTrait, DaProof, DaSpec, DaVerifier, RelevantBlobs, RelevantProofs,
+};
 use sov_rollup_interface::node::da::{
     run_maybe_retryable_async_fn_with_retries, DaService, MaybeRetryable, SubmitBlobReceipt,
 };
@@ -46,6 +48,7 @@ pub struct CelestiaService {
     client: Arc<celestia_client::Client>,
     rollup_batch_namespace: Namespace,
     rollup_proof_namespace: Namespace,
+    verify_on_fetch: bool,
     signer_address: Option<CelestiaAddress>,
     safe_lead_time: Duration,
     backoff_policy: ExponentialBuilder,
@@ -59,6 +62,7 @@ impl CelestiaService {
         client: celestia_client::Client,
         rollup_batch_namespace: Namespace,
         rollup_proof_namespace: Namespace,
+        verify_on_fetch: bool,
         signer_address: Option<CelestiaAddress>,
         safe_lead_time: Duration,
         backoff_policy: ExponentialBuilder,
@@ -70,6 +74,7 @@ impl CelestiaService {
             client: Arc::new(client),
             rollup_batch_namespace,
             rollup_proof_namespace,
+            verify_on_fetch,
             signer_address,
             safe_lead_time,
             backoff_policy,
@@ -232,6 +237,7 @@ impl CelestiaService {
             client,
             chain_params.rollup_batch_namespace,
             chain_params.rollup_proof_namespace,
+            config.verify_on_fetch,
             fetched_signer,
             Duration::from_millis(config.safe_lead_time_ms),
             backoff_policy,
@@ -359,7 +365,11 @@ impl CelestiaService {
             tracker.submit(get_block_measurement);
         });
         tracing::trace!(height, "get_block_at metrics send, returning");
-        FilteredCelestiaBlock::new(rollup_batch_shares, rollup_proof_shares, header)
+        let block = FilteredCelestiaBlock::new(rollup_batch_shares, rollup_proof_shares, header)?;
+        if self.verify_on_fetch {
+            self.verify_block_integrity(&block)?;
+        }
+        Ok(block)
     }
 
     async fn get_head_block_header_inner(
@@ -425,6 +435,28 @@ impl CelestiaService {
             .subscribe()
             .map(|res| res.map(CelestiaHeader::from).map_err(|e| e.into()))
             .boxed())
+    }
+
+    fn verify_block_integrity(&self, block: &FilteredCelestiaBlock) -> anyhow::Result<()> {
+        let verifier = CelestiaVerifier::new(RollupParams {
+            rollup_batch_namespace: self.rollup_batch_namespace,
+            rollup_proof_namespace: self.rollup_proof_namespace,
+        });
+
+        let mut relevant_blobs = extract_relevant_blobs(block);
+        // Advance full blob data first, then derive proofs for the consumed ranges.
+        for blob in relevant_blobs
+            .batch_blobs
+            .iter_mut()
+            .chain(relevant_blobs.proof_blobs.iter_mut())
+        {
+            blob.advance(blob.total_len());
+        }
+        let relevant_proofs = get_extraction_proof(block, &relevant_blobs);
+
+        verifier.verify_relevant_tx_list(&block.header, &relevant_blobs, relevant_proofs)?;
+
+        Ok(())
     }
 }
 

--- a/crates/adapters/celestia/src/test_helper/docker.rs
+++ b/crates/adapters/celestia/src/test_helper/docker.rs
@@ -6,8 +6,7 @@ use crate::config::{
     default_api_request_timeout_secs, default_background_stat_polling_interval_secs,
     default_factor, default_max_delay_ms, default_max_times, default_min_delay_ms,
     default_request_timeout_seconds, default_safe_lead_time_ms, default_tx_priority,
-    default_tx_status_polling_millis,
-    default_verify_on_fetch,
+    default_tx_status_polling_millis, default_verify_on_fetch,
 };
 use crate::verifier::address::CelestiaAddress;
 use crate::{CelestiaConfig, CelestiaService};

--- a/crates/adapters/celestia/src/test_helper/docker.rs
+++ b/crates/adapters/celestia/src/test_helper/docker.rs
@@ -7,6 +7,7 @@ use crate::config::{
     default_factor, default_max_delay_ms, default_max_times, default_min_delay_ms,
     default_request_timeout_seconds, default_safe_lead_time_ms, default_tx_priority,
     default_tx_status_polling_millis,
+    default_verify_on_fetch,
 };
 use crate::verifier::address::CelestiaAddress;
 use crate::{CelestiaConfig, CelestiaService};
@@ -285,6 +286,7 @@ impl CelestiaDevNode {
             api_request_timeout_secs: default_api_request_timeout_secs(),
             tx_status_polling_millis: default_tx_status_polling_millis(),
             background_stat_polling_interval_secs: default_background_stat_polling_interval_secs(),
+            verify_on_fetch: default_verify_on_fetch(),
             safe_lead_time_ms: default_safe_lead_time_ms(),
             tx_priority: default_tx_priority(),
             backoff_min_delay_ms: default_min_delay_ms(),

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -518,10 +518,6 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             let prover_config = prover_config
                 .expect("This code path should not be possible; this is a bug, please report it");
 
-            let prover_service = self
-                .create_prover_service(prover_config, &rollup_config, &da_service)
-                .await;
-
             let proof_sender =
                 Box::new(self.create_proof_sender(&rollup_config, sequencer.proof_sender.clone())?);
 
@@ -544,6 +540,9 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     .await?
                 }
                 OperatingMode::Zk => {
+                    let prover_service = self
+                        .create_prover_service(prover_config, &rollup_config, &da_service)
+                        .await;
                     start_zk_workflow_in_background(
                         prover_service,
                         rollup_config.proof_manager.aggregated_proof_block_jump,

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -48,9 +48,10 @@ signer_private_key = "aec34bb1cfae6e906594dc106af4057a9046f769e2eeed67d040f0107e
 # Default: 30
 #background_stat_polling_interval_secs = 30
 
-# Verify fetched namespace data against the DA header before returning from get_block_at.
-# Disable only if you explicitly want to skip this integrity check.
-# Default: true
+# Whether to verify fetched namespace data against block DAH before returning from `get_block_at`.
+# Disable only if you explicitly want to skip this integrity check for performance reasons.
+# Disabling it might lead to silent consensus breaking fork if connected RPC node returns corrupted data.
+# Default: true.
 #verify_on_fetch = true
 
 # Options are "Low", "Medium" and "High"

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -48,6 +48,11 @@ signer_private_key = "aec34bb1cfae6e906594dc106af4057a9046f769e2eeed67d040f0107e
 # Default: 30
 #background_stat_polling_interval_secs = 30
 
+# Verify fetched namespace data against the DA header before returning from get_block_at.
+# Disable only if you explicitly want to skip this integrity check.
+# Default: true
+#verify_on_fetch = true
+
 # Options are "Low", "Medium" and "High"
 # Defines a priority of rollup blob transactions. Set it to "High" for faster inclusion.
 # Default: High for better blob inclusion.


### PR DESCRIPTION
# Description

We've observed that buggy Celestia RPC node can cause silent state diveregence in operator mode or in zk mode with disabled proving.

This PR adds 

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to #1630 

## Testing
Existing tests are passing. No new tests have been added, because given functions are tested separately and having e2e test will be complicated to setup

## Docs
No updates
