### PR TITLE
Optimize rollup schema fetching to use a single request

### DIFF
--- a/typescript/.changeset/optimize-schema-fetching.md
+++ b/typescript/.changeset/optimize-schema-fetching.md
@@ -1,0 +1,5 @@
+---
+"@sovereign-sdk/web3": minor
+---
+
+Consolidate rollup schema fetching so both serializer and chain hash are populated from a single request. Add `hydrate()` method for eager pre-fetching during initialization.

--- a/typescript/packages/web3/src/rollup/rollup.test.ts
+++ b/typescript/packages/web3/src/rollup/rollup.test.ts
@@ -54,8 +54,7 @@ const testRollup = <S extends BaseTypeSpec, C extends RollupContext>(
 describe("Rollup", () => {
   describe("constructor", () => {
     it("should use the provided serializer if it is provided", async () => {
-      const { rollup, client } = testRollup({ getSerializer });
-      client.rollup.schema = vi.fn().mockResolvedValueOnce({});
+      const { rollup } = testRollup({ getSerializer });
       const actual = await rollup.serializer();
       expect(actual).toBe(mockSerializer);
     });
@@ -442,6 +441,60 @@ describe("Rollup", () => {
       const { rollup } = testRollup({ context });
 
       expect(rollup.context).toBe(context);
+    });
+  });
+  describe("hydrate", () => {
+    it("should populate both serializer and chainHash with a single schema call", async () => {
+      const { rollup, client } = testRollup();
+
+      await rollup.hydrate();
+
+      expect(client.rollup.schema).toHaveBeenCalledTimes(1);
+      const serializer = await rollup.serializer();
+      const chainHash = await rollup.chainHash();
+      expect(serializer).toBe(mockSerializer);
+      expect(chainHash).toEqual(new Uint8Array([1, 2, 3, 4]));
+      // No additional calls after hydrate
+      expect(client.rollup.schema).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not make additional requests when serializer() is called after hydrate()", async () => {
+      const { rollup, client } = testRollup();
+
+      await rollup.hydrate();
+      await rollup.serializer();
+      await rollup.serializer();
+
+      expect(client.rollup.schema).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not make additional requests when chainHash() is called after hydrate()", async () => {
+      const { rollup, client } = testRollup();
+
+      await rollup.hydrate();
+      await rollup.chainHash();
+      await rollup.chainHash();
+
+      expect(client.rollup.schema).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe("schema fetching consolidation", () => {
+    it("should populate both fields when serializer() is called first", async () => {
+      const { rollup, client } = testRollup();
+
+      await rollup.serializer();
+      await rollup.chainHash();
+
+      expect(client.rollup.schema).toHaveBeenCalledTimes(1);
+    });
+
+    it("should populate both fields when chainHash() is called first", async () => {
+      const { rollup, client } = testRollup();
+
+      await rollup.chainHash();
+      await rollup.serializer();
+
+      expect(client.rollup.schema).toHaveBeenCalledTimes(1);
     });
   });
   describe("healthcheck", () => {

--- a/typescript/packages/web3/src/rollup/rollup.ts
+++ b/typescript/packages/web3/src/rollup/rollup.ts
@@ -366,7 +366,8 @@ export class Rollup<S extends BaseTypeSpec, C extends RollupContext> {
    */
   async serializer(): Promise<Serializer> {
     if (!this._serializer) await this._fetchSchema();
-    return this._serializer!;
+    // _fetchSchema always sets _serializer
+    return this._serializer as Serializer;
   }
 
   /**
@@ -378,7 +379,8 @@ export class Rollup<S extends BaseTypeSpec, C extends RollupContext> {
 
   async chainHash(): Promise<Uint8Array> {
     if (!this._chainHash) await this._fetchSchema();
-    return this._chainHash!;
+    // _fetchSchema always sets _chainHash
+    return this._chainHash as Uint8Array;
   }
 
   private async _fetchSchema(): Promise<void> {

--- a/typescript/packages/web3/src/rollup/rollup.ts
+++ b/typescript/packages/web3/src/rollup/rollup.ts
@@ -353,14 +353,20 @@ export class Rollup<S extends BaseTypeSpec, C extends RollupContext> {
   }
 
   /**
+   * Pre-fetches the rollup schema, populating the serializer and chain hash caches.
+   * Call this during initialization to avoid the latency of lazy-loading on the first transaction.
+   */
+  hydrate(): Promise<void> {
+    return this._fetchSchema();
+  }
+
+  /**
    * The serializer for the rollup.
    * Can be used to serialize transactions, runtime calls, etc.
    */
   async serializer(): Promise<Serializer> {
-    if (this._serializer) return this._serializer;
-    const { schema } = await this.rollup.schema();
-    this._serializer = this._config.getSerializer(schema);
-    return this._serializer;
+    if (!this._serializer) await this._fetchSchema();
+    return this._serializer!;
   }
 
   /**
@@ -371,10 +377,14 @@ export class Rollup<S extends BaseTypeSpec, C extends RollupContext> {
   }
 
   async chainHash(): Promise<Uint8Array> {
-    if (this._chainHash) return this._chainHash;
-    const { chain_hash } = await this.rollup.schema();
+    if (!this._chainHash) await this._fetchSchema();
+    return this._chainHash!;
+  }
+
+  private async _fetchSchema(): Promise<void> {
+    const { schema, chain_hash } = await this.rollup.schema();
+    this._serializer = this._config.getSerializer(schema);
     this._chainHash = hexToBytes(chain_hash);
-    return this._chainHash;
   }
 }
 


### PR DESCRIPTION
# Description

Consolidate _serializer and _chainHash initialization into a shared _fetchSchema() method so that the first call to either serializer() or chainHash() populates both fields from one GET /rollup/schema request.

Add public hydrate() method for eager pre-fetching during initialization, avoiding latency on the first transaction.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
