### PR TITLE
Make `opt-level = 3` for dev profile in sov-modules-macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -354,7 +354,7 @@ codegen-units = 256
 [profile.dev.package.sov-modules-macros]
 # Set the optimization level to 3 for the sov-modules-macros crate. This
 # should reduce build times for other packages.
-opt-level = 1
+opt-level = 3
 
 [profile.release-with-opt-level-0]
 inherits = "release"


### PR DESCRIPTION
Partial revert of https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/1201

Unifies comment and should speed up compilation. We know that generated code from this macro is not a bottleneck during runtime

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
Existing tests are passing

## Docs
No updates
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
