### PR TITLE
 Add `RecursiveZkvmHost` trait for recursive proving  

### DIFF
--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -1,14 +1,16 @@
 //! Implementation of the SP1 host for the Sovereign ZkvmHost trait.
 
+use crate::guest::SP1Guest;
+use crate::SP1MethodId;
+use crate::ZkVerifier;
 use serde::Serialize;
 use sov_rollup_interface::reexports::anyhow;
+use sov_rollup_interface::zk::aggregated_proof::ZkvmHostWithInnerProofs;
+use sov_rollup_interface::zk::ZkvmGuest;
 use sov_rollup_interface::zk::{Proof, ZkvmHost};
 use sp1_sdk::blocking::CpuProver;
 use sp1_sdk::blocking::{ProveRequest, Prover, ProverClient};
 use sp1_sdk::{ProvingKey, SP1Proof, SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin};
-
-use crate::guest::SP1Guest;
-use crate::SP1MethodId;
 
 /// SP1 Host implementation.
 pub struct SP1Host<'host> {
@@ -33,7 +35,7 @@ impl<'host> SP1Host<'host> {
 
     /// Adds a compressed SP1 proof and its verifying key to the host's stdin
     /// so it can be verified inside the guest program during aggregation.
-    pub fn add_proof(
+    pub fn add_proof_inner(
         &mut self,
         proof: &SP1ProofWithPublicValues,
         method_id: &SP1MethodId,
@@ -110,5 +112,17 @@ impl ZkvmHost for SP1Host<'static> {
     fn code_commitment(&self) -> anyhow::Result<<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment>{
         let (_, pk) = self.create_prover_and_pk()?;
         Ok(crate::SP1MethodId(bincode::serialize(pk.verifying_key())?))
+    }
+}
+
+impl ZkvmHostWithInnerProofs for SP1Host<'static> {
+    type Proof = SP1ProofWithPublicValues;
+
+    fn add_proof(
+        &mut self,
+        proof: &Self::Proof,
+        code_commitment: &<<Self::Guest as ZkvmGuest>::Verifier as ZkVerifier>::CodeCommitment,
+    ) -> anyhow::Result<()> {
+        self.add_proof_inner(proof, code_commitment)
     }
 }

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -2,7 +2,7 @@
 
 use serde::Serialize;
 use sov_rollup_interface::reexports::anyhow;
-use sov_rollup_interface::zk::aggregated_proof::ZkvmHostWithInnerProofs;
+use sov_rollup_interface::zk::aggregated_proof::RecursiveZkvmHost;
 use sov_rollup_interface::zk::{Proof, ZkvmHost};
 use sp1_sdk::blocking::CpuProver;
 use sp1_sdk::blocking::{ProveRequest, Prover, ProverClient};
@@ -114,7 +114,7 @@ impl ZkvmHost for SP1Host<'static> {
     }
 }
 
