### PR TITLE
test_mock_proof_public_data_matches_witnesses

### DIFF
--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -537,21 +537,7 @@ fn compute_state_update_namespace<S: MerkleProofSpec>(
     let mut finished = session.finish(accesses)?;
     if write_witness {
         let nomt_witness = finished.take_witness().expect("Witness cannot be missing");
-        let nomt::Witness {
-            path_proofs,
-            operations: nomt::WitnessedOperations { .. },
-        } = nomt_witness;
-        // Note, we discard `p.path`, but maybe there's a way to use to have more efficient verification?
-        let mut path_proofs_inner = path_proofs.into_iter().map(|p| p.inner).collect::<Vec<_>>();
-
-        // Sort them as required by
-        // Note that the path proofs produced within a crate::witness::Witness are not guaranteed to be ordered,
-        // so the input should be sorted lexicographically by the terminal path prior to calling this function.
-        // https://github.com/thrumdev/nomt/issues/904
-        path_proofs_inner.sort_by(|a, b| a.terminal.path().cmp(b.terminal.path()));
-
-        let multi_proof = MultiProof::from_path_proofs(path_proofs_inner);
-        witness.add_hint(&multi_proof);
+        witness.add_hint(&nomt_witness);
     }
     Ok(finished)
 }

--- a/crates/module-system/sov-state/src/nomt/zk_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/zk_storage.rs
@@ -105,44 +105,64 @@ impl<S: MerkleProofSpec> NomtVerifierStorage<S> {
             }
         }
 
