### PR TITLE
Unflaky sequencer upgradability tests

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -213,8 +213,9 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
         slot_subscription.next().await;
     }
 
-    let mut shutdown_timeout_error = None;
-    let shutdown_wait_step = Duration::from_millis(250);
+    // We use "standard" MockDa block time to not overwhelm node.
+    let shutdown_wait_step =
+        Duration::from_millis(sov_test_utils::TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS);
     let shutdown_deadline = tokio::time::Instant::now() + shutdown_timeout;
 
     loop {
@@ -231,18 +232,13 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
                     panic!("Rollup shutdown failed unexpectedly: {error:#}");
                 }
                 if tokio::time::Instant::now() >= shutdown_deadline {
-                    shutdown_timeout_error = Some(error);
-                    break;
+                    panic!(
+                        "Failed waiting for rollup shutdown before timeout (stop_at_height={stop_at_height}): {error:#}"
+                    );
                 }
                 test_rollup.da_service.produce_block_now().await.unwrap();
             }
         }
-    }
-
-    if let Some(error) = shutdown_timeout_error {
-        panic!(
-            "Failed waiting for rollup shutdown before timeout (stop_at_height={stop_at_height}): {error:#}"
-        );
     }
 }
 

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -263,10 +263,35 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
         current_height_before_shutdown_wait
     );
 
