### PR TITLE
[ZKP] Panic if witness generation is enabled and pin cache is in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-02-26
+- #2540 Adds a witness generation flag. If witness generation is enabled at the same time as cache pinning a panic with occur at runtime.
+
 # 2026-02-23
 - #2520 reverts #2489
 

--- a/crates/full-node/sov-db/src/storage_manager/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/mod.rs
@@ -8,7 +8,7 @@ pub use delta_reader_based::*;
 pub(crate) use nomt_based::DEFAULT_MAX_PRUNING_BATCH_SIZE;
 pub use nomt_based::{
     FlatStateDb, InitializableNativeNomtStorage, NomtChangeSet, NomtStorageManager,
-    PrunerJobOutput, StateFinishedSession,
+    PrunerJobOutput, StateFinishedSession, WitnessMode,
 };
 use rockbound::cache::delta_reader::DeltaReader;
 

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -202,6 +202,7 @@ where
         rockbound_snapshots: &HashMap<K, SnapshotGroup>,
         nomt_snapshots: Arc<RwLock<HashMap<K, StateOverlay>>>,
         pinned_cache: Option<Box<dyn Any + Send + Sync>>,
+        strict_mode: bool,
         with_witness: bool,
     ) -> anyhow::Result<(S, DeltaReader)> {
         let mut historical_state_snapshots = Vec::with_capacity(relevant_snapshot_refs.len());
@@ -263,6 +264,7 @@ where
             state_session_builder,
             historical_state_mapper,
             accessory_db,
+            strict_mode,
             with_witness,
             pinned_cache,
         );

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/groups.rs
@@ -1,5 +1,4 @@
 use crate::flat_db::DbCache;
-use std::any::Any;
 use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::{Arc, RwLock};
@@ -23,7 +22,9 @@ use crate::pruner::Pruner;
 use crate::schema::namespace::NomtStateValues;
 use crate::schema::tables::ModuleAccessoryState;
 use crate::state_db_nomt::{NomtSessionBuilder, NomtStateDb, StateOverlay, StateRootHashes};
-use crate::storage_manager::{update_ledger_finalized_height, InitializableNativeNomtStorage};
+use crate::storage_manager::{
+    update_ledger_finalized_height, InitializableNativeNomtStorage, WitnessMode,
+};
 
 const GIGABYTE: usize = 1024 * 1024 * 1024;
 
@@ -201,9 +202,8 @@ where
         relevant_snapshot_refs: Vec<K>,
         rockbound_snapshots: &HashMap<K, SnapshotGroup>,
         nomt_snapshots: Arc<RwLock<HashMap<K, StateOverlay>>>,
-        pinned_cache: Option<Box<dyn Any + Send + Sync>>,
         strict_mode: bool,
-        with_witness: bool,
+        witness_mode: WitnessMode,
     ) -> anyhow::Result<(S, DeltaReader)> {
         let mut historical_state_snapshots = Vec::with_capacity(relevant_snapshot_refs.len());
         let mut user_state_snapshots = Vec::with_capacity(relevant_snapshot_refs.len());
@@ -265,8 +265,7 @@ where
             historical_state_mapper,
             accessory_db,
             strict_mode,
-            with_witness,
-            pinned_cache,
+            witness_mode,
         );
         Ok((storage, ledger_reader))
     }

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -46,7 +46,7 @@ impl<Cache> WitnessMode<Cache> {
     }
 
     /// Returns `true` if witness generation is enabled.
-    pub fn with_witness(&self) -> bool {
+    pub fn is_witness_enabled(&self) -> bool {
         matches!(self, Self::On)
     }
 

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -121,7 +121,7 @@ pub struct NomtStorageManager<Da: DaSpec, H, S: InitializableNativeNomtStorage<H
     pruner_max_batch_size: usize,
 
     /// When true, `create_state_for` will generate witness hints for ZK proving.
-    /// This disables pinned cache since it bypasses witness recording. See #2514.
+    /// This disables pinned cache since it bypasses witness recording.
     witness_generation_enabled: bool,
 
     _phantom_s: PhantomData<S>,
@@ -137,7 +137,7 @@ where
     ///
     /// `witness_generation` controls whether `create_state_for` will generate witness hints
     /// for ZK proving. When enabled, pinned cache is disabled since it bypasses witness
-    /// recording. See #2514.
+    /// recording.
     pub fn new(config: RollupDbConfig, witness_generation: bool) -> anyhow::Result<Self> {
         let pruner_block_interval = config.get_pruner_interval();
         let pruner_versions_to_keep = config.get_pruner_versions_to_keep();
@@ -265,7 +265,8 @@ where
         // and we expect a change set from this storage to be saved.
         // That's why it is created in strict mode.
         // If witness generation is enabled, NomtProverStorage::create will panic
-        // if a pinned cache is present — this is intentional, see #2514.
+        // if a pinned cache is present — this is intentional because pinned cache is not
+        // compatible with witness generation. 
         let pinned_cache = self.pinned_caches.remove(&block_header.prev_hash());
         let state = self.create_state_up_to(
             block_header.prev_hash(),

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -45,6 +45,20 @@ impl<Cache> WitnessMode<Cache> {
         Self::Off { pinned_cache: None }
     }
 
+    /// Returns `true` if witness generation is enabled.
+    pub fn with_witness(&self) -> bool {
+        matches!(self, Self::On)
+    }
+
+    /// Takes the pinned cache out of the `Off` variant, leaving `None` in its place.
+    /// Returns `None` if witness mode is `On` or no cache is present.
+    pub fn take_pinned_cache(&mut self) -> Option<Cache> {
+        match self {
+            Self::Off { pinned_cache } => pinned_cache.take(),
+            Self::On => None,
+        }
+    }
+
     /// Constructs a [`WitnessMode`] from separate `with_witness` and `pinned_cache` values.
     ///
     /// # Panics

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -25,6 +25,46 @@ use crate::storage_manager::nomt_based::groups::{CommitGroup, DbGroup, PrunerJob
 pub use groups::PrunerJobOutput;
 pub(crate) use groups::DEFAULT_MAX_PRUNING_BATCH_SIZE;
 
+/// Controls witness generation and pinned cache for storage creation.
+///
+/// Witness generation and pinned cache are mutually exclusive: pinned cache
+/// serves reads from RAM, bypassing witness hint recording.
+pub enum WitnessMode<Cache = Box<dyn Any + Send + Sync>> {
+    /// Record witness hints for ZK proving. Pinned cache is not used.
+    On,
+    /// No witness generation. May include a pinned cache for faster reads.
+    Off {
+        #[allow(missing_docs)]
+        pinned_cache: Option<Cache>,
+    },
+}
+
+impl<Cache> WitnessMode<Cache> {
+    /// Creates a [`WitnessMode::Off`] variant with no pinned cache.
+    pub fn off() -> Self {
+        Self::Off { pinned_cache: None }
+    }
+
+    /// Constructs a [`WitnessMode`] from separate `with_witness` and `pinned_cache` values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `with_witness` is true and `pinned_cache` is `Some`, since pinned cache
+    /// serves reads from RAM, bypassing witness hint recording.
+    pub fn new_with_assert(with_witness: bool, pinned_cache: Option<Cache>) -> Self {
+        if with_witness {
+            assert!(
+                pinned_cache.is_none(),
+                "Pinned cache is incompatible with witness generation: pinned cache serves reads \
+                 from RAM, bypassing witness hint recording."
+            );
+            Self::On
+        } else {
+            Self::Off { pinned_cache }
+        }
+    }
+}
+
 #[allow(missing_docs)]
 pub struct StateFinishedSession {
     user: nomt::FinishedSession,
@@ -94,8 +134,7 @@ where
         historical_state: HistoricalStateReader,
         accessory_db: AccessoryDb,
         strict_mode: bool,
-        with_witness: bool,
-        pinned_cache: Option<Box<dyn Any + Send + Sync>>,
+        witness_mode: WitnessMode,
     ) -> Self;
 }
 
@@ -171,8 +210,7 @@ where
         &self,
         block_hash: Da::SlotHash,
         strict_mode: bool,
-        with_witness: bool,
-        pinned_cache: Option<Box<dyn Any + Send + Sync>>,
+        witness_mode: WitnessMode,
     ) -> anyhow::Result<(S, DeltaReader)> {
         tracing::trace!(%block_hash, "Creating storage up to block hash");
         // References are in reversed chronological order,
@@ -202,9 +240,8 @@ where
             rev_references,
             &self.rockbound_snapshots,
             self.nomt_snapshots.clone(),
-            pinned_cache,
             strict_mode,
-            with_witness,
+            witness_mode,
         )
     }
 
@@ -264,16 +301,10 @@ where
         // Storage created "for" a block implies node context,
         // and we expect a change set from this storage to be saved.
         // That's why it is created in strict mode.
-        // If witness generation is enabled, NomtProverStorage::create will panic
-        // if a pinned cache is present — this is intentional because pinned cache is not
-        // compatible with witness generation.
         let pinned_cache = self.pinned_caches.remove(&block_header.prev_hash());
-        let state = self.create_state_up_to(
-            block_header.prev_hash(),
-            true,
-            self.witness_generation_enabled,
-            pinned_cache,
-        )?;
+        let witness_mode =
+            WitnessMode::new_with_assert(self.witness_generation_enabled, pinned_cache);
+        let state = self.create_state_up_to(block_header.prev_hash(), true, witness_mode)?;
 
         Ok(state)
     }
