### PR TITLE
 SP1: enable mock proving via `SP1_PROVER` env var and remove `MockSp1Prover`.

### DIFF
--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -139,7 +139,6 @@ impl SP1AggregationHost {
 pub struct SP1Host {
     prover: EnvProver,
     pk: Arc<EnvProvingKey>,
-    is_mock: bool,
 }
 
 /// Instantiate a new SP1 Host.
@@ -147,7 +146,6 @@ impl SP1Host {
     /// Create a new SP1 Host.
     pub fn new(elf: &[u8]) -> anyhow::Result<Self> {
         let prover = ProverClient::from_env();
-        let is_mock = std::env::var("SP1_PROVER").as_deref() == Ok("mock");
 
         let pk = prover
             .setup(elf.into())
@@ -156,7 +154,6 @@ impl SP1Host {
         Ok(Self {
             prover,
             pk: Arc::new(pk),
-            is_mock,
         })
     }
 
@@ -188,7 +185,9 @@ impl SP1Host {
         // would fail the executor-side deferred-proof check. Skip that check so
         // mock aggregation can run end-to-end; real backends keep it on.
         let request = self.prover.prove(&self.pk, stdin).compressed();
-        let request = if self.is_mock {
+
+        let is_mock = matches!(&self.prover, &EnvProver::Mock(_));
+        let request = if is_mock {
             request.deferred_proof_verification(false)
         } else {
             request

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -15,9 +15,9 @@ use sov_rollup_interface::zk::aggregated_proof::{
 };
 use sov_rollup_interface::zk::ZkvmHost;
 use sp1_sdk::blocking::ProveRequest;
-use sp1_sdk::blocking::{CpuProver, MockProver, Prover, ProverClient};
+use sp1_sdk::blocking::{EnvProver, EnvProvingKey, Prover, ProverClient};
 use sp1_sdk::ProvingKey;
-use sp1_sdk::{HashableKey, SP1Proof, SP1ProvingKey, SP1Stdin};
+use sp1_sdk::{HashableKey, SP1Proof, SP1Stdin};
 
 /// SP1 host that produces aggregated (outer) proofs by recursively verifying
 /// a batch of inner state-transition proofs inside an SP1 guest program.
@@ -135,16 +135,20 @@ impl SP1AggregationHost {
 }
 
 /// SP1 Host implementation.
+#[derive(Clone)]
 pub struct SP1Host {
-    prover: CpuProver,
-    pk: Arc<SP1ProvingKey>,
+    prover: EnvProver,
+    pk: Arc<EnvProvingKey>,
+    is_mock: bool,
 }
 
 /// Instantiate a new SP1 Host.
 impl SP1Host {
     /// Create a new SP1 Host.
     pub fn new(elf: &[u8]) -> anyhow::Result<Self> {
-        let prover = ProverClient::builder().cpu().build();
+        let prover = ProverClient::from_env();
+        let is_mock = std::env::var("SP1_PROVER").as_deref() == Ok("mock");
+
         let pk = prover
             .setup(elf.into())
             .map_err(|e| anyhow::anyhow!("SP1 setup failed. Error: {:?}", e))?;
@@ -152,6 +156,7 @@ impl SP1Host {
         Ok(Self {
             prover,
             pk: Arc::new(pk),
+            is_mock,
         })
     }
 
@@ -179,23 +184,20 @@ impl SP1Host {
     }
 
     fn run_helper(&self, stdin: SP1Stdin) -> anyhow::Result<sp1_sdk::SP1ProofWithPublicValues> {
-        let output: sp1_sdk::SP1ProofWithPublicValues = self
-            .prover
-            .prove(&self.pk, stdin)
-            .compressed()
+        // Under the mock backend the inner compressed proofs are dummies that
+        // would fail the executor-side deferred-proof check. Skip that check so
+        // mock aggregation can run end-to-end; real backends keep it on.
+        let request = self.prover.prove(&self.pk, stdin).compressed();
+        let request = if self.is_mock {
+            request.deferred_proof_verification(false)
+        } else {
+            request
+        };
+        let output: sp1_sdk::SP1ProofWithPublicValues = request
             .run()
             .map_err(|e| anyhow::anyhow!("SP1 proving failed. Error: {:?}", e))?;
 
         Ok(output)
-    }
-}
-
-impl Clone for SP1Host {
-    fn clone(&self) -> Self {
-        Self {
-            prover: self.prover.clone(),
-            pk: self.pk.clone(),
-        }
     }
 }
 
@@ -224,54 +226,6 @@ impl ZkvmHost for SP1Host {
         Ok(crate::SP1MethodId(bincode::serialize(
             self.pk.verifying_key(),
         )?))
-    }
-}
-
-/// SP1 prover that uses the mock backend for fast, deterministic proving
-/// without generating real cryptographic proofs.
-///
-/// Useful for testing and development where proof validity doesn't matter
-/// but the proving pipeline needs to be exercised end-to-end.
-#[derive(Clone)]
-pub struct MockSp1Prover {
-    prover: MockProver,
-    pk: Arc<SP1ProvingKey>,
-}
-
-impl MockSp1Prover {
-    /// Creates a new mock prover for the given guest ELF binary.
-    pub fn new(elf: &[u8]) -> anyhow::Result<Self> {
-        let prover = ProverClient::builder().mock().build();
-        let pk = prover
-            .setup(elf.into())
-            .map_err(|e| anyhow::anyhow!("SP1 setup failed. Error: {:?}", e))?;
-
-        Ok(Self {
-            prover,
-            pk: Arc::new(pk),
-        })
-    }
-
-    /// Writes `item` to the guest's stdin and generates a compressed mock proof.
-    pub fn add_hint_and_run<T: Serialize>(
-        &self,
-        item: &T,
-    ) -> anyhow::Result<sp1_sdk::SP1ProofWithPublicValues> {
-        let mut stdin = SP1Stdin::new();
-        stdin.write(item);
-
-        self.prover
-            .prove(&self.pk, stdin)
-            .compressed()
-            .run()
-            .map_err(|e| anyhow::anyhow!("SP1 proving failed. Error: {:?}", e))
-    }
-
-    /// Verifies a mock proof against the program's verifying key.
-    pub fn verify(&self, proof: &sp1_sdk::SP1ProofWithPublicValues) -> anyhow::Result<()> {
-        self.prover
-            .verify(proof, self.pk.verifying_key(), None)
-            .map_err(|e| anyhow::anyhow!("SP1 verification failed. Error: {:?}", e))
     }
 }
 

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -103,8 +103,9 @@ impl ZkVerifier for SP1Verifier {
         // public inputs and accepts Core/Compressed unconditionally.
         match &prover {
             sp1_sdk::blocking::EnvProver::Mock(mock) => {
-                sp1_sdk::blocking::Prover::verify(mock, &proof, &verifying_key, None)?
+                sp1_sdk::blocking::Prover::verify(mock, &proof, &verifying_key, None)?;
             }
+
             _ => sp1_sdk::blocking::Prover::verify(&prover, &proof, &verifying_key, None)?,
         }
         Ok(bincode::deserialize(proof.public_values.as_slice())?)

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -94,10 +94,19 @@ impl ZkVerifier for SP1Verifier {
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         let proof = decode_sp1_proof(serialized_proof)?;
-        let prover = sp1_sdk::blocking::ProverClient::builder().cpu().build();
+        let prover = sp1_sdk::blocking::ProverClient::from_env();
         let verifying_key: sp1_sdk::SP1VerifyingKey = bincode::deserialize(&code_commitment.0)?;
 
-        sp1_sdk::blocking::Prover::verify(&prover, &proof, &verifying_key, None)?;
+        // The default `Prover::verify` path performs public-values / committed-digest
+        // checks that the dummy compressed proofs produced by the mock backend don't
+        // satisfy. Dispatch to the inner `MockProver`, which only checks Plonk/Groth16
+        // public inputs and accepts Core/Compressed unconditionally.
+        match &prover {
+            sp1_sdk::blocking::EnvProver::Mock(mock) => {
+                sp1_sdk::blocking::Prover::verify(mock, &proof, &verifying_key, None)?
+            }
+            _ => sp1_sdk::blocking::Prover::verify(&prover, &proof, &verifying_key, None)?,
+        }
         Ok(bincode::deserialize(proof.public_values.as_slice())?)
     }
 }

--- a/crates/adapters/sp1/tests/integration/native.rs
+++ b/crates/adapters/sp1/tests/integration/native.rs
@@ -58,5 +58,5 @@ fn test_fibonnaci_host() {
 
     // Give the input 7 to the fibonnaci program. Under the mock backend this
     // exercises the proving pipeline end-to-end without generating real proofs.
-    let _ = host.add_hint_and_run(&7u32).unwrap();
+    host.add_hint_and_run(&7u32).unwrap();
 }

--- a/crates/adapters/sp1/tests/integration/native.rs
+++ b/crates/adapters/sp1/tests/integration/native.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::zk::ZkvmGuest;
-use sov_sp1_adapter::host::{MockSp1Prover, SP1Host};
+use sov_rollup_interface::zk::{ZkvmGuest, ZkvmHost};
+use sov_sp1_adapter::host::SP1Host;
 use sp1_build::BuildArgs;
 use sp1_sdk::SP1Stdin;
 
@@ -49,11 +49,14 @@ fn build_fibonacci_elf() {
 
 #[test]
 fn test_fibonnaci_host() {
+    // Use the mock prover: CPU proving is far too slow to run in tests.
+    std::env::set_var("SP1_PROVER", "mock");
+
     let fibonacci_elf = include_bytes!("../../test_data/riscv64im-succinct-zkvm-elf");
 
-    let host = MockSp1Prover::new(fibonacci_elf).unwrap();
+    let mut host = SP1Host::new(fibonacci_elf).unwrap();
 
-    // Give the input 7 to the fibonnaci program
-    let proof = host.add_hint_and_run(&7u32).unwrap();
-    host.verify(&proof).unwrap();
+    // Give the input 7 to the fibonnaci program. Under the mock backend this
+    // exercises the proving pipeline end-to-end without generating real proofs.
+    let _ = host.add_hint_and_run(&7u32).unwrap();
 }

--- a/examples/demo-rollup/tests/prover/parallel.rs
+++ b/examples/demo-rollup/tests/prover/parallel.rs
@@ -28,11 +28,10 @@ type TestParallelProverService = ParallelProverService<
 ///
 /// Prerequisites:
 ///   - SP1 guest ELF built (`cargo build` in the prover guest directory)
-///   - Sufficient CPU resources for local proving
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Requires SP1 guest ELF and significant CPU resources for local proving"]
 async fn test_parallel_proof_generation() {
-    tracing_subscriber::fmt::init();
+    // Use the mock prover: CPU proving is far too slow to run in tests.
+    std::env::set_var("SP1_PROVER", "mock");
 
     let elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
     assert!(

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{DefaultSpec, ProofStateRoot, ProofWitness};
+use super::{DefaultSpec, ProofStateRoot, ProofWitness, StfWitness};
 use sov_mock_da::MockDaSpec;
 use sov_modules_api::{Spec, ZkVerifier};
 use sov_rollup_interface::da::BlockHeaderTrait;
@@ -9,7 +9,7 @@ use sov_rollup_interface::zk::SerializedInnerProof;
 use sov_rollup_interface::zk::{
     StateTransitionPublicData, StateTransitionWitnessWithAddress, ZkvmHost,
 };
-use sov_sp1_adapter::host::{MockSp1Prover, SP1Host};
+use sov_sp1_adapter::host::SP1Host;
 use sov_sp1_adapter::{SP1MethodId, SP1Verifier};
 
 type ProofInput = StateTransitionWitnessWithAddress<
@@ -22,7 +22,7 @@ type ProofInput = StateTransitionWitnessWithAddress<
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "This test is used to generate data for testing the aggregate proof circuit and should be enabled only when needed."]
 async fn test_save_proofs() {
-    let (host, code_commitment) = TestHost::new(true).await;
+    let (host, code_commitment) = TestHost::new().await;
     let proof_data = generate_proofs(&host).await;
     let proofs_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
@@ -45,93 +45,97 @@ async fn test_save_proofs() {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(skip_guest_build, ignore)]
 async fn test_proof_generation() {
-    let (host, _) = TestHost::new(false).await;
-    let _ = generate_proofs(&host).await;
+    // Use the mock prover: CPU proving is far too slow to run in tests.
+    std::env::set_var("SP1_PROVER", "mock");
+
+    let (host, code_commitment) = TestHost::new().await;
+    let (_genesis_state_root, witnesses) = super::generate_witnesses().await;
+    let prover_address = default_prover_address();
+
+    for witness in witnesses {
+        let initial_state_root = witness.initial_state_root.clone();
+        let final_state_root = witness.final_state_root.clone();
+
+        let proof = generate_proof(&host, witness, prover_address).await;
+        let proof_public_data = verify(proof.proof.raw_inner_proof, code_commitment.clone()).await;
+
+        assert_eq!(proof_public_data.slot_hash, proof.da_block_header.hash());
+        // TODO: Uncomment after NOmt bug is solved: https://github.com/Sovereign-Labs/sovereign-sdk/pull/2739
+        //assert_eq!(proof_public_data.initial_state_root, initial_state_root);
+        //assert_eq!(proof_public_data.final_state_root, final_state_root);
+        assert_eq!(proof_public_data.prover_address, prover_address);
+    }
 }
 
 async fn generate_proofs(host: &TestHost) -> Vec<BlockHeaderWithProof<MockDaSpec>> {
     let (_genesis_state_root, witnesses) = super::generate_witnesses().await;
+    let prover_address = default_prover_address();
 
-    let prover_address = <DefaultSpec as Spec>::Address::try_from([0u8; 28].as_ref()).unwrap();
     let mut proofs = Vec::new();
-
     for witness in witnesses {
-        let da_block_header = witness.da_block_header.clone();
-
-        let data: ProofInput = StateTransitionWitnessWithAddress {
-            stf_witness: witness,
-            prover_address,
-        };
-
-        let raw_inner_proof = host.run(data).await;
-        proofs.push(BlockHeaderWithProof {
-            da_block_header,
-            proof: SerializedInnerProof { raw_inner_proof },
-        });
+        proofs.push(generate_proof(host, witness, prover_address).await);
     }
-
     proofs
+}
+
+async fn generate_proof(
+    host: &TestHost,
+    witness: StfWitness,
+    prover_address: <DefaultSpec as Spec>::Address,
+) -> BlockHeaderWithProof<MockDaSpec> {
+    let da_block_header = witness.da_block_header.clone();
+
+    let data: ProofInput = StateTransitionWitnessWithAddress {
+        stf_witness: witness,
+        prover_address,
+    };
+
+    let raw_inner_proof = host.run(data).await;
+    BlockHeaderWithProof {
+        da_block_header,
+        proof: SerializedInnerProof { raw_inner_proof },
+    }
+}
+
+fn default_prover_address() -> <DefaultSpec as Spec>::Address {
+    <DefaultSpec as Spec>::Address::try_from([0u8; 28].as_ref()).unwrap()
 }
 
 // The SP1 prover manages its own Tokio runtime, which conflicts with the `tokio::test` runtime.
 // To avoid this, all blocking work must be executed inside `tokio::task::spawn_blocking`.
 struct TestHost {
     host: SP1Host,
-    mock_host: MockSp1Prover,
-    with_proof: bool,
 }
 
 impl TestHost {
-    async fn new(with_proof: bool) -> (Self, SP1MethodId) {
-        let (code_commitment, host, mock_host) = tokio::task::spawn_blocking(move || {
+    async fn new() -> (Self, SP1MethodId) {
+        let (code_commitment, host) = tokio::task::spawn_blocking(move || {
             let host = SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF)
                 .expect("SP1Host should be created successfully");
-
-            let mock_host = MockSp1Prover::new(*sp1::SP1_GUEST_MOCK_ELF)
-                .expect("MockSp1Prover should be created successfully");
 
             (
                 host.code_commitment()
                     .expect("SP1 code commitment should be created successfully"),
                 host,
-                mock_host,
             )
         })
         .await
         .unwrap();
 
-        (
-            Self {
-                host,
-                mock_host,
-                with_proof,
-            },
-            code_commitment,
-        )
+        (Self { host }, code_commitment)
     }
 
     async fn run(&self, data: ProofInput) -> Vec<u8> {
-        if self.with_proof {
-            let mut host = self.host.clone();
-            tokio::task::spawn_blocking(move || -> Vec<u8> {
-                host.add_hint_and_run(&data)
-                    .expect("Prover should run successfully")
-            })
-            .await
-            .unwrap()
-        } else {
-            let mock_host = self.mock_host.clone();
-            tokio::task::spawn_blocking(move || -> Vec<u8> {
-                mock_host.add_hint_and_run(&data).unwrap();
-                Default::default()
-            })
-            .await
-            .unwrap()
-        }
+        let mut host = self.host.clone();
+        tokio::task::spawn_blocking(move || -> Vec<u8> {
+            host.add_hint_and_run(&data)
+                .expect("Prover should run successfully")
+        })
+        .await
+        .unwrap()
     }
 }
 
-#[allow(dead_code)]
 async fn verify(
     proof: Vec<u8>,
     code_commitment: SP1MethodId,

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -53,8 +53,8 @@ async fn test_proof_generation() {
     let prover_address = default_prover_address();
 
     for witness in witnesses {
-        let _initial_state_root = witness.initial_state_root.clone();
-        let _final_state_root = witness.final_state_root.clone();
+        let _initial_state_root = witness.initial_state_root;
+        let _final_state_root = witness.final_state_root;
 
         let proof = generate_proof(&host, witness, prover_address).await;
         let proof_public_data = verify(proof.proof.raw_inner_proof, code_commitment.clone()).await;

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -53,8 +53,8 @@ async fn test_proof_generation() {
     let prover_address = default_prover_address();
 
     for witness in witnesses {
-        let initial_state_root = witness.initial_state_root.clone();
-        let final_state_root = witness.final_state_root.clone();
+        let _initial_state_root = witness.initial_state_root.clone();
+        let _final_state_root = witness.final_state_root.clone();
 
         let proof = generate_proof(&host, witness, prover_address).await;
         let proof_public_data = verify(proof.proof.raw_inner_proof, code_commitment.clone()).await;


### PR DESCRIPTION
# Description

This PR replaces the separate `CpuProver / MockProver` (and the custom `MockSp1Prover` wrapper) with SP1 SDK's unified EnvProver, which selects the proving backend at runtime via the SP1_PROVER environment variable.

This simplifies testing and removes boilerplate code. 

Key changes:
1. `SP1Host` now wraps `EnvProver + EnvProvingKey` instead of `CpuProver + SP1ProvingKey`
2. `MockSp1Prover` struct is deleted entirely; tests set SP1_PROVER=mock and use SP1Host directly
3. Mock-specific workarounds added: deferred proof verification is disabled for mock proofs, and verification dispatches to MockProver inner to avoid digest checks that dummy proofs can't satisfy
4. TestHost in demo-rollup tests simplified: with_proof flag and dual-host setup removed

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551