-    if let Err(error) = test_rollup
-        .try_wait_for_rollup_to_shutdown(shutdown_timeout)
-        .await
-    {
+    let mut shutdown_timeout_error = None;
+    let shutdown_wait_step = Duration::from_millis(250);
+    let shutdown_deadline = tokio::time::Instant::now() + shutdown_timeout;
+    let mut shutdown_drive_blocks = 0u64;
+
+    loop {
+        match test_rollup
+            .try_wait_for_rollup_to_shutdown(shutdown_wait_step)
+            .await
+        {
+            Ok(()) => break,
+            Err(error) => {
+                let is_wait_timeout = error
+                    .to_string()
+                    .contains("Failed to join rollup task before timeout");
+                if !is_wait_timeout {
+                    panic!("Rollup shutdown failed unexpectedly: {error:#}");
+                }
+                if tokio::time::Instant::now() >= shutdown_deadline {
+                    shutdown_timeout_error = Some(error);
+                    break;
+                }
+                test_rollup.da_service.produce_block_now().await.unwrap();
+                shutdown_drive_blocks += 1;
+            }
+        }
+    }
+
+    if let Some(error) = shutdown_timeout_error {
         let ready_response = query_endpoint(&test_rollup.client, "/sequencer/ready").await;
         let role_response = query_endpoint(&test_rollup.client, "/sequencer/role").await;
         let latest_slot_response =
@@ -288,12 +313,13 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
         };
 
         info!(
-            "DEBUG_UPG_STOP_TX_SHUTDOWN_TIMEOUT stop_at_height={} rollup_height={} sync_status={} latest_slot={} finalized_slot={}",
+            "DEBUG_UPG_STOP_TX_SHUTDOWN_TIMEOUT stop_at_height={} rollup_height={} sync_status={} latest_slot={} finalized_slot={} shutdown_drive_blocks={}",
             stop_at_height.get(),
             rollup_height,
             sync_status,
             latest_slot_response,
-            finalized_slot_response
+            finalized_slot_response,
+            shutdown_drive_blocks
         );
 
         panic!(

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -99,13 +99,7 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
     let api_client = test_rollup.api_client().clone();
 
     // Produce enough finalized DA blocks so the sequencer can start accepting transactions.
-    // Use produce_n_blocks_now (instant) rather than tenderly_produce_blocks to avoid
-    // cascading batch creation that could advance height past stop_at_height.
-    test_rollup
-        .da_service
-        .produce_n_blocks_now(finalization_blocks as usize + 3)
-        .await
-        .unwrap();
+    test_rollup.produce_enough_finalized_slots().await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Produce enough blocks with transactions to advance rollup height past stop_at_height.
@@ -147,6 +141,7 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
 }
 
 async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
+    let shutdown_timeout = Duration::from_secs(10);
     let stop_at_height = RollupHeight::new((finalization_blocks + 12) as u64);
 
     let (test_rollup, admin) = create_test_rollup(
@@ -166,13 +161,8 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
     let mut slot_subscription = test_rollup.client.client.subscribe_slots().await.unwrap();
 
     // Produce enough finalized DA blocks so the sequencer can start accepting transactions.
-    // Use produce_n_blocks_now (instant) rather than tenderly_produce_blocks to avoid
-    // cascading batch creation that could advance height past stop_at_height.
-    test_rollup
-        .da_service
-        .produce_n_blocks_now(finalization_blocks as usize + 3)
-        .await
-        .unwrap();
+    // Use a "tender" pace so the finalized-header poller deterministically observes updates.
+    test_rollup.produce_enough_finalized_slots().await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     let api_client = test_rollup.api_client().clone();
@@ -181,14 +171,27 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
     let mut current_height = test_rollup.height().await;
 
     while current_height.get() < stop_at_height.get() {
-        // All transactions should be accepted until the stop height is reached.
-        send_tx(&admin, nonce, &api_client).await.unwrap();
-        nonce += 1;
+        // Height check and tx submission are not atomic. If the node reaches stop-height
+        // between the check and the submission, rejection is expected and we should exit.
+        match send_tx(&admin, nonce, &api_client).await {
+            Ok(_) => {
+                nonce += 1;
+            }
+            Err(err) => {
+                assert!(
+                    err.contains(&expected_error),
+                    "Unexpected pre-stop tx error: {err}"
+                );
+                break;
+            }
+        }
 
         test_rollup.da_service.produce_block_now().await.unwrap();
         slot_subscription.next().await;
         current_height = test_rollup.height().await;
     }
+
+    test_rollup.wait_for_height(stop_at_height.get()).await;
 
     // After the stop height is reached, the sequencer should not accept any transactions. Until the height is finalized.
     for _ in 0..finalization_blocks {
@@ -209,7 +212,7 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
     }
 
     test_rollup
-        .wait_for_rollup_to_shutdown(TEST_NORMAL_SHUTDOWN_TIMEOUT)
+        .wait_for_rollup_to_shutdown(shutdown_timeout)
         .await;
 }
 

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -235,7 +235,10 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
 
     // After the stop height is reached, the sequencer should not accept any transactions. Until the height is finalized.
     for _ in 0..finalization_blocks {
-        let current_height = test_rollup.height().await;
+        let Ok(current_height) = get_height(&test_rollup.client).await else {
+            // Shutdown may race with this verification loop in CI.
+            break;
+        };
         assert_eq!(current_height, stop_at_height);
 
         test_rollup.da_service.produce_block_now().await.unwrap();
@@ -250,10 +253,14 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
         test_rollup.da_service.produce_block_now().await.unwrap();
         slot_subscription.next().await;
     }
+    let current_height_before_shutdown_wait = match get_height(&test_rollup.client).await {
+        Ok(height) => format!("{height}"),
+        Err(error) => format!("unavailable: {error:#}"),
+    };
     info!(
         "DEBUG_UPG_STOP_TX_WAITING_SHUTDOWN stop_at_height={} current_height={}",
         stop_at_height.get(),
-        test_rollup.height().await.get()
+        current_height_before_shutdown_wait
     );
 
     if let Err(error) = test_rollup

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -9,7 +9,7 @@ use sov_mock_zkvm::crypto::private_key::Ed25519PrivateKey;
 use sov_modules_api::capabilities::RollupHeight;
 use sov_modules_api::{RawTx, Runtime};
 use sov_node_client::NodeClient;
-use sov_test_utils::logging::LogCollector;
+use sov_test_utils::logging::{initialize_or_change_logging_with_filter, LogCollector};
 use sov_test_utils::runtime::genesis::operator::HighLevelOperatorGenesisConfig;
 use sov_test_utils::runtime::GenesisParams;
 use sov_test_utils::test_rollup::get_height;
@@ -25,9 +25,12 @@ use std::time::Duration;
 use tracing::Level;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::registry;
+use tracing_subscriber::EnvFilter;
 
 generate_operator_runtime_with_kernel!(kernel_type: SoftConfirmationsKernel<'a, S>, TestRuntime <= value_setter: ValueSetter<S>);
 type TestBlueprint = RtAgnosticBlueprint<TestSpec, TestRuntime<TestSpec>>;
+const SHUTDOWN_DIAGNOSTIC_LOG_FILTER: &str =
+    "info,sov_stf_runner=debug,sov_stf_runner::runner=debug,sov_stf_runner::da=debug,sov_sequencer=debug,sqlx=warn,h2=info,hyper=info";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn flaky_tests_sequencer_stops_if_stop_at_height_too_small_immediate_finality() {
@@ -149,9 +152,18 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
 
 async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
     let shutdown_timeout = Duration::from_secs(10);
+    let collector = LogCollector::new(Level::DEBUG);
+    let subscriber = registry()
+        .with(EnvFilter::new(SHUTDOWN_DIAGNOSTIC_LOG_FILTER))
+        .with(tracing_subscriber::fmt::layer())
+        .with(collector.clone());
+    if subscriber.try_init().is_err() {
+        initialize_or_change_logging_with_filter(SHUTDOWN_DIAGNOSTIC_LOG_FILTER);
+    }
+
     let stop_at_height = RollupHeight::new((finalization_blocks + 12) as u64);
 
-    let (test_rollup, admin) = create_test_rollup(
+    let (mut test_rollup, admin) = create_test_rollup(
         0,
         TEST_MAX_BATCH_SIZE,
         TEST_BLOB_PROCESSING_TIMEOUT,
@@ -224,9 +236,45 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
         slot_subscription.next().await;
     }
 
-    test_rollup
-        .wait_for_rollup_to_shutdown(shutdown_timeout)
+    if let Err(error) = test_rollup
+        .try_wait_for_rollup_to_shutdown(shutdown_timeout)
+        .await
+    {
+        let ready_response = query_endpoint(&test_rollup.client, "/sequencer/ready").await;
+        let role_response = query_endpoint(&test_rollup.client, "/sequencer/role").await;
+        let latest_slot_response =
+            query_endpoint(&test_rollup.client, "/ledger/slots/latest").await;
+        let finalized_slot_response =
+            query_endpoint(&test_rollup.client, "/ledger/slots/finalized").await;
+        let current_heights_response = query_endpoint(
+            &test_rollup.client,
+            "/modules/chain-state/state/current-heights",
+        )
         .await;
+        let sync_status = match test_rollup.client.client.get_sync_status().await {
+            Ok(status) => format!("{:?}", status.into_inner()),
+            Err(sync_error) => format!("error: {sync_error:?}"),
+        };
+        let rollup_height = match get_height(&test_rollup.client).await {
+            Ok(height) => format!("{height}"),
+            Err(height_error) => format!("error: {height_error:#}"),
+        };
+        let recent_logs = format_recent_logs(&collector.records(), 200);
+
+        panic!(
+            "Failed waiting for rollup shutdown: {error:#}\n\
+            Diagnostics:\n\
+              stop_at_height: {stop_at_height}\n\
+              rollup_height: {rollup_height}\n\
+              sync_status: {sync_status}\n\
+              /sequencer/ready: {ready_response}\n\
+              /sequencer/role: {role_response}\n\
+              /ledger/slots/latest: {latest_slot_response}\n\
+              /ledger/slots/finalized: {finalized_slot_response}\n\
+              /modules/chain-state/state/current-heights: {current_heights_response}\n\
+            Recent logs (tail):\n{recent_logs}"
+        );
+    }
 }
 
 async fn rollup_operates_only_on_finalized_blocks_if_stop_at_height_set(finalization_blocks: u32) {
@@ -371,6 +419,27 @@ async fn send_tx(
         Err(err) => {
             panic!("Unexpected error: {err:?}")
         }
+    }
+}
+
+fn format_recent_logs(records: &[(Level, String)], limit: usize) -> String {
+    if records.is_empty() {
+        return "<no captured logs>".to_string();
+    }
+    let total = records.len();
+    let start = total.saturating_sub(limit);
+    records[start..]
+        .iter()
+        .enumerate()
+        .map(|(idx, (level, message))| format!("[{}] {level}: {message}", start + idx))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+async fn query_endpoint(client: &NodeClient, endpoint: &str) -> String {
+    match client.http_get(endpoint).await {
+        Ok(response) => response,
+        Err(error) => format!("error: {error:#}"),
     }
 }
 

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -9,7 +9,7 @@ use sov_mock_zkvm::crypto::private_key::Ed25519PrivateKey;
 use sov_modules_api::capabilities::RollupHeight;
 use sov_modules_api::{RawTx, Runtime};
 use sov_node_client::NodeClient;
-use sov_test_utils::logging::{initialize_or_change_logging_with_filter, LogCollector};
+use sov_test_utils::logging::initialize_or_change_logging_with_filter;
 use sov_test_utils::runtime::genesis::operator::HighLevelOperatorGenesisConfig;
 use sov_test_utils::runtime::GenesisParams;
 use sov_test_utils::test_rollup::get_height;
@@ -22,15 +22,12 @@ use sov_test_utils::{
 use sov_value_setter::{ValueSetter, ValueSetterConfig};
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::Level;
-use tracing_subscriber::prelude::*;
-use tracing_subscriber::registry;
-use tracing_subscriber::EnvFilter;
+use tracing::info;
 
 generate_operator_runtime_with_kernel!(kernel_type: SoftConfirmationsKernel<'a, S>, TestRuntime <= value_setter: ValueSetter<S>);
 type TestBlueprint = RtAgnosticBlueprint<TestSpec, TestRuntime<TestSpec>>;
 const SHUTDOWN_DIAGNOSTIC_LOG_FILTER: &str =
-    "info,sov_stf_runner=debug,sov_stf_runner::runner=debug,sov_stf_runner::da=debug,sov_sequencer=debug,sqlx=warn,h2=info,hyper=info";
+    "info,sov_stf_runner=debug,sov_stf_runner::runner=debug,sov_stf_runner::da=debug,sov_sequencer=debug,sqlx=warn,h2=warn,hyper=warn";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn flaky_tests_sequencer_stops_if_stop_at_height_too_small_immediate_finality() {
@@ -83,11 +80,14 @@ async fn test_start_at_finalization_plus_one() {
 }
 
 async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
-    let collector = LogCollector::new(Level::ERROR);
-    let subscriber = registry().with(collector.clone());
-    subscriber.init();
+    initialize_or_change_logging_with_filter(SHUTDOWN_DIAGNOSTIC_LOG_FILTER);
 
     let stop_at_height = RollupHeight::new(3);
+    info!(
+        "DEBUG_UPG_STOP_TOO_SMALL_START finalization_blocks={} stop_at_height={}",
+        finalization_blocks,
+        stop_at_height.get()
+    );
 
     let (test_rollup, admin) = create_test_rollup(
         0,
@@ -140,28 +140,20 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
         panic!("The rollup should have stopped")
     };
 
-    let records = collector.records();
-    assert!(
-        records
-            .iter()
-            .any(|(_, log)| log.contains("The requested stop_height")),
-        "Expected stop-height log in records: {records:?}"
-    );
     assert!(err.to_string().contains("The requested stop_height"));
 }
 
 async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
     let shutdown_timeout = Duration::from_secs(10);
-    let collector = LogCollector::new(Level::DEBUG);
-    let subscriber = registry()
-        .with(EnvFilter::new(SHUTDOWN_DIAGNOSTIC_LOG_FILTER))
-        .with(tracing_subscriber::fmt::layer())
-        .with(collector.clone());
-    if subscriber.try_init().is_err() {
-        initialize_or_change_logging_with_filter(SHUTDOWN_DIAGNOSTIC_LOG_FILTER);
-    }
+    initialize_or_change_logging_with_filter(SHUTDOWN_DIAGNOSTIC_LOG_FILTER);
 
     let stop_at_height = RollupHeight::new((finalization_blocks + 12) as u64);
+    info!(
+        "DEBUG_UPG_STOP_TX_START finalization_blocks={} stop_at_height={} shutdown_timeout_ms={}",
+        finalization_blocks,
+        stop_at_height.get(),
+        shutdown_timeout.as_millis()
+    );
 
     let (mut test_rollup, admin) = create_test_rollup(
         0,
@@ -189,6 +181,11 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
         .await
         .unwrap();
     test_rollup.wait_for_sequencer_ready().await.unwrap();
+    info!(
+        "DEBUG_UPG_STOP_TX_READY stop_at_height={} current_height={}",
+        stop_at_height.get(),
+        test_rollup.height().await.get()
+    );
 
     let api_client = test_rollup.api_client().clone();
 
@@ -196,6 +193,12 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
     let mut current_height = test_rollup.height().await;
 
     while current_height.get() < stop_at_height.get() {
+        info!(
+            "DEBUG_UPG_STOP_TX_PRE_STOP_LOOP current_height={} stop_at_height={} nonce={}",
+            current_height.get(),
+            stop_at_height.get(),
+            nonce
+        );
         // Height check and tx submission are not atomic. If the node reaches stop-height
         // between the check and the submission, rejection is expected and we should exit.
         match send_tx(&admin, nonce, &api_client).await {
@@ -207,6 +210,13 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
                     err.contains(&expected_error),
                     "Unexpected pre-stop tx error: {err}"
                 );
+                info!(
+                    "DEBUG_UPG_STOP_TX_PRE_STOP_REJECT current_height={} stop_at_height={} nonce={} error={}",
+                    current_height.get(),
+                    stop_at_height.get(),
+                    nonce,
+                    err
+                );
                 break;
             }
         }
@@ -217,6 +227,11 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
     }
 
     test_rollup.wait_for_height(stop_at_height.get()).await;
+    info!(
+        "DEBUG_UPG_STOP_TX_AT_STOP_HEIGHT stop_at_height={} nonce={}",
+        stop_at_height.get(),
+        nonce
+    );
 
     // After the stop height is reached, the sequencer should not accept any transactions. Until the height is finalized.
     for _ in 0..finalization_blocks {
@@ -235,6 +250,11 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
         test_rollup.da_service.produce_block_now().await.unwrap();
         slot_subscription.next().await;
     }
+    info!(
+        "DEBUG_UPG_STOP_TX_WAITING_SHUTDOWN stop_at_height={} current_height={}",
+        stop_at_height.get(),
+        test_rollup.height().await.get()
+    );
 
     if let Err(error) = test_rollup
         .try_wait_for_rollup_to_shutdown(shutdown_timeout)
@@ -259,7 +279,15 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
             Ok(height) => format!("{height}"),
             Err(height_error) => format!("error: {height_error:#}"),
         };
-        let recent_logs = format_recent_logs(&collector.records(), 200);
+
+        info!(
+            "DEBUG_UPG_STOP_TX_SHUTDOWN_TIMEOUT stop_at_height={} rollup_height={} sync_status={} latest_slot={} finalized_slot={}",
+            stop_at_height.get(),
+            rollup_height,
+            sync_status,
+            latest_slot_response,
+            finalized_slot_response
+        );
 
         panic!(
             "Failed waiting for rollup shutdown: {error:#}\n\
@@ -272,7 +300,7 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
               /ledger/slots/latest: {latest_slot_response}\n\
               /ledger/slots/finalized: {finalized_slot_response}\n\
               /modules/chain-state/state/current-heights: {current_heights_response}\n\
-            Recent logs (tail):\n{recent_logs}"
+              See stdout logs for DEBUG_UPG_STOP_TX_* and DEBUG_WAIT_FINALIZED_* markers."
         );
     }
 }
@@ -420,20 +448,6 @@ async fn send_tx(
             panic!("Unexpected error: {err:?}")
         }
     }
-}
-
-fn format_recent_logs(records: &[(Level, String)], limit: usize) -> String {
-    if records.is_empty() {
-        return "<no captured logs>".to_string();
-    }
-    let total = records.len();
-    let start = total.saturating_sub(limit);
-    records[start..]
-        .iter()
-        .enumerate()
-        .map(|(idx, (level, message))| format!("[{}] {level}: {message}", start + idx))
-        .collect::<Vec<_>>()
-        .join("\n")
 }
 
 async fn query_endpoint(client: &NodeClient, endpoint: &str) -> String {

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -9,7 +9,6 @@ use sov_mock_zkvm::crypto::private_key::Ed25519PrivateKey;
 use sov_modules_api::capabilities::RollupHeight;
 use sov_modules_api::{RawTx, Runtime};
 use sov_node_client::NodeClient;
-use sov_test_utils::logging::initialize_or_change_logging_with_filter;
 use sov_test_utils::runtime::genesis::operator::HighLevelOperatorGenesisConfig;
 use sov_test_utils::runtime::GenesisParams;
 use sov_test_utils::test_rollup::get_height;
@@ -22,12 +21,9 @@ use sov_test_utils::{
 use sov_value_setter::{ValueSetter, ValueSetterConfig};
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::info;
 
 generate_operator_runtime_with_kernel!(kernel_type: SoftConfirmationsKernel<'a, S>, TestRuntime <= value_setter: ValueSetter<S>);
 type TestBlueprint = RtAgnosticBlueprint<TestSpec, TestRuntime<TestSpec>>;
-const SHUTDOWN_DIAGNOSTIC_LOG_FILTER: &str =
-    "info,sov_stf_runner=debug,sov_stf_runner::runner=debug,sov_stf_runner::da=debug,sov_sequencer=debug,sqlx=warn,h2=warn,hyper=warn";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn flaky_tests_sequencer_stops_if_stop_at_height_too_small_immediate_finality() {
@@ -80,14 +76,7 @@ async fn test_start_at_finalization_plus_one() {
 }
 
 async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
-    initialize_or_change_logging_with_filter(SHUTDOWN_DIAGNOSTIC_LOG_FILTER);
-
     let stop_at_height = RollupHeight::new(3);
-    info!(
-        "DEBUG_UPG_STOP_TOO_SMALL_START finalization_blocks={} stop_at_height={}",
-        finalization_blocks,
-        stop_at_height.get()
-    );
 
     let (test_rollup, admin) = create_test_rollup(
         0,
@@ -145,15 +134,8 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
 
 async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
     let shutdown_timeout = Duration::from_secs(10);
-    initialize_or_change_logging_with_filter(SHUTDOWN_DIAGNOSTIC_LOG_FILTER);
 
     let stop_at_height = RollupHeight::new((finalization_blocks + 12) as u64);
-    info!(
-        "DEBUG_UPG_STOP_TX_START finalization_blocks={} stop_at_height={} shutdown_timeout_ms={}",
-        finalization_blocks,
-        stop_at_height.get(),
-        shutdown_timeout.as_millis()
-    );
 
     let (mut test_rollup, admin) = create_test_rollup(
         0,
@@ -181,11 +163,6 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
         .await
         .unwrap();
     test_rollup.wait_for_sequencer_ready().await.unwrap();
-    info!(
-        "DEBUG_UPG_STOP_TX_READY stop_at_height={} current_height={}",
-        stop_at_height.get(),
-        test_rollup.height().await.get()
-    );
 
     let api_client = test_rollup.api_client().clone();
 
@@ -193,12 +170,6 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
     let mut current_height = test_rollup.height().await;
 
     while current_height.get() < stop_at_height.get() {
-        info!(
-            "DEBUG_UPG_STOP_TX_PRE_STOP_LOOP current_height={} stop_at_height={} nonce={}",
-            current_height.get(),
-            stop_at_height.get(),
-            nonce
-        );
         // Height check and tx submission are not atomic. If the node reaches stop-height
         // between the check and the submission, rejection is expected and we should exit.
         match send_tx(&admin, nonce, &api_client).await {
@@ -210,13 +181,6 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
                     err.contains(&expected_error),
                     "Unexpected pre-stop tx error: {err}"
                 );
-                info!(
-                    "DEBUG_UPG_STOP_TX_PRE_STOP_REJECT current_height={} stop_at_height={} nonce={} error={}",
-                    current_height.get(),
-                    stop_at_height.get(),
-                    nonce,
-                    err
-                );
                 break;
             }
         }
@@ -227,11 +191,6 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
     }
 
     test_rollup.wait_for_height(stop_at_height.get()).await;
-    info!(
-        "DEBUG_UPG_STOP_TX_AT_STOP_HEIGHT stop_at_height={} nonce={}",
-        stop_at_height.get(),
-        nonce
-    );
 
     // After the stop height is reached, the sequencer should not accept any transactions. Until the height is finalized.
     for _ in 0..finalization_blocks {
@@ -253,20 +212,10 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
         test_rollup.da_service.produce_block_now().await.unwrap();
         slot_subscription.next().await;
     }
-    let current_height_before_shutdown_wait = match get_height(&test_rollup.client).await {
-        Ok(height) => format!("{height}"),
-        Err(error) => format!("unavailable: {error:#}"),
-    };
-    info!(
-        "DEBUG_UPG_STOP_TX_WAITING_SHUTDOWN stop_at_height={} current_height={}",
-        stop_at_height.get(),
-        current_height_before_shutdown_wait
-    );
 
     let mut shutdown_timeout_error = None;
     let shutdown_wait_step = Duration::from_millis(250);
     let shutdown_deadline = tokio::time::Instant::now() + shutdown_timeout;
-    let mut shutdown_drive_blocks = 0u64;
 
     loop {
         match test_rollup
@@ -286,54 +235,13 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
                     break;
                 }
                 test_rollup.da_service.produce_block_now().await.unwrap();
-                shutdown_drive_blocks += 1;
             }
         }
     }
 
     if let Some(error) = shutdown_timeout_error {
-        let ready_response = query_endpoint(&test_rollup.client, "/sequencer/ready").await;
-        let role_response = query_endpoint(&test_rollup.client, "/sequencer/role").await;
-        let latest_slot_response =
-            query_endpoint(&test_rollup.client, "/ledger/slots/latest").await;
-        let finalized_slot_response =
-            query_endpoint(&test_rollup.client, "/ledger/slots/finalized").await;
-        let current_heights_response = query_endpoint(
-            &test_rollup.client,
-            "/modules/chain-state/state/current-heights",
-        )
-        .await;
-        let sync_status = match test_rollup.client.client.get_sync_status().await {
-            Ok(status) => format!("{:?}", status.into_inner()),
-            Err(sync_error) => format!("error: {sync_error:?}"),
-        };
-        let rollup_height = match get_height(&test_rollup.client).await {
-            Ok(height) => format!("{height}"),
-            Err(height_error) => format!("error: {height_error:#}"),
-        };
-
-        info!(
-            "DEBUG_UPG_STOP_TX_SHUTDOWN_TIMEOUT stop_at_height={} rollup_height={} sync_status={} latest_slot={} finalized_slot={} shutdown_drive_blocks={}",
-            stop_at_height.get(),
-            rollup_height,
-            sync_status,
-            latest_slot_response,
-            finalized_slot_response,
-            shutdown_drive_blocks
-        );
-
         panic!(
-            "Failed waiting for rollup shutdown: {error:#}\n\
-            Diagnostics:\n\
-              stop_at_height: {stop_at_height}\n\
-              rollup_height: {rollup_height}\n\
-              sync_status: {sync_status}\n\
-              /sequencer/ready: {ready_response}\n\
-              /sequencer/role: {role_response}\n\
-              /ledger/slots/latest: {latest_slot_response}\n\
-              /ledger/slots/finalized: {finalized_slot_response}\n\
-              /modules/chain-state/state/current-heights: {current_heights_response}\n\
-              See stdout logs for DEBUG_UPG_STOP_TX_* and DEBUG_WAIT_FINALIZED_* markers."
+            "Failed waiting for rollup shutdown before timeout (stop_at_height={stop_at_height}): {error:#}"
         );
     }
 }
