### PR TITLE
 Make preferred Postgres writes idempotent across retries

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/003_unique_tx_events.sql
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/003_unique_tx_events.sql
@@ -1,0 +1,43 @@
+-- Prevent duplicate event rows from retry logic (run_with_retries!).
+-- When a write succeeds at Postgres but the connection drops before acknowledgement,
+-- the retry inserts a second identical row, creating a "poison batch" that crashes on replay.
+
+-- Step 1: Remove duplicate transaction rows that may already exist from retry behavior.
+-- For each (sequence_number, index_in_batch) group, keep only the row with the lowest event_id.
+DELETE FROM events e
+USING (
+    SELECT sequence_number, index_in_batch, MIN(event_id) AS keep_id
+    FROM events
+    WHERE event_type = 'transaction'
+    GROUP BY sequence_number, index_in_batch
+    HAVING COUNT(*) > 1
+) dupes
+WHERE e.event_type = 'transaction'
+  AND e.sequence_number = dupes.sequence_number
+  AND e.index_in_batch = dupes.index_in_batch
+  AND e.event_id <> dupes.keep_id;
+
+-- Step 2: Remove duplicate non-transaction event rows.
+-- For each (sequence_number, event_type) group, keep only the row with the lowest event_id.
+DELETE FROM events e
+USING (
+    SELECT sequence_number, event_type, MIN(event_id) AS keep_id
+    FROM events
+    WHERE event_type IN ('batch_start', 'batch_end', 'new_proof')
+    GROUP BY sequence_number, event_type
+    HAVING COUNT(*) > 1
+) dupes
+WHERE e.event_type = dupes.event_type
+  AND e.sequence_number = dupes.sequence_number
+  AND e.event_id <> dupes.keep_id;
+
+-- Step 3: Create unique indexes.
+-- Transactions: one per (sequence_number, index_in_batch).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_events_unique_tx
+    ON events (sequence_number, index_in_batch)
+    WHERE event_type = 'transaction';
+
+-- Batch start/end and proofs: one per (sequence_number, event_type).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_events_unique_non_tx
+    ON events (sequence_number, event_type)
+    WHERE event_type IN ('batch_start', 'batch_end', 'new_proof');

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/003_unique_tx_events.sql
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/003_unique_tx_events.sql
@@ -1,6 +1,4 @@
--- Prevent duplicate event rows from retry logic (run_with_retries!).
--- When a write succeeds at Postgres but the connection drops before acknowledgement,
--- the retry inserts a second identical row, creating a "poison batch" that crashes on replay.
+-- Prevent duplicate event rows from retry logic (run_with_retries!)h" that crashes on replay.
 
 -- Step 1: Remove duplicate transaction rows that may already exist from retry behavior.
 -- For each (sequence_number, index_in_batch) group, keep only the row with the lowest event_id.

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/003_unique_tx_events.sql
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/003_unique_tx_events.sql
@@ -1,4 +1,4 @@
--- Prevent duplicate event rows from retry logic (run_with_retries!)h" that crashes on replay.
+-- Prevent duplicate event rows from retry logic (run_with_retries!) that crashes on replay.
 
 -- Step 1: Remove duplicate transaction rows that may already exist from retry behavior.
 -- For each (sequence_number, index_in_batch) group, keep only the row with the lowest event_id.

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -412,7 +412,9 @@ impl DbBackend for PostgresBackend {
             visible_slots_to_advance: batch_to_store.visible_slots_to_advance,
         })?;
 
-        // Compound CTE statement to avoid multiple roundtrips
+        // Compound CTE statement to avoid multiple roundtrips.
+        // ON CONFLICT makes both inserts idempotent so retries after
+        // a successful-but-unacknowledged write are harmless.
         let result = run_with_retries!(
             &self.backoff_policy,
             sqlx::query(
@@ -421,11 +423,17 @@ impl DbBackend for PostgresBackend {
                 INSERT INTO in_progress_batch (sequence_number, borsh_value)
                 SELECT $1, $2
                 WHERE is_leader($3)
-            RETURNING sequence_number
+                ON CONFLICT (singleton)
+                DO UPDATE SET sequence_number = EXCLUDED.sequence_number,
+                              borsh_value = EXCLUDED.borsh_value
+                RETURNING sequence_number
             )
             INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data)
             SELECT bi.sequence_number, 'batch_start', NULL, NULL, $2
-            FROM batch_insert bi;
+            FROM batch_insert bi
+            ON CONFLICT (sequence_number, event_type)
+                WHERE event_type IN ('batch_start', 'batch_end', 'new_proof')
+            DO UPDATE SET data = EXCLUDED.data;
             "
             )
             .bind(i64::try_from(batch_to_store.sequence_number)?)
@@ -476,7 +484,10 @@ impl DbBackend for PostgresBackend {
                     $4::bytea[],
                     $5::bytea[]
                 )
-                WHERE is_leader($6);"
+                WHERE is_leader($6)
+                ON CONFLICT (sequence_number, index_in_batch)
+                    WHERE event_type = 'transaction'
+                DO UPDATE SET data = EXCLUDED.data;"
             )
             .bind(&sequence_number[..])
             .bind(&event_types[..])
