### PR TITLE
More defensive StorableMockDaLayer block producing

### DIFF
--- a/crates/adapters/mock-da/src/storable/entity/finalized_height.rs
+++ b/crates/adapters/mock-da/src/storable/entity/finalized_height.rs
@@ -20,7 +20,7 @@ pub const ID: i32 = 1;
 
 /// "upsert" the last finalized height
 pub async fn update_value(
-    db: &DatabaseConnection,
+    db: &impl sea_orm::ConnectionTrait,
     last_finalized_height: u32,
 ) -> Result<(), DbErr> {
     let insert_stmt = Entity::insert(ActiveModel {

--- a/crates/adapters/mock-da/src/storable/entity/mod.rs
+++ b/crates/adapters/mock-da/src/storable/entity/mod.rs
@@ -33,6 +33,11 @@ pub(crate) async fn setup_db(db: &DatabaseConnection) -> anyhow::Result<()> {
             "PRAGMA journal_mode = WAL".to_owned(),
         ))
         .await?;
+        db.execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "PRAGMA busy_timeout = 5000".to_owned(),
+        ))
+        .await?;
     }
     Ok(())
 }

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -561,23 +561,23 @@ impl StorableMockDaLayer {
         }
 
         let conn = &self.conn;
-        retry_db(|| async {
-            Blobs::delete_many()
-                .filter(blobs::Column::BlockHeight.gt(height))
-                .exec(conn)
-                .await?;
-            Ok(())
-        })
-        .await?;
+        let txn = retry_db(|| async { Ok(conn.begin().await?) })
+            .await
+            .context("begin transaction for rewind")?;
 
