### PR TITLE
Add DA-related constraints to the aggregated proof circuit.

### DIFF
--- a/crates/full-node/sov-aggregated-proof/Cargo.lock
+++ b/crates/full-node/sov-aggregated-proof/Cargo.lock
@@ -6266,7 +6266,7 @@ name = "sov-aggregated-proof-shared"
 version = "0.1.0"
 dependencies = [
  "serde",
- "sov-mock-da",
+ "sov-modules-api",
 ]
 
 [[package]]

--- a/crates/full-node/sov-aggregated-proof/program/src/main.rs
+++ b/crates/full-node/sov-aggregated-proof/program/src/main.rs
@@ -43,11 +43,11 @@ fn verify<S: Spec, Da: DaSpec>(proof_inputs: Vec<DeferredProofInput<Da>>, vkey_h
         let stf_public_data =
             deserialize_pub_data::<S, Da>(proof_input.public_values.as_slice(), index);
 
+        // Check that DA blocks form a chain.
         {
             let da_block_header = &proof_input.da_block_header;
             let current_block_hash = da_block_header.hash();
 
-            // Check that DA blocks form a chain.
             if let Some(expected_prev_hash) = &expected_prev_hash {
                 assert_eq!(
                     expected_prev_hash,

--- a/crates/full-node/sov-aggregated-proof/program/src/main.rs
+++ b/crates/full-node/sov-aggregated-proof/program/src/main.rs
@@ -4,12 +4,13 @@ sp1_zkvm::entrypoint!(main);
 
 use demo_stf::MultiAddressEvmSolana;
 use sha2::{Digest, Sha256};
-use sov_aggregated_proof_shared::DeferredProofInput;
+use sov_aggregated_proof_shared::{AggregatedProofWitness, DeferredProofInput};
 use sov_mock_da::MockDaSpec;
 use sov_mock_zkvm::MockZkvm;
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::da::BlockHeaderTrait;
 use sov_modules_api::execution_mode::Zk;
+use sov_modules_api::DaSpec;
 use sov_modules_api::Spec;
 use sov_modules_api::StateTransitionPublicData;
 use sov_modules_api::Storage;
@@ -17,22 +18,74 @@ use sov_sp1_adapter::SP1;
 
 type S = ConfigurableSpec<MockDaSpec, SP1, MockZkvm, MultiAddressEvmSolana, Zk>;
 
+type StPubData<S: Spec, Da: DaSpec> =
+    StateTransitionPublicData<<S as Spec>::Address, Da, <<S as Spec>::Storage as Storage>::Root>;
+
 pub fn main() {
-    let proof_inputs = sp1_zkvm::io::read::<Vec<DeferredProofInput>>();
+    let witness = sp1_zkvm::io::read::<AggregatedProofWitness<MockDaSpec>>();
+    let proof_inputs = witness.proof_inputs;
+    let vkey_hash = witness.vkey_hash;
+
+    verify::<S, MockDaSpec>(proof_inputs, vkey_hash);
+}
+
+fn verify<S: Spec, Da: DaSpec>(proof_inputs: Vec<DeferredProofInput<Da>>, vkey_hash: [u32; 8]) {
+    assert!(
+        !proof_inputs.is_empty(),
+        "Aggregated proof must contain at least one proof input"
+    );
+
+    // `None` means no predecessor to check against (first iteration).
+    let mut expected_prev_hash = None;
+    let mut expected_state_root = None;
 
     for (index, proof_input) in proof_inputs.iter().enumerate() {
-        let stf_public_data: StateTransitionPublicData<
-            <S as Spec>::Address,
-            MockDaSpec,
-            <<S as Spec>::Storage as Storage>::Root,
-        > = bincode::deserialize(proof_input.public_values.as_slice()).unwrap();
+        let stf_public_data =
+            deserialize_pub_data::<S, Da>(proof_input.public_values.as_slice(), index);
 
-        let da_block_header = &proof_input.da_block_header;
-        assert_eq!(da_block_header.hash(), stf_public_data.slot_hash);
+        {
+            let da_block_header = &proof_input.da_block_header;
+            let current_block_hash = da_block_header.hash();
 
-        println!("[guest] verifying proof {index}");
-        let public_values_digest: [u8; 32] = Sha256::digest(&proof_input.public_values).into();
-        sp1_zkvm::lib::verify::verify_sp1_proof(&proof_input.vkey_hash, &public_values_digest);
-        println!("[guest] verified proof {index}");
+            // Check that DA blocks form a chain.
+            if let Some(expected_prev_hash) = &expected_prev_hash {
+                assert_eq!(
+                    expected_prev_hash,
+                    &da_block_header.prev_hash(),
+                    "DA block chain broken at index {index}: prev_hash mismatch"
+                );
+            }
+
+            // Check that the slot hash from the public input matches the current block hash.
+            assert_eq!(
+                current_block_hash, stf_public_data.slot_hash,
+                "Slot hash mismatch at index {index}: DA block header hash doesn't match public data"
+            );
+            expected_prev_hash = Some(current_block_hash);
+        }
+
+        // Check that state roots are sequentially related by the state transition.
+        {
+            if let Some(expected_state_root) = &expected_state_root {
+                assert_eq!(
+                    expected_state_root, &stf_public_data.initial_state_root,
+                    "State root discontinuity at index {index}: previous final_state_root != current initial_state_root"
+                );
+            }
+
+            verify_sp1_proof(proof_input, vkey_hash);
+            expected_state_root = Some(stf_public_data.final_state_root.clone());
+        }
     }
+}
+
+fn verify_sp1_proof<Da: DaSpec>(proof_input: &DeferredProofInput<Da>, vkey_hash: [u32; 8]) {
+    let public_values_digest: [u8; 32] = Sha256::digest(&proof_input.public_values).into();
+    sp1_zkvm::lib::verify::verify_sp1_proof(&vkey_hash, &public_values_digest);
+}
+
+fn deserialize_pub_data<S: Spec, Da: DaSpec>(data: &[u8], index: usize) -> StPubData<S, Da> {
+    bincode::deserialize(data).unwrap_or_else(|error| {
+        panic!("Failed to deserialize public values from proof input {index}: {error}")
+    })
 }

--- a/crates/full-node/sov-aggregated-proof/script/src/main.rs
+++ b/crates/full-node/sov-aggregated-proof/script/src/main.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 
 use anyhow::{bail, ensure, Context};
 use slop_algebra::PrimeField32;
+use sov_aggregated_proof_shared::AggregatedProofWitness;
 use sov_aggregated_proof_shared::DeferredProofInput;
 use sov_mock_da::MockDaSpec;
 use sov_sp1_adapter::BlockHeaderWithProof;
@@ -59,9 +60,8 @@ fn main() -> anyhow::Result<()> {
             index
         );
 
-        let deferred_proof_input = DeferredProofInput {
+        let deferred_proof_input = DeferredProofInput::<MockDaSpec> {
             public_values: proof.public_values.to_vec(),
-            vkey_hash: inner_vk_hash,
             da_block_header: block_header_with_proof.da_block_header,
         };
 
@@ -69,7 +69,12 @@ fn main() -> anyhow::Result<()> {
         stdin.write_proof(*recursion_proof.clone(), verification_key.vk.clone());
     }
 
-    stdin.write(&proof_inputs);
+    let witness = AggregatedProofWitness {
+        proof_inputs,
+        vkey_hash: inner_vk_hash,
+    };
+
+    stdin.write(&witness);
 
     println!("[host] starting outer compressed proof");
     let outer_proof = prover

--- a/crates/full-node/sov-aggregated-proof/shared/Cargo.toml
+++ b/crates/full-node/sov-aggregated-proof/shared/Cargo.toml
@@ -6,5 +6,4 @@ publish = false
 
 [dependencies]
 serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
-
-sov-mock-da = { workspace = true }
+sov-modules-api = { workspace = true }

--- a/crates/full-node/sov-aggregated-proof/shared/src/lib.rs
+++ b/crates/full-node/sov-aggregated-proof/shared/src/lib.rs
@@ -1,9 +1,14 @@
 use serde::{Deserialize, Serialize};
-use sov_mock_da::MockBlockHeader;
+use sov_modules_api::DaSpec;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct DeferredProofInput {
+pub struct DeferredProofInput<Da: DaSpec> {
     pub public_values: Vec<u8>,
+    pub da_block_header: Da::BlockHeader,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AggregatedProofWitness<Da: DaSpec> {
+    pub proof_inputs: Vec<DeferredProofInput<Da>>,
     pub vkey_hash: [u32; 8],
-    pub da_block_header: MockBlockHeader,
 }


### PR DESCRIPTION
# Description

This PR introduces the following changes:

1. Passes the DA header to the aggregation circuit.
2. Verifies that consecutive headers form a chain.
3. Verifies the inner proof for each DA block.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551