### PR TITLE
Simplify Transaction versioned struct generics

### DIFF
--- a/crates/module-system/module-implementations/sov-accounts/tests/integration/main.rs
+++ b/crates/module-system/module-implementations/sov-accounts/tests/integration/main.rs
@@ -219,14 +219,13 @@ fn test_setup_multisig_and_act() {
         .to_multisig_tx(multisig.clone())
     };
 
-    let sign = |tx: &mut Version1<TestAccountsRuntimeCall<S>, S>, key: &TestPrivateKey| {
+    let sign = |tx: &mut Version1<RT, S>, key: &TestPrivateKey| {
         use sov_modules_api::Runtime;
         let chain_hash = &<RT as Runtime<S>>::CHAIN_HASH;
         tx.sign(key, chain_hash).unwrap();
     };
 
-    let assert_tx_success = |tx: Version1<TestAccountsRuntimeCall<S>, S>,
-                             runner: &mut TestRunner<RT, S>| {
+    let assert_tx_success = |tx: Version1<RT, S>, runner: &mut TestRunner<RT, S>| {
         let tx = Transaction::<RT, S>::from(tx);
         let multisig_tx = TransactionType::<RT, S>::PreSigned(RawTx {
             data: borsh::to_vec(&tx).unwrap(),
@@ -239,32 +238,31 @@ fn test_setup_multisig_and_act() {
         });
     };
 
-    let assert_tx_skip = |tx: Version1<TestAccountsRuntimeCall<S>, S>,
-                          runner: &mut TestRunner<RT, S>,
-                          reason: &'static str| {
-        let tx = Transaction::<RT, S>::from(tx);
-        let multisig_tx = TransactionType::<RT, S>::PreSigned(RawTx {
-            data: borsh::to_vec(&tx).unwrap(),
-        });
-        runner.execute_transaction(TransactionTestCase {
-            input: multisig_tx,
-            assert: Box::new(move |result, _state| {
-                assert!(result.tx_receipt.is_skipped());
-                match result.tx_receipt {
-                    TxEffect::Skipped(SkippedTxContents { error, .. }) => {
-                        assert!(
-                            error.to_string().contains(reason),
-                            "Unexpected skip reason. Expected: {reason}, Got: {error}"
-                        );
+    let assert_tx_skip =
+        |tx: Version1<RT, S>, runner: &mut TestRunner<RT, S>, reason: &'static str| {
+            let tx = Transaction::<RT, S>::from(tx);
+            let multisig_tx = TransactionType::<RT, S>::PreSigned(RawTx {
+                data: borsh::to_vec(&tx).unwrap(),
+            });
+            runner.execute_transaction(TransactionTestCase {
+                input: multisig_tx,
+                assert: Box::new(move |result, _state| {
+                    assert!(result.tx_receipt.is_skipped());
+                    match result.tx_receipt {
+                        TxEffect::Skipped(SkippedTxContents { error, .. }) => {
+                            assert!(
+                                error.to_string().contains(reason),
+                                "Unexpected skip reason. Expected: {reason}, Got: {error}"
+                            );
+                        }
+                        _ => panic!(
+                            "Expected skipped transaction but found {:?}",
+                            result.tx_receipt
+                        ),
                     }
-                    _ => panic!(
-                        "Expected skipped transaction but found {:?}",
-                        result.tx_receipt
-                    ),
-                }
-            }),
-        });
-    };
+                }),
+            });
+        };
 
     // A transaction with two valid signatures should succeed in our 2/3 multisig
     let tx_with_two_valid_signatures = {

--- a/crates/module-system/sov-eip712-auth/src/lib.rs
+++ b/crates/module-system/sov-eip712-auth/src/lib.rs
@@ -264,7 +264,7 @@ fn get_eip712_hash<
     raw_tx_hash: TxHash,
 ) -> Result<[u8; EIP712_HASH_LENGTH], AuthenticationError> {
     // Convert the transaction to unsigned transaction (removes signature)
-    let unsigned_tx = tx.to_unsigned_transaction();
+    let unsigned_tx = tx.as_unsigned_transaction();
 
     // Serialize the unsigned transaction - this is what should be signed
     let unsigned_tx_bytes = borsh::to_vec(&unsigned_tx).map_err(|e| {

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -243,7 +243,7 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
         chain_hash: &[u8; 32],
     ) -> Result<Vec<u8>, TransactionVerificationError<S::Gas>> {
         Ok(self
-            .to_unsigned_transaction()
+            .as_unsigned_transaction()
             .serialized_with_chain_hash(chain_hash))
     }
 
@@ -301,10 +301,10 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
     /// Converts the transaction to a versioned unsigned transaction.
     /// For V0, this extracts the common fields. For V1, this also computes the
     /// `credential_address` from the multisig parameters.
-    pub fn to_unsigned_transaction(&self) -> UnsignedTransaction<R, S> {
+    pub fn as_unsigned_transaction(&self) -> UnsignedTransaction<R, S> {
         match &self {
-            Transaction::V0(inner) => inner.to_unsigned(),
-            Transaction::V1(inner) => inner.to_unsigned(),
+            Transaction::V0(inner) => inner.as_unsigned(),
+            Transaction::V1(inner) => inner.as_unsigned(),
         }
     }
 }

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -75,7 +75,7 @@ pub enum Transaction<R: TransactionCallable, S: Spec, C: CryptoSpecExt = <S as S
             serialize = "<C as CryptoSpec>::Signature: BorshSerialize, <C as CryptoSpec>::PublicKey: BorshSerialize",
             deserialize = "<C as CryptoSpec>::Signature: BorshDeserialize, <C as CryptoSpec>::PublicKey: BorshDeserialize",
         ))]
-        Version0<R::Call, S, C>,
+        Version0<R, S, C>,
     ),
     /// A V1 (multisig) transaction.
     V1(
@@ -83,7 +83,7 @@ pub enum Transaction<R: TransactionCallable, S: Spec, C: CryptoSpecExt = <S as S
             serialize = "<C as CryptoSpec>::Signature: BorshSerialize, <C as CryptoSpec>::PublicKey: BorshSerialize",
             deserialize = "<C as CryptoSpec>::Signature: BorshDeserialize, <C as CryptoSpec>::PublicKey: BorshDeserialize",
         ))]
