### PR TITLE
EVM: RPC Fix omitted gas limit for `eth_call` and `eth_estimateGas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2025-03-16
 - #2592 Fixes EVM RPC regression for paymaster enabled rollups
+- #2598 Fixes EVM RPC omitted gas limit for simulation endpoints
 
 # 2025-03-13
 - #2587 EVM: RPC only: Fixes Fee-cap admission consistency across simulation and submission.

--- a/crates/module-system/module-implementations/sov-evm/src/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/helpers.rs
@@ -28,7 +28,7 @@ pub(crate) fn prepare_call_env(
         ..
     } = request;
 
-    let gas_limit = gas.unwrap_or_else(|| tx_gas_limit.unwrap_or(block_env.gas_limit));
+    let gas_limit = gas.unwrap_or_else(|| simulation_gas_limit(block_env.gas_limit, tx_gas_limit));
 
     let env = TxEnv {
         tx_type: TransactionType::Eip1559.into(),
@@ -49,6 +49,11 @@ pub(crate) fn prepare_call_env(
     };
 
     Ok(env)
+}
+
+#[inline]
+fn simulation_gas_limit(block_gas_limit: u64, tx_gas_limit: Option<u64>) -> u64 {
+    block_gas_limit.min(tx_gas_limit.unwrap_or(block_gas_limit))
 }
 
 /// Builds an RPC transaction from a recovered signed transaction with block context.
@@ -139,11 +144,43 @@ mod tests {
             "should use tx_gas_limit when gas is omitted"
         );
 
+        let lower_block_limit = BlockEnv {
+            gas_limit: 500_000,
+            ..Default::default()
+        };
+        let tx_env =
+            prepare_call_env(&lower_block_limit, request.clone(), Some(30_000_000)).unwrap();
+        assert_eq!(
+            tx_env.gas_limit, 500_000,
+            "should respect a lower block gas limit when gas is omitted"
+        );
+
         // When tx_gas_limit is None, omitted gas falls back to block_env.gas_limit
         let tx_env = prepare_call_env(&block_env, request, None).unwrap();
         assert_eq!(
             tx_env.gas_limit, 1_000_000_000,
             "should fall back to block gas limit when tx_gas_limit is None"
+        );
+    }
+
+    #[test]
+    fn prepare_call_env_explicit_gas_bypasses_simulation_limit() {
+        let block_env = BlockEnv {
+            gas_limit: 1_000_000_000,
+            ..Default::default()
+        };
+
+        let explicit_gas = 50_000;
+        let request = TransactionRequest {
+            gas: Some(explicit_gas),
+            ..Default::default()
+        };
+
+        // Explicit gas should be used as-is, ignoring both tx_gas_limit and block_gas_limit
+        let tx_env = prepare_call_env(&block_env, request, Some(30_000_000)).unwrap();
+        assert_eq!(
+            tx_env.gas_limit, explicit_gas,
+            "explicit gas in request should bypass simulation_gas_limit"
         );
     }
 

--- a/crates/module-system/module-implementations/sov-evm/src/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/helpers.rs
@@ -51,7 +51,6 @@ pub(crate) fn prepare_call_env(
     Ok(env)
 }
 
-#[inline]
 fn simulation_gas_limit(block_gas_limit: u64, tx_gas_limit: Option<u64>) -> u64 {
     block_gas_limit.min(tx_gas_limit.unwrap_or(block_gas_limit))
 }

--- a/crates/module-system/module-implementations/sov-evm/src/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/helpers.rs
@@ -14,6 +14,7 @@ use crate::evm::primitive_types::TransactionSigned;
 pub(crate) fn prepare_call_env(
     block_env: &BlockEnv,
     request: TransactionRequest,
+    tx_gas_limit: Option<u64>,
 ) -> EthResult<TxEnv> {
     let TransactionRequest {
         from,
@@ -27,7 +28,7 @@ pub(crate) fn prepare_call_env(
         ..
     } = request;
 
-    let gas_limit = gas.unwrap_or(block_env.gas_limit);
+    let gas_limit = gas.unwrap_or_else(|| tx_gas_limit.unwrap_or(block_env.gas_limit));
 
     let env = TxEnv {
         tx_type: TransactionType::Eip1559.into(),
@@ -97,7 +98,7 @@ mod tests {
 
         let block_env = BlockEnv::default();
 
-        let tx_env = prepare_call_env(&block_env, request).unwrap();
+        let tx_env = prepare_call_env(&block_env, request, None).unwrap();
         let expected = TxEnv {
             tx_type: TransactionType::Eip1559.into(),
             caller: from,
@@ -120,6 +121,30 @@ mod tests {
         assert_eq!(tx_env.chain_id, expected.chain_id);
         assert_eq!(tx_env.nonce, expected.nonce);
         assert_eq!(tx_env.access_list, expected.access_list);
+    }
+
+    #[test]
+    fn prepare_call_env_omitted_gas_uses_tx_gas_limit() {
+        let block_env = BlockEnv {
+            gas_limit: 1_000_000_000,
+            ..Default::default()
+        };
+
+        let request = TransactionRequest::default();
+
+        // When tx_gas_limit is provided, omitted gas falls back to it
+        let tx_env = prepare_call_env(&block_env, request.clone(), Some(30_000_000)).unwrap();
+        assert_eq!(
+            tx_env.gas_limit, 30_000_000,
+            "should use tx_gas_limit when gas is omitted"
+        );
+
+        // When tx_gas_limit is None, omitted gas falls back to block_env.gas_limit
+        let tx_env = prepare_call_env(&block_env, request, None).unwrap();
+        assert_eq!(
+            tx_env.gas_limit, 1_000_000_000,
+            "should fall back to block gas limit when tx_gas_limit is None"
+        );
     }
 
     #[test]

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -350,8 +350,9 @@ where
         // https://github.com/ethereum/go-ethereum/blob/16783c167c4be5e6675fd8de0d1b762c88d6232f/internal/ethapi/api.go#L1359-L1372
         super::validate_call_fee_fields(&request)?;
         let block_env = self.resolve_block_env_for_call(block_id, state)?;
-        let tx_env = crate::helpers::prepare_call_env(&block_env, request)?;
         let cfg = self.cfg_infallible(state);
+        let tx_env =
+            crate::helpers::prepare_call_env(&block_env, request, cfg.chain_spec.tx_gas_limit)?;
         let cfg_env =
             crate::executor::get_cfg_env(&block_env, &cfg, Some(super::get_cfg_env_template()));
         let mut maybe_archival_state = self.resolve_state_for_block_id(block_id, state)?;

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -416,16 +416,23 @@ where
             .unwrap_or(0)
             .saturating_add(1000);
 
-        let multiplier = {
-            let mut multiplier_state = self.resolve_state_for_block_id(block_id, state)?;
-            self.fee_multiplier(multiplier_state.deref_mut())
-                .map_err(into_rpc_error)?
-        };
+        let (block_env, mut maybe_archival_state, cfg) =
+            self.resolve_simulation_context_for_block_id(block_id, state)?;
+        let multiplier = self
+            .fee_multiplier(maybe_archival_state.deref_mut())
+            .map_err(into_rpc_error)?;
 
         let ResultAndState {
             result,
             state: changes,
-        } = self.call(request, block_id, state_overrides, block_overrides, state)?;
+        } = self.call_with_context(
+            request,
+            block_env,
+            maybe_archival_state,
+            &cfg,
+            state_overrides,
+            block_overrides,
+        )?;
 
         let (gas_used, logs) = match result {
             ExecutionResult::Success { gas_used, logs, .. } => (gas_used, logs),

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/handlers.rs
@@ -349,13 +349,12 @@ where
         // requests admissible during access-list generation:
         // https://github.com/ethereum/go-ethereum/blob/16783c167c4be5e6675fd8de0d1b762c88d6232f/internal/ethapi/api.go#L1359-L1372
         super::validate_call_fee_fields(&request)?;
-        let block_env = self.resolve_block_env_for_call(block_id, state)?;
-        let cfg = self.cfg_infallible(state);
+        let (block_env, mut maybe_archival_state, cfg) =
+            self.resolve_simulation_context_for_block_id(block_id, state)?;
         let tx_env =
             crate::helpers::prepare_call_env(&block_env, request, cfg.chain_spec.tx_gas_limit)?;
         let cfg_env =
             crate::executor::get_cfg_env(&block_env, &cfg, Some(super::get_cfg_env_template()));
-        let mut maybe_archival_state = self.resolve_state_for_block_id(block_id, state)?;
         let evm_db = self.db(maybe_archival_state.deref_mut());
 
         let mut inspector = AccessListInspector::new(initial_access_list);

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -976,7 +976,7 @@ where
     DB::Error: Into<EthApiError> + revm_database_interface::DBErrorMarker + std::fmt::Display,
 {
     let cfg_env = get_cfg_env(block_env, cfg, Some(get_cfg_env_template()));
-    let tx_env = prepare_call_env(block_env, request)?;
+    let tx_env = prepare_call_env(block_env, request, cfg.chain_spec.tx_gas_limit)?;
     let caller = tx_env.caller;
     let result = executor::transact(&mut *db, block_env, tx_env, cfg_env)?;
     verify_contract_creation_allowlist(&result.state, &caller, cfg, db)

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -500,15 +500,34 @@ where
 
     fn call(
         &self,
-        mut request: TransactionRequest,
+        request: TransactionRequest,
         block_id: Option<BlockId>,
         state_overrides: Option<StateOverride>,
         block_overrides: Option<Box<BlockOverrides>>,
         state: &mut ApiStateAccessor<S>,
     ) -> Result<ResultAndState, EthApiError> {
-        let has_overrides = state_overrides.is_some() || block_overrides.is_some();
-        let (mut block_env, mut maybe_archival_state, cfg) =
+        let (block_env, maybe_archival_state, cfg) =
             self.resolve_simulation_context_for_block_id(block_id, state)?;
+        self.call_with_context(
+            request,
+            block_env,
+            maybe_archival_state,
+            &cfg,
+            state_overrides,
+            block_overrides,
+        )
+    }
+
+    fn call_with_context(
+        &self,
+        mut request: TransactionRequest,
+        mut block_env: BlockEnv,
+        mut maybe_archival_state: MaybeArchivalState<'_, S>,
+        cfg: &crate::config::EvmRuntimeConfig,
+        state_overrides: Option<StateOverride>,
+        block_overrides: Option<Box<BlockOverrides>>,
+    ) -> Result<ResultAndState, EthApiError> {
+        let has_overrides = state_overrides.is_some() || block_overrides.is_some();
         let enforce_max_fee_check = self
             .is_max_fee_check_active(maybe_archival_state.deref_mut())
             .map_err(|e| EthApiError::other(into_rpc_error(e)))?;
@@ -544,7 +563,7 @@ where
 
         if !has_overrides {
             let mut evm_db: EvmDb<_, S> = self.db(maybe_archival_state.deref_mut());
-            return simulate_call(&mut evm_db, &block_env, &cfg, request);
+            return simulate_call(&mut evm_db, &block_env, cfg, request);
         }
 
         let evm_db: EvmDb<_, S> = self.db(maybe_archival_state.deref_mut());
@@ -555,7 +574,7 @@ where
             state_overrides,
             block_overrides,
         )?;
-        simulate_call(&mut evm_state, &block_env, &cfg, request)
+        simulate_call(&mut evm_state, &block_env, cfg, request)
     }
 
     /// Retrieves a sealed block generated from an existing or pending block.

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/mod.rs
@@ -478,6 +478,26 @@ where
         Ok(Some(receipts))
     }
 
+    fn resolve_simulation_context_for_block_id<'a>(
+        &self,
+        block_id: Option<BlockId>,
+        state: &'a mut ApiStateAccessor<S>,
+    ) -> Result<
+        (
+            BlockEnv,
+            MaybeArchivalState<'a, S>,
+            crate::config::EvmRuntimeConfig,
+        ),
+        EthApiError,
+    > {
+        let block_env = self.resolve_block_env_for_call(block_id, state)?;
+        let mut maybe_archival_state = self.resolve_state_for_block_id(block_id, state)?;
+        // Omitted-gas simulations must read the tx gas cap from the selected state so
+        // archival queries remain stable after later runtime-config updates.
+        let cfg = self.cfg_infallible(maybe_archival_state.deref_mut());
+        Ok((block_env, maybe_archival_state, cfg))
+    }
+
     fn call(
         &self,
         mut request: TransactionRequest,
@@ -487,9 +507,8 @@ where
         state: &mut ApiStateAccessor<S>,
     ) -> Result<ResultAndState, EthApiError> {
         let has_overrides = state_overrides.is_some() || block_overrides.is_some();
-        let mut block_env = self.resolve_block_env_for_call(block_id, state)?;
-        let cfg = self.cfg_infallible(state);
-        let mut maybe_archival_state = self.resolve_state_for_block_id(block_id, state)?;
+        let (mut block_env, mut maybe_archival_state, cfg) =
+            self.resolve_simulation_context_for_block_id(block_id, state)?;
         let enforce_max_fee_check = self
             .is_max_fee_check_active(maybe_archival_state.deref_mut())
             .map_err(|e| EthApiError::other(into_rpc_error(e)))?;

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/archival_state.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/archival_state.rs
@@ -1,5 +1,5 @@
 use alloy_eips::BlockId;
-use alloy_primitives::{Address, TxKind};
+use alloy_primitives::{Address, Bytes, TxKind, U64};
 use alloy_rpc_types::TransactionRequest;
 use sov_evm::{CallMessage, ChainSpecUpdate, Evm, EvmRuntimeConfigUpdate};
 use sov_evm_test_utils::LegacySimpleStorage;
@@ -160,6 +160,34 @@ fn setup_archival_burn_gas_regression_case(
     (runner, caller, admin, contract_addr, iterations)
 }
 
+fn query_historical_call_and_estimate(
+    runner: &mut TestRunner<RT, S>,
+    request: &TransactionRequest,
+) -> (Bytes, U64) {
+    runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let output = evm
+            .eth_call(
+                request.clone(),
+                Some(BlockId::number(HISTORICAL_BLOCK)),
+                None,
+                None,
+                state,
+            )
+            .unwrap();
+        let estimate = evm
+            .eth_estimate_gas(
+                request.clone(),
+                Some(BlockId::number(HISTORICAL_BLOCK)),
+                None,
+                None,
+                state,
+            )
+            .unwrap();
+        (output, estimate)
+    })
+}
+
 #[test]
 fn test_state_at_different_depth_is_accessible() {
     let (mut runner, from, to, _) = setup();
@@ -193,53 +221,12 @@ fn test_historical_eth_call_and_estimate_gas_keep_archival_tx_gas_limit_for_omit
         setup_archival_burn_gas_regression_case();
     let request = burn_gas_request(caller, contract_addr, iterations, None);
 
-    let (before_output, before_estimate) = runner.query_visible_state(|state| {
-        let evm = Evm::<S>::default();
-        let output = evm
-            .eth_call(
-                request.clone(),
-                Some(BlockId::number(HISTORICAL_BLOCK)),
-                None,
-                None,
-                state,
-            )
-            .unwrap();
-        let estimate = evm
-            .eth_estimate_gas(
-                request.clone(),
-                Some(BlockId::number(HISTORICAL_BLOCK)),
-                None,
-                None,
-                state,
-            )
-            .unwrap();
-        (output, estimate)
-    });
+    let (before_output, before_estimate) =
+        query_historical_call_and_estimate(&mut runner, &request);
 
     update_tx_gas_limit(&mut runner, &admin, UPDATED_TX_GAS_LIMIT);
 
-    let (after_output, after_estimate) = runner.query_visible_state(|state| {
-        let evm = Evm::<S>::default();
-        let output = evm
-            .eth_call(
-                request.clone(),
-                Some(BlockId::number(HISTORICAL_BLOCK)),
-                None,
-                None,
-                state,
-            )
-            .unwrap();
-        let estimate = evm
-            .eth_estimate_gas(
-                request.clone(),
-                Some(BlockId::number(HISTORICAL_BLOCK)),
-                None,
-                None,
-                state,
-            )
-            .unwrap();
-        (output, estimate)
-    });
+    let (after_output, after_estimate) = query_historical_call_and_estimate(&mut runner, &request);
 
     assert_eq!(before_output, after_output);
     assert_eq!(before_estimate, after_estimate);

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/archival_state.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/archival_state.rs
@@ -1,8 +1,164 @@
 use alloy_eips::BlockId;
-use sov_evm::Evm;
+use alloy_primitives::{Address, TxKind};
+use alloy_rpc_types::TransactionRequest;
+use sov_evm::{CallMessage, ChainSpecUpdate, Evm, EvmRuntimeConfigUpdate};
+use sov_evm_test_utils::LegacySimpleStorage;
+use sov_modules_api::ApiStateAccessor;
+use sov_test_utils::runtime::TestRunner;
+use sov_test_utils::{AsUser, TestUser, TransactionTestCase};
 
-use crate::helpers::{create_transfer_tx, setup};
-use crate::runtime::S;
+use crate::helpers::{create_deploy_tx, create_transfer_tx, setup};
+use crate::runtime::{RT, S};
+
+const HISTORICAL_BLOCK: u64 = 1;
+const ORIGINAL_TX_GAS_LIMIT: u64 = 30_000_000;
+const UPDATED_TX_GAS_LIMIT: u64 = 20_000_000;
+
+fn burn_gas_request(
+    caller: Address,
+    contract_addr: Address,
+    iterations: u32,
+    gas_limit: Option<u64>,
+) -> TransactionRequest {
+    TransactionRequest {
+        from: Some(caller),
+        to: Some(TxKind::Call(contract_addr)),
+        input: LegacySimpleStorage::default().burn_gas(iterations).into(),
+        gas: gas_limit,
+        ..Default::default()
+    }
+}
+
+fn historical_burn_gas_call_succeeds(
+    evm: &Evm<S>,
+    state: &mut ApiStateAccessor<S>,
+    caller: Address,
+    contract_addr: Address,
+    iterations: u32,
+    gas_limit: u64,
+) -> bool {
+    evm.eth_call(
+        burn_gas_request(caller, contract_addr, iterations, Some(gas_limit)),
+        Some(BlockId::number(HISTORICAL_BLOCK)),
+        None,
+        None,
+        state,
+    )
+    .is_ok()
+}
+
+fn find_burn_gas_iterations_requiring_archival_tx_gas_cap(
+    evm: &Evm<S>,
+    state: &mut ApiStateAccessor<S>,
+    caller: Address,
+    contract_addr: Address,
+) -> u32 {
+    let mut low = 1u32;
+    let mut high = 1u32;
+    while historical_burn_gas_call_succeeds(
+        evm,
+        state,
+        caller,
+        contract_addr,
+        high,
+        UPDATED_TX_GAS_LIMIT,
+    ) {
+        low = high;
+        high = high
+            .checked_mul(2)
+            .expect("burnGas iteration search overflowed");
+        assert!(
+            high <= 16_777_216,
+            "could not find burnGas iterations that exceed the 20M gas cap"
+        );
+    }
+
+    while low + 1 < high {
+        let mid = low + (high - low) / 2;
+        if historical_burn_gas_call_succeeds(
+            evm,
+            state,
+            caller,
+            contract_addr,
+            mid,
+            UPDATED_TX_GAS_LIMIT,
+        ) {
+            low = mid;
+        } else {
+            high = mid;
+        }
+    }
+
+    assert!(
+        historical_burn_gas_call_succeeds(
+            evm,
+            state,
+            caller,
+            contract_addr,
+            high,
+            ORIGINAL_TX_GAS_LIMIT,
+        ),
+        "expected burnGas({high}) to stay below the original 30M tx gas limit"
+    );
+    assert!(
+        !historical_burn_gas_call_succeeds(
+            evm,
+            state,
+            caller,
+            contract_addr,
+            high,
+            UPDATED_TX_GAS_LIMIT,
+        ),
+        "expected burnGas({high}) to exceed the updated 20M tx gas limit"
+    );
+
+    high
+}
+
+fn update_tx_gas_limit(runner: &mut TestRunner<RT, S>, admin: &TestUser<S>, new_tx_gas_limit: u64) {
+    let evm = Evm::<S>::default();
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Evm<S>>(CallMessage::UpdateRuntimeConfig(
+            EvmRuntimeConfigUpdate {
+                new_hardfork: None,
+                new_contract_creation_policy: None,
+                chain_spec_update: Some(ChainSpecUpdate {
+                    new_limit_contract_code_size: None,
+                    new_block_gas_limit: None,
+                    new_tx_gas_limit: Some(new_tx_gas_limit),
+                }),
+                new_admin: None,
+            },
+        )),
+        assert: Box::new(move |ctx, state| {
+            assert!(ctx.tx_receipt.is_successful());
+            assert_eq!(
+                evm.cfg(state).unwrap().chain_spec.tx_gas_limit,
+                Some(new_tx_gas_limit)
+            );
+        }),
+    });
+}
+
+fn setup_archival_burn_gas_regression_case(
+) -> (TestRunner<RT, S>, Address, TestUser<S>, Address, u32) {
+    let (mut runner, account, _, admin) = setup();
+    let contract = LegacySimpleStorage::default();
+    let caller = account.address();
+    let contract_addr = caller.create(0);
+    runner.execute(create_deploy_tx(0, &contract, &account).tx);
+
+    let iterations = runner.query_visible_state(|state| {
+        find_burn_gas_iterations_requiring_archival_tx_gas_cap(
+            &Evm::<S>::default(),
+            state,
+            caller,
+            contract_addr,
+        )
+    });
+
+    (runner, caller, admin, contract_addr, iterations)
+}
 
 #[test]
 fn test_state_at_different_depth_is_accessible() {
@@ -29,4 +185,99 @@ fn test_state_at_different_depth_is_accessible() {
         assert_eq!(balance(Some("0x01")), 1);
         assert_eq!(balance(Some("0x02")), 2);
     });
+}
+
+#[test]
+fn test_historical_eth_call_and_estimate_gas_keep_archival_tx_gas_limit_for_omitted_gas() {
+    let (mut runner, caller, admin, contract_addr, iterations) =
+        setup_archival_burn_gas_regression_case();
+    let request = burn_gas_request(caller, contract_addr, iterations, None);
+
+    let (before_output, before_estimate) = runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let output = evm
+            .eth_call(
+                request.clone(),
+                Some(BlockId::number(HISTORICAL_BLOCK)),
+                None,
+                None,
+                state,
+            )
+            .unwrap();
+        let estimate = evm
+            .eth_estimate_gas(
+                request.clone(),
+                Some(BlockId::number(HISTORICAL_BLOCK)),
+                None,
+                None,
+                state,
+            )
+            .unwrap();
+        (output, estimate)
+    });
+
+    update_tx_gas_limit(&mut runner, &admin, UPDATED_TX_GAS_LIMIT);
+
+    let (after_output, after_estimate) = runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let output = evm
+            .eth_call(
+                request.clone(),
+                Some(BlockId::number(HISTORICAL_BLOCK)),
+                None,
+                None,
+                state,
+            )
+            .unwrap();
+        let estimate = evm
+            .eth_estimate_gas(
+                request.clone(),
+                Some(BlockId::number(HISTORICAL_BLOCK)),
+                None,
+                None,
+                state,
+            )
+            .unwrap();
+        (output, estimate)
+    });
+
+    assert_eq!(before_output, after_output);
+    assert_eq!(before_estimate, after_estimate);
+}
+
+#[test]
+fn test_historical_create_access_list_keeps_archival_tx_gas_limit_for_omitted_gas() {
+    let (mut runner, caller, admin, contract_addr, iterations) =
+        setup_archival_burn_gas_regression_case();
+    let request = burn_gas_request(caller, contract_addr, iterations, None);
+
+    let before = runner.query_visible_state(|state| {
+        Evm::<S>::default()
+            .eth_create_access_list(
+                request.clone(),
+                Some(BlockId::number(HISTORICAL_BLOCK)),
+                state,
+            )
+            .unwrap()
+    });
+    assert!(
+        before.error.is_none(),
+        "precondition failed: historical eth_createAccessList should succeed before lowering the live tx gas limit"
+    );
+
+    update_tx_gas_limit(&mut runner, &admin, UPDATED_TX_GAS_LIMIT);
+
+    let after = runner.query_visible_state(|state| {
+        Evm::<S>::default()
+            .eth_create_access_list(
+                request.clone(),
+                Some(BlockId::number(HISTORICAL_BLOCK)),
+                state,
+            )
+            .unwrap()
+    });
+
+    assert_eq!(before.access_list, after.access_list);
+    assert_eq!(before.gas_used, after.gas_used);
+    assert_eq!(before.error, after.error);
 }

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/rpc_call_overrides.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/rpc_call_overrides.rs
@@ -463,6 +463,46 @@ fn test_eth_call_and_estimate_gas_prefer_fee_cap_over_stale_nonce_after_block_ov
 }
 
 #[test]
+fn test_omitted_gas_respects_lower_block_gas_limit_override() {
+    let (runner, account, _, _) = setup();
+    let target = Address::with_last_byte(0x56);
+    let expected = U256::from(0x1234u64);
+
+    runner.query_visible_state(|state| {
+        let evm = Evm::<S>::default();
+        let request = call_request(account.address(), target);
+        let mut state_overrides = StateOverride::default();
+        state_overrides.insert(
+            target,
+            AccountOverride::default().with_code(runtime_returning_constant(expected)),
+        );
+        let block_overrides = BlockOverrides::default().with_gas_limit(500_000);
+
+        let output = evm
+            .eth_call(
+                request.clone(),
+                None,
+                Some(state_overrides.clone()),
+                Some(Box::new(block_overrides.clone())),
+                state,
+            )
+            .unwrap();
+        assert_eq!(decode_u256(output), expected);
+
+        let estimate = evm
+            .eth_estimate_gas(
+                request,
+                None,
+                Some(state_overrides),
+                Some(Box::new(block_overrides)),
+                state,
+            )
+            .unwrap();
+        assert!(estimate.to::<u64>() > 0);
+    });
+}
+
+#[test]
 fn test_eth_call_block_overrides_base_fee_and_number_are_applied() {
     let (mut runner, account, _, _) = setup();
     let basefee_contract_addr = account.address().create(0);

--- a/examples/demo-rollup/tests/evm/evm_rpc_compliance_validation_2.rs
+++ b/examples/demo-rollup/tests/evm/evm_rpc_compliance_validation_2.rs
@@ -289,7 +289,6 @@ async fn rpc2_002_estimate_send_affordability_consistency() -> anyhow::Result<()
 
 /// RPC2-003 (gasleft probe): Omitted-gas `eth_call` should default to the tx gas cap.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Known discrepancy: will be fixed in the follow up"]
 async fn rpc2_003_eth_call_default_gas_uses_tx_cap() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     rollup.wait_for_rollup_height_advance_by(1).await;
@@ -408,7 +407,6 @@ async fn rpc2_003_eth_call_default_gas_uses_tx_cap() -> anyhow::Result<()> {
 
 /// RPC2-003 (end-to-end burnGas): Omitted-gas simulation agrees with real tx cap on workload classification.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Known discrepancy: will be fixed in the follow up"]
 async fn rpc2_003_omitted_gas_simulation_matches_real_tx_cap() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     rollup.wait_for_rollup_height_advance_by(1).await;


### PR DESCRIPTION
# Description

Omitted gas limit falls back to tx_gas_limit or block_env.gas_limit

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2271 

## Testing
Ignored tests re-enabled

## Docs
No updates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
