### PR TITLE
Fix sequencer recovery test hanging up on MacOS under load

### DIFF
--- a/crates/full-node/sov-sequencer/src/common.rs
+++ b/crates/full-node/sov-sequencer/src/common.rs
@@ -274,6 +274,10 @@ pub struct StateUpdateNotification {
     #[cfg(feature = "test-utils")]
     #[serde(default)]
     pub update_skipped_due_to_pause: bool,
+    /// True when the sequencer entered recovery on this state update.
+    #[cfg(feature = "test-utils")]
+    #[serde(default)]
+    pub triggered_recovery: bool,
 }
 
 /// A notification that the sequencer has processed a forced (non-preferred) batch.

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -686,12 +686,18 @@ where
         .await
         .map_err(|e| e.into_state_update_error())?;
 
-    // Notify tests about the operation BEFORE entering recovery/resync.
-    // This bypasses the state updator message queue (which may be blocked
-    // during trigger_recovery's async calls), letting tests detect recovery
-    // without going through the is_ready() RPC.
+    // For recovery/resync operations, notify tests BEFORE entering the long-running
+    // handler. This bypasses the state updator message queue (which may be blocked
+    // during trigger_recovery's async calls under CPU pressure), letting tests detect
+    // recovery without going through the is_ready() RPC.
+    // For ReplaySoftConfirmationsOnTopOfNodeStateIfNecessary (the normal path), the
+    // notification is already sent by sync_state.rs after processing — skip here to
+    // avoid duplicates that would desync produce_and_wait_for_slot().
     #[cfg(feature = "test-utils")]
-    {
+    if !matches!(
+        operation,
+        PreferredSeqOperation::ReplaySoftConfirmationsOnTopOfNodeStateIfNecessary(..)
+    ) {
         let _ = seq
             .test_only_state_update_notification_sender
             .send(StateUpdateNotification {

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -664,6 +664,7 @@ where
                     slot_number: info.slot_number,
                     finalized_slot_number: info.latest_finalized_slot_number,
                     update_skipped_due_to_pause: true,
+                    triggered_recovery: false,
                 });
         }
         return Ok(());
@@ -684,6 +685,22 @@ where
         )
         .await
         .map_err(|e| e.into_state_update_error())?;
