### PR TITLE
Remove sov-rollup-interface dependency from sov-universal-wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13085,7 +13085,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.9",
- "sov-rollup-interface",
  "sov-universal-wallet",
  "sov-universal-wallet-macros",
  "thiserror 2.0.17",

--- a/crates/universal-wallet/schema/Cargo.toml
+++ b/crates/universal-wallet/schema/Cargo.toml
@@ -33,7 +33,6 @@ schemars = { workspace = true, optional = true }                    # for SafeSt
 borsh = { workspace = true }
 sov-universal-wallet-macros = { workspace = true }
 sov-universal-wallet = { path = ".", features = ["serde", "eip712", "macros"] }
-sov-rollup-interface = { workspace = true }
 serde_arrays = { workspace = true }
 serde_with = { workspace = true }
 serde = { workspace = true }

--- a/crates/universal-wallet/schema/src/lib.rs
+++ b/crates/universal-wallet/schema/src/lib.rs
@@ -35,6 +35,8 @@ pub extern crate bech32;
 /// This annotation may only be applied to fields, not items.
 ///
 /// ```rust
+/// # pub extern crate sov_universal_wallet;
+/// # mod sov_rollup_interface { pub use crate::sov_universal_wallet; }
 /// use sov_rollup_interface::sov_universal_wallet::schema::{Schema, safe_string::SafeString};
 /// use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
 ///
@@ -61,6 +63,8 @@ pub extern crate bech32;
 /// or when you want to override the default schema for a type in a particular context.
 ///
 /// ```rust
+/// # pub extern crate sov_universal_wallet;
+/// # mod sov_rollup_interface { pub use crate::sov_universal_wallet; }
 /// use sov_rollup_interface::sov_universal_wallet::{schema::Schema, UniversalWallet};
 ///
 /// // A foreign type that doesn't derive UniversalWallet
@@ -84,6 +88,8 @@ pub extern crate bech32;
 /// use `#[sov_wallet(hidden)]` instead.
 ///
 /// ```rust
+/// # pub extern crate sov_universal_wallet;
+/// # mod sov_rollup_interface { pub use crate::sov_universal_wallet; }
 /// use sov_rollup_interface::sov_universal_wallet::{schema::Schema, UniversalWallet};
 /// #[derive(UniversalWallet, borsh::BorshSerialize)]
 /// pub struct File {
@@ -107,6 +113,8 @@ pub extern crate bech32;
 ///    fixed-point number.
 ///
 /// ```rust
+/// # pub extern crate sov_universal_wallet;
+/// # mod sov_rollup_interface { pub use crate::sov_universal_wallet; }
 /// use sov_rollup_interface::sov_universal_wallet::{schema::Schema, UniversalWallet};
 /// #[derive(UniversalWallet, borsh::BorshSerialize)]
 /// pub struct Coins {
@@ -138,6 +146,8 @@ pub extern crate bech32;
 /// This annotation may only be applied to fields, not items. The field must have type `[u8;N]` or `Vec<u8>` to use this attribute.
 ///
 /// ```rust
+/// # pub extern crate sov_universal_wallet;
+/// # mod sov_rollup_interface { pub use crate::sov_universal_wallet; }
 /// use sov_rollup_interface::sov_universal_wallet::{schema::Schema, UniversalWallet};
 ///
 /// fn prefix() -> &'static str {

--- a/crates/universal-wallet/schema/tests/integration/eip712.rs
+++ b/crates/universal-wallet/schema/tests/integration/eip712.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use sov_universal_wallet::schema::Schema;
 use sov_universal_wallet::schema::safe_string::SafeString;
+use sov_universal_wallet::schema::Schema;
 use sov_universal_wallet::UniversalWallet;
 
 use crate::sov_rollup_interface;

--- a/crates/universal-wallet/schema/tests/integration/eip712.rs
+++ b/crates/universal-wallet/schema/tests/integration/eip712.rs
@@ -1,9 +1,11 @@
 use std::collections::BTreeMap;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use sov_rollup_interface::common::SafeString;
 use sov_universal_wallet::schema::Schema;
+use sov_universal_wallet::schema::safe_string::SafeString;
 use sov_universal_wallet::UniversalWallet;
+
+use crate::sov_rollup_interface;
 
 #[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]
 struct Address([u8; 32]);


### PR DESCRIPTION
# Description

It was only added to import SafeString in tests, which is re-exported from sov-universal-wallet itself. So now `sov-universal-wallet` has no further dependencies on SDK crates.

Also needed a couple of docs cleanups to keep them compiling (same idea used in the integration tests).

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
