### PR TITLE
 Remove `InnerVm/OuterVm` generics from `StateTransitionFunction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-04-01
+- #PR_NUMBER **Breaking change** Remove `InnerVm` and `OuterVm` generic type parameters from `StateTransitionFunction` trait and all downstream types.
+
 # 2026-03-30
 - #2629 Sequencer: Replica rejects batch starts that outrun the executor rebase window. `STATE_ROOT_DELAY_BLOCKS` was increased from 3 to 5 in `constants.toml`.
 - #2654 Replace `lazy_static` crate with `std::sync::LazyLock`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2026-04-01
-- #PR_NUMBER **Breaking change** Remove `InnerVm` and `OuterVm` generic type parameters from `StateTransitionFunction` trait and all downstream types.
+- #2670 **Breaking change** Remove `InnerVm` and `OuterVm` generic type parameters from `StateTransitionFunction` trait and all downstream types.
 
 # 2026-03-30
 - #2629 Sequencer: Replica rejects batch starts that outrun the executor rebase window. `STATE_ROOT_DELAY_BLOCKS` was increased from 3 to 5 in `constants.toml`.

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -112,7 +112,6 @@ where
 impl<Stf, Sm, Da> StateTransitionRunner<Stf, Sm, Da>
 where
     Da: DaService<Error = anyhow::Error>,
-
     Sm: HierarchicalStorageManager<
         Da::Spec,
         LedgerChangeSet = SchemaBatch,

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -23,7 +23,7 @@ use sov_rollup_interface::stf::{
 };
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
-use sov_rollup_interface::zk::{StateTransitionWitness, Zkvm};
+use sov_rollup_interface::zk::StateTransitionWitness;
 use sov_rollup_interface::{ProvableHeightTracker, StateUpdateInfo};
 use tokio::sync::watch;
 use tracing::{debug, info, trace};
@@ -33,20 +33,17 @@ use crate::processes::{new_stf_info_channel, Receiver};
 use crate::state_manager::{BlockCandidateResolution, StateManager};
 use tokio::net::TcpListener;
 
-type GenesisParams<ST, InnerVm, OuterVm, Da> =
-    <ST as StateTransitionFunction<InnerVm, OuterVm, Da>>::GenesisParams;
+type GenesisParams<ST, Da> = <ST as StateTransitionFunction<Da>>::GenesisParams;
 
 type NextDaHeightToProcess = u64;
 
 /// Combines `DaService` with `StateTransitionFunction` and "runs" the rollup.
 #[allow(clippy::type_complexity)]
-pub struct StateTransitionRunner<Stf, Sm, Da, InnerVm, OuterVm>
+pub struct StateTransitionRunner<Stf, Sm, Da>
 where
     Da: DaService,
-    InnerVm: Zkvm,
-    OuterVm: Zkvm,
     Sm: HierarchicalStorageManager<Da::Spec>,
-    Stf: StateTransitionFunction<InnerVm, OuterVm, Da::Spec>,
+    Stf: StateTransitionFunction<Da::Spec>,
 {
     first_unprocessed_height_at_startup: u64,
     da_polling_interval: Duration,
@@ -69,16 +66,14 @@ where
 /// Initializes rollup genesis.
 /// Gets proper DA block and finalizes storage.
 /// Returns root hashes.
-pub async fn initialize_state<Stf, InnerVm, OuterVm, Da, Sm>(
+pub async fn initialize_state<Stf, Da, Sm>(
     stf: &Stf,
     storage_manager: &mut Sm,
     genesis_block: Da::FilteredBlock,
-    genesis_params: GenesisParams<Stf, InnerVm, OuterVm, Da::Spec>,
+    genesis_params: GenesisParams<Stf, Da::Spec>,
 ) -> anyhow::Result<Stf::StateRoot>
 where
-    Stf: StateTransitionFunction<InnerVm, OuterVm, Da::Spec>,
-    InnerVm: Zkvm,
-    OuterVm: Zkvm,
+    Stf: StateTransitionFunction<Da::Spec>,
     Da: DaService,
     Sm: HierarchicalStorageManager<
         Da::Spec,
@@ -114,24 +109,17 @@ where
     Ok(genesis_state_root)
 }
 
-impl<Stf, Sm, Da, InnerVm, OuterVm> StateTransitionRunner<Stf, Sm, Da, InnerVm, OuterVm>
+impl<Stf, Sm, Da> StateTransitionRunner<Stf, Sm, Da>
 where
     Da: DaService<Error = anyhow::Error>,
-    InnerVm: Zkvm,
-    OuterVm: Zkvm,
+
     Sm: HierarchicalStorageManager<
         Da::Spec,
         LedgerChangeSet = SchemaBatch,
         LedgerState = DeltaReader,
     >,
     Sm::StfState: Clone,
-    Stf: StateTransitionFunction<
-        InnerVm,
-        OuterVm,
-        Da::Spec,
-        PreState = Sm::StfState,
-        ChangeSet = Sm::StfChangeSet,
-    >,
+    Stf: StateTransitionFunction<Da::Spec, PreState = Sm::StfState, ChangeSet = Sm::StfChangeSet>,
 {
     /// Creates a new [`StateTransitionRunner`].
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]

--- a/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
@@ -14,7 +14,6 @@ use sov_mock_da::{
     BlockProducingConfig, MockAddress, MockBlock, MockBlockHeader, MockDaConfig, MockDaService,
     MockDaSpec, MockHash, PlannedFork, RandomizationBehaviour, RandomizationConfig,
 };
-use sov_mock_zkvm::MockZkvm;
 use sov_modules_api::provable_height_tracker::InfiniteHeight;
 use sov_rollup_interface::common::{HexHash, RollupHeight, SlotNumber};
 use sov_rollup_interface::da::{DaSpec, RelevantBlobIters};
@@ -24,7 +23,6 @@ use sov_rollup_interface::stf::GenesisParams;
 use sov_rollup_interface::stf::{
     ApplySlotOutput, BatchReceipt, ExecutionContext, StateTransitionFunction,
 };
-use sov_rollup_interface::zk::Zkvm;
 use sov_state::{
     ArrayWitness, NativeStorage, ProverStorage, SlotKey, SlotValue, StateAccesses, Storage,
 };
@@ -64,9 +62,7 @@ impl GenesisParams for MockGenesisParams {
 #[derive(PartialEq, Debug, Clone, Eq, serde::Serialize, serde::Deserialize, Default)]
 pub struct MockStf;
 
-impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, OuterVm, Da>
-    for MockStf
-{
+impl<Da: DaSpec> StateTransitionFunction<Da> for MockStf {
     type StateRoot = <ProverStorage<S> as Storage>::Root;
     type Address = Vec<u8>;
     type GenesisParams = MockGenesisParams;
@@ -96,8 +92,8 @@ impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, 
         _slot_header: &Da::BlockHeader,
         _relevant_blobs: RelevantBlobIters<&mut [<Da as DaSpec>::BlobTransaction]>,
         _execution_context: ExecutionContext,
-    ) -> ApplySlotOutput<InnerVm, OuterVm, Da, Self> {
-        ApplySlotOutput::<InnerVm, OuterVm, Da, Self> {
+    ) -> ApplySlotOutput<Da, Self> {
+        ApplySlotOutput::<Da, Self> {
             state_root: <ProverStorage<S> as Storage>::PRE_GENESIS_ROOT,
             change_set: (),
             proof_receipts: vec![],
@@ -114,15 +110,12 @@ impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, 
     }
 }
 
-type Vm = MockZkvm;
 type S = sov_state::DefaultStorageSpec<sha2::Sha256>;
 type Stf = MockStf;
-type StateRoot = <Stf as StateTransitionFunction<Vm, Vm, MockDaSpec>>::StateRoot;
-type TestBatchReceiptContents =
-    <Stf as StateTransitionFunction<Vm, Vm, MockDaSpec>>::BatchReceiptContents;
-type TestTxReceiptContents =
-    <Stf as StateTransitionFunction<Vm, Vm, MockDaSpec>>::TxReceiptContents;
-type Witness = <Stf as StateTransitionFunction<Vm, Vm, MockDaSpec>>::Witness;
+type StateRoot = <Stf as StateTransitionFunction<MockDaSpec>>::StateRoot;
+type TestBatchReceiptContents = <Stf as StateTransitionFunction<MockDaSpec>>::BatchReceiptContents;
+type TestTxReceiptContents = <Stf as StateTransitionFunction<MockDaSpec>>::TxReceiptContents;
+type Witness = <Stf as StateTransitionFunction<MockDaSpec>>::Witness;
 type MockSlotCommit = SlotCommit<MockBlock, Witness, TestTxReceiptContents>;
 type TestStateManager<Da> = StateManager<
     StateRoot,

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/hash_stf.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/hash_stf.rs
@@ -9,7 +9,7 @@ use sov_rollup_interface::common::RollupHeight;
 use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait, DaSpec, RelevantBlobIters};
 use sov_rollup_interface::stf::{ApplySlotOutput, GenesisParams, StateTransitionFunction};
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
-use sov_rollup_interface::zk::{ZkVerifier, Zkvm};
+use sov_rollup_interface::zk::ZkVerifier;
 use sov_state::namespaces::User;
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::storage::{NativeStorage, SlotKey, SlotValue};
@@ -91,9 +91,7 @@ impl From<Vec<u8>> for HashStfGenesisParams {
     }
 }
 
-impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, OuterVm, Da>
-    for HashStf
-{
+impl<Da: DaSpec> StateTransitionFunction<Da> for HashStf {
     type Address = MockAddress;
     type StateRoot = StorageRoot<S>;
     type GenesisParams = HashStfGenesisParams;
@@ -132,7 +130,7 @@ impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, 
         slot_header: &Da::BlockHeader,
         relevant_blobs: RelevantBlobIters<&mut [Da::BlobTransaction]>,
         _execution_context: sov_modules_api::ExecutionContext,
-    ) -> ApplySlotOutput<InnerVm, OuterVm, Da, Self> {
+    ) -> ApplySlotOutput<Da, Self> {
         // Note: Uses native code, so won't work in ZK
         let storage_root_hash = pre_state
             .get_latest_root_hash()
@@ -212,7 +210,7 @@ impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, 
             "Post apply slot root hashes",
         );
 
-        ApplySlotOutput::<InnerVm, OuterVm, Da, Self> {
+        ApplySlotOutput::<Da, Self> {
             state_root,
             change_set,
             proof_receipts,

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -26,7 +26,6 @@ use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::node::ledger_api::{AggregatedProofResponse, LedgerStateProvider};
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
-use sov_rollup_interface::zk::Zkvm;
 use sov_sequencer::standard::StdSequencerConfig;
 use sov_sequencer::{react_to_state_updates, SequencerConfig, SequencerKindConfig};
 use sov_state::NativeStorage;
@@ -47,10 +46,9 @@ use tokio::sync::broadcast::Receiver;
 use tokio::sync::watch;
 use tokio::task::JoinSet;
 
-type MockInitVariant = InitVariant<HashStf, MockZkvm, MockZkvm, MockDaService>;
+type MockInitVariant = InitVariant<HashStf, MockDaService>;
 
-pub type HashStfRunner<Da> =
-    StateTransitionRunner<HashStf, TestStorageManager, Da, MockZkvm, MockZkvm>;
+pub type HashStfRunner<Da> = StateTransitionRunner<HashStf, TestStorageManager, Da>;
 
 /// TestNode simulates a full-node.
 pub struct TestNode {
@@ -325,16 +323,10 @@ pub async fn initialize_runner(
     )
 }
 
-type GenesisParams<ST, InnerVm, OuterVm, Da> =
-    <ST as StateTransitionFunction<InnerVm, OuterVm, Da>>::GenesisParams;
+type GenesisParams<ST, Da> = <ST as StateTransitionFunction<Da>>::GenesisParams;
 
 /// How [`StateTransitionRunner`] is initialized
-pub enum InitVariant<
-    Stf: StateTransitionFunction<InnerVm, OuterVm, Da::Spec>,
-    InnerVm: Zkvm,
-    OuterVm: Zkvm,
-    Da: DaService,
-> {
+pub enum InitVariant<Stf: StateTransitionFunction<Da::Spec>, Da: DaService> {
     /// From give state root
     Initialized {
         prev_state_root: Stf::StateRoot,
@@ -345,16 +337,14 @@ pub enum InitVariant<
         /// Genesis block header should be finalized at an initialization moment.
         block: Da::FilteredBlock,
         /// Genesis params for Stf::init.
-        genesis_params: GenesisParams<Stf, InnerVm, OuterVm, Da::Spec>,
+        genesis_params: GenesisParams<Stf, Da::Spec>,
     },
 }
 
-impl<Stf, InnerVm, OuterVm, Da> InitVariant<Stf, InnerVm, OuterVm, Da>
+impl<Stf, Da> InitVariant<Stf, Da>
 where
     Stf::PreState: NativeStorage<Root = Stf::StateRoot>,
-    Stf: StateTransitionFunction<InnerVm, OuterVm, Da::Spec>,
-    InnerVm: Zkvm,
-    OuterVm: Zkvm,
+    Stf: StateTransitionFunction<Da::Spec>,
     Da: DaService,
 {
     pub async fn initialize<Sm>(
@@ -386,13 +376,8 @@ where
                 block,
                 genesis_params: params,
             } => {
-                let genesis_state_root = initialize_state::<Stf, InnerVm, OuterVm, Da, Sm>(
-                    stf,
-                    storage_manager,
-                    block,
-                    params,
-                )
-                .await?;
+                let genesis_state_root =
+                    initialize_state::<Stf, Da, Sm>(stf, storage_manager, block, params).await?;
                 (genesis_state_root.clone(), genesis_state_root)
             }
         };

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_initialization_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_initialization_tests.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
 use sov_mock_da::{MockAddress, MockBlock, MockDaService};
-use sov_mock_zkvm::MockZkvm;
 use sov_rollup_interface::node::da::DaService;
 
 use crate::helpers::hash_stf::HashStf;
 use crate::helpers::runner_init::{initialize_runner, InitVariant};
-type MockInitVariant = InitVariant<HashStf, MockZkvm, MockZkvm, MockDaService>;
+type MockInitVariant = InitVariant<HashStf, MockDaService>;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn init_and_restart() {

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -14,7 +14,7 @@ use sov_mock_da::{
     BlockProducingConfig, FailureBehavior, MockAddress, MockBlob, MockBlock, MockBlockHeader,
     MockDaConfig, MockDaService, MockDaSpec, RandomizationBehaviour, RandomizationConfig,
 };
-use sov_mock_zkvm::MockZkvm;
+
 use sov_modules_api::provable_height_tracker::InfiniteHeight;
 use sov_modules_api::{FullyBakedTx, StateTransitionFunction};
 use sov_rollup_interface::node::da::{DaService, SlotData};
@@ -29,7 +29,7 @@ use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio::sync::watch;
 
-type MockInitVariant = InitVariant<HashStf, MockZkvm, MockZkvm, MockDaService>;
+type MockInitVariant = InitVariant<HashStf, MockDaService>;
 
 const STANDARD_SENDER: MockAddress = MockAddress::new([0u8; 32]);
 const TREE_MINUTES: std::time::Duration = std::time::Duration::from_secs(60 * 3);
@@ -442,7 +442,7 @@ fn get_result_from_blocks(
     let stf = HashStf::new();
 
     let (genesis_state_root, change_set) =
-        <HashStf as StateTransitionFunction<MockZkvm, MockZkvm, MockDaSpec>>::init_chain(
+        <HashStf as StateTransitionFunction<MockDaSpec>>::init_chain(
             &stf,
             &Default::default(),
             storage,
@@ -456,16 +456,15 @@ fn get_result_from_blocks(
         let mut relevant_blobs = block.as_relevant_blobs();
 
         let storage = storage_manager.create_storage();
-        let result =
-            <HashStf as StateTransitionFunction<MockZkvm, MockZkvm, MockDaSpec>>::apply_slot(
-                &stf,
-                &state_root,
-                storage,
-                ArrayWitness::default(),
-                &block.header,
-                relevant_blobs.as_iters(),
-                sov_modules_api::ExecutionContext::Node,
-            );
+        let result = <HashStf as StateTransitionFunction<MockDaSpec>>::apply_slot(
+            &stf,
+            &state_root,
+            storage,
+            ArrayWitness::default(),
+            &block.header,
+            relevant_blobs.as_iters(),
+            sov_modules_api::ExecutionContext::Node,
+        );
 
         state_root = result.state_root;
         storage_manager.commit(result.change_set);

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -408,7 +408,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
 
                 let genesis_header = rollup_genesis_block.header().clone();
                 let genesis_state_root: <<Self::Spec as Spec>::Storage as Storage>::Root =
-                    initialize_state::<_, _, _, Self::DaService, _>(
+                    initialize_state::<_, Self::DaService, _>(
                         &native_stf,
                         &mut storage_manager,
                         rollup_genesis_block,
@@ -646,13 +646,8 @@ pub struct NodeEndpointsContainer {
 pub struct Rollup<S: FullNodeBlueprint<M>, M: ExecutionMode> {
     /// The State Transition Runner.
     #[allow(clippy::type_complexity)]
-    pub runner: StateTransitionRunner<
-        StfBlueprint<S::Spec, S::Runtime>,
-        S::StorageManager,
-        S::DaService,
-        <S::Spec as Spec>::InnerZkvm,
-        <S::Spec as Spec>::OuterZkvm,
-    >,
+    pub runner:
+        StateTransitionRunner<StfBlueprint<S::Spec, S::Runtime>, S::StorageManager, S::DaService>,
 
     /// Server endpoints for the rollup.
     pub endpoints: NodeEndpointsContainer,

--- a/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -252,7 +252,7 @@ where
     }
 }
 
-impl<S, RT> StateTransitionFunction<S::InnerZkvm, S::OuterZkvm, S::Da> for StfBlueprint<S, RT>
+impl<S, RT> StateTransitionFunction<S::Da> for StfBlueprint<S, RT>
 where
     S: Spec,
     RT: Runtime<S>,
@@ -370,7 +370,7 @@ where
         slot_header: &<S::Da as DaSpec>::BlockHeader,
         relevant_blobs: RelevantBlobIters<&mut [<S::Da as DaSpec>::BlobTransaction]>,
         execution_context: ExecutionContext,
-    ) -> ApplySlotOutput<S::InnerZkvm, S::OuterZkvm, S::Da, Self> {
+    ) -> ApplySlotOutput<S::Da, Self> {
         self.apply_slot_with_control_flow(
             pre_state_root,
             pre_state,
@@ -429,7 +429,7 @@ where
         relevant_blobs: RelevantBlobIters<&mut [<S::Da as DaSpec>::BlobTransaction]>,
         execution_context: ExecutionContext,
         cf: CF,
-    ) -> ApplySlotOutput<S::InnerZkvm, S::OuterZkvm, S::Da, Self> {
+    ) -> ApplySlotOutput<S::Da, Self> {
         let mut runtime = RT::default();
         // Sanity check that gas limits are set correctly. This is already checked at genesis, but we check again in case
         // Someone modifies the code after genesis.
@@ -607,7 +607,7 @@ where
             }
         };
 
-        ApplySlotOutput::<S::InnerZkvm, S::OuterZkvm, S::Da, Self> {
+        ApplySlotOutput::<S::Da, Self> {
             state_root,
             change_set,
             proof_receipts,

--- a/crates/rollup-interface/src/state_machine/stf/mod.rs
+++ b/crates/rollup-interface/src/state_machine/stf/mod.rs
@@ -333,12 +333,7 @@ pub struct ApplySlotOutputInner<Root, ChangeSet, BR, PR, Witness> {
 
 /// The result of applying a slot to current state.
 #[allow(type_alias_bounds)]
-pub type ApplySlotOutput<
-    InnerVm: Zkvm,
-    OuterVm: Zkvm,
-    Da: DaSpec,
-    Stf: StateTransitionFunction<InnerVm, OuterVm, Da>,
-> = ApplySlotOutputInner<
+pub type ApplySlotOutput<Da: DaSpec, Stf: StateTransitionFunction<Da>> = ApplySlotOutputInner<
     Stf::StateRoot,
     Stf::ChangeSet,
     BatchReceipt<Stf::BatchReceiptContents, Stf::TxReceiptContents>,
@@ -357,7 +352,7 @@ pub type ApplySlotOutput<
 /// The STF is generic over a DA layer and two `Zkvm`s. The `InnerVm` is used to prove individual slots,
 /// while the `OuterVm` is used to generate recursive proofs over multiple slots. The two VMs *may* be set to be
 /// the  same type.
-pub trait StateTransitionFunction<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> {
+pub trait StateTransitionFunction<Da: DaSpec> {
     /// Root hash of state merkle tree
     type StateRoot: Serialize
         + DeserializeOwned
@@ -429,7 +424,7 @@ pub trait StateTransitionFunction<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> {
         slot_header: &Da::BlockHeader,
         relevant_blobs: RelevantBlobIters<&mut [<Da as DaSpec>::BlobTransaction]>,
         execution_context: ExecutionContext,
-    ) -> ApplySlotOutput<InnerVm, OuterVm, Da, Self>;
+    ) -> ApplySlotOutput<Da, Self>;
 }
 
 /// The parameters for the genesis block.

--- a/crates/rollup-interface/src/state_machine/stf/mod.rs
+++ b/crates/rollup-interface/src/state_machine/stf/mod.rs
@@ -30,7 +30,7 @@ use super::optimistic::Attestation;
 use crate::common::{HexHash, RollupHeight};
 use crate::da::{DaSpec, RelevantBlobIters};
 use crate::zk::aggregated_proof::{AggregatedProofPublicData, SerializedAggregatedProof};
-use crate::zk::{StateTransitionPublicData, Zkvm};
+use crate::zk::StateTransitionPublicData;
 
 /// The configuration of a full node of the rollup which creates zk proofs.
 pub struct ProverConfig;
@@ -341,7 +341,6 @@ pub type ApplySlotOutput<Da: DaSpec, Stf: StateTransitionFunction<Da>> = ApplySl
     Stf::Witness,
 >;
 
-// TODO(@preston-evans98): update spec with simplified API
 /// State transition function defines business logic that responsible for changing state.
 /// Terminology:
 ///  - state root: root hash of state merkle tree
@@ -349,9 +348,7 @@ pub type ApplySlotOutput<Da: DaSpec, Stf: StateTransitionFunction<Da>> = ApplySl
 ///  - batch: Set of transactions grouped together, or block on L2
 ///  - blob: Non serialised batch or anything else that can be posted on DA layer, like attestation or proof.
 ///
-/// The STF is generic over a DA layer and two `Zkvm`s. The `InnerVm` is used to prove individual slots,
-/// while the `OuterVm` is used to generate recursive proofs over multiple slots. The two VMs *may* be set to be
-/// the  same type.
+/// The STF is generic over a DA layer specification.
 pub trait StateTransitionFunction<Da: DaSpec> {
     /// Root hash of state merkle tree
     type StateRoot: Serialize

--- a/crates/rollup-interface/src/state_machine/stf/verifier.rs
+++ b/crates/rollup-interface/src/state_machine/stf/verifier.rs
@@ -8,9 +8,7 @@ use crate::zk::{StateTransitionPublicData, StateTransitionWitnessWithAddress, Zk
 pub struct StateTransitionVerifier<ST, Da, InnerVm, OuterVm>
 where
     Da: DaVerifier,
-    InnerVm: Zkvm,
-    OuterVm: Zkvm,
-    ST: StateTransitionFunction<InnerVm, OuterVm, Da::Spec>,
+    ST: StateTransitionFunction<Da::Spec>,
 {
     app: ST,
     da_verifier: Da,
@@ -22,7 +20,7 @@ where
     Da: DaVerifier,
     InnerVm: Zkvm,
     OuterVm: Zkvm,
-    Stf: StateTransitionFunction<InnerVm, OuterVm, Da::Spec>,
+    Stf: StateTransitionFunction<Da::Spec>,
 {
     /// Create a [`StateTransitionVerifier`]
     pub fn new(app: Stf, da_verifier: Da) -> Self {

--- a/crates/rollup-interface/src/state_machine/stf/verifier.rs
+++ b/crates/rollup-interface/src/state_machine/stf/verifier.rs
@@ -1,40 +1,31 @@
-use std::marker::PhantomData;
-
 use crate::da::{BlockHeaderTrait, DaVerifier};
 use crate::stf::{ExecutionContext, StateTransitionFunction};
-use crate::zk::{StateTransitionPublicData, StateTransitionWitnessWithAddress, Zkvm, ZkvmGuest};
+use crate::zk::{StateTransitionPublicData, StateTransitionWitnessWithAddress, ZkvmGuest};
 
 /// Verifies a state transition.
-pub struct StateTransitionVerifier<ST, Da, InnerVm, OuterVm>
+pub struct StateTransitionVerifier<ST, Da>
 where
     Da: DaVerifier,
     ST: StateTransitionFunction<Da::Spec>,
 {
     app: ST,
     da_verifier: Da,
-    phantom: PhantomData<(InnerVm, OuterVm)>,
 }
 
-impl<Stf, Da, InnerVm, OuterVm> StateTransitionVerifier<Stf, Da, InnerVm, OuterVm>
+impl<Stf, Da> StateTransitionVerifier<Stf, Da>
 where
     Da: DaVerifier,
-    InnerVm: Zkvm,
-    OuterVm: Zkvm,
     Stf: StateTransitionFunction<Da::Spec>,
 {
     /// Create a [`StateTransitionVerifier`]
     pub fn new(app: Stf, da_verifier: Da) -> Self {
-        Self {
-            app,
-            da_verifier,
-            phantom: Default::default(),
-        }
+        Self { app, da_verifier }
     }
 
     /// Verify the next block
-    pub fn run_block(
+    pub fn run_block<G: ZkvmGuest>(
         &self,
-        zkvm: InnerVm::Guest,
+        zkvm: G,
         pre_state: Stf::PreState,
     ) -> Result<(), Da::Error> {
         let data: StateTransitionWitnessWithAddress<Stf::Address, _, _, Da::Spec> =

--- a/crates/utils/sov-test-utils/src/runtime/mod.rs
+++ b/crates/utils/sov-test-utils/src/runtime/mod.rs
@@ -191,12 +191,7 @@ impl<RT: Runtime<S>, S: Spec, Sm: ForklessStorageManager> Drop for TestRunner<RT
 }
 
 /// The output of the apply slot function that uses the test spec and da spec.
-pub type TestApplySlotOutput<RT, S> = ApplySlotOutput<
-    <S as Spec>::InnerZkvm,
-    <S as Spec>::OuterZkvm,
-    <S as Spec>::Da,
-    TestStfBlueprint<RT, S>,
->;
+pub type TestApplySlotOutput<RT, S> = ApplySlotOutput<<S as Spec>::Da, TestStfBlueprint<RT, S>>;
 
 /// The output of the runner
 pub struct RunnerOutput<S: Spec> {

--- a/examples/demo-rollup/provers/risc0/guest-celestia-nomt/src/bin/rollup_nomt.rs
+++ b/examples/demo-rollup/provers/risc0/guest-celestia-nomt/src/bin/rollup_nomt.rs
@@ -43,7 +43,7 @@ pub fn main() {
         rollup_proof_namespace: ROLLUP_PROOF_NAMESPACE,
     };
 
-    let stf_verifier = StfVerifier::<_, _, _, _, _>::new(stf, CelestiaVerifier::new(rollup_params));
+    let stf_verifier = StfVerifier::new(stf, CelestiaVerifier::new(rollup_params));
     stf_verifier
         .run_block(guest, storage)
         .expect("Prover must be honest");

--- a/examples/demo-rollup/provers/risc0/guest-celestia/src/bin/rollup.rs
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/src/bin/rollup.rs
@@ -35,7 +35,7 @@ pub fn main() {
         rollup_proof_namespace: ROLLUP_PROOF_NAMESPACE,
     };
 
-    let stf_verifier = StfVerifier::<_, _, _, _, _>::new(stf, CelestiaVerifier::new(rollup_params));
+    let stf_verifier = StfVerifier::new(stf, CelestiaVerifier::new(rollup_params));
     stf_verifier
         .run_block(guest, storage)
         .expect("Prover must be honest");

--- a/examples/demo-rollup/provers/risc0/guest-mock-nomt/src/bin/mock_da_nomt.rs
+++ b/examples/demo-rollup/provers/risc0/guest-mock-nomt/src/bin/mock_da_nomt.rs
@@ -33,7 +33,7 @@ fn cycles_per_block() {
         Runtime<_>,
     > = StfBlueprint::new();
 
-    let stf_verifier = StfVerifier::<_, _, _, _, _>::new(stf, MockDaVerifier {});
+    let stf_verifier = StfVerifier::new(stf, MockDaVerifier {});
 
     stf_verifier
         .run_block(guest, storage)

--- a/examples/demo-rollup/provers/risc0/guest-mock/src/bin/mock_da.rs
+++ b/examples/demo-rollup/provers/risc0/guest-mock/src/bin/mock_da.rs
@@ -23,7 +23,7 @@ fn cycles_per_block() {
         Runtime<_>,
     > = StfBlueprint::new();
 
-    let stf_verifier = StfVerifier::<_, _, _, _, _>::new(stf, MockDaVerifier {});
+    let stf_verifier = StfVerifier::new(stf, MockDaVerifier {});
 
     stf_verifier
         .run_block(guest, storage)

--- a/examples/demo-rollup/provers/sp1/guest-celestia-nomt/src/main.rs
+++ b/examples/demo-rollup/provers/sp1/guest-celestia-nomt/src/main.rs
@@ -42,8 +42,7 @@ pub fn main() {
         rollup_proof_namespace: ROLLUP_PROOF_NAMESPACE,
     };
 
-    let stf_verifier =
-        StfVerifier::<_, _, _, SP1, MockZkvm>::new(stf, CelestiaVerifier::new(rollup_params));
+    let stf_verifier = StfVerifier::new(stf, CelestiaVerifier::new(rollup_params));
 
     stf_verifier
         .run_block(guest, storage)

--- a/examples/demo-rollup/provers/sp1/guest-celestia/src/main.rs
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/src/main.rs
@@ -32,8 +32,7 @@ pub fn main() {
         rollup_proof_namespace: ROLLUP_PROOF_NAMESPACE,
     };
 
-    let stf_verifier =
-        StfVerifier::<_, _, _, SP1, MockZkvm>::new(stf, CelestiaVerifier::new(rollup_params));
+    let stf_verifier = StfVerifier::new(stf, CelestiaVerifier::new(rollup_params));
 
     stf_verifier
         .run_block(guest, storage)

--- a/examples/demo-rollup/provers/sp1/guest-mock-nomt/src/main.rs
+++ b/examples/demo-rollup/provers/sp1/guest-mock-nomt/src/main.rs
@@ -34,7 +34,7 @@ pub fn main() {
         Runtime<_>,
     > = StfBlueprint::new();
 
-    let stf_verifier = StfVerifier::<_, _, _, _, _>::new(stf, MockDaVerifier {});
+    let stf_verifier = StfVerifier::new(stf, MockDaVerifier {});
 
     stf_verifier
         .run_block(guest, storage)

--- a/examples/demo-rollup/provers/sp1/guest-mock/src/main.rs
+++ b/examples/demo-rollup/provers/sp1/guest-mock/src/main.rs
@@ -24,7 +24,7 @@ pub fn main() {
         Runtime<_>,
     > = StfBlueprint::new();
 
-    let stf_verifier = StfVerifier::<_, _, _, _, _>::new(stf, MockDaVerifier {});
+    let stf_verifier = StfVerifier::new(stf, MockDaVerifier {});
 
     stf_verifier
         .run_block(guest, storage)

--- a/examples/demo-rollup/stf/src/lib.rs
+++ b/examples/demo-rollup/stf/src/lib.rs
@@ -13,7 +13,6 @@ use sov_modules_stf_blueprint::StfBlueprint;
 use sov_rollup_interface::stf::StateTransitionVerifier;
 
 /// Alias for StateTransitionVerifier.
-pub type StfVerifier<DA, ZkSpec, RT, InnerVm, OuterVm> =
-    StateTransitionVerifier<StfBlueprint<ZkSpec, RT>, DA, InnerVm, OuterVm>;
+pub type StfVerifier<DA, ZkSpec, RT> = StateTransitionVerifier<StfBlueprint<ZkSpec, RT>, DA>;
 
 pub use demo_stf_declaration::MultiAddressEvmSolana;

--- a/examples/demo-rollup/tests/prover/mod.rs
+++ b/examples/demo-rollup/tests/prover/mod.rs
@@ -6,7 +6,6 @@ use demo_stf::runtime::Runtime;
 use sov_db::schema::SchemaBatch;
 use sov_db::storage_manager::NativeStorageManager;
 use sov_mock_da::{MockAddress, MockBlock, MockDaService, MockDaSpec};
-use sov_mock_zkvm::MockZkvm;
 use sov_modules_api::execution_mode::WitnessGeneration;
 use sov_modules_api::{OperatingMode, SlotData};
 use sov_modules_stf_blueprint::{GenesisParams, StfBlueprint};
@@ -15,7 +14,6 @@ use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::stf::{ExecutionContext, StateTransitionFunction};
 use sov_rollup_interface::storage::HierarchicalStorageManager;
 use sov_rollup_interface::zk::StateTransitionWitness;
-use sov_sp1_adapter::SP1;
 use sov_state::ProverStorage;
 use sov_test_utils::generators::BlobBuildingCtx;
 use sov_test_utils::TestStorageSpec;
@@ -39,10 +37,8 @@ mod parallel;
 mod sp1_cpu_prover;
 
 pub(super) type TestSTF = StfBlueprint<DefaultSpec, Runtime<DefaultSpec>>;
-pub(super) type ProofStateRoot =
-    <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::StateRoot;
-pub(super) type ProofWitness =
-    <TestSTF as StateTransitionFunction<SP1, MockZkvm, MockDaSpec>>::Witness;
+pub(super) type ProofStateRoot = <TestSTF as StateTransitionFunction<MockDaSpec>>::StateRoot;
+pub(super) type ProofWitness = <TestSTF as StateTransitionFunction<MockDaSpec>>::Witness;
 pub(super) type StfWitness = StateTransitionWitness<ProofStateRoot, ProofWitness, MockDaSpec>;
 
 /// Executes the STF against mock DA blocks and produces per-block witnesses.

--- a/examples/demo-simple-stf/README.md
+++ b/examples/demo-simple-stf/README.md
@@ -87,7 +87,7 @@ Next we need to write the core logic in `apply_slot`:
         _witness: Self::Witness,
         _slot_header: &Da::BlockHeader,
         relevant_blobs: RelevantBlobIters<I>,
-    ) -> ApplySlotOutput<Vm, Da, Self>
+    ) -> ApplySlotOutput<Da, Self>
     where
         I: IntoIterator<Item = &'a mut Da::BlobTransaction>,
     {
@@ -166,7 +166,6 @@ The following test checks the rollup logic. In the test, we call `init_chain, be
 ```rust
 use demo_simple_stf::{ApplySlotResult, CheckHashPreimageStf, Root};
 use sov_mock_da::{MockAddress, MockBlob, MockBlock, MockBlockHeader, MockDaSpec};
-use sov_mock_zkvm::MockZkvm;
 use sov_rollup_interface::da::RelevantBlobIters;
 use sov_rollup_interface::stf::{ExecutionContext, StateTransitionFunction};
 
@@ -174,7 +173,7 @@ fn test_stf_success() {
     let address = MockAddress::from([1; 32]);
 
     let stf = &mut CheckHashPreimageStf::default();
-    StateTransitionFunction::<MockZkvm, MockZkvm, MockDaSpec>::init_chain(stf, &Default::default(), (), Default::default());
+    StateTransitionFunction::<MockDaSpec>::init_chain(stf, &Default::default(), (), Default::default());
 
     let mut batch_blobs = {
         let incorrect_preimage = vec![1; 32];
@@ -207,7 +206,7 @@ fn test_stf_success() {
         batch_blobs: batch_blobs.as_mut_slice(),
     };
 
-    let result = StateTransitionFunction::<MockZkvm, MockZkvm, MockDaSpec>::apply_slot(
+    let result = StateTransitionFunction::<MockDaSpec>::apply_slot(
         stf,
         &Root([]),
         (),

--- a/examples/demo-simple-stf/src/lib.rs
+++ b/examples/demo-simple-stf/src/lib.rs
@@ -7,7 +7,6 @@ use sov_rollup_interface::common::RollupHeight;
 use sov_rollup_interface::da::{BlobReaderTrait, DaSpec, RelevantBlobIters};
 use sov_rollup_interface::stf::GenesisParams as GenesisParamsTrait;
 use sov_rollup_interface::stf::{ApplySlotOutput, BatchReceipt, StateTransitionFunction};
-use sov_rollup_interface::zk::Zkvm;
 
 /// An implementation of the [`StateTransitionFunction`]
 /// that is specifically designed to check if someone knows a preimage of a specific hash.
@@ -49,9 +48,7 @@ impl GenesisParamsTrait for GenesisParams {
     }
 }
 
-impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, OuterVm, Da>
-    for CheckHashPreimageStf
-{
+impl<Da: DaSpec> StateTransitionFunction<Da> for CheckHashPreimageStf {
     // Since our rollup is stateless, we don't need to consider the StateRoot.
     type StateRoot = Root;
 
@@ -96,7 +93,7 @@ impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, 
         _slot_header: &Da::BlockHeader,
         relevant_blobs: RelevantBlobIters<&mut [Da::BlobTransaction]>,
         _execution_context: sov_rollup_interface::stf::ExecutionContext,
-    ) -> ApplySlotOutput<InnerVm, OuterVm, Da, Self> {
+    ) -> ApplySlotOutput<Da, Self> {
         let mut receipts = vec![];
         for blob in relevant_blobs.batch_blobs {
             let data = blob.verified_data();
@@ -123,7 +120,7 @@ impl<InnerVm: Zkvm, OuterVm: Zkvm, Da: DaSpec> StateTransitionFunction<InnerVm, 
             });
         }
 
-        ApplySlotOutput::<InnerVm, OuterVm, Da, Self> {
+        ApplySlotOutput::<Da, Self> {
             state_root: Root([]),
             change_set: (),
             proof_receipts: vec![],

--- a/examples/demo-simple-stf/tests/stf_test.rs
+++ b/examples/demo-simple-stf/tests/stf_test.rs
@@ -1,7 +1,6 @@
 use demo_simple_stf::{ApplySlotResult, CheckHashPreimageStf, Root};
 use sov_mock_da::verifier::MockDaSpec;
 use sov_mock_da::{MockAddress, MockBlob, MockBlockHeader};
-use sov_mock_zkvm::MockZkvm;
 use sov_rollup_interface::da::RelevantBlobIters;
 use sov_rollup_interface::stf::{ExecutionContext, StateTransitionFunction};
 
@@ -10,7 +9,7 @@ fn test_stf_success() {
     let address = MockAddress::from([1; 32]);
 
     let stf: &mut CheckHashPreimageStf = &mut CheckHashPreimageStf;
-    StateTransitionFunction::<MockZkvm, MockZkvm, MockDaSpec>::init_chain(
+    StateTransitionFunction::<MockDaSpec>::init_chain(
         stf,
         &MockBlockHeader::default(),
         (),
@@ -48,7 +47,7 @@ fn test_stf_success() {
         batch_blobs: batch_blobs.as_mut_slice(),
     };
 
-    let result = StateTransitionFunction::<MockZkvm, MockZkvm, MockDaSpec>::apply_slot(
+    let result = StateTransitionFunction::<MockDaSpec>::apply_slot(
         stf,
         &Root([]),
         (),


### PR DESCRIPTION
# Description

`InnerVm` and `OuterVm` were used by `StateTransitionFunction` previously but are no longer needed. This PR removes those unused generic parameters.

  - Remove unused `InnerVm: Zkvm` and `OuterVm: Zkvm` generic parameters from `StateTransitionFunction`, `ApplySlotOutput`, `StateTransitionVerifier`, and `StateTransitionRunner`                                                                            
  - Make `StateTransitionVerifier::run_block` generic over `G: ZkvmGuest` instead of coupling it to the struct's VM type                                                                                                                                    
  - Clean up unused imports (`Zkvm`, `MockZkvm`, `PhantomData`) across all affected crates and tests 

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)