### PR TITLE
Proving workflow: Process proofs from the current slot

### DIFF
--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -72,8 +72,6 @@ impl Default for MockZkvmHost {
 impl sov_rollup_interface::zk::ZkvmHost for MockZkvmHost {
     type Guest = MockZkGuest;
 
-
-
     fn code_commitment(&self) -> anyhow::Result<<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment>{
         Ok(MockCodeCommitment::default())
     }

--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -72,19 +72,19 @@ impl Default for MockZkvmHost {
 impl sov_rollup_interface::zk::ZkvmHost for MockZkvmHost {
     type Guest = MockZkGuest;
 
-    type HostArgs = ();
+
 
     fn code_commitment(&self) -> anyhow::Result<<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment>{
         Ok(MockCodeCommitment::default())
     }
 
-    fn add_hint_and_run<T: Serialize>(&mut self, item: &T) -> anyhow::Result<SerializedZkProof> {
+    fn add_hint_deferred_and_run<T: Serialize>(
+        &mut self,
+        item: &T,
+        _agg_proofs: Vec<SerializedAggregatedProof>,
+    ) -> anyhow::Result<SerializedZkProof> {
         self.add_hint_and_run_inner(item)
             .map(|raw_proof| SerializedZkProof { raw_proof })
-    }
-
-    fn from_args(_args: &Self::HostArgs) -> Self {
-        Self::new_non_blocking()
     }
 }
 

--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -172,7 +172,9 @@ mod tests {
 
         let mut vm = MockZkvmHost::new();
         vm.make_proof();
-        let proof = vm.add_hint_and_run(&pub_data).unwrap();
+        let proof = vm
+            .add_hint_deferred_and_run(&pub_data, Default::default())
+            .unwrap();
         let verified_pub_data =
             MockZkVerifier::verify_with_proof::<TestPublicData>(&proof, &Default::default())?;
 

--- a/crates/adapters/risc0/src/host.rs
+++ b/crates/adapters/risc0/src/host.rs
@@ -93,17 +93,12 @@ impl<'a> Risc0Host<'a> {
 }
 
 impl ZkvmHost for Risc0Host<'static> {
-    type HostArgs = &'static [u8];
-
-    fn from_args(args: &Self::HostArgs) -> Self {
-        Self::new(args)
-    }
-
     type Guest = Risc0Guest;
 
-    fn add_hint_and_run<T: serde::Serialize>(
+    fn add_hint_deferred_and_run<T: Serialize>(
         &mut self,
         item: &T,
+        _agg_proofs: Vec<SerializedAggregatedProof>,
     ) -> anyhow::Result<SerializedZkProof> {
         self.replace_hints(item);
         let session = self.run_without_proving()?;

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -224,7 +224,7 @@ impl SP1Host {
         })
     }
 
-    fn add_hint_deferred_and_run_heler<T: Serialize>(
+    fn add_hint_deferred_and_run_helper<T: Serialize>(
         &mut self,
         item: &T,
         agg_proofs: Vec<SerializedAggregatedProof>,
@@ -251,9 +251,9 @@ impl SP1Host {
 }
 
 /// Verification key.
-pub fn verifying_key_from_elf(elf: &[u8]) -> SP1VerifyingKey {
-    let (_, pk) = prover_and_pk(elf).unwrap();
-    pk.verifying_key().clone()
+pub fn verifying_key_from_elf(elf: &[u8]) -> anyhow::Result<SP1VerifyingKey> {
+    let (_, pk) = prover_and_pk(elf)?;
+    Ok(pk.verifying_key().clone())
 }
 
 fn prover_and_pk(elf: &[u8]) -> anyhow::Result<(EnvProver, EnvProvingKey)> {
@@ -280,7 +280,7 @@ impl ZkvmHost for SP1Host {
         item: &T,
         agg_proofs: Vec<SerializedAggregatedProof>,
     ) -> anyhow::Result<SerializedZkProof> {
-        self.add_hint_deferred_and_run_heler(item, agg_proofs)
+        self.add_hint_deferred_and_run_helper(item, agg_proofs)
     }
 
     fn code_commitment(&self) -> anyhow::Result<<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment>{

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -33,7 +33,7 @@ pub struct SP1AggregationHost {
 }
 
 struct Inner {
-    host: SP1Host,
+    prover: SP1Prover,
     outer_vk: sp1_sdk::SP1VerifyingKey,
     inner_vk: sp1_sdk::SP1VerifyingKey,
     prev_agg_proof: Mutex<Option<sp1_sdk::SP1ProofWithPublicValues>>,
@@ -43,12 +43,12 @@ impl SP1AggregationHost {
     /// Creates a new aggregation host from the aggregation guest `elf` binary
     /// and the verifying key (`inner_method_id`) of the inner proof program.
     pub fn new(elf: &'static [u8], inner_vk: sp1_sdk::SP1VerifyingKey) -> anyhow::Result<Self> {
-        let host = SP1Host::new(elf)?;
-        let outer_vk = host.proving_key()?.verifying_key().clone();
+        let prover = SP1Prover::new(elf)?;
+        let outer_vk = prover.verifying_key().clone();
 
         Ok(Self {
             inner: Arc::new(Inner {
-                host,
+                prover,
                 outer_vk,
                 inner_vk,
                 prev_agg_proof: Mutex::new(None),
@@ -83,10 +83,11 @@ impl SP1AggregationHost {
 
         let prev_outer_proof_witness = if let Some(previous_outer_proof) = prev_agg_proof.as_ref() {
             let serialized = crate::encode_sp1_proof(previous_outer_proof)?;
-            let public_values =
-                self.inner
-                    .host
-                    .add_proof_helper(&mut stdin, &serialized, &self.inner.outer_vk)?;
+            let public_values = self.inner.prover.add_proof_helper(
+                &mut stdin,
+                &serialized,
+                &self.inner.outer_vk,
+            )?;
 
             Some(PreviousOuterProofWitness { public_values })
         } else {
@@ -95,7 +96,7 @@ impl SP1AggregationHost {
 
         let mut proof_inputs = Vec::with_capacity(proofs_and_headers.len());
         for proof_and_header in proofs_and_headers {
-            let public_values = self.inner.host.add_proof_helper(
+            let public_values = self.inner.prover.add_proof_helper(
                 &mut stdin,
                 &proof_and_header.proof,
                 &self.inner.inner_vk,
@@ -123,7 +124,7 @@ impl SP1AggregationHost {
 
         stdin.write(&witness);
 
-        let agg_proof = self.inner.host.run_helper(stdin)?;
+        let agg_proof = self.inner.prover.run(stdin)?;
         let serialized = crate::encode_sp1_proof(&agg_proof)?;
         *prev_agg_proof = Some(agg_proof);
 
@@ -133,36 +134,31 @@ impl SP1AggregationHost {
     }
 }
 
-/// SP1 Host implementation.
+/// SP1 prover bundling the [`EnvProver`] with its proving key.
 #[derive(Clone)]
-pub struct SP1Host {
+pub struct SP1Prover {
     prover: EnvProver,
     pk: Arc<EnvProvingKey>,
 }
 
-/// Instantiate a new SP1 Host.
-impl SP1Host {
-    /// Create a new SP1 Host backed by a real proving key derived from `elf`.
+impl SP1Prover {
+    /// Create a new [`SP1Prover`] by setting up a proving key from `elf`.
     pub fn new(elf: &[u8]) -> anyhow::Result<Self> {
-        let prover = ProverClient::from_env();
-
-        let pk = prover
-            .setup(elf.into())
-            .map_err(|e| anyhow::anyhow!("SP1 setup failed. Error: {:?}", e))?;
-
+        let (prover, pk) = prover_and_pk(elf)?;
         Ok(Self {
             prover,
             pk: Arc::new(pk),
         })
     }
 
-    /// Create a new `Sp1Guest` that reads the provided hints
-    pub fn simulate_with_hints(stdin: SP1Stdin) -> SP1Guest {
-        SP1Guest::with_hints(stdin.buffer)
+    /// Verification key.
+    pub fn verifying_key(&self) -> &SP1VerifyingKey {
+        self.pk.verifying_key()
     }
 
-    pub(crate) fn proving_key(&self) -> anyhow::Result<&EnvProvingKey> {
-        Ok(&self.pk)
+    /// Method id.
+    pub fn method_id(&self) -> SP1MethodId {
+        SP1MethodId(self.pk.verifying_key().hash_u32())
     }
 
     fn add_proof_helper(
@@ -183,7 +179,7 @@ impl SP1Host {
         })
     }
 
-    fn run_helper(&self, stdin: SP1Stdin) -> anyhow::Result<sp1_sdk::SP1ProofWithPublicValues> {
+    fn run(&self, stdin: SP1Stdin) -> anyhow::Result<sp1_sdk::SP1ProofWithPublicValues> {
         // Under the mock backend the inner compressed proofs are dummies that
         // would fail the executor-side deferred-proof check. Skip that check so
         // mock aggregation can run end-to-end; real backends keep it on.
@@ -202,15 +198,72 @@ impl SP1Host {
         Ok(output)
     }
 
-    /// Verification key.
-    pub fn verifying_key(&self) -> &SP1VerifyingKey {
-        self.pk.verifying_key()
+    /// Serialize `item` as a hint, produce a compressed proof, and encode it.
+    pub fn add_hint_and_run<T: Serialize>(&self, item: &T) -> anyhow::Result<SerializedZkProof> {
+        let mut stdin = SP1Stdin::new();
+        stdin.write(item);
+        let output = self.run(stdin)?;
+        crate::encode_sp1_proof(&output)
+    }
+}
+
+/// SP1 Host implementation.
+#[derive(Clone)]
+pub struct SP1Host {
+    prover: SP1Prover,
+    outer_vk: Arc<SP1VerifyingKey>,
+}
+
+/// Instantiate a new SP1 Host.
+impl SP1Host {
+    /// Create a new SP1 Host backed by a real proving key derived from `elf`.
+    pub fn new(elf: &[u8], outer_vk: Arc<SP1VerifyingKey>) -> anyhow::Result<Self> {
+        Ok(Self {
+            prover: SP1Prover::new(elf)?,
+            outer_vk,
+        })
     }
 
-    /// Method id.
-    pub fn method_id(&self) -> SP1MethodId {
-        SP1MethodId(self.pk.verifying_key().hash_u32())
+    fn add_hint_deferred_and_run_heler<T: Serialize>(
+        &mut self,
+        item: &T,
+        agg_proofs: Vec<SerializedAggregatedProof>,
+    ) -> anyhow::Result<SerializedZkProof> {
+        let mut stdin = SP1Stdin::new();
+
+        for raw_agg_proof in agg_proofs {
+            self.prover.add_proof_helper(
+                &mut stdin,
+                &raw_agg_proof.to_serialized_zk_proof(),
+                &self.outer_vk,
+            )?;
+        }
+
+        stdin.write(item);
+        let output = self.prover.run(stdin)?;
+        crate::encode_sp1_proof(&output)
     }
+
+    /// Verification key.
+    pub fn verifying_key(&self) -> &SP1VerifyingKey {
+        self.prover.verifying_key()
+    }
+}
+
+/// Verification key.
+pub fn verifying_key_from_elf(elf: &[u8]) -> SP1VerifyingKey {
+    let (_, pk) = prover_and_pk(elf).unwrap();
+    pk.verifying_key().clone()
+}
+
+fn prover_and_pk(elf: &[u8]) -> anyhow::Result<(EnvProver, EnvProvingKey)> {
+    let prover = ProverClient::from_env();
+
+    let pk = prover
+        .setup(elf.into())
+        .map_err(|e| anyhow::anyhow!("SP1 setup failed. Error: {:?}", e))?;
+
+    Ok((prover, pk))
 }
 
 impl core::fmt::Debug for SP1Host {
@@ -220,22 +273,18 @@ impl core::fmt::Debug for SP1Host {
 }
 
 impl ZkvmHost for SP1Host {
-    type HostArgs = &'static [u8];
     type Guest = SP1Guest;
 
-    fn from_args(args: &Self::HostArgs) -> Self {
-        Self::new(args).unwrap_or_else(|e| panic!("Failed to create SP1Host: {e:?}"))
-    }
-
-    fn add_hint_and_run<T: Serialize>(&mut self, item: &T) -> anyhow::Result<SerializedZkProof> {
-        let mut stdin = SP1Stdin::new();
-        stdin.write(item);
-        let output = self.run_helper(stdin)?;
-        crate::encode_sp1_proof(&output)
+    fn add_hint_deferred_and_run<T: Serialize>(
+        &mut self,
+        item: &T,
+        agg_proofs: Vec<SerializedAggregatedProof>,
+    ) -> anyhow::Result<SerializedZkProof> {
+        self.add_hint_deferred_and_run_heler(item, agg_proofs)
     }
 
     fn code_commitment(&self) -> anyhow::Result<<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment>{
-        Ok(crate::SP1MethodId(self.pk.verifying_key().hash_u32()))
+        Ok(self.prover.method_id())
     }
 }
 

--- a/crates/adapters/sp1/tests/integration/native.rs
+++ b/crates/adapters/sp1/tests/integration/native.rs
@@ -1,38 +1,5 @@
-use serde::{Deserialize, Serialize};
-use sov_rollup_interface::zk::{ZkvmGuest, ZkvmHost};
-use sov_sp1_adapter::host::SP1Host;
+use sov_sp1_adapter::host::SP1Prover;
 use sp1_build::BuildArgs;
-use sp1_sdk::SP1Stdin;
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-struct TestStruct {
-    ints: Vec<i32>,
-    string: String,
-}
-
-#[test]
-fn test_hints_roundtrip() {
-    let hint_a = TestStruct {
-        ints: vec![1, 2, 3, 4, 5],
-        string: "hello".to_string(),
-    };
-    let hint_b = TestStruct {
-        ints: vec![1, 2, 3, 4, 5],
-        string: "hello".to_string(),
-    };
-
-    let mut stdin = SP1Stdin::new();
-    stdin.write(&hint_a);
-    stdin.write(&hint_b);
-
-    let guest = SP1Host::simulate_with_hints(stdin);
-
-    let mut received;
-    received = guest.read_from_host();
-    assert_eq!(hint_a, received);
-    received = guest.read_from_host();
-    assert_eq!(hint_b, received);
-}
 
 #[test]
 #[ignore = "Should be run manually"]
@@ -54,9 +21,9 @@ fn test_fibonnaci_host() {
 
     let fibonacci_elf = include_bytes!("../../test_data/riscv64im-succinct-zkvm-elf");
 
-    let mut host = SP1Host::new(fibonacci_elf).unwrap();
+    let prover = SP1Prover::new(fibonacci_elf).unwrap();
 
     // Give the input 7 to the fibonnaci program. Under the mock backend this
     // exercises the proving pipeline end-to-end without generating real proofs.
-    host.add_hint_and_run(&7u32).unwrap();
+    prover.add_hint_and_run(&7u32).unwrap();
 }

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
@@ -6,7 +6,9 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec, DaVerifier};
 use sov_rollup_interface::node::da::DaService;
-use sov_rollup_interface::zk::aggregated_proof::{BlockProof, OuterZkvmHost};
+use sov_rollup_interface::zk::aggregated_proof::{
+    BlockProof, OuterZkvmHost, SerializedAggregatedProof,
+};
 use sov_rollup_interface::zk::{
     SerializedZkProof, StateTransitionPublicData, StateTransitionWitness,
     StateTransitionWitnessWithAddress, Zkvm, ZkvmHost,
@@ -98,14 +100,21 @@ where
         if start_prover {
             prover_state.set_to_proving(block_header_hash.clone());
 
+            let StateTransitionInfo {
+                data,
+                aggregated_proofs,
+                slot_number,
+            } = state_transition_info;
+
             let data = StateTransitionWitnessWithAddress {
-                stf_witness: state_transition_info.data,
+                stf_witness: data,
                 prover_address: self.prover_address.clone(),
             };
 
             self.pool.spawn(move || {
                 tracing::info_span!("guest_execution").in_scope(|| {
-                    let inner_proof = Self::make_inner_proof::<InnerVm>(inner_vm, &data);
+                    let inner_proof =
+                        Self::make_inner_proof::<InnerVm>(inner_vm, &data, aggregated_proofs);
 
                     let mut prover_state = prover_state_clone.write().expect("Lock was poisoned");
 
@@ -135,7 +144,7 @@ where
                             slot_hash: block_header_hash.clone(),
                             prover_address,
                         },
-                        slot_number: state_transition_info.slot_number,
+                        slot_number,
                     });
 
                     prover_state.set_to_proved(block_header_hash, block_proof);
@@ -210,14 +219,13 @@ where
     fn make_inner_proof<InnerVm>(
         mut vm: InnerVm::Host,
         hint: &StateTransitionWitnessWithAddress<Address, StateRoot, Witness, Da::Spec>,
+        serialized_agg_proofs: Vec<SerializedAggregatedProof>,
     ) -> anyhow::Result<SerializedZkProof>
     where
         InnerVm: Zkvm + 'static,
     {
         let proving_start = std::time::Instant::now();
         info!("Generating proof with {}", std::any::type_name::<InnerVm>());
-
-        let serialized_agg_proofs = hint.stf_witness.aggregated_proofs();
 
         let result = vm.add_hint_deferred_and_run(hint, serialized_agg_proofs);
         sov_metrics::track_metrics(|tracker| {

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
@@ -105,7 +105,7 @@ where
 
             self.pool.spawn(move || {
                 tracing::info_span!("guest_execution").in_scope(|| {
-                    let inner_proof = make_inner_proof::<InnerVm>(inner_vm, &data);
+                    let inner_proof = Self::make_inner_proof::<InnerVm>(inner_vm, &data);
 
                     let mut prover_state = prover_state_clone.write().expect("Lock was poisoned");
 
@@ -206,37 +206,40 @@ where
 
         Ok(ProofAggregationStatus::Success(serialized_aggregated_proof))
     }
-}
 
-fn make_inner_proof<InnerVm>(
-    mut vm: InnerVm::Host,
-    hint: &impl Serialize,
-) -> anyhow::Result<SerializedZkProof>
-where
-    InnerVm: Zkvm + 'static,
-{
-    let proving_start = std::time::Instant::now();
-    info!("Generating proof with {}", std::any::type_name::<InnerVm>());
-    let result = vm.add_hint_and_run(hint);
-    sov_metrics::track_metrics(|tracker| {
-        let proving_time = proving_start.elapsed();
-        let is_success = result.is_ok();
-        tracker.submit(sov_metrics::ZkProvingTime {
-            proving_time,
-            is_success,
-            zk_circuit: sov_metrics::ZkCircuit::Inner,
+    fn make_inner_proof<InnerVm>(
+        mut vm: InnerVm::Host,
+        hint: &StateTransitionWitnessWithAddress<Address, StateRoot, Witness, Da::Spec>,
+    ) -> anyhow::Result<SerializedZkProof>
+    where
+        InnerVm: Zkvm + 'static,
+    {
+        let proving_start = std::time::Instant::now();
+        info!("Generating proof with {}", std::any::type_name::<InnerVm>());
+
+        let serialized_agg_proofs = hint.stf_witness.aggregated_proofs();
+
+        let result = vm.add_hint_deferred_and_run(hint, serialized_agg_proofs);
+        sov_metrics::track_metrics(|tracker| {
+            let proving_time = proving_start.elapsed();
+            let is_success = result.is_ok();
+            tracker.submit(sov_metrics::ZkProvingTime {
+                proving_time,
+                is_success,
+                zk_circuit: sov_metrics::ZkCircuit::Inner,
+            });
         });
-    });
-    match result {
-        Ok(ref proof) => {
-            trace!(
-                bytes = proof.len(),
-                "Proof generation completed successfully"
-            );
+        match result {
+            Ok(ref proof) => {
+                trace!(
+                    bytes = proof.len(),
+                    "Proof generation completed successfully"
+                );
+            }
+            Err(ref e) => {
+                error!("Proof generation failed: {:?}", e);
+            }
         }
-        Err(ref e) => {
-            error!("Proof generation failed: {:?}", e);
-        }
+        result
     }
-    result
 }

--- a/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
@@ -13,6 +13,7 @@ use sov_db::ledger_db::LedgerDb;
 use sov_db::schema::types::StoredStfInfo;
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
 use sov_rollup_interface::zk::StateTransitionWitness;
 use sov_rollup_interface::ProvableHeightTracker;
 use tokio::sync::mpsc;
@@ -23,6 +24,8 @@ use tokio::sync::mpsc;
 pub struct StateTransitionInfo<StateRoot, Witness, Da: DaSpec> {
     /// Public input to the per-block zk proof.
     pub(crate) data: StateTransitionWitness<StateRoot, Witness, Da>,
+    /// Aggregated proofs processed while executing this transition, in verification order.
+    pub(crate) aggregated_proofs: Vec<SerializedAggregatedProof>,
     /// Rollup height.
     pub(crate) slot_number: SlotNumber,
 }
@@ -33,7 +36,11 @@ impl<StateRoot, Witness, Da: DaSpec> StateTransitionInfo<StateRoot, Witness, Da>
         data: StateTransitionWitness<StateRoot, Witness, Da>,
         slot_number: SlotNumber,
     ) -> Self {
-        Self { data, slot_number }
+        Self {
+            data,
+            aggregated_proofs: Vec::new(),
+            slot_number,
+        }
     }
 
     pub(crate) fn da_block_header(&self) -> &Da::BlockHeader {

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -22,7 +22,6 @@ use sov_rollup_interface::stf::{
     StateTransitionFunction,
 };
 use sov_rollup_interface::storage::HierarchicalStorageManager;
-use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
 use sov_rollup_interface::zk::StateTransitionWitness;
 use sov_rollup_interface::ProvableHeightTracker;
 use tokio::sync::watch;
@@ -30,7 +29,7 @@ use tracing::{debug, info, trace};
 
 use crate::da::{DaServiceWithCachedFinalizedHeaders, FinalizedBlocksBulkFetcher};
 use crate::processes::{new_stf_info_channel, Receiver};
-use crate::state_manager::{BlockCandidateResolution, StateManager};
+use crate::state_manager::{AggregatedProofs, BlockCandidateResolution, StateManager};
 use tokio::net::TcpListener;
 
 type GenesisParams<ST, Da> = <ST as StateTransitionFunction<Da>>::GenesisParams;
@@ -705,10 +704,10 @@ where
             Item = ProofReceipt<Stf::Address, Da::Spec, Stf::StateRoot, Stf::StorageProof>,
         >,
     ) -> (
-        Vec<SerializedAggregatedProof>,
+        AggregatedProofs,
         Vec<PartialProofReceipt<Stf::Address, Da::Spec, Stf::StateRoot, Stf::StorageProof>>,
     ) {
-        let mut aggregated_proofs: Vec<SerializedAggregatedProof> = Vec::new();
+        let mut aggregated_proofs = AggregatedProofs::default();
         #[allow(clippy::type_complexity)]
         // Any type alias needs the STF bounds, which are more complex than the original type
         let mut partial_receipts: Vec<
@@ -720,12 +719,25 @@ where
                     _public_data,
                     raw_proof,
                 )) => {
-                    aggregated_proofs.push(std::mem::take(raw_proof));
+                    let raw_proof = std::mem::take(raw_proof);
+                    aggregated_proofs
+                        .all_aggregated_proofs
+                        .push(raw_proof.clone());
+                    aggregated_proofs.accepted_aggregated_proofs.push(raw_proof);
                 }
                 ProofOutcome::Valid(_) => {
                     tracing::info!("Not aggregated proof, probably running in a different mode. Will be fixed in the future.");
                 }
-                _ => {
+                ProofOutcome::Invalid(_, proof) => {
+                    if let Some(proof) = proof.take() {
+                        aggregated_proofs.all_aggregated_proofs.push(proof);
+                    }
+                    tracing::error!(
+                        outcome = ?receipt.outcome,
+                        blob_hash = hex::encode(receipt.blob_hash),
+                        "Invalid proof outcome");
+                }
+                ProofOutcome::Ignored => {
                     tracing::error!(
                         outcome = ?receipt.outcome,
                         blob_hash = hex::encode(receipt.blob_hash),

--- a/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
@@ -48,6 +48,12 @@ pub enum BlockCandidateResolution<StfPreState, StateRoot, LedgerPreState> {
     },
 }
 
+#[derive(Default)]
+pub(crate) struct AggregatedProofs {
+    pub(crate) all_aggregated_proofs: Vec<SerializedAggregatedProof>,
+    pub(crate) accepted_aggregated_proofs: Vec<SerializedAggregatedProof>,
+}
+
 /// Structure that holds a block header and a pre-state root that was on this block header
 struct StateOnBlock<Da: DaSpec, StateRoot> {
     block_header: Da::BlockHeader,
@@ -330,7 +336,7 @@ where
         ledger_pre_state: Sm::LedgerState,
         transition_witness: StateTransitionWitness<StateRoot, Witness, Da::Spec>,
         slot_commit: SlotCommit<S, B, T>,
-        aggregated_proofs: Vec<SerializedAggregatedProof>,
+        aggregated_proofs: AggregatedProofs,
         proof_receipts: Vec<PartialProofReceipt<Address, Da::Spec, StateRoot, StorageProof>>,
     ) -> anyhow::Result<()> {
         let start = std::time::Instant::now();
@@ -349,12 +355,18 @@ where
             );
         }
 
-        let aggregated_proofs_count = aggregated_proofs.len();
+        let AggregatedProofs {
+            all_aggregated_proofs,
+            accepted_aggregated_proofs,
+        } = aggregated_proofs;
+        let aggregated_proofs_count = all_aggregated_proofs.len();
+        let accepted_aggregated_proofs_count = accepted_aggregated_proofs.len();
         let proof_receipts_count = proof_receipts.len();
         tracing::debug!(
             current_state_root = hex::encode(self.last_processed_finalized_state_root.as_ref()),
             next_state_root = hex::encode(new_state_root.as_ref()),
             aggregated_proofs = aggregated_proofs_count,
+            accepted_aggregated_proofs = accepted_aggregated_proofs_count,
             proof_receipts = proof_receipts_count,
             "Saving changes after applying slot"
         );
@@ -423,6 +435,7 @@ where
             tracing::trace!("Going to materialize StateTransitionInfo");
             let stf_info = StateTransitionInfo {
                 data: transition_witness,
+                aggregated_proofs: all_aggregated_proofs,
                 slot_number,
             };
             let stf_info_schema = stf_info_sender
@@ -432,7 +445,7 @@ where
             tracing::trace!("StateTransitionInfo is materialized into Ledger ChangeSet");
         }
 
-        for aggregated_proof in aggregated_proofs {
+        for aggregated_proof in accepted_aggregated_proofs {
             let this_height_data = self
                 .ledger_db
                 .materialize_aggregated_proof(slot_number, aggregated_proof)?;

--- a/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
@@ -217,6 +217,80 @@ async fn test_instant_finality() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn rejected_aggregated_proofs_are_not_published_as_latest() -> anyhow::Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let da_service = MockDaService::new(SEQUENCER_ADDRESS);
+    let (mut state_manager, _initial_state_root, shutdown_sender) =
+        setup_state_manager(tempdir.path(), da_service.clone()).await?;
+
+    let (sender, mut receiver) = crate::processes::new_stf_info_channel(
+        state_manager.ledger_db.clone(),
+        NonZero::new(40).unwrap(),
+        NonZero::new(40).unwrap(),
+    )
+    .await?;
+    state_manager.stf_info_sender = Some(sender);
+
+    da_service.send_transaction(&[1; 10]).await.await??;
+    let filtered_block = da_service.get_block_at(1).await?;
+
+    let (prover_storage, pre_state_root, ledger_pre_state) = unwrap_continuation(
+        state_manager
+            .check_continuation(filtered_block.header(), &da_service)
+            .await?,
+    );
+    let (change_set, transition_witness) = produce_synthetic_state_transition_witness(
+        pre_state_root,
+        prover_storage,
+        &da_service,
+        filtered_block.clone(),
+    )
+    .await;
+    let slot_commit: MockSlotCommit = SlotCommit::new(filtered_block, Default::default());
+
+    let accepted_proof = SerializedAggregatedProof {
+        raw_aggregated_proof: vec![1, 2, 3],
+    };
+    let rejected_proof = SerializedAggregatedProof {
+        raw_aggregated_proof: vec![4, 5, 6],
+    };
+
+    state_manager
+        .process_stf_changes(
+            change_set,
+            ledger_pre_state,
+            transition_witness,
+            slot_commit,
+            AggregatedProofs {
+                all_aggregated_proofs: vec![accepted_proof.clone(), rejected_proof.clone()],
+                accepted_aggregated_proofs: vec![accepted_proof.clone()],
+            },
+            Vec::<DummyProofReceipt>::new(),
+        )
+        .await?;
+
+    let latest_proof = state_manager
+        .ledger_db
+        .get_latest_aggregated_proof()
+        .await?
+        .expect("accepted aggregated proof should be published");
+    assert_eq!(accepted_proof, latest_proof.proof);
+
+    let stf_info = receiver
+        .read_next()
+        .await?
+        .expect("stf info should be available");
+    assert_eq!(
+        vec![accepted_proof, rejected_proof],
+        stf_info.aggregated_proofs
+    );
+
+    shutdown_sender.send(())?;
+
+    Ok(())
+}
+
 // Basic test for single reorg, but detailed check of what state root hash is returned.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_reorg_happened_correct_block_returned() -> anyhow::Result<()> {
@@ -317,7 +391,7 @@ async fn test_reorg_happened_correct_block_returned() -> anyhow::Result<()> {
                     ledger_pre_state,
                     transition_witness,
                     slot_commit,
-                    Vec::new(),
+                    AggregatedProofs::default(),
                     Vec::<DummyProofReceipt>::new(),
                 )
                 .await?;
@@ -403,7 +477,7 @@ async fn test_save_last_finalized_larger_than_seen_latest_seen_transition() -> a
             ledger_pre_state,
             transition_witness,
             slot_commit,
-            Vec::new(),
+            AggregatedProofs::default(),
             Vec::<DummyProofReceipt>::new(),
         )
         .await?;
@@ -514,7 +588,7 @@ async fn test_progressing_with_shuffle(
                 ledger_pre_state,
                 transition_witness,
                 slot_commit,
-                Vec::new(),
+                AggregatedProofs::default(),
                 Vec::<DummyProofReceipt>::new(),
             )
             .await?;
@@ -731,7 +805,7 @@ async fn test_with_frequent_periodic_batch_production() -> anyhow::Result<()> {
                 ledger_pre_state,
                 transition_witness,
                 slot_commit,
-                Vec::new(),
+                AggregatedProofs::default(),
                 Vec::<DummyProofReceipt>::new(),
             )
             .await?;
@@ -829,7 +903,7 @@ async fn test_chain_progress_between_prepare_storage_and_save_changes(
                 ledger_pre_state,
                 transition_witness,
                 slot_commit,
-                Vec::new(),
+                AggregatedProofs::default(),
                 Vec::<DummyProofReceipt>::new(),
             )
             .await?;
@@ -1273,7 +1347,7 @@ async fn process_continuous_transition(
             ledger_pre_state,
             transition_witness,
             slot_commit,
-            Vec::new(),
+            AggregatedProofs::default(),
             Vec::<DummyProofReceipt>::new(),
         )
         .await?;
@@ -1555,7 +1629,7 @@ async fn test_progressing_with_rewind_below_finalized(
                 ledger_pre_state,
                 transition_witness,
                 slot_commit,
-                Vec::new(),
+                AggregatedProofs::default(),
                 Vec::<DummyProofReceipt>::new(),
             )
             .await?;
@@ -1623,7 +1697,7 @@ async fn test_binary_search_handles_da_error() -> anyhow::Result<()> {
                 ledger_pre_state,
                 transition_witness,
                 slot_commit,
-                Vec::new(),
+                AggregatedProofs::default(),
                 Vec::<DummyProofReceipt>::new(),
             )
             .await?;
@@ -1722,7 +1796,7 @@ async fn test_reorg_during_binary_search() -> anyhow::Result<()> {
                 ledger_pre_state,
                 transition_witness,
                 slot_commit,
-                Vec::new(),
+                AggregatedProofs::default(),
                 Vec::<DummyProofReceipt>::new(),
             )
             .await?;
@@ -1774,7 +1848,7 @@ async fn test_reorg_during_binary_search() -> anyhow::Result<()> {
             ledger_pre_state,
             transition_witness,
             slot_commit,
-            Vec::new(),
+            AggregatedProofs::default(),
             Vec::<DummyProofReceipt>::new(),
         )
         .await?;
@@ -1894,7 +1968,7 @@ async fn test_finalized_height_monotonic() -> anyhow::Result<()> {
                 ledger_pre_state,
                 transition_witness,
                 slot_commit,
-                Vec::new(),
+                AggregatedProofs::default(),
                 Vec::<DummyProofReceipt>::new(),
             )
             .await?;

--- a/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/attestation_processing.rs
+++ b/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/attestation_processing.rs
@@ -220,9 +220,10 @@ fn invalid_bond_proof_no_slash(
         assert: Box::new(move |result, state| {
             assert_eq!(
                 result.proof_receipt.unwrap().outcome,
-                ProofOutcome::Invalid(InvalidProofError::PreconditionNotMet(
-                    "Invalid bonding proof".to_string()
-                ))
+                ProofOutcome::Invalid(
+                    InvalidProofError::PreconditionNotMet("Invalid bonding proof".to_string()),
+                    None
+                )
             );
 
             assert_eq!(
@@ -254,7 +255,7 @@ fn invalid_initial_state_slashed(
         assert: Box::new(move |result, state| {
             assert_matches!(
                 result.proof_receipt.unwrap().outcome,
-                ProofOutcome::Invalid(InvalidProofError::ProverSlashed(_))
+                ProofOutcome::Invalid(InvalidProofError::ProverSlashed(_), _)
             );
 
             assert!(TestAttesterIncentives::default()
@@ -295,7 +296,7 @@ fn invalid_post_state_root_is_challengeable(
         assert: Box::new(move |result, state| {
             assert_matches!(
                 result.proof_receipt.unwrap().outcome,
-                ProofOutcome::Invalid(InvalidProofError::ProverSlashed(_))
+                ProofOutcome::Invalid(InvalidProofError::ProverSlashed(_), _)
             );
 
             assert!(TestAttesterIncentives::default()

--- a/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/challenger.rs
+++ b/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/challenger.rs
@@ -99,7 +99,7 @@ fn setup_with_wrong_attestation() -> (
             assert: Box::new(move |result, state| {
                 assert_matches!(
                     result.proof_receipt.unwrap().outcome,
-                    ProofOutcome::Invalid(_)
+                    ProofOutcome::Invalid(_, _)
                 );
 
                 // Check that the attester was slashed
@@ -219,7 +219,7 @@ fn test_invalid_challenge_helper(
         input: ProofInput(challenge_blob),
         assert: Box::new(move |result, state| {
             match &result.proof_receipt.unwrap().outcome {
-                ProofOutcome::Invalid(InvalidProofError::ProverSlashed(msg)) => {
+                ProofOutcome::Invalid(InvalidProofError::ProverSlashed(msg), _) => {
                     assert_eq!(msg, &slashing_reason.to_string());
                 }
                 _ => panic!("Expected invalid outcome"),

--- a/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/invariant.rs
+++ b/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/invariant.rs
@@ -102,7 +102,7 @@ fn test_cannot_attest_below_max_attested_height() {
         input: ProofInput(make_attestation_blob(attestation_proof)),
         assert: Box::new(move |result, state| {
             match &result.proof_receipt.unwrap().outcome {
-                ProofOutcome::Invalid(e@InvalidProofError::PreconditionNotMet(msg)) => {
+                ProofOutcome::Invalid(e @ InvalidProofError::PreconditionNotMet(msg), _) => {
                     assert!(!e.is_not_revertable());
                     assert_eq!(msg, "Transition invariant isn't respected");
                 }
@@ -147,7 +147,7 @@ fn test_cannot_attest_above_max_attested_height_plus_one() {
         assert: Box::new(move |result, state| {
 
         match &result.proof_receipt.unwrap().outcome {
-            ProofOutcome::Invalid(e@InvalidProofError::PreconditionNotMet(msg)) => {
+            ProofOutcome::Invalid(e @ InvalidProofError::PreconditionNotMet(msg), _) => {
                 assert!(!e.is_not_revertable());
                 assert_eq!(msg, "Transition invariant isn't respected");
             }
@@ -249,7 +249,7 @@ fn test_cannot_attest_genesis_height() {
         input: ProofInput(make_attestation_blob(attestation_proof)),
         assert: Box::new(
             move |result, _state| match &result.proof_receipt.unwrap().outcome {
-                ProofOutcome::Invalid(e @ InvalidProofError::PreconditionNotMet(msg)) => {
+                ProofOutcome::Invalid(e @ InvalidProofError::PreconditionNotMet(msg), _) => {
                     assert!(!e.is_not_revertable());
                     assert_eq!(msg, "Transition invariant isn't respected");
                 }

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/proofs.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/proofs.rs
@@ -141,7 +141,7 @@ fn test_valid_proof_penalized_if_reward_already_claimed() {
         input: ProofInput(serialize_proof(aggregated_proof)),
         assert: Box::new(move |result, state| {
             match result.proof_receipt.clone().unwrap().outcome {
-                ProofOutcome::Invalid(InvalidProofError::ProverPenalized(_)) => {}
+                ProofOutcome::Invalid(InvalidProofError::ProverPenalized(_), _) => {}
                 _ => panic!("Expected prover to be penalized"),
             }
 

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/slashing.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/slashing.rs
@@ -22,7 +22,7 @@ fn assert_slashed(
 ) {
     assert_matches!(
         &context.proof_receipt.unwrap().outcome,
-        ProofOutcome::Invalid(e) if matches!(e, InvalidProofError::ProverSlashed(s) if s == slash_reason)
+        ProofOutcome::Invalid(e, _) if matches!(e, InvalidProofError::ProverSlashed(s) if s == slash_reason)
     );
     assert!(TestProverIncentives::default()
         .bonded_provers

--- a/crates/module-system/sov-modules-api/src/lib.rs
+++ b/crates/module-system/sov-modules-api/src/lib.rs
@@ -117,8 +117,6 @@ pub use sov_rollup_interface::stf::{
 pub use sov_rollup_interface::zk::aggregated_proof::{
     AggregatedProofPublicData, CodeCommitmentHash, SerializedAggregatedProof,
 };
-#[cfg(feature = "native")]
-pub use sov_rollup_interface::zk::HostArgs;
 pub use sov_rollup_interface::zk::{
     CodeCommitmentFor, CodeCommitmentTrait, CryptoSpec, StateTransitionPublicData, ZkVerifier, Zkvm,
 };

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -14,7 +14,6 @@ use sov_modules_api::provable_height_tracker::MaximumProvableHeight;
 use sov_modules_api::rest::ApiState;
 use sov_modules_api::{
     DaSpec, NodeEndpoints, OperatingMode, ProofSender, Spec, StateCheckpoint, VersionReader,
-    ZkVerifier,
 };
 use sov_modules_api::{GenesisParamsTrait, ModuleExecutionConfig};
 use sov_modules_stf_blueprint::{GenesisParams, Runtime as RuntimeTrait, StfBlueprint};
@@ -79,11 +78,6 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
 
     /// Serialize proof blob and adds metadata needed for verification.
     type ProofSender: ProofSender + 'static;
-
-    /// Creates code commitments for the outer zkVM program.
-    fn create_outer_code_commitment(
-        &self,
-    ) -> <<Self::ProverService as ProverService>::Verifier as ZkVerifier>::CodeCommitment;
 
     /// Creates RPC methods and REST APIs for the rollup.
     async fn create_endpoints(

--- a/crates/module-system/sov-modules-stf-blueprint/src/proof_processing.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/proof_processing.rs
@@ -98,11 +98,26 @@ where
             };
 
             // `workflow.try_reserve_gas` succeeded, meaning that any charge will be deducted from the sequencer's balance in the bank module, rather than from the sequencer's bond.
+            let mut invalid_aggregated_proof = None;
             let receipt_contents = match proof_with_details.proof {
-                ProofType::ZkAggregatedProof(proof) => runtime
-                    .proof_processor()
-                    .process_aggregated_proof(proof, sequencer_rollup_address, &mut working_set)
-                    .map(|(pub_data, proof)| ProofReceiptContents::AggregateProof(pub_data, proof)),
+                ProofType::ZkAggregatedProof(proof) => {
+                    let proof_for_invalid_outcome = proof.clone();
+                    match runtime.proof_processor().process_aggregated_proof(
+                        proof,
+                        sequencer_rollup_address,
+                        &mut working_set,
+                    ) {
+                        Ok((pub_data, proof)) => {
+                            Ok(ProofReceiptContents::AggregateProof(pub_data, proof))
+                        }
+                        Err(e) => {
+                            if should_retain_invalid_aggregated_proof(&e) {
+                                invalid_aggregated_proof = Some(proof_for_invalid_outcome);
+                            }
+                            Err(e)
+                        }
+                    }
+                }
 
                 ProofType::OptimisticProofAttestation(proof) => runtime
                     .proof_processor()
@@ -132,7 +147,7 @@ where
                 Err(e) if e.is_not_revertable() => {
                     let (scratchpad, transaction_consumption, _) = working_set.finalize();
                     (
-                        ProofOutcome::Invalid(e),
+                        ProofOutcome::Invalid(e, invalid_aggregated_proof),
                         scratchpad,
                         transaction_consumption,
                     )
@@ -140,7 +155,7 @@ where
                 Err(e) => {
                     let (scratchpad, transaction_consumption) = working_set.revert();
                     (
-                        ProofOutcome::Invalid(e),
+                        ProofOutcome::Invalid(e, invalid_aggregated_proof),
                         scratchpad,
                         transaction_consumption,
                     )
@@ -450,10 +465,17 @@ fn invalid_proof_receipt<S: Spec>(
 > {
     ProofReceipt {
         blob_hash,
-        outcome: ProofOutcome::Invalid(reason),
+        outcome: ProofOutcome::Invalid(reason, None),
         gas_used: S::Gas::zero().as_ref().to_vec(),
         gas_price: Vec::new(),
     }
 }
 
 type PreExecWorkingSetResult<S, I> = WorkflowResult<PreExecWorkingSet<S, I>, S, I>;
+
+fn should_retain_invalid_aggregated_proof(error: &InvalidProofError) -> bool {
+    // Aggregate-proof precondition failures happen before proof verification.
+    // Every other error variant can happen after we have attempted verification,
+    // so the guest still needs the proof bytes to replay that path.
+    !matches!(error, InvalidProofError::PreconditionNotMet(_))
+}

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
@@ -74,13 +74,6 @@ where
     type ProverService = <RtAgnosticBlueprint<S, R> as FullNodeBlueprint<Native>>::ProverService;
     type ProofSender = <RtAgnosticBlueprint<S, R> as FullNodeBlueprint<Native>>::ProofSender;
 
-    fn create_outer_code_commitment(
-        &self,
-    ) -> <<Self::ProverService as sov_stf_runner::processes::ProverService>::Verifier as sov_modules_api::ZkVerifier>::CodeCommitment
-    {
-        self.inner.create_outer_code_commitment()
-    }
-
     async fn create_endpoints(
         &self,
         state_update_receiver: StateUpdateReceiver<<Self::Spec as Spec>::Storage>,

--- a/crates/rollup-interface/src/state_machine/stf/mod.rs
+++ b/crates/rollup-interface/src/state_machine/stf/mod.rs
@@ -254,7 +254,7 @@ pub enum ProofOutcomeEnum<Receipt> {
     /// The blob is some kind of valid proof
     Valid(Receipt),
     /// The blob is some kind of invalid proof
-    Invalid(InvalidProofError),
+    Invalid(InvalidProofError, Option<SerializedAggregatedProof>),
 }
 
 impl<Address, Da: DaSpec, Root, StorageProof> From<ProofOutcome<Address, Da, Root, StorageProof>>
@@ -264,7 +264,7 @@ impl<Address, Da: DaSpec, Root, StorageProof> From<ProofOutcome<Address, Da, Roo
         match value {
             ProofOutcomeEnum::Ignored => ProofOutcomeEnum::Ignored,
             ProofOutcomeEnum::Valid(receipt) => ProofOutcomeEnum::Valid(receipt.into()),
-            ProofOutcomeEnum::Invalid(error) => ProofOutcomeEnum::Invalid(error),
+            ProofOutcomeEnum::Invalid(error, proof) => ProofOutcomeEnum::Invalid(error, proof),
         }
     }
 }

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -9,7 +9,6 @@
 pub mod aggregated_proof;
 use core::fmt::Debug;
 
-use crate::state_machine::da::BlobReaderTrait;
 use borsh::{BorshDeserialize, BorshSerialize};
 use digest::typenum::U32;
 use digest::Digest;
@@ -307,20 +306,6 @@ pub struct StateTransitionWitness<StateRoot, Witness, Da: DaSpec> {
     pub relevant_blobs: RelevantBlobs<<Da as DaSpec>::BlobTransaction>,
     /// The witness for the state transition
     pub witness: Witness,
-}
-
-impl<DA: DaSpec, StateRoot, Witness> StateTransitionWitness<StateRoot, Witness, DA> {
-    /// Extracts the aggregated proofs from the proof blobs included in this
-    /// state transition witness.
-    pub fn aggregated_proofs(&self) -> Vec<SerializedAggregatedProof> {
-        self.relevant_blobs
-            .proof_blobs
-            .iter()
-            .map(|blob| SerializedAggregatedProof {
-                raw_aggregated_proof: blob.verified_data().to_vec(),
-            })
-            .collect()
-    }
 }
 
 #[derive(Serialize, Deserialize, UniversalWallet)]

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -9,6 +9,7 @@
 pub mod aggregated_proof;
 use core::fmt::Debug;
 
+use crate::state_machine::da::BlobReaderTrait;
 use borsh::{BorshDeserialize, BorshSerialize};
 use digest::typenum::U32;
 use digest::Digest;
@@ -18,6 +19,7 @@ use sov_universal_wallet::UniversalWallet;
 
 use crate::crypto::{PublicKey, Signature};
 use crate::da::{DaSpec, RelevantBlobs, RelevantProofs};
+use crate::zk::aggregated_proof::SerializedAggregatedProof;
 
 /// The `CryptoSpec` trait configures the cryptographic primitives used by a particular instance of a rollup.
 /// this trait implementation is meant to be provided by the `Zkvm`. module
@@ -72,10 +74,6 @@ pub trait Zkvm: Default + Clone + Send + Sync + 'static {
     type Network: ZkvmNetwork<Guest: ZkvmGuest<Verifier = Self::Verifier>>;
 }
 
-/// The arguments required by the [`Zkvm::Host`]'s constructor function.
-#[cfg(feature = "native")]
-pub type HostArgs<Vm> = <<Vm as Zkvm>::Host as ZkvmHost>::HostArgs;
-
 /// The code commitment for the Zkvm
 pub type CodeCommitmentFor<Vm> = <<Vm as Zkvm>::Verifier as ZkVerifier>::CodeCommitment;
 
@@ -103,14 +101,6 @@ pub trait ZkvmHost: Clone + Send + Sync + 'static {
     /// The associated guest type
     type Guest: ZkvmGuest;
 
-    /// The required arguments to the constructor - usually either a `Vec<u8>`` or a path to the file containing an `ELF`.
-    #[cfg(feature = "native")]
-    type HostArgs: Send + Sync + 'static + Default;
-
-    /// Constructs a new `ZkvmHost`.
-    #[cfg(feature = "native")]
-    fn from_args(args: &Self::HostArgs) -> Self;
-
     /// Returns a commitment to the program to be proven. This method does a lot of heavy cryptographic work - caller beware!
     #[cfg(feature = "native")]
     fn code_commitment(
@@ -119,7 +109,11 @@ pub trait ZkvmHost: Clone + Send + Sync + 'static {
 
     /// Provide a single non-deterministic advice item to the guest and
     /// synchronously generate a SNARK of correct execution over that hint.
-    fn add_hint_and_run<T: Serialize>(&mut self, item: &T) -> anyhow::Result<SerializedZkProof>;
+    fn add_hint_deferred_and_run<T: Serialize>(
+        &mut self,
+        item: &T,
+        agg_proofs: Vec<SerializedAggregatedProof>,
+    ) -> anyhow::Result<SerializedZkProof>;
 }
 
 /// A commitment to a zkVM program binary. Every concrete [`ZkVerifier::CodeCommitment`]
@@ -313,6 +307,20 @@ pub struct StateTransitionWitness<StateRoot, Witness, Da: DaSpec> {
     pub relevant_blobs: RelevantBlobs<<Da as DaSpec>::BlobTransaction>,
     /// The witness for the state transition
     pub witness: Witness,
+}
+
+impl<DA: DaSpec, StateRoot, Witness> StateTransitionWitness<StateRoot, Witness, DA> {
+    /// Extracts the aggregated proofs from the proof blobs included in this
+    /// state transition witness.
+    pub fn aggregated_proofs(&self) -> Vec<SerializedAggregatedProof> {
+        self.relevant_blobs
+            .proof_blobs
+            .iter()
+            .map(|blob| SerializedAggregatedProof {
+                raw_aggregated_proof: blob.verified_data().to_vec(),
+            })
+            .collect()
+    }
 }
 
 #[derive(Serialize, Deserialize, UniversalWallet)]

--- a/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
+++ b/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
@@ -8,11 +8,11 @@ use sov_db::schema::DeltaReader;
 use sov_db::storage_manager::{NativeStorageManager, NomtStorageManager};
 use sov_mock_da::storable::StorableMockDaService;
 use sov_mock_da::{MockDaSpec, MockHash};
-use sov_mock_zkvm::{MockCodeCommitment, MockZkvm, MockZkvmHost};
+use sov_mock_zkvm::{MockZkvm, MockZkvmHost};
 use sov_modules_api::capabilities::{HasCapabilities, HasKernel};
 use sov_modules_api::execution_mode::Native;
 use sov_modules_api::rest::HasRestApi;
-use sov_modules_api::{CryptoSpec, NodeEndpoints, Spec, ZkVerifier, Zkvm};
+use sov_modules_api::{CryptoSpec, NodeEndpoints, Spec, Zkvm};
 use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
 use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
@@ -171,12 +171,6 @@ where
     type ProverService = <Prover as ProverFactory<S>>::ProverService;
 
     type ProofSender = SovApiProofSender<Self::Spec>;
-
-    fn create_outer_code_commitment(
-        &self,
-    ) -> <<Self::ProverService as ProverService>::Verifier as ZkVerifier>::CodeCommitment {
-        MockCodeCommitment::default()
-    }
 
     async fn create_endpoints(
         &self,

--- a/examples/demo-rollup/sov-benchmarks/src/bench_generator/cli.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/bench_generator/cli.rs
@@ -189,7 +189,7 @@ impl BenchCLICustomArgs {
         passed_admin: <<S as Spec>::CryptoSpec as CryptoSpec>::PrivateKey,
     ) -> Benchmark<S> {
         let risc0_host_args = mock_da_risc0_host_args();
-        let risc0_commitment = Risc0Host::from_args(&*risc0_host_args)
+        let risc0_commitment = Risc0Host::new(&risc0_host_args)
             .code_commitment()
             .unwrap_or_else(|e| panic!("Uncable to compute code commitment: {e}"));
 

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -9,10 +9,10 @@ use sov_celestia_adapter::CelestiaService;
 use sov_db::ledger_db::LedgerDb;
 use sov_db::storage_manager::NomtStorageManager;
 use sov_ethereum::EthRpcConfig;
-use sov_mock_zkvm::{MockCodeCommitment, MockZkvm, MockZkvmHost};
+use sov_mock_zkvm::{MockZkvm, MockZkvmHost};
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::Native;
-use sov_modules_api::{NodeEndpoints, Spec, Storage, ZkVerifier};
+use sov_modules_api::{NodeEndpoints, Spec, Storage};
 use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
 use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{
@@ -28,7 +28,7 @@ use sov_rollup_interface::zk::CryptoSpec;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::DefaultStorageSpec;
-use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
+use sov_stf_runner::processes::{ParallelProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
 
 use crate::solana_offchain_endpoint::solana_offchain_router;
@@ -88,12 +88,6 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
     >;
 
     type ProofSender = SovApiProofSender<Self::Spec>;
-
-    fn create_outer_code_commitment(
-        &self,
-    ) -> <<Self::ProverService as ProverService>::Verifier as ZkVerifier>::CodeCommitment {
-        MockCodeCommitment::default()
-    }
 
     async fn create_endpoints(
         &self,

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -9,11 +9,11 @@ use sov_db::storage_manager::NomtStorageManager;
 use sov_ethereum::EthRpcConfig;
 use sov_mock_da::storable::rpc::StorableMockDaClient;
 use sov_mock_da::MockDaSpec;
-use sov_mock_zkvm::{MockCodeCommitment, MockZkvm, MockZkvmHost};
+use sov_mock_zkvm::{MockZkvm, MockZkvmHost};
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::{Native, WitnessGeneration};
 use sov_modules_api::CryptoSpec;
-use sov_modules_api::{NodeEndpoints, Spec, Storage, ZkVerifier};
+use sov_modules_api::{NodeEndpoints, Spec, Storage};
 use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
 use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
@@ -26,7 +26,7 @@ use sov_rollup_interface::node::SyncStatus;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::DefaultStorageSpec;
-use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
+use sov_stf_runner::processes::{ParallelProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
 
 use crate::eth_dev_signer;
@@ -87,12 +87,6 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
     >;
 
     type ProofSender = SovApiProofSender<Self::Spec>;
-
-    fn create_outer_code_commitment(
-        &self,
-    ) -> <<Self::ProverService as ProverService>::Verifier as ZkVerifier>::CodeCommitment {
-        MockCodeCommitment::default()
-    }
 
     async fn create_endpoints(
         &self,

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -9,10 +9,10 @@ use sov_db::storage_manager::NomtStorageManager;
 use sov_ethereum::EthRpcConfig;
 use sov_mock_da::storable::StorableMockDaService;
 use sov_mock_da::MockDaSpec;
-use sov_mock_zkvm::{MockCodeCommitment, MockZkvm, MockZkvmCryptoSpec, MockZkvmHost};
+use sov_mock_zkvm::{MockZkvm, MockZkvmCryptoSpec, MockZkvmHost};
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::{Native, WitnessGeneration};
-use sov_modules_api::{CryptoSpec, NodeEndpoints, Spec, ZkVerifier};
+use sov_modules_api::{CryptoSpec, NodeEndpoints, Spec};
 use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
 use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
@@ -22,7 +22,7 @@ use sov_rollup_interface::node::SyncStatus;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::{DefaultStorageSpec, Storage};
-use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
+use sov_stf_runner::processes::{ParallelProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
 
 use crate::eth_dev_signer;
@@ -83,12 +83,6 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
     >;
 
     type ProofSender = SovApiProofSender<Self::Spec>;
-
-    fn create_outer_code_commitment(
-        &self,
-    ) -> <<Self::ProverService as ProverService>::Verifier as ZkVerifier>::CodeCommitment {
-        MockCodeCommitment::default()
-    }
 
     async fn create_endpoints(
         &self,

--- a/examples/demo-rollup/src/mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/mock_sp1_rollup.rs
@@ -11,20 +11,19 @@ use sov_mock_da::storable::StorableMockDaService;
 use sov_mock_da::MockDaSpec;
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::{Native, WitnessGeneration};
-use sov_modules_api::{CryptoSpec, NodeEndpoints, Spec, ZkVerifier};
+use sov_modules_api::{CryptoSpec, NodeEndpoints, Spec};
 use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
 use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
 use sov_rollup_full_node_interface::StateUpdateReceiver;
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::SyncStatus;
-use sov_rollup_interface::zk::ZkvmHost;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_sp1_adapter::host::{SP1AggregationHost, SP1Host};
 use sov_sp1_adapter::{SP1CryptoSpec, SP1};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::{DefaultStorageSpec, Storage};
-use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
+use sov_stf_runner::processes::{ParallelProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
 
 use crate::eth_dev_signer;
@@ -78,16 +77,6 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
     >;
 
     type ProofSender = SovApiProofSender<Self::Spec>;
-
-    fn create_outer_code_commitment(
-        &self,
-    ) -> <<Self::ProverService as ProverService>::Verifier as ZkVerifier>::CodeCommitment {
-        let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
-        SP1Host::new(agg_elf)
-            .expect("Failed to create SP1Host from aggregation guest ELF")
-            .code_commitment()
-            .expect("SP1 aggregation code commitment should be created successfully")
-    }
 
     async fn create_endpoints(
         &self,
@@ -154,17 +143,23 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
         _da_service: &Self::DaService,
     ) -> Self::ProverService {
         let elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
+        let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
+
+        let outer_verifying_key = tokio::task::spawn_blocking(move || {
+            Arc::new(sov_sp1_adapter::host::verifying_key_from_elf(elf))
+        })
+        .await
+        .unwrap();
 
         // SP1's blocking CPU prover spins up its own tokio runtime during setup,
         // so it must be constructed off the async executor thread.
-        let inner_vm = tokio::task::spawn_blocking(move || SP1Host::new(elf))
+        let inner_vm = tokio::task::spawn_blocking(move || SP1Host::new(elf, outer_verifying_key))
             .await
             .expect("SP1Host setup task panicked")
             .expect("Failed to create SP1Host from guest ELF");
 
         let inner_verifying_key = inner_vm.verifying_key().clone();
 
-        let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
         let outer_vm = tokio::task::spawn_blocking(move || {
             SP1AggregationHost::new(agg_elf, inner_verifying_key)
                 .expect("Failed to create SP1AggregationHost from aggregation guest ELF")

--- a/examples/demo-rollup/src/mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/mock_sp1_rollup.rs
@@ -146,10 +146,11 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
         let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
 
         let outer_verifying_key = tokio::task::spawn_blocking(move || {
-            Arc::new(sov_sp1_adapter::host::verifying_key_from_elf(elf))
+            sov_sp1_adapter::host::verifying_key_from_elf(agg_elf).map(Arc::new)
         })
         .await
-        .unwrap();
+        .expect("Outer verifying key setup task panicked")
+        .expect("Failed to derive outer verifying key from aggregation guest ELF");
 
         // SP1's blocking CPU prover spins up its own tokio runtime during setup,
         // so it must be constructed off the async executor thread.

--- a/examples/demo-rollup/tests/prover/parallel.rs
+++ b/examples/demo-rollup/tests/prover/parallel.rs
@@ -9,6 +9,7 @@ use sov_stf_runner::processes::{
     ParallelProverService, ProofAggregationStatus, ProofProcessingStatus, ProverService,
     StateTransitionInfo,
 };
+use std::sync::Arc;
 
 use super::{DefaultSpec, ProofStateRoot, ProofWitness};
 
@@ -33,16 +34,22 @@ async fn test_parallel_proof_generation() {
     std::env::set_var("SP1_PROVER", "mock");
 
     let elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
+    let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
+
     assert!(
         !elf.is_empty(),
         "SP1 guest ELF is empty — build the guest first"
     );
 
-    let inner_vm = tokio::task::spawn_blocking(move || SP1Host::new(elf).unwrap())
+    let outer_vk = tokio::task::spawn_blocking(move || {
+        Arc::new(sov_sp1_adapter::host::verifying_key_from_elf(elf))
+    })
+    .await
+    .unwrap();
+
+    let inner_vm = tokio::task::spawn_blocking(move || SP1Host::new(elf, outer_vk).unwrap())
         .await
         .unwrap();
-
-    let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
 
     let inner_vm_clone = inner_vm.clone();
 

--- a/examples/demo-rollup/tests/prover/parallel.rs
+++ b/examples/demo-rollup/tests/prover/parallel.rs
@@ -36,15 +36,11 @@ async fn test_parallel_proof_generation() {
     let elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
     let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
 
-    assert!(
-        !elf.is_empty(),
-        "SP1 guest ELF is empty — build the guest first"
-    );
-
     let outer_vk = tokio::task::spawn_blocking(move || {
-        Arc::new(sov_sp1_adapter::host::verifying_key_from_elf(elf))
+        sov_sp1_adapter::host::verifying_key_from_elf(agg_elf).map(Arc::new)
     })
     .await
+    .unwrap()
     .unwrap();
 
     let inner_vm = tokio::task::spawn_blocking(move || SP1Host::new(elf, outer_vk).unwrap())

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -6,10 +6,8 @@ use sov_modules_api::{Spec, ZkVerifier};
 use sov_rollup_interface::da::BlockHeaderTrait;
 use sov_rollup_interface::zk::aggregated_proof::BlockHeaderWithProof;
 use sov_rollup_interface::zk::SerializedZkProof;
-use sov_rollup_interface::zk::{
-    StateTransitionPublicData, StateTransitionWitnessWithAddress, ZkvmHost,
-};
-use sov_sp1_adapter::host::SP1Host;
+use sov_rollup_interface::zk::{StateTransitionPublicData, StateTransitionWitnessWithAddress};
+use sov_sp1_adapter::host::SP1Prover;
 use sov_sp1_adapter::{SP1MethodId, SP1Verifier};
 
 type ProofInput = StateTransitionWitnessWithAddress<
@@ -29,8 +27,8 @@ async fn test_save_proofs() {
         .join("test_data")
         .join("tmp");
 
-    let v_key = host.host.verifying_key();
-    let method_id = host.host.method_id();
+    let v_key = host.prover.verifying_key();
+    let method_id = host.prover.method_id();
 
     std::fs::create_dir_all(&proofs_dir).unwrap();
     std::fs::write(
@@ -55,7 +53,7 @@ async fn test_proof_generation() {
     std::env::set_var("SP1_PROVER", "mock");
 
     let host = TestHost::new().await;
-    let method_id = host.host.method_id();
+    let method_id = host.prover.method_id();
     let (_genesis_state_root, witnesses) = super::generate_witnesses().await;
     let prover_address = default_prover_address();
 
@@ -111,24 +109,26 @@ fn default_prover_address() -> <DefaultSpec as Spec>::Address {
 // The SP1 prover manages its own Tokio runtime, which conflicts with the `tokio::test` runtime.
 // To avoid this, all blocking work must be executed inside `tokio::task::spawn_blocking`.
 struct TestHost {
-    host: SP1Host,
+    prover: SP1Prover,
 }
 
 impl TestHost {
     async fn new() -> Self {
-        let host = tokio::task::spawn_blocking(move || {
-            SP1Host::new(*sp1::SP1_GUEST_MOCK_ELF).expect("SP1Host should be created successfully")
+        let prover = tokio::task::spawn_blocking(move || {
+            SP1Prover::new(*sp1::SP1_GUEST_MOCK_ELF)
+                .expect("SP1Prover should be created successfully")
         })
         .await
         .unwrap();
 
-        Self { host }
+        Self { prover }
     }
 
     async fn run(&self, data: ProofInput) -> SerializedZkProof {
-        let mut host = self.host.clone();
+        let prover = self.prover.clone();
         tokio::task::spawn_blocking(move || -> SerializedZkProof {
-            host.add_hint_and_run(&data)
+            prover
+                .add_hint_and_run(&data)
                 .expect("Prover should run successfully")
         })
         .await


### PR DESCRIPTION
# Description


The last missing piece in the verification workflow is processing proofs in the `ProverIncentives` module. To support this, `ZkvmHost::add_hint_and_run` is replaced with `ZkvmHost::add_hint_deferred_and_run`, which additionally accepts the aggregated proofs  that were verified during the current slot so they can be passed to the guest as deferred proof inputs.                                                                                                                                                                                                                                                                                                                                                                                                                  The rest of the PR is plumbing to thread those deferred proofs through the pipeline.                                                                                                                                                                        
                                                                                                                                                                                                                                                              
  Separately, this PR also drops the unused `ZkvmHost::{from_args, HostArgs}` constructor and the unused `FullNodeBlueprint::create_outer_code_commitment` method.

## Linked Issues
- Related to #2551