### PR TITLE
Fix minor proving workflow bugs

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -295,9 +295,9 @@ impl BlobsCache {
     /// Fetch all proofs that need to be played at the start of the batch with the given sequence number.
     pub fn proofs_for_replay(
         &self,
-        batch_sequence_number: SequenceNumber,
+        target_batch_sequence_number: SequenceNumber,
     ) -> Vec<PreferredProofToReplay> {
-        self.sanity_check_batch_sequence_number_is_in_range(batch_sequence_number);
+        self.sanity_check_batch_sequence_number_is_in_range(target_batch_sequence_number);
 
         let mut output = Vec::new();
         // Given the sequence number of a batch, we want to return all proofs with sequence numbers between the previous batch and the requested batch.
@@ -306,11 +306,11 @@ impl BlobsCache {
                 ReadBlob::Batch(batch) => {
                     // Since we're looking for all proofs in between two batches, we either need to return (if the batch has the sequence number we're looking for)
                     // or we need to reset our output (since the proofs we've already seen would have been handled during processing of the batch we just hit).
-                    if batch.sequence_number == batch_sequence_number {
+                    if batch.sequence_number == target_batch_sequence_number {
                         break;
                     }
                     output.retain(|p: &PreferredProofToReplay| {
-                        p.sequence_number > batch_sequence_number
+                        p.sequence_number > batch.sequence_number
                     });
                 }
                 ReadBlob::Proof {
@@ -320,10 +320,10 @@ impl BlobsCache {
                 } => {
                     // We might have some proofs in cache that come *after* the in-progress batch
                     // If we've passed the requested batch number, we're done.
-                    if *sequence_number > batch_sequence_number {
+                    if *sequence_number > target_batch_sequence_number {
                         break;
                     }
-                    assert_ne!(*sequence_number, batch_sequence_number, "A proof sequence number {sequence_number} was provided to proof_for_replay, which must have a batch sequence number. This is a bug, please report it.");
+                    assert_ne!(*sequence_number, target_batch_sequence_number, "A proof sequence number {sequence_number} was provided to proof_for_replay, which must have a batch sequence number. This is a bug, please report it.");
                     // It it's a proof, just push it to our current output.
                     output.push(PreferredProofToReplay {
                         sequence_number: *sequence_number,
@@ -335,7 +335,7 @@ impl BlobsCache {
         assert!(
             output
                 .last()
-                .map(|p| p.sequence_number == batch_sequence_number.saturating_sub(1))
+                .map(|p| p.sequence_number == target_batch_sequence_number.saturating_sub(1))
                 .unwrap_or(true),
             "The last proof in the list should be the one before the sequence number"
         );

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -249,9 +249,7 @@ where
                 }
 
                 self.synchronized_state_updator
-                    .trigger_batch_production_if_convenient_msg(
-                        "recover_and_catch_up:dump_catchup_batches",
-                    )
+                    .trigger_batch_production_msg("recover_and_catch_up:dump_catchup_batches")
                     .await
                     .map_err(|e| e.into_state_update_error())?;
             }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -399,6 +399,10 @@ where
             return;
         }
 
+        self.trigger_batch_production().await;
+    }
+
+    pub(crate) async fn trigger_batch_production(&mut self) {
         if let Err(e) = self
             .try_to_create_and_start_batch_if_none_in_progress(true)
             .await
@@ -417,9 +421,7 @@ where
 
         // If the node is shutting down, we may not be able to terminate the batch. In that case, just return early.
         if self.shutdown_receiver.has_changed().unwrap_or(true) {
-            info!(
-                "The sequencer is shutting down. Exiting trigger_batch_production_if_convenient."
-            );
+            info!("The sequencer is shutting down. Exiting trigger_batch_production.");
             return;
         }
 

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -403,6 +403,12 @@ where
     }
 
     pub(crate) async fn trigger_batch_production(&mut self) {
+        if !self.seq_config.automatic_batch_production {
+            tracing::error!("Producing batch even though automatic batch production is disabled. This is probably a test bug");
+            #[cfg(debug_assertions)]
+            panic!("Producing batch even though automatic batch production is disabled. This is probably a test bug");
+        }
+
         if let Err(e) = self
             .try_to_create_and_start_batch_if_none_in_progress(true)
             .await

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
@@ -108,7 +108,7 @@ pub(super) enum Message<S: Spec, Rt: Runtime<S>> {
         data: SerializedProofWithDetailsBytes,
         reason: &'static str,
     },
-    TriggerBatchProductionIfConvenient {
+    TriggerBatchProduction {
         reason: &'static str,
     },
     SimpleStateUpdate {

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -323,9 +323,8 @@ where
                 data,
                 reason,
             } => self.process_proof_blob(blob_id, data, reason).await,
-            Message::TriggerBatchProductionIfConvenient { reason } => {
-                self.process_trigger_batch_production_if_convenient(reason)
-                    .await;
+            Message::TriggerBatchProduction { reason } => {
+                self.process_trigger_batch_production(reason).await;
             }
             Message::SimpleStateUpdate { info } => {
                 let slot_number = info.slot_number;
@@ -851,14 +850,13 @@ where
             .await;
     }
 
-    async fn process_trigger_batch_production_if_convenient(&mut self, reason: &'static str) {
+    async fn process_trigger_batch_production(&mut self, reason: &'static str) {
         // We don't run force_overwrite_state() here.
         // This is mostly fine, mainly the API state will be out of date until we've
         // finished sending our batches.
         // Adding parallel state update handling is not worth the complexity right now.
-
         let mut inner = self.get_inner_with_timing(reason).await;
-        inner.trigger_batch_production_if_convenient().await;
+        inner.trigger_batch_production().await;
     }
 
     async fn process_accept_tx(

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/updator.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/updator.rs
@@ -235,12 +235,11 @@ where
         .await
     }
 
-    pub(crate) async fn trigger_batch_production_if_convenient_msg(
+    pub(crate) async fn trigger_batch_production_msg(
         &self,
         reason: &'static str,
     ) -> Result<(), SequencerStateUpdatorError> {
-        self.send(Message::TriggerBatchProductionIfConvenient { reason })
-            .await
+        self.send(Message::TriggerBatchProduction { reason }).await
     }
 
     pub(crate) async fn send_simple_state_update_msg(


### PR DESCRIPTION
# Description
This small PR fixes two bugs in the sequencer. It ports only the functional changes from https://github.com/Sovereign-Labs/sovereign-sdk/pull/2605. The tests will be ported later, but require redesign due to recent changes to the sequencer.

The first bug was that recovery mode used `trigger_batch_production_if_convenient`. This meant that if the blob sender got busy (or for a variety of other reasons), batches would not actually be produced and catch up would not occur. 

Second, the new proof processing logic had a bug where we pruned proofs from our list to process based on the *target* batch version not the current batch version. (This is hard to explain but easy to see when you look at the code - I've flagged it in a github comment below.)

