### PR TITLE
Updated the `SP1Host` and `SP1Verifier` implementations to support SP1 v6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2025-03-10
+- #2554 **Breaking change** Updated the `SP1Host` and `SP1Verifier` implementations to support SP1 v6. `ZkvmHost::code_commitment` now returns a Result, which is a breaking change.
 # 2025-03-05
 - #2554 More stabilization in demo-rollup EVM tests
 # 2026-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2025-03-10
-- #2554 **Breaking change** Updated the `SP1Host` and `SP1Verifier` implementations to support SP1 v6. `ZkvmHost::code_commitment` now returns a Result, which is a breaking change.
+- #2569 **Breaking change** Updated the `SP1Host` and `SP1Verifier` implementations to support SP1 v6. `ZkvmHost::code_commitment` now returns a Result, which is a breaking change.
 # 2025-03-05
 - #2554 More stabilization in demo-rollup EVM tests
 # 2026-03-05

--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -1,9 +1,8 @@
 use std::collections::VecDeque;
 
-use serde::Serialize;
-
 use crate::notifier::NotificationManager;
 use crate::{Empty, Inner, MockCodeCommitment, MockZkGuest, Proof};
+use serde::Serialize;
 
 /// A mock implementing the zkVM trait.
 #[derive(Clone)]
@@ -65,8 +64,8 @@ impl sov_rollup_interface::zk::ZkvmHost for MockZkvmHost {
         self.committed_data.push_back(data);
     }
 
-    fn code_commitment(&self) -> <<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment{
-        MockCodeCommitment::default()
+    fn code_commitment(&self) -> anyhow::Result<<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment>{
+        Ok(MockCodeCommitment::default())
     }
 
     fn run(&mut self, _with_proof: bool) -> anyhow::Result<Vec<u8>> {

--- a/crates/adapters/risc0/src/host.rs
+++ b/crates/adapters/risc0/src/host.rs
@@ -108,11 +108,9 @@ impl ZkvmHost for Risc0Host<'static> {
         Ok(bincode::serialize(&proof)?)
     }
 
-    fn code_commitment(&self) -> <<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment{
-        Risc0MethodId(
-            risc0_zkvm::compute_image_id(self.elf)
-                .expect("Invalid ELF; could not compute image ID")
-                .into(),
-        )
+    fn code_commitment(&self) -> anyhow::Result<<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment>{
+        Ok(Risc0MethodId(
+            risc0_zkvm::compute_image_id(self.elf)?.into(),
+        ))
     }
 }

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -3,8 +3,9 @@
 use serde::Serialize;
 use sov_rollup_interface::reexports::anyhow;
 use sov_rollup_interface::zk::{Proof, ZkvmHost};
+use sp1_sdk::blocking::{CpuProver, SP1PublicValues};
 use sp1_sdk::blocking::{ProveRequest, Prover, ProverClient};
-use sp1_sdk::{ProvingKey, SP1Stdin};
+use sp1_sdk::{ProvingKey, SP1ProvingKey, SP1Stdin};
 
 use crate::guest::SP1Guest;
 
@@ -27,6 +28,15 @@ impl<'host> SP1Host<'host> {
     /// Create a new `Sp1Guest` that reads the provided hints
     pub fn simulate_with_hints(&mut self) -> SP1Guest {
         SP1Guest::with_hints(self.stdin.buffer.clone())
+    }
+
+    fn create_prover_and_pk(&self) -> anyhow::Result<(CpuProver, SP1ProvingKey)> {
+        let prover = ProverClient::builder().cpu().build();
+        let pk = prover
+            .setup(self.elf.into())
+            .map_err(|e| anyhow::anyhow!("SP1 setup failed. Error: {:?}", e))?;
+
+        Ok((prover, pk))
     }
 }
 
@@ -58,31 +68,29 @@ impl ZkvmHost for SP1Host<'static> {
     }
 
     fn run(&mut self, with_proof: bool) -> anyhow::Result<Vec<u8>> {
-        let prover = ProverClient::builder().cpu().build();
-        let proof = if with_proof {
-            let pk = prover
-                .setup(self.elf.into())
-                .map_err(|e| anyhow::anyhow!("SP1 setup failed. Error: {:?}", e))?;
-            let output = prover
-                .prove(&pk, self.stdin.clone())
-                .run()
-                .map_err(|e| anyhow::anyhow!("SP1 proving failed. Error: {:?}", e))?;
-            Proof::Full(output.proof)
-        } else {
-            let prover = ProverClient::builder().mock().build();
-            let execute_request = prover.execute(self.elf.into(), self.stdin.clone());
-            let (public_values, _report) = execute_request
-                .run()
-                .map_err(|e| anyhow::anyhow!("SP1 execution failed. Error: {:?}", e))?;
-            Proof::PublicData(public_values)
+        let proof: Proof<_, SP1PublicValues> = {
+            if with_proof {
+                let (prover, pk) = self.create_prover_and_pk()?;
+                let output: sp1_sdk::SP1ProofWithPublicValues = prover
+                    .prove(&pk, self.stdin.clone())
+                    .compressed()
+                    .run()
+                    .map_err(|e| anyhow::anyhow!("SP1 proving failed. Error: {:?}", e))?;
+
+                Proof::Full(output)
+            } else {
+                let prover = ProverClient::builder().mock().build();
+                let output = prover.execute(self.elf.into(), self.stdin.clone()).run()?;
+                Proof::PublicData(output.0)
+            }
         };
+
+        self.stdin = SP1Stdin::new();
         Ok(bincode::serialize(&proof)?)
     }
 
-    fn code_commitment(&self) -> <<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment{
-        let pk = sp1_sdk::blocking::ProverClient::from_env()
-            .setup(self.elf.into())
-            .expect("SP1 setup failed");
-        crate::SP1MethodId(bincode::serialize(pk.verifying_key()).unwrap())
+    fn code_commitment(&self) -> anyhow::Result<<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment>{
+        let (_, pk) = self.create_prover_and_pk()?;
+        Ok(crate::SP1MethodId(bincode::serialize(pk.verifying_key())?))
     }
 }

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -11,9 +11,13 @@ use crypto::{SP1PublicKey, SP1Signature};
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+#[cfg(not(target_os = "zkvm"))]
+use sov_rollup_interface::zk::Proof;
 use sov_rollup_interface::zk::{CodeCommitment, CryptoSpec, ZkVerifier};
 #[cfg(not(target_os = "zkvm"))]
-use sp1_sdk::SP1ProofWithPublicValues;
+use sp1_sdk::blocking::{Prover, ProverClient};
+#[cfg(not(target_os = "zkvm"))]
+use sp1_sdk::{SP1ProofWithPublicValues, SP1PublicValues, SP1VerifyingKey};
 
 #[cfg(feature = "native")]
 use crate::crypto::private_key::SP1PrivateKey;
@@ -93,12 +97,11 @@ impl ZkVerifier for SP1Verifier {
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
-        let proof: SP1ProofWithPublicValues = bincode::deserialize(serialized_proof)?;
+        let proof = decode_sp1_proof(serialized_proof)?;
+        let prover = ProverClient::builder().cpu().build();
+        let verifying_key: SP1VerifyingKey = bincode::deserialize(&code_commitment.0)?;
 
-        let prover = sp1_sdk::blocking::ProverClient::from_env();
-        let verifying_key: sp1_sdk::SP1VerifyingKey = bincode::deserialize(&code_commitment.0)?;
-        sp1_sdk::blocking::Prover::verify(&prover, &proof, &verifying_key, None)?;
-
+        Prover::verify(&prover, &proof, &verifying_key, None)?;
         Ok(bincode::deserialize(proof.public_values.as_slice())?)
     }
 }
