### PR TITLE
Support eager & parallel proof request submission

### DIFF
--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -129,11 +129,8 @@ pub struct ProofManagerConfig<Address> {
     /// A number of state transition info entries are allowed to be kept in memory.
     /// If the number is exceeded, rollup execution will be blocked until provers cathes up.
     pub max_number_of_transitions_in_memory: NonZero<u64>,
-    /// When true, proofs are submitted to the proving network as each block arrives.
-    /// When false, submission is deferred until the batch is full, then all proofs
-    /// are submitted concurrently.
-    /// Use true when block_time >= proof submission time (~7s for SP1 network).
-    /// Use false when block_time < proof submission time.
+    /// When true, proofs are submitted as each block arrives.
+    /// When false, submission is deferred until the batch is full, then submitted concurrently.
     #[serde(default = "default_eager_proof_submission")]
     pub eager_proof_submission: bool,
 }

--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -129,6 +129,17 @@ pub struct ProofManagerConfig<Address> {
     /// A number of state transition info entries are allowed to be kept in memory.
     /// If the number is exceeded, rollup execution will be blocked until provers cathes up.
     pub max_number_of_transitions_in_memory: NonZero<u64>,
+    /// When true, proofs are submitted to the proving network as each block arrives.
+    /// When false, submission is deferred until the batch is full, then all proofs
+    /// are submitted concurrently.
+    /// Use true when block_time >= proof submission time (~7s for SP1 network).
+    /// Use false when block_time < proof submission time.
+    #[serde(default = "default_eager_proof_submission")]
+    pub eager_proof_submission: bool,
+}
+
+fn default_eager_proof_submission() -> bool {
+    true
 }
 
 /// Rollup Configuration

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config.snap
@@ -51,7 +51,8 @@ expression: config
     "aggregated_proof_block_jump": 22,
     "prover_address": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
     "max_number_of_transitions_in_db": 1025,
