### PR TITLE
Removing dead_code from `sov-evm`

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/db/init.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/db/init.rs
@@ -1,7 +1,7 @@
 use super::{DbAccount, EvmDb};
 use alloy_primitives::{Address, Bytes, B256};
-use reth_primitives::Bytecode;
 use revm::state::AccountInfo;
+use revm::state::Bytecode;
 use sov_modules_api::StateReader;
 use sov_modules_api::{Spec, StateAccessor};
 use sov_state::User;

--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -1,7 +1,7 @@
-use alloy_consensus::{transaction::Recovered, Transaction};
+use alloy_consensus::transaction::{Recovered, SignerRecoverable};
+use alloy_consensus::Transaction;
 use alloy_eips::eip2718::{Decodable2718, Eip2718Error};
 use alloy_primitives::{Address, Bytes, B256, U256};
-use reth_primitives_traits::SignedTransaction;
 use revm::{
     context::{BlockEnv, TransactionType, TxEnv},
     context_interface::block::BlobExcessGasAndPrice,

--- a/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/executor.rs
@@ -59,7 +59,6 @@ pub fn transact_commit<DB: Database<Error = E> + TryDatabaseCommit<Error = E>, E
 }
 
 #[cfg(feature = "native")]
-#[allow(dead_code)]
 pub(crate) fn inspect<'a, DB: Database<Error = E>, E: DBErrorMarker, I>(
     db: DB,
     block_env: &'a BlockEnv,

--- a/crates/module-system/module-implementations/sov-evm/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/lib.rs
@@ -93,7 +93,6 @@ const EXCESS_BLOB_GAS: u64 = 0;
 const BLOB_GAS_PRICE: u128 = 0;
 
 /// The sov-evm module provides compatibility with the EVM.
-#[allow(dead_code)]
 #[derive(Clone, ModuleInfo)]
 pub struct Evm<S: Spec> {
     /// The ID of the evm module.
@@ -117,6 +116,7 @@ pub struct Evm<S: Spec> {
     pub(crate) code: StateMap<B256, Bytecode, BcsCodec>,
 
     /// A set of addresses that are allowed to deploy new contracts
+    #[allow(dead_code)]
     #[state]
     pub(crate) contract_creation_allowlist: StateMap<Address, (), BcsCodec>,
 

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/pruning.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/pruning.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use crate::helpers::*;
 use crate::runtime::S;
 use alloy_consensus::BlockHeader;


### PR DESCRIPTION
# Description

As per title. Bringing closer ability to publish `sov-evm` to crates.io

Follow up of https://github.com/Sovereign-Labs/sovereign-sdk/pull/2676 which cuts 

* `reth_primitives_traits::SignedTransaction`
* `reth_primitives::Bytecode`

Bringing remaining reth deps to only 2 types



- [x] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existing tests are passing

## Docs
No updates
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
