### PR TITLE
EVM: Remove reth from dev related crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2046-04-08
-- #2705 Replaces `reth`-related crates. No breakage is intended.
+- #2704 Replaces `reth`-related crates. No breakage is intended.
 
 # 2026-04-02
 - #2682 Upgrades axum from 0.7 to 0.8. OpenAPI specs are now served as version 3.1.0 (previously 3.0.2). Manual intervention for upgrading pinned dependencies might be needed. Check Cargo.lock after the upgrade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2046-04-08
+- #2705 Replaces `reth`-related crates. No breakage is intended.
+
 # 2026-04-02
 - #2682 Upgrades axum from 0.7 to 0.8. OpenAPI specs are now served as version 3.1.0 (previously 3.0.2). Manual intervention for upgrading pinned dependencies might be needed. Check Cargo.lock after the upgrade
 - #2683 Removes JMT based rollup from demo-rollup examples. JMT-based storage is still available in sov-state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2046-04-08
+# 2026-04-08
 - #2704 Replaces `reth`-related crates. No breakage is intended.
 
 # 2026-04-02

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7266,7 +7266,6 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "arbitrary",
  "derive_more 2.0.1",
  "serde",
  "thiserror 2.0.17",
@@ -8280,16 +8279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest-arbitrary-interop"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1981e49bd2432249da8b0e11e5557099a8e74690d6b94e721f7dc0bb7f3555f"
-dependencies = [
- "arbitrary",
- "proptest",
-]
-
-[[package]]
 name = "proptest-derive"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9036,10 +9025,8 @@ dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
  "alloy-primitives",
- "arbitrary",
  "auto_impl",
  "once_cell",
- "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -9053,13 +9040,9 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "arbitrary",
- "modular-bitfield",
  "reth-codecs",
  "reth-primitives-traits",
- "reth-zstd-compressors",
  "serde",
- "serde_with",
 ]
 
 [[package]]
@@ -9097,7 +9080,6 @@ version = "1.9.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
- "c-kzg",
  "once_cell",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -9117,23 +9099,17 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-trie",
- "arbitrary",
  "auto_impl",
- "byteorder",
  "bytes",
  "derive_more 2.0.1",
- "modular-bitfield",
  "once_cell",
  "op-alloy-consensus",
- "proptest",
- "proptest-arbitrary-interop",
  "reth-codecs",
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
  "secp256k1 0.30.0",
  "serde",
- "serde_with",
  "thiserror 2.0.17",
 ]
 
@@ -9986,9 +9962,6 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-dependencies = [
- "rand 0.8.5",
-]
 
 [[package]]
 name = "rustc-hex"
@@ -11967,7 +11940,6 @@ dependencies = [
  "alloy-primitives",
  "arbitrary",
  "rand_chacha 0.3.1",
- "reth-primitives",
  "revm",
  "secp256k1 0.30.0",
  "sha2 0.10.9",
@@ -11980,9 +11952,7 @@ name = "sov-eth-dev-signer"
 version = "0.3.0"
 dependencies = [
  "alloy-consensus",
- "alloy-rpc-types",
- "reth-primitives",
- "revm",
+ "alloy-primitives",
  "secp256k1 0.30.0",
  "thiserror 2.0.17",
 ]
@@ -13251,7 +13221,6 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "borsh",
- "reth-primitives",
  "schemars 0.8.22",
  "secp256k1 0.30.0",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6756,27 +6756,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "module-template"
 version = "0.3.0"
 dependencies = [
@@ -7254,22 +7233,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42e9de945efe3c2fbd207e69720c9c1af2b8caa6872aee0e216450c25a3ca70"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more 2.0.1",
- "serde",
- "thiserror 2.0.17",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -8966,128 +8929,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-codecs"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive",
- "reth-zstd-compressors",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "reth-consensus"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "auto_impl",
- "reth-execution-types",
- "reth-primitives-traits",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "reth-errors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "reth-consensus",
- "reth-execution-errors",
- "reth-storage-errors",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "reth-codecs",
- "reth-primitives-traits",
- "serde",
-]
-
-[[package]]
-name = "reth-execution-errors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-evm",
- "alloy-primitives",
- "alloy-rlp",
- "nybbles",
- "reth-storage-errors",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "reth-execution-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-primitives",
- "derive_more 2.0.1",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-trie-common",
- "revm",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "once_cell",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
-]
-
-[[package]]
 name = "reth-primitives-traits"
 version = "1.9.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
