### PR TITLE
Switch universal-wallet macro to be standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - #2744 **Manual intervention might be needed**: Adds `serde(deny_unknown_fields)`, which can fail rollup at startup if genesis config is not tidy.
   The change also affects call message de-serialization in sov-paymaster, for all call messages that use `PaymasterPolicyInitializer`
 
+# 2026-04-15
+- #2742 *Minor breaking change (code)*: The `UniversalWallet` macro exported by the `sov-universal-wallet` crate is now meant to be used by depending directly on the crate, and is no longer re-exported from `sov-rollup-interface`. The re-export from `sov-modules-api` is unchanged, so most usage is unaffected; this is only breaking if you were previously importing the macro specifically from `sov-rollup-interface`.
+
 # 2026-04-13
 - #2721 Adds support for fallback gRPC endpoints to celestia-adapter. Optional new field
 - #2735 Internal change: moves EVM RPC tests to sov-ethereum from sov-demo-rollup

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11475,6 +11475,7 @@ dependencies = [
  "sov-modules-macros",
  "sov-rollup-interface",
  "sov-test-utils",
+ "sov-universal-wallet",
  "tendermint",
  "tendermint-proto",
  "test-strategy",
@@ -11595,6 +11596,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sov-rollup-interface",
+ "sov-universal-wallet",
 ]
 
 [[package]]
