### PR TITLE
EVM: Add support for block and state override

### DIFF
--- a/crates/full-node/sov-ethereum/src/handlers/mod.rs
+++ b/crates/full-node/sov-ethereum/src/handlers/mod.rs
@@ -228,6 +228,8 @@ where
             let estimated_gas = evm.eth_estimate_gas(
                 transaction_request.clone(),
                 Some(BlockId::pending()),
+                None,
+                None,
                 &mut state,
             )?;
             transaction_request.gas = Some(estimated_gas.to::<u64>());

--- a/crates/module-system/module-implementations/sov-evm/AGENTS.md
+++ b/crates/module-system/module-implementations/sov-evm/AGENTS.md
@@ -24,7 +24,7 @@ These are by-design repo semantics. Do not flag as bugs unless a concrete toolin
 - `eth_blockNumber` returns latest sealed block number, not synthetic pending height.
 - `eth_gasPrice` returns current `block_env.basefee`.
 - `eth_maxPriorityFeePerGas` returns `0`.
-- `eth_call` accepts `state_overrides`/`block_overrides` but currently ignores them.
+- `eth_call` applies `state_overrides`/`block_overrides` for call simulation.
 - EIP-1898 `requireCanonical` is accepted but effectively a no-op in no-reorg semantics.
 
 ## High-Risk Hotspots

--- a/crates/module-system/module-implementations/sov-evm/AGENTS.md
+++ b/crates/module-system/module-implementations/sov-evm/AGENTS.md
@@ -24,7 +24,7 @@ These are by-design repo semantics. Do not flag as bugs unless a concrete toolin
 - `eth_blockNumber` returns latest sealed block number, not synthetic pending height.
 - `eth_gasPrice` returns current `block_env.basefee`.
 - `eth_maxPriorityFeePerGas` returns `0`.
-- `eth_call` applies `state_overrides`/`block_overrides` for call simulation.
+- `eth_call` and `eth_estimateGas` apply `state_overrides`/`block_overrides` for simulation.
 - EIP-1898 `requireCanonical` is accepted but effectively a no-op in no-reorg semantics.
 
 ## High-Risk Hotspots

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -298,6 +298,8 @@ where
         &self,
         request: TransactionRequest,
         block_id: Option<BlockId>,
+        state_overrides: Option<StateOverride>,
+        block_overrides: Option<Box<BlockOverrides>>,
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<U64> {
         trace!(
@@ -312,7 +314,7 @@ where
         let ResultAndState {
             result,
             state: changes,
-        } = self.call(request, block_id, None, None, state)?;
+        } = self.call(request, block_id, state_overrides, block_overrides, state)?;
 
         let (gas_used, logs) = match result {
             ExecutionResult::Success { gas_used, logs, .. } => (gas_used, logs),

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -326,6 +326,9 @@ where
             }
         };
 
+        // Commit into the RPC-local DB so state-write metering is charged for this simulation.
+        // This intentionally includes override-based hypothetical state, because estimateGas
+        // should reflect the exact scenario requested by eth_call/eth_estimateGas overrides.
         self.db(state)
             .try_commit(changes)
             .expect("Gas meter is initialized with INF");

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -265,8 +265,8 @@ where
         &self,
         request: TransactionRequest,
         block_id: Option<BlockId>,
-        _state_overrides: Option<StateOverride>,
-        _block_overrides: Option<Box<BlockOverrides>>,
+        state_overrides: Option<StateOverride>,
+        block_overrides: Option<Box<BlockOverrides>>,
         state: &mut ApiStateAccessor<S>,
     ) -> RpcResult<Bytes> {
         trace!(
@@ -274,7 +274,9 @@ where
             ?block_id,
             "EVM module JSON-RPC request"
         );
-        let result = self.call(request, block_id, state)?.result;
+        let result = self
+            .call(request, block_id, state_overrides, block_overrides, state)?
+            .result;
         Ok(ensure_success(result)?)
     }
 
@@ -310,7 +312,7 @@ where
         let ResultAndState {
             result,
             state: changes,
-        } = self.call(request, block_id, state)?;
+        } = self.call(request, block_id, None, None, state)?;
 
         let (gas_used, logs) = match result {
             ExecutionResult::Success { gas_used, logs, .. } => (gas_used, logs),

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -849,7 +849,7 @@ where
         apply_state_overrides(db, state_overrides)?;
     }
     if let Some(block_overrides) = block_overrides {
-        apply_block_overrides(db, block_env, *block_overrides);
+        apply_block_overrides(db, block_env, *block_overrides)?;
     }
     Ok(())
 }
