### PR TITLE
Updating celestia adapter for V7 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2543,9 +2543,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-client"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2189137197ca49d776d1a0b931cc925510fcd1094b3182430dfd46a3852bb12"
+checksum = "7c7531886eef1f65e30ba676dba429c98965fb03a3fcf94d8468fecabdc45259"
 dependencies = [
  "async-stream",
  "blockstore",
@@ -2571,9 +2571,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8dbaf0d7c58c92133425c4995a3684f13d154902f0c00ef08b4c749abbdc40"
+checksum = "4e3d17a7cd950e6387bfb7aa494ab23989035763261a1bb725ef4430a2645ade"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -2610,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc-macros"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c9a206faf26365a929f943cea383d445a613f794461fdc6b4c8f1e5b24937d"
+checksum = "1d79e42455c42517ad6a7c3bc301640e534ccf37e1e37777b4a3ea12bca93d2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2621,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9033470dd895f900f97bd674f330ba7d87550fa6a92c92815dd30f31437367a"
+checksum = "65013505b04171f213d833b92bb076e9f229c36e5d144cb2faf25378397e2597"
 dependencies = [
  "bytes",
  "prost 0.13.5",
@@ -2640,9 +2640,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5332519c0e0fca2fa477122b22f752dfd51885d1a2b0462e1ab0c82c29954242"
+checksum = "71f5f1ededb6d3398c6f922ad543594b0706d2de19e02d97024037cb750dbd89"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -2666,9 +2666,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9cc150ce1c20da1a79a9ea3e79d2feed4189bd7243b23fc0752784add94bba"
+checksum = "0fe616393f4c88756ed6b8097167a623c6e4e48e2a3d75109e3ea5d5941587e0"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -5597,17 +5597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags 2.9.4",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6230,9 +6219,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lumina-utils"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949c02e310a43325ec27c258769e93404b789c274b7c8e183a243e75c16be1bf"
+checksum = "2e68ba51207213b3fa8a42465526efdbe6c3c983a78a2a972d3a8e94d2bf9ab8"
 dependencies = [
  "futures",
  "gloo-timers 0.3.0",
@@ -6685,7 +6674,7 @@ dependencies = [
  "dashmap 5.5.3",
  "fxhash",
  "imbl",
- "io-uring 0.6.4",
+ "io-uring",
  "libc",
  "loom",
  "lru 0.12.5",
@@ -10991,7 +10980,6 @@ dependencies = [
  "bincode",
  "borsh",
  "celestia-client",
- "celestia-rpc",
  "celestia-types",
  "derive_more 1.0.0",
  "futures",
@@ -13951,30 +13939,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring 0.7.10",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2 0.6.0",
  "tokio-macros",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/adapters/celestia/Cargo.toml
+++ b/crates/adapters/celestia/Cargo.toml
@@ -20,10 +20,8 @@ bech32 = { workspace = true }
 prost = "0.13"
 
 # Upgrade with care. The new version might be incompatible and require a run of soak tests
-celestia-types = { version = "0.19.0", default-features = false }
-# This is for preventing breaking change in 0.16.2. Can be removed after upgrade above 0.4.1
-celestia-rpc = { version = "=0.16.1", default-features = false, optional = true }
-celestia-client = { version = "0.4.1", optional = true }
+celestia-types = { version = "0.20.0", default-features = false }
+celestia-client = { version = "0.5.0", optional = true }
 tendermint = { version = "0.40.4", default-features = false }
 tendermint-proto = { version = "0.40.4" }
 nmt-rs = { workspace = true, features = ["serde", "borsh"] }
@@ -81,7 +79,6 @@ native = [
     "backon",
     "tendermint/default",
     "dep:celestia-client",
-    "dep:celestia-rpc",
     "dep:futures",
     "dep:tokio",
     "sov-celestia-adapter/native",

--- a/crates/adapters/celestia/README.md
+++ b/crates/adapters/celestia/README.md
@@ -9,8 +9,8 @@ This code has not been audited, and may contain critical vulnerabilities. Do not
 
 ## Celestia Integration
 
-The current version of `sov-celestia-adapter` runs against celestia-node version `v0.23.1`.
-This is the version used on the `mocha` testnet as of Jul 3rd, 2025.
+The current version of `sov-celestia-adapter` runs against celestia-node version `v0.29.1`.
+This is the version used on the `mocha` testnet as of Feb 20th, 2026.
 
 To set up Celestia nodes, please refer to the official documentation provided by Celestia, for example: 
 [how to run a light node](https://docs.celestia.org/how-to-guides/light-node)
@@ -159,14 +159,14 @@ Follow these steps (all paths are from root of the repo):
 
 1. **Update version tags in [`docker/Makefile`](../../../docker/Makefile)**:
    ```makefile
-   CELESTIA_DEVNET_VALIDATOR_TAG := v6.2.2-mocha  # Update this version
-   CELESTIA_DEVNET_BRIDGE_TAG := v0.28.2-mocha    # Update this version
+   CELESTIA_DEVNET_VALIDATOR_TAG := v7.0.2-mocha  # Update this version
+   CELESTIA_DEVNET_BRIDGE_TAG := v0.29.1-mocha    # Update this version
    ```
 
 2. **Update matching tags in `crates/adapters/celestia/src/test_helper/docker.rs`**:
    ```rust
-   const VALIDATOR_TAG: &str = "v6.2.2-mocha";
-   const BRIDGE_TAG: &str = "v0.28.2-mocha";
+   const VALIDATOR_TAG: &str = "v7.0.2-mocha";
+   const BRIDGE_TAG: &str = "v0.29.1-mocha";
    ```
 
 3. **Build the new docker images**:

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -187,14 +187,15 @@ impl CelestiaConfig {
         let mut builder = celestia_client::Client::builder()
             .rpc_url(&self.rpc_url)
             .timeout(api_request_timeout);
+
         if let Some(rpc_auth_token) = &self.rpc_auth_token {
             builder = builder.rpc_auth_token(rpc_auth_token);
         }
         // Submission section.
         if let Some(grpc_url) = &self.grpc_url {
-            builder = builder.grpc_url(grpc_url);
+            let mut endpoint = celestia_client::Endpoint::new(grpc_url.clone());
             if let Some(grpc_auth_token) = &self.grpc_auth_token {
-                builder = builder.grpc_metadata("x-token", grpc_auth_token);
+                endpoint = endpoint.metadata("x-token", grpc_auth_token);
             }
             if let Some(signer_key_hex) = &self.signer_private_key {
                 builder = builder.private_key_hex(signer_key_hex);

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -197,6 +197,7 @@ impl CelestiaConfig {
             if let Some(grpc_auth_token) = &self.grpc_auth_token {
                 endpoint = endpoint.metadata("x-token", grpc_auth_token);
             }
+            builder = builder.grpc_endpoint(endpoint);
             if let Some(signer_key_hex) = &self.signer_private_key {
                 builder = builder.private_key_hex(signer_key_hex);
             }

--- a/crates/adapters/celestia/src/test_helper/docker.rs
+++ b/crates/adapters/celestia/src/test_helper/docker.rs
@@ -20,9 +20,9 @@ use tokio::time::sleep;
 use uuid::Uuid;
 
 const VALIDATOR_IMAGE: &str = "ghcr.io/sovereign-labs/celestia-validator-devnet";
-const VALIDATOR_TAG: &str = "v6.2.2-mocha";
+const VALIDATOR_TAG: &str = "v7.0.2-mocha";
 const BRIDGE_IMAGE: &str = "ghcr.io/sovereign-labs/celestia-bridge-devnet";
-const BRIDGE_TAG: &str = "v0.28.2-mocha";
+const BRIDGE_TAG: &str = "v0.29.1-mocha";
 const VALIDATOR_GRPC_PORT: u16 = 9090;
 const BRIDGE_RPC_PORT: u16 = 26658;
 

--- a/crates/adapters/celestia/src/types/mod.rs
+++ b/crates/adapters/celestia/src/types/mod.rs
@@ -18,7 +18,7 @@ use crate::shares::BlobIterator;
 use crate::verifier::address::CelestiaAddress;
 use crate::CelestiaHeader;
 
-pub(crate) const APP_VERSION: AppVersion = AppVersion::V6;
+pub(crate) const APP_VERSION: AppVersion = AppVersion::V7;
 pub(crate) const SUPPORTED_SHARE_VERSION: u8 = 1;
 
 #[derive(Debug, PartialEq, PartialOrd, Ord, Clone, Eq, Hash, Serialize, Deserialize)]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,9 +10,9 @@ HYPERLANE_CLI_TAG := sov-integration-3
 
 # Celestia Docker image constants
 CELESTIA_DEVNET_VALIDATOR_IMAGE := ghcr.io/sovereign-labs/celestia-validator-devnet
-CELESTIA_DEVNET_VALIDATOR_TAG := v6.4.4-mocha
+CELESTIA_DEVNET_VALIDATOR_TAG := v7.0.2-mocha
 CELESTIA_DEVNET_BRIDGE_IMAGE := ghcr.io/sovereign-labs/celestia-bridge-devnet
-CELESTIA_DEVNET_BRIDGE_TAG := v0.28.5-mocha
+CELESTIA_DEVNET_BRIDGE_TAG := v0.29.1-mocha
 
 docker_compose := docker compose -f $(DOCKER_COMPOSE_CFG)
 

--- a/docker/celestia/Dockerfile.bridge
+++ b/docker/celestia/Dockerfile.bridge
@@ -2,7 +2,7 @@
 # Based on:
 # https://github.com/celestiaorg/celestia-node/blob/main/Dockerfile
 
-ARG CELESTIA_NODE_TAG=v0.28.5-mocha
+ARG CELESTIA_NODE_TAG=v0.29.1-mocha
 
 FROM ghcr.io/celestiaorg/celestia-node:${CELESTIA_NODE_TAG} AS celestia-node
 

--- a/docker/celestia/Dockerfile.validator
+++ b/docker/celestia/Dockerfile.validator
@@ -2,7 +2,7 @@
 # Based on:
 # https://github.com/celestiaorg/celestia-app/blob/main/Dockerfile
 
-ARG CELESTIA_APP_TAG=v6.4.4-mocha
+ARG CELESTIA_APP_TAG=v7.0.2-mocha
 
 FROM ghcr.io/celestiaorg/celestia-app:${CELESTIA_APP_TAG} AS celestia-app
 

--- a/docker/docker-compose.celestia.yml
+++ b/docker/docker-compose.celestia.yml
@@ -1,6 +1,6 @@
 services:
   validator:
-    image: ghcr.io/sovereign-labs/celestia-validator-devnet:v6.4.4-mocha
+    image: ghcr.io/sovereign-labs/celestia-validator-devnet:v7.0.2-mocha
     hostname: validator
     environment:
       NO_COLOR: 1
@@ -15,7 +15,7 @@ services:
       - genesis:/genesis
 
   sequencer-0:
-    image: ghcr.io/sovereign-labs/celestia-bridge-devnet:v0.28.5-mocha
+    image: ghcr.io/sovereign-labs/celestia-bridge-devnet:v0.29.1-mocha
     hostname: sequencer-0
     depends_on:
       - validator

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -1074,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9033470dd895f900f97bd674f330ba7d87550fa6a92c92815dd30f31437367a"
+checksum = "65013505b04171f213d833b92bb076e9f229c36e5d144cb2faf25378397e2597"
 dependencies = [
  "bytes",
  "prost",
@@ -1090,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9cc150ce1c20da1a79a9ea3e79d2feed4189bd7243b23fc0752784add94bba"
+checksum = "0fe616393f4c88756ed6b8097167a623c6e4e48e2a3d75109e3ea5d5941587e0"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -2435,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "lumina-utils"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949c02e310a43325ec27c258769e93404b789c274b7c8e183a243e75c16be1bf"
+checksum = "2e68ba51207213b3fa8a42465526efdbe6c3c983a78a2a972d3a8e94d2bf9ab8"
 dependencies = [
  "js-sys",
 ]

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -1276,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9033470dd895f900f97bd674f330ba7d87550fa6a92c92815dd30f31437367a"
+checksum = "65013505b04171f213d833b92bb076e9f229c36e5d144cb2faf25378397e2597"
 dependencies = [
  "bytes",
  "prost",
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9cc150ce1c20da1a79a9ea3e79d2feed4189bd7243b23fc0752784add94bba"
+checksum = "0fe616393f4c88756ed6b8097167a623c6e4e48e2a3d75109e3ea5d5941587e0"
 dependencies = [
  "base64",
  "bech32",
@@ -3296,9 +3296,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lumina-utils"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949c02e310a43325ec27c258769e93404b789c274b7c8e183a243e75c16be1bf"
+checksum = "2e68ba51207213b3fa8a42465526efdbe6c3c983a78a2a972d3a8e94d2bf9ab8"
 dependencies = [
  "js-sys",
 ]


### PR DESCRIPTION
# Description

Updates celestia adapter to celestia V7 https://github.com/celestiaorg/celestia-app/releases/tag/v7.0.2-mocha

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)



## Testing
Celestia evaluator for at least 5 days is in progress

## Docs
No updates
