### PR TITLE
Add activation height for setting the chain_state oracle timestamp from sequencer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# 2026-02-24 
-- #2512 adds the capability to migrate from mockDa -> Celestia to the demo rollup.
 # 2026-03-02
 - #2543 **Breaking change: code** Adds a new constants.toml value `ENABLE_TIMESTAMP_ORACLE_AT` which disables setting the on-chain timestamp oracle metadata from the sequencer context before the provided height. Should be set to 0 for new chains, and some height after the upgrade for existing chains. Alternatively set to `i64::MAX` to effectively disable it.
+
+# 2026-02-24 
+- #2512 adds the capability to migrate from mockDa -> Celestia to the demo rollup.
 
 # 2026-02-26
 - #2540 Adds a witness generation flag. If witness generation is enabled at the same time as cache pinning a panic with occur at runtime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 2026-02-24 
 - #2512 adds the capability to migrate from mockDa -> Celestia to the demo rollup.
+# 2026-03-02
+- #2543 **Breaking change: code** Adds a new constants.toml value `ENABLE_TIMESTAMP_ORACLE_AT` which disables setting the on-chain timestamp oracle metadata from the sequencer context before the provided height. Should be set to 0 for new chains, and some height after the upgrade for existing chains. Alternatively set to `i64::MAX` to effectively disable it.
+
 # 2026-02-26
 - #2540 Adds a witness generation flag. If witness generation is enabled at the same time as cache pinning a panic with occur at runtime.
 

--- a/constants.testing.toml
+++ b/constants.testing.toml
@@ -22,6 +22,8 @@ EVM_RECEIPT_ACTUAL_FEE_HEIGHT = 0
 # How many rollup blocks to wait before terminating setup mode. While setup mode is enabled,
 # the rollup does not charge gas. This is useful when initializing the rollup with a bridged gas token.
 SETUP_MODE_TERMINATION_HEIGHT = 0 # Disable setup mode entirely by default.
+# Before this rollup height, the timestamp oracle is not updated from sequencing metadata.
+ENABLE_TIMESTAMP_ORACLE_AT = 0
 # When using soft-confirmations, this parameter sets the maximum number of slots that a transaction can be deferred by the sequencer before
 # being force-executed by the rollup. Decreasing the number of slots means that "forced" transactions are processed
 # more quickly in the worst case, but increases the likelihood that some soft confirmations

--- a/constants.toml
+++ b/constants.toml
@@ -45,6 +45,8 @@ EVM_RECEIPT_ACTUAL_FEE_HEIGHT = 0
 # How many rollup blocks to wait before terminating setup mode. While setup mode is enabled,
 # the rollup does not charge gas. This is useful when initializing the rollup with a bridged gas token.
 SETUP_MODE_TERMINATION_HEIGHT = 0 # Disable setup mode entirely by default.
+# Before this rollup height, the timestamp oracle is not updated from sequencing metadata.
+ENABLE_TIMESTAMP_ORACLE_AT = 0
 # When using soft-confirmations, this parameter sets the maximum number of slots that a transaction can be deferred by the sequencer before
 # being force-executed by the rollup. Decreasing the number of slots means that "forced" transactions are processed
 # more quickly in the worst case, but increases the likelihood that some soft confirmations

--- a/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -25,6 +25,7 @@ mod genesis;
 
 pub use gas::{NonZeroRatio, NonZeroRatioConversionError};
 pub use genesis::*;
+use sov_modules_api::macros::config_value;
 use sov_modules_api::OperatingMode;
 use sov_modules_api::{HDTimestamp, TxState};
 
@@ -374,11 +375,16 @@ impl<S: Spec> ChainState<S> {
     /// Updates the oracle time using sequencer-provided sequencing metadata.
     ///
     /// This method is best-effort: invalid, overflowing, or regressing timestamps are ignored.
+    /// Before the `ENABLE_TIMESTAMP_ORACLE_AT` height, this is a no-op.
     pub fn update_oracle_time_from_sequencing_data(
         &mut self,
         timestamp: HDTimestamp,
         state: &mut impl TxState<S>,
     ) -> anyhow::Result<()> {
+        if state.rollup_height_to_access().get() < config_value!("ENABLE_TIMESTAMP_ORACLE_AT") {
+            return Ok(());
+        }
+
         let nanos = timestamp.as_nanos();
         let millis = nanos / NANOS_PER_MILLI;
         if millis > i64::MAX as u128 {


### PR DESCRIPTION
# Description

Needed for compatibility with the already deployed Relay chain, where it will be set to u64::MAX.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