@@ -858,7 +858,7 @@ fn apply_block_overrides<DB: Database>(
     db: &mut RevmState<DB>,
     block_env: &mut BlockEnv,
     block_overrides: BlockOverrides,
-) {
+) -> Result<(), EthApiError> {
     let BlockOverrides {
         number,
         difficulty,
@@ -892,9 +892,11 @@ fn apply_block_overrides<DB: Database>(
         block_env.prevrandao = Some(random);
     }
     if let Some(base_fee) = base_fee {
-        // TODO: Change function to result and return err on overflow
-        block_env.basefee = u64::try_from(base_fee).unwrap_or(u64::MAX);
+        block_env.basefee = u64::try_from(base_fee).map_err(|_| {
+            invalid_override_params(format!("base fee overflow: {base_fee} exceeds u64::MAX"))
+        })?;
     }
+    Ok(())
 }
 
 fn apply_state_overrides<DB: Database>(

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -419,19 +419,19 @@ where
             return Ok(result);
         }
 
-        let db: EvmDb<_, S> = self.db(maybe_archival_state.deref_mut());
-        let mut evm_db = RevmState::builder().with_database(db).build();
+        let evm_db: EvmDb<_, S> = self.db(maybe_archival_state.deref_mut());
+        let mut evm_state = RevmState::builder().with_database(evm_db).build();
         let cfg_env = get_cfg_env(&block_env, &cfg, Some(get_cfg_env_template()));
         apply_call_overrides(
-            &mut evm_db,
+            &mut evm_state,
             &mut block_env,
             state_overrides,
             block_overrides,
         )?;
         let tx_env = prepare_call_env(&block_env, request)?;
         let caller = tx_env.caller;
-        let result = executor::transact(&mut evm_db, &block_env, tx_env, cfg_env)?;
-        verify_contract_creation_allowlist(&result.state, &caller, &cfg, &mut evm_db)
+        let result = executor::transact(&mut evm_state, &block_env, tx_env, cfg_env)?;
+        verify_contract_creation_allowlist(&result.state, &caller, &cfg, &mut evm_state)
             .map_err(|e| EthApiError::other(into_rpc_error(e)))?;
         Ok(result)
     }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -402,20 +402,32 @@ where
         block_overrides: Option<Box<BlockOverrides>>,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<ResultAndState, EthApiError> {
+        let has_overrides = state_overrides.is_some() || block_overrides.is_some();
         let mut block_env = self.resolve_block_env_for_call(block_id, state)?;
         let cfg = self.cfg_infallible(state);
         let mut maybe_archival_state = self.resolve_state_for_block_id(block_id, state)?;
+
+        if !has_overrides {
+            // Fast path for the common case where no call overrides are provided.
+            let tx_env = prepare_call_env(&block_env, request)?;
+            let caller = tx_env.caller;
+            let cfg_env = get_cfg_env(&block_env, &cfg, Some(get_cfg_env_template()));
+            let mut evm_db: EvmDb<_, S> = self.db(maybe_archival_state.deref_mut());
+            let result = executor::transact(&mut evm_db, &block_env, tx_env, cfg_env)?;
+            verify_contract_creation_allowlist(&result.state, &caller, &cfg, &mut evm_db)
+                .map_err(|e| EthApiError::other(into_rpc_error(e)))?;
+            return Ok(result);
+        }
+
         let db: EvmDb<_, S> = self.db(maybe_archival_state.deref_mut());
         let mut evm_db = RevmState::builder().with_database(db).build();
-
         apply_call_overrides(
             &mut evm_db,
             &mut block_env,
             state_overrides,
             block_overrides,
         )?;
-
-        let tx_env = prepare_call_env(&block_env, request.clone())?;
+        let tx_env = prepare_call_env(&block_env, request)?;
         let caller = tx_env.caller;
         let cfg_env = get_cfg_env(&block_env, &cfg, Some(get_cfg_env_template()));
         let result = executor::transact(&mut evm_db, &block_env, tx_env, cfg_env)?;
@@ -874,7 +886,10 @@ fn apply_block_overrides<DB: Database>(
         db.block_hashes.extend(block_hash);
     }
     if let Some(number) = number {
-        block_env.number = number;
+        let block_number = u64::try_from(number).map_err(|_| {
+            invalid_override_params(format!("block number overflow: {number} exceeds u64::MAX"))
+        })?;
+        block_env.number = U256::from(block_number);
     }
     if let Some(difficulty) = difficulty {
         block_env.difficulty = difficulty;
@@ -927,8 +942,14 @@ where
         code,
         state,
         state_diff,
-        move_precompile_to: _,
+        move_precompile_to,
     } = account_override;
+
+    if let Some(move_precompile_to) = move_precompile_to {
+        return Err(invalid_override_params(format!(
+            "movePrecompileToAddress is not supported: {move_precompile_to}"
+        )));
+    }
 
     let mut info = db.basic(address).map_err(Into::into)?.unwrap_or_default();
     if let Some(nonce) = nonce {

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -421,6 +421,7 @@ where
 
         let db: EvmDb<_, S> = self.db(maybe_archival_state.deref_mut());
         let mut evm_db = RevmState::builder().with_database(db).build();
+        let cfg_env = get_cfg_env(&block_env, &cfg, Some(get_cfg_env_template()));
         apply_call_overrides(
             &mut evm_db,
             &mut block_env,
@@ -429,7 +430,6 @@ where
         )?;
         let tx_env = prepare_call_env(&block_env, request)?;
         let caller = tx_env.caller;
-        let cfg_env = get_cfg_env(&block_env, &cfg, Some(get_cfg_env_template()));
         let result = executor::transact(&mut evm_db, &block_env, tx_env, cfg_env)?;
         verify_contract_creation_allowlist(&result.state, &caller, &cfg, &mut evm_db)
             .map_err(|e| EthApiError::other(into_rpc_error(e)))?;

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -22,20 +22,27 @@ use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, BlockHash, BlockNumber, Bloom, B64};
 use alloy_primitives::{Bytes, TxKind, B256, U256};
 use alloy_rpc_types::{
-    Block, BlockTransactions, Log, ReceiptEnvelope, ReceiptWithBloom, Transaction,
+    state::{AccountOverride, StateOverride},
+    Block, BlockOverrides, BlockTransactions, Log, ReceiptEnvelope, ReceiptWithBloom, Transaction,
     TransactionReceipt, TransactionRequest,
 };
 use alloy_rpc_types::{BlockTransactionsKind, Header};
 use maybe_archival_state::MaybeArchivalState;
 use revm::context::result::ResultAndState;
 use revm::context::{BlockEnv, CfgEnv};
+use revm::database::State as RevmState;
+use revm::primitives::HashMap as RevmHashMap;
+use revm::state::{Account, AccountStatus, Bytecode, EvmStorageSlot};
+use revm::{Database, DatabaseCommit};
 use sov_address::{EthereumAddress, FromVmAddress};
 use sov_modules_api::da::Time;
 use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::{AccessoryStateReader, Amount, ApiStateAccessor, Spec, VersionReader};
 use sov_rollup_interface::common::RollupHeight;
-use sov_rpc_eth_types::{EthApiError, LogWithExecutionTimestamp, RpcInvalidTransactionError};
+use sov_rpc_eth_types::{
+    invalid_params_rpc_err, EthApiError, LogWithExecutionTimestamp, RpcInvalidTransactionError,
+};
 
 // Prune synthetic blocks more than this number of blocks away from the latest block.
 const SYNTHETIC_BLOCKS_CACHE_PRUNE_INTERVAL: u64 = 20;
@@ -391,15 +398,26 @@ where
         &self,
         request: TransactionRequest,
         block_id: Option<BlockId>,
+        state_overrides: Option<StateOverride>,
+        block_overrides: Option<Box<BlockOverrides>>,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<ResultAndState, EthApiError> {
-        let block_env = self.resolve_block_env_for_call(block_id, state)?;
+        let mut block_env = self.resolve_block_env_for_call(block_id, state)?;
+        let cfg = self.cfg_infallible(state);
+        let mut maybe_archival_state = self.resolve_state_for_block_id(block_id, state)?;
+        let db: EvmDb<_, S> = self.db(maybe_archival_state.deref_mut());
+        let mut evm_db = RevmState::builder().with_database(db).build();
+
+        apply_call_overrides(
+            &mut evm_db,
+            &mut block_env,
+            state_overrides,
+            block_overrides,
+        )?;
+
         let tx_env = prepare_call_env(&block_env, request.clone())?;
         let caller = tx_env.caller;
-        let cfg = self.cfg_infallible(state);
         let cfg_env = get_cfg_env(&block_env, &cfg, Some(get_cfg_env_template()));
-        let mut maybe_archival_state = self.resolve_state_for_block_id(block_id, state)?;
-        let mut evm_db: EvmDb<_, S> = self.db(maybe_archival_state.deref_mut());
         let result = executor::transact(&mut evm_db, &block_env, tx_env, cfg_env)?;
         verify_contract_creation_allowlist(&result.state, &caller, &cfg, &mut evm_db)
             .map_err(|e| EthApiError::other(into_rpc_error(e)))?;
@@ -812,6 +830,157 @@ where
         };
         Ok(block_env)
     }
