### PR TITLE
Remove `bench` feature flag from sp1 adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3520,15 +3520,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "debugid"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
-dependencies = [
- "uuid",
-]
-
-[[package]]
 name = "deepsize2"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4766,17 +4757,6 @@ checksum = "6c02bfe7bd65f42bcda751456869dfa1eb2bd1c36e309b9ec27f4888d41cf258"
 dependencies = [
  "gdbstub",
  "num-traits",
-]
-
-[[package]]
-name = "gecko_profile"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890852c7e1e02bc6758e325d6b1e0236e4fbf21b492f585ce4d4715be54b4c6a"
-dependencies = [
- "debugid",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -13253,15 +13233,12 @@ dependencies = [
  "elf",
  "enum-map",
  "eyre",
- "gecko_profile",
  "hashbrown 0.14.5",
  "hex",
- "indicatif",
  "itertools 0.14.0",
  "memmap2",
  "num",
  "rrs-succinct",
- "rustc-demangle",
  "serde",
  "serde_arrays 0.2.0",
  "serde_json",

--- a/crates/adapters/sp1/Cargo.toml
+++ b/crates/adapters/sp1/Cargo.toml
@@ -63,11 +63,6 @@ native = [
     "sov-metrics/native",
     "sov-sp1-adapter/native",
 ]
-bench = [
-    "sov-metrics/sp1",
-    "sov-sp1-adapter/bench",
-    "sp1-sdk/profiling",
-]
 arbitrary = [
     "dep:arbitrary",
     "dep:proptest",

--- a/crates/adapters/sp1/src/metrics.rs
+++ b/crates/adapters/sp1/src/metrics.rs
@@ -3,21 +3,6 @@ use std::io::Write;
 
 use sov_metrics::Metric;
 
-#[cfg(feature = "bench")]
-use sp1_sdk::HookEnv;
-
-/// A custom callback for extracting metrics from the SP1 zkvm.
-///
-/// When the "bench" feature is enabled, this callback is registered as a syscall
-/// in the SP1 VM and invoked whenever a function annotated with the `cycle_tracker`
-/// macro is invoked.
-#[cfg(feature = "bench")]
-pub fn metrics_hook(_env: HookEnv, buf: &[u8]) -> Vec<Vec<u8>> {
-    let _ = sov_metrics::cycle_utils::deserialize_metrics_call(buf).unwrap();
-
-    vec![]
-}
-
 /// The type of SP1 prover that generated a proof.
 #[derive(Debug)]
 #[allow(dead_code)]

--- a/examples/demo-rollup/sov-benchmarks/Cargo.toml
+++ b/examples/demo-rollup/sov-benchmarks/Cargo.toml
@@ -35,7 +35,7 @@ demo-stf = { workspace = true, features = ["test-utils", "arbitrary"] }
 reqwest = { workspace = true, features = ["rustls-tls", "stream"], default-features = false }
 
 sov-risc0-adapter = { workspace = true, features = ["arbitrary", "bench", "native"] }
-sov-sp1-adapter = { workspace = true, features = ["arbitrary", "bench", "native"] }
+sov-sp1-adapter = { workspace = true, features = ["arbitrary", "native"] }
 
 # Provers
 risc0 = { path = "../provers/risc0", features = ["bench"] }


### PR DESCRIPTION
# Description

Removes the `bench` feature flag from sp1 adapter crate - it's no longer used 

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
