### PR TITLE
Implement aggregation algorithm with recursive proof verification

### DIFF
--- a/crates/full-node/sov-aggregated-proof/Cargo.lock
+++ b/crates/full-node/sov-aggregated-proof/Cargo.lock
@@ -6229,6 +6229,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "demo-stf",
  "serde",
  "serde_json",
  "slop-algebra",
@@ -6252,12 +6253,15 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "demo-stf",
+ "serde",
  "sha2 0.10.9",
  "sov-aggregated-proof-shared",
  "sov-mock-da",
  "sov-mock-zkvm",
  "sov-modules-api",
+ "sov-rollup-interface",
  "sov-sp1-adapter",
+ "sp1-sdk",
  "sp1-zkvm",
 ]
 

--- a/crates/full-node/sov-aggregated-proof/program/Cargo.toml
+++ b/crates/full-node/sov-aggregated-proof/program/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 bincode = { workspace = true }
+serde = { workspace = true }
 demo-stf = { path = "../../../../examples/demo-rollup/stf", default-features = false }
 sha2 = { workspace = true }
 sp1-zkvm = { workspace = true }
@@ -14,4 +15,9 @@ sov-aggregated-proof-shared = { workspace = true }
 sov-mock-da = { workspace = true }
 sov-mock-zkvm = { workspace = true }
 sov-modules-api = { workspace = true }
+sov-rollup-interface = { workspace = true }
 sov-sp1-adapter = { workspace = true }
+
+[build-dependencies]
+bincode = { workspace = true }
+sp1-sdk = { workspace = true }

--- a/crates/full-node/sov-aggregated-proof/program/build.rs
+++ b/crates/full-node/sov-aggregated-proof/program/build.rs
@@ -1,0 +1,37 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use sp1_sdk::prelude::HashableKey;
+use sp1_sdk::SP1VerifyingKey;
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
+    let data_dir = manifest_dir
+        .parent()
+        .expect("program crate must live under the sov-aggregated-proof workspace root")
+        .join("data");
+    let inner_vk_path = data_dir.join("inner_vk.bin");
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));
+
+    println!("cargo:rerun-if-changed={}", inner_vk_path.display());
+
+    let inner_vk_bytes = fs::read(&inner_vk_path).unwrap_or_else(|error| {
+        panic!(
+            "Failed to read saved inner verifying key fixture at {}: {error}",
+            inner_vk_path.display()
+        )
+    });
+    let inner_vk: SP1VerifyingKey = bincode::deserialize(&inner_vk_bytes).unwrap_or_else(|error| {
+        panic!(
+            "Failed to deserialize saved inner verifying key fixture at {}: {error}",
+            inner_vk_path.display()
+        )
+    });
+    let inner_vk_hash = inner_vk.hash_u32();
+
+    let generated = format!("const INNER_VKEY_HASH: [u32; 8] = {inner_vk_hash:?};\n");
+
+    fs::write(out_dir.join("inner_vk_hash.rs"), generated)
+        .expect("Failed to write generated inner VK hash file");
+}