+}
+
+fn invalid_override_params(message: impl Into<String>) -> EthApiError {
+    EthApiError::other(invalid_params_rpc_err(message.into()))
+}
+
+fn apply_call_overrides<DB: Database>(
+    db: &mut RevmState<DB>,
+    block_env: &mut BlockEnv,
+    state_overrides: Option<StateOverride>,
+    block_overrides: Option<Box<BlockOverrides>>,
+) -> Result<(), EthApiError>
+where
+    DB::Error: Into<EthApiError>,
+{
+    if let Some(state_overrides) = state_overrides {
+        apply_state_overrides(db, state_overrides)?;
+    }
+    if let Some(block_overrides) = block_overrides {
+        apply_block_overrides(db, block_env, *block_overrides);
+    }
+    Ok(())
+}
+
+fn apply_block_overrides<DB: Database>(
+    db: &mut RevmState<DB>,
+    block_env: &mut BlockEnv,
+    block_overrides: BlockOverrides,
+) {
+    let BlockOverrides {
+        number,
+        difficulty,
+        time,
+        gas_limit,
+        coinbase,
+        random,
+        base_fee,
+        block_hash,
+    } = block_overrides;
+
+    if let Some(block_hash) = block_hash {
+        db.block_hashes.extend(block_hash);
+    }
+    if let Some(number) = number {
+        block_env.number = number;
+    }
+    if let Some(difficulty) = difficulty {
+        block_env.difficulty = difficulty;
+    }
+    if let Some(time) = time {
+        block_env.timestamp = U256::from(time);
+    }
+    if let Some(gas_limit) = gas_limit {
+        block_env.gas_limit = gas_limit;
+    }
+    if let Some(coinbase) = coinbase {
+        block_env.beneficiary = coinbase;
+    }
+    if let Some(random) = random {
+        block_env.prevrandao = Some(random);
+    }
+    if let Some(base_fee) = base_fee {
+        // TODO: Change function to result and return err on overflow
+        block_env.basefee = u64::try_from(base_fee).unwrap_or(u64::MAX);
+    }
+}
+
+fn apply_state_overrides<DB: Database>(
+    db: &mut RevmState<DB>,
+    state_overrides: StateOverride,
+) -> Result<(), EthApiError>
+where
+    DB::Error: Into<EthApiError>,
+{
+    for (address, account_override) in state_overrides {
+        apply_account_override(db, address, account_override)?;
+    }
+
+    Ok(())
+}
+
+fn apply_account_override<DB: Database>(
+    db: &mut RevmState<DB>,
+    address: Address,
+    account_override: AccountOverride,
+) -> Result<(), EthApiError>
+where
+    DB::Error: Into<EthApiError>,
+{
+    let AccountOverride {
+        balance,
+        nonce,
+        code,
+        state,
+        state_diff,
+        move_precompile_to: _,
+    } = account_override;
+
+    let mut info = db.basic(address).map_err(Into::into)?.unwrap_or_default();
+    if let Some(nonce) = nonce {
+        info.nonce = nonce;
+    }
+    if let Some(code) = code {
+        let bytecode = Bytecode::new_raw_checked(code).map_err(|err| {
+            invalid_override_params(format!("Invalid account override bytecode: {err}"))
+        })?;
+        info.set_code(bytecode);
+    }
+    if let Some(balance) = balance {
+        info.balance = balance;
+    }
+
+    let mut patched_account = Account {
+        info,
+        status: AccountStatus::Touched,
+        storage: Default::default(),
+        transaction_id: 0,
+    };
+
+    let storage_overrides = match (state, state_diff) {
+        (Some(_), Some(_)) => {
+            return Err(invalid_override_params(format!(
+                "Both 'state' and 'stateDiff' are set for account {address}"
+            )));
+        }
+        (Some(state), None) => {
+            db.commit(RevmHashMap::from_iter([(
+                address,
+                Account {
+                    status: AccountStatus::SelfDestructed | AccountStatus::Touched,
+                    ..Default::default()
+                },
+            )]));
+            patched_account.mark_created();
+            Some(state)
+        }
+        (None, Some(state_diff)) => Some(state_diff),
+        (None, None) => None,
+    };
+
+    if let Some(storage_overrides) = storage_overrides {
+        for (slot, value) in storage_overrides {
+            patched_account.storage.insert(
+                slot.into(),
+                EvmStorageSlot::new_changed((!value).into(), value.into(), 0),
+            );
+        }
+    }
+
+    db.commit(RevmHashMap::from_iter([(address, patched_account)]));
+    Ok(())
 }
 
 fn get_cfg_env_template() -> CfgEnv {

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/main.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/main.rs
@@ -7,6 +7,7 @@ mod helpers;
 mod max_fee;
 mod pruning;
 mod rpc_basefee;
+mod rpc_call_overrides;
 mod runtime;
 mod state;
 mod trace;

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/rpc_call_overrides.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/rpc_call_overrides.rs
@@ -1,0 +1,328 @@
+use crate::helpers::{create_deploy_tx, create_set_arg_tx, setup, EvmAccount};
+use crate::runtime::{RT, S};
+use alloy_consensus::{TxEip1559, TypedTransaction};
+use alloy_eips::eip1559::MIN_PROTOCOL_BASE_FEE;
+use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
+use alloy_rpc_types::{
+    state::{AccountOverride, StateOverride},
+    BlockOverrides, TransactionRequest,
+};
+use jsonrpsee::types::error::INVALID_PARAMS_CODE;
+use sov_evm::{EthereumAuthenticator, Evm};
+use sov_evm_test_utils::LegacySimpleStorage;
+use sov_modules_api::macros::config_value;
+use sov_modules_api::RawTx;
+use sov_test_utils::TransactionType;
+use std::collections::BTreeMap;
+
+struct TxWithHash {
+    tx: TransactionType<RT, S>,
+}
+
+fn create_deploy_tx_with_init_code(
+    nonce: u64,
+    account: &EvmAccount,
+    init_code: Bytes,
+) -> TxWithHash {
+    let tx = TxEip1559 {
+        input: init_code,
+        nonce,
+        gas_limit: 1_000_000,
+        max_fee_per_gas: MIN_PROTOCOL_BASE_FEE as u128 * 2,
+        chain_id: config_value!("CHAIN_ID"),
+        ..Default::default()
+    };
+    let (signed_eth_tx, _) = account.sign(TypedTransaction::Eip1559(tx));
+    let raw_tx = RawTx {
+        data: borsh::to_vec(&signed_eth_tx).expect("RLP tx should serialize"),
+    };
+    TxWithHash {
+        tx: TransactionType::PreAuthenticated(RT::encode_with_ethereum_auth(raw_tx)),
+    }
+}
+
+fn create_init_code(runtime_code: &[u8]) -> Bytes {
+    assert!(runtime_code.len() <= u8::MAX as usize);
+    let runtime_len = runtime_code.len() as u8;
+    let runtime_offset = 12u8;
+
+    let mut init_code = vec![
+        0x60,
+        runtime_len,
+        0x60,
+        runtime_offset,
+        0x60,
+        0x00,
+        0x39,
+        0x60,
+        runtime_len,
+        0x60,
+        0x00,
+        0xf3,
+    ];
+    init_code.extend_from_slice(runtime_code);
+    Bytes::from(init_code)
+}
+
+fn runtime_returning_opcode(opcode: u8) -> Bytes {
+    Bytes::from(vec![opcode, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3])
+}
+
+fn runtime_returning_blockhash(block_number: u8) -> Bytes {
+    Bytes::from(vec![
+        0x60,
+        block_number,
+        0x40,
+        0x60,
+        0x00,
+        0x52,
+        0x60,
+        0x20,
+        0x60,
+        0x00,
+        0xf3,
+    ])
+}
+
+fn runtime_returning_constant(value: U256) -> Bytes {
+    let mut runtime = vec![0x7f];
+    runtime.extend_from_slice(&value.to_be_bytes::<32>());
+    runtime.extend_from_slice(&[0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3]);
+    Bytes::from(runtime)
+}
+
+fn decode_u256(output: Bytes) -> U256 {
+    U256::from_be_slice(output.as_ref())
+}
+
+fn decode_b256(output: Bytes) -> B256 {
+    B256::from_slice(output.as_ref())
+}
+
+fn to_b256(value: U256) -> B256 {
+    B256::from(value.to_be_bytes::<32>())
+}
+
+#[test]
+fn test_eth_call_state_override_code_is_applied() {
+    let (runner, account, _, _) = setup();
+    let target = Address::with_last_byte(0x42);
+    let expected = U256::from(0x1234u64);
+
+    runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let request = TransactionRequest {
+            from: Some(account.address()),
+            to: Some(TxKind::Call(target)),
+            ..Default::default()
+        };
+
+        let baseline = evm
+            .eth_call(request.clone(), None, None, None, state)
+            .unwrap();
+        assert!(baseline.is_empty(), "EOA call should return empty output");
+
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            target,
+            AccountOverride::default().with_code(runtime_returning_constant(expected)),
+        );
+
+        let output = evm
+            .eth_call(request, None, Some(state_overrides), None, state)
+            .unwrap();
+        assert_eq!(decode_u256(output), expected);
+    });
+}
+
+#[test]
+fn test_eth_call_state_and_state_diff_overrides_update_storage() {
+    let (mut runner, account, _, _) = setup();
+    let contract = LegacySimpleStorage::default();
+    let contract_addr = account.address().create(0);
+
+    runner.execute(create_deploy_tx(0, &contract, &account).tx);
+    runner.execute(create_set_arg_tx(5, 1, &contract, contract_addr, &account).tx);
+
+    runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let request = TransactionRequest {
+            from: Some(account.address()),
+            to: Some(TxKind::Call(contract_addr)),
+            input: contract.get().into(),
+            ..Default::default()
+        };
+
+        let baseline = evm
+            .eth_call(request.clone(), None, None, None, state)
+            .unwrap();
+        assert_eq!(decode_u256(baseline), U256::from(5u64));
+
+        let mut state_diff_overrides = StateOverride::default();
+        state_diff_overrides.insert(
+            contract_addr,
+            AccountOverride::default().with_state_diff([(B256::ZERO, to_b256(U256::from(7u64)))]),
+        );
+        let output_with_state_diff = evm
+            .eth_call(
+                request.clone(),
+                None,
+                Some(state_diff_overrides),
+                None,
+                state,
+            )
+            .unwrap();
+        assert_eq!(decode_u256(output_with_state_diff), U256::from(7u64));
+
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            contract_addr,
+            AccountOverride::default().with_state([(B256::ZERO, to_b256(U256::from(9u64)))]),
+        );
+        let output_with_state = evm
+            .eth_call(request, None, Some(state_overrides), None, state)
+            .unwrap();
+        assert_eq!(decode_u256(output_with_state), U256::from(9u64));
+    });
+}
+
+#[test]
+fn test_eth_call_rejects_state_and_state_diff_on_same_account() {
+    let (runner, account, _, _) = setup();
+    let target = Address::with_last_byte(0x53);
+
+    runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let request = TransactionRequest {
+            from: Some(account.address()),
+            to: Some(TxKind::Call(target)),
+            ..Default::default()
+        };
+
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            target,
+            AccountOverride::default()
+                .with_state([(B256::ZERO, B256::ZERO)])
+                .with_state_diff([(B256::ZERO, B256::ZERO)]),
+        );
+
+        let err = evm
+            .eth_call(request, None, Some(state_overrides), None, state)
+            .unwrap_err();
+        assert_eq!(err.code(), INVALID_PARAMS_CODE);
+    });
+}
+
+#[test]
+fn test_eth_call_block_overrides_base_fee_and_number_are_applied() {
+    let (mut runner, account, _, _) = setup();
+    let basefee_contract_addr = account.address().create(0);
+    let number_contract_addr = account.address().create(1);
+    let timestamp_contract_addr = account.address().create(2);
+
+    let basefee_runtime = runtime_returning_opcode(0x48);
+    let number_runtime = runtime_returning_opcode(0x43);
+    let timestamp_runtime = runtime_returning_opcode(0x42);
+
+    runner.execute(
+        create_deploy_tx_with_init_code(0, &account, create_init_code(basefee_runtime.as_ref())).tx,
+    );
+    runner.execute(
+        create_deploy_tx_with_init_code(1, &account, create_init_code(number_runtime.as_ref())).tx,
+    );
+    runner.execute(
+        create_deploy_tx_with_init_code(2, &account, create_init_code(timestamp_runtime.as_ref()))
+            .tx,
+    );
+
+    runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let block_overrides = BlockOverrides::default()
+            .with_base_fee(U256::from(1_234u64))
+            .with_time(5_555)
+            .with_number(U256::from(77u64));
+
+        let basefee_output = evm
+            .eth_call(
+                TransactionRequest {
+                    from: Some(account.address()),
+                    to: Some(TxKind::Call(basefee_contract_addr)),
+                    ..Default::default()
+                },
+                None,
+                None,
+                Some(Box::new(block_overrides.clone())),
+                state,
+            )
+            .unwrap();
+        assert_eq!(decode_u256(basefee_output), U256::from(1_234u64));
+
+        let number_output = evm
+            .eth_call(
+                TransactionRequest {
+                    from: Some(account.address()),
+                    to: Some(TxKind::Call(number_contract_addr)),
+                    ..Default::default()
+                },
+                None,
+                None,
+                Some(Box::new(block_overrides.clone())),
+                state,
+            )
+            .unwrap();
+        assert_eq!(decode_u256(number_output), U256::from(77u64));
+
+        let timestamp_output = evm
+            .eth_call(
+                TransactionRequest {
+                    from: Some(account.address()),
+                    to: Some(TxKind::Call(timestamp_contract_addr)),
+                    ..Default::default()
+                },
+                None,
+                None,
+                Some(Box::new(block_overrides)),
+                state,
+            )
+            .unwrap();
+        assert_eq!(decode_u256(timestamp_output), U256::from(5_555u64));
+    });
+}
+
+#[test]
+fn test_eth_call_block_hash_override_is_applied() {
+    let (mut runner, account, _, _) = setup();
+    let contract_addr = account.address().create(0);
+    let runtime = runtime_returning_blockhash(0);
+    runner.execute(
+        create_deploy_tx_with_init_code(0, &account, create_init_code(runtime.as_ref())).tx,
+    );
+
+    runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let request = TransactionRequest {
+            from: Some(account.address()),
+            to: Some(TxKind::Call(contract_addr)),
+            ..Default::default()
+        };
+
+        let baseline = evm
+            .eth_call(request.clone(), None, None, None, state)
+            .unwrap();
+        let baseline_hash = decode_b256(baseline);
+
+        let custom_hash = B256::with_last_byte(0xAB);
+        let block_overrides = BlockOverrides {
+            block_hash: Some(BTreeMap::from([(0, custom_hash)])),
+            ..Default::default()
+        };
+        let overridden = evm
+            .eth_call(request, None, None, Some(Box::new(block_overrides)), state)
+            .unwrap();
+        let overridden_hash = decode_b256(overridden);
+
+        assert_eq!(overridden_hash, custom_hash);
+        assert_ne!(baseline_hash, overridden_hash);
+    });
+}

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/rpc_call_overrides.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/rpc_call_overrides.rs
@@ -84,6 +84,25 @@ fn runtime_returning_blockhash(block_number: u8) -> Bytes {
     ])
 }
 
