### PR TITLE
Expose the SDK specs as `rustdocs` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12826,6 +12826,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "sov-sdk-specs"
+version = "0.3.0"
+
+[[package]]
 name = "sov-sequencer"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 exclude = ["crates/module-system/module-implementations/extern/hyperlane-solana-register/solana"]
 members = [
     "crates/rollup-interface",
+    "crates/rollup-interface/specs",
     "crates/adapters/mock-da",
     "crates/adapters/mock-zkvm",
     "scripts/switcheroo",

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: help
+.PHONY: docs
 
 PROVER_DIRS := examples/demo-rollup/provers/risc0/guest-mock \
                examples/demo-rollup/provers/risc0/guest-mock-nomt \
@@ -175,7 +176,8 @@ dry-run-publish:
 	yq '.[]' packages_to_publish.yml | xargs -I _ cargo publish --allow-dirty --dry-run -p _
 
 docs:  ## Generates documentation locally
-	cargo doc --open
+	cargo doc --no-deps --no-default-features
+	cargo doc -p sov-sdk-specs --no-deps --open
 
 docs-generate: ## Generate documentation but don't open it, to verify that it would pass CI.
 	cargo doc --no-deps --all-features

--- a/crates/rollup-interface/specs/Cargo.toml
+++ b/crates/rollup-interface/specs/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "sov-sdk-specs"
+publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+version = { workspace = true }

--- a/crates/rollup-interface/specs/src/lib.rs
+++ b/crates/rollup-interface/specs/src/lib.rs
@@ -1,0 +1,17 @@
+#![doc = include_str!("../../README.md")]
+
+#[cfg(doc)]
+#[doc = include_str!("../../specs/overview.md")]
+pub mod specs {
+    #[doc = include_str!("../../specs/interfaces/interface.md")]
+    pub mod interfaces {
+        #[doc = include_str!("../../specs/interfaces/da.md")]
+        pub mod da {}
+
+        #[doc = include_str!("../../specs/interfaces/stf.md")]
+        pub mod stf {}
+
+        #[doc = include_str!("../../specs/interfaces/zkvm.md")]
+        pub mod zkvm {}
+    }
+}

--- a/python/py_sovereign_web3/rust/Cargo.toml
+++ b/python/py_sovereign_web3/rust/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
-name = "sovereign_web3"
+name = "py_sovereign_web3"
 crate-type = ["cdylib"]
 
 [dependencies]


### PR DESCRIPTION
# Description

This PR renders the spec via rustdocs (WIP, as there is frustrating workarounds needed to render on github and IDEs and rustdocs well).

Motivation: the present `make docs` fails with a lib name conflict, that is resolved in ffd8422e28b92b869909649c75df31d705d523c9 - if the rustdocs stuff is unwanted, feel free to cherry pick that commit!

Inspiration: Substrate uses a sophisticated rustdocs setup to render some docs, although it is somewhat of a pain... See https://github.com/paritytech/polkadot-sdk/issues/6191

- To render markdown pages in rustdocs, a dummy crate is introduced in the `rollup-interface/spec/`, but it has no actual code, and is only compiled for `cargo doc`
- Updated `make docs` to open a main README (the spec or some other README) directly alongside a sidebar that includes all SDK crates (I think all the relevant ones, would appreciate a check on that!)

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
  - I have not noted in changelog, I can if we think it's needed!
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing

Run `make docs` to view the result, and navigate pages _not_ with the (presently broken) inline links, but using the `Modules` section at the bottom of each page (overview -> interfaces -> da ...)

## Docs

> Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`

^^ from the issue template, so I think reviewers can check if things work there, but the entrypoint/index for the docs overall is likely not the new spec docs dummy crate, that would need to be worked out to fix it. 