### PR TITLE
EVM tests unflakification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2026-03-02
 - #2543 **Breaking change: code** Adds a new constants.toml value `ENABLE_TIMESTAMP_ORACLE_AT` which disables setting the on-chain timestamp oracle metadata from the sequencer context before the provided height. Should be set to 0 for new chains, and some height after the upgrade for existing chains. Alternatively set to `i64::MAX` to effectively disable it.
+- #2547 Updating EVM tests and test-only sequencer change.
 
 # 2026-02-24 
 - #2512 adds the capability to migrate from mockDa -> Celestia to the demo rollup.

--- a/crates/full-node/sov-sequencer/src/common.rs
+++ b/crates/full-node/sov-sequencer/src/common.rs
@@ -267,6 +267,11 @@ pub struct StateUpdateNotification {
     pub slot_number: SlotNumber,
     /// The finalized slot number.
     pub finalized_slot_number: SlotNumber,
+    /// True when the update loop explicitly skipped processing because
+    /// `SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE=1` was observed.
+    #[cfg(feature = "test-utils")]
+    #[serde(default)]
+    pub update_skipped_due_to_pause: bool,
 }
 
 /// A notification that the sequencer has processed a forced (non-preferred) batch.

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -174,6 +174,10 @@ where
         let test_only_state_update_notification_receiver = synchronized_state
             .test_only_state_update_notification_sender
             .subscribe();
+        #[cfg(feature = "test-utils")]
+        let test_only_state_update_notification_sender = synchronized_state
+            .test_only_state_update_notification_sender
+            .clone();
         let synchronized_state_task = synchronized_state.start().await;
         handles.push(synchronized_state_task);
 
@@ -219,6 +223,8 @@ where
             tx_queue_id,
             stop_at_rollup_height,
             test_only_state_update_notification_receiver,
+            #[cfg(feature = "test-utils")]
+            test_only_state_update_notification_sender,
             test_only_forced_tx_batch_notification_receiver: forced_tx_batch_notifier.subscribe(),
             runtime: Rt::default(),
         }));

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -128,6 +128,9 @@ where
     stop_at_rollup_height: Option<RollupHeight>,
     #[allow(dead_code)] // Used only for testing; unused with some feature combinations.
     test_only_state_update_notification_receiver: broadcast::Receiver<StateUpdateNotification>,
+    #[cfg(feature = "test-utils")]
+    #[allow(dead_code)] // Used only for testing; unused with some feature combinations.
+    test_only_state_update_notification_sender: broadcast::Sender<StateUpdateNotification>,
     #[allow(dead_code)] // Used only for testing; unused with some feature combinations.
     test_only_forced_tx_batch_notification_receiver: broadcast::Receiver<ForcedTxBatchNotification>,
     runtime: Rt,
@@ -640,6 +643,15 @@ where
         let skip_flag = std::env::var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE");
         if skip_flag == Ok("1".to_string()) {
             tracing::warn!("skipping state update due to env var flag");
+            #[cfg(feature = "test-utils")]
+            let _ = seq
+                .test_only_state_update_notification_sender
+                .send(StateUpdateNotification {
+                    slot_number: info.slot_number,
+                    finalized_slot_number: info.latest_finalized_slot_number,
+                    #[cfg(feature = "test-utils")]
+                    update_skipped_due_to_pause: true,
+                });
             return Ok(());
         }
     }

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -644,14 +644,15 @@ where
         if skip_flag == Ok("1".to_string()) {
             tracing::warn!("skipping state update due to env var flag");
             #[cfg(feature = "test-utils")]
-            let _ = seq
-                .test_only_state_update_notification_sender
-                .send(StateUpdateNotification {
-                    slot_number: info.slot_number,
-                    finalized_slot_number: info.latest_finalized_slot_number,
-                    #[cfg(feature = "test-utils")]
-                    update_skipped_due_to_pause: true,
-                });
+            {
+                let _ =
+                    seq.test_only_state_update_notification_sender
+                        .send(StateUpdateNotification {
+                            slot_number: info.slot_number,
+                            finalized_slot_number: info.latest_finalized_slot_number,
+                            update_skipped_due_to_pause: true,
+                        });
+            }
             return Ok(());
         }
     }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -304,6 +304,8 @@ where
                         .send(StateUpdateNotification {
                             slot_number,
                             finalized_slot_number,
+                            #[cfg(feature = "test-utils")]
+                            update_skipped_due_to_pause: false,
                         });
             }
             Message::PruneSequencerDb { reason } => {
@@ -346,6 +348,8 @@ where
                         .send(StateUpdateNotification {
                             slot_number,
                             finalized_slot_number,
+                            #[cfg(feature = "test-utils")]
+                            update_skipped_due_to_pause: false,
                         });
             }
             Message::ReplicaBatchStartMsg {

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -971,6 +971,42 @@ where
         std::env::set_var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE", "1");
     }
 