+fn runtime_require_block_number(block_number: u8) -> Bytes {
+    Bytes::from(vec![
+        0x43,
+        0x60,
+        block_number,
+        0x14,
+        0x60,
+        0x0c,
+        0x57,
+        0x60,
+        0x00,
+        0x60,
+        0x00,
+        0xfd,
+        0x5b,
+        0x00,
+    ])
+}
+
 fn runtime_returning_constant(value: U256) -> Bytes {
     let mut runtime = vec![0x7f];
     runtime.extend_from_slice(&value.to_be_bytes::<32>());
@@ -211,6 +230,108 @@ fn test_eth_call_rejects_state_and_state_diff_on_same_account() {
             .eth_call(request, None, Some(state_overrides), None, state)
             .unwrap_err();
         assert_eq!(err.code(), INVALID_PARAMS_CODE);
+    });
+}
+
+#[test]
+fn test_eth_call_rejects_block_override_base_fee_overflow() {
+    let (runner, account, _, _) = setup();
+    let target = Address::with_last_byte(0x54);
+
+    runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let request = TransactionRequest {
+            from: Some(account.address()),
+            to: Some(TxKind::Call(target)),
+            ..Default::default()
+        };
+
+        let err = evm
+            .eth_call(
+                request,
+                None,
+                None,
+                Some(Box::new(BlockOverrides::default().with_base_fee(U256::MAX))),
+                state,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), INVALID_PARAMS_CODE);
+    });
+}
+
+#[test]
+fn test_eth_estimate_gas_state_override_code_is_applied() {
+    let (mut runner, account, _, _) = setup();
+    let contract = LegacySimpleStorage::default();
+    let contract_addr = account.address().create(0);
+    runner.execute(create_deploy_tx(0, &contract, &account).tx);
+
+    runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let request = TransactionRequest {
+            from: Some(account.address()),
+            to: Some(TxKind::Call(contract_addr)),
+            input: contract.always_revert().into(),
+            ..Default::default()
+        };
+
+        assert!(evm
+            .eth_estimate_gas(request.clone(), None, None, None, state)
+            .is_err());
+
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            contract_addr,
+            AccountOverride::default().with_code(Bytes::from(vec![0x00])),
+        );
+        let estimate = evm
+            .eth_estimate_gas(request, None, Some(state_overrides), None, state)
+            .unwrap();
+        assert!(estimate.to::<u64>() > 0);
+    });
+}
+
+#[test]
+fn test_eth_estimate_gas_block_override_number_is_applied() {
+    let (runner, account, _, _) = setup();
+    let target = Address::with_last_byte(0x55);
+
+    runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let request = TransactionRequest {
+            from: Some(account.address()),
+            to: Some(TxKind::Call(target)),
+            ..Default::default()
+        };
+
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            target,
+            AccountOverride::default().with_code(runtime_require_block_number(77)),
+        );
+
+        assert!(evm
+            .eth_estimate_gas(
+                request.clone(),
+                None,
+                Some(state_overrides.clone()),
+                None,
+                state
+            )
+            .is_err());
+
+        let estimate = evm
+            .eth_estimate_gas(
+                request,
+                None,
+                Some(state_overrides),
+                Some(Box::new(
+                    BlockOverrides::default().with_number(U256::from(77u64)),
+                )),
+                state,
+            )
+            .unwrap();
+        assert!(estimate.to::<u64>() > 0);
     });
 }
 

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/rpc_call_overrides.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/rpc_call_overrides.rs
@@ -1,5 +1,6 @@
 use crate::helpers::{create_deploy_tx, create_set_arg_tx, setup, EvmAccount};
