### PR TITLE
EVM: Fix regression from #2500 on EVM-DB based balance check and paymaster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
+# 2025-03-16
+- #2592 Fixes EVM RPC regression for paymaster enabled rollups
+
 # 2025-03-10
 - #2569 **Breaking change** Updated the `SP1Host` and `SP1Verifier` implementations to support SP1 v6. `ZkvmHost::code_commitment` now returns a Result, which is a breaking change.
 - #2554 **Breaking change** Updated the `SP1Host` and `SP1Verifier` implementations to support SP1 v6. `ZkvmHost::code_commitment` now returns a Result, which is a breaking change.
+
 # 2025-03-05
 - #2554 More stabilization in demo-rollup EVM tests
-# 2026-03-05
 - #2556 **Breaking change**: only for runtimes with AccessPattern module.
-# 2026-03-05
 - #2548 Updates sp1 to v6.
 
 # 2026-02-12

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -343,6 +343,7 @@ where
             "EVM module JSON-RPC request"
         );
         let initial_access_list = request.access_list.clone().unwrap_or_default();
+        super::validate_call_fee_fields(&request)?;
         let block_env = self.resolve_block_env_for_call(block_id, state)?;
         let tx_env = crate::helpers::prepare_call_env(&block_env, request)?;
         let cfg = self.cfg_infallible(state);

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -134,14 +134,6 @@ pub enum PendingOrBlock {
 }
 
 const ABSOLUTE_MARGIN: u64 = 100_000;
-const MIN_TRANSACTION_GAS: u64 = 21_000;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct CallUpfrontCost {
-    total_cost: U256,
-    gas_limit: u64,
-}
-
 /// gas * 1.5 + 100_000
 pub(crate) fn apply_margins(gas: u64) -> Result<u64, RpcInvalidTransactionError> {
     (gas / 2)
@@ -150,11 +142,13 @@ pub(crate) fn apply_margins(gas: u64) -> Result<u64, RpcInvalidTransactionError>
         .ok_or(RpcInvalidTransactionError::GasUintOverflow)
 }
 
