### PR TITLE
 Migrate prover tests from Risc0 to SP1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2025-03-10
 - #2569 **Breaking change** Updated the `SP1Host` and `SP1Verifier` implementations to support SP1 v6. `ZkvmHost::code_commitment` now returns a Result, which is a breaking change.
+- #2554 **Breaking change** Updated the `SP1Host` and `SP1Verifier` implementations to support SP1 v6. `ZkvmHost::code_commitment` now returns a Result, which is a breaking change.
 # 2025-03-05
 - #2554 More stabilization in demo-rollup EVM tests
 # 2026-03-05

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -11,13 +11,7 @@ use crypto::{SP1PublicKey, SP1Signature};
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-#[cfg(not(target_os = "zkvm"))]
-use sov_rollup_interface::zk::Proof;
 use sov_rollup_interface::zk::{CodeCommitment, CryptoSpec, ZkVerifier};
-#[cfg(not(target_os = "zkvm"))]
-use sp1_sdk::blocking::{Prover, ProverClient};
-#[cfg(not(target_os = "zkvm"))]
-use sp1_sdk::{SP1ProofWithPublicValues, SP1PublicValues, SP1VerifyingKey};
 
 #[cfg(feature = "native")]
 use crate::crypto::private_key::SP1PrivateKey;
@@ -98,10 +92,10 @@ impl ZkVerifier for SP1Verifier {
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         let proof = decode_sp1_proof(serialized_proof)?;
-        let prover = ProverClient::builder().cpu().build();
-        let verifying_key: SP1VerifyingKey = bincode::deserialize(&code_commitment.0)?;
+        let prover = sp1_sdk::blocking::ProverClient::builder().cpu().build();
+        let verifying_key: sp1_sdk::SP1VerifyingKey = bincode::deserialize(&code_commitment.0)?;
 
-        Prover::verify(&prover, &proof, &verifying_key, None)?;
+        sp1_sdk::blocking::Prover::verify(&prover, &proof, &verifying_key, None)?;
         Ok(bincode::deserialize(proof.public_values.as_slice())?)
     }
 }
@@ -142,12 +136,14 @@ impl ZkVerifier for SP1Verifier {
 }
 
 #[cfg(not(target_os = "zkvm"))]
