### PR TITLE
Solana offchain: multisig support in Ledger format

### DIFF
--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -211,24 +211,31 @@ pub struct SolanaOffchainSpecCompliantMultisigMessage<S: Spec> {
 }
 
 // Preamble field sizes, per the Solana offchain message spec.
+/// See <https://docs.anza.xyz/proposals/off-chain-message-signing#message-preamble>
 const SIGNING_DOMAIN_LEN: usize = 16;
 const HEADER_VERSION_LEN: usize = 1;
 const APPLICATION_DOMAIN_LEN: usize = 32;
 const MESSAGE_FORMAT_LEN: usize = 1;
 const SIGNER_COUNT_LEN: usize = 1;
-const PUBKEY_LEN: usize = 32;
+pub(crate) const PUBKEY_LEN: usize = 32;
 const MESSAGE_LENGTH_LEN: usize = 2;
 
 /// The sum of all fixed-size preamble fields (everything except the variable-length signers array).
-const PREAMBLE_FIXED_LEN: usize = SIGNING_DOMAIN_LEN
+pub(crate) const PREAMBLE_FIXED_LEN: usize = SIGNING_DOMAIN_LEN
     + HEADER_VERSION_LEN
     + APPLICATION_DOMAIN_LEN
     + MESSAGE_FORMAT_LEN
     + SIGNER_COUNT_LEN
     + MESSAGE_LENGTH_LEN;
 
