### PR TITLE
Sequencer tests: removing sleeps

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/pinned_cache.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/pinned_cache.rs
@@ -367,6 +367,8 @@ async fn test_pinning_after_recovery() {
         if i > max_wait {
             panic!("sequencer never became ready in {max_wait} blocks");
         }
+        // We produce a new DA block above; sleep one DA block interval to avoid a tight poll loop
+        // while recovery catches up.
         tokio::time::sleep(reasonable_time_for_rollup).await;
     }
     test_rollup.wait_for_node_synced().await.unwrap();
@@ -381,6 +383,8 @@ async fn test_pinning_after_recovery() {
             panic!("sequencer never became ready in {max_wait} blocks");
         }
         i += 1;
+        // We produce a new DA block above; sleep one DA block interval to avoid a tight poll loop
+        // while waiting for sequencer readiness to flip back.
         tokio::time::sleep(reasonable_time_for_rollup).await;
     }
     println!("5");

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::time::Duration;
 
 use futures::StreamExt;
 use sov_blob_sender::BlobSelectorStatus;
@@ -117,8 +116,8 @@ async fn test_blobs_are_send_after_rollup_resync() {
     for _ in 0..10 {
         da.produce_block_now().await.unwrap();
         header_subscription.next().await.unwrap().unwrap();
-        tokio::time::sleep(Duration::from_millis(300)).await;
     }
+    test_rollup.wait_for_node_synced().await.unwrap();
 
     let builder = test_rollup.shutdown().await.unwrap();
 

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -94,6 +94,13 @@ struct ValueResponse {
     value: u32,
 }
 
+#[derive(Debug, serde::Deserialize)]
+struct ManyValuesItemResponse {
+    #[allow(unused)]
+    index: u64,
+    value: Option<u8>,
+}
+
 pub struct DaLayerWithSubscription {
     da_layer: Arc<RwLock<StorableMockDaLayer>>,
     state_update_subscription: WsSubscription<StateUpdateNotification>,
@@ -182,6 +189,69 @@ impl DaLayerWithSubscription {
             self.produce_and_wait_for_slot().await;
         }
     }
+}
+
+async fn produce_blocks_until_sequencer_readiness(
+    test_rollup: &TestRollup<TestBlueprint>,
+    da_layer: &mut DaLayerWithSubscription,
+    expected_ready: bool,
+    max_blocks_to_produce: usize,
+    reason: &str,
+) {
+    for _ in 0..max_blocks_to_produce {
+        if test_rollup.is_sequencer_ready().await == expected_ready {
+            return;
+        }
+        da_layer.produce_block().await.unwrap();
+        da_layer.wait_for_new_slot_notification().await;
+    }
+
+    let current_ready = test_rollup.is_sequencer_ready().await;
+    assert_eq!(
+        current_ready, expected_ready,
+        "Sequencer readiness did not reach expected state after producing {max_blocks_to_produce} blocks while {reason}"
+    );
+}
+
+async fn wait_for_many_values_item(
+    test_rollup: &TestRollup<TestBlueprint>,
+    da_layer: &mut DaLayerWithSubscription,
+    index: u64,
+    expected_value: u8,
+    max_blocks_to_produce: usize,
+) -> u8 {
+    let endpoint = format!("/modules/value-setter/state/many-values/items/{index}");
+    let mut last_seen_value: Option<Option<u8>> = None;
+    let mut last_error: Option<String> = None;
+
+    for attempt in 0..=max_blocks_to_produce {
+        match test_rollup
+            .client
+            .query_rest_endpoint::<ManyValuesItemResponse>(&endpoint)
+            .await
+        {
+            Ok(response) => {
+                last_seen_value = Some(response.value);
+                if response.value == Some(expected_value) {
+                    return expected_value;
+                }
+            }
+            Err(error) => {
+                last_error = Some(error.to_string());
+            }
+        }
+
+        if attempt == max_blocks_to_produce {
+            break;
+        }
+
+        da_layer.produce_block().await.unwrap();
+        da_layer.wait_for_new_slot_notification().await;
+    }
+
+    panic!(
+        "Timed out waiting for many_values[{index}] to become {expected_value}. Last seen value: {last_seen_value:?}, last error: {last_error:?}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -820,14 +890,16 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
     tracing::info!("Resuming preferred sequencer batch production.");
     test_rollup.resume_preferred_batches().await;
     // Normally on the next state update, the sequencer should always enter recovery.
-    // However for some reason this was flaky. What is the reason?!
-    test_rollup.da_service.produce_block_now().await.unwrap();
-    while test_rollup.is_sequencer_ready().await {
-        let _ = da_layer.produce_block().await;
-        // DA block production above is asynchronous with respect to sequencer state updates.
-        // Sleep briefly so readiness checks observe the new state instead of busy-looping.
-        sleep(Duration::from_millis(30)).await;
-    }
+    // Drive DA forward and wait for slot notifications so we only re-check readiness
+    // after the node has observed a new block.
+    produce_blocks_until_sequencer_readiness(
+        &test_rollup,
+        &mut da_layer,
+        false,
+        80,
+        "entering recovery after resuming preferred sequencer batch production",
+    )
+    .await;
     test_rollup.wait_for_node_synced().await.unwrap();
 
     // Create transaction that should fail: sequencer should not accept transactions while in
@@ -848,11 +920,14 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
 
     // Give time for the sequencer to catch up its visible state number
     tracing::info!("Producing DA blocks to let the sequencer resync.");
-    while !test_rollup.is_sequencer_ready().await {
-        let _ = da_layer.produce_block().await;
-        // DA notifications are unreliable while recovering, so we use a short poll interval.
-        sleep(Duration::from_millis(50)).await;
-    }
+    produce_blocks_until_sequencer_readiness(
+        &test_rollup,
+        &mut da_layer,
+        true,
+        160,
+        "recovering from deferred-slots lag",
+    )
+    .await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer
@@ -862,10 +937,11 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
         .await
         .unwrap();
 
-    tracing::info!("Producing final run of blocks to include the last tx and confirm the rollup is running normally");
-    for _ in 0..10 {
-        test_rollup.da_service.produce_block_now().await.unwrap();
-    }
+    tracing::info!(
+        "Producing blocks until the post-recovery tx is visible in state (deterministic inclusion)"
+    );
+    let actual_many_value =
+        wait_for_many_values_item(&test_rollup, &mut da_layer, 0, UPDATE_VEC_VALUE, 80).await;
     test_rollup.wait_for_node_synced().await.unwrap();
 
     // Assert that the earlier transactions sent just before the sequencer went into recovery was
@@ -883,18 +959,6 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
 
     // Assert that the transaction sent after the sequencer exited recovery was processed (i.e.
     // that the rollup is now functional)
-    #[derive(Debug, serde::Deserialize)]
-    struct IdxResponse {
-        #[allow(unused)]
-        index: u64,
-        value: Option<u8>,
-    }
-    let many_values_response = test_rollup
-        .client
-        .query_rest_endpoint::<IdxResponse>("/modules/value-setter/state/many-values/items/0")
-        .await
-        .unwrap();
-    let actual_many_value = many_values_response.value.unwrap();
     assert_eq!(
         actual_many_value, 12u8,
         "Expected many_values[0] to be 12, but got {actual_many_value}"
@@ -966,13 +1030,19 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     tracing::info!("Restarting rollup after exceeding deferred_slots_count");
     let test_rollup = builder.start().await.unwrap();
     let client = test_rollup.api_client().clone();
+    let mut da_layer = DaLayerWithSubscription::new(&test_rollup).await;
 
     // First we sync the node to the new DA blocks
     test_rollup.wait_for_node_synced().await.unwrap();
-    // Now on the next state update, the sequencer should always enter recovery
-    test_rollup.da_service.produce_block_now().await.unwrap();
-    test_rollup.wait_for_sequencer_not_ready().await.unwrap();
-    assert!(!test_rollup.is_sequencer_ready().await);
+    // Now on the next state updates, the sequencer should enter recovery.
+    produce_blocks_until_sequencer_readiness(
+        &test_rollup,
+        &mut da_layer,
+        false,
+        80,
+        "entering recovery after restart with deferred-slots lag",
+    )
+    .await;
 
     // Create transaction that should fail: sequencer should not accept transactions while in recovery
     const UPDATE_VEC_VALUE: u8 = 12;
@@ -991,10 +1061,15 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
 
     // Give time for the sequencer to catch up its visible state number
     tracing::info!("Producing DA blocks to let the sequencer resync.");
-    while !test_rollup.is_sequencer_ready().await {
-        test_rollup.da_service.produce_block_now().await.unwrap();
-        test_rollup.wait_for_node_synced().await.unwrap();
-    }
+    produce_blocks_until_sequencer_readiness(
+        &test_rollup,
+        &mut da_layer,
+        true,
+        160,
+        "recovering after restart",
+    )
+    .await;
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer
     client
@@ -1004,10 +1079,11 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
         .await
         .unwrap();
 
-    tracing::info!("Producing final run of blocks to include the last tx and confirm the rollup is running normally");
-    for _ in 0..10 {
-        test_rollup.da_service.produce_block_now().await.unwrap();
-    }
+    tracing::info!(
+        "Producing blocks until the post-recovery tx is visible in state (deterministic inclusion)"
+    );
+    let actual_many_value =
+        wait_for_many_values_item(&test_rollup, &mut da_layer, 0, UPDATE_VEC_VALUE, 80).await;
     test_rollup.wait_for_node_synced().await.unwrap();
 
     // Assert that the earlier transaction sent before shutdown was processed
@@ -1023,18 +1099,6 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     );
 
     // Assert that the transaction sent after recovery was processed
-    #[derive(Debug, serde::Deserialize)]
-    struct IdxResponse {
-        #[allow(unused)]
-        index: u64,
-        value: Option<u8>,
-    }
-    let many_values_response = test_rollup
-        .client
-        .query_rest_endpoint::<IdxResponse>("/modules/value-setter/state/many-values/items/0")
-        .await
-        .unwrap();
-    let actual_many_value = many_values_response.value.unwrap();
     assert_eq!(
         actual_many_value, 12u8,
         "Expected many_values[0] to be 12, but got {actual_many_value}"

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -203,7 +203,10 @@ async fn produce_blocks_until_sequencer_readiness(
             return;
         }
         da_layer.produce_block().await.unwrap();
-        test_rollup.wait_for_node_synced().await.unwrap();
+        // Keep block production paced so readiness transitions can propagate without being
+        // overwhelmed by new blocks.
+        let pause_ms = if expected_ready { 50 } else { 30 };
+        tokio::time::sleep(Duration::from_millis(pause_ms)).await;
     }
 
     let current_ready = test_rollup.is_sequencer_ready().await;

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -191,31 +191,6 @@ impl DaLayerWithSubscription {
     }
 }
 
-async fn produce_blocks_until_sequencer_readiness(
-    test_rollup: &TestRollup<TestBlueprint>,
-    da_layer: &mut DaLayerWithSubscription,
-    expected_ready: bool,
-    max_blocks_to_produce: usize,
-    reason: &str,
-) {
-    for _ in 0..max_blocks_to_produce {
-        if test_rollup.is_sequencer_ready().await == expected_ready {
-            return;
-        }
-        da_layer.produce_block().await.unwrap();
-        // Keep block production paced so readiness transitions can propagate without being
-        // overwhelmed by new blocks.
-        let pause_ms = if expected_ready { 50 } else { 30 };
-        tokio::time::sleep(Duration::from_millis(pause_ms)).await;
-    }
-
-    let current_ready = test_rollup.is_sequencer_ready().await;
-    assert_eq!(
-        current_ready, expected_ready,
-        "Sequencer readiness did not reach expected state after producing {max_blocks_to_produce} blocks while {reason}"
-    );
-}
-
 async fn wait_for_many_values_item(
     test_rollup: &TestRollup<TestBlueprint>,
     da_layer: &mut DaLayerWithSubscription,
@@ -893,16 +868,11 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
     tracing::info!("Resuming preferred sequencer batch production.");
     test_rollup.resume_preferred_batches().await;
     // Normally on the next state update, the sequencer should always enter recovery.
-    // Drive DA forward and wait for slot notifications so we only re-check readiness
-    // after the node has observed a new block.
-    produce_blocks_until_sequencer_readiness(
-        &test_rollup,
-        &mut da_layer,
-        false,
-        80,
-        "entering recovery after resuming preferred sequencer batch production",
-    )
-    .await;
+    test_rollup.da_service.produce_block_now().await.unwrap();
+    while test_rollup.is_sequencer_ready().await {
+        let _ = da_layer.produce_block().await;
+        sleep(Duration::from_millis(30)).await;
+    }
     test_rollup.wait_for_node_synced().await.unwrap();
 
     // Create transaction that should fail: sequencer should not accept transactions while in
@@ -923,14 +893,10 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
 
     // Give time for the sequencer to catch up its visible state number
     tracing::info!("Producing DA blocks to let the sequencer resync.");
-    produce_blocks_until_sequencer_readiness(
-        &test_rollup,
-        &mut da_layer,
-        true,
-        160,
-        "recovering from deferred-slots lag",
-    )
-    .await;
+    while !test_rollup.is_sequencer_ready().await {
+        let _ = da_layer.produce_block().await;
+        sleep(Duration::from_millis(50)).await; // Notifications don't work during recovery.
+    }
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer
@@ -1037,15 +1003,10 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
 
     // First we sync the node to the new DA blocks
     test_rollup.wait_for_node_synced().await.unwrap();
-    // Now on the next state updates, the sequencer should enter recovery.
-    produce_blocks_until_sequencer_readiness(
-        &test_rollup,
-        &mut da_layer,
-        false,
-        80,
-        "entering recovery after restart with deferred-slots lag",
-    )
-    .await;
+    // Now on the next state update, the sequencer should always enter recovery
+    test_rollup.da_service.produce_block_now().await.unwrap();
+    sleep(Duration::from_millis(50)).await;
+    assert!(!test_rollup.is_sequencer_ready().await);
 
     // Create transaction that should fail: sequencer should not accept transactions while in recovery
     const UPDATE_VEC_VALUE: u8 = 12;
@@ -1064,14 +1025,10 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
 
     // Give time for the sequencer to catch up its visible state number
     tracing::info!("Producing DA blocks to let the sequencer resync.");
-    produce_blocks_until_sequencer_readiness(
-        &test_rollup,
-        &mut da_layer,
-        true,
-        160,
-        "recovering after restart",
-    )
-    .await;
+    while !test_rollup.is_sequencer_ready().await {
+        test_rollup.da_service.produce_block_now().await.unwrap();
+        sleep(Duration::from_millis(50)).await;
+    }
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -203,7 +203,7 @@ async fn produce_blocks_until_sequencer_readiness(
             return;
         }
         da_layer.produce_block().await.unwrap();
-        da_layer.wait_for_new_slot_notification().await;
+        test_rollup.wait_for_node_synced().await.unwrap();
     }
 
     let current_ready = test_rollup.is_sequencer_ready().await;
@@ -246,7 +246,7 @@ async fn wait_for_many_values_item(
         }
 
         da_layer.produce_block().await.unwrap();
-        da_layer.wait_for_new_slot_notification().await;
+        test_rollup.wait_for_node_synced().await.unwrap();
     }
 
     panic!(

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -824,6 +824,8 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
     test_rollup.da_service.produce_block_now().await.unwrap();
     while test_rollup.is_sequencer_ready().await {
         let _ = da_layer.produce_block().await;
+        // DA block production above is asynchronous with respect to sequencer state updates.
+        // Sleep briefly so readiness checks observe the new state instead of busy-looping.
         sleep(Duration::from_millis(30)).await;
     }
     test_rollup.wait_for_node_synced().await.unwrap();
@@ -848,7 +850,8 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
     tracing::info!("Producing DA blocks to let the sequencer resync.");
     while !test_rollup.is_sequencer_ready().await {
         let _ = da_layer.produce_block().await;
-        sleep(Duration::from_millis(50)).await; // Notifications don't work during recovery.
+        // DA notifications are unreliable while recovering, so we use a short poll interval.
+        sleep(Duration::from_millis(50)).await;
     }
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
@@ -862,8 +865,8 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
     tracing::info!("Producing final run of blocks to include the last tx and confirm the rollup is running normally");
     for _ in 0..10 {
         test_rollup.da_service.produce_block_now().await.unwrap();
-        sleep(Duration::from_millis(50)).await; // have the node process them
     }
+    test_rollup.wait_for_node_synced().await.unwrap();
 
     // Assert that the earlier transactions sent just before the sequencer went into recovery was
     // flushed and processed by the node
@@ -918,12 +921,11 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     .await;
 
     let client = test_rollup.api_client().clone();
-    // Sleep for the rollup to start up
-    sleep(Duration::from_millis(500)).await;
 
     // Finalise some blocks
     let mut da_layer = DaLayerWithSubscription::new(&test_rollup).await;
     da_layer.produce_and_wait_for_n_slots(8).await;
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Sanity check tx that the rollup works
     let tx_update_one = tx_set_value(&admin.private_key, 0, 8);
@@ -969,7 +971,7 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     test_rollup.wait_for_node_synced().await.unwrap();
     // Now on the next state update, the sequencer should always enter recovery
     test_rollup.da_service.produce_block_now().await.unwrap();
-    sleep(Duration::from_millis(50)).await;
+    test_rollup.wait_for_sequencer_not_ready().await.unwrap();
     assert!(!test_rollup.is_sequencer_ready().await);
 
     // Create transaction that should fail: sequencer should not accept transactions while in recovery
@@ -991,7 +993,7 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     tracing::info!("Producing DA blocks to let the sequencer resync.");
     while !test_rollup.is_sequencer_ready().await {
         test_rollup.da_service.produce_block_now().await.unwrap();
-        sleep(Duration::from_millis(50)).await;
+        test_rollup.wait_for_node_synced().await.unwrap();
     }
 
     // Submit the same transaction to the now-working sequencer
@@ -1005,8 +1007,8 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     tracing::info!("Producing final run of blocks to include the last tx and confirm the rollup is running normally");
     for _ in 0..10 {
         test_rollup.da_service.produce_block_now().await.unwrap();
-        sleep(Duration::from_millis(50)).await;
     }
+    test_rollup.wait_for_node_synced().await.unwrap();
 
     // Assert that the earlier transaction sent before shutdown was processed
     let response = test_rollup
@@ -1586,6 +1588,8 @@ async fn flaky_max_batch_execution_time() {
     let _ = client.send_raw_tx_to_sequencer(&tx_1).await.unwrap();
     let _ = client.send_raw_tx_to_sequencer(&tx_2).await.unwrap();
     let _ = client.send_raw_tx_to_sequencer(&tx_3).await.unwrap();
+    // Wait until tx_2 and tx_3 have accumulated execution time in the current batch.
+    // This creates the intended boundary before sending tx_4..tx_6.
     tokio::time::sleep(std::time::Duration::from_millis(
         max_batch_exec_time_millis / 2,
     ))
@@ -1740,6 +1744,7 @@ async fn flaky_test_state_root_computation_when_blobs_are_delayed() {
     if let Some(sleep_time) =
         TestRollup::<TestBlueprint>::POLLING_TIMEOUT.checked_sub(total_waiting_time)
     {
+        // Wait for delayed blobs to age through the configured delay window before checking sync.
         tokio::time::sleep(sleep_time).await;
     }
     test_rollup.wait_for_node_synced().await.unwrap();
@@ -1982,6 +1987,7 @@ async fn sequencer_back_pressure() {
     let end_padding_blocks = 30;
     for _ in 0..end_padding_blocks {
         test_rollup.da_service.produce_block_now().await.unwrap();
+        // Give the node time to ingest each padding block so debug output reflects progress.
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         print_blobs_at_head(&test_rollup.da_service).await;
     }
@@ -2239,7 +2245,9 @@ async fn do_manual_block_production_test<Fut: Future<Output = ()>>(
         .await
         .unwrap();
     test_rollup.force_close_batch().await.unwrap();
-    sleep(Duration::from_millis(300)).await; // Sleep to make sure the batch is published before we produce a block. If this gets flaky, we'll need to add a blob_sender subscription.
+    // Wait for blob publication after force_close_batch; without this pause the next block can be
+    // produced before the batch is visible in DA.
+    sleep(Duration::from_millis(300)).await;
     da_layer.produce_and_wait_for_slot().await;
 
     // Note: The exact number height asserted here is not important, as long as it's correct
@@ -2261,7 +2269,9 @@ async fn do_manual_block_production_test<Fut: Future<Output = ()>>(
 
     // Close the batch and submit to DA
     test_rollup.force_close_batch().await.unwrap();
-    tokio::time::sleep(Duration::from_millis(500)).await; // Sleep to make sure the batch is published before we produce a block. If this gets flaky, we'll need to add a blob_sender subscription.
+    // Wait for blob publication after force_close_batch; without this pause the next block can be
+    // produced before the batch is visible in DA.
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
     // Ensure that the sequencer has time to see the updated state and submit its batch containing the transaction to DA.
     let next = da_layer.produce_and_wait_for_slot().await;
@@ -2361,8 +2371,9 @@ async fn test_no_crashes_on_resync_with_transactions() {
 
     let test_rollup = builder.start().await.unwrap();
 
-    // Let it resync
-    tokio::time::sleep(Duration::from_secs(15)).await;
+    // Wait deterministically for both components after restart instead of using a fixed delay.
+    test_rollup.wait_for_node_synced().await.unwrap();
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Verify accepting actions works
     let actions = vec![
@@ -2520,6 +2531,7 @@ async fn flaky_txs_that_enter_before_downtime_are_dropped() {
             let client = client.clone();
             async move { client.send_raw_tx_to_sequencer(&delayed_tx).await }
         });
+        // Allow the delayed transaction to enter its speedbump path before submitting the second tx.
         tokio::time::sleep(time_for_seq_to_accept_and_delay).await;
         let set_value_and_sleep_result =
             client.send_raw_tx_to_sequencer(&set_value_and_sleep).await;
@@ -2920,12 +2932,8 @@ async fn flaky_test_hooks_state_is_visible() {
         .unwrap()
     };
 
-    test_rollup
-        .da_service
-        .produce_n_blocks_now(8)
-        .await
-        .unwrap();
-    sleep(Duration::from_millis(200)).await;
+    test_rollup.produce_enough_finalized_slots().await;
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // By the time we query here, the sequencer has *started* the next slot, so it has run the begin slot hook a second time.
     let client = NodeClient::new(test_rollup.api_client().baseurl())
@@ -2953,9 +2961,7 @@ async fn flaky_test_hooks_state_is_visible() {
         for tx in txs {
             client
                 .client
-                .accept_tx(&api_types::AcceptTxBody {
-                    body: BASE64_STANDARD.encode(&tx.raw_tx),
-                })
+                .send_raw_tx_to_sequencer(&tx.raw_tx)
                 .await
                 .unwrap();
         }
@@ -2976,7 +2982,7 @@ async fn flaky_test_hooks_state_is_visible() {
         .produce_n_blocks_now(10)
         .await
         .unwrap();
-    sleep(Duration::from_millis(200)).await;
+    test_rollup.wait_for_node_synced().await.unwrap();
 
     let begin_slot_count = query_hook_counter("begin-rollup-block").await;
     assert_eq!(begin_slot_count, 1);
@@ -3355,6 +3361,7 @@ pub(crate) async fn run_action_against_test_rollup(
     match action {
         TestingAction::PauseUpdateStateExecution(v) => pause_update_state::set(v),
         TestingAction::Sleep { duration_ms } => {
+            // This action intentionally models time passing in scenario-driven tests.
             sleep(Duration::from_millis(duration_ms)).await;
         }
         TestingAction::Restart => {
@@ -3362,7 +3369,7 @@ pub(crate) async fn run_action_against_test_rollup(
             // startup until a StateUpdateInfo from the node has been processed.
             let test_rollup = test_rollup.restart().await?;
             test_rollup.da_service.produce_block_now().await?;
-            sleep(Duration::from_millis(1500)).await;
+            test_rollup.wait_for_sequencer_ready().await?;
             return Ok(test_rollup);
         }
         TestingAction::TryAcceptBadTx { invalid_reason } => {

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -187,10 +187,6 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
 
         test_rollup.da_service.produce_block_now().await.unwrap();
         slot_subscription.next().await;
-        // Slot notifications can arrive before the height endpoint reflects the new rollup height.
-        // Keep a short delay here so the next height read doesn't overshoot `stop_at_height`.
-        // A strict wait_for_height() is unsafe in this test because the rollup can stop mid-wait.
-        tokio::time::sleep(Duration::from_millis(300)).await;
         current_height = test_rollup.height().await;
     }
 

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -99,13 +99,14 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
     let api_client = test_rollup.api_client().clone();
 
     // Produce enough finalized DA blocks so the sequencer can start accepting transactions.
-    let da = test_rollup.da_service.clone();
-    let mut da_sub = da.subscribe_finalized_header().await.unwrap();
-    for _ in 0..finalization_blocks + 3 {
-        test_rollup.da_service.produce_block_now().await.unwrap();
-        tokio::time::sleep(Duration::from_millis(300)).await;
-    }
-    da_sub.next().await;
+    // Use produce_n_blocks_now (instant) rather than tenderly_produce_blocks to avoid
+    // cascading batch creation that could advance height past stop_at_height.
+    test_rollup
+        .da_service
+        .produce_n_blocks_now(finalization_blocks as usize + 3)
+        .await
+        .unwrap();
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Produce enough blocks with transactions to advance rollup height past stop_at_height.
     // Transactions are required to trigger batch production and increment rollup height.
@@ -116,7 +117,6 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
         nonce += 1;
         test_rollup.da_service.produce_block_now().await.unwrap();
         slot_subscription.next().await;
-        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
     let slot_height = test_rollup.height().await;
@@ -136,10 +136,13 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
         panic!("The rollup should have stopped")
     };
 
-    let mut records = collector.records();
-    let (_, log) = records.remove(0);
-
-    assert!(log.contains("The requested stop_height "));
+    let records = collector.records();
+    assert!(
+        records
+            .iter()
+            .any(|(_, log)| log.contains("The requested stop_height")),
+        "Expected stop-height log in records: {records:?}"
+    );
     assert!(err.to_string().contains("The requested stop_height"));
 }
 
@@ -162,14 +165,15 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
 
     let mut slot_subscription = test_rollup.client.client.subscribe_slots().await.unwrap();
 
-    let da = test_rollup.da_service.clone();
-    let mut da_sub = da.subscribe_finalized_header().await.unwrap();
-    // We just need at least one finalized block to proceed with the tests.
-    for _ in 0..finalization_blocks + 3 {
-        test_rollup.da_service.produce_block_now().await.unwrap();
-        tokio::time::sleep(Duration::from_millis(300)).await;
-    }
-    da_sub.next().await;
+    // Produce enough finalized DA blocks so the sequencer can start accepting transactions.
+    // Use produce_n_blocks_now (instant) rather than tenderly_produce_blocks to avoid
+    // cascading batch creation that could advance height past stop_at_height.
+    test_rollup
+        .da_service
+        .produce_n_blocks_now(finalization_blocks as usize + 3)
+        .await
+        .unwrap();
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     let api_client = test_rollup.api_client().clone();
 
@@ -183,7 +187,9 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
 
         test_rollup.da_service.produce_block_now().await.unwrap();
         slot_subscription.next().await;
-
+        // Slot notifications can arrive before the height endpoint reflects the new rollup height.
+        // Keep a short delay here so the next height read doesn't overshoot `stop_at_height`.
+        // A strict wait_for_height() is unsafe in this test because the rollup can stop mid-wait.
         tokio::time::sleep(Duration::from_millis(300)).await;
         current_height = test_rollup.height().await;
     }
@@ -196,7 +202,6 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
         test_rollup.da_service.produce_block_now().await.unwrap();
         slot_subscription.next().await;
 
-        tokio::time::sleep(Duration::from_millis(300)).await;
         let err = send_tx(&admin, nonce, &api_client).await.unwrap_err();
         nonce += 1;
         assert!(err.contains(&expected_error));
@@ -205,7 +210,6 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
     for _ in 0..3 {
         test_rollup.da_service.produce_block_now().await.unwrap();
         slot_subscription.next().await;
-        tokio::time::sleep(Duration::from_millis(300)).await;
     }
 
     test_rollup


### PR DESCRIPTION
# Description

This PR removes or explains some sleeps used in sov-sequencer tests in hope to make them more reliable.

Related to #2038

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)