### PR TITLE
Make `ZkvmHost` proving atomic with `add_hint_and_run`

### DIFF
--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -1,5 +1,3 @@
-use std::collections::VecDeque;
-
 use crate::notifier::NotificationManager;
 use crate::{MockCodeCommitment, MockProof, MockZkGuest};
 use serde::Serialize;
@@ -8,7 +6,6 @@ use serde::Serialize;
 #[derive(Clone)]
 pub struct MockZkvmHost {
     notification_manager: NotificationManager,
-    committed_data: VecDeque<Vec<u8>>,
     wait_for_proof: bool,
 }
 
@@ -18,16 +15,14 @@ impl MockZkvmHost {
         Self {
             wait_for_proof: true,
             notification_manager: Default::default(),
-            committed_data: Default::default(),
         }
     }
 
-    /// Creates a new MockZkvm, the `ZkvmHost::run` will return immediately.
+    /// Creates a new MockZkvm, the `ZkvmHost::add_hint_and_run` will return immediately.
     pub fn new_non_blocking() -> Self {
         Self {
             wait_for_proof: false,
             notification_manager: Default::default(),
-            committed_data: Default::default(),
         }
     }
 
@@ -59,23 +54,18 @@ impl sov_rollup_interface::zk::ZkvmHost for MockZkvmHost {
 
     type HostArgs = ();
 
-    fn add_hint<T: Serialize>(&mut self, item: T) {
-        let data = bincode::serialize(&item).unwrap();
-        self.committed_data.push_back(data);
-    }
-
     fn code_commitment(&self) -> anyhow::Result<<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment>{
         Ok(MockCodeCommitment::default())
     }
 
-    fn run(&mut self) -> anyhow::Result<Vec<u8>> {
+    fn add_hint_and_run<T: Serialize>(&mut self, item: &T) -> anyhow::Result<Vec<u8>> {
+        let pub_data = bincode::serialize(item)?;
         if self.wait_for_proof {
             self.notification_manager.wait();
         }
-        let data = self.committed_data.pop_front().unwrap_or_default();
         Ok(bincode::serialize(&MockProof {
             is_valid: true,
-            pub_data: data,
+            pub_data,
         })?)
     }
 

--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -155,10 +155,8 @@ mod tests {
         };
 
         let mut vm = MockZkvmHost::new();
-        vm.add_hint(&pub_data);
         vm.make_proof();
-
-        let proof = vm.run().unwrap();
+        let proof = vm.add_hint_and_run(&pub_data).unwrap();
         let verified_pub_data =
             MockZkVerifier::verify::<TestPublicData>(&proof, &Default::default())?;
 

--- a/crates/adapters/risc0/src/host.rs
+++ b/crates/adapters/risc0/src/host.rs
@@ -1,6 +1,6 @@
 //! This module implements the [`ZkvmHost`] trait for the RISC0 VM.
 
-use risc0_zkvm::{ExecutorEnvBuilder, ExecutorImpl, Receipt, Session};
+use risc0_zkvm::{ExecutorEnvBuilder, ExecutorImpl, Session};
 use sov_rollup_interface::zk::ZkvmHost;
 
 use crate::guest::Risc0Guest;
@@ -48,32 +48,18 @@ impl<'a> Risc0Host<'a> {
         #[cfg(feature = "bincode")]
         env.write_slice(&[self.env.len() as u32]);
         let env = env.write_slice(&self.env).build().unwrap();
+        self.env.clear();
         let mut executor = ExecutorImpl::from_elf(env, self.elf)?;
         executor.run()
     }
 
-    /// Run a computation in the zkvm and generate a receipt.
-    pub fn run(&mut self) -> anyhow::Result<Receipt> {
-        let session = self.run_without_proving()?;
-        Ok(session.prove()?.receipt)
+    fn replace_hints<T: serde::Serialize>(&mut self, item: &T) {
+        self.env.clear();
+        self.add_hint(item);
     }
 
-    /// Generate a Risc0Guest with provided hints
-    pub fn simulate_with_hints(&mut self) -> Risc0Guest {
-        Risc0Guest::with_hints(std::mem::take(&mut self.env))
-    }
-}
-
-impl ZkvmHost for Risc0Host<'static> {
-    type HostArgs = &'static [u8];
-
-    fn from_args(args: &Self::HostArgs) -> Self {
-        Self::new(args)
-    }
-
-    type Guest = Risc0Guest;
-
-    fn add_hint<T: serde::Serialize>(&mut self, item: T) {
+    /// Push a non-deterministic hint into the zkvm environment.
+    pub fn add_hint<T: serde::Serialize>(&mut self, item: &T) {
         // We use the in-memory size of `item` as an indication of how much
         // space to reserve. This is in no way guaranteed to be exact, but
         // usually the in-memory size and serialized data size are quite close.
@@ -91,12 +77,29 @@ impl ZkvmHost for Risc0Host<'static> {
         }
 
         #[cfg(feature = "bincode")]
-        bincode::serialize_into(&mut self.env, &item)
+        bincode::serialize_into(&mut self.env, item)
             .expect("Risc0 hint serialization is infallible");
     }
 
-    fn run(&mut self) -> anyhow::Result<Vec<u8>> {
-        let receipt = Risc0Host::run(self)?;
+    /// Generate a Risc0Guest with provided hints
+    pub fn simulate_with_hints(&mut self) -> Risc0Guest {
+        Risc0Guest::with_hints(std::mem::take(&mut self.env))
+    }
+}
+
+impl ZkvmHost for Risc0Host<'static> {
+    type HostArgs = &'static [u8];
+
+    fn from_args(args: &Self::HostArgs) -> Self {
+        Self::new(args)
+    }
+
+    type Guest = Risc0Guest;
+
+    fn add_hint_and_run<T: serde::Serialize>(&mut self, item: &T) -> anyhow::Result<Vec<u8>> {
+        self.replace_hints(item);
+        let session = self.run_without_proving()?;
+        let receipt = session.prove()?.receipt;
         Ok(bincode::serialize(&receipt)?)
     }
 

--- a/crates/adapters/risc0/tests/native.rs
+++ b/crates/adapters/risc0/tests/native.rs
@@ -4,7 +4,7 @@ use proptest::prelude::*;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sov_risc0_adapter::host::Risc0Host;
-use sov_rollup_interface::zk::{ZkvmGuest, ZkvmHost};
+use sov_rollup_interface::zk::ZkvmGuest;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct TestStruct {

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -1,5 +1,7 @@
 //! Implementation of the SP1 host for the Sovereign ZkvmHost trait.
 
+use std::sync::Arc;
+
 use crate::guest::SP1Guest;
 use crate::SP1MethodId;
 use serde::Serialize;
@@ -34,12 +36,12 @@ impl SP1AggregationHost {
     /// Creates a new aggregation host from the aggregation guest `elf` binary
     /// and the verifying key (`inner_method_id`) of the inner proof program.
     pub fn new(elf: &'static [u8], inner_method_id: SP1MethodId) -> anyhow::Result<Self> {
-        let host = SP1Host::new(elf);
-        let (_, pk) = host.create_prover_and_pk()?;
-        let code_commitment = SP1MethodId(bincode::serialize(pk.verifying_key())?);
+        let host = SP1Host::new(elf)?;
+        let aggregation_vk = host.pk.verifying_key().clone();
+        let code_commitment = SP1MethodId(bincode::serialize(&aggregation_vk)?);
         Ok(Self {
             host,
-            aggregation_vk: pk.verifying_key().clone(),
+            aggregation_vk,
             code_commitment,
             inner_method_id,
             prev_agg_proof: None,
@@ -116,30 +118,30 @@ impl SP1AggregationHost {
 pub struct SP1Host<'host> {
     elf: &'host [u8],
     stdin: SP1Stdin,
+    prover: Arc<CpuProver>,
+    pk: SP1ProvingKey,
 }
 
 /// Instantiate a new SP1 Host.
 impl<'host> SP1Host<'host> {
     /// Create a new SP1 Host.
-    pub fn new(elf: &'host [u8]) -> Self {
-        Self {
+    pub fn new(elf: &'host [u8]) -> anyhow::Result<Self> {
+        let prover = ProverClient::builder().cpu().build();
+        let pk = prover
+            .setup(elf.into())
+            .map_err(|e| anyhow::anyhow!("SP1 setup failed. Error: {:?}", e))?;
+
+        Ok(Self {
             elf,
             stdin: SP1Stdin::new(),
-        }
+            prover: Arc::new(prover),
+            pk,
+        })
     }
 
     /// Create a new `Sp1Guest` that reads the provided hints
     pub fn simulate_with_hints(&mut self) -> SP1Guest {
         SP1Guest::with_hints(self.stdin.buffer.clone())
-    }
-
-    fn create_prover_and_pk(&self) -> anyhow::Result<(CpuProver, SP1ProvingKey)> {
-        let prover = ProverClient::builder().cpu().build();
-        let pk = prover
-            .setup(self.elf.into())
-            .map_err(|e| anyhow::anyhow!("SP1 setup failed. Error: {:?}", e))?;
-
-        Ok((prover, pk))
     }
 
     fn add_proof_helper(
@@ -163,9 +165,9 @@ impl<'host> SP1Host<'host> {
     fn run_helper(&mut self) -> anyhow::Result<sp1_sdk::SP1ProofWithPublicValues> {
         let stdin = std::mem::take(&mut self.stdin);
 
-        let (prover, pk) = self.create_prover_and_pk()?;
-        let output: sp1_sdk::SP1ProofWithPublicValues = prover
-            .prove(&pk, stdin)
+        let output: sp1_sdk::SP1ProofWithPublicValues = self
+            .prover
+            .prove(&self.pk, stdin)
             .compressed()
             .run()
             .map_err(|e| anyhow::anyhow!("SP1 proving failed. Error: {:?}", e))?;
@@ -179,6 +181,8 @@ impl Clone for SP1Host<'_> {
         Self {
             elf: self.elf,
             stdin: self.stdin.clone(),
+            prover: self.prover.clone(),
+            pk: self.pk.clone(),
         }
     }
 }
@@ -194,7 +198,7 @@ impl ZkvmHost for SP1Host<'static> {
     type Guest = SP1Guest;
 
     fn from_args(args: &Self::HostArgs) -> Self {
-        Self::new(args)
+        Self::new(args).expect("Failed to create SP1Host")
     }
 
     fn add_hint<T: Serialize>(&mut self, item: T) {
@@ -207,8 +211,7 @@ impl ZkvmHost for SP1Host<'static> {
     }
 
     fn code_commitment(&self) -> anyhow::Result<<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment>{
-        let (_, pk) = self.create_prover_and_pk()?;
-        Ok(crate::SP1MethodId(bincode::serialize(pk.verifying_key())?))
+        Ok(crate::SP1MethodId(bincode::serialize(self.pk.verifying_key())?))
     }
 }
 

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -230,7 +230,7 @@ impl MockSp1Prover {
             .map_err(|e| anyhow::anyhow!("SP1 setup failed. Error: {:?}", e))?;
 
         Ok(Self {
-            prover: prover,
+            prover,
             pk: Arc::new(pk),
         })
     }

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -217,54 +217,43 @@ impl ZkvmHost for SP1Host {
 /// but the proving pipeline needs to be exercised end-to-end.
 #[derive(Clone)]
 pub struct MockSp1Prover {
-    elf: &'static [u8],
-    stdin: SP1Stdin,
+    prover: MockProver,
+    pk: Arc<SP1ProvingKey>,
 }
 
 impl MockSp1Prover {
     /// Creates a new mock prover for the given guest ELF binary.
-    pub fn new(elf: &'static [u8]) -> Self {
-        Self {
-            elf,
-            stdin: SP1Stdin::new(),
-        }
+    pub fn new(elf: &[u8]) -> anyhow::Result<Self> {
+        let prover = ProverClient::builder().mock().build();
+        let pk = prover
+            .setup(elf.into())
+            .map_err(|e| anyhow::anyhow!("SP1 setup failed. Error: {:?}", e))?;
+
+        Ok(Self {
+            prover: prover,
+            pk: Arc::new(pk),
+        })
     }
 
-    /// Writes a serializable hint value into the prover's stdin for the guest to read.
-    pub fn add_hint<T: Serialize>(&mut self, item: T) {
-        self.stdin.write(&item);
-    }
+    /// Writes `item` to the guest's stdin and generates a compressed mock proof.
+    pub fn add_hint_and_run<T: Serialize>(
+        &self,
+        item: &T,
+    ) -> anyhow::Result<sp1_sdk::SP1ProofWithPublicValues> {
+        let mut stdin = SP1Stdin::new();
+        stdin.write(item);
 
-    /// Executes the guest program and generates a compressed mock proof.
-    pub fn run(&mut self) -> anyhow::Result<sp1_sdk::SP1ProofWithPublicValues> {
-        let (prover, pk) = self.create_prover_and_pk()?;
-
-        let stdin = std::mem::take(&mut self.stdin);
-
-        let output = prover
-            .prove(&pk, stdin)
+        self.prover
+            .prove(&self.pk, stdin)
             .compressed()
             .run()
-            .map_err(|e| anyhow::anyhow!("SP1 proving failed. Error: {:?}", e))?;
-
-        Ok(output)
+            .map_err(|e| anyhow::anyhow!("SP1 proving failed. Error: {:?}", e))
     }
 
     /// Verifies a mock proof against the program's verifying key.
     pub fn verify(&self, proof: &sp1_sdk::SP1ProofWithPublicValues) -> anyhow::Result<()> {
-        let (prover, pk) = self.create_prover_and_pk()?;
-
-        prover
-            .verify(proof, pk.verifying_key(), None)
+        self.prover
+            .verify(proof, self.pk.verifying_key(), None)
             .map_err(|e| anyhow::anyhow!("SP1 verification failed. Error: {:?}", e))
-    }
-
-    fn create_prover_and_pk(&self) -> anyhow::Result<(MockProver, SP1ProvingKey)> {
-        let prover = ProverClient::builder().mock().build();
-        let pk = prover
-            .setup(self.elf.into())
-            .map_err(|e| anyhow::anyhow!("SP1 setup failed. Error: {:?}", e))?;
-
-        Ok((prover, pk))
     }
 }

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -25,7 +25,7 @@ use sp1_sdk::{HashableKey, SP1Proof, SP1ProvingKey, SP1Stdin};
 /// automatically chains proofs: the previous aggregation proof is fed back as
 /// a deferred proof input so the guest can verify continuity.
 pub struct SP1AggregationHost {
-    host: SP1Host<'static>,
+    host: SP1Host,
     aggregation_vk: sp1_sdk::SP1VerifyingKey,
     code_commitment: SP1MethodId,
     inner_method_id: SP1MethodId,
@@ -65,12 +65,14 @@ impl SP1AggregationHost {
             "At least one inner proof is required"
         );
 
+        let mut stdin = SP1Stdin::new();
+
         let prev_outer_proof_witness =
             if let Some(previous_outer_proof) = self.prev_agg_proof.as_ref() {
                 let serialized = bincode::serialize(previous_outer_proof)?;
-                let public_values = self
-                    .host
-                    .add_proof_helper(&serialized, &self.code_commitment)?;
+                let public_values =
+                    self.host
+                        .add_proof_helper(&mut stdin, &serialized, &self.code_commitment)?;
 
                 Some(PreviousOuterProofWitness { public_values })
             } else {
@@ -80,6 +82,7 @@ impl SP1AggregationHost {
         let mut proof_inputs = Vec::with_capacity(proofs_and_headers.len());
         for proof_and_header in proofs_and_headers {
             let public_values = self.host.add_proof_helper(
+                &mut stdin,
                 &proof_and_header.proof.raw_inner_proof,
                 &self.inner_method_id,
             )?;
@@ -104,9 +107,9 @@ impl SP1AggregationHost {
             prev_outer_proof_witness,
         };
 
-        self.host.add_hint(witness);
+        stdin.write(&witness);
 
-        let agg_proof = self.host.run_helper()?;
+        let agg_proof = self.host.run_helper(stdin)?;
         let serialized = bincode::serialize(&agg_proof)?;
         self.prev_agg_proof = Some(agg_proof);
 
@@ -115,37 +118,34 @@ impl SP1AggregationHost {
 }
 
 /// SP1 Host implementation.
-pub struct SP1Host<'host> {
-    elf: &'host [u8],
-    stdin: SP1Stdin,
-    prover: Arc<CpuProver>,
-    pk: SP1ProvingKey,
+pub struct SP1Host {
+    prover: CpuProver,
+    pk: Arc<SP1ProvingKey>,
 }
 
 /// Instantiate a new SP1 Host.
-impl<'host> SP1Host<'host> {
+impl SP1Host {
     /// Create a new SP1 Host.
-    pub fn new(elf: &'host [u8]) -> anyhow::Result<Self> {
+    pub fn new(elf: &[u8]) -> anyhow::Result<Self> {
         let prover = ProverClient::builder().cpu().build();
         let pk = prover
             .setup(elf.into())
             .map_err(|e| anyhow::anyhow!("SP1 setup failed. Error: {:?}", e))?;
 
         Ok(Self {
-            elf,
-            stdin: SP1Stdin::new(),
-            prover: Arc::new(prover),
-            pk,
+            prover,
+            pk: Arc::new(pk),
         })
     }
 
     /// Create a new `Sp1Guest` that reads the provided hints
-    pub fn simulate_with_hints(&mut self) -> SP1Guest {
-        SP1Guest::with_hints(self.stdin.buffer.clone())
+    pub fn simulate_with_hints(stdin: SP1Stdin) -> SP1Guest {
+        SP1Guest::with_hints(stdin.buffer)
     }
 
     fn add_proof_helper(
-        &mut self,
+        &self,
+        stdin: &mut SP1Stdin,
         proof: &[u8],
         method_id: &SP1MethodId,
     ) -> anyhow::Result<Vec<u8>> {
@@ -157,14 +157,11 @@ impl<'host> SP1Host<'host> {
         let vk: sp1_sdk::SP1VerifyingKey = bincode::deserialize(&method_id.0)
             .map_err(|e| anyhow::anyhow!("Failed to deserialize SP1VerifyingKey: {e}"))?;
 
-        self.stdin
-            .write_proof((**recursion_proof).clone(), vk.vk.clone());
+        stdin.write_proof((**recursion_proof).clone(), vk.vk.clone());
         Ok(proof.public_values.to_vec())
     }
 
-    fn run_helper(&mut self) -> anyhow::Result<sp1_sdk::SP1ProofWithPublicValues> {
-        let stdin = std::mem::take(&mut self.stdin);
-
+    fn run_helper(&self, stdin: SP1Stdin) -> anyhow::Result<sp1_sdk::SP1ProofWithPublicValues> {
         let output: sp1_sdk::SP1ProofWithPublicValues = self
             .prover
             .prove(&self.pk, stdin)
@@ -176,42 +173,40 @@ impl<'host> SP1Host<'host> {
     }
 }
 
-impl Clone for SP1Host<'_> {
+impl Clone for SP1Host {
     fn clone(&self) -> Self {
         Self {
-            elf: self.elf,
-            stdin: self.stdin.clone(),
             prover: self.prover.clone(),
             pk: self.pk.clone(),
         }
     }
 }
 
-impl core::fmt::Debug for SP1Host<'_> {
+impl core::fmt::Debug for SP1Host {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Sp1Host").finish()
     }
 }
 
-impl ZkvmHost for SP1Host<'static> {
+impl ZkvmHost for SP1Host {
     type HostArgs = &'static [u8];
     type Guest = SP1Guest;
 
     fn from_args(args: &Self::HostArgs) -> Self {
-        Self::new(args).expect("Failed to create SP1Host")
+        Self::new(args).unwrap_or_else(|e| panic!("Failed to create SP1Host: {e:?}"))
     }
 
-    fn add_hint<T: Serialize>(&mut self, item: T) {
-        self.stdin.write(&item);
-    }
-
-    fn run(&mut self) -> anyhow::Result<Vec<u8>> {
-        let output = self.run_helper()?;
+    fn add_hint_and_run<T: Serialize>(&mut self, item: &T) -> anyhow::Result<Vec<u8>> {
+        let mut stdin = SP1Stdin::new();
+        stdin.write(item);
+        let output = self.run_helper(stdin)?;
         Ok(bincode::serialize(&output)?)
     }
 
     fn code_commitment(&self) -> anyhow::Result<<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment>{
-        Ok(crate::SP1MethodId(bincode::serialize(self.pk.verifying_key())?))
+        Ok(crate::SP1MethodId(bincode::serialize(
+            self.pk.verifying_key(),
+        )?))
     }
 }
 

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -111,7 +111,7 @@ impl sov_rollup_interface::zk::Zkvm for SP1 {
     type Verifier = SP1Verifier;
 
     #[cfg(feature = "native")]
-    type Host = crate::host::SP1Host<'static>;
+    type Host = crate::host::SP1Host;
 
     #[cfg(feature = "native")]
     type Network = crate::network::SP1Network;

--- a/crates/adapters/sp1/tests/integration/native.rs
+++ b/crates/adapters/sp1/tests/integration/native.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::zk::{ZkvmGuest, ZkvmHost};
+use sov_rollup_interface::zk::ZkvmGuest;
 use sov_sp1_adapter::host::{MockSp1Prover, SP1Host};
 use sp1_build::BuildArgs;
+use sp1_sdk::SP1Stdin;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct TestStruct {
@@ -11,9 +12,6 @@ struct TestStruct {
 
 #[test]
 fn test_hints_roundtrip() {
-    let fibonacci_elf = include_bytes!("../../test_data/riscv64im-succinct-zkvm-elf");
-    let mut host = SP1Host::new(fibonacci_elf).unwrap();
-
     let hint_a = TestStruct {
         ints: vec![1, 2, 3, 4, 5],
         string: "hello".to_string(),
@@ -23,10 +21,11 @@ fn test_hints_roundtrip() {
         string: "hello".to_string(),
     };
 
-    host.add_hint(&hint_a);
-    host.add_hint(&hint_b);
+    let mut stdin = SP1Stdin::new();
+    stdin.write(&hint_a);
+    stdin.write(&hint_b);
 
-    let guest = host.simulate_with_hints();
+    let guest = SP1Host::simulate_with_hints(stdin);
 
     let mut received;
     received = guest.read_from_host();

--- a/crates/adapters/sp1/tests/integration/native.rs
+++ b/crates/adapters/sp1/tests/integration/native.rs
@@ -51,10 +51,9 @@ fn build_fibonacci_elf() {
 fn test_fibonnaci_host() {
     let fibonacci_elf = include_bytes!("../../test_data/riscv64im-succinct-zkvm-elf");
 
-    let mut host = MockSp1Prover::new(fibonacci_elf);
+    let host = MockSp1Prover::new(fibonacci_elf).unwrap();
 
     // Give the input 7 to the fibonnaci program
-    host.add_hint(7u32);
-    let proof = host.run().unwrap();
+    let proof = host.add_hint_and_run(&7u32).unwrap();
     host.verify(&proof).unwrap();
 }

--- a/crates/adapters/sp1/tests/integration/native.rs
+++ b/crates/adapters/sp1/tests/integration/native.rs
@@ -11,7 +11,8 @@ struct TestStruct {
 
 #[test]
 fn test_hints_roundtrip() {
-    let mut host = SP1Host::new(&[]);
+    let fibonacci_elf = include_bytes!("../../test_data/riscv64im-succinct-zkvm-elf");
+    let mut host = SP1Host::new(fibonacci_elf).unwrap();
 
     let hint_a = TestStruct {
         ints: vec![1, 2, 3, 4, 5],

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
@@ -68,7 +68,7 @@ where
         &self,
         state_transition_info: StateTransitionInfo<StateRoot, Witness, <Da as DaService>::Spec>,
         config: RollupProverConfigDiscriminants,
-        mut inner_vm: InnerVm::Host,
+        inner_vm: InnerVm::Host,
         verifier: Arc<Verifier<Da>>,
     ) -> Result<
         ProofProcessingStatus<StateRoot, Witness, <Da as DaService>::Spec>,
@@ -108,11 +108,9 @@ where
                 prover_address: self.prover_address.clone(),
             };
 
-            inner_vm.add_hint(&data);
-
             self.pool.spawn(move || {
                 tracing::info_span!("guest_execution").in_scope(|| {
-                    let proof = make_inner_proof::<InnerVm>(inner_vm, config);
+                    let proof = make_inner_proof::<InnerVm>(inner_vm, &data, config);
 
                     let mut prover_state = prover_state_clone.write().expect("Lock was poisoned");
 
@@ -190,10 +188,10 @@ where
 
         trace!(%public_data, "generating aggregate proof");
         // TODO: https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/316
-        // `add_hint`  should take witness instead of the public input.
-        outer_vm.add_hint(public_data);
+        // Pass the witness here instead of the public input so the guest can
+        // recompute the public data.
         let serialized_aggregated_proof = SerializedAggregatedProof {
-            raw_aggregated_proof: outer_vm.run()?,
+            raw_aggregated_proof: outer_vm.add_hint_and_run(&public_data)?,
         };
 
         for slot_hash in block_header_hashes {
@@ -205,6 +203,7 @@ where
 
 fn make_inner_proof<InnerVm>(
     mut vm: InnerVm::Host,
+    hint: &impl Serialize,
     config: RollupProverConfigDiscriminants,
 ) -> anyhow::Result<Vec<u8>>
 where
@@ -215,7 +214,7 @@ where
         RollupProverConfigDiscriminants::Skip => Ok(Vec::default()),
         RollupProverConfigDiscriminants::Prove => {
             info!("Generating proof with {}", std::any::type_name::<InnerVm>());
-            vm.run()
+            vm.add_hint_and_run(hint)
         }
     };
     sov_metrics::track_metrics(|tracker| {

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -94,18 +94,15 @@ pub trait ZkvmHost: Clone + Send + Sync + 'static {
     #[cfg(feature = "native")]
     fn from_args(args: &Self::HostArgs) -> Self;
 
-    /// Give the guest a piece of advice non-deterministically
-    fn add_hint<T: Serialize>(&mut self, item: T);
-
     /// Returns a commitment to the program to be proven. This method does a lot of heavy cryptographic work - caller beware!
     #[cfg(feature = "native")]
     fn code_commitment(
         &self,
     ) -> anyhow::Result<<<Self::Guest as ZkvmGuest>::Verifier as ZkVerifier>::CodeCommitment>;
 
-    /// Run the guest in the true zk environment using the provided hints
-    /// and generate a SNARK of correct execution.
-    fn run(&mut self) -> anyhow::Result<Vec<u8>>;
+    /// Provide a single non-deterministic advice item to the guest and
+    /// synchronously generate a SNARK of correct execution over that hint.
+    fn add_hint_and_run<T: Serialize>(&mut self, item: &T) -> anyhow::Result<Vec<u8>>;
 }
 
 /// A commitment to a zkVM program binary. Every concrete [`ZkVerifier::CodeCommitment`]
@@ -144,7 +141,7 @@ pub trait ZkVerifier: Default + Clone + Send + Sync + 'static {
 
 /// A network prover that can submit proofs asynchronously and poll for results.
 ///
-/// Unlike [`ZkvmHost`] which runs proofs synchronously via [`ZkvmHost::run`],
+/// Unlike [`ZkvmHost`] which runs proofs synchronously via [`ZkvmHost::add_hint_and_run`],
 /// a `ZkvmNetwork` submits proof requests to a remote proving service and returns
 /// a handle that can be polled for completion. This enables concurrent proof generation
 /// across multiple blocks.

--- a/examples/demo-rollup/tests/prover/parallel.rs
+++ b/examples/demo-rollup/tests/prover/parallel.rs
@@ -41,7 +41,7 @@ async fn test_parallel_proof_generation() {
         "SP1 guest ELF is empty — build the guest first"
     );
 
-    let inner_vm = SP1Host::new(elf);
+    let inner_vm = SP1Host::new(elf).expect("SP1Host should be created successfully");
     // auto-complete outer proofs - real outer not supported yet
     let outer_vm = MockZkvmHost::new_non_blocking();
 

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -94,7 +94,8 @@ impl TestHost {
         .await
         .unwrap();
 
-        let mock_host = MockSp1Prover::new(*sp1::SP1_GUEST_MOCK_ELF);
+        let mock_host = MockSp1Prover::new(*sp1::SP1_GUEST_MOCK_ELF)
+            .expect("MockSp1Prover should be created successfully");
 
         (
             Self {
@@ -116,10 +117,9 @@ impl TestHost {
             .await
             .unwrap()
         } else {
-            let mut mock_host = self.mock_host.clone();
+            let mock_host = self.mock_host.clone();
             tokio::task::spawn_blocking(move || -> Vec<u8> {
-                mock_host.add_hint(data);
-                mock_host.run().unwrap();
+                mock_host.add_hint_and_run(&data).unwrap();
                 Default::default()
             })
             .await

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -83,21 +83,22 @@ struct TestHost {
 
 impl TestHost {
     async fn new(with_proof: bool) -> (Self, SP1MethodId) {
-        let (code_commitment, host) = tokio::task::spawn_blocking(move || {
+        let (code_commitment, host, mock_host) = tokio::task::spawn_blocking(move || {
             let host = SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF)
                 .expect("SP1Host should be created successfully");
+
+            let mock_host = MockSp1Prover::new(*sp1::SP1_GUEST_MOCK_ELF)
+                .expect("MockSp1Prover should be created successfully");
 
             (
                 host.code_commitment()
                     .expect("SP1 code commitment should be created successfully"),
                 host,
+                mock_host,
             )
         })
         .await
         .unwrap();
-
-        let mock_host = MockSp1Prover::new(*sp1::SP1_GUEST_MOCK_ELF)
-            .expect("MockSp1Prover should be created successfully");
 
         (
             Self {

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -76,15 +76,15 @@ async fn generate_proofs(host: &TestHost) -> Vec<BlockHeaderWithProof<MockDaSpec
 // The SP1 prover manages its own Tokio runtime, which conflicts with the `tokio::test` runtime.
 // To avoid this, all blocking work must be executed inside `tokio::task::spawn_blocking`.
 struct TestHost {
-    host: SP1Host<'static>,
+    host: SP1Host,
     mock_host: MockSp1Prover,
     with_proof: bool,
 }
 
 impl TestHost {
     async fn new(with_proof: bool) -> (Self, SP1MethodId) {
-        let host = SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF)
-            .expect("SP1Host should be created successfully");
+        let host =
+            SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF).expect("SP1Host should be created successfully");
         let host_clone = host.clone();
         let code_commitment = tokio::task::spawn_blocking(move || -> SP1MethodId {
             host_clone
@@ -110,8 +110,8 @@ impl TestHost {
         if self.with_proof {
             let mut host = self.host.clone();
             tokio::task::spawn_blocking(move || -> Vec<u8> {
-                host.add_hint(data);
-                host.run().expect("Prover should run successfully")
+                host.add_hint_and_run(&data)
+                    .expect("Prover should run successfully")
             })
             .await
             .unwrap()

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -83,7 +83,8 @@ struct TestHost {
 
 impl TestHost {
     async fn new(with_proof: bool) -> (Self, SP1MethodId) {
-        let host = SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF);
+        let host = SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF)
+            .expect("SP1Host should be created successfully");
         let host_clone = host.clone();
         let code_commitment = tokio::task::spawn_blocking(move || -> SP1MethodId {
             host_clone

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -83,13 +83,15 @@ struct TestHost {
 
 impl TestHost {
     async fn new(with_proof: bool) -> (Self, SP1MethodId) {
-        let host =
-            SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF).expect("SP1Host should be created successfully");
-        let host_clone = host.clone();
-        let code_commitment = tokio::task::spawn_blocking(move || -> SP1MethodId {
-            host_clone
-                .code_commitment()
-                .expect("SP1 code commitment should be created successfully")
+        let (code_commitment, host) = tokio::task::spawn_blocking(move || {
+            let host = SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF)
+                .expect("SP1Host should be created successfully");
+
+            (
+                host.code_commitment()
+                    .expect("SP1 code commitment should be created successfully"),
+                host,
+            )
         })
         .await
         .unwrap();


### PR DESCRIPTION
# Description

 Refactors `ZkvmHost` trait to merge `add_hint(item)` + `run()` into a single `add_hint_and_run(&item)` method. Reworks `SP1Host` to cache the prover and proving key in Arcs (so SP1's expensive setup() runs once instead of per-proof), drops the 'host lifetime, and moves SP1Stdin ownership outside the host.

Changes:
1. replace the two-step `add_hint` + `run` host API with `add_hint_and_run`
2. update mock, `RISC0`, and `SP1` hosts to use the new one-shot proving flow
3. thread the new API through the parallel prover and affected tests
4. make `Risc0Host::add_hint_and_run` prove only the supplied hint, instead of reusing previously queued host input

Why do we need this?
`ZkvmHost` is only used with a single hint in the prover, and we always call run immediately after adding that hint. The old two-step API, therefore, added statefulness without giving us any real flexibility. That became especially awkward in the CPU prover, where proofs for different blocks run in parallel on a thread pool: the host had to carry intermediate hint state even though each proving job was logically one-shot. By merging `add_hint` and `run` into `add_hint_and_run`, we make proof generation atomic, remove unnecessary host state management, and simplify the prover logic.

This refactoring will help with the next PR that will add proof aggregation. 

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 