-fn call_upfront_cost(
-    request: &TransactionRequest,
-    block_env: &BlockEnv,
-    balance: U256,
-) -> Result<Option<CallUpfrontCost>, EthApiError> {
+/// Validates fee-field consistency in an `eth_call` / `eth_estimateGas` request.
+///
+/// These are request-format checks independent of the caller's balance.
+/// Balance-based upfront cost validation was removed because the RPC layer
+/// cannot determine whether a paymaster will cover the caller's gas.
+/// TODO: re-add a paymaster-aware balance check when sov-ethereum supports it.
+fn validate_call_fee_fields(request: &TransactionRequest) -> Result<(), EthApiError> {
     if request.gas_price.is_some()
         && (request.max_fee_per_gas.is_some() || request.max_priority_fee_per_gas.is_some())
     {
@@ -166,80 +160,6 @@ fn call_upfront_cost(
     {
         if max_priority_fee_per_gas > max_fee_per_gas {
             return Err(RpcInvalidTransactionError::TipAboveFeeCap.into());
-        }
-    }
-
-    let Some(fee_per_gas) = request.gas_price.or(request.max_fee_per_gas) else {
-        return Ok(None);
-    };
-
-    let value = request.value.unwrap_or_default();
-    let gas_limit = match request.gas {
-        Some(gas_limit) => gas_limit,
-        None => {
-            if fee_per_gas == 0 {
-                block_env.gas_limit
-            } else {
-                // When gas is omitted, cap by what the caller can actually afford instead of
-                // requiring balance for the full block gas limit. Still require enough
-                // allowance for intrinsic tx gas, otherwise the request is unaffordable.
-                let allowance = balance.checked_sub(value).unwrap_or_default();
-                let max_affordable_gas = allowance / U256::from(fee_per_gas);
-                let gas_limit = max_affordable_gas
-                    .min(U256::from(block_env.gas_limit))
-                    .to::<u64>();
-                if gas_limit < MIN_TRANSACTION_GAS {
-                    return Err(RpcInvalidTransactionError::GasRequiredExceedsAllowance {
-                        gas_limit,
-                    }
-                    .into());
-                }
-                gas_limit
-            }
-        }
-    };
-    let gas_cost = U256::from(gas_limit)
-        .checked_mul(U256::from(fee_per_gas))
-        .ok_or(RpcInvalidTransactionError::GasUintOverflow)?;
-    let total_cost = gas_cost
-        .checked_add(value)
-        .ok_or(RpcInvalidTransactionError::GasUintOverflow)?;
-    Ok(Some(CallUpfrontCost {
-        total_cost,
-        gas_limit,
-    }))
-}
-
-fn call_caller(request: &TransactionRequest) -> Address {
-    // Keep `eth_call` parity with Ethereum clients: when `from` is omitted,
-    // execution uses the zero address as the caller.
-    request.from.unwrap_or_default()
-}
-
-fn enforce_call_upfront_cost<DB: Database>(
-    request: &mut TransactionRequest,
-    block_env: &BlockEnv,
-    db: &mut DB,
-) -> Result<(), EthApiError>
-where
-    DB::Error: Into<EthApiError>,
-{
-    let balance = db
-        .basic(call_caller(request))
-        .map_err(Into::into)?
-        .map(|account| account.balance)
-        .unwrap_or_default();
-    if let Some(upfront) = call_upfront_cost(request, block_env, balance)? {
-        if request.gas.is_none() {
-            request.gas = Some(upfront.gas_limit);
-        }
-
-        if balance < upfront.total_cost {
-            return Err(RpcInvalidTransactionError::InsufficientFunds {
-                cost: upfront.total_cost,
-                balance,
-            }
-            .into());
         }
     }
 
@@ -545,7 +465,7 @@ where
         if !has_overrides {
             // Fast path for the common case where no call overrides are provided.
             let mut evm_db: EvmDb<_, S> = self.db(maybe_archival_state.deref_mut());
-            enforce_call_upfront_cost(&mut request, &block_env, &mut evm_db)?;
+            validate_call_fee_fields(&request)?;
 
             let tx_env = prepare_call_env(&block_env, request)?;
             let caller = tx_env.caller;
@@ -566,7 +486,7 @@ where
             block_overrides,
         )?;
 
-        enforce_call_upfront_cost(&mut request, &block_env, &mut evm_state)?;
+        validate_call_fee_fields(&request)?;
 
         let tx_env = prepare_call_env(&block_env, request)?;
         let caller = tx_env.caller;
@@ -1349,123 +1269,31 @@ mod tests {
     }
 
     #[test]
-    fn call_upfront_cost_caps_omitted_gas_by_caller_balance() {
-        let block_env = BlockEnv {
-            gas_limit: 1_000_000,
-            ..Default::default()
-        };
-        let request = TransactionRequest {
-            gas_price: Some(10),
-            ..Default::default()
-        };
-        let balance = U256::from(1_000_000u64);
-
-        let upfront = call_upfront_cost(&request, &block_env, balance)
-            .unwrap()
-            .expect("fee fields are set");
-
-        assert_eq!(upfront.total_cost, balance);
-        assert_eq!(upfront.gas_limit, 100_000);
-    }
-
-    #[test]
-    fn call_upfront_cost_keeps_explicit_gas_requirements() {
-        let block_env = BlockEnv::default();
-        let request = TransactionRequest {
-            gas_price: Some(10),
-            gas: Some(1_000),
-            ..Default::default()
-        };
-
-        let upfront = call_upfront_cost(&request, &block_env, U256::ZERO)
-            .unwrap()
-            .expect("fee fields are set");
-
-        assert_eq!(upfront.total_cost, U256::from(10_000u64));
-        assert_eq!(upfront.gas_limit, 1_000);
-    }
-
-    #[test]
-    fn call_upfront_cost_reserves_value_before_affordable_gas() {
-        let block_env = BlockEnv {
-            gas_limit: 1_000_000,
-            ..Default::default()
-        };
-        let request = TransactionRequest {
-            gas_price: Some(10),
-            value: Some(U256::from(100_000u64)),
-            ..Default::default()
-        };
-        let balance = U256::from(310_000u64);
-
-        let upfront = call_upfront_cost(&request, &block_env, balance)
-            .unwrap()
-            .expect("fee fields are set");
-
-        assert_eq!(upfront.total_cost, balance);
-        assert_eq!(upfront.gas_limit, MIN_TRANSACTION_GAS);
-    }
-
-    #[test]
-    fn call_upfront_cost_rejects_omitted_gas_when_allowance_below_intrinsic_cost() {
-        let block_env = BlockEnv {
-            gas_limit: 1_000_000,
-            ..Default::default()
-        };
-        let request = TransactionRequest {
-            gas_price: Some(10),
-            ..Default::default()
-        };
-        let balance = U256::from(1000u64);
-
-        let err = call_upfront_cost(&request, &block_env, balance).unwrap_err();
-
-        assert!(matches!(
-            err,
-            EthApiError::InvalidTransaction(
-                RpcInvalidTransactionError::GasRequiredExceedsAllowance { gas_limit: 100 }
-            )
-        ));
-    }
-
-    #[test]
-    fn call_upfront_cost_rejects_conflicting_fee_fields() {
+    fn validate_call_fee_fields_rejects_conflicting_fields() {
         let request = TransactionRequest {
             gas_price: Some(1),
             max_fee_per_gas: Some(1),
             ..Default::default()
         };
 
-        let err = call_upfront_cost(&request, &BlockEnv::default(), U256::ZERO).unwrap_err();
+        let err = validate_call_fee_fields(&request).unwrap_err();
 
         assert!(matches!(err, EthApiError::ConflictingFeeFieldsInRequest));
     }
 
     #[test]
-    fn call_upfront_cost_rejects_tip_above_fee_cap() {
+    fn validate_call_fee_fields_rejects_tip_above_fee_cap() {
         let request = TransactionRequest {
             max_fee_per_gas: Some(1),
             max_priority_fee_per_gas: Some(2),
             ..Default::default()
         };
 
-        let err = call_upfront_cost(&request, &BlockEnv::default(), U256::ZERO).unwrap_err();
+        let err = validate_call_fee_fields(&request).unwrap_err();
 
         assert!(matches!(
             err,
             EthApiError::InvalidTransaction(RpcInvalidTransactionError::TipAboveFeeCap)
         ));
-    }
-
-    #[test]
-    fn call_upfront_cost_returns_none_without_fee_fields() {
-        let upfront = call_upfront_cost(
-            &TransactionRequest::default(),
-            &BlockEnv::default(),
-            U256::ZERO,
-        )
-        .unwrap();
-
-        assert_eq!(upfront, None);
     }
 }

--- a/examples/demo-rollup/tests/evm/evm_call_fee_fields.rs
+++ b/examples/demo-rollup/tests/evm/evm_call_fee_fields.rs
@@ -90,6 +90,7 @@ async fn assert_rpc_succeeds<T: DeserializeOwned>(
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "TODO: re-enable with paymaster-aware balance check"]
 async fn eth_call_rejects_unfunded_caller_with_gas_price() -> anyhow::Result<()> {
     let (_rollup, client) = setup_client().await;
 
@@ -106,6 +107,7 @@ async fn eth_call_rejects_unfunded_caller_with_gas_price() -> anyhow::Result<()>
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "TODO: re-enable with paymaster-aware balance check"]
 async fn eth_estimate_gas_rejects_unfunded_caller_with_omitted_gas_and_fee() -> anyhow::Result<()> {
     let (_rollup, client) = setup_client().await;
 
@@ -130,6 +132,7 @@ async fn eth_estimate_gas_rejects_unfunded_caller_with_omitted_gas_and_fee() -> 
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "TODO: re-enable with paymaster-aware balance check"]
 async fn eth_estimate_gas_rejects_unfunded_caller_with_omitted_gas_and_gas_price(
 ) -> anyhow::Result<()> {
     let (_rollup, client) = setup_client().await;
@@ -154,6 +157,7 @@ async fn eth_estimate_gas_rejects_unfunded_caller_with_omitted_gas_and_gas_price
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "TODO: re-enable with paymaster-aware balance check"]
 async fn eth_estimate_gas_rejects_missing_from_with_gas_price() -> anyhow::Result<()> {
     let (_rollup, client) = setup_client().await;
     assert_unfunded_caller(&client, Address::ZERO).await?;
@@ -177,6 +181,7 @@ async fn eth_estimate_gas_rejects_missing_from_with_gas_price() -> anyhow::Resul
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "TODO: re-enable with paymaster-aware balance check"]
 async fn eth_estimate_gas_rejects_missing_from_with_omitted_gas_and_gas_price() -> anyhow::Result<()>
 {
     let (_rollup, client) = setup_client().await;
@@ -200,6 +205,7 @@ async fn eth_estimate_gas_rejects_missing_from_with_omitted_gas_and_gas_price() 
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "TODO: re-enable with paymaster-aware balance check"]
 async fn eth_estimate_gas_rejects_unfunded_caller_with_max_fee_per_gas() -> anyhow::Result<()> {
     let (_rollup, client) = setup_client().await;
 

--- a/examples/demo-rollup/tests/evm/evm_call_fee_fields.rs
+++ b/examples/demo-rollup/tests/evm/evm_call_fee_fields.rs
@@ -15,6 +15,9 @@ use crate::evm::evm_test_helper::{
 
 const GAS_LIMIT: u64 = 21_000;
 const GAS_REQUIRED_EXCEEDS_ALLOWANCE_ERROR: &str = "gas required exceeds allowance";
+const CONFLICTING_FEE_FIELDS_ERROR: &str =
+    "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified";
+const TIP_ABOVE_FEE_CAP_ERROR: &str = "max priority fee per gas higher than max fee per gas";
 
 fn unfunded_caller() -> Address {
     Address::from([0x11; 20])
@@ -284,6 +287,48 @@ async fn eth_estimate_gas_rejects_below_base_fee_with_max_fee_per_gas() -> anyho
         ..base_request(caller)
     };
     assert_rpc_rejects::<U64>(&client, "eth_estimateGas", &request, FEE_CAP_TOO_LOW_ERROR).await;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn eth_create_access_list_rejects_conflicting_fee_fields() -> anyhow::Result<()> {
+    let (_rollup, client) = setup_client().await;
+    let caller = client.address();
+
+    let request = TransactionRequest {
+        gas_price: Some(MAX_FEE_PER_GAS),
+        max_fee_per_gas: Some(MAX_FEE_PER_GAS),
+        ..base_request(caller)
+    };
+    assert_rpc_rejects::<serde_json::Value>(
+        &client,
+        "eth_createAccessList",
+        &request,
+        CONFLICTING_FEE_FIELDS_ERROR,
+    )
+    .await;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn eth_create_access_list_rejects_tip_above_fee_cap() -> anyhow::Result<()> {
+    let (_rollup, client) = setup_client().await;
+    let caller = client.address();
+
+    let request = TransactionRequest {
+        max_fee_per_gas: Some(1),
+        max_priority_fee_per_gas: Some(2),
+        ..base_request(caller)
+    };
+    assert_rpc_rejects::<serde_json::Value>(
+        &client,
+        "eth_createAccessList",
+        &request,
+        TIP_ABOVE_FEE_CAP_ERROR,
+    )
+    .await;
 
     Ok(())
 }

--- a/examples/demo-rollup/tests/evm/evm_paymaster_balance_check.rs
+++ b/examples/demo-rollup/tests/evm/evm_paymaster_balance_check.rs
@@ -1,14 +1,19 @@
 use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::{Address, Bytes, TxKind, B256, U256, U64};
 use alloy_rpc_types_eth::TransactionRequest;
+use demo_stf::MultiAddressEvmSolana;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::rpc_params;
 use reqwest::Client;
 use serde::de::DeserializeOwned;
 use serde_json::json;
-use sov_demo_rollup::MockDemoRollup;
+use sov_address::EthereumAddress;
+use sov_bank::config_gas_token_id;
+use sov_cli::NodeClient;
+use sov_demo_rollup::{MockDemoRollup, MockRollupSpec};
 use sov_eth_client::SimpleStorageClient;
 use sov_modules_api::execution_mode::Native;
+use sov_modules_api::Amount;
 use sov_test_utils::test_rollup::TestRollup;
 
 use crate::evm::evm_test_helper::{
@@ -97,6 +102,30 @@ async fn get_consistent_response(
     }
 }
 
+async fn assert_zero_balance(client: &NodeClient, addr: &Address) {
+    let balance = client
+        .get_balance::<MockRollupSpec<Native>>(
+            &MultiAddressEvmSolana::Evm(EthereumAddress(*addr)),
+            &config_gas_token_id(),
+            None,
+        )
+        .await
+        .unwrap_or_else(|err| {
+            let err_string = err.to_string();
+            if err_string.contains("404 Not Found") {
+                Amount::ZERO
+            } else {
+                panic!("Error from server: {err_string}");
+            }
+        });
+
+    assert_eq!(
+        Amount::ZERO,
+        balance,
+        "Sender {addr} should have zero balance in those tests, self-check"
+    );
+}
+
 async fn assert_simulation_rejects<T: DeserializeOwned + std::fmt::Debug>(
     client: &SimpleStorageClient,
     request: &TransactionRequest,
@@ -140,7 +169,9 @@ async fn paymaster_simulation_succeeds_without_fee_fields() -> anyhow::Result<()
 // gasPrice set → paymaster covers sender, simulation succeeds
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_with_gas_price() -> anyhow::Result<()> {
-    let (_rollup, client, addr) = setup_paymaster_client().await;
+    let (rollup, client, addr) = setup_paymaster_client().await;
+
+    assert_zero_balance(&rollup.client, &addr).await;
 
     let request = TransactionRequest {
         gas_price: Some(MAX_FEE_PER_GAS),
@@ -154,7 +185,9 @@ async fn paymaster_simulation_succeeds_with_gas_price() -> anyhow::Result<()> {
 // maxFeePerGas set → paymaster covers sender, simulation succeeds
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_with_max_fee_per_gas() -> anyhow::Result<()> {
-    let (_rollup, client, addr) = setup_paymaster_client().await;
+    let (rollup, client, addr) = setup_paymaster_client().await;
+
+    assert_zero_balance(&rollup.client, &addr).await;
 
     let request = TransactionRequest {
         max_fee_per_gas: Some(MAX_FEE_PER_GAS),
@@ -169,7 +202,9 @@ async fn paymaster_simulation_succeeds_with_max_fee_per_gas() -> anyhow::Result<
 // Both gasPrice and maxFeePerGas → conflicting fields error
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_rejects_with_conflicting_fee_fields() -> anyhow::Result<()> {
-    let (_rollup, client, addr) = setup_paymaster_client().await;
+    let (rollup, client, addr) = setup_paymaster_client().await;
+
+    assert_zero_balance(&rollup.client, &addr).await;
 
     let request = TransactionRequest {
         gas_price: Some(MAX_FEE_PER_GAS),
@@ -189,7 +224,9 @@ async fn paymaster_simulation_rejects_with_conflicting_fee_fields() -> anyhow::R
 // gasPrice set, gas omitted → paymaster covers sender, simulation succeeds
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_with_gas_price_gas_omitted() -> anyhow::Result<()> {
-    let (_rollup, client, addr) = setup_paymaster_client().await;
+    let (rollup, client, addr) = setup_paymaster_client().await;
+
+    assert_zero_balance(&rollup.client, &addr).await;
 
     let request = TransactionRequest {
         gas: None,
@@ -204,7 +241,9 @@ async fn paymaster_simulation_succeeds_with_gas_price_gas_omitted() -> anyhow::R
 // maxFeePerGas set, gas omitted → paymaster covers sender, simulation succeeds
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_with_max_fee_per_gas_gas_omitted() -> anyhow::Result<()> {
-    let (_rollup, client, addr) = setup_paymaster_client().await;
+    let (rollup, client, addr) = setup_paymaster_client().await;
+
+    assert_zero_balance(&rollup.client, &addr).await;
 
     let request = TransactionRequest {
         gas: None,
@@ -221,6 +260,8 @@ async fn paymaster_simulation_succeeds_with_max_fee_per_gas_gas_omitted() -> any
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_send_raw_tx_succeeds() -> anyhow::Result<()> {
     let (rollup, client, addr) = setup_paymaster_client().await;
+
+    assert_zero_balance(&rollup.client, &addr).await;
 
     // Simulation should succeed for paymaster-covered sender.
     let request = TransactionRequest {

--- a/examples/demo-rollup/tests/evm/evm_paymaster_balance_check.rs
+++ b/examples/demo-rollup/tests/evm/evm_paymaster_balance_check.rs
@@ -13,12 +13,10 @@ use sov_test_utils::test_rollup::TestRollup;
 
 use crate::evm::evm_test_helper::{
     create_simple_storage_client, raw_signed_eip1559, rpc_call, rpc_result_hex,
-    setup_test_rollup_with_paymaster, tx_count, EVM_EXTENSION, INSUFFICIENT_FUNDS_ERROR,
-    MAX_FEE_PER_GAS, SENDER_PRIV_KEY,
+    setup_test_rollup_with_paymaster, tx_count, EVM_EXTENSION, MAX_FEE_PER_GAS, SENDER_PRIV_KEY,
 };
 
 const GAS_LIMIT: u64 = 21_000;
-const GAS_REQUIRED_EXCEEDS_ALLOWANCE_ERROR: &str = "gas required exceeds allowance";
 
 /// Hardhat #4: 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65
 /// Not in any genesis → starts with zero EVM balance, but covered by the paymaster.
@@ -64,41 +62,71 @@ fn base_request(from: Address) -> TransactionRequest {
     }
 }
 
+#[derive(Debug, Clone)]
+struct CombinedErrors {
+    estimate_gas_error: String,
+    call_error: String,
+}
+
+async fn get_consistent_response(
+    client: &SimpleStorageClient,
+    request: &TransactionRequest,
+) -> Result<(), CombinedErrors> {
+    let eth_estimate_gas_result: Result<U64, _> = client
+        .ws
+        .request("eth_estimateGas", rpc_params![request, "latest"])
+        .await;
+
+    let eth_call_result: Result<String, _> = client
+        .ws
+        .request("eth_call", rpc_params![request, "latest"])
+        .await;
+
+    match (eth_estimate_gas_result, eth_call_result) {
+        (Ok(_), Ok(_)) => Ok(()),
+        (Err(estimate_gas_error), Err(call_err)) => Err(CombinedErrors {
+            estimate_gas_error: estimate_gas_error.to_string(),
+            call_error: call_err.to_string(),
+        }),
+        (Ok(_), Err(call_err)) => {
+            panic!("eth_estimateGas succeeded, but eth_call failed with {call_err}")
+        }
+        (Err(estimate_gas_err), Ok(_)) => {
+            panic!("eth_call succeeded, but eth_estimateGas failed with {estimate_gas_err}")
+        }
+    }
+}
+
 async fn assert_simulation_rejects<T: DeserializeOwned + std::fmt::Debug>(
     client: &SimpleStorageClient,
     request: &TransactionRequest,
     expected_error_substring: &str,
 ) {
-    for method in ["eth_call", "eth_estimateGas"] {
-        let result: Result<T, _> = client
-            .ws
-            .request(method, rpc_params![request, "latest"])
-            .await;
-        let err = result.expect_err(&format!("{method} should reject this request"));
-        let err_msg = err.to_string();
-        assert!(
-            err_msg.contains(expected_error_substring),
-            "{method}: expected error containing {expected_error_substring:?}, got: {err_msg}"
-        );
-    }
+    let combined_err = get_consistent_response(client, request)
+        .await
+        .expect_err("Request should be rejected");
+
+    assert!(
+        combined_err.call_error.contains(expected_error_substring),
+        "eth_call: expected error containing {expected_error_substring:?}, got: {}",
+        combined_err.call_error,
+    );
+    assert!(
+        combined_err
+            .estimate_gas_error
+            .contains(expected_error_substring),
+        "eth_estimateGas: expected error containing {expected_error_substring:?}, got: {}",
+        combined_err.estimate_gas_error
+    );
 }
 
 async fn assert_simulation_succeeds(client: &SimpleStorageClient, request: &TransactionRequest) {
-    let _: String = client
-        .ws
-        .request("eth_call", rpc_params![request, "latest"])
+    get_consistent_response(client, request)
         .await
-        .expect("eth_call must succeed");
-
-    let _: U64 = client
-        .ws
-        .request("eth_estimateGas", rpc_params![request, "latest"])
-        .await
-        .expect("eth_estimateGas must succeed");
+        .expect("Requests should be accepted");
 }
 
-// ── Test 1: No fee fields → balance check skipped ──
-
+// No fee fields → balance check skipped
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_without_fee_fields() -> anyhow::Result<()> {
     let (_rollup, client, addr) = setup_paymaster_client().await;
@@ -109,25 +137,23 @@ async fn paymaster_simulation_succeeds_without_fee_fields() -> anyhow::Result<()
     Ok(())
 }
 
-// ── Test 2: gasPrice set → balance check fires, rejects zero-balance sender ──
-
+// gasPrice set → paymaster covers sender, simulation succeeds
 #[tokio::test(flavor = "multi_thread")]
-async fn paymaster_simulation_rejects_with_gas_price() -> anyhow::Result<()> {
+async fn paymaster_simulation_succeeds_with_gas_price() -> anyhow::Result<()> {
     let (_rollup, client, addr) = setup_paymaster_client().await;
 
     let request = TransactionRequest {
         gas_price: Some(MAX_FEE_PER_GAS),
         ..base_request(addr)
     };
-    assert_simulation_rejects::<String>(&client, &request, INSUFFICIENT_FUNDS_ERROR).await;
+    assert_simulation_succeeds(&client, &request).await;
 
     Ok(())
 }
 
-// ── Test 3: maxFeePerGas set → balance check fires, rejects zero-balance sender ──
-
+// maxFeePerGas set → paymaster covers sender, simulation succeeds
 #[tokio::test(flavor = "multi_thread")]
-async fn paymaster_simulation_rejects_with_max_fee_per_gas() -> anyhow::Result<()> {
+async fn paymaster_simulation_succeeds_with_max_fee_per_gas() -> anyhow::Result<()> {
     let (_rollup, client, addr) = setup_paymaster_client().await;
 
     let request = TransactionRequest {
@@ -135,13 +161,12 @@ async fn paymaster_simulation_rejects_with_max_fee_per_gas() -> anyhow::Result<(
         max_priority_fee_per_gas: Some(0),
         ..base_request(addr)
     };
-    assert_simulation_rejects::<String>(&client, &request, INSUFFICIENT_FUNDS_ERROR).await;
+    assert_simulation_succeeds(&client, &request).await;
 
     Ok(())
 }
 
-// ── Test 4: Both gasPrice and maxFeePerGas → conflicting fields error ──
-
+// Both gasPrice and maxFeePerGas → conflicting fields error
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_rejects_with_conflicting_fee_fields() -> anyhow::Result<()> {
     let (_rollup, client, addr) = setup_paymaster_client().await;
@@ -161,10 +186,9 @@ async fn paymaster_simulation_rejects_with_conflicting_fee_fields() -> anyhow::R
     Ok(())
 }
 
-// ── Test 5: gasPrice set, gas omitted → affordable gas < 21000, exceeds allowance ──
-
+// gasPrice set, gas omitted → paymaster covers sender, simulation succeeds
 #[tokio::test(flavor = "multi_thread")]
-async fn paymaster_simulation_rejects_with_gas_price_gas_omitted() -> anyhow::Result<()> {
+async fn paymaster_simulation_succeeds_with_gas_price_gas_omitted() -> anyhow::Result<()> {
     let (_rollup, client, addr) = setup_paymaster_client().await;
 
     let request = TransactionRequest {
@@ -172,15 +196,14 @@ async fn paymaster_simulation_rejects_with_gas_price_gas_omitted() -> anyhow::Re
         gas_price: Some(MAX_FEE_PER_GAS),
         ..base_request(addr)
     };
-    assert_simulation_rejects::<U64>(&client, &request, GAS_REQUIRED_EXCEEDS_ALLOWANCE_ERROR).await;
+    assert_simulation_succeeds(&client, &request).await;
 
     Ok(())
 }
 
-// ── Test 6: maxFeePerGas set, gas omitted → affordable gas < 21000, exceeds allowance ──
-
+// maxFeePerGas set, gas omitted → paymaster covers sender, simulation succeeds
 #[tokio::test(flavor = "multi_thread")]
-async fn paymaster_simulation_rejects_with_max_fee_per_gas_gas_omitted() -> anyhow::Result<()> {
+async fn paymaster_simulation_succeeds_with_max_fee_per_gas_gas_omitted() -> anyhow::Result<()> {
     let (_rollup, client, addr) = setup_paymaster_client().await;
 
     let request = TransactionRequest {
@@ -189,35 +212,31 @@ async fn paymaster_simulation_rejects_with_max_fee_per_gas_gas_omitted() -> anyh
         max_priority_fee_per_gas: Some(0),
         ..base_request(addr)
     };
-    assert_simulation_rejects::<U64>(&client, &request, GAS_REQUIRED_EXCEEDS_ALLOWANCE_ERROR).await;
+    assert_simulation_succeeds(&client, &request).await;
 
     Ok(())
 }
 
-// ── Test 7: Simulation rejects but sendRawTransaction succeeds (key discrepancy) ──
-
+// Test 7: Simulation succeeds and sendRawTransaction succeeds
 #[tokio::test(flavor = "multi_thread")]
-async fn paymaster_send_raw_tx_succeeds_despite_simulation_rejection() -> anyhow::Result<()> {
+async fn paymaster_send_raw_tx_succeeds() -> anyhow::Result<()> {
     let (rollup, client, addr) = setup_paymaster_client().await;
 
-    // First, confirm simulation rejects with fee fields.
+    // Simulation should succeed for paymaster-covered sender.
     let request = TransactionRequest {
         max_fee_per_gas: Some(MAX_FEE_PER_GAS),
         max_priority_fee_per_gas: Some(0),
         ..base_request(addr)
     };
-    let estimate_result: Result<U64, _> = client
-        .ws
-        .request("eth_estimateGas", rpc_params![&request, "latest"])
-        .await;
-    let err = estimate_result
-        .expect_err("eth_estimateGas should reject zero-balance sender with fee fields");
-    assert!(
-        err.to_string().contains(INSUFFICIENT_FUNDS_ERROR),
-        "expected insufficient funds error, got: {err}"
-    );
+    assert_simulation_succeeds(&client, &request).await;
 
-    // Now send a real signed tx — sendRawTransaction goes through the mempool/STF
+    // Use base_fee * 2 as a reasonable fee the paymaster's SOV bank can afford.
+    let base_fee: U256 = client.ws.request("eth_gasPrice", rpc_params![]).await?;
+    let base_fee_u128: u128 = base_fee.to::<u128>();
+    assert!(base_fee_u128 > 0, "base fee should be non-zero");
+    let reasonable_max_fee = base_fee_u128 * 2;
+
+    // Send a real signed tx — sendRawTransaction goes through the mempool/STF
     // path which IS paymaster-aware.
     let paymaster_signer: PrivateKeySigner = PAYMASTER_SIGNER_PRIV_KEY.parse()?;
     let chain_id: U64 = client.ws.request("eth_chainId", rpc_params![]).await?;
@@ -231,7 +250,7 @@ async fn paymaster_send_raw_tx_succeeds_despite_simulation_rejection() -> anyhow
         TxKind::Call(Address::ZERO),
         U256::ZERO,
         Bytes::new(),
-        MAX_FEE_PER_GAS,
+        reasonable_max_fee,
         0,
     )
     .await?;

--- a/examples/demo-rollup/tests/evm/evm_paymaster_balance_check.rs
+++ b/examples/demo-rollup/tests/evm/evm_paymaster_balance_check.rs
@@ -1,11 +1,9 @@
 use alloy::signers::local::PrivateKeySigner;
-use alloy_primitives::{Address, Bytes, TxKind, B256, U256, U64};
-use alloy_rpc_types_eth::TransactionRequest;
+use alloy_primitives::{Address, B256, U256, U64};
+use alloy_rpc_types_eth::{AccessListResult, TransactionRequest};
 use demo_stf::MultiAddressEvmSolana;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::rpc_params;
-use reqwest::Client;
-use serde_json::json;
 use sov_address::EthereumAddress;
 use sov_bank::config_gas_token_id;
 use sov_demo_rollup::{MockDemoRollup, MockRollupSpec};
@@ -15,8 +13,8 @@ use sov_modules_api::Amount;
 use sov_test_utils::test_rollup::TestRollup;
 
 use crate::evm::evm_test_helper::{
-    create_simple_storage_client, raw_signed_eip1559, rpc_call, rpc_result_hex,
-    setup_test_rollup_with_paymaster, tx_count, EVM_EXTENSION, MAX_FEE_PER_GAS, SENDER_PRIV_KEY,
+    create_simple_storage_client, raw_signed_eip1559, setup_test_rollup_with_paymaster, tx_count,
+    EVM_EXTENSION, MAX_FEE_PER_GAS, SENDER_PRIV_KEY,
 };
 
 // 1_000_000 rather than the minimal 21_000 because state-access charges push the
@@ -85,7 +83,7 @@ async fn setup_paymaster_client() -> (
 fn base_request(from: Address) -> TransactionRequest {
     TransactionRequest {
         from: Some(from),
-        to: Some(TxKind::Call(Address::ZERO)),
+        to: Some(Address::ZERO.into()),
         gas: Some(GAS_LIMIT),
         value: Some(U256::ZERO),
         ..Default::default()
@@ -93,15 +91,34 @@ fn base_request(from: Address) -> TransactionRequest {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
+struct GasValues {
+    estimate_gas: u64,
+    create_access_list_gas: u64,
+    receipt_gas_used: u64,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
 struct CombinedErrors {
     estimate_gas_error: String,
     call_error: String,
+    create_access_list_error: String,
+    send_raw_tx_error: String,
 }
 
+/// Calls `eth_estimateGas`, `eth_call`, `eth_createAccessList`, and
+/// `eth_sendRawTransaction` with the same request parameters and asserts they
+/// all agree (all succeed or all fail).
+///
+/// On the success path, compares gas values across endpoints and verifies that
+/// the receipt gas is within the estimate.
 async fn get_consistent_response(
     client: &SimpleStorageClient,
     request: &TransactionRequest,
-) -> Result<(), CombinedErrors> {
+    signer: &PrivateKeySigner,
+) -> Result<GasValues, CombinedErrors> {
+    // Step 1: 3 simulation calls
     let eth_estimate_gas_result: Result<U64, _> = client
         .ws
         .request("eth_estimateGas", rpc_params![request, "latest"])
@@ -112,62 +129,147 @@ async fn get_consistent_response(
         .request("eth_call", rpc_params![request, "latest"])
         .await;
 
-    match (eth_estimate_gas_result, eth_call_result) {
-        (Ok(_), Ok(_)) => Ok(()),
-        (Err(estimate_gas_error), Err(call_err)) => Err(CombinedErrors {
-            estimate_gas_error: estimate_gas_error.to_string(),
-            call_error: call_err.to_string(),
-        }),
-        (Ok(_), Err(call_err)) => {
-            panic!("eth_estimateGas succeeded, but eth_call failed with {call_err}")
+    let access_list_result: Result<AccessListResult, _> = client
+        .ws
+        .request("eth_createAccessList", rpc_params![request, "latest"])
+        .await;
+
+    // Normalize eth_createAccessList: the RPC call itself may succeed but return
+    // an error in the `error` field of the response.
+    let access_list_result: Result<AccessListResult, String> = match access_list_result {
+        Ok(alr) if alr.error.is_some() => Err(alr.error.unwrap()),
+        Ok(alr) => Ok(alr),
+        Err(e) => Err(e.to_string()),
+    };
+
+    // Step 2: Build and send raw tx
+    let chain_id: U64 = client
+        .ws
+        .request("eth_chainId", rpc_params![])
+        .await
+        .unwrap();
+    let nonce = tx_count(client, signer.address(), "latest").await.unwrap();
+
+    let gas = request.gas.unwrap_or(GAS_LIMIT);
+    let value = request.value.unwrap_or(U256::ZERO);
+    let max_priority_fee = request.max_priority_fee_per_gas.unwrap_or(0);
+    let max_fee = request.gas_price.or(request.max_fee_per_gas).unwrap_or(0);
+    let to = request.to.unwrap_or(alloy_primitives::TxKind::Create);
+    let input = request.input.input.clone().unwrap_or_default();
+
+    let raw_tx = raw_signed_eip1559(
+        signer,
+        chain_id.to::<u64>(),
+        nonce,
+        gas,
+        to,
+        value,
+        input,
+        max_fee,
+        max_priority_fee,
+    )
+    .await
+    .unwrap();
+
+    let send_raw_tx_result: Result<B256, _> = client
+        .ws
+        .request("eth_sendRawTransaction", rpc_params![&raw_tx])
+        .await;
+
+    // Step 3: Return
+    match (
+        &eth_estimate_gas_result,
+        &eth_call_result,
+        &access_list_result,
+        &send_raw_tx_result,
+    ) {
+        (Ok(estimate_gas), Ok(_), Ok(access_list), Ok(tx_hash)) => {
+            let estimate_gas = estimate_gas.to::<u64>();
+            let create_access_list_gas = access_list.gas_used.to::<u64>();
+
+            assert!(
+                estimate_gas >= create_access_list_gas,
+                "eth_estimateGas ({estimate_gas}) should be >= eth_createAccessList gas ({create_access_list_gas})"
+            );
+
+            let receipt = client.wait_for_receipt(*tx_hash).await;
+            assert!(
+                receipt.status(),
+                "transaction should succeed when paymaster covers gas"
+            );
+
+            let receipt_gas_used = receipt.gas_used;
+            assert!(
+                estimate_gas >= receipt_gas_used,
+                "eth_estimateGas ({estimate_gas}) should be >= receipt gas_used ({receipt_gas_used})"
+            );
+
+            Ok(GasValues {
+                estimate_gas,
+                create_access_list_gas,
+                receipt_gas_used,
+            })
         }
-        (Err(estimate_gas_err), Ok(_)) => {
-            panic!("eth_call succeeded, but eth_estimateGas failed with {estimate_gas_err}")
+        (Err(estimate_err), Err(call_err), Err(access_list_err), Err(send_err)) => {
+            Err(CombinedErrors {
+                estimate_gas_error: estimate_err.to_string(),
+                call_error: call_err.to_string(),
+                create_access_list_error: access_list_err.to_string(),
+                send_raw_tx_error: send_err.to_string(),
+            })
+        }
+        // The consistency check above already panics on mismatch, so this is unreachable.
+        _ => {
+            panic!(
+                "Endpoints disagree!\n  \
+             eth_estimateGas: {eth_estimate_gas_result:?}\n  \
+             eth_call: {eth_call_result:?}\n  \
+             eth_createAccessList: {access_list_result:?}\n  \
+             eth_sendRawTransaction: {send_raw_tx_result:?}"
+            );
         }
     }
 }
 
-async fn assert_simulation_rejects(
+async fn assert_simulation_succeeds(
     client: &SimpleStorageClient,
     request: &TransactionRequest,
-    expected_error_substring: &str,
+    signer: &PrivateKeySigner,
 ) {
-    let combined_err = get_consistent_response(client, request)
-        .await
-        .expect_err("Request should be rejected");
-
-    assert!(
-        combined_err.call_error.contains(expected_error_substring),
-        "eth_call: expected error containing {expected_error_substring:?}, got: {}",
-        combined_err.call_error,
-    );
-    assert!(
-        combined_err
-            .estimate_gas_error
-            .contains(expected_error_substring),
-        "eth_estimateGas: expected error containing {expected_error_substring:?}, got: {}",
-        combined_err.estimate_gas_error
-    );
-}
-
-async fn assert_simulation_succeeds(client: &SimpleStorageClient, request: &TransactionRequest) {
-    get_consistent_response(client, request)
+    get_consistent_response(client, request, signer)
         .await
         .expect("Requests should be accepted");
 }
 
-// No fee fields → balance check skipped
+// No fee fields → balance check skipped (simulation only — signed tx with max_fee=0 would fail)
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_without_fee_fields() -> anyhow::Result<()> {
     let (_rollup, client, addr) = setup_paymaster_client().await;
 
     let request = base_request(addr);
-    assert_simulation_succeeds(&client, &request).await;
+
+    let _: U64 = client
+        .ws
+        .request("eth_estimateGas", rpc_params![&request, "latest"])
+        .await?;
+    let _: String = client
+        .ws
+        .request("eth_call", rpc_params![&request, "latest"])
+        .await?;
+    let access_list: AccessListResult = client
+        .ws
+        .request("eth_createAccessList", rpc_params![&request, "latest"])
+        .await?;
+    assert!(
+        access_list.error.is_none(),
+        "eth_createAccessList returned error: {:?}",
+        access_list.error
+    );
 
     Ok(())
 }
 
-// gasPrice set → paymaster covers sender, simulation succeeds
+// gasPrice set → paymaster covers sender, all 4 endpoints succeed
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_with_gas_price() -> anyhow::Result<()> {
     let (_rollup, client, addr) = setup_paymaster_client().await;
@@ -176,12 +278,13 @@ async fn paymaster_simulation_succeeds_with_gas_price() -> anyhow::Result<()> {
         gas_price: Some(MAX_FEE_PER_GAS),
         ..base_request(addr)
     };
-    assert_simulation_succeeds(&client, &request).await;
+    let signer: PrivateKeySigner = PAYMASTER_SIGNER_PRIV_KEY.parse()?;
+    assert_simulation_succeeds(&client, &request, &signer).await;
 
     Ok(())
 }
 
-// maxFeePerGas set → paymaster covers sender, simulation succeeds
+// maxFeePerGas set → paymaster covers sender, all 4 endpoints succeed
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_with_max_fee_per_gas() -> anyhow::Result<()> {
     let (_rollup, client, addr) = setup_paymaster_client().await;
@@ -191,12 +294,14 @@ async fn paymaster_simulation_succeeds_with_max_fee_per_gas() -> anyhow::Result<
         max_priority_fee_per_gas: Some(0),
         ..base_request(addr)
     };
-    assert_simulation_succeeds(&client, &request).await;
+    let signer: PrivateKeySigner = PAYMASTER_SIGNER_PRIV_KEY.parse()?;
+    assert_simulation_succeeds(&client, &request, &signer).await;
 
     Ok(())
 }
 
 // Both gasPrice and maxFeePerGas → conflicting fields error
+// (simulation only — signed EIP-1559 can't express conflicting fields)
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_rejects_with_conflicting_fee_fields() -> anyhow::Result<()> {
     let (_rollup, client, addr) = setup_paymaster_client().await;
@@ -206,17 +311,47 @@ async fn paymaster_simulation_rejects_with_conflicting_fee_fields() -> anyhow::R
         max_fee_per_gas: Some(MAX_FEE_PER_GAS),
         ..base_request(addr)
     };
-    assert_simulation_rejects(
-        &client,
-        &request,
-        "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified",
-    )
-    .await;
+
+    let expected = "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified";
+
+    let estimate_err = client
+        .ws
+        .request::<U64, _>("eth_estimateGas", rpc_params![&request, "latest"])
+        .await
+        .unwrap_err();
+    assert!(
+        estimate_err.to_string().contains(expected),
+        "eth_estimateGas: expected error containing {expected:?}, got: {estimate_err}"
+    );
+
+    let call_err = client
+        .ws
+        .request::<String, _>("eth_call", rpc_params![&request, "latest"])
+        .await
+        .unwrap_err();
+    assert!(
+        call_err.to_string().contains(expected),
+        "eth_call: expected error containing {expected:?}, got: {call_err}"
+    );
+
+    let access_list_result: Result<AccessListResult, _> = client
+        .ws
+        .request("eth_createAccessList", rpc_params![&request, "latest"])
+        .await;
+    let access_list_err = match access_list_result {
+        Ok(alr) if alr.error.is_some() => alr.error.unwrap(),
+        Ok(_) => panic!("eth_createAccessList should fail for conflicting fee fields"),
+        Err(e) => e.to_string(),
+    };
+    assert!(
+        access_list_err.contains(expected),
+        "eth_createAccessList: expected error containing {expected:?}, got: {access_list_err}"
+    );
 
     Ok(())
 }
 
-// gasPrice set, gas omitted → paymaster covers sender, simulation succeeds
+// gasPrice set, gas omitted → paymaster covers sender, all 4 endpoints succeed
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_with_gas_price_gas_omitted() -> anyhow::Result<()> {
     let (_rollup, client, addr) = setup_paymaster_client().await;
@@ -226,12 +361,13 @@ async fn paymaster_simulation_succeeds_with_gas_price_gas_omitted() -> anyhow::R
         gas_price: Some(MAX_FEE_PER_GAS),
         ..base_request(addr)
     };
-    assert_simulation_succeeds(&client, &request).await;
+    let signer: PrivateKeySigner = PAYMASTER_SIGNER_PRIV_KEY.parse()?;
+    assert_simulation_succeeds(&client, &request, &signer).await;
 
     Ok(())
 }
 
-// maxFeePerGas set, gas omitted → paymaster covers sender, simulation succeeds
+// maxFeePerGas set, gas omitted → paymaster covers sender, all 4 endpoints succeed
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_with_max_fee_per_gas_gas_omitted() -> anyhow::Result<()> {
     let (_rollup, client, addr) = setup_paymaster_client().await;
@@ -242,7 +378,8 @@ async fn paymaster_simulation_succeeds_with_max_fee_per_gas_gas_omitted() -> any
         max_priority_fee_per_gas: Some(0),
         ..base_request(addr)
     };
-    assert_simulation_succeeds(&client, &request).await;
+    let signer: PrivateKeySigner = PAYMASTER_SIGNER_PRIV_KEY.parse()?;
+    assert_simulation_succeeds(&client, &request, &signer).await;
 
     Ok(())
 }
@@ -250,15 +387,7 @@ async fn paymaster_simulation_succeeds_with_max_fee_per_gas_gas_omitted() -> any
 // Simulation + sendRawTransaction both succeed for paymaster-covered sender
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_send_raw_tx_succeeds() -> anyhow::Result<()> {
-    let (rollup, client, addr) = setup_paymaster_client().await;
-
-    // Simulation should succeed for paymaster-covered sender.
-    let request = TransactionRequest {
-        max_fee_per_gas: Some(MAX_FEE_PER_GAS),
-        max_priority_fee_per_gas: Some(0),
-        ..base_request(addr)
-    };
-    assert_simulation_succeeds(&client, &request).await;
+    let (_rollup, client, addr) = setup_paymaster_client().await;
 
     // Use base_fee * 2 as a reasonable fee the paymaster's SOV bank can afford.
     let base_fee: U256 = client.ws.request("eth_gasPrice", rpc_params![]).await?;
@@ -266,44 +395,16 @@ async fn paymaster_send_raw_tx_succeeds() -> anyhow::Result<()> {
     assert!(base_fee_u128 > 0, "base fee should be non-zero");
     let reasonable_max_fee = base_fee_u128 * 2;
 
-    // Send a real signed tx — sendRawTransaction goes through the mempool/STF
-    // path which IS paymaster-aware.
-    let paymaster_signer: PrivateKeySigner = PAYMASTER_SIGNER_PRIV_KEY.parse()?;
-    let chain_id: U64 = client.ws.request("eth_chainId", rpc_params![]).await?;
-    let nonce = tx_count(&client, addr, "latest").await?;
+    let request = TransactionRequest {
+        max_fee_per_gas: Some(reasonable_max_fee),
+        max_priority_fee_per_gas: Some(0),
+        ..base_request(addr)
+    };
 
-    let raw_tx = raw_signed_eip1559(
-        &paymaster_signer,
-        chain_id.to::<u64>(),
-        nonce,
-        GAS_LIMIT,
-        TxKind::Call(Address::ZERO),
-        U256::ZERO,
-        Bytes::new(),
-        reasonable_max_fee,
-        0,
-    )
-    .await?;
-
-    let http = Client::new();
-    let send_response = rpc_call(
-        &http,
-        rollup.http_addr,
-        "eth_sendRawTransaction",
-        json!([raw_tx]),
-    )
-    .await?;
-    assert!(
-        send_response.get("error").is_none(),
-        "sendRawTransaction should succeed for paymaster-covered sender: {send_response}"
-    );
-
-    let tx_hash: B256 = rpc_result_hex(&send_response).parse()?;
-    let receipt = client.wait_for_receipt(tx_hash).await;
-    assert!(
-        receipt.status(),
-        "transaction should succeed when paymaster covers gas"
-    );
+    let signer: PrivateKeySigner = PAYMASTER_SIGNER_PRIV_KEY.parse()?;
+    get_consistent_response(&client, &request, &signer)
+        .await
+        .expect("Simulation + sendRawTransaction should both succeed for paymaster-covered sender");
 
     Ok(())
 }

--- a/examples/demo-rollup/tests/evm/evm_paymaster_balance_check.rs
+++ b/examples/demo-rollup/tests/evm/evm_paymaster_balance_check.rs
@@ -19,12 +19,9 @@ use crate::evm::evm_test_helper::{
     setup_test_rollup_with_paymaster, tx_count, EVM_EXTENSION, MAX_FEE_PER_GAS, SENDER_PRIV_KEY,
 };
 
-// max_fee = gas_limit * multiplier * sum(gas_price dimensions)
-//         = 21_000 * 1 * (9 + 9) = 378,000 SOV
-//
-// A simple ETH transfer costs ~430,000 SOV in state accesses, exceeding this budget.
-// The working paymaster test in evm_rpc_compliance_validation_2.rs:1150 uses
-// gas_limit = 1_000_000 for exactly this reason.
+// 1_000_000 rather than the minimal 21_000 because state-access charges push the
+// real cost of a simple ETH transfer to ~430k SOV (21_000 * 1 * (9+9) = 378k is
+// already insufficient).
 const GAS_LIMIT: u64 = 1_000_000;
 
 /// Hardhat #4: 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65
@@ -66,6 +63,8 @@ async fn setup_paymaster_client() -> (
             None,
         )
         .await
+        // The balance endpoint returns 404 when an account has never been seen.
+        // Treat that as zero; propagate any other error.
         .unwrap_or_else(|err| {
             let err_string = err.to_string();
             if err_string.contains("404 Not Found") {
@@ -75,8 +74,8 @@ async fn setup_paymaster_client() -> (
             }
         });
     assert_eq!(
-        Amount::ZERO,
         rollup_balance,
+        Amount::ZERO,
         "test precondition failed: paymaster signer must start with zero rollup gas-token balance"
     );
 
@@ -93,7 +92,7 @@ fn base_request(from: Address) -> TransactionRequest {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct CombinedErrors {
     estimate_gas_error: String,
     call_error: String,
@@ -248,7 +247,7 @@ async fn paymaster_simulation_succeeds_with_max_fee_per_gas_gas_omitted() -> any
     Ok(())
 }
 
-// Test 7: Simulation succeeds and sendRawTransaction succeeds
+// Simulation + sendRawTransaction both succeed for paymaster-covered sender
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_send_raw_tx_succeeds() -> anyhow::Result<()> {
     let (rollup, client, addr) = setup_paymaster_client().await;

--- a/examples/demo-rollup/tests/evm/evm_paymaster_balance_check.rs
+++ b/examples/demo-rollup/tests/evm/evm_paymaster_balance_check.rs
@@ -1,0 +1,260 @@
+use alloy::signers::local::PrivateKeySigner;
+use alloy_primitives::{Address, Bytes, TxKind, B256, U256, U64};
+use alloy_rpc_types_eth::TransactionRequest;
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::rpc_params;
+use reqwest::Client;
+use serde::de::DeserializeOwned;
+use serde_json::json;
+use sov_demo_rollup::MockDemoRollup;
+use sov_eth_client::SimpleStorageClient;
+use sov_modules_api::execution_mode::Native;
+use sov_test_utils::test_rollup::TestRollup;
+
+use crate::evm::evm_test_helper::{
+    create_simple_storage_client, raw_signed_eip1559, rpc_call, rpc_result_hex,
+    setup_test_rollup_with_paymaster, tx_count, EVM_EXTENSION, INSUFFICIENT_FUNDS_ERROR,
+    MAX_FEE_PER_GAS, SENDER_PRIV_KEY,
+};
+
+const GAS_LIMIT: u64 = 21_000;
+const GAS_REQUIRED_EXCEEDS_ALLOWANCE_ERROR: &str = "gas required exceeds allowance";
+
+/// Hardhat #4: 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65
+/// Not in any genesis → starts with zero EVM balance, but covered by the paymaster.
+const PAYMASTER_SIGNER_PRIV_KEY: &str =
+    "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a";
+
+fn paymaster_address() -> Address {
+    let signer: PrivateKeySigner = PAYMASTER_SIGNER_PRIV_KEY.parse().unwrap();
+    signer.address()
+}
+
+async fn setup_paymaster_client() -> (
+    TestRollup<MockDemoRollup<Native>>,
+    SimpleStorageClient,
+    Address,
+) {
+    let rollup = setup_test_rollup_with_paymaster(0, EVM_EXTENSION).await;
+    rollup.wait_for_rollup_height_advance_by(1).await;
+    let client = create_simple_storage_client(rollup.http_addr, SENDER_PRIV_KEY).await;
+
+    let addr = paymaster_address();
+    let balance: U256 = client
+        .ws
+        .request("eth_getBalance", rpc_params![addr, "latest"])
+        .await
+        .unwrap();
+    assert_eq!(
+        balance,
+        U256::ZERO,
+        "test precondition failed: paymaster signer must start with zero EVM balance"
+    );
+
+    (rollup, client, addr)
+}
+
+fn base_request(from: Address) -> TransactionRequest {
+    TransactionRequest {
+        from: Some(from),
+        to: Some(TxKind::Call(Address::ZERO)),
+        gas: Some(GAS_LIMIT),
+        value: Some(U256::ZERO),
+        ..Default::default()
+    }
+}
+
+async fn assert_simulation_rejects<T: DeserializeOwned + std::fmt::Debug>(
+    client: &SimpleStorageClient,
+    request: &TransactionRequest,
+    expected_error_substring: &str,
+) {
+    for method in ["eth_call", "eth_estimateGas"] {
+        let result: Result<T, _> = client
+            .ws
+            .request(method, rpc_params![request, "latest"])
+            .await;
+        let err = result.expect_err(&format!("{method} should reject this request"));
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains(expected_error_substring),
+            "{method}: expected error containing {expected_error_substring:?}, got: {err_msg}"
+        );
+    }
+}
+
+async fn assert_simulation_succeeds(client: &SimpleStorageClient, request: &TransactionRequest) {
+    let _: String = client
+        .ws
+        .request("eth_call", rpc_params![request, "latest"])
+        .await
+        .expect("eth_call must succeed");
+
+    let _: U64 = client
+        .ws
+        .request("eth_estimateGas", rpc_params![request, "latest"])
+        .await
+        .expect("eth_estimateGas must succeed");
+}
+
+// ── Test 1: No fee fields → balance check skipped ──
+
+#[tokio::test(flavor = "multi_thread")]
+async fn paymaster_simulation_succeeds_without_fee_fields() -> anyhow::Result<()> {
+    let (_rollup, client, addr) = setup_paymaster_client().await;
+
+    let request = base_request(addr);
+    assert_simulation_succeeds(&client, &request).await;
+
+    Ok(())
+}
+
+// ── Test 2: gasPrice set → balance check fires, rejects zero-balance sender ──
+
+#[tokio::test(flavor = "multi_thread")]
+async fn paymaster_simulation_rejects_with_gas_price() -> anyhow::Result<()> {
+    let (_rollup, client, addr) = setup_paymaster_client().await;
+
+    let request = TransactionRequest {
+        gas_price: Some(MAX_FEE_PER_GAS),
+        ..base_request(addr)
+    };
+    assert_simulation_rejects::<String>(&client, &request, INSUFFICIENT_FUNDS_ERROR).await;
+
+    Ok(())
+}
+
+// ── Test 3: maxFeePerGas set → balance check fires, rejects zero-balance sender ──
+
+#[tokio::test(flavor = "multi_thread")]
+async fn paymaster_simulation_rejects_with_max_fee_per_gas() -> anyhow::Result<()> {
+    let (_rollup, client, addr) = setup_paymaster_client().await;
+
+    let request = TransactionRequest {
+        max_fee_per_gas: Some(MAX_FEE_PER_GAS),
+        max_priority_fee_per_gas: Some(0),
+        ..base_request(addr)
+    };
+    assert_simulation_rejects::<String>(&client, &request, INSUFFICIENT_FUNDS_ERROR).await;
+
+    Ok(())
+}
+
+// ── Test 4: Both gasPrice and maxFeePerGas → conflicting fields error ──
+
+#[tokio::test(flavor = "multi_thread")]
+async fn paymaster_simulation_rejects_with_conflicting_fee_fields() -> anyhow::Result<()> {
+    let (_rollup, client, addr) = setup_paymaster_client().await;
+
+    let request = TransactionRequest {
+        gas_price: Some(MAX_FEE_PER_GAS),
+        max_fee_per_gas: Some(MAX_FEE_PER_GAS),
+        ..base_request(addr)
+    };
+    assert_simulation_rejects::<String>(
+        &client,
+        &request,
+        "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified",
+    )
+    .await;
+
+    Ok(())
+}
+
+// ── Test 5: gasPrice set, gas omitted → affordable gas < 21000, exceeds allowance ──
+
+#[tokio::test(flavor = "multi_thread")]
+async fn paymaster_simulation_rejects_with_gas_price_gas_omitted() -> anyhow::Result<()> {
+    let (_rollup, client, addr) = setup_paymaster_client().await;
+
+    let request = TransactionRequest {
+        gas: None,
+        gas_price: Some(MAX_FEE_PER_GAS),
+        ..base_request(addr)
+    };
+    assert_simulation_rejects::<U64>(&client, &request, GAS_REQUIRED_EXCEEDS_ALLOWANCE_ERROR).await;
+
+    Ok(())
+}
+
+// ── Test 6: maxFeePerGas set, gas omitted → affordable gas < 21000, exceeds allowance ──
+
+#[tokio::test(flavor = "multi_thread")]
+async fn paymaster_simulation_rejects_with_max_fee_per_gas_gas_omitted() -> anyhow::Result<()> {
+    let (_rollup, client, addr) = setup_paymaster_client().await;
+
+    let request = TransactionRequest {
+        gas: None,
+        max_fee_per_gas: Some(MAX_FEE_PER_GAS),
+        max_priority_fee_per_gas: Some(0),
+        ..base_request(addr)
+    };
+    assert_simulation_rejects::<U64>(&client, &request, GAS_REQUIRED_EXCEEDS_ALLOWANCE_ERROR).await;
+
+    Ok(())
+}
+
+// ── Test 7: Simulation rejects but sendRawTransaction succeeds (key discrepancy) ──
+
+#[tokio::test(flavor = "multi_thread")]
+async fn paymaster_send_raw_tx_succeeds_despite_simulation_rejection() -> anyhow::Result<()> {
+    let (rollup, client, addr) = setup_paymaster_client().await;
+
+    // First, confirm simulation rejects with fee fields.
+    let request = TransactionRequest {
+        max_fee_per_gas: Some(MAX_FEE_PER_GAS),
+        max_priority_fee_per_gas: Some(0),
+        ..base_request(addr)
+    };
+    let estimate_result: Result<U64, _> = client
+        .ws
+        .request("eth_estimateGas", rpc_params![&request, "latest"])
+        .await;
+    let err = estimate_result
+        .expect_err("eth_estimateGas should reject zero-balance sender with fee fields");
+    assert!(
+        err.to_string().contains(INSUFFICIENT_FUNDS_ERROR),
+        "expected insufficient funds error, got: {err}"
+    );
+
+    // Now send a real signed tx — sendRawTransaction goes through the mempool/STF
+    // path which IS paymaster-aware.
+    let paymaster_signer: PrivateKeySigner = PAYMASTER_SIGNER_PRIV_KEY.parse()?;
+    let chain_id: U64 = client.ws.request("eth_chainId", rpc_params![]).await?;
+    let nonce = tx_count(&client, addr, "latest").await?;
+
+    let raw_tx = raw_signed_eip1559(
+        &paymaster_signer,
+        chain_id.to::<u64>(),
+        nonce,
+        GAS_LIMIT,
+        TxKind::Call(Address::ZERO),
+        U256::ZERO,
+        Bytes::new(),
+        MAX_FEE_PER_GAS,
+        0,
+    )
+    .await?;
+
+    let http = Client::new();
+    let send_response = rpc_call(
+        &http,
+        rollup.http_addr,
+        "eth_sendRawTransaction",
+        json!([raw_tx]),
+    )
+    .await?;
+    assert!(
+        send_response.get("error").is_none(),
+        "sendRawTransaction should succeed for paymaster-covered sender: {send_response}"
+    );
+
+    let tx_hash: B256 = rpc_result_hex(&send_response).parse()?;
+    let receipt = client.wait_for_receipt(tx_hash).await;
+    assert!(
+        receipt.status(),
+        "transaction should succeed when paymaster covers gas"
+    );
+
+    Ok(())
+}

--- a/examples/demo-rollup/tests/evm/evm_paymaster_balance_check.rs
+++ b/examples/demo-rollup/tests/evm/evm_paymaster_balance_check.rs
@@ -5,11 +5,9 @@ use demo_stf::MultiAddressEvmSolana;
 use jsonrpsee::core::client::ClientT;
 use jsonrpsee::rpc_params;
 use reqwest::Client;
-use serde::de::DeserializeOwned;
 use serde_json::json;
 use sov_address::EthereumAddress;
 use sov_bank::config_gas_token_id;
-use sov_cli::NodeClient;
 use sov_demo_rollup::{MockDemoRollup, MockRollupSpec};
 use sov_eth_client::SimpleStorageClient;
 use sov_modules_api::execution_mode::Native;
@@ -21,7 +19,13 @@ use crate::evm::evm_test_helper::{
     setup_test_rollup_with_paymaster, tx_count, EVM_EXTENSION, MAX_FEE_PER_GAS, SENDER_PRIV_KEY,
 };
 
-const GAS_LIMIT: u64 = 21_000;
+// max_fee = gas_limit * multiplier * sum(gas_price dimensions)
+//         = 21_000 * 1 * (9 + 9) = 378,000 SOV
+//
+// A simple ETH transfer costs ~430,000 SOV in state accesses, exceeding this budget.
+// The working paymaster test in evm_rpc_compliance_validation_2.rs:1150 uses
+// gas_limit = 1_000_000 for exactly this reason.
+const GAS_LIMIT: u64 = 1_000_000;
 
 /// Hardhat #4: 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65
 /// Not in any genesis → starts with zero EVM balance, but covered by the paymaster.
@@ -52,6 +56,28 @@ async fn setup_paymaster_client() -> (
         balance,
         U256::ZERO,
         "test precondition failed: paymaster signer must start with zero EVM balance"
+    );
+
+    let rollup_balance = rollup
+        .client
+        .get_balance::<MockRollupSpec<Native>>(
+            &MultiAddressEvmSolana::Evm(EthereumAddress(addr)),
+            &config_gas_token_id(),
+            None,
+        )
+        .await
+        .unwrap_or_else(|err| {
+            let err_string = err.to_string();
+            if err_string.contains("404 Not Found") {
+                Amount::ZERO
+            } else {
+                panic!("Error from server: {err_string}");
+            }
+        });
+    assert_eq!(
+        Amount::ZERO,
+        rollup_balance,
+        "test precondition failed: paymaster signer must start with zero rollup gas-token balance"
     );
 
     (rollup, client, addr)
@@ -102,31 +128,7 @@ async fn get_consistent_response(
     }
 }
 
-async fn assert_zero_balance(client: &NodeClient, addr: &Address) {
-    let balance = client
-        .get_balance::<MockRollupSpec<Native>>(
-            &MultiAddressEvmSolana::Evm(EthereumAddress(*addr)),
-            &config_gas_token_id(),
-            None,
-        )
-        .await
-        .unwrap_or_else(|err| {
-            let err_string = err.to_string();
-            if err_string.contains("404 Not Found") {
-                Amount::ZERO
-            } else {
-                panic!("Error from server: {err_string}");
-            }
-        });
-
-    assert_eq!(
-        Amount::ZERO,
-        balance,
-        "Sender {addr} should have zero balance in those tests, self-check"
-    );
-}
-
-async fn assert_simulation_rejects<T: DeserializeOwned + std::fmt::Debug>(
+async fn assert_simulation_rejects(
     client: &SimpleStorageClient,
     request: &TransactionRequest,
     expected_error_substring: &str,
@@ -169,9 +171,7 @@ async fn paymaster_simulation_succeeds_without_fee_fields() -> anyhow::Result<()
 // gasPrice set → paymaster covers sender, simulation succeeds
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_with_gas_price() -> anyhow::Result<()> {
-    let (rollup, client, addr) = setup_paymaster_client().await;
-
-    assert_zero_balance(&rollup.client, &addr).await;
+    let (_rollup, client, addr) = setup_paymaster_client().await;
 
     let request = TransactionRequest {
         gas_price: Some(MAX_FEE_PER_GAS),
@@ -185,9 +185,7 @@ async fn paymaster_simulation_succeeds_with_gas_price() -> anyhow::Result<()> {
 // maxFeePerGas set → paymaster covers sender, simulation succeeds
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_with_max_fee_per_gas() -> anyhow::Result<()> {
-    let (rollup, client, addr) = setup_paymaster_client().await;
-
-    assert_zero_balance(&rollup.client, &addr).await;
+    let (_rollup, client, addr) = setup_paymaster_client().await;
 
     let request = TransactionRequest {
         max_fee_per_gas: Some(MAX_FEE_PER_GAS),
@@ -202,16 +200,14 @@ async fn paymaster_simulation_succeeds_with_max_fee_per_gas() -> anyhow::Result<
 // Both gasPrice and maxFeePerGas → conflicting fields error
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_rejects_with_conflicting_fee_fields() -> anyhow::Result<()> {
-    let (rollup, client, addr) = setup_paymaster_client().await;
-
-    assert_zero_balance(&rollup.client, &addr).await;
+    let (_rollup, client, addr) = setup_paymaster_client().await;
 
     let request = TransactionRequest {
         gas_price: Some(MAX_FEE_PER_GAS),
         max_fee_per_gas: Some(MAX_FEE_PER_GAS),
         ..base_request(addr)
     };
-    assert_simulation_rejects::<String>(
+    assert_simulation_rejects(
         &client,
         &request,
         "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified",
@@ -224,9 +220,7 @@ async fn paymaster_simulation_rejects_with_conflicting_fee_fields() -> anyhow::R
 // gasPrice set, gas omitted → paymaster covers sender, simulation succeeds
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_with_gas_price_gas_omitted() -> anyhow::Result<()> {
-    let (rollup, client, addr) = setup_paymaster_client().await;
-
-    assert_zero_balance(&rollup.client, &addr).await;
+    let (_rollup, client, addr) = setup_paymaster_client().await;
 
     let request = TransactionRequest {
         gas: None,
@@ -241,9 +235,7 @@ async fn paymaster_simulation_succeeds_with_gas_price_gas_omitted() -> anyhow::R
 // maxFeePerGas set, gas omitted → paymaster covers sender, simulation succeeds
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_simulation_succeeds_with_max_fee_per_gas_gas_omitted() -> anyhow::Result<()> {
-    let (rollup, client, addr) = setup_paymaster_client().await;
-
-    assert_zero_balance(&rollup.client, &addr).await;
+    let (_rollup, client, addr) = setup_paymaster_client().await;
 
     let request = TransactionRequest {
         gas: None,
@@ -260,8 +252,6 @@ async fn paymaster_simulation_succeeds_with_max_fee_per_gas_gas_omitted() -> any
 #[tokio::test(flavor = "multi_thread")]
 async fn paymaster_send_raw_tx_succeeds() -> anyhow::Result<()> {
     let (rollup, client, addr) = setup_paymaster_client().await;
-
-    assert_zero_balance(&rollup.client, &addr).await;
 
     // Simulation should succeed for paymaster-covered sender.
     let request = TransactionRequest {

--- a/examples/demo-rollup/tests/evm/mod.rs
+++ b/examples/demo-rollup/tests/evm/mod.rs
@@ -17,6 +17,7 @@ mod evm_logs_validation;
 mod evm_max_fee_validation;
 mod evm_no_gas_limit;
 mod evm_oog_error;
+mod evm_paymaster_balance_check;
 mod evm_publish_reverted_txs;
 mod evm_ram_pinning;
 mod evm_rate_limit;

--- a/examples/demo-rollup/web3-js-sdk-test-runner.sh
+++ b/examples/demo-rollup/web3-js-sdk-test-runner.sh
@@ -2,13 +2,12 @@
 
 # ---------------------------------------------------------------------------
 # DESCRIPTION:
-# This script checks compatibility between the local demo rollup and TypeScript
-# clients by:
+# This script checks compatibility between the local demo rollup and the
+# web3-js SDK by:
 #   1. Building and running the demo rollup.
 #   2. Waiting for a sufficiently advanced slot number.
-#   3. Installing and building the TypeScript workspace.
-#   4. Running the workspace integration tests.
-#   5. Running the viem paymaster integration package against the live node.
+#   3. Installing and building the web3-js SDK.
+#   4. Un-commenting integration tests and running them.
 #
 # IF TESTS FAIL:
 #   - The schema or API may have changed and the web3-js SDK needs updating.
@@ -23,15 +22,6 @@ cargo build
 # we still use `cargo run`, to not deal with `target` folder location
 cargo run >demo_rollup_log.log 2>&1 &
 CARGO_PID=$!
-
-cleanup() {
-    if kill -0 $CARGO_PID 2>/dev/null; then
-        kill $CARGO_PID 2>/dev/null || true
-        wait $CARGO_PID 2>/dev/null || true
-    fi
-}
-
-trap cleanup EXIT
 
 # Check if the process started successfully
 sleep 2
@@ -103,11 +93,3 @@ pnpm exec vitest --project integration --exclude apps/** --passWithNoTests=false
     exit 1
 }
 echo "Integration tests passed!"
-
-echo "Running demo-rollup viem paymaster tests"
-pnpm --filter @sovereign-sdk/demo-rollup-viem-tests test:demo-rollup || {
-    echo "=== Demo Rollup output ==="
-    cat ../examples/demo-rollup/demo_rollup_log.log
-    exit 1
-}
-echo "demo-rollup viem paymaster tests passed!"

--- a/examples/demo-rollup/web3-js-sdk-test-runner.sh
+++ b/examples/demo-rollup/web3-js-sdk-test-runner.sh
@@ -2,12 +2,13 @@
 
 # ---------------------------------------------------------------------------
 # DESCRIPTION:
-# This script checks compatibility between the local demo rollup and the
-# web3-js SDK by:
+# This script checks compatibility between the local demo rollup and TypeScript
+# clients by:
 #   1. Building and running the demo rollup.
 #   2. Waiting for a sufficiently advanced slot number.
-#   3. Installing and building the web3-js SDK.
-#   4. Un-commenting integration tests and running them.
+#   3. Installing and building the TypeScript workspace.
+#   4. Running the workspace integration tests.
+#   5. Running the viem paymaster integration package against the live node.
 #
 # IF TESTS FAIL:
 #   - The schema or API may have changed and the web3-js SDK needs updating.
@@ -22,6 +23,15 @@ cargo build
 # we still use `cargo run`, to not deal with `target` folder location
 cargo run >demo_rollup_log.log 2>&1 &
 CARGO_PID=$!
+
+cleanup() {
+    if kill -0 $CARGO_PID 2>/dev/null; then
+        kill $CARGO_PID 2>/dev/null || true
+        wait $CARGO_PID 2>/dev/null || true
+    fi
+}
+
+trap cleanup EXIT
 
 # Check if the process started successfully
 sleep 2
@@ -93,3 +103,11 @@ pnpm exec vitest --project integration --exclude apps/** --passWithNoTests=false
     exit 1
 }
 echo "Integration tests passed!"
+
+echo "Running demo-rollup viem paymaster tests"
+pnpm --filter @sovereign-sdk/demo-rollup-viem-tests test:demo-rollup || {
+    echo "=== Demo Rollup output ==="
+    cat ../examples/demo-rollup/demo_rollup_log.log
+    exit 1
+}
+echo "demo-rollup viem paymaster tests passed!"


### PR DESCRIPTION
# Description

- Remove the EVM-DB based balance check from `eth_call` / `eth_estimateGas` — the RPC layer cannot know whether a paymaster will cover the caller's gas, so this check produces false rejections for paymaster-covered signers.
- Replace `enforce_call_upfront_cost` with `validate_call_fee_fields`, which only checks fee-field consistency (conflicting fields, tip > fee cap) without touching caller balance
- Add 7 new integration tests (evm_paymaster_balance_check.rs) proving that a zero-balance signer covered by a paymaster can simulate and submit transactions
- #[ignore] 6 existing tests in evm_call_fee_fields.rs that asserted unfunded-caller rejection (no longer applicable; tagged with TODO: re-enable with paymaster-aware balance check)

---

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2500 

## Testing
New tests are added.

## Docs
No updates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
