### PR TITLE
rockbound: Remove bindgen feature from rockbound after sp1 upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,6 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
 ]
 
 [[package]]
@@ -6259,16 +6258,6 @@ checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
 dependencies = [
  "arbitrary",
  "cc",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
-dependencies = [
- "cfg-if",
- "windows-targets 0.53.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,7 +199,7 @@ sov-proxy-utils = { path = "crates/utils/sov-proxy-utils", version = "0.3" }
 # Dependencies maintained by Sovereign
 jmt = { version = "0.12.0", default-features = false }
 reltester = { git = "https://github.com/sovereign-labs/reltester.git", rev = "d6209abff72929f5ba41614f5cea3e4a748428c3" }
-rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "00d4a84f0b9256da681e2138949e01e4c138a5ae", features = ["bindgen-runtime"] }
+rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "00d4a84f0b9256da681e2138949e01e4c138a5ae" }
 nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
 nomt-core = { version = "1.0.3", default-features = false, features = ["borsh", "serde"] }


### PR DESCRIPTION
# Description

After [sp1 upgrade](https://github.com/Sovereign-Labs/sovereign-sdk/pull/2729), bindgen 0.70 is gone, so we don't need to use this feature propagation.

Depends on https://github.com/Sovereign-Labs/sovereign-sdk/pull/2729

This suppose to address slower cargo hack:

```
With bindgen-runtime, every time the build script runs, it must:
1. Load libclang
2. Parse RocksDB C++ headers
3. Generate the bindings dynamically

This would be a one-time cost if it ran once. But...

Why isn't it cached? (The real finding)

It IS being cached — but the cache is being invalidated 11 times per run.
```

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)



## Testing
Existing tests are passing

## Docs
No updates