-    "max_number_of_transitions_in_memory": 768
+    "max_number_of_transitions_in_memory": 768,
+    "eager_proof_submission": true
   },
   "sequencer": {
     "automatic_batch_production": true,

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
@@ -51,7 +51,8 @@ expression: config
     "aggregated_proof_block_jump": 22,
     "prover_address": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
     "max_number_of_transitions_in_db": 1025,
-    "max_number_of_transitions_in_memory": 768
+    "max_number_of_transitions_in_memory": 768,
+    "eager_proof_submission": true
   },
   "sequencer": {
     "automatic_batch_production": true,

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
@@ -51,7 +51,8 @@ expression: config
     "aggregated_proof_block_jump": 22,
     "prover_address": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
     "max_number_of_transitions_in_db": 1025,
-    "max_number_of_transitions_in_memory": 768
+    "max_number_of_transitions_in_memory": 768,
+    "eager_proof_submission": true
   },
   "sequencer": {
     "automatic_batch_production": true,

--- a/crates/full-node/sov-stf-runner/src/processes/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/mod.rs
@@ -19,6 +19,7 @@ pub use zk_manager::*;
 pub async fn start_zk_workflow_in_background<Ps>(
     prover_service: Ps,
     aggregated_proof_block_jump: NonZero<usize>,
+    eager_proof_submission: bool,
     proof_sender: Box<dyn ProofSender>,
     genesis_state_root: Ps::StateRoot,
     stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
@@ -31,6 +32,7 @@ where
     Ok(ZkProofManager::new(
         prover_service,
         aggregated_proof_block_jump,
+        eager_proof_submission,
         proof_sender,
         genesis_state_root,
         stf_info_receiver,

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/network/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/network/prover.rs
@@ -95,24 +95,29 @@ where
         verifier: &Verifier<Da>,
     ) -> Result<ProofProcessingStatus<StateRoot, Witness, Da::Spec>, ProverServiceError> {
         let block_header_hash = state_transition_info.da_block_header().hash();
-        let mut tracker = self.tracker.write().await;
 
-        if let Some(status) = tracker.get(&block_header_hash) {
-            return match status {
-                NetworkProverStatus::Submitted { .. } => {
-                    Err(ProverServiceError::Other(anyhow::anyhow!(
-                        "Proof generation for {} still in progress",
-                        block_header_hash,
-                    )))
-                }
-                NetworkProverStatus::Proved(_) => Err(ProverServiceError::Other(anyhow::anyhow!(
-                    "Witness for block_header_hash {}, submitted multiple times.",
-                    block_header_hash,
-                ))),
-                NetworkProverStatus::Err(e) => {
-                    Err(ProverServiceError::Other(anyhow::format_err!("{}", e)))
-                }
-            };
+        // Short read lock: check for duplicate submission.
+        {
+            let tracker = self.tracker.read().await;
+            if let Some(status) = tracker.get(&block_header_hash) {
+                return match status {
+                    NetworkProverStatus::Submitted { .. } => {
+                        Err(ProverServiceError::Other(anyhow::anyhow!(
+                            "Proof generation for {} still in progress",
+                            block_header_hash,
+                        )))
+                    }
+                    NetworkProverStatus::Proved(_) => {
+                        Err(ProverServiceError::Other(anyhow::anyhow!(
+                            "Witness for block_header_hash {}, submitted multiple times.",
+                            block_header_hash,
+                        )))
+                    }
+                    NetworkProverStatus::Err(e) => {
+                        Err(ProverServiceError::Other(anyhow::format_err!("{}", e)))
+                    }
+                };
+            }
         }
 
         let slot_number = state_transition_info.slot_number;
@@ -133,6 +138,7 @@ where
                 ProverServiceError::Other(anyhow::anyhow!("DA verification failed: {:?}", e))
             })?;
 
+        // Network submission (~7s) — no lock held so concurrent submissions proceed in parallel.
         let handle = self
             .inner_vm
             .add_hint_and_submit(&data)
@@ -164,10 +170,14 @@ where
             block_header_hash
         );
 
-        tracker.insert(
-            block_header_hash,
-            NetworkProverStatus::Submitted { handle, metadata },
-        );
+        // Short write lock: store the proof handle.
+        {
+            let mut tracker = self.tracker.write().await;
+            tracker.insert(
+                block_header_hash,
+                NetworkProverStatus::Submitted { handle, metadata },
+            );
+        }
 
         Ok(ProofProcessingStatus::ProvingInProgress)
     }

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/network/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/network/prover.rs
@@ -96,7 +96,6 @@ where
     ) -> Result<ProofProcessingStatus<StateRoot, Witness, Da::Spec>, ProverServiceError> {
         let block_header_hash = state_transition_info.da_block_header().hash();
 
-        // Short read lock: check for duplicate submission.
         {
             let tracker = self.tracker.read().await;
             if let Some(status) = tracker.get(&block_header_hash) {
@@ -138,7 +137,6 @@ where
                 ProverServiceError::Other(anyhow::anyhow!("DA verification failed: {:?}", e))
             })?;
 
-        // Network submission (~7s) — no lock held so concurrent submissions proceed in parallel.
         let handle = self
             .inner_vm
             .add_hint_and_submit(&data)
@@ -170,7 +168,6 @@ where
             block_header_hash
         );
 
