### PR TITLE
Add GET /ledger/events/counts endpoint for per-event-key counts

### DIFF
--- a/crates/full-node/sov-api-spec/openapi-v3.yaml
+++ b/crates/full-node/sov-api-spec/openapi-v3.yaml
@@ -199,6 +199,22 @@ paths:
           $ref: "#/components/responses/LedgerEvent"
         "404":
           $ref: "#/components/responses/ApiErrorResponse"
+  /ledger/events/counts:
+    get:
+      tags:
+        - Ledger
+      summary: Get total event counts per event key.
+      operationId: get_event_key_counts
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: uint64
   /ledger/events:
     get:
       tags:

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -864,7 +864,12 @@ impl LedgerDb {
                 // Decrement EventCountByKey entries for rolled-back events
                 for (key, deleted_count) in &deleted_events_per_key {
                     let current_count = db.get::<EventCountByKey>(key)?.map(|n| n.0).unwrap_or(0);
-                    let new_count = current_count.saturating_sub(*deleted_count);
+                    let new_count = current_count.checked_sub(*deleted_count).ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Ledger DB corruption during rollback: event count underflow for key {:?} (current_count={}, deleted_count={})",
+                            key, current_count, deleted_count,
+                        )
+                    })?;
                     if new_count == 0 {
                         schema_batch.delete::<EventCountByKey>(key)?;
                     } else {

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -7,17 +8,19 @@ use serde::Serialize;
 use sov_rollup_interface::common::{HexHash, SlotNumber};
 use sov_rollup_interface::node::da::SlotData;
 use sov_rollup_interface::node::ledger_api::AggregatedProofResponse;
-use sov_rollup_interface::stf::{BatchReceipt, DiscardedBlob, StoredEvent, TxReceiptContents};
+use sov_rollup_interface::stf::{
+    BatchReceipt, DiscardedBlob, EventKey, StoredEvent, TxReceiptContents,
+};
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
 
 use crate::schema::tables::DiscardedBlobHahsByNumber;
 use crate::schema::tables::{
-    BatchByHash, BatchByNumber, DiscardedBlobByHash, EventByKey, EventByNumber, FinalizedSlots,
-    ProofByUniqueId, SlotByHash, SlotByNumber, StfInfoByNumber, StfInfoMetadata, TxByHash,
-    TxByNumber, LEDGER_TABLES,
+    BatchByHash, BatchByNumber, DiscardedBlobByHash, EventByKey, EventByNumber, EventCountByKey,
+    FinalizedSlots, ProofByUniqueId, SlotByHash, SlotByNumber, StfInfoByNumber, StfInfoMetadata,
+    TxByHash, TxByNumber, LEDGER_TABLES,
 };
 use crate::schema::types::{
-    split_tx_for_storage, BatchNumber, DiscardedBlobNumber, EventNumber,
+    split_tx_for_storage, BatchNumber, DiscardedBlobNumber, EventKeyNumber, EventNumber,
     LatestFinalizedSlotSingleton, ProofUniqueId, StfInfoUniqueId, StoredBatch, StoredDiscardedBlob,
     StoredSlot, StoredStfInfo, StoredTransaction, TxNumber,
 };
@@ -390,10 +393,26 @@ impl LedgerDb {
         event: &StoredEvent,
         event_number: &EventNumber,
         tx_number: TxNumber,
+        event_key_count: u64,
         schema_batch: &mut SchemaBatch,
     ) -> anyhow::Result<()> {
         schema_batch.put::<EventByNumber>(event_number, event)?;
-        schema_batch.put::<EventByKey>(&(event.key().clone(), tx_number, *event_number), &())
+        schema_batch.put::<EventByKey>(&(event.key().clone(), tx_number, *event_number), &())?;
+        schema_batch.put::<EventCountByKey>(event.key(), &EventKeyNumber(event_key_count))
+    }
+
+    /// Gets the current event count for the given key from the database.
+    fn get_event_key_count(&self, key: &EventKey) -> u64 {
+        // We intentionally ignore errors here because a missing or
+        // unreadable count is treated as zero (new key)
+        self.db
+            .read()
+            .expect(DB_LOCK_POISONED)
+            .get::<EventCountByKey>(key)
+            .ok()
+            .flatten()
+            .map(|n| n.0)
+            .unwrap_or(0)
     }
 
     /// Materializes [`SlotCommit`] into [`SchemaBatch`] by inserting its events,
@@ -409,6 +428,8 @@ impl LedgerDb {
 
         let slot_number = current_item_numbers.slot_number;
 
+        let mut event_key_counts: HashMap<EventKey, u64> = HashMap::new();
+
         let first_batch_number = current_item_numbers.batch_number;
         let last_batch_number = first_batch_number + data_to_commit.batch_receipts.len() as u64;
         // Insert data from "bottom up" to ensure consistency if the application crashes during insertion
@@ -422,10 +443,15 @@ impl LedgerDb {
                 let (tx_to_store, events) =
                     split_tx_for_storage(tx, batch_number, current_item_numbers.event_number);
                 for event in events.into_iter() {
+                    let count = event_key_counts
+                        .entry(event.key().clone())
+                        .or_insert_with(|| self.get_event_key_count(event.key()));
+                    *count += 1;
                     self.put_event(
                         &event,
                         &EventNumber(current_item_numbers.event_number),
                         TxNumber(current_item_numbers.tx_number),
+                        *count,
                         &mut schema_batch,
                     )?;
                     current_item_numbers.event_number += 1;
@@ -789,6 +815,7 @@ impl LedgerDb {
 
                 // Delete hash-indexed entries by iterating through txs
                 // (we need tx_number to delete EventByKey, and tx.hash to delete TxByHash)
+                let mut deleted_events_per_key: HashMap<EventKey, u64> = HashMap::new();
                 for current_tx_number in tx_range_start.0..tx_range_end.0 {
                     let current_tx_number = TxNumber(current_tx_number);
 
@@ -821,6 +848,9 @@ impl LedgerDb {
                                 );
                             }
                         };
+                        *deleted_events_per_key
+                            .entry(event.key().clone())
+                            .or_default() += 1;
                         schema_batch.delete::<EventByKey>(&(
                             event.key().clone(),
                             current_tx_number,
@@ -829,6 +859,21 @@ impl LedgerDb {
                     }
                     // Delete TxByHash entry
                     schema_batch.delete::<TxByHash>(&(tx.hash, current_tx_number))?;
+                }
+
+                // Decrement EventCountByKey entries for rolled-back events
+                for (key, deleted_count) in &deleted_events_per_key {
+                    let current_count = db
+                        .get::<EventCountByKey>(key)?
+                        .map(|n| n.0)
+                        .unwrap_or(0);
+                    let new_count = current_count.saturating_sub(*deleted_count);
+                    if new_count == 0 {
+                        schema_batch.delete::<EventCountByKey>(key)?;
+                    } else {
+                        schema_batch
+                            .put::<EventCountByKey>(key, &EventKeyNumber(new_count))?;
+                    }
                 }
 
                 // Range delete EventByNumber (reduces tombstones).

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -863,16 +863,12 @@ impl LedgerDb {
 
                 // Decrement EventCountByKey entries for rolled-back events
                 for (key, deleted_count) in &deleted_events_per_key {
-                    let current_count = db
-                        .get::<EventCountByKey>(key)?
-                        .map(|n| n.0)
-                        .unwrap_or(0);
+                    let current_count = db.get::<EventCountByKey>(key)?.map(|n| n.0).unwrap_or(0);
                     let new_count = current_count.saturating_sub(*deleted_count);
                     if new_count == 0 {
                         schema_batch.delete::<EventCountByKey>(key)?;
                     } else {
-                        schema_batch
-                            .put::<EventCountByKey>(key, &EventKeyNumber(new_count))?;
+                        schema_batch.put::<EventCountByKey>(key, &EventKeyNumber(new_count))?;
                     }
                 }
 

--- a/crates/full-node/sov-db/src/ledger_db/rpc.rs
+++ b/crates/full-node/sov-db/src/ledger_db/rpc.rs
@@ -202,7 +202,12 @@ impl LedgerRpcReader {
     async fn get_event_key_counts(&self) -> anyhow::Result<Vec<(String, u64)>> {
         use sov_rollup_interface::stf::EventKey;
 
-        let range = EventKey::new(&[])..EventKey::new(&[255u8; 4096]);
+        let Some((max_key, _)) = self.db.get_largest_async::<EventCountByKey>().await? else {
+            return Ok(Vec::new());
+        };
+        let mut upper_bytes = max_key.inner().clone();
+        upper_bytes.push(0x00);
+        let range = EventKey::new(&[])..EventKey::new(&upper_bytes);
         let entries = self
             .db
             .collect_in_range_async::<EventCountByKey, EventKey>(range)

--- a/crates/full-node/sov-db/src/ledger_db/rpc.rs
+++ b/crates/full-node/sov-db/src/ledger_db/rpc.rs
@@ -21,8 +21,8 @@ use crate::ledger_db::rpc_constants::{
 };
 use crate::ledger_db::{LedgerDb, DB_LOCK_POISONED};
 use crate::schema::tables::{
-    BatchByHash, BatchByNumber, EventByNumber, FinalizedSlots, ProofByUniqueId, SlotByHash,
-    SlotByNumber, TxByHash, TxByNumber,
+    BatchByHash, BatchByNumber, EventByNumber, EventCountByKey, FinalizedSlots, ProofByUniqueId,
+    SlotByHash, SlotByNumber, TxByHash, TxByNumber,
 };
 use crate::schema::types::{
     BatchNumber, EventNumber, LatestFinalizedSlotSingleton, StoredBatch, StoredSlot,
@@ -197,6 +197,25 @@ impl LedgerRpcReader {
             Some(e) => Ok(Some(e.0 .0)),
             None => Ok(None),
         }
+    }
+
+    async fn get_event_key_counts(&self) -> anyhow::Result<Vec<(String, u64)>> {
+        use sov_rollup_interface::stf::EventKey;
+
+        let range =
+            EventKey::new(&[])..EventKey::new(&[255u8; 4096]);
+        let entries = self
+            .db
+            .collect_in_range_async::<EventCountByKey, EventKey>(range)
+            .await?;
+        Ok(entries
+            .into_iter()
+            .map(|(key, count)| {
+                let key_str = String::from_utf8(key.inner().clone())
+                    .unwrap_or_else(|_| hex::encode(key.inner()));
+                (key_str, count.0)
+            })
+            .collect())
     }
 
     async fn collect_transaction_numbers(
@@ -797,6 +816,11 @@ impl LedgerStateProvider for LedgerDb {
     {
         let rpc_reader = self.get_rpc_reader().await?;
         rpc_reader.get_events_by_txn_number(txn_num).await
+    }
+
+    async fn get_event_key_counts(&self) -> Result<Vec<(String, u64)>, Self::Error> {
+        let rpc_reader = self.get_rpc_reader().await?;
+        rpc_reader.get_event_key_counts().await
     }
 
     async fn get_slots_range<B, T, E>(

--- a/crates/full-node/sov-db/src/ledger_db/rpc.rs
+++ b/crates/full-node/sov-db/src/ledger_db/rpc.rs
@@ -206,6 +206,7 @@ impl LedgerRpcReader {
             return Ok(Vec::new());
         };
         let mut upper_bytes = max_key.inner().clone();
+        // range query is exclusive, add a byte so we get the max key as well
         upper_bytes.push(0x00);
         let range = EventKey::new(&[])..EventKey::new(&upper_bytes);
         let entries = self

--- a/crates/full-node/sov-db/src/ledger_db/rpc.rs
+++ b/crates/full-node/sov-db/src/ledger_db/rpc.rs
@@ -202,8 +202,7 @@ impl LedgerRpcReader {
     async fn get_event_key_counts(&self) -> anyhow::Result<Vec<(String, u64)>> {
         use sov_rollup_interface::stf::EventKey;
 
-        let range =
-            EventKey::new(&[])..EventKey::new(&[255u8; 4096]);
+        let range = EventKey::new(&[])..EventKey::new(&[255u8; 4096]);
         let entries = self
             .db
             .collect_in_range_async::<EventCountByKey, EventKey>(range)

--- a/crates/full-node/sov-db/src/schema/tables.rs
+++ b/crates/full-node/sov-db/src/schema/tables.rs
@@ -36,7 +36,7 @@ use sov_rollup_interface::stf::{EventKey, StoredEvent};
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
 
 use super::types::{
-    AccessoryKey, AccessoryStateValue, BatchNumber, DbHash, EventNumber,
+    AccessoryKey, AccessoryStateValue, BatchNumber, DbHash, EventKeyNumber, EventNumber,
     LatestFinalizedSlotSingleton, ProofUniqueId, StateRootHashId, StfInfoUniqueId, StoredBatch,
     StoredSlot, StoredStfInfo, StoredTransaction, TxNumber,
 };
@@ -61,6 +61,7 @@ pub const LEDGER_TABLES: &[ColumnFamilyName] = &[
     FinalizedSlots::table_name(),
     StfInfoByNumber::table_name(),
     StfInfoMetadata::table_name(),
+    EventCountByKey::table_name(),
 ];
 
 /// A list of all tables used by the AccessoryDB. These tables store
@@ -276,6 +277,11 @@ define_table_with_seek_key_codec!(
 define_table_with_seek_key_codec!(
     /// An index for event data by key
     (EventByKey) (EventKey, TxNumber, EventNumber) => ()
+);
+
+define_table_with_seek_key_codec!(
+    /// Tracks the total count of events per event key
+    (EventCountByKey) EventKey => EventKeyNumber
 );
 
 define_table_with_seek_key_codec!(

--- a/crates/full-node/sov-db/src/schema/types.rs
+++ b/crates/full-node/sov-db/src/schema/types.rs
@@ -278,3 +278,4 @@ u64_wrapper!(EventNumber);
 u64_wrapper!(ProofUniqueId);
 u64_wrapper!(StfInfoUniqueId);
 u64_wrapper!(StateRootHashId);
+u64_wrapper!(EventKeyNumber);

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -312,6 +312,165 @@ fn assert_next_items_numbers(slot_number: u64, ledger_db: &LedgerDb) {
     );
 }
 
+fn create_slot_with_keys(
+    slot_num: u64,
+    keys: &[&str],
+    ledger_db: &LedgerDb,
+) -> SchemaBatch {
+    let mut block = MockBlock::default();
+    block.header.height = slot_num;
+
+    let mut slot_commit =
+        SlotCommit::<_, i32, TestTxReceiptContents>::new(block, Default::default());
+
+    let mut tx_receipts = vec![];
+    let mut out = [0u8; 32];
+    out[..8].copy_from_slice(&u64::to_le_bytes(1000 + slot_num));
+    let tx_hash = TxHash::new(out);
+
+    let events = keys
+        .iter()
+        .map(|k| StoredEvent::new(k.as_bytes(), b"val", tx_hash.0))
+        .collect();
+
+    tx_receipts.push(TransactionReceipt {
+        tx_hash,
+        body_to_save: None,
+        events,
+        receipt: TxEffect::Successful(0),
+    });
+
+    let batch_receipt = BatchReceipt {
+        batch_hash: [slot_num as u8; 32],
+        tx_receipts,
+        ignored_tx_receipts: vec![],
+        inner: 0,
+    };
+
+    slot_commit.add_batch(batch_receipt);
+
+    ledger_db
+        .materialize_slot(slot_commit, b"state-root")
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_event_key_counts_basic() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
+    let ledger_storage = storage_manager.create_ledger_storage();
+    let ledger_db = LedgerDb::with_reader(ledger_storage).unwrap();
+
+    // Insert a slot with 3 events: 2x "alpha", 1x "beta"
+    let schema_batch = create_slot_with_keys(0, &["alpha", "alpha", "beta"], &ledger_db);
+    storage_manager.commit(&schema_batch);
+
+    let counts: std::collections::HashMap<String, u64> = ledger_db
+        .get_event_key_counts()
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+
+    assert_eq!(counts.get("alpha"), Some(&2), "alpha should have count 2");
+    assert_eq!(counts.get("beta"), Some(&1), "beta should have count 1");
+    assert_eq!(counts.len(), 2, "should have exactly 2 distinct keys");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_event_key_counts_across_slots() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
+    let ledger_storage = storage_manager.create_ledger_storage();
+    let ledger_db = LedgerDb::with_reader(ledger_storage).unwrap();
+
+    // Slot 0: 1x "alpha", 1x "beta"
+    let schema_batch = create_slot_with_keys(0, &["alpha", "beta"], &ledger_db);
+    storage_manager.commit(&schema_batch);
+
+    // Slot 1: 2x "alpha", 1x "gamma"
+    let schema_batch = create_slot_with_keys(1, &["alpha", "alpha", "gamma"], &ledger_db);
+    storage_manager.commit(&schema_batch);
+
+    let counts: std::collections::HashMap<String, u64> = ledger_db
+        .get_event_key_counts()
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+
+    assert_eq!(
+        counts.get("alpha"),
+        Some(&3),
+        "alpha should accumulate across slots"
+    );
+    assert_eq!(counts.get("beta"), Some(&1));
+    assert_eq!(counts.get("gamma"), Some(&1));
+    assert_eq!(counts.len(), 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_event_key_counts_after_rollback() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
+    let ledger_storage = storage_manager.create_ledger_storage();
+    let db = storage_manager.get_db();
+    let ledger_db = LedgerDb::with_reader(ledger_storage).unwrap();
+
+    // Slot 0: 1x "alpha", 1x "beta"
+    let schema_batch = create_slot_with_keys(0, &["alpha", "beta"], &ledger_db);
+    storage_manager.commit(&schema_batch);
+
+    // Slot 1: 2x "alpha", 1x "beta"
+    let schema_batch = create_slot_with_keys(1, &["alpha", "alpha", "beta"], &ledger_db);
+    storage_manager.commit(&schema_batch);
+
+    // Before rollback: alpha=3, beta=2
+    let counts: std::collections::HashMap<String, u64> = ledger_db
+        .get_event_key_counts()
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert_eq!(counts.get("alpha"), Some(&3));
+    assert_eq!(counts.get("beta"), Some(&2));
+
+    // Rollback slot 1
+    LedgerDb::rollback_head_slot(db.clone()).unwrap();
+
+    // After rollback: alpha=1, beta=1
+    let counts: std::collections::HashMap<String, u64> = ledger_db
+        .get_event_key_counts()
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert_eq!(
+        counts.get("alpha"),
+        Some(&1),
+        "alpha should be decremented after rollback"
+    );
+    assert_eq!(
+        counts.get("beta"),
+        Some(&1),
+        "beta should be decremented after rollback"
+    );
+
+    // Rollback slot 0: all counts should go to zero (entries deleted)
+    LedgerDb::rollback_head_slot(db.clone()).unwrap();
+
+    let counts: std::collections::HashMap<String, u64> = ledger_db
+        .get_event_key_counts()
+        .await
+        .unwrap()
+        .into_iter()
+        .collect();
+    assert!(
+        counts.is_empty(),
+        "all event count entries should be deleted after full rollback"
+    );
+}
+
 fn create_slot_schema_batch(slot_num: u64, ledger_db: &LedgerDb) -> SchemaBatch {
     let mut block = MockBlock::default();
     block.header.height = slot_num;

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -312,11 +312,7 @@ fn assert_next_items_numbers(slot_number: u64, ledger_db: &LedgerDb) {
     );
 }
 
-fn create_slot_with_keys(
-    slot_num: u64,
-    keys: &[&str],
-    ledger_db: &LedgerDb,
-) -> SchemaBatch {
+fn create_slot_with_keys(slot_num: u64, keys: &[&str], ledger_db: &LedgerDb) -> SchemaBatch {
     let mut block = MockBlock::default();
     block.header.height = slot_num;
 

--- a/crates/full-node/sov-ledger-apis/src/lib.rs
+++ b/crates/full-node/sov-ledger-apis/src/lib.rs
@@ -159,6 +159,7 @@ where
                 )),
             )
             .route("/events", get(Self::list_events))
+            .route("/events/counts", get(Self::get_event_key_counts))
             .route("/events/latest", get(Self::get_latest_event))
             .nest(
                 "/events/:eventId",
@@ -394,6 +395,15 @@ where
             .map_err(errors::database_error_response_500)?
             .ok_or_else(|| errors::not_found_404("Event", event_number))?;
         Ok(event.into())
+    }
+
+    async fn get_event_key_counts(
+        State(state): State<LedgerState<T>>,
+    ) -> ApiResult<HashMap<String, u64>> {
+        match state.ledger.get_event_key_counts().await {
+            Ok(counts) => Ok(counts.into_iter().collect::<HashMap<_, _>>().into()),
+            Err(err) => Err(errors::database_error_response_500(err)),
+        }
     }
 
     // ENTITY ID RESOLVERS

--- a/crates/rollup-interface/src/node/ledger_api.rs
+++ b/crates/rollup-interface/src/node/ledger_api.rs
@@ -572,6 +572,9 @@ pub trait LedgerStateProvider {
     /// Get the most recent aggregated proof, if any.
     async fn get_latest_aggregated_proof(&self) -> anyhow::Result<Option<AggregatedProofResponse>>;
 
+    /// Get the total event count per event key.
+    async fn get_event_key_counts(&self) -> Result<Vec<(String, u64)>, Self::Error>;
+
     /// Get a notification each time a slot is processed
     fn subscribe_slots(&self) -> BoxStream<'static, SlotNumber>;
 


### PR DESCRIPTION
# Description

Introduces an EventCountByKey table that tracks how many times each event key has been emitted. Counts are incremented during slot materialization and decremented on rollback. The new REST endpoint returns a JSON object mapping event keys to their total counts.

Will require a resync to produce accurate values.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
