### PR TITLE
Replica: Reject PG batches that outrun the executor rebase window.                                                                                                                                                                                         

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-03-30
+- #2629 Sequencer: Replica rejects batch starts that outrun the executor rebase window. `STATE_ROOT_DELAY_BLOCKS` was increased from 3 to 5 in `constants.toml`.
+
 # 2026-03-24
 - #2626 EVM: Fixes estimateGas value to match what will end up in the receipt of actually executed transaction
 - #2634 Test only changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 # 2026-03-30
-<<<<<<< blaze/replica_test_5
 - #2629 Sequencer: Replica rejects batch starts that outrun the executor rebase window. `STATE_ROOT_DELAY_BLOCKS` was increased from 3 to 5 in `constants.toml`.
-=======
 - #2654 Replace `lazy_static` crate with `std::sync::LazyLock`
->>>>>>> dev
 
 # 2026-03-24
 - #2626 EVM: Fixes estimateGas value to match what will end up in the receipt of actually executed transaction

--- a/constants.toml
+++ b/constants.toml
@@ -63,7 +63,7 @@ DEFERRED_SLOTS_COUNT = 120
 MAX_VISIBLE_HEIGHT_INCREASE_PER_SLOT = 10
 # How many *rollup blocks* we wait before making a state root visible to the rollup.
 # This value should always be set to at least 1
-STATE_ROOT_DELAY_BLOCKS = 3
+STATE_ROOT_DELAY_BLOCKS = 5
 # How many blobs from unregistered sequencers we will accept per slot
 # We can't slash misbehaving senders because they aren't a registered sequencer with a stake so
 # this serves as protection against spam.

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -76,6 +76,8 @@ where
     pub(crate) shutdown_sender: watch::Sender<()>,
 
     pub(crate) executor: RollupBlockExecutor<S, Rt>,
+    /// The rollup height of the latest node checkpoint applied to this executor's storage.
+    pub(crate) executor_rebase_height: RollupHeight,
     pub(crate) latest_info: StateUpdateInfo<S::Storage>,
     pub(crate) batch_execution_time_limit_micros: u64,
     pub(crate) batch_size_tracker: BatchSizeTracker,
@@ -251,6 +253,7 @@ where
 
         // Replace known info
         self.latest_info = info.clone();
+        self.executor_rebase_height = new_executor.checkpoint.rollup_height_to_access();
 
         // Replace executor state
         self.executor.replace_state(new_executor).await;

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
@@ -28,6 +28,7 @@ use sov_full_node_configs::sequencer::{PreferredSequencerConfig, SequencerConfig
 use sov_modules_api::capabilities::RollupHeight;
 use sov_modules_api::GasArray;
 use sov_modules_api::GasSpec;
+use sov_modules_api::VersionReader;
 use sov_modules_api::{FullyBakedTx, Runtime, Spec, StateUpdateInfo};
 use sov_state::Storage;
 use std::collections::BTreeMap;
@@ -191,15 +192,19 @@ where
         seq_config.max_batch_size_bytes,
     );
 
+    let executor = RollupBlockExecutor::new(
+        &latest_info,
+        rollup_exec_config.clone(),
+        seq_config.clone(),
+        Default::default(),
+        None, // We'll populate the pinned cache on the first `update_state` call.
+    );
+    let executor_rebase_height = executor.checkpoint.rollup_height_to_access();
+
     let inner = Inner {
         seq_role,
-        executor: RollupBlockExecutor::new(
-            &latest_info,
-            rollup_exec_config.clone(),
-            seq_config.clone(),
-            Default::default(),
-            None, // We'll populate the pinned cache on the first `update_state` call.
-        ),
+        executor,
+        executor_rebase_height,
         latest_info,
         tx_queue_id,
         batch_execution_time_limit_micros,

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -734,6 +734,10 @@ where
             inner.next_unassigned_sequence_number = node_sequence_number;
         }
 
+        inner.executor_rebase_height =
+            StateCheckpoint::new(info.storage.clone(), &Rt::default().kernel(), None)
+                .rollup_height_to_access();
+
         inner.is_ready = Ok(());
         inner.has_finished_startup = true;
         inner.latest_info = info;
@@ -955,6 +959,8 @@ where
         let batch_from_master =
             Self::ensure_replica_batch_start_visible_slot_matches(&mut inner, batch_from_master)?;
 