@@ -512,7 +523,10 @@ impl DbBackend for PostgresBackend {
             sqlx::query::<Postgres>(
                 "INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data)
                     SELECT $1, 'transaction', $2, $3, $4
-                WHERE is_leader($5);",
+                WHERE is_leader($5)
+                ON CONFLICT (sequence_number, index_in_batch)
+                    WHERE event_type = 'transaction'
+                DO UPDATE SET data = EXCLUDED.data;",
             )
             .bind(i64::try_from(sequence_number)?)
             .bind(i64::try_from(tx_index_within_batch)?)
@@ -538,17 +552,27 @@ impl DbBackend for PostgresBackend {
         let stored_blob: StoredBlob = cached.into();
         let blob_data = borsh::to_vec(&stored_blob)?;
 
-        // Compound CTE statement to avoid multiple roundtrips
+        // Compound CTE statement to avoid multiple roundtrips.
+        // The INSERT is gated on is_leader() rather than on the DELETE returning rows,
+        // so that retries after a successful-but-unacknowledged write still insert
+        // (or upsert) the batch_end event even though in_progress_batch is already gone.
         let result = run_with_retries!(
             &self.backoff_policy,
             sqlx::query(
-                "WITH batch_delete AS (
+                "WITH leader_check AS (
+                    SELECT 1 WHERE is_leader($3)
+                ),
+                batch_delete AS (
                     DELETE FROM in_progress_batch
-                    WHERE is_leader($3)
-                    RETURNING 1)
+                    WHERE EXISTS (SELECT 1 FROM leader_check)
+                    RETURNING 1
+                )
                 INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data)
                 SELECT $1, 'batch_end', NULL, NULL, $2
-                FROM batch_delete",
+                WHERE EXISTS (SELECT 1 FROM leader_check)
+                ON CONFLICT (sequence_number, event_type)
+                    WHERE event_type IN ('batch_start', 'batch_end', 'new_proof')
+                DO UPDATE SET data = EXCLUDED.data",
             )
             .bind(i64::try_from(sequence_number)?)
             .bind::<&[u8]>(blob_data.as_ref())
@@ -613,7 +637,9 @@ impl DbBackend for PostgresBackend {
             blob_id,
         })?;
 
-        // Compound CTE statement to avoid multiple roundtrips
+        // Compound CTE statement to avoid multiple roundtrips.
+        // ON CONFLICT makes both inserts idempotent so retries after
+        // a successful-but-unacknowledged write are harmless.
         let result = run_with_retries!(
             &self.backoff_policy,
             sqlx::query(
@@ -622,11 +648,16 @@ impl DbBackend for PostgresBackend {
                     INSERT INTO proof_blobs (sequence_number, borsh_value)
                     SELECT $1, $2
                     WHERE is_leader($3)
+                    ON CONFLICT (sequence_number)
+                    DO UPDATE SET borsh_value = EXCLUDED.borsh_value
                     RETURNING sequence_number
                 )
                 INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data)
                 SELECT bi.sequence_number, 'new_proof', NULL, NULL, NULL
-                FROM blob_insert bi",
+                FROM blob_insert bi
+                ON CONFLICT (sequence_number, event_type)
+                    WHERE event_type IN ('batch_start', 'batch_end', 'new_proof')
+                DO UPDATE SET data = EXCLUDED.data",
             )
             .bind(i64::try_from(sequence_number)?)
             .bind::<&[u8]>(blob_data.as_ref())

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
@@ -226,14 +226,10 @@ fn assert_replica_disallowed(
     }
 }
 
-/// Reproduces the poison transaction crash loop:
-/// When `add_tx` is called twice for the same (sequence_number, index_in_batch)
-/// — which happens when `run_with_retries!` retries after a successful-but-unacknowledged
-/// write — the events table silently stores duplicate rows. On batch replay, the second
-/// copy of the transaction fails `check_generation_uniqueness` because the first copy
-/// already marked it as seen, crashing the node.
+/// Verifies that retrying each write path after a successful-but-unacknowledged
+/// Postgres write is idempotent and does not leave duplicate state behind.
 #[tokio::test(flavor = "multi_thread")]
