### PR TITLE
Solana-offchain authenticator: add multisig support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,10 @@
 demo-rollup-readme.sh
-/target
+target
 lcov.info
 
 rustc-ice*
 
 .idea/
-
-target/
 
 .DS_Store
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - #2654 Replace `lazy_static` crate with `std::sync::LazyLock`
 - #2671 Fixes API archival query race condition
 - #2613 Adds two new constants: CHANGE_GAS_LIMIT_AFTER_HEIGHT and UPDATED_GAS_LIMIT. If your rollup does not need to update its gas limit, set these values to i64::MAX and your existing gas limit, respectively.
+- #2658 (Non-breaking) Add multisig support to the sov-solana-offchain-authenticator, but only when using simple signing (i.e. multisigs are not yet supported with Ledger wallets).
 
 # 2026-03-24
 - #2620 Adds proptests for checking consistency between simulation endpoints and sendRawTransaction

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -34,6 +34,11 @@ mod tests;
 mod types;
 mod unsigned;
 
+/// Re-exports for V1 (multisig) transaction constants.
+pub mod v1 {
+    pub use super::types::v1::MAX_SIGNERS;
+}
+
 /// Structures that implement this trait represent a call message that can be included in a
 /// transaction.
 /// By default, this is blanket-derived on anything implementing the `Runtime` trait, implementing

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -83,11 +83,11 @@ pub struct SolanaOffchainUnsignedTransactionV1<R: TransactionCallable, S: Spec> 
     /// from malicious chains (if the chain name matches some other chain the use but didn't expect
     /// to be signing for right now).
     pub chain_name: SafeString,
-    /// The credential_id derived from the multisig parameters (hash of min_signers + sorted
-    /// pubkeys). Included in the signed message so that signers commit to the multisig
-    /// configuration and prevent credential_id malleability from reusing signed bytes in a
-    /// different multisig envelope.
-    pub credential_id: CredentialId,
+    /// The credential_id (i.e. multisig address) derived from the multisig parameters (hash of
+    /// min_signers + sorted pubkeys). Included in the signed message so that signers commit to
+    /// the multisig configuration and prevent credential malleability from reusing signed bytes
+    /// in a different multisig envelope.
+    pub multisig_address: CredentialId,
     /// Message format version. Must be `1` for this struct.
     pub version: u8,
 }
@@ -594,7 +594,7 @@ where
                 ));
             }
             verify_multisig_commitment::<S>(
-                tx.credential_id,
+                tx.multisig_address,
                 signatures,
                 unused_pub_keys,
                 *min_signers,

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -89,13 +89,28 @@ pub struct SolanaOffchainUnsignedTransactionV1<R: TransactionCallable, S: Spec> 
     /// from malicious chains (if the chain name matches some other chain the use but didn't expect
     /// to be signing for right now).
     pub chain_name: SafeString,
-    /// The multisig address derived from the multisig parameters (hash of min_signers + sorted
+    /// The multisig credential derived from the multisig parameters (hash of min_signers + sorted
     /// pubkeys), formatted in the rollup's native address format. Included in the signed message
     /// so that signers commit to the multisig configuration and prevent credential malleability
     /// from reusing signed bytes in a different multisig envelope.
-    pub multisig_address: S::Address,
+    /// This is the "multisig address" except if the credential is mapped to another address in
+    /// `sov-accounts`.
+    pub multisig_id: S::Address,
     /// Message format version. Must be `1` for this struct.
+    #[serde(deserialize_with = "deserialize_version_1")]
     pub version: u8,
+}
+
+fn deserialize_version_1<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<u8, D::Error> {
+    let v = <u8 as serde::Deserialize>::deserialize(deserializer)?;
+    if v != 1 {
+        return Err(serde::de::Error::custom(format!(
+            "expected message version 1, got {v}"
+        )));
+    }
+    Ok(v)
 }
 
 impl<R, S> SolanaOffchainUnsignedTransactionV1<R, S>
