### PR TITLE
Fix sequencer tests strong isolation

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -31,11 +31,21 @@ priority = 85                                                        # Start lon
 threads-required = 4                                                 # Limit parallelism when these tests run
 slow-timeout = { period = "60s", terminate-after = 10 }              # These tests need up to 10 minutes under load
 
+# Performance benchmark: must run in complete isolation to avoid contention
+[[profile.default.overrides]]
+filter = 'package(sov-sequencer) & test(/flaky_test_sequencer_rocksdb_db_performance_can_run_10k_batches_in_2_minutes/)'
+test-group = 'isolated-perf-tests'
+priority = 95                                                        # Run early to avoid adding tail latency
+slow-timeout = { period = "60s", terminate-after = 10 }              # Needs up to 10 minutes under load
+
 # Conservative default for sequencer tests: allow parallelism while avoiding
 # over-contention on tokio multi-thread tests.
 [[profile.default.overrides]]
 filter = 'package(sov-sequencer)'
 threads-required = 4
+
+[test-groups.isolated-perf-tests]
+max-threads = 1
 
 [test-groups.heavy-sequencer-tests]
 max-threads = 2

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,13 +27,15 @@ threads-required = 3
 [[profile.default.overrides]]
 filter = 'package(sov-sequencer) & test(/seq_behind_deferred_slots_count|test_no_crashes_on_resync|sequencer_back_pressure|heavy_blob_submission/)'
 test-group = 'heavy-sequencer-tests'
+priority = 85                                                        # Start long-running tests early to reduce tail latency
 threads-required = 4                                                 # Limit parallelism when these tests run
 slow-timeout = { period = "60s", terminate-after = 10 }              # These tests need up to 10 minutes under load
 
-# This test has a race condition in archival state queries under load - needs full isolation
+# Conservative default for sequencer tests: allow parallelism while avoiding
+# over-contention on tokio multi-thread tests.
 [[profile.default.overrides]]
 filter = 'package(sov-sequencer)'
-threads-required = 'num-cpus'
+threads-required = 4
 
 [test-groups.heavy-sequencer-tests]
 max-threads = 2
@@ -45,4 +47,9 @@ threads-required = 3
 
 
 [profile.ci]
+default-filter = 'all()'
+
+[profile.local-fast]
+# Local developer profile tuned for fast iteration. Keep this additive:
+# CI should continue using profile.default/profile.ci.
 default-filter = 'all()'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -48,8 +48,3 @@ threads-required = 3
 
 [profile.ci]
 default-filter = 'all()'
-
-[profile.local-fast]
-# Local developer profile tuned for fast iteration. Keep this additive:
-# CI should continue using profile.default/profile.ci.
-default-filter = 'all()'


### PR DESCRIPTION
# Description

While fixing flaky archival test: https://github.com/Sovereign-Labs/sovereign-sdk/pull/2479 test isolation was set too strong by accident:

>  This comment says "this test" (singular) but the filter matches ALL ~154 sov-sequencer tests. On your 32-thread machine, threads-required = 'num-cpus' = 32, **meaning only 1 test runs at a time.**

now nextest time is back to 17-20 minutes from 27-32 minutes before

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
All tests are passing and faster

## Docs
No updates