-        Version1<R::Call, S, C>,
+        Version1<R, S, C>,
     ),
 }
 
@@ -104,9 +104,8 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
         chain_hash: &[u8; 32],
         unsigned_tx: UnsignedTransactionV0<R, S>,
     ) -> Self {
-        let versioned = UnsignedTransaction::<R, S>::V0(unsigned_tx.clone());
-        let mut utx_bytes = borsh::to_vec(&versioned).unwrap();
-        utx_bytes.extend_from_slice(chain_hash);
+        let utx_bytes = UnsignedTransaction::<R, S>::V0(unsigned_tx.clone())
+            .serialized_with_chain_hash(chain_hash);
 
         let pub_key = priv_key.pub_key();
         let signature = priv_key.sign(&utx_bytes);
@@ -243,11 +242,9 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
         &self,
         chain_hash: &[u8; 32],
     ) -> Result<Vec<u8>, TransactionVerificationError<S::Gas>> {
-        let mut serialized_tx = borsh::to_vec(&self.to_unsigned_transaction()).map_err(|e| {
-            TransactionVerificationError::TransactionDeserializationError(e.to_string())
-        })?;
-        serialized_tx.extend_from_slice(chain_hash);
-        Ok(serialized_tx)
+        Ok(self
+            .to_unsigned_transaction()
+            .serialized_with_chain_hash(chain_hash))
     }
 
     /// Charge gas for verifying the transaction signature against the given message.
@@ -306,14 +303,8 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Transaction<R, S, C> {
     /// `credential_address` from the multisig parameters.
     pub fn to_unsigned_transaction(&self) -> UnsignedTransaction<R, S> {
         match &self {
-            Transaction::V0(inner) => {
-                UnsignedTransaction::V0(UnsignedTransactionV0::new_with_details(
-                    inner.runtime_call.clone(),
-                    inner.uniqueness,
-                    inner.details.clone(),
-                ))
-            }
-            Transaction::V1(inner) => UnsignedTransaction::V1(inner.to_unsigned_v1::<R>()),
+            Transaction::V0(inner) => inner.to_unsigned(),
+            Transaction::V1(inner) => inner.to_unsigned(),
         }
     }
 }

