### PR TITLE
`sov-build`: Atomic write to target files

### DIFF
--- a/crates/utils/sov-build/src/lib.rs
+++ b/crates/utils/sov-build/src/lib.rs
@@ -4,12 +4,52 @@
 //! including runtime schema generation and JSON schema output.
 
 use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
 
 use sov_modules_api::schemars::{schema_for, JsonSchema};
 use sov_modules_api::transaction::TransactionCallable;
 use sov_modules_api::{DispatchCall, Spec};
+
+/// Writes to `target` atomically using a temp file + rename pattern.
+///
+/// The `write_fn` closure receives a buffered writer for the temp file.
+/// After the closure returns, data is flushed, synced to disk, and the
+/// temp file is atomically renamed to `target`.
+fn write_atomically<F>(target: &Path, write_fn: F) -> anyhow::Result<()>
+where
+    F: FnOnce(&mut BufWriter<File>) -> anyhow::Result<()>,
+{
+    let mut temp_os = target.as_os_str().to_os_string();
+    temp_os.push(".tmp");
+    let temp_path = PathBuf::from(temp_os);
+
+    let file = File::create(&temp_path)
+        .with_context(|| format!("Failed to create temp file {temp_path:?}"))?;
+    let mut buf_writer = BufWriter::new(file);
+
+    write_fn(&mut buf_writer)
+        .with_context(|| format!("Failed to write to temp file {temp_path:?}"))?;
+
+    buf_writer
+        .flush()
+        .with_context(|| format!("Failed to flush temp file {temp_path:?}"))?;
+
+    let file = buf_writer
+        .into_inner()
+        .map_err(|e| e.into_error())
+        .with_context(|| format!("Failed to unwrap BufWriter for {temp_path:?}"))?;
+
+    file.sync_all()
+        .with_context(|| format!("Failed to sync temp file {temp_path:?} to disk"))?;
+
+    std::fs::rename(&temp_path, target)
+        .with_context(|| format!("Failed to rename {temp_path:?} to {target:?}"))?;
+
+    Ok(())
+}
 
 /// Builder for configuring build options.
 ///
@@ -182,27 +222,20 @@ impl Options {
 
         let schema_json = serde_json::to_string_pretty(&schema)?;
         let schema_borsh = borsh::to_vec(&schema)?;
-
-        let mut file = File::create(out_path)?;
         let chain_hash = schema.chain_hash().unwrap();
 
-        write!(
-            &mut file,
-            "pub const CHAIN_HASH: [u8; 32] = {chain_hash:?};\n\n"
-        )?;
-
-        write!(
-            &mut file,
-            "#[allow(dead_code)]\npub const SCHEMA_BORSH: &[u8] = &{schema_borsh:?};\n\n"
-        )?;
-        write!(
-            &mut file,
-            "#[allow(dead_code)]\npub const SCHEMA_JSON: &str = r#\"{schema_json}\"#;\n"
-        )?;
-
-        file.flush()?;
-
-        Ok(())
+        write_atomically(&out_path, |file| {
+            write!(file, "pub const CHAIN_HASH: [u8; 32] = {chain_hash:?};\n\n")?;
+            write!(
+                file,
+                "#[allow(dead_code)]\npub const SCHEMA_BORSH: &[u8] = &{schema_borsh:?};\n\n"
+            )?;
+            write!(
+                file,
+                "#[allow(dead_code)]\npub const SCHEMA_JSON: &str = r#\"{schema_json}\"#;\n"
+            )?;
+            Ok(())
+        })
     }
 
     fn output_rollup_schema<S, D>(&self) -> anyhow::Result<()>
@@ -214,12 +247,12 @@ impl Options {
         let schema =
             sov_modules_api::runtime::get_runtime_schema::<S, D>().expect("Failed to get schema");
         let json = serde_json::to_string_pretty(&schema)?;
-        let mut file = File::create(out_path)?;
 
-        file.write_all(json.as_bytes())?;
-        file.write_all(b"\n")?;
-
-        Ok(())
+        write_atomically(&out_path, |file| {
+            file.write_all(json.as_bytes())?;
+            file.write_all(b"\n")?;
+            Ok(())
+        })
     }
 
     fn output_json_schema<D>(&self) -> anyhow::Result<()>
@@ -230,12 +263,12 @@ impl Options {
         let out_path = self.out_dir.join("json-schema.json");
         let schema = schema_for!(D::Decodable);
         let json = serde_json::to_string_pretty(&schema)?;
-        let mut file = File::create(out_path)?;
 
-        file.write_all(json.as_bytes())?;
-        file.write_all(b"\n")?;
-
-        Ok(())
+        write_atomically(&out_path, |file| {
+            file.write_all(json.as_bytes())?;
+            file.write_all(b"\n")?;
+            Ok(())
+        })
     }
 
     fn set_git_head_env(&self) -> anyhow::Result<()> {


### PR DESCRIPTION
# Description

To prevent build errors like this one:

```
error: this file contains an unclosed delimiter
 --> examples/demo-rollup/stf/src/../.artifacts/autogenerated.rs:4:3750
  |
4 | ...= &[132, 0, 0, 0, 0, 11, 0, 0, 0, 84, 114, 97, 110, 115, 97,
 ...
```

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
No updates

## Testing
All existing tests are passing

## Docs
No updates
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