-fn decode_sp1_proof(serialized_proof: &[u8]) -> Result<SP1ProofWithPublicValues, Error> {
-    match bincode::deserialize::<Proof<SP1ProofWithPublicValues, SP1PublicValues>>(
-        serialized_proof,
-    )? {
-        Proof::Full(proof) => Ok(proof),
-        Proof::PublicData(_) => anyhow::bail!("SP1Verifier supports only full proofs"),
+fn decode_sp1_proof(serialized_proof: &[u8]) -> Result<sp1_sdk::SP1ProofWithPublicValues, Error> {
+    match bincode::deserialize::<
+        sov_rollup_interface::zk::Proof<sp1_sdk::SP1ProofWithPublicValues, sp1_sdk::SP1PublicValues>,
+    >(serialized_proof)? {
+        sov_rollup_interface::zk::Proof::Full(proof) => Ok(proof),
+        sov_rollup_interface::zk::Proof::PublicData(_) => {
+            anyhow::bail!("SP1Verifier supports only full proofs")
+        }
     }
 }
 

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -138,8 +138,12 @@ impl ZkVerifier for SP1Verifier {
 #[cfg(not(target_os = "zkvm"))]
 fn decode_sp1_proof(serialized_proof: &[u8]) -> Result<sp1_sdk::SP1ProofWithPublicValues, Error> {
     match bincode::deserialize::<
-        sov_rollup_interface::zk::Proof<sp1_sdk::SP1ProofWithPublicValues, sp1_sdk::SP1PublicValues>,
-    >(serialized_proof)? {
+        sov_rollup_interface::zk::Proof<
+            sp1_sdk::SP1ProofWithPublicValues,
+            sp1_sdk::SP1PublicValues,
+        >,
+    >(serialized_proof)?
+    {
         sov_rollup_interface::zk::Proof::Full(proof) => Ok(proof),
         sov_rollup_interface::zk::Proof::PublicData(_) => {
             anyhow::bail!("SP1Verifier supports only full proofs")

--- a/examples/demo-rollup/provers/sp1/guest-celestia-nomt/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia-nomt/Cargo.lock
@@ -1675,7 +1675,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "rustc_version 0.4.1",
- "sp1-lib 6.0.2",
+ "sp1-lib",
  "subtle",
  "zeroize",
 ]
@@ -1693,14 +1693,13 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek-ng.git?branch=patch-v4.1.1#3fb3e7f6047ddeef0f0c9212f4604bd30d64bd28"
+source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.0.0#5854f8bab8842ff6232469b0d93ae4160e4a503d"
 dependencies = [
- "anyhow",
  "byteorder",
  "cfg-if",
  "digest 0.9.0",
  "rand_core 0.6.4",
- "sp1-lib 3.4.0",
+ "sp1-lib",
  "subtle-ng",
  "zeroize",
 ]
@@ -2186,7 +2185,7 @@ dependencies = [
 [[package]]
 name = "ed25519-consensus"
 version = "2.1.0"
-source = "git+https://github.com/sp1-patches/ed25519-consensus?rev=2b2c4b43344bc4daf5b1326f367f2d9d661eeabb#2b2c4b43344bc4daf5b1326f367f2d9d661eeabb"
+source = "git+https://github.com/sp1-patches/ed25519-consensus?rev=78f83b21767077f602f30148e513a52e844abbb6#78f83b21767077f602f30148e513a52e844abbb6"
 dependencies = [
  "curve25519-dalek-ng",
  "hex",
@@ -6754,7 +6753,7 @@ dependencies = [
  "derive-new",
  "hex",
  "serde",
- "sp1-lib 6.0.2",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -6958,7 +6957,7 @@ dependencies = [
  "sha2 0.10.9",
  "sov-rollup-interface",
  "sov-zkvm-utils",
- "sp1-lib 6.0.2",
+ "sp1-lib",
  "sp1-sdk",
  "sp1-zkvm",
 ]
@@ -7299,16 +7298,6 @@ dependencies = [
  "serde",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5729da1b05d56c01457e5ecabdc77f1cc941df23f2921163a2f325aec22428"
-dependencies = [
- "bincode",
- "serde",
 ]
 
 [[package]]
@@ -7655,7 +7644,7 @@ dependencies = [
  "libm",
  "rand 0.8.5",
  "sha2 0.10.9",
- "sp1-lib 6.0.2",
+ "sp1-lib",
  "sp1-primitives",
 ]
 
@@ -8051,7 +8040,7 @@ source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.0
 dependencies = [
  "cfg-if",
  "crunchy",
- "sp1-lib 6.0.2",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -9402,8 +9391,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.0.0#5854f8bab8842ff6232469b0d93ae4160e4a503d"

--- a/examples/demo-rollup/provers/sp1/guest-celestia-nomt/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-celestia-nomt/Cargo.toml
@@ -31,7 +31,7 @@ curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", ta
 # Needed for ed25519-consensus which depends on curve25519-dalek-ng
 curve25519-dalek-ng = { git = "https://github.com/sp1-patches/curve25519-dalek-ng", tag = "patch-4.1.1-sp1-6.0.0" }
 # No V6 tag available yet, using V5 rev
-ed25519-consensus = { git = "https://github.com/sp1-patches/ed25519-consensus", rev = "2b2c4b43344bc4daf5b1326f367f2d9d661eeabb" }
+ed25519-consensus = { git = "https://github.com/sp1-patches/ed25519-consensus", rev = "78f83b21767077f602f30148e513a52e844abbb6" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0" }
 
 [profile.dev]

--- a/examples/demo-rollup/provers/sp1/guest-celestia-nomt/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-celestia-nomt/Cargo.toml
@@ -30,7 +30,7 @@ sha2-v0-10-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", packa
 curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-6.0.0" }
 # Needed for ed25519-consensus which depends on curve25519-dalek-ng
 curve25519-dalek-ng = { git = "https://github.com/sp1-patches/curve25519-dalek-ng", tag = "patch-4.1.1-sp1-6.0.0" }
-# No V6 tag available yet, using V5 rev
+# Pin the SP1-compatible ed25519-consensus revision for the v6 guest dependency graph.
 ed25519-consensus = { git = "https://github.com/sp1-patches/ed25519-consensus", rev = "78f83b21767077f602f30148e513a52e844abbb6" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0" }
 

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -1663,7 +1663,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "rustc_version 0.4.1",
- "sp1-lib 6.0.2",
+ "sp1-lib",
  "subtle",
  "zeroize",
 ]
@@ -1681,14 +1681,13 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek-ng.git?branch=patch-v4.1.1#3fb3e7f6047ddeef0f0c9212f4604bd30d64bd28"
+source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.0.0#5854f8bab8842ff6232469b0d93ae4160e4a503d"
 dependencies = [
- "anyhow",
  "byteorder",
  "cfg-if",
  "digest 0.9.0",
  "rand_core 0.6.4",
- "sp1-lib 3.4.0",
+ "sp1-lib",
  "subtle-ng",
  "zeroize",
 ]
@@ -2174,7 +2173,7 @@ dependencies = [
 [[package]]
 name = "ed25519-consensus"
 version = "2.1.0"
-source = "git+https://github.com/sp1-patches/ed25519-consensus?rev=2b2c4b43344bc4daf5b1326f367f2d9d661eeabb#2b2c4b43344bc4daf5b1326f367f2d9d661eeabb"
+source = "git+https://github.com/sp1-patches/ed25519-consensus?rev=78f83b21767077f602f30148e513a52e844abbb6#78f83b21767077f602f30148e513a52e844abbb6"
 dependencies = [
  "curve25519-dalek-ng",
  "hex",
@@ -6741,7 +6740,7 @@ dependencies = [
  "derive-new",
  "hex",
  "serde",
- "sp1-lib 6.0.2",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -6945,7 +6944,7 @@ dependencies = [
  "sha2 0.10.9",
  "sov-rollup-interface",
  "sov-zkvm-utils",
- "sp1-lib 6.0.2",
+ "sp1-lib",
  "sp1-sdk",
  "sp1-zkvm",
 ]
@@ -7286,16 +7285,6 @@ dependencies = [
  "serde",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5729da1b05d56c01457e5ecabdc77f1cc941df23f2921163a2f325aec22428"
-dependencies = [
- "bincode",
- "serde",
 ]
 
 [[package]]
@@ -7642,7 +7631,7 @@ dependencies = [
  "libm",
  "rand 0.8.5",
  "sha2 0.10.9",
- "sp1-lib 6.0.2",
+ "sp1-lib",
  "sp1-primitives",
 ]
 
@@ -8038,7 +8027,7 @@ source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.0
 dependencies = [
  "cfg-if",
  "crunchy",
- "sp1-lib 6.0.2",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -9389,8 +9378,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.0.0#5854f8bab8842ff6232469b0d93ae4160e4a503d"

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.toml
@@ -29,7 +29,7 @@ sha2-v0-10-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", packa
 curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-6.0.0" }
 # Needed for ed25519-consensus which depends on curve25519-dalek-ng
 curve25519-dalek-ng = { git = "https://github.com/sp1-patches/curve25519-dalek-ng", tag = "patch-4.1.1-sp1-6.0.0" }
-# No V6 tag available yet, using V5 rev
+# Pin the SP1-compatible ed25519-consensus revision for the v6 guest dependency graph.
 ed25519-consensus = { git = "https://github.com/sp1-patches/ed25519-consensus", rev = "78f83b21767077f602f30148e513a52e844abbb6" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0" }
 

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.toml
@@ -30,7 +30,7 @@ curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", ta
 # Needed for ed25519-consensus which depends on curve25519-dalek-ng
 curve25519-dalek-ng = { git = "https://github.com/sp1-patches/curve25519-dalek-ng", tag = "patch-4.1.1-sp1-6.0.0" }
 # No V6 tag available yet, using V5 rev
-ed25519-consensus = { git = "https://github.com/sp1-patches/ed25519-consensus", rev = "2b2c4b43344bc4daf5b1326f367f2d9d661eeabb" }
+ed25519-consensus = { git = "https://github.com/sp1-patches/ed25519-consensus", rev = "78f83b21767077f602f30148e513a52e844abbb6" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0" }
 
 [profile.dev]

--- a/examples/demo-rollup/provers/sp1/guest-mock-nomt/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock-nomt/Cargo.lock
@@ -1566,7 +1566,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "rustc_version 0.4.1",
- "sp1-lib 6.0.2",
+ "sp1-lib",
  "subtle",
  "zeroize",
 ]
@@ -1584,14 +1584,13 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek-ng.git?branch=patch-v4.1.1#3fb3e7f6047ddeef0f0c9212f4604bd30d64bd28"
+source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.0.0#5854f8bab8842ff6232469b0d93ae4160e4a503d"
 dependencies = [
- "anyhow",
  "byteorder",
  "cfg-if",
  "digest 0.9.0",
  "rand_core 0.6.4",
- "sp1-lib 3.4.0",
+ "sp1-lib",
  "subtle-ng",
  "zeroize",
 ]
@@ -2037,7 +2036,7 @@ dependencies = [
 [[package]]
 name = "ed25519-consensus"
 version = "2.1.0"
-source = "git+https://github.com/sp1-patches/ed25519-consensus?rev=2b2c4b43344bc4daf5b1326f367f2d9d661eeabb#2b2c4b43344bc4daf5b1326f367f2d9d661eeabb"
+source = "git+https://github.com/sp1-patches/ed25519-consensus?rev=78f83b21767077f602f30148e513a52e844abbb6#78f83b21767077f602f30148e513a52e844abbb6"
 dependencies = [
  "curve25519-dalek-ng",
  "hex",
@@ -6380,7 +6379,7 @@ dependencies = [
  "derive-new",
  "hex",
  "serde",
- "sp1-lib 6.0.2",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -6603,7 +6602,7 @@ dependencies = [
  "sha2 0.10.9",
  "sov-rollup-interface",
  "sov-zkvm-utils",
- "sp1-lib 6.0.2",
+ "sp1-lib",
  "sp1-sdk",
  "sp1-zkvm",
 ]
@@ -6944,16 +6943,6 @@ dependencies = [
  "serde",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5729da1b05d56c01457e5ecabdc77f1cc941df23f2921163a2f325aec22428"
-dependencies = [
- "bincode",
- "serde",
 ]
 
 [[package]]
@@ -7300,7 +7289,7 @@ dependencies = [
  "libm",
  "rand 0.8.5",
  "sha2 0.10.9",
- "sp1-lib 6.0.2",
+ "sp1-lib",
  "sp1-primitives",
 ]
 
@@ -7642,7 +7631,7 @@ source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.0
 dependencies = [
  "cfg-if",
  "crunchy",
- "sp1-lib 6.0.2",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -8987,8 +8976,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.0.0#5854f8bab8842ff6232469b0d93ae4160e4a503d"

--- a/examples/demo-rollup/provers/sp1/guest-mock-nomt/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-mock-nomt/Cargo.toml
@@ -31,7 +31,7 @@ curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", ta
 # Needed for ed25519-consensus which depends on curve25519-dalek-ng
 curve25519-dalek-ng = { git = "https://github.com/sp1-patches/curve25519-dalek-ng", tag = "patch-4.1.1-sp1-6.0.0" }
 # No V6 tag available yet, using V5 rev
-ed25519-consensus = { git = "https://github.com/sp1-patches/ed25519-consensus", rev = "2b2c4b43344bc4daf5b1326f367f2d9d661eeabb" }
+ed25519-consensus = { git = "https://github.com/sp1-patches/ed25519-consensus", rev = "78f83b21767077f602f30148e513a52e844abbb6" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0" }
 
 [profile.dev]

--- a/examples/demo-rollup/provers/sp1/guest-mock-nomt/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-mock-nomt/Cargo.toml
@@ -30,7 +30,7 @@ sha2-v0-10-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", packa
 curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-6.0.0" }
 # Needed for ed25519-consensus which depends on curve25519-dalek-ng
 curve25519-dalek-ng = { git = "https://github.com/sp1-patches/curve25519-dalek-ng", tag = "patch-4.1.1-sp1-6.0.0" }
-# No V6 tag available yet, using V5 rev
+# Pin the SP1-compatible ed25519-consensus revision for the v6 guest dependency graph.
 ed25519-consensus = { git = "https://github.com/sp1-patches/ed25519-consensus", rev = "78f83b21767077f602f30148e513a52e844abbb6" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0" }
 

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -1554,7 +1554,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "rustc_version 0.4.1",
- "sp1-lib 6.0.2",
+ "sp1-lib",
  "subtle",
  "zeroize",
 ]
@@ -1572,14 +1572,13 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek-ng.git?branch=patch-v4.1.1#3fb3e7f6047ddeef0f0c9212f4604bd30d64bd28"
+source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.0.0#5854f8bab8842ff6232469b0d93ae4160e4a503d"
 dependencies = [
- "anyhow",
  "byteorder",
  "cfg-if",
  "digest 0.9.0",
  "rand_core 0.6.4",
- "sp1-lib 3.4.0",
+ "sp1-lib",
  "subtle-ng",
  "zeroize",
 ]
@@ -2025,7 +2024,7 @@ dependencies = [
 [[package]]
 name = "ed25519-consensus"
 version = "2.1.0"
-source = "git+https://github.com/sp1-patches/ed25519-consensus?rev=2b2c4b43344bc4daf5b1326f367f2d9d661eeabb#2b2c4b43344bc4daf5b1326f367f2d9d661eeabb"
+source = "git+https://github.com/sp1-patches/ed25519-consensus?rev=78f83b21767077f602f30148e513a52e844abbb6#78f83b21767077f602f30148e513a52e844abbb6"
 dependencies = [
  "curve25519-dalek-ng",
  "hex",
@@ -6367,7 +6366,7 @@ dependencies = [
  "derive-new",
  "hex",
  "serde",
- "sp1-lib 6.0.2",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -6590,7 +6589,7 @@ dependencies = [
  "sha2 0.10.9",
  "sov-rollup-interface",
  "sov-zkvm-utils",
- "sp1-lib 6.0.2",
+ "sp1-lib",
  "sp1-sdk",
  "sp1-zkvm",
 ]
@@ -6931,16 +6930,6 @@ dependencies = [
  "serde",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "sp1-lib"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5729da1b05d56c01457e5ecabdc77f1cc941df23f2921163a2f325aec22428"
-dependencies = [
- "bincode",
- "serde",
 ]
 
 [[package]]
@@ -7287,7 +7276,7 @@ dependencies = [
  "libm",
  "rand 0.8.5",
  "sha2 0.10.9",
- "sp1-lib 6.0.2",
+ "sp1-lib",
  "sp1-primitives",
 ]
 
@@ -7629,7 +7618,7 @@ source = "git+https://github.com/sp1-patches/tiny-keccak?tag=patch-2.0.2-sp1-6.0
 dependencies = [
  "cfg-if",
  "crunchy",
- "sp1-lib 6.0.2",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -8974,8 +8963,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "git+https://github.com/sp1-patches/curve25519-dalek-ng?tag=patch-4.1.1-sp1-6.0.0#5854f8bab8842ff6232469b0d93ae4160e4a503d"

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.toml
@@ -29,7 +29,7 @@ sha2-v0-10-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", packa
 curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", tag = "patch-4.1.3-sp1-6.0.0" }
 # Needed for ed25519-consensus which depends on curve25519-dalek-ng
 curve25519-dalek-ng = { git = "https://github.com/sp1-patches/curve25519-dalek-ng", tag = "patch-4.1.1-sp1-6.0.0" }
-# No V6 tag available yet, using V5 rev
+# Pin the SP1-compatible ed25519-consensus revision for the v6 guest dependency graph.
 ed25519-consensus = { git = "https://github.com/sp1-patches/ed25519-consensus", rev = "78f83b21767077f602f30148e513a52e844abbb6" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0" }
 

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.toml
@@ -30,7 +30,7 @@ curve25519-dalek = { git = "https://github.com/sp1-patches/curve25519-dalek", ta
 # Needed for ed25519-consensus which depends on curve25519-dalek-ng
 curve25519-dalek-ng = { git = "https://github.com/sp1-patches/curve25519-dalek-ng", tag = "patch-4.1.1-sp1-6.0.0" }
 # No V6 tag available yet, using V5 rev
-ed25519-consensus = { git = "https://github.com/sp1-patches/ed25519-consensus", rev = "2b2c4b43344bc4daf5b1326f367f2d9d661eeabb" }
+ed25519-consensus = { git = "https://github.com/sp1-patches/ed25519-consensus", rev = "78f83b21767077f602f30148e513a52e844abbb6" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-6.0.0" }
 
 [profile.dev]

--- a/examples/demo-rollup/provers/sp1/src/lib.rs
+++ b/examples/demo-rollup/provers/sp1/src/lib.rs
@@ -15,19 +15,19 @@ fn load_elf(path: &str) -> &'static [u8] {
 // but because we don't include the guest ELFs in the GitHub build, they may potentially not exist.
 lazy_static! {
     pub static ref SP1_GUEST_MOCK_ELF: &'static [u8] = load_elf(&format!(
-        "{}/guest-mock/elf/riscv64im-succinct-zkvm-elf",
+        "{}/guest-mock/target/elf-compilation/riscv64im-succinct-zkvm-elf/release/sov-demo-prover-guest-mock-sp1",
         env!("CARGO_MANIFEST_DIR")
     ));
     pub static ref SP1_GUEST_CELESTIA_ELF: &'static [u8] = load_elf(&format!(
-        "{}/guest-celestia/elf/riscv64im-succinct-zkvm-elf",
+        "{}/guest-celestia/target/elf-compilation/riscv64im-succinct-zkvm-elf/release/sov-demo-prover-guest-celestia-sp1",
         env!("CARGO_MANIFEST_DIR")
     ));
     pub static ref SP1_GUEST_MOCK_NOMT_ELF: &'static [u8] = load_elf(&format!(
-        "{}/guest-mock-nomt/elf/riscv64im-succinct-zkvm-elf",
+        "{}/guest-mock-nomt/target/elf-compilation/riscv64im-succinct-zkvm-elf/release/sov-demo-prover-guest-mock-nomt-sp1",
         env!("CARGO_MANIFEST_DIR")
     ));
     pub static ref SP1_GUEST_CELESTIA_NOMT_ELF: &'static [u8] = load_elf(&format!(
-        "{}/guest-celestia-nomt/elf/riscv64im-succinct-zkvm-elf",
+        "{}/guest-celestia-nomt/target/elf-compilation/riscv64im-succinct-zkvm-elf/release/sov-demo-prover-guest-celestia-nomt-sp1",
         env!("CARGO_MANIFEST_DIR")
     ));
 }

--- a/examples/demo-rollup/tests/prover/datagen.rs
+++ b/examples/demo-rollup/tests/prover/datagen.rs
@@ -1,25 +1,18 @@
 use std::env;
 
+use demo_stf::runtime::Runtime;
 use sov_cli::wallet_state::PrivateKeyAndAddress;
-use sov_demo_rollup::MockDemoRollup;
 use sov_mock_da::{MockAddress, MockBlock, MockDaService};
-use sov_modules_api::execution_mode::{Native, WitnessGeneration};
 use sov_rollup_interface::node::da::DaService;
 use sov_test_utils::generators::bank::BankMessageGenerator;
 use sov_test_utils::generators::BlobBuildingCtx;
 use sov_test_utils::test_rollup::read_private_key;
 use sov_test_utils::MessageGenerator;
 
-type S = sov_modules_api::configurable_spec::ConfigurableSpec<
-    sov_mock_da::MockDaSpec,
-    sov_risc0_adapter::Risc0,
-    sov_mock_zkvm::MockZkvm,
-    demo_stf::MultiAddressEvmSolana,
-    WitnessGeneration,
->;
+type S = super::DefaultSpec;
 
-const DEFAULT_BLOCKS: u64 = 10;
-const DEFAULT_TXNS_PER_BLOCK: u64 = 100;
+const DEFAULT_BLOCKS: u64 = 3;
+const DEFAULT_TXNS_PER_BLOCK: u64 = 2;
 
 pub async fn get_blocks_from_da(mode: BlobBuildingCtx) -> anyhow::Result<Vec<MockBlock>> {
     let txns_per_block = match env::var("SOV_BENCH_TXNS_PER_BLOCK") {
@@ -50,13 +43,13 @@ pub async fn get_blocks_from_da(mode: BlobBuildingCtx) -> anyhow::Result<Vec<Moc
             private_key_and_address.private_key,
         );
 
-    let blob = create_token_message_gen.create_blobs::<<MockDemoRollup<Native> as sov_modules_rollup_blueprint::RollupBlueprint<Native>>::Runtime>(&mode);
+    let blob = create_token_message_gen.create_blobs::<Runtime<S>>(&mode);
     da_service.send_transaction(&blob).await.await??;
     let block1 = da_service.get_block_at(1).await?;
     blocks.push(block1);
 
     for i in 0..block_cnt {
-        let blob = transfer_message_gen.create_blobs::<<MockDemoRollup<Native> as sov_modules_rollup_blueprint::RollupBlueprint<Native>>::Runtime>(&mode);
+        let blob = transfer_message_gen.create_blobs::<Runtime<S>>(&mode);
         da_service.send_transaction(&blob).await.await??;
         let blocki = da_service.get_block_at(2 + i).await?;
         blocks.push(blocki);

--- a/examples/demo-rollup/tests/prover/mod.rs
+++ b/examples/demo-rollup/tests/prover/mod.rs
@@ -151,6 +151,8 @@ async fn test_proof_generation() {
     }
 }
 
+// The SP1 prover manages its own Tokio runtime, which conflicts with the `tokio::test` runtime.
+// To avoid this, all blocking work must be executed inside `tokio::task::spawn_blocking`.
 struct TestHost {
     host: SP1Host<'static>,
     code_commitment: SP1MethodId,

--- a/examples/demo-rollup/tests/prover/mod.rs
+++ b/examples/demo-rollup/tests/prover/mod.rs
@@ -8,17 +8,17 @@ use sov_db::storage_manager::NativeStorageManager;
 use sov_mock_da::{MockAddress, MockBlock, MockDaService, MockDaSpec};
 use sov_mock_zkvm::MockZkvm;
 use sov_modules_api::execution_mode::WitnessGeneration;
-use sov_modules_api::{OperatingMode, SlotData, Spec};
+use sov_modules_api::{OperatingMode, SlotData, Spec, ZkVerifier};
 use sov_modules_stf_blueprint::{GenesisParams, StfBlueprint};
-use sov_risc0_adapter::host::Risc0Host;
-use sov_risc0_adapter::Risc0;
 use sov_rollup_interface::da::BlockHeaderTrait;
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::stf::{ExecutionContext, StateTransitionFunction};
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::{
-    StateTransitionWitness, StateTransitionWitnessWithAddress, ZkvmHost,
+    StateTransitionPublicData, StateTransitionWitness, StateTransitionWitnessWithAddress, ZkvmHost,
 };
+use sov_sp1_adapter::host::SP1Host;
+use sov_sp1_adapter::{SP1MethodId, SP1Verifier, SP1};
 use sov_state::ProverStorage;
 use sov_test_utils::generators::BlobBuildingCtx;
 use sov_test_utils::TestStorageSpec;
@@ -29,7 +29,7 @@ use crate::test_helpers::test_genesis_paths;
 
 type DefaultSpec = sov_modules_api::configurable_spec::ConfigurableSpec<
     sov_mock_da::MockDaSpec,
-    sov_risc0_adapter::Risc0,
+    sov_sp1_adapter::SP1,
     sov_mock_zkvm::MockZkvm,
     demo_stf::MultiAddressEvmSolana,
     WitnessGeneration,
@@ -38,7 +38,21 @@ type DefaultSpec = sov_modules_api::configurable_spec::ConfigurableSpec<
 
 mod datagen;
 
-type TestSTF<'a> = StfBlueprint<DefaultSpec, Runtime<DefaultSpec>>;
+type TestSTF = StfBlueprint<DefaultSpec, Runtime<DefaultSpec>>;
+type ProofStateRoot = <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::StateRoot;
+type ProofWitness = <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::Witness;
+type StfWitness = StateTransitionWitness<ProofStateRoot, ProofWitness, MockDaSpec>;
+
+type ProofInput = StateTransitionWitnessWithAddress<
+    <DefaultSpec as Spec>::Address,
+    ProofStateRoot,
+    ProofWitness,
+    MockDaSpec,
+>;
+
+#[allow(dead_code)]
+type ProofPublicData =
+    StateTransitionPublicData<<DefaultSpec as Spec>::Address, MockDaSpec, ProofStateRoot>;
 
 /// This test reproduces the proof generation process for the rollup used in benchmarks.
 #[tokio::test(flavor = "multi_thread")]
@@ -80,7 +94,9 @@ async fn test_proof_generation() {
         .await
         .expect("Failed to get DA blocks");
 
-    let mut host = Risc0Host::new(risc0::MOCK_DA_ELF);
+    let prover_address = <DefaultSpec as Spec>::Address::try_from([0u8; 28].as_ref()).unwrap();
+
+    let host = TestHost::new().await;
 
     for filtered_block in &mut blocks[..3] {
         let height = filtered_block.header().height();
@@ -106,11 +122,7 @@ async fn test_proof_generation() {
             ExecutionContext::Node,
         );
 
-        let data = StateTransitionWitness::<
-            <TestSTF as StateTransitionFunction<Risc0, MockZkvm, MockDaSpec>>::StateRoot,
-            <TestSTF as StateTransitionFunction<Risc0, MockZkvm, MockDaSpec>>::Witness,
-            MockDaSpec,
-        > {
+        let data = StfWitness {
             initial_state_root: prev_state_root,
             da_block_header: filtered_block.header().clone(),
             relevant_proofs,
@@ -119,18 +131,14 @@ async fn test_proof_generation() {
             final_state_root: result.state_root,
         };
 
-        let data = StateTransitionWitnessWithAddress {
+        let data: ProofInput = StateTransitionWitnessWithAddress {
             stf_witness: data,
-            prover_address: <DefaultSpec as Spec>::Address::try_from([0u8; 28].as_ref()).unwrap(),
+            prover_address: prover_address.clone(),
         };
 
-        host.add_hint(data);
-
         tracing::info!("Run prover without generating a proof for block {height}\n");
-        let _receipt = host
-            .run_without_proving()
-            .expect("Prover should run successfully");
-        tracing::info!("==================================================\n");
+
+        let _proof = host.run(data, false).await;
 
         prev_state_root = result.state_root;
         storage_manager
@@ -140,5 +148,51 @@ async fn test_proof_generation() {
                 SchemaBatch::new(),
             )
             .unwrap();
+    }
+}
+
+struct TestHost {
+    host: SP1Host<'static>,
+    code_commitment: SP1MethodId,
+}
+
+impl TestHost {
+    async fn new() -> Self {
+        let host = SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF);
+        let host_clone = host.clone();
+        let code_commitment = tokio::task::spawn_blocking(move || -> SP1MethodId {
+            host_clone
+                .code_commitment()
+                .expect("SP1 code commitment should be created successfully")
+        })
+        .await
+        .unwrap();
+
+        Self {
+            host,
+            code_commitment,
+        }
+    }
+
+    async fn run(&self, data: ProofInput, with_proof: bool) -> Vec<u8> {
+        let mut host = self.host.clone();
+        tokio::task::spawn_blocking(move || -> Vec<u8> {
+            host.add_hint(data);
+            host.run(with_proof)
+                .expect("Prover should run successfully")
+        })
+        .await
+        .unwrap()
+    }
+
+    #[allow(dead_code)]
+    async fn verify(&self, proof: Vec<u8>) -> ProofPublicData {
+        let code_commitment = self.code_commitment.clone();
+        tokio::task::spawn_blocking(move || -> ProofPublicData {
+            SP1Verifier::verify(&proof, &code_commitment)
+                .expect("SP1 proof verification should succeed")
+        })
+        .await
+        .unwrap()
     }
 }

--- a/examples/demo-rollup/tests/prover/mod.rs
+++ b/examples/demo-rollup/tests/prover/mod.rs
@@ -129,7 +129,7 @@ async fn test_proof_generation() {
 
         let data: ProofInput = StateTransitionWitnessWithAddress {
             stf_witness: data,
-            prover_address: prover_address.clone(),
+            prover_address,
         };
 
         tracing::info!("Run prover without generating a proof for block {height}\n");

--- a/examples/demo-rollup/tests/prover/mod.rs
+++ b/examples/demo-rollup/tests/prover/mod.rs
@@ -50,10 +50,6 @@ type ProofInput = StateTransitionWitnessWithAddress<
     MockDaSpec,
 >;
 
-#[allow(dead_code)]
-type ProofPublicData =
-    StateTransitionPublicData<<DefaultSpec as Spec>::Address, MockDaSpec, ProofStateRoot>;
-
 /// This test reproduces the proof generation process for the rollup used in benchmarks.
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(skip_guest_build, ignore)]
@@ -188,9 +184,12 @@ impl TestHost {
     }
 
     #[allow(dead_code)]
-    async fn verify(&self, proof: Vec<u8>) -> ProofPublicData {
+    async fn verify(
+        &self,
+        proof: Vec<u8>,
+    ) -> StateTransitionPublicData<<DefaultSpec as Spec>::Address, MockDaSpec, ProofStateRoot> {
         let code_commitment = self.code_commitment.clone();
-        tokio::task::spawn_blocking(move || -> ProofPublicData {
+        tokio::task::spawn_blocking(move || -> StateTransitionPublicData<<DefaultSpec as Spec>::Address, MockDaSpec, ProofStateRoot> {
             SP1Verifier::verify(&proof, &code_commitment)
                 .expect("SP1 proof verification should succeed")
         })


### PR DESCRIPTION
# Description

  - Migrated `test_proof_generation` from Risc0 to SP1, including a `TestHost` wrapper that uses `spawn_blocking` for CPU-bound proving
  - Updated SP1 guest ELF paths to match SP1 v6 output layout (`target/elf-compilation/...`)
  - Bumped `ed25519-consensus` SP1 patch rev.

## Linked Issues
- Related to #2551, #2569

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

