### PR TITLE
Cleaning up celestia devnet docker images

### DIFF
--- a/docker/celestia/Dockerfile.bridge
+++ b/docker/celestia/Dockerfile.bridge
@@ -6,16 +6,14 @@ ARG CELESTIA_NODE_TAG=v0.29.1-mocha
 
 FROM ghcr.io/celestiaorg/celestia-node:${CELESTIA_NODE_TAG} AS celestia-node
 
-FROM docker.io/alpine:3.20.1
+FROM docker.io/alpine:3.23
 
 ENV CELESTIA_HOME=/root
 
-RUN apk update && \
-    apk add --no-cache bash jq curl && \
-    wget https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_x86_64.tar.gz && \
-    tar -xvf grpcurl_1.8.7_linux_x86_64.tar.gz && \
-    mv grpcurl /usr/local/bin && \
-    rm grpcurl_1.8.7_linux_x86_64.tar.gz
+RUN apk add --no-cache bash jq curl && \
+    wget -O /tmp/grpcurl.tar.gz https://github.com/fullstorydev/grpcurl/releases/download/v1.9.3/grpcurl_1.9.3_linux_x86_64.tar.gz && \
+    tar -xf /tmp/grpcurl.tar.gz -C /usr/local/bin grpcurl && \
+    rm /tmp/grpcurl.tar.gz
 
 # Copy in the binary
 COPY --from=celestia-node /bin/celestia /bin/celestia
@@ -25,9 +23,8 @@ COPY ./run-bridge.sh /opt/entrypoint.sh
 COPY ./bridge-healthcheck.sh /opt/bridge-healthcheck.sh
 RUN chmod +x /opt/entrypoint.sh && chmod +x /opt/bridge-healthcheck.sh
 
-# TODO: Remove it from here, as it depends
 HEALTHCHECK --interval=5s --timeout=5s --retries=60 --start-period=60s \
-    CMD ["/opt/bridge-healthcheck.sh", "/credentials/bridge-0.jwt"]
+    CMD ["/opt/bridge-healthcheck.sh"]
 
 EXPOSE 2121 26658
 

--- a/docker/celestia/Dockerfile.validator
+++ b/docker/celestia/Dockerfile.validator
@@ -6,16 +6,14 @@ ARG CELESTIA_APP_TAG=v7.0.2-mocha
 
 FROM ghcr.io/celestiaorg/celestia-app:${CELESTIA_APP_TAG} AS celestia-app
 
-FROM docker.io/alpine:3.20.1
+FROM docker.io/alpine:3.23
 
 ENV CELESTIA_HOME=/root
 
-RUN apk update && \
-    apk add --no-cache bash jq curl dasel && \
-    wget https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_x86_64.tar.gz && \
-    tar -xvf grpcurl_1.8.7_linux_x86_64.tar.gz && \
-    mv grpcurl /usr/local/bin && \
-    rm grpcurl_1.8.7_linux_x86_64.tar.gz
+RUN apk add --no-cache bash jq curl dasel && \
+    wget -O /tmp/grpcurl.tar.gz https://github.com/fullstorydev/grpcurl/releases/download/v1.9.3/grpcurl_1.9.3_linux_x86_64.tar.gz && \
+    tar -xf /tmp/grpcurl.tar.gz -C /usr/local/bin grpcurl && \
+    rm /tmp/grpcurl.tar.gz
 
 # Copy in the binary
 COPY --from=celestia-app /bin/celestia-appd /bin/celestia-appd

--- a/docker/celestia/bridge-healthcheck.sh
+++ b/docker/celestia/bridge-healthcheck.sh
@@ -2,14 +2,6 @@
 
 TARGET_HEIGHT=4
 
-# Check existence of the token file
-echo "Checking network head. Token file: '$1'"
-if [ ! -f "$1" ]; then
-  echo "Error: Token file $1 does not exist."
-  exit 1
-fi
-TOKEN=$(cat "$1")
-
 # Check header.NetworkHead
 CURL_OUTPUT=$(curl -s --fail -X POST http://127.0.0.1:26658 \
      -H "Content-Type: application/json" \

--- a/docker/celestia/run-bridge.sh
+++ b/docker/celestia/run-bridge.sh
@@ -50,11 +50,10 @@ add_trusted_genesis_and_set_network() {
   genesis_hash="$(cat "$GENESIS_HASH_FILE")"
   # and make it trusted in the node's config
   echo "Trusting a genesis: $genesis_hash"
-  sed -i'.bak' "s/TrustedHash = .*/TrustedHash = \"$genesis_hash\"/" "$CONFIG_DIR/config.toml"
-  sed -i'.bak' "s/Address = \"localhost\"/Address = \"0.0.0.0\"/" "$CONFIG_DIR/config.toml"
-  sed -i'.bak' "s/SkipAuth = false/SkipAuth = true/" "$CONFIG_DIR/config.toml"
+  sed -i "s/TrustedHash = .*/TrustedHash = \"$genesis_hash\"/" "$CONFIG_DIR/config.toml"
+  sed -i "s/Address = \"localhost\"/Address = \"0.0.0.0\"/" "$CONFIG_DIR/config.toml"
+  sed -i "s/SkipAuth = false/SkipAuth = true/" "$CONFIG_DIR/config.toml"
   # celestia-node requires setting custom network params through env
-  cat
   export CELESTIA_CUSTOM="$P2P_NETWORK:$genesis_hash"
 }
 


### PR DESCRIPTION
# Description

* Alpine 3.20.1 → 3.23 (security patches)
* Minor Size reduction (but noticeable on macos)
* Removed token from health check, since image has disabled auth long ago
* Other bash clean ups

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existing tests are passing

## Docs
No updates
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
