### PR TITLE
AggregatedProof: Make inner proof verification independent of SP1 by implementing ZkVerifier for SP1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13964,6 +13964,7 @@ dependencies = [
  "libm",
  "rand 0.8.5",
  "sha2 0.10.9",
+ "slop-algebra",
  "sp1-lib",
  "sp1-primitives",
 ]

--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -68,22 +68,7 @@ impl Zkvm for MockZkvm {
 )]
 pub struct MockCodeCommitment(pub [u8; 8]);
 
-impl sov_rollup_interface::zk::CodeCommitment for MockCodeCommitment {
-    type DecodeError = MockCodeCommitmentError;
-
-    fn encode(&self) -> Vec<u8> {
-        self.0.to_vec()
-    }
-
-    fn decode(value: &[u8]) -> Result<Self, Self::DecodeError> {
-        if value.len() != 8 {
-            return Err(MockCodeCommitmentError::InvalidLength { found: value.len() });
-        }
-        let mut contents = [0u8; 8];
-        contents.copy_from_slice(value);
-        Ok(Self(contents))
-    }
-}
+impl sov_rollup_interface::zk::CodeCommitment for MockCodeCommitment {}
 
 /// An error that can occur when converting a byte vector to a `MockCodeCommitment`.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]

--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -68,8 +68,6 @@ impl Zkvm for MockZkvm {
 )]
 pub struct MockCodeCommitment(pub [u32; 8]);
 
-impl sov_rollup_interface::zk::CodeCommitment for MockCodeCommitment {}
-
 /// An error that can occur when converting a byte vector to a `MockCodeCommitment`.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum MockCodeCommitmentError {
@@ -129,7 +127,7 @@ impl sov_rollup_interface::zk::ZkVerifier for MockZkVerifier {
 #[cfg(test)]
 mod tests {
     use sov_rollup_interface::crypto::PublicKey;
-    use sov_rollup_interface::zk::{CodeCommitment, ZkVerifier, ZkvmHost, ZkvmNetwork};
+    use sov_rollup_interface::zk::{ZkVerifier, ZkvmHost, ZkvmNetwork};
 
     use super::*;
 

--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -66,7 +66,7 @@ impl Zkvm for MockZkvm {
 #[derive(
     Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, Serialize, Deserialize, Default,
 )]
-pub struct MockCodeCommitment(pub [u8; 8]);
+pub struct MockCodeCommitment(pub [u32; 8]);
 
 impl sov_rollup_interface::zk::CodeCommitment for MockCodeCommitment {}
 
@@ -227,23 +227,5 @@ mod tests {
         let verified = MockZkVerifier::verify::<TestPublicData>(&proof_bytes, &Default::default())?;
         assert_eq!(verified, pub_data);
         Ok(())
-    }
-
-    #[test]
-    fn mock_code_commitment_codec_roundtrip() {
-        // Check a roundtrip with the "digest" type from risc0.
-        // This ensures that our use of `from_ne_bytes` is correct on the target platform.
-        let raw_data = [1; 8];
-        let method_id = MockCodeCommitment(raw_data);
-        let bytes = method_id.encode();
-        let id = MockCodeCommitment::decode(&bytes).expect("Encoding is valid");
-        assert_eq!(id.0, raw_data);
-
-        // Assert that we return the expected error when the length is incorrect.
-        let bytes = vec![1u8; 31];
-        assert!(matches!(
-            MockCodeCommitment::decode(&bytes),
-            Err(MockCodeCommitmentError::InvalidLength { found: 31 })
-        ));
     }
 }

--- a/crates/adapters/risc0/src/lib.rs
+++ b/crates/adapters/risc0/src/lib.rs
@@ -46,8 +46,6 @@ impl PartialEq<[u32; 8]> for Risc0MethodId {
     }
 }
 
-impl CodeCommitment for Risc0MethodId {}
-
 /// An error that can occur when converting a byte vector to a `Risc0MethodId`.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum Risc0MethodIdError {

--- a/crates/adapters/risc0/src/lib.rs
+++ b/crates/adapters/risc0/src/lib.rs
@@ -14,7 +14,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 #[cfg(not(target_os = "zkvm"))]
 use sov_rollup_interface::zk::Proof;
-use sov_rollup_interface::zk::{CodeCommitment, CryptoSpec, ZkVerifier};
+use sov_rollup_interface::zk::{CryptoSpec, ZkVerifier};
 use thiserror::Error;
 
 pub mod crypto;

--- a/crates/adapters/risc0/src/lib.rs
+++ b/crates/adapters/risc0/src/lib.rs
@@ -46,30 +46,7 @@ impl PartialEq<[u32; 8]> for Risc0MethodId {
     }
 }
 
-impl CodeCommitment for Risc0MethodId {
-    type DecodeError = Risc0MethodIdError;
-
-    fn encode(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(32);
-        for word in &self.0 {
-            bytes.extend_from_slice(&word.to_le_bytes());
-        }
-        bytes
-    }
-
-    fn decode(data: &[u8]) -> Result<Self, Self::DecodeError> {
-        if data.len() != 32 {
-            return Err(Risc0MethodIdError::InvalidLength { found: data.len() });
-        }
-        let mut contents = [0u32; 8];
-        for (idx, chunk) in data.chunks_exact(4).enumerate() {
-            let mut bytes = [0u8; 4];
-            bytes.copy_from_slice(chunk);
-            contents[idx] = u32::from_le_bytes(bytes);
-        }
-        Ok(Self(contents))
-    }
-}
+impl CodeCommitment for Risc0MethodId {}
 
 /// An error that can occur when converting a byte vector to a `Risc0MethodId`.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -175,22 +152,4 @@ fn test_sovereign_admin_pubkey() {
         credential_id.to_string(),
         "0xf1ac96b6ad3cd6bddaf2c23f089de73a6816f892c1af345df70f9a573a86bacb"
     );
