### PR TITLE
Add non-required CI step to build the starter and notify of failures

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -538,3 +538,28 @@ jobs:
         run: |
           cd examples/demo-rollup
           bash ./web3-js-sdk-test-runner.sh
+
+  # Optional by design: keep this out of `check-aggregate` so failures stay
+  # visible without blocking merges.
+  rollup_starter_lint:
+    name: rollup_starter_lint
+    if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-dev-300gb-1-93
+    timeout-minutes: 90
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: rust
+      - name: Clone rollup-starter
+        run: git clone --depth 1 https://github.com/Sovereign-Labs/rollup-starter "${RUNNER_TEMP}/rollup-starter"
+      - name: Update starter SDK revision
+        working-directory: ${{ runner.temp }}/rollup-starter
+        # For pull_request events, github.sha is a synthetic merge commit that
+        # can't be fetched from the repo. Use the actual PR head SHA instead.
+        run: ./scripts/update_rev.sh "${{ github.event.pull_request.head.sha || github.sha }}"
+      - name: Run starter lint
+        working-directory: ${{ runner.temp }}/rollup-starter
+        run: make lint


### PR DESCRIPTION
# Description

So we get fast feedback on whether we need up update the `sdk-upgrade` branch in the starter.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