@@ -9097,82 +8938,15 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
  "alloy-trie",
  "auto_impl",
  "bytes",
  "derive_more 2.0.1",
  "once_cell",
- "op-alloy-consensus",
- "reth-codecs",
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
- "secp256k1 0.30.0",
- "serde",
  "thiserror 2.0.17",
-]
-
-[[package]]
-name = "reth-prune-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.0.1",
- "strum 0.27.2",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.0.1",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-storage-errors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "derive_more 2.0.1",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-static-file-types",
- "revm-database-interface",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "reth-trie-common"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "derive_more 2.0.1",
- "itertools 0.14.0",
- "nybbles",
- "reth-primitives-traits",
- "revm-database",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "zstd",
 ]
 
 [[package]]
@@ -11807,7 +11581,6 @@ dependencies = [
  "jsonrpsee",
  "rand 0.8.5",
  "reqwest",
- "reth-primitives",
  "risc0",
  "rockbound",
  "rustls 0.23.31",
@@ -12750,7 +12523,6 @@ dependencies = [
  "derive-new",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "reth-errors",
  "reth-primitives-traits",
  "revm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,10 +328,7 @@ alloy-rpc-types-trace = { version = "1.0.41", default-features = false }
 alloy-signer = { version = "1.0.41", default-features = false }
 alloy-signer-local = { version = "1.0.41", default-features = false }
 alloy-rlp = { version = "0.3.12", default-features = false }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0", default-features = false }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0", default-features = false }
 reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0", default-features = false }
 revm = { version = "31.0.0", features = ["serde"], default-features = false }
 revm-database-interface = { version = "8.0.4", default-features = false }
 revm-context = { version = "11.0.0", default-features = false }

--- a/crates/full-node/sov-eth-dev-generator/Cargo.toml
+++ b/crates/full-node/sov-eth-dev-generator/Cargo.toml
@@ -19,7 +19,6 @@ revm = { workspace = true, features = ["std", "secp256k1", "arbitrary"] }
 sov-transaction-generator = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-consensus = { workspace = true }
-reth-primitives = { workspace = true, features = ["secp256k1", "arbitrary"] }
 secp256k1 = { workspace = true }
 sha2 = { workspace = true }
 rand_chacha = { workspace = true }

--- a/crates/full-node/sov-eth-dev-generator/src/transfer_generator.rs
+++ b/crates/full-node/sov-eth-dev-generator/src/transfer_generator.rs
@@ -3,9 +3,9 @@ use alloy_consensus::TxEip1559;
 use alloy_consensus::TypedTransaction;
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 use arbitrary::Arbitrary;
-use reth_primitives::TransactionSigned;
 use revm::context::transaction::AccessList;
 use secp256k1::SecretKey;
+use sov_eth_dev_signer::TransactionSigned;
 
 use crate::randomness::Randomness;
 use sov_eth_dev_signer::Signer;

--- a/crates/full-node/sov-eth-dev-signer/Cargo.toml
+++ b/crates/full-node/sov-eth-dev-signer/Cargo.toml
@@ -15,8 +15,6 @@ workspace = true
 
 [dependencies]
 thiserror = { workspace = true }
-revm = { workspace = true, features = ["std", "secp256k1"] }
-reth-primitives = { workspace = true, features = ["secp256k1"] }
-alloy-consensus = { workspace = true }
-alloy-rpc-types = { workspace = true }
+alloy-consensus = { workspace = true, features = ["secp256k1"] }
+alloy-primitives = { workspace = true }
 secp256k1 = { workspace = true }

--- a/crates/full-node/sov-eth-dev-signer/src/lib.rs
+++ b/crates/full-node/sov-eth-dev-signer/src/lib.rs
@@ -3,11 +3,18 @@
 
 use std::collections::HashMap;
 
-use alloy_consensus::SignableTransaction;
-use alloy_consensus::{TxEip4844Variant, TypedTransaction};
-use reth_primitives::{sign_message, Transaction, TransactionSigned};
-use revm::primitives::{Address, B256};
+use alloy_consensus::crypto::secp256k1::{public_key_to_address, sign_message};
+use alloy_consensus::{
+    EthereumTxEnvelope, EthereumTypedTransaction, SignableTransaction, TxEip4844, TypedTransaction,
+};
+use alloy_primitives::{Address, B256};
 use secp256k1::{PublicKey, SecretKey};
+
+/// Signed ethereum transaction (EIP-2718 envelope).
+pub type TransactionSigned = EthereumTxEnvelope<TxEip4844>;
+
+/// Unsigned ethereum transaction.
+type Transaction = EthereumTypedTransaction<TxEip4844>;
 
 /// Ethereum transaction signer.
 #[derive(Clone)]
@@ -40,17 +47,15 @@ impl Signer {
 
     /// Address
     pub fn address(&self) -> Address {
-        reth_primitives::public_key_to_address(self.public_key())
+        public_key_to_address(self.public_key())
     }
 
     /// Signs an ethereum transaction.
     pub fn sign_transaction(&self, request: TypedTransaction) -> Result<TransactionSigned, Error> {
-        let transaction =
-            to_primitive_transaction(request).ok_or(Error::InvalidTransactionRequest)?;
+        let transaction: Transaction = request.into();
         let tx_signature_hash = transaction.signature_hash();
         let sk = B256::from_slice(self.0.as_ref());
         let signature = sign_message(sk, tx_signature_hash).map_err(|_| Error::CouldNotSign)?;
-
         Ok(TransactionSigned::new_unhashed(transaction, signature))
     }
 }
@@ -86,18 +91,4 @@ impl Signers {
     pub fn addresses(&self) -> Vec<Address> {
         self.0.keys().cloned().collect()
     }
-}
-
-/// Converts a typed transaction request into a primitive transaction.
-fn to_primitive_transaction(tx_request: TypedTransaction) -> Option<Transaction> {
-    Some(match tx_request {
-        TypedTransaction::Legacy(tx) => Transaction::Legacy(tx),
-        TypedTransaction::Eip2930(tx) => Transaction::Eip2930(tx),
-        TypedTransaction::Eip1559(tx) => Transaction::Eip1559(tx),
-        TypedTransaction::Eip4844(TxEip4844Variant::TxEip4844(tx)) => Transaction::Eip4844(tx),
-        TypedTransaction::Eip4844(TxEip4844Variant::TxEip4844WithSidecar(tx)) => {
-            Transaction::Eip4844(tx.into())
-        }
-        TypedTransaction::Eip7702(tx) => Transaction::Eip7702(tx),
-    })
 }

--- a/crates/module-system/module-implementations/sov-uniqueness/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-uniqueness/Cargo.toml
@@ -20,7 +20,7 @@ sov-modules-api = { workspace = true }
 sov-state = { workspace = true }
 
 [dev-dependencies]
-alloy-consensus = { workspace = true }
+alloy-consensus = { workspace = true, features = ["secp256k1"] }
 alloy-primitives = { workspace = true }
 alloy-eips = { workspace = true }
 sov-modules-stf-blueprint = { workspace = true }
@@ -32,7 +32,6 @@ sov-test-utils = { workspace = true }
 sov-evm-test-utils = { workspace = true }
 sov-value-setter = { workspace = true }
 sov-evm = { workspace = true, features = ["native"] }
-reth-primitives = { workspace = true, features = ["std"] }
 sov-address = { workspace = true, features = ["evm"] }
 sov-rollup-interface = { workspace = true }
 sov-kernels = { workspace = true }
@@ -46,7 +45,6 @@ arbitrary = [
 	"sov-uniqueness/arbitrary",
 	"sov-state/arbitrary",
 	"sov-test-utils/arbitrary",
-	"reth-primitives/arbitrary",
 	"sov-address/arbitrary",
 	"sov-evm/arbitrary",
 	"sov-rollup-interface/arbitrary",
@@ -56,7 +54,6 @@ arbitrary = [
 	"sov-evm-test-utils/arbitrary",
 ]
 native = [
-	"reth-primitives/std",
 	"sov-modules-api/native",
 	"sov-uniqueness/native",
 	"sov-state/native",

--- a/crates/module-system/module-implementations/sov-uniqueness/tests/integration/utils.rs
+++ b/crates/module-system/module-implementations/sov-uniqueness/tests/integration/utils.rs
@@ -3,12 +3,12 @@ use std::str::FromStr;
 use alloy_consensus::{TxEip1559, TypedTransaction};
 use alloy_eips::{eip1559::MIN_PROTOCOL_BASE_FEE, eip2718::Encodable2718};
 use alloy_primitives::{Address, Bytes, TxKind};
-use reth_primitives::TransactionSigned;
 use secp256k1::rand::SeedableRng as _;
 use secp256k1::{PublicKey, SecretKey};
 use sov_address::MultiAddress;
 use sov_address::{EthereumAddress, FromVmAddress};
 use sov_eth_dev_signer::Signer;
+use sov_eth_dev_signer::TransactionSigned;
 use sov_evm::{
     AccountData, EthereumAuthenticator, EvmChainSpec, EvmGenesisConfig, RlpEvmTransaction, SpecId,
 };
@@ -40,7 +40,7 @@ impl EvmAccount {
     }
 
     pub fn address(&self) -> Address {
-        reth_primitives::public_key_to_address(self.public_key())
+        alloy_consensus::crypto::secp256k1::public_key_to_address(self.public_key())
     }
 
     pub fn sign(&self, tx: TypedTransaction) -> (RlpEvmTransaction, TransactionSigned) {

--- a/crates/utils/sov-rpc-eth-types/Cargo.toml
+++ b/crates/utils/sov-rpc-eth-types/Cargo.toml
@@ -20,7 +20,6 @@ alloy-eips = { workspace = true }
 alloy-evm = { workspace = true }
 alloy-sol-types = { workspace = true }
 alloy-transport = { workspace = true }
-reth-errors = { workspace = true }
 reth-primitives-traits = { workspace = true }
 serde = { workspace = true }
 derive-new = { workspace = true }

--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -107,7 +107,6 @@ sov-evm-test-utils = { workspace = true }
 sov-chain-state = { workspace = true }
 sov-blob-storage = { workspace = true }
 sov-synthetic-load = { workspace = true, features = ["native"] }
-reth-primitives = { workspace = true, default-features = false }
 futures = { workspace = true }
 demo-stf = { workspace = true, features = ["native"] }
 demo-stf-json-client = { path = "./stf/demo-stf-json-client", default-features = false }

--- a/examples/demo-rollup/tests/forced_sequencer_registration/mod.rs
+++ b/examples/demo-rollup/tests/forced_sequencer_registration/mod.rs
@@ -15,7 +15,7 @@ use base64::Engine;
 use demo_stf::runtime::{Runtime, RuntimeCall};
 use futures::stream::BoxStream;
 use futures::StreamExt;
-use secp256k1::{PublicKey, SecretKey};
+use secp256k1::SecretKey;
 use sov_api_spec::types as api_types;
 use sov_bank::config_gas_token_id;
 use sov_cli::NodeClient;
@@ -288,12 +288,8 @@ impl EvmAccount {
         Self(secret_key)
     }
 
-    fn public_key(&self) -> PublicKey {
-        PublicKey::from_secret_key(secp256k1::SECP256K1, &self.0)
-    }
-
     fn address(&self) -> Address {
-        reth_primitives::public_key_to_address(self.public_key())
+        Signer::new(self.0).address()
     }
 
     fn sign(&self, tx: TypedTransaction) -> RlpEvmTransaction {


### PR DESCRIPTION
# Description

Replace or remove `reth` crates from:

* `sov-eth-dev-generator`
* `sov-eth-dev-signer`
* `sov-uniqueness` (dev dependency)


**After this PR only `reth-primitives-traits` remains a dependency on `reth` crates**

Depends on #2702 

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existing tests are passing

## Docs
No updates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