--- a/crates/full-node/sov-aggregated-proof/program/src/aggregation.rs
+++ b/crates/full-node/sov-aggregated-proof/program/src/aggregation.rs
@@ -1,0 +1,197 @@
+use sha2::{Digest, Sha256};
+use sov_aggregated_proof_shared::{
+    AggPubData, AggregatedProofWitness, DeferredProofInput, StfPubData,
+};
+use sov_modules_api::da::BlockHeaderTrait;
+use sov_modules_api::{DaSpec, OuterCodeCommitmentHash, Spec, Storage};
+use sov_rollup_interface::common::SlotNumber;
+
+struct BoundaryData<Hash, Root> {
+    slot_hash: Hash,
+    state_root: Root,
+    slot_number: SlotNumber,
+}
+
+struct VerifiedProofData<Address, Hash, Root> {
+    initial_boundary: BoundaryData<Hash, Root>,
+    final_boundary: BoundaryData<Hash, Root>,
+    rewarded_addresses: Vec<Address>,
+}
+
+type VerifyResult<S, Da> = VerifiedProofData<
+    <S as Spec>::Address,
+    <Da as DaSpec>::SlotHash,
+    <<S as Spec>::Storage as Storage>::Root,
+>;
+
+pub(crate) fn run_aggregation_program<S: Spec<Da = Da>, Da: DaSpec>(
+    witness: AggregatedProofWitness<Da>,
+    inner_vkey_hash: [u32; 8],
+) {
+    let proof_inputs = witness.proof_inputs;
+    let outer_vkey_hash = witness.outer_vkey_hash;
+    let prev_outer_proof_witness = witness.prev_outer_proof_witness;
+
+    // Verify the previous aggregation proof if one exists. On the first aggregation
+    // after genesis, there is no predecessor, the chain starts here.
+    let previous_public_data = if let Some(prev_outer_proof_witness) = prev_outer_proof_witness {
+        Some(deserialize_and_verify_pub_data::<AggPubData<S, Da>>(
+            &prev_outer_proof_witness.public_values,
+            outer_vkey_hash,
+        ))
+    } else {
+        None
+    };
+
+    let verified_proof_data: VerifyResult<S, Da> =
+        verify_proof_chain::<S, Da>(proof_inputs, inner_vkey_hash, previous_public_data.as_ref());
+
+    let VerifiedProofData {
+        initial_boundary,
+        final_boundary,
+        rewarded_addresses,
+    } = verified_proof_data;
+
+    // Propagate the genesis state root forward through recursive aggregations.
+    // For the very first aggregation, the genesis root is the initial state root
+    // of the first inner proof (i.e. the state root at chain genesis).
+    let genesis_state_root = previous_public_data
+        .as_ref()
+        .map(|public_data| public_data.genesis_state_root.clone())
+        .unwrap_or_else(|| initial_boundary.state_root.clone());
+
+    let outer_vk_hash = outer_vk_hash_from_vkey_hash(outer_vkey_hash);
+
+    let aggregated_public_data = AggPubData::<S, Da> {
+        initial_slot_number: initial_boundary.slot_number,
+        final_slot_number: final_boundary.slot_number,
+        genesis_state_root,
+        initial_state_root: initial_boundary.state_root,
+        final_state_root: final_boundary.state_root,
+        initial_slot_hash: initial_boundary.slot_hash,
+        final_slot_hash: final_boundary.slot_hash,
+        outer_vk_hash,
+        rewarded_addresses,
+    };
+
+    // Commit the aggregated public data as this program's public output.
+    // This is what external verifiers (and the next recursive aggregation) will see.
+    sp1_zkvm::io::commit(&aggregated_public_data);
+}
+
+fn verify_proof_chain<S: Spec, Da: DaSpec>(
+    proof_inputs: Vec<DeferredProofInput<Da>>,
+    vkey_hash: [u32; 8],
+    previous_agg_proof_public_data: Option<&AggPubData<S, Da>>,
+) -> VerifyResult<S, Da> {
+    assert!(
+        !proof_inputs.is_empty(),
+        "Aggregated proof must contain at least one proof input"
+    );
+
+    let mut expected_prev_slot_hash =
+        previous_agg_proof_public_data.map(|public_data| public_data.final_slot_hash.clone());
+
+    let mut expected_prev_state_root =
+        previous_agg_proof_public_data.map(|public_data| public_data.final_state_root.clone());
+
+    let mut initial_boundary = None;
+    let mut final_boundary = None;
+
+    let mut rewarded_addresses = Vec::with_capacity(proof_inputs.len());
+
+    for (index, proof_input) in proof_inputs.iter().enumerate() {
+        let stf_public_data = deserialize_and_verify_pub_data::<StfPubData<S, Da>>(
+            &proof_input.public_values,
+            vkey_hash,
+        );
+
+        let current_slot_number = SlotNumber::new(proof_input.da_block_header.height());
+
+        // Verify DA block hash-chain continuity: each block's prev_hash must equal
+        // the predecessor's hash. Also cross-check that the DA header hash matches
+        // the slot_hash committed in the STF proof's public data, binding the DA
+        // layer to the execution layer.
+        {
+            let da_block_header = &proof_input.da_block_header;
+            let current_block_hash = da_block_header.hash();
+
+            if let Some(expected_prev_slot_hash) = &expected_prev_slot_hash {
+                assert_eq!(
+                    expected_prev_slot_hash,
+                    &da_block_header.prev_hash(),
+                    "DA block chain broken at index {index}: prev_hash mismatch"
+                );
+            }
+
+            assert_eq!(
+                current_block_hash, stf_public_data.slot_hash,
+                "Slot hash mismatch at index {index}: DA block header hash doesn't match public data"
+            );
+            expected_prev_slot_hash = Some(current_block_hash);
+        }
+
+        // Verify state root continuity: each proof's initial_state_root must equal
+        // the predecessor's final_state_root, ensuring no gaps in the state
+        // transition.
+        {
+            if let Some(expected_prev_state_root) = &expected_prev_state_root {
+                assert_eq!(
+                    expected_prev_state_root, &stf_public_data.initial_state_root,
+                    "State root discontinuity at index {index}: previous final_state_root != current initial_state_root"
+                );
+            }
+
+            expected_prev_state_root = Some(stf_public_data.final_state_root.clone());
+        }
+
+        // Record the boundary data for this aggregation's public output.
+        // initial_boundary is captured only from the first proof; final_boundary
+        // is overwritten on every iteration so it reflects the last proof.
+        if initial_boundary.is_none() {
+            initial_boundary = Some(BoundaryData {
+                slot_hash: proof_input.da_block_header.hash(),
+                state_root: stf_public_data.initial_state_root.clone(),
+                slot_number: current_slot_number.clone(),
+            });
+        }
+
+        rewarded_addresses.push(stf_public_data.prover_address.clone());
+        final_boundary = Some(BoundaryData {
+            slot_hash: proof_input.da_block_header.hash(),
+            state_root: stf_public_data.final_state_root,
+            slot_number: current_slot_number,
+        });
+    }
+
+    let initial_boundary = initial_boundary.expect("proof_inputs is non-empty");
+    let final_boundary = final_boundary.expect("proof_inputs is non-empty");
+
+    VerifyResult::<S, Da> {
+        initial_boundary,
+        final_boundary,
+        rewarded_addresses,
+    }
+}
+
+// Verify that a proof with the given vkey_hash actually
+// produced these public values, then deserialize them. This is the core
+// trust anchor: the vkey_hash pins which program generated the proof.
+fn deserialize_and_verify_pub_data<T: serde::de::DeserializeOwned>(
+    pub_values: &[u8],
+    vkey_hash: [u32; 8],
+) -> T {
+    let public_values_digest: [u8; 32] = Sha256::digest(pub_values).into();
+    sp1_zkvm::lib::verify::verify_sp1_proof(&vkey_hash, &public_values_digest);
+
+    bincode::deserialize(pub_values)
+        .unwrap_or_else(|error| panic!("Failed to deserialize aggregated public data: {error}"))
+}
+
+fn outer_vk_hash_from_vkey_hash(vkey_hash: [u32; 8]) -> OuterCodeCommitmentHash {
+    let mut bytes = Vec::with_capacity(32);
+    for word in vkey_hash {
+        bytes.extend_from_slice(&word.to_le_bytes());
+    }
+    OuterCodeCommitmentHash(bytes)
+}

