### PR TITLE
Network prover testing in demo rollup

### DIFF
--- a/examples/demo-rollup/tests/prover/mod.rs
+++ b/examples/demo-rollup/tests/prover/mod.rs
@@ -39,6 +39,7 @@ type DefaultSpec = sov_modules_api::configurable_spec::ConfigurableSpec<
 >;
 
 mod datagen;
+mod network;
 
 type TestSTF = StfBlueprint<DefaultSpec, Runtime<DefaultSpec>>;
 type ProofStateRoot = <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::StateRoot;

--- a/examples/demo-rollup/tests/prover/mod.rs
+++ b/examples/demo-rollup/tests/prover/mod.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
@@ -9,18 +8,14 @@ use sov_db::storage_manager::NativeStorageManager;
 use sov_mock_da::{MockAddress, MockBlock, MockDaService, MockDaSpec};
 use sov_mock_zkvm::MockZkvm;
 use sov_modules_api::execution_mode::WitnessGeneration;
-use sov_modules_api::{OperatingMode, SlotData, Spec, ZkVerifier};
+use sov_modules_api::{OperatingMode, SlotData};
 use sov_modules_stf_blueprint::{GenesisParams, StfBlueprint};
 use sov_rollup_interface::da::BlockHeaderTrait;
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::stf::{ExecutionContext, StateTransitionFunction};
 use sov_rollup_interface::storage::HierarchicalStorageManager;
-use sov_rollup_interface::zk::{
-    StateTransitionPublicData, StateTransitionWitness, StateTransitionWitnessWithAddress, ZkvmHost,
-};
-use sov_sp1_adapter::host::SP1Host;
-use sov_sp1_adapter::BlockHeaderWithProof;
-use sov_sp1_adapter::{SP1MethodId, SP1Verifier, SP1};
+use sov_rollup_interface::zk::StateTransitionWitness;
+use sov_sp1_adapter::SP1;
 use sov_state::ProverStorage;
 use sov_test_utils::generators::BlobBuildingCtx;
 use sov_test_utils::TestStorageSpec;
@@ -40,6 +35,7 @@ pub(super) type DefaultSpec = sov_modules_api::configurable_spec::ConfigurableSp
 
 mod datagen;
 mod network;
+mod sp1_cpu_prover;
 
 pub(super) type TestSTF = StfBlueprint<DefaultSpec, Runtime<DefaultSpec>>;
 pub(super) type ProofStateRoot =
@@ -47,42 +43,6 @@ pub(super) type ProofStateRoot =
 pub(super) type ProofWitness =
     <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::Witness;
 pub(super) type StfWitness = StateTransitionWitness<ProofStateRoot, ProofWitness, MockDaSpec>;
-
-type ProofInput = StateTransitionWitnessWithAddress<
-    <DefaultSpec as Spec>::Address,
-    ProofStateRoot,
-    ProofWitness,
-    MockDaSpec,
->;
-
-#[tokio::test(flavor = "multi_thread")]
-#[ignore = "This test is used to generate data for testing the aggregate proof circuit and should be enabled only when needed."]
-async fn test_save_proofs() {
-    let host = TestHost::new().await;
-    let proof_data = generate_proofs(true, &host).await;
-    let proofs_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("test_data")
-        .join("tmp");
-
-    std::fs::create_dir_all(&proofs_dir).unwrap();
-    std::fs::write(proofs_dir.join("inner_vk.bin"), host.verifying_key_bytes()).unwrap();
-
-    for (i, data) in proof_data.into_iter().enumerate() {
-        let proof_public_data = host.verify(data.proof.clone()).await;
-        assert_eq!(proof_public_data.slot_hash, data.da_block_header.hash());
-        let json = serde_json::to_string(&data).unwrap();
-        std::fs::write(proofs_dir.join(format!("inner_{i}_proof.json")), &json).unwrap();
-    }
-}
-
-/// This test reproduces the proof generation process for the rollup used in benchmarks.
-#[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(skip_guest_build, ignore)]
-async fn test_proof_generation() {
-    let host = TestHost::new().await;
-    let _ = generate_proofs(false, &host).await;
-}
 
 /// Executes the STF against mock DA blocks and produces per-block witnesses.
 ///
@@ -175,86 +135,4 @@ pub(super) async fn generate_witnesses() -> (ProofStateRoot, Vec<StfWitness>) {
     }
 
     (genesis_state_root, witnesses)