@@ -290,12 +321,11 @@ where
                 Vec::new(),
                 &self.rockbound_snapshots,
                 self.nomt_snapshots.clone(),
-                None,
                 false,
-                false,
+                WitnessMode::off(),
             )
         } else {
-            self.create_state_up_to(block_header.hash(), false, false, None)
+            self.create_state_up_to(block_header.hash(), false, WitnessMode::off())
         }
     }
 

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -93,7 +93,8 @@ where
         state_db: NomtSessionBuilder<H, K>,
         historical_state: HistoricalStateReader,
         accessory_db: AccessoryDb,
-        strict_with_witness: bool,
+        strict_mode: bool,
+        with_witness: bool,
         pinned_cache: Option<Box<dyn Any + Send + Sync>>,
     ) -> Self;
 }
@@ -118,6 +119,10 @@ pub struct NomtStorageManager<Da: DaSpec, H, S: InitializableNativeNomtStorage<H
     pruner_block_interval: Option<u64>,
     pruner_versions_to_keep: usize,
     pruner_max_batch_size: usize,
+
+    /// When true, `create_state_for` will generate witness hints for ZK proving.
+    /// This disables pinned cache since it bypasses witness recording. See #2514.
+    witness_generation_enabled: bool,
 
     _phantom_s: PhantomData<S>,
 }
@@ -152,6 +157,7 @@ where
             pruner_block_interval,
             pruner_versions_to_keep,
             pruner_max_batch_size,
+            witness_generation_enabled: false,
             _phantom_s: Default::default(),
         })
     }
@@ -160,6 +166,7 @@ where
     fn create_state_up_to(
         &self,
         block_hash: Da::SlotHash,
+        strict_mode: bool,
         with_witness: bool,
         pinned_cache: Option<Box<dyn Any + Send + Sync>>,
     ) -> anyhow::Result<(S, DeltaReader)> {
@@ -192,6 +199,7 @@ where
             &self.rockbound_snapshots,
             self.nomt_snapshots.clone(),
             pinned_cache,
+            strict_mode,
             with_witness,
         )
     }
@@ -232,6 +240,10 @@ where
     type LedgerState = DeltaReader;
     type LedgerChangeSet = SchemaBatch;
 
+    fn set_witness_generation(&mut self, enabled: bool) {
+        self.witness_generation_enabled = enabled;
+    }
+
     fn create_state_for(
         &mut self,
         block_header: &Da::BlockHeader,
@@ -251,9 +263,16 @@ where
 
         // Storage created "for" a block implies node context,
         // and we expect a change set from this storage to be saved.
-        // That's why it is created in a strict mode.
+        // That's why it is created in strict mode.
+        // If witness generation is enabled, NomtProverStorage::create will panic
+        // if a pinned cache is present — this is intentional, see #2514.
         let pinned_cache = self.pinned_caches.remove(&block_header.prev_hash());
-        let state = self.create_state_up_to(block_header.prev_hash(), true, pinned_cache)?;
+        let state = self.create_state_up_to(
+            block_header.prev_hash(),
+            true,
+            self.witness_generation_enabled,
+            pinned_cache,
+        )?;
 
         Ok(state)
     }
@@ -263,8 +282,7 @@ where
         block_header: &Da::BlockHeader,
     ) -> anyhow::Result<(Self::StfState, Self::LedgerState)> {
         // Storage created "after" a block is usually used outside of the node context,
-        // So witness is not needed.
-        let with_witness = false;
+        // So neither strict mode nor witness is needed.
         if !self.rockbound_snapshots.contains_key(&block_header.hash()) {
             tracing::debug!(block_header = %block_header.display(), "Creating new storage from finalized data as block header is not in the saved chain");
             self.db_group.create_storage(
@@ -272,10 +290,11 @@ where
                 &self.rockbound_snapshots,
                 self.nomt_snapshots.clone(),
                 None,
-                with_witness,
+                false,
+                false,
             )
         } else {
-            self.create_state_up_to(block_header.hash(), with_witness, None)
+            self.create_state_up_to(block_header.hash(), false, false, None)
         }
     }
 

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -266,7 +266,7 @@ where
         // That's why it is created in strict mode.
         // If witness generation is enabled, NomtProverStorage::create will panic
         // if a pinned cache is present — this is intentional because pinned cache is not
