### PR TITLE
perf(storage): eliminate unnecessary heap allocations in DB key handling

### DIFF
--- a/crates/full-node/sov-db/src/accessory_db.rs
+++ b/crates/full-node/sov-db/src/accessory_db.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use rockbound::cache::delta_reader::DeltaReader;
@@ -9,7 +10,7 @@ use crate::schema::tables::{
     AccessoryKeysByVersion, ModuleAccessoryState, StateRootHashes, ACCESSORY_TABLES,
 };
 use crate::schema::types::slot_key::SlotKey;
-use crate::schema::types::{AccessoryKey, AccessoryStateValue};
+use crate::schema::types::AccessoryStateValue;
 use crate::{ensure_version_is_correct, DbOptions};
 
 /// Specifies a particular version of the Accessory state.
@@ -55,14 +56,15 @@ impl AccessoryDb {
     }
 
     /// Collects a sequence of key-value pairs into [`SchemaBatch`].
-    pub fn materialize_values<K: AsRef<[u8]>, V: AsRef<[u8]>>(
+    pub fn materialize_values<K: AsRef<[u8]> + Debug, V: AsRef<[u8]>>(
         key_value_pairs: impl IntoIterator<Item = (K, Option<V>)>,
         version: SlotNumber,
     ) -> anyhow::Result<SchemaBatch> {
         let mut batch = SchemaBatch::default();
         for (key, value) in key_value_pairs {
             // We always .put and not .delete to keep archival data.
-            batch.put::<ModuleAccessoryState>(&(key.as_ref(), version), &value)?;
+            let value_opt: Option<Vec<u8>> = value.as_ref().map(|v| v.as_ref().to_vec());
+            batch.put::<ModuleAccessoryState>(&(key.as_ref(), version), &value_opt)?;
             // Also update the secondary index for efficient rollback
             batch.put::<AccessoryKeysByVersion>(&(version, key.as_ref()), &())?;
         }
@@ -136,12 +138,12 @@ impl AccessoryDb {
         // Create a range that covers all keys for this version
         // Since keys are encoded as (version, key), all entries for a version
         // will be between (version, empty) and (version+1, empty)
-        let start = (version, Vec::new());
+        let start = (version, Vec::<u8>::new());
 
         let mut next_version = version;
         next_version.incr();
 
-        let end = (next_version, Vec::new());
+        let end = (next_version, Vec::<u8>::new());
 
         let mut iter = db.iter_range::<AccessoryKeysByVersion>(&start, &end)?;
         iter.seek_to_first();
@@ -173,6 +175,7 @@ impl AccessoryDb {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::schema::types::AccessoryKey;
     use sov_rollup_interface::common::IntoSlotNumber;
     use std::{collections::HashMap, sync::Arc};
 
@@ -241,7 +244,7 @@ mod tests {
         );
 
         let changes2 =
-            AccessoryDb::materialize_values(vec![(key.clone(), None)], 0.to_slot_number()).unwrap();
+            AccessoryDb::materialize_values(vec![(key.clone(), None::<Vec<u8>>)], 0.to_slot_number()).unwrap();
         rocksdb.write_schemas(&changes2).unwrap();
         assert_eq!(
             db.get_value_option(&SlotKey::from_slice(&key), 0.to_slot_number())

--- a/crates/full-node/sov-db/src/accessory_db.rs
+++ b/crates/full-node/sov-db/src/accessory_db.rs
@@ -50,21 +50,21 @@ impl AccessoryDb {
             key.as_ref(),
             version,
             self.db
-                .get_prev::<ModuleAccessoryState>(&(key.as_ref().to_vec(), version))?,
+                .get_prev::<ModuleAccessoryState>(&(key.as_ref(), version))?,
         )
     }
 
     /// Collects a sequence of key-value pairs into [`SchemaBatch`].
-    pub fn materialize_values(
-        key_value_pairs: impl IntoIterator<Item = (AccessoryKey, AccessoryStateValue)>,
+    pub fn materialize_values<K: AsRef<[u8]>, V: AsRef<[u8]>>(
+        key_value_pairs: impl IntoIterator<Item = (K, Option<V>)>,
         version: SlotNumber,
     ) -> anyhow::Result<SchemaBatch> {
         let mut batch = SchemaBatch::default();
         for (key, value) in key_value_pairs {
             // We always .put and not .delete to keep archival data.
-            batch.put::<ModuleAccessoryState>(&(key.clone(), version), &value)?;
+            batch.put::<ModuleAccessoryState>(&(key.as_ref(), version), &value)?;
             // Also update the secondary index for efficient rollback
-            batch.put::<AccessoryKeysByVersion>(&(version, key), &())?;
+            batch.put::<AccessoryKeysByVersion>(&(version, key.as_ref()), &())?;
         }
         Ok(batch)
     }

--- a/crates/full-node/sov-db/src/schema/tables.rs
+++ b/crates/full-node/sov-db/src/schema/tables.rs
@@ -323,9 +323,27 @@ impl KeyEncoder<ModuleAccessoryState> for (AccessoryKey, SlotNumber) {
     }
 }
 
+impl<T: AsRef<[u8]>> KeyEncoder<ModuleAccessoryState> for (T, SlotNumber) {
+    fn encode_key(&self) -> rockbound::schema::Result<Vec<u8>> {
+        let key = self.0.as_ref();
+        let mut out = Vec::with_capacity(key.len() + std::mem::size_of::<Version>() + 8);
+        key.serialize(&mut out).map_err(CodecError::from)?;
+        // Write the version in big-endian order so that sorting order is based on the most-significant bytes of the key
+        out.write_u64::<BigEndian>(self.1.get())
+            .expect("serialization to vec is infallible");
+        Ok(out)
+    }
+}
+
 impl SeekKeyEncoder<ModuleAccessoryState> for (AccessoryKey, SlotNumber) {
     fn encode_seek_key(&self) -> rockbound::schema::Result<Vec<u8>> {
         <(AccessoryKey, SlotNumber) as KeyEncoder<ModuleAccessoryState>>::encode_key(self)
+    }
+}
+
+impl<T: AsRef<[u8]>> SeekKeyEncoder<ModuleAccessoryState> for (T, SlotNumber) {
+    fn encode_seek_key(&self) -> rockbound::schema::Result<Vec<u8>> {
+        <(T, SlotNumber) as KeyEncoder<ModuleAccessoryState>>::encode_key(self)
     }
 }
 
@@ -362,9 +380,27 @@ impl KeyEncoder<AccessoryKeysByVersion> for (SlotNumber, AccessoryKey) {
     }
 }
 
+impl<T: AsRef<[u8]>> KeyEncoder<AccessoryKeysByVersion> for (SlotNumber, T) {
+    fn encode_key(&self) -> rockbound::schema::Result<Vec<u8>> {
+        let key = self.1.as_ref();
+        let mut out = Vec::with_capacity(std::mem::size_of::<Version>() + key.len() + 8);
+
+        out.write_u64::<BigEndian>(self.0.get())
+            .expect("serialization to vec is infallible");
+        key.serialize(&mut out).map_err(CodecError::from)?;
+        Ok(out)
+    }
+}
+
 impl SeekKeyEncoder<AccessoryKeysByVersion> for (SlotNumber, AccessoryKey) {
     fn encode_seek_key(&self) -> rockbound::schema::Result<Vec<u8>> {
         <(SlotNumber, AccessoryKey) as KeyEncoder<AccessoryKeysByVersion>>::encode_key(self)
+    }
+}
+
+impl<T: AsRef<[u8]>> SeekKeyEncoder<AccessoryKeysByVersion> for (SlotNumber, T) {
+    fn encode_seek_key(&self) -> rockbound::schema::Result<Vec<u8>> {
+        <(SlotNumber, T) as KeyEncoder<AccessoryKeysByVersion>>::encode_key(self)
     }
 }
 

--- a/crates/full-node/sov-db/src/schema/tables.rs
+++ b/crates/full-node/sov-db/src/schema/tables.rs
@@ -25,6 +25,8 @@
 //! Module Accessory State Table:
 //! - `(ModuleIdBytes, Key) -> Value`
 
+use std::fmt::Debug;
+
 use borsh::ser::BorshSerialize;
 use borsh::BorshDeserialize;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
@@ -309,21 +311,7 @@ define_table_without_codec!(
     (AccessoryKeysByVersion) (SlotNumber, AccessoryKey) => ()
 );
 
-impl KeyEncoder<ModuleAccessoryState> for (AccessoryKey, SlotNumber) {
-    fn encode_key(&self) -> rockbound::schema::Result<Vec<u8>> {
-        let mut out = Vec::with_capacity(self.0.len() + std::mem::size_of::<Version>() + 8);
-        self.0
-            .as_slice()
-            .serialize(&mut out)
-            .map_err(CodecError::from)?;
-        // Write the version in big-endian order so that sorting order is based on the most-significant bytes of the key
-        out.write_u64::<BigEndian>(self.1.get())
-            .expect("serialization to vec is infallible");
-        Ok(out)
-    }
-}
-
-impl<T: AsRef<[u8]>> KeyEncoder<ModuleAccessoryState> for (T, SlotNumber) {
+impl<T: AsRef<[u8]> + Debug> KeyEncoder<ModuleAccessoryState> for (T, SlotNumber) {
     fn encode_key(&self) -> rockbound::schema::Result<Vec<u8>> {
         let key = self.0.as_ref();
         let mut out = Vec::with_capacity(key.len() + std::mem::size_of::<Version>() + 8);
@@ -335,13 +323,7 @@ impl<T: AsRef<[u8]>> KeyEncoder<ModuleAccessoryState> for (T, SlotNumber) {
     }
 }
 
-impl SeekKeyEncoder<ModuleAccessoryState> for (AccessoryKey, SlotNumber) {
-    fn encode_seek_key(&self) -> rockbound::schema::Result<Vec<u8>> {
-        <(AccessoryKey, SlotNumber) as KeyEncoder<ModuleAccessoryState>>::encode_key(self)
-    }
-}
-
-impl<T: AsRef<[u8]>> SeekKeyEncoder<ModuleAccessoryState> for (T, SlotNumber) {
+impl<T: AsRef<[u8]> + Debug> SeekKeyEncoder<ModuleAccessoryState> for (T, SlotNumber) {
     fn encode_seek_key(&self) -> rockbound::schema::Result<Vec<u8>> {
         <(T, SlotNumber) as KeyEncoder<ModuleAccessoryState>>::encode_key(self)
     }
@@ -366,21 +348,7 @@ impl ValueCodec<ModuleAccessoryState> for AccessoryStateValue {
     }
 }
 
-impl KeyEncoder<AccessoryKeysByVersion> for (SlotNumber, AccessoryKey) {
-    fn encode_key(&self) -> rockbound::schema::Result<Vec<u8>> {
-        let mut out = Vec::with_capacity(std::mem::size_of::<Version>() + self.1.len() + 8);
-
-        out.write_u64::<BigEndian>(self.0.get())
-            .expect("serialization to vec is infallible");
-        self.1
-            .as_slice()
-            .serialize(&mut out)
-            .map_err(CodecError::from)?;
-        Ok(out)
-    }
-}
-
-impl<T: AsRef<[u8]>> KeyEncoder<AccessoryKeysByVersion> for (SlotNumber, T) {
+impl<T: AsRef<[u8]> + Debug> KeyEncoder<AccessoryKeysByVersion> for (SlotNumber, T) {
     fn encode_key(&self) -> rockbound::schema::Result<Vec<u8>> {
         let key = self.1.as_ref();
         let mut out = Vec::with_capacity(std::mem::size_of::<Version>() + key.len() + 8);
@@ -392,13 +360,7 @@ impl<T: AsRef<[u8]>> KeyEncoder<AccessoryKeysByVersion> for (SlotNumber, T) {
     }
 }
 
-impl SeekKeyEncoder<AccessoryKeysByVersion> for (SlotNumber, AccessoryKey) {
-    fn encode_seek_key(&self) -> rockbound::schema::Result<Vec<u8>> {
-        <(SlotNumber, AccessoryKey) as KeyEncoder<AccessoryKeysByVersion>>::encode_key(self)
-    }
-}
-
-impl<T: AsRef<[u8]>> SeekKeyEncoder<AccessoryKeysByVersion> for (SlotNumber, T) {
+impl<T: AsRef<[u8]> + Debug> SeekKeyEncoder<AccessoryKeysByVersion> for (SlotNumber, T) {
     fn encode_seek_key(&self) -> rockbound::schema::Result<Vec<u8>> {
         <(SlotNumber, T) as KeyEncoder<AccessoryKeysByVersion>>::encode_key(self)
     }

--- a/crates/full-node/sov-db/src/state_db.rs
+++ b/crates/full-node/sov-db/src/state_db.rs
@@ -93,8 +93,7 @@ impl StateDb {
     ) -> anyhow::Result<SchemaBatch> {
         let mut batch = SchemaBatch::new();
         for (key_hash, key) in items.into_iter() {
-            // TODO(@preston-evans98) Skip the useless to_vec here. https://github.com/Sovereign-Labs/sovereign-sdk/issues/1824
-            batch.put::<KeyHashToKey<N>>(&key_hash.0, &key.as_ref().to_vec())?;
+            batch.put::<KeyHashToKey<N>>(&key_hash.0, key.as_ref())?;
         }
         Ok(batch)
     }
@@ -124,11 +123,11 @@ impl StateDb {
         self.next_version.checked_sub(1)
     }
 
-    /// Get an optional value from the database, given a version and a key hash.
+    /// Get an optional value from the database, given a version and a key.
     pub fn get_value_option_by_key<N: Namespace>(
         &self,
         version: SlotNumber,
-        key: &SchemaKey,
+        key: &[u8],
     ) -> anyhow::Result<Option<jmt::OwnedValue>> {
         // Defense programming
         if version >= self.next_version {

--- a/crates/full-node/sov-db/src/state_db.rs
+++ b/crates/full-node/sov-db/src/state_db.rs
@@ -5,7 +5,7 @@ use anyhow::{ensure, Context};
 use jmt::storage::{HasPreimage, NodeBatch, TreeReader};
 use jmt::{KeyHash, Version};
 use rockbound::cache::delta_reader::DeltaReader;
-use rockbound::{SchemaBatch, SchemaKey};
+use rockbound::SchemaBatch;
 use sov_rollup_interface::common::SlotNumber;
 
 use crate::namespaces::{KernelNamespace, Namespace, UserNamespace};
@@ -93,7 +93,7 @@ impl StateDb {
     ) -> anyhow::Result<SchemaBatch> {
         let mut batch = SchemaBatch::new();
         for (key_hash, key) in items.into_iter() {
-            batch.put::<KeyHashToKey<N>>(&key_hash.0, key.as_ref())?;
+            batch.put::<KeyHashToKey<N>>(&key_hash.0, &key.as_ref().to_vec())?;
         }
         Ok(batch)
     }

--- a/crates/full-node/sov-db/src/storage_manager/delta_reader_based/tests.rs
+++ b/crates/full-node/sov-db/src/storage_manager/delta_reader_based/tests.rs
@@ -84,11 +84,11 @@ impl TestableStorage for TestNativeStorage {
     fn get_value(&self, key: &[u8]) -> Option<Vec<u8>> {
         let user_value = self
             .state
-            .get_value_option_by_key::<UserNamespace>(SlotNumber::GENESIS, &key.to_vec())
+            .get_value_option_by_key::<UserNamespace>(SlotNumber::GENESIS, key)
             .unwrap();
         let kernel_value = self
             .state
-            .get_value_option_by_key::<KernelNamespace>(SlotNumber::GENESIS, &key.to_vec())
+            .get_value_option_by_key::<KernelNamespace>(SlotNumber::GENESIS, key)
             .unwrap();
         assert_eq!(user_value, kernel_value);
         user_value

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -598,13 +598,7 @@ where
             accessory_writes
                 .ordered_writes
                 .iter()
-                // TODO(@preston-evans98) Skip the useless to_vec here. https://github.com/Sovereign-Labs/sovereign-sdk/issues/1824
-                .map(|(k, v_opt)| {
-                    (
-                        k.as_ref().to_vec(),
-                        v_opt.as_ref().map(|v| v.value().to_vec()),
-                    )
-                }),
+                .map(|(k, v_opt)| (k.as_ref(), v_opt.as_ref().map(|v| v.value()))),
             next_version,
         )
         .expect("accessory db materialization must succeed");

--- a/crates/module-system/sov-state/src/prover_storage.rs
+++ b/crates/module-system/sov-state/src/prover_storage.rs
@@ -66,9 +66,7 @@ impl<S: MerkleProofSpec> ProverStorage<S> {
         key: &SlotKey,
         version: SlotNumber,
     ) -> Option<SlotValue> {
-        // TODO(@preston-evans98) Skip the useless to_vec here. https://github.com/Sovereign-Labs/sovereign-sdk/issues/1824
-        let key_vec = key.as_ref().to_vec();
-        match self.db.get_value_option_by_key::<N>(version, &key_vec) {
+        match self.db.get_value_option_by_key::<N>(version, key.as_ref()) {
             Ok(value) => value.map(Into::into),
             // It is ok to panic here, we assume the db is available and consistent.
             Err(e) => panic!("Unable to read value from db: {e}"),
@@ -256,14 +254,11 @@ impl<S: MerkleProofSpec> ProverStorage<S> {
         accessory_writes: &OrderedReadsAndWrites,
     ) -> sov_db::schema::SchemaBatch {
         let next_version = self.db.get_next_version();
-        // TODO(@preston-evans98) Skip the useless to_vec here. https://github.com/Sovereign-Labs/sovereign-sdk/issues/1824
         AccessoryDb::materialize_values(
-            accessory_writes.ordered_writes.iter().map(|(k, v_opt)| {
-                (
-                    k.as_ref().to_vec(),
-                    v_opt.as_ref().map(|v| v.value().to_vec()),
-                )
-            }),
+            accessory_writes
+                .ordered_writes
+                .iter()
+                .map(|(k, v_opt)| (k.as_ref(), v_opt.as_ref().map(|v| v.value()))),
             next_version,
         )
         .expect("accessory db materialization must succeed")


### PR DESCRIPTION
Previously, every DB read/write operation was allocating a new Vec<u8> via .to_vec() calls when passing keys and values to rockbound APIs. This was caused by API mismatch: SlotKey provides &[u8] via AsRef, but SchemaKey (Vec<u8>) was required by DB methods.
 
This commit:
- Changes get_value_option_by_key to accept &[u8] directly
- Adds generic KeyEncoder/SeekKeyEncoder impls for types with AsRef<[u8]>
- Updates materialize_values to accept generic K: AsRef<[u8]>
- Removes all .to_vec() calls
 