--- a/crates/module-system/sov-modules-api/src/transaction/types/v0.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/types/v0.rs
@@ -47,7 +47,7 @@ pub struct Version0<R: TransactionCallable, S: Spec, C: CryptoSpecExt = <S as Sp
 
 impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Version0<R, S, C> {
     /// Extracts the versioned unsigned transaction data from this signed envelope.
-    pub fn to_unsigned(&self) -> UnsignedTransaction<R, S> {
+    pub fn as_unsigned(&self) -> UnsignedTransaction<R, S> {
         UnsignedTransaction::V0(UnsignedTransactionV0::new_with_details(
             self.runtime_call.clone(),
             self.uniqueness,

--- a/crates/module-system/sov-modules-api/src/transaction/types/v0.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/types/v0.rs
@@ -3,7 +3,10 @@ use derivative::Derivative;
 use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
 
 use crate::capabilities::{AuthenticationError, AuthorizationData, UniquenessData};
-use crate::transaction::{hex_field_format, Credentials, Transaction, TransactionCallable};
+use crate::transaction::{
+    hex_field_format, Credentials, Transaction, TransactionCallable, UnsignedTransaction,
+    UnsignedTransactionV0,
+};
 use crate::{metered_credential, CryptoSpecExt, GasMeter, Spec, TxHash};
 
 #[derive(
@@ -17,12 +20,12 @@ use crate::{metered_credential, CryptoSpecExt, GasMeter, Spec, TxHash};
     UniversalWallet,
 )]
 #[derivative(
-    PartialEq(bound = "Call: PartialEq + Eq"),
-    Eq(bound = "Call: PartialEq + Eq")
+    PartialEq(bound = "R::Call: PartialEq + Eq"),
+    Eq(bound = "R::Call: PartialEq + Eq")
 )]
-#[serde(bound = "Call: serde::Serialize + serde::de::DeserializeOwned")]
+#[serde(bound = "R::Call: serde::Serialize + serde::de::DeserializeOwned")]
 /// V0 transaction.
-pub struct Version0<Call, S: Spec, C: CryptoSpecExt = <S as Spec>::CryptoSpec> {
+pub struct Version0<R: TransactionCallable, S: Spec, C: CryptoSpecExt = <S as Spec>::CryptoSpec> {
     /// The signature of the transaction.
     #[serde(with = "hex_field_format")]
     #[sov_wallet(display = "hex")]
@@ -33,16 +36,25 @@ pub struct Version0<Call, S: Spec, C: CryptoSpecExt = <S as Spec>::CryptoSpec> {
     pub pub_key: C::PublicKey,
     /// The runtime call of the transaction.
     #[sov_wallet(
-        bound = "Call: sov_rollup_interface::sov_universal_wallet::schema::UniversalWallet"
+        bound = "R::Call: sov_rollup_interface::sov_universal_wallet::schema::UniversalWallet"
     )]
-    pub runtime_call: Call,
+    pub runtime_call: R::Call,
     /// Uniqueness identifier of this transaction. see [`UniquenessData`] for more details.
     pub uniqueness: UniquenessData,
     /// The transaction metadata. Contains gas parameters and the chain ID.
     pub details: TxDetails<S>,
 }
 
-impl<Call, S: Spec, C: CryptoSpecExt> Version0<Call, S, C> {
+impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Version0<R, S, C> {
+    /// Extracts the versioned unsigned transaction data from this signed envelope.
+    pub fn to_unsigned(&self) -> UnsignedTransaction<R, S> {
+        UnsignedTransaction::V0(UnsignedTransactionV0::new_with_details(
+            self.runtime_call.clone(),
+            self.uniqueness,
+            self.details.clone(),
+        ))
+    }
+
     /// Extracts authorization data from this transaction.
     pub fn auth_data<M: GasMeter<Spec = S>>(
         &self,
@@ -63,8 +75,8 @@ impl<Call, S: Spec, C: CryptoSpecExt> Version0<Call, S, C> {
     }
 }
 
-impl<R: TransactionCallable, S: Spec> From<Version0<R::Call, S>> for Transaction<R, S> {
-    fn from(value: Version0<R::Call, S>) -> Self {
+impl<R: TransactionCallable, S: Spec> From<Version0<R, S>> for Transaction<R, S> {
+    fn from(value: Version0<R, S>) -> Self {
         Transaction::V0(value)
     }
 }

--- a/crates/module-system/sov-modules-api/src/transaction/types/v1.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/types/v1.rs
@@ -1,6 +1,7 @@
 use crate::capabilities::{AuthenticationError, AuthorizationData, UniquenessData};
 use crate::transaction::{
-    Credentials, Transaction, TransactionCallable, TxDetails, UnsignedTransactionV1,
+    Credentials, Transaction, TransactionCallable, TxDetails, UnsignedTransaction,
+    UnsignedTransactionV1,
 };
 use crate::{CryptoSpecExt, GasMeter, GasSpec, Multisig, Spec, TxHash};
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -52,14 +53,14 @@ impl<C: CryptoSpecExt> PubKeyAndSignature<C> {
     UniversalWallet,
 )]
 #[derivative(
-    PartialEq(bound = "Call: PartialEq + Eq"),
-    Eq(bound = "Call: PartialEq + Eq")
+    PartialEq(bound = "R::Call: PartialEq + Eq"),
+    Eq(bound = "R::Call: PartialEq + Eq")
 )]
-#[serde(bound = "Call: serde::Serialize + serde::de::DeserializeOwned")]
+#[serde(bound = "R::Call: serde::Serialize + serde::de::DeserializeOwned")]
 /// A V1 (multisig) transaction. The number of signers is capped at 10.
 ///
 /// The credential ID for a multisig is hash(borsh(min_signers) || borsh(sort(pub_keys)))
-pub struct Version1<Call, S: Spec, C: CryptoSpecExt = <S as Spec>::CryptoSpec> {
+pub struct Version1<R: TransactionCallable, S: Spec, C: CryptoSpecExt = <S as Spec>::CryptoSpec> {
     /// The signatures of the transaction.
     #[borsh(bound(
         serialize = "PubKeyAndSignature<C>: BorshSerialize",
@@ -81,16 +82,16 @@ pub struct Version1<Call, S: Spec, C: CryptoSpecExt = <S as Spec>::CryptoSpec> {
     pub min_signers: u8,
     /// The runtime call of the transaction.
     #[sov_wallet(
-        bound = "Call: sov_rollup_interface::sov_universal_wallet::schema::UniversalWallet"
+        bound = "R::Call: sov_rollup_interface::sov_universal_wallet::schema::UniversalWallet"
     )]
-    pub runtime_call: Call,
+    pub runtime_call: R::Call,
     /// Uniqueness identifier of this transaction. see [`UniquenessData`] for more details.
     pub uniqueness: UniquenessData,
     /// The transaction metadata. Contains gas parameters and the chain ID.
     pub details: TxDetails<S>,
 }
 
-impl<Call, S: Spec, C: CryptoSpecExt> Version1<Call, S, C> {
+impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Version1<R, S, C> {
     /// Computes the multisig credential address from the transaction's multisig parameters.
     /// This is the single source of truth for the derivation used in both signing and verification.
     pub fn credential_address(&self) -> S::Address {
@@ -105,23 +106,18 @@ impl<Call, S: Spec, C: CryptoSpecExt> Version1<Call, S, C> {
             .into()
     }
 
-    /// Extracts the unsigned V1 transaction data from this signed envelope.
-    /// The `R` type parameter is needed to match the `UnsignedTransactionV1<R, S>` type;
-    /// it is inferred from context when called from `Transaction<R, S, C>::to_unsigned_transaction()`.
-    pub fn to_unsigned_v1<R: TransactionCallable<Call = Call>>(&self) -> UnsignedTransactionV1<R, S>
-    where
-        Call: Clone,
-    {
-        UnsignedTransactionV1 {
+    /// Extracts the versioned unsigned transaction data from this signed envelope.
+    pub fn to_unsigned(&self) -> UnsignedTransaction<R, S> {
+        UnsignedTransaction::V1(UnsignedTransactionV1 {
             runtime_call: self.runtime_call.clone(),
             uniqueness: self.uniqueness,
             details: self.details.clone(),
             credential_address: self.credential_address(),
-        }
+        })
     }
 }
 
-impl<Call: BorshSerialize, S: Spec, C: CryptoSpecExt> Version1<Call, S, C> {
+impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Version1<R, S, C> {
     /// Signs the transaction with the given key but does not add the signature to the list in the transaction.
     #[cfg(feature = "native")]
     pub fn sign_without_adding(&self, key: &C::PrivateKey, chain_hash: &[u8; 32]) -> C::Signature {
@@ -135,24 +131,10 @@ impl<Call: BorshSerialize, S: Spec, C: CryptoSpecExt> Version1<Call, S, C> {
         self.add_signature(signature, key.pub_key())
     }
 
-    /// Serializes the versioned unsigned transaction and appends the chain_hash, producing the
-    /// bytes to be signed. The output is identical to
-    /// `borsh(UnsignedTransaction::V1(UnsignedTransactionV1{...})) || chain_hash`.
+    /// Serializes the versioned unsigned transaction and appends the chain hash, producing the
+    /// bytes to be signed.
     pub fn serialize_for_signing(&self, chain_hash: &[u8; 32]) -> Vec<u8> {
-        let credential_address = self.credential_address();
-        let mut out = Vec::with_capacity(128);
-        // V1 enum discriminant
-        out.push(1u8);
-        BorshSerialize::serialize(&self.runtime_call, &mut out)
-            .expect("Serialization to vec is infallible");
-        BorshSerialize::serialize(&self.uniqueness, &mut out)
-            .expect("Serialization to vec is infallible");
-        BorshSerialize::serialize(&self.details, &mut out)
-            .expect("Serialization to vec is infallible");
-        BorshSerialize::serialize(&credential_address, &mut out)
-            .expect("Serialization to vec is infallible");
-        out.extend_from_slice(chain_hash);
-        out
+        self.to_unsigned().serialized_with_chain_hash(chain_hash)
     }
 
     /// Adds a signature to the signing set of the multisig, removing the public key from the set of unused pub keys.
@@ -210,8 +192,8 @@ impl<Call: BorshSerialize, S: Spec, C: CryptoSpecExt> Version1<Call, S, C> {
     }
 }
 
-impl<R: TransactionCallable, S: Spec> From<Version1<R::Call, S>> for Transaction<R, S> {
-    fn from(value: Version1<R::Call, S>) -> Self {
+impl<R: TransactionCallable, S: Spec> From<Version1<R, S>> for Transaction<R, S> {
+    fn from(value: Version1<R, S>) -> Self {
         Transaction::V1(value)
     }
 }

--- a/crates/module-system/sov-modules-api/src/transaction/types/v1.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/types/v1.rs
@@ -107,7 +107,7 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Version1<R, S, C> {
     }
 
     /// Extracts the versioned unsigned transaction data from this signed envelope.
-    pub fn to_unsigned(&self) -> UnsignedTransaction<R, S> {
+    pub fn as_unsigned(&self) -> UnsignedTransaction<R, S> {
         UnsignedTransaction::V1(UnsignedTransactionV1 {
             runtime_call: self.runtime_call.clone(),
             uniqueness: self.uniqueness,
@@ -134,7 +134,7 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Version1<R, S, C> {
     /// Serializes the versioned unsigned transaction and appends the chain hash, producing the
     /// bytes to be signed.
     pub fn serialize_for_signing(&self, chain_hash: &[u8; 32]) -> Vec<u8> {
-        self.to_unsigned().serialized_with_chain_hash(chain_hash)
+        self.as_unsigned().serialized_with_chain_hash(chain_hash)
     }
 
     /// Adds a signature to the signing set of the multisig, removing the public key from the set of unused pub keys.

--- a/crates/module-system/sov-modules-api/src/transaction/unsigned/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/unsigned/mod.rs
@@ -64,6 +64,14 @@ impl<R: TransactionCallable, S: Spec> Eq for UnsignedTransaction<R, S> {}
 
 // Getters on the enum for version-agnostic field access
 impl<R: TransactionCallable, S: Spec> UnsignedTransaction<R, S> {
+    /// Serializes the versioned unsigned transaction and appends the chain hash,
+    /// producing the bytes used for signing and signature verification.
+    pub fn serialized_with_chain_hash(&self, chain_hash: &[u8; 32]) -> Vec<u8> {
+        let mut serialized_tx = borsh::to_vec(self).expect("Serialization to vec is infallible");
+        serialized_tx.extend_from_slice(chain_hash);
+        serialized_tx
+    }
+
     /// Returns a reference to the runtime call.
     pub fn runtime_call(&self) -> &R::Call {
         match self {

--- a/crates/module-system/sov-modules-api/src/transaction/unsigned/v0.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/unsigned/v0.rs
@@ -117,7 +117,7 @@ impl<R: TransactionCallable, S: Spec> UnsignedTransactionV0<R, S> {
     pub fn to_multisig_tx(
         self,
         multisig: Multisig<<S::CryptoSpec as CryptoSpec>::PublicKey>,
-    ) -> Version1<R::Call, S> {
+    ) -> Version1<R, S> {
         Version1 {
             signatures: SafeVec::new(),
             unused_pub_keys: multisig


### PR DESCRIPTION
# Description

`Transaction` and `UnsignedTransaction` were generic in `R: TransactionCallable`, but `Version0` and `Version1` were generic on `R::Call`. This made it awkward to convert between `VersionX` and `UnsignedTransactionVX` as it required re-introducing the R generic.

This PR changes both VersionX structs to be generic on the same TransactionCallable, allowing convenient cross-conversion. This simplifies serialization of V1 transactions in particular, and some general ergonomics as well.

To simplify the signing serialization this also moves `serialize_with_chain_hash` to be a method on `UnsignedTransaction` itself, removing the need to branch on enum variants in the signing helpers.

Fixes some feedback from #2688 

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
