### PR TITLE
Fix: validate replica visible slot before applying leader `BatchStart`

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -948,6 +948,9 @@ where
             seq_nr_from_master,
         )?;
 
+        let batch_from_master =
+            Self::ensure_replica_batch_start_visible_slot_matches(&mut inner, batch_from_master)?;
+
         inner
             .do_batch_start(
                 batch_from_master.visible_slot_number_after_increase,
@@ -997,6 +1000,7 @@ where
         reason: &'static str,
     ) -> Result<(), ReplicaError<S>> {
         let mut inner = self.get_inner_with_timing(reason).await;
+
         let db_data = DbData::BatchEnd(batch_from_master);
         let seq_nr_from_master = db_data.sequence_number();
 
@@ -1062,6 +1066,37 @@ where
         );
 
         Ok(())
+    }
+
+    fn ensure_replica_batch_start_visible_slot_matches(
+        inner: &mut InnerGuard<'_, S, Rt>,
+        batch_from_master: BatchToStore,
+    ) -> Result<BatchToStore, ReplicaError<S>> {
+        let mut replica_vsn = inner.executor.checkpoint.current_visible_slot_number();
+        let replica_expected =
+            replica_vsn.advance(batch_from_master.visible_slots_to_advance.get().into());
+
+        if replica_expected == batch_from_master.visible_slot_number_after_increase {
+            return Ok(batch_from_master);
+        }
+
+        tracing::warn!(
+            %replica_expected,
+            master_expected = %batch_from_master.visible_slot_number_after_increase,
+            "Replica VSN diverged from master. Entering sync mode and retrying."
+        );
+
+        let sync_details = SequencerNotReadyDetails::Syncing {
+            target_da_height: inner.latest_info.sync_status.target_da_height(),
+            synced_da_height: inner.latest_info.sync_status.synced_da_height(),
+        };
+
+        inner.is_ready = Err(sync_details.clone());
+
+        Err(ReplicaError::NotReady(
+            sync_details,
+            Box::new(DbData::BatchStart(batch_from_master)),
+        ))
     }
 }
 

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -895,6 +895,18 @@ where
         }
     }
 
