### PR TITLE
Hyperlane test flakey pt500

### DIFF
--- a/crates/module-system/hyperlane/tests/integration/with_agent/helpers/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/helpers/mod.rs
@@ -39,7 +39,6 @@ type Container = ContainerAsync<GenericImage>;
 
 pub const FINALIZED_BLOCKS_AT_START: usize = 3;
 pub const DEFAULT_FINALIZATION_BLOCKS: u32 = 3;
-pub const MOCK_DA_BLOCK_TIME_MS: u64 = 250;
 /// Use `container.get_host_port_ipv4(RELAYER_METRICS_PORT)` to get metrics
 pub const RELAYER_METRICS_PORT: u16 = 9091;
 pub const VALIDATOR_METRICS_PORT: u16 = 9097;
@@ -161,9 +160,7 @@ pub async fn setup_rollup(
     };
     let rollup_builder = TestRollupBuilder::new(
         GenesisSource::CustomParams(setup.genesis_config.clone().into_genesis_params()),
-        sov_mock_da::BlockProducingConfig::Periodic {
-            block_time_ms: MOCK_DA_BLOCK_TIME_MS,
-        },
+        sov_test_utils::TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING,
         DEFAULT_FINALIZATION_BLOCKS,
     )
     .set_config(|config| {

--- a/crates/module-system/hyperlane/tests/integration/with_agent/helpers/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/helpers/mod.rs
@@ -38,7 +38,8 @@ pub type PrivateKey = <<TestSpec as Spec>::CryptoSpec as CryptoSpec>::PrivateKey
 type Container = ContainerAsync<GenericImage>;
 
 pub const FINALIZED_BLOCKS_AT_START: usize = 3;
-pub const DEFAULT_FINALIZATION_BLOCKS: u32 = 10;
+pub const DEFAULT_FINALIZATION_BLOCKS: u32 = 3;
+pub const MOCK_DA_BLOCK_TIME_MS: u64 = 250;
 /// Use `container.get_host_port_ipv4(RELAYER_METRICS_PORT)` to get metrics
 pub const RELAYER_METRICS_PORT: u16 = 9091;
 pub const VALIDATOR_METRICS_PORT: u16 = 9097;
@@ -160,7 +161,9 @@ pub async fn setup_rollup(
     };
     let rollup_builder = TestRollupBuilder::new(
         GenesisSource::CustomParams(setup.genesis_config.clone().into_genesis_params()),
-        sov_test_utils::TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING,
+        sov_mock_da::BlockProducingConfig::Periodic {
+            block_time_ms: MOCK_DA_BLOCK_TIME_MS,
+        },
         DEFAULT_FINALIZATION_BLOCKS,
     )
     .set_config(|config| {

--- a/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
@@ -558,7 +558,12 @@ async fn test_warp_transfer_back_and_forth_with_evm_counterparty(
         // Periodically check relayer metrics for fast failure on critical errors
         if last_metrics_check.elapsed() >= std::time::Duration::from_millis(500) {
             last_metrics_check = std::time::Instant::now();
-            if hyperlane.metrics().has_critical_error().await.unwrap_or(false) {
+            if hyperlane
+                .metrics()
+                .has_critical_error()
+                .await
+                .unwrap_or(false)
+            {
                 rollup.shutdown().await.unwrap();
                 hyperlane.print_stdout().await;
                 panic!("Relayer reported a critical error during inbound transfer");

--- a/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
@@ -543,23 +543,28 @@ async fn test_warp_transfer_back_and_forth_with_evm_counterparty(
         .await;
     hyperlane.mine_next_block_on_counterparty().await;
 
-    // Wait for the relayer to process the inbound EVM→Sovereign message
-    tracing::info!("Waiting for relayer to process inbound warp transfer...");
-    if let Err(err) = wait_for_messages_processed(
-        hyperlane.metrics(),
-        "ethtest",
-        "sovtest",
-        1,
-        RelayerWaitConfig::default(),
-    )
-    .await
-    {
-        hyperlane.print_stdout().await;
-        panic!("Relayer metrics check failed for inbound transfer: {err}");
-    }
-
+    // Wait for the inbound EVM→Sovereign warp transfer to be relayed and finalized.
+    // Uses a time-based deadline that continuously consumes from the slot subscription,
+    // preventing buffer overflow from accumulating during a separate metrics wait.
+    tracing::info!("Waiting for inbound warp transfer to be relayed and finalized...");
+    let inbound_deadline = std::time::Instant::now() + std::time::Duration::from_secs(120);
     let mut transfer_received = false;
-    for _ in 0..DEFAULT_FINALIZATION_BLOCKS * 30 {
+    let mut last_metrics_check = std::time::Instant::now();
+    loop {
+        if std::time::Instant::now() > inbound_deadline {
+            break;
+        }
+
+        // Periodically check relayer metrics for fast failure on critical errors
+        if last_metrics_check.elapsed() >= std::time::Duration::from_millis(500) {
+            last_metrics_check = std::time::Instant::now();
+            if hyperlane.metrics().has_critical_error().await.unwrap_or(false) {
+                rollup.shutdown().await.unwrap();
+                hyperlane.print_stdout().await;
+                panic!("Relayer reported a critical error during inbound transfer");
+            }
+        }
+
         let events = next_slot_events(rollup.api_client(), &mut slot_subscription).await;
 
         if let Some(token_recv_event) = find_event(&events, "Warp/TokenTransferReceived") {

--- a/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
@@ -490,7 +490,7 @@ async fn test_warp_transfer_back_and_forth_with_evm_counterparty(
     let mut local_route_id = HexString([0; 32]);
     let mut remote_route_id = HexString([0; 32]);
     // look for `route registered` event
-    for _ in 0..DEFAULT_FINALIZATION_BLOCKS * 15 {
+    for _ in 0..DEFAULT_FINALIZATION_BLOCKS * 30 {
         let events = next_slot_events(rollup.api_client(), &mut slot_subscription).await;
 
         if let Some(route_registered_event) = find_event(&events, "Warp/RouteRegistered") {
@@ -559,7 +559,7 @@ async fn test_warp_transfer_back_and_forth_with_evm_counterparty(
     }
 
     let mut transfer_received = false;
-    for _ in 0..DEFAULT_FINALIZATION_BLOCKS * 15 {
+    for _ in 0..DEFAULT_FINALIZATION_BLOCKS * 30 {
         let events = next_slot_events(rollup.api_client(), &mut slot_subscription).await;
 
         if let Some(token_recv_event) = find_event(&events, "Warp/TokenTransferReceived") {
@@ -612,7 +612,7 @@ async fn test_warp_transfer_back_and_forth_with_evm_counterparty(
     let transfer_tx = encode_call(prover.user_info.private_key(), &transfer_call);
     submit_tx(rollup.api_client(), transfer_tx).await;
 
-    for _ in 0..DEFAULT_FINALIZATION_BLOCKS * 15 {
+    for _ in 0..DEFAULT_FINALIZATION_BLOCKS * 30 {
         let events = next_slot_events(rollup.api_client(), &mut slot_subscription).await;
 
         // look for event that sent outbound transfer


### PR DESCRIPTION
# Description

Added a time based polling, waiting for slots like we currently do seems to be the cause of the flakey-ness and this can be influenced by a few different things. Using purely timed based avoids the issues and I'm hoping should be more reliable. `DEFAULT_FINALIZATION_BLOCKS * 15` gives us a slot budget that the event must fall into, using time we avoid this constraint.

These changes also make each of the tests run 20 seconds faster on my local machine.

AI written summary:

```
  The inbound EVM→Sovereign transfer step in test_warp_transfer_back_and_forth consistently failed with Warp/TokenTransferReceived event not found when DEFAULT_FINALIZATION_BLOCKS was lowered to 3 and block time was reduced to 250ms.

  The root cause was a two-phase wait pattern:

  1. Phase 1 — wait_for_messages_processed() blocks for up to 60s polling relayer metrics, without consuming from the WebSocket slot subscription.
  2. Phase 2 — A for loop iterates up to DEFAULT_FINALIZATION_BLOCKS * 15 = 45 times, consuming one slot per iteration via next_slot_events().

  During Phase 1, slots continue to be produced (60s / 250ms = ~240 slots) and buffer in the WebSocket stream. When Phase 2 starts, it must drain all those buffered slots before reaching the slot that actually contains the event. With a budget of only 45 iterations, the loop exhausts before ever seeing the target slot.

  Fix

  Replace the two-phase pattern with a single time-based deadline loop (120s) that continuously consumes slots while also periodically checking relayer metrics for critical errors. This eliminates the unconsumed gap entirely — every slot is consumed as it arrives, so the event is found as soon as it appears regardless of how long the relayer
  takes to process the message.

  The other two loops in this test (Loop 1: Warp/RouteRegistered, Loop 3: Warp/TokenTransferredRemote) don't have this problem because they have no wait_for_messages_processed gap before them. Their iteration budgets were bumped from *15 to *30 as a minor safety margin increase.
```

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
