### PR TITLE
Clean up deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -17,7 +17,7 @@ allow = [
   "Apache-2.0 WITH LLVM-exception",
   "LicenseRef-Sovereign-Permissionless-Commercial-License",
   "Zlib",
-  "BSL-1.0",                                                # Relevant discussion: <https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/985#issuecomment-2242712349>.
+  "BSL-1.0",                                                # Boost Software License 1.0 — NOT Business Source License (BUSL-1.1). Relevant discussion: <https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/985#issuecomment-2242712349>.
 ]
 
 [[licenses.clarify]]
@@ -402,11 +402,6 @@ expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
 license-files = []
 
 [[licenses.clarify]]
-name = "sov-modules-schemas"
-expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
-license-files = []
-
-[[licenses.clarify]]
 name = "sov-soak-testing"
 expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
 license-files = []
@@ -418,11 +413,6 @@ license-files = []
 
 [[licenses.clarify]]
 name = "switcheroo"
-expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
-license-files = []
-
-[[licenses.clarify]]
-name = "sov-hyperlane-integration"
 expression = "LicenseRef-Sovereign-Permissionless-Commercial-License"
 license-files = []
 


### PR DESCRIPTION
# Description

1. BSL-1.0 comment clarified (line 20) — now explicitly states "Boost Software License 1.0 — NOT Business Source License (BUSL-1.1)"
2. Removed stale sov-modules-schemas entry — the package doesn't exist; sov-module-schemas (singular) was already covered
3. Removed duplicate sov-hyperlane-integration entry

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