+
+    // Notify tests about the operation BEFORE entering recovery/resync.
+    // This bypasses the state updator message queue (which may be blocked
+    // during trigger_recovery's async calls), letting tests detect recovery
+    // without going through the is_ready() RPC.
+    #[cfg(feature = "test-utils")]
+    {
+        let _ = seq
+            .test_only_state_update_notification_sender
+            .send(StateUpdateNotification {
+                slot_number: info.slot_number,
+                finalized_slot_number: info.latest_finalized_slot_number,
+                update_skipped_due_to_pause: false,
+                triggered_recovery: matches!(operation, PreferredSeqOperation::RecoverAndCatchUp),
+            });
+    }
 
     match operation {
         PreferredSeqOperation::Unreachable => {

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -295,6 +295,8 @@ where
                             finalized_slot_number,
                             #[cfg(feature = "test-utils")]
                             update_skipped_due_to_pause: false,
+                            #[cfg(feature = "test-utils")]
+                            triggered_recovery: false,
                         });
             }
             Message::PruneSequencerDb { reason } => {
@@ -339,6 +341,8 @@ where
                             finalized_slot_number,
                             #[cfg(feature = "test-utils")]
                             update_skipped_due_to_pause: false,
+                            #[cfg(feature = "test-utils")]
+                            triggered_recovery: false,
                         });
             }
             Message::ReplicaBatchStartMsg {

--- a/crates/full-node/sov-sequencer/tests/integration/pinned_cache.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/pinned_cache.rs
@@ -320,7 +320,10 @@ async fn test_pinning_after_recovery() {
     // Finalise some blocks
     test_rollup.produce_enough_finalized_slots().await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
-    eprintln!("[TIMING] Stage 1 (setup + finalize + ready): {:?}", t_stage.elapsed());
+    eprintln!(
+        "[TIMING] Stage 1 (setup + finalize + ready): {:?}",
+        t_stage.elapsed()
+    );
 
     // Sanity check tx that the rollup works, and send the tx all the way through to DA.
     // Set a value in the pinned cache.
@@ -337,7 +340,10 @@ async fn test_pinning_after_recovery() {
     client.send_raw_tx_to_sequencer(&tx).await.unwrap();
     test_rollup.force_close_batch().await.unwrap();
     da_layer.produce_and_wait_for_n_slots(1).await;
-    eprintln!("[TIMING] Stage 2 (sanity write tx + 1 slot): {:?}", t_stage.elapsed());
+    eprintln!(
+        "[TIMING] Stage 2 (sanity write tx + 1 slot): {:?}",
+        t_stage.elapsed()
+    );
 
     // Pause sequencer update_state and run some blocks so deferred_slots_count is reached
     test_rollup.pause_preferred_batches().await;
@@ -351,7 +357,10 @@ async fn test_pinning_after_recovery() {
     test_rollup.tenderly_produce_blocks(40).await.unwrap();
     // Make sure the DA has synced everything
     test_rollup.wait_for_node_synced().await.unwrap();
-    eprintln!("[TIMING] Stage 3 (pause + 40 DA blocks + sync): {:?}", t_stage.elapsed());
+    eprintln!(
+        "[TIMING] Stage 3 (pause + 40 DA blocks + sync): {:?}",
+        t_stage.elapsed()
+    );
 
     tracing::info!("Resuming preferred sequencer batch production.");
     test_rollup.resume_preferred_batches().await;
@@ -375,7 +384,10 @@ async fn test_pinning_after_recovery() {
         // while recovery catches up.
         tokio::time::sleep(reasonable_time_for_rollup).await;
     }
-    eprintln!("[TIMING] Stage 4 (recovery entry): {i} iterations, {:?}", t_entry.elapsed());
+    eprintln!(
+        "[TIMING] Stage 4 (recovery entry): {i} iterations, {:?}",
+        t_entry.elapsed()
+    );
     test_rollup.wait_for_node_synced().await.unwrap();
 
     i = 0;
@@ -392,7 +404,10 @@ async fn test_pinning_after_recovery() {
         // while waiting for sequencer readiness to flip back.
         tokio::time::sleep(reasonable_time_for_rollup).await;
     }
-    eprintln!("[TIMING] Stage 5 (recovery exit): {i} iterations, {:?}", t_exit.elapsed());
+    eprintln!(
+        "[TIMING] Stage 5 (recovery exit): {i} iterations, {:?}",
+        t_exit.elapsed()
+    );
 
     // Read the value that should be in pinned cache. We should get the correct value (1) and not touch storage.
     let tx2 = tx_read_pinned_cache(
@@ -407,7 +422,10 @@ async fn test_pinning_after_recovery() {
     );
     let t_stage = std::time::Instant::now();
     client.send_raw_tx_to_sequencer(&tx2).await.unwrap();
-    eprintln!("[TIMING] Stage 6 (post-recovery read tx): {:?}", t_stage.elapsed());
+    eprintln!(
+        "[TIMING] Stage 6 (post-recovery read tx): {:?}",
+        t_stage.elapsed()
+    );
 
     test_rollup.force_close_batch().await.unwrap();
     // For some reason DA subscriptions are still broken at this point; if we use produce_and_wait_for_n_slots, the test will hang.
@@ -417,7 +435,10 @@ async fn test_pinning_after_recovery() {
         .await
         .unwrap()
         .unwrap();
-    eprintln!("[TIMING] Total (test_pinning_after_recovery): {:?}", t_total.elapsed());
+    eprintln!(
+        "[TIMING] Total (test_pinning_after_recovery): {:?}",
+        t_total.elapsed()
+    );
 }
 
 /// Ensures that RAM pinning still works after a total resync.

--- a/crates/full-node/sov-sequencer/tests/integration/pinned_cache.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/pinned_cache.rs
@@ -308,10 +308,8 @@ async fn test_nomt_basic_pinning_with_writes_not_cached_address() {
 /// - Letting that transaction go through to the full node to ensure that works as well.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pinning_after_recovery() {
-    let t_total = std::time::Instant::now();
     std::env::set_var("SOV_TEST_CONST_OVERRIDE_DEFERRED_SLOTS_COUNT", "40");
     // sov_test_utils::initialize_logging();
-    let t_stage = std::time::Instant::now();
     let (test_rollup, admin) = create_test_nomt_rollup().await;
 
     let client = test_rollup.api_client().clone();
@@ -320,10 +318,7 @@ async fn test_pinning_after_recovery() {
     // Finalise some blocks
     test_rollup.produce_enough_finalized_slots().await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
-    eprintln!(
-        "[TIMING] Stage 1 (setup + finalize + ready): {:?}",
-        t_stage.elapsed()
-    );
+    println!("1");
 
     // Sanity check tx that the rollup works, and send the tx all the way through to DA.
     // Set a value in the pinned cache.
@@ -336,14 +331,10 @@ async fn test_pinning_after_recovery() {
             value: 1,
         }),
     );
-    let t_stage = std::time::Instant::now();
     client.send_raw_tx_to_sequencer(&tx).await.unwrap();
     test_rollup.force_close_batch().await.unwrap();
     da_layer.produce_and_wait_for_n_slots(1).await;
-    eprintln!(
-        "[TIMING] Stage 2 (sanity write tx + 1 slot): {:?}",
-        t_stage.elapsed()
-    );
+    println!("2");
 
     // Pause sequencer update_state and run some blocks so deferred_slots_count is reached
     test_rollup.pause_preferred_batches().await;
@@ -353,25 +344,21 @@ async fn test_pinning_after_recovery() {
     );
     // This can be lower than DEFERRED_SLOTS_COUNT because the sequencer takes into account a)
     // possible node lag and b) a 90% threshold.
-    let t_stage = std::time::Instant::now();
     test_rollup.tenderly_produce_blocks(40).await.unwrap();
     // Make sure the DA has synced everything
     test_rollup.wait_for_node_synced().await.unwrap();
-    eprintln!(
-        "[TIMING] Stage 3 (pause + 40 DA blocks + sync): {:?}",
-        t_stage.elapsed()
-    );
+    println!("2");
 
     tracing::info!("Resuming preferred sequencer batch production.");
     test_rollup.resume_preferred_batches().await;
+    println!("3");
     // Normally on the next state update, the sequencer should always enter recovery.
     // However for some reason this was flaky.
     test_rollup.tenderly_produce_blocks(1).await.unwrap();
     let max_wait = 1000;
-    let mut i = 0u32;
+    let mut i = 0;
     let reasonable_time_for_rollup =
         std::time::Duration::from_millis(TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS);
-    let t_entry = std::time::Instant::now();
     while test_rollup.is_sequencer_ready().await {
         // For some reason DA subscriptions are still broken at this point; if we use produce_and_wait_for_n_slots, the test will hang.
         // This is unrelated to the feature under test, so I've left it for now. Anyone reading this should feel free to change the test.
@@ -384,14 +371,10 @@ async fn test_pinning_after_recovery() {
         // while recovery catches up.
         tokio::time::sleep(reasonable_time_for_rollup).await;
     }
-    eprintln!(
-        "[TIMING] Stage 4 (recovery entry): {i} iterations, {:?}",
-        t_entry.elapsed()
-    );
     test_rollup.wait_for_node_synced().await.unwrap();
+    println!("4");
 
     i = 0;
-    let t_exit = std::time::Instant::now();
     while !test_rollup.is_sequencer_ready().await {
         // For some reason DA subscriptions are still broken at this point; if we use produce_and_wait_for_n_slots, the test will hang.
         // This is unrelated to the feature under test, so I've left it for now. Anyone reading this should feel free to change the test.
@@ -404,10 +387,7 @@ async fn test_pinning_after_recovery() {
         // while waiting for sequencer readiness to flip back.
         tokio::time::sleep(reasonable_time_for_rollup).await;
     }
-    eprintln!(
-        "[TIMING] Stage 5 (recovery exit): {i} iterations, {:?}",
-        t_exit.elapsed()
-    );
+    println!("5");
 
     // Read the value that should be in pinned cache. We should get the correct value (1) and not touch storage.
     let tx2 = tx_read_pinned_cache(
@@ -420,12 +400,8 @@ async fn test_pinning_after_recovery() {
         }),
         Some(0),
     );
-    let t_stage = std::time::Instant::now();
     client.send_raw_tx_to_sequencer(&tx2).await.unwrap();
-    eprintln!(
-        "[TIMING] Stage 6 (post-recovery read tx): {:?}",
-        t_stage.elapsed()
-    );
+    println!("6");
 
     test_rollup.force_close_batch().await.unwrap();
     // For some reason DA subscriptions are still broken at this point; if we use produce_and_wait_for_n_slots, the test will hang.
@@ -435,10 +411,6 @@ async fn test_pinning_after_recovery() {
         .await
         .unwrap()
         .unwrap();
-    eprintln!(
-        "[TIMING] Total (test_pinning_after_recovery): {:?}",
-        t_total.elapsed()
-    );
 }
 
 /// Ensures that RAM pinning still works after a total resync.

--- a/crates/full-node/sov-sequencer/tests/integration/pinned_cache.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/pinned_cache.rs
@@ -308,8 +308,10 @@ async fn test_nomt_basic_pinning_with_writes_not_cached_address() {
 /// - Letting that transaction go through to the full node to ensure that works as well.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pinning_after_recovery() {
+    let t_total = std::time::Instant::now();
     std::env::set_var("SOV_TEST_CONST_OVERRIDE_DEFERRED_SLOTS_COUNT", "40");
     // sov_test_utils::initialize_logging();
+    let t_stage = std::time::Instant::now();
     let (test_rollup, admin) = create_test_nomt_rollup().await;
 
     let client = test_rollup.api_client().clone();
@@ -318,7 +320,7 @@ async fn test_pinning_after_recovery() {
     // Finalise some blocks
     test_rollup.produce_enough_finalized_slots().await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
-    println!("1");
+    eprintln!("[TIMING] Stage 1 (setup + finalize + ready): {:?}", t_stage.elapsed());
 
     // Sanity check tx that the rollup works, and send the tx all the way through to DA.
     // Set a value in the pinned cache.
@@ -331,10 +333,11 @@ async fn test_pinning_after_recovery() {
             value: 1,
         }),
     );
+    let t_stage = std::time::Instant::now();
     client.send_raw_tx_to_sequencer(&tx).await.unwrap();
     test_rollup.force_close_batch().await.unwrap();
     da_layer.produce_and_wait_for_n_slots(1).await;
-    println!("2");
+    eprintln!("[TIMING] Stage 2 (sanity write tx + 1 slot): {:?}", t_stage.elapsed());
 
     // Pause sequencer update_state and run some blocks so deferred_slots_count is reached
     test_rollup.pause_preferred_batches().await;
@@ -344,21 +347,22 @@ async fn test_pinning_after_recovery() {
     );
     // This can be lower than DEFERRED_SLOTS_COUNT because the sequencer takes into account a)
     // possible node lag and b) a 90% threshold.
+    let t_stage = std::time::Instant::now();
     test_rollup.tenderly_produce_blocks(40).await.unwrap();
     // Make sure the DA has synced everything
     test_rollup.wait_for_node_synced().await.unwrap();
-    println!("2");
+    eprintln!("[TIMING] Stage 3 (pause + 40 DA blocks + sync): {:?}", t_stage.elapsed());
 
     tracing::info!("Resuming preferred sequencer batch production.");
     test_rollup.resume_preferred_batches().await;
-    println!("3");
     // Normally on the next state update, the sequencer should always enter recovery.
     // However for some reason this was flaky.
     test_rollup.tenderly_produce_blocks(1).await.unwrap();
     let max_wait = 1000;
-    let mut i = 0;
+    let mut i = 0u32;
     let reasonable_time_for_rollup =
         std::time::Duration::from_millis(TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS);
+    let t_entry = std::time::Instant::now();
     while test_rollup.is_sequencer_ready().await {
         // For some reason DA subscriptions are still broken at this point; if we use produce_and_wait_for_n_slots, the test will hang.
         // This is unrelated to the feature under test, so I've left it for now. Anyone reading this should feel free to change the test.
@@ -371,10 +375,11 @@ async fn test_pinning_after_recovery() {
         // while recovery catches up.
         tokio::time::sleep(reasonable_time_for_rollup).await;
     }
+    eprintln!("[TIMING] Stage 4 (recovery entry): {i} iterations, {:?}", t_entry.elapsed());
     test_rollup.wait_for_node_synced().await.unwrap();
-    println!("4");
 
     i = 0;
+    let t_exit = std::time::Instant::now();
     while !test_rollup.is_sequencer_ready().await {
         // For some reason DA subscriptions are still broken at this point; if we use produce_and_wait_for_n_slots, the test will hang.
         // This is unrelated to the feature under test, so I've left it for now. Anyone reading this should feel free to change the test.
@@ -387,7 +392,7 @@ async fn test_pinning_after_recovery() {
         // while waiting for sequencer readiness to flip back.
         tokio::time::sleep(reasonable_time_for_rollup).await;
     }
-    println!("5");
+    eprintln!("[TIMING] Stage 5 (recovery exit): {i} iterations, {:?}", t_exit.elapsed());
 
     // Read the value that should be in pinned cache. We should get the correct value (1) and not touch storage.
     let tx2 = tx_read_pinned_cache(
@@ -400,8 +405,9 @@ async fn test_pinning_after_recovery() {
         }),
         Some(0),
     );
+    let t_stage = std::time::Instant::now();
     client.send_raw_tx_to_sequencer(&tx2).await.unwrap();
-    println!("6");
+    eprintln!("[TIMING] Stage 6 (post-recovery read tx): {:?}", t_stage.elapsed());
 
     test_rollup.force_close_batch().await.unwrap();
     // For some reason DA subscriptions are still broken at this point; if we use produce_and_wait_for_n_slots, the test will hang.
@@ -411,6 +417,7 @@ async fn test_pinning_after_recovery() {
         .await
         .unwrap()
         .unwrap();
+    eprintln!("[TIMING] Total (test_pinning_after_recovery): {:?}", t_total.elapsed());
 }
 
 /// Ensures that RAM pinning still works after a total resync.

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -924,7 +924,9 @@ const SEQUENCER_RECOVERY_ERROR: &str = "The preferred sequencer is recovering fr
 
 #[tokio::test(flavor = "multi_thread")]
 async fn seq_behind_deferred_slots_count_simple_lagging() {
+    let t_total = std::time::Instant::now();
     std::env::set_var("SOV_TEST_CONST_OVERRIDE_DEFERRED_SLOTS_COUNT", "40");
+    let t_stage = std::time::Instant::now();
     let (test_rollup, admin) = create_test_rollup(
         0,
         TEST_MAX_BATCH_SIZE,
@@ -937,6 +939,7 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
 
     test_rollup.produce_enough_finalized_slots().await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
+    eprintln!("[TIMING] Stage 1 (setup + finalize + ready): {:?}", t_stage.elapsed());
 
     let client = test_rollup.api_client().clone();
 
@@ -949,10 +952,13 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
         .await
         .unwrap();
 
+    let t_stage = std::time::Instant::now();
     tracing::info!("Producing DA blocks for inclusion sanity check tx inclusion");
     da_layer.produce_and_wait_for_n_slots(10).await;
+    eprintln!("[TIMING] Stage 2 (sanity tx + 10 slots): {:?}", t_stage.elapsed());
 
     // Pause sequencer update_state and run some blocks so deferred_slots_count is reached
+    let t_stage = std::time::Instant::now();
     test_rollup.pause_preferred_batches().await;
     tracing::info!("Preferred sequencer batch production paused.");
 
@@ -975,15 +981,20 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
     }
     // Make sure the DA has synced everything
     test_rollup.wait_for_node_synced().await.unwrap();
+    eprintln!("[TIMING] Stage 3 (pause + 30 DA blocks + sync): {:?}", t_stage.elapsed());
 
     tracing::info!("Resuming preferred sequencer batch production.");
     test_rollup.resume_preferred_batches().await;
     // Normally on the next state update, the sequencer should always enter recovery.
     test_rollup.da_service.produce_block_now().await.unwrap();
+    let t_entry = std::time::Instant::now();
+    let mut entry_iters = 0u32;
     while test_rollup.is_sequencer_ready().await {
         let _ = da_layer.produce_block().await;
         sleep(Duration::from_millis(30)).await;
+        entry_iters += 1;
     }
+    eprintln!("[TIMING] Stage 4 (recovery entry): {entry_iters} iterations, {:?}", t_entry.elapsed());
     test_rollup.wait_for_node_synced().await.unwrap();
 
     // Create transaction that should fail: sequencer should not accept transactions while in
@@ -1004,14 +1015,19 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
 
     // Give time for the sequencer to catch up its visible state number
     tracing::info!("Producing DA blocks to let the sequencer resync.");
+    let t_exit = std::time::Instant::now();
+    let mut exit_iters = 0u32;
     while !test_rollup.is_sequencer_ready().await {
         let _ = da_layer.produce_block().await;
         sleep(Duration::from_millis(50)).await; // Notifications don't work during recovery.
+        exit_iters += 1;
     }
+    eprintln!("[TIMING] Stage 5 (recovery exit): {exit_iters} iterations, {:?}", t_exit.elapsed());
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer
     // This transaction will be soft-confirmed. The assertion should pass at this stage.
+    let t_stage = std::time::Instant::now();
     client
         .send_raw_tx_to_sequencer(&tx_update_vec)
         .await
@@ -1023,6 +1039,7 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
     let actual_many_value =
         wait_for_many_values_item(&test_rollup, &mut da_layer, 0, UPDATE_VEC_VALUE, 80).await;
     test_rollup.wait_for_node_synced().await.unwrap();
+    eprintln!("[TIMING] Stage 6 (post-recovery tx + wait): {:?}", t_stage.elapsed());
 
     // Assert that the earlier transactions sent just before the sequencer went into recovery was
     // flushed and processed by the node
@@ -1049,11 +1066,14 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
         .await
         .unwrap()
         .unwrap();
+    eprintln!("[TIMING] Total (simple_lagging): {:?}", t_total.elapsed());
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn seq_behind_deferred_slots_count_with_shutdown() {
+    let t_total = std::time::Instant::now();
     std::env::set_var("SOV_TEST_CONST_OVERRIDE_DEFERRED_SLOTS_COUNT", "40");
+    let t_stage = std::time::Instant::now();
     let (test_rollup, admin) = create_test_rollup(
         0,
         TEST_MAX_BATCH_SIZE,
@@ -1070,6 +1090,7 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     let mut da_layer = DaLayerWithSubscription::new(&test_rollup).await;
     da_layer.produce_and_wait_for_n_slots(8).await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
+    eprintln!("[TIMING] Stage 1 (setup + 8 slots + ready): {:?}", t_stage.elapsed());
 
     // Sanity check tx that the rollup works
     let tx_update_one = tx_set_value(&admin.private_key, 0, 8);
@@ -1080,8 +1101,10 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
         .await
         .unwrap();
 
+    let t_stage = std::time::Instant::now();
     tracing::info!("Producing DA blocks for inclusion sanity check tx inclusion");
     da_layer.produce_and_wait_for_n_slots(10).await;
+    eprintln!("[TIMING] Stage 2 (sanity tx + 10 slots): {:?}", t_stage.elapsed());
 
     // Send a transaction that will be queued while rollup is shut down
     const UPDATE_TWO_VALUE: u64 = 19;
@@ -1097,6 +1120,7 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     let da_service = test_rollup.da_service.clone();
 
     // Shutdown the rollup while preserving the DA layer
+    let t_stage = std::time::Instant::now();
     tracing::info!("Shutting down rollup to test restart behavior");
     let builder = test_rollup.shutdown().await.unwrap();
 
@@ -1105,8 +1129,10 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     // a) possible node lag
     // b) a 90% threshold.
     da_service.produce_n_blocks_now(30).await.unwrap();
+    eprintln!("[TIMING] Stage 3 (shutdown + 30 DA blocks): {:?}", t_stage.elapsed());
 
     // Restart the rollup
+    let t_stage = std::time::Instant::now();
     tracing::info!("Restarting rollup after exceeding deferred_slots_count");
     let test_rollup = builder.start().await.unwrap();
     let client = test_rollup.api_client().clone();
@@ -1118,6 +1144,7 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     test_rollup.da_service.produce_block_now().await.unwrap();
     sleep(Duration::from_millis(50)).await;
     assert!(!test_rollup.is_sequencer_ready().await);
+    eprintln!("[TIMING] Stage 4 (restart + sync + recovery entry): {:?}", t_stage.elapsed());
 
     // Create transaction that should fail: sequencer should not accept transactions while in recovery
     const UPDATE_VEC_VALUE: u8 = 12;
@@ -1136,13 +1163,18 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
 
     // Give time for the sequencer to catch up its visible state number
     tracing::info!("Producing DA blocks to let the sequencer resync.");
+    let t_exit = std::time::Instant::now();
+    let mut exit_iters = 0u32;
     while !test_rollup.is_sequencer_ready().await {
         test_rollup.da_service.produce_block_now().await.unwrap();
         sleep(Duration::from_millis(50)).await;
+        exit_iters += 1;
     }
+    eprintln!("[TIMING] Stage 5 (recovery exit): {exit_iters} iterations, {:?}", t_exit.elapsed());
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer
+    let t_stage = std::time::Instant::now();
     client
         .accept_tx(&api_types::AcceptTxBody {
             body: BASE64_STANDARD.encode(&tx_update_vec),
@@ -1156,6 +1188,7 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     let actual_many_value =
         wait_for_many_values_item(&test_rollup, &mut da_layer, 0, UPDATE_VEC_VALUE, 80).await;
     test_rollup.wait_for_node_synced().await.unwrap();
+    eprintln!("[TIMING] Stage 6 (post-recovery tx + wait): {:?}", t_stage.elapsed());
 
     // Assert that the earlier transaction sent before shutdown was processed
     let response = test_rollup
@@ -1177,6 +1210,7 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
 
     tracing::info!("All asserts successful, shutting down rollup");
     test_rollup.shutdown().await.unwrap();
+    eprintln!("[TIMING] Total (with_shutdown): {:?}", t_total.elapsed());
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -924,9 +924,7 @@ const SEQUENCER_RECOVERY_ERROR: &str = "The preferred sequencer is recovering fr
 
 #[tokio::test(flavor = "multi_thread")]
 async fn seq_behind_deferred_slots_count_simple_lagging() {
-    let t_total = std::time::Instant::now();
     std::env::set_var("SOV_TEST_CONST_OVERRIDE_DEFERRED_SLOTS_COUNT", "40");
-    let t_stage = std::time::Instant::now();
     let (test_rollup, admin) = create_test_rollup(
         0,
         TEST_MAX_BATCH_SIZE,
@@ -939,10 +937,6 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
 
     test_rollup.produce_enough_finalized_slots().await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
-    eprintln!(
-        "[TIMING] Stage 1 (setup + finalize + ready): {:?}",
-        t_stage.elapsed()
-    );
 
     let client = test_rollup.api_client().clone();
 
@@ -955,16 +949,10 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
         .await
         .unwrap();
 
-    let t_stage = std::time::Instant::now();
     tracing::info!("Producing DA blocks for inclusion sanity check tx inclusion");
     da_layer.produce_and_wait_for_n_slots(10).await;
-    eprintln!(
-        "[TIMING] Stage 2 (sanity tx + 10 slots): {:?}",
-        t_stage.elapsed()
-    );
 
     // Pause sequencer update_state and run some blocks so deferred_slots_count is reached
-    let t_stage = std::time::Instant::now();
     test_rollup.pause_preferred_batches().await;
     tracing::info!("Preferred sequencer batch production paused.");
 
@@ -987,10 +975,6 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
     }
     // Make sure the DA has synced everything
     test_rollup.wait_for_node_synced().await.unwrap();
-    eprintln!(
-        "[TIMING] Stage 3 (pause + 30 DA blocks + sync): {:?}",
-        t_stage.elapsed()
-    );
 
     tracing::info!("Resuming preferred sequencer batch production.");
     // Subscribe to state update notifications BEFORE resuming, so we don't miss the
@@ -1030,22 +1014,14 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
 
     // Give time for the sequencer to catch up its visible state number
     tracing::info!("Producing DA blocks to let the sequencer resync.");
-    let t_exit = std::time::Instant::now();
-    let mut exit_iters = 0u32;
     while !test_rollup.is_sequencer_ready().await {
         let _ = da_layer.produce_block().await;
         sleep(Duration::from_millis(50)).await; // Notifications don't work during recovery.
-        exit_iters += 1;
     }
-    eprintln!(
-        "[TIMING] Stage 5 (recovery exit): {exit_iters} iterations, {:?}",
-        t_exit.elapsed()
-    );
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer
     // This transaction will be soft-confirmed. The assertion should pass at this stage.
-    let t_stage = std::time::Instant::now();
     client
         .send_raw_tx_to_sequencer(&tx_update_vec)
         .await
@@ -1057,10 +1033,6 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
     let actual_many_value =
         wait_for_many_values_item(&test_rollup, &mut da_layer, 0, UPDATE_VEC_VALUE, 80).await;
     test_rollup.wait_for_node_synced().await.unwrap();
-    eprintln!(
-        "[TIMING] Stage 6 (post-recovery tx + wait): {:?}",
-        t_stage.elapsed()
-    );
 
     // Assert that the earlier transactions sent just before the sequencer went into recovery was
     // flushed and processed by the node
@@ -1087,14 +1059,11 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
         .await
         .unwrap()
         .unwrap();
-    eprintln!("[TIMING] Total (simple_lagging): {:?}", t_total.elapsed());
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn seq_behind_deferred_slots_count_with_shutdown() {
-    let t_total = std::time::Instant::now();
     std::env::set_var("SOV_TEST_CONST_OVERRIDE_DEFERRED_SLOTS_COUNT", "40");
-    let t_stage = std::time::Instant::now();
     let (test_rollup, admin) = create_test_rollup(
         0,
         TEST_MAX_BATCH_SIZE,
@@ -1111,10 +1080,6 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     let mut da_layer = DaLayerWithSubscription::new(&test_rollup).await;
     da_layer.produce_and_wait_for_n_slots(8).await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
-    eprintln!(
-        "[TIMING] Stage 1 (setup + 8 slots + ready): {:?}",
-        t_stage.elapsed()
-    );
 
     // Sanity check tx that the rollup works
     let tx_update_one = tx_set_value(&admin.private_key, 0, 8);
@@ -1125,13 +1090,8 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
         .await
         .unwrap();
 
-    let t_stage = std::time::Instant::now();
     tracing::info!("Producing DA blocks for inclusion sanity check tx inclusion");
     da_layer.produce_and_wait_for_n_slots(10).await;
-    eprintln!(
-        "[TIMING] Stage 2 (sanity tx + 10 slots): {:?}",
-        t_stage.elapsed()
-    );
 
     // Send a transaction that will be queued while rollup is shut down
     const UPDATE_TWO_VALUE: u64 = 19;
@@ -1147,7 +1107,6 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     let da_service = test_rollup.da_service.clone();
 
     // Shutdown the rollup while preserving the DA layer
-    let t_stage = std::time::Instant::now();
     tracing::info!("Shutting down rollup to test restart behavior");
     let builder = test_rollup.shutdown().await.unwrap();
 
@@ -1156,13 +1115,8 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     // a) possible node lag
     // b) a 90% threshold.
     da_service.produce_n_blocks_now(30).await.unwrap();
-    eprintln!(
-        "[TIMING] Stage 3 (shutdown + 30 DA blocks): {:?}",
-        t_stage.elapsed()
-    );
 
     // Restart the rollup
-    let t_stage = std::time::Instant::now();
     tracing::info!("Restarting rollup after exceeding deferred_slots_count");
     let test_rollup = builder.start().await.unwrap();
     let client = test_rollup.api_client().clone();
@@ -1187,10 +1141,6 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     })
     .await
     .expect("Timed out waiting for sequencer to enter recovery");
-    eprintln!(
-        "[TIMING] Stage 4 (restart + sync + recovery entry): {:?}",
-        t_stage.elapsed()
-    );
 
     // Create transaction that should fail: sequencer should not accept transactions while in recovery
     const UPDATE_VEC_VALUE: u8 = 12;
@@ -1209,21 +1159,13 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
 
     // Give time for the sequencer to catch up its visible state number
     tracing::info!("Producing DA blocks to let the sequencer resync.");
-    let t_exit = std::time::Instant::now();
-    let mut exit_iters = 0u32;
     while !test_rollup.is_sequencer_ready().await {
         test_rollup.da_service.produce_block_now().await.unwrap();
         sleep(Duration::from_millis(50)).await;
-        exit_iters += 1;
     }
-    eprintln!(
-        "[TIMING] Stage 5 (recovery exit): {exit_iters} iterations, {:?}",
-        t_exit.elapsed()
-    );
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer
-    let t_stage = std::time::Instant::now();
     client
         .accept_tx(&api_types::AcceptTxBody {
             body: BASE64_STANDARD.encode(&tx_update_vec),
@@ -1237,10 +1179,6 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     let actual_many_value =
         wait_for_many_values_item(&test_rollup, &mut da_layer, 0, UPDATE_VEC_VALUE, 80).await;
     test_rollup.wait_for_node_synced().await.unwrap();
-    eprintln!(
-        "[TIMING] Stage 6 (post-recovery tx + wait): {:?}",
-        t_stage.elapsed()
-    );
 
     // Assert that the earlier transaction sent before shutdown was processed
     let response = test_rollup
@@ -1262,7 +1200,6 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
 
     tracing::info!("All asserts successful, shutting down rollup");
     test_rollup.shutdown().await.unwrap();
-    eprintln!("[TIMING] Total (with_shutdown): {:?}", t_total.elapsed());
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -939,7 +939,10 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
 
     test_rollup.produce_enough_finalized_slots().await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
-    eprintln!("[TIMING] Stage 1 (setup + finalize + ready): {:?}", t_stage.elapsed());
+    eprintln!(
+        "[TIMING] Stage 1 (setup + finalize + ready): {:?}",
+        t_stage.elapsed()
+    );
 
     let client = test_rollup.api_client().clone();
 
@@ -955,7 +958,10 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
     let t_stage = std::time::Instant::now();
     tracing::info!("Producing DA blocks for inclusion sanity check tx inclusion");
     da_layer.produce_and_wait_for_n_slots(10).await;
-    eprintln!("[TIMING] Stage 2 (sanity tx + 10 slots): {:?}", t_stage.elapsed());
+    eprintln!(
+        "[TIMING] Stage 2 (sanity tx + 10 slots): {:?}",
+        t_stage.elapsed()
+    );
 
     // Pause sequencer update_state and run some blocks so deferred_slots_count is reached
     let t_stage = std::time::Instant::now();
@@ -981,21 +987,30 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
     }
     // Make sure the DA has synced everything
     test_rollup.wait_for_node_synced().await.unwrap();
-    eprintln!("[TIMING] Stage 3 (pause + 30 DA blocks + sync): {:?}", t_stage.elapsed());
+    eprintln!(
+        "[TIMING] Stage 3 (pause + 30 DA blocks + sync): {:?}",
+        t_stage.elapsed()
+    );
 
     tracing::info!("Resuming preferred sequencer batch production.");
+    // Subscribe to state update notifications BEFORE resuming, so we don't miss the
+    // recovery notification. This channel bypasses the state updator message queue
+    // (which blocks during trigger_recovery's async calls under CPU pressure).
+    let mut recovery_sub = test_rollup.subscribe_state_updates().await.unwrap();
     test_rollup.resume_preferred_batches().await;
-    // Normally on the next state update, the sequencer should always enter recovery.
+    // Produce one block to trigger the state update that detects the gap.
     test_rollup.da_service.produce_block_now().await.unwrap();
-    let t_entry = std::time::Instant::now();
-    let mut entry_iters = 0u32;
-    while test_rollup.is_sequencer_ready().await {
-        let _ = da_layer.produce_block().await;
-        sleep(Duration::from_millis(30)).await;
-        entry_iters += 1;
-    }
-    eprintln!("[TIMING] Stage 4 (recovery entry): {entry_iters} iterations, {:?}", t_entry.elapsed());
-    test_rollup.wait_for_node_synced().await.unwrap();
+    // Wait for the notification that indicates recovery was triggered.
+    tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            let notification = recovery_sub.next().await.unwrap().unwrap();
+            if notification.triggered_recovery {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("Timed out waiting for sequencer to enter recovery");
 
     // Create transaction that should fail: sequencer should not accept transactions while in
     // recovery.
@@ -1022,7 +1037,10 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
         sleep(Duration::from_millis(50)).await; // Notifications don't work during recovery.
         exit_iters += 1;
     }
-    eprintln!("[TIMING] Stage 5 (recovery exit): {exit_iters} iterations, {:?}", t_exit.elapsed());
+    eprintln!(
+        "[TIMING] Stage 5 (recovery exit): {exit_iters} iterations, {:?}",
+        t_exit.elapsed()
+    );
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer
@@ -1039,7 +1057,10 @@ async fn seq_behind_deferred_slots_count_simple_lagging() {
     let actual_many_value =
         wait_for_many_values_item(&test_rollup, &mut da_layer, 0, UPDATE_VEC_VALUE, 80).await;
     test_rollup.wait_for_node_synced().await.unwrap();
-    eprintln!("[TIMING] Stage 6 (post-recovery tx + wait): {:?}", t_stage.elapsed());
+    eprintln!(
+        "[TIMING] Stage 6 (post-recovery tx + wait): {:?}",
+        t_stage.elapsed()
+    );
 
     // Assert that the earlier transactions sent just before the sequencer went into recovery was
     // flushed and processed by the node
@@ -1090,7 +1111,10 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     let mut da_layer = DaLayerWithSubscription::new(&test_rollup).await;
     da_layer.produce_and_wait_for_n_slots(8).await;
     test_rollup.wait_for_sequencer_ready().await.unwrap();
-    eprintln!("[TIMING] Stage 1 (setup + 8 slots + ready): {:?}", t_stage.elapsed());
+    eprintln!(
+        "[TIMING] Stage 1 (setup + 8 slots + ready): {:?}",
+        t_stage.elapsed()
+    );
 
     // Sanity check tx that the rollup works
     let tx_update_one = tx_set_value(&admin.private_key, 0, 8);
@@ -1104,7 +1128,10 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     let t_stage = std::time::Instant::now();
     tracing::info!("Producing DA blocks for inclusion sanity check tx inclusion");
     da_layer.produce_and_wait_for_n_slots(10).await;
-    eprintln!("[TIMING] Stage 2 (sanity tx + 10 slots): {:?}", t_stage.elapsed());
+    eprintln!(
+        "[TIMING] Stage 2 (sanity tx + 10 slots): {:?}",
+        t_stage.elapsed()
+    );
 
     // Send a transaction that will be queued while rollup is shut down
     const UPDATE_TWO_VALUE: u64 = 19;
@@ -1129,7 +1156,10 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     // a) possible node lag
     // b) a 90% threshold.
     da_service.produce_n_blocks_now(30).await.unwrap();
-    eprintln!("[TIMING] Stage 3 (shutdown + 30 DA blocks): {:?}", t_stage.elapsed());
+    eprintln!(
+        "[TIMING] Stage 3 (shutdown + 30 DA blocks): {:?}",
+        t_stage.elapsed()
+    );
 
     // Restart the rollup
     let t_stage = std::time::Instant::now();
@@ -1137,14 +1167,30 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     let test_rollup = builder.start().await.unwrap();
     let client = test_rollup.api_client().clone();
     let mut da_layer = DaLayerWithSubscription::new(&test_rollup).await;
+    // Subscribe BEFORE node sync so we don't miss the recovery notification
+    // (recovery may trigger during the sync phase itself).
+    let mut recovery_sub = test_rollup.subscribe_state_updates().await.unwrap();
 
-    // First we sync the node to the new DA blocks
+    // Sync the node to the new DA blocks. Recovery may trigger during sync.
     test_rollup.wait_for_node_synced().await.unwrap();
-    // Now on the next state update, the sequencer should always enter recovery
+    // Produce one more block in case recovery hasn't triggered yet.
     test_rollup.da_service.produce_block_now().await.unwrap();
-    sleep(Duration::from_millis(50)).await;
-    assert!(!test_rollup.is_sequencer_ready().await);
-    eprintln!("[TIMING] Stage 4 (restart + sync + recovery entry): {:?}", t_stage.elapsed());
+    // Wait for the notification that indicates recovery was triggered. This
+    // bypasses the state updator (which blocks during trigger_recovery under load).
+    tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            let notification = recovery_sub.next().await.unwrap().unwrap();
+            if notification.triggered_recovery {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("Timed out waiting for sequencer to enter recovery");
+    eprintln!(
+        "[TIMING] Stage 4 (restart + sync + recovery entry): {:?}",
+        t_stage.elapsed()
+    );
 
     // Create transaction that should fail: sequencer should not accept transactions while in recovery
     const UPDATE_VEC_VALUE: u8 = 12;
@@ -1170,7 +1216,10 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
         sleep(Duration::from_millis(50)).await;
         exit_iters += 1;
     }
-    eprintln!("[TIMING] Stage 5 (recovery exit): {exit_iters} iterations, {:?}", t_exit.elapsed());
+    eprintln!(
+        "[TIMING] Stage 5 (recovery exit): {exit_iters} iterations, {:?}",
+        t_exit.elapsed()
+    );
     test_rollup.wait_for_sequencer_ready().await.unwrap();
 
     // Submit the same transaction to the now-working sequencer
@@ -1188,7 +1237,10 @@ async fn seq_behind_deferred_slots_count_with_shutdown() {
     let actual_many_value =
         wait_for_many_values_item(&test_rollup, &mut da_layer, 0, UPDATE_VEC_VALUE, 80).await;
     test_rollup.wait_for_node_synced().await.unwrap();
-    eprintln!("[TIMING] Stage 6 (post-recovery tx + wait): {:?}", t_stage.elapsed());
+    eprintln!(
+        "[TIMING] Stage 6 (post-recovery tx + wait): {:?}",
+        t_stage.elapsed()
+    );
 
     // Assert that the earlier transaction sent before shutdown was processed
     let response = test_rollup


### PR DESCRIPTION
# Description

**Root cause:** The tests polled `is_ready()` via RPC to detect recovery. Under CPU load, `trigger_recovery()` blocks the `synchronized_state_updator` (holding the lock during async calls to executor_events_sender and force_overwrite_state). The `CheckReadiness` RPC message queues behind it, so the test either never sees the "not ready" state (race condition) or hangs waiting for the RPC to complete.

**Fix:** Added a triggered_recovery: bool field to `StateUpdateNotification` (#[cfg(feature = "test-utils")]). A notification is sent from `update_state_task_inner` right after sequencer_conditions_msg returns — this bypasses the state updator message queue entirely. Tests now subscribe to this broadcast channel and wait for triggered_recovery: true instead of polling via RPC.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
New test passes stable under load
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
