### PR TITLE
Add non malleable hash for Generation uniqueness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Temporary section for maintaining breaking changes from individual PRs, which wi
   * Previous signatures are no longer valid. Clients will need to upgrade to our latest SDKs to be able to sign transactions in the new format.
   * The `UnsignedTransaction` type, and multiple member methods of `Transaction`, have changed. Our client SDKs have been updated, but for users manually constructing an UnsignedTransaction in Rust, we recommend explicitly using `UnsignedTransactionV0`. For creating a multisig, use `UnsignedTransactionV0::to_multisig_tx()`.
   * The CHAIN_HASH has changed.
+  * The `Generation` uniqueness (replay protection) mechanism has been amended to fix a transaction hash malleability vulnerability with V1 transactions. New, non-malleable hashes are used to prevent replay. **If the rollup has had public V1 transactions submitted**, a migration script must increment the current generation of every user that has submitted a V1 transaction by `PAST_TRANSACTION_GENERATIONS` to invalidate prior existing hashes. No action is needed if there are no users with a prior V1 submission.
 
 # 2026-04-01
 - #2670 **Breaking change** Remove `InnerVm` and `OuterVm` generic type parameters from `StateTransitionFunction` trait and all downstream types.

--- a/crates/full-node/sov-rollup-apis/src/endpoints/simulate.rs
+++ b/crates/full-node/sov-rollup-apis/src/endpoints/simulate.rs
@@ -315,6 +315,7 @@ impl<S: Spec, R: Runtime<S>> SovereignSimulate<S, R> {
 
         AuthorizationData {
             tx_hash: NULL_TX_HASH,
+            non_malleable_hash: NULL_TX_HASH,
             uniqueness,
             credential_id,
             default_address: credential_id.into(),

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/operator/auth_eip712.rs
@@ -135,13 +135,24 @@ fn setup() -> (TestRunner<RT, S>, TestUser<S>) {
 }
 
 pub fn create_utx<S: Spec, RT: Runtime<S>>(message: RT::Decodable) -> UnsignedTransactionV0<RT, S> {
+    create_utx_with_generation::<S, RT>(message, 0)
+}
+
+pub fn create_utx_with_generation<S: Spec, RT: Runtime<S>>(
+    message: RT::Decodable,
+    generation: u64,
+) -> UnsignedTransactionV0<RT, S> {
     let details = TxDetails {
         max_priority_fee_bips: PriorityFeeBips::ZERO,
         max_fee: TEST_DEFAULT_MAX_FEE,
         gas_limit: None,
         chain_id: config_value!("CHAIN_ID"),
     };
-    UnsignedTransactionV0::new_with_details(message, UniquenessData::Generation(0), details)
+    UnsignedTransactionV0::new_with_details(
+        message,
+        UniquenessData::Generation(generation),
+        details,
+    )
 }
 
 pub fn sign_utx_in_place<S: Spec, RT: Runtime<S>>(
@@ -286,16 +297,22 @@ fn test_multisig_signature_verification() {
         }),
     });
 
-    // Create a multisig transaction — signers must sign V1 bytes (with credential_address)
-    let utx = create_utx::<S, RT>(encode_message::<_, RT>());
-    let mut signatures = Vec::new();
-    for key in multisig_keys.iter() {
-        signatures.push(sign_utx_v1_in_place(&utx, &multisig, key));
-    }
     // Generate a signature from a random private key that's not part of the multisig. We'll use this in some of the test cases.
     let random_private_key = TestPrivateKey::generate();
