### PR TITLE
Document that `Bank::transfer_from` does not emit events

### DIFF
--- a/crates/module-system/module-implementations/sov-bank/src/call.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/call.rs
@@ -488,6 +488,9 @@ impl<S: Spec> Bank<S> {
 impl<S: Spec> Bank<S> {
     /// Transfers the set of `coins` from the address `from` to the address `to`.
     ///
+    /// This method does **not** emit any events. Use [`Self::transfer_from_with_memo`]
+    /// if you need a [`Event::TokenTransferred`] event to be emitted.
+    ///
     /// Returns an error if the token ID doesn't exist.
     pub fn transfer_from(
         &mut self,


### PR DESCRIPTION
# Description

`transfer_from` is used in (capabilities) with a state that does not implement `EventContainer`, so we can't emit events there. 

Add doc comment to Bank::transfer_from clarifying it does not emit events and pointing callers to `transfer_from_with_memo` as the event-emitting alternative.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