@@ -135,6 +138,16 @@ impl ZkVerifier for SP1Verifier {
         // which are then read within the verify_sp1_proof method. The `verify_sp1_proof` method takes in the vkey hash, and the public values digest as direct input.
         // In the future, SP1 will support an interface for passing all 3 in directly.
         todo!("Implement this.")
+    }
+}
+
+#[cfg(not(target_os = "zkvm"))]
+fn decode_sp1_proof(serialized_proof: &[u8]) -> Result<SP1ProofWithPublicValues, Error> {
+    match bincode::deserialize::<Proof<SP1ProofWithPublicValues, SP1PublicValues>>(
+        serialized_proof,
+    )? {
+        Proof::Full(proof) => Ok(proof),
+        Proof::PublicData(_) => anyhow::bail!("SP1Verifier supports only full proofs"),
     }
 }
 

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -96,7 +96,7 @@ pub trait ZkvmHost: Clone + Send + Sync + 'static {
     #[cfg(feature = "native")]
     fn code_commitment(
         &self,
-    ) -> <<Self::Guest as ZkvmGuest>::Verifier as ZkVerifier>::CodeCommitment;
+    ) -> anyhow::Result<<<Self::Guest as ZkvmGuest>::Verifier as ZkVerifier>::CodeCommitment>;
 
     /// Run the guest in the true zk environment using the provided hints.
     ///

--- a/examples/demo-rollup/sov-benchmarks/src/bench_generator/cli.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/bench_generator/cli.rs
@@ -190,7 +190,10 @@ impl BenchCLICustomArgs {
         passed_admin: <<S as Spec>::CryptoSpec as CryptoSpec>::PrivateKey,
     ) -> Benchmark<S> {
         let risc0_host_args = mock_da_risc0_host_args();
-        let risc0_commitment = Risc0Host::from_args(&*risc0_host_args).code_commitment();
+        let risc0_commitment = Risc0Host::from_args(&*risc0_host_args)
+            .code_commitment()
+            .unwrap_or_else(|e| panic!("Uncable to compute code commitment: {e}"));
+
         let mut genesis_config =
             HighLevelZkGenesisConfig::generate_with_additional_accounts_and_code_commitments(
                 2,


### PR DESCRIPTION
# Description

This PR introduces the following changes to accommodate `SP1`:
1 `ZkvmHost::code_commitment` now returns a `Result` (to satisfy SP1)
2. Updated the `SP1Host` and `SP1Verifier` implementations
3. `test_proof_generation` that checks e2e workflow will be updated in the next PR (#2570)

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551