-        // Short write lock: store the proof handle.
         {
             let mut tracker = self.tracker.write().await;
             tracker.insert(

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -26,6 +26,7 @@ pub struct ZkProofManager<Ps: ProverService> {
     prover_service: Ps,
     proofs_to_create: UnAggregatedProofList<Ps>,
     aggregated_proof_block_jump: NonZero<usize>,
+    eager_proof_submission: bool,
     proof_sender: Box<dyn ProofSender>,
     backoff_policy: ExponentialBuilder,
     genesis_state_root: Ps::StateRoot,
@@ -42,6 +43,7 @@ where
     pub fn new(
         prover_service: Ps,
         aggregated_proof_block_jump: NonZero<usize>,
+        eager_proof_submission: bool,
         proof_sender: Box<dyn ProofSender>,
         genesis_state_root: Ps::StateRoot,
         stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
@@ -51,6 +53,7 @@ where
             prover_service,
             proofs_to_create: UnAggregatedProofList::new(),
             aggregated_proof_block_jump,
+            eager_proof_submission,
             proof_sender,
             backoff_policy: ExponentialBuilder::default()
                 .with_min_delay(Duration::from_secs(BACKOFF_POLICY_MIN_DELAY))
@@ -184,6 +187,13 @@ where
                 // <https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/440>
                 public_data_size: 0,
             });
+        }
+
+        if self.eager_proof_submission {
+            self.proofs_to_create
+                .oldest_mut()
+                .prove_any_unproven_blocks(prover_service)
+                .await;
         }
 
         let num_proofs_to_create = self.proofs_to_create.current_proof_jump();

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -186,12 +186,6 @@ where
             });
         }
 
-        // Start proving the next block right away... for now.
-        self.proofs_to_create
-            .oldest_mut()
-            .prove_any_unproven_blocks(prover_service)
-            .await;
-
         let num_proofs_to_create = self.proofs_to_create.current_proof_jump();
 
         // If we've covered enough blocks for the aggregate proof, generate and submit it to DA

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/types.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/types.rs
@@ -97,14 +97,16 @@ impl<Ps: ProverService> AggregateProofMetadata<Ps> {
             return;
         }
 