@@ -478,7 +493,13 @@ fn unpack_spec_compliant_message<S: Spec>(
         borsh::from_slice(&envelope.signed_message_with_preamble[0..PREAMBLE_LEN])
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
 
-    let actual_message_length = envelope.signed_message_with_preamble.len() - PREAMBLE_LEN;
+    // Unwrap: we just checked that `envelope.signed_message_with_preamble.len()` >= `PREAMBLE_LEN`,
+    // so this can't underflow
+    let actual_message_length = envelope
+        .signed_message_with_preamble
+        .len()
+        .checked_sub(PREAMBLE_LEN)
+        .unwrap();
     preamble.validate(actual_message_length)?;
 
     let signer: <S::CryptoSpec as CryptoSpec>::PublicKey = borsh::from_slice(&preamble.signer)
@@ -602,17 +623,8 @@ where
         } => {
             let tx = SolanaOffchainUnsignedTransactionV1::<D, S>::unmetered_deserialize(json_slice)
                 .map_err(deser_err)?;
-            if tx.version != 1 {
-                return Err(AuthenticationError::FatalError(
-                    FatalError::DeserializationFailed(format!(
-                        "Expected message version 1, got {}",
-                        tx.version
-                    )),
-                    raw_tx_hash,
-                ));
-            }
             verify_multisig_commitment::<S>(
-                tx.multisig_address,
+                tx.multisig_id,
                 signatures,
                 unused_pub_keys,
                 *min_signers,

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -16,7 +16,7 @@ use sov_modules_api::transaction::{
 };
 use sov_modules_api::SafeVec;
 use sov_modules_api::{
-    charge_gas_to_deserialize_json, CryptoSpec, DispatchCall, GasMeter, GasSpec,
+    charge_gas_to_deserialize_json, CredentialId, CryptoSpec, DispatchCall, GasMeter, GasSpec,
     MeteredSigVerificationError, MeteredSignature, Multisig, ProvableStateReader, SafeString,
     Signature, Spec, TxHash,
 };
@@ -37,7 +37,7 @@ static SIGNATURE_CACHE: std::sync::LazyLock<SignatureVerificationCache<()>> =
 #[serde_with::serde_as]
 #[derive(Debug, Serialize, Deserialize, UniversalWallet)]
 #[serde(bound = "R::Call: serde::Serialize + serde::de::DeserializeOwned")]
-pub struct SolanaOffchainUnsignedTransaction<R: TransactionCallable, S: Spec> {
+pub struct SolanaOffchainUnsignedTransactionV0<R: TransactionCallable, S: Spec> {
     /// The runtime call
     pub runtime_call: R::Call,
     /// The uniqueness identifier
@@ -50,7 +50,7 @@ pub struct SolanaOffchainUnsignedTransaction<R: TransactionCallable, S: Spec> {
     pub chain_name: SafeString,
 }
 
-impl<R, S> SolanaOffchainUnsignedTransaction<R, S>
+impl<R, S> SolanaOffchainUnsignedTransactionV0<R, S>
 where
     S: Spec,
     R: TransactionCallable,
@@ -65,7 +65,49 @@ where
     }
 
     fn unmetered_deserialize(buf: &[u8]) -> Result<Self, serde_json::Error> {
-        serde_json::from_slice::<SolanaOffchainUnsignedTransaction<R, S>>(buf)
+        serde_json::from_slice::<SolanaOffchainUnsignedTransactionV0<R, S>>(buf)
+    }
+}
+
+#[serde_with::serde_as]
+#[derive(Debug, Serialize, Deserialize, UniversalWallet)]
+#[serde(bound = "R::Call: serde::Serialize + serde::de::DeserializeOwned")]
+pub struct SolanaOffchainUnsignedTransactionV1<R: TransactionCallable, S: Spec> {
+    /// The runtime call
+    pub runtime_call: R::Call,
+    /// The uniqueness identifier
+    pub uniqueness: UniquenessData,
+    /// Data related to fees and gas handling.
+    pub details: TxDetails<S>,
+    /// The chain name, so that users can verify the destination chain and avoid replay attacks
+    /// from malicious chains (if the chain name matches some other chain the use but didn't expect
+    /// to be signing for right now).
+    pub chain_name: SafeString,
+    /// The credential_id derived from the multisig parameters (hash of min_signers + sorted
+    /// pubkeys). Included in the signed message so that signers commit to the multisig
+    /// configuration and prevent credential_id malleability from reusing signed bytes in a
+    /// different multisig envelope.
+    pub credential_id: CredentialId,
+    /// Message format version. Must be `1` for this struct.
+    pub version: u8,
+}
+
+impl<R, S> SolanaOffchainUnsignedTransactionV1<R, S>
+where
+    S: Spec,
+    R: TransactionCallable,
+    <R as TransactionCallable>::Call: Serialize + DeserializeOwned,
+{
+    fn into_unsigned_tx(self) -> UnsignedTransaction<R, S> {
+        UnsignedTransaction {
+            runtime_call: self.runtime_call,
+            uniqueness: self.uniqueness,
+            details: self.details,
+        }
+    }
+
+    fn unmetered_deserialize(buf: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice::<SolanaOffchainUnsignedTransactionV1<R, S>>(buf)
     }
 }
 
@@ -94,19 +136,21 @@ pub struct SolanaOffchainSimpleMessage<S: Spec> {
 /// The first byte of a spec-compliant preamble (`\xffsolana offchain`), used to detect spec-compliant messages.
 pub const SPEC_COMPLIANT_DISCRIMINATOR: u8 = 0xff;
 
-/// Discriminator byte prepended to the signed message in the multisig simple format.
+/// Discriminator byte prepended to the wire message in the multisig simple format.
+/// Used only for borsh-level format routing (to distinguish multisig from single-sig envelopes).
 /// This byte is `0x80`, which cannot occur as the first byte of valid UTF-8 (and therefore JSON),
 /// nor does it collide with the spec-compliant preamble's [`SPEC_COMPLIANT_DISCRIMINATOR`].
+/// It is NOT part of the signed content — signers sign the JSON payload directly.
 pub const MULTISIG_SIMPLE_DISCRIMINATOR: u8 = 0x80;
 
 /// The envelope for a multisig "simple" (preamble-less) solana offchain message.
-/// Each signer independently signs the same `signed_message` bytes, which consist of the
-/// [`MULTISIG_SIMPLE_DISCRIMINATOR`] byte followed by the JSON-serialized unsigned transaction.
+/// Each signer independently signs the JSON payload (the bytes after the discriminator prefix).
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct SolanaOffchainSimpleMultisigMessage<S: Spec> {
-    /// The signed message: `[0x80][JSON-serialized SolanaOffchainUnsignedTransaction]`.
-    /// All signers sign the full content of this field (including the discriminator prefix).
-    pub signed_message: Vec<u8>,
+    /// Wire format: `[0x80][JSON-serialized SolanaOffchainUnsignedTransactionV1]`.
+    /// The `0x80` prefix is a parsing discriminator only — the signed content is the JSON
+    /// portion (everything after the first byte).
+    pub wire_bytes: Vec<u8>,
     /// The chain hash at time of signing.
     pub chain_hash: [u8; 32],
     /// Signatures with their corresponding public keys (the signers who actually signed).
@@ -204,10 +248,7 @@ impl<S: Spec> UnpackedSolanaMessage<S> {
                 json_start,
                 ..
             } => &signed_bytes[*json_start..],
-            UnpackedSolanaMessage::V1 { signed_bytes, .. } => {
-                // Skip the 0x80 discriminator prefix
-                &signed_bytes[1..]
-            }
+            UnpackedSolanaMessage::V1 { signed_bytes, .. } => signed_bytes,
         }
     }
 
@@ -361,6 +402,38 @@ fn build_auth_data<S: Spec>(
     }
 }
 
+/// Verifies that the credential_id committed to in the signed message matches the one derived
+/// from the multisig parameters in the transaction envelope. This prevents credential_id
+/// malleability, where signed bytes are reused in a different multisig envelope to derive a
+/// different account.
+fn verify_multisig_commitment<S: Spec>(
+    signed_credential_id: CredentialId,
+    envelope_signatures: &SafeVec<PubKeyAndSignature<S::CryptoSpec>, MAX_SIGNERS>,
+    envelope_unused_pub_keys: &SafeVec<<S::CryptoSpec as CryptoSpec>::PublicKey, MAX_SIGNERS>,
+    envelope_min_signers: u8,
+    raw_tx_hash: TxHash,
+) -> Result<(), AuthenticationError> {
+    let all_keys: Vec<_> = envelope_signatures
+        .iter()
+        .map(|s| s.pub_key.clone())
+        .chain(envelope_unused_pub_keys.iter().cloned())
+        .collect();
+    let envelope_credential_id = Multisig::new(envelope_min_signers, all_keys)
+        .credential_id::<<S::CryptoSpec as CryptoSpec>::Hasher>();
+
+    if signed_credential_id != envelope_credential_id {
+        return Err(AuthenticationError::FatalError(
+            FatalError::SigVerificationFailed(format!(
+                "Multisig credential_id mismatch: signed message commits to \
+                 {signed_credential_id}, but envelope parameters derive {envelope_credential_id}"
+            )),
+            raw_tx_hash,
+        ));
+    }
+
+    Ok(())
+}
+
 fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage<S>, FatalError> {
     // First 4 bytes are the length of the Vec<u8> as u32 (borsh encoding)
     if raw_tx.len() < 5 {
@@ -432,18 +505,21 @@ fn unpack_multisig_simple_message<S: Spec>(
     let msg: SolanaOffchainSimpleMultisigMessage<S> =
         borsh::from_slice(raw_tx).map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
 
-    if msg.signed_message.first() != Some(&MULTISIG_SIMPLE_DISCRIMINATOR) {
+    if msg.wire_bytes.first() != Some(&MULTISIG_SIMPLE_DISCRIMINATOR) {
         return Err(FatalError::DeserializationFailed(
             "Multisig simple message must start with 0x80 discriminator".to_string(),
         ));
     }
+
+    // The signed content is the JSON payload after the discriminator prefix.
+    let signed_bytes = msg.wire_bytes[1..].to_vec();
 
     Ok(UnpackedSolanaMessage::V1 {
         signatures: msg.signatures,
         unused_pub_keys: msg.unused_pub_keys,
         min_signers: msg.min_signers,
         chain_hash: msg.chain_hash,
-        signed_bytes: msg.signed_message,
+        signed_bytes,
     })
 }
 
@@ -455,7 +531,7 @@ where
     <D as DispatchCall>::Decodable: Serialize + DeserializeOwned,
 {
     let unpacked_message = unpack_solana_message::<S>(raw_tx)?;
-    let solana_unsigned_tx: SolanaOffchainUnsignedTransaction<D, S> =
+    let solana_unsigned_tx: SolanaOffchainUnsignedTransactionV0<D, S> =
         serde_json::from_slice(unpacked_message.json_bytes())
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
     Ok(solana_unsigned_tx.into_unsigned_tx().call())
@@ -479,25 +555,54 @@ where
     let unpacked_message = unpack_solana_message::<S>(raw_tx)
         .map_err(|e| AuthenticationError::FatalError(e, raw_tx_hash))?;
 
-    // Deserialize the JSON unsigned transaction (shared for all variants)
+    // Deserialize the JSON unsigned transaction.
+    // V0 (single-sig) and V1 (multisig) use different structs; for V1, we also verify
+    // that the credential_id committed to in the signed message matches the envelope.
     let json_slice = unpacked_message.json_bytes();
     charge_gas_to_deserialize_json(json_slice, state).map_err(|e| {
         AuthenticationError::OutOfGas(format!(
             "Transaction deserialization run out of gas: {e}, tx hash {raw_tx_hash}"
         ))
     })?;
-    let solana_unsigned_tx = SolanaOffchainUnsignedTransaction::<D, S>::unmetered_deserialize(
-        json_slice,
-    )
-    .map_err(|e| {
+    let deser_err = |e: serde_json::Error| {
         AuthenticationError::FatalError(
             FatalError::DeserializationFailed(e.to_string()),
             raw_tx_hash,
         )
-    })?;
-
-    let provided_chain_name = solana_unsigned_tx.chain_name.to_string();
-    let unsigned_tx = solana_unsigned_tx.into_unsigned_tx();
+    };
+    let (provided_chain_name, unsigned_tx) = match &unpacked_message {
+        UnpackedSolanaMessage::V0 { .. } => {
+            let tx = SolanaOffchainUnsignedTransactionV0::<D, S>::unmetered_deserialize(json_slice)
+                .map_err(deser_err)?;
+            (tx.chain_name.to_string(), tx.into_unsigned_tx())
+        }
+        UnpackedSolanaMessage::V1 {
+            signatures,
+            unused_pub_keys,
+            min_signers,
+            ..
+        } => {
+            let tx = SolanaOffchainUnsignedTransactionV1::<D, S>::unmetered_deserialize(json_slice)
+                .map_err(deser_err)?;
+            if tx.version != 1 {
+                return Err(AuthenticationError::FatalError(
+                    FatalError::DeserializationFailed(format!(
+                        "Expected message version 1, got {}",
+                        tx.version
+                    )),
+                    raw_tx_hash,
+                ));
+            }
+            verify_multisig_commitment::<S>(
+                tx.credential_id,
+                signatures,
+                unused_pub_keys,
+                *min_signers,
+                raw_tx_hash,
+            )?;
+            (tx.chain_name.to_string(), tx.into_unsigned_tx())
+        }
+    };
 
     // Validate chain hash, chain name, and chain ID (shared for all variants)
     if *unpacked_message.chain_hash() != *runtime_chain_hash {
@@ -633,8 +738,8 @@ pub mod test {
     #[test]
     fn test_unpack_multisig_simple_message() {
         let json_message = b"{\"test\":\"abcd\"}";
-        let mut signed_message = vec![MULTISIG_SIMPLE_DISCRIMINATOR];
-        signed_message.extend_from_slice(json_message);
+        let mut wire_bytes = vec![MULTISIG_SIMPLE_DISCRIMINATOR];
+        wire_bytes.extend_from_slice(json_message);
 
         let pubkey1 = Ed25519PrivateKey::generate().pub_key();
         let pubkey2 = Ed25519PrivateKey::generate().pub_key();
@@ -643,7 +748,7 @@ pub mod test {
         let sig2: Ed25519Signature = [2u8; 64].as_slice().try_into().unwrap();
 
         let envelope = SolanaOffchainSimpleMultisigMessage::<TestSpec> {
-            signed_message: signed_message.clone(),
+            wire_bytes,
             chain_hash: TEST_CHAIN_HASH,
             signatures: vec![
                 PubKeyAndSignature {
@@ -680,7 +785,8 @@ pub mod test {
         assert_eq!(unused_pub_keys.as_ref(), &[pubkey3]);
         assert_eq!(*min_signers, 2);
         assert_eq!(*chain_hash, TEST_CHAIN_HASH);
-        assert_eq!(signed_bytes, &signed_message);
+        // signed_bytes should be the JSON only (discriminator stripped)
+        assert_eq!(signed_bytes, json_message);
         assert_eq!(unpacked.json_bytes(), json_message);
     }
 

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -3,21 +3,22 @@ use std::fmt::Debug;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use sov_modules_api::capabilities::AuthorizationData;
 use sov_modules_api::capabilities::{
     calculate_hash_metered, verify_chain_id, AuthenticationError, AuthenticationOutput, FatalError,
     UniquenessData,
 };
 use sov_modules_api::macros::UniversalWallet;
+use sov_modules_api::transaction::Credentials;
+use sov_modules_api::transaction::{v1::MAX_SIGNERS, PubKeyAndSignature};
 use sov_modules_api::transaction::{
     AuthenticatedTransactionAndRawHash, TransactionCallable, TxDetails, UnsignedTransaction,
 };
-use sov_modules_api::capabilities::AuthorizationData;
-use sov_modules_api::transaction::PubKeyAndSignature;
-use sov_modules_api::transaction::Credentials;
+use sov_modules_api::SafeVec;
 use sov_modules_api::{
-    charge_gas_to_deserialize_json, CryptoSpec, DispatchCall, GasMeter, GasSpec, Multisig,
-    MeteredSigVerificationError, MeteredSignature, ProvableStateReader, SafeString, Signature,
-    Spec, TxHash,
+    charge_gas_to_deserialize_json, CryptoSpec, DispatchCall, GasMeter, GasSpec,
+    MeteredSigVerificationError, MeteredSignature, Multisig, ProvableStateReader, SafeString,
+    Signature, Spec, TxHash,
 };
 
 #[cfg(feature = "native")]
@@ -29,7 +30,8 @@ static SIGNATURE_CACHE: std::sync::LazyLock<SignatureVerificationCache<()>> =
 
 /// The payload for a solana offchain message.
 /// Essentially a wrapper around `sov_modules_api::transaction::UnsignedTransaction` that also
-/// includes the chain_hash, in order to ensure the hash gets signed as part of the message.
+/// includes the chain_name, in order to ensure the name gets displayed to the user and signed as
+/// part of the message.
 /// We duplicate the UnsignedTransaction type rather than wrapping it to ensure the JSON displayed
 /// to the user doesn't get too nested.
 #[serde_with::serde_as]
@@ -89,9 +91,12 @@ pub struct SolanaOffchainSimpleMessage<S: Spec> {
     pub signature: <S::CryptoSpec as CryptoSpec>::Signature,
 }
 
+/// The first byte of a spec-compliant preamble (`\xffsolana offchain`), used to detect spec-compliant messages.
+pub const SPEC_COMPLIANT_DISCRIMINATOR: u8 = 0xff;
+
 /// Discriminator byte prepended to the signed message in the multisig simple format.
 /// This byte is `0x80`, which cannot occur as the first byte of valid UTF-8 (and therefore JSON),
-/// nor does it collide with the spec-compliant preamble's `0xff` prefix.
+/// nor does it collide with the spec-compliant preamble's [`SPEC_COMPLIANT_DISCRIMINATOR`].
 pub const MULTISIG_SIMPLE_DISCRIMINATOR: u8 = 0x80;
 
 /// The envelope for a multisig "simple" (preamble-less) solana offchain message.
@@ -105,9 +110,17 @@ pub struct SolanaOffchainSimpleMultisigMessage<S: Spec> {
     /// The chain hash at time of signing.
     pub chain_hash: [u8; 32],
     /// Signatures with their corresponding public keys (the signers who actually signed).
-    pub signatures: Vec<PubKeyAndSignature<S::CryptoSpec>>,
+    #[borsh(bound(
+        serialize = "PubKeyAndSignature<S::CryptoSpec>: BorshSerialize",
+        deserialize = "PubKeyAndSignature<S::CryptoSpec>: BorshDeserialize",
+    ))]
+    pub signatures: SafeVec<PubKeyAndSignature<S::CryptoSpec>, MAX_SIGNERS>,
     /// Public keys that are part of the multisig but did not sign this transaction.
-    pub unused_pub_keys: Vec<<S::CryptoSpec as CryptoSpec>::PublicKey>,
+    #[borsh(bound(
+        serialize = "<S::CryptoSpec as CryptoSpec>::PublicKey: BorshSerialize",
+        deserialize = "<S::CryptoSpec as CryptoSpec>::PublicKey: BorshDeserialize",
+    ))]
+    pub unused_pub_keys: SafeVec<<S::CryptoSpec as CryptoSpec>::PublicKey, MAX_SIGNERS>,
     /// Minimum number of signers required for the multisig (the K in K-of-N).
     pub min_signers: u8,
 }
@@ -175,8 +188,8 @@ enum UnpackedSolanaMessage<S: Spec> {
         json_start: usize,
     },
     V1 {
-        signatures: Vec<PubKeyAndSignature<S::CryptoSpec>>,
-        unused_pub_keys: Vec<<S::CryptoSpec as CryptoSpec>::PublicKey>,
+        signatures: SafeVec<PubKeyAndSignature<S::CryptoSpec>, MAX_SIGNERS>,
+        unused_pub_keys: SafeVec<<S::CryptoSpec as CryptoSpec>::PublicKey, MAX_SIGNERS>,
         min_signers: u8,
         chain_hash: [u8; 32],
         signed_bytes: Vec<u8>,
@@ -261,9 +274,7 @@ fn verify_signatures<S: Spec>(
     // 3. Verify signatures (unmetered)
     let res = match unpacked {
         UnpackedSolanaMessage::V0 {
-            pub_key,
-            signature,
-            ..
+            pub_key, signature, ..
         } => signature.verify(pub_key, signed_bytes).map_err(|err| {
             AuthenticationError::FatalError(
                 FatalError::SigVerificationFailed(err.to_string()),
@@ -308,10 +319,9 @@ fn build_auth_data<S: Spec>(
 ) -> Result<AuthorizationData<S>, AuthenticationError> {
     match unpacked {
         UnpackedSolanaMessage::V0 { pub_key, .. } => {
-            let credential_id = sov_modules_api::metered_credential::<S, S::CryptoSpec>(
-                pub_key, meter,
-            )
-            .map_err(|e| AuthenticationError::OutOfGas(e.to_string()))?;
+            let credential_id =
+                sov_modules_api::metered_credential::<S, S::CryptoSpec>(pub_key, meter)
+                    .map_err(|e| AuthenticationError::OutOfGas(e.to_string()))?;
 
             Ok(AuthorizationData {
                 uniqueness,
@@ -338,8 +348,7 @@ fn build_auth_data<S: Spec>(
                 .chain(unused_pub_keys.iter().cloned())
                 .collect();
             let multisig = Multisig::new(*min_signers, all_keys);
-            let credential_id =
-                multisig.credential_id::<<S::CryptoSpec as CryptoSpec>::Hasher>();
+            let credential_id = multisig.credential_id::<<S::CryptoSpec as CryptoSpec>::Hasher>();
 
             Ok(AuthorizationData {
                 uniqueness,
@@ -364,7 +373,7 @@ fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage
     // 0xff → Spec-compliant message (preamble starts with \xffsolana offchain)
     // 0x80 → Multisig simple message (discriminator prefix)
     // Anything else → Simple message (JSON, typically starts with '{')
-    if raw_tx[4] == 0xff {
+    if raw_tx[4] == SPEC_COMPLIANT_DISCRIMINATOR {
         unpack_spec_compliant_message(raw_tx)
     } else if raw_tx[4] == MULTISIG_SIMPLE_DISCRIMINATOR {
         unpack_multisig_simple_message(raw_tx)
@@ -376,8 +385,8 @@ fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage
 fn unpack_spec_compliant_message<S: Spec>(
     raw_tx: &[u8],
 ) -> Result<UnpackedSolanaMessage<S>, FatalError> {
-    let envelope: SolanaOffchainSpecCompliantMessage<S> = borsh::from_slice(raw_tx)
-        .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
+    let envelope: SolanaOffchainSpecCompliantMessage<S> =
+        borsh::from_slice(raw_tx).map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
 
     if envelope.signed_message_with_preamble.len() < PREAMBLE_LEN {
         return Err(FatalError::DeserializationFailed(
@@ -404,11 +413,9 @@ fn unpack_spec_compliant_message<S: Spec>(
     })
 }
 
-fn unpack_simple_message<S: Spec>(
-    raw_tx: &[u8],
-) -> Result<UnpackedSolanaMessage<S>, FatalError> {
-    let raw_message: SolanaOffchainSimpleMessage<S> = borsh::from_slice(raw_tx)
-        .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
+fn unpack_simple_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage<S>, FatalError> {
+    let raw_message: SolanaOffchainSimpleMessage<S> =
+        borsh::from_slice(raw_tx).map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
 
     Ok(UnpackedSolanaMessage::V0 {
         pub_key: raw_message.pubkey,
@@ -422,8 +429,8 @@ fn unpack_simple_message<S: Spec>(
 fn unpack_multisig_simple_message<S: Spec>(
     raw_tx: &[u8],
 ) -> Result<UnpackedSolanaMessage<S>, FatalError> {
-    let msg: SolanaOffchainSimpleMultisigMessage<S> = borsh::from_slice(raw_tx)
-        .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
+    let msg: SolanaOffchainSimpleMultisigMessage<S> =
+        borsh::from_slice(raw_tx).map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
 
     if msg.signed_message.first() != Some(&MULTISIG_SIMPLE_DISCRIMINATOR) {
         return Err(FatalError::DeserializationFailed(
@@ -519,15 +526,23 @@ where
     verify_signatures::<S>(&unpacked_message, raw_tx_hash, state)?;
 
     // Build authorization data (branches internally for single-sig vs multisig)
-    let authorization_data =
-        build_auth_data::<S>(&unpacked_message, unsigned_tx.uniqueness, raw_tx_hash, state)?;
+    let authorization_data = build_auth_data::<S>(
+        &unpacked_message,
+        unsigned_tx.uniqueness,
+        raw_tx_hash,
+        state,
+    )?;
 
     let tx_and_raw_hash = AuthenticatedTransactionAndRawHash {
         raw_tx_hash,
         authenticated_tx: unsigned_tx.details.into(),
     };
 
-    Ok((tx_and_raw_hash, authorization_data, unsigned_tx.runtime_call))
+    Ok((
+        tx_and_raw_hash,
+        authorization_data,
+        unsigned_tx.runtime_call,
+    ))
 }
 
 #[cfg(test)]
@@ -639,8 +654,10 @@ pub mod test {
                     signature: sig2,
                     pub_key: pubkey2.clone(),
                 },
-            ],
-            unused_pub_keys: vec![pubkey3.clone()],
+            ]
+            .try_into()
+            .unwrap(),
+            unused_pub_keys: vec![pubkey3.clone()].try_into().unwrap(),
             min_signers: 2,
         };
 
@@ -660,7 +677,7 @@ pub mod test {
         assert_eq!(signatures.len(), 2);
         assert_eq!(signatures[0].pub_key, pubkey1);
         assert_eq!(signatures[1].pub_key, pubkey2);
-        assert_eq!(unused_pub_keys, &vec![pubkey3]);
+        assert_eq!(unused_pub_keys.as_ref(), &[pubkey3]);
         assert_eq!(*min_signers, 2);
         assert_eq!(*chain_hash, TEST_CHAIN_HASH);
         assert_eq!(signed_bytes, &signed_message);

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -16,7 +16,7 @@ use sov_modules_api::transaction::{
 };
 use sov_modules_api::SafeVec;
 use sov_modules_api::{
-    charge_gas_to_deserialize_json, CredentialId, CryptoSpec, DispatchCall, GasMeter, GasSpec,
+    charge_gas_to_deserialize_json, CryptoSpec, DispatchCall, GasMeter, GasSpec,
     MeteredSigVerificationError, MeteredSignature, Multisig, ProvableStateReader, SafeString,
     Signature, Spec, TxHash,
 };
@@ -36,7 +36,10 @@ static SIGNATURE_CACHE: std::sync::LazyLock<SignatureVerificationCache<()>> =
 /// to the user doesn't get too nested.
 #[serde_with::serde_as]
 #[derive(Debug, Serialize, Deserialize, UniversalWallet)]
-#[serde(deny_unknown_fields, bound = "R::Call: serde::Serialize + serde::de::DeserializeOwned")]
+#[serde(
+    deny_unknown_fields,
+    bound = "R::Call: serde::Serialize + serde::de::DeserializeOwned"
+)]
 pub struct SolanaOffchainUnsignedTransactionV0<R: TransactionCallable, S: Spec> {
     /// The runtime call
     pub runtime_call: R::Call,
@@ -71,7 +74,10 @@ where
 
 #[serde_with::serde_as]
 #[derive(Debug, Serialize, Deserialize, UniversalWallet)]
-#[serde(deny_unknown_fields, bound = "R::Call: serde::Serialize + serde::de::DeserializeOwned")]
+#[serde(
+    deny_unknown_fields,
+    bound = "R::Call: serde::Serialize + serde::de::DeserializeOwned"
+)]
 pub struct SolanaOffchainUnsignedTransactionV1<R: TransactionCallable, S: Spec> {
     /// The runtime call
     pub runtime_call: R::Call,
@@ -83,11 +89,11 @@ pub struct SolanaOffchainUnsignedTransactionV1<R: TransactionCallable, S: Spec> 
     /// from malicious chains (if the chain name matches some other chain the use but didn't expect
     /// to be signing for right now).
     pub chain_name: SafeString,
-    /// The credential_id (i.e. multisig address) derived from the multisig parameters (hash of
-    /// min_signers + sorted pubkeys). Included in the signed message so that signers commit to
-    /// the multisig configuration and prevent credential malleability from reusing signed bytes
-    /// in a different multisig envelope.
-    pub multisig_address: CredentialId,
+    /// The multisig address derived from the multisig parameters (hash of min_signers + sorted
+    /// pubkeys), formatted in the rollup's native address format. Included in the signed message
+    /// so that signers commit to the multisig configuration and prevent credential malleability
+    /// from reusing signed bytes in a different multisig envelope.
+    pub multisig_address: S::Address,
     /// Message format version. Must be `1` for this struct.
     pub version: u8,
 }
@@ -402,12 +408,12 @@ fn build_auth_data<S: Spec>(
     }
 }
 
-/// Verifies that the credential_id committed to in the signed message matches the one derived
-/// from the multisig parameters in the transaction envelope. This prevents credential_id
+/// Verifies that the multisig address committed to in the signed message matches the one derived
+/// from the multisig parameters in the transaction envelope. This prevents credential
 /// malleability, where signed bytes are reused in a different multisig envelope to derive a
 /// different account.
 fn verify_multisig_commitment<S: Spec>(
-    signed_credential_id: CredentialId,
+    signed_address: S::Address,
     envelope_signatures: &SafeVec<PubKeyAndSignature<S::CryptoSpec>, MAX_SIGNERS>,
     envelope_unused_pub_keys: &SafeVec<<S::CryptoSpec as CryptoSpec>::PublicKey, MAX_SIGNERS>,
     envelope_min_signers: u8,
@@ -418,14 +424,15 @@ fn verify_multisig_commitment<S: Spec>(
         .map(|s| s.pub_key.clone())
         .chain(envelope_unused_pub_keys.iter().cloned())
         .collect();
-    let envelope_credential_id = Multisig::new(envelope_min_signers, all_keys)
-        .credential_id::<<S::CryptoSpec as CryptoSpec>::Hasher>();
+    let envelope_address: S::Address = Multisig::new(envelope_min_signers, all_keys)
+        .credential_id::<<S::CryptoSpec as CryptoSpec>::Hasher>()
+        .into();
 
-    if signed_credential_id != envelope_credential_id {
+    if signed_address != envelope_address {
         return Err(AuthenticationError::FatalError(
             FatalError::SigVerificationFailed(format!(
-                "Multisig credential_id mismatch: signed message commits to \
-                 {signed_credential_id}, but envelope parameters derive {envelope_credential_id}"
+                "Multisig address mismatch: signed message commits to \
+                 {signed_address}, but envelope parameters derive {envelope_address}"
             )),
             raw_tx_hash,
         ));
@@ -531,10 +538,21 @@ where
     <D as DispatchCall>::Decodable: Serialize + DeserializeOwned,
 {
     let unpacked_message = unpack_solana_message::<S>(raw_tx)?;
-    let solana_unsigned_tx: SolanaOffchainUnsignedTransactionV0<D, S> =
-        serde_json::from_slice(unpacked_message.json_bytes())
-            .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
-    Ok(solana_unsigned_tx.into_unsigned_tx().call())
+    let json_bytes = unpacked_message.json_bytes();
+    let deser_err = |e: serde_json::Error| FatalError::DeserializationFailed(e.to_string());
+    let unsigned_tx = match &unpacked_message {
+        UnpackedSolanaMessage::V0 { .. } => {
+            SolanaOffchainUnsignedTransactionV0::<D, S>::unmetered_deserialize(json_bytes)
+                .map_err(deser_err)?
+                .into_unsigned_tx()
+        }
+        UnpackedSolanaMessage::V1 { .. } => {
+            SolanaOffchainUnsignedTransactionV1::<D, S>::unmetered_deserialize(json_bytes)
+                .map_err(deser_err)?
+                .into_unsigned_tx()
+        }
+    };
+    Ok(unsigned_tx.call())
 }
 
 pub fn authenticate<Accessor, S, D>(

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -9,10 +9,13 @@ use sov_modules_api::capabilities::{
 };
 use sov_modules_api::macros::UniversalWallet;
 use sov_modules_api::transaction::{
-    self, AuthenticatedTransactionAndRawHash, TransactionCallable, TxDetails, UnsignedTransaction,
+    AuthenticatedTransactionAndRawHash, TransactionCallable, TxDetails, UnsignedTransaction,
 };
+use sov_modules_api::capabilities::AuthorizationData;
+use sov_modules_api::transaction::PubKeyAndSignature;
+use sov_modules_api::transaction::Credentials;
 use sov_modules_api::{
-    charge_gas_to_deserialize_json, CryptoSpec, DispatchCall, GasMeter,
+    charge_gas_to_deserialize_json, CryptoSpec, DispatchCall, GasMeter, GasSpec, Multisig,
     MeteredSigVerificationError, MeteredSignature, ProvableStateReader, SafeString, Signature,
     Spec, TxHash,
 };
@@ -86,6 +89,29 @@ pub struct SolanaOffchainSimpleMessage<S: Spec> {
     pub signature: <S::CryptoSpec as CryptoSpec>::Signature,
 }
 
+/// Discriminator byte prepended to the signed message in the multisig simple format.
+/// This byte is `0x80`, which cannot occur as the first byte of valid UTF-8 (and therefore JSON),
+/// nor does it collide with the spec-compliant preamble's `0xff` prefix.
+pub const MULTISIG_SIMPLE_DISCRIMINATOR: u8 = 0x80;
+
+/// The envelope for a multisig "simple" (preamble-less) solana offchain message.
+/// Each signer independently signs the same `signed_message` bytes, which consist of the
+/// [`MULTISIG_SIMPLE_DISCRIMINATOR`] byte followed by the JSON-serialized unsigned transaction.
+#[derive(BorshSerialize, BorshDeserialize)]
+pub struct SolanaOffchainSimpleMultisigMessage<S: Spec> {
+    /// The signed message: `[0x80][JSON-serialized SolanaOffchainUnsignedTransaction]`.
+    /// All signers sign the full content of this field (including the discriminator prefix).
+    pub signed_message: Vec<u8>,
+    /// The chain hash at time of signing.
+    pub chain_hash: [u8; 32],
+    /// Signatures with their corresponding public keys (the signers who actually signed).
+    pub signatures: Vec<PubKeyAndSignature<S::CryptoSpec>>,
+    /// Public keys that are part of the multisig but did not sign this transaction.
+    pub unused_pub_keys: Vec<<S::CryptoSpec as CryptoSpec>::PublicKey>,
+    /// Minimum number of signers required for the multisig (the K in K-of-N).
+    pub min_signers: u8,
+}
+
 /// The length of a preamble with a single 32-byte signer. This is just the sum of the lengths of
 /// the byte fields/arrays of the struct below.
 pub const PREAMBLE_LEN: usize = 85;
@@ -140,31 +166,61 @@ impl RawSolanaOffchainMessagePreamble {
     }
 }
 
-struct UnpackedSolanaMessage<S: Spec> {
-    pub_key: <S::CryptoSpec as CryptoSpec>::PublicKey,
-    signature: <S::CryptoSpec as CryptoSpec>::Signature,
-    chain_hash: [u8; 32],
-    signed_bytes: Vec<u8>,
-    json_start: usize,
+enum UnpackedSolanaMessage<S: Spec> {
+    V0 {
+        pub_key: <S::CryptoSpec as CryptoSpec>::PublicKey,
+        signature: <S::CryptoSpec as CryptoSpec>::Signature,
+        chain_hash: [u8; 32],
+        signed_bytes: Vec<u8>,
+        json_start: usize,
+    },
+    V1 {
+        signatures: Vec<PubKeyAndSignature<S::CryptoSpec>>,
+        unused_pub_keys: Vec<<S::CryptoSpec as CryptoSpec>::PublicKey>,
+        min_signers: u8,
+        chain_hash: [u8; 32],
+        signed_bytes: Vec<u8>,
+    },
 }
 
 impl<S: Spec> UnpackedSolanaMessage<S> {
     fn json_bytes(&self) -> &[u8] {
-        &self.signed_bytes[self.json_start..]
+        match self {
+            UnpackedSolanaMessage::V0 {
+                signed_bytes,
+                json_start,
+                ..
+            } => &signed_bytes[*json_start..],
+            UnpackedSolanaMessage::V1 { signed_bytes, .. } => {
+                // Skip the 0x80 discriminator prefix
+                &signed_bytes[1..]
+            }
+        }
+    }
+
+    fn chain_hash(&self) -> &[u8; 32] {
+        match self {
+            UnpackedSolanaMessage::V0 { chain_hash, .. }
+            | UnpackedSolanaMessage::V1 { chain_hash, .. } => chain_hash,
+        }
+    }
+
+    fn signed_bytes(&self) -> &[u8] {
+        match self {
+            UnpackedSolanaMessage::V0 { signed_bytes, .. }
+            | UnpackedSolanaMessage::V1 { signed_bytes, .. } => signed_bytes,
+        }
     }
 }
 
-/// Verifies a signature over the signed bytes with gas metering
-fn verify_solana_signature<S: Spec>(
-    pub_key: &<S::CryptoSpec as CryptoSpec>::PublicKey,
+fn charge_sig_gas<S: Spec>(
     signature: &<S::CryptoSpec as CryptoSpec>::Signature,
-    signed_bytes: &[u8],
+    msg_len: usize,
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<(), AuthenticationError> {
-    // Charge gas first, before checking the cache
     MeteredSignature::new::<S>(signature.clone())
-        .charge_gas(meter, signed_bytes.len())
+        .charge_gas(meter, msg_len)
         .map_err(|e| match e {
             MeteredSigVerificationError::GasError(e) => {
                 AuthenticationError::OutOfGas(format!("Signature verification ran out of gas: {e}"))
@@ -173,25 +229,127 @@ fn verify_solana_signature<S: Spec>(
                 FatalError::SigVerificationFailed(e.to_string()),
                 raw_tx_hash,
             ),
-        })?;
+        })
+}
 
+/// Verifies signatures with gas metering and caching, handling both single-sig and multisig.
+fn verify_signatures<S: Spec>(
+    unpacked: &UnpackedSolanaMessage<S>,
+    raw_tx_hash: TxHash,
+    meter: &mut impl GasMeter<Spec = S>,
+) -> Result<(), AuthenticationError> {
+    let signed_bytes = unpacked.signed_bytes();
+
+    // 1. Charge gas for all signatures before checking the cache
+    match unpacked {
+        UnpackedSolanaMessage::V0 { signature, .. } => {
+            charge_sig_gas::<S>(signature, signed_bytes.len(), raw_tx_hash, meter)?;
+        }
+        UnpackedSolanaMessage::V1 { signatures, .. } => {
+            for sig in signatures {
+                charge_sig_gas::<S>(&sig.signature, signed_bytes.len(), raw_tx_hash, meter)?;
+            }
+        }
+    }
+
+    // 2. Check cache (native-only)
     #[cfg(feature = "native")]
     if let Some(known_result) = SIGNATURE_CACHE.get(&raw_tx_hash) {
         return known_result;
     }
 
-    // Now perform the verification (unmetered)
-    let res = signature.verify(pub_key, signed_bytes).map_err(|err| {
-        AuthenticationError::FatalError(
-            FatalError::SigVerificationFailed(err.to_string()),
-            raw_tx_hash,
-        )
-    });
+    // 3. Verify signatures (unmetered)
+    let res = match unpacked {
+        UnpackedSolanaMessage::V0 {
+            pub_key,
+            signature,
+            ..
+        } => signature.verify(pub_key, signed_bytes).map_err(|err| {
+            AuthenticationError::FatalError(
+                FatalError::SigVerificationFailed(err.to_string()),
+                raw_tx_hash,
+            )
+        }),
+        UnpackedSolanaMessage::V1 {
+            signatures,
+            unused_pub_keys,
+            min_signers,
+            ..
+        } => {
+            let all_keys: Vec<_> = signatures
+                .iter()
+                .map(|s| s.pub_key.clone())
+                .chain(unused_pub_keys.iter().cloned())
+                .collect();
+            Multisig::new(*min_signers, all_keys)
+                .verify_signature(signed_bytes, signatures)
+                .map_err(|err| {
+                    AuthenticationError::FatalError(
+                        FatalError::SigVerificationFailed(err.to_string()),
+                        raw_tx_hash,
+                    )
+                })
+        }
+    };
 
+    // 4. Cache result (native-only)
     #[cfg(feature = "native")]
     SIGNATURE_CACHE.insert(raw_tx_hash, res.clone());
 
     res
+}
+
+/// Builds authorization data for either single-sig or multisig transactions.
+fn build_auth_data<S: Spec>(
+    unpacked: &UnpackedSolanaMessage<S>,
+    uniqueness: UniquenessData,
+    raw_tx_hash: TxHash,
+    meter: &mut impl GasMeter<Spec = S>,
+) -> Result<AuthorizationData<S>, AuthenticationError> {
+    match unpacked {
+        UnpackedSolanaMessage::V0 { pub_key, .. } => {
+            let credential_id = sov_modules_api::metered_credential::<S, S::CryptoSpec>(
+                pub_key, meter,
+            )
+            .map_err(|e| AuthenticationError::OutOfGas(e.to_string()))?;
+
+            Ok(AuthorizationData {
+                uniqueness,
+                tx_hash: raw_tx_hash,
+                credential_id,
+                credentials: Credentials::new(pub_key.clone()),
+                default_address: credential_id.into(),
+            })
+        }
+        UnpackedSolanaMessage::V1 {
+            signatures,
+            unused_pub_keys,
+            min_signers,
+            ..
+        } => {
+            let num_keys = (signatures.len() + unused_pub_keys.len()) as u32;
+            meter
+                .charge_linear_gas(S::gas_to_charge_for_credential(), num_keys)
+                .map_err(|e| AuthenticationError::OutOfGas(e.to_string()))?;
+
+            let all_keys: Vec<_> = signatures
+                .iter()
+                .map(|s| s.pub_key.clone())
+                .chain(unused_pub_keys.iter().cloned())
+                .collect();
+            let multisig = Multisig::new(*min_signers, all_keys);
+            let credential_id =
+                multisig.credential_id::<<S::CryptoSpec as CryptoSpec>::Hasher>();
+
+            Ok(AuthorizationData {
+                uniqueness,
+                tx_hash: raw_tx_hash,
+                credential_id,
+                credentials: Credentials::new(multisig),
+                default_address: credential_id.into(),
+            })
+        }
+    }
 }
 
 fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage<S>, FatalError> {
@@ -202,52 +360,84 @@ fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage
         ));
     }
 
-    // The fifth byte tells us which format we're dealing with
+    // The fifth byte tells us which format we're dealing with:
+    // 0xff → Spec-compliant message (preamble starts with \xffsolana offchain)
+    // 0x80 → Multisig simple message (discriminator prefix)
+    // Anything else → Simple message (JSON, typically starts with '{')
     if raw_tx[4] == 0xff {
-        // Spec-compliant message with preamble
-        let envelope: SolanaOffchainSpecCompliantMessage<S> = borsh::from_slice(raw_tx)
-            .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
-
-        // Verify preamble is present and valid
-        if envelope.signed_message_with_preamble.len() < PREAMBLE_LEN {
-            return Err(FatalError::DeserializationFailed(
-                "Message too short for preamble".to_string(),
-            ));
-        }
-
-        let preamble: RawSolanaOffchainMessagePreamble =
-            borsh::from_slice(&envelope.signed_message_with_preamble[0..PREAMBLE_LEN])
-                .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
-
-        // Calculate actual message length (excluding preamble)
-        let actual_message_length = envelope.signed_message_with_preamble.len() - PREAMBLE_LEN;
-
-        // Validate the preamble
-        preamble.validate(actual_message_length)?;
-
-        let signer: <S::CryptoSpec as CryptoSpec>::PublicKey = borsh::from_slice(&preamble.signer)
-            .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
-
-        Ok(UnpackedSolanaMessage {
-            pub_key: signer,
-            signature: envelope.signature,
-            chain_hash: preamble.application_domain,
-            signed_bytes: envelope.signed_message_with_preamble,
-            json_start: PREAMBLE_LEN,
-        })
+        unpack_spec_compliant_message(raw_tx)
+    } else if raw_tx[4] == MULTISIG_SIMPLE_DISCRIMINATOR {
+        unpack_multisig_simple_message(raw_tx)
     } else {
-        // Raw message without preamble (should start with ASCII character, typically '{')
-        let raw_message: SolanaOffchainSimpleMessage<S> = borsh::from_slice(raw_tx)
+        unpack_simple_message(raw_tx)
+    }
+}
+
+fn unpack_spec_compliant_message<S: Spec>(
+    raw_tx: &[u8],
+) -> Result<UnpackedSolanaMessage<S>, FatalError> {
+    let envelope: SolanaOffchainSpecCompliantMessage<S> = borsh::from_slice(raw_tx)
+        .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
+
+    if envelope.signed_message_with_preamble.len() < PREAMBLE_LEN {
+        return Err(FatalError::DeserializationFailed(
+            "Message too short for preamble".to_string(),
+        ));
+    }
+
+    let preamble: RawSolanaOffchainMessagePreamble =
+        borsh::from_slice(&envelope.signed_message_with_preamble[0..PREAMBLE_LEN])
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
 
-        Ok(UnpackedSolanaMessage {
-            pub_key: raw_message.pubkey,
-            signature: raw_message.signature,
-            chain_hash: raw_message.chain_hash,
-            signed_bytes: raw_message.signed_message,
-            json_start: 0,
-        })
+    let actual_message_length = envelope.signed_message_with_preamble.len() - PREAMBLE_LEN;
+    preamble.validate(actual_message_length)?;
+
+    let signer: <S::CryptoSpec as CryptoSpec>::PublicKey = borsh::from_slice(&preamble.signer)
+        .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
+
+    Ok(UnpackedSolanaMessage::V0 {
+        pub_key: signer,
+        signature: envelope.signature,
+        chain_hash: preamble.application_domain,
+        signed_bytes: envelope.signed_message_with_preamble,
+        json_start: PREAMBLE_LEN,
+    })
+}
+
+fn unpack_simple_message<S: Spec>(
+    raw_tx: &[u8],
+) -> Result<UnpackedSolanaMessage<S>, FatalError> {
+    let raw_message: SolanaOffchainSimpleMessage<S> = borsh::from_slice(raw_tx)
+        .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
+
+    Ok(UnpackedSolanaMessage::V0 {
+        pub_key: raw_message.pubkey,
+        signature: raw_message.signature,
+        chain_hash: raw_message.chain_hash,
+        signed_bytes: raw_message.signed_message,
+        json_start: 0,
+    })
+}
+
+fn unpack_multisig_simple_message<S: Spec>(
+    raw_tx: &[u8],
+) -> Result<UnpackedSolanaMessage<S>, FatalError> {
+    let msg: SolanaOffchainSimpleMultisigMessage<S> = borsh::from_slice(raw_tx)
+        .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
+
+    if msg.signed_message.first() != Some(&MULTISIG_SIMPLE_DISCRIMINATOR) {
+        return Err(FatalError::DeserializationFailed(
+            "Multisig simple message must start with 0x80 discriminator".to_string(),
+        ));
     }
+
+    Ok(UnpackedSolanaMessage::V1 {
+        signatures: msg.signatures,
+        unused_pub_keys: msg.unused_pub_keys,
+        min_signers: msg.min_signers,
+        chain_hash: msg.chain_hash,
+        signed_bytes: msg.signed_message,
+    })
 }
 
 /// Decode bytes as a Sovereign SDK transaction, returning the message and tx info.
@@ -282,6 +472,7 @@ where
     let unpacked_message = unpack_solana_message::<S>(raw_tx)
         .map_err(|e| AuthenticationError::FatalError(e, raw_tx_hash))?;
 
+    // Deserialize the JSON unsigned transaction (shared for all variants)
     let json_slice = unpacked_message.json_bytes();
     charge_gas_to_deserialize_json(json_slice, state).map_err(|e| {
         AuthenticationError::OutOfGas(format!(
@@ -299,22 +490,14 @@ where
     })?;
 
     let provided_chain_name = solana_unsigned_tx.chain_name.to_string();
-
-    // This is useful to be able to reuse some of the standard authenticator's logic
     let unsigned_tx = solana_unsigned_tx.into_unsigned_tx();
-    let reconstructed_tx_v0 = transaction::Version0::<_, S, S::CryptoSpec> {
-        runtime_call: unsigned_tx.runtime_call,
-        uniqueness: unsigned_tx.uniqueness,
-        details: unsigned_tx.details,
-        signature: unpacked_message.signature,
-        pub_key: unpacked_message.pub_key,
-    };
 
-    if unpacked_message.chain_hash != *runtime_chain_hash {
+    // Validate chain hash, chain name, and chain ID (shared for all variants)
+    if *unpacked_message.chain_hash() != *runtime_chain_hash {
         return Err(AuthenticationError::FatalError(
             FatalError::InvalidChainHash {
                 expected: hex::encode(runtime_chain_hash),
-                got: hex::encode(unpacked_message.chain_hash),
+                got: hex::encode(unpacked_message.chain_hash()),
             },
             raw_tx_hash,
         ));
@@ -330,28 +513,21 @@ where
         ));
     }
 
-    verify_chain_id(&reconstructed_tx_v0.details, raw_tx_hash)?;
+    verify_chain_id(&unsigned_tx.details, raw_tx_hash)?;
 
-    verify_solana_signature::<S>(
-        &reconstructed_tx_v0.pub_key,
-        &reconstructed_tx_v0.signature,
-        &unpacked_message.signed_bytes,
-        raw_tx_hash,
-        state,
-    )?;
+    // Verify signatures (branches internally for single-sig vs multisig)
+    verify_signatures::<S>(&unpacked_message, raw_tx_hash, state)?;
 
-    let authorization_data = reconstructed_tx_v0.auth_data(raw_tx_hash, state)?;
+    // Build authorization data (branches internally for single-sig vs multisig)
+    let authorization_data =
+        build_auth_data::<S>(&unpacked_message, unsigned_tx.uniqueness, raw_tx_hash, state)?;
 
     let tx_and_raw_hash = AuthenticatedTransactionAndRawHash {
         raw_tx_hash,
-        authenticated_tx: reconstructed_tx_v0.details.clone().into(),
+        authenticated_tx: unsigned_tx.details.into(),
     };
 
-    Ok((
-        tx_and_raw_hash,
-        authorization_data,
-        reconstructed_tx_v0.runtime_call,
-    ))
+    Ok((tx_and_raw_hash, authorization_data, unsigned_tx.runtime_call))
 }
 
 #[cfg(test)]
@@ -371,7 +547,6 @@ pub mod test {
         let message = b"{\"test\":\"abcd\"}";
         let message_len = message.len() as u16;
 
-        // Placeholder pubkey and signature, this is only testing parsing and not authentication
         let pubkey = Ed25519PrivateKey::generate().pub_key();
         let signature: Ed25519Signature = [4u8; 64].as_slice().try_into().unwrap();
 
@@ -388,22 +563,28 @@ pub mod test {
 
         let serialized = borsh::to_vec(&envelope).unwrap();
 
-        let result = unpack_solana_message::<TestSpec>(&serialized);
-        assert!(result.is_ok());
-
-        let unpacked = result.unwrap();
-        assert_eq!(unpacked.pub_key, pubkey);
-        assert_eq!(unpacked.signature, signature);
-        assert_eq!(unpacked.chain_hash, TEST_CHAIN_HASH);
+        let unpacked = unpack_solana_message::<TestSpec>(&serialized).unwrap();
+        let UnpackedSolanaMessage::V0 {
+            pub_key: got_pk,
+            signature: got_sig,
+            chain_hash: got_ch,
+            signed_bytes: got_sb,
+            ..
+        } = &unpacked
+        else {
+            panic!("Expected SingleSig variant");
+        };
+        assert_eq!(*got_pk, pubkey);
+        assert_eq!(*got_sig, signature);
+        assert_eq!(*got_ch, TEST_CHAIN_HASH);
         assert_eq!(unpacked.json_bytes(), message);
-        assert_eq!(unpacked.signed_bytes, signed_message);
+        assert_eq!(*got_sb, signed_message);
     }
 
     #[test]
     fn test_unpack_raw_message() {
         let message = b"{\"test\":\"abcd\"}";
 
-        // Placeholder pubkey and signature, this is only testing parsing and not authentication
         let pubkey = Ed25519PrivateKey::generate().pub_key();
         let signature: Ed25519Signature = [4u8; 64].as_slice().try_into().unwrap();
 
@@ -416,15 +597,74 @@ pub mod test {
 
         let serialized = borsh::to_vec(&raw_message).unwrap();
 
-        let result = unpack_solana_message::<TestSpec>(&serialized);
-        assert!(result.is_ok());
-
-        let unpacked = result.unwrap();
-        assert_eq!(unpacked.pub_key, pubkey);
-        assert_eq!(unpacked.signature, signature);
-        assert_eq!(unpacked.chain_hash, TEST_CHAIN_HASH);
+        let unpacked = unpack_solana_message::<TestSpec>(&serialized).unwrap();
+        let UnpackedSolanaMessage::V0 {
+            pub_key: got_pk,
+            signature: got_sig,
+            chain_hash: got_ch,
+            signed_bytes: got_sb,
+            ..
+        } = &unpacked
+        else {
+            panic!("Expected SingleSig variant");
+        };
+        assert_eq!(*got_pk, pubkey);
+        assert_eq!(*got_sig, signature);
+        assert_eq!(*got_ch, TEST_CHAIN_HASH);
         assert_eq!(unpacked.json_bytes(), message);
-        assert_eq!(unpacked.signed_bytes, message);
+        assert_eq!(got_sb.as_slice(), message);
+    }
+
+    #[test]
+    fn test_unpack_multisig_simple_message() {
+        let json_message = b"{\"test\":\"abcd\"}";
+        let mut signed_message = vec![MULTISIG_SIMPLE_DISCRIMINATOR];
+        signed_message.extend_from_slice(json_message);
+
+        let pubkey1 = Ed25519PrivateKey::generate().pub_key();
+        let pubkey2 = Ed25519PrivateKey::generate().pub_key();
+        let pubkey3 = Ed25519PrivateKey::generate().pub_key();
+        let sig1: Ed25519Signature = [1u8; 64].as_slice().try_into().unwrap();
+        let sig2: Ed25519Signature = [2u8; 64].as_slice().try_into().unwrap();
+
+        let envelope = SolanaOffchainSimpleMultisigMessage::<TestSpec> {
+            signed_message: signed_message.clone(),
+            chain_hash: TEST_CHAIN_HASH,
+            signatures: vec![
+                PubKeyAndSignature {
+                    signature: sig1,
+                    pub_key: pubkey1.clone(),
+                },
+                PubKeyAndSignature {
+                    signature: sig2,
+                    pub_key: pubkey2.clone(),
+                },
+            ],
+            unused_pub_keys: vec![pubkey3.clone()],
+            min_signers: 2,
+        };
+
+        let serialized = borsh::to_vec(&envelope).unwrap();
+
+        let unpacked = unpack_solana_message::<TestSpec>(&serialized).unwrap();
+        let UnpackedSolanaMessage::V1 {
+            signatures,
+            unused_pub_keys,
+            min_signers,
+            chain_hash,
+            signed_bytes,
+        } = &unpacked
+        else {
+            panic!("Expected Multisig variant");
+        };
+        assert_eq!(signatures.len(), 2);
+        assert_eq!(signatures[0].pub_key, pubkey1);
+        assert_eq!(signatures[1].pub_key, pubkey2);
+        assert_eq!(unused_pub_keys, &vec![pubkey3]);
+        assert_eq!(*min_signers, 2);
+        assert_eq!(*chain_hash, TEST_CHAIN_HASH);
+        assert_eq!(signed_bytes, &signed_message);
+        assert_eq!(unpacked.json_bytes(), json_message);
     }
 
     #[test]
@@ -455,7 +695,6 @@ pub mod test {
 
         let serialized = borsh::to_vec(&envelope).unwrap();
 
-        // Should fail validation
         let result = unpack_solana_message::<TestSpec>(&serialized);
         assert!(result.is_err());
         assert!(matches!(result, Err(FatalError::DeserializationFailed(_))));

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -36,7 +36,7 @@ static SIGNATURE_CACHE: std::sync::LazyLock<SignatureVerificationCache<()>> =
 /// to the user doesn't get too nested.
 #[serde_with::serde_as]
 #[derive(Debug, Serialize, Deserialize, UniversalWallet)]
-#[serde(bound = "R::Call: serde::Serialize + serde::de::DeserializeOwned")]
+#[serde(deny_unknown_fields, bound = "R::Call: serde::Serialize + serde::de::DeserializeOwned")]
 pub struct SolanaOffchainUnsignedTransactionV0<R: TransactionCallable, S: Spec> {
     /// The runtime call
     pub runtime_call: R::Call,
@@ -71,7 +71,7 @@ where
 
 #[serde_with::serde_as]
 #[derive(Debug, Serialize, Deserialize, UniversalWallet)]
-#[serde(bound = "R::Call: serde::Serialize + serde::de::DeserializeOwned")]
+#[serde(deny_unknown_fields, bound = "R::Call: serde::Serialize + serde::de::DeserializeOwned")]
 pub struct SolanaOffchainUnsignedTransactionV1<R: TransactionCallable, S: Spec> {
     /// The runtime call
     pub runtime_call: R::Call,

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
@@ -13,9 +13,9 @@ use sov_mock_da::{BlockProducingConfig, MockAddress, MockDaService};
 use sov_mock_zkvm::crypto::Ed25519Signature;
 use sov_modules_api::capabilities::{TransactionAuthenticator, UniquenessData};
 use sov_modules_api::configurable_spec::ConfigurableSpec;
-use sov_modules_api::transaction::{Transaction, UnsignedTransaction};
+use sov_modules_api::transaction::{PubKeyAndSignature, Transaction, UnsignedTransaction};
 use sov_modules_api::{prelude::*, Base58Address, PrivateKey, SafeVec};
-use sov_modules_api::{FullyBakedTx, RawTx, Runtime, Spec};
+use sov_modules_api::{CryptoSpec, FullyBakedTx, RawTx, Runtime, Spec};
 use sov_modules_stf_blueprint::GenesisParams;
 use sov_paymaster::{
     AuthorizedSequencers, PayeePolicy, PayerGenesisConfig, PaymasterConfig,
@@ -24,8 +24,9 @@ use sov_paymaster::{
 use sov_rollup_interface::execution_mode::Native;
 use sov_sequencer::rest_api::AcceptTx;
 use sov_solana_offchain_auth::authentication::{
-    SolanaOffchainSimpleMessage, SolanaOffchainSpecCompliantMessage,
-    SolanaOffchainUnsignedTransaction,
+    SolanaOffchainSimpleMessage, SolanaOffchainSimpleMultisigMessage,
+    SolanaOffchainSpecCompliantMessage, SolanaOffchainUnsignedTransaction,
+    MULTISIG_SIMPLE_DISCRIMINATOR,
 };
 use sov_solana_offchain_auth::utils::make_preamble_for_message;
 use sov_solana_offchain_auth::{
@@ -84,6 +85,7 @@ impl<S: Spec> SolanaOffchainAuthenticatorTrait<S> for TestRuntime<S> {
 
 type RT = TestRuntime<SolanaTestSpec>;
 type S = SolanaTestSpec;
+type TestHasher = <<S as Spec>::CryptoSpec as CryptoSpec>::Hasher;
 
 async fn create_test_rollup() -> anyhow::Result<(
     TestRollup<SolanaOffchainAuthBlueprint<SolanaTestSpec, RT>>,
@@ -423,4 +425,201 @@ fn test_auth_wrapper() {
         solana_auth,
         SolanaOffchainAuthenticatorInput::SolanaOffchain(_)
     ));
+}
+
+fn create_multisig_signed_message(json_str: &str) -> Vec<u8> {
+    let mut signed_message = vec![MULTISIG_SIMPLE_DISCRIMINATOR];
+    signed_message.extend_from_slice(json_str.as_bytes());
+    signed_message
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_submit_multisig_simple_message_transaction() {
+    let (test_rollup, admin) = create_test_rollup().await.expect("Failed to create rollup");
+
+    // Create 3 signers for a 2-of-3 multisig
+    let key1 = Ed25519PrivateKey::generate();
+    let key2 = Ed25519PrivateKey::generate();
+    let key3 = Ed25519PrivateKey::generate();
+    let pub1 = key1.pub_key();
+    let pub2 = key2.pub_key();
+    let pub3 = key3.pub_key();
+    let min_signers: u8 = 2;
+
+    // Compute the multisig address
+    let multisig = sov_modules_api::Multisig::new(min_signers, vec![pub1.clone(), pub2.clone(), pub3.clone()]);
+    let credential_id = multisig.credential_id::<TestHasher>();
+    let multisig_address: <SolanaTestSpec as Spec>::Address = credential_id.into();
+    let multisig_address_str = multisig_address.to_string();
+
+    // Fund the multisig address from admin
+    {
+        let funding_json = create_transfer_tx_json(Amount(20_000), &multisig_address_str);
+        let encoded_tx = funding_json.as_bytes().to_vec();
+        let signer = admin.private_key();
+        let pubkey = signer.pub_key();
+        let signature = signer.sign(&encoded_tx);
+
+        let message = SolanaOffchainSimpleMessage::<S> {
+            signed_message: encoded_tx,
+            chain_hash: RT::CHAIN_HASH,
+            pubkey,
+            signature,
+        };
+        let raw_tx_bytes = borsh::to_vec(&message).unwrap();
+        let response = submit_tx(test_rollup.api_client(), raw_tx_bytes).await;
+        assert!(
+            response.status().is_success(),
+            "Expected funding transaction to succeed"
+        );
+    }
+
+    let funded_balance = query_balance(&test_rollup.client, &multisig_address_str).await;
+    assert_eq!(funded_balance, Some(Amount::new(20_000)));
+
+    // Build a transfer from the multisig to the recipient
+    let transfer_json = create_transfer_tx_json(Amount(7_000), RECIPIENT_ADDRESS);
+    let signed_message = create_multisig_signed_message(&transfer_json);
+
+    // Signers 1 and 2 sign the message (2 of 3)
+    let sig1 = key1.sign(&signed_message);
+    let sig2 = key2.sign(&signed_message);
+
+    let multisig_msg = SolanaOffchainSimpleMultisigMessage::<S> {
+        signed_message: signed_message.clone(),
+        chain_hash: RT::CHAIN_HASH,
+        signatures: vec![
+            PubKeyAndSignature { signature: sig1, pub_key: pub1.clone() },
+            PubKeyAndSignature { signature: sig2, pub_key: pub2.clone() },
+        ],
+        unused_pub_keys: vec![pub3.clone()],
+        min_signers,
+    };
+
+    let raw_tx_bytes = borsh::to_vec(&multisig_msg).unwrap();
+    let response = submit_tx(test_rollup.api_client(), raw_tx_bytes).await;
+    assert!(
+        response.status().is_success(),
+        "Expected multisig transaction to succeed. Response: {response:?}"
+    );
+
+    let recipient_balance = query_balance(&test_rollup.client, RECIPIENT_ADDRESS).await;
+    assert_eq!(
+        recipient_balance,
+        Some(Amount::new(7_000)),
+        "Expected recipient to have received 7,000 tokens"
+    );
+
+    let multisig_balance = query_balance(&test_rollup.client, &multisig_address_str).await;
+    assert_eq!(
+        multisig_balance,
+        Some(Amount::new(13_000)),
+        "Expected multisig to have 13,000 tokens remaining"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_submit_multisig_insufficient_signatures() {
+    let (test_rollup, admin) = create_test_rollup().await.expect("Failed to create rollup");
+
+    let key1 = Ed25519PrivateKey::generate();
+    let key2 = Ed25519PrivateKey::generate();
+    let key3 = Ed25519PrivateKey::generate();
+    let pub1 = key1.pub_key();
+    let pub2 = key2.pub_key();
+    let pub3 = key3.pub_key();
+    let min_signers: u8 = 2;
+
+    let multisig = sov_modules_api::Multisig::new(min_signers, vec![pub1.clone(), pub2.clone(), pub3.clone()]);
+    let credential_id = multisig.credential_id::<TestHasher>();
+    let multisig_address: <SolanaTestSpec as Spec>::Address = credential_id.into();
+    let multisig_address_str = multisig_address.to_string();
+
+    // Fund the multisig
+    {
+        let funding_json = create_transfer_tx_json(Amount(20_000), &multisig_address_str);
+        let encoded_tx = funding_json.as_bytes().to_vec();
+        let signer = admin.private_key();
+        let message = SolanaOffchainSimpleMessage::<S> {
+            signed_message: encoded_tx.clone(),
+            chain_hash: RT::CHAIN_HASH,
+            pubkey: signer.pub_key(),
+            signature: signer.sign(&encoded_tx),
+        };
+        let response = submit_tx(test_rollup.api_client(), borsh::to_vec(&message).unwrap()).await;
+        assert!(response.status().is_success());
+    }
+
+    // Only 1 signer for a 2-of-3 multisig — should fail
+    let transfer_json = create_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS);
+    let signed_message = create_multisig_signed_message(&transfer_json);
+    let sig1 = key1.sign(&signed_message);
+
+    let multisig_msg = SolanaOffchainSimpleMultisigMessage::<S> {
+        signed_message,
+        chain_hash: RT::CHAIN_HASH,
+        signatures: vec![
+            PubKeyAndSignature { signature: sig1, pub_key: pub1 },
+        ],
+        unused_pub_keys: vec![pub2, pub3],
+        min_signers,
+    };
+
+    let response = submit_tx(test_rollup.api_client(), borsh::to_vec(&multisig_msg).unwrap()).await;
+    assert_eq!(response.status(), 400, "Expected 400 for insufficient signatures");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_submit_multisig_invalid_signature() {
+    let (test_rollup, admin) = create_test_rollup().await.expect("Failed to create rollup");
+
+    let key1 = Ed25519PrivateKey::generate();
+    let key2 = Ed25519PrivateKey::generate();
+    let key3 = Ed25519PrivateKey::generate();
+    let pub1 = key1.pub_key();
+    let pub2 = key2.pub_key();
+    let pub3 = key3.pub_key();
+    let min_signers: u8 = 2;
+
+    let multisig = sov_modules_api::Multisig::new(min_signers, vec![pub1.clone(), pub2.clone(), pub3.clone()]);
+    let credential_id = multisig.credential_id::<TestHasher>();
+    let multisig_address: <SolanaTestSpec as Spec>::Address = credential_id.into();
+    let multisig_address_str = multisig_address.to_string();
+
+    // Fund the multisig
+    {
+        let funding_json = create_transfer_tx_json(Amount(20_000), &multisig_address_str);
+        let encoded_tx = funding_json.as_bytes().to_vec();
+        let signer = admin.private_key();
+        let message = SolanaOffchainSimpleMessage::<S> {
+            signed_message: encoded_tx.clone(),
+            chain_hash: RT::CHAIN_HASH,
+            pubkey: signer.pub_key(),
+            signature: signer.sign(&encoded_tx),
+        };
+        let response = submit_tx(test_rollup.api_client(), borsh::to_vec(&message).unwrap()).await;
+        assert!(response.status().is_success());
+    }
+
+    // Corrupt the second signature
+    let transfer_json = create_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS);
+    let signed_message = create_multisig_signed_message(&transfer_json);
+    let sig1 = key1.sign(&signed_message);
+    let mut sig2_bytes = key2.sign(&signed_message).msg_sig.to_bytes();
+    sig2_bytes[10] = sig2_bytes[10].wrapping_add(1);
+    let sig2: Ed25519Signature = sig2_bytes.as_slice().try_into().unwrap();
+
+    let multisig_msg = SolanaOffchainSimpleMultisigMessage::<S> {
+        signed_message,
+        chain_hash: RT::CHAIN_HASH,
+        signatures: vec![
+            PubKeyAndSignature { signature: sig1, pub_key: pub1 },
+            PubKeyAndSignature { signature: sig2, pub_key: pub2 },
+        ],
+        unused_pub_keys: vec![pub3],
+        min_signers,
+    };
+
+    let response = submit_tx(test_rollup.api_client(), borsh::to_vec(&multisig_msg).unwrap()).await;
+    assert_eq!(response.status(), 400, "Expected 400 for invalid signature");
 }

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
@@ -15,7 +15,7 @@ use sov_modules_api::capabilities::{TransactionAuthenticator, UniquenessData};
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::transaction::{PubKeyAndSignature, Transaction, UnsignedTransaction};
 use sov_modules_api::{prelude::*, Base58Address, PrivateKey, SafeVec};
-use sov_modules_api::{CredentialId, CryptoSpec, FullyBakedTx, RawTx, Runtime, Spec};
+use sov_modules_api::{CryptoSpec, FullyBakedTx, RawTx, Runtime, Spec};
 use sov_modules_stf_blueprint::GenesisParams;
 use sov_paymaster::{
     AuthorizedSequencers, PayeePolicy, PayerGenesisConfig, PaymasterConfig,
@@ -430,7 +430,7 @@ fn test_auth_wrapper() {
 fn create_multisig_transfer_tx_json(
     amount: Amount,
     recipient: &str,
-    multisig_address: CredentialId,
+    multisig_address: <S as Spec>::Address,
 ) -> String {
     let msg: TestRuntimeCall<S> = TestRuntimeCall::Bank(BankCallMessage::Transfer {
         to: <S as Spec>::Address::from_str(recipient).unwrap(),
@@ -512,7 +512,7 @@ async fn test_submit_multisig_simple_message_transaction() {
     // Build a transfer from the multisig to the recipient, using V1 format which commits
     // to the credential_id in the signed message.
     let transfer_json =
-        create_multisig_transfer_tx_json(Amount(7_000), RECIPIENT_ADDRESS, credential_id);
+        create_multisig_transfer_tx_json(Amount(7_000), RECIPIENT_ADDRESS, multisig_address);
     let json_bytes = transfer_json.as_bytes();
     let wire_bytes = create_multisig_wire_bytes(&transfer_json);
 
@@ -597,7 +597,7 @@ async fn test_submit_multisig_insufficient_signatures() {
 
     // Only 1 signer for a 2-of-3 multisig — should fail
     let transfer_json =
-        create_multisig_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS, credential_id);
+        create_multisig_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS, multisig_address);
     let json_bytes = transfer_json.as_bytes();
     let wire_bytes = create_multisig_wire_bytes(&transfer_json);
     let sig1 = key1.sign(json_bytes);
@@ -662,7 +662,7 @@ async fn test_submit_multisig_invalid_signature() {
 
     // Corrupt the second signature
     let transfer_json =
-        create_multisig_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS, credential_id);
+        create_multisig_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS, multisig_address);
     let json_bytes = transfer_json.as_bytes();
     let wire_bytes = create_multisig_wire_bytes(&transfer_json);
     let sig1 = key1.sign(json_bytes);

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
@@ -430,7 +430,7 @@ fn test_auth_wrapper() {
 fn create_multisig_transfer_tx_json(
     amount: Amount,
     recipient: &str,
-    credential_id: CredentialId,
+    multisig_address: CredentialId,
 ) -> String {
     let msg: TestRuntimeCall<S> = TestRuntimeCall::Bank(BankCallMessage::Transfer {
         to: <S as Spec>::Address::from_str(recipient).unwrap(),
@@ -452,7 +452,7 @@ fn create_multisig_transfer_tx_json(
         uniqueness: unsigned_tx.uniqueness,
         details: unsigned_tx.details,
         chain_name: config_value!("CHAIN_NAME").to_string().try_into().unwrap(),
-        credential_id,
+        multisig_address,
         version: 1,
     };
     serde_json::to_string(&solana_unsigned_tx).unwrap()

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
@@ -15,7 +15,7 @@ use sov_modules_api::capabilities::{TransactionAuthenticator, UniquenessData};
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::transaction::{PubKeyAndSignature, Transaction, UnsignedTransaction};
 use sov_modules_api::{prelude::*, Base58Address, PrivateKey, SafeVec};
-use sov_modules_api::{CryptoSpec, FullyBakedTx, RawTx, Runtime, Spec};
+use sov_modules_api::{CredentialId, CryptoSpec, FullyBakedTx, RawTx, Runtime, Spec};
 use sov_modules_stf_blueprint::GenesisParams;
 use sov_paymaster::{
     AuthorizedSequencers, PayeePolicy, PayerGenesisConfig, PaymasterConfig,
@@ -25,8 +25,8 @@ use sov_rollup_interface::execution_mode::Native;
 use sov_sequencer::rest_api::AcceptTx;
 use sov_solana_offchain_auth::authentication::{
     SolanaOffchainSimpleMessage, SolanaOffchainSimpleMultisigMessage,
-    SolanaOffchainSpecCompliantMessage, SolanaOffchainUnsignedTransaction,
-    MULTISIG_SIMPLE_DISCRIMINATOR,
+    SolanaOffchainSpecCompliantMessage, SolanaOffchainUnsignedTransactionV0,
+    SolanaOffchainUnsignedTransactionV1, MULTISIG_SIMPLE_DISCRIMINATOR,
 };
 use sov_solana_offchain_auth::utils::make_preamble_for_message;
 use sov_solana_offchain_auth::{
@@ -186,7 +186,7 @@ fn create_transfer_tx_json(amount: Amount, recipient: &str) -> String {
         UniquenessData::Generation(0),
         Some(TEST_DEFAULT_GAS_LIMIT.into()),
     );
-    let solana_unsigned_tx = SolanaOffchainUnsignedTransaction::<RT, S> {
+    let solana_unsigned_tx = SolanaOffchainUnsignedTransactionV0::<RT, S> {
         runtime_call: unsigned_tx.runtime_call,
         uniqueness: unsigned_tx.uniqueness,
         details: unsigned_tx.details,
@@ -427,7 +427,38 @@ fn test_auth_wrapper() {
     ));
 }
 
-fn create_multisig_signed_message(json_str: &str) -> Vec<u8> {
+fn create_multisig_transfer_tx_json(
+    amount: Amount,
+    recipient: &str,
+    credential_id: CredentialId,
+) -> String {
+    let msg: TestRuntimeCall<S> = TestRuntimeCall::Bank(BankCallMessage::Transfer {
+        to: <S as Spec>::Address::from_str(recipient).unwrap(),
+        coins: Coins {
+            amount,
+            token_id: config_value!("GAS_TOKEN_ID"),
+        },
+    });
+    let unsigned_tx = UnsignedTransaction::<RT, S>::new(
+        msg,
+        config_value!("CHAIN_ID"),
+        TEST_DEFAULT_MAX_PRIORITY_FEE,
+        TEST_DEFAULT_MAX_FEE,
+        UniquenessData::Generation(0),
+        Some(TEST_DEFAULT_GAS_LIMIT.into()),
+    );
+    let solana_unsigned_tx = SolanaOffchainUnsignedTransactionV1::<RT, S> {
+        runtime_call: unsigned_tx.runtime_call,
+        uniqueness: unsigned_tx.uniqueness,
+        details: unsigned_tx.details,
+        chain_name: config_value!("CHAIN_NAME").to_string().try_into().unwrap(),
+        credential_id,
+        version: 1,
+    };
+    serde_json::to_string(&solana_unsigned_tx).unwrap()
+}
+
+fn create_multisig_wire_bytes(json_str: &str) -> Vec<u8> {
     let mut signed_message = vec![MULTISIG_SIMPLE_DISCRIMINATOR];
     signed_message.extend_from_slice(json_str.as_bytes());
     signed_message
@@ -478,17 +509,20 @@ async fn test_submit_multisig_simple_message_transaction() {
     let funded_balance = query_balance(&test_rollup.client, &multisig_address_str).await;
     assert_eq!(funded_balance, Some(Amount::new(20_000)));
 
-    // Build a transfer from the multisig to the recipient
-    let transfer_json = create_transfer_tx_json(Amount(7_000), RECIPIENT_ADDRESS);
-    let signed_message = create_multisig_signed_message(&transfer_json);
+    // Build a transfer from the multisig to the recipient, using V1 format which commits
+    // to the credential_id in the signed message.
+    let transfer_json =
+        create_multisig_transfer_tx_json(Amount(7_000), RECIPIENT_ADDRESS, credential_id);
+    let json_bytes = transfer_json.as_bytes();
+    let wire_bytes = create_multisig_wire_bytes(&transfer_json);
 
-    // Signers 3 and 1 sign (deliberately out of order relative to how the credential was
-    // constructed from [pub1, pub2, pub3]) to verify order independence.
-    let sig3 = key3.sign(&signed_message);
-    let sig1 = key1.sign(&signed_message);
+    // Signers 3 and 1 sign the JSON directly (deliberately out of order relative to how
+    // the credential was constructed from [pub1, pub2, pub3]) to verify order independence.
+    let sig3 = key3.sign(json_bytes);
+    let sig1 = key1.sign(json_bytes);
 
     let multisig_msg = SolanaOffchainSimpleMultisigMessage::<S> {
-        signed_message: signed_message.clone(),
+        wire_bytes,
         chain_hash: RT::CHAIN_HASH,
         signatures: vec![
             PubKeyAndSignature {
@@ -562,12 +596,14 @@ async fn test_submit_multisig_insufficient_signatures() {
     }
 
     // Only 1 signer for a 2-of-3 multisig — should fail
-    let transfer_json = create_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS);
-    let signed_message = create_multisig_signed_message(&transfer_json);
-    let sig1 = key1.sign(&signed_message);
+    let transfer_json =
+        create_multisig_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS, credential_id);
+    let json_bytes = transfer_json.as_bytes();
+    let wire_bytes = create_multisig_wire_bytes(&transfer_json);
+    let sig1 = key1.sign(json_bytes);
 
     let multisig_msg = SolanaOffchainSimpleMultisigMessage::<S> {
-        signed_message,
+        wire_bytes,
         chain_hash: RT::CHAIN_HASH,
         signatures: vec![PubKeyAndSignature {
             signature: sig1,
@@ -625,15 +661,17 @@ async fn test_submit_multisig_invalid_signature() {
     }
 
     // Corrupt the second signature
-    let transfer_json = create_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS);
-    let signed_message = create_multisig_signed_message(&transfer_json);
-    let sig1 = key1.sign(&signed_message);
-    let mut sig2_bytes = key2.sign(&signed_message).msg_sig.to_bytes();
+    let transfer_json =
+        create_multisig_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS, credential_id);
+    let json_bytes = transfer_json.as_bytes();
+    let wire_bytes = create_multisig_wire_bytes(&transfer_json);
+    let sig1 = key1.sign(json_bytes);
+    let mut sig2_bytes = key2.sign(json_bytes).msg_sig.to_bytes();
     sig2_bytes[10] = sig2_bytes[10].wrapping_add(1);
     let sig2: Ed25519Signature = sig2_bytes.as_slice().try_into().unwrap();
 
     let multisig_msg = SolanaOffchainSimpleMultisigMessage::<S> {
-        signed_message,
+        wire_bytes,
         chain_hash: RT::CHAIN_HASH,
         signatures: vec![
             PubKeyAndSignature {

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
@@ -447,7 +447,8 @@ async fn test_submit_multisig_simple_message_transaction() {
     let min_signers: u8 = 2;
 
     // Compute the multisig address
-    let multisig = sov_modules_api::Multisig::new(min_signers, vec![pub1.clone(), pub2.clone(), pub3.clone()]);
+    let multisig =
+        sov_modules_api::Multisig::new(min_signers, vec![pub1.clone(), pub2.clone(), pub3.clone()]);
     let credential_id = multisig.credential_id::<TestHasher>();
     let multisig_address: <SolanaTestSpec as Spec>::Address = credential_id.into();
     let multisig_address_str = multisig_address.to_string();
@@ -481,18 +482,27 @@ async fn test_submit_multisig_simple_message_transaction() {
     let transfer_json = create_transfer_tx_json(Amount(7_000), RECIPIENT_ADDRESS);
     let signed_message = create_multisig_signed_message(&transfer_json);
 
-    // Signers 1 and 2 sign the message (2 of 3)
+    // Signers 3 and 1 sign (deliberately out of order relative to how the credential was
+    // constructed from [pub1, pub2, pub3]) to verify order independence.
+    let sig3 = key3.sign(&signed_message);
     let sig1 = key1.sign(&signed_message);
-    let sig2 = key2.sign(&signed_message);
 
     let multisig_msg = SolanaOffchainSimpleMultisigMessage::<S> {
         signed_message: signed_message.clone(),
         chain_hash: RT::CHAIN_HASH,
         signatures: vec![
-            PubKeyAndSignature { signature: sig1, pub_key: pub1.clone() },
-            PubKeyAndSignature { signature: sig2, pub_key: pub2.clone() },
-        ],
-        unused_pub_keys: vec![pub3.clone()],
+            PubKeyAndSignature {
+                signature: sig3,
+                pub_key: pub3.clone(),
+            },
+            PubKeyAndSignature {
+                signature: sig1,
+                pub_key: pub1.clone(),
+            },
+        ]
+        .try_into()
+        .unwrap(),
+        unused_pub_keys: vec![pub2.clone()].try_into().unwrap(),
         min_signers,
     };
 
@@ -530,7 +540,8 @@ async fn test_submit_multisig_insufficient_signatures() {
     let pub3 = key3.pub_key();
     let min_signers: u8 = 2;
 
-    let multisig = sov_modules_api::Multisig::new(min_signers, vec![pub1.clone(), pub2.clone(), pub3.clone()]);
+    let multisig =
+        sov_modules_api::Multisig::new(min_signers, vec![pub1.clone(), pub2.clone(), pub3.clone()]);
     let credential_id = multisig.credential_id::<TestHasher>();
     let multisig_address: <SolanaTestSpec as Spec>::Address = credential_id.into();
     let multisig_address_str = multisig_address.to_string();
@@ -558,15 +569,26 @@ async fn test_submit_multisig_insufficient_signatures() {
     let multisig_msg = SolanaOffchainSimpleMultisigMessage::<S> {
         signed_message,
         chain_hash: RT::CHAIN_HASH,
-        signatures: vec![
-            PubKeyAndSignature { signature: sig1, pub_key: pub1 },
-        ],
-        unused_pub_keys: vec![pub2, pub3],
+        signatures: vec![PubKeyAndSignature {
+            signature: sig1,
+            pub_key: pub1,
+        }]
+        .try_into()
+        .unwrap(),
+        unused_pub_keys: vec![pub2, pub3].try_into().unwrap(),
         min_signers,
     };
 
-    let response = submit_tx(test_rollup.api_client(), borsh::to_vec(&multisig_msg).unwrap()).await;
-    assert_eq!(response.status(), 400, "Expected 400 for insufficient signatures");
+    let response = submit_tx(
+        test_rollup.api_client(),
+        borsh::to_vec(&multisig_msg).unwrap(),
+    )
+    .await;
+    assert_eq!(
+        response.status(),
+        400,
+        "Expected 400 for insufficient signatures"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -581,7 +603,8 @@ async fn test_submit_multisig_invalid_signature() {
     let pub3 = key3.pub_key();
     let min_signers: u8 = 2;
 
-    let multisig = sov_modules_api::Multisig::new(min_signers, vec![pub1.clone(), pub2.clone(), pub3.clone()]);
+    let multisig =
+        sov_modules_api::Multisig::new(min_signers, vec![pub1.clone(), pub2.clone(), pub3.clone()]);
     let credential_id = multisig.credential_id::<TestHasher>();
     let multisig_address: <SolanaTestSpec as Spec>::Address = credential_id.into();
     let multisig_address_str = multisig_address.to_string();
@@ -613,13 +636,25 @@ async fn test_submit_multisig_invalid_signature() {
         signed_message,
         chain_hash: RT::CHAIN_HASH,
         signatures: vec![
-            PubKeyAndSignature { signature: sig1, pub_key: pub1 },
-            PubKeyAndSignature { signature: sig2, pub_key: pub2 },
-        ],
-        unused_pub_keys: vec![pub3],
+            PubKeyAndSignature {
+                signature: sig1,
+                pub_key: pub1,
+            },
+            PubKeyAndSignature {
+                signature: sig2,
+                pub_key: pub2,
+            },
+        ]
+        .try_into()
+        .unwrap(),
+        unused_pub_keys: vec![pub3].try_into().unwrap(),
         min_signers,
     };
 
-    let response = submit_tx(test_rollup.api_client(), borsh::to_vec(&multisig_msg).unwrap()).await;
+    let response = submit_tx(
+        test_rollup.api_client(),
+        borsh::to_vec(&multisig_msg).unwrap(),
+    )
+    .await;
     assert_eq!(response.status(), 400, "Expected 400 for invalid signature");
 }

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
@@ -430,7 +430,7 @@ fn test_auth_wrapper() {
 fn create_multisig_transfer_tx_json(
     amount: Amount,
     recipient: &str,
-    multisig_address: <S as Spec>::Address,
+    multisig_id: <S as Spec>::Address,
 ) -> String {
     let msg: TestRuntimeCall<S> = TestRuntimeCall::Bank(BankCallMessage::Transfer {
         to: <S as Spec>::Address::from_str(recipient).unwrap(),
@@ -452,7 +452,7 @@ fn create_multisig_transfer_tx_json(
         uniqueness: unsigned_tx.uniqueness,
         details: unsigned_tx.details,
         chain_name: config_value!("CHAIN_NAME").to_string().try_into().unwrap(),
-        multisig_address,
+        multisig_id,
         version: 1,
     };
     serde_json::to_string(&solana_unsigned_tx).unwrap()


### PR DESCRIPTION
# Description

Adds multisig signing suport to the `sov-solana-offchain-auth` authenticator, for `Simple` (i.e. non-Ledger) transactions. (Ledger support has separate considerations, so it's been deprioritised for now: #2659)
The serialized message uses an `0x80` discriminator byte for deserializing. This mirrors the `0xff` byte used for ledger messages, but from the other side of the extended ASCII range (the first extended byte rather than the last). It also shares the property that it's not a valid UTF-8 starting byte.

The multisig commits to the version, and the credential_id encoded as the rollup's default address. I considered a few alternatives here:
* Encoding as `Base58Address`: this would make a difference for rollups using a MultiAddress enum; users signing with Solana wallets would see a Solana-formatted multisig address. I decided against this because the multisig address is entirely synthetic, and in theory the same multisig could be signed from any wallet; having a single canonical format in all authenticators (i.e. using the rollup's default `Spec::Address::From<CredentialId>`) ensures the multisig credential is consistent when presented to users.
* Resolving the actual account address from `sov_accounts`: not only would this complicate the implementation (and the client) significantly, but it's also useful to commit to the actual multisig credential rather than the account it might map to. E.g. if several different multisigs with different thresholds or signing sets are mapped to the same account, it's important for a user to be able to sign a partial transaction for one specific multisig set and not have it be reusable for another multisig set even for the same account. But this does need to be clearly documented for users, that the `"multisig_address"` is the "raw" address of the specific multisig credential and may not necessarily match the "account address".

Typescript support coming in a follow-up PR.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