-/// The preamble/header required for signing solana offchain messages, supporting a single signer.
-/// See <https://docs.anza.xyz/proposals/off-chain-message-signing#message-preamble>
+// Derived offsets within the preamble (cumulative).
+const HEADER_VERSION_OFFSET: usize = SIGNING_DOMAIN_LEN;
+const APPLICATION_DOMAIN_OFFSET: usize = HEADER_VERSION_OFFSET + HEADER_VERSION_LEN;
+const MESSAGE_FORMAT_OFFSET: usize = APPLICATION_DOMAIN_OFFSET + APPLICATION_DOMAIN_LEN;
+const SIGNER_COUNT_OFFSET: usize = MESSAGE_FORMAT_OFFSET + MESSAGE_FORMAT_LEN;
+const SIGNERS_START: usize = SIGNER_COUNT_OFFSET + SIGNER_COUNT_LEN;
+
+/// The preamble/header required for signing solana offchain messages, see above for spec link.
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct RawSolanaOffchainMessagePreamble {
     pub signing_domain: [u8; SIGNING_DOMAIN_LEN],
@@ -294,13 +301,6 @@ fn parse_and_validate_multisig_preamble(
     data: &[u8],
     actual_message_length: usize,
 ) -> Result<ParsedMultisigPreamble, FatalError> {
-    // Field offsets within the preamble (cumulative).
-    const HEADER_VERSION_OFFSET: usize = SIGNING_DOMAIN_LEN;
-    const APPLICATION_DOMAIN_START: usize = HEADER_VERSION_OFFSET + HEADER_VERSION_LEN;
-    const MESSAGE_FORMAT_OFFSET: usize = APPLICATION_DOMAIN_START + APPLICATION_DOMAIN_LEN;
-    const SIGNER_COUNT_OFFSET: usize = MESSAGE_FORMAT_OFFSET + MESSAGE_FORMAT_LEN;
-    const SIGNERS_START: usize = SIGNER_COUNT_OFFSET + SIGNER_COUNT_LEN;
-
     let min_multisig_preamble = preamble_len(2);
     if data.len() < min_multisig_preamble {
         return Err(FatalError::DeserializationFailed(
@@ -321,9 +321,9 @@ fn parse_and_validate_multisig_preamble(
         )));
     }
 
-    let application_domain_end = APPLICATION_DOMAIN_START + APPLICATION_DOMAIN_LEN;
+    let application_domain_end = APPLICATION_DOMAIN_OFFSET + APPLICATION_DOMAIN_LEN;
     let application_domain: [u8; APPLICATION_DOMAIN_LEN] = data
-        [APPLICATION_DOMAIN_START..application_domain_end]
+        [APPLICATION_DOMAIN_OFFSET..application_domain_end]
         .try_into()
         .unwrap();
 
@@ -607,19 +607,14 @@ fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage
     // 0x80 → Multisig simple message (discriminator prefix)
     // Anything else → Simple message (JSON, typically starts with '{')
     if raw_tx[BORSH_VEC_LEN_PREFIX] == SPEC_COMPLIANT_DISCRIMINATOR {
-        // signer_count sits after the borsh Vec<u8> length prefix (4 bytes) plus the fixed
-        // preamble fields before the signers array.
-        const SIGNER_COUNT_OFFSET: usize = BORSH_VEC_LEN_PREFIX
-            + SIGNING_DOMAIN_LEN
-            + HEADER_VERSION_LEN
-            + APPLICATION_DOMAIN_LEN
-            + MESSAGE_FORMAT_LEN;
-        if raw_tx.len() <= SIGNER_COUNT_OFFSET {
+        // signer_count sits after the borsh Vec<u8> length prefix plus the preamble offset.
+        const RAW_TX_SIGNER_COUNT_OFFSET: usize = BORSH_VEC_LEN_PREFIX + SIGNER_COUNT_OFFSET;
+        if raw_tx.len() <= RAW_TX_SIGNER_COUNT_OFFSET {
             return Err(FatalError::DeserializationFailed(
                 "Message too short to read signer count".to_string(),
             ));
         }
-        if raw_tx[SIGNER_COUNT_OFFSET] > 1 {
+        if raw_tx[RAW_TX_SIGNER_COUNT_OFFSET] > 1 {
             unpack_spec_compliant_multisig_message(raw_tx)
         } else {
             unpack_spec_compliant_message(raw_tx)
@@ -707,19 +702,18 @@ fn unpack_multisig_simple_message<S: Spec>(
     })
 }
 
+type SignaturesAndUnusedKeys<C> = (
+    SafeVec<PubKeyAndSignature<C>, MAX_SIGNERS>,
+    SafeVec<<C as CryptoSpec>::PublicKey, MAX_SIGNERS>,
+);
+
 /// Uses the signer bitfield to pair each signature with its corresponding preamble pubkey,
 /// and collects the remaining pubkeys as unused.
 fn pair_signatures_with_preamble_pubkeys<S: Spec>(
     preamble_signers: &[[u8; 32]],
     signatures: &SafeVec<<S::CryptoSpec as CryptoSpec>::Signature, MAX_SIGNERS>,
     signer_bitfield: u32,
-) -> Result<
-    (
-        SafeVec<PubKeyAndSignature<S::CryptoSpec>, MAX_SIGNERS>,
-        SafeVec<<S::CryptoSpec as CryptoSpec>::PublicKey, MAX_SIGNERS>,
-    ),
-    FatalError,
-> {
+) -> Result<SignaturesAndUnusedKeys<S::CryptoSpec>, FatalError> {
     let signer_count = preamble_signers.len();
 
     // Validate bitfield: no out-of-range bits set
@@ -774,13 +768,13 @@ fn unpack_spec_compliant_multisig_message<S: Spec>(
         borsh::from_slice(raw_tx).map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
 
     let data = &envelope.signed_message_with_preamble;
-    if data.len() < 51 {
+    if data.len() < (SIGNER_COUNT_OFFSET + 1) {
         return Err(FatalError::DeserializationFailed(
             "Message too short for multisig preamble".to_string(),
         ));
     }
 
-    let signer_count = data[50];
+    let signer_count = data[SIGNER_COUNT_OFFSET];
     let preamble_size = preamble_len(signer_count);
     if data.len() < preamble_size {
         return Err(FatalError::DeserializationFailed(format!(

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -210,21 +210,34 @@ pub struct SolanaOffchainSpecCompliantMultisigMessage<S: Spec> {
     pub min_signers: u8,
 }
 
-/// The length of a preamble with a single 32-byte signer. This is just the sum of the lengths of
-/// the byte fields/arrays of the struct below.
-pub const PREAMBLE_LEN: usize = 85;
+// Preamble field sizes, per the Solana offchain message spec.
+const SIGNING_DOMAIN_LEN: usize = 16;
+const HEADER_VERSION_LEN: usize = 1;
+const APPLICATION_DOMAIN_LEN: usize = 32;
+const MESSAGE_FORMAT_LEN: usize = 1;
+const SIGNER_COUNT_LEN: usize = 1;
+const PUBKEY_LEN: usize = 32;
+const MESSAGE_LENGTH_LEN: usize = 2;
+
+/// The sum of all fixed-size preamble fields (everything except the variable-length signers array).
+const PREAMBLE_FIXED_LEN: usize = SIGNING_DOMAIN_LEN
+    + HEADER_VERSION_LEN
+    + APPLICATION_DOMAIN_LEN
+    + MESSAGE_FORMAT_LEN
+    + SIGNER_COUNT_LEN
+    + MESSAGE_LENGTH_LEN;
 
 /// The preamble/header required for signing solana offchain messages, supporting a single signer.
 /// See <https://docs.anza.xyz/proposals/off-chain-message-signing#message-preamble>
 #[derive(BorshSerialize, BorshDeserialize)]
 pub struct RawSolanaOffchainMessagePreamble {
-    pub signing_domain: [u8; 16],
+    pub signing_domain: [u8; SIGNING_DOMAIN_LEN],
     pub header_version: u8,
-    pub application_domain: [u8; 32],
+    pub application_domain: [u8; APPLICATION_DOMAIN_LEN],
     pub message_format: u8,
     pub signer_count: u8,
-    pub signer: [u8; 32],
-    pub message_length: [u8; 2],
+    pub signer: [u8; PUBKEY_LEN],
+    pub message_length: [u8; MESSAGE_LENGTH_LEN],
 }
 
 impl RawSolanaOffchainMessagePreamble {
@@ -264,11 +277,9 @@ impl RawSolanaOffchainMessagePreamble {
     }
 }
 
-/// Computes the preamble length for `signer_count` 32-byte signers.
+/// Computes the total preamble length for `signer_count` signers.
 fn preamble_len(signer_count: u8) -> usize {
-    // signing_domain(16) + header_version(1) + application_domain(32) +
-    // message_format(1) + signer_count(1) + signers(32*N) + message_length(2)
-    53 + 32 * signer_count as usize
+    PREAMBLE_FIXED_LEN + PUBKEY_LEN * signer_count as usize
 }
 
 /// Parsed result of a multisig preamble (signer_count >= 2).
@@ -278,41 +289,52 @@ struct ParsedMultisigPreamble {
 }
 
 /// Parses a Solana offchain message preamble with multiple signers.
-/// Validates all fields and returns the parsed data along with the total preamble length.
+/// Validates all fields and returns the parsed data.
 fn parse_and_validate_multisig_preamble(
     data: &[u8],
     actual_message_length: usize,
 ) -> Result<ParsedMultisigPreamble, FatalError> {
-    // Minimum: 53 bytes of fixed fields + at least 2*32 bytes for signers
-    if data.len() < 53 + 64 {
+    // Field offsets within the preamble (cumulative).
+    const HEADER_VERSION_OFFSET: usize = SIGNING_DOMAIN_LEN;
+    const APPLICATION_DOMAIN_START: usize = HEADER_VERSION_OFFSET + HEADER_VERSION_LEN;
+    const MESSAGE_FORMAT_OFFSET: usize = APPLICATION_DOMAIN_START + APPLICATION_DOMAIN_LEN;
+    const SIGNER_COUNT_OFFSET: usize = MESSAGE_FORMAT_OFFSET + MESSAGE_FORMAT_LEN;
+    const SIGNERS_START: usize = SIGNER_COUNT_OFFSET + SIGNER_COUNT_LEN;
+
+    let min_multisig_preamble = preamble_len(2);
+    if data.len() < min_multisig_preamble {
         return Err(FatalError::DeserializationFailed(
             "Preamble too short for multisig".to_string(),
         ));
     }
 
-    if data[0..16] != *b"\xffsolana offchain" {
+    if data[0..SIGNING_DOMAIN_LEN] != *b"\xffsolana offchain" {
         return Err(FatalError::DeserializationFailed(
             "Invalid Solana signing domain in preamble".to_string(),
         ));
     }
 
-    let header_version = data[16];
+    let header_version = data[HEADER_VERSION_OFFSET];
     if header_version != 0 && header_version != 1 {
         return Err(FatalError::DeserializationFailed(format!(
             "Invalid header version in preamble: only versions 0 and 1 are supported, but version {header_version} was provided"
         )));
     }
 
-    let application_domain: [u8; 32] = data[17..49].try_into().unwrap();
+    let application_domain_end = APPLICATION_DOMAIN_START + APPLICATION_DOMAIN_LEN;
+    let application_domain: [u8; APPLICATION_DOMAIN_LEN] = data
+        [APPLICATION_DOMAIN_START..application_domain_end]
+        .try_into()
+        .unwrap();
 
-    let message_format = data[49];
+    let message_format = data[MESSAGE_FORMAT_OFFSET];
     if message_format != 0 {
         return Err(FatalError::DeserializationFailed(format!(
             "Invalid message format in preamble: only format 0 is supported, but format {message_format} was provided"
         )));
     }
 
-    let signer_count = data[50];
+    let signer_count = data[SIGNER_COUNT_OFFSET];
     if signer_count < 2 || signer_count as usize > MAX_SIGNERS {
         return Err(FatalError::DeserializationFailed(format!(
             "Invalid signer count in multisig preamble: expected 2..={MAX_SIGNERS}, got {signer_count}"
@@ -329,14 +351,17 @@ fn parse_and_validate_multisig_preamble(
 
     let mut signers = Vec::with_capacity(signer_count as usize);
     for i in 0..signer_count as usize {
-        let start = 51 + i * 32;
-        let signer: [u8; 32] = data[start..start + 32].try_into().unwrap();
+        let start = SIGNERS_START + i * PUBKEY_LEN;
+        let signer: [u8; PUBKEY_LEN] = data[start..start + PUBKEY_LEN].try_into().unwrap();
         signers.push(signer);
     }
 
-    let msg_len_offset = 51 + signer_count as usize * 32;
-    let message_length =
-        u16::from_le_bytes(data[msg_len_offset..msg_len_offset + 2].try_into().unwrap());
+    let msg_len_offset = SIGNERS_START + signer_count as usize * PUBKEY_LEN;
+    let message_length = u16::from_le_bytes(
+        data[msg_len_offset..msg_len_offset + MESSAGE_LENGTH_LEN]
+            .try_into()
+            .unwrap(),
+    );
 
     if message_length as usize != actual_message_length {
         return Err(FatalError::DeserializationFailed(format!(
@@ -570,7 +595,8 @@ fn verify_multisig_commitment<S: Spec>(
 
 fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage<S>, FatalError> {
     // First 4 bytes are the length of the Vec<u8> as u32 (borsh encoding)
-    if raw_tx.len() < 5 {
+    const BORSH_VEC_LEN_PREFIX: usize = 4;
+    if raw_tx.len() < BORSH_VEC_LEN_PREFIX + 1 {
         return Err(FatalError::DeserializationFailed(
             "Message too short".to_string(),
         ));
@@ -580,10 +606,14 @@ fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage
     // 0xff → Spec-compliant message (preamble starts with \xffsolana offchain)
     // 0x80 → Multisig simple message (discriminator prefix)
     // Anything else → Simple message (JSON, typically starts with '{')
-    if raw_tx[4] == SPEC_COMPLIANT_DISCRIMINATOR {
-        // Byte 54 is signer_count in the preamble (4 bytes borsh vec length + 50 bytes into
-        // the preamble). Use it to distinguish single-sig from multisig spec-compliant.
-        const SIGNER_COUNT_OFFSET: usize = 4 + 16 + 1 + 32 + 1;
+    if raw_tx[BORSH_VEC_LEN_PREFIX] == SPEC_COMPLIANT_DISCRIMINATOR {
+        // signer_count sits after the borsh Vec<u8> length prefix (4 bytes) plus the fixed
+        // preamble fields before the signers array.
+        const SIGNER_COUNT_OFFSET: usize = BORSH_VEC_LEN_PREFIX
+            + SIGNING_DOMAIN_LEN
+            + HEADER_VERSION_LEN
+            + APPLICATION_DOMAIN_LEN
+            + MESSAGE_FORMAT_LEN;
         if raw_tx.len() <= SIGNER_COUNT_OFFSET {
             return Err(FatalError::DeserializationFailed(
                 "Message too short to read signer count".to_string(),
@@ -594,7 +624,7 @@ fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage
         } else {
             unpack_spec_compliant_message(raw_tx)
         }
-    } else if raw_tx[4] == MULTISIG_SIMPLE_DISCRIMINATOR {
+    } else if raw_tx[BORSH_VEC_LEN_PREFIX] == MULTISIG_SIMPLE_DISCRIMINATOR {
         unpack_multisig_simple_message(raw_tx)
     } else {
         unpack_simple_message(raw_tx)
@@ -604,25 +634,26 @@ fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage
 fn unpack_spec_compliant_message<S: Spec>(
     raw_tx: &[u8],
 ) -> Result<UnpackedSolanaMessage<S>, FatalError> {
+    let single_key_preamble_len = preamble_len(1);
+
     let envelope: SolanaOffchainSpecCompliantMessage<S> =
         borsh::from_slice(raw_tx).map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
 
-    if envelope.signed_message_with_preamble.len() < PREAMBLE_LEN {
+    if envelope.signed_message_with_preamble.len() < single_key_preamble_len {
         return Err(FatalError::DeserializationFailed(
             "Message too short for preamble".to_string(),
         ));
     }
 
     let preamble: RawSolanaOffchainMessagePreamble =
-        borsh::from_slice(&envelope.signed_message_with_preamble[0..PREAMBLE_LEN])
+        borsh::from_slice(&envelope.signed_message_with_preamble[0..single_key_preamble_len])
             .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
 
-    // Unwrap: we just checked that `envelope.signed_message_with_preamble.len()` >= `PREAMBLE_LEN`,
-    // so this can't underflow
+    // Unwrap: we just checked the length is >= single_key_preamble_len, so this can't underflow
     let actual_message_length = envelope
         .signed_message_with_preamble
         .len()
-        .checked_sub(PREAMBLE_LEN)
+        .checked_sub(single_key_preamble_len)
         .unwrap();
     preamble.validate(actual_message_length)?;
 
@@ -634,7 +665,7 @@ fn unpack_spec_compliant_message<S: Spec>(
         signature: envelope.signature,
         chain_hash: preamble.application_domain,
         signed_bytes: envelope.signed_message_with_preamble,
-        json_start: PREAMBLE_LEN,
+        json_start: single_key_preamble_len,
     })
 }
 
@@ -758,7 +789,8 @@ fn unpack_spec_compliant_multisig_message<S: Spec>(
     }
 
     let actual_message_length = data.len() - preamble_size;
-    let preamble = parse_and_validate_multisig_preamble(&data[..preamble_size], actual_message_length)?;
+    let preamble =
+        parse_and_validate_multisig_preamble(&data[..preamble_size], actual_message_length)?;
 
     let (signatures, unused_pub_keys) = pair_signatures_with_preamble_pubkeys::<S>(
         &preamble.signers,

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -190,6 +190,26 @@ pub struct SolanaOffchainSimpleMultisigMessage<S: Spec> {
     pub min_signers: u8,
 }
 
+/// The envelope for a multisig spec-compliant solana offchain message.
+/// All pubkeys are embedded in the preamble (part of the signed bytes). The envelope carries only
+/// signatures, a bitfield mapping each signature to its pubkey in the preamble, and the threshold.
+#[derive(BorshSerialize, BorshDeserialize)]
+pub struct SolanaOffchainSpecCompliantMultisigMessage<S: Spec> {
+    /// Preamble (with all N pubkeys) followed by JSON-serialized `SolanaOffchainUnsignedTransactionV1`.
+    pub signed_message_with_preamble: Vec<u8>,
+    /// One signature per signer, ordered to match set bits in `signer_bitfield` from LSB to MSB.
+    #[borsh(bound(
+        serialize = "<S::CryptoSpec as CryptoSpec>::Signature: BorshSerialize",
+        deserialize = "<S::CryptoSpec as CryptoSpec>::Signature: BorshDeserialize",
+    ))]
+    pub signatures: SafeVec<<S::CryptoSpec as CryptoSpec>::Signature, MAX_SIGNERS>,
+    /// Bitfield marking which pubkeys in the preamble have corresponding signatures.
+    /// Bit `i` (0-indexed from LSB) = 1 means the `i`-th preamble pubkey signed.
+    pub signer_bitfield: u32,
+    /// Minimum number of signers required for the multisig (the K in K-of-N).
+    pub min_signers: u8,
+}
+
 /// The length of a preamble with a single 32-byte signer. This is just the sum of the lengths of
 /// the byte fields/arrays of the struct below.
 pub const PREAMBLE_LEN: usize = 85;
@@ -244,6 +264,93 @@ impl RawSolanaOffchainMessagePreamble {
     }
 }
 
+/// Computes the preamble length for `signer_count` 32-byte signers.
+fn preamble_len(signer_count: u8) -> usize {
+    // signing_domain(16) + header_version(1) + application_domain(32) +
+    // message_format(1) + signer_count(1) + signers(32*N) + message_length(2)
+    53 + 32 * signer_count as usize
+}
+
+/// Parsed result of a multisig preamble (signer_count >= 2).
+struct ParsedMultisigPreamble {
+    application_domain: [u8; 32],
+    signers: Vec<[u8; 32]>,
+}
+
+/// Parses a Solana offchain message preamble with multiple signers.
+/// Validates all fields and returns the parsed data along with the total preamble length.
+fn parse_and_validate_multisig_preamble(
+    data: &[u8],
+    actual_message_length: usize,
+) -> Result<ParsedMultisigPreamble, FatalError> {
+    // Minimum: 53 bytes of fixed fields + at least 2*32 bytes for signers
+    if data.len() < 53 + 64 {
+        return Err(FatalError::DeserializationFailed(
+            "Preamble too short for multisig".to_string(),
+        ));
+    }
+
+    if data[0..16] != *b"\xffsolana offchain" {
+        return Err(FatalError::DeserializationFailed(
+            "Invalid Solana signing domain in preamble".to_string(),
+        ));
+    }
+
+    let header_version = data[16];
+    if header_version != 0 && header_version != 1 {
+        return Err(FatalError::DeserializationFailed(format!(
+            "Invalid header version in preamble: only versions 0 and 1 are supported, but version {header_version} was provided"
+        )));
+    }
+
+    let application_domain: [u8; 32] = data[17..49].try_into().unwrap();
+
+    let message_format = data[49];
+    if message_format != 0 {
+        return Err(FatalError::DeserializationFailed(format!(
+            "Invalid message format in preamble: only format 0 is supported, but format {message_format} was provided"
+        )));
+    }
+
+    let signer_count = data[50];
+    if signer_count < 2 || signer_count as usize > MAX_SIGNERS {
+        return Err(FatalError::DeserializationFailed(format!(
+            "Invalid signer count in multisig preamble: expected 2..={MAX_SIGNERS}, got {signer_count}"
+        )));
+    }
+
+    let total_preamble = preamble_len(signer_count);
+    if data.len() < total_preamble {
+        return Err(FatalError::DeserializationFailed(format!(
+            "Preamble too short: need {total_preamble} bytes for {signer_count} signers, got {}",
+            data.len()
+        )));
+    }
+
+    let mut signers = Vec::with_capacity(signer_count as usize);
+    for i in 0..signer_count as usize {
+        let start = 51 + i * 32;
+        let signer: [u8; 32] = data[start..start + 32].try_into().unwrap();
+        signers.push(signer);
+    }
+
+    let msg_len_offset = 51 + signer_count as usize * 32;
+    let message_length =
+        u16::from_le_bytes(data[msg_len_offset..msg_len_offset + 2].try_into().unwrap());
+
+    if message_length as usize != actual_message_length {
+        return Err(FatalError::DeserializationFailed(format!(
+            "Message length mismatch: expected {message_length}, got {actual_message_length}"
+        )));
+    }
+
+    Ok(ParsedMultisigPreamble {
+        application_domain,
+        signers,
+    })
+}
+
+#[derive(Debug)]
 enum UnpackedSolanaMessage<S: Spec> {
     V0 {
         pub_key: <S::CryptoSpec as CryptoSpec>::PublicKey,
@@ -258,6 +365,7 @@ enum UnpackedSolanaMessage<S: Spec> {
         min_signers: u8,
         chain_hash: [u8; 32],
         signed_bytes: Vec<u8>,
+        json_start: usize,
     },
 }
 
@@ -268,8 +376,12 @@ impl<S: Spec> UnpackedSolanaMessage<S> {
                 signed_bytes,
                 json_start,
                 ..
+            }
+            | UnpackedSolanaMessage::V1 {
+                signed_bytes,
+                json_start,
+                ..
             } => &signed_bytes[*json_start..],
-            UnpackedSolanaMessage::V1 { signed_bytes, .. } => signed_bytes,
         }
     }
 
@@ -469,7 +581,19 @@ fn unpack_solana_message<S: Spec>(raw_tx: &[u8]) -> Result<UnpackedSolanaMessage
     // 0x80 → Multisig simple message (discriminator prefix)
     // Anything else → Simple message (JSON, typically starts with '{')
     if raw_tx[4] == SPEC_COMPLIANT_DISCRIMINATOR {
-        unpack_spec_compliant_message(raw_tx)
+        // Byte 54 is signer_count in the preamble (4 bytes borsh vec length + 50 bytes into
+        // the preamble). Use it to distinguish single-sig from multisig spec-compliant.
+        const SIGNER_COUNT_OFFSET: usize = 4 + 16 + 1 + 32 + 1;
+        if raw_tx.len() <= SIGNER_COUNT_OFFSET {
+            return Err(FatalError::DeserializationFailed(
+                "Message too short to read signer count".to_string(),
+            ));
+        }
+        if raw_tx[SIGNER_COUNT_OFFSET] > 1 {
+            unpack_spec_compliant_multisig_message(raw_tx)
+        } else {
+            unpack_spec_compliant_message(raw_tx)
+        }
     } else if raw_tx[4] == MULTISIG_SIMPLE_DISCRIMINATOR {
         unpack_multisig_simple_message(raw_tx)
     } else {
@@ -548,6 +672,107 @@ fn unpack_multisig_simple_message<S: Spec>(
         min_signers: msg.min_signers,
         chain_hash: msg.chain_hash,
         signed_bytes,
+        json_start: 0,
+    })
+}
+
+/// Uses the signer bitfield to pair each signature with its corresponding preamble pubkey,
+/// and collects the remaining pubkeys as unused.
+fn pair_signatures_with_preamble_pubkeys<S: Spec>(
+    preamble_signers: &[[u8; 32]],
+    signatures: &SafeVec<<S::CryptoSpec as CryptoSpec>::Signature, MAX_SIGNERS>,
+    signer_bitfield: u32,
+) -> Result<
+    (
+        SafeVec<PubKeyAndSignature<S::CryptoSpec>, MAX_SIGNERS>,
+        SafeVec<<S::CryptoSpec as CryptoSpec>::PublicKey, MAX_SIGNERS>,
+    ),
+    FatalError,
+> {
+    let signer_count = preamble_signers.len();
+
+    // Validate bitfield: no out-of-range bits set
+    let valid_bits_mask = (1u32 << signer_count) - 1;
+    if signer_bitfield & !valid_bits_mask != 0 {
+        return Err(FatalError::DeserializationFailed(format!(
+            "Signer bitfield has bits set beyond signer_count ({signer_count})"
+        )));
+    }
+
+    // Validate bitfield popcount matches number of signatures
+    let expected_sig_count = signer_bitfield.count_ones() as usize;
+    if expected_sig_count != signatures.len() {
+        return Err(FatalError::DeserializationFailed(format!(
+            "Signer bitfield popcount ({expected_sig_count}) doesn't match signature count ({})",
+            signatures.len()
+        )));
+    }
+
+    let mut paired = Vec::with_capacity(expected_sig_count);
+    let mut unused = Vec::with_capacity(signer_count - expected_sig_count);
+    let mut sig_idx = 0;
+
+    for (i, signer_bytes) in preamble_signers.iter().enumerate() {
+        let pub_key: <S::CryptoSpec as CryptoSpec>::PublicKey = borsh::from_slice(signer_bytes)
+            .map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
+
+        if signer_bitfield & (1 << i) != 0 {
+            paired.push(PubKeyAndSignature {
+                signature: signatures[sig_idx].clone(),
+                pub_key,
+            });
+            sig_idx += 1;
+        } else {
+            unused.push(pub_key);
+        }
+    }
+
+    let paired = paired
+        .try_into()
+        .map_err(|_| FatalError::DeserializationFailed("Too many signatures".to_string()))?;
+    let unused = unused
+        .try_into()
+        .map_err(|_| FatalError::DeserializationFailed("Too many unused pubkeys".to_string()))?;
+    Ok((paired, unused))
+}
+
+fn unpack_spec_compliant_multisig_message<S: Spec>(
+    raw_tx: &[u8],
+) -> Result<UnpackedSolanaMessage<S>, FatalError> {
+    let envelope: SolanaOffchainSpecCompliantMultisigMessage<S> =
+        borsh::from_slice(raw_tx).map_err(|e| FatalError::DeserializationFailed(e.to_string()))?;
+
+    let data = &envelope.signed_message_with_preamble;
+    if data.len() < 51 {
+        return Err(FatalError::DeserializationFailed(
+            "Message too short for multisig preamble".to_string(),
+        ));
+    }
+
+    let signer_count = data[50];
+    let preamble_size = preamble_len(signer_count);
+    if data.len() < preamble_size {
+        return Err(FatalError::DeserializationFailed(format!(
+            "Message too short for preamble with {signer_count} signers"
+        )));
+    }
+
+    let actual_message_length = data.len() - preamble_size;
+    let preamble = parse_and_validate_multisig_preamble(&data[..preamble_size], actual_message_length)?;
+
+    let (signatures, unused_pub_keys) = pair_signatures_with_preamble_pubkeys::<S>(
+        &preamble.signers,
+        &envelope.signatures,
+        envelope.signer_bitfield,
+    )?;
+
+    Ok(UnpackedSolanaMessage::V1 {
+        signatures,
+        unused_pub_keys,
+        min_signers: envelope.min_signers,
+        chain_hash: preamble.application_domain,
+        signed_bytes: envelope.signed_message_with_preamble,
+        json_start: preamble_size,
     })
 }
 
@@ -805,6 +1030,7 @@ pub mod test {
             min_signers,
             chain_hash,
             signed_bytes,
+            json_start,
         } = &unpacked
         else {
             panic!("Expected Multisig variant");
@@ -815,6 +1041,7 @@ pub mod test {
         assert_eq!(unused_pub_keys.as_ref(), &[pubkey3]);
         assert_eq!(*min_signers, 2);
         assert_eq!(*chain_hash, TEST_CHAIN_HASH);
+        assert_eq!(*json_start, 0);
         // signed_bytes should be the JSON only (discriminator stripped)
         assert_eq!(signed_bytes, json_message);
         assert_eq!(unpacked.json_bytes(), json_message);
@@ -851,5 +1078,141 @@ pub mod test {
         let result = unpack_solana_message::<TestSpec>(&serialized);
         assert!(result.is_err());
         assert!(matches!(result, Err(FatalError::DeserializationFailed(_))));
+    }
+
+    #[test]
+    fn test_unpack_spec_compliant_multisig_message() {
+        use crate::utils::make_multisig_preamble_for_message;
+
+        let json_message = b"{\"test\":\"abcd\"}";
+        let message_len = json_message.len() as u16;
+
+        let pubkey1 = Ed25519PrivateKey::generate().pub_key();
+        let pubkey2 = Ed25519PrivateKey::generate().pub_key();
+        let pubkey3 = Ed25519PrivateKey::generate().pub_key();
+        let sig1: Ed25519Signature = [1u8; 64].as_slice().try_into().unwrap();
+        let sig3: Ed25519Signature = [3u8; 64].as_slice().try_into().unwrap();
+
+        let preamble = make_multisig_preamble_for_message(
+            &[*pubkey1.bytes(), *pubkey2.bytes(), *pubkey3.bytes()],
+            &TEST_CHAIN_HASH,
+            message_len,
+        );
+
+        let mut signed_message = preamble.clone();
+        signed_message.extend_from_slice(json_message);
+
+        // Signers 0 and 2 signed (bitfield = 0b101 = 5), signer 1 did not
+        let envelope = SolanaOffchainSpecCompliantMultisigMessage::<TestSpec> {
+            signed_message_with_preamble: signed_message.clone(),
+            signatures: vec![sig1.clone(), sig3.clone()].try_into().unwrap(),
+            signer_bitfield: 0b101,
+            min_signers: 2,
+        };
+
+        let serialized = borsh::to_vec(&envelope).unwrap();
+        let unpacked = unpack_solana_message::<TestSpec>(&serialized).unwrap();
+
+        let UnpackedSolanaMessage::V1 {
+            signatures,
+            unused_pub_keys,
+            min_signers,
+            chain_hash,
+            signed_bytes,
+            json_start,
+        } = &unpacked
+        else {
+            panic!("Expected Multisig variant");
+        };
+
+        // Signatures should be paired with pubkeys 0 and 2 (matching bitfield order)
+        assert_eq!(signatures.len(), 2);
+        assert_eq!(signatures[0].pub_key, pubkey1);
+        assert_eq!(signatures[0].signature, sig1);
+        assert_eq!(signatures[1].pub_key, pubkey3);
+        assert_eq!(signatures[1].signature, sig3);
+
+        // Pubkey 1 is unused
+        assert_eq!(unused_pub_keys.as_ref(), &[pubkey2]);
+
+        assert_eq!(*min_signers, 2);
+        assert_eq!(*chain_hash, TEST_CHAIN_HASH);
+        assert_eq!(*json_start, preamble.len());
+        assert_eq!(*signed_bytes, signed_message);
+        assert_eq!(unpacked.json_bytes(), json_message);
+    }
+
+    #[test]
+    fn test_spec_compliant_multisig_bitfield_popcount_mismatch() {
+        use crate::utils::make_multisig_preamble_for_message;
+
+        let json_message = b"{\"test\":\"abcd\"}";
+        let pubkey1 = Ed25519PrivateKey::generate().pub_key();
+        let pubkey2 = Ed25519PrivateKey::generate().pub_key();
+        let sig1: Ed25519Signature = [1u8; 64].as_slice().try_into().unwrap();
+
+        let preamble = make_multisig_preamble_for_message(
+            &[*pubkey1.bytes(), *pubkey2.bytes()],
+            &TEST_CHAIN_HASH,
+            json_message.len() as u16,
+        );
+
+        let mut signed_message = preamble;
+        signed_message.extend_from_slice(json_message);
+
+        // 1 signature but bitfield says 2 signers (0b11)
+        let envelope = SolanaOffchainSpecCompliantMultisigMessage::<TestSpec> {
+            signed_message_with_preamble: signed_message,
+            signatures: vec![sig1].try_into().unwrap(),
+            signer_bitfield: 0b11,
+            min_signers: 2,
+        };
+
+        let serialized = borsh::to_vec(&envelope).unwrap();
+        let result = unpack_solana_message::<TestSpec>(&serialized);
+        let Err(FatalError::DeserializationFailed(err_msg)) = result else {
+            panic!("Expected DeserializationFailed, got: {result:?}");
+        };
+        assert!(
+            err_msg.contains("popcount"),
+            "Expected popcount mismatch error, got: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_spec_compliant_multisig_bitfield_out_of_range() {
+        use crate::utils::make_multisig_preamble_for_message;
+
+        let json_message = b"{\"test\":\"abcd\"}";
+        let pubkey1 = Ed25519PrivateKey::generate().pub_key();
+        let pubkey2 = Ed25519PrivateKey::generate().pub_key();
+        let sig1: Ed25519Signature = [1u8; 64].as_slice().try_into().unwrap();
+
+        let preamble = make_multisig_preamble_for_message(
+            &[*pubkey1.bytes(), *pubkey2.bytes()],
+            &TEST_CHAIN_HASH,
+            json_message.len() as u16,
+        );
+
+        let mut signed_message = preamble;
+        signed_message.extend_from_slice(json_message);
+
+        // Bit 2 is set but there are only 2 signers (indices 0 and 1)
+        let envelope = SolanaOffchainSpecCompliantMultisigMessage::<TestSpec> {
+            signed_message_with_preamble: signed_message,
+            signatures: vec![sig1].try_into().unwrap(),
+            signer_bitfield: 0b100,
+            min_signers: 1,
+        };
+
+        let serialized = borsh::to_vec(&envelope).unwrap();
+        let result = unpack_solana_message::<TestSpec>(&serialized);
+        let Err(FatalError::DeserializationFailed(err_msg)) = result else {
+            panic!("Expected DeserializationFailed, got: {result:?}");
+        };
+        assert!(
+            err_msg.contains("bits set beyond"),
+            "Expected out-of-range bitfield error, got: {err_msg}"
+        );
     }
 }

--- a/crates/module-system/sov-solana-offchain-auth/src/utils.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/utils.rs
@@ -28,11 +28,12 @@ pub fn make_multisig_preamble_for_message(
     chain_hash: &[u8; 32],
     message_length: u16,
 ) -> Vec<u8> {
+    use crate::authentication::{PREAMBLE_FIXED_LEN, PUBKEY_LEN};
     assert!(
         pubkeys.len() >= 2 && pubkeys.len() <= 255,
         "multisig preamble requires 2..=255 signers"
     );
-    let mut header = Vec::with_capacity(53 + 32 * pubkeys.len());
+    let mut header = Vec::with_capacity(PREAMBLE_FIXED_LEN + PUBKEY_LEN * pubkeys.len());
     // Signing domain (pre-defined constant)
     header.extend(b"\xffsolana offchain");
     // Header version (only 0 is valid)

--- a/crates/module-system/sov-solana-offchain-auth/src/utils.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/utils.rs
@@ -21,3 +21,32 @@ pub fn make_preamble_for_message(
     header.extend(&message_length.to_le_bytes());
     header.try_into().unwrap()
 }
+
+/// Generate the header for a multisig spec-compliant message with multiple signers.
+pub fn make_multisig_preamble_for_message(
+    pubkeys: &[[u8; 32]],
+    chain_hash: &[u8; 32],
+    message_length: u16,
+) -> Vec<u8> {
+    assert!(
+        pubkeys.len() >= 2 && pubkeys.len() <= 255,
+        "multisig preamble requires 2..=255 signers"
+    );
+    let mut header = Vec::with_capacity(53 + 32 * pubkeys.len());
+    // Signing domain (pre-defined constant)
+    header.extend(b"\xffsolana offchain");
+    // Header version (only 0 is valid)
+    header.push(0);
+    // Application domain
+    header.extend(chain_hash);
+    // Message format - 0 is for ASCII, hardware wallet compatible
+    header.push(0);
+    // Signer count
+    header.push(pubkeys.len() as u8);
+    for pubkey in pubkeys {
+        header.extend(pubkey);
+    }
+    // Message length as little-endian u16
+    header.extend(&message_length.to_le_bytes());
+    header
+}

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
@@ -25,10 +25,13 @@ use sov_rollup_interface::execution_mode::Native;
 use sov_sequencer::rest_api::AcceptTx;
 use sov_solana_offchain_auth::authentication::{
     SolanaOffchainSimpleMessage, SolanaOffchainSimpleMultisigMessage,
-    SolanaOffchainSpecCompliantMessage, SolanaOffchainUnsignedTransactionV0,
-    SolanaOffchainUnsignedTransactionV1, MULTISIG_SIMPLE_DISCRIMINATOR,
+    SolanaOffchainSpecCompliantMessage, SolanaOffchainSpecCompliantMultisigMessage,
+    SolanaOffchainUnsignedTransactionV0, SolanaOffchainUnsignedTransactionV1,
+    MULTISIG_SIMPLE_DISCRIMINATOR,
 };
-use sov_solana_offchain_auth::utils::make_preamble_for_message;
+use sov_solana_offchain_auth::utils::{
+    make_multisig_preamble_for_message, make_preamble_for_message,
+};
 use sov_solana_offchain_auth::{
     SolanaOffchainAuthenticator, SolanaOffchainAuthenticatorInput, SolanaOffchainAuthenticatorTrait,
 };
@@ -686,6 +689,237 @@ async fn test_submit_multisig_invalid_signature() {
         .try_into()
         .unwrap(),
         unused_pub_keys: vec![pub3].try_into().unwrap(),
+        min_signers,
+    };
+
+    let response = submit_tx(
+        test_rollup.api_client(),
+        borsh::to_vec(&multisig_msg).unwrap(),
+    )
+    .await;
+    assert_eq!(response.status(), 400, "Expected 400 for invalid signature");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_submit_multisig_spec_compliant_message_transaction() {
+    let (test_rollup, admin) = create_test_rollup().await.expect("Failed to create rollup");
+
+    // Create 3 signers for a 2-of-3 multisig
+    let key1 = Ed25519PrivateKey::generate();
+    let key2 = Ed25519PrivateKey::generate();
+    let key3 = Ed25519PrivateKey::generate();
+    let pub1 = key1.pub_key();
+    let pub2 = key2.pub_key();
+    let pub3 = key3.pub_key();
+    let min_signers: u8 = 2;
+
+    // Compute the multisig address
+    let multisig =
+        sov_modules_api::Multisig::new(min_signers, vec![pub1.clone(), pub2.clone(), pub3.clone()]);
+    let credential_id = multisig.credential_id::<TestHasher>();
+    let multisig_address: <SolanaTestSpec as Spec>::Address = credential_id.into();
+    let multisig_address_str = multisig_address.to_string();
+
+    // Fund the multisig address from admin
+    {
+        let funding_json = create_transfer_tx_json(Amount(20_000), &multisig_address_str);
+        let encoded_tx = funding_json.as_bytes().to_vec();
+        let signer = admin.private_key();
+        let pubkey = signer.pub_key();
+        let signature = signer.sign(&encoded_tx);
+
+        let message = SolanaOffchainSimpleMessage::<S> {
+            signed_message: encoded_tx,
+            chain_hash: RT::CHAIN_HASH,
+            pubkey,
+            signature,
+        };
+        let raw_tx_bytes = borsh::to_vec(&message).unwrap();
+        let response = submit_tx(test_rollup.api_client(), raw_tx_bytes).await;
+        assert!(
+            response.status().is_success(),
+            "Expected funding transaction to succeed"
+        );
+    }
+
+    let funded_balance = query_balance(&test_rollup.client, &multisig_address_str).await;
+    assert_eq!(funded_balance, Some(Amount::new(20_000)));
+
+    // Build a transfer from the multisig using spec-compliant format.
+    let transfer_json =
+        create_multisig_transfer_tx_json(Amount(7_000), RECIPIENT_ADDRESS, multisig_address);
+    let json_bytes = transfer_json.as_bytes();
+
+    // Build the multisig preamble with all 3 pubkeys
+    let preamble = make_multisig_preamble_for_message(
+        &[*pub1.bytes(), *pub2.bytes(), *pub3.bytes()],
+        &RT::CHAIN_HASH,
+        json_bytes.len() as u16,
+    );
+
+    let mut signed_message_with_preamble = preamble;
+    signed_message_with_preamble.extend_from_slice(json_bytes);
+
+    // Signers 1 and 3 sign the preamble+JSON (deliberately out of order to verify independence)
+    let sig1 = key1.sign(&signed_message_with_preamble);
+    let sig3 = key3.sign(&signed_message_with_preamble);
+
+    // Bitfield: signers 0 and 2 signed (0-indexed) → 0b101 = 5
+    let multisig_msg = SolanaOffchainSpecCompliantMultisigMessage::<S> {
+        signed_message_with_preamble,
+        signatures: vec![sig1, sig3].try_into().unwrap(),
+        signer_bitfield: 0b101,
+        min_signers,
+    };
+
+    let raw_tx_bytes = borsh::to_vec(&multisig_msg).unwrap();
+    let response = submit_tx(test_rollup.api_client(), raw_tx_bytes).await;
+    assert!(
+        response.status().is_success(),
+        "Expected spec-compliant multisig transaction to succeed. Response: {response:?}"
+    );
+
+    let recipient_balance = query_balance(&test_rollup.client, RECIPIENT_ADDRESS).await;
+    assert_eq!(
+        recipient_balance,
+        Some(Amount::new(7_000)),
+        "Expected recipient to have received 7,000 tokens"
+    );
+
+    let multisig_balance = query_balance(&test_rollup.client, &multisig_address_str).await;
+    assert_eq!(
+        multisig_balance,
+        Some(Amount::new(13_000)),
+        "Expected multisig to have 13,000 tokens remaining"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_submit_spec_compliant_multisig_insufficient_signatures() {
+    let (test_rollup, admin) = create_test_rollup().await.expect("Failed to create rollup");
+
+    let key1 = Ed25519PrivateKey::generate();
+    let key2 = Ed25519PrivateKey::generate();
+    let key3 = Ed25519PrivateKey::generate();
+    let pub1 = key1.pub_key();
+    let pub2 = key2.pub_key();
+    let pub3 = key3.pub_key();
+    let min_signers: u8 = 2;
+
+    let multisig =
+        sov_modules_api::Multisig::new(min_signers, vec![pub1.clone(), pub2.clone(), pub3.clone()]);
+    let credential_id = multisig.credential_id::<TestHasher>();
+    let multisig_address: <SolanaTestSpec as Spec>::Address = credential_id.into();
+    let multisig_address_str = multisig_address.to_string();
+
+    // Fund the multisig
+    {
+        let funding_json = create_transfer_tx_json(Amount(20_000), &multisig_address_str);
+        let encoded_tx = funding_json.as_bytes().to_vec();
+        let signer = admin.private_key();
+        let message = SolanaOffchainSimpleMessage::<S> {
+            signed_message: encoded_tx.clone(),
+            chain_hash: RT::CHAIN_HASH,
+            pubkey: signer.pub_key(),
+            signature: signer.sign(&encoded_tx),
+        };
+        let response = submit_tx(test_rollup.api_client(), borsh::to_vec(&message).unwrap()).await;
+        assert!(response.status().is_success());
+    }
+
+    // Only 1 signer when 2 are required
+    let transfer_json =
+        create_multisig_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS, multisig_address);
+    let json_bytes = transfer_json.as_bytes();
+
+    let preamble = make_multisig_preamble_for_message(
+        &[*pub1.bytes(), *pub2.bytes(), *pub3.bytes()],
+        &RT::CHAIN_HASH,
+        json_bytes.len() as u16,
+    );
+
+    let mut signed_message_with_preamble = preamble;
+    signed_message_with_preamble.extend_from_slice(json_bytes);
+
+    let sig1 = key1.sign(&signed_message_with_preamble);
+
+    // Only signer 0 signed → bitfield 0b001
+    let multisig_msg = SolanaOffchainSpecCompliantMultisigMessage::<S> {
+        signed_message_with_preamble,
+        signatures: vec![sig1].try_into().unwrap(),
+        signer_bitfield: 0b001,
+        min_signers,
+    };
+
+    let response = submit_tx(
+        test_rollup.api_client(),
+        borsh::to_vec(&multisig_msg).unwrap(),
+    )
+    .await;
+    assert_eq!(
+        response.status(),
+        400,
+        "Expected 400 for insufficient signatures"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_submit_spec_compliant_multisig_invalid_signature() {
+    let (test_rollup, admin) = create_test_rollup().await.expect("Failed to create rollup");
+
+    let key1 = Ed25519PrivateKey::generate();
+    let key2 = Ed25519PrivateKey::generate();
+    let key3 = Ed25519PrivateKey::generate();
+    let pub1 = key1.pub_key();
+    let pub2 = key2.pub_key();
+    let pub3 = key3.pub_key();
+    let min_signers: u8 = 2;
+
+    let multisig =
+        sov_modules_api::Multisig::new(min_signers, vec![pub1.clone(), pub2.clone(), pub3.clone()]);
+    let credential_id = multisig.credential_id::<TestHasher>();
+    let multisig_address: <SolanaTestSpec as Spec>::Address = credential_id.into();
+    let multisig_address_str = multisig_address.to_string();
+
+    // Fund the multisig
+    {
+        let funding_json = create_transfer_tx_json(Amount(20_000), &multisig_address_str);
+        let encoded_tx = funding_json.as_bytes().to_vec();
+        let signer = admin.private_key();
+        let message = SolanaOffchainSimpleMessage::<S> {
+            signed_message: encoded_tx.clone(),
+            chain_hash: RT::CHAIN_HASH,
+            pubkey: signer.pub_key(),
+            signature: signer.sign(&encoded_tx),
+        };
+        let response = submit_tx(test_rollup.api_client(), borsh::to_vec(&message).unwrap()).await;
+        assert!(response.status().is_success());
+    }
+
+    let transfer_json =
+        create_multisig_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS, multisig_address);
+    let json_bytes = transfer_json.as_bytes();
+
+    let preamble = make_multisig_preamble_for_message(
+        &[*pub1.bytes(), *pub2.bytes(), *pub3.bytes()],
+        &RT::CHAIN_HASH,
+        json_bytes.len() as u16,
+    );
+
+    let mut signed_message_with_preamble = preamble;
+    signed_message_with_preamble.extend_from_slice(json_bytes);
+
+    let sig1 = key1.sign(&signed_message_with_preamble);
+    // Corrupt signer 2's signature
+    let mut sig2_bytes = key2.sign(&signed_message_with_preamble).msg_sig.to_bytes();
+    sig2_bytes[10] = sig2_bytes[10].wrapping_add(1);
+    let sig2: Ed25519Signature = sig2_bytes.as_slice().try_into().unwrap();
+
+    // Signers 0 and 1 → bitfield 0b011
+    let multisig_msg = SolanaOffchainSpecCompliantMultisigMessage::<S> {
+        signed_message_with_preamble,
+        signatures: vec![sig1, sig2].try_into().unwrap(),
+        signer_bitfield: 0b011,
         min_signers,
     };
 

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
@@ -284,7 +284,8 @@ async fn test_submit_ledger_signed_transaction() {
     // updated.)
     assert_eq!(
         transfer_json_tx,
-        r#"{"runtime_call":{"bank":{"transfer":{"to":"4zdwHNaEa5npHtRtaZ3RL1m6rptuQZ6RBLHG6cAyVHjL","coins":{"amount":"5000","token_id":"token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"}}}},"uniqueness":{"generation":0},"details":{"max_priority_fee_bips":0,"max_fee":"100000000000","gas_limit":[1000000000,1000000000],"chain_id":4321},"chain_name":"TestChain"}"#
+        r#"{"runtime_call":{"bank":{"transfer":{"to":"4zdwHNaEa5npHtRtaZ3RL1m6rptuQZ6RBLHG6cAyVHjL","coins":{"amount":"5000","token_id":"token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"}}}},"uniqueness":{"generation":0},"details":{"max_priority_fee_bips":0,"max_fee":"100000000000","gas_limit":[1000000000,1000000000],"chain_id":4321},"chain_name":"TestChain"}"#,
+        "JSON changed - re-sign on Ledger and update the hardcoded signature"
     );
     let encoded_tx = transfer_json_tx.as_bytes().to_vec();
     let pubkey: [u8; 32] = bs58::decode(LEDGER_ADDRESS)
@@ -304,6 +305,14 @@ async fn test_submit_ledger_signed_transaction() {
     let mut signed_message_with_preamble =
         make_preamble_for_message(&pubkey, &RT::CHAIN_HASH, encoded_tx.len() as u16).to_vec();
     signed_message_with_preamble.extend_from_slice(&encoded_tx);
+
+    // Sanity check — if this changes, re-sign on the Ledger and update the signature below.
+    let message_str = bs58::encode(&signed_message_with_preamble).into_string();
+    assert_eq!(
+        message_str,
+        "45bxAZgjJHtL6EmowbCZiBduiwEePySEehCCaCVVJouRB7hQRL3qsv4PNmQvE9NVDfFKmfmVNaNS5a32X1fpSmjJVk19Dk9VSqLyYXxeVuGCZR4jCx7JTx1qbLHD3amNkHvmCnhkgLbT8HgkPwHZWPMeapAo2cL9N3CRzPMZFM5ikWb8yJXzFpCzBjsL1fkCtkDz2BoZPHAtrh5Zvhdae6W9Qypme1iUys8iu4A4e3mk6Nh2us2iLgPcEJhK7xsNxm66CxogjGnwBW3ioTfjRby9LHVzJwQ2dFLJT8kugres5xGG6PxKFNkhFRV4bPgYJvh4ZUUUZSWKkVeW4Ep3nH4BTn1N5WkouYWjKvhy54FCasbM8AyWYAyCnSpX5e8jFEN12rBzmq4HEEJxJY51rTULCEK8Uq2ZJKAe5yTXUisQRw1hZo5bQGku5DwfGyupyfiE6b78vm7uJvQcipLFBoDByrrwPRGhYXK3m8axmcDUFm2PiCpRfYSMk7kGsNn1LLD7D2EwovWDCVERVEB5zftfj6gx9ZeFeZi1c2PdUYsvhZjHdVEa8JVFmts5Q8hD1Wf53DjQAmCFa8GzTK1cekDN47ENFfPaPQsLRFTEXn",
+        "Multisig message bytes changed - re-sign on ledger and update the hardcoded signature"
+    );
 
     let message = SolanaOffchainSpecCompliantMessage::<S> {
         signed_message_with_preamble,
@@ -461,7 +470,7 @@ fn create_multisig_transfer_tx_json(
     serde_json::to_string(&solana_unsigned_tx).unwrap()
 }
 
-fn create_multisig_wire_bytes(json_str: &str) -> Vec<u8> {
+fn create_multisig_simple_wire_bytes(json_str: &str) -> Vec<u8> {
     let mut signed_message = vec![MULTISIG_SIMPLE_DISCRIMINATOR];
     signed_message.extend_from_slice(json_str.as_bytes());
     signed_message
@@ -517,7 +526,7 @@ async fn test_submit_multisig_simple_message_transaction() {
     let transfer_json =
         create_multisig_transfer_tx_json(Amount(7_000), RECIPIENT_ADDRESS, multisig_address);
     let json_bytes = transfer_json.as_bytes();
-    let wire_bytes = create_multisig_wire_bytes(&transfer_json);
+    let wire_bytes = create_multisig_simple_wire_bytes(&transfer_json);
 
     // Signers 3 and 1 sign the JSON directly (deliberately out of order relative to how
     // the credential was constructed from [pub1, pub2, pub3]) to verify order independence.
@@ -602,7 +611,7 @@ async fn test_submit_multisig_insufficient_signatures() {
     let transfer_json =
         create_multisig_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS, multisig_address);
     let json_bytes = transfer_json.as_bytes();
-    let wire_bytes = create_multisig_wire_bytes(&transfer_json);
+    let wire_bytes = create_multisig_simple_wire_bytes(&transfer_json);
     let sig1 = key1.sign(json_bytes);
 
     let multisig_msg = SolanaOffchainSimpleMultisigMessage::<S> {
@@ -667,7 +676,7 @@ async fn test_submit_multisig_invalid_signature() {
     let transfer_json =
         create_multisig_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS, multisig_address);
     let json_bytes = transfer_json.as_bytes();
-    let wire_bytes = create_multisig_wire_bytes(&transfer_json);
+    let wire_bytes = create_multisig_simple_wire_bytes(&transfer_json);
     let sig1 = key1.sign(json_bytes);
     let mut sig2_bytes = key2.sign(json_bytes).msg_sig.to_bytes();
     sig2_bytes[10] = sig2_bytes[10].wrapping_add(1);
@@ -929,4 +938,128 @@ async fn test_submit_spec_compliant_multisig_invalid_signature() {
     )
     .await;
     assert_eq!(response.status(), 400, "Expected 400 for invalid signature");
+}
+
+/// 2-of-3 multisig where one signer is a Ledger device (spec-compliant preamble) and the other
+/// two are mock Ed25519 keys with hardcoded seeds. The Ledger signature and exact JSON bytes are
+/// hardcoded — if the transaction format changes, re-sign on the Ledger and update the constants.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_submit_ledger_signed_multisig_transaction() {
+    // Ledger device pubkey (signer index 0 in the preamble)
+    const LEDGER_ADDRESS: &str = "8YkzDTyLd3buhMw9CMfYYt3FLmcu1BeFr5nMeierYM1v";
+
+    let (test_rollup, admin) = create_test_rollup().await.expect("Failed to create rollup");
+
+    let ledger_pubkey: [u8; 32] = bs58::decode(LEDGER_ADDRESS)
+        .into_vec()
+        .unwrap()
+        .try_into()
+        .unwrap();
+
+    // Fixed mock signers — seeds must not change, otherwise the multisig_id (and thus the JSON
+    // the Ledger signs) will change and invalidate the hardcoded Ledger signature.
+    let key2: Ed25519PrivateKey = vec![0x02u8; 32].try_into().unwrap();
+    let key3: Ed25519PrivateKey = vec![0x03u8; 32].try_into().unwrap();
+    let pub2 = key2.pub_key();
+    let pub3 = key3.pub_key();
+    let min_signers: u8 = 2;
+
+    // The Ledger pubkey is placed at index 0 in the preamble signer list.
+    let ledger_pub: <<S as Spec>::CryptoSpec as CryptoSpec>::PublicKey =
+        borsh::from_slice(&ledger_pubkey).unwrap();
+    let multisig = sov_modules_api::Multisig::new(
+        min_signers,
+        vec![ledger_pub.clone(), pub2.clone(), pub3.clone()],
+    );
+    let credential_id = multisig.credential_id::<TestHasher>();
+    let multisig_address: <SolanaTestSpec as Spec>::Address = credential_id.into();
+    let multisig_address_str = multisig_address.to_string();
+
+    // Fund the multisig address from admin
+    {
+        let funding_json_str = create_transfer_tx_json(Amount(13_000), &multisig_address_str);
+        let encoded_tx = funding_json_str.as_bytes().to_vec();
+        let signer = admin.private_key();
+        let pubkey = signer.pub_key();
+        let signature = signer.sign(&encoded_tx);
+
+        let message = SolanaOffchainSimpleMessage::<S> {
+            signed_message: encoded_tx,
+            chain_hash: RT::CHAIN_HASH,
+            pubkey,
+            signature,
+        };
+        let raw_tx_bytes = borsh::to_vec(&message).unwrap();
+        let response = submit_tx(test_rollup.api_client(), raw_tx_bytes).await;
+        assert!(
+            response.status().is_success(),
+            "Expected funding transaction to succeed"
+        );
+    }
+
+    // Build the V1 multisig transfer transaction
+    let transfer_json_tx =
+        create_multisig_transfer_tx_json(Amount(5_000), RECIPIENT_ADDRESS, multisig_address);
+    let encoded_tx = transfer_json_tx.as_bytes();
+
+    // Build the multisig preamble with all 3 pubkeys (Ledger at index 0)
+    let preamble = make_multisig_preamble_for_message(
+        &[ledger_pubkey, *pub2.bytes(), *pub3.bytes()],
+        &RT::CHAIN_HASH,
+        encoded_tx.len() as u16,
+    );
+
+    let mut signed_message_with_preamble = preamble;
+    signed_message_with_preamble.extend_from_slice(encoded_tx);
+
+    // Sanity check — if this changes, re-sign on the Ledger and update the signature below.
+    let message_str = bs58::encode(&signed_message_with_preamble).into_string();
+    assert_eq!(
+        message_str,
+        "5Xs1emFNEE4zJWJygV42AVRxrrX7VFcFdbRwYcBfd2rTjvHgWYLvUk24jtEX7MunW4fSHHw6Vt8R31Y8M93qM3FzT9afaiEHpmxbTrQ4W3VT1tQMPr5NSFMPPc3yUgbuAnooajsg5isEoTEG9vFM6iTPF6dLF3zQwj6Xtzy1TfiuPHoqhmEabcL8McDiQXmM7VSDd9J1PUZNoRX1NewzmdUcC3YTE57Piazi7S9DKfwjj1U8VxaNQ9aLgBrUQZG5Rhf5D97jqGZ8U7ry19sUx2vg9u8gFfAZJhxhHL5fSRtpAVWVKwrLHmYdriCDgEKgCq6nbcncfk4En16vPGcK2TuyyZtDQ3zjL5j5i1sL5ogyVK9MYQSMoQnaMjv1PyTX1nbMQDU8AuTD4MqE1Pvb4UWXXmtrFz7jYncoVv3k6QL65319wv7cYULfgwNQYygyvExfyxYoaxbwYyFgtvK8tyjqNaEn4KUmGVmucvnvpmy7kqd3pcxseuUM9aGPewt5YjrJL74aSo3LFSESA4XCdYijkxJE4FcFq6LFSuUb3WKS9wT4WifP6xh1DinbfV2MofSexGYuakybmg61AnCd5H8wZi612LmZgq3xQYGDvxaZc4hcap4Ex36VH8U3TFxCQpZLS48iZERgeZzYr5Xa9bDhb9HWAFY2dskJfma3EwfR3EfmeGLtRKmJC73bGhYvyTbL78LWASEzPfDqpszUVNBAsXVh3bZyqaqp5jcTuJFqwnunitnvpuGVN8RNWgh4x5jAuX7HPE5o2Z65r85EsDbwscXYCgo9cwAW8",
+        "Multisig message bytes changed - re-sign on ledger and update the hardcoded signature"
+    );
+
+    // Ledger signs the full preamble+JSON (spec-compliant).
+    // TODO: replace with actual Ledger signature after manual signing of `signed_message_with_preamble`.
+    let ledger_signature: Ed25519Signature = bs58::decode(
+        "5VP3KWw8a2PrrhcU9QiHzULEjaExQ99c2Ke3hgrohHggpAeqJv2fL7MsHTHfQMC6sNpukJou2QswBEwukaQr25Ev",
+    )
+    .into_vec()
+    .unwrap()
+    .as_slice()
+    .try_into()
+    .unwrap();
+
+    // Mock signer key2 also signs the preamble+JSON
+    let sig2 = key2.sign(&signed_message_with_preamble);
+
+    // Bitfield: signers 0 (Ledger) and 1 (key2) signed → 0b011
+    let multisig_msg = SolanaOffchainSpecCompliantMultisigMessage::<S> {
+        signed_message_with_preamble,
+        signatures: vec![ledger_signature, sig2].try_into().unwrap(),
+        signer_bitfield: 0b011,
+        min_signers,
+    };
+
+    let raw_tx_bytes = borsh::to_vec(&multisig_msg).unwrap();
+    let response = submit_tx(test_rollup.api_client(), raw_tx_bytes).await;
+    assert!(
+        response.status().is_success(),
+        "Expected Ledger multisig transaction to succeed"
+    );
+
+    let multisig_balance = query_balance(&test_rollup.client, &multisig_address_str).await;
+    assert_eq!(
+        multisig_balance,
+        Some(Amount::new(8_000)),
+        "Expected multisig to have 8,000 tokens remaining"
+    );
+
+    let recipient_balance = query_balance(&test_rollup.client, RECIPIENT_ADDRESS).await;
+    assert_eq!(
+        recipient_balance,
+        Some(Amount::new(5_000)),
+        "Expected recipient to have received 5,000 tokens"
+    );
 }


### PR DESCRIPTION
# Description

Adds multisig support to Ledger (i.e. spec-compliant) messages.

Somewhat similar to the `simple` format implementation but compatible with the spec's preamble. In particular, all the pubkeys are required to be part of the signed bytes, so the envelope format only needs to store the signatures and `min_signers` to recover the credential ID.

Since the pubkeys and signatures aren't paired due to this, a bitfield is used to signify which pubkeys were actually used for signing. The signatures are also required to be sorted in the same order as the pubkeys in the message.

Also, the single-signature preamble happens to be borsh-deserializable; but with multiple signatures, the pubkeys are a vector prefixed with the length as a `u8` which doesn't conform to the borsh format (which serializes length as `u32`). So there's some boilerplate required to manually parse the bytes in the preamble.

Some parts of the code can be refactored a bit or extracted to helper functions (and the entire `authentication.rs` file should be split into modules at this point), but this will be done in a follow-up PR so that the diff here is focused on the actual multisig changes.

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
