### PR TITLE
Disable default features on rust web3-sdk, reducing build tree for python SDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ sov-universal-wallet-macros = { path = "crates/universal-wallet/macros", version
 sov-universal-wallet-macro-helpers = { path = "crates/universal-wallet/macro-helpers", version = "0.3" }
 sov-zkvm-utils = { path = "crates/utils/sov-zkvm-utils" }
 sov-build = { path = "crates/utils/sov-build" }
-sovereign-web3 = { path = "crates/web3" }
+sovereign-web3 = { path = "crates/web3", default-features = false }
 workspace-hack = { path = "crates/utils/workspace-hack" }
 nearly-linear = { path = "crates/utils/nearly-linear", version = "0.3" }
 sov-proxy-utils = { path = "crates/utils/sov-proxy-utils", version = "0.3" }


### PR DESCRIPTION
# Description

The rust crate has both `"rust"` and `"schema"` in default-features; the python SDK only uses the latter, but the former depends on `sov-modules-api` and thus blows up the dependency graph. With this change the python SDK now barely bulds any rust crates.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