-        let mut submissions = Vec::new();
-        for proof in self.block_proof_info.iter_mut() {
-            let mut prev_status = BlockProofStatus::Submitted;
-            std::mem::swap(&mut prev_status, &mut proof.status);
-            if let BlockProofStatus::Waiting(witness) = prev_status {
-                submissions.push(witness);
-            }
-        }
+        let submissions: Vec<_> = self
+            .block_proof_info
+            .iter_mut()
+            .filter_map(|proof| {
+                match std::mem::replace(&mut proof.status, BlockProofStatus::Submitted) {
+                    BlockProofStatus::Waiting(w) => Some(w),
+                    BlockProofStatus::Submitted => None,
+                }
+            })
+            .collect();
 
         let futs = submissions.into_iter().map(|mut witness| async {
             loop {

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/types.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/types.rs
@@ -96,29 +96,38 @@ impl<Ps: ProverService> AggregateProofMetadata<Ps> {
         if self.is_ready {
             return;
         }
+
+        // Collect all Waiting witnesses, marking their slots as Submitted.
+        let mut submissions = Vec::new();
         for proof in self.block_proof_info.iter_mut() {
             let mut prev_status = BlockProofStatus::Submitted;
             std::mem::swap(&mut prev_status, &mut proof.status);
-            if let BlockProofStatus::Waiting(mut witness) = prev_status {
-                // TODO: Add backoff on proof submission attempts
-                //  <https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/446>
-                loop {
-                    let status = prover_service
-                        .prove(witness)
-                        .await
-                        .expect("The proof submission should succeed");
+            if let BlockProofStatus::Waiting(witness) = prev_status {
+                submissions.push(witness);
+            }
+        }
 
-                    // Stop the runner loop until prover is ready.
-                    match status {
-                        ProofProcessingStatus::ProvingInProgress => break,
-                        ProofProcessingStatus::Busy(data) => {
-                            witness = data;
-                            tokio::time::sleep(Duration::from_millis(100)).await;
-                        }
+        // Submit all proofs concurrently.
+        // TODO: Add backoff on proof submission attempts
+        //  <https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/446>
+        let futs = submissions.into_iter().map(|mut witness| async {
+            loop {
+                let status = prover_service
+                    .prove(witness)
+                    .await
+                    .expect("The proof submission should succeed");
+
+                match status {
+                    ProofProcessingStatus::ProvingInProgress => break,
+                    ProofProcessingStatus::Busy(data) => {
+                        witness = data;
+                        tokio::time::sleep(Duration::from_millis(100)).await;
                     }
                 }
             }
-        }
+        });
+        futures::future::join_all(futs).await;
+
         self.is_ready = true;
     }
 

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/types.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/types.rs
@@ -97,7 +97,6 @@ impl<Ps: ProverService> AggregateProofMetadata<Ps> {
             return;
         }
 
-        // Collect all Waiting witnesses, marking their slots as Submitted.
         let mut submissions = Vec::new();
         for proof in self.block_proof_info.iter_mut() {
             let mut prev_status = BlockProofStatus::Submitted;
@@ -107,9 +106,6 @@ impl<Ps: ProverService> AggregateProofMetadata<Ps> {
             }
         }
 
-        // Submit all proofs concurrently.
-        // TODO: Add backoff on proof submission attempts
-        //  <https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/446>
         let futs = submissions.into_iter().map(|mut witness| async {
             loop {
                 let status = prover_service

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -416,6 +416,7 @@ pub fn rollup_config_with_da<Da: DaService<Config = MockDaConfig>>(
             prover_address: MockAddress::new([0u8; 32]),
             max_number_of_transitions_in_db: NonZero::new(30).unwrap(),
             max_number_of_transitions_in_memory: NonZero::new(20).unwrap(),
+            eager_proof_submission: true,
         },
         sequencer: SequencerConfig {
             automatic_batch_production: true,

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -288,6 +288,7 @@ pub async fn initialize_runner(
         let handle = start_zk_workflow_in_background::<_>(
             prover_service,
             rollup_config.proof_manager.aggregated_proof_block_jump,
+            rollup_config.proof_manager.eager_proof_submission,
             Box::new(MockProofSender {
                 da: da_service.clone(),
             }),

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -655,6 +655,11 @@
           "format": "uint",
           "minimum": 1.0
         },
+        "eager_proof_submission": {
+          "description": "When true, proofs are submitted as each block arrives. When false, submission is deferred until the batch is full, then submitted concurrently.",
+          "default": true,
+          "type": "boolean"
+        },
         "max_number_of_transitions_in_db": {
           "description": "A number of state transition info entries are allowed to be stored in the database. When the number is exceeded, older entries are removed.",
           "type": "integer",

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -559,6 +559,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     start_zk_workflow_in_background(
                         prover_service,
                         rollup_config.proof_manager.aggregated_proof_block_jump,
+                        rollup_config.proof_manager.eager_proof_submission,
                         proof_sender,
                         genesis_state_root,
                         stf_info_receiver,

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -373,6 +373,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                 max_number_of_transitions_in_db: NonZero::new(self.config.max_infos_in_db).unwrap(),
                 max_number_of_transitions_in_memory: NonZero::new(self.config.max_channel_size)
                     .unwrap(),
+                eager_proof_submission: true,
             },
             sequencer: SequencerConfig {
                 automatic_batch_production: self.config.automatic_batch_production,


### PR DESCRIPTION
# Description

The ZK proof manager submits proofs to the SP1 proving network one at a time as each block arrives. Each submission takes ~7s. This works fine when block_time >= 7s, but when block_time < 7s, the prover can never keep up.

So we add a config flag `eager_proof_submission` on `ProofManagerConfig`

  - true (default): Submit each proof immediately as its block arrives. Optimal for slow chains (e.g., 12s block time) because SP1 starts proving as early as possible. (EiganDA)
  - false: Defer submission until the full batch is collected (aggregated_proof_block_jump blocks), then submit all proofs concurrently via join_all. Optimal for fast chains where block_time < proof submit time, since the upload cost is ~7s regardless of batch size as opposed to 7 * aggregate_jump_size. (Celestia)

  The lock in NetworkProver::start_proving is also split so that concurrent submissions in deferred mode don't serialize on a write lock held during the network call.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