-    let random_signature = sign_utx_v1_in_place(&utx, &multisig, &random_private_key);
-    let tx = utx.to_multisig_tx(multisig);
+    let make_multisig_tx = |generation| {
+        let utx = create_utx_with_generation::<S, RT>(encode_message::<_, RT>(), generation);
+        let signatures = multisig_keys
+            .iter()
+            .map(|key| sign_utx_v1_in_place(&utx, &multisig, key))
+            .collect::<Vec<_>>();
+        let random_signature = sign_utx_v1_in_place(&utx, &multisig, &random_private_key);
+
+        (
+            utx.to_multisig_tx(multisig.clone()),
+            signatures,
+            random_signature,
+        )
+    };
 
     // Helper functions to assert the expected behavior of the transaction
     let assert_tx_success = |tx: Transaction<RT, S>, runner: &mut TestRunner<RT, S>| {
@@ -319,7 +336,7 @@ fn test_multisig_signature_verification() {
 
     // A transaction with three valid signatures should succeed
     let tx_with_three_sigs = {
-        let mut tx = tx.clone();
+        let (mut tx, signatures, _) = make_multisig_tx(0);
         for (key, signature) in multisig_keys.iter().zip(signatures.iter()) {
             tx.add_signature(signature.clone(), key.pub_key()).unwrap();
         }
@@ -329,7 +346,7 @@ fn test_multisig_signature_verification() {
 
     // A transaction with only two valid signatures should succeed
     let tx_with_two_sigs = {
-        let mut tx = tx.clone();
+        let (mut tx, signatures, _) = make_multisig_tx(1);
         for (key, signature) in multisig_keys.iter().zip(signatures.iter().take(2)) {
             tx.add_signature(signature.clone(), key.pub_key()).unwrap();
         }
@@ -337,10 +354,15 @@ fn test_multisig_signature_verification() {
     };
     assert_tx_success(tx_with_two_sigs, &mut runner);
 
+    let (base_skipped_tx, skipped_tx_signatures, random_signature) = make_multisig_tx(2);
+
     // A transaction with only one valid signature should be skipped, since this is a 2/3 multisig.
     let tx_with_one_sig = {
-        let mut tx = tx.clone();
-        for (key, signature) in multisig_keys.iter().zip(signatures.iter().take(1)) {
+        let mut tx = base_skipped_tx.clone();
+        for (key, signature) in multisig_keys
+            .iter()
+            .zip(skipped_tx_signatures.iter().take(1))
+        {
             tx.add_signature(signature.clone(), key.pub_key()).unwrap();
         }
         Transaction::<RT, S>::from(tx)
@@ -353,8 +375,8 @@ fn test_multisig_signature_verification() {
 
     // A transaction where one of the signatures isn't from this account should be skipped, since this changes the computed credential ID.
     let tx_with_random_sig = {
-        let mut tx = tx.clone();
-        tx.add_signature(signatures[0].clone(), multisig_keys[0].pub_key())
+        let mut tx = base_skipped_tx.clone();
+        tx.add_signature(skipped_tx_signatures[0].clone(), multisig_keys[0].pub_key())
             .unwrap();
         tx.signatures
             .try_push(PubKeyAndSignature {
@@ -371,12 +393,12 @@ fn test_multisig_signature_verification() {
     // A transaction with a duplicate signature should be skipped — the duplicate changes
     // the credential_address, causing signature verification failure.
     let tx_with_duplicate_sig = {
-        let mut tx = tx.clone();
-        tx.add_signature(signatures[0].clone(), multisig_keys[0].pub_key())
+        let mut tx = base_skipped_tx.clone();
+        tx.add_signature(skipped_tx_signatures[0].clone(), multisig_keys[0].pub_key())
             .unwrap();
         tx.signatures
             .try_push(PubKeyAndSignature {
-                signature: signatures[0].clone(),
+                signature: skipped_tx_signatures[0].clone(),
                 pub_key: multisig_keys[0].pub_key(),
             })
             .unwrap();
@@ -386,8 +408,8 @@ fn test_multisig_signature_verification() {
 
     // A transaction with a bad signature should be skipped
     let tx_with_bad_sig = {
-        let mut tx = tx.clone();
-        tx.add_signature(signatures[0].clone(), multisig_keys[0].pub_key())
+        let mut tx = base_skipped_tx;
+        tx.add_signature(skipped_tx_signatures[0].clone(), multisig_keys[0].pub_key())
             .unwrap();
         tx.add_signature(
             multisig_keys[1].sign(&[1, 2, 3]),

--- a/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/authenticate.rs
@@ -216,6 +216,7 @@ where
     AuthorizationData {
         uniqueness: UniquenessData::Nonce(nonce),
         tx_hash,
+        non_malleable_hash: tx_hash,
         credential_id,
         credentials,
         default_address: S::Address::from_vm_address(ethereum_address),

--- a/crates/module-system/module-implementations/sov-uniqueness/tests/integration/hooks_tests.rs
+++ b/crates/module-system/module-implementations/sov-uniqueness/tests/integration/hooks_tests.rs
@@ -1,12 +1,20 @@
 use sov_modules_api::capabilities::UniquenessData;
 use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::UnwrapInfallible;
-use sov_modules_api::{CredentialId, HexHash, TxEffect};
-use sov_test_utils::{TransactionTestCase, TxProcessingError};
+use sov_modules_api::transaction::{Transaction, UnsignedTransactionV0};
+use sov_modules_api::{
+    CredentialId, CryptoSpec, EncodeCall, HexHash, Multisig, PrivateKey, RawTx, Runtime, Spec,
+    TxEffect,
+};
+use sov_test_utils::{
+    default_test_tx_details, TestPrivateKey, TestUser, TransactionTestCase, TransactionType,
+    TxProcessingError,
+};
 use sov_uniqueness::Uniqueness;
+use sov_value_setter::ValueSetter;
 
-use crate::runtime::S;
-use crate::utils::{generate_default_tx, setup};
+use crate::runtime::{RT, S};
+use crate::utils::{generate_default_tx, setup, setup_with_admin};
 
 #[test]
 fn send_tx_works_nonce() {
@@ -123,6 +131,89 @@ fn send_tx_bad_generation_duplicate() {
                     "Expected Skipped error, but got a different TxEffect: {:?}",
                     ctx.tx_receipt
                 );
+            }
+        }),
+    });
+}
+
+#[test]
+fn send_tx_bad_generation_duplicate_with_malleated_v1_envelope() {
+    let multisig_keys = [
+        TestPrivateKey::generate(),
+        TestPrivateKey::generate(),
+        TestPrivateKey::generate(),
+        TestPrivateKey::generate(),
+    ];
+    let runtime_msg =
+        <RT as EncodeCall<ValueSetter<S>>>::to_decodable(sov_value_setter::CallMessage::SetValue {
+            value: 10,
+            gas: None,
+        });
+    let multisig = Multisig::new(2, multisig_keys.iter().map(|key| key.pub_key()).collect());
+    let multisig_credential_id =
+        multisig.credential_id::<<<S as Spec>::CryptoSpec as CryptoSpec>::Hasher>();
+    let (_, mut runner, _) = setup_with_admin(
+        TestUser::<S>::generate_with_default_balance().add_credential_id(multisig_credential_id),
+    );
+
+    let mut original_tx = UnsignedTransactionV0::<RT, S>::new_with_details(
+        runtime_msg,
+        UniquenessData::Generation(0),
+        default_test_tx_details::<S>(),
+    )
+    .to_multisig_tx(multisig);
+    original_tx
+        .sign(&multisig_keys[0], &RT::CHAIN_HASH)
+        .unwrap();
+    original_tx
+        .sign(&multisig_keys[1], &RT::CHAIN_HASH)
+        .unwrap();
+
+    let mut malleated_tx = original_tx.clone();
+    malleated_tx.unused_pub_keys.swap(0, 1);
+
+    assert_eq!(
+        original_tx.serialize_for_signing(&RT::CHAIN_HASH),
+        malleated_tx.serialize_for_signing(&RT::CHAIN_HASH),
+        "The signable payload should be unchanged by V1 envelope malleation"
+    );
+    assert_ne!(
+        Transaction::<RT, S>::from(original_tx.clone()).hash(),
+        Transaction::<RT, S>::from(malleated_tx.clone()).hash(),
+        "The raw transaction hash should change when the V1 envelope is malleated"
+    );
+
+    runner.execute_transaction(TransactionTestCase {
+        input: TransactionType::PreSigned(RawTx {
+            data: borsh::to_vec(&Transaction::<RT, S>::from(original_tx)).unwrap(),
+        }),
+        assert: Box::new(move |ctx, _state| {
+            assert!(ctx.tx_receipt.is_successful(), "{:?}", ctx.tx_receipt);
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: TransactionType::PreSigned(RawTx {
+            data: borsh::to_vec(&Transaction::<RT, S>::from(malleated_tx)).unwrap(),
+        }),
+        assert: Box::new(move |ctx, _state| {
+            let TxEffect::Skipped(skipped) = &ctx.tx_receipt else {
+                panic!(
+                    "Expected Skipped error from uniqueness check, got {:?}",
+                    ctx.tx_receipt
+                );
+            };
+
+            match &skipped.error {
+                TxProcessingError::CheckUniquenessFailed(reason) => {
+                    assert!(reason.contains("Duplicate transaction"));
+                }
+                _ => {
+                    panic!(
+                        "Expected uniqueness rejection, got a different error: {:?}",
+                        skipped.error
+                    );
+                }
             }
         }),
     });

--- a/crates/module-system/module-implementations/sov-uniqueness/tests/integration/utils.rs
+++ b/crates/module-system/module-implementations/sov-uniqueness/tests/integration/utils.rs
@@ -113,10 +113,15 @@ pub(crate) fn generate_value_setter_tx(
 }
 
 pub(crate) fn setup() -> (TestUser<S>, TestRunner<TestNonceRuntime<S>, S>, EvmAccount) {
+    setup_with_admin(TestUser::generate_with_default_balance())
+}
+
+pub(crate) fn setup_with_admin(
+    admin: TestUser<S>,
+) -> (TestUser<S>, TestRunner<TestNonceRuntime<S>, S>, EvmAccount) {
     // Generate a genesis config, then overwrite the attester key/address with ones that
     // we know. We leave the other values untouched.
-    let genesis_config =
-        HighLevelOptimisticGenesisConfig::generate().add_accounts_with_default_balance(1);
+    let genesis_config = HighLevelOptimisticGenesisConfig::generate().add_accounts(vec![admin]);
 
     let admin = genesis_config
         .additional_accounts()

--- a/crates/module-system/sov-capabilities/src/lib.rs
+++ b/crates/module-system/sov-capabilities/src/lib.rs
@@ -284,7 +284,7 @@ impl<S: Spec, T> TransactionAuthorizer<S> for StandardProvenRollupCapabilities<'
         self.uniqueness.check_uniqueness(
             &auth_data.credential_id,
             auth_data.uniqueness,
-            auth_data.tx_hash,
+            auth_data.non_malleable_hash,
             execution_context,
             state,
         )
@@ -300,7 +300,7 @@ impl<S: Spec, T> TransactionAuthorizer<S> for StandardProvenRollupCapabilities<'
         self.uniqueness.mark_tx_attempted(
             &auth_data.credential_id,
             auth_data.uniqueness,
-            auth_data.tx_hash,
+            auth_data.non_malleable_hash,
             state,
         )
     }

--- a/crates/module-system/sov-eip712-auth/src/lib.rs
+++ b/crates/module-system/sov-eip712-auth/src/lib.rs
@@ -28,13 +28,14 @@ pub use stub_evm_rpc::stub_evm_rpc;
 #[cfg(feature = "native")]
 use sov_modules_api::capabilities::{SignatureVerificationCache, DEFAULT_SIGNATURE_CACHE_SIZE};
 
-#[cfg(feature = "native")]
-static SIGNATURE_CACHE: std::sync::LazyLock<SignatureVerificationCache<()>> =
-    std::sync::LazyLock::new(|| SignatureVerificationCache::new(DEFAULT_SIGNATURE_CACHE_SIZE));
-
 /// The length of an EIP712 signing hash in bytes.
 /// EIP712 hashes are 66 bytes: 1 byte prefix (0x19) + 1 byte version (0x01) + 32 bytes domain separator + 32 bytes struct hash.
 const EIP712_HASH_LENGTH: usize = 66;
+type Eip712Hash = [u8; EIP712_HASH_LENGTH];
+
+#[cfg(feature = "native")]
+static SIGNATURE_CACHE: std::sync::LazyLock<SignatureVerificationCache<Eip712Hash>> =
+    std::sync::LazyLock::new(|| SignatureVerificationCache::new(DEFAULT_SIGNATURE_CACHE_SIZE));
 
 /// Trait for providing schema to the EIP-712 authenticator.
 pub trait SchemaProvider {
@@ -268,7 +269,7 @@ fn get_eip712_hash<
 >(
     tx: &Transaction<D, S, <S::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec>,
     raw_tx_hash: TxHash,
-) -> Result<[u8; EIP712_HASH_LENGTH], AuthenticationError> {
+) -> Result<Eip712Hash, AuthenticationError> {
     // Convert the transaction to unsigned transaction (removes signature)
     let unsigned_tx = tx.as_unsigned_transaction();
 
@@ -310,7 +311,7 @@ fn verify_eip712_signature<
     tx: &Transaction<D, S, <S::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec>,
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
-) -> Result<[u8; EIP712_HASH_LENGTH], AuthenticationError> {
+) -> Result<Eip712Hash, AuthenticationError> {
     tx.charge_gas_for_signature(EIP712_HASH_LENGTH, meter)
         .map_err(|e| match e {
             TransactionVerificationError::GasError(_) => {
@@ -322,12 +323,12 @@ fn verify_eip712_signature<
             ),
         })?;
 
-    let eip712_hash = get_eip712_hash::<S, D, SP>(tx, raw_tx_hash)?;
-
     #[cfg(feature = "native")]
     if let Some(known_result) = SIGNATURE_CACHE.get(&raw_tx_hash) {
-        return known_result.map(|()| eip712_hash);
+        return known_result;
     }
+
+    let eip712_hash = get_eip712_hash::<S, D, SP>(tx, raw_tx_hash)?;
 
     let res = tx
         .verify_signature_unmetered(&eip712_hash)
@@ -340,9 +341,10 @@ fn verify_eip712_signature<
                 raw_tx_hash,
             ),
         });
+    let res = res.map(|()| eip712_hash);
 
     #[cfg(feature = "native")]
     SIGNATURE_CACHE.insert(raw_tx_hash, res.clone());
 
-    res.map(|()| eip712_hash)
+    res
 }

--- a/crates/module-system/sov-eip712-auth/src/lib.rs
+++ b/crates/module-system/sov-eip712-auth/src/lib.rs
@@ -3,9 +3,9 @@ use std::sync::OnceLock;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use sov_modules_api::capabilities::{
-    self, calculate_hash_metered, verify_chain_id, AuthenticationError, AuthenticationOutput,
-    BatchFromUnregisteredSequencer, FatalError, TransactionAuthenticator,
-    UnregisteredAuthenticationError,
+    self, calculate_hash_metered, calculate_non_malleable_hash_metered, verify_chain_id,
+    AuthenticationError, AuthenticationOutput, BatchFromUnregisteredSequencer, FatalError,
+    ReplayHashMaterial, TransactionAuthenticator, UnregisteredAuthenticationError,
 };
 use sov_modules_api::sov_universal_wallet::schema::Schema;
 use sov_modules_api::transaction::{
@@ -233,19 +233,25 @@ fn verify_and_decode_tx<
     tx: Transaction<D, S, <S::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec>,
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<AuthenticationOutput<S, D::Decodable>, AuthenticationError> {
-    let (auth_data, details, runtime_call) = match &tx {
-        Transaction::V0(tx_v0) => {
-            let auth_data = tx_v0.auth_data(raw_tx_hash, meter)?;
-            (auth_data, &tx_v0.details, &tx_v0.runtime_call)
-        }
-        Transaction::V1(tx_v1) => {
-            let auth_data = tx_v1.auth_data(raw_tx_hash, meter)?;
-            (auth_data, &tx_v1.details, &tx_v1.runtime_call)
-        }
+    let (details, runtime_call) = match &tx {
+        Transaction::V0(tx_v0) => (&tx_v0.details, &tx_v0.runtime_call),
+        Transaction::V1(tx_v1) => (&tx_v1.details, &tx_v1.runtime_call),
     };
 
     verify_chain_id(details, raw_tx_hash)?;
-    verify_eip712_signature::<S, D, SP>(&tx, raw_tx_hash, meter)?;
+    let eip712_hash = verify_eip712_signature::<S, D, SP>(&tx, raw_tx_hash, meter)?;
+    let non_malleable_hash = calculate_non_malleable_hash_metered::<_, S>(
+        match &tx {
+            Transaction::V0(_) => ReplayHashMaterial::AlreadyNonMalleableHash(raw_tx_hash),
+            Transaction::V1(_) => ReplayHashMaterial::VerifiedSignatureMessage(&eip712_hash),
+        },
+        meter,
+    )
+    .map_err(|e| AuthenticationError::OutOfGas(e.to_string()))?;
+    let auth_data = match &tx {
+        Transaction::V0(tx_v0) => tx_v0.auth_data(raw_tx_hash, non_malleable_hash, meter)?,
+        Transaction::V1(tx_v1) => tx_v1.auth_data(raw_tx_hash, non_malleable_hash, meter)?,
+    };
 
     let tx_and_raw_hash = AuthenticatedTransactionAndRawHash {
         raw_tx_hash,
@@ -304,7 +310,7 @@ fn verify_eip712_signature<
     tx: &Transaction<D, S, <S::CryptoSpec as Secp256k1CryptoSpec>::CryptoSpec>,
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
-) -> Result<(), AuthenticationError> {
+) -> Result<[u8; EIP712_HASH_LENGTH], AuthenticationError> {
     tx.charge_gas_for_signature(EIP712_HASH_LENGTH, meter)
         .map_err(|e| match e {
             TransactionVerificationError::GasError(_) => {
@@ -316,12 +322,13 @@ fn verify_eip712_signature<
             ),
         })?;
 
+    let eip712_hash = get_eip712_hash::<S, D, SP>(tx, raw_tx_hash)?;
+
     #[cfg(feature = "native")]
     if let Some(known_result) = SIGNATURE_CACHE.get(&raw_tx_hash) {
-        return known_result;
+        return known_result.map(|()| eip712_hash);
     }
 
-    let eip712_hash = get_eip712_hash::<S, D, SP>(tx, raw_tx_hash)?;
     let res = tx
         .verify_signature_unmetered(&eip712_hash)
         .map_err(|e| match e {
@@ -337,5 +344,5 @@ fn verify_eip712_signature<
     #[cfg(feature = "native")]
     SIGNATURE_CACHE.insert(raw_tx_hash, res.clone());
 
-    res
+    res.map(|()| eip712_hash)
 }

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authentication.rs
@@ -248,6 +248,14 @@ pub type AuthenticationOutput<S, Decodable> = (
     Decodable,
 );
 
+/// The material from which a non-malleable transaction hash can be derived.
+pub enum ReplayHashMaterial<'a> {
+    /// The raw transaction hash is already non-malleable and can be used directly.
+    AlreadyNonMalleableHash(TxHash),
+    /// The verified message bytes are the non-malleable material and should be hashed.
+    VerifiedSignatureMessage(&'a [u8]),
+}
+
 /// Error variants that can be raised as a [`AuthenticationError::FatalError`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Error)]
 #[serde(rename_all = "snake_case")]
@@ -370,7 +378,7 @@ fn verify_signature<S: Spec, D: DispatchCall<Spec = S>>(
     chain_hash: &[u8; 32],
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
-) -> Result<(), AuthenticationError> {
+) -> Result<Vec<u8>, AuthenticationError> {
     let serialized_tx = tx.serialized_with_chain_hash(chain_hash).map_err(|e| {
         AuthenticationError::FatalError(
             FatalError::DeserializationFailed(e.to_string()),
@@ -391,7 +399,7 @@ fn verify_signature<S: Spec, D: DispatchCall<Spec = S>>(
 
     #[cfg(feature = "native")]
     if let Some(known_result) = SIGNATURE_CACHE.get(&(raw_tx_hash, *chain_hash)) {
-        return known_result;
+        return known_result.map(|()| serialized_tx);
     }
 
     let res = tx
@@ -409,7 +417,20 @@ fn verify_signature<S: Spec, D: DispatchCall<Spec = S>>(
     #[cfg(feature = "native")]
     SIGNATURE_CACHE.insert((raw_tx_hash, *chain_hash), res.clone());
 
-    res
+    res.map(|()| serialized_tx)
+}
+
+/// Calculates the non-malleable hash to use for replay protection.
+pub fn calculate_non_malleable_hash_metered<G: GasMeter<Spec = S>, S: Spec>(
+    material: ReplayHashMaterial<'_>,
+    gas_meter: &mut G,
+) -> Result<TxHash, GasMeteringError<S::Gas>> {
+    match material {
+        ReplayHashMaterial::AlreadyNonMalleableHash(hash) => Ok(hash),
+        ReplayHashMaterial::VerifiedSignatureMessage(message) => {
+            calculate_hash_metered::<G, S>(message, gas_meter)
+        }
+    }
 }
 
 /// Authenticate and verify deserialized sov-tx. See `authenticate`.
@@ -485,16 +506,9 @@ fn verify_and_decode_tx_multi_hash<S: Spec, D: DispatchCall<Spec = S>>(
     resolved_hashes: crate::runtime::ResolvedChainHashes,
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<AuthenticationOutput<S, D::Decodable>, AuthenticationError> {
-    // Extract auth_data and verify chain_id (these don't depend on chain_hash)
-    let (auth_data, details, runtime_call) = match &tx {
-        Transaction::V0(tx_v0) => {
-            let auth_data = tx_v0.auth_data(raw_tx_hash, meter)?;
-            (auth_data, &tx_v0.details, &tx_v0.runtime_call)
-        }
-        Transaction::V1(tx_v1) => {
-            let auth_data = tx_v1.auth_data(raw_tx_hash, meter)?;
-            (auth_data, &tx_v1.details, &tx_v1.runtime_call)
-        }
+    let (details, runtime_call) = match &tx {
+        Transaction::V0(tx_v0) => (&tx_v0.details, &tx_v0.runtime_call),
+        Transaction::V1(tx_v1) => (&tx_v1.details, &tx_v1.runtime_call),
     };
 
     verify_chain_id(details, raw_tx_hash)?;
@@ -503,7 +517,27 @@ fn verify_and_decode_tx_multi_hash<S: Spec, D: DispatchCall<Spec = S>>(
     let mut last_error = None;
     for chain_hash in resolved_hashes.iter() {
         match verify_signature(&tx, chain_hash, raw_tx_hash, meter) {
-            Ok(()) => {
+            Ok(serialized_tx) => {
+                let non_malleable_hash = calculate_non_malleable_hash_metered::<_, S>(
+                    match &tx {
+                        Transaction::V0(_) => {
+                            ReplayHashMaterial::AlreadyNonMalleableHash(raw_tx_hash)
+                        }
+                        Transaction::V1(_) => {
+                            ReplayHashMaterial::VerifiedSignatureMessage(&serialized_tx)
+                        }
+                    },
+                    meter,
+                )
+                .map_err(|e| AuthenticationError::OutOfGas(e.to_string()))?;
+                let auth_data = match &tx {
+                    Transaction::V0(tx_v0) => {
+                        tx_v0.auth_data(raw_tx_hash, non_malleable_hash, meter)?
+                    }
+                    Transaction::V1(tx_v1) => {
+                        tx_v1.auth_data(raw_tx_hash, non_malleable_hash, meter)?
+                    }
+                };
                 let tx_and_raw_hash = AuthenticatedTransactionAndRawHash {
                     raw_tx_hash,
                     authenticated_tx: details.clone().into(),

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authorization.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authorization.rs
@@ -83,8 +83,15 @@ pub struct AuthorizationData<S: Spec> {
     /// The nonce of the transaction.
     pub uniqueness: UniquenessData,
 
-    /// The hash of the transaction.
+    /// The hash of the transaction as received on the wire.
     pub tx_hash: TxHash,
+
+    /// The non-malleable hash used for replay protection.
+    ///
+    /// This is equal to [`Self::tx_hash`] for non-malleable transaction envelopes. For malleable
+    /// envelopes such as V1 rollup transactions, this instead hashes the witnessless bytes that
+    /// were actually signed.
+    pub non_malleable_hash: TxHash,
 
     /// Credential identifier used to retrieve relevant rollup address.
     pub credential_id: CredentialId,

--- a/crates/module-system/sov-modules-api/src/transaction/types/v0.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/types/v0.rs
@@ -57,6 +57,7 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Version0<R, S, C> {
     pub fn auth_data<M: GasMeter<Spec = S>>(
         &self,
         raw_tx_hash: TxHash,
+        non_malleable_hash: TxHash,
         meter: &mut M,
     ) -> Result<AuthorizationData<S>, AuthenticationError> {
         let pub_key = self.pub_key.clone();
@@ -66,6 +67,7 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Version0<R, S, C> {
         Ok(AuthorizationData {
             uniqueness: self.uniqueness,
             tx_hash: raw_tx_hash,
+            non_malleable_hash,
             credential_id,
             credentials: Credentials::new(pub_key),
             default_address: credential_id.into(),

--- a/crates/module-system/sov-modules-api/src/transaction/types/v1.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/types/v1.rs
@@ -162,6 +162,7 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Version1<R, S, C> {
     pub fn auth_data<M: GasMeter<Spec = S>>(
         &self,
         raw_tx_hash: TxHash,
+        non_malleable_hash: TxHash,
         meter: &mut M,
     ) -> Result<AuthorizationData<S>, AuthenticationError> {
         // Charge gas; We charge for credential ID calculation based on the number of keys in the multisig
@@ -183,6 +184,7 @@ impl<R: TransactionCallable, S: Spec, C: CryptoSpecExt> Version1<R, S, C> {
         Ok(AuthorizationData {
             uniqueness: self.uniqueness,
             tx_hash: raw_tx_hash,
+            non_malleable_hash,
             credential_id,
             credentials: Credentials::new(multisig),
             default_address: credential_id.into(),

--- a/crates/module-system/sov-modules-api/src/transaction/unsigned/mod.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/unsigned/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod v1;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
+use sov_universal_wallet::UniversalWallet;
 
 pub use v0::UnsignedTransactionV0;
 pub use v1::UnsignedTransactionV1;

--- a/crates/module-system/sov-modules-api/src/transaction/unsigned/v1.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/unsigned/v1.rs
@@ -1,6 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::sov_universal_wallet::UniversalWallet;
+use sov_universal_wallet::UniversalWallet;
 
 use crate::{
     capabilities::UniquenessData,

--- a/crates/module-system/sov-solana-offchain-auth/src/authentication/mod.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication/mod.rs
@@ -5,8 +5,8 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sov_modules_api::capabilities::AuthorizationData;
 use sov_modules_api::capabilities::{
-    calculate_hash_metered, verify_chain_id, AuthenticationError, AuthenticationOutput, FatalError,
-    UniquenessData,
+    calculate_hash_metered, calculate_non_malleable_hash_metered, verify_chain_id,
+    AuthenticationError, AuthenticationOutput, FatalError, ReplayHashMaterial, UniquenessData,
 };
 use sov_modules_api::transaction::AuthenticatedTransactionAndRawHash;
 use sov_modules_api::transaction::Credentials;
@@ -128,6 +128,19 @@ fn build_auth_data<S: Spec>(
     raw_tx_hash: TxHash,
     meter: &mut impl GasMeter<Spec = S>,
 ) -> Result<AuthorizationData<S>, AuthenticationError> {
+    let non_malleable_hash = calculate_non_malleable_hash_metered::<_, S>(
+        match unpacked {
+            UnpackedSolanaMessage::V0 { .. } => {
+                ReplayHashMaterial::AlreadyNonMalleableHash(raw_tx_hash)
+            }
+            UnpackedSolanaMessage::V1 { .. } => {
+                ReplayHashMaterial::VerifiedSignatureMessage(unpacked.signed_bytes())
+            }
+        },
+        meter,
+    )
+    .map_err(|e| AuthenticationError::OutOfGas(e.to_string()))?;
+
     match unpacked {
         UnpackedSolanaMessage::V0 { pub_key, .. } => {
             let credential_id =
@@ -137,6 +150,7 @@ fn build_auth_data<S: Spec>(
             Ok(AuthorizationData {
                 uniqueness,
                 tx_hash: raw_tx_hash,
+                non_malleable_hash,
                 credential_id,
                 credentials: Credentials::new(pub_key.clone()),
                 default_address: credential_id.into(),
@@ -164,6 +178,7 @@ fn build_auth_data<S: Spec>(
             Ok(AuthorizationData {
                 uniqueness,
                 tx_hash: raw_tx_hash,
+                non_malleable_hash,
                 credential_id,
                 credentials: Credentials::new(multisig),
                 default_address: credential_id.into(),


### PR DESCRIPTION
# Description

Adds a new `non_malleable_hash` field to `AuthorizationData`. Generation-based uniqueness now uses this hash for keying its generation buckets.

V0 transactions simply reuse the raw_tx_hash for it, under the assumption that the crypto primitives used as the signature and pubkey has a non-malleable canonical encoding.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] ~~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