-        // compatible with witness generation. 
+        // compatible with witness generation.
         let pinned_cache = self.pinned_caches.remove(&block_header.prev_hash());
         let state = self.create_state_up_to(
             block_header.prev_hash(),

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/mod.rs
@@ -134,7 +134,11 @@ where
     S: InitializableNativeNomtStorage<H, Da::SlotHash>,
 {
     /// Create a new [` NomtStorageManager`].
-    pub fn new(config: RollupDbConfig) -> anyhow::Result<Self> {
+    ///
+    /// `witness_generation` controls whether `create_state_for` will generate witness hints
+    /// for ZK proving. When enabled, pinned cache is disabled since it bypasses witness
+    /// recording. See #2514.
+    pub fn new(config: RollupDbConfig, witness_generation: bool) -> anyhow::Result<Self> {
         let pruner_block_interval = config.get_pruner_interval();
         let pruner_versions_to_keep = config.get_pruner_versions_to_keep();
         let pruner_max_batch_size = config.get_pruner_max_batch_size();
@@ -157,7 +161,7 @@ where
             pruner_block_interval,
             pruner_versions_to_keep,
             pruner_max_batch_size,
-            witness_generation_enabled: false,
+            witness_generation_enabled: witness_generation,
             _phantom_s: Default::default(),
         })
     }
@@ -239,10 +243,6 @@ where
     type StfChangeSet = NomtChangeSet;
     type LedgerState = DeltaReader;
     type LedgerChangeSet = SchemaBatch;
-
-    fn set_witness_generation(&mut self, enabled: bool) {
-        self.witness_generation_enabled = enabled;
-    }
 
     fn create_state_for(
         &mut self,

--- a/crates/full-node/sov-db/src/storage_manager/nomt_based/tests.rs
+++ b/crates/full-node/sov-db/src/storage_manager/nomt_based/tests.rs
@@ -177,7 +177,7 @@ type Sm = NomtStorageManager<MockDaSpec, H, TestNomtStorage>;
 impl TestableStorageManager for Sm {
     fn new(path: impl AsRef<Path>) -> Self {
         let config = RollupDbConfig::default_in_path(path.as_ref().to_path_buf());
-        Sm::new(config).unwrap()
+        Sm::new(config, false).unwrap()
     }
 
     fn verify_stf_storage(stf_storage: &Self::StfState, expected_values: &[(u64, MockHash)]) {
@@ -302,7 +302,7 @@ async fn test_historical_state_with_pruning() {
     config.pruner_block_interval = Some(pruning_frequency);
     config.pruner_versions_to_keep = Some(versions_to_keep);
     let mut storage_manager =
-        NomtStorageManager::<MockDaSpec, H, TestNomtStorage>::new(config.clone()).unwrap();
+        NomtStorageManager::<MockDaSpec, H, TestNomtStorage>::new(config.clone(), false).unwrap();
 
     let blocks: u64 = 14;
 

--- a/crates/full-node/sov-db/src/test_utils.rs
+++ b/crates/full-node/sov-db/src/test_utils.rs
@@ -76,6 +76,7 @@ impl crate::storage_manager::InitializableNativeNomtStorage<H, SlotHash> for Tes
         state_session_builder: crate::state_db_nomt::NomtSessionBuilder<H, SlotHash>,
         historical_state: crate::historical_state::HistoricalStateReader,
         accessory_db: AccessoryDb,
+        _strict_mode: bool,
         _with_witness: bool,
         _pinned_cache: Option<Box<dyn Any + Send + Sync>>,
     ) -> Self {

--- a/crates/full-node/sov-db/src/test_utils.rs
+++ b/crates/full-node/sov-db/src/test_utils.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use std::any::Any;
 use std::cmp::max;
 use std::collections::HashSet;
 
@@ -77,8 +75,7 @@ impl crate::storage_manager::InitializableNativeNomtStorage<H, SlotHash> for Tes
         historical_state: crate::historical_state::HistoricalStateReader,
         accessory_db: AccessoryDb,
         _strict_mode: bool,
-        _with_witness: bool,
-        _pinned_cache: Option<Box<dyn Any + Send + Sync>>,
+        _witness_mode: crate::storage_manager::WitnessMode,
     ) -> Self {
         TestNomtStorage {
             state_session_builder,

--- a/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
@@ -628,6 +628,7 @@ mod tests {
         let path = tempfile::tempdir().unwrap();
         let storage_manager = NomtStorageManager::<MockDaSpec, TestHasher, _>::new(
             RollupDbConfig::default_in_path(path.path().to_path_buf()),
+            false,
         )
         .unwrap();
         known_rollup_height_state_root_on_stale_storage_with_deep_jumps::<

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/mod.rs
@@ -31,6 +31,16 @@ pub enum RollupProverConfig<Vm: Zkvm> {
     Prove(Arc<<Vm::Host as ZkvmHost>::HostArgs>),
 }
 
+impl<Vm: Zkvm> RollupProverConfig<Vm> {
+    /// Returns `true` if witness generation is needed for this prover configuration.
+    ///
+    /// Only [`Execute`](Self::Execute) and [`Prove`](Self::Prove) require witness data;
+    /// [`Skip`](Self::Skip) does not run the verifier, so recording witness hints is wasted work.
+    pub fn needs_witness(&self) -> bool {
+        !matches!(self, Self::Skip)
+    }
+}
+
 /// The associated discriminants of [`RollupProverConfig`]. Possible configurations of the prover
 // Note: it's best if all string conversions to and from this type (even
 // `Debug`) use the same casing, to avoid bad UX or confusion around env. vars

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -201,7 +201,8 @@ pub async fn initialize_runner(
     });
 
     let db_config = RollupDbConfig::default_in_path(path.to_path_buf());
-    let mut storage_manager: TestStorageManager = NomtStorageManager::new(db_config).unwrap();
+    let mut storage_manager: TestStorageManager =
+        NomtStorageManager::new(db_config, false).unwrap();
 
     let finalized_header = da_service.get_last_finalized_block_header().await.unwrap();
     let (_, ledger_state) = storage_manager

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -65,9 +65,10 @@ async fn test_runner_with_background_da_service(
 
     let stf = HashStf::new();
 
-    let mut storage_manager = NomtStorageManager::new(RollupDbConfig::default_in_path(
-        tempdir.path().to_path_buf(),
-    ))?;
+    let mut storage_manager = NomtStorageManager::new(
+        RollupDbConfig::default_in_path(tempdir.path().to_path_buf()),
+        false,
+    )?;
 
     let block = da_service.get_block_at(0).await?;
     let genesis_header = block.header().clone();
@@ -397,7 +398,7 @@ fn get_saved_root_hash(
     path: &std::path::Path,
 ) -> anyhow::Result<Option<<TestStorage as Storage>::Root>> {
     let config = RollupDbConfig::default_in_path(path.to_path_buf());
-    let mut storage_manager = TestStorageManager::new(config)?;
+    let mut storage_manager = TestStorageManager::new(config, false)?;
     let mock_block_header = MockBlockHeader::from_height(1000000);
     let (stf_state, ledger_state) = storage_manager.create_state_for(&mock_block_header)?;
 

--- a/crates/module-system/module-implementations/integration-tests/tests/concurrent_prover_storages.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/concurrent_prover_storages.rs
@@ -559,3 +559,52 @@ fn assert_root_hashes<S: NativeStorage>(storage: &S, expected_root_hashes: Vec<S
     let expected_error = format!("Root node not found for version {next_version}.");
     assert_eq!(expected_error, future_root.to_string());
 }
+
+// Regression tests for #2514: pinned cache is incompatible with witness generation.
+
+use sov_state::DefaultStorageSpec;
+type NomtSpec = DefaultStorageSpec<TestHasher>;
+
+#[test]
+#[should_panic(expected = "Pinned cache is incompatible with witness generation")]
+fn nomt_pinned_cache_with_witness_panics() {
+    use sov_state::pinned_cache::PinnedCache;
+
+    let storage_manager = SimpleStorageManager::<NomtSpec>::new();
+    // Inject a pinned cache and ensure witness generation is enabled (the default).
+    storage_manager.set_pinned_cache(PinnedCache::default());
+    // This should panic because with_witness=true and pinned_cache is Some.
+    let _storage = storage_manager.create_storage();
+}
+
+#[test]
+fn nomt_pinned_cache_without_witness_succeeds() {
+    use sov_state::pinned_cache::PinnedCache;
+
+    let mut storage_manager = SimpleStorageManager::<NomtSpec>::new();
+    storage_manager.set_witness_generation(false);
+    storage_manager.set_pinned_cache(PinnedCache::default());
+    // This should succeed because with_witness=false.
+    let _storage = storage_manager.create_storage();
+}
+
+#[test]
+#[should_panic(expected = "JMT ProverStorage does not support pinned cache")]
+fn jmt_pinned_cache_panics() {
+    use sov_state::pinned_cache::PinnedCache;
+
+    type JmtSpec = DefaultStorageSpec<TestHasher>;
+    let storage_manager = SimpleJmtStorageManager::<JmtSpec>::new();
+    let storage = storage_manager.create_storage();
+    let state_accesses = StateAccesses {
+        user: Default::default(),
+        kernel: Default::default(),
+    };
+    // This should panic because pinned_cache is Some.
+    let _ = storage.compute_state_update(
+        state_accesses,
+        &Default::default(),
+        <sov_state::ProverStorage<JmtSpec> as Storage>::PRE_GENESIS_ROOT,
+        Some(PinnedCache::default()),
+    );
+}

--- a/crates/module-system/module-implementations/integration-tests/tests/concurrent_prover_storages.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/concurrent_prover_storages.rs
@@ -593,8 +593,7 @@ fn nomt_pinned_cache_without_witness_succeeds() {
 fn jmt_pinned_cache_panics() {
     use sov_state::pinned_cache::PinnedCache;
 
-    type JmtSpec = DefaultStorageSpec<TestHasher>;
-    let storage_manager = SimpleJmtStorageManager::<JmtSpec>::new();
+    let storage_manager = SimpleJmtStorageManager::<NomtSpec>::new();
     let storage = storage_manager.create_storage();
     let state_accesses = StateAccesses {
         user: Default::default(),
@@ -604,7 +603,7 @@ fn jmt_pinned_cache_panics() {
     let _ = storage.compute_state_update(
         state_accesses,
         &Default::default(),
-        <sov_state::ProverStorage<JmtSpec> as Storage>::PRE_GENESIS_ROOT,
+        <sov_state::ProverStorage<NomtSpec> as Storage>::PRE_GENESIS_ROOT,
         Some(PinnedCache::default()),
     );
 }

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -361,9 +361,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         .await?;
         let current_finalized_header = da_service.get_last_finalized_block_header().await?;
 
-        let witness_generation = prover_config
-            .as_ref()
-            .is_some_and(|c| c.needs_witness());
+        let witness_generation = prover_config.as_ref().is_some_and(|c| c.needs_witness());
         let mut storage_manager =
             self.create_storage_manager(&rollup_config, witness_generation)?;
 

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -361,8 +361,11 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         .await?;
         let current_finalized_header = da_service.get_last_finalized_block_header().await?;
 
+        let witness_generation = prover_config
+            .as_ref()
+            .is_some_and(|c| c.needs_witness());
         let mut storage_manager =
-            self.create_storage_manager(&rollup_config, prover_config.is_some())?;
+            self.create_storage_manager(&rollup_config, witness_generation)?;
 
         let (prover_storage, ledger_state) =
             storage_manager.create_state_after(&current_finalized_header)?;

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -130,9 +130,14 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
 
     /// Creates an instance of [`Self::StorageManager`].
     /// Panics if initialization fails.
+    ///
+    /// `witness_generation` indicates whether the storage manager should generate witnesses
+    /// for ZK proving. This is a node-level decision known at startup (true when a prover
+    /// config exists).
     fn create_storage_manager(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        witness_generation: bool,
     ) -> anyhow::Result<Self::StorageManager>;
 
     /// Instantiates [`FullNodeBlueprint::ProofSender`].
@@ -356,10 +361,8 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         .await?;
         let current_finalized_header = da_service.get_last_finalized_block_header().await?;
 
-        let mut storage_manager = self.create_storage_manager(&rollup_config)?;
-        if prover_config.is_some() {
-            storage_manager.set_witness_generation(true);
-        }
+        let mut storage_manager =
+            self.create_storage_manager(&rollup_config, prover_config.is_some())?;
 
         let (prover_storage, ledger_state) =
             storage_manager.create_state_after(&current_finalized_header)?;

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -357,6 +357,9 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         let current_finalized_header = da_service.get_last_finalized_block_header().await?;
 
         let mut storage_manager = self.create_storage_manager(&rollup_config)?;
+        if prover_config.is_some() {
+            storage_manager.set_witness_generation(true);
+        }
 
         let (prover_storage, ledger_state) =
             storage_manager.create_state_after(&current_finalized_header)?;

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
@@ -151,8 +151,10 @@ where
     fn create_storage_manager(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        witness_generation: bool,
     ) -> anyhow::Result<Self::StorageManager> {
-        self.inner.create_storage_manager(rollup_config)
+        self.inner
+            .create_storage_manager(rollup_config, witness_generation)
     }
 
     fn create_proof_sender(

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -116,7 +116,6 @@ where
     #[cfg(feature = "test-utils")]
     pub fn change_strict_mode(&mut self, use_strict_mode: bool) {
         self.strict_mode = use_strict_mode;
-        self.with_witness = use_strict_mode;
     }
 
     /// Returns a double option: The outer option is `None` if there is no reasonable version to use,

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -54,7 +54,7 @@ where
         if matches!(self.witness_mode, WitnessMode::Off { pinned_cache: Some(_) }) {
             tracing::warn!("Cloning NomtProverStorage which has an active pinned cache. The pinned cache will not be propagated to the clone.");
         }
-        let witness_mode = if self.witness_mode.with_witness() {
+        let witness_mode = if self.witness_mode.is_witness_enabled() {
             WitnessMode::On
         } else {
             WitnessMode::off()
@@ -422,7 +422,7 @@ where
         StorageRoot::new(nomt::trie::TERMINATOR, nomt::trie::TERMINATOR);
 
     fn put_in_witness(&self, value: Option<SlotValue>, witness: &Self::Witness) {
-        if self.witness_mode.with_witness() {
+        if self.witness_mode.is_witness_enabled() {
             witness.add_hint(&value);
         }
     }
@@ -432,7 +432,7 @@ where
         key: &SlotKey,
         witness: &Self::Witness,
     ) -> Option<NodeLeafAndMaybeValue> {
-        let witness_ref = if self.witness_mode.with_witness() {
+        let witness_ref = if self.witness_mode.is_witness_enabled() {
             Some(witness)
         } else {
             None
@@ -453,7 +453,7 @@ where
     ) -> Option<SlotValue> {
         match self.read_value::<N>(key, None) {
             Ok(val) => {
-                if self.witness_mode.with_witness() {
+                if self.witness_mode.is_witness_enabled() {
                     witness.add_hint(&val);
                 }
                 val
@@ -496,7 +496,7 @@ where
             kernel: kernel_session,
         } = self
             .state_session_builder
-            .begin_both_sessions(self.witness_mode.with_witness())?;
+            .begin_both_sessions(self.witness_mode.is_witness_enabled())?;
         let starting_session_time = start_session.elapsed();
         tracing::debug!(%prev_state_root, %next_version, sesssion_starting_time = ?starting_session_time, "computing state update, sessions are live");
 
@@ -520,7 +520,7 @@ where
                 user_session,
                 nomt_accesses_user,
                 witness,
-                self.witness_mode.with_witness(),
+                self.witness_mode.is_witness_enabled(),
             )
             .context("user state")?
         };
@@ -531,7 +531,7 @@ where
                 kernel_session,
                 nomt_accesses_kernel,
                 witness,
-                self.witness_mode.with_witness(),
+                self.witness_mode.is_witness_enabled(),
             )
             .context("kernel state")?
         };
@@ -541,7 +541,7 @@ where
         let user_writes = state_accesses.user.ordered_writes.len();
         let kernel_reads = state_accesses.kernel.ordered_reads.len();
         let kernel_writes = state_accesses.kernel.ordered_writes.len();
-        let with_witness = self.witness_mode.with_witness();
+        let with_witness = self.witness_mode.is_witness_enabled();
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(NomtProverComputeStateResult {
                 user_reads,

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -41,10 +41,8 @@ where
     /// Enable staleness/consistency checks (NOMT vs rocksdb, root hash comparison).
     /// Should be true for all node-context block processing.
     strict_mode: bool,
-    /// Enable witness hint generation for ZK proofs.
-    /// Should only be true for proving nodes.
-    with_witness: bool,
-    pinned_cache: Option<PinnedCache>,
+    /// Controls witness hint generation for ZK proofs and optional pinned cache.
+    witness_mode: WitnessMode<PinnedCache>,
 }
 
 impl<S: MerkleProofSpec, K: Clone> Clone for NomtProverStorage<S, K>
@@ -53,16 +51,20 @@ where
     K: Clone,
 {
     fn clone(&self) -> Self {
-        if self.pinned_cache.is_some() {
+        if matches!(self.witness_mode, WitnessMode::Off { pinned_cache: Some(_) }) {
             tracing::warn!("Cloning NomtProverStorage which has an active pinned cache. The pinned cache will not be propagated to the clone.");
         }
+        let witness_mode = if self.witness_mode.with_witness() {
+            WitnessMode::On
+        } else {
+            WitnessMode::off()
+        };
         Self {
             state_session_builder: self.state_session_builder.clone(),
             historical_state: self.historical_state.clone(),
             accessory: self.accessory.clone(),
             strict_mode: self.strict_mode,
-            with_witness: self.with_witness,
-            pinned_cache: None,
+            witness_mode,
         }
     }
 }
@@ -90,17 +92,12 @@ where
         strict_mode: bool,
         witness_mode: WitnessMode<PinnedCache>,
     ) -> Self {
-        let (with_witness, pinned_cache) = match witness_mode {
-            WitnessMode::On => (true, None),
-            WitnessMode::Off { pinned_cache } => (false, pinned_cache),
-        };
         Self {
             state_session_builder,
             historical_state,
             accessory,
             strict_mode,
-            with_witness,
-            pinned_cache,
+            witness_mode,
         }
     }
     /// Utility method for checking if storage is empty.
@@ -425,7 +422,7 @@ where
         StorageRoot::new(nomt::trie::TERMINATOR, nomt::trie::TERMINATOR);
 
     fn put_in_witness(&self, value: Option<SlotValue>, witness: &Self::Witness) {
-        if self.with_witness {
+        if self.witness_mode.with_witness() {
             witness.add_hint(&value);
         }
     }
@@ -435,7 +432,11 @@ where
         key: &SlotKey,
         witness: &Self::Witness,
     ) -> Option<NodeLeafAndMaybeValue> {
-        let witness_ref = if self.with_witness { Some(witness) } else { None };
+        let witness_ref = if self.witness_mode.with_witness() {
+            Some(witness)
+        } else {
+            None
+        };
         match self.do_get_leaf::<N>(key, None, witness_ref) {
             Ok(val) => val,
             Err(e) => {
@@ -452,7 +453,7 @@ where
     ) -> Option<SlotValue> {
         match self.read_value::<N>(key, None) {
             Ok(val) => {
-                if self.with_witness {
+                if self.witness_mode.with_witness() {
                     witness.add_hint(&val);
                 }
                 val
@@ -495,7 +496,7 @@ where
             kernel: kernel_session,
         } = self
             .state_session_builder
-            .begin_both_sessions(self.with_witness)?;
+            .begin_both_sessions(self.witness_mode.with_witness())?;
         let starting_session_time = start_session.elapsed();
         tracing::debug!(%prev_state_root, %next_version, sesssion_starting_time = ?starting_session_time, "computing state update, sessions are live");
 
@@ -519,7 +520,7 @@ where
                 user_session,
                 nomt_accesses_user,
                 witness,
-                self.with_witness,
+                self.witness_mode.with_witness(),
             )
             .context("user state")?
         };
@@ -530,7 +531,7 @@ where
                 kernel_session,
                 nomt_accesses_kernel,
                 witness,
-                self.with_witness,
+                self.witness_mode.with_witness(),
             )
             .context("kernel state")?
         };
@@ -540,7 +541,7 @@ where
         let user_writes = state_accesses.user.ordered_writes.len();
         let kernel_reads = state_accesses.kernel.ordered_reads.len();
         let kernel_writes = state_accesses.kernel.ordered_writes.len();
-        let with_witness = self.with_witness;
+        let with_witness = self.witness_mode.with_witness();
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(NomtProverComputeStateResult {
                 user_reads,
@@ -787,7 +788,7 @@ where
     }
 
     fn try_load_saved_pinned_cache(&mut self) -> Option<PinnedCache> {
-        self.pinned_cache.take()
+        self.witness_mode.take_pinned_cache()
     }
 }
 

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -51,7 +51,12 @@ where
     K: Clone,
 {
     fn clone(&self) -> Self {
-        if matches!(self.witness_mode, WitnessMode::Off { pinned_cache: Some(_) }) {
+        if matches!(
+            self.witness_mode,
+            WitnessMode::Off {
+                pinned_cache: Some(_)
+            }
+        ) {
             tracing::warn!("Cloning NomtProverStorage which has an active pinned cache. The pinned cache will not be propagated to the clone.");
         }
         let witness_mode = if self.witness_mode.is_witness_enabled() {

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -38,10 +38,12 @@ where
     state_session_builder: NomtSessionBuilder<S::Hasher, K>,
     historical_state: HistoricalStateReader,
     accessory: AccessoryDb,
-    /// If set to true, witness will be populated in all necessary places.
-    /// Also, will do consistency check between NOMT and rocksdb in some cases.
-    /// Please check [`NomtProverStorage::should_check_dbs_sync`] for more details.
-    strict_with_witness: bool,
+    /// Enable staleness/consistency checks (NOMT vs rocksdb, root hash comparison).
+    /// Should be true for all node-context block processing.
+    strict_mode: bool,
+    /// Enable witness hint generation for ZK proofs.
+    /// Should only be true for proving nodes.
+    with_witness: bool,
     pinned_cache: Option<PinnedCache>,
 }
 
@@ -58,7 +60,8 @@ where
             state_session_builder: self.state_session_builder.clone(),
             historical_state: self.historical_state.clone(),
             accessory: self.accessory.clone(),
-            strict_with_witness: self.strict_with_witness,
+            strict_mode: self.strict_mode,
+            with_witness: self.with_witness,
             pinned_cache: None,
         }
     }
@@ -78,21 +81,28 @@ where
     K: Clone,
 {
     /// Create the new instance of [`NomtProverStorage`] with the given sessions.
-    /// If `strict_with_witness` is set to true,
-    /// Witness will be recorded and consistency between NOMT and rocksdb will be checked in some cases.
-    // Please check [`NomtProverStorage::should_check_dbs_sync`] for more details.
+    /// If `strict_mode` is true, consistency checks between NOMT and rocksdb will be performed.
+    /// If `with_witness` is true, witness hints will be recorded for ZK proving.
+    /// Please check [`NomtProverStorage::should_check_dbs_sync`] for more details.
     pub fn create(
         state_session_builder: NomtSessionBuilder<S::Hasher, K>,
         historical_state: HistoricalStateReader,
         accessory: AccessoryDb,
-        strict_with_witness: bool,
+        strict_mode: bool,
+        with_witness: bool,
         pinned_cache: Option<PinnedCache>,
     ) -> Self {
+        assert!(
+            !(with_witness && pinned_cache.is_some()),
+            "Pinned cache is incompatible with witness generation: pinned cache serves reads \
+             from RAM, bypassing witness hint recording. See #2514."
+        );
         Self {
             state_session_builder,
             historical_state,
             accessory,
-            strict_with_witness,
+            strict_mode,
+            with_witness,
             pinned_cache,
         }
     }
@@ -105,7 +115,8 @@ where
     /// Allows changing strict mode for the existing storage.
     #[cfg(feature = "test-utils")]
     pub fn change_strict_mode(&mut self, use_strict_mode: bool) {
-        self.strict_with_witness = use_strict_mode;
+        self.strict_mode = use_strict_mode;
+        self.with_witness = use_strict_mode;
     }
 
     /// Returns a double option: The outer option is `None` if there is no reasonable version to use,
@@ -140,7 +151,7 @@ where
     /// not the latest known to this storage.
     fn should_check_dbs_sync(&self, version_to_use: SlotNumber) -> bool {
         cfg!(debug_assertions) &&
-            self.strict_with_witness
+            self.strict_mode
             // latest version can be equal to genesis in 2 cases: pre-genesis and at genesis.
             // Since genesis is a special case and not covered by normal stf transition,
             // we exclude this case for simpler testing.
@@ -363,7 +374,8 @@ where
         state_db: NomtSessionBuilder<S::Hasher, K>,
         historical_state: HistoricalStateReader,
         accessory_db: AccessoryDb,
-        strict_with_witness: bool,
+        strict_mode: bool,
+        with_witness: bool,
         pinned_cache: Option<Box<dyn Any + Send + Sync>>,
     ) -> Self {
         let pinned_cache: Option<PinnedCache> = pinned_cache.map(|c| *c.downcast().expect("Failed to downcast the pinned_cache argument to `NomtProverStorage`. This is a bug. Please report it."));
@@ -371,7 +383,8 @@ where
             state_db,
             historical_state,
             accessory_db,
-            strict_with_witness,
+            strict_mode,
+            with_witness,
             pinned_cache,
         )
     }
@@ -436,7 +449,7 @@ where
     ) -> Option<SlotValue> {
         match self.read_value::<N>(key, None) {
             Ok(val) => {
-                if self.strict_with_witness {
+                if self.with_witness {
                     witness.add_hint(&val);
                 }
                 val
@@ -479,7 +492,7 @@ where
             kernel: kernel_session,
         } = self
             .state_session_builder
-            .begin_both_sessions(self.strict_with_witness)?;
+            .begin_both_sessions(self.with_witness)?;
         let starting_session_time = start_session.elapsed();
         tracing::debug!(%prev_state_root, %next_version, sesssion_starting_time = ?starting_session_time, "computing state update, sessions are live");
 
@@ -488,7 +501,7 @@ where
         let current_prev_root = StorageRoot::new(current_prev_user_root, current_prev_kernel_root);
 
         // Check staleness, pre-computation:
-        if self.strict_with_witness && current_prev_root != prev_state_root {
+        if self.strict_mode && current_prev_root != prev_state_root {
             anyhow::bail!("stale storage on next_version={}, passed prev_state_root {} does not match the current prev_state_root {}",
                 next_version,
                 prev_state_root,
@@ -503,7 +516,7 @@ where
                 user_session,
                 nomt_accesses_user,
                 witness,
-                self.strict_with_witness,
+                self.with_witness,
             )
             .context("user state")?
         };
@@ -514,7 +527,7 @@ where
                 kernel_session,
                 nomt_accesses_kernel,
                 witness,
-                self.strict_with_witness,
+                self.with_witness,
             )
             .context("kernel state")?
         };
@@ -524,7 +537,7 @@ where
         let user_writes = state_accesses.user.ordered_writes.len();
         let kernel_reads = state_accesses.kernel.ordered_reads.len();
         let kernel_writes = state_accesses.kernel.ordered_writes.len();
-        let with_witness = self.strict_with_witness;
+        let with_witness = self.with_witness;
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(NomtProverComputeStateResult {
                 user_reads,
@@ -544,7 +557,7 @@ where
         );
 
         // Check staleness, post-computation. This should check if storage became stale during the computation.
-        if self.strict_with_witness && prev_state_root != finished_session_prev_root {
+        if self.strict_mode && prev_state_root != finished_session_prev_root {
             anyhow::bail!("stale storage on next_version={}, passed prev_state_root {} does not match the current prev_state_root {}",
                 next_version,
                 prev_state_root,

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -95,7 +95,7 @@ where
         assert!(
             !(with_witness && pinned_cache.is_some()),
             "Pinned cache is incompatible with witness generation: pinned cache serves reads \
-             from RAM, bypassing witness hint recording. See #2514."
+             from RAM, bypassing witness hint recording."
         );
         Self {
             state_session_builder,

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -425,7 +425,9 @@ where
         StorageRoot::new(nomt::trie::TERMINATOR, nomt::trie::TERMINATOR);
 
     fn put_in_witness(&self, value: Option<SlotValue>, witness: &Self::Witness) {
-        witness.add_hint(&value);
+        if self.with_witness {
+            witness.add_hint(&value);
+        }
     }
 
     fn get_leaf<N: ProvableCompileTimeNamespace>(
@@ -433,7 +435,8 @@ where
         key: &SlotKey,
         witness: &Self::Witness,
     ) -> Option<NodeLeafAndMaybeValue> {
-        match self.do_get_leaf::<N>(key, None, Some(witness)) {
+        let witness_ref = if self.with_witness { Some(witness) } else { None };
+        match self.do_get_leaf::<N>(key, None, witness_ref) {
             Ok(val) => val,
             Err(e) => {
                 // Historical errors are not expected when fetching without a version

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -82,8 +82,8 @@ where
 {
     /// Create the new instance of [`NomtProverStorage`] with the given sessions.
     /// If `strict_mode` is true, consistency checks between NOMT and rocksdb will be performed.
-    /// If `with_witness` is true, witness hints will be recorded for ZK proving.
     /// Please check [`NomtProverStorage::should_check_dbs_sync`] for more details.
+    /// If `with_witness` is true, witness hints will be recorded for ZK proving.
     pub fn create(
         state_session_builder: NomtSessionBuilder<S::Hasher, K>,
         historical_state: HistoricalStateReader,

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -14,7 +14,7 @@ use sov_db::accessory_db::AccessoryDb;
 use sov_db::historical_state::HistoricalStateReader;
 use sov_db::state_db_nomt::{HistoricalValueError, NomtSessionBuilder, SessionsContainer};
 use sov_db::storage_manager::{
-    InitializableNativeNomtStorage, NomtChangeSet, StateFinishedSession,
+    InitializableNativeNomtStorage, NomtChangeSet, StateFinishedSession, WitnessMode,
 };
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::reexports::digest::Digest;
@@ -83,20 +83,17 @@ where
     /// Create the new instance of [`NomtProverStorage`] with the given sessions.
     /// If `strict_mode` is true, consistency checks between NOMT and rocksdb will be performed.
     /// Please check [`NomtProverStorage::should_check_dbs_sync`] for more details.
-    /// If `with_witness` is true, witness hints will be recorded for ZK proving.
     pub fn create(
         state_session_builder: NomtSessionBuilder<S::Hasher, K>,
         historical_state: HistoricalStateReader,
         accessory: AccessoryDb,
         strict_mode: bool,
-        with_witness: bool,
-        pinned_cache: Option<PinnedCache>,
+        witness_mode: WitnessMode<PinnedCache>,
     ) -> Self {
-        assert!(
-            !(with_witness && pinned_cache.is_some()),
-            "Pinned cache is incompatible with witness generation: pinned cache serves reads \
-             from RAM, bypassing witness hint recording."
-        );
+        let (with_witness, pinned_cache) = match witness_mode {
+            WitnessMode::On => (true, None),
+            WitnessMode::Off { pinned_cache } => (false, pinned_cache),
+        };
         Self {
             state_session_builder,
             historical_state,
@@ -374,17 +371,21 @@ where
         historical_state: HistoricalStateReader,
         accessory_db: AccessoryDb,
         strict_mode: bool,
-        with_witness: bool,
-        pinned_cache: Option<Box<dyn Any + Send + Sync>>,
+        witness_mode: WitnessMode,
     ) -> Self {
-        let pinned_cache: Option<PinnedCache> = pinned_cache.map(|c| *c.downcast().expect("Failed to downcast the pinned_cache argument to `NomtProverStorage`. This is a bug. Please report it."));
+        let witness_mode = match witness_mode {
+            WitnessMode::On => WitnessMode::On,
+            WitnessMode::Off { pinned_cache } => {
+                let pinned_cache: Option<PinnedCache> = pinned_cache.map(|c| *c.downcast().expect("Failed to downcast the pinned_cache argument to `NomtProverStorage`. This is a bug. Please report it."));
+                WitnessMode::Off { pinned_cache }
+            }
+        };
         Self::create(
             state_db,
             historical_state,
             accessory_db,
             strict_mode,
-            with_witness,
-            pinned_cache,
+            witness_mode,
         )
     }
 }

--- a/crates/module-system/sov-state/src/prover_storage.rs
+++ b/crates/module-system/sov-state/src/prover_storage.rs
@@ -373,6 +373,9 @@ impl<S: MerkleProofSpec> Storage for ProverStorage<S> {
         self.read_value::<Accessory>(key, None)
     }
 
+    /// # Panics
+    ///
+    /// Panics if `pinned_cache` is `Some`, as JMT prover storage is incompatible with pinned caches.
     fn compute_state_update(
         &self,
         state_accesses: StateAccesses,

--- a/crates/module-system/sov-state/src/prover_storage.rs
+++ b/crates/module-system/sov-state/src/prover_storage.rs
@@ -378,8 +378,12 @@ impl<S: MerkleProofSpec> Storage for ProverStorage<S> {
         state_accesses: StateAccesses,
         witness: &Self::Witness,
         prev_state_root: Self::Root,
-        _pinned_cache: Option<PinnedCache>,
+        pinned_cache: Option<PinnedCache>,
     ) -> anyhow::Result<(Self::Root, Self::StateUpdate)> {
+        assert!(
+            pinned_cache.is_none(),
+            "JMT ProverStorage does not support pinned cache. See #2514."
+        );
         let prev_user_root = prev_state_root.namespace_root(ProvableNamespace::User);
         let prev_kernel_root = prev_state_root.namespace_root(ProvableNamespace::Kernel);
         let (user_root, user_state_update) = self

--- a/crates/module-system/sov-state/src/prover_storage.rs
+++ b/crates/module-system/sov-state/src/prover_storage.rs
@@ -382,7 +382,7 @@ impl<S: MerkleProofSpec> Storage for ProverStorage<S> {
     ) -> anyhow::Result<(Self::Root, Self::StateUpdate)> {
         assert!(
             pinned_cache.is_none(),
-            "JMT ProverStorage does not support pinned cache. See #2514."
+            "JMT ProverStorage does not support pinned cache as it is incompatible with ZKPs."
         );
         let prev_user_root = prev_state_root.namespace_root(ProvableNamespace::User);
         let prev_kernel_root = prev_state_root.namespace_root(ProvableNamespace::Kernel);

--- a/crates/rollup-interface/src/state_machine/storage.rs
+++ b/crates/rollup-interface/src/state_machine/storage.rs
@@ -17,10 +17,6 @@ pub trait HierarchicalStorageManager<Da: DaSpec>: Send + Sync {
     /// Type which is produced by a ledger.
     type LedgerChangeSet;
 
-    /// Enable witness generation for ZK proving. When enabled, `create_state_for` will
-    /// generate complete witnesses (at the cost of disabling pinned cache). See #2514.
-    fn set_witness_generation(&mut self, _enabled: bool) {}
-
     /// Creates a state that can be used for execution of given DA block,
     /// meaning that at will have access to previous state in same fork.
     fn create_state_for(

--- a/crates/rollup-interface/src/state_machine/storage.rs
+++ b/crates/rollup-interface/src/state_machine/storage.rs
@@ -17,6 +17,10 @@ pub trait HierarchicalStorageManager<Da: DaSpec>: Send + Sync {
     /// Type which is produced by a ledger.
     type LedgerChangeSet;
 
+    /// Enable witness generation for ZK proving. When enabled, `create_state_for` will
+    /// generate complete witnesses (at the cost of disabling pinned cache). See #2514.
+    fn set_witness_generation(&mut self, _enabled: bool) {}
+
     /// Creates a state that can be used for execution of given DA block,
     /// meaning that at will have access to previous state in same fork.
     fn create_state_for(

--- a/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
+++ b/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
@@ -156,8 +156,9 @@ where
     fn create_storage_manager(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        witness_generation: bool,
     ) -> anyhow::Result<Self::StorageManager> {
-        Manager::from_config(rollup_config)
+        Manager::from_config(rollup_config, witness_generation)
     }
 
     fn create_proof_sender(
@@ -170,7 +171,10 @@ where
 }
 
 trait StorageManagerInitializer<S: Spec, Da: DaService>: Sized {
-    fn from_config(config: &RollupConfig<S::Address, Da>) -> anyhow::Result<Self>;
+    fn from_config(
+        config: &RollupConfig<S::Address, Da>,
+        witness_generation: bool,
+    ) -> anyhow::Result<Self>;
 }
 
 impl<S: Spec> StorageManagerInitializer<S, StorableMockDaService>
@@ -181,6 +185,7 @@ impl<S: Spec> StorageManagerInitializer<S, StorableMockDaService>
 {
     fn from_config(
         config: &RollupConfig<<S as Spec>::Address, StorableMockDaService>,
+        _witness_generation: bool,
     ) -> anyhow::Result<Self> {
         NativeStorageManager::new(&config.storage.path)
     }
@@ -198,7 +203,8 @@ impl<S: Spec> StorageManagerInitializer<S, StorableMockDaService>
 {
     fn from_config(
         config: &RollupConfig<<S as Spec>::Address, StorableMockDaService>,
+        witness_generation: bool,
     ) -> anyhow::Result<Self> {
-        NomtStorageManager::new(config.storage.clone())
+        NomtStorageManager::new(config.storage.clone(), witness_generation)
     }
 }

--- a/crates/utils/sov-test-utils/src/sequencer.rs
+++ b/crates/utils/sov-test-utils/src/sequencer.rs
@@ -216,7 +216,7 @@ impl<Rt: Runtime<TestSpec>> TestSequencerSetup<Rt> {
             MockDaSpec,
             TestHasher,
             NomtProverStorage<DefaultStorageSpec<TestHasher>, TestSlotHash>,
-        >::new(config)?;
+        >::new(config, false)?;
 
         Self::with_storage_manager(
             dir,

--- a/crates/utils/sov-test-utils/src/storage.rs
+++ b/crates/utils/sov-test-utils/src/storage.rs
@@ -163,6 +163,7 @@ pub struct SimpleStorageManager<S: MerkleProofSpec> {
     accessory: Arc<rockbound::DB>,
     root: StorageRoot<S>,
     is_strict_mode: bool,
+    with_witness: bool,
     pinned_cache: Mutex<Option<PinnedCache>>,
 }
 
@@ -186,6 +187,7 @@ impl<S: MerkleProofSpec> SimpleStorageManager<S> {
             accessory: Arc::new(accessory_rocksdb),
             root: <NomtProverStorage<S, TestSlotHash> as Storage>::PRE_GENESIS_ROOT,
             is_strict_mode: true,
+            with_witness: true,
             pinned_cache: Mutex::new(None),
         }
     }
@@ -193,6 +195,17 @@ impl<S: MerkleProofSpec> SimpleStorageManager<S> {
     /// Change in which mode storage is going to be created.
     pub fn set_strict_mode(&mut self, use_strict_mode: bool) {
         self.is_strict_mode = use_strict_mode;
+        self.with_witness = use_strict_mode;
+    }
+
+    /// Set witness generation independently from strict mode.
+    pub fn set_witness_generation(&mut self, with_witness: bool) {
+        self.with_witness = with_witness;
+    }
+
+    /// Inject a pinned cache that will be passed to the next `create_storage` call.
+    pub fn set_pinned_cache(&self, cache: PinnedCache) {
+        *self.pinned_cache.lock().unwrap() = Some(cache);
     }
 
     /// Create a new [`NomtProverStorage`] that has a view only on data written to disc.
@@ -228,6 +241,7 @@ impl<S: MerkleProofSpec> SimpleStorageManager<S> {
             historical_state_reader,
             accessory_db,
             self.is_strict_mode,
+            self.with_witness,
             self.pinned_cache.lock().unwrap().take(),
         )
     }

--- a/crates/utils/sov-test-utils/src/storage.rs
+++ b/crates/utils/sov-test-utils/src/storage.rs
@@ -14,7 +14,7 @@ use sov_db::schema::namespace::NomtStateValues;
 use sov_db::state_db::StateDb;
 use sov_db::state_db_nomt::get_session_builder_from_committed;
 use sov_db::storage_manager::{
-    FlatStateDb, InitializableNativeNomtStorage, InitializableNativeStorage,
+    FlatStateDb, InitializableNativeNomtStorage, InitializableNativeStorage, WitnessMode,
 };
 pub use sov_db::storage_manager::{
     NativeChangeSet, NativeStorageManager, NomtChangeSet, NomtStorageManager,
@@ -235,13 +235,14 @@ impl<S: MerkleProofSpec> SimpleStorageManager<S> {
             AccessoryDb::with_reader(DeltaReader::new(self.accessory.clone(), Vec::new()))
                 .expect("Failed to create accessory db");
 
+        let pinned_cache = self.pinned_cache.lock().unwrap().take();
+        let witness_mode = WitnessMode::new_with_assert(self.with_witness, pinned_cache);
         NomtProverStorage::create(
             state_session_builder,
             historical_state_reader,
             accessory_db,
             self.is_strict_mode,
-            self.with_witness,
-            self.pinned_cache.lock().unwrap().take(),
+            witness_mode,
         )
     }
 

--- a/crates/utils/sov-test-utils/src/storage.rs
+++ b/crates/utils/sov-test-utils/src/storage.rs
@@ -195,7 +195,6 @@ impl<S: MerkleProofSpec> SimpleStorageManager<S> {
     /// Change in which mode storage is going to be created.
     pub fn set_strict_mode(&mut self, use_strict_mode: bool) {
         self.is_strict_mode = use_strict_mode;
-        self.with_witness = use_strict_mode;
     }
 
     /// Set witness generation independently from strict mode.

--- a/crates/utils/sov-test-utils/src/storage.rs
+++ b/crates/utils/sov-test-utils/src/storage.rs
@@ -371,7 +371,7 @@ where
 {
     fn new_in_path(path: impl AsRef<Path>) -> Self {
         let config = RollupDbConfig::default_in_path(path.as_ref().to_path_buf());
-        Self::new(config).unwrap()
+        Self::new(config, false).unwrap()
     }
 }
 

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -606,7 +606,7 @@ where
         let mut shutdown_receiver = shutdown_sender.subscribe();
         let blueprint: R = Default::default();
 
-        let mut storage_manager = blueprint.create_storage_manager(&rollup_config)?;
+        let mut storage_manager = blueprint.create_storage_manager(&rollup_config, false)?;
         let finalized_header = secondary_da_service
             .get_last_finalized_block_header()
             .await?;

--- a/examples/demo-rollup/src/celestia_nomt_rollup.rs
+++ b/examples/demo-rollup/src/celestia_nomt_rollup.rs
@@ -188,8 +188,9 @@ impl FullNodeBlueprint<Native> for CelestiaNomtDemoRollup<Native> {
     fn create_storage_manager(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        witness_generation: bool,
     ) -> anyhow::Result<Self::StorageManager> {
-        NomtStorageManager::new(rollup_config.storage.clone())
+        NomtStorageManager::new(rollup_config.storage.clone(), witness_generation)
     }
 
     fn create_proof_sender(

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -175,6 +175,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
     fn create_storage_manager(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        _witness_generation: bool,
     ) -> anyhow::Result<Self::StorageManager> {
         NativeStorageManager::new(&rollup_config.storage.path)
     }

--- a/examples/demo-rollup/src/external_mock_nomt_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_nomt_rollup.rs
@@ -175,8 +175,9 @@ impl FullNodeBlueprint<Native> for ExternalMockNomtDemoRollup<Native> {
     fn create_storage_manager(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        witness_generation: bool,
     ) -> anyhow::Result<Self::StorageManager> {
-        NomtStorageManager::new(rollup_config.storage.clone())
+        NomtStorageManager::new(rollup_config.storage.clone(), witness_generation)
     }
 
     fn create_proof_sender(

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -159,6 +159,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
     fn create_storage_manager(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        _witness_generation: bool,
     ) -> anyhow::Result<Self::StorageManager> {
         NativeStorageManager::new(&rollup_config.storage.path)
     }

--- a/examples/demo-rollup/src/mock_nomt_rollup.rs
+++ b/examples/demo-rollup/src/mock_nomt_rollup.rs
@@ -171,8 +171,9 @@ impl FullNodeBlueprint<Native> for MockNomtDemoRollup<Native> {
     fn create_storage_manager(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        witness_generation: bool,
     ) -> anyhow::Result<Self::StorageManager> {
-        NomtStorageManager::new(rollup_config.storage.clone())
+        NomtStorageManager::new(rollup_config.storage.clone(), witness_generation)
     }
 
     fn create_proof_sender(

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -158,6 +158,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
     fn create_storage_manager(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
+        _witness_generation: bool,
     ) -> anyhow::Result<Self::StorageManager> {
         NativeStorageManager::new(&rollup_config.storage.path)
     }


### PR DESCRIPTION
# Description

Closes #2534 

- Decouples the consistency check & witness generation flag so they can be enabled independently
- Passes a flag that indicates if witnesses should be generated (currently based on the presence of a prover confg)
- If witness generation is enabled and a pin cache is present then panic in the storage constructor


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