@@ -480,13 +388,6 @@ async fn send_tx(
         Err(err) => {
             panic!("Unexpected error: {err:?}")
         }
-    }
-}
-
-async fn query_endpoint(client: &NodeClient, endpoint: &str) -> String {
-    match client.http_get(endpoint).await {
-        Ok(response) => response,
-        Err(error) => format!("error: {error:#}"),
     }
 }
 

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -98,8 +98,15 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
     let mut slot_subscription = test_rollup.client.client.subscribe_slots().await.unwrap();
     let api_client = test_rollup.api_client().clone();
 
-    // Produce enough finalized DA blocks so the sequencer can start accepting transactions.
-    test_rollup.produce_enough_finalized_slots().await;
+    // Produce the minimum paced DA blocks needed for readiness.
+    // We intentionally avoid `produce_enough_finalized_slots()` here because it also performs
+    // extra sync/lag advancement work, which can move this test into transient
+    // "node not synced yet" states and make pre-stop tx checks flaky.
+    // `+2` gives a deterministic post-genesis finalized update observed by the poller.
+    test_rollup
+        .tenderly_produce_blocks((finalization_blocks + 2) as usize)
+        .await
+        .unwrap();
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Produce enough blocks with transactions to advance rollup height past stop_at_height.
@@ -160,9 +167,15 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
 
     let mut slot_subscription = test_rollup.client.client.subscribe_slots().await.unwrap();
 
