### PR TITLE
Add missing code commitment method to zkvm network trait

### DIFF
--- a/crates/adapters/mock-zkvm/src/network.rs
+++ b/crates/adapters/mock-zkvm/src/network.rs
@@ -105,4 +105,12 @@ impl sov_rollup_interface::zk::ZkvmNetwork for MockZkvmNetwork {
             None => anyhow::bail!("unknown proof handle: {handle}"),
         }
     }
+
+    fn code_commitment(
+        &self,
+    ) -> anyhow::Result<
+        <<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment,
+    >{
+        Ok(crate::MockCodeCommitment::default())
+    }
 }

--- a/crates/adapters/sp1/src/network.rs
+++ b/crates/adapters/sp1/src/network.rs
@@ -7,7 +7,7 @@ use sov_rollup_interface::zk::{Proof, ZkVerifier, ZkvmGuest, ZkvmNetwork};
 use sp1_sdk::network::proto::auction_types::FulfillmentStatus;
 use sp1_sdk::network::{NetworkMode, B256};
 use sp1_sdk::prover::{ProveRequest, Prover};
-use sp1_sdk::{NetworkProver, ProverClient, SP1ProvingKey, SP1Stdin};
+use sp1_sdk::{NetworkProver, ProverClient, ProvingKey, SP1ProvingKey, SP1Stdin};
 
 use crate::guest::SP1Guest;
 

--- a/crates/adapters/sp1/src/network.rs
+++ b/crates/adapters/sp1/src/network.rs
@@ -3,7 +3,7 @@
 //! Submits proof requests to the Succinct proving network and polls for results.
 
 use serde::Serialize;
-use sov_rollup_interface::zk::{Proof, ZkvmNetwork};
+use sov_rollup_interface::zk::{Proof, ZkVerifier, ZkvmGuest, ZkvmNetwork};
 use sp1_sdk::network::proto::auction_types::FulfillmentStatus;
 use sp1_sdk::network::{NetworkMode, B256};
 use sp1_sdk::prover::{ProveRequest, Prover};
@@ -74,5 +74,13 @@ impl ZkvmNetwork for SP1Network {
             >::Full(proof))?)),
             None => Ok(None),
         }
+    }
+
+    fn code_commitment(
+        &self,
+    ) -> anyhow::Result<<<Self::Guest as ZkvmGuest>::Verifier as ZkVerifier>::CodeCommitment> {
+        Ok(crate::SP1MethodId(bincode::serialize(
+            self.pk.verifying_key(),
+        )?))
     }
 }

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -165,6 +165,14 @@ pub trait ZkvmNetwork: Send + Sync + 'static {
         &self,
         handle: &Self::ProofHandle,
     ) -> impl core::future::Future<Output = anyhow::Result<Option<Vec<u8>>>> + Send;
+
+    /// Returns a commitment to the program being proven.
+    ///
+    /// This is the verifying key that identifies the guest program and can be
+    /// stored at genesis for proof verification.
+    fn code_commitment(
+        &self,
+    ) -> anyhow::Result<<<Self::Guest as ZkvmGuest>::Verifier as ZkVerifier>::CodeCommitment>;
 }
 
 /// A no-op [`ZkvmNetwork`] for ZKVMs that don't support network proving.
@@ -190,6 +198,12 @@ impl<G: ZkvmGuest + 'static> ZkvmNetwork for NoopZkvmNetwork<G> {
     }
 
     async fn poll(&self, _handle: &Self::ProofHandle) -> anyhow::Result<Option<Vec<u8>>> {
+        match self._void {}
+    }
+
+    fn code_commitment(
+        &self,
+    ) -> anyhow::Result<<<Self::Guest as ZkvmGuest>::Verifier as ZkVerifier>::CodeCommitment> {
         match self._void {}
     }
 }


### PR DESCRIPTION
# Description

Adds missing `code_commitment` method to `ZkvmNetwork` trait

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
