### PR TITLE
Celestia: Add support for gRPC fallback endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-04-13
+- #2721 Adds support for fallback gRPC endpoints to celestia-adapter. Optional new field
+
 # 2026-04-08
 - #2695 adds a new `ext_getStorageProof` RPC endpoint to the EVM module
 - #2704 Replaces `reth`-related crates. No breakage is intended.

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -219,6 +219,9 @@ impl CelestiaConfig {
             builder = builder.rpc_auth_token(rpc_auth_token);
         }
         // Submission section.
+        if self.grpc_url.is_none() && !self.grpc_fallback_endpoints.is_empty() {
+            anyhow::bail!("`grpc_fallback_endpoints` requires `grpc_url` to be set");
+        }
         if let Some(grpc_url) = &self.grpc_url {
             let mut endpoint = celestia_client::Endpoint::new(grpc_url.clone());
             if let Some(grpc_auth_token) = &self.grpc_auth_token {
@@ -492,6 +495,22 @@ mod tests {
         assert!(debug_output.contains("REDACTED"));
         assert!(debug_output.contains("http://fallback1:9090"));
         assert!(debug_output.contains("http://fallback2:9090"));
+    }
+
+    #[tokio::test]
+    async fn build_client_rejects_fallback_endpoints_without_grpc_url() {
+        let mut config = CelestiaConfig::minimal("ws://localhost:26658".to_string());
+        config.grpc_fallback_endpoints = vec![GrpcEndpointConfig {
+            url: "http://fallback:9090".to_string(),
+            token: None,
+        }];
+        let error = config.build_client().await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("`grpc_fallback_endpoints` requires `grpc_url` to be set"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/adapters/celestia/src/config.rs
+++ b/crates/adapters/celestia/src/config.rs
@@ -4,6 +4,24 @@ use std::num::NonZero;
 use schemars::JsonSchema;
 use std::fmt;
 
+/// Configuration for a single gRPC fallback endpoint.
+#[derive(Clone, PartialEq, serde::Deserialize, serde::Serialize, JsonSchema)]
+pub struct GrpcEndpointConfig {
+    /// The URL of the gRPC endpoint, for example `http://fallback1:9090`.
+    pub url: String,
+    /// Optional authentication token, sent as `x-token` metadata.
+    pub token: Option<String>,
+}
+
+impl fmt::Debug for GrpcEndpointConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GrpcEndpointConfig")
+            .field("url", &self.url)
+            .field("token", &self.token.as_ref().map(|_| "REDACTED"))
+            .finish()
+    }
+}
+
 /// Runtime configuration for the [`sov_rollup_interface::node::da::DaService`] implementation.
 #[derive(Clone, PartialEq, serde::Deserialize, serde::Serialize, JsonSchema)]
 pub struct CelestiaConfig {
@@ -32,6 +50,13 @@ pub struct CelestiaConfig {
     /// Optional, used only if `grpc_url` is set.
     #[serde(default = "default_grpc_auth_token")]
     pub grpc_auth_token: Option<String>,
+
+    /// Optional list of fallback gRPC endpoints for blob submission.
+    /// Used alongside `grpc_url` for failover. Each entry has a mandatory `url`
+    /// and an optional `token` (sent as `x-token` metadata).
+    /// Default: empty (no fallback endpoints).
+    #[serde(default)]
+    pub grpc_fallback_endpoints: Vec<GrpcEndpointConfig>,
 
     /// The private key in hex format of Celestia wallet that has enough TIA to publish blobs.
     /// If not specified in the config, will be pulled from `SOV_CELESTIA_SIGNER_KEY`.
@@ -100,6 +125,7 @@ impl fmt::Debug for CelestiaConfig {
                 "grpc_auth_token",
                 &self.grpc_auth_token.as_ref().map(|_| "REDACTED"),
             )
+            .field("grpc_fallback_endpoints", &self.grpc_fallback_endpoints)
             .field(
                 "signer_private_key",
                 &self.signer_private_key.as_ref().map(|_| "REDACTED"),
@@ -147,6 +173,7 @@ impl CelestiaConfig {
             rpc_auth_token: None,
             grpc_url: None,
             grpc_auth_token: None,
+            grpc_fallback_endpoints: Vec::new(),
             signer_private_key: None,
             request_timeout_secs: default_request_timeout_seconds(),
             api_request_timeout_secs: default_api_request_timeout_secs(),
@@ -198,6 +225,16 @@ impl CelestiaConfig {
                 endpoint = endpoint.metadata("x-token", grpc_auth_token);
             }
             builder = builder.grpc_endpoint(endpoint);
+            if !self.grpc_fallback_endpoints.is_empty() {
+                let fallback_endpoints = self.grpc_fallback_endpoints.iter().map(|ep| {
+                    let mut endpoint = celestia_client::Endpoint::new(ep.url.clone());
+                    if let Some(token) = &ep.token {
+                        endpoint = endpoint.metadata("x-token", token);
+                    }
+                    endpoint
+                });
+                builder = builder.grpc_endpoints(fallback_endpoints);
+            }
             if let Some(signer_key_hex) = &self.signer_private_key {
                 builder = builder.private_key_hex(signer_key_hex);
             }
@@ -295,7 +332,7 @@ pub(crate) fn default_background_stat_polling_interval_secs() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{validate_rpc_url, CelestiaConfig};
+    use super::{validate_rpc_url, CelestiaConfig, GrpcEndpointConfig};
 
     const RPC_ENV_VAR: &str = "SOV_CELESTIA_RPC_URL";
     const GRPC_ENV_VAR: &str = "SOV_CELESTIA_GRPC_URL";
@@ -393,5 +430,79 @@ mod tests {
         )
         .unwrap();
         assert_eq!(config.grpc_url.as_deref(), Some("http://config-grpc:9090"));
+    }
+
+    #[test]
+    fn grpc_fallback_endpoints_default_to_empty() {
+        let _rpc_guard = EnvVarGuard::set(RPC_ENV_VAR, Some("ws://env-rpc:26658"));
+        let _grpc_guard = EnvVarGuard::set(GRPC_ENV_VAR, None);
+
+        let config = deserialize_config("{}").unwrap();
+        assert!(config.grpc_fallback_endpoints.is_empty());
+    }
+
+    #[test]
+    fn grpc_fallback_endpoints_with_token_deserialize() {
+        let _rpc_guard = EnvVarGuard::set(RPC_ENV_VAR, Some("ws://env-rpc:26658"));
+        let _grpc_guard = EnvVarGuard::set(GRPC_ENV_VAR, None);
+
+        let config = deserialize_config(
+            r#"{
+                "grpc_fallback_endpoints": [
+                    {"url": "http://fallback1:9090", "token": "secret-token"},
+                    {"url": "http://fallback2:9090"}
+                ]
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(config.grpc_fallback_endpoints.len(), 2);
+        assert_eq!(
+            config.grpc_fallback_endpoints[0].url,
+            "http://fallback1:9090"
+        );
+        assert_eq!(
+            config.grpc_fallback_endpoints[0].token.as_deref(),
+            Some("secret-token"),
+        );
+        assert_eq!(
+            config.grpc_fallback_endpoints[1].url,
+            "http://fallback2:9090"
+        );
+        assert_eq!(config.grpc_fallback_endpoints[1].token, None);
+    }
+
+    #[test]
+    fn debug_redacts_fallback_endpoint_tokens() {
+        let mut config = CelestiaConfig::minimal("ws://rpc:26658".to_string());
+        config.grpc_fallback_endpoints = vec![
+            GrpcEndpointConfig {
+                url: "http://fallback1:9090".to_string(),
+                token: Some("super-secret".to_string()),
+            },
+            GrpcEndpointConfig {
+                url: "http://fallback2:9090".to_string(),
+                token: None,
+            },
+        ];
+        let debug_output = format!("{:?}", config);
+        assert!(
+            !debug_output.contains("super-secret"),
+            "token should be redacted in debug output: {debug_output}"
+        );
+        assert!(debug_output.contains("REDACTED"));
+        assert!(debug_output.contains("http://fallback1:9090"));
+        assert!(debug_output.contains("http://fallback2:9090"));
+    }
+
+    #[test]
+    fn grpc_fallback_endpoints_roundtrip() {
+        let mut config = CelestiaConfig::minimal("ws://rpc:26658".to_string());
+        config.grpc_fallback_endpoints = vec![GrpcEndpointConfig {
+            url: "http://fallback1:9090".to_string(),
+            token: Some("token1".to_string()),
+        }];
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: CelestiaConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, deserialized);
     }
 }

--- a/crates/adapters/celestia/src/test_helper/docker.rs
+++ b/crates/adapters/celestia/src/test_helper/docker.rs
@@ -289,6 +289,7 @@ impl CelestiaDevNode {
             rpc_auth_token: None,
             grpc_url: Some(grpc_url),
             grpc_auth_token: None,
+            grpc_fallback_endpoints: Vec::new(),
             signer_private_key: Some(key_0),
             request_timeout_secs: default_request_timeout_seconds(),
             api_request_timeout_secs: default_api_request_timeout_secs(),

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -22,6 +22,16 @@ grpc_url = "http://127.0.0.1:9090"
 # For QuickNode, use X-token header.
 #grpc_auth_token = ""
 
+# Optional fallback gRPC endpoints for blob submission.
+# Used alongside grpc_url for failover. Each entry has a mandatory url
+# and an optional token (sent as x-token metadata).
+#[[da.grpc_fallback_endpoints]]
+#url = "http://fallback1:9090"
+#token = "secret-token"
+#
+#[[da.grpc_fallback_endpoints]]
+#url = "http://fallback2:9090"
+
 # The private key in hex format of Celestia wallet that has enough TIA to publish blobs.
 # If not specified in the config, will be pulled from `SOV_CELESTIA_SIGNER_KEY` environment variable.
 # Can be exported from celestia-appd:


### PR DESCRIPTION
# Description

Allow specify several gRPC endpoints for celestia adapter, so blobs can continue being submitted.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #1630  

## Testing
Tests for configuration parsing has been added. Core functionality is outside of SDK code and assumed to be working. 

## Docs
No updates