-}
-
-async fn generate_proofs(
-    with_proof: bool,
-    host: &TestHost,
-) -> Vec<BlockHeaderWithProof<MockDaSpec>> {
-    let (_genesis_state_root, witnesses) = generate_witnesses().await;
-
-    let prover_address = <DefaultSpec as Spec>::Address::try_from([0u8; 28].as_ref()).unwrap();
-    let mut proofs = Vec::new();
-
-    for witness in witnesses {
-        let da_block_header = witness.da_block_header.clone();
-
-        let data: ProofInput = StateTransitionWitnessWithAddress {
-            stf_witness: witness,
-            prover_address,
-        };
-
-        let proof = host.run(data, with_proof).await;
-        proofs.push(BlockHeaderWithProof {
-            da_block_header,
-            proof,
-        });
-    }
-
-    proofs
-}
-
-// The SP1 prover manages its own Tokio runtime, which conflicts with the `tokio::test` runtime.
-// To avoid this, all blocking work must be executed inside `tokio::task::spawn_blocking`.
-struct TestHost {
-    host: SP1Host<'static>,
-    code_commitment: SP1MethodId,
-}
-
-impl TestHost {
-    async fn new() -> Self {
-        let host = SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF);
-        let host_clone = host.clone();
-        let code_commitment = tokio::task::spawn_blocking(move || -> SP1MethodId {
-            host_clone
-                .code_commitment()
-                .expect("SP1 code commitment should be created successfully")
-        })
-        .await
-        .unwrap();
-
-        Self {
-            host,
-            code_commitment,
-        }
-    }
-
-    async fn run(&self, data: ProofInput, with_proof: bool) -> Vec<u8> {
-        let mut host = self.host.clone();
-        tokio::task::spawn_blocking(move || -> Vec<u8> {
-            host.add_hint(data);
-            host.run(with_proof)
-                .expect("Prover should run successfully")
-        })
-        .await
-        .unwrap()
-    }
-
-    fn verifying_key_bytes(&self) -> Vec<u8> {
-        self.code_commitment.0.clone()
-    }
-
-    #[allow(dead_code)]
-    async fn verify(
-        &self,
-        proof: Vec<u8>,
-    ) -> StateTransitionPublicData<<DefaultSpec as Spec>::Address, MockDaSpec, ProofStateRoot> {
-        let code_commitment = self.code_commitment.clone();
-        tokio::task::spawn_blocking(move || -> StateTransitionPublicData<<DefaultSpec as Spec>::Address, MockDaSpec, ProofStateRoot> {
-            SP1Verifier::verify(&proof, &code_commitment)
-                .expect("SP1 proof verification should succeed")
-        })
-        .await
-        .unwrap()
-    }
 }

--- a/examples/demo-rollup/tests/prover/mod.rs
+++ b/examples/demo-rollup/tests/prover/mod.rs
@@ -29,7 +29,7 @@ use tempfile::TempDir;
 use crate::prover::datagen::{get_blocks_from_da, DEFAULT_BLOCKS};
 use crate::test_helpers::test_genesis_paths;
 
-type DefaultSpec = sov_modules_api::configurable_spec::ConfigurableSpec<
+pub(super) type DefaultSpec = sov_modules_api::configurable_spec::ConfigurableSpec<
     sov_mock_da::MockDaSpec,
     sov_sp1_adapter::SP1,
     sov_mock_zkvm::MockZkvm,
@@ -41,10 +41,12 @@ type DefaultSpec = sov_modules_api::configurable_spec::ConfigurableSpec<
 mod datagen;
 mod network;
 
-type TestSTF = StfBlueprint<DefaultSpec, Runtime<DefaultSpec>>;
-type ProofStateRoot = <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::StateRoot;
-type ProofWitness = <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::Witness;
-type StfWitness = StateTransitionWitness<ProofStateRoot, ProofWitness, MockDaSpec>;
+pub(super) type TestSTF = StfBlueprint<DefaultSpec, Runtime<DefaultSpec>>;
+pub(super) type ProofStateRoot =
+    <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::StateRoot;
+pub(super) type ProofWitness =
+    <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::Witness;
+pub(super) type StfWitness = StateTransitionWitness<ProofStateRoot, ProofWitness, MockDaSpec>;
 
 type ProofInput = StateTransitionWitnessWithAddress<
     <DefaultSpec as Spec>::Address,
@@ -82,10 +84,13 @@ async fn test_proof_generation() {
     let _ = generate_proofs(false, &host).await;
 }
 