--- a/crates/full-node/sov-aggregated-proof/program/src/aggregation.rs
+++ b/crates/full-node/sov-aggregated-proof/program/src/aggregation.rs
@@ -195,7 +195,8 @@ fn deserialize_and_verify_pub_data<T: serde::de::DeserializeOwned>(
 fn outer_vk_hash_from_vkey_hash(vkey_hash: [u32; 8]) -> OuterCodeCommitmentHash {
     let mut bytes = Vec::with_capacity(32);
     for word in vkey_hash {
-        bytes.extend_from_slice(&word.to_le_bytes());
+        // Match SP1's HashableKey::hash_bytes representation for hash_u32().
+        bytes.extend_from_slice(&word.to_be_bytes());
     }
     OuterCodeCommitmentHash(bytes)
 }

--- a/crates/full-node/sov-aggregated-proof/program/src/aggregation.rs
+++ b/crates/full-node/sov-aggregated-proof/program/src/aggregation.rs
@@ -95,6 +95,10 @@ fn verify_proof_chain<S: Spec, Da: DaSpec>(
     let mut expected_prev_state_root =
         previous_agg_proof_public_data.map(|public_data| public_data.final_state_root.clone());
 
+    // We intentionally scope the output to the current set of inner proofs only.
+    // The predecessor proof is verified for chain continuity, but its slot range
+    // and rewards are not carried forward — each aggregation covers only the
+    // proofs it directly verifies.
     let mut initial_boundary = None;
     let mut final_boundary = None;
 

--- a/crates/full-node/sov-aggregated-proof/program/src/main.rs
+++ b/crates/full-node/sov-aggregated-proof/program/src/main.rs
@@ -1,103 +1,23 @@
 #![no_main]
 
+mod aggregation;
+
 sp1_zkvm::entrypoint!(main);
 
+use crate::aggregation::run_aggregation_program;
 use demo_stf::MultiAddressEvmSolana;
-use sha2::{Digest, Sha256};
-use sov_aggregated_proof_shared::{
-    AggregatedProofWitness, DeferredProofInput, PreviousOuterProofWitness,
-};
+use sov_aggregated_proof_shared::AggregatedProofWitness;
 use sov_mock_da::MockDaSpec;
 use sov_mock_zkvm::MockZkvm;
 use sov_modules_api::configurable_spec::ConfigurableSpec;
-use sov_modules_api::da::BlockHeaderTrait;
 use sov_modules_api::execution_mode::Zk;
-use sov_modules_api::DaSpec;
-use sov_modules_api::Spec;
-use sov_modules_api::StateTransitionPublicData;
-use sov_modules_api::Storage;
 use sov_sp1_adapter::SP1;
 
-type S = ConfigurableSpec<MockDaSpec, SP1, MockZkvm, MultiAddressEvmSolana, Zk>;
+include!(concat!(env!("OUT_DIR"), "/inner_vk_hash.rs"));
 
-type StPubData<S: Spec, Da: DaSpec> =
-    StateTransitionPublicData<<S as Spec>::Address, Da, <<S as Spec>::Storage as Storage>::Root>;
+type ProgramSpec = ConfigurableSpec<MockDaSpec, SP1, MockZkvm, MultiAddressEvmSolana, Zk>;
 
 pub fn main() {
     let witness = sp1_zkvm::io::read::<AggregatedProofWitness<MockDaSpec>>();
-    let proof_inputs = witness.proof_inputs;
-    let vkey_hash = witness.vkey_hash;
-    let prev_outer_proof_witness = witness.prev_outer_proof_witness;
-
-    verify::<S, MockDaSpec>(proof_inputs, vkey_hash);
-
-    if let Some(prev_outer_proof_witness) = prev_outer_proof_witness {
-        verify_sp1_proof(
-            &prev_outer_proof_witness.public_values,
-            prev_outer_proof_witness.vkey_hash,
-        );
-    }
-}
-
-fn verify<S: Spec, Da: DaSpec>(proof_inputs: Vec<DeferredProofInput<Da>>, vkey_hash: [u32; 8]) {
-    assert!(
-        !proof_inputs.is_empty(),
-        "Aggregated proof must contain at least one proof input"
-    );
-
-    // `None` means no predecessor to check against (first iteration).
-    let mut expected_prev_hash = None;
-    let mut expected_state_root = None;
-
-    for (index, proof_input) in proof_inputs.iter().enumerate() {
-        let stf_public_data =
-            deserialize_pub_data::<S, Da>(proof_input.public_values.as_slice(), index);
-
-        // Check that DA blocks form a chain.
-        {
-            let da_block_header = &proof_input.da_block_header;
-            let current_block_hash = da_block_header.hash();
-
-            if let Some(expected_prev_hash) = &expected_prev_hash {
-                assert_eq!(
-                    expected_prev_hash,
-                    &da_block_header.prev_hash(),
-                    "DA block chain broken at index {index}: prev_hash mismatch"
-                );
-            }
-
-            // Check that the slot hash from the public input matches the current block hash.
-            assert_eq!(
-                current_block_hash, stf_public_data.slot_hash,
-                "Slot hash mismatch at index {index}: DA block header hash doesn't match public data"
-            );
-            expected_prev_hash = Some(current_block_hash);
-        }
-
-        // Check that state roots are sequentially related by the state transition.
-        {
-            if let Some(expected_state_root) = &expected_state_root {
-                assert_eq!(
-                    expected_state_root, &stf_public_data.initial_state_root,
-                    "State root discontinuity at index {index}: previous final_state_root != current initial_state_root"
-                );
-            }
-
-            println!("Verifying {index}");
-            verify_sp1_proof(&proof_input.public_values, vkey_hash);
-
-            expected_state_root = Some(stf_public_data.final_state_root.clone());
-        }
-    }
-}
-
-fn verify_sp1_proof(public_values: &[u8], vkey_hash: [u32; 8]) {
-    let public_values_digest: [u8; 32] = Sha256::digest(public_values).into();
-    sp1_zkvm::lib::verify::verify_sp1_proof(&vkey_hash, &public_values_digest);
-}
-
-fn deserialize_pub_data<S: Spec, Da: DaSpec>(data: &[u8], index: usize) -> StPubData<S, Da> {
-    bincode::deserialize(data).unwrap_or_else(|error| {
-        panic!("Failed to deserialize public values from proof input {index}: {error}")
-    })
+    run_aggregation_program::<ProgramSpec, MockDaSpec>(witness, INNER_VKEY_HASH);
 }

--- a/crates/full-node/sov-aggregated-proof/script/Cargo.toml
+++ b/crates/full-node/sov-aggregated-proof/script/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 bincode = { workspace = true }
+demo-stf = { path = "../../../../examples/demo-rollup/stf", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 slop-algebra = "6.0.2"

--- a/crates/full-node/sov-aggregated-proof/script/src/main.rs
+++ b/crates/full-node/sov-aggregated-proof/script/src/main.rs
@@ -4,12 +4,18 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use anyhow::{bail, ensure, Context};
+use demo_stf::MultiAddressEvmSolana;
 use slop_algebra::PrimeField32;
 use sov_aggregated_proof_shared::{
-    AggregatedProofWitness, DeferredProofInput, PreviousOuterProofWitness,
+    AggPubData, AggregatedProofWitness, DeferredProofInput, PreviousOuterProofWitness, StfPubData,
 };
 use sov_mock_da::MockDaSpec;
+use sov_mock_zkvm::MockZkvm;
+use sov_modules_api::configurable_spec::ConfigurableSpec;
+use sov_modules_api::execution_mode::Zk;
+use sov_modules_api::{Spec, Storage};
 use sov_sp1_adapter::BlockHeaderWithProof;
+use sov_sp1_adapter::SP1;
 use sp1_recursion_executor::RecursionPublicValues;
 use sp1_sdk::blocking::{ProveRequest, Prover, ProverClient};
 use sp1_sdk::prelude::{include_elf, Elf, HashableKey, SP1Stdin};
@@ -17,6 +23,8 @@ use sp1_sdk::{ProvingKey, SP1Proof, SP1ProofWithPublicValues, SP1VerifyingKey};
 
 const AGGREGATION_ELF: Elf = include_elf!("sov-aggregated-proof-program");
 const JUMP: usize = 3;
+
+type S = ConfigurableSpec<MockDaSpec, SP1, MockZkvm, MultiAddressEvmSolana, Zk>;
 
 fn main() -> anyhow::Result<()> {
     let start = Instant::now();
@@ -37,7 +45,6 @@ fn main() -> anyhow::Result<()> {
     );
 
     let verification_key = saved_inner_vk()?;
-    let inner_vk_hash = verification_key.hash_u32();
     let prover = ProverClient::builder().cpu().build();
 
     let aggregation_pk = prover.setup(AGGREGATION_ELF).map_err(|error| {
@@ -50,7 +57,7 @@ fn main() -> anyhow::Result<()> {
         .collect::<Vec<_>>();
     let num_outer_proofs = proof_batches.len();
 
-    let mut previous_outer_proof = None;
+    let mut previous_outer_proof: Option<SP1ProofWithPublicValues> = None;
 
     for (batch_index, proof_batch) in proof_batches.into_iter().enumerate() {
         println!(
@@ -60,14 +67,55 @@ fn main() -> anyhow::Result<()> {
             proof_batch.len()
         );
 
-        previous_outer_proof = Some(create_agg_proof(
+        let previous_outer_public_data = previous_outer_proof
+            .as_ref()
+            .map(|proof| {
+                deserialize_pub_data::<AggPubData<S, MockDaSpec>>(proof.public_values.as_slice())
+            })
+            .transpose()
+            .context("Failed to deserialize previous outer proof public data")?;
+
+        let (expected_initial_state_root, expected_final_state_root) =
+            batch_state_roots(&proof_batch)
+                .context("Failed to derive expected state roots from the current proof batch")?;
+
+        let outer_proof = create_agg_proof(
             &prover,
             &aggregation_pk,
             &verification_key,
-            inner_vk_hash,
             proof_batch,
-            previous_outer_proof,
-        )?);
+            previous_outer_proof.take(),
+        )?;
+
+        let public_data: AggPubData<S, MockDaSpec> =
+            deserialize_pub_data(outer_proof.public_values.as_slice())
+                .context("Failed to deserialize outer proof public data")?;
+
+        ensure!(
+            public_data.initial_state_root == expected_initial_state_root,
+            "Outer proof {} initial_state_root does not match the first inner proof initial_state_root",
+            batch_index + 1
+        );
+        ensure!(
+            public_data.final_state_root == expected_final_state_root,
+            "Outer proof {} final_state_root does not match the last inner proof final_state_root",
+            batch_index + 1
+        );
+
+        if let Some(previous_outer_public_data) = previous_outer_public_data.as_ref() {
+            ensure!(
+                public_data.genesis_state_root == previous_outer_public_data.genesis_state_root,
+                "Outer proof {} genesis_state_root changed across recursive aggregation",
+                batch_index + 1
+            );
+            ensure!(
+                public_data.initial_state_root == previous_outer_public_data.final_state_root,
+                "Outer proof {} initial_state_root does not continue the previous outer proof final_state_root",
+                batch_index + 1
+            );
+        }
+
+        previous_outer_proof = Some(outer_proof);
     }
 
     println!("[host] verified outer proof(s) in {:?}", start.elapsed());
@@ -79,7 +127,6 @@ fn create_agg_proof<P: Prover>(
     prover: &P,
     aggregation_pk: &P::ProvingKey,
     verification_key: &SP1VerifyingKey,
-    inner_vk_hash: [u32; 8],
     raw_proofs: Vec<BlockHeaderWithProof<MockDaSpec>>,
     previous_outer_proof: Option<SP1ProofWithPublicValues>,
 ) -> anyhow::Result<SP1ProofWithPublicValues> {
@@ -89,8 +136,26 @@ fn create_agg_proof<P: Prover>(
     );
 
     let aggregation_vk_hash = aggregation_pk.verifying_key().hash_u32();
-
+    let inner_vk_hash = verification_key.hash_u32();
     let mut stdin = SP1Stdin::new();
+
+    let prev_outer_proof_witness = if let Some(previous_outer_proof) = previous_outer_proof {
+        let SP1Proof::Compressed(recursion_proof) = &previous_outer_proof.proof else {
+            bail!("Expected the previous outer proof to be a compressed SP1 proof");
+        };
+
+        stdin.write_proof(
+            *recursion_proof.clone(),
+            aggregation_pk.verifying_key().vk.clone(),
+        );
+
+        Some(PreviousOuterProofWitness {
+            public_values: previous_outer_proof.public_values.to_vec(),
+        })
+    } else {
+        None
+    };
+
     let mut proof_inputs = Vec::with_capacity(raw_proofs.len());
 
     for (index, block_header_with_proof) in raw_proofs.into_iter().enumerate() {
@@ -122,27 +187,9 @@ fn create_agg_proof<P: Prover>(
         stdin.write_proof(*recursion_proof.clone(), verification_key.vk.clone());
     }
 
-    let prev_outer_proof_witness = if let Some(previous_outer_proof) = previous_outer_proof {
-        let SP1Proof::Compressed(recursion_proof) = &previous_outer_proof.proof else {
-            bail!("Expected the previous outer proof to be a compressed SP1 proof");
-        };
-
-        stdin.write_proof(
-            *recursion_proof.clone(),
-            aggregation_pk.verifying_key().vk.clone(),
-        );
-
-        Some(PreviousOuterProofWitness {
-            public_values: previous_outer_proof.public_values.to_vec(),
-            vkey_hash: aggregation_vk_hash,
-        })
-    } else {
-        None
-    };
-
     let witness = AggregatedProofWitness {
         proof_inputs,
-        vkey_hash: inner_vk_hash,
+        outer_vkey_hash: aggregation_vk_hash,
         prev_outer_proof_witness,
     };
 
@@ -159,6 +206,18 @@ fn create_agg_proof<P: Prover>(
     prover
         .verify(&outer_proof, aggregation_pk.verifying_key(), None)
         .context("Failed to verify the outer SP1 aggregation proof")?;
+
+    let public_data: AggPubData<S, MockDaSpec> =
+        deserialize_pub_data(outer_proof.public_values.as_slice())
+            .context("Failed to deserialize outer proof public data")?;
+
+    println!(
+        "[host] outer proof emits slots {}..={} with hashes {} -> {}",
+        public_data.initial_slot_number,
+        public_data.final_slot_number,
+        public_data.initial_slot_hash,
+        public_data.final_slot_hash
+    );
 
     Ok(outer_proof)
 }
@@ -221,4 +280,38 @@ fn read_saved_proof(file_path: &Path) -> anyhow::Result<BlockHeaderWithProof<Moc
         })?;
 
     Ok(block_header_with_proof)
+}
+
+fn deserialize_pub_data<T: serde::de::DeserializeOwned>(data: &[u8]) -> anyhow::Result<T> {
+    bincode::deserialize(data).context("Failed to deserialize public data")
+}
+
+fn batch_state_roots(
+    proof_batch: &[BlockHeaderWithProof<MockDaSpec>],
+) -> anyhow::Result<(
+    <<S as Spec>::Storage as Storage>::Root,
+    <<S as Spec>::Storage as Storage>::Root,
+)> {
+    let first_proof = proof_batch
+        .first()
+        .expect("proof batches are guaranteed to be non-empty");
+    let last_proof = proof_batch
+        .last()
+        .expect("proof batches are guaranteed to be non-empty");
+
+    let first_public_data: StfPubData<S, MockDaSpec> = deserialize_pub_data(
+        sov_sp1_adapter::decode_sp1_proof(&first_proof.proof)?
+            .public_values
+            .as_slice(),
+    )?;
+    let last_public_data: StfPubData<S, MockDaSpec> = deserialize_pub_data(
+        sov_sp1_adapter::decode_sp1_proof(&last_proof.proof)?
+            .public_values
+            .as_slice(),
+    )?;
+
+    Ok((
+        first_public_data.initial_state_root,
+        last_public_data.final_state_root,
+    ))
 }

--- a/crates/full-node/sov-aggregated-proof/shared/src/lib.rs
+++ b/crates/full-node/sov-aggregated-proof/shared/src/lib.rs
@@ -1,5 +1,13 @@
 use serde::{Deserialize, Serialize};
-use sov_modules_api::DaSpec;
+use sov_modules_api::{
+    AggregatedProofPublicData, DaSpec, Spec, StateTransitionPublicData, Storage,
+};
+
+pub type StfPubData<S, Da> =
+    StateTransitionPublicData<<S as Spec>::Address, Da, <<S as Spec>::Storage as Storage>::Root>;
+
+pub type AggPubData<S, Da> =
+    AggregatedProofPublicData<<S as Spec>::Address, Da, <<S as Spec>::Storage as Storage>::Root>;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DeferredProofInput<Da: DaSpec> {
@@ -10,12 +18,11 @@ pub struct DeferredProofInput<Da: DaSpec> {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AggregatedProofWitness<Da: DaSpec> {
     pub proof_inputs: Vec<DeferredProofInput<Da>>,
-    pub vkey_hash: [u32; 8],
+    pub outer_vkey_hash: [u32; 8],
     pub prev_outer_proof_witness: Option<PreviousOuterProofWitness>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PreviousOuterProofWitness {
     pub public_values: Vec<u8>,
-    pub vkey_hash: [u32; 8],
 }

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -9,7 +9,7 @@ use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
 use sov_rollup_interface::stf::{BatchReceipt, BlobDiscardReason, TransactionReceipt, TxEffect};
 use sov_rollup_interface::stf::{DiscardedBlob, StoredEvent};
 use sov_rollup_interface::zk::aggregated_proof::{
-    AggregatedProofPublicData, CodeCommitment, SerializedAggregatedProof,
+    AggregatedProofPublicData, OuterCodeCommitmentHash, SerializedAggregatedProof,
 };
 use sov_rollup_interface::TxHash;
 use sov_test_utils::ledger_db::sov_api_spec::types::IntOrHash;
@@ -94,7 +94,7 @@ async fn test_save_aggregated_proof() {
             final_state_root: vec![i + 1],
             initial_slot_hash: MockHash([i + 2; 32]),
             final_slot_hash: MockHash([i + 3; 32]),
-            code_commitment: CodeCommitment::default(),
+            outer_vk_hash: OuterCodeCommitmentHash::default(),
             rewarded_addresses: vec![MockAddress::default()],
         };
 

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/mod.rs
@@ -9,7 +9,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::da::DaService;
-use sov_rollup_interface::zk::aggregated_proof::CodeCommitment;
+use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
 use sov_rollup_interface::zk::{Zkvm, ZkvmGuest};
 
 use super::{ProverService, ProverServiceError, RollupProverConfigDiscriminants};
@@ -59,7 +59,7 @@ where
         da_verifier: Da::Verifier,
         config: RollupProverConfigDiscriminants,
         num_threads: usize,
-        code_commitment: CodeCommitment,
+        outer_vk_hash: OuterCodeCommitmentHash,
         prover_address: Address,
     ) -> Self {
         let verifier = Arc::new(Verifier { da_verifier });
@@ -68,7 +68,7 @@ where
             inner_vm,
             outer_vm,
             prover_config: config,
-            prover_state: Prover::new(prover_address, num_threads, code_commitment),
+            prover_state: Prover::new(prover_address, num_threads, outer_vk_hash),
             verifier,
         }
     }
@@ -80,7 +80,7 @@ where
         outer_vm: OuterVm::Host,
         da_verifier: Da::Verifier,
         config: RollupProverConfigDiscriminants,
-        code_commitment: CodeCommitment,
+        outer_vk_hash: OuterCodeCommitmentHash,
         prover_address: Address,
     ) -> Self {
         let num_cpus = num_cpus::get();
@@ -92,7 +92,7 @@ where
             da_verifier,
             config,
             num_cpus - 1,
-            code_commitment,
+            outer_vk_hash,
             prover_address,
         )
     }

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec, DaVerifier};
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::zk::aggregated_proof::{
-    AggregatedProofPublicData, CodeCommitment, SerializedAggregatedProof,
+    AggregatedProofPublicData, OuterCodeCommitmentHash, SerializedAggregatedProof,
 };
 use sov_rollup_interface::zk::{
     StateTransitionPublicData, StateTransitionWitness, StateTransitionWitnessWithAddress, Zkvm,
@@ -37,7 +37,7 @@ pub(crate) struct Prover<Address, StateRoot, Witness, Da: DaService> {
     // and automatically terminate.
     // """
     pool: rayon::ThreadPool,
-    code_commitment: CodeCommitment,
+    outer_vk_hash: OuterCodeCommitmentHash,
     phantom: std::marker::PhantomData<(StateRoot, Witness, Da)>,
 }
 
@@ -52,10 +52,10 @@ where
     pub(crate) fn new(
         prover_address: Address,
         num_threads: usize,
-        code_commitment: CodeCommitment,
+        outer_vk_hash: OuterCodeCommitmentHash,
     ) -> Self {
         Self {
-            code_commitment,
+            outer_vk_hash,
             num_threads,
             pool: rayon::ThreadPoolBuilder::new()
                 .num_threads(num_threads)
@@ -208,7 +208,7 @@ where
             final_state_root: final_block_proof.st.final_state_root.clone(),
             initial_slot_hash: initial_block_proof.st.slot_hash.clone(),
             final_slot_hash: final_block_proof.st.slot_hash.clone(),
-            code_commitment: self.code_commitment.clone(),
+            outer_vk_hash: self.outer_vk_hash.clone(),
         };
 
         trace!(%public_data, "generating aggregate proof");

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
@@ -7,8 +7,8 @@ use sov_mock_zkvm::MockCodeCommitment;
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::registration_lib::StakeRegistration;
 use sov_modules_api::{
-    AggregatedProofPublicData, Amount, ApiStateAccessor, CodeCommitment, SerializedAggregatedProof,
-    Spec, Storage,
+    AggregatedProofPublicData, Amount, ApiStateAccessor, OuterCodeCommitmentHash,
+    SerializedAggregatedProof, Spec, Storage,
 };
 use sov_modules_rollup_blueprint::proof_sender::serialize_proof_blob_with_metadata;
 use sov_prover_incentives::ProverIncentives;
@@ -101,7 +101,7 @@ pub(crate) fn build_proof(
         final_state_root: *end_transition.post_state_root(),
         initial_slot_hash: *initial_transition.slot_hash(),
         final_slot_hash: *end_transition.slot().slot_hash(),
-        code_commitment: CodeCommitment(MOCK_CODE_COMMITMENT.0.to_vec()),
+        outer_vk_hash: OuterCodeCommitmentHash(MOCK_CODE_COMMITMENT.0.to_vec()),
         rewarded_addresses: vec![prover_address],
     })
 }

--- a/crates/module-system/sov-modules-api/src/lib.rs
+++ b/crates/module-system/sov-modules-api/src/lib.rs
@@ -117,7 +117,7 @@ pub use sov_rollup_interface::stf::{
     ProofSender, StateTransitionFunction, StoredEvent,
 };
 pub use sov_rollup_interface::zk::aggregated_proof::{
-    AggregatedProofPublicData, CodeCommitment, SerializedAggregatedProof,
+    AggregatedProofPublicData, OuterCodeCommitmentHash, SerializedAggregatedProof,
 };
 #[cfg(feature = "native")]
 pub use sov_rollup_interface::zk::HostArgs;

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof.rs
@@ -9,18 +9,18 @@ use super::ZkVerifier;
 use crate::common::SlotNumber;
 use crate::da::DaSpec;
 
-/// Aggregated proof code commitment.
+/// Aggregated proof outer code commitment hash.
 #[derive(
     Debug, Eq, PartialEq, BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone, Default,
 )]
-pub struct CodeCommitment(pub Vec<u8>);
+pub struct OuterCodeCommitmentHash(pub Vec<u8>);
 
-impl core::fmt::Display for CodeCommitment {
+impl core::fmt::Display for OuterCodeCommitmentHash {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if self.0.is_empty() {
-            return write!(f, "CodeCommitment([])");
+            return write!(f, "OuterCodeCommitmentHash([])");
         }
-        write!(f, "CodeCommitment(0x{})", hex::encode(&self.0))
+        write!(f, "OuterCodeCommitmentHash(0x{})", hex::encode(&self.0))
     }
 }
 
@@ -41,8 +41,8 @@ pub struct AggregatedProofPublicData<Address, Da: DaSpec, Root> {
     pub initial_slot_hash: Da::SlotHash,
     /// The final slot hash of the aggregated proof.
     pub final_slot_hash: Da::SlotHash,
-    /// Code Commitment of the aggregated proof circuit.
-    pub code_commitment: CodeCommitment,
+    /// Outer verifying key hash of the aggregated proof circuit.
+    pub outer_vk_hash: OuterCodeCommitmentHash,
     /// These are the addresses of the provers who proved individual blocks.
     pub rewarded_addresses: Vec<Address>,
 }
@@ -53,7 +53,7 @@ impl<Address, Da: DaSpec, Root: AsRef<[u8]>> core::fmt::Display
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
-            "AggregatedProofPublicData(initial_slot_number: {}, final_slot_number: {}, genesis_state_root: {}, initial_state_root: 0x{}, final_state_root: 0x{}, initial_slot_hash: 0x{}, final_slot_hash: 0x{}, code_commitment: {})",
+            "AggregatedProofPublicData(initial_slot_number: {}, final_slot_number: {}, genesis_state_root: {}, initial_state_root: 0x{}, final_state_root: 0x{}, initial_slot_hash: 0x{}, final_slot_hash: 0x{}, outer_vk_hash: {})",
             self.initial_slot_number,
             self.final_slot_number,
             hex::encode(self.genesis_state_root.as_ref()),
@@ -61,7 +61,7 @@ impl<Address, Da: DaSpec, Root: AsRef<[u8]>> core::fmt::Display
             hex::encode(self.final_state_root.as_ref()),
             hex::encode(self.initial_slot_hash.as_ref()),
             hex::encode(self.final_slot_hash.as_ref()),
-            self.code_commitment
+            self.outer_vk_hash
         )
     }
 }

