### PR TITLE
Adds metrics to ZK proving related tasks

### DIFF
--- a/crates/full-node/sov-stf-runner/src/processes/metrics.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/metrics.rs
@@ -57,4 +57,3 @@ impl Metric for ZkProofManagerMetrics {
         )
     }
 }
-

--- a/crates/full-node/sov-stf-runner/src/processes/metrics.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/metrics.rs
@@ -20,7 +20,7 @@ impl Metric for ZkStfInfoChannelMetrics {
     fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
         write!(
             buffer,
-            "{} channel_depth={},channel_capacity={}",
+            "{} channel_depth={}i,channel_capacity={}i",
             self.measurement_name(),
             self.channel_depth,
             self.channel_capacity,
@@ -49,7 +49,7 @@ impl Metric for ZkProofManagerMetrics {
     fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
         write!(
             buffer,
-            "{} proving_lag={},proofs_to_create={},slot_number={}",
+            "{} proving_lag={}i,proofs_to_create={}i,slot_number={}i",
             self.measurement_name(),
             self.proving_lag,
             self.proofs_to_create,

--- a/crates/full-node/sov-stf-runner/src/processes/metrics.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/metrics.rs
@@ -57,3 +57,48 @@ impl Metric for ZkProofManagerMetrics {
         )
     }
 }
+
+/// Metrics emitted after each completed aggregated proof.
+#[derive(Debug)]
+pub(crate) struct ZkAggregatedProofMetrics {
+    /// Wall-clock time for the full aggregated proof cycle, in milliseconds.
+    pub aggregation_duration_ms: u128,
+}
+
+impl Metric for ZkAggregatedProofMetrics {
+    fn measurement_name(&self) -> &'static str {
+        "sov_rollup_zk_aggregated_proof"
+    }
+
+    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        write!(
+            buffer,
+            "{} aggregation_duration_ms={}i",
+            self.measurement_name(),
+            self.aggregation_duration_ms,
+        )
+    }
+}
+
+/// Metrics for the network prover.
+/// Emitted after each proof submission to the proving network.
+#[derive(Debug)]
+pub(crate) struct ZkNetworkProverMetrics {
+    /// Time in milliseconds for submitting a proof request to the network.
+    pub submit_duration_ms: u128,
+}
+
+impl Metric for ZkNetworkProverMetrics {
+    fn measurement_name(&self) -> &'static str {
+        "sov_rollup_zk_network_prover"
+    }
+
+    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        write!(
+            buffer,
+            "{} submit_duration_ms={}i",
+            self.measurement_name(),
+            self.submit_duration_ms,
+        )
+    }
+}

--- a/crates/full-node/sov-stf-runner/src/processes/metrics.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/metrics.rs
@@ -1,0 +1,60 @@
+use std::io::Write;
+
+use sov_metrics::Metric;
+
+/// Metrics tracking the depth of the STF info channel between the state manager and the ZK prover.
+/// Emitted after each `Sender::notify()` batch to detect backpressure.
+#[derive(Debug)]
+pub(crate) struct ZkStfInfoChannelMetrics {
+    /// Number of items currently in the mpsc channel.
+    pub channel_depth: usize,
+    /// Maximum capacity of the channel.
+    pub channel_capacity: usize,
+}
+
+impl Metric for ZkStfInfoChannelMetrics {
+    fn measurement_name(&self) -> &'static str {
+        "sov_rollup_zk_stf_info_channel"
+    }
+
+    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        write!(
+            buffer,
+            "{} channel_depth={},channel_capacity={}",
+            self.measurement_name(),
+            self.channel_depth,
+            self.channel_capacity,
+        )
+    }
+}
+
+/// Metrics tracking the state of the ZK proof manager pipeline.
+/// Emitted on every `process_stf_info()` call.
+#[derive(Debug)]
+pub(crate) struct ZkProofManagerMetrics {
+    /// Difference between latest received slot and the first unproven height.
+    /// Represents the total proving lag across the pipeline.
+    pub proving_lag: u64,
+    /// Number of blocks in the current aggregation batch.
+    pub proofs_to_create: usize,
+    /// The slot number of the most recently received state transition.
+    pub slot_number: u64,
+}
+
+impl Metric for ZkProofManagerMetrics {
+    fn measurement_name(&self) -> &'static str {
+        "sov_rollup_zk_proof_manager"
+    }
+
+    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        write!(
+            buffer,
+            "{} proving_lag={},proofs_to_create={},slot_number={}",
+            self.measurement_name(),
+            self.proving_lag,
+            self.proofs_to_create,
+            self.slot_number,
+        )
+    }
+}
+