-use crate::runtime::{RT, S};
+use crate::runtime::{GenesisConfig, RT, S};
+use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_consensus::{TxEip1559, TypedTransaction};
 use alloy_eips::eip1559::MIN_PROTOCOL_BASE_FEE;
 use alloy_primitives::{Address, Bytes, TxKind, B256, U256};
@@ -8,11 +9,17 @@ use alloy_rpc_types::{
     BlockOverrides, TransactionRequest,
 };
 use jsonrpsee::types::error::INVALID_PARAMS_CODE;
-use sov_evm::{EthereumAuthenticator, Evm};
+use sov_address::{EthereumAddress, MultiAddress};
+use sov_evm::{
+    AccountData, ContractCreationPolicy, EthereumAuthenticator, Evm, EvmChainSpec,
+    EvmGenesisConfig, SpecId,
+};
 use sov_evm_test_utils::LegacySimpleStorage;
 use sov_modules_api::macros::config_value;
 use sov_modules_api::RawTx;
-use sov_test_utils::TransactionType;
+use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
+use sov_test_utils::runtime::TestRunner;
+use sov_test_utils::{TransactionType, TEST_DEFAULT_USER_BALANCE};
 use std::collections::BTreeMap;
 
 fn create_deploy_tx_with_init_code(
@@ -104,6 +111,10 @@ fn runtime_returning_constant(value: U256) -> Bytes {
     Bytes::from(runtime)
 }
 
+fn runtime_returning_push0() -> Bytes {
+    Bytes::from(vec![0x5f, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3])
+}
+
 fn decode_u256(output: Bytes) -> U256 {
     U256::from_be_slice(output.as_ref())
 }
@@ -122,6 +133,47 @@ fn call_request(from: Address, to: Address) -> TransactionRequest {
         to: Some(TxKind::Call(to)),
         ..Default::default()
     }
+}
+
+fn setup_with_hardforks(hardforks: Vec<(u64, SpecId)>) -> (TestRunner<RT, S>, EvmAccount) {
+    let evm_account = EvmAccount::generate();
+    let genesis_config =
+        HighLevelOptimisticGenesisConfig::generate().add_accounts_with_default_balance(1);
+    let admin = genesis_config
+        .additional_accounts()
+        .first()
+        .expect("genesis should include a default account")
+        .clone();
+
+    let evm_config = EvmGenesisConfig {
+        accounts: vec![AccountData {
+            address: evm_account.address(),
+            code_hash: KECCAK_EMPTY,
+            code: Default::default(),
+        }],
+        chain_spec: EvmChainSpec {
+            limit_contract_code_size: None,
+            coinbase: Address::ZERO,
+            block_gas_limit: 1_000_000_000,
+            tx_gas_limit: Some(30_000_000),
+            hardforks,
+        },
+        contract_creation_policy: ContractCreationPolicy::Everyone,
+        initial_base_fee: 0,
+        genesis_timestamp: 0,
+        admin: admin.address(),
+    };
+
+    let mut genesis = GenesisConfig::from_minimal_config(genesis_config.into(), evm_config);
+    if let Some(c) = genesis.bank.gas_token_config.as_mut() {
+        c.address_and_balances.push((
+            MultiAddress::Vm(EthereumAddress::from(evm_account.address())),
+            TEST_DEFAULT_USER_BALANCE,
+        ));
+    }
+
+    let runner = TestRunner::new_with_genesis(genesis.into_genesis_params(), RT::default());
+    (runner, evm_account)
 }
 
 #[test]