--- a/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
+++ b/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
@@ -19,7 +19,7 @@ use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, Sequencer
 use sov_modules_stf_blueprint::Runtime as RuntimeTrait;
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::storage::HierarchicalStorageManager;
-use sov_rollup_interface::zk::aggregated_proof::CodeCommitment;
+use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
 use sov_rollup_interface::zk::ZkvmHost;
 use sov_sequencer::ProofBlobSender;
 use sov_state::nomt::prover_storage::NomtProverStorage;
@@ -148,7 +148,7 @@ where
             outer_vm,
             da_verifier,
             prover_config_disc,
-            CodeCommitment::default(),
+            OuterCodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/examples/demo-rollup/src/celestia_nomt_rollup.rs
+++ b/examples/demo-rollup/src/celestia_nomt_rollup.rs
@@ -23,7 +23,7 @@ use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::{Risc0, Risc0CryptoSpec};
 use sov_rollup_interface::da::{DaSpec, DaVerifier};
 use sov_rollup_interface::execution_mode::WitnessGeneration;
-use sov_rollup_interface::zk::aggregated_proof::CodeCommitment;
+use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
 use sov_rollup_interface::zk::CryptoSpec;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_state::nomt::prover_storage::NomtProverStorage;
@@ -180,7 +180,7 @@ impl FullNodeBlueprint<Native> for CelestiaNomtDemoRollup<Native> {
             outer_vm,
             da_verifier,
             prover_config_disc,
-            CodeCommitment::default(),
+            OuterCodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -23,7 +23,7 @@ use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::Risc0;
 use sov_rollup_interface::da::DaVerifier;
 use sov_rollup_interface::execution_mode::WitnessGeneration;
-use sov_rollup_interface::zk::aggregated_proof::CodeCommitment;
+use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
@@ -167,7 +167,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
             outer_vm,
             da_verifier,
             prover_config_disc,
-            CodeCommitment::default(),
+            OuterCodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/examples/demo-rollup/src/external_mock_nomt_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_nomt_rollup.rs
@@ -22,7 +22,7 @@ use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::Risc0;
 use sov_risc0_adapter::Risc0CryptoSpec;
 use sov_rollup_interface::da::DaSpec;
-use sov_rollup_interface::zk::aggregated_proof::CodeCommitment;
+use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::DefaultStorageSpec;
@@ -167,7 +167,7 @@ impl FullNodeBlueprint<Native> for ExternalMockNomtDemoRollup<Native> {
             outer_vm,
             da_verifier,
             prover_config_discriminant,
-            CodeCommitment::default(),
+            OuterCodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -19,7 +19,7 @@ use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
 use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::Risc0;
-use sov_rollup_interface::zk::aggregated_proof::CodeCommitment;
+use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
@@ -151,7 +151,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
             outer_vm,
             da_verifier,
             prover_config_discriminant,
-            CodeCommitment::default(),
+            OuterCodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/examples/demo-rollup/src/mock_nomt_rollup.rs
+++ b/examples/demo-rollup/src/mock_nomt_rollup.rs
@@ -20,7 +20,7 @@ use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, Sequencer
 use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::{Risc0, Risc0CryptoSpec};
 use sov_rollup_interface::da::DaSpec;
-use sov_rollup_interface::zk::aggregated_proof::CodeCommitment;
+use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::{DefaultStorageSpec, Storage};
@@ -163,7 +163,7 @@ impl FullNodeBlueprint<Native> for MockNomtDemoRollup<Native> {
             outer_vm,
             da_verifier,
             prover_config_discriminant,
-            CodeCommitment::default(),
+            OuterCodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -19,7 +19,7 @@ use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
 use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::Risc0;
-use sov_rollup_interface::zk::aggregated_proof::CodeCommitment;
+use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
@@ -150,7 +150,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
             outer_vm,
             da_verifier,
             prover_config_discriminant,
-            CodeCommitment::default(),
+            OuterCodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }


### PR DESCRIPTION
# Description

This PR introduces the following changes:

1. Extracts the aggregation logic from `main.r`s into a dedicated `aggregation.rs` module, with a generic `run_aggregation_program` function for verifying inner proof chains and recursive outer proofs.

2. Adds a `build.rs` step that precomputes the inner verifying key hash at compile time, removing it from the runtime witness.

3. Renames `CodeCommitment` to `OuterCodeCommitmentHash` and `vkey_hash` to `outer_vkey_hash` throughout the codebase for improved clarity.

Note for reviewers: The substantive change is in aggregation.rs. The remaining changes are primarily renaming and script-related improvements, and are not relevant to the security of the outer circuit.                                                                                                                                        

- [ ] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
