### PR TITLE
Cleaning up dependencies with cargo-machette

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -46,9 +46,6 @@ runs:
     - uses: taiki-e/install-action@nextest
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
-    - uses: taiki-e/install-action@machete
-      env:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
     - uses: taiki-e/install-action@cargo-llvm-cov
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -46,6 +46,9 @@ runs:
     - uses: taiki-e/install-action@nextest
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
+    - uses: taiki-e/install-action@machete
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
     - uses: taiki-e/install-action@cargo-llvm-cov
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11555,7 +11555,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sov-rollup-interface",
  "sov-universal-wallet",
 ]
 
@@ -12784,7 +12783,6 @@ dependencies = [
  "hex",
  "insta",
  "jsonrpsee",
- "num_cpus",
  "proptest",
  "rand 0.8.5",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,6 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
- "borsh",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,10 +185,8 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
- "arbitrary",
  "derive_more 2.0.1",
  "itoa",
- "proptest",
  "serde",
  "serde_json",
  "winnow 0.7.13",
@@ -262,23 +260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-evm"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428b58c17ab5f9f71765dc5f116acb6580f599ce243b8ce391de3ba859670c61"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-hardforks",
- "alloy-primitives",
- "alloy-sol-types",
- "auto_impl",
- "derive_more 2.0.1",
- "revm",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "alloy-genesis"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,19 +271,6 @@ dependencies = [
  "alloy-trie",
  "serde",
  "serde_with",
-]
-
-[[package]]
-name = "alloy-hardforks"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e29d7eacf42f89c21d7f089916d0bdb4f36139a31698790e8837d2dbbd4b2c3"
-dependencies = [
- "alloy-chains",
- "alloy-eip2124",
- "alloy-primitives",
- "auto_impl",
- "dyn-clone",
 ]
 
 [[package]]
@@ -3620,14 +3588,12 @@ dependencies = [
  "anyhow",
  "borsh",
  "demo-stf-declaration",
- "schemars 1.2.1",
  "serde",
  "serde_json",
  "sov-accounts",
  "sov-address",
  "sov-attester-incentives",
  "sov-bank",
- "sov-blob-storage",
  "sov-build",
  "sov-capabilities",
  "sov-chain-state",
@@ -3641,7 +3607,6 @@ dependencies = [
  "sov-operator-incentives",
  "sov-paymaster",
  "sov-prover-incentives",
- "sov-revenue-share",
  "sov-rollup-apis",
  "sov-rollup-interface",
  "sov-sequencer-registry",
@@ -3650,7 +3615,6 @@ dependencies = [
  "sov-synthetic-load",
  "sov-test-modules",
  "sov-test-utils",
- "sov-uniqueness",
  "tracing",
 ]
 
@@ -3661,8 +3625,6 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "borsh",
- "clap",
- "jsonrpsee",
  "schemars 1.2.1",
  "serde",
  "sov-accounts",
@@ -3670,21 +3632,16 @@ dependencies = [
  "sov-attester-incentives",
  "sov-bank",
  "sov-blob-storage",
- "sov-capabilities",
  "sov-chain-state",
  "sov-evm",
  "sov-hyperlane-integration",
- "sov-kernels",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-operator-incentives",
  "sov-paymaster",
  "sov-prover-incentives",
  "sov-revenue-share",
- "sov-rollup-apis",
- "sov-rollup-interface",
  "sov-sequencer-registry",
- "sov-state",
  "sov-synthetic-load",
  "sov-test-modules",
  "sov-test-utils",
@@ -10033,7 +9990,6 @@ dependencies = [
  "serde",
  "sov-address",
  "sov-modules-api",
- "sov-state",
  "sov-test-utils",
  "strum 0.28.0",
  "thiserror 2.0.18",
@@ -10048,10 +10004,8 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "sov-address",
- "sov-bank",
  "sov-chain-state",
  "sov-modules-api",
- "sov-state",
  "sov-test-utils",
  "strum 0.28.0",
  "thiserror 2.0.18",
@@ -11251,15 +11205,12 @@ dependencies = [
  "demo-stf",
  "serde",
  "serde_json",
- "slop-algebra",
  "sov-mock-da",
  "sov-mock-zkvm",
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-sp1-adapter",
  "sp1",
- "sp1-core-executor",
- "sp1-recursion-executor",
  "sp1-sdk",
 ]
 
@@ -11295,7 +11246,6 @@ dependencies = [
  "derivative",
  "schemars 1.2.1",
  "serde",
- "sov-address",
  "sov-attester-incentives",
  "sov-bank",
  "sov-chain-state",
@@ -11321,7 +11271,6 @@ dependencies = [
  "borsh",
  "derive_more 2.0.1",
  "proptest",
- "proptest-derive 0.5.1",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -11349,8 +11298,6 @@ dependencies = [
  "clap",
  "criterion",
  "demo-stf",
- "derivative",
- "derive_more 2.0.1",
  "futures",
  "humantime",
  "prettytable-rs",
@@ -11358,7 +11305,6 @@ dependencies = [
  "risc0",
  "serde",
  "sov-address",
- "sov-capabilities",
  "sov-db",
  "sov-hyperlane-integration",
  "sov-metrics",
@@ -11366,7 +11312,6 @@ dependencies = [
  "sov-mock-zkvm",
  "sov-modules-api",
  "sov-modules-rollup-blueprint",
- "sov-modules-stf-blueprint",
  "sov-node-client",
  "sov-risc0-adapter",
  "sov-rollup-interface",
@@ -11376,7 +11321,6 @@ dependencies = [
  "sov-test-modules",
  "sov-test-utils",
  "sov-transaction-generator",
- "strum 0.28.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -11391,7 +11335,6 @@ dependencies = [
  "bincode",
  "borsh",
  "derive_more 2.0.1",
- "futures",
  "rockbound",
  "serde",
  "serde_json",
@@ -11441,7 +11384,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "serde",
  "serde_json",
  "sov-modules-api",
 ]
@@ -11505,7 +11447,6 @@ dependencies = [
  "testcontainers",
  "thiserror 2.0.18",
  "tokio",
- "tower 0.5.2",
  "tracing",
  "uuid",
 ]
@@ -11570,7 +11511,6 @@ dependencies = [
  "borsh",
  "byteorder",
  "criterion",
- "derivative",
  "digest 0.10.7",
  "futures",
  "hex",
@@ -11584,7 +11524,6 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "serde_with",
  "sha2 0.10.9",
  "sov-db",
  "sov-db-types",
@@ -11600,7 +11539,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -11672,7 +11610,6 @@ dependencies = [
  "sov-full-node-configs",
  "sov-hyperlane-integration",
  "sov-kernels",
- "sov-metrics",
  "sov-mock-da",
  "sov-mock-zkvm",
  "sov-modules-api",
@@ -11699,7 +11636,6 @@ dependencies = [
  "tempfile",
  "testcontainers",
  "tokio",
- "tokio-stream",
  "tracing",
  "tracing-panic",
  "tracing-subscriber 0.3.20",
@@ -11710,18 +11646,14 @@ name = "sov-demo-rollup-rest-api-load-testing"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
  "demo-stf",
  "rest-api-load-testing",
- "sha2 0.10.9",
  "sov-address",
  "sov-api-spec",
  "sov-bank",
  "sov-cli",
  "sov-demo-rollup",
  "sov-hyperlane-integration",
- "sov-mock-da",
- "sov-mock-zkvm",
  "sov-modules-api",
  "sov-modules-rollup-blueprint",
  "sov-test-utils",
@@ -11734,15 +11666,12 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "derive_more 2.0.1",
  "jsonrpsee",
- "serde",
  "serde_json",
  "sov-address",
  "sov-modules-api",
  "sov-state",
  "sov-universal-wallet",
- "tracing",
 ]
 
 [[package]]
@@ -11762,7 +11691,6 @@ dependencies = [
  "derive_more 2.0.1",
  "futures",
  "jsonrpsee",
- "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sov-cli",
@@ -11779,10 +11707,8 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "arbitrary",
- "rand_chacha 0.3.1",
  "revm",
  "secp256k1 0.30.0",
- "sha2 0.10.9",
  "sov-eth-dev-signer",
  "sov-transaction-generator",
 ]
@@ -11879,8 +11805,6 @@ dependencies = [
  "itertools 0.14.0",
  "jsonrpsee",
  "jsonschema",
- "proptest",
- "rand 0.8.5",
  "revm",
  "revm-database-interface",
  "revm-inspectors",
@@ -11943,10 +11867,8 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "anyhow",
- "arbitrary",
  "async-trait",
  "hex",
- "proptest",
 ]
 
 [[package]]
@@ -12038,7 +11960,6 @@ name = "sov-kernels"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "serde_json",
  "sov-blob-storage",
  "sov-chain-state",
  "sov-modules-api",
@@ -12058,14 +11979,11 @@ dependencies = [
  "borsh",
  "derive_more 2.0.1",
  "futures",
- "hex",
  "insta",
- "openapiv3",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_with",
- "serde_yaml",
  "sov-api-spec",
  "sov-db",
  "sov-mock-da",
@@ -12076,7 +11994,6 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -12098,7 +12015,6 @@ dependencies = [
  "serde",
  "sov-metrics",
  "sp1-lib",
- "strum 0.28.0",
  "tokio",
  "tokio-metrics",
  "toml 0.8.23",
@@ -12155,7 +12071,6 @@ dependencies = [
  "arbitrary",
  "bincode",
  "borsh",
- "digest 0.10.7",
  "ed25519-dalek",
  "hex",
  "rand 0.8.5",
@@ -12288,7 +12203,6 @@ dependencies = [
  "async-trait",
  "borsh",
  "console-subscriber",
- "derivative",
  "futures",
  "hex",
  "openapiv3",
@@ -12324,18 +12238,14 @@ name = "sov-modules-stf-blueprint"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "axum 0.8.8",
  "borsh",
  "hex",
- "jsonrpsee",
- "schemars 1.2.1",
  "serde",
  "sov-metrics",
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
 ]
 
@@ -12363,16 +12273,11 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "derive_more 2.0.1",
  "schemars 1.2.1",
  "serde",
  "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
  "sov-test-utils",
  "strum 0.28.0",
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -12380,13 +12285,9 @@ name = "sov-paymaster"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "arbitrary",
- "bcs",
  "borsh",
  "derivative",
  "derive_more 2.0.1",
- "proptest",
- "proptest-derive 0.5.1",
  "schemars 1.2.1",
  "serde",
  "sov-bank",
@@ -12395,7 +12296,6 @@ dependencies = [
  "sov-paymaster",
  "sov-state",
  "sov-test-utils",
- "sov-universal-wallet",
  "strum 0.28.0",
  "tempfile",
  "tracing",
@@ -12507,10 +12407,8 @@ dependencies = [
  "bincode",
  "borsh",
  "bytemuck",
- "digest 0.10.7",
  "ed25519-dalek",
  "hex",
- "home",
  "jsonschema",
  "proptest",
  "rand 0.8.5",
@@ -12537,17 +12435,11 @@ dependencies = [
  "anyhow",
  "axum 0.8.8",
  "axum-server",
- "base64 0.22.1",
  "borsh",
- "derivative",
- "derive_more 2.0.1",
  "hex",
- "openapiv3",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
- "serde_with",
- "serde_yaml",
  "sov-api-spec",
  "sov-bank",
  "sov-kernels",
@@ -12563,7 +12455,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
- "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -12613,7 +12504,6 @@ name = "sov-rpc-eth-types"
 version = "0.3.0"
 dependencies = [
  "alloy-eips",
- "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types",
  "alloy-serde",
@@ -12641,15 +12531,12 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "borsh",
- "dashmap 6.1.0",
  "derivative",
  "derive_more 2.0.1",
  "flume",
  "futures",
  "hex",
- "jsonrpsee",
  "mini-moka",
- "openapiv3",
  "proptest",
  "proptest-derive 0.5.1",
  "reltester",
@@ -12658,7 +12545,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "serde_yaml",
  "sov-api-spec",
  "sov-blob-sender",
  "sov-blob-storage",
@@ -12693,7 +12579,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber 0.3.20",
- "utoipa-swagger-ui",
  "uuid",
 ]
 
@@ -12730,17 +12615,13 @@ dependencies = [
  "borsh",
  "clap",
  "demo-stf",
- "derivative",
- "rand 0.8.5",
  "reqwest 0.13.3",
  "schemars 1.2.1",
  "serde",
- "sov-address",
  "sov-api-spec",
  "sov-bank",
  "sov-celestia-adapter",
  "sov-db",
- "sov-evm-test-utils",
  "sov-kernels",
  "sov-metrics",
  "sov-mock-da",
@@ -12748,7 +12629,6 @@ dependencies = [
  "sov-modules-api",
  "sov-modules-rollup-blueprint",
  "sov-modules-stf-blueprint",
- "sov-node-client",
  "sov-paymaster",
  "sov-rollup-interface",
  "sov-sequencer",
@@ -12759,7 +12639,6 @@ dependencies = [
  "sov-synthetic-load",
  "sov-test-utils",
  "sov-transaction-generator",
- "sov-value-setter",
  "sp1",
  "strum 0.28.0",
  "tokio",
@@ -12770,11 +12649,8 @@ name = "sov-soak-testing-lib"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "borsh",
  "clap",
  "rand 0.8.5",
- "schemars 1.2.1",
- "serde",
  "sov-api-spec",
  "sov-bank",
  "sov-modules-api",
@@ -12782,7 +12658,6 @@ dependencies = [
  "sov-test-state-consistency",
  "sov-test-utils",
  "sov-transaction-generator",
- "sov-value-setter",
  "tokio",
 ]
 
@@ -12878,11 +12753,9 @@ dependencies = [
  "nomt",
  "nomt-core",
  "proptest",
- "proptest-derive 0.5.1",
  "serde",
  "serde-big-array",
  "serde_json",
- "serde_with",
  "sha2 0.10.9",
  "sov-db",
  "sov-db-types",
@@ -12955,8 +12828,6 @@ dependencies = [
  "sov-address",
  "sov-metrics",
  "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
  "strum 0.28.0",
 ]
 
@@ -12981,7 +12852,6 @@ dependencies = [
  "sov-universal-wallet",
  "strum 0.28.0",
  "tempfile",
- "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -13019,7 +12889,6 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sov-accounts",
- "sov-address",
  "sov-api-spec",
  "sov-attester-incentives",
  "sov-bank",
@@ -13092,6 +12961,7 @@ dependencies = [
  "futures",
  "hex",
  "indexmap 2.14.0",
+ "progenitor-client",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "schemars 1.2.1",
@@ -13179,19 +13049,16 @@ dependencies = [
  "borsh",
  "bs58",
  "darling 0.21.3",
- "hex",
  "proc-macro2",
  "quote",
  "serde_derive_internals",
  "syn 2.0.117",
- "syn_derive",
 ]
 
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
 dependencies = [
- "proc-macro2",
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
 ]
@@ -13206,7 +13073,6 @@ dependencies = [
  "serde",
  "sov-address",
  "sov-modules-api",
- "sov-rollup-interface",
  "sov-state",
  "sov-test-utils",
  "sov-value-setter",
@@ -13241,7 +13107,6 @@ name = "sovereign-web3"
 version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
- "borsh",
  "hex",
  "reqwest 0.13.3",
  "serde",
@@ -14283,18 +14148,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff790eb176cc81bb8936aed0f7b9f14fc4670069a2d371b3e3b0ecce908b2cb3"
 dependencies = [
  "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb066a04799e45f5d582e8fc6ec8e6d6896040d00898eb4e6a835196815b219"
-dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15598,7 +15451,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sov-modules-api",
- "sov-rollup-interface",
  "sov-universal-wallet",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ concread = { version = "0.5.7" }
 
 anyhow = { version = "1.0.95" }
 async-trait = "0.1.81"
-arrayvec = { version = "0.7.6", features = ["serde", "borsh"] }
+arrayvec = "0.7.6"
 console-subscriber = "0.5"
 
 axum = { version = "0.8.8", default-features = false }
@@ -232,12 +232,9 @@ bytes = { version = "1.10", default-features = false }
 convert_case = { version = "0.6", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["now"] }
 darling = "0.21"
-dashmap = "6.1.0"
-delegate = "0.13.4"
 derive-new = "0.7.0"
 derivative = { version = "2.2", features = ["use_core"] }
 digest = { version = "0.10.7", default-features = false, features = ["alloc"] }
-derive-getters = { version = "0.5.0" }
 # Don't forget to upgrade zkVM patches if changing this one.
 ed25519-dalek = { version = "=2.1.1", default-features = false }
 futures = { version = "0.3", default-features = false }
@@ -246,7 +243,6 @@ insta = { version = "1.39", features = ["json"] }
 jsonschema = "0.26.1"
 once_cell = "1.19"
 openapiv3 = "2.0.0"
-prometheus = { version = "0.14", default-features = false }
 proc-macro2 = { version = "1.0" }
 proptest = { version = "1.5", default-features = false, features = ["std", "alloc"] }
 proptest-derive = "0.5.0"
@@ -313,12 +309,10 @@ ethereum-types = { version = "0.14.1", default-features = false }
 alloy = { version = "1.0.41", default-features = false, features = ["std", "essentials"] }
 alloy-serde = { version = "1.1.3", default-features = false }
 alloy-pubsub = { version = "1.0.41", default-features = false }
-alloy-chains = { version = "0.2.14", default-features = false }
 alloy-primitives = { version = "1.4.1", default-features = false }
 alloy-sol-types = { version = "1.4.1", default-features = false }
 alloy-dyn-abi = { version = "1.4.1", default-features = false }
 alloy-eips = { version = "1.1.0", default-features = false }
-alloy-evm = { version = "0.23.1", default-features = false }
 alloy-consensus = { version = "1.1.0", default-features = false }
 alloy-contract = { version = "1.0.41", default-features = false }
 alloy-transport = { version = "1.0.41", default-features = false }
@@ -335,10 +329,6 @@ alloy-rlp = { version = "0.3.12", default-features = false }
 reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0", default-features = false }
 revm = { version = "31.0.0", features = ["serde"], default-features = false }
 revm-database-interface = { version = "8.0.4", default-features = false }
-revm-context = { version = "11.0.0", default-features = false }
-revm-handler = { version = "12.0.0", default-features = false }
-revm-context-interface = { version = "12.0.0", default-features = false }
-revm-inspector = { version = "12.0.0", default-features = false }
 revm-inspectors = { version = "0.32.0", default-features = false }
 secp256k1 = { version = "=0.30.0", default-features = false, features = [
     "global-context",

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ install-dev-tools: install-cargo-tools install-risc0-toolchain install-sp1-toolc
 	cp .vscode/settings.default.json .vscode/settings.json
 	cargo install cargo-llvm-cov
 	cargo install cargo-hack
-	cargo install cargo-udeps
+	cargo install cargo-machete
 	cargo install cargo-deny
 	cargo install flaky-finder
 	cargo install cargo-insta
@@ -106,7 +106,7 @@ install-dev-tools: install-cargo-tools install-risc0-toolchain install-sp1-toolc
 install-cargo-tools:  ## Installs all necessary cargo helpers
 	cargo install cargo-llvm-cov
 	cargo install cargo-hack
-	cargo install cargo-udeps
+	cargo install cargo-machete
 	cargo install cargo-deny
 	cargo install flaky-finder
 	cargo install cargo-insta

--- a/crates/adapters/avail/Cargo.toml
+++ b/crates/adapters/avail/Cargo.toml
@@ -27,7 +27,6 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 tokio = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["fmt"] }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/crates/adapters/celestia/Cargo.toml
+++ b/crates/adapters/celestia/Cargo.toml
@@ -44,7 +44,6 @@ serde_json = { workspace = true, features = ["alloc"] }
 
 thiserror = { workspace = true }
 tokio = { workspace = true, optional = true, features = ["sync"] }
-tower = { workspace = true, optional = true }
 tracing = { workspace = true }
 # Used by the checker.
 rand = { workspace = true, optional = true }
@@ -72,7 +71,7 @@ risc0-zkvm-platform = { workspace = true }
 bincode = { workspace = true }
 rand = { workspace = true, features = ["small_rng"] }
 testcontainers = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
+uuid = { workspace = true, features = ["v4", "arbitrary"] }
 
 [features]
 default = []
@@ -86,7 +85,6 @@ native = [
     "sov-rollup-interface/native",
     "dep:sov-metrics",
     "sov-metrics/native",
-    "dep:tower",
     "sov-modules-macros?/native",
     "dep:rand",
 ]

--- a/crates/adapters/mock-zkvm/Cargo.toml
+++ b/crates/adapters/mock-zkvm/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true }
-digest = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true }
 sov-rollup-interface = { workspace = true }

--- a/crates/adapters/risc0/Cargo.toml
+++ b/crates/adapters/risc0/Cargo.toml
@@ -18,7 +18,6 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 bincode = { workspace = true }
 borsh = { workspace = true, features = ["derive"] }
 bytemuck = "1.17.0"
-digest = { workspace = true, features = ["alloc"] }
 ed25519-dalek = { workspace = true, features = ["serde", "alloc"] }
 hex = { workspace = true }
 proptest = { workspace = true, features = ["alloc", "std"], optional = true }
@@ -33,7 +32,6 @@ serde = { workspace = true, features = [
 
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-home = { version = "=0.5.9", optional = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 
@@ -59,7 +57,6 @@ native = [
     "sov-metrics?/native",
     "risc0-zkvm/prove",
     "sov-rollup-interface/native",
-    "home",
     "sov-risc0-adapter/native"
 ]
 bench = [

--- a/crates/adapters/sp1/Cargo.toml
+++ b/crates/adapters/sp1/Cargo.toml
@@ -63,6 +63,10 @@ native = [
     "sov-metrics/native",
     "sov-sp1-adapter/native",
 ]
+bench = [
+    "sov-metrics",
+    "sov-sp1-adapter/bench",
+]
 arbitrary = [
     "dep:arbitrary",
     "dep:proptest",

--- a/crates/adapters/sp1/fibonacci-program/Cargo.lock
+++ b/crates/adapters/sp1/fibonacci-program/Cargo.lock
@@ -1046,9 +1046,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-algebra"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691beea96fd18d4881f9ca1cb4e58194dac6366f24956a2fdae00c8ee382a0c9"
+checksum = "733912d564a68ff209707e71fdc517d4ff82d4362b6a409f6a8241dfcb7a576a"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -1057,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1852499c245f7f3dec23408b4930b3ea7570ae914b9c31f12950ac539d85ee"
+checksum = "a71b23ede427299e139fb822c5d0ea8fb931dc297eba0c6e2f30f774c04ebc81"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -1073,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4349af93602f3876a3eda948a74d9d16d774c401dfe25f41a45ffd84f230bc1"
+checksum = "59e4993210936ab317c0d56ee8257e1cdfe6c2fae4df1e158737f034e21d45f9"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574784c044d11cf9d8238dc18bce9b897bc34d0fb1daaceafd75ebb400084016"
+checksum = "8986e94b9a43d58fc8ce5bf111b0985479ab888ced923e3052fb19943f7859b4"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -1101,36 +1101,36 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af617970b63e8d7199204bc02996745b6c35c39f2b513a118c62c7b1a0b2f1b"
+checksum = "5b06e4a24cba104a0a39740eedd97e60e8896926cc38e6a58d5866cc9811affa"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d82c53508f3ebff8acdabb5db2584f37686257a2549a17c977cf30cd9e24e6"
+checksum = "0b0b66701c82f6aab97f4990b5d9ed7463beb5b5042dbe5eda5f6c71a6207b35"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-symmetric"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15acfa7f567ffa4f36de134492632a397c33fa6af2e48894e50978b52eeeb871"
+checksum = "e6d159948b924fd00f280064d7a049e43dceb2f26067f32fb99570d3169969ee"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "sp1-lib"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517e820776910468611149dda66791bdb700c1b7d68b96f0ea2e604f00ad8771"
+checksum = "9b96392c1b1c197beaa6b0806099a8d73643a09d5ac0874e26c9c5153a7fcb4c"
 dependencies = [
  "bincode",
  "serde",
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f395525b4fc46d37136f45be264c81718a67f4409c14c547ff491a263e019e7"
+checksum = "b6b77098dae9d62e080be3af253188c08e7e96e666423306654eede0110bf363"
 dependencies = [
  "bincode",
  "blake3",
@@ -1163,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45aa8c53b0332dcce1f588185df97e8ed9e7a6b37b0c6584f29674017628831f"
+checksum = "d31a7c3f072f248342284031684c9195e2264422964129c3b8652f9196ecc937"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/crates/full-node/sov-api-spec/Cargo.toml
+++ b/crates/full-node/sov-api-spec/Cargo.toml
@@ -12,6 +12,9 @@ repository.workspace = true
 [lints]
 workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["chrono", "regress", "reqwest"]
+
 [dependencies]
 openapiv3 = { workspace = true }
 sov-modules-api = { workspace = true, features = ["native"] }

--- a/crates/full-node/sov-blob-sender/Cargo.toml
+++ b/crates/full-node/sov-blob-sender/Cargo.toml
@@ -18,7 +18,6 @@ async-trait = { workspace = true }
 bincode = { workspace = true }
 borsh = { workspace = true }
 derive_more = { workspace = true }
-futures = { workspace = true }
 rockbound = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -28,10 +27,13 @@ sov-modules-api = { workspace = true, features = ["native"] }
 sov-db = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt"] }
 tracing = { workspace = true }
-uuid = { workspace = true, features = ["v7"] }
+uuid = { workspace = true, features = ["std", "v7"] }
 
 [dev-dependencies]
 sov-mock-da = { workspace = true, features = ["native"] }
 tempfile = { workspace = true }
 sov-test-utils = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["bincode"]

--- a/crates/full-node/sov-db-types/Cargo.toml
+++ b/crates/full-node/sov-db-types/Cargo.toml
@@ -9,7 +9,6 @@ publish.workspace = true
 repository.workspace = true
 
 [dependencies]
-sov-rollup-interface = { workspace = true }
 sov-universal-wallet = { workspace = true, features = ["macros"] }
 borsh = { workspace = true, features = ["rc"] }
 digest = { workspace = true }
@@ -32,13 +31,11 @@ workspace = true
 default = []
 native = [
 	"dep:rockbound",
-	"sov-rollup-interface/native"
 ]
 arbitrary = [
 	"dep:arbitrary",
 	"dep:proptest",
 	"dep:proptest-derive",
-	"sov-rollup-interface/arbitrary",
 	"rockbound?/arbitrary"
 ]
 

--- a/crates/full-node/sov-db-types/Cargo.toml
+++ b/crates/full-node/sov-db-types/Cargo.toml
@@ -41,3 +41,6 @@ arbitrary = [
 	"sov-rollup-interface/arbitrary",
 	"rockbound?/arbitrary"
 ]
+
+[package.metadata.cargo-machete]
+ignored = ["proptest"]

--- a/crates/full-node/sov-db/Cargo.toml
+++ b/crates/full-node/sov-db/Cargo.toml
@@ -39,9 +39,6 @@ hex = { workspace = true }
 tracing = { workspace = true }
 rand = { workspace = true, optional = true }
 schemars = { workspace = true }
-uuid = { workspace = true, features = ["std", "v7"] }
-serde_with = { workspace = true }
-derivative = { workspace = true }
 digest = { workspace = true }
 sov-db-types = { workspace = true, features = ["native"] }
 strum = { workspace = true, features = ["derive"], optional = true }
@@ -73,7 +70,6 @@ arbitrary = [
 	"sov-test-utils/arbitrary",
 	"sov-mock-da/arbitrary",
 	"sov-db/arbitrary",
-	"uuid/arbitrary",
 	"sov-db-types/arbitrary"
 ]
 migration-script = []

--- a/crates/full-node/sov-eth-dev-generator/Cargo.toml
+++ b/crates/full-node/sov-eth-dev-generator/Cargo.toml
@@ -20,6 +20,4 @@ sov-transaction-generator = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-consensus = { workspace = true }
 secp256k1 = { workspace = true }
-sha2 = { workspace = true }
-rand_chacha = { workspace = true }
 arbitrary = { workspace = true }

--- a/crates/full-node/sov-ledger-apis/Cargo.toml
+++ b/crates/full-node/sov-ledger-apis/Cargo.toml
@@ -18,19 +18,15 @@ axum = { workspace = true, features = ["http1", "http2", "ws", "json"] }
 borsh = { workspace = true }
 derive_more = { workspace = true, features = ["display"] }
 futures = { workspace = true }
-hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["base64"] }
-serde_yaml = { workspace = true }
 sov-db = { workspace = true }
 sov-modules-api = { workspace = true, features = ["native"] }
 sov-rest-utils = { workspace = true }
 sov-rollup-interface = { workspace = true, features = ["native"] }
 tokio = { workspace = true, features = ["macros"] }
 tracing = { workspace = true }
-utoipa-swagger-ui = { workspace = true, features = ["axum"] }
-openapiv3 = { workspace = true }
 
 [dev-dependencies]
 assert-json-diff = "2"

--- a/crates/full-node/sov-metrics/Cargo.toml
+++ b/crates/full-node/sov-metrics/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 
 [dependencies]
 tracing = { workspace = true, optional = true }
-strum = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["sync", "net", "macros", "rt", "io-util"], default-features = false, optional = true }
 serde = { workspace = true }
 bincode = { workspace = true, optional = true }
@@ -56,7 +55,6 @@ native = [
     "dep:tokio",
     "dep:schemars",
     "dep:tracing",
-    "dep:strum",
     "dep:bincode",
     "dep:http",
     "dep:derivative",

--- a/crates/full-node/sov-rollup-apis/Cargo.toml
+++ b/crates/full-node/sov-rollup-apis/Cargo.toml
@@ -17,17 +17,10 @@ workspace = true
 [dependencies]
 axum = { workspace = true }
 borsh = { workspace = true }
-derive_more = { workspace = true }
-derivative = { workspace = true }
 thiserror = { workspace = true }
 hex = { workspace = true }
 serde = { workspace = true }
-utoipa-swagger-ui = { workspace = true, features = ["axum"] }
-openapiv3 = { workspace = true }
 serde_json = { workspace = true }
-serde_with = { workspace = true, features = ["base64"] }
-serde_yaml = { workspace = true }
-base64 = { workspace = true }
 tracing = { workspace = true }
 
 # Sovereign dependencies

--- a/crates/full-node/sov-sequencer/Cargo.toml
+++ b/crates/full-node/sov-sequencer/Cargo.toml
@@ -21,19 +21,16 @@ axum = { workspace = true, features = ["http1", "http2", "ws", "json", "query"] 
 base64 = { workspace = true }
 bincode = { workspace = true }
 borsh = { workspace = true }
-dashmap = { workspace = true }
 derivative = { workspace = true }
 derive_more = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
-jsonrpsee = { workspace = true, default-features = false, features = ["client", "server"] }
 mini-moka = "0.10"
 sov-full-node-configs = { workspace = true }
 rockbound = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 serde_with = { workspace = true, features = ["base64"] }
 sov-blob-sender = { workspace = true }
 sov-blob-storage = { workspace = true, features = ["native"] }
@@ -53,8 +50,6 @@ tracing = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt"] }
 tokio-stream = { workspace = true }
 uuid = { workspace = true, features = ["std", "v7", "serde",] }
-utoipa-swagger-ui = { workspace = true, features = ["axum"] }
-openapiv3 = { workspace = true }
 backon = { workspace = true }
 flume = { workspace = true }
 time = "0.3"
@@ -91,3 +86,6 @@ default = []
 test-utils = [
     "sov-modules-api/test-utils"
 ]
+
+[package.metadata.cargo-machete]
+ignored = ["bincode"]

--- a/crates/full-node/sov-stf-runner/Cargo.toml
+++ b/crates/full-node/sov-stf-runner/Cargo.toml
@@ -20,7 +20,6 @@ rockbound = { workspace = true }
 bincode = { workspace = true }
 derivative = { workspace = true }
 backon = { workspace = true }
-num_cpus = { workspace = true }
 thiserror = { workspace = true }
 borsh = { workspace = true }
 serde = { workspace = true }

--- a/crates/module-system/module-implementations/extern/hyperlane-solana-register/solana/program/Cargo.toml
+++ b/crates/module-system/module-implementations/extern/hyperlane-solana-register/solana/program/Cargo.toml
@@ -11,21 +11,17 @@ publish = false
 [features]
 default = ["debug-logs"]
 no-entrypoint = []
-test-client = ["dep:solana-sdk", "dep:spl-noop"]
+test-client = ["dep:spl-noop"]
 test-utils = []
 debug-logs = []
 
 [dependencies]
-solana-sdk = { workspace = true, optional = true }
 borsh = { workspace = true }
 solana-program = { workspace = true }
 spl-noop = { workspace = true, features = ["no-entrypoint"], optional = true }
 
 hyperlane-sealevel-mailbox = { workspace = true, features = ["no-entrypoint"] }
-hyperlane-sealevel-igp = { workspace = true, features = ["no-entrypoint"] }
-account-utils = { workspace = true }
 hyperlane-core = { workspace = true }
-hyperlane-sealevel-connection-client = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/crates/module-system/module-implementations/module-template/Cargo.toml
+++ b/crates/module-system/module-implementations/module-template/Cargo.toml
@@ -50,3 +50,6 @@ native = [
 	"sov-modules-api/native",
 	"sov-state/native",
 ]
+
+[package.metadata.cargo-machete]
+ignored = ["proptest"]

--- a/crates/module-system/module-implementations/sb-blacklist/Cargo.toml
+++ b/crates/module-system/module-implementations/sb-blacklist/Cargo.toml
@@ -9,18 +9,20 @@ readme = "README.md"
 publish = false
 resolver = "2"
 
+[package.metadata.cargo-machete]
+ignored = ["borsh", "serde"]
+
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 serde = { workspace = true }
 
 sov-modules-api = { workspace = true }
-sov-state = { workspace = true }
 schemars = { workspace = true }
 thiserror = "2.0.17"
 
 [dev-dependencies]
-sov-address = { workspace = true, features = ["evm"] }
+sov-address = { workspace = true, features = ["native", "evm"] }
 sov-test-utils = { workspace = true }
 strum = { workspace = true }
 
@@ -28,12 +30,10 @@ strum = { workspace = true }
 default = []
 arbitrary = [
 	"sov-modules-api/arbitrary",
-	"sov-state/arbitrary",
 	"sov-test-utils/arbitrary",
 	"sov-address/arbitrary"
 ]
 native = [
     "sov-modules-api/native",
-    "sov-state/native",
     "sov-address/native",
 ]

--- a/crates/module-system/module-implementations/sb-session-registry/Cargo.toml
+++ b/crates/module-system/module-implementations/sb-session-registry/Cargo.toml
@@ -9,20 +9,21 @@ readme = "README.md"
 publish = false
 resolver = "2"
 
+[package.metadata.cargo-machete]
+ignored = ["borsh", "serde"]
+
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 serde = { workspace = true }
 
 sov-chain-state = { workspace = true }
-sov-bank = { workspace = true }
 sov-modules-api = { workspace = true }
-sov-state = { workspace = true }
 schemars = { workspace = true }
 thiserror = "2.0.17"
 
 [dev-dependencies]
-sov-address = { workspace = true, features = ["evm"] }
+sov-address = { workspace = true, features = ["native", "evm"] }
 sov-test-utils = { workspace = true }
 schemars = { workspace = true }
 strum = { workspace = true }
@@ -31,15 +32,11 @@ strum = { workspace = true }
 default = []
 arbitrary = [
 	"sov-modules-api/arbitrary",
-	"sov-state/arbitrary",
 	"sov-test-utils/arbitrary",
 	"sov-address/arbitrary",
-	"sov-bank/arbitrary"
 ]
 native = [
-	"sov-bank/native",
 	"sov-modules-api/native",
-	"sov-state/native",
 	"sov-address/native",
 	"sov-chain-state/native"
 ]

--- a/crates/module-system/module-implementations/sov-attester-incentives/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-attester-incentives/Cargo.toml
@@ -14,6 +14,9 @@ publish = false
 [lints]
 workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["tokio"]
+
 [dev-dependencies]
 strum = { workspace = true }
 sov-attester-incentives = { workspace = true, features = ["native"] }
@@ -34,7 +37,6 @@ derivative = { workspace = true }
 tracing = { workspace = true }
 schemars = { workspace = true }
 
-sov-address = { workspace = true }
 sov-bank = { workspace = true }
 sov-chain-state = { workspace = true }
 sov-modules-api = { workspace = true }
@@ -46,7 +48,6 @@ tokio = { workspace = true, optional = true }
 default = []
 native = [
     "sov-attester-incentives/native",
-    "sov-address/native",
     "sov-bank/native",
     "sov-chain-state/native",
     "sov-mock-da/native",

--- a/crates/module-system/module-implementations/sov-attester-incentives/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-attester-incentives/Cargo.toml
@@ -14,9 +14,6 @@ publish = false
 [lints]
 workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["tokio"]
-
 [dev-dependencies]
 strum = { workspace = true }
 sov-attester-incentives = { workspace = true, features = ["native"] }

--- a/crates/module-system/module-implementations/sov-bank/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-bank/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 derive_more = { workspace = true, features = ["display"] }
 proptest = { workspace = true, optional = true }
-proptest-derive = { workspace = true, optional = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -40,9 +39,8 @@ sov-test-utils = { workspace = true }
 [features]
 default = []
 arbitrary = [
-  "sov-modules-api/arbitrary",
   "dep:proptest",
-  "dep:proptest-derive",
+  "sov-modules-api/arbitrary",
   "sov-bank/arbitrary",
   "sov-state/arbitrary",
   "sov-test-utils/arbitrary",
@@ -58,3 +56,6 @@ native = [
 ]
 cli = ["native"]
 test-utils = []
+
+[package.metadata.cargo-machete]
+ignored = ["proptest"]

--- a/crates/module-system/module-implementations/sov-blob-storage/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-blob-storage/Cargo.toml
@@ -19,7 +19,6 @@ borsh = { workspace = true }
 derive_more = { workspace = true }
 tracing = { workspace = true }
 hex = { workspace = true }
-schemars = { workspace = true }
 serde = { workspace = true }
 
 sov-modules-api = { workspace = true }
@@ -31,6 +30,7 @@ sov-chain-state = { workspace = true }
 
 
 [dev-dependencies]
+schemars = { workspace = true }
 tempfile = { workspace = true }
 strum = { workspace = true }
 sov-blob-storage = { path = ".", features = ["native", "test-utils"] }
@@ -58,3 +58,6 @@ native = [
 	"sov-rollup-interface/native",
 	"sov-value-setter/native",
 ]
+
+[package.metadata.cargo-machete]
+ignored = ["schemars"]

--- a/crates/module-system/module-implementations/sov-evm/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-evm/Cargo.toml
@@ -70,8 +70,6 @@ revm = { workspace = true, features = [
 revm-database-interface = { workspace = true }
 revm-inspectors = { workspace = true, default-features = false, optional = true }
 sov-rpc-eth-types = { workspace = true, optional = true }
-rand = { workspace = true, optional = true }
-proptest = { workspace = true, optional = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["getrandom"] }
@@ -96,8 +94,6 @@ sov-modules-api = { workspace = true, features = ["test-utils"] }
 [features]
 arbitrary = [
 	"dep:arbitrary",
-	"dep:rand",
-	"dep:proptest",
 	"alloy-eips/arbitrary",
 	"alloy-primitives/arbitrary",
 	"alloy-rpc-types?/arbitrary",
@@ -111,14 +107,12 @@ arbitrary = [
 	"sov-test-utils/arbitrary",
 	"sov-bank/arbitrary",
 	"sov-uniqueness/arbitrary",
-	"alloy-consensus/arbitrary",
-	"sov-evm-test-utils/arbitrary"
+	"alloy-consensus/arbitrary"
 ]
 native = [
 	"alloy-rpc-types",
 	"alloy-rpc-types-trace",
 	"jsonrpsee",
-	"dep:rand",
 	"revm-inspectors",
 	"alloy-primitives/std",
 	"dep:sov-rpc-eth-types",

--- a/crates/module-system/module-implementations/sov-operator-incentives/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-operator-incentives/Cargo.toml
@@ -16,16 +16,11 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-borsh = { workspace = true, features = ["rc"] }
+borsh = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
-thiserror = { workspace = true }
-tracing = { workspace = true }
-derive_more = { workspace = true }
 strum = { workspace = true }
 sov-modules-api = { workspace = true }
-sov-rollup-interface = { workspace = true }
-sov-state = { workspace = true }
 
 [dev-dependencies]
 sov-test-utils = { workspace = true }
@@ -34,6 +29,7 @@ sov-test-utils = { workspace = true }
 default = []
 native = [
     "sov-modules-api/native",
-    "sov-rollup-interface/native",
-    "sov-state/native",
 ]
+
+[package.metadata.cargo-machete]
+ignored = ["borsh"]

--- a/crates/module-system/module-implementations/sov-paymaster/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-paymaster/Cargo.toml
@@ -15,13 +15,9 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-arbitrary = { workspace = true, optional = true }
 borsh = { workspace = true, features = ["rc"] }
-bcs = { workspace = true }
 derivative = { workspace = true }
 derive_more = { workspace = true }
-proptest = { workspace = true, optional = true }
-proptest-derive = { workspace = true, optional = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
@@ -29,7 +25,6 @@ tracing = { workspace = true }
 sov-bank = { workspace = true }
 sov-state = { workspace = true }
 sov-modules-api = { workspace = true }
-sov-universal-wallet = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
@@ -49,9 +44,6 @@ native = [
 ]
 default = []
 arbitrary = [
-	"dep:arbitrary",
-	"dep:proptest",
-	"dep:proptest-derive",
 	"sov-paymaster/arbitrary",
 	"sov-modules-api/arbitrary",
 	"sov-state/arbitrary",

--- a/crates/module-system/module-implementations/sov-revenue-share/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-revenue-share/Cargo.toml
@@ -13,6 +13,9 @@ readme = "README.md"
 [lints]
 workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["borsh", "serde"]
+
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
@@ -36,7 +39,7 @@ serde_json = { workspace = true }
 sov-mock-da = { workspace = true }
 sov-mock-zkvm = { workspace = true }
 sha2 = { workspace = true }
-sov-address = { workspace = true, features = ["evm"] }
+sov-address = { workspace = true, features = ["native", "evm"] }
 
 [features]
 default = []

--- a/crates/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-sequencer-registry/Cargo.toml
@@ -59,3 +59,6 @@ native = [
 	"sov-value-setter/native",
 	"sov-chain-state/native",
 ]
+
+[package.metadata.cargo-machete]
+ignored = ["proptest"]

--- a/crates/module-system/module-implementations/sov-synthetic-load/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-synthetic-load/Cargo.toml
@@ -14,21 +14,21 @@ publish = false
 [lints]
 workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["borsh", "serde"]
+
 [dev-dependencies]
 sov-address = { workspace = true }
 strum = { workspace = true }
 sov-modules-api = { workspace = true, features = ["native"] }
-sov-state = { workspace = true, features = ["native"] }
 
 [dependencies]
 anyhow = { workspace = true }
+borsh = { workspace = true }
 strum = { workspace = true }
 sov-modules-api = { workspace = true }
-sov-rollup-interface = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
-borsh = { workspace = true, features = ["rc"] }
-sov-state = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 sov-metrics = { workspace = true }
@@ -37,8 +37,6 @@ sov-metrics = { workspace = true }
 default = []
 native = [
     "sov-modules-api/native",
-    "sov-rollup-interface/native",
-    "sov-state/native",
     "sov-address/native",
     "sov-metrics/native"
 ]

--- a/crates/module-system/module-implementations/sov-test-modules/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-test-modules/Cargo.toml
@@ -33,7 +33,6 @@ strum = { workspace = true }
 sov-modules-api = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
-thiserror = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
 sov-state = { workspace = true }
 hex = { workspace = true }

--- a/crates/module-system/module-implementations/sov-timelock/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-timelock/Cargo.toml
@@ -44,3 +44,6 @@ native = [
 	"sov-timelock/native",
 	"sov-value-setter/native"
 ]
+
+[package.metadata.cargo-machete]
+ignored = ["serde_json"]

--- a/crates/module-system/module-implementations/sov-uniqueness/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-uniqueness/Cargo.toml
@@ -13,8 +13,6 @@ readme = "README.md"
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true, features = ["rc"] }
-schemars = { workspace = true }
-serde = { workspace = true }
 
 sov-modules-api = { workspace = true }
 sov-state = { workspace = true }
@@ -23,6 +21,8 @@ sov-state = { workspace = true }
 alloy-consensus = { workspace = true, features = ["secp256k1"] }
 alloy-primitives = { workspace = true }
 alloy-eips = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
 sov-modules-stf-blueprint = { workspace = true }
 sov-uniqueness = { path = ".", features = ["native"] }
 tempfile = { workspace = true }
@@ -32,7 +32,7 @@ sov-test-utils = { workspace = true }
 sov-evm-test-utils = { workspace = true }
 sov-value-setter = { workspace = true }
 sov-evm = { workspace = true, features = ["native"] }
-sov-address = { workspace = true, features = ["evm"] }
+sov-address = { workspace = true, features = ["native", "evm"] }
 sov-rollup-interface = { workspace = true }
 sov-kernels = { workspace = true }
 secp256k1 = { workspace = true, features = ["rand"] }
@@ -51,7 +51,6 @@ arbitrary = [
 	"alloy-consensus/arbitrary",
 	"alloy-eips/arbitrary",
 	"alloy-primitives/arbitrary",
-	"sov-evm-test-utils/arbitrary",
 ]
 native = [
 	"sov-modules-api/native",
@@ -64,3 +63,6 @@ native = [
 	"sov-kernels/native",
 	"sov-rollup-interface/native",
 ]
+
+[package.metadata.cargo-machete]
+ignored = ["schemars", "serde"]

--- a/crates/module-system/module-implementations/sov-value-setter/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-value-setter/Cargo.toml
@@ -27,7 +27,6 @@ sov-state = { workspace = true, features = ["native"] }
 anyhow = { workspace = true }
 strum = { workspace = true }
 sov-modules-api = { workspace = true }
-sov-rollup-interface = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
@@ -39,7 +38,6 @@ sov-state = { workspace = true }
 default = []
 native = [
     "sov-modules-api/native",
-    "sov-rollup-interface/native",
     "sov-value-setter/native",
     "sov-state/native",
     "sov-address/native"

--- a/crates/module-system/sov-eip712-auth/Cargo.toml
+++ b/crates/module-system/sov-eip712-auth/Cargo.toml
@@ -14,17 +14,17 @@ publish = false
 [lints]
 workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["sov-universal-wallet"]
+
 [dependencies]
 sov-address = { workspace = true, features = ["evm"] } # to implement the compatibility marker on EvmCryptoSpec
 sov-modules-api = { workspace = true }
+sov-universal-wallet = { workspace = true, features = ["eip712"] } # enables Schema::eip712_signing_digest on the re-export used below
 sov-state = { workspace = true }
-sov-universal-wallet = { workspace = true, features = ["eip712"] }
 anyhow = { workspace = true }
 borsh = { workspace = true }
-derive_more = { workspace = true, default-features = true, features = [ "debug" ] }
 jsonrpsee = { workspace = true, features = ["jsonrpsee-types"] }
-serde = { workspace = true }
-tracing = { workspace = true }
 # For the stub RPC for chains not using EVM. Not needed for those using EVM,
 # but in that case the dependency is almost certainly already present:
 serde_json = { workspace = true } 

--- a/crates/module-system/sov-kernels/Cargo.toml
+++ b/crates/module-system/sov-kernels/Cargo.toml
@@ -20,8 +20,6 @@ sov-blob-storage = { workspace = true }
 sov-chain-state = { workspace = true }
 sov-rollup-interface = { workspace = true }
 
-serde_json = { workspace = true, optional = true }
-
 [features]
 default = []
 native = [
@@ -29,7 +27,6 @@ native = [
 	"sov-chain-state/native",
 	"sov-modules-api/native",
 	"sov-state/native",
-	"dep:serde_json",
 	"sov-rollup-interface/native"
 ]
 test-utils = []

--- a/crates/module-system/sov-modules-macros/Cargo.toml
+++ b/crates/module-system/sov-modules-macros/Cargo.toml
@@ -44,7 +44,7 @@ sov-modules-macros = { path = ".", features = ["native"] }
 sov-modules-api = { workspace = true, features = ["native", "test-utils"] }
 sov-chain-state = { workspace = true, features = ["native"] }
 borsh = { workspace = true }
-jsonrpsee = { workspace = true, default-features = false, features = ["macros", "server-core"] }
+jsonrpsee = { workspace = true, default-features = false, features = ["client-core", "macros", "server-core"] }
 schemars = { workspace = true }
 serde = { workspace = true }
 strum = { workspace = true }

--- a/crates/module-system/sov-modules-rollup-blueprint/Cargo.toml
+++ b/crates/module-system/sov-modules-rollup-blueprint/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 
 [dependencies]
 console-subscriber = { workspace = true, optional = true }
-derivative = { workspace = true, optional = true }
 sov-rollup-interface = { workspace = true, features = ["native"] }
 sov-stf-runner = { workspace = true, optional = true }
 sov-state = { workspace = true }
@@ -55,7 +54,6 @@ native = [
 	"async-trait",
 	"futures",
 	"console-subscriber",
-	"derivative",
 	"serde_json",
 	"sov-cli",
 	"sov-db",

--- a/crates/module-system/sov-modules-stf-blueprint/Cargo.toml
+++ b/crates/module-system/sov-modules-stf-blueprint/Cargo.toml
@@ -15,14 +15,10 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-axum = { workspace = true, optional = true }
 thiserror = { workspace = true }
 borsh = { workspace = true }
-jsonrpsee = { workspace = true, features = ["server"], optional = true }
 serde = { workspace = true, features = ["derive"] }
-schemars = { workspace = true }
 tracing = { workspace = true }
-tokio = { workspace = true, features = ["sync"], optional = true }
 hex = { workspace = true }
 
 # WARNING: The `stf-blueprint` crate should NOT depend on any Sovereign module.
@@ -38,12 +34,9 @@ bench = [
     "sov-state/bench",
 ]
 native = [
-    "axum",
-    "jsonrpsee",
     "sov-modules-api/native",
     "sov-rollup-interface/native",
     "sov-state/native",
-    "tokio",
     "sov-metrics/native",
 ]
 test-utils = []

--- a/crates/module-system/sov-solana-offchain-auth/Cargo.toml
+++ b/crates/module-system/sov-solana-offchain-auth/Cargo.toml
@@ -17,7 +17,6 @@ anyhow = { workspace = true }
 borsh = { workspace = true }
 tracing = { workspace = true }
 hex = { workspace = true }
-schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true, features = ["hex"] }
@@ -29,6 +28,7 @@ sov-state = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 base64 = { workspace = true }
+schemars = { workspace = true }
 tokio-stream = { workspace = true }
 sov-solana-offchain-auth = { path = ".", features = ["native"] }
 tempfile = { workspace = true }
@@ -71,3 +71,6 @@ native = [
 	"sov-state/native",
 	"sov-value-setter/native"
 ]
+
+[package.metadata.cargo-machete]
+ignored = ["schemars"]

--- a/crates/module-system/sov-state/Cargo.toml
+++ b/crates/module-system/sov-state/Cargo.toml
@@ -20,7 +20,6 @@ borsh = { workspace = true, features = ["rc", "bytes"] }
 bcs = { workspace = true }
 derivative = { workspace = true }
 proptest = { workspace = true, optional = true }
-proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true, features = ["rc"] }
 derive_more = { workspace = true }
 serde-big-array = "0.5.1"
@@ -34,7 +33,6 @@ nomt = { workspace = true, optional = true }
 sov-metrics = { workspace = true }
 sov-modules-macros = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
-serde_with = { workspace = true }
 sov-db-types = { workspace = true }
 
 [dev-dependencies]
@@ -50,7 +48,6 @@ tempfile = { workspace = true }
 arbitrary = [
 	"dep:arbitrary",
 	"dep:proptest",
-	"dep:proptest-derive",
 	"sov-db?/arbitrary",
 	"sov-rollup-interface/arbitrary",
 	"sov-modules-macros?/arbitrary",

--- a/crates/universal-wallet/fuzz/Cargo.toml
+++ b/crates/universal-wallet/fuzz/Cargo.toml
@@ -20,7 +20,6 @@ serde = { workspace = true, features = ["alloc", "derive"] }
 serde_json = { workspace = true }
 sov-universal-wallet = { workspace = true, features = ["serde"] }
 sov-modules-api = { workspace = true, features = ["arbitrary"] }
-sov-rollup-interface = { workspace = true, features = ["arbitrary"] }
 
 [lib]
 name = "universal_wallet_fuzz"

--- a/crates/universal-wallet/macro-helpers/Cargo.toml
+++ b/crates/universal-wallet/macro-helpers/Cargo.toml
@@ -10,11 +10,9 @@ repository = { workspace = true }
 
 [dependencies]
 syn = { features = ["parsing", "derive"], workspace = true }
-syn_derive = "0.2.0"
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 darling = { workspace = true }
-hex = { workspace = true }
 borsh = { workspace = true }
 bs58 = { workspace = true }
 bech32 = { workspace = true }

--- a/crates/universal-wallet/macros/Cargo.toml
+++ b/crates/universal-wallet/macros/Cargo.toml
@@ -13,5 +13,4 @@ proc-macro = true
 
 [dependencies]
 syn = { workspace = true }
-proc-macro2 = { workspace = true }
 sov-universal-wallet-macro-helpers = { workspace = true }

--- a/crates/utils/sov-build/Cargo.toml
+++ b/crates/utils/sov-build/Cargo.toml
@@ -12,10 +12,6 @@ repository.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 borsh = { workspace = true }
-serde = { workspace = true, default-features = false, features = [
-  "alloc",
-  "derive",
-] }
 serde_json = { workspace = true, default-features = false, features = [
   "alloc",
 ] }

--- a/crates/utils/sov-eth-client/Cargo.toml
+++ b/crates/utils/sov-eth-client/Cargo.toml
@@ -19,7 +19,6 @@ alloy-rpc-types  = { workspace = true }
 alloy-provider = { workspace = true }
 alloy-pubsub = { workspace = true }
 alloy-signer = { workspace = true }
-reqwest = { workspace = true }
 async-trait = { workspace = true }
 derive_more = { workspace = true }
 futures = { workspace = true }

--- a/crates/utils/sov-evm-test-utils/Cargo.toml
+++ b/crates/utils/sov-evm-test-utils/Cargo.toml
@@ -18,23 +18,10 @@ alloy-sol-types = { workspace = true, features = ["json"] }
 alloy-primitives = { workspace = true }
 alloy-rpc-types-eth = { workspace = true }
 alloy = { workspace = true }
-
-arbitrary = { workspace = true, optional = true }
-proptest = { workspace = true, optional = true }
-
 alloy-dyn-abi = { workspace = true, features = ["eip712", "std"] }
-
 
 [lints]
 workspace = true
 
-[features]
-arbitrary = [
-	"dep:arbitrary",
-	"dep:proptest",
-	"alloy-primitives/arbitrary",
-	"alloy-rpc-types-eth/arbitrary",
-	"alloy-sol-types/arbitrary",
-	"alloy/arbitrary",
-	"alloy-dyn-abi/arbitrary"
-]
+[package.metadata.cargo-machete]
+ignored = ["alloy-contract", "alloy-dyn-abi"]

--- a/crates/utils/sov-rest-utils/Cargo.toml
+++ b/crates/utils/sov-rest-utils/Cargo.toml
@@ -9,6 +9,9 @@ license = { workspace = true }
 repository = { workspace = true }
 publish = true
 
+[package.metadata.cargo-machete]
+ignored = ["proptest"]
+
 [dependencies]
 anyhow = { workspace = true }
 client-ip = "0.1.1"

--- a/crates/utils/sov-rpc-eth-types/Cargo.toml
+++ b/crates/utils/sov-rpc-eth-types/Cargo.toml
@@ -17,7 +17,6 @@ sov-modules-api = { workspace = true, features = ["native"] }
 thiserror = { workspace = true }
 revm = { workspace = true }
 alloy-eips = { workspace = true }
-alloy-evm = { workspace = true }
 alloy-sol-types = { workspace = true }
 alloy-transport = { workspace = true }
 reth-primitives-traits = { workspace = true }

--- a/crates/utils/sov-soak-testing-lib/Cargo.toml
+++ b/crates/utils/sov-soak-testing-lib/Cargo.toml
@@ -10,13 +10,6 @@ publish = false
 
 [dependencies]
 tokio = { workspace = true, default-features = false }
-borsh = { workspace = true, features = ["derive"] }
-
-schemars = { workspace = true, features = ["derive"] }
-serde = { workspace = true, default-features = false, features = [
-    "alloc",
-    "derive",
-] }
 anyhow = { workspace = true }
 rand = { workspace = true }
 clap = { workspace = true }
@@ -26,7 +19,6 @@ sov-transaction-generator = { workspace = true }
 sov-modules-api = { workspace = true }
 sov-test-utils = { workspace = true, features = ["arbitrary"] }
 # modules
-sov-value-setter = { workspace = true }
 sov-bank = { workspace = true, features = ["native", "arbitrary"] }
 sov-synthetic-load = { workspace = true }
 sov-test-state-consistency = { workspace = true }

--- a/crates/utils/sov-test-utils/Cargo.toml
+++ b/crates/utils/sov-test-utils/Cargo.toml
@@ -22,6 +22,7 @@ borsh = { workspace = true }
 derivative = { workspace = true }
 derive_more = { workspace = true }
 jsonschema = { workspace = true }
+strum = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 serde = { workspace = true }
 schemars = { workspace = true }
@@ -33,7 +34,6 @@ num_cpus = { workspace = true }
 tokio-stream = { workspace = true }
 
 sha2 = { workspace = true }
-sov-address = { workspace = true }
 sov-cli = { workspace = true }
 sov-rollup-interface = { workspace = true }
 sov-rollup-full-node-interface = { workspace = true }
@@ -64,7 +64,6 @@ sov-db = { workspace = true, features = ["test-utils"] }
 sov-state = { workspace = true, features = ["native"] }
 sov-mock-da = { workspace = true, features = ["native"] }
 sov-mock-zkvm = { workspace = true, features = ["native"] }
-strum = { workspace = true }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 rockbound = { workspace = true }
@@ -79,10 +78,12 @@ arbitrary = [
 	"sov-sequencer-registry/arbitrary",
 	"sov-state/arbitrary",
 	"rockbound/arbitrary",
-	"sov-address/arbitrary",
 	"sov-accounts/arbitrary",
 	"sov-uniqueness/arbitrary",
 	"sov-mock-da/arbitrary",
 	"sov-bank/arbitrary",
 	"sov-paymaster/arbitrary",
 ]
+
+[package.metadata.cargo-machete]
+ignored = ["strum"]

--- a/crates/utils/transaction-generator/Cargo.toml
+++ b/crates/utils/transaction-generator/Cargo.toml
@@ -22,7 +22,6 @@ sov-state = { workspace = true, features = ["native"] }
 sov-mock-da = { workspace = true, features = ["native", "arbitrary"] }
 
 async-trait = { workspace = true }
-schemars = { workspace = true }
 serde = { workspace = true }
 backon = { workspace = true }
 anyhow = { workspace = true }
@@ -58,7 +57,12 @@ sov-test-utils = { workspace = true, features = ["arbitrary"] }
 
 futures = { workspace = true }
 borsh = { workspace = true }
+progenitor-client = { version = "0.14" }
+schemars = { workspace = true }
 serde = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["schemars"]

--- a/crates/utils/workspace-hack/Cargo.toml
+++ b/crates/utils/workspace-hack/Cargo.toml
@@ -8,6 +8,16 @@ homepage.workspace = true
 publish.workspace = true
 repository.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = [
+    "ethereum-types",
+    "sov-accounts",
+    "sov-evm",
+    "sov-mock-da",
+    "sov-mock-zkvm",
+    "sov-sequencer-registry",
+]
+
 [dependencies]
 sov-mock-zkvm = { workspace = true, features = ["arbitrary", "native"] }
 sov-mock-da = { workspace = true, features = ["arbitrary", "native"] }

--- a/crates/web3/Cargo.toml
+++ b/crates/web3/Cargo.toml
@@ -17,8 +17,6 @@ serde_with = { workspace = true, features = ["hex"] }
 serde_json = { workspace = true, default-features = false, features = [
   "alloc",
 ] }
-borsh = { workspace = true, features = ["rc"] }
-hex = { workspace = true }
 thiserror = { workspace = true }
 sov-modules-api = { workspace = true, features = ["native"], optional = true }
 sov-universal-wallet = { workspace = true, features = ["serde"] }

--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -20,7 +20,6 @@ sov-mock-da = { workspace = true, features = ["native"] }
 sov-rollup-interface = { workspace = true, features = ["native"] }
 sov-rollup-full-node-interface = { workspace = true }
 sov-stf-runner = { workspace = true }
-sov-metrics = { workspace = true, features = ["native"] }
 
 # Sovereign crates
 sov-bank = { workspace = true, features = ["native"] }
@@ -54,7 +53,6 @@ borsh = { workspace = true, features = ["bytes", "derive"] }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 axum = { workspace = true }
-schemars = { workspace = true }
 serde = { workspace = true, default-features = false, features = [
     "alloc",
     "derive",
@@ -71,7 +69,6 @@ tokio = { workspace = true, features = [
     "macros",
     "tracing",
 ] }
-tokio-stream = { workspace = true }
 tracing = { workspace = true }
 rockbound = { workspace = true, optional = true }
 clap = { workspace = true, features = ["derive"] }
@@ -85,6 +82,7 @@ sov-zkvm-utils = { workspace = true }
 [dev-dependencies]
 sov-eth-client = { workspace = true }
 jsonrpsee = { workspace = true }
+schemars = { workspace = true }
 sov-address = { workspace = true, features = ["native"] }
 sov-risc0-adapter = { workspace = true, features = ["native"] }
 sov-celestia-adapter = { workspace = true, features = ["native"] }
@@ -135,6 +133,9 @@ strum = { workspace = true }
 reqwest = { workspace = true }
 sov-proxy-utils = { workspace = true }
 testcontainers = { workspace = true }
+
+[package.metadata.cargo-machete]
+ignored = ["schemars"]
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/examples/demo-rollup/Cargo.toml
+++ b/examples/demo-rollup/Cargo.toml
@@ -76,8 +76,6 @@ secp256k1 = { workspace = true, features = ["global-context", "recovery"] }
 alloy = { workspace = true, features = ["genesis"] }
 alloy-primitives = { workspace = true }
 alloy-rlp = { workspace = true }
-sov-zkvm-utils = { workspace = true }
-
 
 [dev-dependencies]
 sov-eth-client = { workspace = true }

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -4234,7 +4234,6 @@ dependencies = [
  "hex",
  "serde",
  "serde_with",
- "sov-rollup-interface",
  "sov-universal-wallet",
 ]
 

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -654,12 +654,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -943,7 +937,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "394ae3bd14f0a3792c312fd0ffc1a1719fd3c8d28cf1f8016afd01cce6197001"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bech32",
  "bitvec",
  "blockstore",
@@ -1013,12 +1007,6 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
 ]
-
-[[package]]
-name = "const-default"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
 name = "const-hex"
@@ -1141,12 +1129,6 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-utils"
@@ -1339,13 +1321,11 @@ dependencies = [
  "anyhow",
  "borsh",
  "demo-stf-declaration",
- "schemars 1.2.0",
  "serde",
  "sov-accounts",
  "sov-address",
  "sov-attester-incentives",
  "sov-bank",
- "sov-blob-storage",
  "sov-build",
  "sov-capabilities",
  "sov-chain-state",
@@ -1359,14 +1339,12 @@ dependencies = [
  "sov-operator-incentives",
  "sov-paymaster",
  "sov-prover-incentives",
- "sov-revenue-share",
  "sov-rollup-interface",
  "sov-sequencer-registry",
  "sov-solana-offchain-auth",
  "sov-state",
  "sov-synthetic-load",
  "sov-test-modules",
- "sov-uniqueness",
  "tracing",
 ]
 
@@ -1383,20 +1361,16 @@ dependencies = [
  "sov-attester-incentives",
  "sov-bank",
  "sov-blob-storage",
- "sov-capabilities",
  "sov-chain-state",
  "sov-evm",
  "sov-hyperlane-integration",
- "sov-kernels",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-operator-incentives",
  "sov-paymaster",
  "sov-prover-incentives",
  "sov-revenue-share",
- "sov-rollup-interface",
  "sov-sequencer-registry",
- "sov-state",
  "sov-synthetic-load",
  "sov-test-modules",
  "sov-uniqueness",
@@ -1620,18 +1594,6 @@ dependencies = [
  "serdect",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "embedded-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2de9133f68db0d4627ad69db767726c99ff8585272716708227008d3f1bddd"
-dependencies = [
- "const-default",
- "critical-section",
- "linked_list_allocator",
- "rlsf",
 ]
 
 [[package]]
@@ -2346,12 +2308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "linked_list_allocator"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,27 +2921,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit 0.23.10+spec-1.0.0",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -3645,8 +3580,6 @@ checksum = "cfaa10feba15828c788837ddde84b994393936d8f5715228627cfe8625122a40"
 dependencies = [
  "bytemuck",
  "cfg-if",
- "critical-section",
- "embedded-alloc",
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "libm",
@@ -3663,18 +3596,6 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
-]
-
-[[package]]
-name = "rlsf"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222fb240c3286247ecdee6fa5341e7cdad0ffdf8e7e401d9937f2d58482a20bf"
-dependencies = [
- "cfg-if",
- "const-default",
- "libc",
- "svgbobdoc",
 ]
 
 [[package]]
@@ -4033,7 +3954,7 @@ version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4189,7 +4110,6 @@ dependencies = [
  "derivative",
  "schemars 1.2.0",
  "serde",
- "sov-address",
  "sov-bank",
  "sov-chain-state",
  "sov-modules-api",
@@ -4225,7 +4145,6 @@ dependencies = [
  "borsh",
  "derive_more",
  "hex",
- "schemars 1.2.0",
  "serde",
  "sov-bank",
  "sov-chain-state",
@@ -4242,7 +4161,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "serde",
  "serde_json",
  "sov-modules-api",
 ]
@@ -4327,12 +4245,8 @@ version = "0.3.0"
 dependencies = [
  "demo-stf",
  "risc0-zkvm",
- "risc0-zkvm-platform",
  "sha2 0.10.9",
- "sov-address",
  "sov-celestia-adapter",
- "sov-kernels",
- "sov-metrics",
  "sov-mock-zkvm",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
@@ -4448,7 +4362,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "borsh",
- "digest 0.10.7",
  "ed25519-dalek",
  "hex",
  "schemars 1.2.0",
@@ -4516,7 +4429,6 @@ dependencies = [
  "anyhow",
  "borsh",
  "hex",
- "schemars 1.2.0",
  "serde",
  "sov-metrics",
  "sov-modules-api",
@@ -4532,15 +4444,10 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "derive_more",
  "schemars 1.2.0",
  "serde",
  "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
  "strum",
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -4548,7 +4455,6 @@ name = "sov-paymaster"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "bcs",
  "borsh",
  "derivative",
  "derive_more",
@@ -4557,7 +4463,6 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-state",
- "sov-universal-wallet",
  "tracing",
 ]
 
@@ -4602,7 +4507,6 @@ dependencies = [
  "bincode",
  "borsh",
  "bytemuck",
- "digest 0.10.7",
  "ed25519-dalek",
  "hex",
  "risc0-zkvm",
@@ -4660,7 +4564,6 @@ dependencies = [
  "anyhow",
  "borsh",
  "hex",
- "schemars 1.2.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -4683,7 +4586,6 @@ dependencies = [
  "nomt-core",
  "serde",
  "serde-big-array",
- "serde_with",
  "sov-db-types",
  "sov-metrics",
  "sov-modules-macros",
@@ -4703,8 +4605,6 @@ dependencies = [
  "serde",
  "sov-metrics",
  "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
  "strum",
 ]
 
@@ -4722,7 +4622,6 @@ dependencies = [
  "sov-modules-api",
  "sov-state",
  "strum",
- "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -4732,8 +4631,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "schemars 1.2.0",
- "serde",
  "sov-modules-api",
  "sov-state",
 ]
@@ -4766,19 +4663,16 @@ dependencies = [
  "borsh",
  "bs58",
  "darling 0.21.3",
- "hex",
  "proc-macro2",
  "quote",
  "serde_derive_internals",
  "syn 2.0.114",
- "syn_derive",
 ]
 
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
 dependencies = [
- "proc-macro2",
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.114",
 ]
@@ -4878,19 +4772,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
-name = "svgbobdoc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c04b93fc15d79b39c63218f15e3fdffaa4c227830686e3b7c5f41244eb3e50"
-dependencies = [
- "base64 0.13.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-width",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4910,18 +4791,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb066a04799e45f5d582e8fc6ec8e6d6896040d00898eb4e6a835196815b219"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -582,7 +582,6 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
- "borsh",
  "serde",
 ]
 

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.toml
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.toml
@@ -9,18 +9,14 @@ resolver = "2"
 
 [dependencies]
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
-risc0-zkvm-platform = { version = "2.2", features = ["sys-getenv", "heap-embedded-alloc"] }
 demo-stf = { path = "../../../stf" }
 sov-risc0-adapter = { path = "../../../../../crates/adapters/risc0" }
 sov-rollup-interface = { path = "../../../../../crates/rollup-interface" }
 sov-mock-zkvm = { path = "../../../../../crates/adapters/mock-zkvm" }
 sov-celestia-adapter = { path = "../../../../../crates/adapters/celestia" }
 sov-modules-api = { path = "../../../../../crates/module-system/sov-modules-api" }
-sov-address = { path = "../../../../../crates/module-system/sov-address" }
 sov-state = { path = "../../../../../crates/module-system/sov-state" }
 sov-modules-stf-blueprint = { path = "../../../../../crates/module-system/sov-modules-stf-blueprint" }
-sov-kernels = { path = "../../../../../crates/module-system/sov-kernels" }
-sov-metrics = { path = "../../../../../crates/full-node/sov-metrics", optional = true }
 sha2 = { version = "0.10", default-features = false }
 
 [patch.crates-io]
@@ -52,5 +48,4 @@ bench = [
     "sov-modules-stf-blueprint/bench",
     "sov-risc0-adapter/bench",
     "sov-celestia-adapter/bench",
-    "sov-metrics/risc0",
 ]

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -3571,7 +3571,6 @@ dependencies = [
  "hex",
  "serde",
  "serde_with",
- "sov-rollup-interface",
  "sov-universal-wallet",
 ]
 

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -1135,13 +1135,11 @@ dependencies = [
  "anyhow",
  "borsh",
  "demo-stf-declaration",
- "schemars 1.2.0",
  "serde",
  "sov-accounts",
  "sov-address",
  "sov-attester-incentives",
  "sov-bank",
- "sov-blob-storage",
  "sov-build",
  "sov-capabilities",
  "sov-chain-state",
@@ -1155,14 +1153,12 @@ dependencies = [
  "sov-operator-incentives",
  "sov-paymaster",
  "sov-prover-incentives",
- "sov-revenue-share",
  "sov-rollup-interface",
  "sov-sequencer-registry",
  "sov-solana-offchain-auth",
  "sov-state",
  "sov-synthetic-load",
  "sov-test-modules",
- "sov-uniqueness",
  "tracing",
 ]
 
@@ -1179,20 +1175,16 @@ dependencies = [
  "sov-attester-incentives",
  "sov-bank",
  "sov-blob-storage",
- "sov-capabilities",
  "sov-chain-state",
  "sov-evm",
  "sov-hyperlane-integration",
- "sov-kernels",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-operator-incentives",
  "sov-paymaster",
  "sov-prover-incentives",
  "sov-revenue-share",
- "sov-rollup-interface",
  "sov-sequencer-registry",
- "sov-state",
  "sov-synthetic-load",
  "sov-test-modules",
  "sov-uniqueness",
@@ -2468,27 +2460,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3502,7 +3473,6 @@ dependencies = [
  "derivative",
  "schemars 1.2.0",
  "serde",
- "sov-address",
  "sov-bank",
  "sov-chain-state",
  "sov-modules-api",
@@ -3538,7 +3508,6 @@ dependencies = [
  "borsh",
  "derive_more",
  "hex",
- "schemars 1.2.0",
  "serde",
  "sov-bank",
  "sov-chain-state",
@@ -3555,7 +3524,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "serde",
  "serde_json",
  "sov-modules-api",
 ]
@@ -3614,10 +3582,7 @@ version = "0.3.0"
 dependencies = [
  "demo-stf",
  "risc0-zkvm",
- "risc0-zkvm-platform",
  "sha2",
- "sov-address",
- "sov-kernels",
  "sov-metrics",
  "sov-mock-da",
  "sov-mock-zkvm",
@@ -3734,7 +3699,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "borsh",
- "digest 0.10.7",
  "ed25519-dalek",
  "hex",
  "schemars 1.2.0",
@@ -3802,7 +3766,6 @@ dependencies = [
  "anyhow",
  "borsh",
  "hex",
- "schemars 1.2.0",
  "serde",
  "sov-metrics",
  "sov-modules-api",
@@ -3818,15 +3781,10 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "derive_more",
  "schemars 1.2.0",
  "serde",
  "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
  "strum",
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -3834,7 +3792,6 @@ name = "sov-paymaster"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "bcs",
  "borsh",
  "derivative",
  "derive_more",
@@ -3843,7 +3800,6 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-state",
- "sov-universal-wallet",
  "tracing",
 ]
 
@@ -3888,7 +3844,6 @@ dependencies = [
  "bincode",
  "borsh",
  "bytemuck",
- "digest 0.10.7",
  "ed25519-dalek",
  "hex",
  "risc0-zkvm",
@@ -3946,7 +3901,6 @@ dependencies = [
  "anyhow",
  "borsh",
  "hex",
- "schemars 1.2.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -3969,7 +3923,6 @@ dependencies = [
  "nomt-core",
  "serde",
  "serde-big-array",
- "serde_with",
  "sov-db-types",
  "sov-metrics",
  "sov-modules-macros",
@@ -3989,8 +3942,6 @@ dependencies = [
  "serde",
  "sov-metrics",
  "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
  "strum",
 ]
 
@@ -4008,7 +3959,6 @@ dependencies = [
  "sov-modules-api",
  "sov-state",
  "strum",
- "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -4018,8 +3968,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "schemars 1.2.0",
- "serde",
  "sov-modules-api",
  "sov-state",
 ]
@@ -4052,19 +4000,16 @@ dependencies = [
  "borsh",
  "bs58",
  "darling 0.21.3",
- "hex",
  "proc-macro2",
  "quote",
  "serde_derive_internals",
  "syn 2.0.114",
- "syn_derive",
 ]
 
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
 dependencies = [
- "proc-macro2",
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.114",
 ]
@@ -4168,18 +4113,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb066a04799e45f5d582e8fc6ec8e6d6896040d00898eb4e6a835196815b219"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.lock
@@ -573,7 +573,6 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
- "borsh",
  "serde",
 ]
 

--- a/examples/demo-rollup/provers/risc0/guest-mock/Cargo.toml
+++ b/examples/demo-rollup/provers/risc0/guest-mock/Cargo.toml
@@ -9,17 +9,14 @@ resolver = "2"
 
 [dependencies]
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
-risc0-zkvm-platform = { version = "2.2", features = ["sys-getenv"] }
 sov-mock-da = { path = "../../../../../crates/adapters/mock-da" }
 demo-stf = { path = "../../../stf" }
+sov-metrics = { path = "../../../../../crates/full-node/sov-metrics", optional = true }
 sov-risc0-adapter = { path = "../../../../../crates/adapters/risc0" }
-sov-address = { path = "../../../../../crates/module-system/sov-address" }
 sov-mock-zkvm = { path = "../../../../../crates/adapters/mock-zkvm" }
 sov-modules-api = { path = "../../../../../crates/module-system/sov-modules-api" }
 sov-state = { path = "../../../../../crates/module-system/sov-state" }
 sov-modules-stf-blueprint = { path = "../../../../../crates/module-system/sov-modules-stf-blueprint" }
-sov-kernels = { path = "../../../../../crates/module-system/sov-kernels" }
-sov-metrics = { path = "../../../../../crates/full-node/sov-metrics", optional = true }
 sha2 = { version = "0.10", default-features = false }
 
 [patch.crates-io]
@@ -46,10 +43,13 @@ opt-level = 3
 
 [features]
 bench = [
+    "dep:sov-metrics",
     "sov-modules-api/bench",
     "sov-state/bench",
     "sov-modules-stf-blueprint/bench",
     "sov-risc0-adapter/bench",
-    "sov-metrics/risc0",
 ]
 bincode = ["sov-risc0-adapter/bincode"]
+
+[package.metadata.cargo-machete]
+ignored = ["sov-metrics"]

--- a/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
@@ -1614,13 +1614,11 @@ dependencies = [
  "anyhow",
  "borsh",
  "demo-stf-declaration",
- "schemars 1.2.1",
  "serde",
  "sov-accounts",
  "sov-address",
  "sov-attester-incentives",
  "sov-bank",
- "sov-blob-storage",
  "sov-build",
  "sov-capabilities",
  "sov-chain-state",
@@ -1634,14 +1632,12 @@ dependencies = [
  "sov-operator-incentives",
  "sov-paymaster",
  "sov-prover-incentives",
- "sov-revenue-share",
  "sov-rollup-interface",
  "sov-sequencer-registry",
  "sov-solana-offchain-auth",
  "sov-state",
  "sov-synthetic-load",
  "sov-test-modules",
- "sov-uniqueness",
  "tracing",
 ]
 
@@ -1658,20 +1654,16 @@ dependencies = [
  "sov-attester-incentives",
  "sov-bank",
  "sov-blob-storage",
- "sov-capabilities",
  "sov-chain-state",
  "sov-evm",
  "sov-hyperlane-integration",
- "sov-kernels",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-operator-incentives",
  "sov-paymaster",
  "sov-prover-incentives",
  "sov-revenue-share",
- "sov-rollup-interface",
  "sov-sequencer-registry",
- "sov-state",
  "sov-synthetic-load",
  "sov-test-modules",
  "sov-uniqueness",
@@ -5874,7 +5866,6 @@ dependencies = [
  "derivative",
  "schemars 1.2.1",
  "serde",
- "sov-address",
  "sov-bank",
  "sov-chain-state",
  "sov-modules-api",
@@ -5910,7 +5901,6 @@ dependencies = [
  "borsh",
  "derive_more 2.1.1",
  "hex",
- "schemars 1.2.1",
  "serde",
  "sov-bank",
  "sov-chain-state",
@@ -5927,7 +5917,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "serde",
  "serde_json",
  "sov-modules-api",
 ]
@@ -6084,7 +6073,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "borsh",
- "digest 0.10.7",
  "ed25519-dalek",
  "hex",
  "schemars 1.2.1",
@@ -6152,7 +6140,6 @@ dependencies = [
  "anyhow",
  "borsh",
  "hex",
- "schemars 1.2.1",
  "serde",
  "sov-metrics",
  "sov-modules-api",
@@ -6168,15 +6155,10 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "derive_more 2.1.1",
  "schemars 1.2.1",
  "serde",
  "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
  "strum 0.28.0",
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -6184,7 +6166,6 @@ name = "sov-paymaster"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "bcs",
  "borsh",
  "derivative",
  "derive_more 2.1.1",
@@ -6193,7 +6174,6 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-state",
- "sov-universal-wallet",
  "tracing",
 ]
 
@@ -6271,7 +6251,6 @@ dependencies = [
  "anyhow",
  "borsh",
  "hex",
- "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_with",
@@ -6318,7 +6297,6 @@ dependencies = [
  "nomt-core",
  "serde",
  "serde-big-array",
- "serde_with",
  "sov-db-types",
  "sov-metrics",
  "sov-modules-macros",
@@ -6338,8 +6316,6 @@ dependencies = [
  "serde",
  "sov-metrics",
  "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
  "strum 0.28.0",
 ]
 
@@ -6357,7 +6333,6 @@ dependencies = [
  "sov-modules-api",
  "sov-state",
  "strum 0.28.0",
- "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -6367,8 +6342,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "schemars 1.2.1",
- "serde",
  "sov-modules-api",
  "sov-state",
 ]
@@ -6401,19 +6374,16 @@ dependencies = [
  "borsh",
  "bs58",
  "darling 0.21.3",
- "hex",
  "proc-macro2",
  "quote",
  "serde_derive_internals",
  "syn 2.0.117",
- "syn_derive",
 ]
 
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
 dependencies = [
- "proc-macro2",
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
 ]
@@ -7153,18 +7123,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb066a04799e45f5d582e8fc6ec8e6d6896040d00898eb4e6a835196815b219"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]

--- a/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
@@ -5849,7 +5849,6 @@ version = "0.1.0"
 dependencies = [
  "demo-stf",
  "sov-mock-da",
- "sov-mock-zkvm",
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-sp1-adapter",
@@ -5964,7 +5963,6 @@ dependencies = [
  "hex",
  "serde",
  "serde_with",
- "sov-rollup-interface",
  "sov-universal-wallet",
 ]
 

--- a/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
@@ -620,7 +620,6 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
- "borsh",
  "serde",
 ]
 

--- a/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.toml
@@ -11,7 +11,6 @@ demo-stf = { path = "../../../stf", default-features = false }
 sp1-zkvm = "6.1.0"
 
 sov-mock-da = { path = "../../../../../crates/adapters/mock-da", default-features = false }
-sov-mock-zkvm = { path = "../../../../../crates/adapters/mock-zkvm", default-features = false }
 sov-modules-api = { path = "../../../../../crates/module-system/sov-modules-api", default-features = false }
 sov-rollup-interface = { path = "../../../../../crates/rollup-interface", default-features = false }
 sov-sp1-adapter = { path = "../../../../../crates/adapters/sp1", default-features = false }

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -6296,7 +6296,6 @@ dependencies = [
  "hex",
  "serde",
  "serde_with",
- "sov-rollup-interface",
  "sov-universal-wallet",
 ]
 

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -1741,13 +1741,11 @@ dependencies = [
  "anyhow",
  "borsh",
  "demo-stf-declaration",
- "schemars 1.2.0",
  "serde",
  "sov-accounts",
  "sov-address",
  "sov-attester-incentives",
  "sov-bank",
- "sov-blob-storage",
  "sov-build",
  "sov-capabilities",
  "sov-chain-state",
@@ -1761,14 +1759,12 @@ dependencies = [
  "sov-operator-incentives",
  "sov-paymaster",
  "sov-prover-incentives",
- "sov-revenue-share",
  "sov-rollup-interface",
  "sov-sequencer-registry",
  "sov-solana-offchain-auth",
  "sov-state",
  "sov-synthetic-load",
  "sov-test-modules",
- "sov-uniqueness",
  "tracing",
 ]
 
@@ -1785,20 +1781,16 @@ dependencies = [
  "sov-attester-incentives",
  "sov-bank",
  "sov-blob-storage",
- "sov-capabilities",
  "sov-chain-state",
  "sov-evm",
  "sov-hyperlane-integration",
- "sov-kernels",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-operator-incentives",
  "sov-paymaster",
  "sov-prover-incentives",
  "sov-revenue-share",
- "sov-rollup-interface",
  "sov-sequencer-registry",
- "sov-state",
  "sov-synthetic-load",
  "sov-test-modules",
  "sov-uniqueness",
@@ -6180,7 +6172,6 @@ dependencies = [
  "derivative",
  "schemars 1.2.0",
  "serde",
- "sov-address",
  "sov-bank",
  "sov-chain-state",
  "sov-modules-api",
@@ -6216,7 +6207,6 @@ dependencies = [
  "borsh",
  "derive_more 2.1.1",
  "hex",
- "schemars 1.2.0",
  "serde",
  "sov-bank",
  "sov-chain-state",
@@ -6233,7 +6223,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "serde",
  "serde_json",
  "sov-modules-api",
 ]
@@ -6318,10 +6307,7 @@ version = "0.3.0"
 dependencies = [
  "demo-stf",
  "sha2 0.10.9",
- "sov-address",
  "sov-celestia-adapter",
- "sov-kernels",
- "sov-metrics",
  "sov-mock-zkvm",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
@@ -6437,7 +6423,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "borsh",
- "digest 0.10.7",
  "ed25519-dalek",
  "hex",
  "schemars 1.2.0",
@@ -6505,7 +6490,6 @@ dependencies = [
  "anyhow",
  "borsh",
  "hex",
- "schemars 1.2.0",
  "serde",
  "sov-metrics",
  "sov-modules-api",
@@ -6521,15 +6505,10 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "derive_more 2.1.1",
  "schemars 1.2.0",
  "serde",
  "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
  "strum 0.28.0",
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -6537,7 +6516,6 @@ name = "sov-paymaster"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "bcs",
  "borsh",
  "derivative",
  "derive_more 2.1.1",
@@ -6546,7 +6524,6 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-state",
- "sov-universal-wallet",
  "tracing",
 ]
 
@@ -6624,7 +6601,6 @@ dependencies = [
  "anyhow",
  "borsh",
  "hex",
- "schemars 1.2.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -6646,6 +6622,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "slop-algebra",
+ "sov-metrics",
  "sov-rollup-interface",
  "sov-universal-wallet",
  "sov-zkvm-utils",
@@ -6671,7 +6648,6 @@ dependencies = [
  "nomt-core",
  "serde",
  "serde-big-array",
- "serde_with",
  "sov-db-types",
  "sov-metrics",
  "sov-modules-macros",
@@ -6691,8 +6667,6 @@ dependencies = [
  "serde",
  "sov-metrics",
  "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
  "strum 0.28.0",
 ]
 
@@ -6710,7 +6684,6 @@ dependencies = [
  "sov-modules-api",
  "sov-state",
  "strum 0.28.0",
- "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -6720,8 +6693,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "schemars 1.2.0",
- "serde",
  "sov-modules-api",
  "sov-state",
 ]
@@ -6754,19 +6725,16 @@ dependencies = [
  "borsh",
  "bs58",
  "darling 0.21.3",
- "hex",
  "proc-macro2",
  "quote",
  "serde_derive_internals",
  "syn 2.0.114",
- "syn_derive",
 ]
 
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
 dependencies = [
- "proc-macro2",
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.114",
 ]
@@ -7515,18 +7483,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb066a04799e45f5d582e8fc6ec8e6d6896040d00898eb4e6a835196815b219"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -607,7 +607,6 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
- "borsh",
  "serde",
 ]
 

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.toml
@@ -15,13 +15,8 @@ sov-celestia-adapter = { path = "../../../../../crates/adapters/celestia" }
 sov-mock-zkvm = { path = "../../../../../crates/adapters/mock-zkvm" }
 sov-rollup-interface = { path = "../../../../../crates/rollup-interface" }
 sov-modules-api = { path = "../../../../../crates/module-system/sov-modules-api" }
-sov-address = { path = "../../../../../crates/module-system/sov-address" }
 sov-state = { path = "../../../../../crates/module-system/sov-state" }
 sov-modules-stf-blueprint = { path = "../../../../../crates/module-system/sov-modules-stf-blueprint" }
-sov-kernels = { path = "../../../../../crates/module-system/sov-kernels" }
-sov-metrics = { path = "../../../../../crates/full-node/sov-metrics", optional = true, features = [
-    "sp1",
-] }
 sha2 = { version = "0.10", default-features = false }
 
 [patch.crates-io]
@@ -53,4 +48,5 @@ bench = [
     "sov-state/bench",
     "sov-modules-stf-blueprint/bench",
     "sov-celestia-adapter/bench",
+    "sov-sp1-adapter/bench",
 ]

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -5921,7 +5921,6 @@ dependencies = [
  "hex",
  "serde",
  "serde_with",
- "sov-rollup-interface",
  "sov-universal-wallet",
 ]
 
@@ -5933,7 +5932,6 @@ dependencies = [
  "sha2 0.10.9",
  "sov-metrics",
  "sov-mock-da",
- "sov-mock-zkvm",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-sp1-adapter",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -1592,13 +1592,11 @@ dependencies = [
  "anyhow",
  "borsh",
  "demo-stf-declaration",
- "schemars 1.2.0",
  "serde",
  "sov-accounts",
  "sov-address",
  "sov-attester-incentives",
  "sov-bank",
- "sov-blob-storage",
  "sov-build",
  "sov-capabilities",
  "sov-chain-state",
@@ -1612,14 +1610,12 @@ dependencies = [
  "sov-operator-incentives",
  "sov-paymaster",
  "sov-prover-incentives",
- "sov-revenue-share",
  "sov-rollup-interface",
  "sov-sequencer-registry",
  "sov-solana-offchain-auth",
  "sov-state",
  "sov-synthetic-load",
  "sov-test-modules",
- "sov-uniqueness",
  "tracing",
 ]
 
@@ -1636,20 +1632,16 @@ dependencies = [
  "sov-attester-incentives",
  "sov-bank",
  "sov-blob-storage",
- "sov-capabilities",
  "sov-chain-state",
  "sov-evm",
  "sov-hyperlane-integration",
- "sov-kernels",
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-operator-incentives",
  "sov-paymaster",
  "sov-prover-incentives",
  "sov-revenue-share",
- "sov-rollup-interface",
  "sov-sequencer-registry",
- "sov-state",
  "sov-synthetic-load",
  "sov-test-modules",
  "sov-uniqueness",
@@ -5831,7 +5823,6 @@ dependencies = [
  "derivative",
  "schemars 1.2.0",
  "serde",
- "sov-address",
  "sov-bank",
  "sov-chain-state",
  "sov-modules-api",
@@ -5867,7 +5858,6 @@ dependencies = [
  "borsh",
  "derive_more 2.1.1",
  "hex",
- "schemars 1.2.0",
  "serde",
  "sov-bank",
  "sov-chain-state",
@@ -5884,7 +5874,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "serde",
  "serde_json",
  "sov-modules-api",
 ]
@@ -5941,11 +5930,8 @@ dependencies = [
 name = "sov-demo-prover-guest-mock-sp1"
 version = "0.3.0"
 dependencies = [
- "anyhow",
  "demo-stf",
  "sha2 0.10.9",
- "sov-address",
- "sov-kernels",
  "sov-metrics",
  "sov-mock-da",
  "sov-mock-zkvm",
@@ -6062,7 +6048,6 @@ dependencies = [
  "anyhow",
  "bincode",
  "borsh",
- "digest 0.10.7",
  "ed25519-dalek",
  "hex",
  "schemars 1.2.0",
@@ -6130,7 +6115,6 @@ dependencies = [
  "anyhow",
  "borsh",
  "hex",
- "schemars 1.2.0",
  "serde",
  "sov-metrics",
  "sov-modules-api",
@@ -6146,15 +6130,10 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "derive_more 2.1.1",
  "schemars 1.2.0",
  "serde",
  "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
  "strum 0.28.0",
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -6162,7 +6141,6 @@ name = "sov-paymaster"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "bcs",
  "borsh",
  "derivative",
  "derive_more 2.1.1",
@@ -6171,7 +6149,6 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-state",
- "sov-universal-wallet",
  "tracing",
 ]
 
@@ -6249,7 +6226,6 @@ dependencies = [
  "anyhow",
  "borsh",
  "hex",
- "schemars 1.2.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -6271,6 +6247,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "slop-algebra",
+ "sov-metrics",
  "sov-rollup-interface",
  "sov-universal-wallet",
  "sov-zkvm-utils",
@@ -6296,7 +6273,6 @@ dependencies = [
  "nomt-core",
  "serde",
  "serde-big-array",
- "serde_with",
  "sov-db-types",
  "sov-metrics",
  "sov-modules-macros",
@@ -6316,8 +6292,6 @@ dependencies = [
  "serde",
  "sov-metrics",
  "sov-modules-api",
- "sov-rollup-interface",
- "sov-state",
  "strum 0.28.0",
 ]
 
@@ -6335,7 +6309,6 @@ dependencies = [
  "sov-modules-api",
  "sov-state",
  "strum 0.28.0",
- "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -6345,8 +6318,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "borsh",
- "schemars 1.2.0",
- "serde",
  "sov-modules-api",
  "sov-state",
 ]
@@ -6379,19 +6350,16 @@ dependencies = [
  "borsh",
  "bs58",
  "darling 0.21.3",
- "hex",
  "proc-macro2",
  "quote",
  "serde_derive_internals",
  "syn 2.0.114",
- "syn_derive",
 ]
 
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
 dependencies = [
- "proc-macro2",
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.114",
 ]
@@ -7131,18 +7099,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb066a04799e45f5d582e8fc6ec8e6d6896040d00898eb4e6a835196815b219"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -607,7 +607,6 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
- "borsh",
  "serde",
 ]
 

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.toml
@@ -13,7 +13,6 @@ sov-mock-da = { path = "../../../../../crates/adapters/mock-da" }
 demo-stf = { path = "../../../stf" }
 sov-metrics = { path = "../../../../../crates/full-node/sov-metrics", optional = true }
 sov-sp1-adapter = { path = "../../../../../crates/adapters/sp1" }
-sov-mock-zkvm = { path = "../../../../../crates/adapters/mock-zkvm" }
 sov-modules-api = { path = "../../../../../crates/module-system/sov-modules-api" }
 sov-state = { path = "../../../../../crates/module-system/sov-state" }
 sov-modules-stf-blueprint = { path = "../../../../../crates/module-system/sov-modules-stf-blueprint" }

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.toml
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.toml
@@ -8,20 +8,15 @@ resolver = "2"
 [workspace]
 
 [dependencies]
-anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.1.0" }
 sov-mock-da = { path = "../../../../../crates/adapters/mock-da" }
 demo-stf = { path = "../../../stf" }
+sov-metrics = { path = "../../../../../crates/full-node/sov-metrics", optional = true }
 sov-sp1-adapter = { path = "../../../../../crates/adapters/sp1" }
 sov-mock-zkvm = { path = "../../../../../crates/adapters/mock-zkvm" }
 sov-modules-api = { path = "../../../../../crates/module-system/sov-modules-api" }
-sov-address = { path = "../../../../../crates/module-system/sov-address" }
 sov-state = { path = "../../../../../crates/module-system/sov-state" }
 sov-modules-stf-blueprint = { path = "../../../../../crates/module-system/sov-modules-stf-blueprint" }
-sov-kernels = { path = "../../../../../crates/module-system/sov-kernels" }
-sov-metrics = { path = "../../../../../crates/full-node/sov-metrics", optional = true, features = [
-    "sp1",
-] }
 sha2 = { version = "0.10", default-features = false }
 
 [patch.crates-io]
@@ -50,8 +45,12 @@ opt-level = 3
 [features]
 default = []
 bench = [
+    "sov-metrics/sp1",
     "sov-modules-api/bench",
     "sov-state/bench",
     "sov-modules-stf-blueprint/bench",
-    "sov-metrics",
+    "sov-sp1-adapter/bench",
 ]
+
+[package.metadata.cargo-machete]
+ignored = ["sov-metrics"]

--- a/examples/demo-rollup/rest-api-load-testing/Cargo.toml
+++ b/examples/demo-rollup/rest-api-load-testing/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 tokio = { workspace = true, features = ["full"] }
-borsh = { workspace = true }
 
 anyhow = { workspace = true }
 sov-address = { workspace = true, features = ["evm"] }
@@ -23,10 +22,7 @@ sov-cli = { workspace = true }
 rest-api-load-testing = {workspace = true}
 sov-modules-api = {workspace = true}
 sov-api-spec = { workspace = true }
-sov-mock-da = { workspace = true, features = ["native"] }
-sov-mock-zkvm = { workspace = true, features = ["native"] }
 sov-bank = { workspace = true, features = ["native", "test-utils"] }
 demo-stf = { workspace = true, features = ["native"] }
 sov-modules-rollup-blueprint = { workspace = true }
 sov-demo-rollup = { path = ".." }
-sha2 = { workspace = true }

--- a/examples/demo-rollup/sov-benchmarks/Cargo.toml
+++ b/examples/demo-rollup/sov-benchmarks/Cargo.toml
@@ -8,11 +8,14 @@ license = { workspace = true }
 repository = { workspace = true }
 publish = false
 
+[package.metadata.cargo-machete]
+ignored = ["prettytable-rs"]
+
 [dependencies]
 # Sovereign dependencies
 sov-rollup-interface = { workspace = true, features = ["arbitrary"] }
 sov-modules-api = { workspace = true, features = ["arbitrary", "bench", "native"] }
-sov-capabilities = { workspace = true }
+sov-modules-rollup-blueprint = { workspace = true }
 sov-state = { workspace = true }
 sov-db = { workspace = true }
 
@@ -20,9 +23,7 @@ sov-test-modules = { workspace = true, features = ["native"] }
 sov-test-utils = { workspace = true, features = ["arbitrary"] }
 sov-address = { workspace = true }
 sov-hyperlane-integration = { workspace = true, features = ["native"] }
-sov-modules-stf-blueprint = { workspace = true, features = ["bench"] }
 sov-transaction-generator = { workspace = true }
-sov-modules-rollup-blueprint = { workspace = true, default-features = false }
 sov-node-client = { workspace = true }
 
 sov-metrics = { workspace = true, default-features = false }
@@ -41,12 +42,10 @@ sov-sp1-adapter = { workspace = true, features = ["arbitrary", "native"] }
 risc0 = { path = "../provers/risc0", features = ["bench"] }
 
 # Other dependencies
-derive_more = { workspace = true, default-features = false, features = ["std"] }
 tracing = { workspace = true, default-features = false }
 prettytable-rs = "^0.10"
 criterion = "0.5.1"
 bincode = { workspace = true }
-derivative = { workspace = true, features = ["use_core"] }
 anyhow = { workspace = true }
 serde = { workspace = true, default-features = false, features = [
     "alloc",
@@ -58,7 +57,6 @@ async-trait = { workspace = true }
 humantime = "2.1"
 clap = { workspace = true }
 tempfile = { workspace = true }
-strum = { workspace = true, features = ["derive"] }
 futures = { workspace = true, default-features = false }
 
 [[bench]]
@@ -75,5 +73,4 @@ harness = false
 gas-constant-estimation = [
     "sov-modules-api/gas-constant-estimation",
     "sov-metrics/gas-constant-estimation",
-    "sov-modules-stf-blueprint/gas-constant-estimation",
 ]

--- a/examples/demo-rollup/sov-soak-testing/Cargo.toml
+++ b/examples/demo-rollup/sov-soak-testing/Cargo.toml
@@ -11,20 +11,17 @@ default-run = "main"
 
 [dependencies]
 tokio = { workspace = true, default-features = false }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 borsh = { workspace = true, features = ["derive"] }
-
+clap = { workspace = true }
+reqwest = { workspace = true }
 schemars = { workspace = true, features = ["derive"] }
 serde = { workspace = true, default-features = false, features = [
     "alloc",
     "derive",
 ] }
-anyhow = { workspace = true }
-async-trait = { workspace = true }
-derivative = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
-rand = { workspace = true }
-clap = { workspace = true }
-reqwest = { workspace = true }
 
 sov-api-spec = { workspace = true }
 sov-metrics = { workspace = true }
@@ -33,21 +30,17 @@ sov-modules-stf-blueprint = { workspace = true, features = ["native"] }
 sov-transaction-generator = { workspace = true }
 sov-modules-api = { workspace = true }
 sov-test-utils = { workspace = true, features = ["arbitrary"] }
-sov-evm-test-utils = { workspace = true, features = ["arbitrary"] }
 sov-mock-da = { workspace = true, features = ["arbitrary", "native"] }
 sov-mock-zkvm = { workspace = true, features = ["native"] }
 sov-rollup-interface = { workspace = true, features = ["arbitrary"] }
-sov-node-client = { workspace = true }
 sov-sequencer = { workspace = true, default-features = false }
 sov-kernels = { workspace = true, features = ["native"] }
 sov-state = { workspace = true, features = ["arbitrary"] }
 # modules
-sov-value-setter = { workspace = true }
 sov-synthetic-load = { workspace = true }
 sov-bank = { workspace = true, features = ["native", "arbitrary"] }
 sov-paymaster = { workspace = true, features = ["native"] }
 sov-celestia-adapter = { workspace = true, features = ["native", "arbitrary"] }
-sov-address = { workspace = true }
 demo-stf = { workspace = true, features = ["native", "arbitrary"] }
 sov-soak-testing-lib = { workspace = true }
 sov-db = { workspace = true }
@@ -62,3 +55,6 @@ path = "src/bin/main.rs"
 [[bin]]
 name = "generator"
 path = "src/bin/generator.rs"
+
+[package.metadata.cargo-machete]
+ignored = ["borsh", "schemars", "serde", "strum"]

--- a/examples/demo-rollup/stf/Cargo.toml
+++ b/examples/demo-rollup/stf/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = { workspace = true }
 borsh = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["alloc", "derive"] }
 serde_json = { workspace = true, optional = true }
-schemars = { workspace = true }
 tracing = { workspace = true }
 
 sov-accounts = { workspace = true }
@@ -27,13 +26,10 @@ sov-attester-incentives = { workspace = true }
 sov-bank = { workspace = true }
 sov-capabilities = { workspace = true }
 sov-chain-state = { workspace = true }
-sov-blob-storage = { workspace = true }
 sov-evm = { workspace = true }
 sov-hyperlane-integration = { workspace = true, features = ["evm"] }
-sov-revenue-share = { workspace = true }
 sov-modules-api = { workspace = true }
 sov-modules-stf-blueprint = { workspace = true }
-sov-uniqueness = { workspace = true }
 sov-paymaster = { workspace = true }
 sov-operator-incentives = { workspace = true }
 sov-prover-incentives = { workspace = true }
@@ -70,7 +66,6 @@ arbitrary = [
 	"sov-sequencer-registry/arbitrary",
 	"sov-state/arbitrary",
 	"sov-test-utils?/arbitrary",
-	"sov-uniqueness/arbitrary",
 	"sov-mock-da/arbitrary",
 	"sov-mock-zkvm/arbitrary",
 	"sov-hyperlane-integration/arbitrary"
@@ -84,18 +79,15 @@ native = [
 	"sov-chain-state/native",
 	"sov-evm/native",
 	"sov-hyperlane-integration/native",
-	"sov-revenue-share/native",
 	"sov-kernels/native",
 	"sov-modules-api/native",
 	"sov-modules-stf-blueprint/native",
-	"sov-uniqueness/native",
 	"sov-operator-incentives/native",
 	"sov-prover-incentives/native",
 	"sov-rollup-interface/native",
 	"sov-sequencer-registry/native",
 	"sov-state/native",
 	"sov-synthetic-load/native",
-	"sov-blob-storage/native",
 	"sov-rollup-apis",
 	"serde_json",
 	"sov-paymaster/native",

--- a/examples/demo-rollup/stf/demo-stf-json-client/Cargo.toml
+++ b/examples/demo-rollup/stf/demo-stf-json-client/Cargo.toml
@@ -8,6 +8,9 @@ homepage.workspace = true
 repository.workspace = true
 publish = false
 
+[package.metadata.cargo-machete]
+ignored = ["futures", "progenitor-client", "regress", "reqwest", "serde", "serde_json"]
+
 # These dependencies are not defined through workspace inheritance because
 # `progenitor` demands very specific version ranges for its dependencies. Read
 # more here: <https://github.com/oxidecomputer/progenitor>.

--- a/examples/demo-rollup/stf/stf-declaration/Cargo.toml
+++ b/examples/demo-rollup/stf/stf-declaration/Cargo.toml
@@ -17,21 +17,16 @@ sov-address = { workspace = true, features = ["evm"] }
 sov-attester-incentives = { workspace = true }
 sov-bank = { workspace = true }
 sov-blob-storage = { workspace = true }
-sov-capabilities = { workspace = true }
 sov-chain-state = { workspace = true }
 sov-evm = { workspace = true }
 sov-hyperlane-integration = { workspace = true, features = ["evm"] }
 sov-revenue-share = { workspace = true }
-sov-kernels = { workspace = true }
 sov-modules-api = { workspace = true }
 sov-modules-stf-blueprint = { workspace = true }
 sov-operator-incentives = { workspace = true }
 sov-paymaster = { workspace = true }
 sov-prover-incentives = { workspace = true }
-sov-rollup-apis = { workspace = true, optional = true }
-sov-rollup-interface = { workspace = true }
 sov-sequencer-registry = { workspace = true }
-sov-state = { workspace = true }
 sov-synthetic-load = { workspace = true }
 sov-test-modules = { workspace = true }
 sov-test-utils = { workspace = true, optional = true }
@@ -40,8 +35,6 @@ sov-uniqueness = { workspace = true }
 anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
 borsh = { workspace = true, features = ["derive"] }
-clap = { workspace = true, features = ["derive"], optional = true }
-jsonrpsee = { workspace = true, features = ["http-client", "server"], optional = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["alloc", "derive"] }
 strum = { workspace = true, features = ["derive"] }
@@ -49,28 +42,21 @@ strum = { workspace = true, features = ["derive"] }
 [features]
 default = []
 native = [
-	"clap",
-	"jsonrpsee",
 	"sov-accounts/native",
 	"sov-address/native",
 	"sov-attester-incentives/native",
 	"sov-bank/native",
 	"sov-blob-storage/native",
-	"sov-capabilities/native",
 	"sov-chain-state/native",
 	"sov-evm/native",
 	"sov-hyperlane-integration/native",
 	"sov-revenue-share/native",
-	"sov-kernels/native",
 	"sov-modules-api/native",
 	"sov-modules-stf-blueprint/native",
 	"sov-operator-incentives/native",
 	"sov-paymaster/native",
 	"sov-prover-incentives/native",
-	"sov-rollup-apis",
-	"sov-rollup-interface/native",
 	"sov-sequencer-registry/native",
-	"sov-state/native",
 	"sov-synthetic-load/native",
 	"sov-test-modules/native",
 	"sov-uniqueness/native",
@@ -83,9 +69,7 @@ arbitrary = [
 	"sov-evm/arbitrary",
 	"sov-modules-api/arbitrary",
 	"sov-paymaster/arbitrary",
-	"sov-rollup-interface/arbitrary",
 	"sov-sequencer-registry/arbitrary",
-	"sov-state/arbitrary",
 	"sov-test-utils?/arbitrary",
 	"sov-uniqueness/arbitrary",
 	"sov-hyperlane-integration/arbitrary"
@@ -94,3 +78,6 @@ test-utils = [
     "native",
     "sov-test-utils",
 ]
+
+[package.metadata.cargo-machete]
+ignored = ["strum"]

--- a/examples/demo-rollup/tests/prover/sov-aggregated-proof/Cargo.toml
+++ b/examples/demo-rollup/tests/prover/sov-aggregated-proof/Cargo.toml
@@ -16,10 +16,7 @@ bincode = "1.3.3"
 demo-stf = { workspace = true, features = ["native"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-slop-algebra = "6.1.0"
 sp1 = { path = "../../../provers/sp1" }
-sp1-core-executor = "6.1.0"
-sp1-recursion-executor = "6.1.0"
 sp1-sdk = { version = "6.1.0", default-features = false, features = ["blocking"] }
 sov-mock-da = { workspace = true, features = ["native"] }
 sov-mock-zkvm = { workspace = true, features = ["native"] }

--- a/typescript/packages/universal-wallet-wasm/Cargo.lock
+++ b/typescript/packages/universal-wallet-wasm/Cargo.lock
@@ -268,7 +268,6 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
- "borsh",
  "serde",
 ]
 
@@ -1202,6 +1201,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,11 +1348,12 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
+ "ref-cast",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -1341,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
# Description

Our makefile's `install-dev-tools` section installs cargo-udeps, but it seems broken because it requires a nightly compiler and it breaks sp1 crates when I tried it.

This PR replaces it with `cargo machete`, which is must faster and works fine, except it has a lot of false positives. Codex worked for some hours in the background adding `[package.metadata.cargo-machete]` sections to Cargo.toml files where necessary to get everything to compile again.

Net changes:
* -150 in Cargo.lock, a couple of dependency versions removed from the workspace
* Net minus in sp1 and risc0 crate Cargo.locks
* 10 completely unused dependencies removed from Cargo.toml
* A number of `[package.metadata.cargo-machete]` noise added to many Cargo.toml files
* With those metadata sections, `cargo machete` can run in CI for the future (once we update the Namespace base image)

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
