### PR TITLE
Enrich NonAccessibleError from sov-modules-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-03-27
+- #2650 Adds more information to ApiStateAccessorError errors.
+
 # 2026-03-24
 - #2626 EVM: Fixes estimateGas value to match what will end up in the receipt of actually executed transaction
 - #2634 Test only changes

--- a/crates/module-system/module-implementations/integration-tests/tests/archival_queries/basic.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/archival_queries/basic.rs
@@ -110,8 +110,9 @@ async fn query_invalid_rollup_height_returns_error() {
     let error = api_response.errors.first().unwrap();
     assert_eq!(error.status, 404);
     assert_eq!(error.title, "invalid rollup height");
-    assert_eq!(
-        error.details.get("message").unwrap(),
-        "Impossible to get the rollup state at the specified height. The requested height may have been pruned, or it may be in the future. Please ensure you have queried the correct height."
+    let message = error.details.get("message").unwrap().as_str().unwrap();
+    assert!(
+        message.contains("not accessible"),
+        "Expected error to contain 'not accessible', got: {message}"
     );
 }

--- a/crates/module-system/sov-modules-api/src/rest/mod.rs
+++ b/crates/module-system/sov-modules-api/src/rest/mod.rs
@@ -248,7 +248,7 @@ impl<S: Spec, T> ApiState<S, T> {
                 .kernel
                 .base_fee_per_gas_at(height, &mut state)
                 .ok_or_else(|| {
-                    anyhow::anyhow!("Impossible to get the rollup state at the specified height. The requested height may have been pruned, or it may be in the future. Please ensure you have queried the correct height.")
+                    anyhow::anyhow!("Base fee per gas not available at rollup height {height}. The height may have been pruned or is not yet fully committed.")
                 })?;
 
                 state.set_gas_price(gas_price);
@@ -273,7 +273,7 @@ impl<S: Spec, T> ApiState<S, T> {
                 .kernel
                 .base_fee_per_gas_at(height, &mut state)
                 .ok_or_else(|| {
-                    anyhow::anyhow!("Impossible to get the rollup state at the specified height. The requested height may have been pruned, or it may be in the future. Please ensure you have queried the correct height.")
+                    anyhow::anyhow!("Base fee per gas not available at current rollup height {height}. This may indicate a transient state during slot processing.")
                 })?;
 
                 state.set_gas_price(gas_price);

--- a/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/http_api.rs
@@ -527,9 +527,22 @@ impl<S: Spec> ApiStateAccessor<S> {
 /// An error that can occur when creating an [`ApiStateAccessor`].
 #[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
 pub enum ApiStateAccessorError {
-    /// The requested height is not accessible.
-    #[error("Impossible to get the rollup state at the specified height. The requested height may have been pruned, or it may be in the future. Please ensure you have queried the correct height.")]
-    HeightNotAccessible,
+    /// The requested height is not accessible (future, not found, or not yet committed).
+    #[error("Rollup state not accessible. Requested: {requested}, latest: {latest}")]
+    HeightNotAccessible {
+        /// The height or slot number that was requested.
+        requested: u64,
+        /// The latest available height or slot number.
+        latest: u64,
+    },
+    /// The requested height has been pruned from storage.
+    #[error("Rollup state has been pruned. Requested: {requested}, latest: {latest}")]
+    HeightPruned {
+        /// The height or slot number that was requested.
+        requested: u64,
+        /// The latest available height or slot number.
+        latest: u64,
+    },
 }
 
 impl<S: Spec + 'static> ApiStateAccessor<S> {
@@ -694,13 +707,33 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
             let Some(rollup_height) =
                 kernel.true_slot_number_to_rollup_height(slot_number, &mut out)
             else {
-                return Err(ApiStateAccessorError::HeightNotAccessible);
+                return Err(ApiStateAccessorError::HeightNotAccessible {
+                    requested: slot_number.get(),
+                    latest: out
+                        .checkpoint_and_read_txn
+                        .state_checkpoint
+                        .storage()
+                        .latest_version()
+                        .get(),
+                });
             };
             out.state_to_access = StateToAccess::TrueSlotNumber(slot_number, Some(rollup_height));
         }
 
         let Some(visible_slot_number) = out.lookup_visible_slot_number() else {
-            return Err(ApiStateAccessorError::HeightNotAccessible);
+            let requested = match state_to_access {
+                StateToAccess::RollupHeight(h) => h.get(),
+                StateToAccess::TrueSlotNumber(s, _) => s.get(),
+            };
+            return Err(ApiStateAccessorError::HeightNotAccessible {
+                requested,
+                latest: out
+                    .checkpoint_and_read_txn
+                    .state_checkpoint
+                    .storage()
+                    .latest_version()
+                    .get(),
+            });
         };
 
         out.visible_slot_number = Some(visible_slot_number);
@@ -791,7 +824,10 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
                 {
                     // If the requested height is greater than our uncommitted changes, we can't access it.
                     if max_height < height {
-                        return Err(ApiStateAccessorError::HeightNotAccessible);
+                        return Err(ApiStateAccessorError::HeightNotAccessible {
+                            requested: height.get(),
+                            latest: max_height.get(),
+                        });
                     }
                     // Otherwise, drop any uncommitted changes that are after the requested height and use our latest slot number from storage as a safe commit.
                     // (Anything not already in storage by that point will be in the uncommitted changes)
@@ -808,12 +844,18 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
                     // as reported by the kernel. (Recall that, since the caches are empty, the "current_rollup_height" value reported by the kernel is the value stored at S::Storage::latest_version.)
                     latest_true_slot_number
                 } else {
-                    return Err(ApiStateAccessorError::HeightNotAccessible);
+                    return Err(ApiStateAccessorError::HeightNotAccessible {
+                        requested: height.get(),
+                        latest: latest_true_slot_number.get(),
+                    });
                 }
             }
             StateToAccess::TrueSlotNumber(slot_number, _) => {
                 if slot_number > latest_true_slot_number {
-                    return Err(ApiStateAccessorError::HeightNotAccessible);
+                    return Err(ApiStateAccessorError::HeightNotAccessible {
+                        requested: slot_number.get(),
+                        latest: latest_true_slot_number.get(),
+                    });
                 }
                 slot_number
             }
@@ -826,7 +868,10 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
             StateToAccess::TrueSlotNumber(slot_number, None) => {
                 let result = kernel.true_slot_number_to_rollup_height(slot_number, &mut state);
                 if state.encountered_pruning_error.is_some() {
-                    return Err(ApiStateAccessorError::HeightNotAccessible);
+                    return Err(ApiStateAccessorError::HeightPruned {
+                        requested: slot_number.get(),
+                        latest: latest_true_slot_number.get(),
+                    });
                 }
                 result.unwrap_or_else(|| panic!("Visible slot number not available for slot_number {slot_number}, but that slot exists in storage. This is a bug. Please report it."))
             }
@@ -853,7 +898,10 @@ impl<S: Spec + 'static> ApiStateAccessor<S> {
             &mut StateAccessMetric::new_read(), // We throw away the metric from this test query because it should almost always be cached and wasn't requested by the user
         );
         if state.encountered_pruning_error.is_some() {
-            return Err(ApiStateAccessorError::HeightNotAccessible);
+            return Err(ApiStateAccessorError::HeightPruned {
+                requested: true_slot_number.get(),
+                latest: latest_true_slot_number.get(),
+            });
         }
 
         // Clear out any new values that were put in cache during initialization. Otherwise, we'd incorrectly estimate gas costs for

--- a/examples/demo-rollup/tests/rest_api/mod.rs
+++ b/examples/demo-rollup/tests/rest_api/mod.rs
@@ -334,7 +334,7 @@ async fn check_historical_data(client: &demo_stf_json_client::Client) -> anyhow:
         state_vec_element_response,
         "invalid rollup height",
         "error",
-        "Impossible to get the rollup state at the specified height. The requested height may have been pruned, or it may be in the future. Please ensure you have queried the correct height.",
+        "not accessible",
     );
     Ok(())
 }
@@ -343,7 +343,7 @@ fn check_not_found_error(
     credential_id_response: demo_stf_json_client::Error<RuntimeError>,
     expected_title: &str,
     expected_details_key: &str,
-    expected_key: &str,
+    expected_substring: &str,
 ) {
     match credential_id_response {
         demo_stf_json_client::Error::ErrorResponse(error) => {
@@ -351,9 +351,15 @@ fn check_not_found_error(
             assert_eq!(404, error.status);
             assert_eq!(1, error.details.len());
             assert!(error.details.contains_key(expected_details_key));
-            assert_eq!(
-                Some(serde_json::Value::String(expected_key.to_string())),
-                error.details.get(expected_details_key).cloned()
+            let value = error
+                .details
+                .get(expected_details_key)
+                .unwrap()
+                .as_str()
+                .unwrap();
+            assert!(
+                value.contains(expected_substring),
+                "Expected error to contain '{expected_substring}', got: {value}"
             );
         }
         _ => {


### PR DESCRIPTION
# Description

Add actual heights to error messages, so we can distinguish future request from pruning and also monitor how far request lagged

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Minor updates

## Docs
No updates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