-async fn test_duplicate_add_tx_creates_poison_batch() {
+async fn test_retry_sensitive_writes_are_idempotent() {
     let Some(postgres) = setup_test_postgres().await else {
         return;
     };
@@ -246,51 +242,140 @@ async fn test_duplicate_add_tx_creates_poison_batch() {
     .await;
     db.maybe_update_leader().await.unwrap();
 
-    let sequence_number = 1;
-    let batch_to_store = batch_to_store(sequence_number);
+    let batch_sequence_number = 1;
+    let proof_sequence_number = 2;
+    let batch_to_store = batch_to_store(batch_sequence_number);
 
     db.as_mut()
         .begin_rollup_block(batch_to_store)
         .await
         .unwrap();
 
+    db.as_mut()
+        .begin_rollup_block(batch_to_store)
+        .await
+        .unwrap();
+
+    let in_progress_batch = db.as_mut().read_in_progress_batch().await.unwrap().unwrap();
+    assert_eq!(in_progress_batch.sequence_number, batch_sequence_number);
+
+    let batch_start_count = count_events(db, batch_sequence_number, "batch_start").await;
+    assert_eq!(
+        batch_start_count, 1,
+        "Duplicate begin_rollup_block retry should not create multiple batch_start events",
+    );
+
     let tx_data = FullyBakedTx::new(vec![1, 2, 3]);
     let tx_hash = TxHash::new([0xf1; 32]);
 
     // First add_tx — simulates the original write that succeeded at the Postgres level
     db.as_mut()
-        .add_tx(sequence_number, 0, tx_data.clone(), tx_hash)
+        .add_tx(batch_sequence_number, 0, tx_data.clone(), tx_hash)
         .await
         .unwrap();
 
     // Second add_tx with identical arguments — simulates the retry after a connection drop.
-    // This SHOULD fail or be a no-op, but currently succeeds and creates a duplicate row.
+    // This is idempotent thanks to the unique index + ON CONFLICT DO UPDATE.
     db.as_mut()
-        .add_tx(sequence_number, 0, tx_data.clone(), tx_hash)
+        .add_tx(batch_sequence_number, 0, tx_data.clone(), tx_hash)
+        .await
+        .unwrap();
+
+    let tx_count = count_events(db, batch_sequence_number, "transaction").await;
+    assert_eq!(
+        tx_count, 1,
+        "Duplicate add_tx retry should not create multiple transaction events",
+    );
+
+    let proof_data = PreferredProofDataBytes(Arc::new(*b"proof_data"));
+    db.as_mut()
+        .add_proof_blob(proof_sequence_number, 3, proof_data.clone())
         .await
         .unwrap();
 
     db.as_mut()
-        .end_rollup_block(batch_to_store)
+        .add_proof_blob(proof_sequence_number, 3, proof_data.clone())
         .await
         .unwrap();
 
-    // Read the batch back — this is what replay_soft_confirmations_on_top_of_node_state does
+    let proof_blob_count = count_proof_blobs(db, proof_sequence_number).await;
+    assert_eq!(
+        proof_blob_count, 1,
+        "Duplicate add_proof_blob retry should not create multiple proof rows",
+    );
+
+    let new_proof_count = count_events(db, proof_sequence_number, "new_proof").await;
+    assert_eq!(
+        new_proof_count, 1,
+        "Duplicate add_proof_blob retry should not create multiple new_proof events",
+    );
+
+    db.as_mut().end_rollup_block(batch_to_store).await.unwrap();
+
+    db.as_mut().end_rollup_block(batch_to_store).await.unwrap();
+
+    let batch_end_count = count_events(db, batch_sequence_number, "batch_end").await;
+    assert_eq!(
+        batch_end_count, 1,
+        "Duplicate end_rollup_block retry should not create multiple batch_end events",
+    );
+
     let data = db.as_mut().current_data().await.unwrap();
+    assert_eq!(data.completed_blobs.len(), 2);
+
     let ReadBlob::Batch(batch) = &data.completed_blobs[0] else {
         panic!("Expected a batch blob");
     };
 
-    // THE BUG: the batch now contains 2 copies of the same transaction.
-    // Replay will execute the first copy (marking the tx hash as seen),
-    // then crash on the second copy with CheckUniquenessFailed.
-    assert_eq!(
-        batch.txs.len(),
-        1,
-        "Batch should contain exactly 1 transaction, but contains {} \
-         (duplicate rows in events table due to non-idempotent add_tx retry)",
-        batch.txs.len()
+    assert_eq!(batch.sequence_number, batch_sequence_number);
+    assert_eq!(batch.txs.len(), 1);
+
+    let ReadBlob::Proof {
+        sequence_number,
+        data: stored_proof_data,
+        ..
+    } = &data.completed_blobs[1]
+    else {
+        panic!("Expected a proof blob");
+    };
+
+    assert_eq!(*sequence_number, proof_sequence_number);
+    assert_eq!(stored_proof_data, &proof_data);
+
+    assert!(
+        db.as_mut()
+            .read_in_progress_batch()
+            .await
+            .unwrap()
+            .is_none(),
+        "Retrying end_rollup_block should leave no in-progress batch behind",
     );
+}
+
+async fn count_events(db: &DB, sequence_number: SequenceNumber, event_type: &str) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM events
+         WHERE sequence_number = $1
+           AND event_type = $2::event_type",
+    )
+    .bind(i64::try_from(sequence_number).unwrap())
+    .bind(event_type)
+    .fetch_one(&db.backend.pool)
+    .await
+    .unwrap()
+}
+
+async fn count_proof_blobs(db: &DB, sequence_number: SequenceNumber) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM proof_blobs
+         WHERE sequence_number = $1",
+    )
+    .bind(i64::try_from(sequence_number).unwrap())
+    .fetch_one(&db.backend.pool)
+    .await
+    .unwrap()
 }
 
 fn batch_to_store(sequence_number: SequenceNumber) -> BatchToStore {

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
@@ -226,6 +226,73 @@ fn assert_replica_disallowed(
     }
 }
 