--- a/crates/full-node/sov-stf-runner/src/processes/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/mod.rs
@@ -1,4 +1,5 @@
 //! Processes responsible for creating different kind of proofs.
+mod metrics;
 mod op_manager;
 mod prover_service;
 mod stf_info_manager;

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/network/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/network/prover.rs
@@ -141,10 +141,9 @@ where
             .await
             .map_err(ProverServiceError::Other)?;
         sov_metrics::track_metrics(|tracker| {
-            tracker.submit_inline(
-                "sov_rollup_zk_network_proof_submit",
-                format!("duration_ms={}i", submit_start.elapsed().as_millis()),
-            );
+            tracker.submit(crate::processes::metrics::ZkNetworkProverMetrics {
+                submit_duration_ms: submit_start.elapsed().as_millis(),
+            });
         });
 
         let StateTransitionWitnessWithAddress {

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/network/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/network/prover.rs
@@ -143,7 +143,7 @@ where
         sov_metrics::track_metrics(|tracker| {
             tracker.submit_inline(
                 "sov_rollup_zk_network_proof_submit",
-                format!("duration_ms={}", submit_start.elapsed().as_millis()),
+                format!("duration_ms={}i", submit_start.elapsed().as_millis()),
             );
         });
 

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/network/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/network/prover.rs
@@ -134,11 +134,18 @@ where
                 ProverServiceError::Other(anyhow::anyhow!("DA verification failed: {:?}", e))
             })?;
 
