### PR TITLE
Make rt agostic blueprint generic prover

### DIFF
--- a/crates/utils/sov-test-utils/src/lib.rs
+++ b/crates/utils/sov-test-utils/src/lib.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 pub use generators::MessageGenerator;
 pub use interface::*;
-pub use rt_agnostic_blueprint::RtAgnosticBlueprint;
+pub use rt_agnostic_blueprint::{ParallelProverFactory, ProverFactory, RtAgnosticBlueprint};
 use serde::{Deserialize, Serialize};
 pub use sov_db::schema::SchemaBatch;
 pub use sov_mock_da::verifier::MockDaSpec;

--- a/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
+++ b/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
@@ -20,12 +20,71 @@ use sov_modules_stf_blueprint::Runtime as RuntimeTrait;
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
-use sov_rollup_interface::zk::ZkvmHost;
+use sov_rollup_interface::zk::{ZkvmGuest, ZkvmHost};
 use sov_sequencer::ProofBlobSender;
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::{DefaultStorageSpec, ProverStorage, Storage};
 use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
+
+/// Factory for creating a prover service within [`RtAgnosticBlueprint`].
+///
+/// Implement this trait to plug different prover backends (parallel, network, etc.)
+/// into the blueprint without reimplementing the entire [`FullNodeBlueprint`].
+#[async_trait]
+pub trait ProverFactory<S: Spec<Da = MockDaSpec, OuterZkvm = MockZkvm>>:
+    Send + Sync + 'static
+{
+    /// The prover service type this factory creates.
+    type ProverService: ProverService<
+        StateRoot = <S::Storage as Storage>::Root,
+        Witness = <S::Storage as Storage>::Witness,
+        DaService = StorableMockDaService,
+        Verifier = <<MockZkvm as Zkvm>::Guest as ZkvmGuest>::Verifier,
+    >;
+
+    /// Create the prover service from the given config.
+    async fn create(
+        prover_config: RollupProverConfig<S::InnerZkvm>,
+        rollup_config: &RollupConfig<S::Address, StorableMockDaService>,
+    ) -> Self::ProverService;
+}
+
+/// Default prover factory using local parallel proving.
+pub struct ParallelProverFactory<S>(PhantomData<S>);
+
+#[async_trait]
+impl<S> ProverFactory<S> for ParallelProverFactory<S>
+where
+    S: Spec<Da = MockDaSpec, OuterZkvm = MockZkvm> + PluggableSpec,
+{
+    type ProverService = ParallelProverService<
+        S::Address,
+        <S::Storage as Storage>::Root,
+        <S::Storage as Storage>::Witness,
+        StorableMockDaService,
+        S::InnerZkvm,
+        S::OuterZkvm,
+    >;
+
+    async fn create(
+        prover_config: RollupProverConfig<S::InnerZkvm>,
+        rollup_config: &RollupConfig<S::Address, StorableMockDaService>,
+    ) -> Self::ProverService {
+        let (host_args, prover_config_disc) = prover_config.split();
+        let inner_vm = <S::InnerZkvm as Zkvm>::Host::from_args(&host_args);
+        let outer_vm = MockZkvmHost::new_non_blocking();
+
+        ParallelProverService::new_with_default_workers(
+            inner_vm,
+            outer_vm,
+            Default::default(),
+            prover_config_disc,
+            CodeCommitmentHash::default(),
+            rollup_config.proof_manager.prover_address,
+        )
+    }
+}
 
 /// A basic, "vanilla" [`FullNodeBlueprint`] to be used for testing.
 pub struct RtAgnosticBlueprint<
@@ -39,11 +98,14 @@ pub struct RtAgnosticBlueprint<
             MockHash,
         >,
     >,
+    Prover = ParallelProverFactory<S>,
 > {
-    phantom: PhantomData<(S, R, Manager)>,
+    phantom: PhantomData<(S, R, Manager, Prover)>,
 }
 
