### PR TITLE
Add `chain_data` getter to `Schema`

### DIFF
--- a/crates/universal-wallet/schema/src/schema/mod.rs
+++ b/crates/universal-wallet/schema/src/schema/mod.rs
@@ -306,6 +306,11 @@ impl Schema {
         Ok(schema)
     }
 
+    /// Get the chain data for the schema.
+    pub fn chain_data(&self) -> &ChainData {
+        &self.chain_data
+    }
+
     #[cfg(not(feature = "serde"))]
     pub fn metadata_hash(&self) -> Result<[u8; 32], SchemaError> {
         // In borsh-only context, the hash must have been deserialized


### PR DESCRIPTION
# Description

Adds a `chain_data` getter to `Schema`, as requested by Zeta.
