### PR TITLE
EVM: Fix `feeHistory` edge case for zero blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,19 @@
-# 2025-03-16
+# 2026-03-24
+- #2621 EVM: Fix feeHistory endpoint for zero blocks
+
+# 2026-03-16
 - #2592 Fixes EVM RPC regression for paymaster enabled rollups
 - #2598 Fixes EVM RPC omitted gas limit for simulation endpoints
 - #2599 Make EVM RPC affordances checks paymaster-aware
 
-# 2025-03-13
+# 2026-03-13
 - #2587 EVM: RPC only: Fixes Fee-cap admission consistency across simulation and submission.
 
-# 2025-03-10
+# 2026-03-10
 - #2569 **Breaking change** Updated the `SP1Host` and `SP1Verifier` implementations to support SP1 v6. `ZkvmHost::code_commitment` now returns a Result, which is a breaking change.
 - #2554 **Breaking change** Updated the `SP1Host` and `SP1Verifier` implementations to support SP1 v6. `ZkvmHost::code_commitment` now returns a Result, which is a breaking change.
 
-# 2025-03-05
+# 2026-03-05
 - #2554 More stabilization in demo-rollup EVM tests
 - #2556 **Breaking change**: only for runtimes with AccessPattern module.
 - #2548 Updates sp1 to v6.

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/fee_history.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/fee_history.rs
@@ -3,7 +3,7 @@ use std::ops::RangeInclusive;
 use alloy_consensus::BlockHeader;
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_rpc_types::FeeHistory;
-use jsonrpsee::types::error::{INTERNAL_ERROR_CODE, INVALID_PARAMS_CODE};
+use jsonrpsee::types::error::INTERNAL_ERROR_CODE;
 use jsonrpsee::types::ErrorObjectOwned;
 use sov_address::{EthereumAddress, FromVmAddress};
 use sov_bank::Amount;
@@ -43,11 +43,7 @@ where
         state: &mut ApiStateAccessor<S>,
     ) -> Result<FeeHistory, EthApiError> {
         if block_count == 0 {
-            return Err(EthApiError::other(ErrorObjectOwned::owned(
-                INVALID_PARAMS_CODE,
-                "block_count must be greater than 0",
-                None::<()>,
-            )));
+            return Ok(FeeHistory::default());
         }
 
         if block_count > 1024 {

--- a/examples/demo-rollup/tests/evm/evm_rpc_compliance_validation_2.rs
+++ b/examples/demo-rollup/tests/evm/evm_rpc_compliance_validation_2.rs
@@ -1014,7 +1014,6 @@ async fn rpc2_005_receipt_fee_fields_reconcile_exactly_with_balance_delta() -> a
 
 /// RPC2-006: `eth_feeHistory(block_count=0)` should return an empty result, not an error.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Known discrepancy: will be fixed in the follow up"]
 async fn rpc2_006_fee_history_zero_block_count_returns_empty_response() -> anyhow::Result<()> {
     let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
     let http = Client::new();

--- a/examples/demo-rollup/tests/evm/evm_rpc_compliance_validation_2.rs
+++ b/examples/demo-rollup/tests/evm/evm_rpc_compliance_validation_2.rs
@@ -1032,10 +1032,10 @@ async fn rpc2_006_fee_history_zero_block_count_returns_empty_response() -> anyho
     );
 
     assert_eq!(response["result"]["oldestBlock"].as_str(), Some("0x0"));
-    assert_eq!(
-        response["result"]["baseFeePerGas"],
-        json!([]),
-        "baseFeePerGas should be exactly [] for zero-block feeHistory"
+    assert!(
+        response["result"]["baseFeePerGas"].is_null()
+            || response["result"]["baseFeePerGas"] == json!([]),
+        "baseFeePerGas should be empty or omitted for zero-block feeHistory"
     );
     assert_eq!(
         response["result"]["gasUsedRatio"],


### PR DESCRIPTION
# Description

Minor fix in EVM RPC for feeHistory endpoint, to match geth

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2271 

## Testing
Unignored previous test with minor adjustment

## Docs
No updates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