-        retry_db(|| async {
-            BlockHeaders::delete_many()
-                .filter(block_headers::Column::Height.gt(height))
-                .exec(conn)
-                .await?;
-            Ok(())
-        })
-        .await?;
+        Blobs::delete_many()
+            .filter(blobs::Column::BlockHeight.gt(height))
+            .exec(&txn)
+            .await
+            .context("delete blobs above rewind height")?;
+
+        BlockHeaders::delete_many()
+            .filter(block_headers::Column::Height.gt(height))
+            .exec(&txn)
+            .await
+            .context("delete block_headers above rewind height")?;
+
+        txn.commit().await.context("commit rewind transaction")?;
 
         let past_next_height = self.next_height;
         self.next_height = height + 1;

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -167,9 +167,8 @@ impl StorableMockDaLayer {
         // Acquire a single DB connection via transaction upfront. This avoids
         // repeated pool checkout/checkin per query and guarantees the connection
         // is available for all operations within this block production.
-        let txn = self
-            .conn
-            .begin()
+        let conn = &self.conn;
+        let txn = retry_db(|| async { Ok(conn.begin().await?) })
             .await
             .context("begin transaction for produce_block")?;
 

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -225,7 +225,12 @@ impl StorableMockDaLayer {
         // Meaning that "chain head - blocks to finalization" has moved beyond genesis block.
         if next_finalized_height > 0 && next_finalized_height > self.last_finalized_height {
             self.last_finalized_height = next_finalized_height;
-            finalized_height::update_value(&self.conn, self.last_finalized_height).await?;
+            let lfh = self.last_finalized_height;
+            retry_db(|| async {
+                finalized_height::update_value(conn, lfh).await?;
+                Ok(())
+            })
+            .await?;
             let finalized_header = self.get_header_at(next_finalized_height).await?;
             tracing::trace!(
                 header = %finalized_header,
@@ -311,7 +316,13 @@ impl StorableMockDaLayer {
         );
         let start = std::time::Instant::now();
         let (blob, hash) = blobs::build_batch_blob(self.next_height as i32, batch_data, sender);
-        blob.insert(&self.conn).await?;
+        let conn = &self.conn;
+        retry_db(|| async {
+            let blob = blob.clone();
+            blob.insert(conn).await?;
+            Ok(())
+        })
+        .await?;
         let include_at = self.next_height + self.delay_blobs_by;
         tracing::debug!(
             %hash,
@@ -339,7 +350,13 @@ impl StorableMockDaLayer {
         );
         let start = std::time::Instant::now();
         let (blob, hash) = blobs::build_proof_blob(self.next_height as i32, proof_data, sender);
-        blob.insert(&self.conn).await?;
+        let conn = &self.conn;
+        retry_db(|| async {
+            let blob = blob.clone();
+            blob.insert(conn).await?;
+            Ok(())
+        })
+        .await?;
         tracing::trace!(
             %hash,
             %sender,
@@ -519,15 +536,24 @@ impl StorableMockDaLayer {
             );
         }
 
-        Blobs::delete_many()
-            .filter(blobs::Column::BlockHeight.gt(height))
-            .exec(&self.conn)
-            .await?;
+        let conn = &self.conn;
+        retry_db(|| async {
+            Blobs::delete_many()
+                .filter(blobs::Column::BlockHeight.gt(height))
+                .exec(conn)
+                .await?;
+            Ok(())
+        })
+        .await?;
 
-        BlockHeaders::delete_many()
-            .filter(block_headers::Column::Height.gt(height))
-            .exec(&self.conn)
-            .await?;
+        retry_db(|| async {
+            BlockHeaders::delete_many()
+                .filter(block_headers::Column::Height.gt(height))
+                .exec(conn)
+                .await?;
+            Ok(())
+        })
+        .await?;
 
         let past_next_height = self.next_height;
         self.next_height = height + 1;

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -159,15 +159,27 @@ impl StorableMockDaLayer {
             anyhow::bail!("Due to database limitation cannot produce anymore blocks: {} is more than max supported height {}", self.next_height, i32::MAX);
         }
 
-        // Read previous block hash from in-memory watch channel instead of querying DB.
-        // `head_header_sender` always holds the latest produced header (or genesis at startup).
-        assert_eq!(
-            self.head_header_sender.borrow().height.checked_add(1),
-            Some(self.next_height as u64)
-        );
-        let prev_block_hash = self.head_header_sender.borrow().hash.0;
-
         let conn = &self.conn;
+        let prev_block_hash = if self.next_height > 1 {
+            let prev_height = self.next_height - 1;
+            let block = retry_db(|| async {
+                Ok(BlockHeaders::find()
+                    .filter(block_headers::Column::Height.eq(prev_height))
+                    .one(conn)
+                    .await?
+                    .expect("Previous block is missing from the database"))
+            })
+            .await?;
+            let hash: [u8; 32] = block.hash.try_into().map_err(|e: Vec<u8>| {
+                anyhow::anyhow!(
+                    "BlockHash should be 32 bytes long in database, but it is {}",
+                    e.len()
+                )
+            })?;
+            hash
+        } else {
+            GENESIS_HEADER.hash.0
+        };
         let blob_height = self.next_height + self.delay_blobs_by;
         let blobs_for_hash = retry_db(|| async {
             Ok(Blobs::find()

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -232,23 +232,22 @@ impl StorableMockDaLayer {
             .checked_sub(self.blocks_to_finality.saturating_add(1))
             .unwrap_or_default();
         // Meaning that "chain head - blocks to finalization" has moved beyond genesis block.
-        let finalized_header = if next_finalized_height > 0
-            && next_finalized_height > self.last_finalized_height
-        {
-            finalized_height::update_value(&txn, next_finalized_height)
-                .await
-                .context("update finalized_height")?;
-            let header = BlockHeaders::find()
-                .filter(block_headers::Column::Height.eq(next_finalized_height))
-                .one(&txn)
-                .await
-                .context("get finalized header")?
-                .map(MockBlockHeader::from)
-                .expect("Finalized block header not found");
-            Some(header)
-        } else {
-            None
-        };
+        let finalized_header =
+            if next_finalized_height > 0 && next_finalized_height > self.last_finalized_height {
+                finalized_height::update_value(&txn, next_finalized_height)
+                    .await
+                    .context("update finalized_height")?;
+                let header = BlockHeaders::find()
+                    .filter(block_headers::Column::Height.eq(next_finalized_height))
+                    .one(&txn)
+                    .await
+                    .context("get finalized header")?
+                    .map(MockBlockHeader::from)
+                    .expect("Finalized block header not found");
+                Some(header)
+            } else {
+                None
+            };
 
         txn.commit()
             .await

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -225,28 +225,17 @@ impl StorableMockDaLayer {
             .insert(&txn)
             .await
             .context("insert block_header")?;
-        let _ = self.head_header_sender.send_replace(new_head);
-        tracing::debug!(
-            blobs_count,
-            height = self.next_height,
-            prev_hash = %HexHash::new(prev_block_hash),
-            hash = %HexHash::new(this_block_hash),
-            producing_time = ?start.elapsed(),
-            "New block has been produced"
-        );
 
-        self.next_height += 1;
-
-        let next_finalized_height = self
-            .next_height
+        // Compute finalization using what next_height will be after increment.
+        let new_next_height = self.next_height + 1;
+        let next_finalized_height = new_next_height
             .checked_sub(self.blocks_to_finality.saturating_add(1))
             .unwrap_or_default();
         // Meaning that "chain head - blocks to finalization" has moved beyond genesis block.
         let finalized_header = if next_finalized_height > 0
             && next_finalized_height > self.last_finalized_height
         {
-            self.last_finalized_height = next_finalized_height;
-            finalized_height::update_value(&txn, self.last_finalized_height)
+            finalized_height::update_value(&txn, next_finalized_height)
                 .await
                 .context("update finalized_height")?;
             let header = BlockHeaders::find()
@@ -264,6 +253,21 @@ impl StorableMockDaLayer {
         txn.commit()
             .await
             .context("commit produce_block transaction")?;
+
+        // Only mutate in-memory state after successful commit.
+        let _ = self.head_header_sender.send_replace(new_head);
+        self.next_height = new_next_height;
+        if next_finalized_height > self.last_finalized_height {
+            self.last_finalized_height = next_finalized_height;
+        }
+        tracing::debug!(
+            blobs_count,
+            height = self.next_height - 1,
+            prev_hash = %HexHash::new(prev_block_hash),
+            hash = %HexHash::new(this_block_hash),
+            producing_time = ?start.elapsed(),
+            "New block has been produced"
+        );
 
         if let Some(finalized_header) = finalized_header {
             tracing::trace!(

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -51,7 +51,7 @@ impl StorableMockDaLayer {
     ) -> anyhow::Result<Self> {
         let mut opts = sea_orm::ConnectOptions::new(connection_string);
 
-        opts.max_connections(50);
+        opts.max_connections(5);
         opts.sqlx_logging_level(tracing::log::LevelFilter::Trace);
 
         let conn: DatabaseConnection = Database::connect(opts).await?;

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -4,7 +4,7 @@ use rand::prelude::{SliceRandom, SmallRng};
 use rand::{Rng, RngCore, SeedableRng};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, Database, DatabaseConnection, EntityTrait, QueryFilter,
-    QueryOrder, QuerySelect,
+    QueryOrder, QuerySelect, TransactionTrait,
 };
 use sha2::Digest;
 use sov_rollup_interface::common::{HexHash, HexString};
@@ -12,6 +12,7 @@ use std::ops::Range;
 use std::sync::Arc;
 use tokio::sync::{broadcast, watch, Mutex};
 
+use anyhow::Context;
 use std::future::Future;
 
 use crate::config::{GENESIS_BLOCK, GENESIS_HEADER};
@@ -50,6 +51,10 @@ const DB_RETRY_BASE_DELAY_MS: u64 = 50;
 
 /// Retries a database operation with exponential backoff.
 /// Handles transient SQLite errors (SQLITE_CANTOPEN, SQLITE_BUSY) that occur under contention.
+///
+/// Only use for idempotent operations (reads, upserts, conditional deletes).
+/// Do NOT use for plain inserts — they can commit despite returning a transient error,
+/// causing a UNIQUE constraint violation on retry.
 async fn retry_db<T, F, Fut>(f: F) -> anyhow::Result<T>
 where
     F: Fn() -> Fut,
@@ -159,17 +164,23 @@ impl StorableMockDaLayer {
             anyhow::bail!("Due to database limitation cannot produce anymore blocks: {} is more than max supported height {}", self.next_height, i32::MAX);
         }
 
-        let conn = &self.conn;
+        // Acquire a single DB connection via transaction upfront. This avoids
+        // repeated pool checkout/checkin per query and guarantees the connection
+        // is available for all operations within this block production.
+        let txn = self
+            .conn
+            .begin()
+            .await
+            .context("begin transaction for produce_block")?;
+
         let prev_block_hash = if self.next_height > 1 {
             let prev_height = self.next_height - 1;
-            let block = retry_db(|| async {
-                Ok(BlockHeaders::find()
-                    .filter(block_headers::Column::Height.eq(prev_height))
-                    .one(conn)
-                    .await?
-                    .expect("Previous block is missing from the database"))
-            })
-            .await?;
+            let block = BlockHeaders::find()
+                .filter(block_headers::Column::Height.eq(prev_height))
+                .one(&txn)
+                .await
+                .context("get prev block hash")?
+                .expect("Previous block is missing from the database");
             let hash: [u8; 32] = block.hash.try_into().map_err(|e: Vec<u8>| {
                 anyhow::anyhow!(
                     "BlockHash should be 32 bytes long in database, but it is {}",
@@ -181,19 +192,17 @@ impl StorableMockDaLayer {
             GENESIS_HEADER.hash.0
         };
         let blob_height = self.next_height + self.delay_blobs_by;
-        let blobs_for_hash = retry_db(|| async {
-            Ok(Blobs::find()
-                .filter(blobs::Column::BlockHeight.eq(blob_height))
-                .select_only()
-                .column(blobs::Column::Id)
-                .column(blobs::Column::Hash)
-                .column(blobs::Column::Sender)
-                .column(blobs::Column::Namespace)
-                .into_model::<blobs::BlobHashData>()
-                .all(conn)
-                .await?)
-        })
-        .await?;
+        let blobs_for_hash = Blobs::find()
+            .filter(blobs::Column::BlockHeight.eq(blob_height))
+            .select_only()
+            .column(blobs::Column::Id)
+            .column(blobs::Column::Hash)
+            .column(blobs::Column::Sender)
+            .column(blobs::Column::Namespace)
+            .into_model::<blobs::BlobHashData>()
+            .all(&txn)
+            .await
+            .context("get blobs for block hash")?;
         let blobs_count = blobs_for_hash.len();
         tracing::trace!(
             blobs_count,
@@ -211,13 +220,11 @@ impl StorableMockDaLayer {
             time: timestamp,
         };
 
-        let new_head_clone = new_head.clone();
-        retry_db(|| async {
-            let block_model = block_headers::ActiveModel::from(new_head_clone.clone());
-            block_model.insert(conn).await?;
-            Ok(())
-        })
-        .await?;
+        let block_model = block_headers::ActiveModel::from(new_head.clone());
+        block_model
+            .insert(&txn)
+            .await
+            .context("insert block_header")?;
         let _ = self.head_header_sender.send_replace(new_head);
         tracing::debug!(
             blobs_count,
@@ -235,15 +242,30 @@ impl StorableMockDaLayer {
             .checked_sub(self.blocks_to_finality.saturating_add(1))
             .unwrap_or_default();
         // Meaning that "chain head - blocks to finalization" has moved beyond genesis block.
-        if next_finalized_height > 0 && next_finalized_height > self.last_finalized_height {
+        let finalized_header = if next_finalized_height > 0
+            && next_finalized_height > self.last_finalized_height
+        {
             self.last_finalized_height = next_finalized_height;
-            let lfh = self.last_finalized_height;
-            retry_db(|| async {
-                finalized_height::update_value(conn, lfh).await?;
-                Ok(())
-            })
-            .await?;
-            let finalized_header = self.get_header_at(next_finalized_height).await?;
+            finalized_height::update_value(&txn, self.last_finalized_height)
+                .await
+                .context("update finalized_height")?;
+            let header = BlockHeaders::find()
+                .filter(block_headers::Column::Height.eq(next_finalized_height))
+                .one(&txn)
+                .await
+                .context("get finalized header")?
+                .map(MockBlockHeader::from)
+                .expect("Finalized block header not found");
+            Some(header)
+        } else {
+            None
+        };
+
+        txn.commit()
+            .await
+            .context("commit produce_block transaction")?;
+
+        if let Some(finalized_header) = finalized_header {
             tracing::trace!(
                 header = %finalized_header,
                 "Submitting finalized header at"
@@ -328,13 +350,7 @@ impl StorableMockDaLayer {
         );
         let start = std::time::Instant::now();
         let (blob, hash) = blobs::build_batch_blob(self.next_height as i32, batch_data, sender);
-        let conn = &self.conn;
-        retry_db(|| async {
-            let blob = blob.clone();
-            blob.insert(conn).await?;
-            Ok(())
-        })
-        .await?;
+        blob.insert(&self.conn).await.context("insert batch blob")?;
         let include_at = self.next_height + self.delay_blobs_by;
         tracing::debug!(
             %hash,
@@ -362,13 +378,7 @@ impl StorableMockDaLayer {
         );
         let start = std::time::Instant::now();
         let (blob, hash) = blobs::build_proof_blob(self.next_height as i32, proof_data, sender);
-        let conn = &self.conn;
-        retry_db(|| async {
-            let blob = blob.clone();
-            blob.insert(conn).await?;
-            Ok(())
-        })
-        .await?;
+        blob.insert(&self.conn).await.context("insert proof blob")?;
         tracing::trace!(
             %hash,
             %sender,

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -12,6 +12,8 @@ use std::ops::Range;
 use std::sync::Arc;
 use tokio::sync::{broadcast, watch, Mutex};
 
+use std::future::Future;
+
 use crate::config::{GENESIS_BLOCK, GENESIS_HEADER};
 use crate::storable::entity;
 use crate::storable::entity::blobs::Entity as Blobs;
@@ -121,22 +123,13 @@ impl StorableMockDaLayer {
             anyhow::bail!("Due to database limitation cannot produce anymore blocks: {} is more than max supported height {}", self.next_height, i32::MAX);
         }
 
-        let prev_block_hash = if self.next_height > 1 {
-            let block = BlockHeaders::find()
-                .filter(block_headers::Column::Height.eq(self.next_height - 1))
-                .one(&self.conn)
-                .await?
-                .expect("Previous block is missing from the database");
-            let hash: [u8; 32] = block.hash.try_into().map_err(|e: Vec<u8>| {
-                anyhow::anyhow!(
-                    "BlockHash should be 32 bytes long in database, but it is {}",
-                    e.len()
-                )
-            })?;
-            hash
-        } else {
-            GENESIS_HEADER.hash.0
-        };
+        // Read previous block hash from in-memory watch channel instead of querying DB.
+        // `head_header_sender` always holds the latest produced header (or genesis at startup).
+        assert_eq!(
+            self.head_header_sender.borrow().height.checked_add(1),
+            Some(self.next_height as u64)
+        );
+        let prev_block_hash = self.head_header_sender.borrow().hash.0;
 
         let blobs_for_hash = Blobs::find()
             .filter(blobs::Column::BlockHeight.eq(self.next_height + self.delay_blobs_by))

--- a/crates/adapters/mock-da/src/storable/layer.rs
+++ b/crates/adapters/mock-da/src/storable/layer.rs
@@ -45,6 +45,42 @@ pub struct StorableMockDaLayer {
     last_reported_finalized: std::sync::atomic::AtomicU32,
 }
 
+const DB_RETRY_ATTEMPTS: u32 = 5;
+const DB_RETRY_BASE_DELAY_MS: u64 = 50;
+
+/// Retries a database operation with exponential backoff.
+/// Handles transient SQLite errors (SQLITE_CANTOPEN, SQLITE_BUSY) that occur under contention.
+async fn retry_db<T, F, Fut>(f: F) -> anyhow::Result<T>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = anyhow::Result<T>>,
+{
+    let mut last_err = None;
+    for attempt in 0..DB_RETRY_ATTEMPTS {
+        match f().await {
+            Ok(val) => return Ok(val),
+            Err(err) => {
+                let err_str = err.to_string();
+                let is_retryable = err_str.contains("unable to open database file")
+                    || err_str.contains("database is locked");
+                if !is_retryable || attempt + 1 == DB_RETRY_ATTEMPTS {
+                    return Err(err);
+                }
+                let delay = DB_RETRY_BASE_DELAY_MS * (1 << attempt);
+                tracing::warn!(
+                    attempt = attempt + 1,
+                    delay_ms = delay,
+                    error = %err,
+                    "Retrying transient DB error"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                last_err = Some(err);
+            }
+        }
+    }
+    Err(last_err.unwrap())
+}
+
 impl StorableMockDaLayer {
     /// Creates new [`StorableMockDaLayer`] by passing connections string directly to [`Database`]
     pub async fn new_from_connection(
@@ -131,16 +167,21 @@ impl StorableMockDaLayer {
         );
         let prev_block_hash = self.head_header_sender.borrow().hash.0;
 
-        let blobs_for_hash = Blobs::find()
-            .filter(blobs::Column::BlockHeight.eq(self.next_height + self.delay_blobs_by))
-            .select_only()
-            .column(blobs::Column::Id)
-            .column(blobs::Column::Hash)
-            .column(blobs::Column::Sender)
-            .column(blobs::Column::Namespace)
-            .into_model::<blobs::BlobHashData>()
-            .all(&self.conn)
-            .await?;
+        let conn = &self.conn;
+        let blob_height = self.next_height + self.delay_blobs_by;
+        let blobs_for_hash = retry_db(|| async {
+            Ok(Blobs::find()
+                .filter(blobs::Column::BlockHeight.eq(blob_height))
+                .select_only()
+                .column(blobs::Column::Id)
+                .column(blobs::Column::Hash)
+                .column(blobs::Column::Sender)
+                .column(blobs::Column::Namespace)
+                .into_model::<blobs::BlobHashData>()
+                .all(conn)
+                .await?)
+        })
+        .await?;
         let blobs_count = blobs_for_hash.len();
         tracing::trace!(
             blobs_count,
@@ -158,8 +199,13 @@ impl StorableMockDaLayer {
             time: timestamp,
         };
 
-        let block_model = block_headers::ActiveModel::from(new_head.clone());
-        block_model.insert(&self.conn).await?;
+        let new_head_clone = new_head.clone();
+        retry_db(|| async {
+            let block_model = block_headers::ActiveModel::from(new_head_clone.clone());
+            block_model.insert(conn).await?;
+            Ok(())
+        })
+        .await?;
         let _ = self.head_header_sender.send_replace(new_head);
         tracing::debug!(
             blobs_count,


### PR DESCRIPTION
# Description

The test `seq_many_invalid_txs` intermittently fails with:
```
     (code: 14) unable to open database file
```

The intermittent `SQLITE_CANTOPEN (code 14)` error was caused by excessive SQLite contention in `seq_many_invalid_txs`. 

These fixes applied:

1. Reduced connection pool from 50 to 5 The primary fix. SQLite is single-writer, and the `StorableMockDaLayer` is already behind a tokio::RwLock. 50 connections created ~150 file descriptors for one database (.sqlite + .sqlite-wal + .sqlite-shm per connection), causing `SQLITE_CANTOPEN` under heavy contention. Tests use concurrent_sync_tasks=1, so max concurrent readers is ~3. Pool of 5 = 3 readers + 1 writer + 1 buffer.
2. crates/adapters/mock-da/src/storable/entity/mod.rs:33-40 — Added PRAGMA busy_timeout = 5000 Defensive safety net. Tells SQLite to retry for up to 5 seconds instead of failing immediately on lock contention.

3. Wrap produce_block_with_timestamp in a transaction. This is the key fix. Previously, each of the 5 DB operations inside produce_block_with_timestamp independently checked out a pool connection, ran a query, and returned it. Under system-wide FD pressure, any checkout could fail.
  Now conn.begin() acquires one pool connection at the start and all operations run on it:
  ```
   begin()          ← checks out 1 connection from pool
     SELECT prev block hash
     SELECT blobs
     INSERT block header
     UPSERT finalized height
     SELECT finalized header
  commit()         ← returns connection to pool
  ```

  This eliminates per-operation pool contention entirely. The connection is reserved for the duration of the block production — no other operation can steal it. As a bonus, if any operation fails mid-way, the transaction rolls back automatically, preventing partial state.

4. retry_db helper for idempotent operations. A retry helper with exponential backoff (50ms base, 5 attempts) for transient SQLITE_CANTOPEN and database is locked errors. Only used for idempotent operations:
  - Conditional deletes in rewind_to_height (DELETE WHERE height > X — safe to re-execute) Not used for inserts (they can commit-then-error, causing UNIQUE violations on retry).
5. anyhow::Context on all DB operations. Every DB call now has a .context("operation name") so failures identify exactly which operation failed (e.g., insert block_header, get prev block hash).
6. finalized_height::update_value accepts impl ConnectionTrait. Changed from &DatabaseConnection to &impl ConnectionTrait so it works inside a transaction.


---

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Existing tests should pass

## Docs
No updates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
