### PR TITLE
Change `CodeCommitmentHash([u32; 8])` to `CodeCommitmentHash(Vec<u8>)`

### DIFF
--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -66,7 +66,7 @@ impl Zkvm for MockZkvm {
 #[derive(
     Debug, Clone, PartialEq, Eq, BorshDeserialize, BorshSerialize, Serialize, Deserialize, Default,
 )]
-pub struct MockCodeCommitment(pub [u32; 8]);
+pub struct MockCodeCommitment(pub [u8; 8]);
 
 /// An error that can occur when converting a byte vector to a `MockCodeCommitment`.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -120,7 +120,8 @@ impl ZkVerifier for SP1Verifier {
         use sha2::Digest;
 
         let public_values_digest: [u8; 32] = sha2::Sha256::digest(public_values).into();
-        sp1_zkvm::lib::verify::verify_sp1_proof(&vkey_hash.0, &public_values_digest);
+        let vkey_u32 = vkey_hash.to_u32_array();
+        sp1_zkvm::lib::verify::verify_sp1_proof(&vkey_u32, &public_values_digest);
         Ok(bincode::deserialize(public_values)?)
     }
 }

--- a/crates/full-node/sov-aggregated-proof/program/src/main.rs
+++ b/crates/full-node/sov-aggregated-proof/program/src/main.rs
@@ -21,6 +21,6 @@ type ProgramSpec = ConfigurableSpec<MockDaSpec, SP1, MockZkvm, MultiAddressEvmSo
 pub fn main() {
     let witness = sp1_zkvm::io::read::<AggregatedProofWitness<MockDaSpec>>();
 
-    let inner = CodeCommitmentHash(INNER_VKEY_HASH);
+    let inner = CodeCommitmentHash::from_u32_array(INNER_VKEY_HASH);
     run_aggregation_program::<ProgramSpec, MockDaSpec, SP1Verifier>(witness, inner);
 }

--- a/crates/full-node/sov-aggregated-proof/script/src/main.rs
+++ b/crates/full-node/sov-aggregated-proof/script/src/main.rs
@@ -189,7 +189,7 @@ fn create_agg_proof<P: Prover>(
         stdin.write_proof(*recursion_proof.clone(), verification_key.vk.clone());
     }
 
-    let outer_vkey_hash = CodeCommitmentHash(aggregation_vk_hash);
+    let outer_vkey_hash = CodeCommitmentHash::from_u32_array(aggregation_vk_hash);
 
     let witness = AggregatedProofWitness {
         proof_inputs,

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
@@ -3,7 +3,6 @@ use std::convert::Infallible;
 use serde::Serialize;
 use sov_bank::{config_gas_token_id, Bank};
 use sov_chain_state::ChainState;
-use sov_mock_zkvm::MockCodeCommitment;
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::registration_lib::StakeRegistration;
 use sov_modules_api::{

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
@@ -23,7 +23,7 @@ use sov_value_setter::ValueSetterConfig;
 pub(crate) type S = sov_test_utils::TestSpec;
 pub(crate) type TestProverIncentives = ProverIncentives<S>;
 pub(crate) type RT = TestRuntime<S>;
-pub(crate) const MOCK_CODE_COMMITMENT: MockCodeCommitment = MockCodeCommitment([0u32; 8]);
+pub(crate) const MOCK_CODE_COMMITMENT: MockCodeCommitment = MockCodeCommitment([0u8; 8]);
 
 generate_zk_runtime!(TestRuntime <= value_setter: sov_value_setter::ValueSetter<S>);
 
@@ -101,7 +101,7 @@ pub(crate) fn build_proof(
         final_state_root: *end_transition.post_state_root(),
         initial_slot_hash: *initial_transition.slot_hash(),
         final_slot_hash: *end_transition.slot().slot_hash(),
-        outer_vk_hash: CodeCommitmentHash(MOCK_CODE_COMMITMENT.0),
+        outer_vk_hash: CodeCommitmentHash::default(),
         rewarded_addresses: vec![prover_address],
     })
 }

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
@@ -23,7 +23,6 @@ use sov_value_setter::ValueSetterConfig;
 pub(crate) type S = sov_test_utils::TestSpec;
 pub(crate) type TestProverIncentives = ProverIncentives<S>;
 pub(crate) type RT = TestRuntime<S>;
-pub(crate) const MOCK_CODE_COMMITMENT: MockCodeCommitment = MockCodeCommitment([0u8; 8]);
 
 generate_zk_runtime!(TestRuntime <= value_setter: sov_value_setter::ValueSetter<S>);
 

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof.rs
@@ -23,15 +23,40 @@ pub struct BlockProof<Address, Da: DaSpec, Root> {
 #[derive(
     Debug, Eq, PartialEq, BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone, Default,
 )]
-pub struct CodeCommitmentHash(pub [u32; 8]);
+pub struct CodeCommitmentHash(pub Vec<u8>);
+
+impl CodeCommitmentHash {
+    /// Creates a [`CodeCommitmentHash`] from a `[u32; 8]` array using big-endian byte order.
+    /// This matches the representation used by SP1's `HashableKey::hash_bytes`.
+    pub fn from_u32_array(arr: [u32; 8]) -> Self {
+        let mut bytes = Vec::with_capacity(32);
+        for word in arr {
+            bytes.extend_from_slice(&word.to_be_bytes());
+        }
+        Self(bytes)
+    }
+
+    /// Converts this hash back to a `[u32; 8]` array using big-endian byte order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the inner byte vector is not exactly 32 bytes long.
+    pub fn to_u32_array(&self) -> [u32; 8] {
+        assert_eq!(self.0.len(), 32, "CodeCommitmentHash must be 32 bytes");
+        let mut arr = [0u32; 8];
+        for (idx, chunk) in self.0.chunks_exact(4).enumerate() {
+            arr[idx] = u32::from_be_bytes(chunk.try_into().unwrap());
+        }
+        arr
+    }
+}
 
 impl core::fmt::Display for CodeCommitmentHash {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "CodeCommitmentHash(0x")?;
-        for word in self.0 {
-            write!(f, "{word:08x}")?;
+        if self.0.is_empty() {
+            return write!(f, "CodeCommitmentHash([])");
         }
-        write!(f, ")")
+        write!(f, "CodeCommitmentHash(0x{})", hex::encode(&self.0))
     }
 }
 


### PR DESCRIPTION
# Description

In #2630, we changed the representation of CodeCommitmentHash. Because it is stored on-chain, this also changed the state root hash. This PR reverts that change.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