-impl<S: Spec, R: RuntimeTrait<S>, Manager> Default for RtAgnosticBlueprint<S, R, Manager> {
+impl<S: Spec, R: RuntimeTrait<S>, Manager, Prover> Default
+    for RtAgnosticBlueprint<S, R, Manager, Prover>
+{
     fn default() -> Self {
         Self {
             phantom: PhantomData,
@@ -51,18 +113,20 @@ impl<S: Spec, R: RuntimeTrait<S>, Manager> Default for RtAgnosticBlueprint<S, R,
     }
 }
 
-impl<S, R, Manager> RollupBlueprint<Native> for RtAgnosticBlueprint<S, R, Manager>
+impl<S, R, Manager, Prover> RollupBlueprint<Native> for RtAgnosticBlueprint<S, R, Manager, Prover>
 where
     S: Spec + PluggableSpec,
     R: RuntimeTrait<S> + HasKernel<S> + HasCapabilities<S> + HasKernel<S>,
     Manager: Send + Sync + 'static,
+    Prover: Send + Sync + 'static,
 {
     type Spec = S;
     type Runtime = R;
 }
 
 #[async_trait]
-impl<S, R, Manager> FullNodeBlueprint<Native> for RtAgnosticBlueprint<S, R, Manager>
+impl<S, R, Manager, Prover> FullNodeBlueprint<Native>
+    for RtAgnosticBlueprint<S, R, Manager, Prover>
 where
     S: Spec<Da = MockDaSpec, OuterZkvm = MockZkvm> + PluggableSpec,
     R: RuntimeTrait<S> + HasRestApi<S> + HasCapabilities<S> + HasKernel<S> + 'static,
@@ -77,19 +141,13 @@ where
             StfChangeSet = <S::Storage as Storage>::ChangeSet,
         >
         + StorageManagerInitializer<S, StorableMockDaService>,
+    Prover: ProverFactory<S>,
 {
     type DaService = StorableMockDaService;
 
     type StorageManager = Manager;
 
-    type ProverService = ParallelProverService<
-        <Self::Spec as Spec>::Address,
-        <<Self::Spec as Spec>::Storage as Storage>::Root,
-        <<Self::Spec as Spec>::Storage as Storage>::Witness,
-        Self::DaService,
-        <Self::Spec as Spec>::InnerZkvm,
-        <Self::Spec as Spec>::OuterZkvm,
-    >;
+    type ProverService = <Prover as ProverFactory<S>>::ProverService;
 
     type ProofSender = SovApiProofSender<Self::Spec>;
 
@@ -136,21 +194,7 @@ where
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
     ) -> Self::ProverService {
-        let (host_args, prover_config_disc) = prover_config.split();
-
-        let inner_vm = <S::InnerZkvm as Zkvm>::Host::from_args(&host_args);
-        let outer_vm = MockZkvmHost::new_non_blocking();
-
-        let da_verifier = Default::default();
-
-        ParallelProverService::new_with_default_workers(
-            inner_vm,
-            outer_vm,
-            da_verifier,
-            prover_config_disc,
-            CodeCommitmentHash::default(),
-            rollup_config.proof_manager.prover_address,
-        )
+        Prover::create(prover_config, rollup_config).await
     }
 
     fn create_storage_manager(

--- a/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
+++ b/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
@@ -125,8 +125,7 @@ where
 }
 
 #[async_trait]
-impl<S, R, Manager, Prover> FullNodeBlueprint<Native>
-    for RtAgnosticBlueprint<S, R, Manager, Prover>
+impl<S, R, Manager, Prover> FullNodeBlueprint<Native> for RtAgnosticBlueprint<S, R, Manager, Prover>
 where
     S: Spec<Da = MockDaSpec, OuterZkvm = MockZkvm> + PluggableSpec,
     R: RuntimeTrait<S> + HasRestApi<S> + HasCapabilities<S> + HasKernel<S> + 'static,


### PR DESCRIPTION
# Description

Make rt agostic blueprint generic prover. Still default to parallel prover service because it is local and has no external dependencies. This work is required to allow using sp1 proving network in soak tests

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
