### PR TITLE
Remove lazy-static in favor of std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-03-30
+- #2654 Replace `lazy_static` crate with `std::sync::LazyLock`
+
 # 2026-03-24
 - #2626 EVM: Fixes estimateGas value to match what will end up in the receipt of actually executed transaction
 - #2634 Test only changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12087,7 +12087,6 @@ dependencies = [
  "itertools 0.14.0",
  "jsonrpsee",
  "jsonschema",
- "lazy_static",
  "proptest",
  "rand 0.8.5",
  "reth-ethereum-primitives",
@@ -13421,7 +13420,6 @@ name = "sp1"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "lazy_static",
  "sov-zkvm-utils",
  "sp1-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,7 +294,6 @@ tokio = { version = "1.42.2", default-features = false }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-tungstenite = { version = "0.28.0", default-features = false }
 uuid = { version = "1.10", default-features = false } # v1.9 is important because it guarantees monotic UUIDv7 generation: https://github.com/uuid-rs/uuid/releases/tag/1.9.0.
-lazy_static = "1.5.0"
 num_cpus = "1.16"
 ruint = { version = "1", default-features = false }
 risc0-zkvm = { version = "2.1", default-features = false }

--- a/crates/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-evm/Cargo.toml
@@ -90,7 +90,6 @@ tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 tempfile = { workspace = true }
 bytes = { workspace = true }
 secp256k1 = { workspace = true, features = ["rand"] }
-lazy_static = { workspace = true }
 jsonschema = { workspace = true }
 bincode = { workspace = true }
 

--- a/examples/demo-rollup/provers/sp1/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/Cargo.toml
@@ -23,7 +23,6 @@ semicolon_if_nothing_returned = "deny"
 float_arithmetic = "deny"              # Can cause subtle bugs due to different behavior between native and zkVM execution.
 
 [dependencies]
-lazy_static = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/examples/demo-rollup/provers/sp1/src/lib.rs
+++ b/examples/demo-rollup/provers/sp1/src/lib.rs
@@ -1,4 +1,4 @@
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 
 /// Attempt to load the ELF file at the given path. If the file is empty or cannot be read,
 /// a warning will be printed and the default empty vector will be returned.
@@ -13,21 +13,27 @@ fn load_elf(path: &str) -> &'static [u8] {
 
 // Initialize the SP1 guest ELFs. Note: Normally this is done with include_bytes!(PATH_TO_FILE),
 // but because we don't include the guest ELFs in the GitHub build, they may potentially not exist.
-lazy_static! {
-    pub static ref SP1_GUEST_MOCK_ELF: &'static [u8] = load_elf(&format!(
+pub static SP1_GUEST_MOCK_ELF: LazyLock<&'static [u8]> = LazyLock::new(|| {
+    load_elf(&format!(
         "{}/guest-mock/target/elf-compilation/riscv64im-succinct-zkvm-elf/release/sov-demo-prover-guest-mock-sp1",
         env!("CARGO_MANIFEST_DIR")
-    ));
-    pub static ref SP1_GUEST_CELESTIA_ELF: &'static [u8] = load_elf(&format!(
+    ))
+});
+pub static SP1_GUEST_CELESTIA_ELF: LazyLock<&'static [u8]> = LazyLock::new(|| {
+    load_elf(&format!(
         "{}/guest-celestia/target/elf-compilation/riscv64im-succinct-zkvm-elf/release/sov-demo-prover-guest-celestia-sp1",
         env!("CARGO_MANIFEST_DIR")
-    ));
-    pub static ref SP1_GUEST_MOCK_NOMT_ELF: &'static [u8] = load_elf(&format!(
+    ))
+});
+pub static SP1_GUEST_MOCK_NOMT_ELF: LazyLock<&'static [u8]> = LazyLock::new(|| {
+    load_elf(&format!(
         "{}/guest-mock-nomt/target/elf-compilation/riscv64im-succinct-zkvm-elf/release/sov-demo-prover-guest-mock-nomt-sp1",
         env!("CARGO_MANIFEST_DIR")
-    ));
-    pub static ref SP1_GUEST_CELESTIA_NOMT_ELF: &'static [u8] = load_elf(&format!(
+    ))
+});
+pub static SP1_GUEST_CELESTIA_NOMT_ELF: LazyLock<&'static [u8]> = LazyLock::new(|| {
+    load_elf(&format!(
         "{}/guest-celestia-nomt/target/elf-compilation/riscv64im-succinct-zkvm-elf/release/sov-demo-prover-guest-celestia-nomt-sp1",
         env!("CARGO_MANIFEST_DIR")
-    ));
-}
+    ))
+});


### PR DESCRIPTION
# Description

Remove `lazy_static` dependency and use `std` equivalent instead

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