+/// Reproduces the poison transaction crash loop:
+/// When `add_tx` is called twice for the same (sequence_number, index_in_batch)
+/// — which happens when `run_with_retries!` retries after a successful-but-unacknowledged
+/// write — the events table silently stores duplicate rows. On batch replay, the second
+/// copy of the transaction fails `check_generation_uniqueness` because the first copy
+/// already marked it as seen, crashing the node.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_duplicate_add_tx_creates_poison_batch() {
+    let Some(postgres) = setup_test_postgres().await else {
+        return;
+    };
+
+    let db = &mut DB::new(
+        &postgres,
+        String::from("node_id_1"),
+        ConfiguredNodeRole::Leader,
+    )
+    .await;
+    db.maybe_update_leader().await.unwrap();
+
+    let sequence_number = 1;
+    let batch_to_store = batch_to_store(sequence_number);
+
+    db.as_mut()
+        .begin_rollup_block(batch_to_store)
+        .await
+        .unwrap();
+
+    let tx_data = FullyBakedTx::new(vec![1, 2, 3]);
+    let tx_hash = TxHash::new([0xf1; 32]);
+
+    // First add_tx — simulates the original write that succeeded at the Postgres level
+    db.as_mut()
+        .add_tx(sequence_number, 0, tx_data.clone(), tx_hash)
+        .await
+        .unwrap();
+
+    // Second add_tx with identical arguments — simulates the retry after a connection drop.
+    // This SHOULD fail or be a no-op, but currently succeeds and creates a duplicate row.
+    db.as_mut()
+        .add_tx(sequence_number, 0, tx_data.clone(), tx_hash)
+        .await
+        .unwrap();
+
+    db.as_mut()
+        .end_rollup_block(batch_to_store)
+        .await
+        .unwrap();
+
+    // Read the batch back — this is what replay_soft_confirmations_on_top_of_node_state does
+    let data = db.as_mut().current_data().await.unwrap();
+    let ReadBlob::Batch(batch) = &data.completed_blobs[0] else {
+        panic!("Expected a batch blob");
+    };
+
+    // THE BUG: the batch now contains 2 copies of the same transaction.
+    // Replay will execute the first copy (marking the tx hash as seen),
+    // then crash on the second copy with CheckUniquenessFailed.
+    assert_eq!(
+        batch.txs.len(),
+        1,
+        "Batch should contain exactly 1 transaction, but contains {} \
+         (duplicate rows in events table due to non-idempotent add_tx retry)",
+        batch.txs.len()
+    );
+}
+
 fn batch_to_store(sequence_number: SequenceNumber) -> BatchToStore {
     BatchToStore {
         blob_id: 42,

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/migrations.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/migrations.rs
@@ -10,17 +10,15 @@ async fn test_003_step1_deduplicates_transaction_events() {
         return;
     };
 
-    let keep_hash = vec![0x11; 32];
-    let keep_data = vec![0x21, 0x22];
-    let drop_hash = vec![0x12; 32];
-    let drop_data = vec![0x23, 0x24];
-    let control_same_batch_hash = vec![0x13; 32];
-    let control_same_batch_data = vec![0x25, 0x26];
-    let control_other_batch_hash = vec![0x14; 32];
-    let control_other_batch_data = vec![0x27, 0x28];
+    let tx_hash = vec![0x11; 32];
+    let tx_data = vec![0x21, 0x22];
+    let control_same_batch_hash = vec![0x12; 32];
+    let control_same_batch_data = vec![0x23, 0x24];
+    let control_other_batch_hash = vec![0x13; 32];
+    let control_other_batch_data = vec![0x25, 0x26];
 
-    let keep_id = insert_transaction_event(&pool, 7, 0, &keep_hash, &keep_data).await;
-    let drop_id = insert_transaction_event(&pool, 7, 0, &drop_hash, &drop_data).await;
+    let keep_id = insert_transaction_event(&pool, 7, 0, &tx_hash, &tx_data).await;
+    let drop_id = insert_transaction_event(&pool, 7, 0, &tx_hash, &tx_data).await;
     let control_same_batch_id = insert_transaction_event(
         &pool,
         7,
@@ -38,27 +36,16 @@ async fn test_003_step1_deduplicates_transaction_events() {
     )
     .await;
 
+    assert_eq!(count_transaction_events(&pool, 7, 0).await, 2);
+    assert_eq!(count_transaction_events(&pool, 7, 1).await, 1);
+    assert_eq!(count_transaction_events(&pool, 8, 0).await, 1);
+
     apply_003_migration(&pool).await;
 
-    let deduped_rows: Vec<(i64, Vec<u8>, Vec<u8>)> = sqlx::query_as(
-        "SELECT event_id, hash, data
-         FROM events
-         WHERE sequence_number = $1
-           AND event_type = 'transaction'
-           AND index_in_batch = $2
-         ORDER BY event_id",
-    )
-    .bind(7_i64)
-    .bind(0_i64)
-    .fetch_all(&pool)
-    .await
-    .unwrap();
-
-    assert_eq!(deduped_rows.len(), 1);
-    assert_eq!(deduped_rows[0].0, keep_id);
-    assert_eq!(deduped_rows[0].1, keep_hash);
-    assert_eq!(deduped_rows[0].2, keep_data);
-
+    assert_eq!(count_transaction_events(&pool, 7, 0).await, 1);
+    assert_eq!(count_transaction_events(&pool, 7, 1).await, 1);
+    assert_eq!(count_transaction_events(&pool, 8, 0).await, 1);
+    assert_eq!(count_event_by_id(&pool, keep_id).await, 1);
     assert_eq!(count_event_by_id(&pool, drop_id).await, 0);
     assert_eq!(count_event_by_id(&pool, control_same_batch_id).await, 1);
     assert_eq!(count_event_by_id(&pool, control_other_batch_id).await, 1);
@@ -70,70 +57,48 @@ async fn test_003_step2_deduplicates_non_transaction_events() {
         return;
     };
 
-    let batch_start_keep_data = vec![0x31, 0x32];
-    let batch_start_drop_data = vec![0x33, 0x34];
-    let batch_end_keep_data = vec![0x41, 0x42];
-    let batch_end_drop_data = vec![0x43, 0x44];
+    let batch_start_data = vec![0x31, 0x32];
+    let batch_end_data = vec![0x41, 0x42];
     let tx_hash = vec![0x51; 32];
     let tx_data = vec![0x61, 0x62];
 
     let batch_start_keep_id =
-        insert_non_transaction_event(&pool, 9, "batch_start", Some(&batch_start_keep_data)).await;
+        insert_non_transaction_event(&pool, 9, "batch_start", Some(&batch_start_data)).await;
     let batch_start_drop_id =
-        insert_non_transaction_event(&pool, 9, "batch_start", Some(&batch_start_drop_data)).await;
+        insert_non_transaction_event(&pool, 9, "batch_start", Some(&batch_start_data)).await;
     let batch_end_keep_id =
-        insert_non_transaction_event(&pool, 9, "batch_end", Some(&batch_end_keep_data)).await;
+        insert_non_transaction_event(&pool, 9, "batch_end", Some(&batch_end_data)).await;
     let batch_end_drop_id =
-        insert_non_transaction_event(&pool, 9, "batch_end", Some(&batch_end_drop_data)).await;
+        insert_non_transaction_event(&pool, 9, "batch_end", Some(&batch_end_data)).await;
     let new_proof_keep_id = insert_non_transaction_event(&pool, 10, "new_proof", None).await;
     let new_proof_drop_id = insert_non_transaction_event(&pool, 10, "new_proof", None).await;
     let tx_control_id = insert_transaction_event(&pool, 9, 0, &tx_hash, &tx_data).await;
 
+    assert_eq!(
+        count_non_transaction_events(&pool, 9, "batch_start").await,
+        2
+    );
+    assert_eq!(count_non_transaction_events(&pool, 9, "batch_end").await, 2);
+    assert_eq!(
+        count_non_transaction_events(&pool, 10, "new_proof").await,
+        2
+    );
+    assert_eq!(count_transaction_events(&pool, 9, 0).await, 1);
+
     apply_003_migration(&pool).await;
 
-    let batch_start_rows: Vec<(i64, Vec<u8>)> = sqlx::query_as(
-        "SELECT event_id, data
-         FROM events
-         WHERE sequence_number = $1
-           AND event_type = 'batch_start'
-         ORDER BY event_id",
-    )
-    .bind(9_i64)
-    .fetch_all(&pool)
-    .await
-    .unwrap();
-    assert_eq!(batch_start_rows.len(), 1);
-    assert_eq!(batch_start_rows[0].0, batch_start_keep_id);
-    assert_eq!(batch_start_rows[0].1, batch_start_keep_data);
-
-    let batch_end_rows: Vec<(i64, Vec<u8>)> = sqlx::query_as(
-        "SELECT event_id, data
-         FROM events
-         WHERE sequence_number = $1
-           AND event_type = 'batch_end'
-         ORDER BY event_id",
-    )
-    .bind(9_i64)
-    .fetch_all(&pool)
-    .await
-    .unwrap();
-    assert_eq!(batch_end_rows.len(), 1);
-    assert_eq!(batch_end_rows[0].0, batch_end_keep_id);
-    assert_eq!(batch_end_rows[0].1, batch_end_keep_data);
-
-    let new_proof_rows: Vec<i64> = sqlx::query_scalar(
-        "SELECT event_id
-         FROM events
-         WHERE sequence_number = $1
-           AND event_type = 'new_proof'
-         ORDER BY event_id",
-    )
-    .bind(10_i64)
-    .fetch_all(&pool)
-    .await
-    .unwrap();
-    assert_eq!(new_proof_rows, vec![new_proof_keep_id]);
-
+    assert_eq!(
+        count_non_transaction_events(&pool, 9, "batch_start").await,
+        1
+    );
+    assert_eq!(count_non_transaction_events(&pool, 9, "batch_end").await, 1);
+    assert_eq!(
+        count_non_transaction_events(&pool, 10, "new_proof").await,
+        1
+    );
+    assert_eq!(count_event_by_id(&pool, batch_start_keep_id).await, 1);
+    assert_eq!(count_event_by_id(&pool, batch_end_keep_id).await, 1);
+    assert_eq!(count_event_by_id(&pool, new_proof_keep_id).await, 1);
     assert_eq!(count_event_by_id(&pool, batch_start_drop_id).await, 0);
     assert_eq!(count_event_by_id(&pool, batch_end_drop_id).await, 0);
     assert_eq!(count_event_by_id(&pool, new_proof_drop_id).await, 0);
@@ -215,4 +180,37 @@ async fn count_event_by_id(pool: &PgPool, event_id: i64) -> i64 {
         .fetch_one(pool)
         .await
         .unwrap()
+}
+
+async fn count_transaction_events(pool: &PgPool, sequence_number: i64, index_in_batch: i64) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM events
+         WHERE sequence_number = $1
+           AND event_type = 'transaction'
+           AND index_in_batch = $2",
+    )
+    .bind(sequence_number)
+    .bind(index_in_batch)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn count_non_transaction_events(
+    pool: &PgPool,
+    sequence_number: i64,
+    event_type: &str,
+) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM events
+         WHERE sequence_number = $1
+           AND event_type = $2::event_type",
+    )
+    .bind(sequence_number)
+    .bind(event_type)
+    .fetch_one(pool)
+    .await
+    .unwrap()
 }

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/migrations.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/migrations.rs
@@ -1,0 +1,218 @@
+use super::*;
+use sov_test_utils::postgres::{
+    connection_string_from_postgres_container, ContainerAsync, Postgres,
+};
+use sqlx::postgres::{PgPool, PgPoolOptions};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_003_step1_deduplicates_transaction_events() {
+    let Some((_postgres, pool)) = setup_pre_003_pool().await else {
+        return;
+    };
+
+    let keep_hash = vec![0x11; 32];
+    let keep_data = vec![0x21, 0x22];
+    let drop_hash = vec![0x12; 32];
+    let drop_data = vec![0x23, 0x24];
+    let control_same_batch_hash = vec![0x13; 32];
+    let control_same_batch_data = vec![0x25, 0x26];
+    let control_other_batch_hash = vec![0x14; 32];
+    let control_other_batch_data = vec![0x27, 0x28];
+
+    let keep_id = insert_transaction_event(&pool, 7, 0, &keep_hash, &keep_data).await;
+    let drop_id = insert_transaction_event(&pool, 7, 0, &drop_hash, &drop_data).await;
+    let control_same_batch_id = insert_transaction_event(
+        &pool,
+        7,
+        1,
+        &control_same_batch_hash,
+        &control_same_batch_data,
+    )
+    .await;
+    let control_other_batch_id = insert_transaction_event(
+        &pool,
+        8,
+        0,
+        &control_other_batch_hash,
+        &control_other_batch_data,
+    )
+    .await;
+
+    apply_003_migration(&pool).await;
+
+    let deduped_rows: Vec<(i64, Vec<u8>, Vec<u8>)> = sqlx::query_as(
+        "SELECT event_id, hash, data
+         FROM events
+         WHERE sequence_number = $1
+           AND event_type = 'transaction'
+           AND index_in_batch = $2
+         ORDER BY event_id",
+    )
+    .bind(7_i64)
+    .bind(0_i64)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(deduped_rows.len(), 1);
+    assert_eq!(deduped_rows[0].0, keep_id);
+    assert_eq!(deduped_rows[0].1, keep_hash);
+    assert_eq!(deduped_rows[0].2, keep_data);
+
+    assert_eq!(count_event_by_id(&pool, drop_id).await, 0);
+    assert_eq!(count_event_by_id(&pool, control_same_batch_id).await, 1);
+    assert_eq!(count_event_by_id(&pool, control_other_batch_id).await, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_003_step2_deduplicates_non_transaction_events() {
+    let Some((_postgres, pool)) = setup_pre_003_pool().await else {
+        return;
+    };
+
+    let batch_start_keep_data = vec![0x31, 0x32];
+    let batch_start_drop_data = vec![0x33, 0x34];
+    let batch_end_keep_data = vec![0x41, 0x42];
+    let batch_end_drop_data = vec![0x43, 0x44];
+    let tx_hash = vec![0x51; 32];
+    let tx_data = vec![0x61, 0x62];
+
+    let batch_start_keep_id =
+        insert_non_transaction_event(&pool, 9, "batch_start", Some(&batch_start_keep_data)).await;
+    let batch_start_drop_id =
+        insert_non_transaction_event(&pool, 9, "batch_start", Some(&batch_start_drop_data)).await;
+    let batch_end_keep_id =
+        insert_non_transaction_event(&pool, 9, "batch_end", Some(&batch_end_keep_data)).await;
+    let batch_end_drop_id =
+        insert_non_transaction_event(&pool, 9, "batch_end", Some(&batch_end_drop_data)).await;
+    let new_proof_keep_id = insert_non_transaction_event(&pool, 10, "new_proof", None).await;
+    let new_proof_drop_id = insert_non_transaction_event(&pool, 10, "new_proof", None).await;
+    let tx_control_id = insert_transaction_event(&pool, 9, 0, &tx_hash, &tx_data).await;
+
+    apply_003_migration(&pool).await;
+
+    let batch_start_rows: Vec<(i64, Vec<u8>)> = sqlx::query_as(
+        "SELECT event_id, data
+         FROM events
+         WHERE sequence_number = $1
+           AND event_type = 'batch_start'
+         ORDER BY event_id",
+    )
+    .bind(9_i64)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(batch_start_rows.len(), 1);
+    assert_eq!(batch_start_rows[0].0, batch_start_keep_id);
+    assert_eq!(batch_start_rows[0].1, batch_start_keep_data);
+
+    let batch_end_rows: Vec<(i64, Vec<u8>)> = sqlx::query_as(
+        "SELECT event_id, data
+         FROM events
+         WHERE sequence_number = $1
+           AND event_type = 'batch_end'
+         ORDER BY event_id",
+    )
+    .bind(9_i64)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(batch_end_rows.len(), 1);
+    assert_eq!(batch_end_rows[0].0, batch_end_keep_id);
+    assert_eq!(batch_end_rows[0].1, batch_end_keep_data);
+
+    let new_proof_rows: Vec<i64> = sqlx::query_scalar(
+        "SELECT event_id
+         FROM events
+         WHERE sequence_number = $1
+           AND event_type = 'new_proof'
+         ORDER BY event_id",
+    )
+    .bind(10_i64)
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+    assert_eq!(new_proof_rows, vec![new_proof_keep_id]);
+
+    assert_eq!(count_event_by_id(&pool, batch_start_drop_id).await, 0);
+    assert_eq!(count_event_by_id(&pool, batch_end_drop_id).await, 0);
+    assert_eq!(count_event_by_id(&pool, new_proof_drop_id).await, 0);
+    assert_eq!(count_event_by_id(&pool, tx_control_id).await, 1);
+}
+
+async fn setup_pre_003_pool() -> Option<(ContainerAsync<Postgres>, PgPool)> {
+    let postgres = setup_test_postgres().await?;
+    let connection_string = connection_string_from_postgres_container(&postgres)
+        .await
+        .unwrap();
+    let pool = PgPoolOptions::new()
+        .connect(&connection_string)
+        .await
+        .unwrap();
+
+    sqlx::raw_sql(include_str!("../migrations/001_init.sql"))
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::raw_sql(include_str!("../migrations/002_nodes.sql"))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    Some((postgres, pool))
+}
+
+async fn apply_003_migration(pool: &PgPool) {
+    sqlx::raw_sql(include_str!("../migrations/003_unique_tx_events.sql"))
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn insert_transaction_event(
+    pool: &PgPool,
+    sequence_number: i64,
+    index_in_batch: i64,
+    hash: &[u8],
+    data: &[u8],
+) -> i64 {
+    sqlx::query_scalar(
+        "INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data)
+         VALUES ($1, 'transaction', $2, $3, $4)
+         RETURNING event_id",
+    )
+    .bind(sequence_number)
+    .bind(index_in_batch)
+    .bind(hash)
+    .bind(data)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn insert_non_transaction_event(
+    pool: &PgPool,
+    sequence_number: i64,
+    event_type: &str,
+    data: Option<&[u8]>,
+) -> i64 {
+    sqlx::query_scalar(
+        "INSERT INTO events (sequence_number, event_type, index_in_batch, hash, data)
+         VALUES ($1, $2::event_type, NULL, NULL, $3)
+         RETURNING event_id",
+    )
+    .bind(sequence_number)
+    .bind(event_type)
+    .bind(data)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+async fn count_event_by_id(pool: &PgPool, event_id: i64) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE event_id = $1")
+        .bind(event_id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/mod.rs
@@ -1,5 +1,6 @@
 mod db_operations;
 mod leader_election;
+mod migrations;
 
 use std::net::SocketAddr;
 

--- a/crates/full-node/sov-sequencer/src/preferred/replica/db_data.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/db_data.rs
@@ -144,10 +144,11 @@ impl DbData {
 
 pub(crate) async fn rows(
     query_pool: &PgPool,
-    page_end: u64,
     current_event_id: u64,
+    target_event_id: u64,
+    page_size: usize,
 ) -> Result<Vec<PgRow>, sqlx::Error> {
-    // Query and process events for this page
+    // Fetch the next existing rows in event_id order rather than assuming ids are dense.
     sqlx::query(
         "SELECT e.event_id, e.sequence_number, e.index_in_batch, e.event_type, e.hash, COALESCE(e.data, p.borsh_value) AS data
         FROM events e
@@ -155,10 +156,12 @@ pub(crate) async fn rows(
           ON p.sequence_number = e.sequence_number
           AND e.event_type = 'new_proof'
         WHERE e.event_id >= $1 AND e.event_id <= $2
-        ORDER BY e.event_id ASC",
+        ORDER BY e.event_id ASC
+        LIMIT $3",
     )
     .bind(current_event_id as i64)
-    .bind(page_end as i64)
+    .bind(target_event_id as i64)
+    .bind(page_size as i64)
     .fetch_all(query_pool)
     .await
 }

--- a/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/event_receiver.rs
@@ -10,6 +10,7 @@ use sov_rollup_interface::node::future_or_shutdown;
 use sov_rollup_interface::node::FutureOrShutdownOutput;
 use sqlx::postgres::{PgListener, PgPoolOptions};
 use sqlx::PgPool;
+use sqlx::Row;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{debug, error, trace};
@@ -294,22 +295,28 @@ impl EventReceiver {
         // After analyzing real-world workloads, we can revisit this optimization. Implementing it would only affect
         // the contents of this method and would not require significant refactoring.
         while current_event_id <= target_event_id {
-            let page_end = std::cmp::min(current_event_id + self.page_size as u64, target_event_id);
-
             trace!(
-                "Processing backfill page: events {} to {}",
+                "Processing backfill page starting at event {} up to {}",
                 current_event_id,
-                page_end
+                target_event_id
             );
 
             // Query and process events for this page
-            let db_rows = rows(&self.query_pool, page_end, current_event_id).await?;
+            let db_rows = rows(
+                &self.query_pool,
+                current_event_id,
+                target_event_id,
+                self.page_size,
+            )
+            .await?;
 
             if db_rows.is_empty() {
-                return Err(EventReceiverError::DbRowDoesNotExist(current_event_id));
+                return Err(EventReceiverError::DbRowDoesNotExist(target_event_id));
             }
 
+            let mut last_event_id = current_event_id;
             for row in db_rows {
+                last_event_id = row.get::<i64, _>("event_id") as u64;
                 let (event, event_type) = row_to_event(row)?;
 
                 if !(EventType::is_event_sequence_valid(prev_event_type, event_type)) {
@@ -323,7 +330,7 @@ impl EventReceiver {
                 prev_event_type = Some(event_type);
             }
 
-            current_event_id = page_end + 1;
+            current_event_id = last_event_id + 1;
         }
 
         Ok(prev_event_type)

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -189,13 +189,13 @@ mod tests {
     use crate::preferred::db::postgres::PostgresBackend;
     use crate::preferred::db::BatchToStore;
     use crate::preferred::db::DbBackend;
-    use sqlx::postgres::PgPoolOptions;
     use sov_full_node_configs::sequencer::ConfiguredNodeRole;
     use sov_modules_api::FullyBakedTx;
     use sov_modules_api::TxHash;
     use sov_modules_api::VisibleSlotNumber;
     use sov_test_utils::postgres::config_from_postgres_container;
     use sov_test_utils::postgres::{create_postgres_container, CreatePostgresError};
+    use sqlx::postgres::PgPoolOptions;
     use std::net::Ipv4Addr;
     use std::net::SocketAddr;
     use std::sync::atomic::Ordering;

--- a/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/replica/replica_sync_task.rs
@@ -189,6 +189,7 @@ mod tests {
     use crate::preferred::db::postgres::PostgresBackend;
     use crate::preferred::db::BatchToStore;
     use crate::preferred::db::DbBackend;
+    use sqlx::postgres::PgPoolOptions;
     use sov_full_node_configs::sequencer::ConfiguredNodeRole;
     use sov_modules_api::FullyBakedTx;
     use sov_modules_api::TxHash;
@@ -270,7 +271,7 @@ mod tests {
         BatchEnd(u64),
     }
 
-    async fn execute(mut db: PostgresBackend, data: Vec<TestCase>) {
+    async fn execute(db: &mut PostgresBackend, data: Vec<TestCase>) {
         let mut index = 0;
         for db_data in data {
             match db_data {
@@ -305,6 +306,21 @@ mod tests {
                     db.end_rollup_block(stored_batch).await.unwrap();
                 }
             };
+        }
+    }
+
+    async fn burn_event_ids(connection_string: &str, count: usize) {
+        let pool = PgPoolOptions::new()
+            .connect(connection_string)
+            .await
+            .unwrap();
+
+        for _ in 0..count {
+            let _: i64 =
+                sqlx::query_scalar("SELECT nextval(pg_get_serial_sequence('events', 'event_id'))")
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
         }
     }
 
@@ -379,6 +395,71 @@ mod tests {
         run(test_data, expected, 6).await;
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_notifications_with_event_id_gap_larger_than_page_size() {
+        let postgres = create_postgres_container().await;
+        let postgres = match postgres {
+            Ok(pg) => pg,
+            Err(CreatePostgresError::DockerNotSupported) => return,
+            Err(CreatePostgresError::DockerError(e)) => {
+                panic!("Failed to create Postgres container: {e}");
+            }
+        };
+
+        let postgres_config = config_from_postgres_container(
+            &postgres,
+            "Replica".into(),
+            ConfiguredNodeRole::Replica,
+        )
+        .await
+        .unwrap();
+
+        let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+        let mut db = PostgresBackend::connect(&postgres_config, addr)
+            .await
+            .unwrap();
+
+        let _ = db
+            .heartbeat(Some(postgres_config.leader_election))
+            .await
+            .unwrap();
+
+        let (shutdown_snd, _shutdown_rcv) = watch::channel(());
+        let (mut sync_task, start_replica_task_notifier) =
+            ReplicaSyncTask::new_with_page_size(shutdown_snd, 2, SequencerRole::PgSyncReplica)
+                .await
+                .unwrap();
+
+        start_replica_task_notifier.notify();
+
+        let (test_handler, mut recv) = TestHandler::new(0);
+        sync_task.start(test_handler, &postgres_config).await;
+
+        // Wait for sync_task.start to spawn the sync task
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let first_batch = vec![TestCase::CompleteBatch(1, 1)];
+        let first_expected = to_db_data(&first_batch);
+        execute(&mut db, first_batch).await;
+
+        for data in first_expected {
+            let recv_data = recv.recv().await.unwrap();
+            assert_eq!(recv_data, data, "Expected: {data:?}, got: {recv_data:?}");
+        }
+
+        // Burn enough ids to create an empty numeric range larger than the receiver page size.
+        burn_event_ids(&postgres_config.postgres_connection_string, 5).await;
+
+        let second_batch = vec![TestCase::CompleteBatch(2, 1)];
+        let second_expected = to_db_data(&second_batch);
+        execute(&mut db, second_batch).await;
+
+        for data in second_expected {
+            let recv_data = recv.recv().await.unwrap();
+            assert_eq!(recv_data, data, "Expected: {data:?}, got: {recv_data:?}");
+        }
+    }
+
     async fn run(test_cases: Vec<TestCase>, expected: Vec<DbData>, exec_seq_nr: u64) {
         let postgres = create_postgres_container().await;
         let postgres = match postgres {
@@ -421,7 +502,8 @@ mod tests {
         // Wait for sync_task.start to spawn the sync task
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        execute(db, test_cases).await;
+        let mut db = db;
+        execute(&mut db, test_cases).await;
 
         for data in expected {
             let recv_data = recv.recv().await.unwrap();


### PR DESCRIPTION
# Description

  This PR makes the retry-sensitive preferred Postgres write paths idempotent, cleans up existing duplicate rows with a migration, and adds coverage for the affected paths.

  ## Changes
1. add `003_unique_tx_events.sql` to deduplicate existing `transaction`, `batch_start`, `batch_end`, and `new_proof` events before creating partial unique indexes
2. use `ON CONFLICT ... DO UPDATE` for batch start, transaction, batch end, and proof inserts so a retry updates the same logical row instead of creating a duplicate
3. gate `end_rollup_block` on the leader check rather than the delete result so a retry still records `batch_end` after `in_progress_batch` was already removed
4.  add an integration test that retries `begin_rollup_block`, `add_tx`, `add_proof_blob`, and `end_rollup_block` and asserts that state remains consistent

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