@@ -12110,6 +12112,7 @@ dependencies = [
  "sov-mock-da",
  "sov-rollup-interface",
  "sov-test-utils",
+ "sov-universal-wallet",
  "tempfile",
  "testcontainers",
  "testcontainers-modules",
@@ -12138,6 +12141,7 @@ dependencies = [
  "sha2 0.10.9",
  "sov-mock-zkvm",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "thiserror 2.0.17",
  "tokio",
 ]
@@ -12493,6 +12497,7 @@ dependencies = [
  "sov-metrics",
  "sov-risc0-adapter",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "sov-zkvm-utils",
  "thiserror 2.0.17",
  "tracing",
@@ -12807,6 +12812,7 @@ dependencies = [
  "sov-rollup-interface",
  "sov-sp1-adapter",
  "sov-test-utils",
+ "sov-universal-wallet",
  "sov-zkvm-utils",
  "sp1-build",
  "sp1-lib",
@@ -12841,6 +12847,7 @@ dependencies = [
  "sov-mock-da",
  "sov-modules-macros",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "tempfile",
  "test-strategy",
  "tracing",

--- a/crates/adapters/celestia/Cargo.toml
+++ b/crates/adapters/celestia/Cargo.toml
@@ -52,6 +52,7 @@ rand = { workspace = true, optional = true }
 sov-metrics = { workspace = true, optional = true }
 sov-modules-macros = { workspace = true, optional = true }
 sov-rollup-interface = { workspace = true }
+sov-universal-wallet = { workspace = true, features = ["macros"] }
 
 [dev-dependencies]
 sov-celestia-adapter = { path = ".", features = ["native", "arbitrary"] }

--- a/crates/adapters/celestia/src/types/mod.rs
+++ b/crates/adapters/celestia/src/types/mod.rs
@@ -10,7 +10,8 @@ pub use error::*;
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::common::HexHash;
 use sov_rollup_interface::da::{BlobReaderTrait, BlockHashTrait, CountedBufReader};
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
+use sov_universal_wallet::schema::OverrideSchema;
+use sov_universal_wallet::UniversalWallet;
 
 use crate::shares::BlobIterator;
 use crate::verifier::address::CelestiaAddress;
@@ -27,7 +28,7 @@ pub struct TmHash(pub tendermint::Hash);
 #[doc(hidden)]
 pub struct TmHashSchema(#[sov_wallet(display(hex))] [u8; 32]);
 
-impl sov_rollup_interface::sov_universal_wallet::schema::OverrideSchema for TmHash {
+impl OverrideSchema for TmHash {
     type Output = TmHashSchema;
 }
 

--- a/crates/adapters/celestia/src/verifier/address.rs
+++ b/crates/adapters/celestia/src/verifier/address.rs
@@ -6,7 +6,7 @@ use celestia_types::state::{AccAddress, AddressKind, AddressTrait};
 // use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::reexports::schemars::{self};
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
+use sov_universal_wallet::UniversalWallet;
 
 #[derive(
     Debug,
@@ -150,7 +150,7 @@ mod tests {
 
     const CELESTIA_HRP: Hrp = Hrp::parse_unchecked("celestia");
 
-    use sov_rollup_interface::sov_universal_wallet::schema::Schema;
+    use sov_universal_wallet::schema::Schema;
     use sov_test_utils::validate_schema;
 
     use super::*;

--- a/crates/adapters/celestia/src/verifier/address.rs
+++ b/crates/adapters/celestia/src/verifier/address.rs
@@ -150,8 +150,8 @@ mod tests {
 
     const CELESTIA_HRP: Hrp = Hrp::parse_unchecked("celestia");
 
-    use sov_universal_wallet::schema::Schema;
     use sov_test_utils::validate_schema;
+    use sov_universal_wallet::schema::Schema;
 
     use super::*;
 

--- a/crates/adapters/mock-da/Cargo.toml
+++ b/crates/adapters/mock-da/Cargo.toml
@@ -35,6 +35,7 @@ tokio = { workspace = true, optional = true, features = [
 futures = { workspace = true, optional = true, features = ["std"] }
 tracing = { workspace = true }
 sov-rollup-interface = { workspace = true }
+sov-universal-wallet = { workspace = true, features = ["macros"] }
 
 # For storable service
 sea-orm = { version = "1.1", features = [

--- a/crates/adapters/mock-da/src/types/address.rs
+++ b/crates/adapters/mock-da/src/types/address.rs
@@ -1,8 +1,9 @@
 use std::str::FromStr;
 
 use sov_rollup_interface::crypto::CredentialId;
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
 use sov_rollup_interface::BasicAddress;
+use sov_universal_wallet::schema::OverrideSchema;
+use sov_universal_wallet::UniversalWallet;
 
 /// Sequencer DA address used in tests.
 pub const MOCK_SEQUENCER_DA_ADDRESS: [u8; 32] = [0u8; 32];
@@ -36,7 +37,7 @@ pub struct MockAddress {
 #[allow(dead_code)]
 #[doc(hidden)]
 pub struct MockAddressSchema(#[sov_wallet(display(hex))] [u8; 32]);
-impl sov_rollup_interface::sov_universal_wallet::schema::OverrideSchema for MockAddress {
+impl OverrideSchema for MockAddress {
     type Output = MockAddressSchema;
 }
 
@@ -144,7 +145,7 @@ mod tests {
 
     use proptest::prelude::any;
     use proptest::proptest;
-    use sov_rollup_interface::sov_universal_wallet::schema::Schema;
+    use sov_universal_wallet::schema::Schema;
     use sov_test_utils::validate_schema;
 
     use super::*;

--- a/crates/adapters/mock-da/src/types/address.rs
+++ b/crates/adapters/mock-da/src/types/address.rs
@@ -145,8 +145,8 @@ mod tests {
 
     use proptest::prelude::any;
     use proptest::proptest;
-    use sov_universal_wallet::schema::Schema;
     use sov_test_utils::validate_schema;
+    use sov_universal_wallet::schema::Schema;
 
     use super::*;
 

--- a/crates/adapters/mock-da/src/types/mod.rs
+++ b/crates/adapters/mock-da/src/types/mod.rs
@@ -10,8 +10,8 @@ use sov_rollup_interface::da::{
     BlockHashTrait, BlockHeaderTrait, CountedBufReader, DaProof, RelevantBlobs, RelevantProofs,
     Time,
 };
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
 use sov_rollup_interface::Bytes;
+use sov_universal_wallet::UniversalWallet;
 
 use crate::utils::hash_to_array;
 

--- a/crates/adapters/mock-zkvm/Cargo.toml
+++ b/crates/adapters/mock-zkvm/Cargo.toml
@@ -19,6 +19,7 @@ digest = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true }
 sov-rollup-interface = { workspace = true }
+sov-universal-wallet = { workspace = true }
 
 hex = { workspace = true }
 ed25519-dalek = { workspace = true, features = ["serde", "alloc"] }

--- a/crates/adapters/mock-zkvm/src/crypto.rs
+++ b/crates/adapters/mock-zkvm/src/crypto.rs
@@ -10,7 +10,7 @@ use ed25519_dalek::{
 use schemars::JsonSchema;
 use sov_rollup_interface::common::HexString;
 use sov_rollup_interface::crypto::{PublicKeyHex, SigVerificationError};
-use sov_rollup_interface::sov_universal_wallet::schema::OverrideSchema;
+use sov_universal_wallet::schema::OverrideSchema;
 
 /// Defines private key types and operations
 #[cfg(feature = "native")]

--- a/crates/adapters/risc0/Cargo.toml
+++ b/crates/adapters/risc0/Cargo.toml
@@ -38,6 +38,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 
 sov-rollup-interface = { workspace = true }
+sov-universal-wallet = { workspace = true }
 sov-metrics = { workspace = true, features = ["risc0"], optional = true }
 
 [dev-dependencies]

--- a/crates/adapters/risc0/src/crypto.rs
+++ b/crates/adapters/risc0/src/crypto.rs
@@ -9,7 +9,7 @@ use ed25519_dalek::{
 };
 use sov_rollup_interface::crypto::{PublicKeyHex, SigVerificationError};
 use sov_rollup_interface::reexports::schemars::{self, JsonSchema};
-use sov_rollup_interface::sov_universal_wallet::schema::OverrideSchema;
+use sov_universal_wallet::schema::OverrideSchema;
 
 /// Defines private key types and operations
 #[cfg(feature = "native")]

--- a/crates/adapters/sp1/Cargo.toml
+++ b/crates/adapters/sp1/Cargo.toml
@@ -30,6 +30,7 @@ sha2 = { workspace = true }
 sp1-lib = { version = "6.1.0" }
 
 sov-rollup-interface = { workspace = true }
+sov-universal-wallet = { workspace = true }
 sov-metrics = { workspace = true, features = ["sp1"], optional = true }
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]

--- a/crates/adapters/sp1/src/crypto.rs
+++ b/crates/adapters/sp1/src/crypto.rs
@@ -7,7 +7,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use ed25519_consensus::{Error, Signature, VerificationKey};
 use sov_rollup_interface::crypto::{PublicKeyHex, SigVerificationError};
 use sov_rollup_interface::reexports::schemars::{self, JsonSchema};
-use sov_rollup_interface::sov_universal_wallet::schema::OverrideSchema;
+use sov_universal_wallet::schema::OverrideSchema;
 
 /// Defines private key types and operations
 #[cfg(feature = "native")]

--- a/crates/full-node/sov-db-types/Cargo.toml
+++ b/crates/full-node/sov-db-types/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 
 [dependencies]
 sov-rollup-interface = { workspace = true }
+sov-universal-wallet = { workspace = true, features = ["macros"] }
 borsh = { workspace = true, features = ["rc"] }
 digest = { workspace = true }
 rockbound = { workspace = true, optional = true }

--- a/crates/full-node/sov-db-types/src/lib.rs
+++ b/crates/full-node/sov-db-types/src/lib.rs
@@ -9,7 +9,7 @@ use rockbound::versioned_db::HasPrefix;
 #[cfg(feature = "native")]
 use rockbound::versioned_db::VersionedSchemaKeyMarker;
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
+use sov_universal_wallet::UniversalWallet;
 
 use core::{fmt, str};
 
@@ -77,7 +77,7 @@ mod private {
     use borsh::{BorshDeserialize, BorshSerialize};
     use serde::{Deserialize, Serialize};
     use serde_with::{serde_as, Bytes};
-    use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
+    use sov_universal_wallet::UniversalWallet;
 
     /// The total number of bytes in an inline key.
     ///

--- a/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -3,8 +3,8 @@
 
 use schemars::JsonSchema;
 use sov_modules_api::capabilities::{BlockGasInfo, RollupHeight};
+use sov_modules_api::macros::UniversalWallet;
 use sov_modules_api::prelude::UnwrapInfallible;
-use sov_modules_api::sov_universal_wallet::UniversalWallet;
 #[cfg(feature = "native")]
 use sov_modules_api::ApiStateAccessor;
 use sov_modules_api::{

--- a/crates/module-system/sov-modules-api/Cargo.toml
+++ b/crates/module-system/sov-modules-api/Cargo.toml
@@ -31,7 +31,7 @@ sov-rest-utils = { workspace = true, optional = true }
 sov-state = { workspace = true }
 sov-rollup-interface = { workspace = true }
 sov-modules-macros = { workspace = true }
-sov-universal-wallet = { workspace = true, features = ["serde"] }
+sov-universal-wallet = { workspace = true, features = ["serde", "macros"] }
 sov-db = { workspace = true, optional = true }
 sov-metrics = { workspace = true }
 serde = { workspace = true }

--- a/crates/module-system/sov-modules-api/src/common/address.rs
+++ b/crates/module-system/sov-modules-api/src/common/address.rs
@@ -356,7 +356,7 @@ impl PartialOrd for Address {
 
 // Serialize Address without field labels. This changes the output from `{ addr: sov1pv9skzctpv9skzctpv9skzctpv9skzctpv9skzctpv9skzctpv9stup8tx}`
 // to just `sov1pv9skzctpv9skzctpv9skzctpv9skzctpv9skzctpv9skzctpv9stup8tx`
-impl sov_rollup_interface::sov_universal_wallet::schema::OverrideSchema for Address {
+impl sov_universal_wallet::schema::OverrideSchema for Address {
     type Output = AddressSchema;
 }
 
@@ -365,7 +365,7 @@ pub const fn address_prefix() -> &'static str {
     config_value_private!("ADDRESS_PREFIX")
 }
 
-#[derive(sov_rollup_interface::sov_universal_wallet::UniversalWallet)]
+#[derive(sov_universal_wallet::UniversalWallet)]
 #[allow(dead_code)]
 #[doc(hidden)]
 pub struct AddressSchema(#[sov_wallet(display(bech32m(prefix = "address_prefix()")))] [u8; 28]);
@@ -471,7 +471,7 @@ impl BasicAddress for Address {}
     Hash,
     BorshDeserialize,
     BorshSerialize,
-    sov_rollup_interface::sov_universal_wallet::UniversalWallet,
+    sov_universal_wallet::UniversalWallet,
 )]
 #[cfg_attr(
     feature = "arbitrary",

--- a/crates/module-system/sov-modules-api/src/common/amount.rs
+++ b/crates/module-system/sov-modules-api/src/common/amount.rs
@@ -1,7 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
+use sov_universal_wallet::UniversalWallet;
 use sov_universal_wallet::ty::IntegerDisplayable;
 
 /// Maximum number of decimal places for a fixed-point number stored as a u128 integer

--- a/crates/module-system/sov-modules-api/src/common/amount.rs
+++ b/crates/module-system/sov-modules-api/src/common/amount.rs
@@ -1,8 +1,8 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use sov_universal_wallet::UniversalWallet;
 use sov_universal_wallet::ty::IntegerDisplayable;
+use sov_universal_wallet::UniversalWallet;
 
 /// Maximum number of decimal places for a fixed-point number stored as a u128 integer
 /// In other words, `log_10(u128::MAX)`

--- a/crates/module-system/sov-modules-api/src/gas/price.rs
+++ b/crates/module-system/sov-modules-api/src/gas/price.rs
@@ -2,7 +2,7 @@ use crate::Amount;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use derive_more::{AsMut, AsRef, Display, Into};
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
+use sov_universal_wallet::UniversalWallet;
 use std::fmt::Debug;
 
 /// A gas price for multi-dimensional gas.

--- a/crates/module-system/sov-modules-api/src/reexport_macros.rs
+++ b/crates/module-system/sov-modules-api/src/reexport_macros.rs
@@ -600,7 +600,7 @@ pub mod macros {
     /// This annotation may only be applied to fields, not items.
     ///
     /// ```rust
-    /// use sov_universal_wallet::schema::Schema;
+    /// use sov_modules_api::sov_universal_wallet::schema::Schema;
     /// use sov_modules_api::macros::UniversalWallet;
     /// use sov_modules_api::SafeString;
     ///
@@ -627,7 +627,8 @@ pub mod macros {
     /// or when you want to override the default schema for a type in a particular context.
     ///
     /// ```rust
-    /// use sov_rollup_interface::sov_universal_wallet::{schema::Schema, UniversalWallet};
+    /// use sov_modules_api::macros::UniversalWallet;
+    /// use sov_modules_api::sov_universal_wallet::schema::Schema;
     ///
     /// // A foreign type that doesn't derive UniversalWallet
     /// #[derive(borsh::BorshSerialize)]
@@ -654,7 +655,8 @@ pub mod macros {
     ///    given offset `m`. The offset defaults to `0` if not specified.
     ///
     /// ```rust
-    /// use sov_rollup_interface::sov_universal_wallet::{schema::Schema, UniversalWallet};
+    /// use sov_modules_api::macros::UniversalWallet;
+    /// use sov_modules_api::sov_universal_wallet::schema::Schema;
     /// #[derive(UniversalWallet, borsh::BorshSerialize)]
     /// pub struct Coins {
     ///     #[sov_wallet(fixed_point(from_field(1)))]
@@ -723,8 +725,8 @@ pub mod macros {
     /// named in the variant's own attribute will be available on that attribute.
     ///
     /// ```rust
-    /// use sov_universal_wallet::schema::Schema;
-    /// use sov_universal_wallet::schema::safe_string::SafeString;
+    /// use sov_modules_api::sov_universal_wallet::schema::safe_string::SafeString;
+    /// use sov_modules_api::sov_universal_wallet::schema::Schema;
     /// use sov_modules_api::macros::UniversalWallet;
     /// #[derive(UniversalWallet, borsh::BorshSerialize)]
     /// pub enum CallMessage {
@@ -772,7 +774,8 @@ pub mod macros {
     ///   to `template_override_ty`.
     ///
     /// ```rust
-    /// use sov_rollup_interface::sov_universal_wallet::{schema::Schema, UniversalWallet};
+    /// use sov_modules_api::macros::UniversalWallet;
+    /// use sov_modules_api::sov_universal_wallet::schema::Schema;
     ///
     /// /// A foreign module
     /// mod foreign {
@@ -823,7 +826,7 @@ pub mod macros {
     /// use `#[sov_wallet(hidden)]` instead.
     ///
     /// ```rust
-    /// use sov_universal_wallet::schema::Schema;
+    /// use sov_modules_api::sov_universal_wallet::schema::Schema;
     /// use sov_modules_api::macros::UniversalWallet;
     /// #[derive(UniversalWallet, borsh::BorshSerialize)]
     /// pub struct File {
@@ -841,7 +844,7 @@ pub mod macros {
     /// Causes the tag of an enum to be skipped when displaying from its human-readable representation.
     ///
     /// ```rust
-    /// use sov_universal_wallet::schema::Schema;
+    /// use sov_modules_api::sov_universal_wallet::schema::Schema;
     /// use sov_modules_api::macros::UniversalWallet;
     /// #[derive(UniversalWallet, borsh::BorshSerialize)]
     /// #[sov_wallet(hide_tag)]
@@ -864,7 +867,7 @@ pub mod macros {
     /// This annotation may only be applied to fields, not items. The field must have type `[u8;N]` or `Vec<u8>` to use this attribute.
     ///
     /// ```rust
-    /// use sov_universal_wallet::schema::Schema;
+    /// use sov_modules_api::sov_universal_wallet::schema::Schema;
     /// use sov_modules_api::macros::UniversalWallet;
     ///
     /// fn prefix() -> &'static str {

--- a/crates/module-system/sov-modules-api/src/runtime/mod.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/mod.rs
@@ -84,7 +84,7 @@ pub trait Runtime<S: Spec>:
     + 'static
 {
     /// Chain root hash used for transaction verification. Generated from a
-    /// [schema](sov_rollup_interface::sov_universal_wallet::schema::Schema).
+    /// [schema](crate::sov_universal_wallet::schema::Schema).
     const CHAIN_HASH: [u8; 32];
 
     /// GenesisConfig type.
@@ -195,7 +195,7 @@ pub trait Runtime<S: Spec>:
     + 'static
 {
     /// Chain root hash used for transaction verification. Generated from a
-    /// [schema](sov_rollup_interface::sov_universal_wallet::schema::Schema).
+    /// [schema](crate::sov_universal_wallet::schema::Schema).
     const CHAIN_HASH: [u8; 32];
 
     /// `GenesisConfig` type.

--- a/crates/module-system/sov-modules-api/src/transaction/data.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/data.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 use borsh::{BorshDeserialize, BorshSerialize};
 use derive_more::{From, Into};
 use serde::{Deserialize, Serialize};
+use sov_universal_wallet::UniversalWallet;
 
 use crate::{Amount, BasicGasMeter, Gas, GasArray, Spec};
 
@@ -27,7 +28,7 @@ use crate::{Amount, BasicGasMeter, Gas, GasArray, Spec};
     Eq,
     PartialOrd,
     Ord,
-    sov_rollup_interface::sov_universal_wallet::UniversalWallet,
+    UniversalWallet,
 )]
 pub struct PriorityFeeBips(pub u64);
 
@@ -89,7 +90,7 @@ impl PriorityFeeBips {
     borsh::BorshSerialize,
     serde::Serialize,
     serde::Deserialize,
-    sov_rollup_interface::sov_universal_wallet::UniversalWallet,
+    UniversalWallet,
 )]
 #[serde(bound = "S: Spec")]
 pub struct TxDetails<S: Spec> {

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -12,9 +12,9 @@ pub use rewards::{ProverReward, RemainingFunds, SequencerReward, TransactionCons
 #[cfg(feature = "native")]
 pub use sov_rollup_interface::crypto::PrivateKey;
 use sov_rollup_interface::crypto::{SigVerificationError, Signature};
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
 use sov_rollup_interface::zk::CryptoSpec;
 use sov_rollup_interface::TxHash;
+use sov_universal_wallet::UniversalWallet;
 use sov_universal_wallet::schema::UniversalWallet;
 use thiserror::Error;
 pub use types::{

--- a/crates/module-system/sov-modules-api/src/transaction/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/mod.rs
@@ -14,8 +14,8 @@ pub use sov_rollup_interface::crypto::PrivateKey;
 use sov_rollup_interface::crypto::{SigVerificationError, Signature};
 use sov_rollup_interface::zk::CryptoSpec;
 use sov_rollup_interface::TxHash;
-use sov_universal_wallet::UniversalWallet;
 use sov_universal_wallet::schema::UniversalWallet;
+use sov_universal_wallet::UniversalWallet;
 use thiserror::Error;
 pub use types::{
     v0::Version0,

--- a/crates/module-system/sov-modules-api/src/transaction/types/v0.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/types/v0.rs
@@ -1,6 +1,6 @@
 use crate::transaction::data::TxDetails;
 use derivative::Derivative;
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
+use sov_universal_wallet::UniversalWallet;
 
 use crate::capabilities::{AuthenticationError, AuthorizationData, UniquenessData};
 use crate::transaction::{hex_field_format, Credentials, Transaction, TransactionCallable};
@@ -32,9 +32,7 @@ pub struct Version0<Call, S: Spec, C: CryptoSpecExt = <S as Spec>::CryptoSpec> {
     #[sov_wallet(display = "hex")]
     pub pub_key: C::PublicKey,
     /// The runtime call of the transaction.
-    #[sov_wallet(
-        bound = "Call: sov_rollup_interface::sov_universal_wallet::schema::UniversalWallet"
-    )]
+    #[sov_wallet(bound = "Call: sov_universal_wallet::schema::UniversalWallet")]
     pub runtime_call: Call,
     /// Uniqueness identifier of this transaction. see [`UniquenessData`] for more details.
     pub uniqueness: UniquenessData,

--- a/crates/module-system/sov-modules-api/src/transaction/types/v1.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/types/v1.rs
@@ -6,8 +6,8 @@ use derivative::Derivative;
 use sov_rollup_interface::common::SafeVec;
 #[cfg(feature = "native")]
 pub use sov_rollup_interface::crypto::PrivateKey;
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
 use sov_rollup_interface::zk::CryptoSpec;
+use sov_universal_wallet::UniversalWallet;
 
 /// The maximum number of signers allowed in a multisig.
 pub const MAX_SIGNERS: usize = 21;
@@ -78,9 +78,7 @@ pub struct Version1<Call, S: Spec, C: CryptoSpecExt = <S as Spec>::CryptoSpec> {
     // This is used to compute the credential ID statelessly.
     pub min_signers: u8,
     /// The runtime call of the transaction.
-    #[sov_wallet(
-        bound = "Call: sov_rollup_interface::sov_universal_wallet::schema::UniversalWallet"
-    )]
+    #[sov_wallet(bound = "Call: sov_universal_wallet::schema::UniversalWallet")]
     pub runtime_call: Call,
     /// Uniqueness identifier of this transaction. see [`UniquenessData`] for more details.
     pub uniqueness: UniquenessData,

--- a/crates/module-system/sov-modules-api/src/transaction/unsigned.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/unsigned.rs
@@ -1,8 +1,8 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sov_rollup_interface::common::SafeVec;
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
 use sov_rollup_interface::zk::CryptoSpec;
+use sov_universal_wallet::UniversalWallet;
 
 use crate::{
     capabilities::UniquenessData,

--- a/crates/module-system/sov-state/Cargo.toml
+++ b/crates/module-system/sov-state/Cargo.toml
@@ -25,6 +25,7 @@ serde = { workspace = true, features = ["rc"] }
 derive_more = { workspace = true }
 serde-big-array = "0.5.1"
 sov-rollup-interface = { workspace = true }
+sov-universal-wallet = { workspace = true, features = ["macros"] }
 sov-db = { workspace = true, optional = true }
 hex = { workspace = true }
 jmt = { workspace = true, features = ["std", "sha2"] }

--- a/crates/module-system/sov-state/src/namespaces.rs
+++ b/crates/module-system/sov-state/src/namespaces.rs
@@ -2,7 +2,7 @@
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
+use sov_universal_wallet::UniversalWallet;
 
 #[derive(
     Clone,

--- a/crates/module-system/sov-state/src/storage.rs
+++ b/crates/module-system/sov-state/src/storage.rs
@@ -7,10 +7,10 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use jmt::KeyHash;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use sov_universal_wallet::UniversalWallet;
 #[cfg(feature = "native")]
 use sov_rollup_interface::common::{RollupHeight, SlotNumber};
 use sov_rollup_interface::reexports::digest::{typenum, Digest};
+use sov_universal_wallet::UniversalWallet;
 
 use crate::codec::EncodeLike;
 use crate::namespaces::{ProvableCompileTimeNamespace, ProvableNamespace};

--- a/crates/module-system/sov-state/src/storage.rs
+++ b/crates/module-system/sov-state/src/storage.rs
@@ -7,10 +7,10 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use jmt::KeyHash;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use sov_universal_wallet::UniversalWallet;
 #[cfg(feature = "native")]
 use sov_rollup_interface::common::{RollupHeight, SlotNumber};
 use sov_rollup_interface::reexports::digest::{typenum, Digest};
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
 
 use crate::codec::EncodeLike;
 use crate::namespaces::{ProvableCompileTimeNamespace, ProvableNamespace};

--- a/crates/module-system/sov-state/src/storage_internals.rs
+++ b/crates/module-system/sov-state/src/storage_internals.rs
@@ -7,8 +7,8 @@ use derivative::Derivative;
 use jmt::SimpleHasher;
 use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;
-use sov_universal_wallet::UniversalWallet;
 use sov_rollup_interface::reexports::digest::Digest;
+use sov_universal_wallet::UniversalWallet;
 
 use crate::{MerkleProofSpec, ProvableNamespace, StateRoot};
 /// Combined root hash of the user and kernel namespaces. The user root hash is the first 32 bytes, whereas the

--- a/crates/module-system/sov-state/src/storage_internals.rs
+++ b/crates/module-system/sov-state/src/storage_internals.rs
@@ -7,8 +7,8 @@ use derivative::Derivative;
 use jmt::SimpleHasher;
 use serde::{Deserialize, Serialize};
 use serde_big_array::BigArray;
+use sov_universal_wallet::UniversalWallet;
 use sov_rollup_interface::reexports::digest::Digest;
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
 
 use crate::{MerkleProofSpec, ProvableNamespace, StateRoot};
 /// Combined root hash of the user and kernel namespaces. The user root hash is the first 32 bytes, whereas the
@@ -130,7 +130,7 @@ pub struct SparseMerkleProof<H: SimpleHasher>(
 // However, since they only appear in the Schema (which isn't Rust code), Rustc doesn't know that.
 #[allow(dead_code)]
 mod wallet_placeholders {
-    use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
+    use sov_universal_wallet::UniversalWallet;
     #[derive(UniversalWallet)]
     pub struct MerkleDisplayPlaceholder {
         leaf: Option<SparseMerkleLeafNodePlacholder>,

--- a/crates/rollup-interface/src/common/hex_string.rs
+++ b/crates/rollup-interface/src/common/hex_string.rs
@@ -3,11 +3,10 @@ use std::str::FromStr;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::ser::SerializeSeq;
+use sov_universal_wallet::UniversalWallet;
 
 use super::SafeVec;
-use crate as sov_rollup_interface;
 use crate::da::BlockHashTrait;
-use crate::sov_universal_wallet::UniversalWallet; // Needed for UniversalWallet, as it requires global paths
 
 /// A [`hex`]-encoded 32-byte hash. Note, this is not necessarily a transaction
 /// hash, rather a generic hash.

--- a/crates/rollup-interface/src/common/slot_numbering.rs
+++ b/crates/rollup-interface/src/common/slot_numbering.rs
@@ -2,10 +2,6 @@ use std::ops::{Deref, DerefMut};
 
 use sov_universal_wallet::UniversalWallet;
 
-// Needed for UniversalWallet derive macro because we are inside the
-// sov_rollup_interface crate.
-use crate as sov_rollup_interface;
-
 /// Uniquely identifies a slot **within the canonical DA fork**.
 ///
 /// Slots across reorgs can have the same [`SlotNumber`].

--- a/crates/rollup-interface/src/lib.rs
+++ b/crates/rollup-interface/src/lib.rs
@@ -11,8 +11,6 @@ pub use state_machine::*;
 #[cfg(feature = "native")]
 pub mod node;
 
-pub use sov_universal_wallet;
-
 /// Useful third-party crate re-exports.
 pub mod reexports {
     pub use {anyhow, digest, schemars};

--- a/crates/rollup-interface/src/state_machine/crypto/mod.rs
+++ b/crates/rollup-interface/src/state_machine/crypto/mod.rs
@@ -5,7 +5,6 @@ mod signatures;
 pub use signatures::*;
 use sov_universal_wallet::UniversalWallet;
 
-use crate as sov_rollup_interface; // Needed for UniversalWallet, as it requires global paths
 use crate::common::HexHash;
 
 /// Type that represents an identifier for an authorizer of the transaction.

--- a/crates/rollup-interface/src/state_machine/crypto/signatures.rs
+++ b/crates/rollup-interface/src/state_machine/crypto/signatures.rs
@@ -11,8 +11,7 @@ use sov_universal_wallet::ty::ByteDisplayable;
 use sov_universal_wallet::UniversalWallet;
 
 use super::CredentialId;
-use crate as sov_rollup_interface;
-use crate::common::SafeString; // Needed for UniversalWallet, as it requires global paths
+use crate::common::SafeString;
 
 /// Representation of a signature verification error.
 #[derive(Debug, Display)]

--- a/crates/rollup-interface/src/state_machine/da.rs
+++ b/crates/rollup-interface/src/state_machine/da.rs
@@ -8,7 +8,6 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sov_universal_wallet::UniversalWallet;
 
-use crate as sov_rollup_interface; // Needed for UniversalWallet, as it requires global paths
 use crate::BasicAddress;
 
 /// The blob hash type of a given [`DaSpec`].

--- a/crates/rollup-interface/src/state_machine/optimistic.rs
+++ b/crates/rollup-interface/src/state_machine/optimistic.rs
@@ -3,7 +3,6 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use sov_universal_wallet::UniversalWallet;
 
-use crate as sov_rollup_interface; // Needed for UniversalWallet, as it requires global paths
 use crate::common::SlotNumber;
 use crate::da::DaSpec;
 use crate::zk::StateTransitionPublicData;

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -16,7 +16,6 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sov_universal_wallet::UniversalWallet;
 
-use crate as sov_rollup_interface; // Needed for UniversalWallet, as it requires global paths
 use crate::crypto::{PublicKey, Signature};
 use crate::da::{DaSpec, RelevantBlobs, RelevantProofs};
 

--- a/crates/universal-wallet/macros/src/lib.rs
+++ b/crates/universal-wallet/macros/src/lib.rs
@@ -6,8 +6,8 @@ pub fn derive_wallet(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let result = sov_universal_wallet_macro_helpers::schema::derive(
         input,
-        Some(syn::parse_quote! { sov_rollup_interface }),
-        syn::parse_quote! { sov_rollup_interface::sov_universal_wallet::UniversalWallet },
+        None,
+        syn::parse_quote! { sov_universal_wallet::UniversalWallet },
     );
     handle_macro_error_and_expand(result.map(Into::into))
 }

--- a/crates/universal-wallet/schema/src/lib.rs
+++ b/crates/universal-wallet/schema/src/lib.rs
@@ -1,4 +1,5 @@
 mod visitors;
+extern crate self as sov_universal_wallet;
 pub use visitors::display;
 #[cfg(feature = "serde")]
 pub use visitors::json_to_borsh;
@@ -35,10 +36,8 @@ pub extern crate bech32;
 /// This annotation may only be applied to fields, not items.
 ///
 /// ```rust
-/// # pub extern crate sov_universal_wallet;
-/// # mod sov_rollup_interface { pub use crate::sov_universal_wallet; }
-/// use sov_rollup_interface::sov_universal_wallet::schema::{Schema, safe_string::SafeString};
-/// use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
+/// use sov_universal_wallet::schema::{Schema, safe_string::SafeString};
+/// use sov_universal_wallet::UniversalWallet;
 ///
 /// #[derive(UniversalWallet, borsh::BorshSerialize)]
 /// pub struct Unreadable {
@@ -63,9 +62,7 @@ pub extern crate bech32;
 /// or when you want to override the default schema for a type in a particular context.
 ///
 /// ```rust
-/// # pub extern crate sov_universal_wallet;
-/// # mod sov_rollup_interface { pub use crate::sov_universal_wallet; }
-/// use sov_rollup_interface::sov_universal_wallet::{schema::Schema, UniversalWallet};
+/// use sov_universal_wallet::{schema::Schema, UniversalWallet};
 ///
 /// // A foreign type that doesn't derive UniversalWallet
 /// #[derive(borsh::BorshSerialize)]
@@ -88,9 +85,7 @@ pub extern crate bech32;
 /// use `#[sov_wallet(hidden)]` instead.
 ///
 /// ```rust
-/// # pub extern crate sov_universal_wallet;
-/// # mod sov_rollup_interface { pub use crate::sov_universal_wallet; }
-/// use sov_rollup_interface::sov_universal_wallet::{schema::Schema, UniversalWallet};
+/// use sov_universal_wallet::{schema::Schema, UniversalWallet};
 /// #[derive(UniversalWallet, borsh::BorshSerialize)]
 /// pub struct File {
 ///     #[borsh(skip)]
@@ -113,9 +108,7 @@ pub extern crate bech32;
 ///    fixed-point number.
 ///
 /// ```rust
-/// # pub extern crate sov_universal_wallet;
-/// # mod sov_rollup_interface { pub use crate::sov_universal_wallet; }
-/// use sov_rollup_interface::sov_universal_wallet::{schema::Schema, UniversalWallet};
+/// use sov_universal_wallet::{schema::Schema, UniversalWallet};
 /// #[derive(UniversalWallet, borsh::BorshSerialize)]
 /// pub struct Coins {
 ///     #[sov_wallet(fixed_point(from_field(1)))]
@@ -146,9 +139,7 @@ pub extern crate bech32;
 /// This annotation may only be applied to fields, not items. The field must have type `[u8;N]` or `Vec<u8>` to use this attribute.
 ///
 /// ```rust
-/// # pub extern crate sov_universal_wallet;
-/// # mod sov_rollup_interface { pub use crate::sov_universal_wallet; }
-/// use sov_rollup_interface::sov_universal_wallet::{schema::Schema, UniversalWallet};
+/// use sov_universal_wallet::{schema::Schema, UniversalWallet};
 ///
 /// fn prefix() -> &'static str {
 ///   "celestia"

--- a/crates/universal-wallet/schema/tests/integration/eip712.rs
+++ b/crates/universal-wallet/schema/tests/integration/eip712.rs
@@ -5,8 +5,6 @@ use sov_universal_wallet::schema::safe_string::SafeString;
 use sov_universal_wallet::schema::Schema;
 use sov_universal_wallet::UniversalWallet;
 
-use crate::sov_rollup_interface;
-
 #[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]
 struct Address([u8; 32]);
 #[derive(BorshSerialize, BorshDeserialize, UniversalWallet)]

--- a/crates/universal-wallet/schema/tests/integration/main.rs
+++ b/crates/universal-wallet/schema/tests/integration/main.rs
@@ -1,9 +1,2 @@
 mod eip712;
 mod schema;
-
-// Hack - because the macro is configured to be re-exported from sov_rollup_interface;
-// but _we_ are a dependency of sov_rollup_interface so we can't import it without causing a cycle
-// This should not be an issue anywhere else except inside this crate's tests right here
-mod sov_rollup_interface {
-    pub use sov_universal_wallet;
-}

--- a/crates/universal-wallet/schema/tests/integration/schema.rs
+++ b/crates/universal-wallet/schema/tests/integration/schema.rs
@@ -12,9 +12,6 @@ use sov_universal_wallet::schema::{
 };
 use sov_universal_wallet::UniversalWallet;
 
-// The fake sov_rollup_interface for fixing macro namespacing
-use crate::sov_rollup_interface;
-
 #[derive(Debug, Serialize)]
 struct TestVector {
     /// The JSON object to be serialized to borsh

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -4263,6 +4263,7 @@ dependencies = [
  "sov-metrics",
  "sov-modules-macros",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "tendermint",
  "tendermint-proto",
  "thiserror 2.0.18",
@@ -4295,6 +4296,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sov-rollup-interface",
+ "sov-universal-wallet",
 ]
 
 [[package]]
@@ -4412,6 +4414,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "tracing",
  "url",
 ]
@@ -4430,6 +4433,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "thiserror 2.0.18",
 ]
 
@@ -4585,6 +4589,7 @@ dependencies = [
  "sha2 0.10.9",
  "sov-metrics",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "sov-zkvm-utils",
  "thiserror 2.0.18",
  "tracing",
@@ -4660,6 +4665,7 @@ dependencies = [
  "sov-metrics",
  "sov-modules-macros",
  "sov-rollup-interface",
+ "sov-universal-wallet",
 ]
 
 [[package]]

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -3583,6 +3583,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sov-rollup-interface",
+ "sov-universal-wallet",
 ]
 
 [[package]]
@@ -3699,6 +3700,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "tracing",
  "url",
 ]
@@ -3717,6 +3719,7 @@ dependencies = [
  "serde",
  "sha2",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "thiserror 2.0.18",
 ]
 
@@ -3872,6 +3875,7 @@ dependencies = [
  "sha2",
  "sov-metrics",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "sov-zkvm-utils",
  "thiserror 2.0.18",
  "tracing",
@@ -3947,6 +3951,7 @@ dependencies = [
  "sov-metrics",
  "sov-modules-macros",
  "sov-rollup-interface",
+ "sov-universal-wallet",
 ]
 
 [[package]]

--- a/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
@@ -5989,6 +5989,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sov-rollup-interface",
+ "sov-universal-wallet",
 ]
 
 [[package]]
@@ -6083,6 +6084,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "tracing",
  "url",
 ]
@@ -6101,6 +6103,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "thiserror 2.0.18",
 ]
 
@@ -6301,6 +6304,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "sov-zkvm-utils",
  "sp1-lib",
  "sp1-sdk",
@@ -6326,6 +6330,7 @@ dependencies = [
  "sov-metrics",
  "sov-modules-macros",
  "sov-rollup-interface",
+ "sov-universal-wallet",
 ]
 
 [[package]]

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -6254,6 +6254,7 @@ dependencies = [
  "sov-metrics",
  "sov-modules-macros",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "tendermint",
  "tendermint-proto",
  "thiserror 2.0.18",
@@ -6286,6 +6287,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sov-rollup-interface",
+ "sov-universal-wallet",
 ]
 
 [[package]]
@@ -6401,6 +6403,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "tracing",
  "url",
 ]
@@ -6419,6 +6422,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "thiserror 2.0.18",
 ]
 
@@ -6619,6 +6623,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "sov-zkvm-utils",
  "sp1-lib",
  "sp1-sdk",
@@ -6644,6 +6649,7 @@ dependencies = [
  "sov-metrics",
  "sov-modules-macros",
  "sov-rollup-interface",
+ "sov-universal-wallet",
 ]
 
 [[package]]

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -5912,6 +5912,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sov-rollup-interface",
+ "sov-universal-wallet",
 ]
 
 [[package]]
@@ -6027,6 +6028,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "tracing",
  "url",
 ]
@@ -6045,6 +6047,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "thiserror 2.0.18",
 ]
 
@@ -6245,6 +6248,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "sov-rollup-interface",
+ "sov-universal-wallet",
  "sov-zkvm-utils",
  "sp1-lib",
  "sp1-sdk",
@@ -6270,6 +6274,7 @@ dependencies = [
  "sov-metrics",
  "sov-modules-macros",
  "sov-rollup-interface",
+ "sov-universal-wallet",
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Opinionated fix: changes the default macro exported from `sov-universal-wallet` to expand crate paths to `::sov_universal_wallet` rather than `::sov_rollup_interface::sov_universal_wallet`. This makes the default macro usable standalone and decouples `sov_universal_wallet` from the SDK.

Most user-facing rollup code will be using the re-export from `sov_modules_api::macros::UniversalWallet`, which is unaffected. What _is_ affected is what was previously a re-export from `sov-rollup-interface`. This PR makes the choice to simply drop the re-export: most internal crates (i.e. rollup-interface itself, sov-modules-api internally, and adapter crates) now explicitly depend upon `sov-universal-wallet` rather importing it from rollup-interface.

An alternative would be to have _three_ separate macro definitions: a standalone one, the sov_modules_api one and a separate re-export for rollup-interface. The cleanest way to do that would probably be to have sov-rollup-interface define its own macro. This would reduce the diff significantly here, but IMO it's not worth it for internal crates: the UniversalWallet macro should conceptually work standalone, so internal crates should be fine importing it standalone.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
