### PR TITLE
Short-circuit transaction submission retries on a stop-height rejection

### DIFF
--- a/crates/full-node/sov-api-spec/src/client.rs
+++ b/crates/full-node/sov-api-spec/src/client.rs
@@ -29,13 +29,24 @@ pub extern crate tokio_tungstenite;
 pub type WsSubscription<T> = Result<BoxStream<'static, anyhow::Result<T>>, WsError>;
 
 /// Message substring returned by the sequencer when it reached the configured stop height.
-const STOP_HEIGHT_ERROR_MARKER: &str = "The preferred sequencer has reached the stop height ";
+const STOP_HEIGHT_ERROR_MARKER: &[u8] = b"The preferred sequencer has reached the stop height ";
+const HTTP_4XX_STATUS_MARKER: &[u8] = b"\"status\":4";
+
+fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
+}
 
 /// Checks whether an API client error indicates that the preferred sequencer reached stop height.
 pub fn is_stop_height_error(err: &Error<types::ApiError>) -> bool {
     matches!(
         err,
-        Error::ErrorResponse(response) if response.message.contains(STOP_HEIGHT_ERROR_MARKER)
+        Error::ErrorResponse(response)
+            if contains_subslice(response.message.as_bytes(), STOP_HEIGHT_ERROR_MARKER)
     )
 }
 
@@ -158,12 +169,12 @@ impl Client {
                     // This needs further improvement on the generated client.
                     // Details in https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/2799
                     Error::InvalidResponsePayload(bytes, _error) => {
-                        let response_body = std::str::from_utf8(bytes.as_ref()).unwrap_or("");
-                        if response_body.contains(STOP_HEIGHT_ERROR_MARKER) {
+                        let response_body = bytes.as_ref();
+                        if contains_subslice(response_body, STOP_HEIGHT_ERROR_MARKER) {
                             return false;
                         }
                         // All non-HTTP 4** are retried.
-                        !response_body.contains("\"status\":4")
+                        !contains_subslice(response_body, HTTP_4XX_STATUS_MARKER)
                     }
                 }
             })

--- a/crates/full-node/sov-api-spec/src/client.rs
+++ b/crates/full-node/sov-api-spec/src/client.rs
@@ -170,11 +170,13 @@ impl Client {
                     // Details in https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/2799
                     Error::InvalidResponsePayload(bytes, _error) => {
                         let response_body = bytes.as_ref();
-                        if contains_subslice(response_body, STOP_HEIGHT_ERROR_MARKER) {
-                            return false;
-                        }
-                        // All non-HTTP 4** are retried.
-                        !contains_subslice(response_body, HTTP_4XX_STATUS_MARKER)
+                        // We don't retry HTTP 4** errors, and we don't retry "reached the stop
+                        // height" errors since that means the rollup has shut down.
+                        let is_non_retryable = contains_subslice(
+                            response_body,
+                            STOP_HEIGHT_ERROR_MARKER,
+                        ) || contains_subslice(response_body, HTTP_4XX_STATUS_MARKER);
+                        !is_non_retryable
                     }
                 }
             })

--- a/crates/full-node/sov-api-spec/src/client.rs
+++ b/crates/full-node/sov-api-spec/src/client.rs
@@ -28,6 +28,17 @@ pub extern crate tokio_tungstenite;
 
 pub type WsSubscription<T> = Result<BoxStream<'static, anyhow::Result<T>>, WsError>;
 