+    /// Pauses preferred batch production and waits until the sequencer confirms
+    /// that at least one state update was skipped because of the pause flag.
+    ///
+    /// This is stronger than a timing-based wait because it relies on an explicit
+    /// test notification from the update-state loop.
+    pub async fn pause_preferred_batches_and_wait(&self) -> anyhow::Result<()> {
+        let mut updates = self
+            .subscribe_state_updates()
+            .await
+            .map_err(anyhow::Error::from)?;
+        self.pause_preferred_batches().await;
+
+        let wait_loop = async {
+            loop {
+                let Some(next) = updates.next().await else {
+                    return Err(anyhow::anyhow!(
+                        "state update subscription closed while waiting for pause acknowledgment"
+                    ));
+                };
+                let notification = next?;
+                if notification.update_skipped_due_to_pause {
+                    return Ok(());
+                }
+            }
+        };
+
+        timeout(Self::POLLING_TIMEOUT, wait_loop)
+            .await
+            .with_context(|| {
+                format!(
+                    "Timeout waiting for pause acknowledgment after {:?}",
+                    Self::POLLING_TIMEOUT
+                )
+            })?
+    }
+
     /// Resumes batch production after [`TestRollup::pause_preferred_batches`].
     ///
     /// Note: calling this method MAY NOT immediately produce a batch.