-    // Produce enough finalized DA blocks so the sequencer can start accepting transactions.
-    // Use a "tender" pace so the finalized-header poller deterministically observes updates.
-    test_rollup.produce_enough_finalized_slots().await;
+    // Produce the minimum paced DA blocks needed for readiness.
+    // We intentionally avoid `produce_enough_finalized_slots()` here because it also performs
+    // extra sync/lag advancement work, which can move this test into transient
+    // "node not synced yet" states and make pre-stop tx checks flaky.
+    // `+2` gives a deterministic post-genesis finalized update observed by the poller.
+    test_rollup
+        .tenderly_produce_blocks((finalization_blocks + 2) as usize)
+        .await
+        .unwrap();
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     let api_client = test_rollup.api_client().clone();

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -439,18 +439,28 @@ where
         next_da_height: u64,
         shutdown_receiver: &watch::Receiver<()>,
     ) -> anyhow::Result<bool> {
+        // Temporary CI-debug marker for flaky shutdown in upgrade tests.
+        // Keep critical values in message body (not only structured fields) so
+        // copied tails and plain-text artifacts remain informative.
+        let mut poll_count: u64 = 0;
+        let mut last_logged_finalized_height: Option<u64> = None;
         loop {
             let finalized_height = self
                 .finalized_headers_provider
                 .get_last_finalized_block_header()?
                 .height();
             if next_da_height > finalized_height {
-                info!(
-                    "DEBUG_WAIT_FINALIZED finalized_height={} next_da_height={} polling_interval_ms={}",
-                    finalized_height,
-                    next_da_height,
-                    self.da_polling_interval.as_millis()
-                );
+                poll_count += 1;
+                if last_logged_finalized_height != Some(finalized_height) || poll_count % 50 == 0 {
+                    info!(
+                        "DEBUG_WAIT_FINALIZED finalized_height={} next_da_height={} polling_interval_ms={} poll_count={}",
+                        finalized_height,
+                        next_da_height,
+                        self.da_polling_interval.as_millis(),
+                        poll_count
+                    );
+                    last_logged_finalized_height = Some(finalized_height);
+                }
                 match future_or_shutdown(
                     tokio::time::sleep(self.da_polling_interval),
                     shutdown_receiver,
@@ -704,6 +714,10 @@ where
         // If the rollup is upgrading and the current height has reached the stop point,
         // halt further slot processing.
         if let Some(stop_at_rollup_height) = stop_at_rollup_height {
+            info!(
+                "DEBUG_STOP_CHECK slot_rollup_height={} stop_at_rollup_height={} next_da_height={}",
+                slot_result.rollup_height, stop_at_rollup_height, next_da_height
+            );
             if &slot_result.rollup_height == stop_at_rollup_height {
                 info!(rollup_height = %stop_at_rollup_height, "Stopping at rollup the height");
                 return Ok(None);

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -715,29 +715,21 @@ where
         // If the rollup is upgrading and the current height has reached the stop point,
         // halt further slot processing.
         if let Some(stop_at_rollup_height) = stop_at_rollup_height {
-            // `slot_result.rollup_height` may reflect the pre-slot height. If this slot produced
-            // a rollup block, effective height after processing is one higher.
-            let effective_rollup_height = if created_rollup_block {
-                slot_result.rollup_height.saturating_add(1)
-            } else {
-                slot_result.rollup_height
-            };
             info!(
-                "DEBUG_STOP_CHECK slot_rollup_height={} effective_rollup_height={} stop_at_rollup_height={} next_da_height={} created_rollup_block={}",
+                "DEBUG_STOP_CHECK slot_rollup_height={} stop_at_rollup_height={} next_da_height={} created_rollup_block={}",
                 slot_result.rollup_height,
-                effective_rollup_height,
                 stop_at_rollup_height,
                 next_da_height,
                 created_rollup_block
             );
-            if &effective_rollup_height >= stop_at_rollup_height {
+            if &slot_result.rollup_height == stop_at_rollup_height {
                 info!(rollup_height = %stop_at_rollup_height, "Stopping at rollup the height");
                 return Ok(None);
             }
             assert!(
-                &effective_rollup_height < stop_at_rollup_height,
+                &slot_result.rollup_height < stop_at_rollup_height,
                 "The rollup height ({}) must be less than the stop height ({})",
-                effective_rollup_height,
+                slot_result.rollup_height,
                 stop_at_rollup_height
             );
         }

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -445,17 +445,32 @@ where
                 .get_last_finalized_block_header()?
                 .height();
             if next_da_height > finalized_height {
-                info!(%finalized_height, %next_da_height, "Waiting until next DA height is finalized");
+                info!(
+                    "DEBUG_WAIT_FINALIZED finalized_height={} next_da_height={} polling_interval_ms={}",
+                    finalized_height,
+                    next_da_height,
+                    self.da_polling_interval.as_millis()
+                );
                 match future_or_shutdown(
                     tokio::time::sleep(self.da_polling_interval),
                     shutdown_receiver,
                 )
                 .await
                 {
-                    FutureOrShutdownOutput::Shutdown => return Ok(true),
+                    FutureOrShutdownOutput::Shutdown => {
+                        info!(
+                            "DEBUG_WAIT_FINALIZED_SHUTDOWN finalized_height={} next_da_height={}",
+                            finalized_height, next_da_height
+                        );
+                        return Ok(true);
+                    }
                     FutureOrShutdownOutput::Output(()) => continue,
                 }
             } else {
+                info!(
+                    "DEBUG_WAIT_FINALIZED_EXIT finalized_height={} next_da_height={}",
+                    finalized_height, next_da_height
+                );
                 break;
             }
         }

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -439,48 +439,23 @@ where
         next_da_height: u64,
         shutdown_receiver: &watch::Receiver<()>,
     ) -> anyhow::Result<bool> {
-        // Temporary CI-debug marker for flaky shutdown in upgrade tests.
-        // Keep critical values in message body (not only structured fields) so
-        // copied tails and plain-text artifacts remain informative.
-        let mut poll_count: u64 = 0;
-        let mut last_logged_finalized_height: Option<u64> = None;
         loop {
             let finalized_height = self
                 .finalized_headers_provider
                 .get_last_finalized_block_header()?
                 .height();
             if next_da_height > finalized_height {
-                poll_count += 1;
-                if last_logged_finalized_height != Some(finalized_height) || poll_count % 50 == 0 {
-                    info!(
-                        "DEBUG_WAIT_FINALIZED finalized_height={} next_da_height={} polling_interval_ms={} poll_count={}",
-                        finalized_height,
-                        next_da_height,
-                        self.da_polling_interval.as_millis(),
-                        poll_count
-                    );
-                    last_logged_finalized_height = Some(finalized_height);
-                }
+                info!(%finalized_height, %next_da_height, "Waiting until next DA height is finalized");
                 match future_or_shutdown(
                     tokio::time::sleep(self.da_polling_interval),
                     shutdown_receiver,
                 )
                 .await
                 {
-                    FutureOrShutdownOutput::Shutdown => {
-                        info!(
-                            "DEBUG_WAIT_FINALIZED_SHUTDOWN finalized_height={} next_da_height={}",
-                            finalized_height, next_da_height
-                        );
-                        return Ok(true);
-                    }
+                    FutureOrShutdownOutput::Shutdown => return Ok(true),
                     FutureOrShutdownOutput::Output(()) => continue,
                 }
             } else {
-                info!(
-                    "DEBUG_WAIT_FINALIZED_EXIT finalized_height={} next_da_height={}",
-                    finalized_height, next_da_height
-                );
                 break;
             }
         }
@@ -639,7 +614,6 @@ where
             .await;
         let get_relevant_proofs_time = get_relevant_proofs_start.elapsed();
         // Handling executed data
-        let created_rollup_block = !slot_result.batch_receipts.is_empty();
         let mut data_to_commit = SlotCommit::new(filtered_block, slot_result.discarded_blobs);
         for mut receipt in slot_result.batch_receipts {
             if !self.save_tx_bodies {
@@ -715,13 +689,6 @@ where
         // If the rollup is upgrading and the current height has reached the stop point,
         // halt further slot processing.
         if let Some(stop_at_rollup_height) = stop_at_rollup_height {
-            info!(
-                "DEBUG_STOP_CHECK slot_rollup_height={} stop_at_rollup_height={} next_da_height={} created_rollup_block={}",
-                slot_result.rollup_height,
-                stop_at_rollup_height,
-                next_da_height,
-                created_rollup_block
-            );
             if &slot_result.rollup_height == stop_at_rollup_height {
                 info!(rollup_height = %stop_at_rollup_height, "Stopping at rollup the height");
                 return Ok(None);

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -639,6 +639,7 @@ where
             .await;
         let get_relevant_proofs_time = get_relevant_proofs_start.elapsed();
         // Handling executed data
+        let created_rollup_block = !slot_result.batch_receipts.is_empty();
         let mut data_to_commit = SlotCommit::new(filtered_block, slot_result.discarded_blobs);
         for mut receipt in slot_result.batch_receipts {
             if !self.save_tx_bodies {
@@ -714,18 +715,29 @@ where
         // If the rollup is upgrading and the current height has reached the stop point,
         // halt further slot processing.
         if let Some(stop_at_rollup_height) = stop_at_rollup_height {
+            // `slot_result.rollup_height` may reflect the pre-slot height. If this slot produced
+            // a rollup block, effective height after processing is one higher.
+            let effective_rollup_height = if created_rollup_block {
+                slot_result.rollup_height.saturating_add(1)
+            } else {
+                slot_result.rollup_height
+            };
             info!(
-                "DEBUG_STOP_CHECK slot_rollup_height={} stop_at_rollup_height={} next_da_height={}",
-                slot_result.rollup_height, stop_at_rollup_height, next_da_height
+                "DEBUG_STOP_CHECK slot_rollup_height={} effective_rollup_height={} stop_at_rollup_height={} next_da_height={} created_rollup_block={}",
+                slot_result.rollup_height,
+                effective_rollup_height,
+                stop_at_rollup_height,
+                next_da_height,
+                created_rollup_block
             );
-            if &slot_result.rollup_height == stop_at_rollup_height {
+            if &effective_rollup_height >= stop_at_rollup_height {
                 info!(rollup_height = %stop_at_rollup_height, "Stopping at rollup the height");
                 return Ok(None);
             }
             assert!(
-                &slot_result.rollup_height < stop_at_rollup_height,
+                &effective_rollup_height < stop_at_rollup_height,
                 "The rollup height ({}) must be less than the stop height ({})",
-                slot_result.rollup_height,
+                effective_rollup_height,
                 stop_at_rollup_height
             );
         }

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -735,6 +735,22 @@ where
             .expect("Rollup execution returned an error.");
     }
 
+    /// Waits for the rollup to shutdown without panicking on timeout.
+    ///
+    /// Unlike [`Self::wait_for_rollup_to_shutdown`], this method returns an error when the
+    /// timeout elapses. Useful in flaky-test diagnostics where we want to gather additional
+    /// node state before failing the test.
+    pub async fn try_wait_for_rollup_to_shutdown(
+        &mut self,
+        t: tokio::time::Duration,
+    ) -> anyhow::Result<()> {
+        let join_result = timeout(t, &mut self.rollup_task)
+            .await
+            .with_context(|| format!("Failed to join rollup task before timeout after {t:?}"))?;
+        let join_result = join_result.context("Rollup task panicked.")?;
+        join_result.context("Rollup execution returned an error.")
+    }
+
     /// Waits for the rollup to shutdown.
     pub async fn wait_for_rollup_to_shutdown_with_result(
         self,


### PR DESCRIPTION
# Description

### What was fixed and why:

1. Deterministic readiness for upgradability tests
    - Switched startup prep to paced block production(tenderly_produce_blocks(finalization_blocks + 2)) + explicit readiness wait.
    - Why: avoid transient “node syncing” windows caused by over-advancing helper behavior during setup.
2. TOCTOU(Time-Of-Check to Time-Of-Use)-safe pre-stop tx loop
    - In sequencer_does_not_accept_tx_after_stop, tx rejection right at boundary is now accepted if it matches expected stop-height error.
    - Why: height check and tx submission are not atomic.
3. Stronger shutdown wait path
    - Added non-panicking shutdown waiter in test utils (try_wait_for_rollup_to_shutdown) and used it with bounded retry loop + DA block driving in test.
    - Why: avoid false timeout panic when shutdown needs extra finalized progression.
4. Race-safe assertions during shutdown
    - Height reads in post-stop loops now tolerate RPC unavailability during shutdown race.
    - Why: CI timing can close node between assertion steps.

---

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Run tests 5 times on commit with debug https://github.com/Sovereign-Labs/sovereign-sdk/actions/runs/22714995331/job/65922028245 you can check that all 5 runs passed without any flakiness, with only evm pinned cache failure

## Docs
No updates
