### PR TITLE
Adds `ZkvmNetwork` trait & initial Sp1 implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,7 @@ checksum = "f72cf87cda808e593381fb9f005ffa4d2475552b7a6c5ac33d087bf77d82abd0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "http",
+ "http 1.3.1",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -645,6 +645,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-signer-aws"
+version = "1.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58eaf63923ca3eade1181958f002ad4cbdf26a387061979e084b0f2a84fbba0d"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "aws-config",
+ "aws-sdk-kms",
+ "k256",
+ "spki",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-signer-local"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,8 +800,8 @@ dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http",
- "rustls",
+ "http 1.3.1",
+ "rustls 0.23.31",
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.26.2",
@@ -1430,6 +1449,395 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a8fc176d53d6fe85017f230405e3255cedb4a02221cb55ed6d76dccbbb099b2"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.3.1",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26bbf46abc608f2dc61fd6cb3b7b0665497cc259a21520151ed98f8b37d2c79"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f92058d22a46adf53ec57a6a96f34447daf02bff52e8fb956c66bcd5c6ac12"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-kms"
+version = "1.101.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dca55e9417ba817965206945209c061a77cf03380d93ce9556b0ea76499e02"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.3.1",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.94.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699da1961a289b23842d88fe2984c6ff68735fdf9bdcbc69ceaeb2491c9bf434"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.3.1",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e3a4cb3b124833eafea9afd1a6cc5f8ddf3efefffc6651ef76a03cbc6b4981"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.3.1",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c4f19655ab0856375e169865c91264de965bd74c407c7f1e403184b1049409"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.3.1",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f6ae9b71597dc5fd115d52849d7a5556ad9265885ad3492ea8d73b93bbc46e"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.3.1",
+ "percent-encoding",
+ "sha2 0.10.9",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4a8a5fe3e4ac7ee871237c340bbce13e982d37543b65700f4419e039f5d78e"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0709f0083aa19b704132684bc26d3c868e06bd428ccc4373b0b55c3e8748a58b"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.12",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.7.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.31",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tower 0.5.2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b3a779093e18cad88bbae08dc4261e1d95018c4c5b9356a52bcae7c0b6e9bb"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3f39d5bb871aaf461d59144557f16d5927a5248a983a40654d9cf3b9ba183b"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f76a580e3d8f8961e5d48763214025a2af65c2fa4cd1fb7f270a0e107a71b0"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd3dfc18c1ce097cf81fced7192731e63809829c6cbf933c1ec47452d08e1aa"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c55e0837e9b8526f49e0b9bfa9ee18ddee70e853f5bc09c5d11ebceddcb0fec"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.3.1",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576b0d6991c9c32bc14fc340582ef148311f924d41815f641a308b5d11e8e7cd"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c50f3cdf47caa8d01f2be4a6663ea02418e892f9bbfd82c7b9a3a37eaccdd3a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version 0.4.1",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,10 +1848,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
@@ -1475,8 +1883,8 @@ dependencies = [
  "axum-core 0.5.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "matchit 0.8.4",
@@ -1501,8 +1909,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1521,8 +1929,8 @@ checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1541,16 +1949,16 @@ dependencies = [
  "arc-swap",
  "bytes",
  "fs-err",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
- "rustls",
+ "rustls 0.23.31",
  "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tower-service",
 ]
 
@@ -1559,6 +1967,20 @@ name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.16",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
 
 [[package]]
 name = "backon"
@@ -1615,6 +2037,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -1875,18 +2307,18 @@ dependencies = [
  "futures-util",
  "hex",
  "home",
- "http",
+ "http 1.3.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-named-pipe",
- "hyper-rustls",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "hyperlocal",
  "log",
  "num",
  "pin-project-lite",
  "rand 0.9.2",
- "rustls",
+ "rustls 0.23.31",
  "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -2027,6 +2459,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2145,8 +2587,8 @@ dependencies = [
  "futures-util",
  "getrandom 0.2.16",
  "hex",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "jsonrpsee-core",
  "jsonrpsee-types",
  "k256",
@@ -2173,8 +2615,8 @@ dependencies = [
  "getrandom 0.2.16",
  "gloo-timers 0.3.0",
  "hex",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "ics23",
  "js-sys",
@@ -2239,7 +2681,7 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "gloo-timers 0.3.0",
- "http",
+ "http 1.3.1",
  "jsonrpsee",
  "send_wrapper 0.6.0",
  "serde",
@@ -2429,7 +2871,16 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31211fc26899744f5b22521fdc971e5f3875991d8880537537470685a0e9552d"
 dependencies = [
- "http",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4124,6 +4575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4371,7 +4828,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http",
+ "http 1.3.1",
  "js-sys",
  "pin-project",
  "serde",
@@ -4454,6 +4911,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.11.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
@@ -4463,7 +4939,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.3.1",
  "indexmap 2.11.1",
  "slab",
  "tokio",
@@ -4722,6 +5198,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -4733,12 +5220,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -4749,8 +5247,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -4774,6 +5272,30 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
@@ -4782,9 +5304,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -4802,7 +5324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4812,19 +5334,34 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.3.1",
+ "hyper 1.7.0",
  "hyper-util",
  "log",
- "rustls",
+ "rustls 0.23.31",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tower-service",
  "webpki-roots 1.0.2",
 ]
@@ -4835,7 +5372,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4853,9 +5390,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -4874,7 +5411,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5162,6 +5699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "integration-tests"
 version = "0.3.0"
 dependencies = [
@@ -5404,16 +5950,16 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http",
+ "http 1.3.1",
  "jsonrpsee-core",
  "pin-project",
- "rustls",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
  "thiserror 2.0.17",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tokio-util",
  "tracing",
  "url",
@@ -5429,8 +5975,8 @@ dependencies = [
  "bytes",
  "futures-timer",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot",
@@ -5454,13 +6000,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790bedefcec85321e007ff3af84b4e417540d5c87b3c9779b9e247d1bcc3dab8"
 dependencies = [
  "base64 0.22.1",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "http-body 1.0.1",
+ "hyper 1.7.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "rustls",
+ "rustls 0.23.31",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -5490,10 +6036,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c51b7c290bb68ce3af2d029648148403863b982f138484a73f02a9dd52dbd7f"
 dependencies = [
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -5516,7 +6062,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
 dependencies = [
- "http",
+ "http 1.3.1",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -5540,7 +6086,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6fceceeb05301cc4c065ab3bd2fa990d41ff4eb44e4ca1b30fa99c057c3e79"
 dependencies = [
- "http",
+ "http 1.3.1",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -6749,7 +7295,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
- "http",
+ "http 1.3.1",
  "opentelemetry 0.31.0",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -7645,7 +8191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d85934a440963a69f9f04f48507ff6e7aa2952a5b2d8f96cc37fa3dd5c270f66"
 dependencies = [
  "heck 0.5.0",
- "http",
+ "http 1.3.1",
  "indexmap 2.11.1",
  "openapiv3",
  "proc-macro2",
@@ -8017,7 +8563,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.31",
  "socket2 0.6.0",
  "thiserror 2.0.17",
  "tokio",
@@ -8037,7 +8583,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.17",
@@ -8305,6 +8851,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8350,13 +8902,13 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.4.12",
  "hickory-resolver",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.7.0",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
@@ -8365,7 +8917,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.31",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -8373,7 +8925,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tokio-util",
  "tower 0.5.2",
  "tower-http 0.6.6",
@@ -8384,6 +8936,21 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562ceb5a604d3f7c885a792d42c199fd8af239d0a51b2fa6a78aafa092452b04"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.3.1",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
 ]
 
 [[package]]
@@ -9456,15 +10023,28 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.5",
  "subtle",
  "zeroize",
 ]
@@ -9511,10 +10091,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.31",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.5",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
@@ -9529,10 +10109,21 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
 version = "0.103.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a37813727b78798e53c2bec3f5e8fe12a6d6f8389bf9ca7802add4c9905ad8"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -9734,6 +10325,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sdd"
@@ -10798,7 +11399,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -11069,7 +11670,7 @@ dependencies = [
  "reltester",
  "risc0-zkvm",
  "risc0-zkvm-platform",
- "rustls",
+ "rustls 0.23.31",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -11230,7 +11831,7 @@ dependencies = [
  "reth-primitives",
  "risc0",
  "rockbound",
- "rustls",
+ "rustls 0.23.31",
  "schemars 0.8.22",
  "secp256k1 0.30.0",
  "serde",
@@ -11660,7 +12261,7 @@ dependencies = [
  "derive-new",
  "derive_more 1.0.0",
  "hex",
- "http",
+ "http 1.3.1",
  "insta",
  "risc0-zkvm",
  "risc0-zkvm-platform",
@@ -13263,8 +13864,15 @@ version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d8dae789acfa3b4e8211234d05901c28cd1b988f230c9db0c29207fa131071a"
 dependencies = [
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-aws",
+ "alloy-signer-local",
  "anyhow",
  "async-trait",
+ "aws-config",
+ "aws-sdk-kms",
+ "backoff",
  "bincode",
  "cfg-if",
  "dirs",
@@ -13275,6 +13883,10 @@ dependencies = [
  "itertools 0.14.0",
  "k256",
  "num-bigint 0.4.6",
+ "prost 0.13.5",
+ "reqwest",
+ "reqwest-middleware",
+ "rustls 0.23.31",
  "serde",
  "sha2 0.10.9",
  "slop-algebra",
@@ -13302,7 +13914,10 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tonic 0.12.3",
  "tracing",
+ "twirp-rs",
+ "zstd",
 ]
 
 [[package]]
@@ -13413,7 +14028,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.31",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -14209,11 +14824,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls",
+ "rustls 0.23.31",
  "tokio",
 ]
 
@@ -14264,10 +14889,10 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tungstenite 0.26.2",
  "webpki-roots 0.26.11",
 ]
@@ -14400,25 +15025,27 @@ dependencies = [
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost 0.13.5",
+ "rustls-native-certs",
  "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -14431,11 +15058,11 @@ dependencies = [
  "axum 0.8.4",
  "base64 0.22.1",
  "bytes",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -14444,7 +15071,7 @@ dependencies = [
  "rustls-native-certs",
  "socket2 0.5.10",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tokio-stream",
  "tower 0.5.2",
  "tower-layer",
@@ -14462,11 +15089,11 @@ dependencies = [
  "axum 0.8.4",
  "base64 0.22.1",
  "bytes",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.7.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -14530,8 +15157,8 @@ dependencies = [
  "byteorder",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "httparse",
  "js-sys",
@@ -14592,8 +15219,8 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.9.4",
  "bytes",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
  "tower-layer",
@@ -14610,8 +15237,8 @@ dependencies = [
  "bitflags 2.9.4",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower 0.5.2",
@@ -14631,7 +15258,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357a1f99dd439c1aa9ebbaf9c6431b41c05a26bf137e9e92879941bdac5cb66d"
 dependencies = [
- "http",
+ "http 1.3.1",
  "tower-layer",
  "tower-service",
  "ulid",
@@ -14834,7 +15461,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -14851,11 +15478,11 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.17",
@@ -14870,13 +15497,35 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.3.1",
  "httparse",
  "log",
  "rand 0.9.2",
  "sha1",
  "thiserror 2.0.17",
  "utf-8",
+]
+
+[[package]]
+name = "twirp-rs"
+version = "0.13.0-succinct"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27dfcc06b8d9262bc2d4b8d1847c56af9971a52dd8a0076876de9db763227d0d"
+dependencies = [
+ "async-trait",
+ "axum 0.7.9",
+ "futures",
+ "http 1.3.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "prost 0.13.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower 0.5.2",
+ "url",
 ]
 
 [[package]]
@@ -15142,7 +15791,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.11",
@@ -15159,6 +15808,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -16091,6 +16746,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xz2"

--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -54,6 +54,9 @@ impl Zkvm for MockZkvm {
 
     #[cfg(feature = "native")]
     type Host = crate::host::MockZkvmHost;
+
+    #[cfg(feature = "native")]
+    type Network = sov_rollup_interface::zk::NoopZkvmNetwork<MockZkGuest>;
 }
 /// A mock commitment to a particular zkVM program.
 #[derive(

--- a/crates/adapters/risc0/src/lib.rs
+++ b/crates/adapters/risc0/src/lib.rs
@@ -143,6 +143,9 @@ impl sov_rollup_interface::zk::Zkvm for Risc0 {
 
     #[cfg(feature = "native")]
     type Host = crate::host::Risc0Host<'static>;
+
+    #[cfg(feature = "native")]
+    type Network = sov_rollup_interface::zk::NoopZkvmNetwork<crate::guest::Risc0Guest>;
 }
 
 #[cfg(target_os = "zkvm")]

--- a/crates/adapters/sp1/Cargo.toml
+++ b/crates/adapters/sp1/Cargo.toml
@@ -33,7 +33,7 @@ sov-rollup-interface = { workspace = true }
 sov-metrics = { workspace = true, features = ["sp1"], optional = true }
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
-sp1-sdk = { version = "6.0.2", default-features = false, features = ["blocking"] }
+sp1-sdk = { version = "6.0.2", default-features = false, features = ["blocking", "network"] }
 
 [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
 sp1-zkvm = { version = "6.0.2" }

--- a/crates/adapters/sp1/Cargo.toml
+++ b/crates/adapters/sp1/Cargo.toml
@@ -51,9 +51,9 @@ sov-zkvm-utils = { workspace = true }
 
 [features]
 default = []
-network = ["sp1-sdk/network"]
 native = [
     "rand",
+    "sp1-sdk/network",
     "sov-rollup-interface/native",
     "sov-metrics?/native",
     "sov-sp1-adapter/native",

--- a/crates/adapters/sp1/Cargo.toml
+++ b/crates/adapters/sp1/Cargo.toml
@@ -33,7 +33,7 @@ sov-rollup-interface = { workspace = true }
 sov-metrics = { workspace = true, features = ["sp1"], optional = true }
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
-sp1-sdk = { version = "6.0.2", default-features = false, features = ["blocking", "network"] }
+sp1-sdk = { version = "6.0.2", default-features = false, features = ["blocking"] }
 
 [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
 sp1-zkvm = { version = "6.0.2" }
@@ -51,6 +51,7 @@ sov-zkvm-utils = { workspace = true }
 
 [features]
 default = []
+network = ["sp1-sdk/network"]
 native = [
     "rand",
     "sov-rollup-interface/native",

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -20,6 +20,8 @@ pub mod crypto;
 pub mod guest;
 #[cfg(feature = "native")]
 pub mod host;
+#[cfg(feature = "native")]
+pub mod network;
 
 #[cfg(all(feature = "native", feature = "bench"))]
 pub mod metrics;
@@ -110,6 +112,9 @@ impl sov_rollup_interface::zk::Zkvm for SP1 {
 
     #[cfg(feature = "native")]
     type Host = crate::host::SP1Host<'static>;
+
+    #[cfg(feature = "native")]
+    type Network = crate::network::SP1Network;
 }
 
 #[cfg(target_os = "zkvm")]

--- a/crates/adapters/sp1/src/network.rs
+++ b/crates/adapters/sp1/src/network.rs
@@ -10,7 +10,7 @@ mod _impl {
     use serde::Serialize;
     use sov_rollup_interface::zk::{Proof, ZkvmNetwork};
     use sp1_sdk::network::proto::auction_types::FulfillmentStatus;
-    use sp1_sdk::network::{B256, NetworkMode};
+    use sp1_sdk::network::{NetworkMode, B256};
     use sp1_sdk::prover::{ProveRequest, Prover};
     use sp1_sdk::{NetworkProver, ProverClient, SP1ProvingKey, SP1Stdin};
 
@@ -31,8 +31,10 @@ mod _impl {
         ///
         /// Connects to the Succinct proving network (mainnet) and runs setup.
         pub async fn new(elf: &[u8]) -> anyhow::Result<Self> {
-            let prover: NetworkProver =
-                ProverClient::builder().network_for(NetworkMode::Mainnet).build().await;
+            let prover: NetworkProver = ProverClient::builder()
+                .network_for(NetworkMode::Mainnet)
+                .build()
+                .await;
             let pk = prover
                 .setup(elf.into())
                 .await
@@ -75,9 +77,10 @@ mod _impl {
             }
 
             match maybe_proof {
-                Some(proof) => Ok(Some(bincode::serialize(
-                    &Proof::<_, sp1_sdk::SP1PublicValues>::Full(proof),
-                )?)),
+                Some(proof) => Ok(Some(bincode::serialize(&Proof::<
+                    _,
+                    sp1_sdk::SP1PublicValues,
+                >::Full(proof))?)),
                 None => Ok(None),
             }
         }

--- a/crates/adapters/sp1/src/network.rs
+++ b/crates/adapters/sp1/src/network.rs
@@ -1,0 +1,72 @@
+//! Network prover implementation for SP1.
+//!
+//! Submits proof requests to the Succinct proving network and polls for results.
+
+use serde::Serialize;
+use sov_rollup_interface::zk::{Proof, ZkvmNetwork};
+use sp1_sdk::network::B256;
+use sp1_sdk::network::proto::base_types::FulfillmentStatus;
+use sp1_sdk::prover::{Prover, ProveRequest};
+use sp1_sdk::{NetworkProver, SP1ProvingKey, SP1Stdin};
+
+use crate::guest::SP1Guest;
+
+pub type ProofHandle = B256;
+
+/// SP1 network prover that submits proofs to the Succinct proving network.
+pub struct SP1Network {
+    prover: NetworkProver,
+    pk: SP1ProvingKey,
+    stdin: SP1Stdin,
+}
+
+impl SP1Network {
+    /// Create a new `SP1Network` from an existing [`NetworkProver`] and an ELF binary.
+    pub async fn new(prover: NetworkProver, elf: &[u8]) -> anyhow::Result<Self> {
+        let pk = prover
+            .setup(elf.into())
+            .await
+            .map_err(|e| anyhow::anyhow!("SP1 network setup failed: {e}"))?;
+
+        Ok(Self {
+            prover,
+            pk,
+            stdin: SP1Stdin::new(),
+        })
+    }
+}
+
+impl ZkvmNetwork for SP1Network {
+    type Guest = SP1Guest;
+    type ProofHandle = ProofHandle;
+
+    fn add_hint<T: Serialize>(&mut self, item: &T) {
+        self.stdin.write(item);
+    }
+
+    async fn submit(&mut self) -> anyhow::Result<Self::ProofHandle> {
+        let request_id = self
+            .prover
+            .prove(&self.pk, self.stdin.clone())
+            .compressed()
+            .skip_simulation(true)
+            .request()
+            .await?;
+
+        self.stdin = SP1Stdin::new();
+        Ok(request_id)
+    }
+
+    async fn poll(&self, handle: &Self::ProofHandle) -> anyhow::Result<Option<Vec<u8>>> {
+        let (maybe_proof, status) = self.prover.process_proof_status(*handle, None).await?;
+
+        if matches!(status, FulfillmentStatus::Unfulfillable) {
+            anyhow::bail!("Proof request {} is unfulfillable", handle);
+        }
+
+        match maybe_proof {
+            Some(proof) => Ok(Some(bincode::serialize(&Proof::<_, sp1_sdk::SP1PublicValues>::Full(proof))?)),
+            None => Ok(None),
+        }
+    }
+}

--- a/crates/adapters/sp1/src/network.rs
+++ b/crates/adapters/sp1/src/network.rs
@@ -4,9 +4,9 @@
 
 use serde::Serialize;
 use sov_rollup_interface::zk::{Proof, ZkvmNetwork};
+use sp1_sdk::network::proto::auction_types::FulfillmentStatus;
 use sp1_sdk::network::{B256, NetworkMode};
-use sp1_sdk::network::proto::base_types::FulfillmentStatus;
-use sp1_sdk::prover::{Prover, ProveRequest};
+use sp1_sdk::prover::{ProveRequest, Prover};
 use sp1_sdk::{NetworkProver, ProverClient, SP1ProvingKey, SP1Stdin};
 
 use crate::guest::SP1Guest;
@@ -22,9 +22,12 @@ pub struct SP1Network {
 }
 
 impl SP1Network {
-    /// Create a new `SP1Network` from an existing [`NetworkProver`] and an ELF binary.
+    /// Create a new `SP1Network` for the given ELF binary.
+    ///
+    /// Connects to the Succinct proving network (mainnet) and runs setup.
     pub async fn new(elf: &[u8]) -> anyhow::Result<Self> {
-        let prover = ProverClient::builder().network_for(NetworkMode::Mainnet).build().await?;
+        let prover: NetworkProver =
+            ProverClient::builder().network_for(NetworkMode::Mainnet).build().await;
         let pk = prover
             .setup(elf.into())
             .await
@@ -66,6 +69,11 @@ impl ZkvmNetwork for SP1Network {
             anyhow::bail!("Proof request {} is unfulfillable", handle);
         }
 
-        maybe_proof.map(bincode::serialize)
+        match maybe_proof {
+            Some(proof) => Ok(Some(bincode::serialize(
+                &Proof::<_, sp1_sdk::SP1PublicValues>::Full(proof),
+            )?)),
+            None => Ok(None),
+        }
     }
 }

--- a/crates/adapters/sp1/src/network.rs
+++ b/crates/adapters/sp1/src/network.rs
@@ -1,95 +1,82 @@
 //! Network prover implementation for SP1.
 //!
 //! Submits proof requests to the Succinct proving network and polls for results.
-//!
-//! Requires the `network` feature to be enabled. Without it, [`SP1Network`] is a
-//! no-op alias that cannot be constructed.
 
-#[cfg(feature = "network")]
-mod _impl {
-    use serde::Serialize;
-    use sov_rollup_interface::zk::{Proof, ZkvmNetwork};
-    use sp1_sdk::network::proto::auction_types::FulfillmentStatus;
-    use sp1_sdk::network::{NetworkMode, B256};
-    use sp1_sdk::prover::{ProveRequest, Prover};
-    use sp1_sdk::{NetworkProver, ProverClient, SP1ProvingKey, SP1Stdin};
+use serde::Serialize;
+use sov_rollup_interface::zk::{Proof, ZkvmNetwork};
+use sp1_sdk::network::proto::auction_types::FulfillmentStatus;
+use sp1_sdk::network::{NetworkMode, B256};
+use sp1_sdk::prover::{ProveRequest, Prover};
+use sp1_sdk::{NetworkProver, ProverClient, SP1ProvingKey, SP1Stdin};
 
-    use crate::guest::SP1Guest;
+use crate::guest::SP1Guest;
 
-    /// Re-export of the proof handle type used by the SP1 network.
-    pub type ProofHandle = B256;
+/// Re-export of the proof handle type used by the SP1 network.
+pub type ProofHandle = B256;
 
-    /// SP1 network prover that submits proofs to the Succinct proving network.
-    pub struct SP1Network {
-        prover: NetworkProver,
-        pk: SP1ProvingKey,
-        stdin: SP1Stdin,
-    }
+/// SP1 network prover that submits proofs to the Succinct proving network.
+pub struct SP1Network {
+    prover: NetworkProver,
+    pk: SP1ProvingKey,
+    stdin: SP1Stdin,
+}
 
-    impl SP1Network {
-        /// Create a new `SP1Network` for the given ELF binary.
-        ///
-        /// Connects to the Succinct proving network (mainnet) and runs setup.
-        pub async fn new(elf: &[u8]) -> anyhow::Result<Self> {
-            let prover: NetworkProver = ProverClient::builder()
-                .network_for(NetworkMode::Mainnet)
-                .build()
-                .await;
-            let pk = prover
-                .setup(elf.into())
-                .await
-                .map_err(|e| anyhow::anyhow!("SP1 network setup failed: {e}"))?;
+impl SP1Network {
+    /// Create a new `SP1Network` for the given ELF binary.
+    ///
+    /// Connects to the Succinct proving network (mainnet) and runs setup.
+    pub async fn new(elf: &[u8]) -> anyhow::Result<Self> {
+        let prover: NetworkProver = ProverClient::builder()
+            .network_for(NetworkMode::Mainnet)
+            .build()
+            .await;
+        let pk = prover
+            .setup(elf.into())
+            .await
+            .map_err(|e| anyhow::anyhow!("SP1 network setup failed: {e}"))?;
 
-            Ok(Self {
-                prover,
-                pk,
-                stdin: SP1Stdin::new(),
-            })
-        }
-    }
-
-    impl ZkvmNetwork for SP1Network {
-        type Guest = SP1Guest;
-        type ProofHandle = ProofHandle;
-
-        fn add_hint<T: Serialize>(&mut self, item: &T) {
-            self.stdin.write(item);
-        }
-
-        async fn submit(&mut self) -> anyhow::Result<Self::ProofHandle> {
-            let request_id = self
-                .prover
-                .prove(&self.pk, self.stdin.clone())
-                .compressed()
-                .skip_simulation(true)
-                .request()
-                .await?;
-
-            self.stdin = SP1Stdin::new();
-            Ok(request_id)
-        }
-
-        async fn poll(&self, handle: &Self::ProofHandle) -> anyhow::Result<Option<Vec<u8>>> {
-            let (maybe_proof, status) = self.prover.process_proof_status(*handle, None).await?;
-
-            if matches!(status, FulfillmentStatus::Unfulfillable) {
-                anyhow::bail!("Proof request {} is unfulfillable", handle);
-            }
-
-            match maybe_proof {
-                Some(proof) => Ok(Some(bincode::serialize(&Proof::<
-                    _,
-                    sp1_sdk::SP1PublicValues,
-                >::Full(proof))?)),
-                None => Ok(None),
-            }
-        }
+        Ok(Self {
+            prover,
+            pk,
+            stdin: SP1Stdin::new(),
+        })
     }
 }
 
-#[cfg(feature = "network")]
-pub use _impl::{ProofHandle, SP1Network};
+impl ZkvmNetwork for SP1Network {
+    type Guest = SP1Guest;
+    type ProofHandle = ProofHandle;
 
-#[cfg(not(feature = "network"))]
-/// Network proving requires the `network` feature.
-pub type SP1Network = sov_rollup_interface::zk::NoopZkvmNetwork<crate::guest::SP1Guest>;
+    fn add_hint<T: Serialize>(&mut self, item: &T) {
+        self.stdin.write(item);
+    }
+
+    async fn submit(&mut self) -> anyhow::Result<Self::ProofHandle> {
+        let request_id = self
+            .prover
+            .prove(&self.pk, self.stdin.clone())
+            .compressed()
+            .skip_simulation(true)
+            .request()
+            .await?;
+
+        self.stdin = SP1Stdin::new();
+        Ok(request_id)
+    }
+
+    async fn poll(&self, handle: &Self::ProofHandle) -> anyhow::Result<Option<Vec<u8>>> {
+        let (maybe_proof, status) = self.prover.process_proof_status(*handle, None).await?;
+
+        if matches!(status, FulfillmentStatus::Unfulfillable) {
+            anyhow::bail!("Proof request {} is unfulfillable", handle);
+        }
+
+        match maybe_proof {
+            Some(proof) => Ok(Some(bincode::serialize(&Proof::<
+                _,
+                sp1_sdk::SP1PublicValues,
+            >::Full(proof))?)),
+            None => Ok(None),
+        }
+    }
+}

--- a/crates/adapters/sp1/src/network.rs
+++ b/crates/adapters/sp1/src/network.rs
@@ -1,79 +1,92 @@
 //! Network prover implementation for SP1.
 //!
 //! Submits proof requests to the Succinct proving network and polls for results.
+//!
+//! Requires the `network` feature to be enabled. Without it, [`SP1Network`] is a
+//! no-op alias that cannot be constructed.
 
-use serde::Serialize;
-use sov_rollup_interface::zk::{Proof, ZkvmNetwork};
-use sp1_sdk::network::proto::auction_types::FulfillmentStatus;
-use sp1_sdk::network::{B256, NetworkMode};
-use sp1_sdk::prover::{ProveRequest, Prover};
-use sp1_sdk::{NetworkProver, ProverClient, SP1ProvingKey, SP1Stdin};
+#[cfg(feature = "network")]
+mod _impl {
+    use serde::Serialize;
+    use sov_rollup_interface::zk::{Proof, ZkvmNetwork};
+    use sp1_sdk::network::proto::auction_types::FulfillmentStatus;
+    use sp1_sdk::network::{B256, NetworkMode};
+    use sp1_sdk::prover::{ProveRequest, Prover};
+    use sp1_sdk::{NetworkProver, ProverClient, SP1ProvingKey, SP1Stdin};
 
-use crate::guest::SP1Guest;
+    use crate::guest::SP1Guest;
 
-/// Re-export of the proof handle type used by the SP1 network.
-pub type ProofHandle = B256;
+    /// Re-export of the proof handle type used by the SP1 network.
+    pub type ProofHandle = B256;
 
-/// SP1 network prover that submits proofs to the Succinct proving network.
-pub struct SP1Network {
-    prover: NetworkProver,
-    pk: SP1ProvingKey,
-    stdin: SP1Stdin,
-}
-
-impl SP1Network {
-    /// Create a new `SP1Network` for the given ELF binary.
-    ///
-    /// Connects to the Succinct proving network (mainnet) and runs setup.
-    pub async fn new(elf: &[u8]) -> anyhow::Result<Self> {
-        let prover: NetworkProver =
-            ProverClient::builder().network_for(NetworkMode::Mainnet).build().await;
-        let pk = prover
-            .setup(elf.into())
-            .await
-            .map_err(|e| anyhow::anyhow!("SP1 network setup failed: {e}"))?;
-
-        Ok(Self {
-            prover,
-            pk,
-            stdin: SP1Stdin::new(),
-        })
-    }
-}
-
-impl ZkvmNetwork for SP1Network {
-    type Guest = SP1Guest;
-    type ProofHandle = ProofHandle;
-
-    fn add_hint<T: Serialize>(&mut self, item: &T) {
-        self.stdin.write(item);
+    /// SP1 network prover that submits proofs to the Succinct proving network.
+    pub struct SP1Network {
+        prover: NetworkProver,
+        pk: SP1ProvingKey,
+        stdin: SP1Stdin,
     }
 
-    async fn submit(&mut self) -> anyhow::Result<Self::ProofHandle> {
-        let request_id = self
-            .prover
-            .prove(&self.pk, self.stdin.clone())
-            .compressed()
-            .skip_simulation(true)
-            .request()
-            .await?;
+    impl SP1Network {
+        /// Create a new `SP1Network` for the given ELF binary.
+        ///
+        /// Connects to the Succinct proving network (mainnet) and runs setup.
+        pub async fn new(elf: &[u8]) -> anyhow::Result<Self> {
+            let prover: NetworkProver =
+                ProverClient::builder().network_for(NetworkMode::Mainnet).build().await;
+            let pk = prover
+                .setup(elf.into())
+                .await
+                .map_err(|e| anyhow::anyhow!("SP1 network setup failed: {e}"))?;
 
-        self.stdin = SP1Stdin::new();
-        Ok(request_id)
-    }
-
-    async fn poll(&self, handle: &Self::ProofHandle) -> anyhow::Result<Option<Vec<u8>>> {
-        let (maybe_proof, status) = self.prover.process_proof_status(*handle, None).await?;
-
-        if matches!(status, FulfillmentStatus::Unfulfillable) {
-            anyhow::bail!("Proof request {} is unfulfillable", handle);
-        }
-
-        match maybe_proof {
-            Some(proof) => Ok(Some(bincode::serialize(
-                &Proof::<_, sp1_sdk::SP1PublicValues>::Full(proof),
-            )?)),
-            None => Ok(None),
+            Ok(Self {
+                prover,
+                pk,
+                stdin: SP1Stdin::new(),
+            })
         }
     }
+
+    impl ZkvmNetwork for SP1Network {
+        type Guest = SP1Guest;
+        type ProofHandle = ProofHandle;
+
+        fn add_hint<T: Serialize>(&mut self, item: &T) {
+            self.stdin.write(item);
+        }
+
+        async fn submit(&mut self) -> anyhow::Result<Self::ProofHandle> {
+            let request_id = self
+                .prover
+                .prove(&self.pk, self.stdin.clone())
+                .compressed()
+                .skip_simulation(true)
+                .request()
+                .await?;
+
+            self.stdin = SP1Stdin::new();
+            Ok(request_id)
+        }
+
+        async fn poll(&self, handle: &Self::ProofHandle) -> anyhow::Result<Option<Vec<u8>>> {
+            let (maybe_proof, status) = self.prover.process_proof_status(*handle, None).await?;
+
+            if matches!(status, FulfillmentStatus::Unfulfillable) {
+                anyhow::bail!("Proof request {} is unfulfillable", handle);
+            }
+
+            match maybe_proof {
+                Some(proof) => Ok(Some(bincode::serialize(
+                    &Proof::<_, sp1_sdk::SP1PublicValues>::Full(proof),
+                )?)),
+                None => Ok(None),
+            }
+        }
+    }
 }
+
+#[cfg(feature = "network")]
+pub use _impl::{ProofHandle, SP1Network};
+
+#[cfg(not(feature = "network"))]
+/// Network proving requires the `network` feature.
+pub type SP1Network = sov_rollup_interface::zk::NoopZkvmNetwork<crate::guest::SP1Guest>;

--- a/crates/adapters/sp1/src/network.rs
+++ b/crates/adapters/sp1/src/network.rs
@@ -4,13 +4,14 @@
 
 use serde::Serialize;
 use sov_rollup_interface::zk::{Proof, ZkvmNetwork};
-use sp1_sdk::network::B256;
+use sp1_sdk::network::{B256, NetworkMode};
 use sp1_sdk::network::proto::base_types::FulfillmentStatus;
 use sp1_sdk::prover::{Prover, ProveRequest};
-use sp1_sdk::{NetworkProver, SP1ProvingKey, SP1Stdin};
+use sp1_sdk::{NetworkProver, ProverClient, SP1ProvingKey, SP1Stdin};
 
 use crate::guest::SP1Guest;
 
+/// Re-export of the proof handle type used by the SP1 network.
 pub type ProofHandle = B256;
 
 /// SP1 network prover that submits proofs to the Succinct proving network.
@@ -22,7 +23,8 @@ pub struct SP1Network {
 
 impl SP1Network {
     /// Create a new `SP1Network` from an existing [`NetworkProver`] and an ELF binary.
-    pub async fn new(prover: NetworkProver, elf: &[u8]) -> anyhow::Result<Self> {
+    pub async fn new(elf: &[u8]) -> anyhow::Result<Self> {
+        let prover = ProverClient::builder().network_for(NetworkMode::Mainnet).build().await?;
         let pk = prover
             .setup(elf.into())
             .await
@@ -64,9 +66,6 @@ impl ZkvmNetwork for SP1Network {
             anyhow::bail!("Proof request {} is unfulfillable", handle);
         }
 
-        match maybe_proof {
-            Some(proof) => Ok(Some(bincode::serialize(&Proof::<_, sp1_sdk::SP1PublicValues>::Full(proof))?)),
-            None => Ok(None),
-        }
+        maybe_proof.map(bincode::serialize)
     }
 }

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -183,6 +183,34 @@ pub trait ZkvmNetwork: Send + Sync + 'static {
     ) -> impl core::future::Future<Output = anyhow::Result<Option<Vec<u8>>>> + Send;
 }
 
+/// A no-op [`ZkvmNetwork`] for ZKVMs that don't support network proving.
+///
+/// This type cannot be constructed because it contains an [`Infallible`](core::convert::Infallible)
+/// field. All trait methods use `match self._void {}` to statically prove they are unreachable.
+#[cfg(feature = "native")]
+pub struct NoopZkvmNetwork<G> {
+    _guest: core::marker::PhantomData<G>,
+    _void: core::convert::Infallible,
+}
+
+#[cfg(feature = "native")]
+impl<G: ZkvmGuest + 'static> ZkvmNetwork for NoopZkvmNetwork<G> {
+    type Guest = G;
+    type ProofHandle = ();
+
+    fn add_hint<T: Serialize>(&mut self, _item: &T) {
+        match self._void {}
+    }
+
+    async fn submit(&mut self) -> anyhow::Result<Self::ProofHandle> {
+        match self._void {}
+    }
+
+    async fn poll(&self, _handle: &Self::ProofHandle) -> anyhow::Result<Option<Vec<u8>>> {
+        match self._void {}
+    }
+}
+
 /// A trait which is accessible from within a zkVM program.
 pub trait ZkvmGuest: Send + Sync {
     /// The verifier type associated with this vm.

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -67,6 +67,11 @@ pub trait Zkvm: Default + Clone + Send + Sync + 'static {
     /// The proof generator. Only available under the `"native"` feature.
     #[cfg(feature = "native")]
     type Host: ZkvmHost<Guest: ZkvmGuest<Verifier = Self::Verifier>>;
+
+    /// Network proving implementation for this Zkvm.
+    /// Only available under the `"native"` feature.
+    #[cfg(feature = "native")]
+    type Network: ZkvmNetwork<Guest: ZkvmGuest<Verifier = Self::Verifier>>;
 }
 
 /// The arguments required by the [`Zkvm::Host`]'s constructor function.
@@ -141,6 +146,41 @@ pub trait ZkVerifier: Default + Clone + Send + Sync + 'static {
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error>;
+}
+
+/// A network prover that can submit proofs asynchronously and poll for results.
+///
+/// Unlike [`ZkvmHost`] which runs proofs synchronously via [`ZkvmHost::run`],
+/// a `ZkvmNetwork` submits proof requests to a remote proving service and returns
+/// a handle that can be polled for completion. This enables concurrent proof generation
+/// across multiple blocks.
+#[cfg(feature = "native")]
+pub trait ZkvmNetwork: Send + Sync + 'static {
+    /// The associated guest type.
+    type Guest: ZkvmGuest;
+
+    /// An opaque handle returned by [`ZkvmNetwork::submit`] that identifies a pending proof.
+    type ProofHandle: Send + Sync + Clone + core::fmt::Debug + 'static;
+
+    /// Give the guest a piece of advice non-deterministically.
+    fn add_hint<T: Serialize>(&mut self, item: T);
+
+    /// Submit the current program and hints for remote proving.
+    ///
+    /// Returns a [`Self::ProofHandle`] that can be passed to [`ZkvmNetwork::check`] to poll for the result.
+    fn submit(
+        &mut self,
+        with_proof: bool,
+    ) -> impl core::future::Future<Output = anyhow::Result<Self::ProofHandle>> + Send;
+
+    /// Check whether a previously submitted proof is ready.
+    ///
+    /// Returns `Ok(Some(proof_bytes))` when the proof is complete,
+    /// `Ok(None)` if it is still pending, or an error if proving failed.
+    fn poll(
+        &self,
+        handle: &Self::ProofHandle,
+    ) -> impl core::future::Future<Output = anyhow::Result<Option<Vec<u8>>>> + Send;
 }
 
 /// A trait which is accessible from within a zkVM program.

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -202,15 +202,15 @@ impl<G: ZkvmGuest + 'static> ZkvmNetwork for NoopZkvmNetwork<G> {
     type ProofHandle = ();
 
     fn add_hint<T: Serialize>(&mut self, _item: &T) {
-        match self._void {}
+        unreachable!()
     }
 
     async fn submit(&mut self) -> anyhow::Result<Self::ProofHandle> {
-        match self._void {}
+        unreachable!()
     }
 
     async fn poll(&self, _handle: &Self::ProofHandle) -> anyhow::Result<Option<Vec<u8>>> {
-        match self._void {}
+        unreachable!()
     }
 }
 

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -163,14 +163,14 @@ pub trait ZkvmNetwork: Send + Sync + 'static {
     type ProofHandle: Send + Sync + Clone + core::fmt::Debug + 'static;
 
     /// Give the guest a piece of advice non-deterministically.
-    fn add_hint<T: Serialize>(&mut self, item: T);
+    fn add_hint<T: Serialize>(&mut self, item: &T);
 
     /// Submit the current program and hints for remote proving.
     ///
-    /// Returns a [`Self::ProofHandle`] that can be passed to [`ZkvmNetwork::check`] to poll for the result.
+    /// Network proving always generates a real proof.
+    /// Returns a [`Self::ProofHandle`] that can be passed to [`ZkvmNetwork::poll`] to check for the result.
     fn submit(
         &mut self,
-        with_proof: bool,
     ) -> impl core::future::Future<Output = anyhow::Result<Self::ProofHandle>> + Send;
 
     /// Check whether a previously submitted proof is ready.

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -70,6 +70,9 @@ pub trait Zkvm: Default + Clone + Send + Sync + 'static {
 
     /// Network proving implementation for this Zkvm.
     /// Only available under the `"native"` feature.
+    ///
+    /// This is an optional component - if the Zkvm does not support network proving, this can be set to `NoopZkvmNetwork<Self::Guest>`,
+    /// which is a dummy implementation that cannot be used or constructed.
     #[cfg(feature = "native")]
     type Network: ZkvmNetwork<Guest: ZkvmGuest<Verifier = Self::Verifier>>;
 }

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -202,15 +202,15 @@ impl<G: ZkvmGuest + 'static> ZkvmNetwork for NoopZkvmNetwork<G> {
     type ProofHandle = ();
 
     fn add_hint<T: Serialize>(&mut self, _item: &T) {
-        unreachable!()
+        match self._void {}
     }
 
     async fn submit(&mut self) -> anyhow::Result<Self::ProofHandle> {
-        unreachable!()
+        match self._void {}
     }
 
     async fn poll(&self, _handle: &Self::ProofHandle) -> anyhow::Result<Option<Vec<u8>>> {
-        unreachable!()
+        match self._void {}
     }
 }
 


### PR DESCRIPTION
# Description

Adds a `ZkvmNetwork` trait that `Zkvm`s that support a prover network can implement to support this.

Following PRs will add a network based `ProverService` that will utilise the `ZkvmNetwork` to perform network proving.

`sp1` network proving is heavy on dependencies so sp1 adapter proving functionality is behind a `network` feature gate. 

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