--- a/examples/demo-rollup/tests/evm/evm_block_pinned_state_reads.rs
+++ b/examples/demo-rollup/tests/evm/evm_block_pinned_state_reads.rs
@@ -346,7 +346,10 @@ async fn block_pinned_eth_call_excludes_pending() {
 
     let get_tx = client.make_tx(Some(contract_addr), Some(client.contract.get()));
 
-    rollup.pause_preferred_batches().await;
+    rollup
+        .pause_preferred_batches_and_wait()
+        .await
+        .expect("pause should be acknowledged before eth_call assertions");
     let new_value = 0x5678u32;
     let tx_hash = client.set_value(contract_addr, new_value).await;
     wait_for_pending_tx(&client, tx_hash, head_number, finalized_head_before_pause).await;
@@ -399,7 +402,10 @@ async fn block_pinned_estimate_gas_excludes_pending() {
         "Pinned baseline by number and hash should match"
     );
 
-    rollup.pause_preferred_batches().await;
+    rollup
+        .pause_preferred_batches_and_wait()
+        .await
+        .expect("pause should be acknowledged before estimate_gas assertions");
     // Pending mutation makes slot non-zero in current state, lowering cost for the same call.
     let tx_hash = client.set_value(contract_addr, 0x1234).await;
     wait_for_pending_tx(&client, tx_hash, head_number, finalized_head_before_pause).await;

--- a/examples/demo-rollup/tests/evm/evm_block_pinned_state_reads.rs
+++ b/examples/demo-rollup/tests/evm/evm_block_pinned_state_reads.rs
@@ -156,7 +156,10 @@ async fn block_pinned_nonce_excludes_pending() {
     let finalized_head_before_pause = finalized_block_number_and_hash(&client).await;
     let sealed_nonce = nonce_at(&client, address, "latest").await;
 
-    rollup.pause_preferred_batches().await;
+    rollup
+        .pause_preferred_batches_and_wait()
+        .await
+        .expect("pause should be acknowledged before nonce assertions");
     let tx_hash = client.send_eth(Address::ZERO, U256::from(0x1234)).await;
     wait_for_pending_tx(&client, tx_hash, head_number, finalized_head_before_pause).await;
 
@@ -199,7 +202,10 @@ async fn block_pinned_balance_excludes_pending() {
         "Receiver should start with zero balance"
     );
 
-    rollup.pause_preferred_batches().await;
+    rollup
+        .pause_preferred_batches_and_wait()
+        .await
+        .expect("pause should be acknowledged before balance assertions");
     let transfer_amount = U256::from(0x1_0000_0000u64);
     let tx_hash = client.send_eth(receiver, transfer_amount).await;
     wait_for_pending_tx(&client, tx_hash, head_number, finalized_head_before_pause).await;
@@ -235,7 +241,10 @@ async fn block_pinned_code_excludes_pending() {
     let (head_number, head_hash) = sealed_head_number_and_hash(&client).await;
     let finalized_head_before_pause = finalized_block_number_and_hash(&client).await;
 
-    rollup.pause_preferred_batches().await;
+    rollup
+        .pause_preferred_batches_and_wait()
+        .await
+        .expect("pause should be acknowledged before code assertions");
     let deploy_tx = client.deploy_contract().await.unwrap();
     let receipt = client.wait_for_receipt(deploy_tx).await;
     assert_pause_effect(&client, head_number, finalized_head_before_pause).await;
@@ -283,7 +292,10 @@ async fn block_pinned_storage_excludes_pending() {
     let (head_number, head_hash) = sealed_head_number_and_hash(&client).await;
     let finalized_head_before_pause = finalized_block_number_and_hash(&client).await;
 
-    rollup.pause_preferred_batches().await;
+    rollup
+        .pause_preferred_batches_and_wait()
+        .await
+        .expect("pause should be acknowledged before storage assertions");
     let new_value = 0x5678u32;
     let tx_hash = client.set_value(contract_addr, new_value).await;
     wait_for_pending_tx(&client, tx_hash, head_number, finalized_head_before_pause).await;

--- a/examples/demo-rollup/tests/evm/evm_fee_history.rs
+++ b/examples/demo-rollup/tests/evm/evm_fee_history.rs
@@ -1557,7 +1557,10 @@ async fn test_fee_history_base_fee_stability() -> anyhow::Result<()> {
 /// TC06: finalized and safe return identical results
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fee_history_finalized_equals_safe() -> anyhow::Result<()> {
-    let (_rollup, client) = setup_fee_history_test(5).await;
+    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
+    let client = alloy_client(rollup.http_addr);
+    rollup.wait_for_next_blocks(5).await;
+    rollup.pause_preferred_batches_and_wait().await?;
 
     let finalized = client
         .get_fee_history(3, BlockNumberOrTag::Finalized, &[25.0, 75.0])

--- a/examples/demo-rollup/tests/evm/evm_fee_history.rs
+++ b/examples/demo-rollup/tests/evm/evm_fee_history.rs
@@ -216,7 +216,10 @@ async fn setup_fee_history_test(
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
     rollup.wait_for_next_blocks(wait_blocks).await;
-    rollup.pause_preferred_batches().await;
+    rollup
+        .pause_preferred_batches_and_wait()
+        .await
+        .expect("pause should be acknowledged before fee_history queries");
     (rollup, client)
 }
 
@@ -229,7 +232,10 @@ async fn setup_with_pending_tx(
     let contract_address = deploy_contract_check(&simple_storage)
         .await
         .expect("deploy should succeed");
-    rollup.pause_preferred_batches().await;
+    rollup
+        .pause_preferred_batches_and_wait()
+        .await
+        .expect("pause should be acknowledged before creating pending tx");
     simple_storage.set_value(contract_address, 42).await;
     (simple_storage, contract_address)
 }
@@ -498,7 +504,7 @@ async fn test_eth_fee_history_large_count_capped() -> anyhow::Result<()> {
         .expect("receipt should include block number");
     // Wait for the slot to complete so gas_info is recorded
     rollup.wait_for_next_blocks(1).await;
-    rollup.pause_preferred_batches().await;
+    rollup.pause_preferred_batches_and_wait().await?;
 
     assert!(client
         .get_fee_history(2000, BlockNumberOrTag::Number(newest_block), &[])
@@ -1096,7 +1102,7 @@ async fn test_fee_history_values_match_block_headers() -> anyhow::Result<()> {
         .expect("deploy receipt should include block number");
 
     rollup.wait_for_next_blocks(2).await;
-    rollup.pause_preferred_batches().await;
+    rollup.pause_preferred_batches_and_wait().await?;
 
     let newest_block = deploy_block + 1;
     let fee_history = client
@@ -1199,7 +1205,7 @@ async fn test_fee_history_block_with_tx_nonzero_ratio() -> anyhow::Result<()> {
         .expect("receipt should include block number");
     // Wait for the slot to complete so gas_info is recorded
     rollup.wait_for_next_blocks(1).await;
-    rollup.pause_preferred_batches().await;
+    rollup.pause_preferred_batches_and_wait().await?;
 
     assert!(
         receipt.gas_used > 0,
@@ -1313,7 +1319,7 @@ async fn test_fee_history_multiple_txs_across_blocks() -> anyhow::Result<()> {
         rollup.wait_for_next_blocks(1).await;
     }
 
-    rollup.pause_preferred_batches().await;
+    rollup.pause_preferred_batches_and_wait().await?;
 
     // Query fee history covering all transaction blocks
     let latest_block = client.get_block_number().await?;
@@ -1405,7 +1411,7 @@ async fn test_fee_history_consistent_query_methods() -> anyhow::Result<()> {
         .await
         .expect("set_value should succeed");
     rollup.wait_for_next_blocks(2).await;
-    rollup.pause_preferred_batches().await;
+    rollup.pause_preferred_batches_and_wait().await?;
 
     // Get the current block number
     let block_num = client.get_block_number().await?;
@@ -1476,7 +1482,7 @@ async fn test_fee_history_mixed_pattern() -> anyhow::Result<()> {
         .expect("set_value should succeed");
     rollup.wait_for_next_blocks(1).await;
 
-    rollup.pause_preferred_batches().await;
+    rollup.pause_preferred_batches_and_wait().await?;
 
     // Query for 5 blocks after start_block
     let end_block = start_block + 5;
@@ -1830,7 +1836,7 @@ async fn test_fee_history_heavy_gas_usage() -> anyhow::Result<()> {
     // Ensure the block containing the tx is sealed before pausing.
     rollup.wait_for_next_blocks(1).await;
 
-    rollup.pause_preferred_batches().await;
+    rollup.pause_preferred_batches_and_wait().await?;
 
     let block_after = client.get_block_number().await?;
 

--- a/examples/demo-rollup/tests/evm/evm_get_transaction_count.rs
+++ b/examples/demo-rollup/tests/evm/evm_get_transaction_count.rs
@@ -173,7 +173,7 @@ async fn eth_get_transaction_count_safe_finalized_semantics() -> anyhow::Result<
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_get_transaction_count_latest_vs_pending() -> anyhow::Result<()> {
     let (rollup, client) = setup_rollup().await;
-    rollup.pause_preferred_batches().await;
+    rollup.pause_preferred_batches_and_wait().await?;
 
     let address = client.address();
     // In paused mode, `eth_blockNumber`/`latest` may point to pending.
@@ -227,7 +227,7 @@ async fn eth_get_transaction_count_latest_vs_pending() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_get_transaction_count_block_number_and_hash() -> anyhow::Result<()> {
     let (rollup, client) = setup_rollup().await;
-    rollup.pause_preferred_batches().await;
+    rollup.pause_preferred_batches_and_wait().await?;
 
     let (sealed_head_number, sealed_head_hash) = finalized_block_number_and_hash(&client).await;
     assert_ne!(sealed_head_hash, B256::ZERO);


### PR DESCRIPTION
# Description

## Why

- We had a race in flaky EVM tests: pause_preferred_batches() sets a flag, but tests could still submit txs before the update-state loop actually observed that pause.

## What

- Added an explicit pause-ack signal from the preferred sequencer update-state loop, reusing the existing state-update test notification stream (no sleep/poll hacks).

### How

- Extended StateUpdateNotification with update_skipped_due_to_pause (test-utils only, serde-defaulted for compatibility):
  `common.rs:265`
- In preferred sequencer update_state_task_inner, when SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE=1 is observed, it now emits a notification with update_skipped_due_to_pause: true before returning early: `preferred/mod.rs:640`
- Normal state-update notifications now explicitly set update_skipped_due_to_pause: false so tests can reliably distinguish normal updates from pause acknowledgments:
    `sync_state.rs:303`
- Wired the notification sender into PreferredSequencerFields behind test-utils to keep blast radius minimal:
    `preferred/initialization.rs:174`, `preferred/mod.rs:131`

Net effect: deterministic, signal-based pause acknowledgment in tests; no production behavior change.

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
Run tests 50 times on sov-dev-box

## Docs
No updates
