### PR TITLE
Add event-free `do_transfer_from` for internal token transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-03-24
+- #2625 Bank: Add `do_transfer_from` for internal transfers without event emission. `transfer_from` now always emits a `TokenTransferred` event. Infrastructure callers (capabilities, incentives, registries) migrated to `do_transfer_from`.
+
 # 2025-03-16
 - #2592 Fixes EVM RPC regression for paymaster enabled rollups
 - #2598 Fixes EVM RPC omitted gas limit for simulation endpoints

--- a/crates/module-system/module-implementations/sov-attester-incentives/src/helpers.rs
+++ b/crates/module-system/module-implementations/sov-attester-incentives/src/helpers.rs
@@ -124,7 +124,7 @@ where
 
         // The reward tokens are unlocked from the module's id.
         self.bank
-            .transfer_from(self.id.to_payable(), sender, coins, state)?;
+            .do_transfer_from(self.id.to_payable(), sender, coins, state)?;
 
         Ok(())
     }

--- a/crates/module-system/module-implementations/sov-attester-incentives/src/registration/mod.rs
+++ b/crates/module-system/module-implementations/sov-attester-incentives/src/registration/mod.rs
@@ -115,8 +115,12 @@ where
         amount: Amount,
         state: &mut ST,
     ) -> anyhow::Result<()> {
-        self.bank
-            .transfer_from(address, self.id.to_payable(), gas_coins(amount), state)?;
+        self.bank.do_transfer_from(
+            address,
+            self.id.to_payable(),
+            gas_coins(amount),
+            state,
+        )?;
         Ok(())
     }
 
@@ -126,8 +130,12 @@ where
         amount: Amount,
         state: &mut ST,
     ) -> anyhow::Result<()> {
-        self.bank
-            .transfer_from(self.id.to_payable(), address, gas_coins(amount), state)?;
+        self.bank.do_transfer_from(
+            self.id.to_payable(),
+            address,
+            gas_coins(amount),
+            state,
+        )?;
         Ok(())
     }
 

--- a/crates/module-system/module-implementations/sov-bank/src/call.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/call.rs
@@ -220,7 +220,7 @@ impl<S: Spec> Bank<S> {
         let to = to.as_token_holder();
         let sender = context.sender();
 
-        self.transfer_from_with_memo(sender, to, coins.clone(), memo, state)?;
+        self.transfer_from_with_memo(sender, to, coins, memo, state)?;
 
         Ok(())
     }

--- a/crates/module-system/module-implementations/sov-bank/src/call.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/call.rs
@@ -220,24 +220,8 @@ impl<S: Spec> Bank<S> {
         let to = to.as_token_holder();
         let sender = context.sender();
 
-        self.transfer_from(sender, to, coins.clone(), state)?;
+        self.transfer_from_with_memo(sender, to, coins.clone(), memo, state)?;
 
-        tracing::trace!(
-            from = %sender,
-            %to,
-            %coins,
-            "Token transfer successful"
-        );
-
-        self.emit_event(
-            state,
-            Event::TokenTransferred {
-                from: sender.as_token_holder().into(),
-                to: to.into(),
-                coins,
-                memo,
-            },
-        );
         Ok(())
     }
 
@@ -494,12 +478,9 @@ impl<S: Spec> Bank<S> {
         from: impl Payable<S>,
         to: impl Payable<S>,
         coins: Coins,
-        state: &mut impl StateAccessor,
+        state: &mut (impl StateAccessor + EventContainer),
     ) -> Result<(), TransferTokenError> {
-        let from = from.as_token_holder();
-        let to = to.as_token_holder();
-
-        self.do_transfer(from, to, &coins.token_id, coins.amount, state)
+        self.transfer_from_with_memo(from, to, coins, None, state)
     }
 
     /// Transfers the set of `coins` from the address `from` to the address `to` with an optional memo.
