### PR TITLE
Add per-node sequencer pause and leader-only recovery test.

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -627,6 +627,17 @@ pub(crate) enum PreferredSeqOperation<S: Spec, Rt: Runtime<S>> {
     ),
 }
 
+/// Returns `true` when the test pause flag is set and applies to this node.
+///
+/// * `"1"` pauses all nodes (backward-compatible).
+/// * A specific `node_id` pauses only the node whose postgres config matches.
+fn should_skip_update_state(postgres_config: Option<&PostgresConfig>) -> bool {
+    let Ok(flag_value) = std::env::var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE") else {
+        return false;
+    };
+    flag_value == "1" || postgres_config.is_some_and(|c| c.node_id == flag_value)
+}
+
 #[tracing::instrument(skip_all, level = "debug")]
 async fn update_state_task_inner<S, Rt, Da>(
     seq: PreferredSequencer<S, Rt, Da>,
@@ -640,33 +651,22 @@ where
 {
     let info =
         poll_state_update::<S>(state_update_receiver, shutdown_receiver, "update_state").await?;
-    if cfg!(debug_assertions) {
-        let skip_flag = std::env::var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE");
-        if let Ok(flag_value) = skip_flag {
-            // "1" pauses all nodes (backward-compatible).
-            // A specific node_id pauses only the matching node.
-            let dominated_node_id = seq
-                .config
-                .sequencer_kind_config
-                .postgres_config
-                .as_ref()
-                .map(|c| c.node_id.as_str());
-            let should_skip = flag_value == "1" || dominated_node_id == Some(flag_value.as_str());
-            if should_skip {
-                tracing::warn!("skipping state update due to env var flag");
-                #[cfg(feature = "test-utils")]
-                {
-                    let _ = seq.test_only_state_update_notification_sender.send(
-                        StateUpdateNotification {
-                            slot_number: info.slot_number,
-                            finalized_slot_number: info.latest_finalized_slot_number,
-                            update_skipped_due_to_pause: true,
-                        },
-                    );
-                }
-                return Ok(());
-            }
+
+    if cfg!(debug_assertions)
+        && should_skip_update_state(seq.config.sequencer_kind_config.postgres_config.as_ref())
+    {
+        tracing::warn!("skipping state update due to env var flag");
+        #[cfg(feature = "test-utils")]
+        {
+            let _ = seq
+                .test_only_state_update_notification_sender
+                .send(StateUpdateNotification {
+                    slot_number: info.slot_number,
+                    finalized_slot_number: info.latest_finalized_slot_number,
+                    update_skipped_due_to_pause: true,
+                });
         }
+        return Ok(());
     }
 
     let mut rt = Rt::default();

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -642,19 +642,30 @@ where
         poll_state_update::<S>(state_update_receiver, shutdown_receiver, "update_state").await?;
     if cfg!(debug_assertions) {
         let skip_flag = std::env::var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE");
-        if skip_flag == Ok("1".to_string()) {
-            tracing::warn!("skipping state update due to env var flag");
-            #[cfg(feature = "test-utils")]
-            {
-                let _ =
-                    seq.test_only_state_update_notification_sender
-                        .send(StateUpdateNotification {
+        if let Ok(flag_value) = skip_flag {
+            // "1" pauses all nodes (backward-compatible).
+            // A specific node_id pauses only the matching node.
+            let dominated_node_id = seq
+                .config
+                .sequencer_kind_config
+                .postgres_config
+                .as_ref()
+                .map(|c| c.node_id.as_str());
+            let should_skip = flag_value == "1" || dominated_node_id == Some(flag_value.as_str());
+            if should_skip {
+                tracing::warn!("skipping state update due to env var flag");
+                #[cfg(feature = "test-utils")]
+                {
+                    let _ = seq.test_only_state_update_notification_sender.send(
+                        StateUpdateNotification {
                             slot_number: info.slot_number,
                             finalized_slot_number: info.latest_finalized_slot_number,
                             update_skipped_due_to_pause: true,
-                        });
+                        },
+                    );
+                }
+                return Ok(());
             }
-            return Ok(());
         }
     }
 

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -1010,6 +1010,13 @@ where
         std::env::set_var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE", "1");
     }
 
+    /// Like [`TestRollup::pause_preferred_batches`], but only pauses the node
+    /// whose `node_id` matches the given value. Other nodes sharing the same
+    /// process (e.g. a replica) will continue producing batches.
+    pub async fn pause_preferred_batches_for_node(&self, node_id: &str) {
+        std::env::set_var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE", node_id);
+    }
+
     /// Pauses preferred batch production and waits until the sequencer confirms
     /// that at least one state update was skipped because of the pause flag.
     ///
@@ -1054,6 +1061,19 @@ where
             std::env::var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE").unwrap(),
             "1",
             "Resuming but it was never paused in the first place",
+        );
+
+        std::env::remove_var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE");
+    }
+
+    /// Resumes batch production after [`TestRollup::pause_preferred_batches_for_node`].
+    ///
+    /// Note: calling this method MAY NOT immediately produce a batch.
+    pub async fn resume_preferred_batches_for_node(&self, node_id: &str) {
+        assert_eq!(
+            std::env::var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE").unwrap(),
+            node_id,
+            "Resuming but it was never paused for this node in the first place",
         );
 
         std::env::remove_var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE");

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -248,13 +248,21 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
 
     pub async fn start_test_rollup(self) -> anyhow::Result<TestRollup<R>> {
         let blueprint: R = Default::default();
+
+        let mut node_id = None;
         if let SequencerKindConfig::Preferred(sequencer_conf) = &self.config.sequencer_config {
             if self.config.rollup_prover_config.is_some()
                 && !sequencer_conf.disable_state_root_consistency_checks
             {
                 tracing::warn!("Prover process is enabled, but state root consistency checks are not disabled. This will cause crashes in the sequencer since proofs are created but not yet handled by the sequencer. Consider disabling one of the two options.");
             }
+
+            node_id = sequencer_conf
+                .postgres_config
+                .as_ref()
+                .map(|postgres_config| postgres_config.node_id.clone());
         }
+
         std::fs::create_dir_all(self.config.storage.path()).with_context(|| {
             format!(
                 "Failed to create storage directory: {}",
@@ -330,6 +338,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
             rollup_task,
             http_addr: rest_addr,
             rollup_config,
+            node_id,
             client,
             da_service,
             shutdown_sender,
@@ -689,6 +698,8 @@ pub struct TestRollup<R: FullNodeBlueprint<Native>> {
     pub http_addr: SocketAddr,
     /// The rollup config used to run the rollup.
     pub rollup_config: RollupConfig<<R::Spec as Spec>::Address, R::DaService>,
+    /// Configured postgres node id for preferred-sequencer tests, if present.
+    pub node_id: Option<String>,
     /// A copy of the [`DaService`]
     /// that the node uses.
     ///
@@ -1010,10 +1021,14 @@ where
         std::env::set_var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE", "1");
     }
 
-    /// Like [`TestRollup::pause_preferred_batches`], but only pauses the node
-    /// whose `node_id` matches the given value. Other nodes sharing the same
-    /// process (e.g. a replica) will continue producing batches.
-    pub async fn pause_preferred_batches_for_node(&self, node_id: &str) {
+    /// Like [`TestRollup::pause_preferred_batches`], but only pauses this
+    /// rollup's configured postgres node. Other nodes sharing the same process
+    /// (e.g. a replica) will continue producing batches.
+    pub async fn pause_preferred_batches_for_node(&self) {
+        let node_id = self
+            .node_id
+            .as_deref()
+            .expect("pause_preferred_batches_for_node requires TestRollup.node_id to be set");
         std::env::set_var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE", node_id);
     }
 
@@ -1069,7 +1084,12 @@ where
     /// Resumes batch production after [`TestRollup::pause_preferred_batches_for_node`].
     ///
     /// Note: calling this method MAY NOT immediately produce a batch.
-    pub async fn resume_preferred_batches_for_node(&self, node_id: &str) {
+    pub async fn resume_preferred_batches_for_node(&self) {
+        let node_id = self
+            .node_id
+            .as_deref()
+            .expect("resume_preferred_batches_for_node requires TestRollup.node_id to be set");
+
         assert_eq!(
             std::env::var("SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE").unwrap(),
             node_id,

--- a/examples/demo-rollup/tests/replica/recovery.rs
+++ b/examples/demo-rollup/tests/replica/recovery.rs
@@ -41,8 +41,6 @@ async fn test_db_elected_leader_recovery_with_replica() {
     // Pause the sequencer update_state loop to prevent batch production.
     leader.pause_preferred_batches().await;
 
-    // Produce DA blocks while sequencer is paused to exceed the deferred slots threshold.
-    // With DEFERRED_SLOTS_COUNT=40, the 90% threshold triggers at ~26 blocks of lag.
     for _ in 0..30 {
         setup.da_service.produce_block_now().await.unwrap();
     }
@@ -52,13 +50,83 @@ async fn test_db_elected_leader_recovery_with_replica() {
 
     // Resume batch production; on the next state update the leader should enter recovery
     leader.resume_preferred_batches().await;
-    setup.da_service.produce_block_now().await.unwrap();
 
     // Wait until the leader enters recovery.
     leader.wait_for_sequencer_recovering().await.unwrap();
     leader.wait_for_sequencer_ready().await.unwrap();
 
     // // Send a transaction to confirm the cluster works after recovery.
+    verify_replica_processes_tx(
+        &leader,
+        &replica,
+        &key_and_address.private_key,
+        token_id,
+        receiver_addr,
+        1,
+    )
+    .await;
+
+    replica.shutdown().await.unwrap();
+    leader.shutdown().await.unwrap();
+    setup.shutdown().await;
+}
+
+/// Test that if only the elected leader pauses batch production and enters
+/// recovery after falling behind, the replica continues to function correctly
+/// once recovery completes.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused() {
+    std::env::set_var("SOV_TEST_CONST_OVERRIDE_DEFERRED_SLOTS_COUNT", "40");
+
+    let Some(setup) = NodeDiscoveryTestSetup::new().await else {
+        return;
+    };
+
+    let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
+
+    let node_1 = setup
+        .start_node("node_1", ConfiguredNodeRole::DbElected)
+        .await;
+    let node_2 = setup
+        .start_node("node_2", ConfiguredNodeRole::DbElected)
+        .await;
+
+    node_1.wait_for_sequencer_ready().await.unwrap();
+    node_2.wait_for_sequencer_ready().await.unwrap();
+
+    let (leader, replica) = establish_leader_and_replica(node_1, node_2).await;
+
+    // Send a transaction to confirm the cluster works before recovery.
+    let token_id = config_gas_token_id();
+    let receiver_addr = random_address();
+
+    verify_replica_processes_tx(
+        &leader,
+        &replica,
+        &key_and_address.private_key,
+        token_id,
+        receiver_addr,
+        0,
+    )
+    .await;
+
+    // Pause only the elected leader's sequencer update_state loop.
+    leader.pause_preferred_batches_for_node().await;
+
+    for _ in 0..30 {
+        setup.da_service.produce_block_now().await.unwrap();
+    }
+
+    leader.wait_for_node_synced().await.unwrap();
+
+    // Resume batch production only for the leader; on the next state update it should enter recovery.
+    leader.resume_preferred_batches_for_node().await;
+
+    // Wait until the leader enters recovery.
+    leader.wait_for_sequencer_recovering().await.unwrap();
+    leader.wait_for_sequencer_ready().await.unwrap();
+
+    // Send a transaction to confirm the cluster works after recovery.
     verify_replica_processes_tx(
         &leader,
         &replica,
@@ -91,6 +159,5 @@ async fn verify_replica_processes_tx(
         .unwrap();
 
     leader.send_tx_to_sequencer(&tx).await.unwrap();
-
     wait_for_all_events_with_timeout(Duration::from_millis(500), 1, &mut event_subscription).await;
 }


### PR DESCRIPTION
# Description

This PR introduces the following changes:

1. Extend SOV_TEST_PAUSE_SEQUENCER_UPDATE_STATE to accept a specific node_id value (in addition to "1" for all nodes), enabling per-node pause/resume of preferred batch production in tests                                                                 
2. Add pause_preferred_batches_for_node / resume_preferred_batches_for_node helpers to TestRollup
3. Add test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused which verifies that pausing only the elected leader (while the replica continues) correctly triggers recovery and restores cluster functionality    

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