+        let submit_start = std::time::Instant::now();
         let handle = self
             .inner_vm
             .add_hint_and_submit(&data)
             .await
             .map_err(ProverServiceError::Other)?;
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit_inline(
+                "sov_rollup_zk_network_proof_submit",
+                format!("duration_ms={}", submit_start.elapsed().as_millis()),
+            );
+        });
 
         let StateTransitionWitnessWithAddress {
             stf_witness:

--- a/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
@@ -262,6 +262,13 @@ where
             tracing::trace!(%height, "Notified about stf info height for proving/attesting");
         }
 
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit(super::metrics::ZkStfInfoChannelMetrics {
+                channel_depth: self.notifier.max_capacity() - self.notifier.capacity(),
+                channel_capacity: self.notifier.max_capacity(),
+            });
+        });
+
         if height_to_notify >= next_height_to_send {
             self.next_height_to_send = height_to_notify.saturating_add(1);
         }

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -215,13 +215,9 @@ where
             let aggregation_duration = proving_start.elapsed();
 
             sov_metrics::track_metrics(|tracker| {
-                tracker.submit_inline(
-                    "sov_rollup_zk_aggregated_proof",
-                    format!(
-                        "aggregation_duration_ms={}i",
-                        aggregation_duration.as_millis()
-                    ),
-                );
+                tracker.submit(super::metrics::ZkAggregatedProofMetrics {
+                    aggregation_duration_ms: aggregation_duration.as_millis(),
+                });
             });
 
             tracing::debug!(

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -170,6 +170,14 @@ where
         let first_height_unproven = self.stf_info_receiver.next_height_to_receive();
         let received_slot_number = stf_info.slot_number;
 
+        if received_slot_number.get() < first_height_unproven.get() {
+            tracing::warn!(
+                %received_slot_number,
+                %first_height_unproven,
+                "Received slot is behind first unproven height — this is a bug"
+            );
+        }
+
         let prover_service = &self.prover_service;
 
         // We ensure that we're not trying to prove blocks that are being proven.

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -168,6 +168,7 @@ where
         >,
     ) -> anyhow::Result<()> {
         let first_height_unproven = self.stf_info_receiver.next_height_to_receive();
+        let received_slot_number = stf_info.slot_number;
 
         let prover_service = &self.prover_service;
 
@@ -203,6 +204,7 @@ where
             self.proofs_to_create.close_newest_proof();
             let metadata = self.proofs_to_create.take_oldest();
 
+            let proving_start = std::time::Instant::now();
             let agg_proof = self
                 .create_aggregate_proof_with_retries(
                     metadata,
@@ -210,6 +212,14 @@ where
                     &self.genesis_state_root,
                 )
                 .await?;
+            let aggregation_duration = proving_start.elapsed();
+
+            sov_metrics::track_metrics(|tracker| {
+                tracker.submit_inline(
+                    "sov_rollup_zk_aggregated_proof",
+                    format!("aggregation_duration_ms={}", aggregation_duration.as_millis()),
+                );
+            });
 
             tracing::debug!(
                 bytes = agg_proof.raw_aggregated_proof.len(),
@@ -224,6 +234,17 @@ where
             self.stf_info_receiver
                 .inc_next_height_to_receive_by(num_proofs_to_create as u64);
         }
+
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit(super::metrics::ZkProofManagerMetrics {
+                proving_lag: received_slot_number
+                    .get()
+                    .saturating_sub(first_height_unproven.get()),
+                proofs_to_create: self.proofs_to_create.current_proof_jump(),
+                slot_number: received_slot_number.get(),
+            });
+        });
+
         Ok(())
     }
 }

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -217,7 +217,10 @@ where
             sov_metrics::track_metrics(|tracker| {
                 tracker.submit_inline(
                     "sov_rollup_zk_aggregated_proof",
-                    format!("aggregation_duration_ms={}i", aggregation_duration.as_millis()),
+                    format!(
+                        "aggregation_duration_ms={}i",
+                        aggregation_duration.as_millis()
+                    ),
                 );
             });
 

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -217,7 +217,7 @@ where
             sov_metrics::track_metrics(|tracker| {
                 tracker.submit_inline(
                     "sov_rollup_zk_aggregated_proof",
-                    format!("aggregation_duration_ms={}", aggregation_duration.as_millis()),
+                    format!("aggregation_duration_ms={}i", aggregation_duration.as_millis()),
                 );
             });
 

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -170,13 +170,10 @@ where
         let first_height_unproven = self.stf_info_receiver.next_height_to_receive();
         let received_slot_number = stf_info.slot_number;
 
-        if received_slot_number.get() < first_height_unproven.get() {
-            tracing::warn!(
-                %received_slot_number,
-                %first_height_unproven,
-                "Received slot is behind first unproven height — this is a bug"
-            );
-        }
+        assert!(
+            received_slot_number.get() >= first_height_unproven.get(),
+            "Received slot {received_slot_number} is behind first unproven height {first_height_unproven}"
+        );
 
         let prover_service = &self.prover_service;
 
@@ -244,9 +241,7 @@ where
 
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(super::metrics::ZkProofManagerMetrics {
-                proving_lag: received_slot_number
-                    .get()
-                    .saturating_sub(first_height_unproven.get()),
+                proving_lag: received_slot_number.get() - first_height_unproven.get(),
                 proofs_to_create: self.proofs_to_create.current_proof_jump(),
                 slot_number: received_slot_number.get(),
             });


### PR DESCRIPTION
# Description

- `sov_rollup_zk_stf_info_channel`: channel depth and capacity of the mpsc channel between state manager and ZK prover — detects backpressure that would block the node
- `sov_rollup_zk_proof_manager`: proving lag (slots between latest received and first unproven), current aggregation batch size, and current slot number
- `sov_rollup_zk_aggregated_proof`: wall-clock duration of aggregated proof generation
- `sov_rollup_zk_network_proof_submit`: duration of the add_hint_and_submit call to SP1 network (from manual observation this can take around 7 seconds)

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2514

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
