### PR TITLE
Add resolver = "2" to hyperlane-solana workspace to fix cargo warning

### DIFF
--- a/crates/module-system/module-implementations/extern/hyperlane-solana-register/solana/Cargo.toml
+++ b/crates/module-system/module-implementations/extern/hyperlane-solana-register/solana/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["program", "program-tests"]
+resolver = "2"
 
 [workspace.package]
 version = "0.1.0"


### PR DESCRIPTION
# Description

Removes warning that is observed during `make total-clean`:
```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
  1 [workspace]
  |
  = note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
  = note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
  = note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
     Removed 0 files
```

---

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Tried to run cargo check from the folder, but got this error:

```
fatal: remote error: upload-pack: not our ref 99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec
error: failed to get `account-utils` as a dependency of package `hyperlane-solana-sovereign-register v0.1.0 (/opt/fast-data/workspace/sovereign-sdk/crates/module-system/module-implementations/extern/hyperlane-solana-register/solana/program)`

Caused by:
  failed to load source for dependency `account-utils`

Caused by:
  Unable to update https://github.com/Sovereign-Labs/hyperlane-monorepo.git?rev=99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec#99f4861c

Caused by:
  failed to clone into: /home/stig/.cargo/git/db/hyperlane-monorepo-21cbc5e0cd2944a4

Caused by:
  revision 99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec not found

Caused by:
  process didn't exit successfully: `git fetch --no-tags --force --update-head-ok 'https://github.com/Sovereign-Labs/hyperlane-monorepo.git' '+99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec:refs/commit/99f4861cb3e3d0cd803dcdbc20c8394eac14b8ec'` (exit status: 128)
  
```

## Docs
No updates