-async fn generate_proofs(
-    with_proof: bool,
-    host: &TestHost,
-) -> Vec<BlockHeaderWithProof<MockDaSpec>> {
+/// Executes the STF against mock DA blocks and produces per-block witnesses.
+///
+/// This is the shared data generation logic used by both the local (host) prover
+/// tests and the network prover tests.
+///
+/// Returns `(genesis_state_root, witnesses)`.
+pub(super) async fn generate_witnesses() -> (ProofStateRoot, Vec<StfWitness>) {
     let temp_dir = TempDir::new().expect("Unable to create temporary directory");
     tracing::info!("Creating temp dir at {}", temp_dir.path().display());
     let da_service = MockDaService::new(MockAddress::default());
@@ -117,14 +122,14 @@ async fn generate_proofs(
     // Write it to the database immediately!
     storage_manager.finalize(&genesis_block.header).unwrap();
 
+    let genesis_state_root = prev_state_root;
+
     // TODO: Fix this with genesis logic.
     let mut blocks = get_blocks_from_da(sequencer_mode)
         .await
         .expect("Failed to get DA blocks");
 
-    let prover_address = <DefaultSpec as Spec>::Address::try_from([0u8; 28].as_ref()).unwrap();
-
-    let mut proofs = Vec::new();
+    let mut witnesses = Vec::new();
 
     for filtered_block in &mut blocks[..(DEFAULT_BLOCKS as usize)] {
         let height = filtered_block.header().height();
@@ -150,24 +155,13 @@ async fn generate_proofs(
             ExecutionContext::Node,
         );
 
-        let data = StfWitness {
+        witnesses.push(StfWitness {
             initial_state_root: prev_state_root,
             da_block_header: filtered_block.header().clone(),
             relevant_proofs,
             witness: result.witness,
             relevant_blobs,
             final_state_root: result.state_root,
-        };
-
-        let data: ProofInput = StateTransitionWitnessWithAddress {
-            stf_witness: data,
-            prover_address,
-        };
-
-        let proof = host.run(data, with_proof).await;
-        proofs.push(BlockHeaderWithProof {
-            da_block_header: filtered_block.header().clone(),
-            proof,
         });
 
         prev_state_root = result.state_root;
@@ -178,6 +172,33 @@ async fn generate_proofs(
                 SchemaBatch::new(),
             )
             .unwrap();
+    }
+
+    (genesis_state_root, witnesses)
+}
+
+async fn generate_proofs(
+    with_proof: bool,
+    host: &TestHost,
+) -> Vec<BlockHeaderWithProof<MockDaSpec>> {
+    let (_genesis_state_root, witnesses) = generate_witnesses().await;
+
+    let prover_address = <DefaultSpec as Spec>::Address::try_from([0u8; 28].as_ref()).unwrap();
+    let mut proofs = Vec::new();
+
+    for witness in witnesses {
+        let da_block_header = witness.da_block_header.clone();
+
+        let data: ProofInput = StateTransitionWitnessWithAddress {
+            stf_witness: witness,
+            prover_address,
+        };
+
+        let proof = host.run(data, with_proof).await;
+        proofs.push(BlockHeaderWithProof {
+            da_block_header,
+            proof,
+        });
     }
 
     proofs

--- a/examples/demo-rollup/tests/prover/network.rs
+++ b/examples/demo-rollup/tests/prover/network.rs
@@ -29,7 +29,7 @@ type TestNetworkProverService = NetworkProverService<
 /// (inner) proofs, and uses MockZkvmNetwork (auto-complete) for aggregation (outer).
 ///
 /// Prerequisites:
-///   - `SP1_PRIVATE_KEY` env var set (Succinct network auth)
+///   - `NETWORK_PRIVATE_KEY` env var set (Succinct network auth)
 ///   - SP1 guest ELF built (`cargo build` in the prover guest directory)
 ///   - Network access to Succinct's proving infrastructure
 #[tokio::test(flavor = "multi_thread")]
@@ -45,8 +45,9 @@ async fn test_network_proof_generation() {
 
     let inner_vm = SP1Network::new(elf)
         .await
-        .expect("Failed to create SP1Network — is SP1_PRIVATE_KEY set?");
-    let outer_vm = MockZkvmNetwork::new(true); // auto-complete outer proofs
+        .expect("Failed to create SP1 network prover");
+     // auto-complete outer proofs - real outer not supported yet
+    let outer_vm = MockZkvmNetwork::new(true);
 
     let da_verifier = sov_mock_da::MockDaVerifier::default();
     let prover_address = <DefaultSpec as Spec>::Address::try_from([0u8; 28].as_ref()).unwrap();

--- a/examples/demo-rollup/tests/prover/network.rs
+++ b/examples/demo-rollup/tests/prover/network.rs
@@ -1,48 +1,18 @@
-use std::sync::atomic::AtomicU64;
-use std::sync::Arc;
 use std::time::Duration;
 
-use demo_stf::genesis_config::create_genesis_config;
-use demo_stf::runtime::Runtime;
-use sov_db::schema::SchemaBatch;
-use sov_db::storage_manager::NativeStorageManager;
-use sov_mock_da::{MockAddress, MockBlock, MockDaService, MockDaSpec};
+use sov_mock_da::{MockDaService, MockDaSpec};
 use sov_mock_zkvm::{MockZkvm, MockZkvmNetwork};
-use sov_modules_api::execution_mode::WitnessGeneration;
-use sov_modules_api::{OperatingMode, SlotData, Spec};
-use sov_modules_stf_blueprint::{GenesisParams, StfBlueprint};
+use sov_modules_api::Spec;
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::BlockHeaderTrait;
-use sov_rollup_interface::node::da::DaService;
-use sov_rollup_interface::stf::{ExecutionContext, StateTransitionFunction};
-use sov_rollup_interface::storage::HierarchicalStorageManager;
-use sov_rollup_interface::zk::StateTransitionWitness;
 use sov_sp1_adapter::network::SP1Network;
 use sov_sp1_adapter::SP1;
-use sov_state::ProverStorage;
 use sov_stf_runner::processes::{
     NetworkProverService, ProofAggregationStatus, ProofProcessingStatus, ProverService,
     StateTransitionInfo,
 };
-use sov_test_utils::generators::BlobBuildingCtx;
-use sov_test_utils::TestStorageSpec;
-use tempfile::TempDir;
 
-use crate::prover::datagen::{get_blocks_from_da, DEFAULT_BLOCKS};
-use crate::test_helpers::test_genesis_paths;
-
-type DefaultSpec = sov_modules_api::configurable_spec::ConfigurableSpec<
-    sov_mock_da::MockDaSpec,
-    sov_sp1_adapter::SP1,
-    sov_mock_zkvm::MockZkvm,
-    demo_stf::MultiAddressEvmSolana,
-    WitnessGeneration,
-    sov_mock_zkvm::MockZkvmCryptoSpec,
->;
-
-type TestSTF = StfBlueprint<DefaultSpec, Runtime<DefaultSpec>>;
-type ProofStateRoot = <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::StateRoot;
-type ProofWitness = <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::Witness;
+use super::{DefaultSpec, ProofStateRoot, ProofWitness};
 
 type TestNetworkProverService = NetworkProverService<
     <DefaultSpec as Spec>::Address,
@@ -90,8 +60,35 @@ async fn test_network_proof_generation() {
         Duration::from_secs(600),
     );
 
-    let (block_hashes, genesis_state_root) =
-        generate_witnesses_and_prove(&prover_service).await;
+    let (genesis_state_root, witnesses) = super::generate_witnesses().await;
+
+    // Submit all blocks to the network prover.
+    let mut block_hashes = Vec::new();
+    for (i, witness) in witnesses.into_iter().enumerate() {
+        let block_header_hash = witness.da_block_header.hash();
+        block_hashes.push(block_header_hash);
+
+        let slot_number = SlotNumber::new(i as u64 + 1);
+        let state_transition_info = StateTransitionInfo::new(witness, slot_number);
+
+        let status = prover_service
+            .prove(state_transition_info)
+            .await
+            .expect("prove() should succeed");
+        assert!(
+            matches!(
+                status,
+                ProofProcessingStatus::<ProofStateRoot, ProofWitness, MockDaSpec>::ProvingInProgress
+            ),
+            "Expected ProvingInProgress after submitting block {i}"
+        );
+        tracing::info!("Block {} submitted to network prover", i);
+    }
+
+    tracing::info!(
+        "All {} blocks submitted, waiting for proofs...",
+        block_hashes.len()
+    );
 
     // Poll until the aggregated proof is ready.
     let status = loop {
@@ -116,122 +113,4 @@ async fn test_network_proof_generation() {
         !status.raw_aggregated_proof.is_empty(),
         "Aggregated proof should not be empty"
     );
-}
-
-/// Generates witnesses by executing the STF against mock DA blocks, then submits
-/// each block to the network prover service.
-///
-/// Returns the block header hashes and the genesis state root (needed for aggregation).
-async fn generate_witnesses_and_prove(
-    prover_service: &TestNetworkProverService,
-) -> (
-    Vec<<MockDaSpec as sov_rollup_interface::da::DaSpec>::SlotHash>,
-    ProofStateRoot,
-) {
-    let temp_dir = TempDir::new().expect("Unable to create temporary directory");
-    tracing::info!("Creating temp dir at {}", temp_dir.path().display());
-
-    let da_service = MockDaService::new(MockAddress::default());
-    let sequencer_mode = BlobBuildingCtx::Preferred {
-        curr_sequence_number: Arc::new(AtomicU64::new(0)),
-    };
-
-    let mut storage_manager =
-        NativeStorageManager::<MockDaSpec, ProverStorage<TestStorageSpec>>::new(temp_dir.path())
-            .expect("NativeStorageManager initialization has failed");
-    let stf = TestSTF::new();
-
-    let genesis_config = {
-        let rt_params =
-            create_genesis_config::<DefaultSpec>(&test_genesis_paths(OperatingMode::Zk)).unwrap();
-        GenesisParams { runtime: rt_params }
-    };
-
-    tracing::info!("Starting from empty storage, initialization chain");
-    let genesis_block = MockBlock::default();
-    let (stf_state, _) = storage_manager
-        .create_state_for(genesis_block.header())
-        .unwrap();
-    let (mut prev_state_root, stf_state) =
-        stf.init_chain(&Default::default(), stf_state, genesis_config);
-    storage_manager
-        .save_change_set(genesis_block.header(), stf_state, SchemaBatch::new())
-        .unwrap();
-    storage_manager.finalize(&genesis_block.header).unwrap();
-
-    let genesis_state_root = prev_state_root;
-
-    let mut blocks = get_blocks_from_da(sequencer_mode)
-        .await
-        .expect("Failed to get DA blocks");
-
-    let mut block_hashes = Vec::new();
-
-    for (i, filtered_block) in blocks[..(DEFAULT_BLOCKS as usize)].iter_mut().enumerate() {
-        let height = filtered_block.header().height();
-        tracing::info!(
-            "Processing block {} (height {}) with prev_state_root 0x{}",
-            i,
-            height,
-            hex::encode(prev_state_root.root_hash())
-        );
-
-        let (mut relevant_blobs, relevant_proofs) = da_service
-            .extract_relevant_blobs_with_proof(filtered_block)
-            .await;
-
-        let (stf_state, _) = storage_manager
-            .create_state_for(filtered_block.header())
-            .unwrap();
-
-        let result = stf.apply_slot(
-            &prev_state_root,
-            stf_state,
-            Default::default(),
-            filtered_block.header(),
-            relevant_blobs.as_iters(),
-            ExecutionContext::Node,
-        );
-
-        let block_header_hash = filtered_block.header().hash();
-        block_hashes.push(block_header_hash);
-
-        let witness = StateTransitionWitness {
-            initial_state_root: prev_state_root,
-            da_block_header: filtered_block.header().clone(),
-            relevant_proofs,
-            witness: result.witness,
-            relevant_blobs,
-            final_state_root: result.state_root,
-        };
-
-        let slot_number = SlotNumber::new(i as u64 + 1);
-        let state_transition_info = StateTransitionInfo::new(witness, slot_number);
-
-        let status = prover_service
-            .prove(state_transition_info)
-            .await
-            .expect("prove() should succeed");
-        assert!(
-            matches!(status, ProofProcessingStatus::ProvingInProgress),
-            "Expected ProvingInProgress after submitting block {i}"
-        );
-        tracing::info!("Block {} submitted to network prover", i);
-
-        prev_state_root = result.state_root;
-        storage_manager
-            .save_change_set(
-                filtered_block.header(),
-                result.change_set,
-                SchemaBatch::new(),
-            )
-            .unwrap();
-    }
-
-    tracing::info!(
-        "All {} blocks submitted, waiting for proofs...",
-        block_hashes.len()
-    );
-
-    (block_hashes, genesis_state_root)
 }

--- a/examples/demo-rollup/tests/prover/network.rs
+++ b/examples/demo-rollup/tests/prover/network.rs
@@ -1,0 +1,237 @@
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::Duration;
+
+use demo_stf::genesis_config::create_genesis_config;
+use demo_stf::runtime::Runtime;
+use sov_db::schema::SchemaBatch;
+use sov_db::storage_manager::NativeStorageManager;
+use sov_mock_da::{MockAddress, MockBlock, MockDaService, MockDaSpec};
+use sov_mock_zkvm::{MockZkvm, MockZkvmNetwork};
+use sov_modules_api::execution_mode::WitnessGeneration;
+use sov_modules_api::{OperatingMode, SlotData, Spec};
+use sov_modules_stf_blueprint::{GenesisParams, StfBlueprint};
+use sov_rollup_interface::common::SlotNumber;
+use sov_rollup_interface::da::BlockHeaderTrait;
+use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::stf::{ExecutionContext, StateTransitionFunction};
+use sov_rollup_interface::storage::HierarchicalStorageManager;
+use sov_rollup_interface::zk::StateTransitionWitness;
+use sov_sp1_adapter::network::SP1Network;
+use sov_sp1_adapter::SP1;
+use sov_state::ProverStorage;
+use sov_stf_runner::processes::{
+    NetworkProverService, ProofAggregationStatus, ProofProcessingStatus, ProverService,
+    StateTransitionInfo,
+};
+use sov_test_utils::generators::BlobBuildingCtx;
+use sov_test_utils::TestStorageSpec;
+use tempfile::TempDir;
+
+use crate::prover::datagen::{get_blocks_from_da, DEFAULT_BLOCKS};
+use crate::test_helpers::test_genesis_paths;
+
+type DefaultSpec = sov_modules_api::configurable_spec::ConfigurableSpec<
+    sov_mock_da::MockDaSpec,
+    sov_sp1_adapter::SP1,
+    sov_mock_zkvm::MockZkvm,
+    demo_stf::MultiAddressEvmSolana,
+    WitnessGeneration,
+    sov_mock_zkvm::MockZkvmCryptoSpec,
+>;
+
+type TestSTF = StfBlueprint<DefaultSpec, Runtime<DefaultSpec>>;
+type ProofStateRoot = <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::StateRoot;
+type ProofWitness = <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::Witness;
+
+type TestNetworkProverService = NetworkProverService<
+    <DefaultSpec as Spec>::Address,
+    ProofStateRoot,
+    ProofWitness,
+    MockDaService,
+    SP1,
+    MockZkvm,
+>;
+
+/// Tests proof generation using the SP1 network prover service.
+///
+/// This submits real proof requests to the Succinct proving network for per-block
+/// (inner) proofs, and uses MockZkvmNetwork (auto-complete) for aggregation (outer).
+///
+/// Prerequisites:
+///   - `SP1_PRIVATE_KEY` env var set (Succinct network auth)
+///   - SP1 guest ELF built (`cargo build` in the prover guest directory)
+///   - Network access to Succinct's proving infrastructure
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "Requires SP1_PRIVATE_KEY and network access to the Succinct proving network"]
+async fn test_network_proof_generation() {
+    tracing_subscriber::fmt::init();
+
+    let elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
+    assert!(
+        !elf.is_empty(),
+        "SP1 guest ELF is empty — build the guest first"
+    );
+
+    let inner_vm = SP1Network::new(elf)
+        .await
+        .expect("Failed to create SP1Network — is SP1_PRIVATE_KEY set?");
+    let outer_vm = MockZkvmNetwork::new(true); // auto-complete outer proofs
+
+    let da_verifier = sov_mock_da::MockDaVerifier::default();
+    let prover_address = <DefaultSpec as Spec>::Address::try_from([0u8; 28].as_ref()).unwrap();
+
+    let prover_service = TestNetworkProverService::new(
+        inner_vm,
+        outer_vm,
+        da_verifier,
+        Default::default(),
+        prover_address,
+        Duration::from_secs(600),
+    );
+
+    let (block_hashes, genesis_state_root) =
+        generate_witnesses_and_prove(&prover_service).await;
+
+    // Poll until the aggregated proof is ready.
+    let status = loop {
+        match prover_service
+            .create_aggregated_proof(&block_hashes, &genesis_state_root)
+            .await
+        {
+            Ok(ProofAggregationStatus::Success(proof)) => break proof,
+            Ok(ProofAggregationStatus::ProofGenerationInProgress) => {
+                tracing::info!("Inner proofs still in progress, polling again in 30s...");
+                tokio::time::sleep(Duration::from_secs(30)).await;
+            }
+            Err(e) => panic!("Aggregation failed: {e}"),
+        }
+    };
+
+    tracing::info!(
+        "Aggregated proof generated successfully ({} bytes)",
+        status.raw_aggregated_proof.len()
+    );
+    assert!(
+        !status.raw_aggregated_proof.is_empty(),
+        "Aggregated proof should not be empty"
+    );
+}
+
+/// Generates witnesses by executing the STF against mock DA blocks, then submits
+/// each block to the network prover service.
+///
+/// Returns the block header hashes and the genesis state root (needed for aggregation).
+async fn generate_witnesses_and_prove(
+    prover_service: &TestNetworkProverService,
+) -> (
+    Vec<<MockDaSpec as sov_rollup_interface::da::DaSpec>::SlotHash>,
+    ProofStateRoot,
+) {
+    let temp_dir = TempDir::new().expect("Unable to create temporary directory");
+    tracing::info!("Creating temp dir at {}", temp_dir.path().display());
+
+    let da_service = MockDaService::new(MockAddress::default());
+    let sequencer_mode = BlobBuildingCtx::Preferred {
+        curr_sequence_number: Arc::new(AtomicU64::new(0)),
+    };
+
+    let mut storage_manager =
+        NativeStorageManager::<MockDaSpec, ProverStorage<TestStorageSpec>>::new(temp_dir.path())
+            .expect("NativeStorageManager initialization has failed");
+    let stf = TestSTF::new();
+
+    let genesis_config = {
+        let rt_params =
+            create_genesis_config::<DefaultSpec>(&test_genesis_paths(OperatingMode::Zk)).unwrap();
+        GenesisParams { runtime: rt_params }
+    };
+
+    tracing::info!("Starting from empty storage, initialization chain");
+    let genesis_block = MockBlock::default();
+    let (stf_state, _) = storage_manager
+        .create_state_for(genesis_block.header())
+        .unwrap();
+    let (mut prev_state_root, stf_state) =
+        stf.init_chain(&Default::default(), stf_state, genesis_config);
+    storage_manager
+        .save_change_set(genesis_block.header(), stf_state, SchemaBatch::new())
+        .unwrap();
+    storage_manager.finalize(&genesis_block.header).unwrap();
+
+    let genesis_state_root = prev_state_root;
+
+    let mut blocks = get_blocks_from_da(sequencer_mode)
+        .await
+        .expect("Failed to get DA blocks");
+
+    let mut block_hashes = Vec::new();
+
+    for (i, filtered_block) in blocks[..(DEFAULT_BLOCKS as usize)].iter_mut().enumerate() {
+        let height = filtered_block.header().height();
+        tracing::info!(
+            "Processing block {} (height {}) with prev_state_root 0x{}",
+            i,
+            height,
+            hex::encode(prev_state_root.root_hash())
+        );
+
+        let (mut relevant_blobs, relevant_proofs) = da_service
+            .extract_relevant_blobs_with_proof(filtered_block)
+            .await;
+
+        let (stf_state, _) = storage_manager
+            .create_state_for(filtered_block.header())
+            .unwrap();
+
+        let result = stf.apply_slot(
+            &prev_state_root,
+            stf_state,
+            Default::default(),
+            filtered_block.header(),
+            relevant_blobs.as_iters(),
+            ExecutionContext::Node,
+        );
+
+        let block_header_hash = filtered_block.header().hash();
+        block_hashes.push(block_header_hash);
+
+        let witness = StateTransitionWitness {
+            initial_state_root: prev_state_root,
+            da_block_header: filtered_block.header().clone(),
+            relevant_proofs,
+            witness: result.witness,
+            relevant_blobs,
+            final_state_root: result.state_root,
+        };
+
+        let slot_number = SlotNumber::new(i as u64 + 1);
+        let state_transition_info = StateTransitionInfo::new(witness, slot_number);
+
+        let status = prover_service
+            .prove(state_transition_info)
+            .await
+            .expect("prove() should succeed");
+        assert!(
+            matches!(status, ProofProcessingStatus::ProvingInProgress),
+            "Expected ProvingInProgress after submitting block {i}"
+        );
+        tracing::info!("Block {} submitted to network prover", i);
+
+        prev_state_root = result.state_root;
+        storage_manager
+            .save_change_set(
+                filtered_block.header(),
+                result.change_set,
+                SchemaBatch::new(),
+            )
+            .unwrap();
+    }
+
+    tracing::info!(
+        "All {} blocks submitted, waiting for proofs...",
+        block_hashes.len()
+    );
+
+    (block_hashes, genesis_state_root)
+}

--- a/examples/demo-rollup/tests/prover/network.rs
+++ b/examples/demo-rollup/tests/prover/network.rs
@@ -46,7 +46,7 @@ async fn test_network_proof_generation() {
     let inner_vm = SP1Network::new(elf)
         .await
         .expect("Failed to create SP1 network prover");
-     // auto-complete outer proofs - real outer not supported yet
+    // auto-complete outer proofs - real outer not supported yet
     let outer_vm = MockZkvmNetwork::new(true);
 
     let da_verifier = sov_mock_da::MockDaVerifier::default();

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -1,0 +1,131 @@
+use std::path::PathBuf;
+
+use sov_mock_da::MockDaSpec;
+use sov_modules_api::{Spec, ZkVerifier};
+use sov_rollup_interface::da::BlockHeaderTrait;
+use sov_rollup_interface::zk::{
+    StateTransitionPublicData, StateTransitionWitnessWithAddress, ZkvmHost,
+};
+use sov_sp1_adapter::host::SP1Host;
+use sov_sp1_adapter::BlockHeaderWithProof;
+use sov_sp1_adapter::{SP1MethodId, SP1Verifier};
+
+use super::{DefaultSpec, ProofStateRoot, ProofWitness};
+
+type ProofInput = StateTransitionWitnessWithAddress<
+    <DefaultSpec as Spec>::Address,
+    ProofStateRoot,
+    ProofWitness,
+    MockDaSpec,
+>;
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "This test is used to generate data for testing the aggregate proof circuit and should be enabled only when needed."]
+async fn test_save_proofs() {
+    let host = TestHost::new().await;
+    let proof_data = generate_proofs(true, &host).await;
+    let proofs_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("test_data")
+        .join("tmp");
+
+    std::fs::create_dir_all(&proofs_dir).unwrap();
+    std::fs::write(proofs_dir.join("inner_vk.bin"), host.verifying_key_bytes()).unwrap();
+
+    for (i, data) in proof_data.into_iter().enumerate() {
+        let proof_public_data = host.verify(data.proof.clone()).await;
+        assert_eq!(proof_public_data.slot_hash, data.da_block_header.hash());
+        let json = serde_json::to_string(&data).unwrap();
+        std::fs::write(proofs_dir.join(format!("inner_{i}_proof.json")), &json).unwrap();
+    }
+}
+
+/// This test reproduces the proof generation process for the rollup used in benchmarks.
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(skip_guest_build, ignore)]
+async fn test_proof_generation() {
+    let host = TestHost::new().await;
+    let _ = generate_proofs(false, &host).await;
+}
+
+async fn generate_proofs(
+    with_proof: bool,
+    host: &TestHost,
+) -> Vec<BlockHeaderWithProof<MockDaSpec>> {
+    let (_genesis_state_root, witnesses) = super::generate_witnesses().await;
+
+    let prover_address = <DefaultSpec as Spec>::Address::try_from([0u8; 28].as_ref()).unwrap();
+    let mut proofs = Vec::new();
+
+    for witness in witnesses {
+        let da_block_header = witness.da_block_header.clone();
+
+        let data: ProofInput = StateTransitionWitnessWithAddress {
+            stf_witness: witness,
+            prover_address,
+        };
+
+        let proof = host.run(data, with_proof).await;
+        proofs.push(BlockHeaderWithProof {
+            da_block_header,
+            proof,
+        });
+    }
+
+    proofs
+}
+
+// The SP1 prover manages its own Tokio runtime, which conflicts with the `tokio::test` runtime.
+// To avoid this, all blocking work must be executed inside `tokio::task::spawn_blocking`.
+struct TestHost {
+    host: SP1Host<'static>,
+    code_commitment: SP1MethodId,
+}
+
+impl TestHost {
+    async fn new() -> Self {
+        let host = SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF);
+        let host_clone = host.clone();
+        let code_commitment = tokio::task::spawn_blocking(move || -> SP1MethodId {
+            host_clone
+                .code_commitment()
+                .expect("SP1 code commitment should be created successfully")
+        })
+        .await
+        .unwrap();
+
+        Self {
+            host,
+            code_commitment,
+        }
+    }
+
+    async fn run(&self, data: ProofInput, with_proof: bool) -> Vec<u8> {
+        let mut host = self.host.clone();
+        tokio::task::spawn_blocking(move || -> Vec<u8> {
+            host.add_hint(data);
+            host.run(with_proof)
+                .expect("Prover should run successfully")
+        })
+        .await
+        .unwrap()
+    }
+
+    fn verifying_key_bytes(&self) -> Vec<u8> {
+        self.code_commitment.0.clone()
+    }
+
+    #[allow(dead_code)]
+    async fn verify(
+        &self,
+        proof: Vec<u8>,
+    ) -> StateTransitionPublicData<<DefaultSpec as Spec>::Address, MockDaSpec, ProofStateRoot> {
+        let code_commitment = self.code_commitment.clone();
+        tokio::task::spawn_blocking(move || -> StateTransitionPublicData<<DefaultSpec as Spec>::Address, MockDaSpec, ProofStateRoot> {
+            SP1Verifier::verify(&proof, &code_commitment)
+                .expect("SP1 proof verification should succeed")
+        })
+        .await
+        .unwrap()
+    }
+}


### PR DESCRIPTION
# Description

Adds a test that uses `NetworkProverService` with the real prover network for inner vm (outer vm wip).

View successful executions: https://explorer.succinct.xyz/requester/0x72773b3e9b8a39c6ab3bb42fdebf559a325acb74

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