-impl ZkvmHostWithInnerProofs for SP1Host<'static> {
+impl RecursiveZkvmHost for SP1Host<'static> {
     type Proof = SP1ProofWithPublicValues;
 
     fn add_proof(

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -1,16 +1,15 @@
 //! Implementation of the SP1 host for the Sovereign ZkvmHost trait.
 
-use crate::guest::SP1Guest;
-use crate::SP1MethodId;
-use crate::ZkVerifier;
 use serde::Serialize;
 use sov_rollup_interface::reexports::anyhow;
 use sov_rollup_interface::zk::aggregated_proof::ZkvmHostWithInnerProofs;
-use sov_rollup_interface::zk::ZkvmGuest;
 use sov_rollup_interface::zk::{Proof, ZkvmHost};
 use sp1_sdk::blocking::CpuProver;
 use sp1_sdk::blocking::{ProveRequest, Prover, ProverClient};
 use sp1_sdk::{ProvingKey, SP1Proof, SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin};
+
+use crate::guest::SP1Guest;
+use crate::SP1MethodId;
 
 /// SP1 Host implementation.
 pub struct SP1Host<'host> {
@@ -121,7 +120,7 @@ impl ZkvmHostWithInnerProofs for SP1Host<'static> {
     fn add_proof(
         &mut self,
         proof: &Self::Proof,
-        code_commitment: &<<Self::Guest as ZkvmGuest>::Verifier as ZkVerifier>::CodeCommitment,
+        code_commitment: &<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as crate::ZkVerifier>::CodeCommitment,
     ) -> anyhow::Result<()> {
         self.add_proof_inner(proof, code_commitment)
     }

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -34,7 +34,7 @@ impl<'host> SP1Host<'host> {
 
     /// Adds a compressed SP1 proof and its verifying key to the host's stdin
     /// so it can be verified inside the guest program during aggregation.
-    pub fn add_proof_inner(
+    fn add_proof_inner(
         &mut self,
         proof: &SP1ProofWithPublicValues,
         method_id: &SP1MethodId,

--- a/crates/full-node/sov-aggregated-proof/script/src/main.rs
+++ b/crates/full-node/sov-aggregated-proof/script/src/main.rs
@@ -17,7 +17,7 @@ use sov_rollup_interface::execution_mode::Native;
 use sov_rollup_interface::zk::aggregated_proof::common::{
     AggregatedProofWitness, DeferredProofInput, PreviousOuterProofWitness,
 };
-use sov_rollup_interface::zk::aggregated_proof::ZkvmHostWithInnerProofs;
+use sov_rollup_interface::zk::aggregated_proof::RecursiveZkvmHost;
 use sov_rollup_interface::zk::{ZkVerifier, ZkvmHost};
 use sov_sp1_adapter::host::SP1Host;
 use sov_sp1_adapter::SP1;

--- a/crates/full-node/sov-aggregated-proof/script/src/main.rs
+++ b/crates/full-node/sov-aggregated-proof/script/src/main.rs
@@ -17,6 +17,7 @@ use sov_rollup_interface::execution_mode::Native;
 use sov_rollup_interface::zk::aggregated_proof::common::{
     AggregatedProofWitness, DeferredProofInput, PreviousOuterProofWitness,
 };
+use sov_rollup_interface::zk::aggregated_proof::ZkvmHostWithInnerProofs;
 use sov_rollup_interface::zk::{ZkVerifier, ZkvmHost};
 use sov_sp1_adapter::host::SP1Host;
 use sov_sp1_adapter::SP1;

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -6,13 +6,34 @@ pub mod common;
 
 use core::marker::PhantomData;
 
+use super::{StateTransitionPublicData, ZkVerifier};
+use crate::common::SlotNumber;
+use crate::da::DaSpec;
+use crate::zk::ZkvmGuest;
+use crate::zk::ZkvmHost;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use super::{StateTransitionPublicData, ZkVerifier};
-use crate::common::SlotNumber;
-use crate::da::DaSpec;
+/// TODO
+pub trait ZkvmHostWithInnerProofs: ZkvmHost {
+    /// Innet proof.
+    type Proof;
+
+    /// Add inner proof.
+    fn add_proof(
+        &mut self,
+        proof: &Self::Proof,
+        code_commitment: &<<Self::Guest as ZkvmGuest>::Verifier as ZkVerifier>::CodeCommitment,
+    );
+
+    /// Run the guest in the true zk environment using the provided hints.
+    ///
+    /// This runs the guest binary compiled for the zkVM target, optionally
+    /// creating a SNARK of correct execution. Running the true guest binary comes
+    /// with some mild performance overhead, but it is orders of magnitude less expensive than generating a proof.
+    fn run(&mut self, with_proof: bool) -> anyhow::Result<Vec<u8>>;
+}
 
 /// A single block's proof data, used to build an [`AggregatedProofPublicData`].
 pub struct BlockProof<Address, Da: DaSpec, Root> {

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -16,7 +16,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 /// Extension of `ZkvmHost` that enables recursive proving.
-pub trait ZkvmHostWithInnerProofs: ZkvmHost {
+pub trait RecursiveZkvmHost: ZkvmHost {
     /// Inner proof.
     type Proof;
 

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -15,9 +15,9 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-/// Extension of `ZkvmHost`` that enables recursive proving.
+/// Extension of `ZkvmHost` that enables recursive proving.
 pub trait ZkvmHostWithInnerProofs: ZkvmHost {
-    /// Innet proof.
+    /// Inner proof.
     type Proof;
 
     /// Add inner proof.

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -4,14 +4,13 @@ pub mod circuit;
 /// Common types shared between the aggregated proof program and the host script.
 pub mod common;
 
-use core::marker::PhantomData;
-
 use super::{StateTransitionPublicData, ZkVerifier};
 use crate::common::SlotNumber;
 use crate::da::DaSpec;
 use crate::zk::ZkvmGuest;
 use crate::zk::ZkvmHost;
 use borsh::{BorshDeserialize, BorshSerialize};
+use core::marker::PhantomData;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -25,14 +25,7 @@ pub trait ZkvmHostWithInnerProofs: ZkvmHost {
         &mut self,
         proof: &Self::Proof,
         code_commitment: &<<Self::Guest as ZkvmGuest>::Verifier as ZkVerifier>::CodeCommitment,
-    );
-
-    /// Run the guest in the true zk environment using the provided hints.
-    ///
-    /// This runs the guest binary compiled for the zkVM target, optionally
-    /// creating a SNARK of correct execution. Running the true guest binary comes
-    /// with some mild performance overhead, but it is orders of magnitude less expensive than generating a proof.
-    fn run(&mut self, with_proof: bool) -> anyhow::Result<Vec<u8>>;
+    ) -> anyhow::Result<()>;
 }
 
 /// A single block's proof data, used to build an [`AggregatedProofPublicData`].

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -15,7 +15,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-/// TODO
+/// Extension of `ZkvmHost`` that enables recursive proving.
 pub trait ZkvmHostWithInnerProofs: ZkvmHost {
     /// Innet proof.
     type Proof;


### PR DESCRIPTION
# Description
  - Introduces `RecursiveZkvmHost` trait in `rollup-interface` that extends `ZkvmHost` with the ability to add inner proofs for recursive proof aggregation                                                                                             
  - Implements the trait for `SP1Host`, delegating to the renamed `add_proof_inner` method                                                                                                                                                                    
  - Updates the aggregated proof script to use the trait method

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551