-}
-
-#[test]
-fn risc0_method_id_codec_roundtrip() {
-    // Check a roundtrip with the "digest" type from risc0.
-    // This ensures that our use of `from_ne_bytes` is correct on the target platform.
-    let raw_data = [1u32, 2, 3, 4, 5, 6, 7, 8];
-    let method_id = Risc0MethodId(raw_data);
-    let bytes = method_id.encode();
-    let id = Risc0MethodId::decode(&bytes).expect("Encoding is valid");
-    assert_eq!(id.0, raw_data);
-
-    // Assert that we return the expected error when the length is incorrect.
-    let bytes = vec![1u8; 31];
-    assert!(matches!(
-        Risc0MethodId::decode(&bytes),
-        Err(Risc0MethodIdError::InvalidLength { found: 31 })
-    ));
 }

--- a/crates/adapters/sp1/Cargo.toml
+++ b/crates/adapters/sp1/Cargo.toml
@@ -36,7 +36,7 @@ sov-metrics = { workspace = true, features = ["sp1"], optional = true }
 sp1-sdk = { version = "6.0.2", default-features = false, features = ["blocking"] }
 
 [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
-sp1-zkvm = { version = "6.0.2" }
+sp1-zkvm = { version = "6.0.2", features = ["verify"] }
 
 [dev-dependencies]
 reltester = { workspace = true }

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -33,7 +33,7 @@ pub mod metrics;
 ///
 /// Use the [`ZkvmHost::code_commitment`](sov_rollup_interface::zk::ZkvmHost) method to get the MethodId for a given binary.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SP1MethodId(Vec<u8>);
+pub struct SP1MethodId(pub Vec<u8>);
 
 impl Debug for SP1MethodId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -41,17 +41,7 @@ impl Debug for SP1MethodId {
     }
 }
 
-impl CodeCommitment for SP1MethodId {
-    type DecodeError = Error;
-
-    fn encode(&self) -> Vec<u8> {
-        self.0.clone()
-    }
-
-    fn decode(verifying_key_bytes: &[u8]) -> Result<Self, Self::DecodeError> {
-        Ok(Self(verifying_key_bytes.to_vec()))
-    }
-}
+impl CodeCommitment for SP1MethodId {}
 
 /// The cryptographic primitives provided by SP1.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, JsonSchema)]
@@ -119,24 +109,21 @@ impl sov_rollup_interface::zk::Zkvm for SP1 {
 
 #[cfg(target_os = "zkvm")]
 impl ZkVerifier for SP1Verifier {
-    type CodeCommitment = SP1MethodId;
+    type CodeCommitment = sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
 
     type CryptoSpec = SP1CryptoSpec;
 
     type Error = anyhow::Error;
 
     fn verify<T: DeserializeOwned>(
-        _serialized_proof: &[u8],
-        _code_commitment: &Self::CodeCommitment,
+        public_values: &[u8],
+        vkey_hash: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
-        // Implement this, SP1 already supports recursion.
-        // Use sp1_zkvm::lib::verify::verify_sp1_proof(vkey, &public_values_digest.into());
-        // Example can be found here: https://github.com/succinctlabs/sp1/blob/14eb569d41d24721ffbd407d6060e202482d659c/examples/aggregation/program/src/main.rs#L47-L60
-        //
-        // Note: Currently SP1 does not support this interface for recursion. It expects proofs to be written into SP1Stdin with stdin.write_proof,
-        // which are then read within the verify_sp1_proof method. The `verify_sp1_proof` method takes in the vkey hash, and the public values digest as direct input.
-        // In the future, SP1 will support an interface for passing all 3 in directly.
-        todo!("Implement this.")
+        use sha2::Digest;
+
+        let public_values_digest: [u8; 32] = sha2::Sha256::digest(public_values).into();
+        sp1_zkvm::lib::verify::verify_sp1_proof(&vkey_hash.0, &public_values_digest);
+        Ok(bincode::deserialize(public_values)?)
     }
 }
 
@@ -183,26 +170,5 @@ mod tests {
             credential_id.to_string(),
             "0xf1ac96b6ad3cd6bddaf2c23f089de73a6816f892c1af345df70f9a573a86bacb"
         );
-    }
-
-    // See <https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/1209>.
-    #[cfg(not(coverage))]
-    #[test]
-    fn test_sp1_method_id_codec_roundtrip() {
-        use sov_rollup_interface::zk::CodeCommitment;
-        use sp1_sdk::blocking::{Prover, ProverClient};
-        use sp1_sdk::ProvingKey;
-
-        use crate::SP1MethodId;
-
-        const ELF: &[u8] = include_bytes!("../test_data/riscv64im-succinct-zkvm-elf");
-
-        let prover = ProverClient::builder().mock().build();
-        let pk = prover.setup(ELF.into()).unwrap();
-        let method_id = SP1MethodId(bincode::serialize(pk.verifying_key()).unwrap());
-        let encoded = method_id.encode();
-        let decoded = SP1MethodId::decode(&encoded).unwrap();
-
-        assert_eq!(method_id, decoded);
     }
 }

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -11,7 +11,7 @@ use crypto::{SP1PublicKey, SP1Signature};
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::zk::{CodeCommitment, CryptoSpec, ZkVerifier};
+use sov_rollup_interface::zk::{CryptoSpec, ZkVerifier};
 
 #[cfg(feature = "native")]
 use crate::crypto::private_key::SP1PrivateKey;