+/// Message substring returned by the sequencer when it reached the configured stop height.
+const STOP_HEIGHT_ERROR_MARKER: &str = "The preferred sequencer has reached the stop height ";
+
+/// Checks whether an API client error indicates that the preferred sequencer reached stop height.
+pub fn is_stop_height_error(err: &Error<types::ApiError>) -> bool {
+    matches!(
+        err,
+        Error::ErrorResponse(response) if response.message.contains(STOP_HEIGHT_ERROR_MARKER)
+    )
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct WsMessage<T> {
     pub id: String,
@@ -142,12 +153,17 @@ impl Client {
             .when(|err| {
                 match err {
                     Error::InvalidRequest(_) | Error::InvalidUpgrade(_) | Error::PreHookError(_) => false,
-                    Error::CommunicationError(_) | Error::ErrorResponse(_) | Error::ResponseBodyError(_) | Error::UnexpectedResponse(_) => true,
+                    Error::ErrorResponse(_) => !is_stop_height_error(err),
+                    Error::CommunicationError(_) | Error::ResponseBodyError(_) | Error::UnexpectedResponse(_) => true,
                     // This needs further improvement on the generated client.
                     // Details in https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/2799
                     Error::InvalidResponsePayload(bytes, _error) => {
+                        let response_body = std::str::from_utf8(bytes.as_ref()).unwrap_or("");
+                        if response_body.contains(STOP_HEIGHT_ERROR_MARKER) {
+                            return false;
+                        }
                         // All non-HTTP 4** are retried.
-                        !std::str::from_utf8(bytes.as_ref()).unwrap_or("").contains("\"status\":4")
+                        !response_body.contains("\"status\":4")
                     }
                 }
             })

--- a/crates/utils/sov-soak-testing-lib/src/lib.rs
+++ b/crates/utils/sov-soak-testing-lib/src/lib.rs
@@ -33,20 +33,6 @@ use sov_transaction_generator::interface::MessageValidity;
 use sov_transaction_generator::{Distribution, GeneratedMessage, Percent, State};
 use tokio::sync::watch::Receiver;
 
-/// The message substring that indicates the sequencer has reached its configured stop height.
-const STOP_HEIGHT_ERROR_MARKER: &str = "The preferred sequencer has reached the stop height ";
-
-/// Checks if an API error indicates the sequencer has reached its configured stop height.
-/// When a rollup is configured with a stop height, transactions are rejected once that height
-/// is reached. This is not a real error condition for soak tests.
-fn is_stop_height_error(err: &sov_api_spec::Error<sov_api_spec::types::ApiError>) -> bool {
-    if let sov_api_spec::Error::ErrorResponse(response) = err {
-        // ResponseValue<T> implements Deref<Target = T>, so we can access ApiError fields directly
-        return response.message.contains(STOP_HEIGHT_ERROR_MARKER);
-    }
-    false
-}
-
 pub const BUFFER_SIZE: usize = 100_000;
 // The minimum randomness needed to guarantee successful transaction generation
 pub const SAFE_MIN_RANDOMNESS: usize = 1_000;
@@ -421,22 +407,21 @@ async fn prepare_and_send_txs<R: Runtime<S> + Clone, S: Spec>(
                     anyhow::bail!("Outdated transaction should have failed");
                 }
             } else {
-                // Always try a fail-fast call first to check for stop height error
-                match client.send_tx_to_sequencer(tx).await {
-                    Ok(_) => {}
-                    Err(err) if is_stop_height_error(&err) => {
+                let result = if use_retries {
+                    client.send_tx_to_sequencer_with_retry(tx).await
+                } else {
+                    client.send_tx_to_sequencer(tx).await
+                };
+
+                if let Err(err) = result {
+                    if sov_api_spec::is_stop_height_error(&err) {
                         tracing::info!(
                             "Sequencer reached stop height, gracefully stopping soak worker"
                         );
                         return Ok(());
                     }
-                    Err(_) if use_retries => {
-                        // First attempt failed with a non-stop-height error, kick off retries
-                        client.send_tx_to_sequencer_with_retry(tx).await?;
-                    }
-                    Err(err) => {
-                        return Err(err.into());
-                    }
+
+                    return Err(err.into());
                 }
             }
             total_txns += 1;


### PR DESCRIPTION
# Description

Some time ago we added a special case to `sov-soak-testing-lib` to shutdown a soak worker if a "sequencer has reached the stop height and is shutting down" error is returned. However if a transaction is rejected for another reason (e.g. batch is full), and `use_retries == true`, the soak test calls `client.send_tx_to_sequencer_with_retry()`, and if this happened near the end of the soak test this would then swallow the "stop height reached" error.

Moving this check to the actual client code has implications for everyone else using the client as well. Do we believe upgrades will eventually be so low downtime, that continuing to retry with backoff across an upgrade will be a good strategy? If so then the error should *not* be special-cased, but otherwise IMO this change would makes sense: we float the error to the user's code which is then responsible for polling until the rollup goes back up (and e.g. fetching the new chain hash, if needed).

As far as the soak tests go, this can be worked around (by ignoring errors near the expected end of the test) so it's not strictly necessary. So the main question is what behaviour we want to expose from the client.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
