### PR TITLE
Unflake `test_replica_catches_up_via_da_after_postgres_partition` and rename `wait_for_next_blocks` to `wait_for_height_advance_by`

### DIFF
--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -1033,7 +1033,7 @@ where
         }
     }
 
-    /// locks until the sequencer progresses by the specified number of heights.
+    /// Waits until the chain height advances by `delta`.
     pub async fn wait_for_height_advance_by(&self, delta: u64) {
         let current_height = get_height(&self.client).await.unwrap();
         let end_height = current_height.get() + delta;

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -1033,8 +1033,8 @@ where
         }
     }
 
-    /// Waits until the sequencer advances by the given number of blocks.
-    pub async fn wait_for_next_blocks(&self, delta: u64) {
+    /// locks until the sequencer progresses by the specified number of heights.
+    pub async fn wait_for_height_advance_by(&self, delta: u64) {
         let current_height = get_height(&self.client).await.unwrap();
         let end_height = current_height.get() + delta;
         self.wait_for_height(end_height).await;

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -1033,8 +1033,9 @@ where
         }
     }
 
-    /// Waits until the chain height advances by `delta`.
-    pub async fn wait_for_height_advance_by(&self, delta: u64) {
+    /// Waits until the rollup_height advances by `delta`.
+    /// Note that the rollup_height remains the same while DA is progressing if no batches are being created.
+    pub async fn wait_for_rollup_height_advance_by(&self, delta: u64) {
         let current_height = get_height(&self.client).await.unwrap();
         let end_height = current_height.get() + delta;
         self.wait_for_height(end_height).await;

--- a/docs/eth_feeHistory_test_cases.md
+++ b/docs/eth_feeHistory_test_cases.md
@@ -149,7 +149,7 @@ These test realistic usage patterns with actual blockchain state changes.
 
 #### Setup for state scenarios
 - Use `SimpleStorage` contract for lightweight transactions
-- Use `wait_for_height_advance_by(1)` between transactions to ensure separate blocks
+- Use `wait_for_rollup_height_advance_by(1)` between transactions to ensure separate blocks
 - Record block numbers when transactions are mined for targeted queries
 - Use `pause_preferred_batches()` before final assertions
 
@@ -172,7 +172,7 @@ For reference, these cases are already covered in `evm_fee_history.rs`:
 
 ## Test dependencies
 
-- Requires rollup with multiple sealed blocks (use `wait_for_height_advance_by`)
+- Requires rollup with multiple sealed blocks (use `wait_for_rollup_height_advance_by`)
 - Pause sequencer before assertions to ensure deterministic state
 - For TC21, ensure at least one block includes a transaction (a simple transfer is sufficient)
 - **For state scenarios**: Deploy `SimpleStorage` contract, use `set_value()` for transactions

--- a/docs/eth_feeHistory_test_cases.md
+++ b/docs/eth_feeHistory_test_cases.md
@@ -149,7 +149,7 @@ These test realistic usage patterns with actual blockchain state changes.
 
 #### Setup for state scenarios
 - Use `SimpleStorage` contract for lightweight transactions
-- Use `wait_for_next_blocks(1)` between transactions to ensure separate blocks
+- Use `wait_for_height_advance_by(1)` between transactions to ensure separate blocks
 - Record block numbers when transactions are mined for targeted queries
 - Use `pause_preferred_batches()` before final assertions
 
@@ -172,7 +172,7 @@ For reference, these cases are already covered in `evm_fee_history.rs`:
 
 ## Test dependencies
 
-- Requires rollup with multiple sealed blocks (use `wait_for_next_blocks`)
+- Requires rollup with multiple sealed blocks (use `wait_for_height_advance_by`)
 - Pause sequencer before assertions to ensure deterministic state
 - For TC21, ensure at least one block includes a transaction (a simple transfer is sufficient)
 - **For state scenarios**: Deploy `SimpleStorage` contract, use `set_value()` for transactions

--- a/docs/eth_getTransactionCount_test_cases.md
+++ b/docs/eth_getTransactionCount_test_cases.md
@@ -82,7 +82,7 @@ let client_b = create_simple_storage_client(rollup.http_addr, SECONDARY_SENDER_P
 // Control block production
 rollup.pause_preferred_batches().await;
 rollup.resume_preferred_batches().await;
-rollup.wait_for_next_blocks(1).await;
+rollup.wait_for_height_advance_by(1).await;
 ```
 
 ## Core fixture (deterministic, reused)

--- a/docs/eth_getTransactionCount_test_cases.md
+++ b/docs/eth_getTransactionCount_test_cases.md
@@ -82,7 +82,7 @@ let client_b = create_simple_storage_client(rollup.http_addr, SECONDARY_SENDER_P
 // Control block production
 rollup.pause_preferred_batches().await;
 rollup.resume_preferred_batches().await;
-rollup.wait_for_height_advance_by(1).await;
+rollup.wait_for_rollup_height_advance_by(1).await;
 ```
 
 ## Core fixture (deterministic, reused)

--- a/examples/demo-rollup/tests/evm/evm_balances.rs
+++ b/examples/demo-rollup/tests/evm/evm_balances.rs
@@ -29,7 +29,7 @@ async fn evm_test_balances() -> anyhow::Result<()> {
     evm_client
         .send_eth(reciever_address, U256::from(eth_to_send))
         .await;
-    test_rollup.wait_for_next_blocks(2).await;
+    test_rollup.wait_for_height_advance_by(2).await;
 
     let (sender_bank_balance_end, sender_evm_balance_end) =
         get_balances(sender_address, &test_rollup, &evm_client).await;

--- a/examples/demo-rollup/tests/evm/evm_balances.rs
+++ b/examples/demo-rollup/tests/evm/evm_balances.rs
@@ -29,7 +29,7 @@ async fn evm_test_balances() -> anyhow::Result<()> {
     evm_client
         .send_eth(reciever_address, U256::from(eth_to_send))
         .await;
-    test_rollup.wait_for_height_advance_by(2).await;
+    test_rollup.wait_for_rollup_height_advance_by(2).await;
 
     let (sender_bank_balance_end, sender_evm_balance_end) =
         get_balances(sender_address, &test_rollup, &evm_client).await;

--- a/examples/demo-rollup/tests/evm/evm_basefee.rs
+++ b/examples/demo-rollup/tests/evm/evm_basefee.rs
@@ -17,7 +17,7 @@ use crate::evm::evm_test_helper::SENDER_PRIV_KEY;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_basefee_opcode_returns_nonzero() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let client = alloy_client(rollup.http_addr);
 
     // Deploy the SimpleStorage contract
@@ -62,7 +62,7 @@ async fn test_basefee_opcode_returns_nonzero() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_transaction_gas_price_uses_effective_price() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let client = alloy_client(rollup.http_addr);
     let ws_client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 

--- a/examples/demo-rollup/tests/evm/evm_basefee.rs
+++ b/examples/demo-rollup/tests/evm/evm_basefee.rs
@@ -17,7 +17,7 @@ use crate::evm::evm_test_helper::SENDER_PRIV_KEY;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_basefee_opcode_returns_nonzero() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let client = alloy_client(rollup.http_addr);
 
     // Deploy the SimpleStorage contract
@@ -62,7 +62,7 @@ async fn test_basefee_opcode_returns_nonzero() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_transaction_gas_price_uses_effective_price() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let client = alloy_client(rollup.http_addr);
     let ws_client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 

--- a/examples/demo-rollup/tests/evm/evm_block_by_number_hash.rs
+++ b/examples/demo-rollup/tests/evm/evm_block_by_number_hash.rs
@@ -32,7 +32,9 @@ async fn setup_paused_rollup(
     initial_blocks: u64,
 ) -> TestRollup<MockDemoRollup<Native>> {
     let rollup = setup_test_rollup(finalization_blocks as u32, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(initial_blocks).await;
+    rollup
+        .wait_for_rollup_height_advance_by(initial_blocks)
+        .await;
     rollup.pause_preferred_batches().await;
     rollup
 }
@@ -45,7 +47,7 @@ async fn setup_with_contract() -> (
     Address,
 ) {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract_address = deploy_contract_check(&simple_storage)
         .await
@@ -145,7 +147,7 @@ async fn test_finalized_block_with_non_instant_finality_config() -> anyhow::Resu
     // Use finalization_blocks = 2 (not 0)
     let finalization = 2;
     let rollup = setup_test_rollup(finalization as u32, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(5).await;
+    rollup.wait_for_rollup_height_advance_by(5).await;
     // Ensure finalized slots advance
     rollup.produce_enough_finalized_slots().await;
     rollup.pause_preferred_batches().await;
@@ -498,7 +500,7 @@ async fn test_synthetic_hash_tx_block_hash_consistency() -> anyhow::Result<()> {
     let (rollup, simple_storage, contract_address) = setup_with_contract().await;
     let client = alloy_client(rollup.http_addr);
     // Wait for a block to ensure the deploy tx is sealed before we pause
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let sealed_head_number = client
@@ -594,7 +596,7 @@ async fn test_synthetic_hash_receipt_block_hash_consistency() -> anyhow::Result<
     let (rollup, simple_storage, contract_address) = setup_with_contract().await;
     let client = alloy_client(rollup.http_addr);
     // Wait for a block to ensure the deploy tx is sealed before we pause
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let sealed_head_number = client.get_block_number().await?;
@@ -716,7 +718,7 @@ async fn test_transactions_hashes_vs_full() -> anyhow::Result<()> {
     use sov_evm_test_utils::{Erc20, Submit};
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Deploy contract and mint (creates 2 txs)
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
@@ -821,7 +823,7 @@ async fn test_empty_block_transactions() -> anyhow::Result<()> {
 
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     // Block 0 (genesis) should have no transactions
@@ -919,12 +921,12 @@ async fn test_get_block_by_hash_full_transactions() -> anyhow::Result<()> {
 
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Create a sealed block with transactions
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
     usdc.mint(Address::ZERO, parse_ether("1")?).submit().await?;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let sealed_head = client.get_block_number().await?;
@@ -1171,13 +1173,13 @@ async fn test_block_receipts_cross_check() -> anyhow::Result<()> {
 
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Deploy contract and mint (creates 2 txs)
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
     usdc.mint(Address::ZERO, parse_ether("1")?).submit().await?;
 
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let sealed_head = client.get_block_number().await?;

--- a/examples/demo-rollup/tests/evm/evm_block_by_number_hash.rs
+++ b/examples/demo-rollup/tests/evm/evm_block_by_number_hash.rs
@@ -32,7 +32,7 @@ async fn setup_paused_rollup(
     initial_blocks: u64,
 ) -> TestRollup<MockDemoRollup<Native>> {
     let rollup = setup_test_rollup(finalization_blocks as u32, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(initial_blocks).await;
+    rollup.wait_for_height_advance_by(initial_blocks).await;
     rollup.pause_preferred_batches().await;
     rollup
 }
@@ -45,7 +45,7 @@ async fn setup_with_contract() -> (
     Address,
 ) {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract_address = deploy_contract_check(&simple_storage)
         .await
@@ -145,7 +145,7 @@ async fn test_finalized_block_with_non_instant_finality_config() -> anyhow::Resu
     // Use finalization_blocks = 2 (not 0)
     let finalization = 2;
     let rollup = setup_test_rollup(finalization as u32, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(5).await;
+    rollup.wait_for_height_advance_by(5).await;
     // Ensure finalized slots advance
     rollup.produce_enough_finalized_slots().await;
     rollup.pause_preferred_batches().await;
@@ -498,7 +498,7 @@ async fn test_synthetic_hash_tx_block_hash_consistency() -> anyhow::Result<()> {
     let (rollup, simple_storage, contract_address) = setup_with_contract().await;
     let client = alloy_client(rollup.http_addr);
     // Wait for a block to ensure the deploy tx is sealed before we pause
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let sealed_head_number = client
@@ -594,7 +594,7 @@ async fn test_synthetic_hash_receipt_block_hash_consistency() -> anyhow::Result<
     let (rollup, simple_storage, contract_address) = setup_with_contract().await;
     let client = alloy_client(rollup.http_addr);
     // Wait for a block to ensure the deploy tx is sealed before we pause
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let sealed_head_number = client.get_block_number().await?;
@@ -716,7 +716,7 @@ async fn test_transactions_hashes_vs_full() -> anyhow::Result<()> {
     use sov_evm_test_utils::{Erc20, Submit};
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Deploy contract and mint (creates 2 txs)
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
@@ -821,7 +821,7 @@ async fn test_empty_block_transactions() -> anyhow::Result<()> {
 
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     // Block 0 (genesis) should have no transactions
@@ -919,12 +919,12 @@ async fn test_get_block_by_hash_full_transactions() -> anyhow::Result<()> {
 
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Create a sealed block with transactions
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
     usdc.mint(Address::ZERO, parse_ether("1")?).submit().await?;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let sealed_head = client.get_block_number().await?;
@@ -1171,13 +1171,13 @@ async fn test_block_receipts_cross_check() -> anyhow::Result<()> {
 
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Deploy contract and mint (creates 2 txs)
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
     usdc.mint(Address::ZERO, parse_ether("1")?).submit().await?;
 
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let sealed_head = client.get_block_number().await?;

--- a/examples/demo-rollup/tests/evm/evm_block_hash.rs
+++ b/examples/demo-rollup/tests/evm/evm_block_hash.rs
@@ -9,7 +9,7 @@ use crate::evm::evm_test_helper::{alloy_client, setup_test_rollup, EVM_EXTENSION
 async fn block_hash() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let block_hash = BlockHash::deploy(client.clone()).await?;
     rollup.pause_preferred_batches().await;
     let pending_number = client

--- a/examples/demo-rollup/tests/evm/evm_block_hash.rs
+++ b/examples/demo-rollup/tests/evm/evm_block_hash.rs
@@ -9,7 +9,7 @@ use crate::evm::evm_test_helper::{alloy_client, setup_test_rollup, EVM_EXTENSION
 async fn block_hash() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let block_hash = BlockHash::deploy(client.clone()).await?;
     rollup.pause_preferred_batches().await;
     let pending_number = client

--- a/examples/demo-rollup/tests/evm/evm_block_number.rs
+++ b/examples/demo-rollup/tests/evm/evm_block_number.rs
@@ -9,7 +9,7 @@ use alloy_rpc_types_eth::BlockNumberOrTag;
 async fn pending_block_number() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let pending_block = client

--- a/examples/demo-rollup/tests/evm/evm_block_number.rs
+++ b/examples/demo-rollup/tests/evm/evm_block_number.rs
@@ -9,7 +9,7 @@ use alloy_rpc_types_eth::BlockNumberOrTag;
 async fn pending_block_number() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let pending_block = client

--- a/examples/demo-rollup/tests/evm/evm_block_pinned_state_reads.rs
+++ b/examples/demo-rollup/tests/evm/evm_block_pinned_state_reads.rs
@@ -103,7 +103,7 @@ fn assert_pause_window_height(observed: u64, head_before_pause: u64) {
 
 async fn setup_rollup_and_client() -> (TestRollup<MockDemoRollup<Native>>, SimpleStorageClient) {
     let (rollup, client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     (rollup, client)
 }
 
@@ -287,7 +287,7 @@ async fn block_pinned_storage_excludes_pending() {
     set_value_check(&client, contract_addr, initial_value)
         .await
         .unwrap();
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let (head_number, head_hash) = sealed_head_number_and_hash(&client).await;
     let finalized_head_before_pause = finalized_block_number_and_hash(&client).await;
@@ -339,7 +339,7 @@ async fn block_pinned_eth_call_excludes_pending() {
     set_value_check(&client, contract_addr, initial_value)
         .await
         .unwrap();
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let (head_number, head_hash) = sealed_head_number_and_hash(&client).await;
     let finalized_head_before_pause = finalized_block_number_and_hash(&client).await;
@@ -383,7 +383,7 @@ async fn block_pinned_estimate_gas_excludes_pending() {
     let (rollup, client) = setup_rollup_and_client().await;
 
     let contract_addr = deploy_contract_check(&client).await.unwrap();
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let (head_number, head_hash) = sealed_head_number_and_hash(&client).await;
     let finalized_head_before_pause = finalized_block_number_and_hash(&client).await;

--- a/examples/demo-rollup/tests/evm/evm_block_pinned_state_reads.rs
+++ b/examples/demo-rollup/tests/evm/evm_block_pinned_state_reads.rs
@@ -103,7 +103,7 @@ fn assert_pause_window_height(observed: u64, head_before_pause: u64) {
 
 async fn setup_rollup_and_client() -> (TestRollup<MockDemoRollup<Native>>, SimpleStorageClient) {
     let (rollup, client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     (rollup, client)
 }
 
@@ -287,7 +287,7 @@ async fn block_pinned_storage_excludes_pending() {
     set_value_check(&client, contract_addr, initial_value)
         .await
         .unwrap();
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let (head_number, head_hash) = sealed_head_number_and_hash(&client).await;
     let finalized_head_before_pause = finalized_block_number_and_hash(&client).await;
@@ -339,7 +339,7 @@ async fn block_pinned_eth_call_excludes_pending() {
     set_value_check(&client, contract_addr, initial_value)
         .await
         .unwrap();
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let (head_number, head_hash) = sealed_head_number_and_hash(&client).await;
     let finalized_head_before_pause = finalized_block_number_and_hash(&client).await;
@@ -383,7 +383,7 @@ async fn block_pinned_estimate_gas_excludes_pending() {
     let (rollup, client) = setup_rollup_and_client().await;
 
     let contract_addr = deploy_contract_check(&client).await.unwrap();
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let (head_number, head_hash) = sealed_head_number_and_hash(&client).await;
     let finalized_head_before_pause = finalized_block_number_and_hash(&client).await;

--- a/examples/demo-rollup/tests/evm/evm_call_fee_fields.rs
+++ b/examples/demo-rollup/tests/evm/evm_call_fee_fields.rs
@@ -24,7 +24,7 @@ fn unfunded_caller() -> Address {
 /// Returns the rollup handle alongside the client — the rollup must stay alive for the client to function.
 async fn setup_client() -> (TestRollup<MockDemoRollup<Native>>, SimpleStorageClient) {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     (rollup, client)
 }

--- a/examples/demo-rollup/tests/evm/evm_call_fee_fields.rs
+++ b/examples/demo-rollup/tests/evm/evm_call_fee_fields.rs
@@ -24,7 +24,7 @@ fn unfunded_caller() -> Address {
 /// Returns the rollup handle alongside the client — the rollup must stay alive for the client to function.
 async fn setup_client() -> (TestRollup<MockDemoRollup<Native>>, SimpleStorageClient) {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     (rollup, client)
 }

--- a/examples/demo-rollup/tests/evm/evm_contract_creation_allowlist.rs
+++ b/examples/demo-rollup/tests/evm/evm_contract_creation_allowlist.rs
@@ -8,7 +8,7 @@ use sov_evm_test_utils::SimpleStorage;
 #[tokio::test(flavor = "multi_thread")]
 async fn allowed() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let client = alloy_client_with_signer(rollup.http_addr, SENDER_PRIV_KEY);
 
     let _ = SimpleStorage::deploy(client).await?;
@@ -18,7 +18,7 @@ async fn allowed() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn denied() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let client = alloy_client_with_signer(rollup.http_addr, SECONDARY_SENDER_PRIV_KEY);
 
     let err = SimpleStorage::deploy(client).await.unwrap_err();

--- a/examples/demo-rollup/tests/evm/evm_contract_creation_allowlist.rs
+++ b/examples/demo-rollup/tests/evm/evm_contract_creation_allowlist.rs
@@ -8,7 +8,7 @@ use sov_evm_test_utils::SimpleStorage;
 #[tokio::test(flavor = "multi_thread")]
 async fn allowed() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let client = alloy_client_with_signer(rollup.http_addr, SENDER_PRIV_KEY);
 
     let _ = SimpleStorage::deploy(client).await?;
@@ -18,7 +18,7 @@ async fn allowed() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn denied() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let client = alloy_client_with_signer(rollup.http_addr, SECONDARY_SENDER_PRIV_KEY);
 
     let err = SimpleStorage::deploy(client).await.unwrap_err();

--- a/examples/demo-rollup/tests/evm/evm_effective_gas_price.rs
+++ b/examples/demo-rollup/tests/evm/evm_effective_gas_price.rs
@@ -11,7 +11,7 @@ use crate::evm::evm_test_helper::{
 #[tokio::test(flavor = "multi_thread")]
 async fn eip1559_tx_and_receipt_have_valid_effective_gas_price() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
 
     let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let sender = client.address();

--- a/examples/demo-rollup/tests/evm/evm_effective_gas_price.rs
+++ b/examples/demo-rollup/tests/evm/evm_effective_gas_price.rs
@@ -11,7 +11,7 @@ use crate::evm::evm_test_helper::{
 #[tokio::test(flavor = "multi_thread")]
 async fn eip1559_tx_and_receipt_have_valid_effective_gas_price() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
 
     let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let sender = client.address();

--- a/examples/demo-rollup/tests/evm/evm_fee_history.rs
+++ b/examples/demo-rollup/tests/evm/evm_fee_history.rs
@@ -215,7 +215,7 @@ async fn setup_fee_history_test(
 ) -> (TestRollup<MockDemoRollup<Native>>, DynProvider) {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(wait_blocks).await;
+    rollup.wait_for_rollup_height_advance_by(wait_blocks).await;
     rollup
         .pause_preferred_batches_and_wait()
         .await
@@ -491,19 +491,19 @@ async fn test_eth_fee_history_specific_block() -> anyhow::Result<()> {
 async fn test_eth_fee_history_large_count_capped() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
 
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract_address = deploy_contract_check(&simple_storage)
         .await
         .expect("deploy should succeed");
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let receipt = send_high_fee_set_value(&simple_storage, contract_address, 10).await?;
     let newest_block = receipt
         .block_number
         .expect("receipt should include block number");
     // Wait for the slot to complete so gas_info is recorded
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches_and_wait().await?;
 
     assert!(client
@@ -568,7 +568,7 @@ async fn test_eth_fee_history_large_count_capped() -> anyhow::Result<()> {
 async fn test_fee_history_pending_tag() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(3).await;
+    rollup.wait_for_rollup_height_advance_by(3).await;
 
     let _ = setup_with_pending_tx(&rollup).await;
 
@@ -632,7 +632,7 @@ async fn test_fee_history_pending_tag() -> anyhow::Result<()> {
 async fn test_fee_history_pending_base_fee_matches_pending_block() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
 
     let _ = setup_with_pending_tx(&rollup).await;
 
@@ -748,7 +748,7 @@ async fn test_fee_history_earliest_tag() -> anyhow::Result<()> {
 async fn test_fee_history_latest_equals_pending() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(3).await;
+    rollup.wait_for_rollup_height_advance_by(3).await;
 
     let _ = setup_with_pending_tx(&rollup).await;
 
@@ -1089,7 +1089,7 @@ async fn test_fee_history_earliest_values_match_block_header() -> anyhow::Result
 async fn test_fee_history_values_match_block_headers() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
 
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let tx_hash = simple_storage
@@ -1101,7 +1101,7 @@ async fn test_fee_history_values_match_block_headers() -> anyhow::Result<()> {
         .block_number
         .expect("deploy receipt should include block number");
 
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
     rollup.pause_preferred_batches_and_wait().await?;
 
     let newest_block = deploy_block + 1;
@@ -1192,19 +1192,19 @@ async fn test_fee_history_empty_blocks_zero_ratio() -> anyhow::Result<()> {
 async fn test_fee_history_block_with_tx_nonzero_ratio() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract_address = deploy_contract_check(&simple_storage)
         .await
         .expect("deploy should succeed");
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let receipt = send_high_fee_set_value(&simple_storage, contract_address, 100).await?;
     let tx_block = receipt
         .block_number
         .expect("receipt should include block number");
     // Wait for the slot to complete so gas_info is recorded
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches_and_wait().await?;
 
     assert!(
@@ -1298,7 +1298,7 @@ async fn test_fee_history_block_with_tx_nonzero_ratio() -> anyhow::Result<()> {
 async fn test_fee_history_multiple_txs_across_blocks() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
 
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract_address = deploy_contract_check(&simple_storage)
@@ -1306,7 +1306,7 @@ async fn test_fee_history_multiple_txs_across_blocks() -> anyhow::Result<()> {
         .expect("deploy should succeed");
 
     // Wait for deploy to finalize
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
 
     // Track blocks where transactions land
     let mut tx_blocks = Vec::new();
@@ -1321,7 +1321,7 @@ async fn test_fee_history_multiple_txs_across_blocks() -> anyhow::Result<()> {
             tx_blocks.push(block_num);
         }
         // Ensure next block starts before sending next tx
-        rollup.wait_for_height_advance_by(1).await;
+        rollup.wait_for_rollup_height_advance_by(1).await;
     }
 
     rollup.pause_preferred_batches_and_wait().await?;
@@ -1371,14 +1371,14 @@ async fn test_fee_history_multiple_txs_across_blocks() -> anyhow::Result<()> {
 async fn test_fee_history_progression() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(5).await;
+    rollup.wait_for_rollup_height_advance_by(5).await;
 
     let history1 = client
         .get_fee_history(3, BlockNumberOrTag::Latest, &[])
         .await?;
     let oldest1 = history1.oldest_block;
 
-    rollup.wait_for_height_advance_by(3).await;
+    rollup.wait_for_rollup_height_advance_by(3).await;
 
     let history2 = client
         .get_fee_history(3, BlockNumberOrTag::Latest, &[])
@@ -1404,18 +1404,18 @@ async fn test_fee_history_progression() -> anyhow::Result<()> {
 async fn test_fee_history_consistent_query_methods() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
 
     // Create some gas usage
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract_address = deploy_contract_check(&simple_storage)
         .await
         .expect("deploy should succeed");
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
     set_value_check(&simple_storage, contract_address, 999)
         .await
         .expect("set_value should succeed");
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
     rollup.pause_preferred_batches_and_wait().await?;
 
     // Get the current block number
@@ -1449,7 +1449,7 @@ async fn test_fee_history_consistent_query_methods() -> anyhow::Result<()> {
 async fn test_fee_history_mixed_pattern() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
 
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract_address = deploy_contract_check(&simple_storage)
@@ -1457,35 +1457,35 @@ async fn test_fee_history_mixed_pattern() -> anyhow::Result<()> {
         .expect("deploy should succeed");
 
     // Wait for deploy block
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Record starting block
     let start_block = client.get_block_number().await?;
 
     // Create pattern: [empty, tx, empty, tx, tx]
     // Block 1: empty
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Block 2: tx
     set_value_check(&simple_storage, contract_address, 1)
         .await
         .expect("set_value should succeed");
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Block 3: empty
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Block 4: tx
     set_value_check(&simple_storage, contract_address, 2)
         .await
         .expect("set_value should succeed");
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Block 5: tx
     set_value_check(&simple_storage, contract_address, 3)
         .await
         .expect("set_value should succeed");
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     rollup.pause_preferred_batches_and_wait().await?;
 
@@ -1570,7 +1570,7 @@ async fn test_fee_history_base_fee_stability() -> anyhow::Result<()> {
 async fn test_fee_history_finalized_equals_safe() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(5).await;
+    rollup.wait_for_rollup_height_advance_by(5).await;
     rollup.pause_preferred_batches_and_wait().await?;
 
     let finalized = client
@@ -1826,12 +1826,12 @@ async fn test_fee_history_heavy_gas_usage() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
 
     let contract_address = deploy_contract_check(&simple_storage)
         .await
         .expect("deploy should succeed");
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let block_before = client.get_block_number().await?;
 
@@ -1839,7 +1839,7 @@ async fn test_fee_history_heavy_gas_usage() -> anyhow::Result<()> {
     let tx_hash = simple_storage.alloy_burn_gas(contract_address, 10000).await;
     simple_storage.wait_for_finalized_receipt(tx_hash).await;
     // Ensure the block containing the tx is sealed before pausing.
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     rollup.pause_preferred_batches_and_wait().await?;
 

--- a/examples/demo-rollup/tests/evm/evm_fee_history.rs
+++ b/examples/demo-rollup/tests/evm/evm_fee_history.rs
@@ -215,7 +215,7 @@ async fn setup_fee_history_test(
 ) -> (TestRollup<MockDemoRollup<Native>>, DynProvider) {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(wait_blocks).await;
+    rollup.wait_for_height_advance_by(wait_blocks).await;
     rollup
         .pause_preferred_batches_and_wait()
         .await
@@ -491,19 +491,19 @@ async fn test_eth_fee_history_specific_block() -> anyhow::Result<()> {
 async fn test_eth_fee_history_large_count_capped() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
 
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract_address = deploy_contract_check(&simple_storage)
         .await
         .expect("deploy should succeed");
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let receipt = send_high_fee_set_value(&simple_storage, contract_address, 10).await?;
     let newest_block = receipt
         .block_number
         .expect("receipt should include block number");
     // Wait for the slot to complete so gas_info is recorded
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches_and_wait().await?;
 
     assert!(client
@@ -568,7 +568,7 @@ async fn test_eth_fee_history_large_count_capped() -> anyhow::Result<()> {
 async fn test_fee_history_pending_tag() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(3).await;
+    rollup.wait_for_height_advance_by(3).await;
 
     let _ = setup_with_pending_tx(&rollup).await;
 
@@ -632,7 +632,7 @@ async fn test_fee_history_pending_tag() -> anyhow::Result<()> {
 async fn test_fee_history_pending_base_fee_matches_pending_block() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
 
     let _ = setup_with_pending_tx(&rollup).await;
 
@@ -748,7 +748,7 @@ async fn test_fee_history_earliest_tag() -> anyhow::Result<()> {
 async fn test_fee_history_latest_equals_pending() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(3).await;
+    rollup.wait_for_height_advance_by(3).await;
 
     let _ = setup_with_pending_tx(&rollup).await;
 
@@ -1089,7 +1089,7 @@ async fn test_fee_history_earliest_values_match_block_header() -> anyhow::Result
 async fn test_fee_history_values_match_block_headers() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
 
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let tx_hash = simple_storage
@@ -1101,7 +1101,7 @@ async fn test_fee_history_values_match_block_headers() -> anyhow::Result<()> {
         .block_number
         .expect("deploy receipt should include block number");
 
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
     rollup.pause_preferred_batches_and_wait().await?;
 
     let newest_block = deploy_block + 1;
@@ -1192,19 +1192,19 @@ async fn test_fee_history_empty_blocks_zero_ratio() -> anyhow::Result<()> {
 async fn test_fee_history_block_with_tx_nonzero_ratio() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract_address = deploy_contract_check(&simple_storage)
         .await
         .expect("deploy should succeed");
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let receipt = send_high_fee_set_value(&simple_storage, contract_address, 100).await?;
     let tx_block = receipt
         .block_number
         .expect("receipt should include block number");
     // Wait for the slot to complete so gas_info is recorded
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches_and_wait().await?;
 
     assert!(
@@ -1298,7 +1298,7 @@ async fn test_fee_history_block_with_tx_nonzero_ratio() -> anyhow::Result<()> {
 async fn test_fee_history_multiple_txs_across_blocks() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
 
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract_address = deploy_contract_check(&simple_storage)
@@ -1306,7 +1306,7 @@ async fn test_fee_history_multiple_txs_across_blocks() -> anyhow::Result<()> {
         .expect("deploy should succeed");
 
     // Wait for deploy to finalize
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
 
     // Track blocks where transactions land
     let mut tx_blocks = Vec::new();
@@ -1321,7 +1321,7 @@ async fn test_fee_history_multiple_txs_across_blocks() -> anyhow::Result<()> {
             tx_blocks.push(block_num);
         }
         // Ensure next block starts before sending next tx
-        rollup.wait_for_next_blocks(1).await;
+        rollup.wait_for_height_advance_by(1).await;
     }
 
     rollup.pause_preferred_batches_and_wait().await?;
@@ -1371,14 +1371,14 @@ async fn test_fee_history_multiple_txs_across_blocks() -> anyhow::Result<()> {
 async fn test_fee_history_progression() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(5).await;
+    rollup.wait_for_height_advance_by(5).await;
 
     let history1 = client
         .get_fee_history(3, BlockNumberOrTag::Latest, &[])
         .await?;
     let oldest1 = history1.oldest_block;
 
-    rollup.wait_for_next_blocks(3).await;
+    rollup.wait_for_height_advance_by(3).await;
 
     let history2 = client
         .get_fee_history(3, BlockNumberOrTag::Latest, &[])
@@ -1404,18 +1404,18 @@ async fn test_fee_history_progression() -> anyhow::Result<()> {
 async fn test_fee_history_consistent_query_methods() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
 
     // Create some gas usage
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract_address = deploy_contract_check(&simple_storage)
         .await
         .expect("deploy should succeed");
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
     set_value_check(&simple_storage, contract_address, 999)
         .await
         .expect("set_value should succeed");
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
     rollup.pause_preferred_batches_and_wait().await?;
 
     // Get the current block number
@@ -1449,7 +1449,7 @@ async fn test_fee_history_consistent_query_methods() -> anyhow::Result<()> {
 async fn test_fee_history_mixed_pattern() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
 
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract_address = deploy_contract_check(&simple_storage)
@@ -1457,35 +1457,35 @@ async fn test_fee_history_mixed_pattern() -> anyhow::Result<()> {
         .expect("deploy should succeed");
 
     // Wait for deploy block
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Record starting block
     let start_block = client.get_block_number().await?;
 
     // Create pattern: [empty, tx, empty, tx, tx]
     // Block 1: empty
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Block 2: tx
     set_value_check(&simple_storage, contract_address, 1)
         .await
         .expect("set_value should succeed");
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Block 3: empty
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Block 4: tx
     set_value_check(&simple_storage, contract_address, 2)
         .await
         .expect("set_value should succeed");
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Block 5: tx
     set_value_check(&simple_storage, contract_address, 3)
         .await
         .expect("set_value should succeed");
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     rollup.pause_preferred_batches_and_wait().await?;
 
@@ -1570,7 +1570,7 @@ async fn test_fee_history_base_fee_stability() -> anyhow::Result<()> {
 async fn test_fee_history_finalized_equals_safe() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(5).await;
+    rollup.wait_for_height_advance_by(5).await;
     rollup.pause_preferred_batches_and_wait().await?;
 
     let finalized = client
@@ -1826,12 +1826,12 @@ async fn test_fee_history_heavy_gas_usage() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
 
     let contract_address = deploy_contract_check(&simple_storage)
         .await
         .expect("deploy should succeed");
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let block_before = client.get_block_number().await?;
 
@@ -1839,7 +1839,7 @@ async fn test_fee_history_heavy_gas_usage() -> anyhow::Result<()> {
     let tx_hash = simple_storage.alloy_burn_gas(contract_address, 10000).await;
     simple_storage.wait_for_finalized_receipt(tx_hash).await;
     // Ensure the block containing the tx is sealed before pausing.
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     rollup.pause_preferred_batches_and_wait().await?;
 

--- a/examples/demo-rollup/tests/evm/evm_gas_estimation.rs
+++ b/examples/demo-rollup/tests/evm/evm_gas_estimation.rs
@@ -36,7 +36,7 @@ fn create_simulation_create_params(
 #[tokio::test(flavor = "multi_thread")]
 async fn big_accessory_state_writes() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let client = alloy_client(rollup.http_addr);
     let contract = SimpleStorage::deploy(client).await?;
 
@@ -53,7 +53,7 @@ async fn big_accessory_state_writes() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_estimate_gas_revert_returns_error() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let client = alloy_client(rollup.http_addr);
     let contract = SimpleStorage::deploy(client).await?;
 
@@ -69,7 +69,7 @@ async fn eth_estimate_gas_revert_returns_error() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_estimate_gas_rejects_stale_explicit_nonce_after_nonce_advance() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let client = alloy_client(rollup.http_addr);
     let from = sender_address()?;
 
@@ -135,7 +135,7 @@ async fn eth_estimate_gas_rejects_stale_explicit_nonce_after_nonce_advance() -> 
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_call_omitted_nonce_matches_explicit_nonce_for_create() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let client = alloy_client(rollup.http_addr);
     let from = sender_address()?;
 

--- a/examples/demo-rollup/tests/evm/evm_gas_estimation.rs
+++ b/examples/demo-rollup/tests/evm/evm_gas_estimation.rs
@@ -36,7 +36,7 @@ fn create_simulation_create_params(
 #[tokio::test(flavor = "multi_thread")]
 async fn big_accessory_state_writes() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let client = alloy_client(rollup.http_addr);
     let contract = SimpleStorage::deploy(client).await?;
 
@@ -53,7 +53,7 @@ async fn big_accessory_state_writes() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_estimate_gas_revert_returns_error() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let client = alloy_client(rollup.http_addr);
     let contract = SimpleStorage::deploy(client).await?;
 
@@ -69,7 +69,7 @@ async fn eth_estimate_gas_revert_returns_error() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_estimate_gas_rejects_stale_explicit_nonce_after_nonce_advance() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let client = alloy_client(rollup.http_addr);
     let from = sender_address()?;
 
@@ -135,7 +135,7 @@ async fn eth_estimate_gas_rejects_stale_explicit_nonce_after_nonce_advance() -> 
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_call_omitted_nonce_matches_explicit_nonce_for_create() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let client = alloy_client(rollup.http_addr);
     let from = sender_address()?;
 

--- a/examples/demo-rollup/tests/evm/evm_get_transaction_count.rs
+++ b/examples/demo-rollup/tests/evm/evm_get_transaction_count.rs
@@ -20,7 +20,7 @@ async fn setup_rollup_with_finality(
     finalization_blocks: u32,
 ) -> (TestRollup<MockDemoRollup<Native>>, SimpleStorageClient) {
     let (rollup, client, _) = setup_with_simple_storage(finalization_blocks, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     (rollup, client)
 }
 
@@ -155,7 +155,7 @@ async fn eth_get_transaction_count_safe_finalized_semantics() -> anyhow::Result<
     client.wait_for_finalized_receipt(tx_hash).await;
 
     // Wait for the next block to ensure finalization
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     assert_equal_nonces_for_tags(
         &client,
@@ -522,7 +522,7 @@ async fn eth_get_transaction_count_sealed_receipts_nonce_delta() -> anyhow::Resu
     }
 
     // Wait for a new block
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Get nonce at block H1
     let h1_number = client.block_number().await;
@@ -597,7 +597,7 @@ async fn eth_get_transaction_count_historical_block_diverges_from_current() -> a
     // Send transaction and wait for finalization in a new block
     let tx_hash = client.send_eth(Address::ZERO, U256::from(0x5432)).await;
     client.wait_for_finalized_receipt(tx_hash).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let h1_number = client.block_number().await;
     assert!(h1_number > h0_number, "New block should be produced");
@@ -647,7 +647,7 @@ async fn eth_get_transaction_count_block_hash_returns_correct_historical() -> an
     // Send transaction and finalize
     let tx_hash = client.send_eth(Address::ZERO, U256::from(0x6543)).await;
     client.wait_for_finalized_receipt(tx_hash).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Get block H1 info
     let h1_number = client.block_number().await;
@@ -854,7 +854,7 @@ async fn eth_get_transaction_count_latest_after_seal() -> anyhow::Result<()> {
     // Send and wait for finalization
     let tx_hash = client.send_eth(Address::ZERO, U256::from(0xABCD)).await;
     client.wait_for_finalized_receipt(tx_hash).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let nonce_after = nonce_at_tag(&client, address, "latest").await;
 
@@ -882,7 +882,7 @@ async fn eth_get_transaction_count_block_boundary() -> anyhow::Result<()> {
     // Send tx and wait for finalization
     let tx_hash = client.send_eth(Address::ZERO, U256::from(0xBCDE)).await;
     let receipt = client.wait_for_finalized_receipt(tx_hash).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let tx_block = receipt
         .block_number
@@ -939,7 +939,7 @@ async fn eth_get_transaction_count_finalized_lags_with_non_instant_finality() ->
     // Send a transaction and wait for it to be sealed into a block
     let tx_hash = client.send_eth(Address::ZERO, U256::from(0xF1A1)).await;
     client.wait_for_finalized_receipt(tx_hash).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // "latest" should reflect the sealed transaction immediately
     let nonce_latest = nonce_at_tag(&client, address, "latest").await;
@@ -959,7 +959,7 @@ async fn eth_get_transaction_count_finalized_lags_with_non_instant_finality() ->
 
     // Produce enough blocks to push the tx block past the finalization threshold
     rollup
-        .wait_for_height_advance_by(finality_depth as u64)
+        .wait_for_rollup_height_advance_by(finality_depth as u64)
         .await;
 
     // Now "finalized" should have caught up

--- a/examples/demo-rollup/tests/evm/evm_get_transaction_count.rs
+++ b/examples/demo-rollup/tests/evm/evm_get_transaction_count.rs
@@ -20,7 +20,7 @@ async fn setup_rollup_with_finality(
     finalization_blocks: u32,
 ) -> (TestRollup<MockDemoRollup<Native>>, SimpleStorageClient) {
     let (rollup, client, _) = setup_with_simple_storage(finalization_blocks, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     (rollup, client)
 }
 
@@ -155,7 +155,7 @@ async fn eth_get_transaction_count_safe_finalized_semantics() -> anyhow::Result<
     client.wait_for_finalized_receipt(tx_hash).await;
 
     // Wait for the next block to ensure finalization
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     assert_equal_nonces_for_tags(
         &client,
@@ -522,7 +522,7 @@ async fn eth_get_transaction_count_sealed_receipts_nonce_delta() -> anyhow::Resu
     }
 
     // Wait for a new block
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Get nonce at block H1
     let h1_number = client.block_number().await;
@@ -597,7 +597,7 @@ async fn eth_get_transaction_count_historical_block_diverges_from_current() -> a
     // Send transaction and wait for finalization in a new block
     let tx_hash = client.send_eth(Address::ZERO, U256::from(0x5432)).await;
     client.wait_for_finalized_receipt(tx_hash).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let h1_number = client.block_number().await;
     assert!(h1_number > h0_number, "New block should be produced");
@@ -647,7 +647,7 @@ async fn eth_get_transaction_count_block_hash_returns_correct_historical() -> an
     // Send transaction and finalize
     let tx_hash = client.send_eth(Address::ZERO, U256::from(0x6543)).await;
     client.wait_for_finalized_receipt(tx_hash).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Get block H1 info
     let h1_number = client.block_number().await;
@@ -854,7 +854,7 @@ async fn eth_get_transaction_count_latest_after_seal() -> anyhow::Result<()> {
     // Send and wait for finalization
     let tx_hash = client.send_eth(Address::ZERO, U256::from(0xABCD)).await;
     client.wait_for_finalized_receipt(tx_hash).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let nonce_after = nonce_at_tag(&client, address, "latest").await;
 
@@ -882,7 +882,7 @@ async fn eth_get_transaction_count_block_boundary() -> anyhow::Result<()> {
     // Send tx and wait for finalization
     let tx_hash = client.send_eth(Address::ZERO, U256::from(0xBCDE)).await;
     let receipt = client.wait_for_finalized_receipt(tx_hash).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let tx_block = receipt
         .block_number
@@ -939,7 +939,7 @@ async fn eth_get_transaction_count_finalized_lags_with_non_instant_finality() ->
     // Send a transaction and wait for it to be sealed into a block
     let tx_hash = client.send_eth(Address::ZERO, U256::from(0xF1A1)).await;
     client.wait_for_finalized_receipt(tx_hash).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // "latest" should reflect the sealed transaction immediately
     let nonce_latest = nonce_at_tag(&client, address, "latest").await;
@@ -958,7 +958,9 @@ async fn eth_get_transaction_count_finalized_lags_with_non_instant_finality() ->
     );
 
     // Produce enough blocks to push the tx block past the finalization threshold
-    rollup.wait_for_next_blocks(finality_depth as u64).await;
+    rollup
+        .wait_for_height_advance_by(finality_depth as u64)
+        .await;
 
     // Now "finalized" should have caught up
     let nonce_finalized_after = nonce_at_tag(&client, address, "finalized").await;

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -319,7 +319,10 @@ async fn get_logs_single_block_range() -> anyhow::Result<()> {
         .produce_logs(2, nb_of_logs_per_tx, Some(1))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let block_number = rollup_and_client
         .client
@@ -613,7 +616,10 @@ async fn get_logs_safe_finalized_exclude_pending() -> anyhow::Result<()> {
         .client
         .alloy_emit_logs(rollup_and_client.contract_address, 1, 2)
         .await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let sealed_hash = rollup_and_client
         .client
@@ -717,7 +723,10 @@ async fn get_logs_ordered_and_not_removed() -> anyhow::Result<()> {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(1))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let logs = rollup_and_client
         .client
@@ -810,7 +819,10 @@ async fn get_logs_emitted_fields_match_event() -> anyhow::Result<()> {
             nb_of_logs_per_tx,
         )
         .await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let receipt = rollup_and_client
         .client
@@ -875,7 +887,10 @@ async fn get_logs_full_topic_log() -> anyhow::Result<()> {
         .client
         .alloy_emit_full_topic_log(rollup_and_client.contract_address, t0, t1, t2, data)
         .await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let receipt = rollup_and_client
         .client
@@ -927,7 +942,10 @@ async fn get_logs_data_only_log() -> anyhow::Result<()> {
         .client
         .alloy_emit_data_only_log(rollup_and_client.contract_address, v1, v2)
         .await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let receipt = rollup_and_client
         .client
@@ -978,7 +996,10 @@ async fn get_logs_indexed_only_log_data_empty() -> anyhow::Result<()> {
         .client
         .alloy_emit_indexed_only_log(rollup_and_client.contract_address, value)
         .await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let receipt = rollup_and_client
         .client
@@ -1110,7 +1131,10 @@ async fn get_logs_earliest_tag() -> anyhow::Result<()> {
     let rollup_and_client = RollupAndClient::new_with_default_limits().await;
 
     let tx_hashes = rollup_and_client.produce_logs(3, 2, Some(1)).await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
     let last_tx = *tx_hashes.last().expect("expected log tx hash");
     let last_receipt = rollup_and_client
         .client
@@ -1143,7 +1167,10 @@ async fn get_logs_schema_correctness() -> anyhow::Result<()> {
     let rollup_and_client = RollupAndClient::new_with_default_limits().await;
 
     let tx_hashes = rollup_and_client.produce_logs(2, 3, Some(1)).await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
     let last_tx = *tx_hashes.last().expect("expected log tx hash");
     let last_receipt = rollup_and_client
         .client
@@ -1181,7 +1208,10 @@ async fn get_logs_eip1898_block_hash_object() -> anyhow::Result<()> {
         .client
         .alloy_emit_logs(rollup_and_client.contract_address, 7, 2)
         .await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let receipt = rollup_and_client
         .client
@@ -1229,7 +1259,10 @@ async fn get_logs_empty_result() -> anyhow::Result<()> {
     let rollup_and_client = RollupAndClient::new_with_default_limits().await;
 
     rollup_and_client.produce_logs(1, 2, None).await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let empty_address = Address::from([0x11; 20]);
     let filter = Filter::new()
@@ -1246,7 +1279,10 @@ async fn get_logs_empty_topics_matches_all() -> anyhow::Result<()> {
     let rollup_and_client = RollupAndClient::new_with_default_limits().await;
 
     let tx_hashes = rollup_and_client.produce_logs(2, 2, Some(1)).await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
     let last_tx = *tx_hashes.last().expect("expected log tx hash");
     let last_receipt = rollup_and_client
         .client
@@ -1293,7 +1329,10 @@ async fn get_logs_topic0_only_matches_any_indexed() -> anyhow::Result<()> {
             3,
         )
         .await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let receipt = rollup_and_client
         .client
@@ -1361,7 +1400,10 @@ async fn get_logs_topic1_without_topic0() -> anyhow::Result<()> {
             U256::from(2),
         )
         .await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
     let simple_receipt = rollup_and_client
         .client
         .alloy_receipt(simple_tx)
@@ -1446,7 +1488,10 @@ async fn get_logs_topic0_or_semantics_multiple() -> anyhow::Result<()> {
             U256::from(10),
         )
         .await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
     let simple_receipt = rollup_and_client
         .client
         .alloy_receipt(simple_tx)
@@ -1560,7 +1605,10 @@ async fn get_logs_topic0_and_topic1_or_semantics() -> anyhow::Result<()> {
             U256::from(3),
         )
         .await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
     let simple_receipt = rollup_and_client
         .client
         .alloy_receipt(simple_tx)
@@ -1661,7 +1709,10 @@ async fn get_logs_trailing_null_topics_ignored() -> anyhow::Result<()> {
     let rollup_and_client = RollupAndClient::new_with_default_limits().await;
 
     let tx_hashes = rollup_and_client.produce_logs(2, 2, Some(1)).await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
     let last_tx = *tx_hashes.last().expect("expected log tx hash");
     let last_receipt = rollup_and_client
         .client
@@ -1706,7 +1757,10 @@ async fn evm_test_get_logs() {
 
     let rollup_and_client = RollupAndClient::new_with_default_limits().await;
 
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     // Make sure all the txs are in the same blcok.
     rollup_and_client
@@ -1722,7 +1776,10 @@ async fn evm_test_get_logs() {
         .test_rollup
         .resume_preferred_batches()
         .await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let tx_hash = tx_hashes[0];
     let rec = rollup_and_client
@@ -1769,7 +1826,10 @@ async fn evm_test_get_logs_range() {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let sender = rollup_and_client.client.address();
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
@@ -1812,7 +1872,10 @@ async fn evm_test_get_logs_range_limit() {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let logs = rollup_and_client.client.get_logs_allow_error().await;
     assert!(logs.is_err());
@@ -2402,7 +2465,10 @@ async fn evm_test_get_logs_with_cursor_and_filter() {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
     let expected = expected_simple_logs_for_rollup(&rollup_and_client, &plans).await;
@@ -2472,7 +2538,10 @@ async fn evm_test_get_logs_with_cursor() {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
     let expected = expected_simple_logs_for_rollup(&rollup_and_client, &plans).await;
@@ -2529,7 +2598,10 @@ async fn evm_test_get_logs_at_max_response_size() {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
     let expected = expected_simple_logs_for_rollup(&rollup_and_client, &plans).await;
@@ -2567,7 +2639,10 @@ async fn evm_test_get_logs_at_max_response_size_without_cursor_throws_error() {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let err = rollup_and_client
         .client
@@ -2586,12 +2661,18 @@ async fn logs_resumed_from_the_middle_of_tx_have_correct_indices() {
 
     let rollup_and_client =
         RollupAndClient::new(max_log_limit, EVM_EXTENSION.response_size_limit).await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let tx_hashes = rollup_and_client
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, None)
         .await;
-    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
+    rollup_and_client
+        .test_rollup
+        .wait_for_height_advance_by(1)
+        .await;
 
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
     let expected = expected_simple_logs_for_rollup(&rollup_and_client, &plans).await;

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -38,7 +38,7 @@ use std::collections::HashMap;
 async fn get_log_from_pending_block() -> anyhow::Result<()> {
     let (rollup, client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
     let contract_address = client.alloy_deploy_contract().await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let sender = client.address();
@@ -321,7 +321,7 @@ async fn get_logs_single_block_range() -> anyhow::Result<()> {
 
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let block_number = rollup_and_client
@@ -618,7 +618,7 @@ async fn get_logs_safe_finalized_exclude_pending() -> anyhow::Result<()> {
         .await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let sealed_hash = rollup_and_client
@@ -725,7 +725,7 @@ async fn get_logs_ordered_and_not_removed() -> anyhow::Result<()> {
 
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let logs = rollup_and_client
@@ -743,7 +743,7 @@ async fn get_logs_ordered_and_not_removed() -> anyhow::Result<()> {
 async fn get_logs_time_executed_ms_per_tx() -> anyhow::Result<()> {
     let (test_rollup, evm_client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
     let contract_address = evm_client.alloy_deploy_contract().await;
-    test_rollup.wait_for_height_advance_by(1).await;
+    test_rollup.wait_for_rollup_height_advance_by(1).await;
 
     let start_block = evm_client
         .eth_get_block_by_number(Some(BlockNumberOrTag::Latest.to_string()))
@@ -752,7 +752,7 @@ async fn get_logs_time_executed_ms_per_tx() -> anyhow::Result<()> {
 
     let tx1 = evm_client.alloy_emit_logs(contract_address, 0, 3).await;
     let tx2 = evm_client.alloy_emit_logs(contract_address, 1, 2).await;
-    test_rollup.wait_for_height_advance_by(1).await;
+    test_rollup.wait_for_rollup_height_advance_by(1).await;
 
     let filter = Filter::new()
         .from_block(start_block)
@@ -821,7 +821,7 @@ async fn get_logs_emitted_fields_match_event() -> anyhow::Result<()> {
         .await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let receipt = rollup_and_client
@@ -889,7 +889,7 @@ async fn get_logs_full_topic_log() -> anyhow::Result<()> {
         .await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let receipt = rollup_and_client
@@ -944,7 +944,7 @@ async fn get_logs_data_only_log() -> anyhow::Result<()> {
         .await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let receipt = rollup_and_client
@@ -998,7 +998,7 @@ async fn get_logs_indexed_only_log_data_empty() -> anyhow::Result<()> {
         .await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let receipt = rollup_and_client
@@ -1133,7 +1133,7 @@ async fn get_logs_earliest_tag() -> anyhow::Result<()> {
     let tx_hashes = rollup_and_client.produce_logs(3, 2, Some(1)).await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
     let last_tx = *tx_hashes.last().expect("expected log tx hash");
     let last_receipt = rollup_and_client
@@ -1169,7 +1169,7 @@ async fn get_logs_schema_correctness() -> anyhow::Result<()> {
     let tx_hashes = rollup_and_client.produce_logs(2, 3, Some(1)).await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
     let last_tx = *tx_hashes.last().expect("expected log tx hash");
     let last_receipt = rollup_and_client
@@ -1210,7 +1210,7 @@ async fn get_logs_eip1898_block_hash_object() -> anyhow::Result<()> {
         .await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let receipt = rollup_and_client
@@ -1261,7 +1261,7 @@ async fn get_logs_empty_result() -> anyhow::Result<()> {
     rollup_and_client.produce_logs(1, 2, None).await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let empty_address = Address::from([0x11; 20]);
@@ -1281,7 +1281,7 @@ async fn get_logs_empty_topics_matches_all() -> anyhow::Result<()> {
     let tx_hashes = rollup_and_client.produce_logs(2, 2, Some(1)).await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
     let last_tx = *tx_hashes.last().expect("expected log tx hash");
     let last_receipt = rollup_and_client
@@ -1331,7 +1331,7 @@ async fn get_logs_topic0_only_matches_any_indexed() -> anyhow::Result<()> {
         .await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let receipt = rollup_and_client
@@ -1402,7 +1402,7 @@ async fn get_logs_topic1_without_topic0() -> anyhow::Result<()> {
         .await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
     let simple_receipt = rollup_and_client
         .client
@@ -1490,7 +1490,7 @@ async fn get_logs_topic0_or_semantics_multiple() -> anyhow::Result<()> {
         .await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
     let simple_receipt = rollup_and_client
         .client
@@ -1607,7 +1607,7 @@ async fn get_logs_topic0_and_topic1_or_semantics() -> anyhow::Result<()> {
         .await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
     let simple_receipt = rollup_and_client
         .client
@@ -1711,7 +1711,7 @@ async fn get_logs_trailing_null_topics_ignored() -> anyhow::Result<()> {
     let tx_hashes = rollup_and_client.produce_logs(2, 2, Some(1)).await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
     let last_tx = *tx_hashes.last().expect("expected log tx hash");
     let last_receipt = rollup_and_client
@@ -1759,7 +1759,7 @@ async fn evm_test_get_logs() {
 
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     // Make sure all the txs are in the same blcok.
@@ -1778,7 +1778,7 @@ async fn evm_test_get_logs() {
         .await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let tx_hash = tx_hashes[0];
@@ -1828,7 +1828,7 @@ async fn evm_test_get_logs_range() {
 
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let sender = rollup_and_client.client.address();
@@ -1874,7 +1874,7 @@ async fn evm_test_get_logs_range_limit() {
 
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let logs = rollup_and_client.client.get_logs_allow_error().await;
@@ -2467,7 +2467,7 @@ async fn evm_test_get_logs_with_cursor_and_filter() {
 
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
@@ -2540,7 +2540,7 @@ async fn evm_test_get_logs_with_cursor() {
 
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
@@ -2600,7 +2600,7 @@ async fn evm_test_get_logs_at_max_response_size() {
 
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
@@ -2641,7 +2641,7 @@ async fn evm_test_get_logs_at_max_response_size_without_cursor_throws_error() {
 
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let err = rollup_and_client
@@ -2663,7 +2663,7 @@ async fn logs_resumed_from_the_middle_of_tx_have_correct_indices() {
         RollupAndClient::new(max_log_limit, EVM_EXTENSION.response_size_limit).await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let tx_hashes = rollup_and_client
@@ -2671,7 +2671,7 @@ async fn logs_resumed_from_the_middle_of_tx_have_correct_indices() {
         .await;
     rollup_and_client
         .test_rollup
-        .wait_for_height_advance_by(1)
+        .wait_for_rollup_height_advance_by(1)
         .await;
 
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
@@ -2737,7 +2737,7 @@ async fn setup_two_contracts() -> (
     let (test_rollup, evm_client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
     let contract_a = evm_client.alloy_deploy_contract().await;
     let contract_b = evm_client.alloy_deploy_contract().await;
-    test_rollup.wait_for_height_advance_by(1).await;
+    test_rollup.wait_for_rollup_height_advance_by(1).await;
     (test_rollup, evm_client, contract_a, contract_b)
 }
 
@@ -2764,7 +2764,7 @@ impl RollupAndClient {
 
         let (test_rollup, evm_client, _) = setup_with_simple_storage(0, ext).await;
         let contract_address = evm_client.alloy_deploy_contract().await;
-        test_rollup.wait_for_height_advance_by(1).await;
+        test_rollup.wait_for_rollup_height_advance_by(1).await;
 
         RollupAndClient {
             test_rollup,
@@ -2788,7 +2788,7 @@ impl RollupAndClient {
             tx_hashes.push(hash);
             if let Some(block_interval) = block_interval {
                 if i % block_interval == 0 {
-                    self.test_rollup.wait_for_height_advance_by(1).await;
+                    self.test_rollup.wait_for_rollup_height_advance_by(1).await;
                 }
             }
         }

--- a/examples/demo-rollup/tests/evm/evm_logs.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs.rs
@@ -38,7 +38,7 @@ use std::collections::HashMap;
 async fn get_log_from_pending_block() -> anyhow::Result<()> {
     let (rollup, client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
     let contract_address = client.alloy_deploy_contract().await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let sender = client.address();
@@ -319,7 +319,7 @@ async fn get_logs_single_block_range() -> anyhow::Result<()> {
         .produce_logs(2, nb_of_logs_per_tx, Some(1))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let block_number = rollup_and_client
         .client
@@ -613,7 +613,7 @@ async fn get_logs_safe_finalized_exclude_pending() -> anyhow::Result<()> {
         .client
         .alloy_emit_logs(rollup_and_client.contract_address, 1, 2)
         .await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let sealed_hash = rollup_and_client
         .client
@@ -717,7 +717,7 @@ async fn get_logs_ordered_and_not_removed() -> anyhow::Result<()> {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(1))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let logs = rollup_and_client
         .client
@@ -734,7 +734,7 @@ async fn get_logs_ordered_and_not_removed() -> anyhow::Result<()> {
 async fn get_logs_time_executed_ms_per_tx() -> anyhow::Result<()> {
     let (test_rollup, evm_client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
     let contract_address = evm_client.alloy_deploy_contract().await;
-    test_rollup.wait_for_next_blocks(1).await;
+    test_rollup.wait_for_height_advance_by(1).await;
 
     let start_block = evm_client
         .eth_get_block_by_number(Some(BlockNumberOrTag::Latest.to_string()))
@@ -743,7 +743,7 @@ async fn get_logs_time_executed_ms_per_tx() -> anyhow::Result<()> {
 
     let tx1 = evm_client.alloy_emit_logs(contract_address, 0, 3).await;
     let tx2 = evm_client.alloy_emit_logs(contract_address, 1, 2).await;
-    test_rollup.wait_for_next_blocks(1).await;
+    test_rollup.wait_for_height_advance_by(1).await;
 
     let filter = Filter::new()
         .from_block(start_block)
@@ -810,7 +810,7 @@ async fn get_logs_emitted_fields_match_event() -> anyhow::Result<()> {
             nb_of_logs_per_tx,
         )
         .await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let receipt = rollup_and_client
         .client
@@ -875,7 +875,7 @@ async fn get_logs_full_topic_log() -> anyhow::Result<()> {
         .client
         .alloy_emit_full_topic_log(rollup_and_client.contract_address, t0, t1, t2, data)
         .await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let receipt = rollup_and_client
         .client
@@ -927,7 +927,7 @@ async fn get_logs_data_only_log() -> anyhow::Result<()> {
         .client
         .alloy_emit_data_only_log(rollup_and_client.contract_address, v1, v2)
         .await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let receipt = rollup_and_client
         .client
@@ -978,7 +978,7 @@ async fn get_logs_indexed_only_log_data_empty() -> anyhow::Result<()> {
         .client
         .alloy_emit_indexed_only_log(rollup_and_client.contract_address, value)
         .await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let receipt = rollup_and_client
         .client
@@ -1110,7 +1110,7 @@ async fn get_logs_earliest_tag() -> anyhow::Result<()> {
     let rollup_and_client = RollupAndClient::new_with_default_limits().await;
 
     let tx_hashes = rollup_and_client.produce_logs(3, 2, Some(1)).await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
     let last_tx = *tx_hashes.last().expect("expected log tx hash");
     let last_receipt = rollup_and_client
         .client
@@ -1143,7 +1143,7 @@ async fn get_logs_schema_correctness() -> anyhow::Result<()> {
     let rollup_and_client = RollupAndClient::new_with_default_limits().await;
 
     let tx_hashes = rollup_and_client.produce_logs(2, 3, Some(1)).await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
     let last_tx = *tx_hashes.last().expect("expected log tx hash");
     let last_receipt = rollup_and_client
         .client
@@ -1181,7 +1181,7 @@ async fn get_logs_eip1898_block_hash_object() -> anyhow::Result<()> {
         .client
         .alloy_emit_logs(rollup_and_client.contract_address, 7, 2)
         .await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let receipt = rollup_and_client
         .client
@@ -1229,7 +1229,7 @@ async fn get_logs_empty_result() -> anyhow::Result<()> {
     let rollup_and_client = RollupAndClient::new_with_default_limits().await;
 
     rollup_and_client.produce_logs(1, 2, None).await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let empty_address = Address::from([0x11; 20]);
     let filter = Filter::new()
@@ -1246,7 +1246,7 @@ async fn get_logs_empty_topics_matches_all() -> anyhow::Result<()> {
     let rollup_and_client = RollupAndClient::new_with_default_limits().await;
 
     let tx_hashes = rollup_and_client.produce_logs(2, 2, Some(1)).await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
     let last_tx = *tx_hashes.last().expect("expected log tx hash");
     let last_receipt = rollup_and_client
         .client
@@ -1293,7 +1293,7 @@ async fn get_logs_topic0_only_matches_any_indexed() -> anyhow::Result<()> {
             3,
         )
         .await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let receipt = rollup_and_client
         .client
@@ -1361,7 +1361,7 @@ async fn get_logs_topic1_without_topic0() -> anyhow::Result<()> {
             U256::from(2),
         )
         .await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
     let simple_receipt = rollup_and_client
         .client
         .alloy_receipt(simple_tx)
@@ -1446,7 +1446,7 @@ async fn get_logs_topic0_or_semantics_multiple() -> anyhow::Result<()> {
             U256::from(10),
         )
         .await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
     let simple_receipt = rollup_and_client
         .client
         .alloy_receipt(simple_tx)
@@ -1560,7 +1560,7 @@ async fn get_logs_topic0_and_topic1_or_semantics() -> anyhow::Result<()> {
             U256::from(3),
         )
         .await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
     let simple_receipt = rollup_and_client
         .client
         .alloy_receipt(simple_tx)
@@ -1661,7 +1661,7 @@ async fn get_logs_trailing_null_topics_ignored() -> anyhow::Result<()> {
     let rollup_and_client = RollupAndClient::new_with_default_limits().await;
 
     let tx_hashes = rollup_and_client.produce_logs(2, 2, Some(1)).await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
     let last_tx = *tx_hashes.last().expect("expected log tx hash");
     let last_receipt = rollup_and_client
         .client
@@ -1706,7 +1706,7 @@ async fn evm_test_get_logs() {
 
     let rollup_and_client = RollupAndClient::new_with_default_limits().await;
 
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     // Make sure all the txs are in the same blcok.
     rollup_and_client
@@ -1722,7 +1722,7 @@ async fn evm_test_get_logs() {
         .test_rollup
         .resume_preferred_batches()
         .await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let tx_hash = tx_hashes[0];
     let rec = rollup_and_client
@@ -1769,7 +1769,7 @@ async fn evm_test_get_logs_range() {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let sender = rollup_and_client.client.address();
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
@@ -1812,7 +1812,7 @@ async fn evm_test_get_logs_range_limit() {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let logs = rollup_and_client.client.get_logs_allow_error().await;
     assert!(logs.is_err());
@@ -2402,7 +2402,7 @@ async fn evm_test_get_logs_with_cursor_and_filter() {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
     let expected = expected_simple_logs_for_rollup(&rollup_and_client, &plans).await;
@@ -2472,7 +2472,7 @@ async fn evm_test_get_logs_with_cursor() {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
     let expected = expected_simple_logs_for_rollup(&rollup_and_client, &plans).await;
@@ -2529,7 +2529,7 @@ async fn evm_test_get_logs_at_max_response_size() {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
     let expected = expected_simple_logs_for_rollup(&rollup_and_client, &plans).await;
@@ -2567,7 +2567,7 @@ async fn evm_test_get_logs_at_max_response_size_without_cursor_throws_error() {
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, Some(3))
         .await;
 
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let err = rollup_and_client
         .client
@@ -2586,12 +2586,12 @@ async fn logs_resumed_from_the_middle_of_tx_have_correct_indices() {
 
     let rollup_and_client =
         RollupAndClient::new(max_log_limit, EVM_EXTENSION.response_size_limit).await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let tx_hashes = rollup_and_client
         .produce_logs(nb_of_txs, nb_of_logs_per_tx, None)
         .await;
-    rollup_and_client.test_rollup.wait_for_next_blocks(1).await;
+    rollup_and_client.test_rollup.wait_for_height_advance_by(1).await;
 
     let plans = simple_log_plans_from_hashes(&tx_hashes, nb_of_logs_per_tx as u64, U256::ZERO);
     let expected = expected_simple_logs_for_rollup(&rollup_and_client, &plans).await;
@@ -2656,7 +2656,7 @@ async fn setup_two_contracts() -> (
     let (test_rollup, evm_client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
     let contract_a = evm_client.alloy_deploy_contract().await;
     let contract_b = evm_client.alloy_deploy_contract().await;
-    test_rollup.wait_for_next_blocks(1).await;
+    test_rollup.wait_for_height_advance_by(1).await;
     (test_rollup, evm_client, contract_a, contract_b)
 }
 
@@ -2683,7 +2683,7 @@ impl RollupAndClient {
 
         let (test_rollup, evm_client, _) = setup_with_simple_storage(0, ext).await;
         let contract_address = evm_client.alloy_deploy_contract().await;
-        test_rollup.wait_for_next_blocks(1).await;
+        test_rollup.wait_for_height_advance_by(1).await;
 
         RollupAndClient {
             test_rollup,
@@ -2707,7 +2707,7 @@ impl RollupAndClient {
             tx_hashes.push(hash);
             if let Some(block_interval) = block_interval {
                 if i % block_interval == 0 {
-                    self.test_rollup.wait_for_next_blocks(1).await;
+                    self.test_rollup.wait_for_height_advance_by(1).await;
                 }
             }
         }

--- a/examples/demo-rollup/tests/evm/evm_logs_validation.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs_validation.rs
@@ -33,7 +33,7 @@ async fn eth_get_logs_reversed_block_range_returns_invalid_params() -> anyhow::R
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_get_logs_future_block_range_returns_invalid_params() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let client = Client::new();
 
     let block_number_response =

--- a/examples/demo-rollup/tests/evm/evm_logs_validation.rs
+++ b/examples/demo-rollup/tests/evm/evm_logs_validation.rs
@@ -33,7 +33,7 @@ async fn eth_get_logs_reversed_block_range_returns_invalid_params() -> anyhow::R
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_get_logs_future_block_range_returns_invalid_params() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let client = Client::new();
 
     let block_number_response =

--- a/examples/demo-rollup/tests/evm/evm_max_fee_validation.rs
+++ b/examples/demo-rollup/tests/evm/evm_max_fee_validation.rs
@@ -97,7 +97,7 @@ async fn test_max_fee_check_height_is_respected() -> anyhow::Result<()> {
     .await;
 
     // Advance past the threshold (height 15)
-    rollup.wait_for_next_blocks(20).await;
+    rollup.wait_for_height_advance_by(20).await;
 
     // After threshold: low fee should fail, high fee should pass
     send_tx_expect_failure(
@@ -119,7 +119,7 @@ async fn test_max_fee_check_height_is_respected() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_big_call_data() {
     let (rollup, client) = setup().await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let mut tx = TransactionRequest::default().with_to(Address::ZERO);
 
     tx.input = TransactionInput {

--- a/examples/demo-rollup/tests/evm/evm_max_fee_validation.rs
+++ b/examples/demo-rollup/tests/evm/evm_max_fee_validation.rs
@@ -97,7 +97,7 @@ async fn test_max_fee_check_height_is_respected() -> anyhow::Result<()> {
     .await;
 
     // Advance past the threshold (height 15)
-    rollup.wait_for_height_advance_by(20).await;
+    rollup.wait_for_rollup_height_advance_by(20).await;
 
     // After threshold: low fee should fail, high fee should pass
     send_tx_expect_failure(
@@ -119,7 +119,7 @@ async fn test_max_fee_check_height_is_respected() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_big_call_data() {
     let (rollup, client) = setup().await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let mut tx = TransactionRequest::default().with_to(Address::ZERO);
 
     tx.input = TransactionInput {

--- a/examples/demo-rollup/tests/evm/evm_no_gas_limit.rs
+++ b/examples/demo-rollup/tests/evm/evm_no_gas_limit.rs
@@ -12,7 +12,7 @@ use sov_evm_test_utils::SimpleStorage;
 #[tokio::test(flavor = "multi_thread")]
 async fn contract_deploy_via_eth_send_transaction_with_no_gas_limit() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let signer: PrivateKeySigner = SENDER_PRIV_KEY.parse().unwrap();
     let from = signer.address();
     let client = alloy_client(rollup.http_addr);

--- a/examples/demo-rollup/tests/evm/evm_no_gas_limit.rs
+++ b/examples/demo-rollup/tests/evm/evm_no_gas_limit.rs
@@ -12,7 +12,7 @@ use sov_evm_test_utils::SimpleStorage;
 #[tokio::test(flavor = "multi_thread")]
 async fn contract_deploy_via_eth_send_transaction_with_no_gas_limit() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let signer: PrivateKeySigner = SENDER_PRIV_KEY.parse().unwrap();
     let from = signer.address();
     let client = alloy_client(rollup.http_addr);

--- a/examples/demo-rollup/tests/evm/evm_oog_error.rs
+++ b/examples/demo-rollup/tests/evm/evm_oog_error.rs
@@ -26,7 +26,7 @@ async fn deploy_with_gas(addr: SocketAddr, gas: u64) -> String {
 #[ignore = "see https://github.com/Sovereign-Labs/sovereign-sdk/pull/2100"]
 async fn returns_readable_oog_error() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     assert_eq!(deploy_with_gas(rollup.http_addr, 0).await, "\"400 Bad Request - 'Transaction execution unsuccessful' ({\\\"error\\\": String(\\\"TransactionReceipt { tx_hash: 0x79ac94a6435e0941eca945e2270e649de138f2f3aa973688cc67ded90d817358, body_to_save: \\\\\\\"<removed>\\\\\\\", events: [], receipt: Skipped(SkippedTxContents { gas_used: GasUnit[3426, 3426], error: OutOfGas(\\\\\\\"The amount to charge is greater than the funds available in the meter. Amount to charge 61668, remaining_funds  0, price GasPrice[9, 9]\\\\\\\") }) }\\\")})\"");
     assert_eq!(deploy_with_gas(rollup.http_addr, 20_000).await, "\"400 Bad Request - 'Transaction execution unsuccessful' ({\\\"CoreModuleError\\\": Object {\\\"error_code\\\": String(\\\"generic\\\"), \\\"message\\\": String(\\\"EVM execution error: Halt { reason: OutOfGas(Basic), gas_used: 8614 }\\\")}})\"");

--- a/examples/demo-rollup/tests/evm/evm_oog_error.rs
+++ b/examples/demo-rollup/tests/evm/evm_oog_error.rs
@@ -26,7 +26,7 @@ async fn deploy_with_gas(addr: SocketAddr, gas: u64) -> String {
 #[ignore = "see https://github.com/Sovereign-Labs/sovereign-sdk/pull/2100"]
 async fn returns_readable_oog_error() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     assert_eq!(deploy_with_gas(rollup.http_addr, 0).await, "\"400 Bad Request - 'Transaction execution unsuccessful' ({\\\"error\\\": String(\\\"TransactionReceipt { tx_hash: 0x79ac94a6435e0941eca945e2270e649de138f2f3aa973688cc67ded90d817358, body_to_save: \\\\\\\"<removed>\\\\\\\", events: [], receipt: Skipped(SkippedTxContents { gas_used: GasUnit[3426, 3426], error: OutOfGas(\\\\\\\"The amount to charge is greater than the funds available in the meter. Amount to charge 61668, remaining_funds  0, price GasPrice[9, 9]\\\\\\\") }) }\\\")})\"");
     assert_eq!(deploy_with_gas(rollup.http_addr, 20_000).await, "\"400 Bad Request - 'Transaction execution unsuccessful' ({\\\"CoreModuleError\\\": Object {\\\"error_code\\\": String(\\\"generic\\\"), \\\"message\\\": String(\\\"EVM execution error: Halt { reason: OutOfGas(Basic), gas_used: 8614 }\\\")}})\"");

--- a/examples/demo-rollup/tests/evm/evm_publish_reverted_txs.rs
+++ b/examples/demo-rollup/tests/evm/evm_publish_reverted_txs.rs
@@ -82,7 +82,7 @@ async fn do_revert_tx_test(preferred_sequencer_publish_reverted_txs: bool) -> an
         exec_config_path.clone(),
     )
     .await;
-    test_rollup.wait_for_next_blocks(1).await;
+    test_rollup.wait_for_height_advance_by(1).await;
     let client = alloy_client_with_signer(test_rollup.http_addr, SENDER_PRIV_KEY);
 
     let rpc_nonce_before = client.get_transaction_count(signer.address()).await?;

--- a/examples/demo-rollup/tests/evm/evm_publish_reverted_txs.rs
+++ b/examples/demo-rollup/tests/evm/evm_publish_reverted_txs.rs
@@ -82,7 +82,7 @@ async fn do_revert_tx_test(preferred_sequencer_publish_reverted_txs: bool) -> an
         exec_config_path.clone(),
     )
     .await;
-    test_rollup.wait_for_height_advance_by(1).await;
+    test_rollup.wait_for_rollup_height_advance_by(1).await;
     let client = alloy_client_with_signer(test_rollup.http_addr, SENDER_PRIV_KEY);
 
     let rpc_nonce_before = client.get_transaction_count(signer.address()).await?;

--- a/examples/demo-rollup/tests/evm/evm_ram_pinning.rs
+++ b/examples/demo-rollup/tests/evm/evm_ram_pinning.rs
@@ -75,7 +75,7 @@ async fn test_ram_pinning_config_updates() -> anyhow::Result<()> {
     let test_rollup =
         start_node_with_ram_pinning(RollupProverConfig::Skip, temp_dir, exec_config_path.clone())
             .await;
-    test_rollup.wait_for_height_advance_by(1).await;
+    test_rollup.wait_for_rollup_height_advance_by(1).await;
     let client = alloy_client_with_signer(test_rollup.http_addr, SENDER_PRIV_KEY);
 
     tracing::info!("Deploying contract");
@@ -116,7 +116,7 @@ async fn test_contract_not_pinned_on_touch() -> anyhow::Result<()> {
     let test_rollup =
         start_node_with_ram_pinning(RollupProverConfig::Skip, temp_dir, exec_config_path.clone())
             .await;
-    test_rollup.wait_for_height_advance_by(1).await;
+    test_rollup.wait_for_rollup_height_advance_by(1).await;
     let client = alloy_client_with_signer(test_rollup.http_addr, SECONDARY_SENDER_PRIV_KEY);
     let client_with_non_prvileged_signer =
         alloy_client_with_signer(test_rollup.http_addr, SENDER_PRIV_KEY);

--- a/examples/demo-rollup/tests/evm/evm_ram_pinning.rs
+++ b/examples/demo-rollup/tests/evm/evm_ram_pinning.rs
@@ -75,7 +75,7 @@ async fn test_ram_pinning_config_updates() -> anyhow::Result<()> {
     let test_rollup =
         start_node_with_ram_pinning(RollupProverConfig::Skip, temp_dir, exec_config_path.clone())
             .await;
-    test_rollup.wait_for_next_blocks(1).await;
+    test_rollup.wait_for_height_advance_by(1).await;
     let client = alloy_client_with_signer(test_rollup.http_addr, SENDER_PRIV_KEY);
 
     tracing::info!("Deploying contract");
@@ -116,7 +116,7 @@ async fn test_contract_not_pinned_on_touch() -> anyhow::Result<()> {
     let test_rollup =
         start_node_with_ram_pinning(RollupProverConfig::Skip, temp_dir, exec_config_path.clone())
             .await;
-    test_rollup.wait_for_next_blocks(1).await;
+    test_rollup.wait_for_height_advance_by(1).await;
     let client = alloy_client_with_signer(test_rollup.http_addr, SECONDARY_SENDER_PRIV_KEY);
     let client_with_non_prvileged_signer =
         alloy_client_with_signer(test_rollup.http_addr, SENDER_PRIV_KEY);

--- a/examples/demo-rollup/tests/evm/evm_rate_limit.rs
+++ b/examples/demo-rollup/tests/evm/evm_rate_limit.rs
@@ -56,7 +56,7 @@ async fn evm_test_rate_limit() -> anyhow::Result<()> {
     };
 
     let rollup = setup_test_rollup(rate_limiter).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Make first request.
     {

--- a/examples/demo-rollup/tests/evm/evm_rate_limit.rs
+++ b/examples/demo-rollup/tests/evm/evm_rate_limit.rs
@@ -56,7 +56,7 @@ async fn evm_test_rate_limit() -> anyhow::Result<()> {
     };
 
     let rollup = setup_test_rollup(rate_limiter).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Make first request.
     {

--- a/examples/demo-rollup/tests/evm/evm_rpc.rs
+++ b/examples/demo-rollup/tests/evm/evm_rpc.rs
@@ -56,7 +56,7 @@ async fn eth_get_block_by_number() -> anyhow::Result<()> {
     assert_eq!(by_number(&client, 2).await?, None);
 
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     assert_eq!(
@@ -105,7 +105,7 @@ async fn eth_get_block_by_hash() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
 
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
     rollup.pause_preferred_batches().await;
 
     let latest_hash = by_number(&client, BlockNumberOrTag::Latest)
@@ -131,7 +131,7 @@ async fn eth_get_block_by_hash() -> anyhow::Result<()> {
 async fn eth_get_block_receipts() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
     usdc.mint(Address::ZERO, parse_ether("1")?).submit().await?;
@@ -163,7 +163,7 @@ async fn eth_get_block_receipts() -> anyhow::Result<()> {
 async fn block_size() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let header = by_number(&client, 0).await?.unwrap();
@@ -177,7 +177,7 @@ async fn block_size() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_get_storage_at_returns_32_byte_data_hex() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let client = crate::evm::evm_test_helper::create_simple_storage_client(
         rollup.http_addr,
@@ -218,7 +218,7 @@ async fn eth_get_storage_at_returns_32_byte_data_hex() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_get_block_transaction_count_by_hash_accepts_synthetic_hash() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let ws_client = crate::evm::evm_test_helper::create_simple_storage_client(
@@ -289,7 +289,7 @@ async fn eth_get_transaction_receipt_fields() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Deploy contract in an isolated block.
     rollup.pause_preferred_batches().await;
@@ -299,7 +299,7 @@ async fn eth_get_transaction_receipt_fields() -> anyhow::Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let deploy_receipt = fetch_receipt(&client, deploy_tx).await?;
@@ -320,7 +320,7 @@ async fn eth_get_transaction_receipt_fields() -> anyhow::Result<()> {
     assert_pending_block_empty(&client).await?;
     let set_tx = simple_storage.set_value(contract_address, set_arg).await;
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let set_receipt = fetch_receipt(&client, set_tx).await?;
@@ -353,7 +353,7 @@ async fn eth_get_transaction_receipt_pending_behavior() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let deploy_tx = simple_storage
@@ -377,7 +377,7 @@ async fn eth_get_transaction_receipt_pending_behavior() -> anyhow::Result<()> {
 
     // Seal the block
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let sealed_receipt = client.get_transaction_receipt(deploy_tx).await?.unwrap();
 
@@ -455,7 +455,7 @@ async fn eth_get_transaction_receipt_pending_is_null() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
     assert_pending_block_empty(&client).await?;
 
@@ -469,7 +469,7 @@ async fn eth_get_transaction_receipt_pending_is_null() -> anyhow::Result<()> {
     assert!(pending_receipt.is_some());
 
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let mined = client.get_transaction_receipt(deploy_tx).await?;
     assert!(mined.is_some());
@@ -483,7 +483,7 @@ async fn eth_get_transaction_receipt_multi_tx_block() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Deploy contract in its own block to get a stable address.
     rollup.pause_preferred_batches().await;
@@ -493,7 +493,7 @@ async fn eth_get_transaction_receipt_multi_tx_block() -> anyhow::Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let deploy_receipt = fetch_receipt(&client, deploy_tx).await?;
@@ -511,7 +511,7 @@ async fn eth_get_transaction_receipt_multi_tx_block() -> anyhow::Result<()> {
     let tx3 = simple_storage.set_value(contract_address, 11).await;
 
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let r1 = fetch_receipt(&client, tx1).await?;
@@ -598,7 +598,7 @@ async fn eth_get_transaction_receipt_many_logs() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Deploy contract
     rollup.pause_preferred_batches().await;
@@ -608,7 +608,7 @@ async fn eth_get_transaction_receipt_many_logs() -> anyhow::Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let deploy_receipt = client.get_transaction_receipt(deploy_tx).await?.unwrap();
     let contract_address = deploy_receipt.contract_address.unwrap();
 
@@ -619,7 +619,7 @@ async fn eth_get_transaction_receipt_many_logs() -> anyhow::Result<()> {
         .alloy_emit_logs(contract_address, 0, 15)
         .await;
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let receipt = client.get_transaction_receipt(emit_tx).await?.unwrap();
 
@@ -642,14 +642,14 @@ async fn eth_get_transaction_receipt_zero_address() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Send to zero address
     rollup.pause_preferred_batches().await;
     assert_pending_block_empty(&client).await?;
     let tx = simple_storage.send_eth(Address::ZERO, U256::from(1)).await;
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let receipt = client.get_transaction_receipt(tx).await?.unwrap();
 

--- a/examples/demo-rollup/tests/evm/evm_rpc.rs
+++ b/examples/demo-rollup/tests/evm/evm_rpc.rs
@@ -56,7 +56,7 @@ async fn eth_get_block_by_number() -> anyhow::Result<()> {
     assert_eq!(by_number(&client, 2).await?, None);
 
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     assert_eq!(
@@ -105,7 +105,7 @@ async fn eth_get_block_by_hash() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
 
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
     rollup.pause_preferred_batches().await;
 
     let latest_hash = by_number(&client, BlockNumberOrTag::Latest)
@@ -131,7 +131,7 @@ async fn eth_get_block_by_hash() -> anyhow::Result<()> {
 async fn eth_get_block_receipts() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
     usdc.mint(Address::ZERO, parse_ether("1")?).submit().await?;
@@ -163,7 +163,7 @@ async fn eth_get_block_receipts() -> anyhow::Result<()> {
 async fn block_size() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_client(rollup.http_addr);
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let header = by_number(&client, 0).await?.unwrap();
@@ -177,7 +177,7 @@ async fn block_size() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_get_storage_at_returns_32_byte_data_hex() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let client = crate::evm::evm_test_helper::create_simple_storage_client(
         rollup.http_addr,
@@ -218,7 +218,7 @@ async fn eth_get_storage_at_returns_32_byte_data_hex() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn eth_get_block_transaction_count_by_hash_accepts_synthetic_hash() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let ws_client = crate::evm::evm_test_helper::create_simple_storage_client(
@@ -289,7 +289,7 @@ async fn eth_get_transaction_receipt_fields() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Deploy contract in an isolated block.
     rollup.pause_preferred_batches().await;
@@ -299,7 +299,7 @@ async fn eth_get_transaction_receipt_fields() -> anyhow::Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let deploy_receipt = fetch_receipt(&client, deploy_tx).await?;
@@ -320,7 +320,7 @@ async fn eth_get_transaction_receipt_fields() -> anyhow::Result<()> {
     assert_pending_block_empty(&client).await?;
     let set_tx = simple_storage.set_value(contract_address, set_arg).await;
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let set_receipt = fetch_receipt(&client, set_tx).await?;
@@ -353,7 +353,7 @@ async fn eth_get_transaction_receipt_pending_behavior() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let deploy_tx = simple_storage
@@ -377,7 +377,7 @@ async fn eth_get_transaction_receipt_pending_behavior() -> anyhow::Result<()> {
 
     // Seal the block
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let sealed_receipt = client.get_transaction_receipt(deploy_tx).await?.unwrap();
 
@@ -455,7 +455,7 @@ async fn eth_get_transaction_receipt_pending_is_null() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
     assert_pending_block_empty(&client).await?;
 
@@ -469,7 +469,7 @@ async fn eth_get_transaction_receipt_pending_is_null() -> anyhow::Result<()> {
     assert!(pending_receipt.is_some());
 
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let mined = client.get_transaction_receipt(deploy_tx).await?;
     assert!(mined.is_some());
@@ -483,7 +483,7 @@ async fn eth_get_transaction_receipt_multi_tx_block() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Deploy contract in its own block to get a stable address.
     rollup.pause_preferred_batches().await;
@@ -493,7 +493,7 @@ async fn eth_get_transaction_receipt_multi_tx_block() -> anyhow::Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let deploy_receipt = fetch_receipt(&client, deploy_tx).await?;
@@ -511,7 +511,7 @@ async fn eth_get_transaction_receipt_multi_tx_block() -> anyhow::Result<()> {
     let tx3 = simple_storage.set_value(contract_address, 11).await;
 
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let r1 = fetch_receipt(&client, tx1).await?;
@@ -598,7 +598,7 @@ async fn eth_get_transaction_receipt_many_logs() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Deploy contract
     rollup.pause_preferred_batches().await;
@@ -608,7 +608,7 @@ async fn eth_get_transaction_receipt_many_logs() -> anyhow::Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let deploy_receipt = client.get_transaction_receipt(deploy_tx).await?.unwrap();
     let contract_address = deploy_receipt.contract_address.unwrap();
 
@@ -619,7 +619,7 @@ async fn eth_get_transaction_receipt_many_logs() -> anyhow::Result<()> {
         .alloy_emit_logs(contract_address, 0, 15)
         .await;
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let receipt = client.get_transaction_receipt(emit_tx).await?.unwrap();
 
@@ -642,14 +642,14 @@ async fn eth_get_transaction_receipt_zero_address() -> anyhow::Result<()> {
     let client = alloy_client(rollup.http_addr);
     let simple_storage = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     // Send to zero address
     rollup.pause_preferred_batches().await;
     assert_pending_block_empty(&client).await?;
     let tx = simple_storage.send_eth(Address::ZERO, U256::from(1)).await;
     rollup.resume_preferred_batches().await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let receipt = client.get_transaction_receipt(tx).await?.unwrap();
 

--- a/examples/demo-rollup/tests/evm/evm_rpc_compliance_validation.rs
+++ b/examples/demo-rollup/tests/evm/evm_rpc_compliance_validation.rs
@@ -156,7 +156,7 @@ async fn rpc_002_block_pinned_nonce_excludes_pending_tx() -> anyhow::Result<()> 
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_003_estimate_gas_uses_account_nonce_when_nonce_omitted() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let provider = alloy_client(rollup.http_addr);
     let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let sender = client.address();
@@ -248,7 +248,7 @@ async fn rpc_004_eth_call_applies_state_overrides() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_005_tx_rejection_should_use_standard_json_rpc_error_class() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let ws_client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let signer: PrivateKeySigner = SENDER_PRIV_KEY.parse()?;
     let nonce = tx_count(&ws_client, signer.address(), "latest").await?;
@@ -287,7 +287,7 @@ async fn rpc_005_tx_rejection_should_use_standard_json_rpc_error_class() -> anyh
 async fn rpc_006_get_balance_accepts_eip_1898_block_selector() -> anyhow::Result<()> {
     let (rollup, client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
     let address = client.address();
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let provider = alloy_client(rollup.http_addr);
     let finalized = provider
@@ -343,7 +343,7 @@ async fn rpc_007_web3_client_version_should_be_available() -> anyhow::Result<()>
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_008_receipt_fee_fields_match_balance_delta() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let sender = client.address();
     let recipient = Address::repeat_byte(0x77);
@@ -418,7 +418,7 @@ async fn rpc_009_pending_trace_matches_original_tx_input() -> anyhow::Result<()>
 async fn rpc_010_send_raw_transaction_sync_returns_receipt_under_preferred_sequencer(
 ) -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let signer: PrivateKeySigner = SENDER_PRIV_KEY.parse()?;
@@ -469,7 +469,7 @@ async fn rpc_010_send_raw_transaction_sync_returns_receipt_under_preferred_seque
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_011_pruned_log_range_should_not_use_custom_4444_code() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
     let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract = deploy_contract_check(&client)
         .await
@@ -481,7 +481,7 @@ async fn rpc_011_pruned_log_range_should_not_use_custom_4444_code() -> anyhow::R
         .expect("log tx should be finalized and have block number");
 
     // Wait until the tx/log-bearing block is old enough that lookup can go through the pruned path.
-    rollup.wait_for_height_advance_by(45).await;
+    rollup.wait_for_rollup_height_advance_by(45).await;
 
     let http = Client::new();
     let response = rpc_call(
@@ -519,7 +519,7 @@ async fn rpc_011_debug_trace_pruned_tx_should_not_use_custom_4444_code() -> anyh
     std::env::set_var(override_key, "5");
 
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(2).await;
+    rollup.wait_for_rollup_height_advance_by(2).await;
     let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
     let tx_hash = client.send_eth(Address::ZERO, U256::from(1)).await;
@@ -529,7 +529,7 @@ async fn rpc_011_debug_trace_pruned_tx_should_not_use_custom_4444_code() -> anyh
     let mut saw_pruned_error = false;
 
     for _ in 0..30 {
-        rollup.wait_for_height_advance_by(1).await;
+        rollup.wait_for_rollup_height_advance_by(1).await;
         let response = rpc_call(
             &http,
             rollup.http_addr,
@@ -664,7 +664,7 @@ async fn rpc_015_estimate_gas_is_stable_for_identical_input() -> anyhow::Result<
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_016_eth_send_transaction_should_preserve_user_gas() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let signer: PrivateKeySigner = SENDER_PRIV_KEY.parse()?;
     let from = signer.address();

--- a/examples/demo-rollup/tests/evm/evm_rpc_compliance_validation.rs
+++ b/examples/demo-rollup/tests/evm/evm_rpc_compliance_validation.rs
@@ -156,7 +156,7 @@ async fn rpc_002_block_pinned_nonce_excludes_pending_tx() -> anyhow::Result<()> 
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_003_estimate_gas_uses_account_nonce_when_nonce_omitted() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let provider = alloy_client(rollup.http_addr);
     let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let sender = client.address();
@@ -248,7 +248,7 @@ async fn rpc_004_eth_call_applies_state_overrides() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_005_tx_rejection_should_use_standard_json_rpc_error_class() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let ws_client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let signer: PrivateKeySigner = SENDER_PRIV_KEY.parse()?;
     let nonce = tx_count(&ws_client, signer.address(), "latest").await?;
@@ -287,7 +287,7 @@ async fn rpc_005_tx_rejection_should_use_standard_json_rpc_error_class() -> anyh
 async fn rpc_006_get_balance_accepts_eip_1898_block_selector() -> anyhow::Result<()> {
     let (rollup, client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
     let address = client.address();
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let provider = alloy_client(rollup.http_addr);
     let finalized = provider
@@ -343,7 +343,7 @@ async fn rpc_007_web3_client_version_should_be_available() -> anyhow::Result<()>
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_008_receipt_fee_fields_match_balance_delta() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let sender = client.address();
     let recipient = Address::repeat_byte(0x77);
@@ -418,7 +418,7 @@ async fn rpc_009_pending_trace_matches_original_tx_input() -> anyhow::Result<()>
 async fn rpc_010_send_raw_transaction_sync_returns_receipt_under_preferred_sequencer(
 ) -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     rollup.pause_preferred_batches().await;
 
     let signer: PrivateKeySigner = SENDER_PRIV_KEY.parse()?;
@@ -469,7 +469,7 @@ async fn rpc_010_send_raw_transaction_sync_returns_receipt_under_preferred_seque
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_011_pruned_log_range_should_not_use_custom_4444_code() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
     let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
     let contract = deploy_contract_check(&client)
         .await
@@ -481,7 +481,7 @@ async fn rpc_011_pruned_log_range_should_not_use_custom_4444_code() -> anyhow::R
         .expect("log tx should be finalized and have block number");
 
     // Wait until the tx/log-bearing block is old enough that lookup can go through the pruned path.
-    rollup.wait_for_next_blocks(45).await;
+    rollup.wait_for_height_advance_by(45).await;
 
     let http = Client::new();
     let response = rpc_call(
@@ -519,7 +519,7 @@ async fn rpc_011_debug_trace_pruned_tx_should_not_use_custom_4444_code() -> anyh
     std::env::set_var(override_key, "5");
 
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(2).await;
+    rollup.wait_for_height_advance_by(2).await;
     let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
 
     let tx_hash = client.send_eth(Address::ZERO, U256::from(1)).await;
@@ -529,7 +529,7 @@ async fn rpc_011_debug_trace_pruned_tx_should_not_use_custom_4444_code() -> anyh
     let mut saw_pruned_error = false;
 
     for _ in 0..30 {
-        rollup.wait_for_next_blocks(1).await;
+        rollup.wait_for_height_advance_by(1).await;
         let response = rpc_call(
             &http,
             rollup.http_addr,
@@ -664,7 +664,7 @@ async fn rpc_015_estimate_gas_is_stable_for_identical_input() -> anyhow::Result<
 #[tokio::test(flavor = "multi_thread")]
 async fn rpc_016_eth_send_transaction_should_preserve_user_gas() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let signer: PrivateKeySigner = SENDER_PRIV_KEY.parse()?;
     let from = signer.address();

--- a/examples/demo-rollup/tests/evm/evm_soft_conf.rs
+++ b/examples/demo-rollup/tests/evm/evm_soft_conf.rs
@@ -9,7 +9,7 @@ async fn evm_test_soft_confirmations() -> anyhow::Result<()> {
         .await
         .unwrap();
 
-    test_rollup.wait_for_height_advance_by(1).await;
+    test_rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Test: Pause the sequencer and verify that the transaction receipt has no assigned block hash,
     // since the block hash is not yet known.
@@ -73,7 +73,7 @@ async fn evm_test_soft_confirmations() -> anyhow::Result<()> {
         // Now we created a block and the block hash becomes available.
         test_rollup.resume_preferred_batches().await;
 
-        test_rollup.wait_for_height_advance_by(1).await;
+        test_rollup.wait_for_rollup_height_advance_by(1).await;
 
         {
             let rec = evm_client.receipt(tx_hash).await.unwrap();

--- a/examples/demo-rollup/tests/evm/evm_soft_conf.rs
+++ b/examples/demo-rollup/tests/evm/evm_soft_conf.rs
@@ -9,7 +9,7 @@ async fn evm_test_soft_confirmations() -> anyhow::Result<()> {
         .await
         .unwrap();
 
-    test_rollup.wait_for_next_blocks(1).await;
+    test_rollup.wait_for_height_advance_by(1).await;
 
     // Test: Pause the sequencer and verify that the transaction receipt has no assigned block hash,
     // since the block hash is not yet known.
@@ -73,7 +73,7 @@ async fn evm_test_soft_confirmations() -> anyhow::Result<()> {
         // Now we created a block and the block hash becomes available.
         test_rollup.resume_preferred_batches().await;
 
-        test_rollup.wait_for_next_blocks(1).await;
+        test_rollup.wait_for_height_advance_by(1).await;
 
         {
             let rec = evm_client.receipt(tx_hash).await.unwrap();

--- a/examples/demo-rollup/tests/evm/evm_subscribe.rs
+++ b/examples/demo-rollup/tests/evm/evm_subscribe.rs
@@ -28,7 +28,7 @@ async fn evm_test_log_subscription() {
     let mut log_collector = LogCollector::new();
 
     let contract_address = evm_client.alloy_deploy_contract().await;
-    test_rollup.wait_for_next_blocks(1).await;
+    test_rollup.wait_for_height_advance_by(1).await;
 
     // Logs from this transactions should not appear in the subscription because we haven't subscribed yet.
     send_txs_and_pause(0..10, contract_address, &evm_client, &test_rollup).await;
@@ -85,7 +85,7 @@ async fn evm_test_log_subscription_with_pending_blcok() {
     let mut log_collector = LogCollector::new();
 
     let contract_address = evm_client.alloy_deploy_contract().await;
-    test_rollup.wait_for_next_blocks(1).await;
+    test_rollup.wait_for_height_advance_by(1).await;
     test_rollup.pause_preferred_batches().await;
 
     let nb_of_txs = 100;
@@ -145,7 +145,7 @@ async fn evm_test_log_subscription_with_pending_block_range_is_alllowed() {
     let mut log_collector = LogCollector::new();
 
     let contract_address = evm_client.alloy_deploy_contract().await;
-    test_rollup.wait_for_next_blocks(1).await;
+    test_rollup.wait_for_height_advance_by(1).await;
     test_rollup.pause_preferred_batches().await;
 
     let nb_of_txs = 100;
@@ -257,7 +257,7 @@ impl TestCase {
     async fn run(&self) {
         let (test_rollup, evm_client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
         let contract_address = evm_client.alloy_deploy_contract().await;
-        test_rollup.wait_for_next_blocks(1).await;
+        test_rollup.wait_for_height_advance_by(1).await;
 
         let filter = self.filter();
 
@@ -367,7 +367,7 @@ async fn send_txs_and_pause(
         let set_arg = i;
         let hash = evm_client.alloy_set_value(contract_address, set_arg).await;
         if i % 3 == 0 {
-            test_rollup.wait_for_next_blocks(1).await;
+            test_rollup.wait_for_height_advance_by(1).await;
         }
         tx_hashes.push(hash);
     }
@@ -411,7 +411,7 @@ async fn get_filtered_logs(
             .await;
 
         if i % 5 == 0 {
-            test_rollup.wait_for_next_blocks(1).await;
+            test_rollup.wait_for_height_advance_by(1).await;
         }
     }
 

--- a/examples/demo-rollup/tests/evm/evm_subscribe.rs
+++ b/examples/demo-rollup/tests/evm/evm_subscribe.rs
@@ -28,7 +28,7 @@ async fn evm_test_log_subscription() {
     let mut log_collector = LogCollector::new();
 
     let contract_address = evm_client.alloy_deploy_contract().await;
-    test_rollup.wait_for_height_advance_by(1).await;
+    test_rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Logs from this transactions should not appear in the subscription because we haven't subscribed yet.
     send_txs_and_pause(0..10, contract_address, &evm_client, &test_rollup).await;
@@ -85,7 +85,7 @@ async fn evm_test_log_subscription_with_pending_blcok() {
     let mut log_collector = LogCollector::new();
 
     let contract_address = evm_client.alloy_deploy_contract().await;
-    test_rollup.wait_for_height_advance_by(1).await;
+    test_rollup.wait_for_rollup_height_advance_by(1).await;
     test_rollup.pause_preferred_batches().await;
 
     let nb_of_txs = 100;
@@ -145,7 +145,7 @@ async fn evm_test_log_subscription_with_pending_block_range_is_alllowed() {
     let mut log_collector = LogCollector::new();
 
     let contract_address = evm_client.alloy_deploy_contract().await;
-    test_rollup.wait_for_height_advance_by(1).await;
+    test_rollup.wait_for_rollup_height_advance_by(1).await;
     test_rollup.pause_preferred_batches().await;
 
     let nb_of_txs = 100;
@@ -257,7 +257,7 @@ impl TestCase {
     async fn run(&self) {
         let (test_rollup, evm_client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
         let contract_address = evm_client.alloy_deploy_contract().await;
-        test_rollup.wait_for_height_advance_by(1).await;
+        test_rollup.wait_for_rollup_height_advance_by(1).await;
 
         let filter = self.filter();
 
@@ -367,7 +367,7 @@ async fn send_txs_and_pause(
         let set_arg = i;
         let hash = evm_client.alloy_set_value(contract_address, set_arg).await;
         if i % 3 == 0 {
-            test_rollup.wait_for_height_advance_by(1).await;
+            test_rollup.wait_for_rollup_height_advance_by(1).await;
         }
         tx_hashes.push(hash);
     }
@@ -411,7 +411,7 @@ async fn get_filtered_logs(
             .await;
 
         if i % 5 == 0 {
-            test_rollup.wait_for_height_advance_by(1).await;
+            test_rollup.wait_for_rollup_height_advance_by(1).await;
         }
     }
 

--- a/examples/demo-rollup/tests/evm/evm_test_helper.rs
+++ b/examples/demo-rollup/tests/evm/evm_test_helper.rs
@@ -313,7 +313,7 @@ pub async fn setup_with_simple_storage(
     extension: SeqConfigExtension,
 ) -> (TestRollup<MockDemoRollup<Native>>, SimpleStorageClient, u64) {
     let test_rollup = setup_test_rollup(finalization_blocks, extension).await;
-    test_rollup.wait_for_height_advance_by(10).await;
+    test_rollup.wait_for_rollup_height_advance_by(10).await;
     let simple_storage = create_simple_storage_client(test_rollup.http_addr, SENDER_PRIV_KEY).await;
     (test_rollup, simple_storage, config_value!("CHAIN_ID"))
 }

--- a/examples/demo-rollup/tests/evm/evm_test_helper.rs
+++ b/examples/demo-rollup/tests/evm/evm_test_helper.rs
@@ -313,7 +313,7 @@ pub async fn setup_with_simple_storage(
     extension: SeqConfigExtension,
 ) -> (TestRollup<MockDemoRollup<Native>>, SimpleStorageClient, u64) {
     let test_rollup = setup_test_rollup(finalization_blocks, extension).await;
-    test_rollup.wait_for_next_blocks(10).await;
+    test_rollup.wait_for_height_advance_by(10).await;
     let simple_storage = create_simple_storage_client(test_rollup.http_addr, SENDER_PRIV_KEY).await;
     (test_rollup, simple_storage, config_value!("CHAIN_ID"))
 }

--- a/examples/demo-rollup/tests/evm/evm_timestamp.rs
+++ b/examples/demo-rollup/tests/evm/evm_timestamp.rs
@@ -19,7 +19,7 @@ async fn setup_test_rollup() -> (
     let host_args = mock_da_risc0_host_args();
     let config = get_appropriate_rollup_prover_config::<MockRollupSpec<Native>>(host_args);
     let test_rollup = start_node(config, 0, Some(EVM_EXTENSION), None).await;
-    test_rollup.wait_for_height_advance_by(10).await;
+    test_rollup.wait_for_rollup_height_advance_by(10).await;
     let evm_client = create_simple_storage_client(test_rollup.http_addr, SENDER_PRIV_KEY).await;
 
     let contract_address = evm_client.alloy_deploy_contract().await;
@@ -41,7 +41,7 @@ async fn evm_test_logs_timestamp_gets_updated_with_txs() {
     tokio::time::sleep(std::time::Duration::from_millis(5)).await;
     evm_client.alloy_emit_logs(contract_addr, 0, 2).await;
 
-    test_rollup.wait_for_height_advance_by(1).await;
+    test_rollup.wait_for_rollup_height_advance_by(1).await;
 
     // Check logs from evm txs.
     {

--- a/examples/demo-rollup/tests/evm/evm_timestamp.rs
+++ b/examples/demo-rollup/tests/evm/evm_timestamp.rs
@@ -19,7 +19,7 @@ async fn setup_test_rollup() -> (
     let host_args = mock_da_risc0_host_args();
     let config = get_appropriate_rollup_prover_config::<MockRollupSpec<Native>>(host_args);
     let test_rollup = start_node(config, 0, Some(EVM_EXTENSION), None).await;
-    test_rollup.wait_for_next_blocks(10).await;
+    test_rollup.wait_for_height_advance_by(10).await;
     let evm_client = create_simple_storage_client(test_rollup.http_addr, SENDER_PRIV_KEY).await;
 
     let contract_address = evm_client.alloy_deploy_contract().await;
@@ -41,7 +41,7 @@ async fn evm_test_logs_timestamp_gets_updated_with_txs() {
     tokio::time::sleep(std::time::Duration::from_millis(5)).await;
     evm_client.alloy_emit_logs(contract_addr, 0, 2).await;
 
-    test_rollup.wait_for_next_blocks(1).await;
+    test_rollup.wait_for_height_advance_by(1).await;
 
     // Check logs from evm txs.
     {

--- a/examples/demo-rollup/tests/evm/evm_tracing.rs
+++ b/examples/demo-rollup/tests/evm/evm_tracing.rs
@@ -12,7 +12,7 @@ use crate::evm::evm_test_helper::EVM_EXTENSION;
 #[tokio::test(flavor = "multi_thread")]
 async fn debug_trace_pending_tx() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let client = alloy_client(rollup.http_addr);
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
@@ -50,7 +50,7 @@ async fn debug_trace_pending_tx() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn debug_trace_pending_block() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let client = alloy_client(rollup.http_addr);
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
@@ -88,12 +88,12 @@ async fn debug_trace_pending_block() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn debug_trace_block_by_number() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let client = alloy_client(rollup.http_addr);
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
     let mint_tx = usdc.mint(Address::ZERO, parse_ether("1")?).send().await?;
-    rollup.wait_for_height_advance_by(1).await; // Block nr 2 mined with 2 transactions
+    rollup.wait_for_rollup_height_advance_by(1).await; // Block nr 2 mined with 2 transactions
 
     let opts = GethDebugTracingOptions::call_tracer(CallConfig::default());
     let trace = client

--- a/examples/demo-rollup/tests/evm/evm_tracing.rs
+++ b/examples/demo-rollup/tests/evm/evm_tracing.rs
@@ -12,7 +12,7 @@ use crate::evm::evm_test_helper::EVM_EXTENSION;
 #[tokio::test(flavor = "multi_thread")]
 async fn debug_trace_pending_tx() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let client = alloy_client(rollup.http_addr);
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
@@ -50,7 +50,7 @@ async fn debug_trace_pending_tx() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn debug_trace_pending_block() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let client = alloy_client(rollup.http_addr);
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
@@ -88,12 +88,12 @@ async fn debug_trace_pending_block() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn debug_trace_block_by_number() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let client = alloy_client(rollup.http_addr);
     let usdc = Erc20::deploy(client.clone(), "Usdc".into(), "USDC".into()).await?;
     let mint_tx = usdc.mint(Address::ZERO, parse_ether("1")?).send().await?;
-    rollup.wait_for_next_blocks(1).await; // Block nr 2 mined with 2 transactions
+    rollup.wait_for_height_advance_by(1).await; // Block nr 2 mined with 2 transactions
 
     let opts = GethDebugTracingOptions::call_tracer(CallConfig::default());
     let trace = client

--- a/examples/demo-rollup/tests/evm/evm_ws_watch.rs
+++ b/examples/demo-rollup/tests/evm/evm_ws_watch.rs
@@ -13,7 +13,7 @@ use crate::evm::evm_test_helper::EVM_EXTENSION;
 #[tokio::test(flavor = "multi_thread")]
 async fn ws_watch_returns_receipt() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let client = alloy_ws_client(rollup.http_addr).await;
 
     let tx = TransactionRequest::default().with_to(Address::ZERO);
@@ -31,7 +31,7 @@ async fn ws_watch_returns_receipt() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn ws_get_receipt() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
     let client = alloy_ws_client(rollup.http_addr).await;
 
     let tx = TransactionRequest::default().with_to(Address::ZERO);
@@ -50,7 +50,7 @@ async fn ws_subscribe_new_heads() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_ws_client(rollup.http_addr).await;
     let subscription = client.subscribe_blocks().await?;
-    rollup.wait_for_next_blocks(3).await;
+    rollup.wait_for_height_advance_by(3).await;
 
     let headers: Vec<_> = subscription.into_stream().take(3).collect().await;
 
@@ -66,7 +66,7 @@ async fn ws_subscribe_new_heads_sizes() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_ws_client(rollup.http_addr).await;
     let mut subscription = client.subscribe_blocks().await?;
-    rollup.wait_for_next_blocks(1).await;
+    rollup.wait_for_height_advance_by(1).await;
 
     let header = subscription.recv().await?;
     assert_eq!(header.number, 2);

--- a/examples/demo-rollup/tests/evm/evm_ws_watch.rs
+++ b/examples/demo-rollup/tests/evm/evm_ws_watch.rs
@@ -13,7 +13,7 @@ use crate::evm::evm_test_helper::EVM_EXTENSION;
 #[tokio::test(flavor = "multi_thread")]
 async fn ws_watch_returns_receipt() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let client = alloy_ws_client(rollup.http_addr).await;
 
     let tx = TransactionRequest::default().with_to(Address::ZERO);
@@ -31,7 +31,7 @@ async fn ws_watch_returns_receipt() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 async fn ws_get_receipt() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
     let client = alloy_ws_client(rollup.http_addr).await;
 
     let tx = TransactionRequest::default().with_to(Address::ZERO);
@@ -50,7 +50,7 @@ async fn ws_subscribe_new_heads() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_ws_client(rollup.http_addr).await;
     let subscription = client.subscribe_blocks().await?;
-    rollup.wait_for_height_advance_by(3).await;
+    rollup.wait_for_rollup_height_advance_by(3).await;
 
     let headers: Vec<_> = subscription.into_stream().take(3).collect().await;
 
@@ -66,7 +66,7 @@ async fn ws_subscribe_new_heads_sizes() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let client = alloy_ws_client(rollup.http_addr).await;
     let mut subscription = client.subscribe_blocks().await?;
-    rollup.wait_for_height_advance_by(1).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
 
     let header = subscription.recv().await?;
     assert_eq!(header.number, 2);

--- a/examples/demo-rollup/tests/forced_sequencer_registration/mod.rs
+++ b/examples/demo-rollup/tests/forced_sequencer_registration/mod.rs
@@ -372,7 +372,7 @@ async fn setup_with_block_producing(
     if is_manual {
         rollup.tenderly_produce_blocks(10).await.unwrap();
     } else {
-        rollup.wait_for_height_advance_by(10).await;
+        rollup.wait_for_rollup_height_advance_by(10).await;
     }
     rollup.wait_for_sequencer_ready().await.unwrap();
 

--- a/examples/demo-rollup/tests/forced_sequencer_registration/mod.rs
+++ b/examples/demo-rollup/tests/forced_sequencer_registration/mod.rs
@@ -372,7 +372,7 @@ async fn setup_with_block_producing(
     if is_manual {
         rollup.tenderly_produce_blocks(10).await.unwrap();
     } else {
-        rollup.wait_for_next_blocks(10).await;
+        rollup.wait_for_height_advance_by(10).await;
     }
     rollup.wait_for_sequencer_ready().await.unwrap();
 

--- a/examples/demo-rollup/tests/replica/replica_partitioned_db.rs
+++ b/examples/demo-rollup/tests/replica/replica_partitioned_db.rs
@@ -1,16 +1,19 @@
 use super::toxi_proxy_helper::NodeTestSetup;
 use super::*;
-use sov_test_utils::logging::LogCollector;
-use tracing::Level;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::registry;
-use tracing_subscriber::util::SubscriberInitExt;
 
 const BASELINE_TRANSFER_COUNT: u64 = 1;
 const PARTITIONED_TRANSFER_COUNT: u64 = 3;
 
-/// Verifies a DB-elected replica remain consistent after sequencer db partition.
 #[tokio::test(flavor = "multi_thread")]
+async fn test_repl_x() {
+    for i in 0..100 {
+        println!("Iter {i}");
+        test_replica_catches_up_via_da_after_postgres_partition().await;
+    }
+}
+
+/// Verifies a DB-elected replica remain consistent after sequencer db partition.
+
 async fn test_replica_catches_up_via_da_after_postgres_partition() {
     let Some(mut setup) = NodeTestSetup::new().await else {
         return;
@@ -58,10 +61,6 @@ async fn test_replica_catches_up_via_da_after_postgres_partition() {
         let replica_balance = get_balance(&replica, &receiver_addr, &token_id).await;
         assert_eq!(replica_balance, expected_baseline_balance);
     }
-
-    let collector = LogCollector::new(Level::ERROR);
-    let subscriber = registry().with(collector.clone());
-    subscriber.init();
 
     // Simulate a partitioned sequencer DB. Now replica is disconnected and the DA is very slow.
     // `setup.set_replica_da_slow`` ensures that the replica is not updated immediately via DA after a DB partition, allowing the system to diverge for a couple of blocks.

--- a/examples/demo-rollup/tests/replica/replica_partitioned_db.rs
+++ b/examples/demo-rollup/tests/replica/replica_partitioned_db.rs
@@ -49,7 +49,6 @@ async fn test_replica_catches_up_via_da_after_postgres_partition() {
         .await;
 
         wait_for_replica_to_catchup(&leader, &replica).await;
-
         let replica_balance = get_balance(&replica, &receiver_addr, &token_id).await;
         assert_eq!(replica_balance, expected_baseline_balance);
     }
@@ -87,7 +86,6 @@ async fn test_replica_catches_up_via_da_after_postgres_partition() {
     // Check that the replica receives the data via DA.
     {
         wait_for_replica_to_catchup(&leader, &replica).await;
-
         let replica_balance = get_balance(&replica, &receiver_addr, &token_id).await;
         assert_eq!(replica_balance, expected_balance_after_partitioned_tx);
     }

--- a/examples/demo-rollup/tests/replica/replica_partitioned_db.rs
+++ b/examples/demo-rollup/tests/replica/replica_partitioned_db.rs
@@ -79,7 +79,7 @@ async fn test_replica_catches_up_via_da_after_postgres_partition() {
         )
         .await;
 
-        leader.wait_for_next_blocks(3).await;
+        leader.wait_for_height_advance_by(3).await;
         setup.set_replica_da_slow(false).await;
     }
 

--- a/examples/demo-rollup/tests/replica/replica_partitioned_db.rs
+++ b/examples/demo-rollup/tests/replica/replica_partitioned_db.rs
@@ -78,7 +78,7 @@ async fn test_replica_catches_up_via_da_after_postgres_partition() {
         )
         .await;
 
-        leader.wait_for_height_advance_by(3).await;
+        leader.wait_for_rollup_height_advance_by(3).await;
         setup.set_replica_da_slow(false).await;
     }
 

--- a/examples/demo-rollup/tests/replica/replica_partitioned_db.rs
+++ b/examples/demo-rollup/tests/replica/replica_partitioned_db.rs
@@ -4,16 +4,8 @@ use super::*;
 const BASELINE_TRANSFER_COUNT: u64 = 1;
 const PARTITIONED_TRANSFER_COUNT: u64 = 3;
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_repl_x() {
-    for i in 0..100 {
-        println!("Iter {i}");
-        test_replica_catches_up_via_da_after_postgres_partition().await;
-    }
-}
-
 /// Verifies a DB-elected replica remain consistent after sequencer db partition.
-
+#[tokio::test(flavor = "multi_thread")]
 async fn test_replica_catches_up_via_da_after_postgres_partition() {
     let Some(mut setup) = NodeTestSetup::new().await else {
         return;
@@ -87,7 +79,7 @@ async fn test_replica_catches_up_via_da_after_postgres_partition() {
         )
         .await;
 
-        leader.wait_for_height(3).await;
+        leader.wait_for_next_blocks(3).await;
         setup.set_replica_da_slow(false).await;
     }
 
@@ -95,12 +87,14 @@ async fn test_replica_catches_up_via_da_after_postgres_partition() {
     // Check that the replica receives the data via DA.
     {
         wait_for_replica_to_catchup(&leader, &replica).await;
+
         let replica_balance = get_balance(&replica, &receiver_addr, &token_id).await;
         assert_eq!(replica_balance, expected_balance_after_partitioned_tx);
     }
 
     // Here the DB partition is ended. We check that we can still query the replica
     setup.set_postgres_partition(false).await;
+
     let replica_balance = get_balance(&replica, &receiver_addr, &token_id).await;
     assert_eq!(replica_balance, expected_balance_after_partitioned_tx);
 

--- a/examples/demo-rollup/tests/restart/crash.rs
+++ b/examples/demo-rollup/tests/restart/crash.rs
@@ -193,7 +193,7 @@ async fn test_start_stop_with_crash(crash_moment: CrashLocation) -> anyhow::Resu
     {
         let test_rollup = start_node(temp_dir, da_layer.clone()).await;
         test_rollup.wait_for_sequencer_ready().await.unwrap();
-        test_rollup.wait_for_next_blocks(10).await;
+        test_rollup.wait_for_height_advance_by(10).await;
 
         let client = test_rollup.client.clone();
         let mut event_subscription = subscribe_to_bank_events(&test_rollup).await;

--- a/examples/demo-rollup/tests/restart/crash.rs
+++ b/examples/demo-rollup/tests/restart/crash.rs
@@ -193,7 +193,7 @@ async fn test_start_stop_with_crash(crash_moment: CrashLocation) -> anyhow::Resu
     {
         let test_rollup = start_node(temp_dir, da_layer.clone()).await;
         test_rollup.wait_for_sequencer_ready().await.unwrap();
-        test_rollup.wait_for_height_advance_by(10).await;
+        test_rollup.wait_for_rollup_height_advance_by(10).await;
 
         let client = test_rollup.client.clone();
         let mut event_subscription = subscribe_to_bank_events(&test_rollup).await;


### PR DESCRIPTION
# Description

This PR fixes a flake reported here:
https://github.com/Sovereign-Labs/sovereign-sdk/actions/runs/22679377040/job/65745195434

It introduces the following changes:

1. Replaces `wait_for_height` with `wait_for_next_blocks` in `replica_partitioned_db.rs`. This was the main issue: the test was waiting for height 3, which had already been reached, so it proceeded immediately rather than waiting.

Relevant diff: https://github.com/Sovereign-Labs/sovereign-sdk/pull/2552/changes#diff-dd66dd614c1fd33a815e43fee7710163e5518a7f67a19b8d896d8da5f7d7e495R81

2. Removes some unnused code from `replica_partitioned_db.rs`

3. Renames `wait_for_next_blocks` to `wait_for_height_advance_by`. Most of the diff comes from this rename, but the functionality remains the same.


- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2552" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