+    /// Check if the sequencer is recovering.
+    pub async fn is_sequencer_recovering(&self) -> bool {
+        let is_ready = self.client.client.is_ready().await;
+
+        if let Err(err) = is_ready {
+            err.to_string()
+                .contains("The preferred sequencer is recovering from downtime")
+        } else {
+            false
+        }
+    }
+
     /// Returns the current sequencer role.
     pub async fn sequencer_role(&self) -> anyhow::Result<SequencerRole> {
         self.client.query_rest_endpoint("/sequencer/role").await
@@ -914,6 +926,17 @@ where
     /// Times out after TestRollup::POLLING_TIMEOUT seconds.
     pub async fn wait_for_sequencer_ready(&self) -> anyhow::Result<()> {
         self.wait_for_sequencer_state(true).await
+    }
+
+    /// Polls the sequencer until it enters recovery mode.
+    ///
+    /// Times out after TestRollup::POLLING_TIMEOUT seconds.
+    pub async fn wait_for_sequencer_recovering(&self) -> anyhow::Result<()> {
+        self.wait_for_condition(
+            || async { Ok(self.is_sequencer_recovering().await) },
+            "sequencer to enter recovery",
+        )
+        .await
     }
 
     /// Generic helper for waiting on a condition with timeout and polling.

--- a/examples/demo-rollup/tests/replica/mod.rs
+++ b/examples/demo-rollup/tests/replica/mod.rs
@@ -1,4 +1,5 @@
 mod db_elected;
+mod recovery;
 mod replica_gets_txs_from_master;
 mod replica_partitioned_db;
 mod replica_registers_in_db;
@@ -31,6 +32,7 @@ use sov_proxy_utils::ClusterInfoService;
 use sov_proxy_utils::RootHashCheck;
 use sov_proxy_utils::RootHashConsistency;
 use sov_sequencer::preferred::ConfiguredNodeRole;
+use sov_sequencer::preferred::RecoveryStrategy;
 use sov_sequencer::SequencerRole;
 use sov_test_utils::postgres::CreatePostgresError;
 use sov_test_utils::test_rollup::read_private_key;
@@ -101,6 +103,7 @@ async fn start_rollup_with_connection_string(
             }
             SequencerKindConfig::Preferred(p) => {
                 p.num_cache_warmup_workers = 0;
+                p.recovery_strategy = RecoveryStrategy::TryToSave;
                 if let Some(connection_string) = postgres_connection_override.as_ref() {
                     p.postgres_config
                         .as_mut()
@@ -186,6 +189,7 @@ type Rollup = ExternalMockDemoRollup<Native>;
 /// Test setup for DbElected tests with two nodes (leader and replica).
 struct NodeDiscoveryTestSetup {
     postgres: Arc<PostgresData>,
+    da_service: StorableMockDaService,
     da_addr: SocketAddr,
     da_shutdown: watch::Sender<()>,
     cluster_info_service: ClusterInfoService,
@@ -211,7 +215,7 @@ impl NodeDiscoveryTestSetup {
             }
         };
 
-        let (_, da_shutdown, da_addr) = create_da_service_periodic().await;
+        let (da_service, da_shutdown, da_addr) = create_da_service_periodic().await;
 
         let cluster_info_service =
             ClusterInfoService::spawn(postgres.connection_string(), max_age, None)
@@ -220,6 +224,7 @@ impl NodeDiscoveryTestSetup {
 
         Some(Self {
             postgres,
+            da_service,
             da_shutdown,
             da_addr,
             cluster_info_service,

--- a/examples/demo-rollup/tests/replica/recovery.rs
+++ b/examples/demo-rollup/tests/replica/recovery.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+/// Test that if the leader enters recovery after falling behind the deferred-slots threshold,
+/// the replica continues to function correctly once recovery completes.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_db_elected_leader_recovery_with_replica() {
+    std::env::set_var("SOV_TEST_CONST_OVERRIDE_DEFERRED_SLOTS_COUNT", "40");
+
+    let Some(setup) = NodeDiscoveryTestSetup::new().await else {
+        return;
+    };
+
+    let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
+
+    let node_1 = setup
+        .start_node("node_1", ConfiguredNodeRole::DbElected)
+        .await;
+    let node_2 = setup
+        .start_node("node_2", ConfiguredNodeRole::DbElected)
+        .await;
+
+    node_1.wait_for_sequencer_ready().await.unwrap();
+    node_2.wait_for_sequencer_ready().await.unwrap();
+
+    let (leader, replica) = establish_leader_and_replica(node_1, node_2).await;
+
+    // Send a transaction to confirm the cluster works before recovery
+    let token_id = config_gas_token_id();
+    let receiver_addr = random_address();
+
+    verify_replica_processes_tx(
+        &leader,
+        &replica,
+        &key_and_address.private_key,
+        token_id,
+        receiver_addr,
+        0,
+    )
+    .await;
+
+    // Pause the sequencer update_state loop to prevent batch production.
+    leader.pause_preferred_batches().await;
+
+    // Produce DA blocks while sequencer is paused to exceed the deferred slots threshold.
+    // With DEFERRED_SLOTS_COUNT=40, the 90% threshold triggers at ~26 blocks of lag.
+    for _ in 0..30 {
+        setup.da_service.produce_block_now().await.unwrap();
+    }
+
+    // Wait for the nodes to sync the DA blocks
+    leader.wait_for_node_synced().await.unwrap();
+
+    // Resume batch production; on the next state update the leader should enter recovery
+    leader.resume_preferred_batches().await;
+    setup.da_service.produce_block_now().await.unwrap();
+
+    // Wait until the leader enters recovery.
+    leader.wait_for_sequencer_recovering().await.unwrap();
+    leader.wait_for_sequencer_ready().await.unwrap();
+
+    // // Send a transaction to confirm the cluster works after recovery.
+    verify_replica_processes_tx(
+        &leader,
+        &replica,
+        &key_and_address.private_key,
+        token_id,
+        receiver_addr,
+        1,
+    )
+    .await;
+
+    replica.shutdown().await.unwrap();
+    leader.shutdown().await.unwrap();
+    setup.shutdown().await;
+}
+
+async fn verify_replica_processes_tx(
+    leader: &TestRollup<Rollup>,
+    replica: &TestRollup<Rollup>,
+    key: &<<S as Spec>::CryptoSpec as CryptoSpec>::PrivateKey,
+    token_id: sov_bank::TokenId,
+    receiver_addr: <S as Spec>::Address,
+    nonce: u64,
+) {
+    let tx = build_transfer_token_tx::<S>(key, token_id, receiver_addr, AMOUNT, nonce);
+
+    let mut event_subscription = replica
+        .api_client()
+        .subscribe_to_events_with_filter("Bank/*")
+        .await
+        .unwrap();
+
+    leader.send_tx_to_sequencer(&tx).await.unwrap();
+
+    wait_for_all_events_with_timeout(Duration::from_millis(500), 1, &mut event_subscription).await;
+}


### PR DESCRIPTION
# Description

When a preferred leader falls behind and enters recovery, it may later resume batch production with a visible slot number that diverges from the replica's local state. Previously the replica would apply this inconsistent `BatchStart` blindly, leading to state corruption.

## Changes

- **Validate visible slot on replica `BatchStart`**: before applying a `BatchStart` from the leader, compute the expected visible slot number locally and compare it against the leader's value. If they diverge, mark the replica as syncing and return `NotReady` instead of applying inconsistent state.
- **Integration test**: add `test_db_elected_leader_recovery_replica_keeps_running` which forces the leader into recovery (by exceeding the deferred slots threshold), verifies the replica stays operational throughout, and confirms both nodes return to ready with successful transaction processing afterward.

## Test plan

- [x] New integration test covers the leader-recovery → replica-continues → cluster-resumes scenario
- [x] Existing replica tests pass with the shared `RecoveryStrategy::TryToSave` default

---

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
