### PR TITLE
Extend `make total-clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,11 @@ total-clean:
     done;
 	rm -rf "soak_data/examples/demo-rollup/sov-soak-testing/soak_data"
 	rm -rf typescript/node_modules
+	rm -rf typescript/.turbo
+	rm -rf typescript/.cache
+	rm -rf typescript/packages/universal-wallet-wasm/target
 	cargo clean --manifest-path crates/full-node/sov-aggregated-proof/Cargo.toml
+	cargo clean --manifest-path python/py_sovereign_web3/rust/Cargo.toml
 	@for dir in $(DATA_DIRS); do \
 		rm -rf "$$dir"; \
 	done;

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,13 @@ PROVER_DIRS := examples/demo-rollup/provers/risc0/guest-mock \
 ALL_DIRS := $(PROVER_DIRS) \
 						crates/module-system/module-implementations/extern/hyperlane-solana-register/solana
 
+DATA_DIRS := ./crates/module-system/sov-modules-macros/data \
+             ./crates/module-system/sov-solana-offchain-auth/data \
+             ./crates/module-system/hyperlane/data \
+             ./crates/full-node/sov-stf-runner/data \
+             ./crates/full-node/sov-metrics/data \
+             ./examples/demo-rollup/data
+
 # We run `cargo hack` with the `--partition 1/1` by default, but overrides allow
 # CI to parallelize checks.
 CARGO_HACK_PARTITION_N ?= 1
@@ -50,6 +57,11 @@ total-clean:
     	(cargo clean --manifest-path "$$dir/Cargo.toml"); \
     done;
 	rm -rf "soak_data/examples/demo-rollup/sov-soak-testing/soak_data"
+	rm -rf typescript/node_modules
+	cargo clean --manifest-path crates/full-node/sov-aggregated-proof/Cargo.toml
+	@for dir in $(DATA_DIRS); do \
+		rm -rf "$$dir"; \
+	done;
 
 test:  ## Runs test suite using next test
 	@cargo nextest run --no-fail-fast --status-level skip --all-features


### PR DESCRIPTION
To remove `node_modules` and `data/YYYY-MM-DD` folders

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
