### PR TITLE
Disallow chain id 0 until eip7702 is enabled

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -187,8 +187,7 @@ fn validate_chain_id(
         tx_hash,
     ))?;
 
-    // Allow 0 chain id for compatibility with EIP7702
-    if tx_chain_id != rollup_chain_id && tx_chain_id != 0 {
+    if tx_chain_id != rollup_chain_id {
         return Err(AuthenticationError::FatalError(
             FatalError::InvalidChainId {
                 expected: rollup_chain_id,


### PR DESCRIPTION
# Description

This PR rejects txs with chain-id 0 since eip7702 is not yet supported.