### PR TITLE
Celestia: Allow get RPC and gRPC urls from env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2026-02-17
-- #2493 Non-breaking, but **important**: CelestiaConfig `rpc_url` param is now mandatory. You can use `SOV_CELESTIA_RPC_URL` for setup.
+- #2493 **Infra only breaking change**: CelestiaConfig `rpc_url` param is now mandatory. Please don't rely on previous default value and provide explicit value.
+  You can use `SOV_CELESTIA_RPC_URL` for setup.
 
 # 2026-02-09
 - #2459 Fixes in EVM RPC `eth_estimateGas` and `eth_getStorageAt`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-02-17
+- #2493 Non-breaking, but **important**: CelestiaConfig `rpc_url` param is now mandatory. You can use `SOV_CELESTIA_RPC_URL` for setup.
+
 # 2026-02-09
 - #2459 Fixes in EVM RPC `eth_estimateGas` and `eth_getStorageAt`
 - #2458 **Infra only breaking change**: for EVM rollups only: added new constant `EVM_RECEIPT_ACTUAL_FEE_HEIGHT` that should be set to 0 for new rollups, or some future height for existing rollups.

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -9,7 +9,9 @@ use std::fmt;
 pub struct CelestiaConfig {
     /// The address of the Celestia RPC server
     /// For example: ws://localhost:26658
-    #[serde(default = "default_rpc_addr", alias = "celestia_rpc_address")]
+    /// Required. If not specified in the config, will be pulled from `SOV_CELESTIA_RPC_URL`.
+    /// Client construction fails if both are missing.
+    #[serde(default = "default_rpc_url_from_env", alias = "celestia_rpc_address")]
     pub rpc_url: String,
     /// JWT token for RPC server.
     /// If not specified in the config will be pulled from `SOV_CELESTIA_RPC_AUTH_TOKEN`
@@ -19,8 +21,10 @@ pub struct CelestiaConfig {
     pub rpc_auth_token: Option<String>,
 
     /// The address of the Celestia gRPC server, for example, http://localhost:9090
+    /// If not specified in the config, will be pulled from `SOV_CELESTIA_GRPC_URL`.
     /// Optional.
     /// Set only if DaService needs to submit blobs.
+    #[serde(default = "default_grpc_url")]
     pub grpc_url: Option<String>,
 
     /// The token for accessing Celestia gRPC server.
@@ -176,6 +180,8 @@ impl CelestiaConfig {
     }
 
     pub(crate) async fn build_client(&self) -> anyhow::Result<celestia_client::Client> {
+        validate_rpc_url(&self.rpc_url)?;
+
         let api_request_timeout =
             std::time::Duration::from_secs(self.api_request_timeout_secs.get());
         let mut builder = celestia_client::Client::builder()
@@ -202,8 +208,20 @@ pub(crate) const fn default_safe_lead_time_ms() -> u64 {
     500
 }
 
-fn default_rpc_addr() -> String {
-    "ws://localhost:26658".into()
+fn validate_rpc_url(rpc_url: &str) -> anyhow::Result<()> {
+    if rpc_url.trim().is_empty() {
+        anyhow::bail!("`rpc_url` must be set in the config or via `SOV_CELESTIA_RPC_URL`");
+    }
+
+    Ok(())
+}
+
+fn default_rpc_url_from_env() -> String {
+    std::env::var("SOV_CELESTIA_RPC_URL").unwrap_or_default()
+}
+
+fn default_grpc_url() -> Option<String> {
+    std::env::var("SOV_CELESTIA_GRPC_URL").ok()
 }
 
 fn default_rpc_auth_token() -> Option<String> {
@@ -271,4 +289,107 @@ pub(crate) fn default_tx_status_polling_millis() -> u64 {
 
 pub(crate) fn default_background_stat_polling_interval_secs() -> u64 {
     30
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{validate_rpc_url, CelestiaConfig};
+
+    const RPC_ENV_VAR: &str = "SOV_CELESTIA_RPC_URL";
+    const GRPC_ENV_VAR: &str = "SOV_CELESTIA_GRPC_URL";
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous_value: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: Option<&str>) -> Self {
+            let previous_value = std::env::var(key).ok();
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+            Self {
+                key,
+                previous_value,
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous_value {
+                Some(previous_value) => std::env::set_var(self.key, previous_value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    fn deserialize_config(json: &str) -> Result<CelestiaConfig, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    #[test]
+    fn rpc_url_is_read_from_env_when_missing_from_config() {
+        let _rpc_guard = EnvVarGuard::set(RPC_ENV_VAR, Some("ws://env-rpc:26658"));
+        let _grpc_guard = EnvVarGuard::set(GRPC_ENV_VAR, None);
+
+        let config = deserialize_config("{}").unwrap();
+        assert_eq!(config.rpc_url, "ws://env-rpc:26658");
+    }
+
+    #[test]
+    fn rpc_url_validation_fails_when_missing_from_config_and_env() {
+        let _rpc_guard = EnvVarGuard::set(RPC_ENV_VAR, None);
+        let _grpc_guard = EnvVarGuard::set(GRPC_ENV_VAR, None);
+
+        let config = deserialize_config("{}").unwrap();
+        let error = validate_rpc_url(&config.rpc_url).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("`rpc_url` must be set in the config or via `SOV_CELESTIA_RPC_URL`"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn explicit_rpc_url_overrides_env() {
+        let _rpc_guard = EnvVarGuard::set(RPC_ENV_VAR, Some("ws://env-rpc:26658"));
+        let _grpc_guard = EnvVarGuard::set(GRPC_ENV_VAR, None);
+
+        let config = deserialize_config(r#"{"rpc_url":"ws://config-rpc:26658"}"#).unwrap();
+        assert_eq!(config.rpc_url, "ws://config-rpc:26658");
+    }
+
+    #[test]
+    fn grpc_url_is_read_from_env_when_missing_from_config() {
+        let _rpc_guard = EnvVarGuard::set(RPC_ENV_VAR, Some("ws://env-rpc:26658"));
+        let _grpc_guard = EnvVarGuard::set(GRPC_ENV_VAR, Some("http://env-grpc:9090"));
+
+        let config = deserialize_config("{}").unwrap();
+        assert_eq!(config.grpc_url.as_deref(), Some("http://env-grpc:9090"));
+    }
+
+    #[test]
+    fn grpc_url_is_none_when_missing_from_config_and_env() {
+        let _rpc_guard = EnvVarGuard::set(RPC_ENV_VAR, Some("ws://env-rpc:26658"));
+        let _grpc_guard = EnvVarGuard::set(GRPC_ENV_VAR, None);
+
+        let config = deserialize_config("{}").unwrap();
+        assert_eq!(config.grpc_url, None);
+    }
+
+    #[test]
+    fn explicit_grpc_url_overrides_env() {
+        let _rpc_guard = EnvVarGuard::set(RPC_ENV_VAR, Some("ws://env-rpc:26658"));
+        let _grpc_guard = EnvVarGuard::set(GRPC_ENV_VAR, Some("http://env-grpc:9090"));
+
+        let config = deserialize_config(
+            r#"{"rpc_url":"ws://config-rpc:26658","grpc_url":"http://config-grpc:9090"}"#,
+        )
+        .unwrap();
+        assert_eq!(config.grpc_url.as_deref(), Some("http://config-grpc:9090"));
+    }
 }

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -2,7 +2,7 @@
 # The address of the Celestia RPC server to interact with.
 # Example for local: ws://127.0.0.1:26658
 # Example for QuickNode: wss://a-b-c.celestia-mocha.quiknode.pro/YOUR_ENDPOINT_ID
-# Default value: ws://127.0.0.1:26658
+# Required. If not specified in the config, it must be provided via `SOV_CELESTIA_RPC_URL`.
 rpc_url = "ws://127.0.0.1:26658"
 
 # JWT token for RPC server.
@@ -12,6 +12,7 @@ rpc_url = "ws://127.0.0.1:26658"
 
 # The address of the Celestia gRPC server for submitting blobs.
 # Example: http://127.0.0.1:9090
+# If not specified in the config, will be pulled from `SOV_CELESTIA_GRPC_URL` environment variable.
 # Optional. Set only if DaService needs to submit blobs.
 grpc_url = "http://127.0.0.1:9090"
 


### PR DESCRIPTION
# Description

Adds support for 2 environment variables `SOV_CELESTIA_RPC_URL` and `SOV_CELESTIA_GRPC_URL` in CelestiaConfig.

`rpc_url` params is now mandatory and does not have default `localhost:26658` value, because it can lead to confusion during mis-configuration. All known rollups have explicit option, so this breakaga is not critical.


- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1630 

## Testing
New tests have been added

## Docs
Docstrings have been updated
