### PR TITLE
Add original error into assert for easier debugging in the future

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -85,7 +85,7 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
         None,
         finalization_blocks,
     )
-        .await;
+    .await;
 
     let mut slot_subscription = test_rollup.client.client.subscribe_slots().await.unwrap();
     let api_client = test_rollup.api_client().clone();
@@ -130,7 +130,10 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
     };
 
     let pattern = "The requested stop_height";
-    assert!(err.to_string().contains(pattern), "Error: '{err}' does not contain expected pattern: '{pattern}'");
+    assert!(
+        err.to_string().contains(pattern),
+        "Error: '{err}' does not contain expected pattern: '{pattern}'"
+    );
 }
 
 async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
@@ -145,7 +148,7 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
         Some(stop_at_height),
         finalization_blocks,
     )
-        .await;
+    .await;
 
     let expected_error = format!(
         "The preferred sequencer has reached the stop height {} and is no longer accepting transactions.",
@@ -254,7 +257,7 @@ async fn rollup_operates_only_on_finalized_blocks_if_stop_at_height_set(finaliza
         Some(stop_at_height),
         finalization_blocks,
     )
-        .await;
+    .await;
 
     // Produce a few blocks to DA blocks to make sure there's a finalized slot after genesis.
     // This is for make rollup operational, so rollup will give out slot notifications.
@@ -308,7 +311,7 @@ async fn check_start_at(finalization_blocks: u32) {
         Some(stop_at_height),
         finalization_blocks,
     )
-        .await;
+    .await;
 
     let client = test_rollup.client.clone();
 
@@ -333,8 +336,8 @@ async fn check_start_at(finalization_blocks: u32) {
             last_height = height;
         }
     })
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     assert_eq!(last_height, stop_at_height);
 
@@ -457,7 +460,7 @@ async fn create_test_rollup(
             stop_at_rollup_height,
             finalization_blocks,
         )
-            .await,
+        .await,
         admin,
     )
 }

--- a/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs
@@ -85,7 +85,7 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
         None,
         finalization_blocks,
     )
-    .await;
+        .await;
 
     let mut slot_subscription = test_rollup.client.client.subscribe_slots().await.unwrap();
     let api_client = test_rollup.api_client().clone();
@@ -129,7 +129,8 @@ async fn sequencer_stops_if_stop_at_height_too_small(finalization_blocks: u32) {
         panic!("The rollup should have stopped")
     };
 
-    assert!(err.to_string().contains("The requested stop_height"));
+    let pattern = "The requested stop_height";
+    assert!(err.to_string().contains(pattern), "Error: '{err}' does not contain expected pattern: '{pattern}'");
 }
 
 async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
@@ -144,7 +145,7 @@ async fn sequencer_does_not_accept_tx_after_stop(finalization_blocks: u32) {
         Some(stop_at_height),
         finalization_blocks,
     )
-    .await;
+        .await;
 
     let expected_error = format!(
         "The preferred sequencer has reached the stop height {} and is no longer accepting transactions.",
@@ -253,7 +254,7 @@ async fn rollup_operates_only_on_finalized_blocks_if_stop_at_height_set(finaliza
         Some(stop_at_height),
         finalization_blocks,
     )
-    .await;
+        .await;
 
     // Produce a few blocks to DA blocks to make sure there's a finalized slot after genesis.
     // This is for make rollup operational, so rollup will give out slot notifications.
@@ -307,7 +308,7 @@ async fn check_start_at(finalization_blocks: u32) {
         Some(stop_at_height),
         finalization_blocks,
     )
-    .await;
+        .await;
 
     let client = test_rollup.client.clone();
 
@@ -332,8 +333,8 @@ async fn check_start_at(finalization_blocks: u32) {
             last_height = height;
         }
     })
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     assert_eq!(last_height, stop_at_height);
 
@@ -456,7 +457,7 @@ async fn create_test_rollup(
             stop_at_rollup_height,
             finalization_blocks,
         )
-        .await,
+            .await,
         admin,
     )
 }


### PR DESCRIPTION
# Description

So it is easier to see what is happening in failure like this one:

```
  TRY 1 FAIL [   1.762s] sov-sequencer::integration upgradability::flaky_tests_sequencer_stops_if_stop_at_height_too_small_immediate_finality
  stdout ───

    running 1 test
    test upgradability::flaky_tests_sequencer_stops_if_stop_at_height_too_small_immediate_finality ... FAILED

    failures:

    failures:
        upgradability::flaky_tests_sequencer_stops_if_stop_at_height_too_small_immediate_finality

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 92 filtered out; finished in 1.74s

  stderr ───

    thread 'upgradability::flaky_tests_sequencer_stops_if_stop_at_height_too_small_immediate_finality' (3846953) panicked at crates/full-node/sov-sequencer/tests/integration/upgradability/mod.rs:132:5:
    assertion failed: err.to_string().contains("The requested stop_height")
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    ```

- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
 

## Testing
Minor update

## Docs
No updates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