@@ -515,8 +496,14 @@ impl<S: Spec> Bank<S> {
     ) -> Result<(), TransferTokenError> {
         let from = from.as_token_holder();
         let to = to.as_token_holder();
-
         self.do_transfer(from, to, &coins.token_id, coins.amount, state)?;
+
+        tracing::trace!(
+            from = %from,
+            %to,
+            %coins,
+            "Token transfer successful"
+        );
 
         self.emit_event(
             state,
@@ -529,6 +516,22 @@ impl<S: Spec> Bank<S> {
         );
 
         Ok(())
+    }
+
+    /// Transfers the set of `coins` from the address `from` to the address `to` without emitting any events.
+    ///
+    /// Returns an error if the token ID doesn't exist.
+    pub fn do_transfer_from(
+        &mut self,
+        from: impl Payable<S>,
+        to: impl Payable<S>,
+        coins: Coins,
+        state: &mut impl StateAccessor,
+    ) -> Result<(), TransferTokenError> {
+        let from = from.as_token_holder();
+        let to = to.as_token_holder();
+
+        self.do_transfer(from, to, &coins.token_id, coins.amount, state)
     }
 
     /// Transfer the amount `amount` of tokens from the address `from` to the address `to`.

--- a/crates/module-system/module-implementations/sov-bank/src/capability.rs
+++ b/crates/module-system/module-implementations/sov-bank/src/capability.rs
@@ -76,7 +76,7 @@ impl<S: Spec> Bank<S> {
         // Only do this after all checks have passed because the paymaster does not revert on error, so
         // any state changes may persist!
         let id = self.id;
-        if let Err(err) = self.transfer_from(
+        if let Err(err) = self.do_transfer_from(
             payer,
             id.to_payable(),
             Coins {

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/registration.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/registration.rs
@@ -54,7 +54,7 @@ impl<S: Spec> StakeRegistration for ProverIncentives<S> {
         amount: Amount,
         state: &mut ST,
     ) -> anyhow::Result<()> {
-        self.bank.transfer_from(
+        self.bank.do_transfer_from(
             address,
             self.id().clone().to_payable(),
             gas_coins(amount),
@@ -69,7 +69,7 @@ impl<S: Spec> StakeRegistration for ProverIncentives<S> {
         amount: Amount,
         state: &mut ST,
     ) -> anyhow::Result<()> {
-        self.bank.transfer_from(
+        self.bank.do_transfer_from(
             self.id().clone().to_payable(),
             address,
             gas_coins(amount),

--- a/crates/module-system/module-implementations/sov-sequencer-registry/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-sequencer-registry/src/capabilities.rs
@@ -56,8 +56,12 @@ impl<S: Spec> SequencerRegistry<S> {
                 token_id: config_gas_token_id(),
             };
 
-            self.bank
-                .transfer_from(self.id.clone().to_payable(), beneficiary, coins, state)?;
+            self.bank.do_transfer_from(
+                self.id.clone().to_payable(),
+                beneficiary,
+                coins,
+                state,
+            )?;
 
             self.known_sequencers
                 .set(
@@ -114,7 +118,7 @@ impl<S: Spec> SequencerRegistry<S> {
                 token_id: config_gas_token_id(),
             };
             self.bank
-                .transfer_from(sender, self.id.to_payable(), coins, state)?;
+                .do_transfer_from(sender, self.id.to_payable(), coins, state)?;
 
             self.known_sequencers
                 .set(

--- a/crates/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-sequencer-registry/src/lib.rs
@@ -279,14 +279,14 @@ impl<S: Spec> SequencerRegistry<S> {
             );
         };
 
-        self.bank.transfer_from(
+        self.bank.do_transfer_from(
             holder.to_payable(),
             recipient,
             gas_coins(amount_to_refund),
             state,
         )?;
         self.bank
-            .transfer_from(
+            .do_transfer_from(
                 holder.to_payable(),
                 self.bank.id().clone().to_payable(),
                 gas_coins(tokens_needed_for_pre_exec_checks),
@@ -312,7 +312,7 @@ impl<S: Spec> SequencerRegistry<S> {
             return;
         };
         self.bank
-            .transfer_from(
+            .do_transfer_from(
                 holder.to_payable(),
                 recipient,
                 gas_coins(reserved_balance),

--- a/crates/module-system/sov-capabilities/src/lib.rs
+++ b/crates/module-system/sov-capabilities/src/lib.rs
@@ -147,7 +147,7 @@ where
         let rewarded_module = self.get_prover_token_holder(oprating_mode, state);
 
         self.bank
-            .transfer_from(
+            .do_transfer_from(
                 self.bank.id.clone().to_payable(),
                 rewarded_module.to_owned().as_token_holder(),
                 Coins {
@@ -169,7 +169,7 @@ where
         // We refund the payer. We need to give back the remaining funds on the gas meter, plus the unspent tip.
         // This is also the maximum fee minus everything that was spent for the tip and base fee (ie the total reward).
         self.bank
-            .transfer_from(
+            .do_transfer_from(
                 self.bank.id.clone().to_payable(),
                 recipient,
                 gas_coins(remaining_funds.0),
@@ -188,7 +188,7 @@ where
     ) -> anyhow::Result<()> {
         let rewarded_prover_module = self.get_prover_token_holder(oprating_mode, state);
         // Transfer the penalty from the sequencer bank to the sequencer
-        Ok(self.bank.transfer_from(
+        Ok(self.bank.do_transfer_from(
             self.bank.id.clone().to_payable(),
             rewarded_prover_module.to_owned(),
             gas_coins(amount),
@@ -446,7 +446,7 @@ impl<S: Spec, T> SequencerRemuneration<S> for StandardProvenRollupCapabilities<'
         // In this case, we will refund the rewards to the user.
         if stake_increased.is_err() {
             self.bank
-                .transfer_from(
+                .do_transfer_from(
                     self.bank.id.clone().to_payable(),
                     sequencer_rollup_address.as_token_holder(),
                     gas_coins(reward.0),


### PR DESCRIPTION
# Description
This PR fixes an inconsistency where `Bank::transfer` emitted an event, but `Bank::transfer_from` did not.

  - Introduces `do_transfer_from` — a transfer method that skips event emission and tracing, for use by internal/infrastructure callers (gas locking, staking, rewards)
  - Migrates all capability, incentive, and registry modules to `do_transfer_from`, keeping the event-emitting `transfer_from` for user-facing call handlers                                                                                                  
  - Refactors `transfer_from` to delegate to `transfer_from_with_memo`, removing duplicated transfer + event logic   


- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