@@ -40,8 +40,6 @@ impl Debug for SP1MethodId {
         f.debug_tuple("SP1MethodId").field(&self.0).finish()
     }
 }
-
-impl CodeCommitment for SP1MethodId {}
 
 /// The cryptographic primitives provided by SP1.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, JsonSchema)]

--- a/crates/full-node/sov-aggregated-proof/Cargo.toml
+++ b/crates/full-node/sov-aggregated-proof/Cargo.toml
@@ -16,7 +16,7 @@ sha2 = "0.10.8"
 sp1-build = "6.0.2"
 sp1-core-executor = "6.0.2"
 sp1-sdk = { version = "6.0.2", default-features = false, features = ["blocking"] }
-sp1-zkvm = { version = "6.0.2", features = ["verify"] }
+sp1-zkvm = { version = "6.0.2" }
 sov-aggregated-proof-shared = { path = "shared" }
 
 sov-mock-da = { path = "../../adapters/mock-da", default-features = false }

--- a/crates/full-node/sov-aggregated-proof/program/src/aggregation.rs
+++ b/crates/full-node/sov-aggregated-proof/program/src/aggregation.rs
@@ -3,7 +3,8 @@ use sov_aggregated_proof_shared::{
     AggPubData, AggregatedProofWitness, DeferredProofInput, StfPubData,
 };
 use sov_modules_api::da::BlockHeaderTrait;
