### PR TITLE
Sequencer tests sleep clean up

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
@@ -82,8 +82,8 @@ async fn test_discard_oversized_blobs() {
     );
     let (test_rollup, admin) = create_test_rollup().await;
 
-    test_rollup.da_service.produce_block_now().await.unwrap();
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    test_rollup.produce_enough_finalized_slots().await;
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
     let client = test_rollup.api_client().clone();
 
     // Blob with this transaction will be discarded becuse the blob is bigger than `MAX_ALLOWED_DATA_SIZE_RETURNED_BY_BLOB_STORAGE`

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -2391,13 +2391,8 @@ async fn delayed_tx_is_processed_after_delay() {
     )
     .await;
 
-    // Produce a few blocks to DA blocks to make sure there's a finalized slot after genesis.
-    test_rollup
-        .da_service
-        .produce_n_blocks_now(5)
-        .await
-        .unwrap();
-    sleep(Duration::from_millis(200)).await;
+    test_rollup.produce_enough_finalized_slots().await;
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     let client = test_rollup.api_client().clone();
 
@@ -3275,15 +3270,7 @@ pub(crate) async fn setup_test_rollup_with_initial_state(
     test_rollup: TestRollup<TestBlueprint>,
     admin: &TestUser<TestSpec>,
 ) -> (TestRollup<TestBlueprint>, TestState) {
-    test_rollup
-        .da_service
-        .produce_n_blocks_now(10)
-        .await
-        .unwrap();
-
-    // Wait for all blocks to be processed by the node+sequencer. TODO: better
-    // logic not prone to race conditions.
-    sleep(Duration::from_millis(500)).await;
+    test_rollup.produce_enough_finalized_slots().await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     let client = test_rollup.api_client().clone();


### PR DESCRIPTION
# Description

Follow of #2444 and #2464 for less flakiness in CI

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Tests have been updated

## Docs
No updates
