### PR TITLE
Unflake `blob_sender_exit_if_blob_not_processed` test

### DIFF
--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -277,6 +277,7 @@ async fn blob_sender_exit_if_blob_not_processed() -> anyhow::Result<()> {
     subscriber.init();
 
     let deps = create_deps().await;
+    let mut shutdown_receiver = deps.shutdown_sender.subscribe();
 
     let (mut blob_sender, blob_sender_handle) = create_blob_sender(
         Duration::from_secs(1),
@@ -292,12 +293,14 @@ async fn blob_sender_exit_if_blob_not_processed() -> anyhow::Result<()> {
         .publish_batch_blob(data, blob_id as BlobInternalId)
         .await?;
 
-    // Blob publication failed due to the absence of DA blocks.
-    // After MAX_NB_OF_BLOB_SUBMISSION_RETRIES attempts, the BlobSender should terminate gracefully.
-    let result = tokio::time::timeout(Duration::from_secs(5), blob_sender_handle).await;
-    result
-        .expect("The BlobSender should exit gracefully after failing to publish blobs.")
-        .unwrap();
+    // Blob publication fails due to the absence of DA blocks.
+    // After MAX_NB_OF_BLOB_SUBMISSION_RETRIES attempts, BlobSender should request shutdown.
+    shutdown_receiver
+        .changed()
+        .await
+        .expect("The BlobSender should request shutdown after failing to process blobs.");
+
+    blob_sender_handle.await.unwrap();
 
     let mut records = collector.records();
     assert_eq!(records.len(), 4);


### PR DESCRIPTION
# Description

The flake was reported here:
https://github.com/Sovereign-Labs/sovereign-sdk/actions/runs/22679377040/job/65745195498

Fix:

Use `shutdown_receiver` in the test to make sure that the `shutdown` signal is sent.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
