### PR TITLE
`ClusterInfo`: Remove call to `write_to_file_atomically`. 

### DIFF
--- a/crates/utils/sov-proxy-utils/src/cluster_info_service.rs
+++ b/crates/utils/sov-proxy-utils/src/cluster_info_service.rs
@@ -5,7 +5,6 @@ use crate::node_discovery::NodeDiscoveryTask;
 use crate::root_hash_checker::ClusterRootHashChecker;
 use crate::root_hash_checker::ClusterRootHashCheckerTask;
 use anyhow::{Context, Result};
-use std::path::PathBuf;
 use std::time::Duration;
 
 /// Service that keeps cluster info updated by running a [`NodeDiscovery`] task.
@@ -19,11 +18,9 @@ impl ClusterInfoService {
     pub async fn spawn(
         connection_string: &str,
         max_age: Duration,
-        path: PathBuf,
         notifier: Option<Box<dyn ClusterUpdateNotifier>>,
     ) -> Result<Self> {
-        let node_discovery =
-            NodeDiscovery::connect(connection_string, max_age, path, notifier).await?;
+        let node_discovery = NodeDiscovery::connect(connection_string, max_age, notifier).await?;
         let root_hash_checker = ClusterRootHashChecker::new(node_discovery.receiver.clone())?;
 
         let node_discovery_task = node_discovery.spawn();

--- a/crates/utils/sov-proxy-utils/src/file_writer.rs
+++ b/crates/utils/sov-proxy-utils/src/file_writer.rs
@@ -6,7 +6,7 @@ use tokio::io::AsyncWriteExt;
 ///
 /// Uses write-to-temp-then-rename pattern to ensure the file is never
 /// partially written. The data is synced to disk before renaming.
-pub(crate) async fn write_to_file_atomically(path: &Path, content: &str) -> anyhow::Result<()> {
+pub async fn write_to_file_atomically(path: &Path, content: &str) -> anyhow::Result<()> {
     let dir = path.parent().context("Path has no parent directory")?;
 
     // Create temp file in same directory to ensure same filesystem for atomic rename.

--- a/crates/utils/sov-proxy-utils/src/lib.rs
+++ b/crates/utils/sov-proxy-utils/src/lib.rs
@@ -4,6 +4,7 @@ mod node_discovery;
 mod root_hash_check_metric;
 mod root_hash_checker;
 pub use cluster_info_service::*;
+pub use file_writer::*;
 pub use node_discovery::*;
 pub use root_hash_check_metric::*;
 pub use root_hash_checker::*;

--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -1,13 +1,11 @@
 //! Utilities for discovering cluster nodes from PostgreSQL and persisting snapshots.
-use crate::file_writer::write_to_file_atomically;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use async_trait::async_trait;
 use sqlx::postgres::{PgListener, PgPool};
 use sqlx::FromRow;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::SocketAddr;
-use std::path::PathBuf;
 use std::time::Duration;
 pub use time::OffsetDateTime;
 use tokio::sync::watch;
@@ -22,17 +20,6 @@ pub struct NodeInfo {
     pub address: SocketAddr,
     /// The last time the node updated its heartbeat.
     pub last_updated: OffsetDateTime,
-}
-
-impl NodeInfo {
-    fn to_file_line(&self, role: &str) -> String {
-        let ts = self
-            .last_updated
-            .format(&time::format_description::well_known::Rfc3339)
-            .unwrap_or_else(|e| panic!("Failed to format timestamp: {e}"));
-
-        format!("{role}={},{ts},{}", self.address, self.node_id)
-    }
 }
 
 /// Result of querying cluster node information.
@@ -55,41 +42,8 @@ impl ClusterInfo {
         self.followers.contains_key(node_id)
     }
 
-    /// Formats the cluster info as a string suitable for writing to a file.
-    /// Each node is written on a separate line in the format `role=address,timestamp,node_id`.
-    pub fn to_file_content(&self) -> String {
-        let mut lines = Vec::new();
-
-        if let Some(leader) = &self.leader {
-            lines.push(leader.to_file_line("leader"));
-        }
-
-        for follower in self.followers.values() {
-            lines.push(follower.to_file_line("follower"));
-        }
-
-        lines.join("\n")
-    }
-
     fn leader_id(&self) -> Option<String> {
         self.leader.as_ref().map(|l| l.node_id.clone())
-    }
-}
-
-impl NodeInfo {
-    /// Parses a node info from a string in the format `address,timestamp,node_id`.
-    pub fn parse(s: &str) -> Result<Self> {
-        let mut parts = s.split(',');
-        let addr = parts.next().context("Missing address")?;
-        let ts = parts.next().context("Missing timestamp")?;
-        let node_id = parts.next().context("Missing node_id")?;
-
-        Ok(NodeInfo {
-            node_id: node_id.to_string(),
-            address: addr.parse().context("Invalid address")?,
-            last_updated: OffsetDateTime::parse(ts, &time::format_description::well_known::Rfc3339)
-                .context("Invalid timestamp")?,
-        })
     }
 }
 
@@ -123,7 +77,6 @@ pub struct NodeDiscovery {
     listener: PgListener,
     prev_followers: BTreeSet<String>,
     prev_leader_id: Option<String>,
-    path: PathBuf,
     notifier: Option<Box<dyn ClusterUpdateNotifier>>,
     sender: watch::Sender<ClusterInfo>,
     pub(crate) receiver: watch::Receiver<ClusterInfo>,
@@ -139,7 +92,6 @@ impl NodeDiscovery {
     pub async fn connect(
         connection_string: &str,
         max_age: Duration,
-        path: PathBuf,
         notifier: Option<Box<dyn ClusterUpdateNotifier>>,
     ) -> Result<Self> {
         tracing::info!("Connecting to database.");
@@ -148,9 +100,6 @@ impl NodeDiscovery {
             .connect(connection_string)
             .await?;
         tracing::info!("DB connection established.");
-
-        // On startup, write an empty file. If the cluster is not empty, the file will be populated on the first call to `handle_cluster_update`.
-        write_to_file_atomically(&path, "").await?;
 
         let mut listener = PgListener::connect(connection_string).await?;
         listener
@@ -166,7 +115,6 @@ impl NodeDiscovery {
             listener,
             prev_followers: BTreeSet::new(),
             prev_leader_id: None,
-            path,
             notifier,
             sender,
             receiver,
@@ -277,10 +225,6 @@ impl NodeDiscovery {
             );
         }
 
-        let content = info.to_file_content();
-        write_to_file_atomically(&self.path, &content).await?;
-        tracing::info!(?self.path, content, "Cluster info file updated");
-
         // Notify watchers that the cluster was updated.
         if let Some(notifier) = &mut self.notifier {
             notifier.on_cluster_update(&info).await?;
@@ -331,58 +275,6 @@ mod tests {
 
     fn test_timestamp() -> OffsetDateTime {
         OffsetDateTime::UNIX_EPOCH
-    }
-
-    const TEST_TIME_STAMP: &str = "1970-01-01T00:00:00Z";
-
-    #[test]
-    fn cluster_with_leader_and_followers() {
-        let ts = test_timestamp();
-        let info = NodeDiscovery::cluster(
-            Some("node1".to_string()),
-            vec![
-                ("node1".to_string(), "127.0.0.1:8000".to_string(), ts),
-                ("node2".to_string(), "127.0.0.1:8001".to_string(), ts),
-                ("node3".to_string(), "127.0.0.1:8002".to_string(), ts),
-            ],
-        )
-        .unwrap();
-
-        assert_eq!(
-            info.to_file_content(),
-            format!(
-                "leader=127.0.0.1:8000,{TEST_TIME_STAMP},node1\n\
-                 follower=127.0.0.1:8001,{TEST_TIME_STAMP},node2\n\
-                 follower=127.0.0.1:8002,{TEST_TIME_STAMP},node3"
-            ),
-        );
-    }
-
-    #[test]
-    fn cluster_with_no_leader() {
-        let ts = test_timestamp();
-        let info = NodeDiscovery::cluster(
-            None,
-            vec![
-                ("node1".to_string(), "127.0.0.1:8000".to_string(), ts),
-                ("node2".to_string(), "127.0.0.1:8001".to_string(), ts),
-            ],
-        )
-        .unwrap();
-
-        assert_eq!(
-            info.to_file_content(),
-            format!(
-                "follower=127.0.0.1:8000,{TEST_TIME_STAMP},node1\n\
-                 follower=127.0.0.1:8001,{TEST_TIME_STAMP},node2"
-            ),
-        );
-    }
-
-    #[test]
-    fn cluster_empty() {
-        let info = NodeDiscovery::cluster(None, vec![]).unwrap();
-        assert_eq!(info.to_file_content(), "");
     }
 
     #[test]

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -166,7 +166,6 @@ struct NodeDiscoveryTestSetup {
     da_addr: SocketAddr,
     da_shutdown: watch::Sender<()>,
     cluster_info_service: ClusterInfoService,
-    _temp_dir: tempfile::TempDir,
 }
 
 const MAX_AGE: Duration = Duration::from_secs(10);
@@ -191,11 +190,8 @@ impl NodeDiscoveryTestSetup {
 
         let (_, da_shutdown, da_addr) = create_da_service_periodic().await;
 
-        let temp_dir = tempfile::tempdir().unwrap();
-        let path = temp_dir.path().join("cluster_info.txt");
-
         let cluster_info_service =
-            ClusterInfoService::spawn(postgres.connection_string(), max_age, path, None)
+            ClusterInfoService::spawn(postgres.connection_string(), max_age, None)
                 .await
                 .expect("Failed to create ClusterInfoService");
 
@@ -204,7 +200,6 @@ impl NodeDiscoveryTestSetup {
             da_shutdown,
             da_addr,
             cluster_info_service,
-            _temp_dir: temp_dir,
         })
     }
 


### PR DESCRIPTION
# Description

This PR removes that file-writing side effect from `NodeDiscovery`. The file is now written by the caller of the ClusterService.

See https://github.com/Sovereign-Labs/rollup-starter/pull/129 for more details

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #https://github.com/Sovereign-Labs/rollup-starter/pull/129 