+        Self::ensure_replica_batch_start_within_rebase_window(&mut inner, batch_from_master)?;
+
         inner
             .do_batch_start(
                 batch_from_master.visible_slot_number_after_increase,
@@ -1088,6 +1094,44 @@ where
             %replica_expected,
             master_expected = %batch_from_master.visible_slot_number_after_increase,
             "Replica VSN diverged from master. Entering sync mode and retrying."
+        );
+
+        let sync_details = SequencerNotReadyDetails::Syncing {
+            target_da_height: inner.latest_info.sync_status.target_da_height(),
+            synced_da_height: inner.latest_info.sync_status.synced_da_height(),
+        };
+
+        inner.is_ready = Err(sync_details.clone());
+
+        Err(ReplicaError::NotReady(
+            sync_details,
+            Box::new(DbData::BatchStart(batch_from_master)),
+        ))
+    }
+
+    fn ensure_replica_batch_start_within_rebase_window(
+        inner: &mut InnerGuard<'_, S, Rt>,
+        batch_from_master: BatchToStore,
+    ) -> Result<(), ReplicaError<S>> {
+        let state_root_delay_blocks: u64 =
+            sov_modules_api::macros::config_value!("STATE_ROOT_DELAY_BLOCKS");
+        let current_height = inner.executor.checkpoint.rollup_height_to_access();
+        let rebase_height = inner.executor_rebase_height;
+
+        if current_height.get().saturating_sub(rebase_height.get())
+            <= state_root_delay_blocks.saturating_sub(1)
+        {
+            return Ok(());
+        }
+
+        let heights_since_rebase = current_height.get().saturating_sub(rebase_height.get());
+
+        tracing::warn!(
+            %current_height,
+            %rebase_height,
+            %heights_since_rebase,
+            %state_root_delay_blocks,
+            "Replica has accepted too many PG batches since the last executor rebase. Rejecting batch start until node replay catches up."
         );
 
         let sync_details = SequencerNotReadyDetails::Syncing {

--- a/examples/demo-rollup/tests/replica/recovery.rs
+++ b/examples/demo-rollup/tests/replica/recovery.rs
@@ -142,6 +142,72 @@ async fn test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused
     setup.shutdown().await;
 }
 
+/// Test that if only the replica pauses `update_state`, it enters sync mode
+/// while the leader continues to process batches, then catches back up after resuming.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_db_elected_replica_recovers_after_only_replica_is_paused() {
+    std::env::set_var("SOV_TEST_CONST_OVERRIDE_STATE_ROOT_DELAY_BLOCKS", "5");
+    let Some(setup) = NodeDiscoveryTestSetup::new().await else {
+        return;
+    };
+
+    let key_and_address = read_private_key::<S>("tx_signer_private_key.json");
+
+    let node_1 = setup
+        .start_node("node_1", ConfiguredNodeRole::DbElected)
+        .await;
+    let node_2 = setup
+        .start_node("node_2", ConfiguredNodeRole::DbElected)
+        .await;
+
+    node_1.wait_for_sequencer_ready().await.unwrap();
+
+    node_2.wait_for_sequencer_ready().await.unwrap();
+
+    let (leader, replica) = establish_leader_and_replica(node_1, node_2).await;
+
+    let token_id = config_gas_token_id();
+    let receiver_addr = random_address();
+
+    verify_replica_processes_tx(
+        &leader,
+        &replica,
+        &key_and_address.private_key,
+        token_id,
+        receiver_addr,
+        0,
+    )
+    .await;
+
+    replica.pause_preferred_batches_for_node().await;
+
+    for _ in 0..60 {
+        setup.da_service.produce_block_now().await.unwrap();
+    }
+
+    replica.wait_for_sequencer_not_ready().await.unwrap();
+    leader.wait_for_node_synced().await.unwrap();
+    replica.wait_for_node_synced().await.unwrap();
+
+    replica.resume_preferred_batches_for_node().await;
+    setup.da_service.produce_block_now().await.unwrap();
+    replica.wait_for_sequencer_ready().await.unwrap();
+
+    verify_replica_processes_tx(
+        &leader,
+        &replica,
+        &key_and_address.private_key,
+        token_id,
+        receiver_addr,
+        1,
+    )
+    .await;
+
+    replica.shutdown().await.unwrap();
+    leader.shutdown().await.unwrap();
+    setup.shutdown().await;
+}
+
 async fn verify_replica_processes_tx(
     leader: &TestRollup<Rollup>,
     replica: &TestRollup<Rollup>,
@@ -159,5 +225,5 @@ async fn verify_replica_processes_tx(
         .unwrap();
 
     leader.send_tx_to_sequencer(&tx).await.unwrap();
-    wait_for_all_events_with_timeout(Duration::from_millis(500), 1, &mut event_subscription).await;
+    wait_for_all_events_with_timeout(Duration::from_millis(3500), 1, &mut event_subscription).await;
 }


### PR DESCRIPTION
# Description

Before this fix, a replica could accept an unbounded number of BatchStart messages from the leader while its update_state (node replay) was paused or slow.  But after enough PG batches, the next batch depends on kernel state newer than that rebase anchor (the last state the replica received from the node).

This PR adds a safety guard `ensure_replica_batch_start_within_rebase_window` that prevents a replica sequencer from accepting too many batches (via PG) without its executor rebasing to a fresh node checkpoint. It also adds a test for replica recovery when only the replica is paused, and bumps `STATE_ROOT_DELAY_BLOCKS` from 3 to 5.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