@@ -430,6 +482,59 @@ fn test_eth_call_block_overrides_base_fee_and_number_are_applied() {
             )
             .unwrap();
         assert_eq!(decode_u256(timestamp_output), U256::from(5_555u64));
+    });
+}
+
+#[test]
+fn test_eth_call_block_number_override_does_not_change_hardfork_spec() {
+    let (runner, account) = setup_with_hardforks(vec![(0, SpecId::LONDON), (100, SpecId::CANCUN)]);
+    let push0_contract_addr = Address::with_last_byte(0x56);
+    let number_contract_addr = Address::with_last_byte(0x57);
+
+    runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let mut push0_overrides = StateOverride::default();
+        push0_overrides.insert(
+            push0_contract_addr,
+            AccountOverride::default().with_code(runtime_returning_push0()),
+        );
+
+        assert!(evm
+            .eth_call(
+                call_request(account.address(), push0_contract_addr),
+                None,
+                Some(push0_overrides.clone()),
+                None,
+                state,
+            )
+            .is_err());
+
+        let block_overrides = BlockOverrides::default().with_number(U256::from(100u64));
+        assert!(evm
+            .eth_call(
+                call_request(account.address(), push0_contract_addr),
+                None,
+                Some(push0_overrides),
+                Some(Box::new(block_overrides.clone())),
+                state,
+            )
+            .is_err());
+
+        let mut number_overrides = StateOverride::default();
+        number_overrides.insert(
+            number_contract_addr,
+            AccountOverride::default().with_code(runtime_returning_opcode(0x43)),
+        );
+        let number_output = evm
+            .eth_call(
+                call_request(account.address(), number_contract_addr),
+                None,
+                Some(number_overrides),
+                Some(Box::new(block_overrides)),
+                state,
+            )
+            .unwrap();
+        assert_eq!(decode_u256(number_output), U256::from(100u64));
     });
 }
 

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/rpc_call_overrides.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/rpc_call_overrides.rs
@@ -15,15 +15,11 @@ use sov_modules_api::RawTx;
 use sov_test_utils::TransactionType;
 use std::collections::BTreeMap;
 
