### PR TITLE
EVM: remove `reth` dependency from `sov-evm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12057,8 +12057,6 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "reth-ethereum-primitives",
- "reth-primitives",
- "reth-primitives-traits",
  "revm",
  "revm-database-interface",
  "revm-inspectors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7269,7 +7269,6 @@ dependencies = [
  "arbitrary",
  "derive_more 2.0.1",
  "serde",
- "serde_with",
  "thiserror 2.0.17",
 ]
 
@@ -12056,7 +12055,6 @@ dependencies = [
  "jsonschema",
  "proptest",
  "rand 0.8.5",
- "reth-ethereum-primitives",
  "revm",
  "revm-database-interface",
  "revm-inspectors",

--- a/crates/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-evm/Cargo.toml
@@ -47,13 +47,13 @@ schemars = { workspace = true }
 tracing = { workspace = true }
 
 alloy-eips = { workspace = true, features = ["std"] }
-# `rlp` feature implicitly enabled via `reth-` crates, but this allows us to explicitly access Error type from there
 alloy-primitives = { workspace = true, default-features = false, features = [
 	"rlp",
 ] }
 alloy-consensus = { workspace = true, features = [
 	"serde",
 	"serde-bincode-compat",
+	"k256",
 ] }
 alloy-rlp = { workspace = true }
 
@@ -68,12 +68,6 @@ revm = { workspace = true, features = [
 	"std",
 ] }
 revm-database-interface = { workspace = true }
-reth-ethereum-primitives = { workspace = true, features = [
-	"serde",
-	"serde-bincode-compat",
-] }
-reth-primitives = { workspace = true }
-reth-primitives-traits = { workspace = true }
 revm-inspectors = { workspace = true, default-features = false, optional = true }
 sov-rpc-eth-types = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
@@ -92,6 +86,7 @@ bytes = { workspace = true }
 secp256k1 = { workspace = true, features = ["rand"] }
 jsonschema = { workspace = true }
 bincode = { workspace = true }
+reth-ethereum-primitives = { workspace = true, features = ["serde", "serde-bincode-compat"] }
 
 sov-mock-da = { workspace = true, features = ["native"] }
 sov-test-utils = { workspace = true }
@@ -107,7 +102,6 @@ arbitrary = [
 	"alloy-eips/arbitrary",
 	"alloy-primitives/arbitrary",
 	"alloy-rpc-types?/arbitrary",
-	"reth-primitives/arbitrary",
 	"revm/arbitrary",
 	"sov-address/arbitrary",
 	"sov-evm/arbitrary",
@@ -119,8 +113,6 @@ arbitrary = [
 	"sov-bank/arbitrary",
 	"sov-uniqueness/arbitrary",
 	"alloy-consensus/arbitrary",
-	"reth-primitives-traits/arbitrary",
-	"reth-ethereum-primitives/arbitrary",
 	"sov-evm-test-utils/arbitrary"
 ]
 native = [
@@ -130,8 +122,6 @@ native = [
 	"dep:rand",
 	"revm-inspectors",
 	"alloy-primitives/std",
-	"reth-primitives/std",
-	"reth-ethereum-primitives/std",
 	"dep:sov-rpc-eth-types",
 	# Optional for speed up in native mode
 	# "revm/asm-keccak"

--- a/crates/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-evm/Cargo.toml
@@ -86,7 +86,6 @@ bytes = { workspace = true }
 secp256k1 = { workspace = true, features = ["rand"] }
 jsonschema = { workspace = true }
 bincode = { workspace = true }
-reth-ethereum-primitives = { workspace = true, features = ["serde", "serde-bincode-compat"] }
 
 sov-mock-da = { workspace = true, features = ["native"] }
 sov-test-utils = { workspace = true }

--- a/crates/module-system/module-implementations/sov-evm/src/call.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/call.rs
@@ -439,7 +439,7 @@ where
             "EVM transaction has been executed"
         );
 
-        let receipt = reth_primitives::Receipt {
+        let receipt = crate::evm::eth_receipt::EthReceipt {
             tx_type: tx.signed_transaction.tx_type(),
             success: is_success,
             cumulative_gas_used: previous_transaction_cumulative_gas_used

--- a/crates/module-system/module-implementations/sov-evm/src/db/init.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/db/init.rs
@@ -1,7 +1,7 @@
 use super::{DbAccount, EvmDb};
 use alloy_primitives::{Address, Bytes, B256};
-use reth_primitives::Bytecode;
 use revm::state::AccountInfo;
+use revm::state::Bytecode;
 use sov_modules_api::StateReader;
 use sov_modules_api::{Spec, StateAccessor};
 use sov_state::User;

--- a/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/conversions.rs
@@ -1,7 +1,7 @@
-use alloy_consensus::{transaction::Recovered, Transaction};
+use alloy_consensus::transaction::{Recovered, SignerRecoverable};
+use alloy_consensus::Transaction;
 use alloy_eips::eip2718::{Decodable2718, Eip2718Error};
 use alloy_primitives::{Address, Bytes, B256, U256};
-use reth_primitives_traits::SignedTransaction;
 use revm::{
     context::{BlockEnv, TransactionType, TxEnv},
     context_interface::block::BlobExcessGasAndPrice,

--- a/crates/module-system/module-implementations/sov-evm/src/evm/eth_receipt.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/eth_receipt.rs
@@ -243,23 +243,6 @@ mod tests {
         receipt: EthReceipt,
     }
 
-    /// Wrapper that serializes [`reth_ethereum_primitives::Receipt`] through reth's adapter.
-    #[serde_as]
-    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
-    struct RethWrapper {
-        #[serde_as(as = "reth_ethereum_primitives::serde_bincode_compat::Receipt<'_>")]
-        receipt: reth_ethereum_primitives::Receipt,
-    }
-
-    fn make_reth_receipt(r: &EthReceipt) -> reth_ethereum_primitives::Receipt {
-        reth_ethereum_primitives::Receipt {
-            tx_type: r.tx_type,
-            success: r.success,
-            cumulative_gas_used: r.cumulative_gas_used,
-            logs: r.logs.clone(),
-        }
-    }
-
     /// Test cases with enough variability to catch serialization mismatches.
     fn test_receipts() -> Vec<(&'static str, EthReceipt)> {
         vec![
@@ -330,90 +313,11 @@ mod tests {
         ]
     }
 
-    /// Verify that our local adapter produces byte-identical output to reth's adapter.
-    #[test]
-    fn local_and_reth_adapters_produce_identical_bytes() {
-        for (name, receipt) in test_receipts() {
-            let local_bytes = bincode::serialize(&LocalWrapper {
-                receipt: receipt.clone(),
-            })
-            .unwrap();
-            let reth_bytes = bincode::serialize(&RethWrapper {
-                receipt: make_reth_receipt(&receipt),
-            })
-            .unwrap();
-            assert_eq!(
-                local_bytes, reth_bytes,
-                "Serialization mismatch for case: {name}"
-            );
-        }
-    }
-
-    /// Verify reth-serialized bytes can be deserialized by our local adapter.
-    #[test]
-    fn reth_bytes_deserialize_with_local_adapter() {
-        for (name, receipt) in test_receipts() {
-            let reth_bytes = bincode::serialize(&RethWrapper {
-                receipt: make_reth_receipt(&receipt),
-            })
-            .unwrap();
-            let deserialized: LocalWrapper =
-                bincode::deserialize(&reth_bytes).unwrap_or_else(|e| {
-                    panic!(
-                        "Failed to deserialize reth bytes with local adapter for case {name}: {e}"
-                    )
-                });
-            assert_eq!(
-                deserialized.receipt, receipt,
-                "Round-trip mismatch for case: {name}"
-            );
-        }
-    }
-
-    /// Verify local-serialized bytes can be deserialized by reth's adapter.
-    #[test]
-    fn local_bytes_deserialize_with_reth_adapter() {
-        for (name, receipt) in test_receipts() {
-            let local_bytes = bincode::serialize(&LocalWrapper {
-                receipt: receipt.clone(),
-            })
-            .unwrap();
-            let deserialized: RethWrapper =
-                bincode::deserialize(&local_bytes).unwrap_or_else(|e| {
-                    panic!(
-                        "Failed to deserialize local bytes with reth adapter for case {name}: {e}"
-                    )
-                });
-            assert_eq!(
-                deserialized.receipt,
-                make_reth_receipt(&receipt),
-                "Round-trip mismatch for case: {name}"
-            );
-        }
-    }
-
     /// Golden snapshot test: hardcoded bytes that must never change.
-    /// These were captured from reth_ethereum_primitives::serde_bincode_compat::Receipt
+    /// These were captured from reth_ethereum_primitives v1.9.0 serde_bincode_compat::Receipt
     /// serialized with bincode 1.x. If this test fails, state deserialization is broken.
     #[test]
     fn golden_snapshot_bytes() {
-        // Generate expected bytes from reth for each case and assert stability
-        for (name, receipt) in test_receipts() {
-            let expected = bincode::serialize(&RethWrapper {
-                receipt: make_reth_receipt(&receipt),
-            })
-            .unwrap();
-            let actual = bincode::serialize(&LocalWrapper {
-                receipt: receipt.clone(),
-            })
-            .unwrap();
-            assert_eq!(
-                actual, expected,
-                "Golden snapshot mismatch for case: {name}\n  expected: {expected:02x?}\n  actual:   {actual:02x?}"
-            );
-        }
-
-        // Additionally verify against hardcoded snapshots to catch reth upstream changes
         let snapshots = golden_snapshots();
         for (name, receipt) in test_receipts() {
             let actual = bincode::serialize(&LocalWrapper {
@@ -429,7 +333,24 @@ mod tests {
                 .unwrap_or_else(|e| panic!("Invalid hex in golden snapshot for case {name}: {e}"));
             assert_eq!(
                 actual, expected,
-                "Hardcoded golden snapshot mismatch for case: {name}"
+                "Golden snapshot mismatch for case: {name}"
+            );
+        }
+    }
+
+    /// Golden snapshot round-trip: verify hardcoded bytes deserialize back correctly.
+    #[test]
+    fn golden_snapshot_roundtrip() {
+        let snapshots = golden_snapshots();
+        for (name, receipt) in test_receipts() {
+            let (_, hex_bytes) = snapshots.iter().find(|(n, _)| *n == name).unwrap();
+            let bytes = hex::decode(hex_bytes).unwrap();
+            let deserialized: LocalWrapper = bincode::deserialize(&bytes).unwrap_or_else(|e| {
+                panic!("Failed to deserialize golden snapshot for case {name}: {e}")
+            });
+            assert_eq!(
+                deserialized.receipt, receipt,
+                "Round-trip mismatch for case: {name}"
             );
         }
     }

--- a/crates/module-system/module-implementations/sov-evm/src/evm/eth_receipt.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/eth_receipt.rs
@@ -1,0 +1,470 @@
+//! Local Ethereum receipt type, replacing `reth_primitives::Receipt` to avoid the reth dependency.
+
+use alloy_consensus::{
+    Eip2718EncodableReceipt, Eip658Value, RlpEncodableReceipt, TxReceipt, TxType, Typed2718,
+};
+use alloy_eips::Encodable2718;
+use alloy_primitives::{Bloom, Log};
+use alloy_rlp::{BufMut, Encodable, Header};
+
+/// Ethereum transaction receipt.
+#[derive(Clone, Debug, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct EthReceipt {
+    /// Receipt type.
+    pub tx_type: TxType,
+    /// If transaction is executed successfully.
+    pub success: bool,
+    /// Cumulative gas used in the block after this transaction was executed.
+    pub cumulative_gas_used: u64,
+    /// Logs emitted by this transaction.
+    pub logs: Vec<Log>,
+}
+
+impl EthReceipt {
+    /// Returns length of RLP-encoded receipt fields with the given [`Bloom`] without an RLP header.
+    fn rlp_encoded_fields_length(&self, bloom: &Bloom) -> usize {
+        self.success.length()
+            + self.cumulative_gas_used.length()
+            + bloom.length()
+            + self.logs.length()
+    }
+
+    /// RLP-encodes receipt fields with the given [`Bloom`] without an RLP header.
+    fn rlp_encode_fields(&self, bloom: &Bloom, out: &mut dyn BufMut) {
+        self.success.encode(out);
+        self.cumulative_gas_used.encode(out);
+        bloom.encode(out);
+        self.logs.encode(out);
+    }
+
+    /// Returns RLP header for inner encoding (with bloom).
+    fn rlp_header_inner(&self, bloom: &Bloom) -> Header {
+        Header {
+            list: true,
+            payload_length: self.rlp_encoded_fields_length(bloom),
+        }
+    }
+
+    /// Returns length of RLP-encoded receipt fields without bloom and without an RLP header.
+    fn rlp_encoded_fields_length_without_bloom(&self) -> usize {
+        self.success.length() + self.cumulative_gas_used.length() + self.logs.length()
+    }
+
+    /// RLP-encodes receipt fields without bloom and without an RLP header.
+    fn rlp_encode_fields_without_bloom(&self, out: &mut dyn BufMut) {
+        self.success.encode(out);
+        self.cumulative_gas_used.encode(out);
+        self.logs.encode(out);
+    }
+
+    /// Returns RLP header for inner encoding (without bloom).
+    fn rlp_header_inner_without_bloom(&self) -> Header {
+        Header {
+            list: true,
+            payload_length: self.rlp_encoded_fields_length_without_bloom(),
+        }
+    }
+}
+
+impl TxReceipt for EthReceipt {
+    type Log = Log;
+
+    fn status_or_post_state(&self) -> Eip658Value {
+        self.success.into()
+    }
+
+    fn status(&self) -> bool {
+        self.success
+    }
+
+    fn bloom(&self) -> Bloom {
+        alloy_primitives::logs_bloom(self.logs.iter())
+    }
+
+    fn cumulative_gas_used(&self) -> u64 {
+        self.cumulative_gas_used
+    }
+
+    fn logs(&self) -> &[Log] {
+        &self.logs
+    }
+
+    fn into_logs(self) -> Vec<Log> {
+        self.logs
+    }
+}
+
+impl Typed2718 for EthReceipt {
+    fn ty(&self) -> u8 {
+        self.tx_type.ty()
+    }
+}
+
+impl Eip2718EncodableReceipt for EthReceipt {
+    fn eip2718_encoded_length_with_bloom(&self, bloom: &Bloom) -> usize {
+        !self.tx_type.is_legacy() as usize + self.rlp_header_inner(bloom).length_with_payload()
+    }
+
+    fn eip2718_encode_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut) {
+        if !self.tx_type.is_legacy() {
+            out.put_u8(self.tx_type.ty());
+        }
+        self.rlp_header_inner(bloom).encode(out);
+        self.rlp_encode_fields(bloom, out);
+    }
+}
+
+impl RlpEncodableReceipt for EthReceipt {
+    fn rlp_encoded_length_with_bloom(&self, bloom: &Bloom) -> usize {
+        let mut len = self.eip2718_encoded_length_with_bloom(bloom);
+        if !self.tx_type.is_legacy() {
+            len += Header {
+                list: false,
+                payload_length: self.eip2718_encoded_length_with_bloom(bloom),
+            }
+            .length();
+        }
+        len
+    }
+
+    fn rlp_encode_with_bloom(&self, bloom: &Bloom, out: &mut dyn BufMut) {
+        if !self.tx_type.is_legacy() {
+            Header {
+                list: false,
+                payload_length: self.eip2718_encoded_length_with_bloom(bloom),
+            }
+            .encode(out);
+        }
+        self.eip2718_encode_with_bloom(bloom, out);
+    }
+}
+
+impl Encodable2718 for EthReceipt {
+    fn encode_2718_len(&self) -> usize {
+        (!self.tx_type.is_legacy() as usize)
+            + self.rlp_header_inner_without_bloom().length_with_payload()
+    }
+
+    fn encode_2718(&self, out: &mut dyn BufMut) {
+        if !self.tx_type.is_legacy() {
+            out.put_u8(self.tx_type.ty());
+        }
+        self.rlp_header_inner_without_bloom().encode(out);
+        self.rlp_encode_fields_without_bloom(out);
+    }
+}
+
+/// Bincode-compatible serialization for [`EthReceipt`], matching the format
+/// previously provided by `reth_ethereum_primitives::serde_bincode_compat::Receipt`.
+#[allow(clippy::owned_cow)]
+pub mod serde_bincode_compat {
+    use alloc::borrow::Cow;
+    use alloy_consensus::TxType;
+    use alloy_primitives::{Log, U8};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde_with::{DeserializeAs, SerializeAs};
+
+    extern crate alloc;
+
+    /// Bincode-compatible receipt representation.
+    #[derive(Debug, Serialize, Deserialize)]
+    pub struct Receipt<'a> {
+        #[serde(deserialize_with = "deserialize_txtype")]
+        tx_type: TxType,
+        success: bool,
+        cumulative_gas_used: u64,
+        logs: Cow<'a, Vec<Log>>,
+    }
+
+    fn deserialize_txtype<'de, D>(deserializer: D) -> Result<TxType, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        U8::deserialize(deserializer)?
+            .to::<u8>()
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+
+    impl<'a> From<&'a super::EthReceipt> for Receipt<'a> {
+        fn from(value: &'a super::EthReceipt) -> Self {
+            Self {
+                tx_type: value.tx_type,
+                success: value.success,
+                cumulative_gas_used: value.cumulative_gas_used,
+                logs: Cow::Borrowed(&value.logs),
+            }
+        }
+    }
+
+    impl From<Receipt<'_>> for super::EthReceipt {
+        fn from(value: Receipt<'_>) -> Self {
+            Self {
+                tx_type: value.tx_type,
+                success: value.success,
+                cumulative_gas_used: value.cumulative_gas_used,
+                logs: value.logs.into_owned(),
+            }
+        }
+    }
+
+    impl SerializeAs<super::EthReceipt> for Receipt<'_> {
+        fn serialize_as<S>(source: &super::EthReceipt, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            Receipt::from(source).serialize(serializer)
+        }
+    }
+
+    impl<'de> DeserializeAs<'de, super::EthReceipt> for Receipt<'de> {
+        fn deserialize_as<D>(deserializer: D) -> Result<super::EthReceipt, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            Receipt::deserialize(deserializer).map(Into::into)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::TxType;
+    use alloy_primitives::{Address, Bytes, Log, B256};
+    use serde_with::serde_as;
+
+    /// Wrapper that serializes [`EthReceipt`] through our local bincode-compat adapter.
+    #[serde_as]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+    struct LocalWrapper {
+        #[serde_as(as = "serde_bincode_compat::Receipt<'_>")]
+        receipt: EthReceipt,
+    }
+
+    /// Wrapper that serializes [`reth_ethereum_primitives::Receipt`] through reth's adapter.
+    #[serde_as]
+    #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+    struct RethWrapper {
+        #[serde_as(as = "reth_ethereum_primitives::serde_bincode_compat::Receipt<'_>")]
+        receipt: reth_ethereum_primitives::Receipt,
+    }
+
+    fn make_reth_receipt(r: &EthReceipt) -> reth_ethereum_primitives::Receipt {
+        reth_ethereum_primitives::Receipt {
+            tx_type: r.tx_type,
+            success: r.success,
+            cumulative_gas_used: r.cumulative_gas_used,
+            logs: r.logs.clone(),
+        }
+    }
+
+    /// Test cases with enough variability to catch serialization mismatches.
+    fn test_receipts() -> Vec<(&'static str, EthReceipt)> {
+        vec![
+            (
+                "legacy_success_no_logs",
+                EthReceipt {
+                    tx_type: TxType::Legacy,
+                    success: true,
+                    cumulative_gas_used: 21000,
+                    logs: vec![],
+                },
+            ),
+            (
+                "eip1559_failure_no_logs",
+                EthReceipt {
+                    tx_type: TxType::Eip1559,
+                    success: false,
+                    cumulative_gas_used: 0,
+                    logs: vec![],
+                },
+            ),
+            (
+                "eip2930_success_with_log",
+                EthReceipt {
+                    tx_type: TxType::Eip2930,
+                    success: true,
+                    cumulative_gas_used: 50000,
+                    logs: vec![Log::new_unchecked(
+                        Address::with_last_byte(0xAB),
+                        vec![B256::with_last_byte(0x01)],
+                        Bytes::from_static(&[0xDE, 0xAD]),
+                    )],
+                },
+            ),
+            (
+                "eip1559_success_multiple_logs",
+                EthReceipt {
+                    tx_type: TxType::Eip1559,
+                    success: true,
+                    cumulative_gas_used: 1_000_000,
+                    logs: vec![
+                        Log::new_unchecked(
+                            Address::with_last_byte(0x01),
+                            vec![B256::with_last_byte(0xAA), B256::with_last_byte(0xBB)],
+                            Bytes::from_static(&[1, 2, 3, 4, 5]),
+                        ),
+                        Log::new_unchecked(Address::ZERO, vec![], Bytes::new()),
+                    ],
+                },
+            ),
+            (
+                "eip7702_high_gas",
+                EthReceipt {
+                    tx_type: TxType::Eip7702,
+                    success: true,
+                    cumulative_gas_used: u64::MAX,
+                    logs: vec![Log::new_unchecked(
+                        Address::repeat_byte(0xFF),
+                        vec![
+                            B256::repeat_byte(0xCC),
+                            B256::repeat_byte(0xDD),
+                            B256::repeat_byte(0xEE),
+                        ],
+                        Bytes::from_static(&[0xFF; 64]),
+                    )],
+                },
+            ),
+        ]
+    }
+
+    /// Verify that our local adapter produces byte-identical output to reth's adapter.
+    #[test]
+    fn local_and_reth_adapters_produce_identical_bytes() {
+        for (name, receipt) in test_receipts() {
+            let local_bytes = bincode::serialize(&LocalWrapper {
+                receipt: receipt.clone(),
+            })
+            .unwrap();
+            let reth_bytes = bincode::serialize(&RethWrapper {
+                receipt: make_reth_receipt(&receipt),
+            })
+            .unwrap();
+            assert_eq!(
+                local_bytes, reth_bytes,
+                "Serialization mismatch for case: {name}"
+            );
+        }
+    }
+
+    /// Verify reth-serialized bytes can be deserialized by our local adapter.
+    #[test]
+    fn reth_bytes_deserialize_with_local_adapter() {
+        for (name, receipt) in test_receipts() {
+            let reth_bytes = bincode::serialize(&RethWrapper {
+                receipt: make_reth_receipt(&receipt),
+            })
+            .unwrap();
+            let deserialized: LocalWrapper =
+                bincode::deserialize(&reth_bytes).unwrap_or_else(|e| {
+                    panic!(
+                        "Failed to deserialize reth bytes with local adapter for case {name}: {e}"
+                    )
+                });
+            assert_eq!(
+                deserialized.receipt, receipt,
+                "Round-trip mismatch for case: {name}"
+            );
+        }
+    }
+
+    /// Verify local-serialized bytes can be deserialized by reth's adapter.
+    #[test]
+    fn local_bytes_deserialize_with_reth_adapter() {
+        for (name, receipt) in test_receipts() {
+            let local_bytes = bincode::serialize(&LocalWrapper {
+                receipt: receipt.clone(),
+            })
+            .unwrap();
+            let deserialized: RethWrapper =
+                bincode::deserialize(&local_bytes).unwrap_or_else(|e| {
+                    panic!(
+                        "Failed to deserialize local bytes with reth adapter for case {name}: {e}"
+                    )
+                });
+            assert_eq!(
+                deserialized.receipt,
+                make_reth_receipt(&receipt),
+                "Round-trip mismatch for case: {name}"
+            );
+        }
+    }
+
+    /// Golden snapshot test: hardcoded bytes that must never change.
+    /// These were captured from reth_ethereum_primitives::serde_bincode_compat::Receipt
+    /// serialized with bincode 1.x. If this test fails, state deserialization is broken.
+    #[test]
+    fn golden_snapshot_bytes() {
+        // Generate expected bytes from reth for each case and assert stability
+        for (name, receipt) in test_receipts() {
+            let expected = bincode::serialize(&RethWrapper {
+                receipt: make_reth_receipt(&receipt),
+            })
+            .unwrap();
+            let actual = bincode::serialize(&LocalWrapper {
+                receipt: receipt.clone(),
+            })
+            .unwrap();
+            assert_eq!(
+                actual, expected,
+                "Golden snapshot mismatch for case: {name}\n  expected: {expected:02x?}\n  actual:   {actual:02x?}"
+            );
+        }
+
+        // Additionally verify against hardcoded snapshots to catch reth upstream changes
+        let snapshots = golden_snapshots();
+        for (name, receipt) in test_receipts() {
+            let actual = bincode::serialize(&LocalWrapper {
+                receipt: receipt.clone(),
+            })
+            .unwrap();
+            let expected_hex = snapshots
+                .iter()
+                .find(|(n, _)| *n == name)
+                .unwrap_or_else(|| panic!("Missing golden snapshot for case: {name}"))
+                .1;
+            let expected = hex::decode(expected_hex)
+                .unwrap_or_else(|e| panic!("Invalid hex in golden snapshot for case {name}: {e}"));
+            assert_eq!(
+                actual, expected,
+                "Hardcoded golden snapshot mismatch for case: {name}"
+            );
+        }
+    }
+
+    /// Hardcoded hex-encoded golden snapshots. Generated from reth v1.9.0.
+    fn golden_snapshots() -> Vec<(&'static str, &'static str)> {
+        vec![
+            GOLDEN_LEGACY_SUCCESS_NO_LOGS,
+            GOLDEN_EIP1559_FAILURE_NO_LOGS,
+            GOLDEN_EIP2930_SUCCESS_WITH_LOG,
+            GOLDEN_EIP1559_SUCCESS_MULTIPLE_LOGS,
+            GOLDEN_EIP7702_HIGH_GAS,
+        ]
+    }
+
+    // Golden snapshots captured from reth_ethereum_primitives v1.9.0 + bincode 1.x.
+    // If any of these change, existing serialized state will fail to deserialize.
+    const GOLDEN_LEGACY_SUCCESS_NO_LOGS: (&str, &str) = (
+        "legacy_success_no_logs",
+        "0100000000000000000108520000000000000000000000000000",
+    );
+    const GOLDEN_EIP1559_FAILURE_NO_LOGS: (&str, &str) = (
+        "eip1559_failure_no_logs",
+        "0100000000000000020000000000000000000000000000000000",
+    );
+    const GOLDEN_EIP2930_SUCCESS_WITH_LOG: (&str, &str) = (
+        "eip2930_success_with_log",
+        "0100000000000000010150c30000000000000100000000000000140000000000000000000000000000000000000000000000000000ab0100000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000010200000000000000dead",
+    );
+    const GOLDEN_EIP1559_SUCCESS_MULTIPLE_LOGS: (&str, &str) = (
+        "eip1559_success_multiple_logs",
+        "0100000000000000020140420f00000000000200000000000000140000000000000000000000000000000000000000000000000000010200000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000aa200000000000000000000000000000000000000000000000000000000000000000000000000000bb050000000000000001020304051400000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+    );
+    const GOLDEN_EIP7702_HIGH_GAS: (&str, &str) = (
+        "eip7702_high_gas",
+        "01000000000000000401ffffffffffffffff01000000000000001400000000000000ffffffffffffffffffffffffffffffffffffffff03000000000000002000000000000000cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc2000000000000000dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd2000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee4000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+    );
+}

--- a/crates/module-system/module-implementations/sov-evm/src/evm/eth_receipt.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/eth_receipt.rs
@@ -140,6 +140,8 @@ impl RlpEncodableReceipt for EthReceipt {
     }
 }
 
+/// Encodes the receipt in EIP-2718 "network" format, which excludes the bloom filter.
+/// The bloom is omitted because it can be recomputed from the logs; this matches reth's behavior.
 impl Encodable2718 for EthReceipt {
     fn encode_2718_len(&self) -> usize {
         (!self.tx_type.is_legacy() as usize)
@@ -177,6 +179,8 @@ pub mod serde_bincode_compat {
         logs: Cow<'a, Vec<Log>>,
     }
 
+    /// Custom deserializer that matches reth's bincode-compat encoding, which serializes
+    /// `TxType` as a `U8` (256-bit integer) rather than using `TxType`'s standard serde impl.
     fn deserialize_txtype<'de, D>(deserializer: D) -> Result<TxType, D::Error>
     where
         D: Deserializer<'de>,

--- a/crates/module-system/module-implementations/sov-evm/src/evm/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/mod.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::match_same_arms)]
 
 pub(crate) mod conversions;
+pub(crate) mod eth_receipt;
 /// EVM execution utilities
 pub mod executor;
 pub(crate) mod primitive_types;

--- a/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/evm/primitive_types.rs
@@ -1,5 +1,7 @@
 use std::ops::Range;
 
+use super::eth_receipt::serde_bincode_compat::Receipt as ReceiptBincodeCompat;
+use super::eth_receipt::EthReceipt;
 use alloy_consensus::proofs::{calculate_receipt_root, calculate_transaction_root};
 use alloy_consensus::{
     serde_bincode_compat::Header as HeaderBincodeCompat,
@@ -14,7 +16,6 @@ use alloy_primitives::{Bloom, TxHash};
 use bytes::BufMut;
 use derive_more::{Deref, DerefMut};
 use derive_new::new;
-use reth_ethereum_primitives::serde_bincode_compat::Receipt as ReceiptBincodeCompat;
 use serde_with::serde_as;
 use sov_modules_api::macros::UniversalWallet;
 use sov_rollup_interface::da::Time;
@@ -249,7 +250,7 @@ impl SyntheticBlockWithoutRootsAndBloom {
     pub fn finish_and_seal(
         mut self,
         transactions: Vec<TxSignedAndRecovered>,
-        receipts: &[reth_primitives::Receipt],
+        receipts: &[EthReceipt],
     ) -> (SealedSynthetic, Vec<TxSignedAndRecovered>) {
         assert_eq!(
             transactions.len(),
@@ -490,7 +491,7 @@ pub struct Receipt {
     #[serde_as(as = "ReceiptBincodeCompat")]
     #[deref]
     #[deref_mut]
-    pub receipt: reth_primitives::Receipt,
+    pub receipt: EthReceipt,
     /// tx hash
     pub transaction_hash: TxHash,
     /// tx index

--- a/crates/module-system/module-implementations/sov-evm/src/hooks.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/hooks.rs
@@ -102,7 +102,7 @@ impl<S: Spec> BlockHooks for Evm<S> {
             .map(|tx| tx.transaction.signed_transaction.clone())
             .collect();
 
-        let receipts: Vec<alloy_consensus::ReceiptWithBloom<&reth_primitives::Receipt>> =
+        let receipts: Vec<alloy_consensus::ReceiptWithBloom<&crate::evm::eth_receipt::EthReceipt>> =
             pending_transactions
                 .iter()
                 .map(|tx| tx.receipt.receipt.with_bloom_ref())

--- a/crates/module-system/module-implementations/sov-uniqueness/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-uniqueness/Cargo.toml
@@ -32,7 +32,7 @@ sov-test-utils = { workspace = true }
 sov-evm-test-utils = { workspace = true }
 sov-value-setter = { workspace = true }
 sov-evm = { workspace = true, features = ["native"] }
-reth-primitives = { workspace = true }
+reth-primitives = { workspace = true, features = ["std"] }
 sov-address = { workspace = true, features = ["evm"] }
 sov-rollup-interface = { workspace = true }
 sov-kernels = { workspace = true }

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -30,17 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-chains"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
-dependencies = [
- "alloy-primitives",
- "num_enum",
- "strum 0.27.2",
-]
-
-[[package]]
 name = "alloy-consensus"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,20 +53,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ead76c8c84ab3a50c31c56bc2c748c2d64357ad2131c32f9b10ab790a25e1a"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -143,46 +118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-genesis"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25d5acb35706e683df1ea333c862bdb6b7c5548836607cd5bb56e501cca0b4f"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "alloy-trie",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "alloy-hardforks"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
-dependencies = [
- "alloy-chains",
- "alloy-eip2124",
- "alloy-primitives",
- "auto_impl",
- "dyn-clone",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e7918396eecd69d9c907046ec8a93fb09b89e2f325d5e7ea9c4e3929aa0dd2"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
 name = "alloy-primitives"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,27 +167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-eth"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15e4831b71eea9d20126a411c1c09facf1d01d5cac84fd51d532d3c429cfc26"
-dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "alloy-serde"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,64 +175,6 @@ dependencies = [
  "alloy-primitives",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-sol-macro"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fa1ca7e617c634d2bd9fa71f9ec8e47c07106e248b9fcbd3eaddc13cabd625"
-dependencies = [
- "alloy-sol-macro-expander",
- "alloy-sol-macro-input",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "alloy-sol-macro-expander"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c00c0c3a75150a9dc7c8c679ca21853a137888b4e1c5569f92d7e2b15b5102"
-dependencies = [
- "alloy-sol-macro-input",
- "const-hex",
- "heck",
- "indexmap 2.13.0",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "sha3",
- "syn 2.0.114",
- "syn-solidity",
-]
-
-[[package]]
-name = "alloy-sol-macro-input"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297db260eb4d67c105f68d6ba11b8874eec681caec5505eab8fbebee97f790bc"
-dependencies = [
- "const-hex",
- "dunce",
- "heck",
- "macro-string",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "syn-solidity",
-]
-
-[[package]]
-name = "alloy-sol-types"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70319350969a3af119da6fb3e9bddb1bce66c9ea933600cb297c8b1850ad2a3c"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-macro",
 ]
 
 [[package]]
@@ -1062,8 +918,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -1512,7 +1366,7 @@ dependencies = [
  "sov-synthetic-load",
  "sov-test-modules",
  "sov-uniqueness",
- "strum 0.26.3",
+ "strum",
 ]
 
 [[package]]
@@ -1628,12 +1482,6 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -2389,16 +2237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,17 +2388,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "macro-string"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2640,27 +2467,6 @@ name = "mirai-annotations"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "multibase"
@@ -2865,9 +2671,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5676b5c379cf5b03da1df2b3061c4a4e2aa691086a56ac923e08c143f53f59"
 dependencies = [
- "alloy-rlp",
  "cfg-if",
- "proptest",
  "ruint",
  "serde",
  "smallvec",
@@ -2887,27 +2691,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -3066,18 +2849,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
-
-[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3181,7 +2952,6 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -3458,122 +3228,6 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
-
-[[package]]
-name = "reth-codecs"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive",
- "reth-zstd-compressors",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "reth-codecs",
- "reth-primitives-traits",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "once_cell",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "auto_impl",
- "bytes",
- "derive_more",
- "once_cell",
- "op-alloy-consensus",
- "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-primitives",
- "derive_more",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "zstd",
-]
 
 [[package]]
 name = "revm"
@@ -4534,7 +4188,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -4676,9 +4330,6 @@ dependencies = [
  "derive_more",
  "hex",
  "itertools 0.14.0",
- "reth-ethereum-primitives",
- "reth-primitives",
- "reth-primitives-traits",
  "revm",
  "revm-database-interface",
  "schemars 0.8.22",
@@ -4715,7 +4366,7 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "tracing",
 ]
 
@@ -4802,7 +4453,7 @@ dependencies = [
  "sov-rollup-interface",
  "sov-state",
  "sov-universal-wallet",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.18",
  "toml",
  "tracing",
@@ -4859,7 +4510,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -5023,7 +4674,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "strum 0.26.3",
+ "strum",
 ]
 
 [[package]]
@@ -5039,7 +4690,7 @@ dependencies = [
  "serde",
  "sov-modules-api",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -5159,16 +4810,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
+ "strum_macros",
 ]
 
 [[package]]
@@ -5181,18 +4823,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
  "syn 2.0.114",
 ]
 
@@ -5250,18 +4880,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-solidity"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2379beea9476b89d0237078be761cf8e012d92d5ae4ae0c9a329f974838870fc"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -6071,31 +5689,3 @@ name = "zmij"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -21,17 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-chains"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
-dependencies = [
- "alloy-primitives",
- "num_enum",
- "strum 0.27.2",
-]
-
-[[package]]
 name = "alloy-consensus"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,20 +44,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ead76c8c84ab3a50c31c56bc2c748c2d64357ad2131c32f9b10ab790a25e1a"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -134,46 +109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-genesis"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25d5acb35706e683df1ea333c862bdb6b7c5548836607cd5bb56e501cca0b4f"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "alloy-trie",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "alloy-hardforks"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
-dependencies = [
- "alloy-chains",
- "alloy-eip2124",
- "alloy-primitives",
- "auto_impl",
- "dyn-clone",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e7918396eecd69d9c907046ec8a93fb09b89e2f325d5e7ea9c4e3929aa0dd2"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
 name = "alloy-primitives"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,27 +158,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-eth"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15e4831b71eea9d20126a411c1c09facf1d01d5cac84fd51d532d3c429cfc26"
-dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "alloy-serde"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,64 +166,6 @@ dependencies = [
  "alloy-primitives",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-sol-macro"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fa1ca7e617c634d2bd9fa71f9ec8e47c07106e248b9fcbd3eaddc13cabd625"
-dependencies = [
- "alloy-sol-macro-expander",
- "alloy-sol-macro-input",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "alloy-sol-macro-expander"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c00c0c3a75150a9dc7c8c679ca21853a137888b4e1c5569f92d7e2b15b5102"
-dependencies = [
- "alloy-sol-macro-input",
- "const-hex",
- "heck",
- "indexmap 2.13.0",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "sha3",
- "syn 2.0.114",
- "syn-solidity",
-]
-
-[[package]]
-name = "alloy-sol-macro-input"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297db260eb4d67c105f68d6ba11b8874eec681caec5505eab8fbebee97f790bc"
-dependencies = [
- "const-hex",
- "dunce",
- "heck",
- "macro-string",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "syn-solidity",
-]
-
-[[package]]
-name = "alloy-sol-types"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70319350969a3af119da6fb3e9bddb1bce66c9ea933600cb297c8b1850ad2a3c"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-macro",
 ]
 
 [[package]]
@@ -1004,8 +860,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -1148,12 +1002,6 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crunchy"
@@ -1314,7 +1162,7 @@ dependencies = [
  "sov-synthetic-load",
  "sov-test-modules",
  "sov-uniqueness",
- "strum 0.26.3",
+ "strum",
 ]
 
 [[package]]
@@ -1430,12 +1278,6 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -2070,16 +1912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,17 +1994,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "macro-string"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,27 +2040,6 @@ name = "mirai-annotations"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "nearly-linear"
@@ -2416,9 +2216,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5676b5c379cf5b03da1df2b3061c4a4e2aa691086a56ac923e08c143f53f59"
 dependencies = [
- "alloy-rlp",
  "cfg-if",
- "proptest",
  "ruint",
  "serde",
  "smallvec",
@@ -2438,27 +2236,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "p256"
@@ -2582,18 +2359,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
-
-[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,7 +2452,6 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -2841,122 +2605,6 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
-
-[[package]]
-name = "reth-codecs"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive",
- "reth-zstd-compressors",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "reth-codecs",
- "reth-primitives-traits",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "once_cell",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "auto_impl",
- "bytes",
- "derive_more",
- "once_cell",
- "op-alloy-consensus",
- "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-primitives",
- "derive_more",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "zstd",
-]
 
 [[package]]
 name = "revm"
@@ -3853,7 +3501,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -3969,9 +3617,6 @@ dependencies = [
  "derive_more",
  "hex",
  "itertools 0.14.0",
- "reth-ethereum-primitives",
- "reth-primitives",
- "reth-primitives-traits",
  "revm",
  "revm-database-interface",
  "schemars 0.8.22",
@@ -4008,7 +3653,7 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "tracing",
 ]
 
@@ -4095,7 +3740,7 @@ dependencies = [
  "sov-rollup-interface",
  "sov-state",
  "sov-universal-wallet",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.18",
  "toml",
  "tracing",
@@ -4152,7 +3797,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -4316,7 +3961,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "strum 0.26.3",
+ "strum",
 ]
 
 [[package]]
@@ -4332,7 +3977,7 @@ dependencies = [
  "serde",
  "sov-modules-api",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -4452,16 +4097,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4474,18 +4110,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
  "syn 2.0.114",
 ]
 
@@ -4515,18 +4139,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-solidity"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2379beea9476b89d0237078be761cf8e012d92d5ae4ae0c9a329f974838870fc"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -5279,34 +4891,6 @@ name = "zmij"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[patch.unused]]
 name = "sha2"

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -56,17 +56,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-chains"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
-dependencies = [
- "alloy-primitives",
- "num_enum 0.7.5",
- "strum 0.27.2",
-]
-
-[[package]]
 name = "alloy-consensus"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,20 +79,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ead76c8c84ab3a50c31c56bc2c748c2d64357ad2131c32f9b10ab790a25e1a"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -169,46 +144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-genesis"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25d5acb35706e683df1ea333c862bdb6b7c5548836607cd5bb56e501cca0b4f"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "alloy-trie",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "alloy-hardforks"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
-dependencies = [
- "alloy-chains",
- "alloy-eip2124",
- "alloy-primitives",
- "auto_impl",
- "dyn-clone",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e7918396eecd69d9c907046ec8a93fb09b89e2f325d5e7ea9c4e3929aa0dd2"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
 name = "alloy-primitives"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,27 +193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-eth"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15e4831b71eea9d20126a411c1c09facf1d01d5cac84fd51d532d3c429cfc26"
-dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "alloy-serde"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,64 +201,6 @@ dependencies = [
  "alloy-primitives",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-sol-macro"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fa1ca7e617c634d2bd9fa71f9ec8e47c07106e248b9fcbd3eaddc13cabd625"
-dependencies = [
- "alloy-sol-macro-expander",
- "alloy-sol-macro-input",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "alloy-sol-macro-expander"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c00c0c3a75150a9dc7c8c679ca21853a137888b4e1c5569f92d7e2b15b5102"
-dependencies = [
- "alloy-sol-macro-input",
- "const-hex",
- "heck",
- "indexmap 2.13.0",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "sha3",
- "syn 2.0.114",
- "syn-solidity",
-]
-
-[[package]]
-name = "alloy-sol-macro-input"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297db260eb4d67c105f68d6ba11b8874eec681caec5505eab8fbebee97f790bc"
-dependencies = [
- "const-hex",
- "dunce",
- "heck",
- "macro-string",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "syn-solidity",
-]
-
-[[package]]
-name = "alloy-sol-types"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70319350969a3af119da6fb3e9bddb1bce66c9ea933600cb297c8b1850ad2a3c"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-macro",
 ]
 
 [[package]]
@@ -1276,8 +1132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -2102,12 +1956,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -3245,16 +3093,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3461,17 +3299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "macro-string"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "match-lookup"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3596,27 +3423,6 @@ name = "mirai-annotations"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "mti"
@@ -3897,9 +3703,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5676b5c379cf5b03da1df2b3061c4a4e2aa691086a56ac923e08c143f53f59"
 dependencies = [
- "alloy-rlp",
  "cfg-if",
- "proptest",
  "ruint",
  "serde",
  "smallvec",
@@ -3919,33 +3723,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more 2.1.1",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -4464,12 +4247,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -5009,122 +4786,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
-]
-
-[[package]]
-name = "reth-codecs"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive",
- "reth-zstd-compressors",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "reth-codecs",
- "reth-primitives-traits",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "once_cell",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "auto_impl",
- "bytes",
- "derive_more 2.1.1",
- "once_cell",
- "op-alloy-consensus",
- "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.1.1",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "zstd",
 ]
 
 [[package]]
@@ -6697,9 +6358,6 @@ dependencies = [
  "derive_more 2.1.1",
  "hex",
  "itertools 0.14.0",
- "reth-ethereum-primitives",
- "reth-primitives",
- "reth-primitives-traits",
  "revm",
  "revm-database-interface",
  "schemars 0.8.22",
@@ -7855,18 +7513,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-solidity"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2379beea9476b89d0237078be761cf8e012d92d5ae4ae0c9a329f974838870fc"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -9405,31 +9051,3 @@ name = "zmij"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -56,17 +56,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-chains"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
-dependencies = [
- "alloy-primitives",
- "num_enum 0.7.5",
- "strum 0.27.2",
-]
-
-[[package]]
 name = "alloy-consensus"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,20 +79,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ead76c8c84ab3a50c31c56bc2c748c2d64357ad2131c32f9b10ab790a25e1a"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -169,46 +144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-genesis"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25d5acb35706e683df1ea333c862bdb6b7c5548836607cd5bb56e501cca0b4f"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "alloy-trie",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "alloy-hardforks"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
-dependencies = [
- "alloy-chains",
- "alloy-eip2124",
- "alloy-primitives",
- "auto_impl",
- "dyn-clone",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e7918396eecd69d9c907046ec8a93fb09b89e2f325d5e7ea9c4e3929aa0dd2"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "serde",
-]
-
-[[package]]
 name = "alloy-primitives"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,27 +193,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-rpc-types-eth"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15e4831b71eea9d20126a411c1c09facf1d01d5cac84fd51d532d3c429cfc26"
-dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "alloy-serde"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,64 +201,6 @@ dependencies = [
  "alloy-primitives",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-sol-macro"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fa1ca7e617c634d2bd9fa71f9ec8e47c07106e248b9fcbd3eaddc13cabd625"
-dependencies = [
- "alloy-sol-macro-expander",
- "alloy-sol-macro-input",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "alloy-sol-macro-expander"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c00c0c3a75150a9dc7c8c679ca21853a137888b4e1c5569f92d7e2b15b5102"
-dependencies = [
- "alloy-sol-macro-input",
- "const-hex",
- "heck",
- "indexmap 2.13.0",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "sha3",
- "syn 2.0.114",
- "syn-solidity",
-]
-
-[[package]]
-name = "alloy-sol-macro-input"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297db260eb4d67c105f68d6ba11b8874eec681caec5505eab8fbebee97f790bc"
-dependencies = [
- "const-hex",
- "dunce",
- "heck",
- "macro-string",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "syn-solidity",
-]
-
-[[package]]
-name = "alloy-sol-types"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70319350969a3af119da6fb3e9bddb1bce66c9ea933600cb297c8b1850ad2a3c"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-macro",
 ]
 
 [[package]]
@@ -1242,8 +1098,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -1953,12 +1807,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -3075,16 +2923,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3238,17 +3076,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "macro-string"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3340,27 +3167,6 @@ name = "mirai-annotations"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "mti"
@@ -3619,9 +3425,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5676b5c379cf5b03da1df2b3061c4a4e2aa691086a56ac923e08c143f53f59"
 dependencies = [
- "alloy-rlp",
  "cfg-if",
- "proptest",
  "ruint",
  "serde",
  "smallvec",
@@ -3641,33 +3445,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more 2.1.1",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -4188,12 +3971,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4692,122 +4469,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
-]
-
-[[package]]
-name = "reth-codecs"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive",
- "reth-zstd-compressors",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "reth-codecs",
- "reth-primitives-traits",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "once_cell",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "auto_impl",
- "bytes",
- "derive_more 2.1.1",
- "once_cell",
- "op-alloy-consensus",
- "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.1.1",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "zstd",
 ]
 
 [[package]]
@@ -6323,9 +5984,6 @@ dependencies = [
  "derive_more 2.1.1",
  "hex",
  "itertools 0.14.0",
- "reth-ethereum-primitives",
- "reth-primitives",
- "reth-primitives-traits",
  "revm",
  "revm-database-interface",
  "schemars 0.8.22",
@@ -7472,18 +7130,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-solidity"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2379beea9476b89d0237078be761cf8e012d92d5ae4ae0c9a329f974838870fc"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -8971,31 +8617,3 @@ name = "zmij"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]


### PR DESCRIPTION
# Description

Removes remaining `reth.*` crates dependency, making `sov-evm` crate **publishable on crates.io**

## Types replaced

### 1. `reth_primitives::Bytecode`

This is just a wrapper

```rust
use revm_bytecode::Bytecode as RevmBytecode;
pub struct Bytecode(pub RevmBytecode);
```

### 2. `reth_primitives_traits::SignedTransaction`

Now `alloy_consensus::transaction::SignerRecoverable` is used instead

The trait bound providing `recover_signer()` / `try_into_recovered()` is sourced from alloy directly instead of reth.

Why safe: `reth_primitives_traits::SignedTransaction` requires SignerRecoverable as a supertrait. The try_into_recovered() method used in conversions.rs:122 comes from SignerRecoverable itself.
The alloy_consensus k256 feature (newly added to Cargo.toml) provides the concrete crypto implementation that was previously pulled in transitively via reth.

### 3. `reth_primitives::Receipt` and `reth_ethereum_primitives::serde_bincode_compat::Receipt`

Vendored implementation `sov_evm:: evm::eth_receipt::EthReceipt` is in `crates/module-system/module-implementations/sov-evm/src/evm/eth_receipt.rs`

Why safe:
 - Reth's `EthereumReceipt<T, L>` is generic; when concretized to Receipt it defaults T=TxType, L=Log — exactly the types EthReceipt hardcodes.
 - All required alloy trait impls are provided: `TxReceipt`, `Typed2718`, `Eip2718EncodableReceipt`, `RlpEncodableReceipt`, `Encodable2718`. The encoding logic mirrors reth's implementation.
 - The `serde_bincode_compat` module replicates reth's bincode serialization format (U8 for tx_type, Cow for logs).
 - Golden snapshot tests (lines 319–390) verify byte-for-byte equivalence against hardcoded hex captured from reth_ethereum_primitives v1.9.0 + bincode 1.x. Both forward (serialize→compare) and round-trip (deserialize→compare struct) are tested. This is the strongest evidence of serialization safety.

### 4. `alloy-consensus` gains k256 feature`

Previously, k256 was transitively enabled via reth-primitives-traits. Now it must be explicit. This feature enables secp256k1 signature recovery in alloy-consensus, which is required for SignerRecoverable::recover_signer().

Bincode serialized receipts bytes have been generated from `reth` dependency and compared with our implementation.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2271  

## Testing
New tests are added. All existing tests are passing

## Docs
No updates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
