### PR TITLE
 Fix recovery panic caused by stale StateRootTask cache entries

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -285,6 +285,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
         self.next_event_number = other.next_event_number;
         self.next_tx_number = other.next_tx_number;
         self.uncommitted_changes = other.uncommitted_changes;
+        self.id = other.id;
 
         // Update our list of state roots from the other executor.
         self.state_roots = other.state_roots;
@@ -814,6 +815,7 @@ impl<S: Spec, Rt: Runtime<S>> RollupBlockExecutor<S, Rt> {
         if self
             .state_root_request_sender
             .send(StateRootComputeRequest {
+                executor_id: self.id,
                 raw_state_changes: changes.clone(),
                 uncommitted_changes: self.uncommitted_changes.clone(),
                 storage: self.checkpoint.storage().clone(),

--- a/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
@@ -12,6 +12,7 @@ use sov_state::{NativeStorage, ProvableNamespace, SlotKey, SlotValue, StateAcces
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, span, trace, Level};
+use uuid::Uuid;
 
 /// The memory limit for old write sets that we keep around. These old sets are useful because they tell us what keys have been changed.
 /// Which lets us output a much handier error message when the state root computation changes.
@@ -21,6 +22,7 @@ const NUM_STATE_ROOT_COMPUTE_REQUESTS: usize = 50;
 
 type Hasher<S> = <<S as Spec>::CryptoSpec as CryptoSpec>::Hasher;
 pub(crate) struct StateRootComputeRequest<S: Spec> {
+    pub executor_id: Uuid,
     pub raw_state_changes: Arc<RawStateChanges>,
     pub uncommitted_changes: SequencerStateChanges<Hasher<S>>,
     pub storage: S::Storage,
@@ -206,7 +208,8 @@ impl<S: Spec> StateRootTask<S> {
         info!("Starting sequencer state root computation background task");
         let (request_sender, mut request_receiver) = mpsc::channel(NUM_STATE_ROOT_COMPUTE_REQUESTS);
 
-        let mut cached_results: BTreeMap<RollupHeight, StateRootCacheEntry<S>> = BTreeMap::new();
+        let mut cached_results: BTreeMap<(Uuid, RollupHeight), StateRootCacheEntry<S>> =
+            BTreeMap::new();
         let mut cached_results_size = 0;
         let handle = tokio::spawn(async move {
             loop {
@@ -232,19 +235,20 @@ impl<S: Spec> StateRootTask<S> {
                 };
                 // Wait for a new request, or shutdown.
                 let StateRootComputeRequest::<S> {
+                    executor_id,
                     raw_state_changes,
                     mut uncommitted_changes,
                     storage,
                     rollup_height,
                     max_slot_number,
                     response_channel,
-                    ..
                 } = request;
                 uncommitted_changes.push_front(raw_state_changes);
                 let state_accesses = uncommitted_changes.to_state_accesses();
+                let cache_key = (executor_id, rollup_height);
                 // If the entry is in cache, check that the state root is consistent and return early
-                if let Some(cached_entry) = cached_results.get(&rollup_height) {
-                    trace!(%rollup_height, "Known state root");
+                if let Some(cached_entry) = cached_results.get(&cache_key) {
+                    trace!(%executor_id, %rollup_height, "Known state root");
                     // If we're checking that the state roots are equal, we have some work to do.
                     let result = if check_state_roots {
                         cached_entry
@@ -302,7 +306,7 @@ impl<S: Spec> StateRootTask<S> {
 
                 // Add the new entry to the cache
                 cached_results.insert(
-                    rollup_height,
+                    cache_key,
                     StateRootCacheEntry {
                         root: root.clone(),
                         writes: writes_to_save,
@@ -323,7 +327,7 @@ impl<S: Spec> StateRootTask<S> {
     }
 
     fn prune_cache(
-        cached_results: &mut BTreeMap<RollupHeight, StateRootCacheEntry<S>>,
+        cached_results: &mut BTreeMap<(Uuid, RollupHeight), StateRootCacheEntry<S>>,
         cached_results_size: &mut usize,
     ) {
         // If the cache is too big, prune the oldest writes sets
@@ -360,6 +364,7 @@ mod tests {
         generate_optimistic_runtime, TestHasher, TestJmtSpec, TestSpec, TestStorageSpec,
     };
     use tokio::task::JoinHandle;
+    use uuid::Uuid;
 
     generate_optimistic_runtime!(TestRuntime <=);
 
@@ -462,6 +467,42 @@ mod tests {
         header: &MockBlockHeader,
         pre_state_root: &<S::Storage as Storage>::Root,
     ) -> Arc<RawStateChanges> {
+        sample_batch_with_height_and_writes::<S, Rt, _>(
+            storage,
+            header,
+            pre_state_root,
+            |changes, height| {
+                changes.user.set(
+                    &SlotKey::from_slice(b"user_key_static"),
+                    SlotValue::from(b"value_user_{height}".to_vec()),
+                );
+                changes.user.set(
+                    &SlotKey::from_slice(format!("user_key_{height}").as_bytes()),
+                    SlotValue::from(b"value_a_{height}".to_vec()),
+                );
+                changes.kernel.set(
+                    &SlotKey::from_slice(format!("kernel_key_{height}").as_bytes()),
+                    SlotValue::from(b"value_2_{height}".to_vec()),
+                );
+                changes.user.set(
+                    &SlotKey::from_slice(b"kernel_key_static"),
+                    SlotValue::from(b"value_kernel_{height}".to_vec()),
+                );
+            },
+        )
+    }
+
+    fn sample_batch_with_height_and_writes<S, Rt, F>(
+        storage: &S::Storage,
+        header: &MockBlockHeader,
+        pre_state_root: &<S::Storage as Storage>::Root,
+        add_writes: F,
+    ) -> Arc<RawStateChanges>
+    where
+        S: Spec<Da = MockDaSpec>,
+        Rt: Runtime<S>,
+        F: FnOnce(&mut RawStateChanges, u64),
+    {
         let mut rt = Rt::default();
         let mut kernel = rt.kernel();
         let mut checkpoint = StateCheckpoint::new(storage.clone(), &kernel, None);
@@ -480,22 +521,7 @@ mod tests {
         );
         checkpoint.commit_revertable_storage_cache();
         let mut changes = checkpoint.to_raw_state_changes();
-        changes.user.set(
-            &SlotKey::from_slice(b"user_key_static"),
-            SlotValue::from(b"value_user_{height}".to_vec()),
-        );
-        changes.user.set(
-            &SlotKey::from_slice(format!("user_key_{height}").as_bytes()),
-            SlotValue::from(b"value_a_{height}".to_vec()),
-        );
-        changes.kernel.set(
-            &SlotKey::from_slice(format!("kernel_key_{height}").as_bytes()),
-            SlotValue::from(b"value_2_{height}".to_vec()),
-        );
-        changes.user.set(
-            &SlotKey::from_slice(b"kernel_key_static"),
-            SlotValue::from(b"value_kernel_{height}".to_vec()),
-        );
+        add_writes(&mut changes, height);
         changes.user.commit_revertable_storage_cache();
         changes.kernel.commit_revertable_storage_cache();
 
@@ -519,9 +545,31 @@ mod tests {
         rollup_height: RollupHeight,
         slot_number: SlotNumber,
     ) -> <S::Storage as Storage>::Root {
+        get_root_from_background_task_with_executor_id(
+            task,
+            Uuid::nil(),
+            storage,
+            raw_state_changes,
+            uncommitted_changes,
+            rollup_height,
+            slot_number,
+        )
+        .await
+    }
+
+    async fn get_root_from_background_task_with_executor_id<S: Spec>(
+        task: &StateRootTask<S>,
+        executor_id: Uuid,
+        storage: S::Storage,
+        raw_state_changes: Arc<RawStateChanges>,
+        uncommitted_changes: SequencerStateChanges<Hasher<S>>,
+        rollup_height: RollupHeight,
+        slot_number: SlotNumber,
+    ) -> <S::Storage as Storage>::Root {
         let (response_channel, response_receiver) = oneshot::channel();
         task.request_sender
             .send(StateRootComputeRequest {
+                executor_id,
                 raw_state_changes,
                 uncommitted_changes,
                 storage,
@@ -622,6 +670,65 @@ mod tests {
         .await;
 
         assert_eq!(node_new_root, task_new_root);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_nomt_same_rollup_height_on_different_executor_generations() {
+        let mut storage_manager = SimpleStorageManager::<TestStorageSpec>::new();
+        genesis::<TestSpec, _, TestRuntime<TestSpec>>(&mut storage_manager);
+
+        let storage = storage_manager.create_prover_storage();
+        let prev_root = storage.get_root_hash(storage.latest_version()).unwrap();
+        let first_changes = sample_batch::<TestSpec, TestRuntime<TestSpec>>(&storage, &prev_root);
+        let second_changes =
+            sample_batch_with_height_and_writes::<TestSpec, TestRuntime<TestSpec>, _>(
+                &storage,
+                &MockBlockHeader::from_height(1),
+                &prev_root,
+                |changes, height| {
+                    changes.user.set(
+                        &SlotKey::from_slice(b"user_key_static"),
+                        SlotValue::from(b"value_user_generation_2".to_vec()),
+                    );
+                    changes.user.set(
+                        &SlotKey::from_slice(format!("user_key_{height}").as_bytes()),
+                        SlotValue::from(b"value_b_1".to_vec()),
+                    );
+                },
+            );
+
+        let (task, handle, shutdown_sender) =
+            start_background_task::<TestSpec, TestRuntime<TestSpec>>();
+
+        let first_root = get_root_from_background_task_with_executor_id::<TestSpec>(
+            &task,
+            Uuid::from_u128(1),
+            storage.clone(),
+            first_changes,
+            SequencerStateChanges::default(),
+            RollupHeight::new(1),
+            SlotNumber::new(1),
+        )
+        .await;
+
+        let second_root = get_root_from_background_task_with_executor_id::<TestSpec>(
+            &task,
+            Uuid::from_u128(2),
+            storage,
+            second_changes,
+            SequencerStateChanges::default(),
+            RollupHeight::new(1),
+            SlotNumber::new(1),
+        )
+        .await;
+
+        shutdown_sender.try_send(()).unwrap();
+        handle.await.unwrap();
+
+        assert_ne!(
+            first_root.namespace_root(ProvableNamespace::User),
+            second_root.namespace_root(ProvableNamespace::User)
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/state_root_compute.rs
@@ -21,6 +21,8 @@ const MAX_STATE_ROOTS_TO_CACHE: usize = 100;
 const NUM_STATE_ROOT_COMPUTE_REQUESTS: usize = 50;
 
 type Hasher<S> = <<S as Spec>::CryptoSpec as CryptoSpec>::Hasher;
+type StateRootCacheKey = (RollupHeight, Uuid);
+
 pub(crate) struct StateRootComputeRequest<S: Spec> {
     pub executor_id: Uuid,
     pub raw_state_changes: Arc<RawStateChanges>,
@@ -208,7 +210,7 @@ impl<S: Spec> StateRootTask<S> {
         info!("Starting sequencer state root computation background task");
         let (request_sender, mut request_receiver) = mpsc::channel(NUM_STATE_ROOT_COMPUTE_REQUESTS);
 
-        let mut cached_results: BTreeMap<(Uuid, RollupHeight), StateRootCacheEntry<S>> =
+        let mut cached_results: BTreeMap<StateRootCacheKey, StateRootCacheEntry<S>> =
             BTreeMap::new();
         let mut cached_results_size = 0;
         let handle = tokio::spawn(async move {
@@ -245,7 +247,7 @@ impl<S: Spec> StateRootTask<S> {
                 } = request;
                 uncommitted_changes.push_front(raw_state_changes);
                 let state_accesses = uncommitted_changes.to_state_accesses();
-                let cache_key = (executor_id, rollup_height);
+                let cache_key = (rollup_height, executor_id);
                 // If the entry is in cache, check that the state root is consistent and return early
                 if let Some(cached_entry) = cached_results.get(&cache_key) {
                     trace!(%executor_id, %rollup_height, "Known state root");
@@ -327,7 +329,7 @@ impl<S: Spec> StateRootTask<S> {
     }
 
     fn prune_cache(
-        cached_results: &mut BTreeMap<(Uuid, RollupHeight), StateRootCacheEntry<S>>,
+        cached_results: &mut BTreeMap<StateRootCacheKey, StateRootCacheEntry<S>>,
         cached_results_size: &mut usize,
     ) {
         // If the cache is too big, prune the oldest writes sets

--- a/examples/demo-rollup/tests/replica/recovery.rs
+++ b/examples/demo-rollup/tests/replica/recovery.rs
@@ -71,10 +71,18 @@ async fn test_db_elected_leader_recovery_with_replica() {
     setup.shutdown().await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_recovery_in_loop() {
+    for i in 0..100 {
+        println!("====={i}");
+        test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused().await;
+    }
+}
+
 /// Test that if only the elected leader pauses batch production and enters
 /// recovery after falling behind, the replica continues to function correctly
 /// once recovery completes.
-#[tokio::test(flavor = "multi_thread")]
+//#[tokio::test(flavor = "multi_thread")]
 async fn test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused() {
     std::env::set_var("SOV_TEST_CONST_OVERRIDE_DEFERRED_SLOTS_COUNT", "40");
 
@@ -87,19 +95,26 @@ async fn test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused
     let node_1 = setup
         .start_node("node_1", ConfiguredNodeRole::DbElected)
         .await;
+
+    /*
     let node_2 = setup
         .start_node("node_2", ConfiguredNodeRole::DbElected)
-        .await;
+        .await
+        */
 
     node_1.wait_for_sequencer_ready().await.unwrap();
-    node_2.wait_for_sequencer_ready().await.unwrap();
+    //node_2.wait_for_sequencer_ready().await.unwrap();
 
-    let (leader, replica) = establish_leader_and_replica(node_1, node_2).await;
+    // let (leader, replica) = establish_leader_and_replica(node_1, node_2).await;
+    // replica.shutdown().await.unwrap();
+    let leader = node_1;
+    println!("Rep");
 
     // Send a transaction to confirm the cluster works before recovery.
     let token_id = config_gas_token_id();
     let receiver_addr = random_address();
 
+    /*
     verify_replica_processes_tx(
         &leader,
         &replica,
@@ -108,7 +123,7 @@ async fn test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused
         receiver_addr,
         0,
     )
-    .await;
+    .await;*/
 
     // Pause only the elected leader's sequencer update_state loop.
     leader.pause_preferred_batches_for_node().await;
@@ -127,7 +142,7 @@ async fn test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused
     leader.wait_for_sequencer_ready().await.unwrap();
 
     // Send a transaction to confirm the cluster works after recovery.
-    verify_replica_processes_tx(
+    /*verify_replica_processes_tx(
         &leader,
         &replica,
         &key_and_address.private_key,
@@ -135,9 +150,8 @@ async fn test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused
         receiver_addr,
         1,
     )
-    .await;
+    .await;*/
 
-    replica.shutdown().await.unwrap();
     leader.shutdown().await.unwrap();
     setup.shutdown().await;
 }

--- a/examples/demo-rollup/tests/replica/recovery.rs
+++ b/examples/demo-rollup/tests/replica/recovery.rs
@@ -71,18 +71,10 @@ async fn test_db_elected_leader_recovery_with_replica() {
     setup.shutdown().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_recovery_in_loop() {
-    for i in 0..100 {
-        println!("====={i}");
-        test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused().await;
-    }
-}
-
 /// Test that if only the elected leader pauses batch production and enters
 /// recovery after falling behind, the replica continues to function correctly
 /// once recovery completes.
-//#[tokio::test(flavor = "multi_thread")]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused() {
     std::env::set_var("SOV_TEST_CONST_OVERRIDE_DEFERRED_SLOTS_COUNT", "40");
 
@@ -95,26 +87,19 @@ async fn test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused
     let node_1 = setup
         .start_node("node_1", ConfiguredNodeRole::DbElected)
         .await;
-
-    /*
     let node_2 = setup
         .start_node("node_2", ConfiguredNodeRole::DbElected)
-        .await
-        */
+        .await;
 
     node_1.wait_for_sequencer_ready().await.unwrap();
-    //node_2.wait_for_sequencer_ready().await.unwrap();
+    node_2.wait_for_sequencer_ready().await.unwrap();
 
-    // let (leader, replica) = establish_leader_and_replica(node_1, node_2).await;
-    // replica.shutdown().await.unwrap();
-    let leader = node_1;
-    println!("Rep");
+    let (leader, replica) = establish_leader_and_replica(node_1, node_2).await;
 
     // Send a transaction to confirm the cluster works before recovery.
     let token_id = config_gas_token_id();
     let receiver_addr = random_address();
 
-    /*
     verify_replica_processes_tx(
         &leader,
         &replica,
@@ -123,7 +108,7 @@ async fn test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused
         receiver_addr,
         0,
     )
-    .await;*/
+    .await;
 
     // Pause only the elected leader's sequencer update_state loop.
     leader.pause_preferred_batches_for_node().await;
@@ -142,7 +127,7 @@ async fn test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused
     leader.wait_for_sequencer_ready().await.unwrap();
 
     // Send a transaction to confirm the cluster works after recovery.
-    /*verify_replica_processes_tx(
+    verify_replica_processes_tx(
         &leader,
         &replica,
         &key_and_address.private_key,
@@ -150,8 +135,9 @@ async fn test_db_elected_leader_recovery_with_replica_when_only_leader_is_paused
         receiver_addr,
         1,
     )
-    .await;*/
+    .await;
 
+    replica.shutdown().await.unwrap();
     leader.shutdown().await.unwrap();
     setup.shutdown().await;
 }


### PR DESCRIPTION
# Description

See the relevant issue: #2652

  This PR fixes a bug where the preferred sequencer could reuse stale `StateRootTask` cache entries after the speculative executor was replaced.

  When recovery creates a fresh executor, the old speculative state is intentionally discarded. However, `StateRootTask` was keeping a separate cache keyed only by `rollup_height`, so the new executor could still hit cache entries produced by the old executor. That could trigger the panic:
  `User state root has changed at rollup_height=...`

  ## What this fixes

  - Prevents stale state-root cache entries from surviving an executor replacement
  - Fixes the recovery panic caused by cross-executor cache reuse
  - Preserves cache entries built by the replacement executor during replay/catchup

  ## How

  Each state-root request now carries the executor `executor_id`, and `StateRootTask` caches roots by `(executor_id, rollup_height)` instead of just rollup_height.

  That means:
  - old executor entries stay isolated to the old generation
  - the new executor cannot reuse stale roots from the discarded executor
  - replay still keeps the replacement executor’s own cache after swap

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2652
