### PR TITLE
Remove redundant runtime_call getter

### DIFF
--- a/crates/module-system/sov-modules-api/src/transaction/unsigned/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/unsigned/mod.rs
@@ -95,9 +95,4 @@ impl<R: TransactionCallable, S: Spec> UnsignedTransaction<R, S> {
             Self::V1(v1) => &v1.details,
         }
     }
-
-    /// Returns a clone of the runtime call.
-    pub fn call(&self) -> R::Call {
-        self.runtime_call().clone()
-    }
 }

--- a/crates/module-system/sov-modules-api/src/transaction/unsigned/v0.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/unsigned/v0.rs
@@ -131,8 +131,8 @@ impl<R: TransactionCallable, S: Spec> UnsignedTransactionV0<R, S> {
         }
     }
 
-    /// Returns a copy of the RuntimeCall from this unsigned transaction.
-    pub fn call(&self) -> R::Call {
-        self.runtime_call.clone()
+    /// Returns a reference to the runtime call.
+    pub fn runtime_call(&self) -> &R::Call {
+        &self.runtime_call
     }
 }

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication.rs
@@ -816,7 +816,7 @@ where
                 .into_unsigned_tx()
         }
     };
-    Ok(unsigned_tx.call())
+    Ok(unsigned_tx.runtime_call().clone())
 }
 
 pub fn authenticate<Accessor, S, D>(


### PR DESCRIPTION
# Description

Small opinionated cleanup: we used to have both `runtime_call() -> &R::Call` and `call() -> R::Call` getters on unsigned transactions. This doesn't follow rust conventions for naming getters, and there's also not much reason to have both at once, as they are used in very few places.

This keeps only the `runtime_call()` getter, returning `&R::Call`, and the few callsites can call `clone()` if needed (turned out there was only one such callsite).

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
