### PR TITLE
CI clean up

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -254,7 +254,7 @@ jobs:
   nextest_all_features:
     name: nextest_all_features
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-300gb-1-93;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=nextest_all_features-1-93
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-all-features-300gb-1-93;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=nextest_all_features-1-93
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -110,8 +110,6 @@ jobs:
         with:
           cache: rust
           path: ./crates/fuzz/target
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -146,8 +144,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -168,8 +164,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       - name: rollup bench check
         env:
           SOV_BENCH_BLOCKS: 10
@@ -200,8 +194,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -233,8 +225,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -256,8 +246,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -277,8 +265,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -299,8 +285,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -323,8 +307,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       # Coverage is intentionally run without heavy crates, like demo-rollup.
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
@@ -347,8 +329,6 @@ jobs:
       - uses: taiki-e/install-action@cargo-deny
         with:
           tool: cargo-deny@0.18.4
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -464,8 +444,6 @@ jobs:
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       - name: Login to Docker Hub
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
@@ -494,8 +472,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -512,8 +488,6 @@ jobs:
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       - run: make check-constant-overriding-is-disabled-in-release-mode
 
   validate-packages-to-publish-yml:
@@ -546,8 +520,6 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: true
     steps:
       - uses: actions/checkout@v5
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y clang libclang-dev
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: |

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -116,5 +116,5 @@ RUN rm -rf /home/runner/.cargo/.global-cache
 
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true \
     PATH="/home/runner/.risc0/bin:/home/runner/.sp1/bin:/home/runner/.cargo/bin:${PATH}" \
-    RISC0_RUST_TOOLCHAIN_VERSION=1.88.0 \
+    RISC0_RUST_TOOLCHAIN_VERSION=1.91.1 \
     RISC0_CPP_TOOLCHAIN_VERSION=2024.1.5

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -86,8 +86,9 @@ SHELL ["/bin/bash", "-c"]
 RUN . /home/runner/.cargo/env \
     && curl -L https://risczero.com/install | bash \
     && export PATH="/home/runner/.risc0/bin:$PATH" \
-    && /home/runner/.risc0/bin/rzup install cargo-risczero 2.0.2 \
-    && /home/runner/.risc0/bin/rzup install rust 1.88.0 \
+    && /home/runner/.risc0/bin/rzup install cargo-risczero 3.0.5 \
+    && /home/runner/.risc0/bin/rzup install r0vm 3.0.5 \
+    && /home/runner/.risc0/bin/rzup install rust 1.91.1 \
     && /home/runner/.risc0/bin/rzup install cpp 2024.1.5 \
     && rm -rf /home/runner/.cargo/registry /home/runner/.cargo/git
 


### PR DESCRIPTION
# Description

* remove unnecessary libclang installation #2717 , because it is already installed in the base image
* use separate base image for nexttest-all-features to improve hash matches
* base images have updated risc0 version