-use sov_modules_api::{DaSpec, OuterCodeCommitmentHash, Spec, Storage};
+use sov_modules_api::ZkVerifier;
+use sov_modules_api::{CodeCommitmentHash, DaSpec, Spec, Storage};
 use sov_rollup_interface::common::SlotNumber;
 
 struct BoundaryData<Hash, Root> {
@@ -24,9 +25,13 @@ type VerifyResult<S, Da> = VerifiedProofData<
     <<S as Spec>::Storage as Storage>::Root,
 >;
 
-pub(crate) fn run_aggregation_program<S: Spec<Da = Da>, Da: DaSpec>(
+pub(crate) fn run_aggregation_program<
+    S: Spec<Da = Da>,
+    Da: DaSpec,
+    V: ZkVerifier<CodeCommitment = CodeCommitmentHash>,
+>(
     witness: AggregatedProofWitness<Da>,
-    inner_vkey_hash: [u32; 8],
+    inner_vkey_hash: CodeCommitmentHash,
 ) {
     let proof_inputs = witness.proof_inputs;
     let outer_vkey_hash = witness.outer_vkey_hash;
@@ -35,16 +40,22 @@ pub(crate) fn run_aggregation_program<S: Spec<Da = Da>, Da: DaSpec>(
     // Verify the previous aggregation proof if one exists. On the first aggregation
     // after genesis, there is no predecessor, the chain starts here.
     let previous_public_data = if let Some(prev_outer_proof_witness) = prev_outer_proof_witness {
-        Some(deserialize_and_verify_pub_data::<AggPubData<S, Da>>(
+        let pub_data = V::verify::<AggPubData<S, Da>>(
             &prev_outer_proof_witness.public_values,
-            outer_vkey_hash,
-        ))
+            &outer_vkey_hash,
+        )
+        .unwrap_or_else(|error| panic!("Failed to verify aggregated proof: {error:?}"));
+
+        Some(pub_data)
     } else {
         None
     };
 
-    let verified_proof_data: VerifyResult<S, Da> =
-        verify_proof_chain::<S, Da>(proof_inputs, inner_vkey_hash, previous_public_data.as_ref());
+    let verified_proof_data: VerifyResult<S, Da> = verify_proof_chain::<S, Da, V>(
+        proof_inputs,
+        inner_vkey_hash,
+        previous_public_data.as_ref(),
+    );
 
     let VerifiedProofData {
         initial_boundary,
@@ -60,8 +71,6 @@ pub(crate) fn run_aggregation_program<S: Spec<Da = Da>, Da: DaSpec>(
         .map(|public_data| public_data.genesis_state_root.clone())
         .unwrap_or_else(|| initial_boundary.state_root.clone());
 
-    let outer_vk_hash = outer_vk_hash_from_vkey_hash(outer_vkey_hash);
-
     let aggregated_public_data = AggPubData::<S, Da> {
         initial_slot_number: initial_boundary.slot_number,
         final_slot_number: final_boundary.slot_number,
@@ -70,7 +79,7 @@ pub(crate) fn run_aggregation_program<S: Spec<Da = Da>, Da: DaSpec>(
         final_state_root: final_boundary.state_root,
         initial_slot_hash: initial_boundary.slot_hash,
         final_slot_hash: final_boundary.slot_hash,
-        outer_vk_hash,
+        outer_vk_hash: outer_vkey_hash,
         rewarded_addresses,
     };
 
@@ -79,9 +88,9 @@ pub(crate) fn run_aggregation_program<S: Spec<Da = Da>, Da: DaSpec>(
     sp1_zkvm::io::commit(&aggregated_public_data);
 }
 
-fn verify_proof_chain<S: Spec, Da: DaSpec>(
+fn verify_proof_chain<S: Spec, Da: DaSpec, V: ZkVerifier<CodeCommitment = CodeCommitmentHash>>(
     proof_inputs: Vec<DeferredProofInput<Da>>,
-    vkey_hash: [u32; 8],
+    vkey_hash: CodeCommitmentHash,
     previous_agg_proof_public_data: Option<&AggPubData<S, Da>>,
 ) -> VerifyResult<S, Da> {
     assert!(
@@ -105,10 +114,9 @@ fn verify_proof_chain<S: Spec, Da: DaSpec>(
     let mut rewarded_addresses = Vec::with_capacity(proof_inputs.len());
 
     for (index, proof_input) in proof_inputs.iter().enumerate() {
-        let stf_public_data = deserialize_and_verify_pub_data::<StfPubData<S, Da>>(
-            &proof_input.public_values,
-            vkey_hash,
-        );
+        let stf_public_data =
+            V::verify::<StfPubData<S, Da>>(&proof_input.public_values, &vkey_hash)
+                .unwrap_or_else(|error| panic!("Failed to verify inner proof: {error:?}"));
 
         let current_slot_number = SlotNumber::new(proof_input.da_block_header.height());
 
@@ -176,27 +184,4 @@ fn verify_proof_chain<S: Spec, Da: DaSpec>(
         final_boundary,
         rewarded_addresses,
     }
-}
-
-// Verify that a proof with the given vkey_hash actually
-// produced these public values, then deserialize them. This is the core
-// trust anchor: the vkey_hash pins which program generated the proof.
-fn deserialize_and_verify_pub_data<T: serde::de::DeserializeOwned>(
-    pub_values: &[u8],
-    vkey_hash: [u32; 8],
-) -> T {
-    let public_values_digest: [u8; 32] = Sha256::digest(pub_values).into();
-    sp1_zkvm::lib::verify::verify_sp1_proof(&vkey_hash, &public_values_digest);
-
-    bincode::deserialize(pub_values)
-        .unwrap_or_else(|error| panic!("Failed to deserialize aggregated public data: {error}"))
-}
-
-fn outer_vk_hash_from_vkey_hash(vkey_hash: [u32; 8]) -> OuterCodeCommitmentHash {
-    let mut bytes = Vec::with_capacity(32);
-    for word in vkey_hash {
-        // Match SP1's HashableKey::hash_bytes representation for hash_u32().
-        bytes.extend_from_slice(&word.to_be_bytes());
-    }
-    OuterCodeCommitmentHash(bytes)
 }

--- a/crates/full-node/sov-aggregated-proof/program/src/aggregation.rs
+++ b/crates/full-node/sov-aggregated-proof/program/src/aggregation.rs
@@ -39,17 +39,10 @@ pub(crate) fn run_aggregation_program<
 
     // Verify the previous aggregation proof if one exists. On the first aggregation
     // after genesis, there is no predecessor, the chain starts here.
-    let previous_public_data = if let Some(prev_outer_proof_witness) = prev_outer_proof_witness {
-        let pub_data = V::verify::<AggPubData<S, Da>>(
-            &prev_outer_proof_witness.public_values,
-            &outer_vkey_hash,
-        )
-        .unwrap_or_else(|error| panic!("Failed to verify aggregated proof: {error:?}"));
-
-        Some(pub_data)
-    } else {
-        None
-    };
+    let previous_public_data = prev_outer_proof_witness.map(|prev_outer_proof_witness| {
+        V::verify::<AggPubData<S, Da>>(&prev_outer_proof_witness.public_values, &outer_vkey_hash)
+            .unwrap_or_else(|error| panic!("Failed to verify aggregated proof: {error:?}"))
+    });
 
     let verified_proof_data: VerifyResult<S, Da> = verify_proof_chain::<S, Da, V>(
         proof_inputs,

--- a/crates/full-node/sov-aggregated-proof/program/src/main.rs
+++ b/crates/full-node/sov-aggregated-proof/program/src/main.rs
@@ -10,7 +10,8 @@ use sov_aggregated_proof_shared::AggregatedProofWitness;
 use sov_mock_da::MockDaSpec;
 use sov_mock_zkvm::MockZkvm;
 use sov_modules_api::configurable_spec::ConfigurableSpec;
-use sov_modules_api::execution_mode::Zk;
+use sov_modules_api::{execution_mode::Zk, CodeCommitmentHash};
+use sov_sp1_adapter::SP1Verifier;
 use sov_sp1_adapter::SP1;
 
 include!(concat!(env!("OUT_DIR"), "/inner_vk_hash.rs"));
@@ -19,5 +20,7 @@ type ProgramSpec = ConfigurableSpec<MockDaSpec, SP1, MockZkvm, MultiAddressEvmSo
 
 pub fn main() {
     let witness = sp1_zkvm::io::read::<AggregatedProofWitness<MockDaSpec>>();
-    run_aggregation_program::<ProgramSpec, MockDaSpec>(witness, INNER_VKEY_HASH);
+
+    let inner = CodeCommitmentHash(INNER_VKEY_HASH);
+    run_aggregation_program::<ProgramSpec, MockDaSpec, SP1Verifier>(witness, inner);
 }

--- a/crates/full-node/sov-aggregated-proof/script/src/main.rs
+++ b/crates/full-node/sov-aggregated-proof/script/src/main.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 use anyhow::{bail, ensure, Context};
 use demo_stf::MultiAddressEvmSolana;
 use slop_algebra::PrimeField32;
+
 use sov_aggregated_proof_shared::{
     AggPubData, AggregatedProofWitness, DeferredProofInput, PreviousOuterProofWitness, StfPubData,
 };
@@ -13,6 +14,7 @@ use sov_mock_da::MockDaSpec;
 use sov_mock_zkvm::MockZkvm;
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::Zk;
+use sov_modules_api::CodeCommitmentHash;
 use sov_modules_api::{Spec, Storage};
 use sov_sp1_adapter::BlockHeaderWithProof;
 use sov_sp1_adapter::SP1;
@@ -187,9 +189,11 @@ fn create_agg_proof<P: Prover>(
         stdin.write_proof(*recursion_proof.clone(), verification_key.vk.clone());
     }
 
+    let outer_vkey_hash = CodeCommitmentHash(aggregation_vk_hash);
+
     let witness = AggregatedProofWitness {
         proof_inputs,
-        outer_vkey_hash: aggregation_vk_hash,
+        outer_vkey_hash: outer_vkey_hash,
         prev_outer_proof_witness,
     };
 

--- a/crates/full-node/sov-aggregated-proof/shared/src/lib.rs
+++ b/crates/full-node/sov-aggregated-proof/shared/src/lib.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use sov_modules_api::CodeCommitmentHash;
 use sov_modules_api::{
     AggregatedProofPublicData, DaSpec, Spec, StateTransitionPublicData, Storage,
 };
@@ -18,7 +19,7 @@ pub struct DeferredProofInput<Da: DaSpec> {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AggregatedProofWitness<Da: DaSpec> {
     pub proof_inputs: Vec<DeferredProofInput<Da>>,
-    pub outer_vkey_hash: [u32; 8],
+    pub outer_vkey_hash: CodeCommitmentHash,
     pub prev_outer_proof_witness: Option<PreviousOuterProofWitness>,
 }
 

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -9,7 +9,7 @@ use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
 use sov_rollup_interface::stf::{BatchReceipt, BlobDiscardReason, TransactionReceipt, TxEffect};
 use sov_rollup_interface::stf::{DiscardedBlob, StoredEvent};
 use sov_rollup_interface::zk::aggregated_proof::{
-    AggregatedProofPublicData, OuterCodeCommitmentHash, SerializedAggregatedProof,
+    AggregatedProofPublicData, CodeCommitmentHash, SerializedAggregatedProof,
 };
 use sov_rollup_interface::TxHash;
 use sov_test_utils::ledger_db::sov_api_spec::types::IntOrHash;
@@ -94,7 +94,7 @@ async fn test_save_aggregated_proof() {
             final_state_root: vec![i + 1],
             initial_slot_hash: MockHash([i + 2; 32]),
             final_slot_hash: MockHash([i + 3; 32]),
-            outer_vk_hash: OuterCodeCommitmentHash::default(),
+            outer_vk_hash: CodeCommitmentHash::default(),
             rewarded_addresses: vec![MockAddress::default()],
         };
 

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/network/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/network/mod.rs
@@ -9,7 +9,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::da::DaService;
-use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
+use sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
 use sov_rollup_interface::zk::{Zkvm, ZkvmGuest};
 
 use super::{ProverService, ProverServiceError, Verifier};
@@ -49,7 +49,7 @@ where
         inner_vm: InnerVm::Network,
         outer_vm: OuterVm::Network,
         da_verifier: Da::Verifier,
-        code_commitment: OuterCodeCommitmentHash,
+        code_commitment: CodeCommitmentHash,
         prover_address: Address,
         outer_proof_timeout: std::time::Duration,
     ) -> Self {

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/network/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/network/prover.rs
@@ -5,7 +5,7 @@ use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec, DaVerifier};
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::zk::aggregated_proof::{
-    AggregatedProofPublicData, BlockProof, OuterCodeCommitmentHash, SerializedAggregatedProof,
+    AggregatedProofPublicData, BlockProof, CodeCommitmentHash, SerializedAggregatedProof,
 };
 use sov_rollup_interface::zk::{
     StateTransitionPublicData, StateTransitionWitness, StateTransitionWitnessWithAddress, Zkvm,
@@ -55,7 +55,7 @@ pub(crate) struct NetworkProver<
     inner_vm: InnerVm::Network,
     outer_vm: OuterVm::Network,
     tracker: tokio::sync::RwLock<ProofStatusMap<Address, StateRoot, Da::Spec, InnerVm>>,
-    code_commitment: OuterCodeCommitmentHash,
+    code_commitment: CodeCommitmentHash,
     outer_proof_timeout: std::time::Duration,
     phantom: PhantomData<Witness>,
 }
@@ -75,7 +75,7 @@ where
         prover_address: Address,
         inner_vm: InnerVm::Network,
         outer_vm: OuterVm::Network,
-        code_commitment: OuterCodeCommitmentHash,
+        code_commitment: CodeCommitmentHash,
         outer_proof_timeout: std::time::Duration,
     ) -> Self {
         Self {

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/mod.rs
@@ -9,7 +9,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::da::DaService;
-use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
+use sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
 use sov_rollup_interface::zk::{Zkvm, ZkvmGuest};
 
 use super::{ProverService, ProverServiceError, RollupProverConfigDiscriminants, Verifier};
@@ -53,7 +53,7 @@ where
         da_verifier: Da::Verifier,
         config: RollupProverConfigDiscriminants,
         num_threads: usize,
-        outer_vk_hash: OuterCodeCommitmentHash,
+        outer_vk_hash: CodeCommitmentHash,
         prover_address: Address,
     ) -> Self {
         let verifier = Arc::new(Verifier { da_verifier });
@@ -74,7 +74,7 @@ where
         outer_vm: OuterVm::Host,
         da_verifier: Da::Verifier,
         config: RollupProverConfigDiscriminants,
-        outer_vk_hash: OuterCodeCommitmentHash,
+        outer_vk_hash: CodeCommitmentHash,
         prover_address: Address,
     ) -> Self {
         let num_cpus = num_cpus::get();

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec, DaVerifier};
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::zk::aggregated_proof::{
-    AggregatedProofPublicData, BlockProof, OuterCodeCommitmentHash, SerializedAggregatedProof,
+    AggregatedProofPublicData, BlockProof, CodeCommitmentHash, SerializedAggregatedProof,
 };
 use sov_rollup_interface::zk::{
     StateTransitionPublicData, StateTransitionWitness, StateTransitionWitnessWithAddress, Zkvm,
@@ -36,7 +36,7 @@ pub(crate) struct Prover<Address, StateRoot, Witness, Da: DaService> {
     // and automatically terminate.
     // """
     pool: rayon::ThreadPool,
-    outer_vk_hash: OuterCodeCommitmentHash,
+    outer_vk_hash: CodeCommitmentHash,
     phantom: std::marker::PhantomData<(StateRoot, Witness, Da)>,
 }
 
@@ -51,7 +51,7 @@ where
     pub(crate) fn new(
         prover_address: Address,
         num_threads: usize,
-        outer_vk_hash: OuterCodeCommitmentHash,
+        outer_vk_hash: CodeCommitmentHash,
     ) -> Self {
         Self {
             outer_vk_hash,

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
@@ -7,7 +7,7 @@ use sov_mock_zkvm::MockCodeCommitment;
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::registration_lib::StakeRegistration;
 use sov_modules_api::{
-    AggregatedProofPublicData, Amount, ApiStateAccessor, OuterCodeCommitmentHash,
+    AggregatedProofPublicData, Amount, ApiStateAccessor, CodeCommitmentHash,
     SerializedAggregatedProof, Spec, Storage,
 };
 use sov_modules_rollup_blueprint::proof_sender::serialize_proof_blob_with_metadata;
@@ -101,7 +101,7 @@ pub(crate) fn build_proof(
         final_state_root: *end_transition.post_state_root(),
         initial_slot_hash: *initial_transition.slot_hash(),
         final_slot_hash: *end_transition.slot().slot_hash(),
-        outer_vk_hash: OuterCodeCommitmentHash(MOCK_CODE_COMMITMENT.0.to_vec()),
+        outer_vk_hash: CodeCommitmentHash(MOCK_CODE_COMMITMENT.0.to_vec()),
         rewarded_addresses: vec![prover_address],
     })
 }

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
@@ -23,7 +23,7 @@ use sov_value_setter::ValueSetterConfig;
 pub(crate) type S = sov_test_utils::TestSpec;
 pub(crate) type TestProverIncentives = ProverIncentives<S>;
 pub(crate) type RT = TestRuntime<S>;
-pub(crate) const MOCK_CODE_COMMITMENT: MockCodeCommitment = MockCodeCommitment([0u8; 8]);
+pub(crate) const MOCK_CODE_COMMITMENT: MockCodeCommitment = MockCodeCommitment([0u32; 8]);
 
 generate_zk_runtime!(TestRuntime <= value_setter: sov_value_setter::ValueSetter<S>);
 
@@ -101,7 +101,7 @@ pub(crate) fn build_proof(
         final_state_root: *end_transition.post_state_root(),
         initial_slot_hash: *initial_transition.slot_hash(),
         final_slot_hash: *end_transition.slot().slot_hash(),
-        outer_vk_hash: CodeCommitmentHash(MOCK_CODE_COMMITMENT.0.to_vec()),
+        outer_vk_hash: CodeCommitmentHash(MOCK_CODE_COMMITMENT.0),
         rewarded_addresses: vec![prover_address],
     })
 }

--- a/crates/module-system/sov-modules-api/src/lib.rs
+++ b/crates/module-system/sov-modules-api/src/lib.rs
@@ -117,7 +117,7 @@ pub use sov_rollup_interface::stf::{
     ProofSender, StateTransitionFunction, StoredEvent,
 };
 pub use sov_rollup_interface::zk::aggregated_proof::{
-    AggregatedProofPublicData, OuterCodeCommitmentHash, SerializedAggregatedProof,
+    AggregatedProofPublicData, CodeCommitmentHash, SerializedAggregatedProof,
 };
 #[cfg(feature = "native")]
 pub use sov_rollup_interface::zk::HostArgs;

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof.rs
@@ -19,18 +19,22 @@ pub struct BlockProof<Address, Da: DaSpec, Root> {
     pub st: StateTransitionPublicData<Address, Da, Root>,
 }
 
-/// Aggregated proof outer code commitment hash.
+/// A code commitment hash used to identify ZK circuits (both inner and outer).
 #[derive(
     Debug, Eq, PartialEq, BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone, Default,
 )]
-pub struct OuterCodeCommitmentHash(pub Vec<u8>);
+pub struct CodeCommitmentHash(pub [u32; 8]);
 
-impl core::fmt::Display for OuterCodeCommitmentHash {
+use crate::zk::CodeCommitment;
+impl CodeCommitment for CodeCommitmentHash {}
+
+impl core::fmt::Display for CodeCommitmentHash {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if self.0.is_empty() {
-            return write!(f, "OuterCodeCommitmentHash([])");
+        write!(f, "CodeCommitmentHash(0x")?;
+        for word in self.0 {
+            write!(f, "{word:08x}")?;
         }
-        write!(f, "OuterCodeCommitmentHash(0x{})", hex::encode(&self.0))
+        write!(f, ")")
     }
 }
 
@@ -52,7 +56,7 @@ pub struct AggregatedProofPublicData<Address, Da: DaSpec, Root> {
     /// The final slot hash of the aggregated proof.
     pub final_slot_hash: Da::SlotHash,
     /// Outer verifying key hash of the aggregated proof circuit.
-    pub outer_vk_hash: OuterCodeCommitmentHash,
+    pub outer_vk_hash: CodeCommitmentHash,
     /// These are the addresses of the provers who proved individual blocks.
     pub rewarded_addresses: Vec<Address>,
 }
@@ -66,7 +70,7 @@ where
     pub fn from_block_proofs(
         block_proofs: &[&BlockProof<Address, Da, Root>],
         genesis_state_root: Root,
-        outer_vk_hash: OuterCodeCommitmentHash,
+        outer_vk_hash: CodeCommitmentHash,
     ) -> Self {
         let initial = block_proofs
             .first()

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof.rs
@@ -25,9 +25,6 @@ pub struct BlockProof<Address, Da: DaSpec, Root> {
 )]
 pub struct CodeCommitmentHash(pub [u32; 8]);
 
-use crate::zk::CodeCommitment;
-impl CodeCommitment for CodeCommitmentHash {}
-
 impl core::fmt::Display for CodeCommitmentHash {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "CodeCommitmentHash(0x")?;

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -114,17 +114,11 @@ pub trait ZkvmHost: Clone + Send + Sync + 'static {
     fn run(&mut self, with_proof: bool) -> anyhow::Result<Vec<u8>>;
 }
 
-/// A commitment to a zkVM program.
-pub trait CodeCommitment:
-    Clone + Debug + Serialize + DeserializeOwned + Send + Sync + PartialEq + Eq
-{
-}
-
 /// A Zk proof system capable of proving and verifying arbitrary Rust code
 /// Must support recursive proofs.
 pub trait ZkVerifier: Default + Clone + Send + Sync + 'static {
     /// A commitment to the zkVM program which is being proven
-    type CodeCommitment: CodeCommitment;
+    type CodeCommitment: Clone + Debug + Serialize + DeserializeOwned + Send + Sync + PartialEq + Eq;
 
     /// Defines the cryptographic operations provided natively by the Zkvm.
     type CryptoSpec: CryptoSpec;

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -118,17 +118,6 @@ pub trait ZkvmHost: Clone + Send + Sync + 'static {
 pub trait CodeCommitment:
     Clone + Debug + Serialize + DeserializeOwned + Send + Sync + PartialEq + Eq
 {
-    /// An error that occurs while trying to decode a commitment.
-    type DecodeError: Debug;
-
-    /// Encodes the commitment into a byte sequence. Any kind of serializer may be used,
-    /// as long as this method is inverted by the [`CodeCommitment::decode`] method.
-    fn encode(&self) -> Vec<u8>;
-
-    /// Decodes the commitment from a byte sequence.
-    ///
-    /// This method must be the inverse of the [`CodeCommitment::encode`] method.
-    fn decode(data: &[u8]) -> Result<Self, Self::DecodeError>;
 }
 
 /// A Zk proof system capable of proving and verifying arbitrary Rust code
@@ -143,10 +132,10 @@ pub trait ZkVerifier: Default + Clone + Send + Sync + 'static {
     /// The error type which is returned when a proof fails to verify
     type Error: Debug;
 
-    /// Interpret a sequence of a bytes as a proof and attempt to verify it against the code commitment.
-    /// If the proof is valid, return a public outputs of the proof.
+    /// Interpret a sequence of a bytes as a receipt and attempt to verify it against the code commitment.
+    /// If the receipt is valid, return a public outputs of the proof.
     fn verify<T: DeserializeOwned>(
-        serialized_proof: &[u8],
+        serialized_receipt: &[u8],
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error>;
 }

--- a/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
+++ b/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
@@ -19,7 +19,7 @@ use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, Sequencer
 use sov_modules_stf_blueprint::Runtime as RuntimeTrait;
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::storage::HierarchicalStorageManager;
-use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
+use sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
 use sov_rollup_interface::zk::ZkvmHost;
 use sov_sequencer::ProofBlobSender;
 use sov_state::nomt::prover_storage::NomtProverStorage;
@@ -148,7 +148,7 @@ where
             outer_vm,
             da_verifier,
             prover_config_disc,
-            OuterCodeCommitmentHash::default(),
+            CodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/examples/demo-rollup/provers/sp1/guest-celestia-nomt/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia-nomt/Cargo.lock
@@ -7644,6 +7644,7 @@ dependencies = [
  "libm",
  "rand 0.8.5",
  "sha2 0.10.9",
+ "slop-algebra",
  "sp1-lib",
  "sp1-primitives",
 ]

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -7631,6 +7631,7 @@ dependencies = [
  "libm",
  "rand 0.8.5",
  "sha2 0.10.9",
+ "slop-algebra",
  "sp1-lib",
  "sp1-primitives",
 ]

--- a/examples/demo-rollup/provers/sp1/guest-mock-nomt/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock-nomt/Cargo.lock
@@ -7289,6 +7289,7 @@ dependencies = [
  "libm",
  "rand 0.8.5",
  "sha2 0.10.9",
+ "slop-algebra",
  "sp1-lib",
  "sp1-primitives",
 ]

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -7276,6 +7276,7 @@ dependencies = [
  "libm",
  "rand 0.8.5",
  "sha2 0.10.9",
+ "slop-algebra",
  "sp1-lib",
  "sp1-primitives",
 ]

--- a/examples/demo-rollup/src/celestia_nomt_rollup.rs
+++ b/examples/demo-rollup/src/celestia_nomt_rollup.rs
@@ -23,7 +23,7 @@ use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::{Risc0, Risc0CryptoSpec};
 use sov_rollup_interface::da::{DaSpec, DaVerifier};
 use sov_rollup_interface::execution_mode::WitnessGeneration;
-use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
+use sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
 use sov_rollup_interface::zk::CryptoSpec;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_state::nomt::prover_storage::NomtProverStorage;
@@ -184,7 +184,7 @@ impl FullNodeBlueprint<Native> for CelestiaNomtDemoRollup<Native> {
             outer_vm,
             da_verifier,
             prover_config_disc,
-            OuterCodeCommitmentHash::default(),
+            CodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -23,7 +23,7 @@ use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::Risc0;
 use sov_rollup_interface::da::DaVerifier;
 use sov_rollup_interface::execution_mode::WitnessGeneration;
-use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
+use sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
@@ -171,7 +171,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
             outer_vm,
             da_verifier,
             prover_config_disc,
-            OuterCodeCommitmentHash::default(),
+            CodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/examples/demo-rollup/src/external_mock_nomt_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_nomt_rollup.rs
@@ -22,7 +22,7 @@ use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::Risc0;
 use sov_risc0_adapter::Risc0CryptoSpec;
 use sov_rollup_interface::da::DaSpec;
-use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
+use sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::DefaultStorageSpec;
@@ -171,7 +171,7 @@ impl FullNodeBlueprint<Native> for ExternalMockNomtDemoRollup<Native> {
             outer_vm,
             da_verifier,
             prover_config_discriminant,
-            OuterCodeCommitmentHash::default(),
+            CodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -19,7 +19,7 @@ use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
 use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::Risc0;
-use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
+use sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
@@ -155,7 +155,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
             outer_vm,
             da_verifier,
             prover_config_discriminant,
-            OuterCodeCommitmentHash::default(),
+            CodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/examples/demo-rollup/src/mock_nomt_rollup.rs
+++ b/examples/demo-rollup/src/mock_nomt_rollup.rs
@@ -20,7 +20,7 @@ use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, Sequencer
 use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::{Risc0, Risc0CryptoSpec};
 use sov_rollup_interface::da::DaSpec;
-use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
+use sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::{DefaultStorageSpec, Storage};
@@ -167,7 +167,7 @@ impl FullNodeBlueprint<Native> for MockNomtDemoRollup<Native> {
             outer_vm,
             da_verifier,
             prover_config_discriminant,
-            OuterCodeCommitmentHash::default(),
+            CodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -19,7 +19,7 @@ use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
 use sov_risc0_adapter::host::Risc0Host;
 use sov_risc0_adapter::Risc0;
-use sov_rollup_interface::zk::aggregated_proof::OuterCodeCommitmentHash;
+use sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
@@ -154,7 +154,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
             outer_vm,
             da_verifier,
             prover_config_discriminant,
-            OuterCodeCommitmentHash::default(),
+            CodeCommitmentHash::default(),
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/examples/demo-rollup/tests/prover/mod.rs
+++ b/examples/demo-rollup/tests/prover/mod.rs
@@ -220,7 +220,7 @@ impl TestHost {
     }
 
     fn verifying_key_bytes(&self) -> Vec<u8> {
-        self.code_commitment.encode()
+        self.code_commitment.0.clone()
     }
 
     #[allow(dead_code)]

--- a/examples/demo-rollup/tests/prover/mod.rs
+++ b/examples/demo-rollup/tests/prover/mod.rs
@@ -16,8 +16,7 @@ use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::stf::{ExecutionContext, StateTransitionFunction};
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::{
-    CodeCommitment, StateTransitionPublicData, StateTransitionWitness,
-    StateTransitionWitnessWithAddress, ZkvmHost,
+    StateTransitionPublicData, StateTransitionWitness, StateTransitionWitnessWithAddress, ZkvmHost,
 };
 use sov_sp1_adapter::host::SP1Host;
 use sov_sp1_adapter::BlockHeaderWithProof;


### PR DESCRIPTION
# Description

This PR makes the `run_aggregation_program` method independent of the verifier type by implementing `ZkVerifier` for `SP1Verifier`. This PR doesn't change the circuit's logic; it is just code reorganization. 

  - Implement `SP1Verifier::verify` for target_os = "zkvm" using `sp1_zkvm::lib::verify::verify_sp1_proof`, replacing the previous todo!() stub                                                                                                                   
  - Rename `OuterCodeCommitmentHash(Vec<u8>)` to `CodeCommitmentHash([u32; 8])` — the type is now used for both inner and outer proof verification.
  - Refactor aggregation program to use `V: ZkVerifier` trait for proof verification instead of calling `sp1_zkvm` directly, making verification backend-agnostic                                                                                                 
  - Remove `CodeCommitment::encode/decode` methods.
  - Remove deserialize_and_verify_pub_data and outer_vk_hash_from_vkey_hash helper functions that are no longer needed 

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to  #2551
