### PR TITLE
Update `SP1Verifier` to use `verify_compressed_with_public_values`, which uses the verification key hash instead of the key itself.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12823,6 +12823,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "slop-algebra",
  "sov-metrics",
  "sov-rollup-interface",
  "sov-sp1-adapter",
@@ -12831,7 +12832,10 @@ dependencies = [
  "sov-zkvm-utils",
  "sp1-build",
  "sp1-lib",
+ "sp1-primitives",
+ "sp1-recursion-executor",
  "sp1-sdk",
+ "sp1-verifier",
  "sp1-zkvm",
 ]
 

--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -72,13 +72,18 @@ impl Zkvm for MockZkvm {
 pub struct MockCodeCommitment(pub [u8; 8]);
 
 impl sov_rollup_interface::zk::CodeCommitmentTrait for MockCodeCommitment {
-    fn to_hash(
-        &self,
-    ) -> anyhow::Result<sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash> {
+    fn to_hash(&self) -> sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash {
         // Pad the 8-byte mock commitment to 32 bytes to match the canonical hash layout.
         let mut bytes = vec![0u8; 32];
         bytes[..8].copy_from_slice(&self.0);
-        Ok(sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash(bytes))
+        sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash(bytes)
+    }
+
+    fn from_hash(hash: sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash) -> Self {
+        let mut bytes = [0u8; 8];
+        let len = hash.0.len().min(8);
+        bytes[..len].copy_from_slice(&hash.0[..len]);
+        Self(bytes)
     }
 }
 

--- a/crates/adapters/risc0/src/lib.rs
+++ b/crates/adapters/risc0/src/lib.rs
@@ -31,10 +31,12 @@ pub mod metrics;
 pub struct Risc0MethodId([u32; 8]);
 
 impl sov_rollup_interface::zk::CodeCommitmentTrait for Risc0MethodId {
-    fn to_hash(
-        &self,
-    ) -> anyhow::Result<sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash> {
-        Ok(sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash::from_u32_array(self.0))
+    fn to_hash(&self) -> sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash {
+        sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash::from_u32_array(self.0)
+    }
+
+    fn from_hash(hash: sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash) -> Self {
+        Self(hash.to_u32_array())
     }
 }
 

--- a/crates/adapters/sp1/Cargo.toml
+++ b/crates/adapters/sp1/Cargo.toml
@@ -35,6 +35,10 @@ sov-metrics = { workspace = true, features = ["sp1"], optional = true }
 
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
 sp1-sdk = { version = "6.1.0", default-features = false, features = ["blocking"] }
+sp1-verifier = { version = "6.1.0", default-features = false, features = ["std"] }
+sp1-primitives = { version = "6.1.0", default-features = false }
+sp1-recursion-executor = { version = "6.1.0", default-features = false }
+slop-algebra = { version = "6.1.0", default-features = false }
 
 [target.'cfg(all(target_os = "zkvm", target_vendor = "succinct"))'.dependencies]
 sp1-zkvm = { version = "6.1.0", features = ["verify"] }

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -17,6 +17,7 @@ use sov_rollup_interface::zk::ZkvmHost;
 use sp1_sdk::blocking::ProveRequest;
 use sp1_sdk::blocking::{EnvProver, EnvProvingKey, Prover, ProverClient};
 use sp1_sdk::ProvingKey;
+use sp1_sdk::SP1VerifyingKey;
 use sp1_sdk::{HashableKey, SP1Proof, SP1Stdin};
 
 /// SP1 host that produces aggregated (outer) proofs by recursively verifying
@@ -34,24 +35,22 @@ pub struct SP1AggregationHost {
 struct Inner {
     host: SP1Host,
     aggregation_vk: sp1_sdk::SP1VerifyingKey,
-    code_commitment: SP1MethodId,
-    inner_method_id: SP1MethodId,
+    inner_vk: sp1_sdk::SP1VerifyingKey,
     prev_agg_proof: Mutex<Option<sp1_sdk::SP1ProofWithPublicValues>>,
 }
 
 impl SP1AggregationHost {
     /// Creates a new aggregation host from the aggregation guest `elf` binary
     /// and the verifying key (`inner_method_id`) of the inner proof program.
-    pub fn new(elf: &'static [u8], inner_method_id: SP1MethodId) -> anyhow::Result<Self> {
+    pub fn new(elf: &'static [u8], inner_vk: sp1_sdk::SP1VerifyingKey) -> anyhow::Result<Self> {
         let host = SP1Host::new(elf)?;
         let aggregation_vk = host.proving_key()?.verifying_key().clone();
-        let code_commitment = SP1MethodId(bincode::serialize(&aggregation_vk)?);
+
         Ok(Self {
             inner: Arc::new(Inner {
                 host,
                 aggregation_vk,
-                code_commitment,
-                inner_method_id,
+                inner_vk,
                 prev_agg_proof: Mutex::new(None),
             }),
         })
@@ -59,7 +58,7 @@ impl SP1AggregationHost {
 
     /// Returns the code commitment (verifying key) of the aggregation program.
     pub fn code_commitment(&self) -> SP1MethodId {
-        self.inner.code_commitment.clone()
+        SP1MethodId(self.inner.aggregation_vk.hash_u32())
     }
 
     /// Generates a compressed aggregation proof over the supplied inner
@@ -87,7 +86,7 @@ impl SP1AggregationHost {
             let public_values = self.inner.host.add_proof_helper(
                 &mut stdin,
                 &serialized,
-                &self.inner.code_commitment,
+                &self.inner.aggregation_vk,
             )?;
 
             Some(PreviousOuterProofWitness { public_values })
@@ -100,7 +99,7 @@ impl SP1AggregationHost {
             let public_values = self.inner.host.add_proof_helper(
                 &mut stdin,
                 &proof_and_header.proof.raw_inner_proof,
-                &self.inner.inner_method_id,
+                &self.inner.inner_vk,
             )?;
             let proof_input = DeferredProofInput::<Da> {
                 public_values,
@@ -111,9 +110,8 @@ impl SP1AggregationHost {
         }
 
         let aggregation_vk_hash = self.inner.aggregation_vk.hash_u32();
-        let inner_vk: sp1_sdk::SP1VerifyingKey =
-            bincode::deserialize(&self.inner.inner_method_id.0)
-                .map_err(|e| anyhow::anyhow!("Failed to deserialize inner SP1VerifyingKey: {e}"))?;
+        let inner_vk = &self.inner.inner_vk;
+
         let inner_vkey_hash = CodeCommitmentHash::from_u32_array(inner_vk.hash_u32());
         let outer_vkey_hash = CodeCommitmentHash::from_u32_array(aggregation_vk_hash);
 
@@ -170,15 +168,13 @@ impl SP1Host {
         &self,
         stdin: &mut SP1Stdin,
         proof: &[u8],
-        method_id: &SP1MethodId,
+        vk: &sp1_sdk::SP1VerifyingKey,
     ) -> anyhow::Result<Vec<u8>> {
         let proof = crate::decode_sp1_proof(proof)?;
 
         let SP1Proof::Compressed(recursion_proof) = &proof.proof else {
             anyhow::bail!("Expected a compressed SP1 proof");
         };
-        let vk: sp1_sdk::SP1VerifyingKey = bincode::deserialize(&method_id.0)
-            .map_err(|e| anyhow::anyhow!("Failed to deserialize SP1VerifyingKey: {e}"))?;
 
         stdin.write_proof((**recursion_proof).clone(), vk.vk.clone());
         Ok(proof.public_values.to_vec())
@@ -201,6 +197,16 @@ impl SP1Host {
             .map_err(|e| anyhow::anyhow!("SP1 proving failed. Error: {:?}", e))?;
 
         Ok(output)
+    }
+
+    /// Verification key.
+    pub fn verifying_key(&self) -> &SP1VerifyingKey {
+        self.pk.verifying_key()
+    }
+
+    /// Method id.
+    pub fn method_id(&self) -> SP1MethodId {
+        SP1MethodId(self.pk.verifying_key().hash_u32())
     }
 }
 
@@ -226,9 +232,7 @@ impl ZkvmHost for SP1Host {
     }
 
     fn code_commitment(&self) -> anyhow::Result<<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment>{
-        Ok(crate::SP1MethodId(bincode::serialize(
-            self.pk.verifying_key(),
-        )?))
+        Ok(crate::SP1MethodId(self.pk.verifying_key().hash_u32()))
     }
 }
 

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -94,20 +94,23 @@ impl ZkVerifier for SP1Verifier {
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         let proof = decode_sp1_proof(serialized_proof)?;
-        let prover = sp1_sdk::blocking::ProverClient::from_env();
-        let verifying_key: sp1_sdk::SP1VerifyingKey = bincode::deserialize(&code_commitment.0)?;
+        let is_mock = std::env::var("SP1_PROVER").ok().as_deref() == Some("mock");
+        if !is_mock {
+            let verifying_key: sp1_sdk::SP1VerifyingKey = bincode::deserialize(&code_commitment.0)?;
 
-        // The default `Prover::verify` path performs public-values / committed-digest
-        // checks that the dummy compressed proofs produced by the mock backend don't
-        // satisfy. Dispatch to the inner `MockProver`, which only checks Plonk/Groth16
-        // public inputs and accepts Core/Compressed unconditionally.
-        match &prover {
-            sp1_sdk::blocking::EnvProver::Mock(mock) => {
-                sp1_sdk::blocking::Prover::verify(mock, &proof, &verifying_key, None)?;
-            }
-
-            _ => sp1_sdk::blocking::Prover::verify(&prover, &proof, &verifying_key, None)?,
+            use sp1_sdk::HashableKey;
+            let sp1_sdk::SP1Proof::Compressed(ref compressed) = proof.proof else {
+                anyhow::bail!("SP1Verifier only supports compressed proofs");
+            };
+            let vkey_hash = verifying_key.hash_koalabear();
+            sp1_verifier::compressed::SP1CompressedVerifier::new()
+                .verify_compressed_with_public_values(
+                    compressed.as_ref(),
+                    proof.public_values.as_slice(),
+                    &vkey_hash,
+                )?;
         }
+
         Ok(bincode::deserialize(proof.public_values.as_slice())?)
     }
 }

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -10,6 +10,7 @@ use crypto::{SP1PublicKey, SP1Signature};
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
 use sov_rollup_interface::zk::{CryptoSpec, ZkVerifier};
 
 #[cfg(feature = "native")]
@@ -28,8 +29,8 @@ pub mod metrics;
 /// Uniquely identifies a SP1 binary. Stored as a serialized version of `SP1VerifyingKey`.
 ///
 /// Use the [`ZkvmHost::code_commitment`](sov_rollup_interface::zk::ZkvmHost) method to get the MethodId for a given binary.
-#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct SP1MethodId(pub Vec<u8>);
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SP1MethodId(pub [u32; 8]);
 
 impl Debug for SP1MethodId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -37,19 +38,13 @@ impl Debug for SP1MethodId {
     }
 }
 
-#[cfg(not(target_os = "zkvm"))]
 impl sov_rollup_interface::zk::CodeCommitmentTrait for SP1MethodId {
-    fn to_hash(
-        &self,
-    ) -> anyhow::Result<sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash> {
-        use sp1_sdk::HashableKey;
-        let verifying_key: sp1_sdk::SP1VerifyingKey = bincode::deserialize(&self.0)
-            .map_err(|e| anyhow::anyhow!("Failed to deserialize SP1VerifyingKey: {e}"))?;
-        Ok(
-            sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash::from_u32_array(
-                verifying_key.hash_u32(),
-            ),
-        )
+    fn to_hash(&self) -> CodeCommitmentHash {
+        CodeCommitmentHash::from_u32_array(self.0)
+    }
+
+    fn from_hash(hash: sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash) -> Self {
+        Self(hash.to_u32_array())
     }
 }
 
@@ -93,22 +88,38 @@ impl ZkVerifier for SP1Verifier {
         serialized_proof: &[u8],
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
+        use core::borrow::Borrow;
+        use slop_algebra::AbstractField;
+        use slop_algebra::PrimeField32;
+
         let proof = decode_sp1_proof(serialized_proof)?;
         let is_mock = std::env::var("SP1_PROVER").ok().as_deref() == Some("mock");
-        if !is_mock {
-            let verifying_key: sp1_sdk::SP1VerifyingKey = bincode::deserialize(&code_commitment.0)?;
 
-            use sp1_sdk::HashableKey;
+        if !is_mock {
             let sp1_sdk::SP1Proof::Compressed(ref compressed) = proof.proof else {
                 anyhow::bail!("SP1Verifier only supports compressed proofs");
             };
-            let vkey_hash = verifying_key.hash_koalabear();
+
+            let vkey_hash: [sp1_primitives::SP1Field; 8] = code_commitment
+                .0
+                .map(sp1_primitives::SP1Field::from_canonical_u32);
+
             sp1_verifier::compressed::SP1CompressedVerifier::new()
                 .verify_compressed_with_public_values(
                     compressed.as_ref(),
                     proof.public_values.as_slice(),
                     &vkey_hash,
                 )?;
+
+            // `SP1CompressedVerifier` does not inspect `exit_code`; the SDK's
+            // verifier does. Enforce SUCCESS here after the proof shape has been validated.
+            let recursion_public_values: &sp1_recursion_executor::RecursionPublicValues<
+                sp1_primitives::SP1Field,
+            > = compressed.proof.public_values.as_slice().borrow();
+            let exit_code = recursion_public_values.exit_code.as_canonical_u32();
+            if exit_code != 0 {
+                anyhow::bail!("SP1 proof has non-success exit code: {exit_code}");
+            }
         }
 
         Ok(bincode::deserialize(proof.public_values.as_slice())?)
@@ -135,7 +146,7 @@ impl sov_rollup_interface::zk::Zkvm for SP1 {
 
 #[cfg(target_os = "zkvm")]
 impl ZkVerifier for SP1Verifier {
-    type CodeCommitment = sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
+    type CodeCommitment = SP1MethodId;
 
     type CryptoSpec = SP1CryptoSpec;
 
@@ -146,10 +157,8 @@ impl ZkVerifier for SP1Verifier {
         vkey_hash: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         use sha2::Digest;
-
         let public_values_digest: [u8; 32] = sha2::Sha256::digest(public_values).into();
-        let vkey_u32 = vkey_hash.to_u32_array();
-        sp1_zkvm::lib::verify::verify_sp1_proof(&vkey_u32, &public_values_digest);
+        sp1_zkvm::lib::verify::verify_sp1_proof(&vkey_hash.0, &public_values_digest);
         Ok(bincode::deserialize(public_values)?)
     }
 }

--- a/crates/adapters/sp1/src/network.rs
+++ b/crates/adapters/sp1/src/network.rs
@@ -2,14 +2,14 @@
 //!
 //! Submits proof requests to the Succinct proving network and polls for results.
 
+use crate::guest::SP1Guest;
 use serde::Serialize;
 use sov_rollup_interface::zk::{ZkVerifier, ZkvmGuest, ZkvmNetwork};
 use sp1_sdk::network::proto::auction_types::FulfillmentStatus;
 use sp1_sdk::network::{NetworkMode, B256};
 use sp1_sdk::prover::{ProveRequest, Prover};
+use sp1_sdk::HashableKey;
 use sp1_sdk::{NetworkProver, ProverClient, ProvingKey, SP1ProvingKey, SP1Stdin};
-
-use crate::guest::SP1Guest;
 
 /// Re-export of the proof handle type used by the SP1 network.
 pub type ProofHandle = B256;
@@ -76,8 +76,6 @@ impl ZkvmNetwork for SP1Network {
     fn code_commitment(
         &self,
     ) -> anyhow::Result<<<Self::Guest as ZkvmGuest>::Verifier as ZkVerifier>::CodeCommitment> {
-        Ok(crate::SP1MethodId(bincode::serialize(
-            self.pk.verifying_key(),
-        )?))
+        Ok(crate::SP1MethodId(self.pk.verifying_key().hash_u32()))
     }
 }

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
@@ -91,12 +91,12 @@ pub(crate) fn build_proof(
         .inner_code_commitment(state)
         .unwrap()
         .expect("Inner code commitment must be set at genesis")
-        .to_hash()?;
+        .to_hash();
     let outer_vk_hash = chain_state
         .outer_code_commitment(state)
         .unwrap()
         .expect("Outer code commitment must be set at genesis")
-        .to_hash()?;
+        .to_hash();
 
     Ok(AggregatedProofPublicData {
         initial_slot_number: initial_slot,

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
@@ -10,7 +10,7 @@ use super::common::{AggregatedProofWitness, DeferredProofInput};
 use super::{AggregatedProofPublicData, CodeCommitmentHash};
 use crate::common::SlotNumber;
 use crate::da::{BlockHeaderTrait, DaSpec};
-use crate::zk::{StateTransitionPublicData, ZkVerifier, ZkvmGuest};
+use crate::zk::{CodeCommitmentTrait, StateTransitionPublicData, ZkVerifier, ZkvmGuest};
 
 struct BoundaryData<Hash, Root> {
     slot_hash: Hash,
@@ -34,7 +34,7 @@ where
     Address: Clone + Serialize + DeserializeOwned,
     Da: DaSpec,
     Root: Clone + Debug + PartialEq + Serialize + DeserializeOwned,
-    V: ZkVerifier<CodeCommitment = CodeCommitmentHash>,
+    V: ZkVerifier,
     G: ZkvmGuest<Verifier = V>,
 {
     let AggregatedProofWitness {
@@ -49,7 +49,7 @@ where
     let previous_public_data = prev_outer_proof_witness.map(|prev_outer_proof_witness| {
         let public_data = V::verify::<AggregatedProofPublicData<Address, Da, Root>>(
             &prev_outer_proof_witness.public_values,
-            &outer_vkey_hash,
+            &<V::CodeCommitment as CodeCommitmentTrait>::from_hash(outer_vkey_hash.clone()),
         )
         .unwrap_or_else(|error| panic!("Failed to verify aggregated proof: {error:?}"));
 
@@ -64,7 +64,7 @@ where
     let verified_proof_data: VerifyResult<Address, Da, Root> =
         verify_proof_chain::<Address, Da, Root, V>(
             proof_inputs,
-            &inner_vkey_hash,
+            inner_vkey_hash.clone(),
             previous_public_data.as_ref(),
         );
 
@@ -102,14 +102,14 @@ where
 
 fn verify_proof_chain<Address, Da, Root, V>(
     proof_inputs: Vec<DeferredProofInput<Da>>,
-    vkey_hash: &CodeCommitmentHash,
+    vkey_hash: CodeCommitmentHash,
     previous_agg_proof_public_data: Option<&AggregatedProofPublicData<Address, Da, Root>>,
 ) -> VerifyResult<Address, Da, Root>
 where
     Address: Clone + Serialize + DeserializeOwned,
     Da: DaSpec,
     Root: Clone + Debug + PartialEq + Serialize + DeserializeOwned,
-    V: ZkVerifier<CodeCommitment = CodeCommitmentHash>,
+    V: ZkVerifier,
 {
     assert!(
         !proof_inputs.is_empty(),
@@ -134,7 +134,7 @@ where
     for (index, proof_input) in proof_inputs.iter().enumerate() {
         let stf_public_data = V::verify::<StateTransitionPublicData<Address, Da, Root>>(
             &proof_input.public_values,
-            vkey_hash,
+            &<V::CodeCommitment as CodeCommitmentTrait>::from_hash(vkey_hash.clone()),
         )
         .unwrap_or_else(|error| panic!("Failed to verify inner proof: {error:?}"));
 

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -83,12 +83,6 @@ impl core::fmt::Display for CodeCommitmentHash {
     }
 }
 
-impl crate::zk::CodeCommitmentTrait for CodeCommitmentHash {
-    fn to_hash(&self) -> anyhow::Result<CodeCommitmentHash> {
-        Ok(self.clone())
-    }
-}
-
 /// Public data of an aggregated proof.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct AggregatedProofPublicData<Address, Da: DaSpec, Root> {

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -121,7 +121,10 @@ pub trait CodeCommitmentTrait:
     /// form of this commitment. Implementations that decode an opaque byte
     /// representation (e.g. SP1's serialized verifying key) may fail if the
     /// bytes are malformed.
-    fn to_hash(&self) -> anyhow::Result<aggregated_proof::CodeCommitmentHash>;
+    fn to_hash(&self) -> aggregated_proof::CodeCommitmentHash;
+
+    /// Constructs the code commitment from its canonical hash.
+    fn from_hash(hash: aggregated_proof::CodeCommitmentHash) -> Self;
 }
 
 /// A Zk proof system capable of proving and verifying arbitrary Rust code

--- a/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
@@ -6303,11 +6303,14 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "sha2 0.10.9",
+ "slop-algebra",
  "sov-rollup-interface",
  "sov-universal-wallet",
  "sov-zkvm-utils",
  "sp1-lib",
+ "sp1-primitives",
  "sp1-sdk",
+ "sp1-verifier",
  "sp1-zkvm",
 ]
 

--- a/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
@@ -6309,6 +6309,7 @@ dependencies = [
  "sov-zkvm-utils",
  "sp1-lib",
  "sp1-primitives",
+ "sp1-recursion-executor",
  "sp1-sdk",
  "sp1-verifier",
  "sp1-zkvm",

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -6622,11 +6622,14 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "sha2 0.10.9",
+ "slop-algebra",
  "sov-rollup-interface",
  "sov-universal-wallet",
  "sov-zkvm-utils",
  "sp1-lib",
+ "sp1-primitives",
  "sp1-sdk",
+ "sp1-verifier",
  "sp1-zkvm",
 ]
 

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -6628,6 +6628,7 @@ dependencies = [
  "sov-zkvm-utils",
  "sp1-lib",
  "sp1-primitives",
+ "sp1-recursion-executor",
  "sp1-sdk",
  "sp1-verifier",
  "sp1-zkvm",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -6253,6 +6253,7 @@ dependencies = [
  "sov-zkvm-utils",
  "sp1-lib",
  "sp1-primitives",
+ "sp1-recursion-executor",
  "sp1-sdk",
  "sp1-verifier",
  "sp1-zkvm",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -6247,11 +6247,14 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "sha2 0.10.9",
+ "slop-algebra",
  "sov-rollup-interface",
  "sov-universal-wallet",
  "sov-zkvm-utils",
  "sp1-lib",
+ "sp1-primitives",
  "sp1-sdk",
+ "sp1-verifier",
  "sp1-zkvm",
 ]
 

--- a/examples/demo-rollup/tests/prover/parallel.rs
+++ b/examples/demo-rollup/tests/prover/parallel.rs
@@ -4,14 +4,13 @@ use sov_mock_da::{MockDaService, MockDaSpec};
 use sov_modules_api::{AggregatedProofPublicData, Spec, Storage, ZkVerifier};
 use sov_rollup_interface::common::SlotNumber;
 use sov_sp1_adapter::host::{SP1AggregationHost, SP1Host};
-use sov_sp1_adapter::{SP1MethodId, SP1Verifier, SP1};
+use sov_sp1_adapter::{SP1Verifier, SP1};
 use sov_stf_runner::processes::{
     ParallelProverService, ProofAggregationStatus, ProofProcessingStatus, ProverService,
     RollupProverConfigDiscriminants, StateTransitionInfo,
 };
 
 use super::{DefaultSpec, ProofStateRoot, ProofWitness};
-use sov_rollup_interface::zk::ZkvmHost;
 
 type TestParallelProverService = ParallelProverService<
     <DefaultSpec as Spec>::Address,
@@ -43,20 +42,12 @@ async fn test_parallel_proof_generation() {
         .await
         .unwrap();
 
-    let inner_vm_clone = inner_vm.clone();
-
-    let code_commitment: SP1MethodId = tokio::task::spawn_blocking(move || -> SP1MethodId {
-        inner_vm_clone
-            .code_commitment()
-            .expect("SP1 code commitment should be created successfully")
-    })
-    .await
-    .unwrap();
-
     let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
 
+    let inner_vm_clone = inner_vm.clone();
+
     let outer_vm = tokio::task::spawn_blocking(move || {
-        SP1AggregationHost::new(agg_elf, code_commitment).unwrap()
+        SP1AggregationHost::new(agg_elf, inner_vm_clone.verifying_key().clone()).unwrap()
     })
     .await
     .unwrap();
@@ -131,9 +122,5 @@ async fn test_parallel_proof_generation() {
         <DefaultSpec as Spec>::Address,
         MockDaSpec,
         <<DefaultSpec as Spec>::Storage as Storage>::Root,
-    > = tokio::task::spawn_blocking(move || {
-        SP1Verifier::verify(&status.raw_aggregated_proof, &outer_code_commitment).unwrap()
-    })
-    .await
-    .unwrap();
+    > = SP1Verifier::verify(&status.raw_aggregated_proof, &outer_code_commitment).unwrap();
 }

--- a/examples/demo-rollup/tests/prover/sov-aggregated-proof/script/src/main.rs
+++ b/examples/demo-rollup/tests/prover/sov-aggregated-proof/script/src/main.rs
@@ -14,8 +14,9 @@ use sov_rollup_interface::zk::aggregated_proof::BlockHeaderWithProof;
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
 use sov_rollup_interface::zk::ZkVerifier;
 use sov_sp1_adapter::host::SP1AggregationHost;
+use sov_sp1_adapter::SP1Verifier;
 use sov_sp1_adapter::SP1;
-use sov_sp1_adapter::{SP1MethodId, SP1Verifier};
+use sp1_sdk::SP1VerifyingKey;
 
 const JUMP: usize = 3;
 
@@ -45,7 +46,7 @@ fn main() -> anyhow::Result<()> {
         "SP1 aggregation guest ELF is empty — build the guest first"
     );
 
-    let verification_key = SP1MethodId(saved_inner_vk_bytes()?);
+    let verification_key = saved_inner_vk_bytes()?;
 
     let prover = SP1AggregationHost::new(aggregation_elf, verification_key)?;
 
@@ -117,14 +118,16 @@ fn proofs() -> Vec<BlockHeaderWithProof<MockDaSpec>> {
     block_headers_with_proofs
 }
 
-fn saved_inner_vk_bytes() -> anyhow::Result<Vec<u8>> {
+fn saved_inner_vk_bytes() -> anyhow::Result<SP1VerifyingKey> {
     let path = data_dir().join("inner_vk.bin");
-    fs::read(&path).with_context(|| {
+    let bytes = fs::read(&path).with_context(|| {
         format!(
             "Failed to read saved verifying key fixture at {}",
             path.display()
         )
-    })
+    })?;
+
+    Ok(bincode::deserialize(&bytes)?)
 }
 
 fn data_dir() -> PathBuf {

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -22,19 +22,25 @@ type ProofInput = StateTransitionWitnessWithAddress<
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "This test is used to generate data for testing the aggregate proof circuit and should be enabled only when needed."]
 async fn test_save_proofs() {
-    let (host, code_commitment) = TestHost::new().await;
+    let host = TestHost::new().await;
     let proof_data = generate_proofs(&host).await;
     let proofs_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("test_data")
         .join("tmp");
 
+    let v_key = host.host.verifying_key();
+    let method_id = host.host.method_id();
+
     std::fs::create_dir_all(&proofs_dir).unwrap();
-    std::fs::write(proofs_dir.join("inner_vk.bin"), code_commitment.0.clone()).unwrap();
+    std::fs::write(
+        proofs_dir.join("inner_vk.bin"),
+        bincode::serialize(v_key).unwrap(),
+    )
+    .unwrap();
 
     for (i, data) in proof_data.into_iter().enumerate() {
-        let proof_public_data =
-            verify(data.proof.raw_inner_proof.clone(), code_commitment.clone()).await;
+        let proof_public_data = verify(data.proof.raw_inner_proof.clone(), method_id.clone()).await;
         assert_eq!(proof_public_data.slot_hash, data.da_block_header.hash());
         let json = serde_json::to_string(&data).unwrap();
         std::fs::write(proofs_dir.join(format!("inner_{i}_proof.json")), &json).unwrap();
@@ -48,7 +54,8 @@ async fn test_proof_generation() {
     // Use the mock prover: CPU proving is far too slow to run in tests.
     std::env::set_var("SP1_PROVER", "mock");
 
-    let (host, code_commitment) = TestHost::new().await;
+    let host = TestHost::new().await;
+    let method_id = host.host.method_id();
     let (_genesis_state_root, witnesses) = super::generate_witnesses().await;
     let prover_address = default_prover_address();
 
@@ -57,7 +64,7 @@ async fn test_proof_generation() {
         let _final_state_root = witness.final_state_root;
 
         let proof = generate_proof(&host, witness, prover_address).await;
-        let proof_public_data = verify(proof.proof.raw_inner_proof, code_commitment.clone()).await;
+        let proof_public_data = verify(proof.proof.raw_inner_proof, method_id.clone()).await;
 
         assert_eq!(proof_public_data.slot_hash, proof.da_block_header.hash());
         // TODO: Uncomment after NOmt bug is solved: https://github.com/Sovereign-Labs/sovereign-sdk/pull/2739
@@ -108,21 +115,14 @@ struct TestHost {
 }
 
 impl TestHost {
-    async fn new() -> (Self, SP1MethodId) {
-        let (code_commitment, host) = tokio::task::spawn_blocking(move || {
-            let host = SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF)
-                .expect("SP1Host should be created successfully");
-
-            (
-                host.code_commitment()
-                    .expect("SP1 code commitment should be created successfully"),
-                host,
-            )
+    async fn new() -> Self {
+        let host = tokio::task::spawn_blocking(move || {
+            SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF).expect("SP1Host should be created successfully")
         })
         .await
         .unwrap();
 
-        (Self { host }, code_commitment)
+        Self { host }
     }
 
     async fn run(&self, data: ProofInput) -> Vec<u8> {
@@ -140,10 +140,5 @@ async fn verify(
     proof: Vec<u8>,
     code_commitment: SP1MethodId,
 ) -> StateTransitionPublicData<<DefaultSpec as Spec>::Address, MockDaSpec, ProofStateRoot> {
-    tokio::task::spawn_blocking(move || -> StateTransitionPublicData<<DefaultSpec as Spec>::Address, MockDaSpec, ProofStateRoot> {
-            SP1Verifier::verify(&proof, &code_commitment)
-                .expect("SP1 proof verification should succeed")
-        })
-        .await
-        .unwrap()
+    SP1Verifier::verify(&proof, &code_commitment).expect("SP1 proof verification should succeed")
 }


### PR DESCRIPTION
# Description
In the `Chain-State` module, we store verification key hashes rather than the keys themselves. For this reason, we updated the Sp1Verifier to use `verify_compressed_with_public_values`, which works with hashes.

The remaining changes are related to cleaning up `CodeCommitmentHash` vs. `SP1MethodId` usage.

  - Change `SP1MethodId` from a bincode-serialized `SP1VerifyingKey` (`Vec<u8>`) to the canonical `[u32; 8]` vkey hash, eliminating repeated deserialization roundtrips in the host, verifier, and network adapters.                                          
  - Rework `SP1Verifier::verify` (native target) to call `sp1_verifier::compressed::SP1CompressedVerifier` directly against the vkey hash. Adds `sp1-verifier`, `sp1-primitives`, and `slop-algebra` as host-side deps.                                       
  - Make `CodeCommitmentTrait::to_hash` infallible and add a `from_hash` constructor; drop the `CodeCommitment = CodeCommitmentHash` bound on the aggregated-proof circuit so adapters can keep native commitment types end-to-end.                           
  - Thread `SP1VerifyingKey` (instead of a serialized `SP1MethodId`) through `SP1AggregationHost::new` and expose `SP1Host::verifying_key()` / `method_id()` helpers. Update `mock-zkvm` and `risc0` adapters, plus the aggregated-proof test fixtures, to the
   new trait shape

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551