-struct TxWithHash {
-    tx: TransactionType<RT, S>,
-}
-
 fn create_deploy_tx_with_init_code(
     nonce: u64,
     account: &EvmAccount,
     init_code: Bytes,
-) -> TxWithHash {
+) -> TransactionType<RT, S> {
     let tx = TxEip1559 {
         input: init_code,
         nonce,
@@ -36,9 +32,7 @@ fn create_deploy_tx_with_init_code(
     let raw_tx = RawTx {
         data: borsh::to_vec(&signed_eth_tx).expect("RLP tx should serialize"),
     };
-    TxWithHash {
-        tx: TransactionType::PreAuthenticated(RT::encode_with_ethereum_auth(raw_tx)),
-    }
+    TransactionType::PreAuthenticated(RT::encode_with_ethereum_auth(raw_tx))
 }
 
 fn create_init_code(runtime_code: &[u8]) -> Bytes {
@@ -122,6 +116,14 @@ fn to_b256(value: U256) -> B256 {
     B256::from(value.to_be_bytes::<32>())
 }
 
+fn call_request(from: Address, to: Address) -> TransactionRequest {
+    TransactionRequest {
+        from: Some(from),
+        to: Some(TxKind::Call(to)),
+        ..Default::default()
+    }
+}
+
 #[test]
 fn test_eth_call_state_override_code_is_applied() {
     let (runner, account, _, _) = setup();
@@ -130,11 +132,7 @@ fn test_eth_call_state_override_code_is_applied() {
 
     runner.query_visible_state(|state| {
         let evm = Evm::<S>::default();
-        let request = TransactionRequest {
-            from: Some(account.address()),
-            to: Some(TxKind::Call(target)),
-            ..Default::default()
-        };
+        let request = call_request(account.address(), target);
 
         let baseline = evm
             .eth_call(request.clone(), None, None, None, state)
@@ -212,11 +210,7 @@ fn test_eth_call_rejects_state_and_state_diff_on_same_account() {
 
     runner.query_visible_state(|state| {
         let evm = Evm::<S>::default();
-        let request = TransactionRequest {
-            from: Some(account.address()),
-            to: Some(TxKind::Call(target)),
-            ..Default::default()
-        };
+        let request = call_request(account.address(), target);
 
         let mut state_overrides = StateOverride::default();
         state_overrides.insert(
@@ -240,11 +234,7 @@ fn test_eth_call_rejects_block_override_base_fee_overflow() {
 
     runner.query_visible_state(|state| {
         let evm = Evm::<S>::default();
-        let request = TransactionRequest {
-            from: Some(account.address()),
-            to: Some(TxKind::Call(target)),
-            ..Default::default()
-        };
+        let request = call_request(account.address(), target);
 
         let err = evm
             .eth_call(
@@ -254,6 +244,49 @@ fn test_eth_call_rejects_block_override_base_fee_overflow() {
                 Some(Box::new(BlockOverrides::default().with_base_fee(U256::MAX))),
                 state,
             )
+            .unwrap_err();
+        assert_eq!(err.code(), INVALID_PARAMS_CODE);
+    });
+}
+
+#[test]
+fn test_eth_call_rejects_block_override_number_overflow() {
+    let (runner, account, _, _) = setup();
+    let target = Address::with_last_byte(0x5A);
+
+    runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let request = call_request(account.address(), target);
+
+        let err = evm
+            .eth_call(
+                request,
+                None,
+                None,
+                Some(Box::new(BlockOverrides::default().with_number(U256::MAX))),
+                state,
+            )
+            .unwrap_err();
+        assert_eq!(err.code(), INVALID_PARAMS_CODE);
+    });
+}
+
+#[test]
+fn test_eth_call_rejects_move_precompile_override() {
+    let (runner, account, _, _) = setup();
+    let target = Address::with_last_byte(0x5B);
+
+    runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let request = call_request(account.address(), target);
+
+        let mut account_override = AccountOverride::default();
+        account_override.set_move_precompile_to(Address::with_last_byte(0x11));
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(target, account_override);
+
+        let err = evm
+            .eth_call(request, None, Some(state_overrides), None, state)
             .unwrap_err();
         assert_eq!(err.code(), INVALID_PARAMS_CODE);
     });
@@ -298,11 +331,7 @@ fn test_eth_estimate_gas_block_override_number_is_applied() {
 
     runner.query_visible_state(|state| {
         let evm = Evm::<S>::default();
-        let request = TransactionRequest {
-            from: Some(account.address()),
-            to: Some(TxKind::Call(target)),
-            ..Default::default()
-        };
+        let request = call_request(account.address(), target);
 
         let mut state_overrides = StateOverride::default();
         state_overrides.insert(
@@ -346,16 +375,21 @@ fn test_eth_call_block_overrides_base_fee_and_number_are_applied() {
     let number_runtime = runtime_returning_opcode(0x43);
     let timestamp_runtime = runtime_returning_opcode(0x42);
 
-    runner.execute(
-        create_deploy_tx_with_init_code(0, &account, create_init_code(basefee_runtime.as_ref())).tx,
-    );
-    runner.execute(
-        create_deploy_tx_with_init_code(1, &account, create_init_code(number_runtime.as_ref())).tx,
-    );
-    runner.execute(
-        create_deploy_tx_with_init_code(2, &account, create_init_code(timestamp_runtime.as_ref()))
-            .tx,
-    );
+    runner.execute(create_deploy_tx_with_init_code(
+        0,
+        &account,
+        create_init_code(basefee_runtime.as_ref()),
+    ));
+    runner.execute(create_deploy_tx_with_init_code(
+        1,
+        &account,
+        create_init_code(number_runtime.as_ref()),
+    ));
+    runner.execute(create_deploy_tx_with_init_code(
+        2,
+        &account,
+        create_init_code(timestamp_runtime.as_ref()),
+    ));
 
     runner.query_visible_state(|state| {
         let evm = Evm::<S>::default();
@@ -366,11 +400,7 @@ fn test_eth_call_block_overrides_base_fee_and_number_are_applied() {
 
         let basefee_output = evm
             .eth_call(
-                TransactionRequest {
-                    from: Some(account.address()),
-                    to: Some(TxKind::Call(basefee_contract_addr)),
-                    ..Default::default()
-                },
+                call_request(account.address(), basefee_contract_addr),
                 None,
                 None,
                 Some(Box::new(block_overrides.clone())),
@@ -381,11 +411,7 @@ fn test_eth_call_block_overrides_base_fee_and_number_are_applied() {
 
         let number_output = evm
             .eth_call(
-                TransactionRequest {
-                    from: Some(account.address()),
-                    to: Some(TxKind::Call(number_contract_addr)),
-                    ..Default::default()
-                },
+                call_request(account.address(), number_contract_addr),
                 None,
                 None,
                 Some(Box::new(block_overrides.clone())),
@@ -396,11 +422,7 @@ fn test_eth_call_block_overrides_base_fee_and_number_are_applied() {
 
         let timestamp_output = evm
             .eth_call(
-                TransactionRequest {
-                    from: Some(account.address()),
-                    to: Some(TxKind::Call(timestamp_contract_addr)),
-                    ..Default::default()
-                },
+                call_request(account.address(), timestamp_contract_addr),
                 None,
                 None,
                 Some(Box::new(block_overrides)),
@@ -416,17 +438,15 @@ fn test_eth_call_block_hash_override_is_applied() {
     let (mut runner, account, _, _) = setup();
     let contract_addr = account.address().create(0);
     let runtime = runtime_returning_blockhash(0);
-    runner.execute(
-        create_deploy_tx_with_init_code(0, &account, create_init_code(runtime.as_ref())).tx,
-    );
+    runner.execute(create_deploy_tx_with_init_code(
+        0,
+        &account,
+        create_init_code(runtime.as_ref()),
+    ));
 
     runner.query_visible_state(|state| {
         let evm = Evm::<S>::default();
-        let request = TransactionRequest {
-            from: Some(account.address()),
-            to: Some(TxKind::Call(contract_addr)),
-            ..Default::default()
-        };
+        let request = call_request(account.address(), contract_addr);
 
         let baseline = evm
             .eth_call(request.clone(), None, None, None, state)

--- a/docs/ethereum-rpc-compliance-findings.md
+++ b/docs/ethereum-rpc-compliance-findings.md
@@ -55,7 +55,7 @@ Parameter handling gaps
   Affects: eth_getBlockByNumber, eth_getBalance, eth_getCode, eth_getStorageAt,
   eth_getTransactionCount, eth_getBlockReceipts, eth_call, eth_estimateGas.
   Files: crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
-- eth_call supports state_override and block_overrides; eth_estimateGas does not accept overrides.
+- eth_call and eth_estimateGas support state_override and block_overrides.
   File: crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
 - eth_call / eth_estimateGas ignore fee fields and transaction type (always EIP-1559, zero fees).
   File: crates/module-system/module-implementations/sov-evm/src/helpers.rs

--- a/docs/ethereum-rpc-compliance-findings.md
+++ b/docs/ethereum-rpc-compliance-findings.md
@@ -55,7 +55,7 @@ Parameter handling gaps
   Affects: eth_getBlockByNumber, eth_getBalance, eth_getCode, eth_getStorageAt,
   eth_getTransactionCount, eth_getBlockReceipts, eth_call, eth_estimateGas.
   Files: crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
-- eth_call ignores state_override and block_overrides; eth_estimateGas does not accept overrides.
+- eth_call supports state_override and block_overrides; eth_estimateGas does not accept overrides.
   File: crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
 - eth_call / eth_estimateGas ignore fee fields and transaction type (always EIP-1559, zero fees).
   File: crates/module-system/module-implementations/sov-evm/src/helpers.rs
@@ -86,4 +86,3 @@ Appendix: RPC methods present (non-exhaustive)
 - sov-ethereum wrapper: eth_gasPrice, eth_sendRawTransaction, eth_sendRawTransactionSync,
   realtime_sendRawTransaction, eth_getLogs, eth_getLogsWithCursor, eth_subscribe,
   (local) eth_accounts, eth_sendTransaction.
-

--- a/docs/rpc_inventory.md
+++ b/docs/rpc_inventory.md
@@ -35,7 +35,7 @@ Source: `crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
 | `eth_getTransactionByHash` | implemented | Looks up sealed or pending txs in accessory state. |
 | `eth_getBlockReceipts` | implemented | Receipts by block. |
 | `eth_getTransactionReceipt` | implemented | Receipt by tx hash. |
-| `eth_call` | implemented | Block-tagged call; `state_overrides` and `block_overrides` ignored. |
+| `eth_call` | implemented | Block-tagged call; supports `state_overrides` and `block_overrides`. |
 | `eth_blockNumber` | implemented | Returns latest sealed block number. |
 | `eth_estimateGas` | implemented | Block-tagged estimation with safety margin. |
 | `debug_traceBlockByNumber` | implemented | Geth tracing; only `callTracer` supported. |

--- a/docs/rpc_inventory.md
+++ b/docs/rpc_inventory.md
@@ -37,7 +37,7 @@ Source: `crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
 | `eth_getTransactionReceipt` | implemented | Receipt by tx hash. |
 | `eth_call` | implemented | Block-tagged call; supports `state_overrides` and `block_overrides`. |
 | `eth_blockNumber` | implemented | Returns latest sealed block number. |
-| `eth_estimateGas` | implemented | Block-tagged estimation with safety margin. |
+| `eth_estimateGas` | implemented | Block-tagged estimation with safety margin; supports `state_overrides` and `block_overrides`. |
 | `debug_traceBlockByNumber` | implemented | Geth tracing; only `callTracer` supported. |
 | `debug_traceTransaction` | implemented | Geth tracing; only `callTracer` supported. |
 | `web3_clientVersion` | implemented | `sov-evm/<version>`. |

--- a/docs/rpc_priority_sorted.md
+++ b/docs/rpc_priority_sorted.md
@@ -99,8 +99,8 @@
    Minimal repro: run with `finalization_blocks > 0`, compare `safe` vs `finalized`; L1 allows `safe` to be ahead of `finalized`.
 5. `eth_gasPrice` and `eth_maxPriorityFeePerGas` always return 0 [crates/full-node/sov-ethereum/src/lib.rs:122] [crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs:414].  
    Minimal repro: call both endpoints; L1 typically returns non-zero.
-6. `eth_estimateGas` does not accept `state_overrides`/`block_overrides` parameters (unlike clients that support optional call overrides there).  
-   Minimal repro: send override params to `eth_estimateGas`; request shape is rejected at parameter parsing.
+6. `eth_call` / `eth_estimateGas` ignore fee fields and transaction type in request encoding (always EIP-1559 + zero fee call context) [crates/module-system/module-implementations/sov-evm/src/helpers.rs:29].  
+   Minimal repro: vary `gasPrice`, `maxFeePerGas`, `maxPriorityFeePerGas`, and `type`; observe unchanged call context behavior.
 7. Synthetic block state cache can grow quickly under high pending-tx churn (one accessor clone per synthetic hash; prune window is block-distance based, not count-based) [crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs:41] [crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs:69].  
    Operational risk: transient memory spikes during sustained high tx-rate bursts and frequent pending-hash queries/subscriptions.
 

--- a/docs/rpc_priority_sorted.md
+++ b/docs/rpc_priority_sorted.md
@@ -99,8 +99,8 @@
    Minimal repro: run with `finalization_blocks > 0`, compare `safe` vs `finalized`; L1 allows `safe` to be ahead of `finalized`.
 5. `eth_gasPrice` and `eth_maxPriorityFeePerGas` always return 0 [crates/full-node/sov-ethereum/src/lib.rs:122] [crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs:414].  
    Minimal repro: call both endpoints; L1 typically returns non-zero.
-6. `eth_call` ignores `state_overrides` and `block_overrides` [crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs:268].  
-   Minimal repro: pass overrides that would change state; expect no effect.
+6. `eth_estimateGas` does not accept `state_overrides`/`block_overrides` parameters (unlike clients that support optional call overrides there).  
+   Minimal repro: send override params to `eth_estimateGas`; request shape is rejected at parameter parsing.
 7. Synthetic block state cache can grow quickly under high pending-tx churn (one accessor clone per synthetic hash; prune window is block-distance based, not count-based) [crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs:41] [crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs:69].  
    Operational risk: transient memory spikes during sustained high tx-rate bursts and frequent pending-hash queries/subscriptions.
 


### PR DESCRIPTION
## Summary

Implements `stateOverrides` and `blockOverrides` parameters for `eth_call` and `eth_estimateGas`, which were previously accepted but ignored.

## What changed

**Core logic** (`sov-evm/src/rpc/mod.rs`):
- `apply_state_overrides()` — overrides account code, balance, nonce, and storage (supports both full `state` and partial `state_diff`)
- `apply_block_overrides()` — overrides block number, timestamp, basefee, difficulty, coinbase, gas limit, and block hashes
- `apply_call_overrides()` — orchestrates both; wraps `EvmDb` in `revm::State` only when overrides are present (fast path for the common case)
- Validation: rejects basefee/block number overflow, precompile address overrides, and simultaneous `state` + `state_diff`

**Handler plumbing** (`handlers.rs`, `sov-ethereum/handlers/mod.rs`):
- `eth_call` and `eth_estimate_gas` now accept and forward override params instead of discarding them

**Tests** (`rpc_call_overrides.rs`, +574 lines):
- State overrides: code injection, balance, nonce, storage (`state` vs `state_diff`)
- Block overrides: basefee, number, timestamp, block hash
- Validation: overflow rejection, precompile rejection, conflicting state+state_diff
- Hardfork spec stability under block number overrides

## Review attention

- **`apply_state_overrides`** — storage slot construction uses `EvmStorageSlot::new_changed(!value, value, 0)` (inverted original to force dirty-marking). This matches the alloy-evm reference impl but is worth understanding.
- **`apply_block_overrides`** — strict overflow rejection (returns error) vs alloy-evm's saturation. Intentional choice for stricter validation.
- **Fast path** — when no overrides are provided, the existing `EvmDb` is used directly without wrapping in `revm::State`.

## Linked Issues
- Related to #2271

## Testing
New integration test module with 11 tests covering happy paths and error cases.