-        let mut writes_by_path = vec![Vec::<(KeyPath, Option<ValueHash>)>::new(); nomt_witness.path_proofs.len()];
-
+        let mut witnessed_writes = BTreeMap::new();
         for write in nomt_witness.operations.writes {
             let Some(expected_value) = expected_writes.remove(&write.key) else {
                 anyhow::bail!("Unexpected or duplicate NOMT write witness entry");
             };
-            let Some(path_writes) = writes_by_path.get_mut(write.path_index) else {
-                anyhow::bail!("NOMT write witness path index out of bounds");
+            if write.value != expected_value {
+                anyhow::bail!(
+                    "Mismatched NOMT write witness value for key {:?}: witness={:?}, expected={:?}",
+                    write.key,
+                    write.value,
+                    expected_value
+                );
+            }
+            if witnessed_writes
+                .insert(write.key, expected_value)
+                .is_some()
+            {
+                anyhow::bail!("Duplicate NOMT write witness entry");
             };
-            path_writes.push((write.key, expected_value));
         }
 
         if !expected_writes.is_empty() {
             anyhow::bail!("Missing NOMT write witness entries");
         }
 
-        let mut path_entries = nomt_witness
+        let mut verified_paths = nomt_witness
             .path_proofs
             .into_iter()
-            .enumerate()
-            .map(|(index, path)| {
-                (
-                    path,
-                    std::mem::take(&mut writes_by_path[index]),
-                )
+            .map(|path| {
+                let verified = path
+                    .inner
+                    .verify::<BinaryHasher<S::Hasher>>(path.path.path(), prev_root)
+                    .map_err(|e| anyhow::anyhow!("Failed to verify path proof: {:?}", e))?;
+                Ok((verified, Vec::<(KeyPath, Option<ValueHash>)>::new()))
             })
-            .collect::<Vec<_>>();
-        path_entries.sort_by(|a, b| a.0.path.path().cmp(b.0.path.path()));
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        verified_paths.sort_by(|a, b| a.0.path().cmp(b.0.path()));
+
+        for (key, value) in witnessed_writes {
+            let matching_index = verified_paths
+                .iter()
+                .enumerate()
+                .filter_map(|(index, (verified, _))| {
+                    verified
+                        .confirm_nonexistence(&key)
+                        .ok()
+                        .map(|_| (index, verified.path().len()))
+                })
+                .max_by_key(|(_, path_len)| *path_len)
+                .map(|(index, _)| index)
+                .ok_or_else(|| anyhow::anyhow!("No NOMT path proof covers write key {:?}", key))?;
+
+            verified_paths[matching_index].1.push((key, value));
+        }
 
         let mut updates = Vec::new();
-        for (path, mut writes) in path_entries {
-            let verified = path
-                .inner
-                .verify::<BinaryHasher<S::Hasher>>(path.path.path(), prev_root)
-                .map_err(|e| anyhow::anyhow!("Failed to verify path proof: {:?}", e))?;
-
+        for (verified, writes) in verified_paths {
             if !writes.is_empty() {
-                writes.sort_by(|a, b| a.0.cmp(&b.0));
                 updates.push(PathUpdate {
                     inner: verified,
                     ops: writes,

--- a/crates/module-system/sov-state/src/nomt/zk_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/zk_storage.rs
@@ -1,9 +1,11 @@
 //! ZK Verifier part of the NOMT based Storage implementation
+use std::collections::BTreeMap;
 use std::marker::PhantomData;
 
 use nomt_core::hasher::BinaryHasher;
-use nomt_core::proof::MultiProof;
+use nomt_core::proof::{MultiProof, PathUpdate};
 use nomt_core::trie::{KeyPath, LeafData, Node, ValueHash};
+use nomt_core::witness::Witness as NomtWitness;
 #[cfg(all(feature = "test-utils", feature = "native"))]
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::reexports::digest::Digest;
@@ -41,66 +43,115 @@ impl<S: MerkleProofSpec> NomtVerifierStorage<S> {
             ordered_reads: state_reads,
             ordered_writes: state_writes,
         } = state_accesses;
+        let mut expected_reads = BTreeMap::new();
+        for (key, value) in state_reads {
+            let key_hash: KeyPath = S::Hasher::digest(key.as_ref()).into();
+            let value_hash = value.map(|node_leaf| {
+                S::Hasher::digest(node_leaf.combine_val_hash_and_size()).into()
+            });
+            if expected_reads.insert(key_hash, value_hash).is_some() {
+                anyhow::bail!("Duplicate key read in state accesses: {:?}", key);
+            }
+        }
 
-        let multi_proof: MultiProof = array_witness.get_hint();
+        let mut expected_writes = BTreeMap::new();
+        for (key, value) in state_writes {
+            let key_hash: KeyPath = S::Hasher::digest(key.as_ref()).into();
+            let value_hash = value.map(|slot_value| {
+                // Authenticated write is hash of a combination of size and original value hash.
+                S::Hasher::digest(slot_value.combine_val_hash_and_size::<S::Hasher>()).into()
+            });
+            if expected_writes.insert(key_hash, value_hash).is_some() {
+                anyhow::bail!("Duplicate key write in state accesses: {:?}", key);
+            }
+        }
+
+        let nomt_witness: NomtWitness = array_witness.get_hint();
+        let mut path_proofs_inner = nomt_witness
+            .path_proofs
+            .iter()
+            .map(|path| path.inner.clone())
+            .collect::<Vec<_>>();
+        path_proofs_inner.sort_by(|a, b| a.terminal.path().cmp(b.terminal.path()));
+        let multi_proof = MultiProof::from_path_proofs(path_proofs_inner);
         let verified_multi_proof = nomt_core::proof::verify_multi_proof::<BinaryHasher<S::Hasher>>(
             &multi_proof,
             prev_root,
         )
         .map_err(|e| anyhow::anyhow!("Failed to verify multi proof: {:?}", e))?;
 
-        for (key, value) in state_reads {
-            let key_hash: KeyPath = S::Hasher::digest(key.as_ref()).into();
+        for (key, value) in &expected_reads {
             match value {
                 None => {
                     if !verified_multi_proof
-                        .confirm_nonexistence(&key_hash)
+                        .confirm_nonexistence(key)
                         .map_err(|e| anyhow::anyhow!("Failed to confirm non-existence: {:?}", e))?
                     {
-                        anyhow::bail!("Failed to verify non-existence of key: {:?}", key);
+                        anyhow::bail!("Failed to verify non-existence of key");
                     }
                 }
-                Some(node_leaf) => {
-                    let authenticated_write = node_leaf.combine_val_hash_and_size();
-                    let value_hash = S::Hasher::digest(&authenticated_write).into();
+                Some(value_hash) => {
                     let leaf = LeafData {
-                        key_path: key_hash,
-                        value_hash,
+                        key_path: *key,
+                        value_hash: *value_hash,
                     };
                     if !verified_multi_proof
                         .confirm_value(&leaf)
                         .map_err(|e| anyhow::anyhow!("Failed to confirm value: {:?}", e))?
                     {
-                        anyhow::bail!("Failed to verify inclusion of key: {:?}", key);
+                        anyhow::bail!("Failed to verify inclusion of key");
                     }
                 }
             }
         }
 
-        let mut updates = state_writes
+        let mut writes_by_path = vec![Vec::<(KeyPath, Option<ValueHash>)>::new(); nomt_witness.path_proofs.len()];
+
+        for write in nomt_witness.operations.writes {
+            let Some(expected_value) = expected_writes.remove(&write.key) else {
+                anyhow::bail!("Unexpected or duplicate NOMT write witness entry");
+            };
+            let Some(path_writes) = writes_by_path.get_mut(write.path_index) else {
+                anyhow::bail!("NOMT write witness path index out of bounds");
+            };
+            path_writes.push((write.key, expected_value));
+        }
+
+        if !expected_writes.is_empty() {
+            anyhow::bail!("Missing NOMT write witness entries");
+        }
+
+        let mut path_entries = nomt_witness
+            .path_proofs
             .into_iter()
-            .map(|(key, value)| {
+            .enumerate()
+            .map(|(index, path)| {
                 (
-                    S::Hasher::digest(key.as_ref()).into(),
-                    value.map(|slot_value| {
-                        // Authenticated write is hash of a combination of size and orignal value hash.
-                        S::Hasher::digest(slot_value.combine_val_hash_and_size::<S::Hasher>())
-                            .into()
-                    }),
+                    path,
+                    std::mem::take(&mut writes_by_path[index]),
                 )
             })
-            .collect::<Vec<(KeyPath, Option<ValueHash>)>>();
+            .collect::<Vec<_>>();
+        path_entries.sort_by(|a, b| a.0.path.path().cmp(b.0.path.path()));
 
-        // Sort them by key hash, as required by [`nomt_core::proof::verify_multi_proof_update`]
-        updates.sort_by(|a, b| a.0.cmp(&b.0));
+        let mut updates = Vec::new();
+        for (path, mut writes) in path_entries {
+            let verified = path
+                .inner
+                .verify::<BinaryHasher<S::Hasher>>(path.path.path(), prev_root)
+                .map_err(|e| anyhow::anyhow!("Failed to verify path proof: {:?}", e))?;
 
-        nomt_core::proof::verify_multi_proof_update::<BinaryHasher<S::Hasher>>(
-            &verified_multi_proof,
-            updates,
-        )
-        .map_err(|e| anyhow::anyhow!("Failed to verify update: {:?}", e))
-        // Note: we don't check exhaustion of the proof
-        // because it does not impact the correctness of the guest, only performance.
+            if !writes.is_empty() {
+                writes.sort_by(|a, b| a.0.cmp(&b.0));
+                updates.push(PathUpdate {
+                    inner: verified,
+                    ops: writes,
+                });
+            }
+        }
+
+        nomt_core::proof::verify_update::<BinaryHasher<S::Hasher>>(prev_root, &updates)
+            .map_err(|e| anyhow::anyhow!("Failed to verify update: {:?}", e))
     }
 }
 

--- a/crates/module-system/sov-state/src/nomt/zk_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/zk_storage.rs
@@ -138,30 +138,46 @@ impl<S: MerkleProofSpec> NomtVerifierStorage<S> {
                     .inner
                     .verify::<BinaryHasher<S::Hasher>>(path.path.path(), prev_root)
                     .map_err(|e| anyhow::anyhow!("Failed to verify path proof: {:?}", e))?;
-                Ok((verified, Vec::<(KeyPath, Option<ValueHash>)>::new()))
+                Ok((
+                    verified,
+                    path.path.depth() as usize,
+                    truncate_key_path(path.path.raw_path(), path.path.depth() as usize),
+                    Vec::<(KeyPath, Option<ValueHash>)>::new(),
+                ))
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
         verified_paths.sort_by(|a, b| a.0.path().cmp(b.0.path()));
 
+        let mut path_index_by_prefix = BTreeMap::new();
+        let mut path_depths_desc = Vec::new();
+        for (index, (_, depth, prefix, _)) in verified_paths.iter().enumerate() {
+            if path_index_by_prefix
+                .insert((*depth, *prefix), index)
+                .is_some()
+            {
+                anyhow::bail!("Duplicate NOMT path proof prefix");
+            }
+            path_depths_desc.push(*depth);
+        }
+        path_depths_desc.sort_unstable();
+        path_depths_desc.dedup();
+        path_depths_desc.reverse();
+
         for (key, value) in witnessed_writes {
-            let matching_index = verified_paths
+            let matching_index = path_depths_desc
                 .iter()
-                .enumerate()
-                .filter_map(|(index, (verified, _))| {
-                    verified
-                        .confirm_nonexistence(&key)
-                        .ok()
-                        .map(|_| (index, verified.path().len()))
+                .find_map(|depth| {
+                    path_index_by_prefix
+                        .get(&(*depth, truncate_key_path(key, *depth)))
+                        .copied()
                 })
-                .max_by_key(|(_, path_len)| *path_len)
-                .map(|(index, _)| index)
                 .ok_or_else(|| anyhow::anyhow!("No NOMT path proof covers write key {:?}", key))?;
 
-            verified_paths[matching_index].1.push((key, value));
+            verified_paths[matching_index].3.push((key, value));
         }
 
         let mut updates = Vec::new();
-        for (verified, writes) in verified_paths {
+        for (verified, _, _, writes) in verified_paths {
             if !writes.is_empty() {
                 updates.push(PathUpdate {
                     inner: verified,
@@ -173,6 +189,25 @@ impl<S: MerkleProofSpec> NomtVerifierStorage<S> {
         nomt_core::proof::verify_update::<BinaryHasher<S::Hasher>>(prev_root, &updates)
             .map_err(|e| anyhow::anyhow!("Failed to verify update: {:?}", e))
     }
+}
+
+fn truncate_key_path(mut key: KeyPath, depth: usize) -> KeyPath {
+    debug_assert!(depth <= 256);
+
+    let full_bytes = depth / 8;
+    let partial_bits = depth % 8;
+
+    if full_bytes < key.len() {
+        if partial_bits == 0 {
+            key[full_bytes..].fill(0);
+        } else {
+            let keep_mask = u8::MAX << (8 - partial_bits);
+            key[full_bytes] &= keep_mask;
+            key[full_bytes + 1..].fill(0);
+        }
+    }
+
+    key
 }
 
 impl<S: MerkleProofSpec> Storage for NomtVerifierStorage<S> {

--- a/examples/demo-rollup/tests/prover/datagen.rs
+++ b/examples/demo-rollup/tests/prover/datagen.rs
@@ -11,8 +11,8 @@ use sov_test_utils::MessageGenerator;
 
 type S = super::DefaultSpec;
 
-pub const DEFAULT_BLOCKS: u64 = 3;
-const DEFAULT_TXNS_PER_BLOCK: u64 = 2;
+pub const DEFAULT_BLOCKS: u64 = 1;
+const DEFAULT_TXNS_PER_BLOCK: u64 = 0;
 
 pub async fn get_blocks_from_da(mode: BlobBuildingCtx) -> anyhow::Result<Vec<MockBlock>> {
     let txns_per_block = match env::var("SOV_BENCH_TXNS_PER_BLOCK") {

--- a/examples/demo-rollup/tests/prover/datagen.rs
+++ b/examples/demo-rollup/tests/prover/datagen.rs
@@ -11,8 +11,8 @@ use sov_test_utils::MessageGenerator;
 
 type S = super::DefaultSpec;
 
-pub const DEFAULT_BLOCKS: u64 = 1;
-const DEFAULT_TXNS_PER_BLOCK: u64 = 0;
+pub const DEFAULT_BLOCKS: u64 = 3;
+const DEFAULT_TXNS_PER_BLOCK: u64 = 2;
 
 pub async fn get_blocks_from_da(mode: BlobBuildingCtx) -> anyhow::Result<Vec<MockBlock>> {
     let txns_per_block = match env::var("SOV_BENCH_TXNS_PER_BLOCK") {

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -20,7 +20,7 @@ type ProofInput = StateTransitionWitnessWithAddress<
 >;
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "This test is used to generate data for testing the aggregate proof circuit and should be enabled only when needed."]
+//#[ignore = "This test is used to generate data for testing the aggregate proof circuit and should be enabled only when needed."]
 async fn test_save_proofs() {
     let (host, code_commitment) = TestHost::new(true).await;
     let proof_data = generate_proofs(&host).await;
@@ -55,7 +55,8 @@ async fn generate_proofs(host: &TestHost) -> Vec<BlockHeaderWithProof<MockDaSpec
     let prover_address = <DefaultSpec as Spec>::Address::try_from([0u8; 28].as_ref()).unwrap();
     let mut proofs = Vec::new();
 
-    for witness in witnesses {
+    for (i, witness) in witnesses.into_iter().enumerate() {
+        println!("XX {i}");
         let da_block_header = witness.da_block_header.clone();
 
         let data: ProofInput = StateTransitionWitnessWithAddress {

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -11,6 +11,7 @@ use sov_rollup_interface::zk::{
 };
 use sov_sp1_adapter::host::{MockSp1Prover, SP1Host};
 use sov_sp1_adapter::{SP1MethodId, SP1Verifier};
+use tokio::time::Instant;
 
 type ProofInput = StateTransitionWitnessWithAddress<
     <DefaultSpec as Spec>::Address,
@@ -20,7 +21,7 @@ type ProofInput = StateTransitionWitnessWithAddress<
 >;
 
 #[tokio::test(flavor = "multi_thread")]
-//#[ignore = "This test is used to generate data for testing the aggregate proof circuit and should be enabled only when needed."]
+#[ignore = "This test is used to generate data for testing the aggregate proof circuit and should be enabled only when needed."]
 async fn test_save_proofs() {
     let (host, code_commitment) = TestHost::new(true).await;
     let proof_data = generate_proofs(&host).await;
@@ -56,7 +57,6 @@ async fn generate_proofs(host: &TestHost) -> Vec<BlockHeaderWithProof<MockDaSpec
     let mut proofs = Vec::new();
 
     for (i, witness) in witnesses.into_iter().enumerate() {
-        println!("XX {i}");
         let da_block_header = witness.da_block_header.clone();
 
         let data: ProofInput = StateTransitionWitnessWithAddress {
@@ -64,7 +64,9 @@ async fn generate_proofs(host: &TestHost) -> Vec<BlockHeaderWithProof<MockDaSpec
             prover_address,
         };
 
+        let start = Instant::now();
         let raw_inner_proof = host.run(data).await;
+        println!("XX {i} proof generated in {:?}", start.elapsed());
         proofs.push(BlockHeaderWithProof {
             da_block_header,
             proof: SerializedInnerProof { raw_inner_proof },

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -73,6 +73,30 @@ async fn generate_proofs(host: &TestHost) -> Vec<BlockHeaderWithProof<MockDaSpec
     proofs
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mock_proof_public_data_matches_witnesses() {
+    let (host, _) = TestHost::new(false).await;
+    let (_genesis_state_root, witnesses) = super::generate_witnesses().await;
+    let prover_address = <DefaultSpec as Spec>::Address::try_from([0u8; 28].as_ref()).unwrap();
+
+    for witness in witnesses {
+        let expected_initial_state_root = witness.initial_state_root.clone();
+        let expected_final_state_root = witness.final_state_root.clone();
+        let expected_slot_hash = witness.da_block_header.hash();
+
+        let public_data = host
+            .run_mock_public_data(ProofInput {
+                stf_witness: witness,
+                prover_address,
+            })
+            .await;
+
+        assert_eq!(public_data.initial_state_root, expected_initial_state_root);
+        assert_eq!(public_data.final_state_root, expected_final_state_root);
+        assert_eq!(public_data.slot_hash, expected_slot_hash);
+    }
+}
+
 // The SP1 prover manages its own Tokio runtime, which conflicts with the `tokio::test` runtime.
 // To avoid this, all blocking work must be executed inside `tokio::task::spawn_blocking`.
 struct TestHost {
@@ -128,6 +152,25 @@ impl TestHost {
             .await
             .unwrap()
         }
+    }
+
+    async fn run_mock_public_data(
+        &self,
+        data: ProofInput,
+    ) -> StateTransitionPublicData<<DefaultSpec as Spec>::Address, MockDaSpec, ProofStateRoot> {
+        tokio::task::spawn_blocking(move || {
+            let mock_host = MockSp1Prover::new(*sp1::SP1_GUEST_MOCK_ELF)
+                .expect("MockSp1Prover should be created successfully");
+
+            let proof = mock_host
+                .add_hint_and_run(&data)
+                .expect("Mock prover should run successfully");
+
+            bincode::deserialize(proof.public_values.as_slice())
+                .expect("Mock proof public values should deserialize")
+        })
+        .await
+        .unwrap()
     }
 }
 


### PR DESCRIPTION
What Was Broken
  The failing test was showing that native witness generation and guest-side replay produced different public data, specifically a different final state root. The important part is that the STF logic was not the problem. The bug was in how Sovereign eplayed NOMT state updates inside the guest.

  Before the fix, Sovereign effectively treated NOMT like:

  - one compact multiproof for reads
  - one flat sorted list of writes for updates

  That is too lossy. NOMT update verification is path-scoped, not just “all writes sorted by key”.

  1. Add a Regression Test
  The new test in examples/demo-rollup/tests/prover/sp1_cpu_prover.rs:79 runs the mock SP1 guest for each witness and checks that the guest’s public outputs match the witness:

  - initial_state_root
  - final_state_root
  - slot_hash

  The helper in examples/demo-rollup/tests/prover/sp1_cpu_prover.rs:160 deserializes public_values from the mock proof so the test compares exactly what the guest computed.

  That test is what exposed the NOMT replay bug.

  2. Preserve the Full NOMT Witness on the Prover Side
  The key prover-side change is in crates/module-system/sov-state/src/nomt/prover_storage.rs:537.

  Before this change, the prover took NOMT’s full witness and collapsed it into a MultiProof, discarding:

  - original witnessed paths
  - NOMT read/write operation metadata
  - path-to-operation structure

  Now it stores the full nomt::Witness in the Sovereign witness:

  - path_proofs
  - operations.reads
  - operations.writes

  That is necessary because the verifier needs more than a flat multiproof if it wants to replay updates correctly.

  3. Rewrite Guest-Side Replay Around the Full Witness
  The main fix is in crates/module-system/sov-state/src/nomt/zk_storage.rs:37.

  The flow now is:

  1. Build canonical expected read/write maps from Sovereign state accesses.
     Code: crates/module-system/sov-state/src/nomt/zk_storage.rs:46
  2. Deserialize the full NomtWitness.
     Code: crates/module-system/sov-state/src/nomt/zk_storage.rs:69
  3. Reconstruct a MultiProof from the witnessed paths and use it only for reads.
     Code: crates/module-system/sov-state/src/nomt/zk_storage.rs:70
  4. Verify all reads against that multiproof.
     Code: crates/module-system/sov-state/src/nomt/zk_storage.rs:83
  5. Validate the witnessed write set against expected writes:

  - no unexpected writes
  - no missing writes
  - no duplicates
  - witnessed value hash must exactly match the expected authenticated write hash
    Code: crates/module-system/sov-state/src/nomt/zk_storage.rs:108

  6. Verify each path proof independently into a VerifiedPathProof.
     Code: crates/module-system/sov-state/src/nomt/zk_storage.rs:133
  7. Group each write onto the deepest matching path prefix using:

  - the verified path depth
  - a canonical truncated prefix key
  - a map keyed by (depth, truncated_prefix)
    Code: crates/module-system/sov-state/src/nomt/zk_storage.rs:151
    Support function: crates/module-system/sov-state/src/nomt/zk_storage.rs:194

  8. Build PathUpdates and call NOMT’s path-based verify_update.
     Code: crates/module-system/sov-state/src/nomt/zk_storage.rs:179

  Why This Fix Works
  The old approach was wrong because it replayed updates as a flat batch. Reads can be checked that way, but writes cannot. NOMT updates need each write attached to a path that actually scopes that key.

  The final version fixes that by:

  - keeping the full NOMT witness
  - using the multiproof only for read verification
  - validating the exact write set
  - regrouping writes by actual path scope
  - using path-based verify_update

  That is why the final_state_root mismatch disappeared.

  Why There Was a Second Failure on Larger Data
  After the first fix, larger data still hit OpOutOfScope. That showed another issue: you could not safely rely on NOMT’s serialized write-to-path bookkeeping alone for guest replay.

  The current code avoids that by deriving write grouping from actual path prefixes instead of trusting the witness path_index. The likely upstream cause is NOMT witness assembly under larger workloads; that part is an inference. The proven part is that
  regrouping by prefix scope fixes the failure.

  Net Effect
  The PR changes the protocol from:

  - “store compact multiproof, replay flat writes”

  to:

  - “store full NOMT witness, verify reads globally, verify updates path-by-path”



- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
