### PR TITLE
Fix flake in `test_stale_nodes_are_filtered_from_cluster_info `

### DIFF
--- a/examples/demo-rollup/tests/replica/db_elected.rs
+++ b/examples/demo-rollup/tests/replica/db_elected.rs
@@ -11,11 +11,11 @@ async fn test_db_elected_two_nodes_leader_and_replica() {
     let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
 
     let node_1 = setup
-        .start_node("replica_then_leader", ConfiguredNodeRole::DbElected)
+        .start_node("node_1", ConfiguredNodeRole::DbElected)
         .await;
 
     let node_2 = setup
-        .start_node("replica", ConfiguredNodeRole::DbElected)
+        .start_node("node_2", ConfiguredNodeRole::DbElected)
         .await;
 
     node_1.wait_for_sequencer_ready().await.unwrap();
@@ -60,11 +60,11 @@ async fn test_db_elected_leader_failover() {
     };
 
     let node_1 = setup
-        .start_node("replica_then_leader", ConfiguredNodeRole::DbElected)
+        .start_node("node_1", ConfiguredNodeRole::DbElected)
         .await;
 
     let node_2 = setup
-        .start_node("replica", ConfiguredNodeRole::DbElected)
+        .start_node("node_2", ConfiguredNodeRole::DbElected)
         .await;
 
     node_1.wait_for_sequencer_ready().await.unwrap();

--- a/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
+++ b/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
@@ -71,7 +71,7 @@ async fn test_stale_nodes_are_filtered_from_cluster_info() {
     // Start a leader node that will keep sending heartbeats.
     let leader = setup.start_node("leader", ConfiguredNodeRole::Leader).await;
     leader.wait_for_sequencer_ready().await.unwrap();
-    // Wait for leader to appear in cluster info.
+    // Wait for the leader to appear in cluster info.
     let _ = setup.wait_for_cluster_change().await;
 
     // Start a replica node.
@@ -81,7 +81,7 @@ async fn test_stale_nodes_are_filtered_from_cluster_info() {
 
     replica.wait_for_sequencer_ready().await.unwrap();
 
-    // Wait for replica to appear in cluster info.
+    // Wait for the replica to appear in cluster info.
     let cluster_info = setup.wait_for_cluster_change().await;
     assert!(
         cluster_info.has_leader("leader"),

--- a/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
+++ b/examples/demo-rollup/tests/replica/replica_registers_in_db.rs
@@ -16,6 +16,9 @@ async fn test_multiple_replicas_register_in_nodes_table() {
         .start_node("replica_then_leader", ConfiguredNodeRole::Replica)
         .await;
 
+    // Wait for the first replica to appear in cluster info.
+    let _ = setup.wait_for_cluster_change().await;
+
     let replica_rollup = setup
         .start_node("replica", ConfiguredNodeRole::Replica)
         .await;
@@ -68,6 +71,8 @@ async fn test_stale_nodes_are_filtered_from_cluster_info() {
     // Start a leader node that will keep sending heartbeats.
     let leader = setup.start_node("leader", ConfiguredNodeRole::Leader).await;
     leader.wait_for_sequencer_ready().await.unwrap();
+    // Wait for leader to appear in cluster info.
+    let _ = setup.wait_for_cluster_change().await;
 
     // Start a replica node.
     let replica = setup
@@ -76,7 +81,7 @@ async fn test_stale_nodes_are_filtered_from_cluster_info() {
 
     replica.wait_for_sequencer_ready().await.unwrap();
 
-    // Wait for both nodes to appear in cluster info.
+    // Wait for replica to appear in cluster info.
     let cluster_info = setup.wait_for_cluster_change().await;
     assert!(
         cluster_info.has_leader("leader"),


### PR DESCRIPTION
# Description


This PR introduces two fixes:
1. Fixes `node_ids` in `test_db_elected_two_nodes_leader_and_replica`. This does not affect the test behavior; the node IDs were previously copy-pasted from another test.

2. Fixes a flake in `test_stale_nodes_are_filtered_from_cluster_info`. The test now waits at the beginning for both nodes to be registered in the database before proceeding. 

See test failure here.: https://github.com/Sovereign-Labs/sovereign-sdk/actions/runs/21906136525/job/63246793798?pr=2471


- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
