### PR TITLE
Restore outer-host aggregation state on restart 

### DIFF
--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -1,7 +1,11 @@
+use std::sync::{Arc, Mutex};
+
 use crate::notifier::NotificationManager;
 use crate::{MockCodeCommitment, MockProof, MockZkGuest};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::zk::aggregated_proof::AggregatedProofPublicData;
 use sov_rollup_interface::zk::aggregated_proof::{
     BlockProof, OuterZkvmHost, SerializedAggregatedProof,
 };
@@ -12,6 +16,21 @@ use sov_rollup_interface::zk::SerializedZkProof;
 pub struct MockZkvmHost {
     notification_manager: NotificationManager,
     wait_for_proof: bool,
+    /// Most recently produced aggregated proof. Shared across clones so that
+    /// continuity assertions in [`OuterZkvmHost::run_proof_aggregation`] hold
+    /// across the whole prover service.
+    previous_aggregated_proof: Arc<Mutex<Option<SerializedAggregatedProof>>>,
+}
+
+/// Mirrors the prefix of [`AggregatedProofPublicData`](sov_rollup_interface::zk::aggregated_proof::AggregatedProofPublicData)
+/// so we can read the slot bounds of a previous aggregated proof without
+/// requiring `DeserializeOwned` bounds on the generic `Address`/`Root` types.
+#[derive(Deserialize)]
+struct AggregatedProofSlotBounds {
+    // Read so bincode advances to `final_slot_number`; not used directly.
+    #[allow(dead_code)]
+    initial_slot_number: SlotNumber,
+    final_slot_number: SlotNumber,
 }
 
 impl MockZkvmHost {
@@ -20,14 +39,26 @@ impl MockZkvmHost {
         Self {
             wait_for_proof: true,
             notification_manager: Default::default(),
+            previous_aggregated_proof: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Creates a new MockZkvm, the `ZkvmHost::add_hint_and_run` will return immediately.
     pub fn new_non_blocking() -> Self {
+        Self::new_non_blocking_with_previous_proof(None)
+    }
+
+    /// Like [`Self::new_non_blocking`], but seeded with the latest aggregated
+    /// proof previously persisted in the ledger DB so that continuity
+    /// assertions in [`OuterZkvmHost::run_proof_aggregation`] survive a node
+    /// restart.
+    pub fn new_non_blocking_with_previous_proof(
+        previous_aggregated_proof: Option<SerializedAggregatedProof>,
+    ) -> Self {
         Self {
             wait_for_proof: false,
             notification_manager: Default::default(),
+            previous_aggregated_proof: Arc::new(Mutex::new(previous_aggregated_proof)),
         }
     }
 
@@ -92,8 +123,6 @@ impl OuterZkvmHost for MockZkvmHost {
         genesis_state_root: Root,
         headers_with_block_proofs: Vec<(Da::BlockHeader, BlockProof<Address, Da, Root>)>,
     ) -> anyhow::Result<SerializedAggregatedProof> {
-        use sov_rollup_interface::zk::aggregated_proof::AggregatedProofPublicData;
-
         let block_proofs_data = headers_with_block_proofs
             .iter()
             .map(|(_, bp)| bp)
@@ -104,9 +133,39 @@ impl OuterZkvmHost for MockZkvmHost {
             genesis_state_root,
         );
 
-        self.add_hint_and_run_inner(&public_data)
+        let mut previous = self
+            .previous_aggregated_proof
+            .lock()
+            .expect("previous_aggregated_proof mutex was poisoned");
+
+        if let Some(previous_proof) = previous.as_ref() {
+            let envelope: MockProof = bincode::deserialize(&previous_proof.raw_aggregated_proof)
+                .expect("previous aggregated proof envelope must be a MockProof");
+            // `bincode::deserialize_from` reads only the bytes needed for the
+            // declared fields, so we can extract the slot bounds without knowing
+            // the concrete `Address`/`Root` types of the previous proof.
+            let prev_bounds: AggregatedProofSlotBounds =
+                bincode::deserialize_from(envelope.pub_data.as_slice())
+                    .expect("previous aggregated proof public data must start with slot bounds");
+
+            assert_eq!(
+                public_data.initial_slot_number,
+                prev_bounds.final_slot_number.next(),
+                "Aggregated proof continuity violated: new aggregation starts at slot {} but previous aggregation ended at slot {}",
+                public_data.initial_slot_number,
+                prev_bounds.final_slot_number,
+            );
+        } else {
+            assert_eq!(public_data.initial_slot_number, SlotNumber::ONE);
+        }
+
+        let serialized = self
+            .add_hint_and_run_inner(&public_data)
             .map(|raw_aggregated_proof| SerializedAggregatedProof {
                 raw_aggregated_proof,
-            })
+            })?;
+
+        *previous = Some(serialized.clone());
+        Ok(serialized)
     }
 }

--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -1,13 +1,14 @@
+use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
 
 use crate::notifier::NotificationManager;
 use crate::{MockCodeCommitment, MockProof, MockZkGuest};
-use serde::{Deserialize, Serialize};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::DaSpec;
-use sov_rollup_interface::zk::aggregated_proof::AggregatedProofPublicData;
 use sov_rollup_interface::zk::aggregated_proof::{
-    BlockProof, OuterZkvmHost, SerializedAggregatedProof,
+    AggregatedProofPublicData, BlockProof, OuterZkvmHost, SerializedAggregatedProof,
 };
 use sov_rollup_interface::zk::SerializedZkProof;
 
@@ -16,21 +17,48 @@ use sov_rollup_interface::zk::SerializedZkProof;
 pub struct MockZkvmHost {
     notification_manager: NotificationManager,
     wait_for_proof: bool,
-    /// Most recently produced aggregated proof. Shared across clones so that
-    /// continuity assertions in [`OuterZkvmHost::run_proof_aggregation`] hold
-    /// across the whole prover service.
-    previous_aggregated_proof: Arc<Mutex<Option<SerializedAggregatedProof>>>,
+    /// Anchor extracted from the most recently produced aggregated proof.
+    /// Shared across clones so that continuity assertions in
+    /// [`OuterZkvmHost::run_proof_aggregation`] hold across the whole prover
+    /// service.
+    previous_anchor: Arc<Mutex<Option<PreviousAggregatedProofAnchor>>>,
 }
 
-/// Mirrors the prefix of [`AggregatedProofPublicData`](sov_rollup_interface::zk::aggregated_proof::AggregatedProofPublicData)
-/// so we can read the slot bounds of a previous aggregated proof without
-/// requiring `DeserializeOwned` bounds on the generic `Address`/`Root` types.
-#[derive(Deserialize)]
-struct AggregatedProofSlotBounds {
-    // Read so bincode advances to `final_slot_number`; not used directly.
-    #[allow(dead_code)]
-    initial_slot_number: SlotNumber,
+/// Continuity anchor extracted from a previously produced aggregated proof.
+#[derive(Clone, Debug)]
+struct PreviousAggregatedProofAnchor {
     final_slot_number: SlotNumber,
+    genesis_state_root: Vec<u8>,
+    final_state_root: Vec<u8>,
+}
+
+impl PreviousAggregatedProofAnchor {
+    fn from_public_data<Address, Da, Root>(
+        public_data: &AggregatedProofPublicData<Address, Da, Root>,
+    ) -> Self
+    where
+        Address: Serialize,
+        Da: DaSpec,
+        Root: Serialize,
+    {
+        Self {
+            final_slot_number: public_data.final_slot_number,
+            genesis_state_root: bincode::serialize(&public_data.genesis_state_root)
+                .expect("genesis_state_root must be bincode-serializable"),
+            final_state_root: bincode::serialize(&public_data.final_state_root)
+                .expect("final_state_root must be bincode-serializable"),
+        }
+    }
+
+    fn deserialize_genesis_state_root<Root: DeserializeOwned>(&self) -> Root {
+        bincode::deserialize(&self.genesis_state_root)
+            .expect("genesis_state_root must be bincode-deserializable")
+    }
+
+    fn deserialize_final_state_root<Root: DeserializeOwned>(&self) -> Root {
+        bincode::deserialize(&self.final_state_root)
+            .expect("final_state_root must be bincode-deserializable")
+    }
 }
 
 impl MockZkvmHost {
@@ -39,26 +67,37 @@ impl MockZkvmHost {
         Self {
             wait_for_proof: true,
             notification_manager: Default::default(),
-            previous_aggregated_proof: Arc::new(Mutex::new(None)),
+            previous_anchor: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Creates a new MockZkvm, the `ZkvmHost::add_hint_and_run` will return immediately.
     pub fn new_non_blocking() -> Self {
-        Self::new_non_blocking_with_previous_proof(None)
-    }
-
-    /// Like [`Self::new_non_blocking`], but seeded with the latest aggregated
-    /// proof previously persisted in the ledger DB so that continuity
-    /// assertions in [`OuterZkvmHost::run_proof_aggregation`] survive a node
-    /// restart.
-    pub fn new_non_blocking_with_previous_proof(
-        previous_aggregated_proof: Option<SerializedAggregatedProof>,
-    ) -> Self {
         Self {
             wait_for_proof: false,
             notification_manager: Default::default(),
-            previous_aggregated_proof: Arc::new(Mutex::new(previous_aggregated_proof)),
+            previous_anchor: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Like [`Self::new_non_blocking`], but seeded with the public data of the
+    /// latest verified aggregated proof previously persisted in the ledger DB
+    /// so that continuity assertions in
+    /// [`OuterZkvmHost::run_proof_aggregation`] survive a node restart.
+    pub fn new_non_blocking_with_previous_anchor<Address, Da, Root>(
+        previous_public_data: Option<&AggregatedProofPublicData<Address, Da, Root>>,
+    ) -> Self
+    where
+        Address: Serialize,
+        Da: DaSpec,
+        Root: Serialize,
+    {
+        let previous_anchor =
+            previous_public_data.map(PreviousAggregatedProofAnchor::from_public_data);
+        Self {
+            wait_for_proof: false,
+            notification_manager: Default::default(),
+            previous_anchor: Arc::new(Mutex::new(previous_anchor)),
         }
     }
 
@@ -118,7 +157,11 @@ impl sov_rollup_interface::zk::ZkvmHost for MockZkvmHost {
 }
 
 impl OuterZkvmHost for MockZkvmHost {
-    fn run_proof_aggregation<Address: Serialize + Clone, Da: DaSpec, Root: Serialize + Clone>(
+    fn run_proof_aggregation<
+        Address: Serialize + Clone,
+        Da: DaSpec,
+        Root: Serialize + DeserializeOwned + Clone + PartialEq + Debug,
+    >(
         &self,
         genesis_state_root: Root,
         headers_with_block_proofs: Vec<(Da::BlockHeader, BlockProof<Address, Da, Root>)>,
@@ -134,26 +177,29 @@ impl OuterZkvmHost for MockZkvmHost {
         );
 
         let mut previous = self
-            .previous_aggregated_proof
+            .previous_anchor
             .lock()
-            .expect("previous_aggregated_proof mutex was poisoned");
+            .expect("previous_anchor mutex was poisoned");
 
-        if let Some(previous_proof) = previous.as_ref() {
-            let envelope: MockProof = bincode::deserialize(&previous_proof.raw_aggregated_proof)
-                .expect("previous aggregated proof envelope must be a MockProof");
-            // `bincode::deserialize_from` reads only the bytes needed for the
-            // declared fields, so we can extract the slot bounds without knowing
-            // the concrete `Address`/`Root` types of the previous proof.
-            let prev_bounds: AggregatedProofSlotBounds =
-                bincode::deserialize_from(envelope.pub_data.as_slice())
-                    .expect("previous aggregated proof public data must start with slot bounds");
-
+        if let Some(prev) = previous.as_ref() {
             assert_eq!(
                 public_data.initial_slot_number,
-                prev_bounds.final_slot_number.next(),
+                prev.final_slot_number.next(),
                 "Aggregated proof continuity violated: new aggregation starts at slot {} but previous aggregation ended at slot {}",
                 public_data.initial_slot_number,
-                prev_bounds.final_slot_number,
+                prev.final_slot_number,
+            );
+
+            let prev_genesis_state_root: Root = prev.deserialize_genesis_state_root();
+            let prev_final_state_root: Root = prev.deserialize_final_state_root();
+
+            assert_eq!(
+                public_data.genesis_state_root, prev_genesis_state_root,
+                "Aggregated proof continuity violated: genesis_state_root differs from previous aggregation",
+            );
+            assert_eq!(
+                public_data.initial_state_root, prev_final_state_root,
+                "Aggregated proof continuity violated: new initial_state_root does not match previous final_state_root",
             );
         } else {
             assert_eq!(public_data.initial_slot_number, SlotNumber::ONE);
@@ -165,7 +211,9 @@ impl OuterZkvmHost for MockZkvmHost {
                 raw_aggregated_proof,
             })?;
 
-        *previous = Some(serialized.clone());
+        *previous = Some(PreviousAggregatedProofAnchor::from_public_data(
+            &public_data,
+        ));
         Ok(serialized)
     }
 }

--- a/crates/adapters/risc0/src/host.rs
+++ b/crates/adapters/risc0/src/host.rs
@@ -116,7 +116,11 @@ impl ZkvmHost for Risc0Host<'static> {
 }
 
 impl OuterZkvmHost for Risc0Host<'static> {
-    fn run_proof_aggregation<Address: Serialize + Clone, Da: DaSpec, Root: Serialize + Clone>(
+    fn run_proof_aggregation<
+        Address: Serialize + Clone,
+        Da: DaSpec,
+        Root: Serialize + serde::de::DeserializeOwned + Clone + PartialEq + core::fmt::Debug,
+    >(
         &self,
         _genesis_state_root: Root,
         _headers_with_block_proofs: Vec<(Da::BlockHeader, BlockProof<Address, Da, Root>)>,

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -43,15 +43,30 @@ impl SP1AggregationHost {
     /// Creates a new aggregation host from the aggregation guest `elf` binary
     /// and the verifying key (`inner_method_id`) of the inner proof program.
     pub fn new(elf: &'static [u8], inner_vk: sp1_sdk::SP1VerifyingKey) -> anyhow::Result<Self> {
+        Self::new_with_previous_proof(elf, inner_vk, None)
+    }
+
+    /// Like [`Self::new`], but seeded with the latest aggregated proof
+    /// previously persisted in the ledger DB so that recursive verification of
+    /// the previous outer proof survives a node restart.
+    pub fn new_with_previous_proof(
+        elf: &'static [u8],
+        inner_vk: sp1_sdk::SP1VerifyingKey,
+        previous_aggregated_proof: Option<SerializedAggregatedProof>,
+    ) -> anyhow::Result<Self> {
         let prover = SP1Prover::new(elf)?;
         let outer_vk = prover.verifying_key().clone();
+
+        let prev_agg_proof = previous_aggregated_proof
+            .map(|proof| crate::decode_sp1_proof(&proof.to_serialized_zk_proof()))
+            .transpose()?;
 
         Ok(Self {
             inner: Arc::new(Inner {
                 prover,
                 outer_vk,
                 inner_vk,
-                prev_agg_proof: Mutex::new(None),
+                prev_agg_proof: Mutex::new(prev_agg_proof),
             }),
         })
     }
@@ -295,7 +310,11 @@ impl ZkvmHost for SP1Host {
 }
 
 impl OuterZkvmHost for SP1AggregationHost {
-    fn run_proof_aggregation<Address: Serialize + Clone, Da: DaSpec, Root: Serialize + Clone>(
+    fn run_proof_aggregation<
+        Address: Serialize + Clone,
+        Da: DaSpec,
+        Root: Serialize + serde::de::DeserializeOwned + Clone + PartialEq + core::fmt::Debug,
+    >(
         &self,
         _genesis_state_root: Root,
         headers_with_block_proofs: Vec<(Da::BlockHeader, BlockProof<Address, Da, Root>)>,

--- a/crates/full-node/sov-db/src/ledger_db/mod.rs
+++ b/crates/full-node/sov-db/src/ledger_db/mod.rs
@@ -260,8 +260,6 @@ pub struct LedgerDb {
 
 // Db key for the latest height of the written STF info.
 const WRITE_ROLLUP_HEIGHT_ID: StfInfoUniqueId = StfInfoUniqueId(0);
-// DB key for the latest height of the retrieved STF info.
-const NEXT_SLOT_NUMBER_TO_RECEIVE_ID: StfInfoUniqueId = StfInfoUniqueId(1);
 // Db key for the oldest saved STF info.
 const LAST_SLOT_NUMBER_ID: StfInfoUniqueId = StfInfoUniqueId(2);
 
@@ -653,25 +651,6 @@ impl LedgerDb {
     pub async fn get_stf_info_write_slot_number(&self) -> anyhow::Result<Option<SlotNumber>> {
         let db = self.db.read().expect(DB_LOCK_POISONED).clone();
         db.get_async::<StfInfoMetadata>(&WRITE_ROLLUP_HEIGHT_ID)
-            .await
-    }
-
-    /// Materializes the latest height of the retrieved STF info.
-    pub fn materialize_stf_info_next_slot_number_to_receive(
-        &self,
-        read_slot_number: SlotNumber,
-    ) -> anyhow::Result<SchemaBatch> {
-        let mut schema_batch = SchemaBatch::new();
-        schema_batch.put::<StfInfoMetadata>(&NEXT_SLOT_NUMBER_TO_RECEIVE_ID, &read_slot_number)?;
-        Ok(schema_batch)
-    }
-
-    /// Gets the latest height of the submitted STF info.
-    pub async fn get_stf_info_next_slot_number_to_receive(
-        &self,
-    ) -> anyhow::Result<Option<SlotNumber>> {
-        let db = self.db.read().expect(DB_LOCK_POISONED).clone();
-        db.get_async::<StfInfoMetadata>(&NEXT_SLOT_NUMBER_TO_RECEIVE_ID)
             .await
     }
 

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -148,20 +148,6 @@ async fn test_stf_info() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn next_slot_number_to_receive_is_none_at_startup() {
-    let temp_dir = tempfile::tempdir().unwrap();
-    let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
-    let ledger_storage = storage_manager.create_ledger_storage();
-
-    let ledger_db = LedgerDb::with_reader(ledger_storage).unwrap();
-    assert!(ledger_db
-        .get_stf_info_next_slot_number_to_receive()
-        .await
-        .unwrap()
-        .is_none());
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_rollback() {
     let temp_dir = tempfile::tempdir().unwrap();
     let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/mod.rs
@@ -18,7 +18,7 @@ use crate::processes::{ProofAggregationStatus, ProofProcessingStatus, StateTrans
 pub struct ParallelProverService<Address, StateRoot, Witness, Da, InnerVm, OuterVm>
 where
     Address: Serialize + DeserializeOwned,
-    StateRoot: Serialize + DeserializeOwned + Clone + AsRef<[u8]>,
+    StateRoot: Serialize + DeserializeOwned + Clone + AsRef<[u8]> + PartialEq + core::fmt::Debug,
     Witness: Serialize + DeserializeOwned,
     Da: DaService,
     InnerVm: Zkvm,
@@ -37,7 +37,15 @@ impl<Address, StateRoot, Witness, Da, InnerVm, OuterVm>
 where
     Address:
         BorshSerialize + AsRef<[u8]> + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-    StateRoot: Serialize + DeserializeOwned + Clone + AsRef<[u8]> + Send + Sync + 'static,
+    StateRoot: Serialize
+        + DeserializeOwned
+        + Clone
+        + AsRef<[u8]>
+        + PartialEq
+        + core::fmt::Debug
+        + Send
+        + Sync
+        + 'static,
     Witness: Serialize + DeserializeOwned + Send + Sync + 'static,
     Da: DaService,
     InnerVm: Zkvm,
@@ -87,8 +95,16 @@ impl<Address, StateRoot, Witness, Da, InnerVm, OuterVm> ProverService
 where
     Address:
         BorshSerialize + AsRef<[u8]> + Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
-    StateRoot:
-        BorshSerialize + Serialize + DeserializeOwned + Clone + AsRef<[u8]> + Send + Sync + 'static,
+    StateRoot: BorshSerialize
+        + Serialize
+        + DeserializeOwned
+        + Clone
+        + AsRef<[u8]>
+        + PartialEq
+        + core::fmt::Debug
+        + Send
+        + Sync
+        + 'static,
     Witness: Serialize + DeserializeOwned + Send + Sync + 'static,
     Da: DaService,
     InnerVm: Zkvm + 'static,

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
@@ -42,7 +42,15 @@ where
     Da: DaService,
     Address:
         BorshSerialize + Serialize + DeserializeOwned + AsRef<[u8]> + Clone + Send + Sync + 'static,
-    StateRoot: Serialize + DeserializeOwned + Clone + AsRef<[u8]> + Send + Sync + 'static,
+    StateRoot: Serialize
+        + DeserializeOwned
+        + Clone
+        + AsRef<[u8]>
+        + PartialEq
+        + core::fmt::Debug
+        + Send
+        + Sync
+        + 'static,
     Witness: Serialize + DeserializeOwned + Send + Sync + 'static,
 {
     pub(crate) fn new(prover_address: Address, num_threads: usize) -> Self {

--- a/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
@@ -112,29 +112,6 @@ impl<
 
         match maybe_write_rollup_height {
             Some(write_rollup_height) => {
-                let ledger_next_height_to_receive = ledger_db
-                    .get_stf_info_next_slot_number_to_receive()
-                    .await?
-                    .unwrap_or(SlotNumber::ONE);
-
-                // The in-memory pointer can diverge from the DB pointer in
-                // either direction when `new_stf_info_channel` realigned it
-                // to the latest verified aggregated proof:
-                // - DB ahead of in-memory: the prover bumped the DB pointer
-                //   as soon as a proof was submitted to DA, but the proof's
-                //   round-trip didn't complete before shutdown.
-                // - DB behind in-memory: the in-memory counter advanced
-                //   after a successful aggregation but no later slot was
-                //   materialized to persist the bump.
-                // Either way, the in-memory value is re-persisted on the
-                // next `materialize_stf_info` call.
-                let _ = ledger_next_height_to_receive;
-
-                // Sanity check for `write_rollup_height & next_rollup_height_to_receive`.
-                // After a realign-forward in `new_stf_info_channel`, the
-                // in-memory pointer can sit exactly one slot beyond the last
-                // written STF info (the receiver is ready to consume the very
-                // next slot once it's materialized).
                 assert!(
                     write_rollup_height.get() + 1 >= next_rollup_height_to_receive,
                     "The `write_rollup_height` ({write_rollup_height}) is more than one slot behind `next_rollup_height_to_receive` ({next_rollup_height_to_receive})"
@@ -154,10 +131,6 @@ impl<
             }
             // Db is empty
             None => {
-                assert!(ledger_db
-                    .get_stf_info_next_slot_number_to_receive()
-                    .await?
-                    .is_none());
                 assert!(ledger_db.get_stf_info_oldest_slot_number().await?.is_none());
             }
         }
@@ -222,38 +195,14 @@ pub async fn new_stf_info_channel<StateRoot, Witness, Da: DaSpec>(
     let (notifier, receiver) =
         tokio::sync::mpsc::channel::<SlotNumber>(max_channel_size.get().try_into()?);
 
-    let stored_next_height_to_receive = ledger_db
-        .get_stf_info_next_slot_number_to_receive()
-        .await?
+    // Resume STF-info processing from the last aggregated proof that was
+    // verified on-chain and persisted in the DB: that proof's `final_slot` is
+    // the last slot we know is committed, so the prover picks up at
+    // `final_slot + 1`. If no such proof exists yet (fresh node), start from
+    // genesis.
+    let next_height_to_receive = latest_proof_final_slot
+        .map(|final_slot| final_slot.saturating_add(1))
         .unwrap_or(SlotNumber::ONE);
-
-    // Anchor the resume point to the latest verified aggregated proof. The
-    // STF-info pointer in the DB is unreliable across restarts: it can be
-    // ahead of the verified proof (the prover submitted a proof to DA whose
-    // round-trip didn't complete before shutdown) or behind it (the in-memory
-    // counter advanced after a successful aggregation but no later slot was
-    // materialized to persist it). The verified proof on disk is the only
-    // self-consistent record of what's been committed, so we resume from
-    // `final_slot + 1` whenever we have one. The atomic is re-persisted to
-    // the DB on the next `materialize_stf_info` call.
-    //
-    // A proof covering up to genesis carries no useful anchor and is treated
-    // as no proof at all, in which case we trust the stored DB pointer.
-    let next_height_to_receive = match latest_proof_final_slot {
-        Some(final_slot) if final_slot > SlotNumber::GENESIS => {
-            let anchor = final_slot.saturating_add(1);
-            if anchor != stored_next_height_to_receive {
-                tracing::warn!(
-                    stored = %stored_next_height_to_receive,
-                    anchor = %anchor,
-                    %final_slot,
-                    "Realigning STF-info next_height_to_receive to stay contiguous with the latest verified aggregated proof"
-                );
-            }
-            anchor
-        }
-        _ => stored_next_height_to_receive,
-    };
 
     let next_height_to_receive_ref = Arc::new(AtomicU64::new(next_height_to_receive.get()));
 
@@ -381,12 +330,7 @@ where
         // Update the write rollup height.
         schema.merge(ledger_db.materialize_stf_info_write_slot_number(write_rollup_height)?);
 
-        // Send the new changes to the subscribers
         let next_rollup_height_to_receive = self.next_height_to_receive();
-        schema.merge(
-            ledger_db
-                .materialize_stf_info_next_slot_number_to_receive(next_rollup_height_to_receive)?,
-        );
 
         // Prune the oldest entries if needed
         schema.merge(
@@ -511,6 +455,20 @@ mod tests {
         Sender<StateRoot, Witness, MockDaSpec>,
         Receiver<StateRoot, Witness, MockDaSpec>,
     )> {
+        setup_with_resume(path, max_channel_size, max_nb_of_infos_in_db, None).await
+    }
+
+    async fn setup_with_resume(
+        path: &Path,
+        max_channel_size: u64,
+        max_nb_of_infos_in_db: u64,
+        latest_proof_final_slot: Option<SlotNumber>,
+    ) -> anyhow::Result<(
+        LedgerDb,
+        SimpleLedgerStorageManager,
+        Sender<StateRoot, Witness, MockDaSpec>,
+        Receiver<StateRoot, Witness, MockDaSpec>,
+    )> {
         let mut storage_manager = SimpleLedgerStorageManager::new(path);
         let ledger_db = LedgerDb::with_reader(storage_manager.create_ledger_storage())?;
 
@@ -518,7 +476,7 @@ mod tests {
             ledger_db.clone(),
             NonZero::new(max_channel_size).unwrap(),
             NonZero::new(max_nb_of_infos_in_db).unwrap(),
-            None,
+            latest_proof_final_slot,
         )
         .await?;
 
@@ -594,8 +552,16 @@ mod tests {
 
         // Now the reads are visible.
         {
-            let (ledger_db, _, sender, mut receiver) =
-                setup(temp_dir.path(), channel_size, max_nb_of_infos_in_db).await?;
+            // The previous block advanced `next_height_to_receive` to 3 in
+            // memory and persisted writes through slot 12. Resume the channel
+            // at slot 3 by anchoring to a "previous proof" with `final_slot=2`.
+            let (ledger_db, _, sender, mut receiver) = setup_with_resume(
+                temp_dir.path(),
+                channel_size,
+                max_nb_of_infos_in_db,
+                Some(SlotNumber::new(2)),
+            )
+            .await?;
 
             let stf_info = receiver.read_next().await?.unwrap();
             assert_eq!(stf_info.slot_number.get(), 3);

--- a/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
@@ -117,22 +117,36 @@ impl<
                     .await?
                     .unwrap_or(SlotNumber::ONE);
 
-                assert_eq!(
-                    ledger_next_height_to_receive.get(),
-                    next_rollup_height_to_receive,
-                    "The next height to receive should be the same as the one stored in the db"
+                // The in-memory pointer can diverge from the DB pointer in
+                // either direction when `new_stf_info_channel` realigned it
+                // to the latest verified aggregated proof:
+                // - DB ahead of in-memory: the prover bumped the DB pointer
+                //   as soon as a proof was submitted to DA, but the proof's
+                //   round-trip didn't complete before shutdown.
+                // - DB behind in-memory: the in-memory counter advanced
+                //   after a successful aggregation but no later slot was
+                //   materialized to persist the bump.
+                // Either way, the in-memory value is re-persisted on the
+                // next `materialize_stf_info` call.
+                let _ = ledger_next_height_to_receive;
+
+                // Sanity check for `write_rollup_height & next_rollup_height_to_receive`.
+                // After a realign-forward in `new_stf_info_channel`, the
+                // in-memory pointer can sit exactly one slot beyond the last
+                // written STF info (the receiver is ready to consume the very
+                // next slot once it's materialized).
+                assert!(
+                    write_rollup_height.get() + 1 >= next_rollup_height_to_receive,
+                    "The `write_rollup_height` ({write_rollup_height}) is more than one slot behind `next_rollup_height_to_receive` ({next_rollup_height_to_receive})"
                 );
 
-                // Sanity check for `write_rollup_height & next_rollup_height_to_receive`
+                let outstanding = write_rollup_height
+                    .get()
+                    .saturating_sub(next_rollup_height_to_receive);
                 assert!(
-                    write_rollup_height.get() >= next_rollup_height_to_receive,
-                    "The `write_rollup_height` should always be greater than the `next_rollup_height_to_receive`"
-                );
-
-                assert!(
-                    (write_rollup_height.get() - next_rollup_height_to_receive) <= self.max_nb_of_infos_in_db.get(),
+                    outstanding <= self.max_nb_of_infos_in_db.get(),
                     "Too many STF infos in the db: {}, vs max allowed {} last_submitted={} write={}",
-                    write_rollup_height.get() - next_rollup_height_to_receive,
+                    outstanding,
                     self.max_nb_of_infos_in_db,
                     next_rollup_height_to_receive,
                     write_rollup_height,
@@ -189,6 +203,7 @@ pub async fn new_stf_info_channel<StateRoot, Witness, Da: DaSpec>(
     ledger_db: LedgerDb,
     max_channel_size: NonZero<u64>,
     max_nb_of_infos_in_db: NonZero<u64>,
+    latest_proof_final_slot: Option<SlotNumber>,
 ) -> anyhow::Result<(
     Sender<StateRoot, Witness, Da>,
     Receiver<StateRoot, Witness, Da>,
@@ -207,10 +222,38 @@ pub async fn new_stf_info_channel<StateRoot, Witness, Da: DaSpec>(
     let (notifier, receiver) =
         tokio::sync::mpsc::channel::<SlotNumber>(max_channel_size.get().try_into()?);
 
-    let next_height_to_receive = ledger_db
+    let stored_next_height_to_receive = ledger_db
         .get_stf_info_next_slot_number_to_receive()
         .await?
         .unwrap_or(SlotNumber::ONE);
+
+    // Anchor the resume point to the latest verified aggregated proof. The
+    // STF-info pointer in the DB is unreliable across restarts: it can be
+    // ahead of the verified proof (the prover submitted a proof to DA whose
+    // round-trip didn't complete before shutdown) or behind it (the in-memory
+    // counter advanced after a successful aggregation but no later slot was
+    // materialized to persist it). The verified proof on disk is the only
+    // self-consistent record of what's been committed, so we resume from
+    // `final_slot + 1` whenever we have one. The atomic is re-persisted to
+    // the DB on the next `materialize_stf_info` call.
+    //
+    // A proof covering up to genesis carries no useful anchor and is treated
+    // as no proof at all, in which case we trust the stored DB pointer.
+    let next_height_to_receive = match latest_proof_final_slot {
+        Some(final_slot) if final_slot > SlotNumber::GENESIS => {
+            let anchor = final_slot.saturating_add(1);
+            if anchor != stored_next_height_to_receive {
+                tracing::warn!(
+                    stored = %stored_next_height_to_receive,
+                    anchor = %anchor,
+                    %final_slot,
+                    "Realigning STF-info next_height_to_receive to stay contiguous with the latest verified aggregated proof"
+                );
+            }
+            anchor
+        }
+        _ => stored_next_height_to_receive,
+    };
 
     let next_height_to_receive_ref = Arc::new(AtomicU64::new(next_height_to_receive.get()));
 
@@ -475,6 +518,7 @@ mod tests {
             ledger_db.clone(),
             NonZero::new(max_channel_size).unwrap(),
             NonZero::new(max_nb_of_infos_in_db).unwrap(),
+            None,
         )
         .await?;
 

--- a/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
@@ -395,7 +395,7 @@ where
     }
 
     /// Gets [`StateTransitionInfo`] for the corresponding slot number
-    pub fn get(
+    fn get(
         &self,
         slot_number: SlotNumber,
     ) -> anyhow::Result<Option<StateTransitionInfo<StateRoot, Witness, Da>>> {

--- a/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
@@ -59,8 +59,7 @@ impl<StateRoot, Witness, Da: DaSpec> StateTransitionInfo<StateRoot, Witness, Da>
 /// Materializes STF infos and sends notifications to the associated [`Receiver`].
 pub struct Sender<StateRoot, Witness, Da: DaSpec> {
     /// Height of the next `StateTransitionInfo` that should be received by the [`Receiver`].
-    /// This value is synchronized with the receiver end of the channel. On the sender end
-    /// it is only persisted in the database after a slot completion.
+    /// This value is synchronized with the receiver end of the channel.
     next_height_to_receive: Arc<AtomicU64>,
 
     /// The next height to send to the [`Receiver`]. This value is not persisted in the database and

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -121,11 +121,6 @@ where
     Stf: StateTransitionFunction<Da::Spec, PreState = Sm::StfState, ChangeSet = Sm::StfChangeSet>,
 {
     /// Creates a new [`StateTransitionRunner`].
-    ///
-    /// `latest_proof_final_slot` is the `final_slot_number` of the most recent
-    /// aggregated proof persisted in the ledger DB, as validated by the prover
-    /// service. When provided, the STF-info channel resumes at
-    /// `final_slot + 1` even if the in-DB STF-info pointer is ahead of it.
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     pub async fn new(
         runner_config: RunnerConfig,

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -121,6 +121,11 @@ where
     Stf: StateTransitionFunction<Da::Spec, PreState = Sm::StfState, ChangeSet = Sm::StfChangeSet>,
 {
     /// Creates a new [`StateTransitionRunner`].
+    ///
+    /// `latest_proof_final_slot` is the `final_slot_number` of the most recent
+    /// aggregated proof persisted in the ledger DB, as validated by the prover
+    /// service. When provided, the STF-info channel resumes at
+    /// `final_slot + 1` even if the in-DB STF-info pointer is ahead of it.
     #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     pub async fn new(
         runner_config: RunnerConfig,
@@ -139,6 +144,7 @@ where
         sync_state: Arc<DaSyncState>,
         da_service_with_cached_finalized_headers: DaServiceWithCachedFinalizedHeaders<Da>,
         genesis_da_height: u64,
+        latest_proof_final_slot: Option<SlotNumber>,
     ) -> anyhow::Result<Self> {
         error_if_tokio_runtime_is_not_multi_threaded()?;
         tracing::info!(config = ?runner_config, "Initializing StateTransitionRunner");
@@ -172,6 +178,7 @@ where
                 ledger_db.clone(),
                 config.max_number_of_transitions_in_memory,
                 config.max_number_of_transitions_in_db,
+                latest_proof_final_slot,
             )
             .await?;
 

--- a/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
@@ -172,6 +172,7 @@ async fn test_instant_finality() -> anyhow::Result<()> {
         state_manager.ledger_db.clone(),
         NonZero::new(40).unwrap(),
         NonZero::new(40).unwrap(),
+        None,
     )
     .await?;
     state_manager.stf_info_sender = Some(sender);
@@ -228,6 +229,7 @@ async fn rejected_aggregated_proofs_are_not_published_as_latest() -> anyhow::Res
         state_manager.ledger_db.clone(),
         NonZero::new(40).unwrap(),
         NonZero::new(40).unwrap(),
+        None,
     )
     .await?;
     state_manager.stf_info_sender = Some(sender);

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -270,6 +270,7 @@ pub async fn initialize_runner(
         da_sync_state,
         da_service_with_cache,
         0,
+        None,
     )
     .await
     .unwrap();

--- a/crates/full-node/sov-stf-runner/tests/integration/prover_service/mod.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/prover_service/mod.rs
@@ -25,7 +25,7 @@ fn make_header(header_hash: MockHash, height: u64) -> MockBlockHeader {
 fn make_transition_info(
     da_block_header: MockBlockHeader,
 ) -> StateTransitionInfo<StateRoot, Vec<u8>, MockDaSpec> {
-    let height = da_block_header.height;
+    let height = da_block_header.height + 1;
 
     StateTransitionInfo::new(
         StateTransitionWitness {

--- a/crates/full-node/sov-stf-runner/tests/integration/prover_service/network.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/prover_service/network.rs
@@ -50,7 +50,7 @@ async fn test_network_prove_and_aggregate() {
         ..
     } = make_network_prover(false, true, Duration::from_secs(60));
 
-    let header = make_header(MockHash::from([1; 32]), 1);
+    let header = make_header(MockHash::from([1; 32]), 0);
     let genesis = genesis_state_root();
 
     // Submit one block — should return ProvingInProgress.
@@ -158,8 +158,8 @@ async fn test_network_aggregated_proof_multiple_blocks() {
                 AggregatedProofPublicData<Address, MockDaSpec, StateRoot>,
             >(&serialized_proof, &MockCodeCommitment::default())
             .unwrap();
-            assert_eq!(public_data.initial_slot_number.get(), 0);
-            assert_eq!(public_data.final_slot_number.get(), 4);
+            assert_eq!(public_data.initial_slot_number.get(), 1);
+            assert_eq!(public_data.final_slot_number.get(), 5);
         }
         ProofAggregationStatus::ProofGenerationInProgress => {
             panic!("Expected Success after completing all inner proofs")
@@ -300,8 +300,8 @@ async fn test_network_aggregation_preserves_proved_entries_across_calls() {
     } = make_network_prover(false, true, Duration::from_secs(60));
 
     let genesis = genesis_state_root();
-    let header_a = make_header(MockHash::from([8; 32]), 1);
-    let header_b = make_header(MockHash::from([9; 32]), 2);
+    let header_a = make_header(MockHash::from([8; 32]), 0);
+    let header_b = make_header(MockHash::from([9; 32]), 1);
 
     // Submit two blocks.
     prover_service

--- a/crates/full-node/sov-stf-runner/tests/integration/prover_service/parallel.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/prover_service/parallel.rs
@@ -44,7 +44,7 @@ async fn test_successful_prover_execution() -> Result<(), ProverServiceError> {
         ..
     } = make_new_prover();
 
-    let header = make_header(MockHash::from([0; 32]), 1);
+    let header = make_header(MockHash::from([0; 32]), 0);
     prover_service
         .prove(make_transition_info(header.clone()))
         .await?;
@@ -86,8 +86,8 @@ async fn test_prover_status_busy() -> anyhow::Result<()> {
 
     let genesis_state_root = genesis_state_root();
 
-    let headers: Vec<_> = (1..num_worker_threads + 1)
-        .map(|height| make_header(MockHash::from([height as u8; 32]), height as u64))
+    let headers: Vec<_> = (0..num_worker_threads)
+        .map(|height| make_header(MockHash::from([(height + 1) as u8; 32]), height as u64))
         .collect();
 
     // Saturate the prover.
@@ -242,8 +242,8 @@ async fn test_aggregated_proof() -> Result<(), ProverServiceError> {
                         AggregatedProofPublicData<Address, MockDaSpec, StateRoot>,
                     >(&serialized_proof, &MockCodeCommitment::default())
                     .unwrap();
-                assert_eq!(public_data.initial_slot_number.get(), 0);
-                assert_eq!(public_data.final_slot_number.get(), (jump - 1) as u64);
+                assert_eq!(public_data.initial_slot_number.get(), 1);
+                assert_eq!(public_data.final_slot_number.get(), jump as u64);
             }
             ProofAggregationStatus::ProofGenerationInProgress => panic!("Prover should succeed"),
         }
@@ -272,10 +272,10 @@ async fn test_aggregated_proof() -> Result<(), ProverServiceError> {
                         AggregatedProofPublicData<Address, MockDaSpec, StateRoot>,
                     >(&serialized_proof, &MockCodeCommitment::default())
                     .unwrap();
-                assert_eq!(public_data.initial_slot_number.get() as usize, jump);
+                assert_eq!(public_data.initial_slot_number.get() as usize, jump + 1);
                 assert_eq!(
                     public_data.final_slot_number.get() as usize,
-                    total_nb_of_blocks - 1
+                    total_nb_of_blocks
                 );
             }
             ProofAggregationStatus::ProofGenerationInProgress => panic!("Proves should succeed"),

--- a/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/runner_reorg_tests.rs
@@ -118,6 +118,7 @@ async fn test_runner_with_background_da_service(
         da_sync_state,
         da_service_with_cache,
         genesis_da_height,
+        None,
     )
     .await?;
 

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -500,9 +500,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
 
         // The prover service validates the latest aggregated proof persisted in
         // the ledger DB and returns its `final_slot_number`. We pass this slot
-        // into the runner so the STF-info stream resumes at `final_slot + 1`,
-        // keeping it contiguous with the on-disk proof even when the in-DB
-        // STF-info pointer is ahead of the latest verified proof.
+        // into the runner so the STF-info stream resumes at `final_slot + 1`.
         let (prover_service, latest_proof_final_slot) = if prover_config.is_enabled() {
             let (svc, slot) = self
                 .create_prover_service(prover_config, &rollup_config, &da_service, &ledger_db)

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -119,12 +119,18 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
     ) -> Self::DaService;
 
     /// Creates an instance of [`ProverService`].
+    ///
+    /// Returns the prover service together with the `final_slot_number` of the
+    /// latest aggregated proof persisted in the ledger DB (if any). The caller
+    /// uses this slot to anchor the STF-info stream so the next aggregation is
+    /// contiguous with the proof on disk.
     async fn create_prover_service(
         &self,
         prover_config: RollupProverConfig,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         da_service: &Self::DaService,
-    ) -> Self::ProverService;
+        ledger_db: &LedgerDb,
+    ) -> (Self::ProverService, Option<SlotNumber>);
 
     /// Creates an instance of [`Self::StorageManager`].
     /// Panics if initialization fails.
@@ -492,6 +498,20 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         let axum_tcp = TcpListener::bind(axum_socket_addr).await?;
         let axum_socket_addr = axum_tcp.local_addr()?;
 
+        // The prover service validates the latest aggregated proof persisted in
+        // the ledger DB and returns its `final_slot_number`. We pass this slot
+        // into the runner so the STF-info stream resumes at `final_slot + 1`,
+        // keeping it contiguous with the on-disk proof even when the in-DB
+        // STF-info pointer is ahead of the latest verified proof.
+        let (prover_service, latest_proof_final_slot) = if prover_config.is_enabled() {
+            let (svc, slot) = self
+                .create_prover_service(prover_config, &rollup_config, &da_service, &ledger_db)
+                .await;
+            (Some(svc), slot)
+        } else {
+            (None, None)
+        };
+
         let mut runner = StateTransitionRunner::new(
             rollup_config.runner.clone(),
             axum_tcp,
@@ -513,6 +533,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             da_sync_state.clone(),
             da_service_with_cache,
             genesis_da_height,
+            latest_proof_final_slot,
         )
         .await?;
 
@@ -532,10 +553,8 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             .await?;
 
         if let Some(stf_info_receiver) = runner.take_stf_info_receiver() {
-            let prover_service = self
-                .create_prover_service(prover_config, &rollup_config, &da_service)
-                .await;
-
+            let prover_service = prover_service
+                .expect("prover service must be present when stf_info_receiver is Some");
             let proof_sender =
                 Box::new(self.create_proof_sender(&rollup_config, sequencer.proof_sender.clone())?);
 

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
@@ -136,9 +136,13 @@ where
         prover_config: sov_stf_runner::processes::RollupProverConfig,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         da_service: &Self::DaService,
-    ) -> Self::ProverService {
+        ledger_db: &sov_db::ledger_db::LedgerDb,
+    ) -> (
+        Self::ProverService,
+        Option<sov_rollup_interface::common::SlotNumber>,
+    ) {
         self.inner
-            .create_prover_service(prover_config, rollup_config, da_service)
+            .create_prover_service(prover_config, rollup_config, da_service, ledger_db)
             .await
     }
 

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -19,7 +19,11 @@ use crate::zk::SerializedZkProof;
 /// Host-side interface for the outer zkVM that produces aggregated proofs.
 pub trait OuterZkvmHost: Clone + Send + Sync + 'static {
     /// Aggregates per-block inner proofs into a single serialized aggregated proof.
-    fn run_proof_aggregation<Address: Serialize + Clone, Da: DaSpec, Root: Serialize + Clone>(
+    fn run_proof_aggregation<
+        Address: Serialize + Clone,
+        Da: DaSpec,
+        Root: Serialize + DeserializeOwned + Clone + PartialEq + core::fmt::Debug,
+    >(
         &self,
         genesis_state_root: Root,
         headers_with_block_proofs: Vec<(Da::BlockHeader, BlockProof<Address, Da, Root>)>,

--- a/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
+++ b/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
@@ -208,8 +208,12 @@ where
         prover_config: RollupProverConfig,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
-    ) -> Self::ProverService {
-        Prover::create(prover_config, rollup_config).await
+        _ledger_db: &LedgerDb,
+    ) -> (
+        Self::ProverService,
+        Option<sov_rollup_interface::common::SlotNumber>,
+    ) {
+        (Prover::create(prover_config, rollup_config).await, None)
     }
 
     fn create_storage_manager(

--- a/examples/demo-rollup/src/aggregated_proof.rs
+++ b/examples/demo-rollup/src/aggregated_proof.rs
@@ -1,0 +1,21 @@
+//! Helper for reading the latest aggregated proof persisted in the ledger DB.
+
+use sov_db::ledger_db::LedgerDb;
+use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
+use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
+
+/// Reads the raw bytes of the latest aggregated proof persisted in the ledger
+/// DB, without verifying.
+///
+/// Panics if the DB read fails.
+pub async fn read_latest_aggregated_proof(
+    ledger_db: &LedgerDb,
+) -> Option<SerializedAggregatedProof> {
+    Some(
+        ledger_db
+            .get_latest_aggregated_proof()
+            .await
+            .expect("Failed to read latest aggregated proof from ledger DB")?
+            .proof,
+    )
+}

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -160,7 +160,11 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
         _prover_config: RollupProverConfig,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
-    ) -> Self::ProverService {
+        _ledger_db: &LedgerDb,
+    ) -> (
+        Self::ProverService,
+        Option<sov_rollup_interface::common::SlotNumber>,
+    ) {
         let inner_vm = Risc0Host::new(risc0::ROLLUP_ELF);
 
         let outer_vm = MockZkvmHost::new_non_blocking();
@@ -172,12 +176,14 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
 
         let da_verifier = CelestiaVerifier::new(rollup_params);
 
-        ParallelProverService::new_with_default_workers(
+        let prover = ParallelProverService::new_with_default_workers(
             inner_vm,
             outer_vm,
             da_verifier,
             rollup_config.proof_manager.prover_address,
-        )
+        );
+
+        (prover, None)
     }
 
     fn create_storage_manager(

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -9,7 +9,7 @@ use sov_db::storage_manager::NomtStorageManager;
 use sov_ethereum::EthRpcConfig;
 use sov_mock_da::storable::rpc::StorableMockDaClient;
 use sov_mock_da::MockDaSpec;
-use sov_mock_zkvm::{MockCodeCommitment, MockZkvm, MockZkvmHost};
+use sov_mock_zkvm::{MockCodeCommitment, MockZkvm, MockZkvmCryptoSpec, MockZkvmHost};
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::{Native, WitnessGeneration};
 use sov_modules_api::CryptoSpec;
@@ -17,14 +17,9 @@ use sov_modules_api::{NodeEndpoints, Spec, Storage};
 use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
 use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
-use sov_risc0_adapter::host::Risc0Host;
-use sov_risc0_adapter::Risc0;
-use sov_risc0_adapter::Risc0CryptoSpec;
-use sov_risc0_adapter::Risc0MethodId;
 use sov_rollup_full_node_interface::StateUpdateReceiver;
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::SyncStatus;
-use sov_rollup_interface::zk::ZkvmHost;
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::DefaultStorageSpec;
@@ -34,18 +29,18 @@ use sov_stf_runner::RollupConfig;
 use crate::eth_dev_signer;
 use crate::solana_offchain_endpoint::solana_offchain_router;
 
-type Hasher = <Risc0CryptoSpec as CryptoSpec>::Hasher;
+type Hasher = <MockZkvmCryptoSpec as CryptoSpec>::Hasher;
 type NativeStorage =
     NomtProverStorage<DefaultStorageSpec<Hasher>, <MockDaSpec as DaSpec>::SlotHash>;
 
 /// The default spec of the rollup
 pub type ExternalMockRollupSpec<M> = ConfigurableSpec<
     MockDaSpec,
-    Risc0,
+    MockZkvm,
     MockZkvm,
     MultiAddressEvmSolana,
     M,
-    Risc0CryptoSpec,
+    MockZkvmCryptoSpec,
     NativeStorage,
 >;
 
@@ -155,8 +150,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
     ) -> Self::ProverService {
-        let inner_vm = Risc0Host::new(risc0::MOCK_DA_ELF);
-
+        let inner_vm = MockZkvmHost::new_non_blocking();
         let outer_vm = MockZkvmHost::new_non_blocking();
         let da_verifier = Default::default();
 
@@ -184,9 +178,9 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
         Ok(Self::ProofSender::new(sequence_number_provider))
     }
 
-    fn compute_code_commitments() -> anyhow::Result<(Risc0MethodId, MockCodeCommitment)> {
-        let inner = Risc0Host::new(risc0::MOCK_DA_ELF).code_commitment()?;
-        let outer = MockZkvmHost::new_non_blocking().code_commitment()?;
-        Ok((inner, outer))
+    fn compute_code_commitments() -> anyhow::Result<(MockCodeCommitment, MockCodeCommitment)> {
+        // MockZkvm has no ELF to derive a commitment from — the default zero
+        // commitment matches what `MockZkvmHost::code_commitment` returns.
+        Ok((MockCodeCommitment::default(), MockCodeCommitment::default()))
     }
 }

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -9,7 +9,9 @@ use sov_db::storage_manager::NomtStorageManager;
 use sov_ethereum::EthRpcConfig;
 use sov_mock_da::storable::rpc::StorableMockDaClient;
 use sov_mock_da::MockDaSpec;
-use sov_mock_zkvm::{MockCodeCommitment, MockZkvm, MockZkvmCryptoSpec, MockZkvmHost};
+use sov_mock_zkvm::{
+    MockCodeCommitment, MockZkVerifier, MockZkvm, MockZkvmCryptoSpec, MockZkvmHost,
+};
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::{Native, WitnessGeneration};
 use sov_modules_api::CryptoSpec;
@@ -18,8 +20,13 @@ use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
 use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
 use sov_rollup_full_node_interface::StateUpdateReceiver;
+use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
 use sov_rollup_interface::node::SyncStatus;
+use sov_rollup_interface::zk::aggregated_proof::{
+    AggregateProofVerifier, AggregatedProofPublicData,
+};
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::DefaultStorageSpec;
@@ -149,17 +156,42 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
         _prover_config: RollupProverConfig,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
-    ) -> Self::ProverService {
+        ledger_db: &LedgerDb,
+    ) -> (Self::ProverService, Option<SlotNumber>) {
+        let previous_aggregated_proof = ledger_db
+            .get_latest_aggregated_proof()
+            .await
+            .expect("Failed to read latest aggregated proof from ledger DB")
+            .map(|response| response.proof);
+
+        // Validate the persisted proof and extract the `final_slot_number` so
+        // the runner can rewind the STF-info stream to `final_slot + 1`.
+        let latest_proof_final_slot = previous_aggregated_proof.as_ref().map(|proof| {
+            let verifier =
+                AggregateProofVerifier::<MockZkVerifier>::new(MockCodeCommitment::default());
+            let public_data: AggregatedProofPublicData<
+                <Self::Spec as Spec>::Address,
+                MockDaSpec,
+                <<Self::Spec as Spec>::Storage as Storage>::Root,
+            > = verifier
+                .verify(proof)
+                .expect("Persisted aggregated proof failed verification");
+            public_data.final_slot_number
+        });
+
         let inner_vm = MockZkvmHost::new_non_blocking();
-        let outer_vm = MockZkvmHost::new_non_blocking();
+        let outer_vm =
+            MockZkvmHost::new_non_blocking_with_previous_proof(previous_aggregated_proof);
         let da_verifier = Default::default();
 
-        ParallelProverService::new_with_default_workers(
+        let prover = ParallelProverService::new_with_default_workers(
             inner_vm,
             outer_vm,
             da_verifier,
             rollup_config.proof_manager.prover_address,
-        )
+        );
+
+        (prover, latest_proof_final_slot)
     }
 
     fn create_storage_manager(

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -22,7 +22,6 @@ use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, Sequencer
 use sov_rollup_full_node_interface::StateUpdateReceiver;
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::DaSpec;
-use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
 use sov_rollup_interface::node::SyncStatus;
 use sov_rollup_interface::zk::aggregated_proof::{
     AggregateProofVerifier, AggregatedProofPublicData,
@@ -34,6 +33,7 @@ use sov_stf_runner::processes::{ParallelProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
 
 use crate::eth_dev_signer;
+use crate::read_latest_aggregated_proof;
 use crate::solana_offchain_endpoint::solana_offchain_router;
 
 type Hasher = <MockZkvmCryptoSpec as CryptoSpec>::Hasher;
@@ -158,30 +158,23 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
         _da_service: &Self::DaService,
         ledger_db: &LedgerDb,
     ) -> (Self::ProverService, Option<SlotNumber>) {
-        let previous_aggregated_proof = ledger_db
-            .get_latest_aggregated_proof()
-            .await
-            .expect("Failed to read latest aggregated proof from ledger DB")
-            .map(|response| response.proof);
-
-        // Validate the persisted proof and extract the `final_slot_number` so
-        // the runner can rewind the STF-info stream to `final_slot + 1`.
-        let latest_proof_final_slot = previous_aggregated_proof.as_ref().map(|proof| {
-            let verifier =
-                AggregateProofVerifier::<MockZkVerifier>::new(MockCodeCommitment::default());
-            let public_data: AggregatedProofPublicData<
+        let previous_public_data: Option<
+            AggregatedProofPublicData<
                 <Self::Spec as Spec>::Address,
                 MockDaSpec,
                 <<Self::Spec as Spec>::Storage as Storage>::Root,
-            > = verifier
-                .verify(proof)
-                .expect("Persisted aggregated proof failed verification");
-            public_data.final_slot_number
+            >,
+        > = read_latest_aggregated_proof(ledger_db).await.map(|proof| {
+            AggregateProofVerifier::<MockZkVerifier>::new(MockCodeCommitment::default())
+                .verify(&proof)
+                .expect("Persisted aggregated proof failed verification")
         });
+
+        let latest_proof_final_slot = previous_public_data.as_ref().map(|p| p.final_slot_number);
 
         let inner_vm = MockZkvmHost::new_non_blocking();
         let outer_vm =
-            MockZkvmHost::new_non_blocking_with_previous_proof(previous_aggregated_proof);
+            MockZkvmHost::new_non_blocking_with_previous_anchor(previous_public_data.as_ref());
         let da_verifier = Default::default();
 
         let prover = ParallelProverService::new_with_default_workers(

--- a/examples/demo-rollup/src/lib.rs
+++ b/examples/demo-rollup/src/lib.rs
@@ -9,6 +9,9 @@ use std::str::FromStr;
 use sov_celestia_adapter::types::Namespace;
 use sov_modules_api::macros::config_value;
 
+mod aggregated_proof;
+pub use aggregated_proof::read_latest_aggregated_proof;
+
 mod mock_rollup;
 
 pub use mock_rollup::*;

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -21,7 +21,6 @@ use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, Sequencer
 use sov_rollup_full_node_interface::StateUpdateReceiver;
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::DaSpec;
-use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
 use sov_rollup_interface::node::SyncStatus;
 use sov_rollup_interface::zk::aggregated_proof::{
     AggregateProofVerifier, AggregatedProofPublicData,
@@ -33,6 +32,7 @@ use sov_stf_runner::processes::{ParallelProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
 
 use crate::eth_dev_signer;
+use crate::read_latest_aggregated_proof;
 use crate::solana_offchain_endpoint::solana_offchain_router;
 
 /// Rollup with a [`ConfigurableSpec`] with [`MockDaSpec`] as Da spec, [`MockZkvm`] inner vm and [`MockZkvm`] for outer vm
@@ -156,30 +156,23 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
         _da_service: &Self::DaService,
         ledger_db: &LedgerDb,
     ) -> (Self::ProverService, Option<SlotNumber>) {
-        let previous_aggregated_proof = ledger_db
-            .get_latest_aggregated_proof()
-            .await
-            .expect("Failed to read latest aggregated proof from ledger DB")
-            .map(|response| response.proof);
-
-        // Validate the persisted proof and extract the `final_slot_number` so
-        // the runner can rewind the STF-info stream to `final_slot + 1`.
-        let latest_proof_final_slot = previous_aggregated_proof.as_ref().map(|proof| {
-            let verifier =
-                AggregateProofVerifier::<MockZkVerifier>::new(MockCodeCommitment::default());
-            let public_data: AggregatedProofPublicData<
+        let previous_public_data: Option<
+            AggregatedProofPublicData<
                 <Self::Spec as Spec>::Address,
                 MockDaSpec,
                 <<Self::Spec as Spec>::Storage as Storage>::Root,
-            > = verifier
-                .verify(proof)
-                .expect("Persisted aggregated proof failed verification");
-            public_data.final_slot_number
+            >,
+        > = read_latest_aggregated_proof(ledger_db).await.map(|proof| {
+            AggregateProofVerifier::<MockZkVerifier>::new(MockCodeCommitment::default())
+                .verify(&proof)
+                .expect("Persisted aggregated proof failed verification")
         });
+
+        let latest_proof_final_slot = previous_public_data.as_ref().map(|p| p.final_slot_number);
 
         let inner_vm = MockZkvmHost::new_non_blocking();
         let outer_vm =
-            MockZkvmHost::new_non_blocking_with_previous_proof(previous_aggregated_proof);
+            MockZkvmHost::new_non_blocking_with_previous_anchor(previous_public_data.as_ref());
         let da_verifier = Default::default();
 
         let prover = ParallelProverService::new_with_default_workers(

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -9,7 +9,9 @@ use sov_db::storage_manager::NomtStorageManager;
 use sov_ethereum::EthRpcConfig;
 use sov_mock_da::storable::StorableMockDaService;
 use sov_mock_da::MockDaSpec;
-use sov_mock_zkvm::{MockCodeCommitment, MockZkvm, MockZkvmCryptoSpec, MockZkvmHost};
+use sov_mock_zkvm::{
+    MockCodeCommitment, MockZkVerifier, MockZkvm, MockZkvmCryptoSpec, MockZkvmHost,
+};
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::{Native, WitnessGeneration};
 use sov_modules_api::{CryptoSpec, NodeEndpoints, Spec};
@@ -17,8 +19,13 @@ use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
 use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
 use sov_rollup_full_node_interface::StateUpdateReceiver;
+use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
 use sov_rollup_interface::node::SyncStatus;
+use sov_rollup_interface::zk::aggregated_proof::{
+    AggregateProofVerifier, AggregatedProofPublicData,
+};
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::{DefaultStorageSpec, Storage};
@@ -147,17 +154,42 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
         _prover_config: RollupProverConfig,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
-    ) -> Self::ProverService {
+        ledger_db: &LedgerDb,
+    ) -> (Self::ProverService, Option<SlotNumber>) {
+        let previous_aggregated_proof = ledger_db
+            .get_latest_aggregated_proof()
+            .await
+            .expect("Failed to read latest aggregated proof from ledger DB")
+            .map(|response| response.proof);
+
+        // Validate the persisted proof and extract the `final_slot_number` so
+        // the runner can rewind the STF-info stream to `final_slot + 1`.
+        let latest_proof_final_slot = previous_aggregated_proof.as_ref().map(|proof| {
+            let verifier =
+                AggregateProofVerifier::<MockZkVerifier>::new(MockCodeCommitment::default());
+            let public_data: AggregatedProofPublicData<
+                <Self::Spec as Spec>::Address,
+                MockDaSpec,
+                <<Self::Spec as Spec>::Storage as Storage>::Root,
+            > = verifier
+                .verify(proof)
+                .expect("Persisted aggregated proof failed verification");
+            public_data.final_slot_number
+        });
+
         let inner_vm = MockZkvmHost::new_non_blocking();
-        let outer_vm = MockZkvmHost::new_non_blocking();
+        let outer_vm =
+            MockZkvmHost::new_non_blocking_with_previous_proof(previous_aggregated_proof);
         let da_verifier = Default::default();
 
-        ParallelProverService::new_with_default_workers(
+        let prover = ParallelProverService::new_with_default_workers(
             inner_vm,
             outer_vm,
             da_verifier,
             rollup_config.proof_manager.prover_address,
-        )
+        );
+
+        (prover, latest_proof_final_slot)
     }
 
     fn create_storage_manager(

--- a/examples/demo-rollup/src/mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/mock_sp1_rollup.rs
@@ -16,17 +16,22 @@ use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
 use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
 use sov_rollup_full_node_interface::StateUpdateReceiver;
+use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::SyncStatus;
+use sov_rollup_interface::zk::aggregated_proof::{
+    AggregateProofVerifier, AggregatedProofPublicData,
+};
 use sov_sequencer::{ProofBlobSender, Sequencer};
 use sov_sp1_adapter::host::{SP1AggregationHost, SP1Host};
-use sov_sp1_adapter::{SP1CryptoSpec, SP1MethodId, SP1};
+use sov_sp1_adapter::{SP1CryptoSpec, SP1MethodId, SP1Verifier, SP1};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::{DefaultStorageSpec, Storage};
 use sov_stf_runner::processes::{ParallelProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
 
 use crate::eth_dev_signer;
+use crate::read_latest_aggregated_proof;
 use crate::solana_offchain_endpoint::solana_offchain_router;
 
 /// Rollup with a [`ConfigurableSpec`] with [`MockDaSpec`] as Da spec, and [`SP1`] for both inner and outer vm
@@ -141,11 +146,8 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
         _prover_config: RollupProverConfig,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
-        _ledger_db: &LedgerDb,
-    ) -> (
-        Self::ProverService,
-        Option<sov_rollup_interface::common::SlotNumber>,
-    ) {
+        ledger_db: &LedgerDb,
+    ) -> (Self::ProverService, Option<SlotNumber>) {
         let elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
         let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
 
@@ -165,12 +167,32 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
 
         let inner_verifying_key = inner_vm.verifying_key().clone();
 
+        let previous_aggregated_proof = read_latest_aggregated_proof(ledger_db).await;
+
+        let previous_for_outer = previous_aggregated_proof.clone();
         let outer_vm = tokio::task::spawn_blocking(move || {
-            SP1AggregationHost::new(agg_elf, inner_verifying_key)
-                .expect("Failed to create SP1AggregationHost from aggregation guest ELF")
+            SP1AggregationHost::new_with_previous_proof(
+                agg_elf,
+                inner_verifying_key,
+                previous_for_outer,
+            )
+            .expect("Failed to create SP1AggregationHost from aggregation guest ELF")
         })
         .await
         .expect("SP1AggregationHost setup task panicked");
+
+        // Validate the persisted proof and extract the `final_slot_number` so
+        // the runner can rewind the STF-info stream to `final_slot + 1`.
+        let latest_proof_final_slot = previous_aggregated_proof.as_ref().map(|proof| {
+            let public_data: AggregatedProofPublicData<
+                <Self::Spec as Spec>::Address,
+                MockDaSpec,
+                <<Self::Spec as Spec>::Storage as Storage>::Root,
+            > = AggregateProofVerifier::<SP1Verifier>::new(outer_vm.code_commitment())
+                .verify(proof)
+                .expect("Persisted aggregated proof failed verification");
+            public_data.final_slot_number
+        });
 
         let da_verifier = Default::default();
 
@@ -181,7 +203,7 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
             rollup_config.proof_manager.prover_address,
         );
 
-        (prover, None)
+        (prover, latest_proof_final_slot)
     }
 
     fn create_storage_manager(

--- a/examples/demo-rollup/src/mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/mock_sp1_rollup.rs
@@ -141,7 +141,11 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
         _prover_config: RollupProverConfig,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
-    ) -> Self::ProverService {
+        _ledger_db: &LedgerDb,
+    ) -> (
+        Self::ProverService,
+        Option<sov_rollup_interface::common::SlotNumber>,
+    ) {
         let elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
         let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
 
@@ -170,12 +174,14 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
 
         let da_verifier = Default::default();
 
-        ParallelProverService::new_with_default_workers(
+        let prover = ParallelProverService::new_with_default_workers(
             inner_vm,
             outer_vm,
             da_verifier,
             rollup_config.proof_manager.prover_address,
-        )
+        );
+
+        (prover, None)
     }
 
     fn create_storage_manager(

--- a/examples/demo-rollup/tests/restart/graceful.rs
+++ b/examples/demo-rollup/tests/restart/graceful.rs
@@ -107,7 +107,7 @@ fn build_sleep_schedule(
     schedule
 }
 
-fn known_restart_warnings() -> [(Level, String); 10] {
+fn known_restart_warnings() -> [(Level, String); 9] {
     [
         // https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/1878:
         (
@@ -117,10 +117,6 @@ fn known_restart_warnings() -> [(Level, String); 10] {
         (
             Level::WARN,
             "Received error updating target height, stopping background task".to_string(),
-        ),
-        (
-            Level::WARN,
-            "Rewinding STF-info next_height_to_receive to stay contiguous with the latest verified aggregated proof".to_string(),
         ),
         // The node gets out of sync during the restart
         (

--- a/examples/demo-rollup/tests/restart/graceful.rs
+++ b/examples/demo-rollup/tests/restart/graceful.rs
@@ -107,7 +107,7 @@ fn build_sleep_schedule(
     schedule
 }
 
-fn known_restart_warnings() -> [(Level, String); 9] {
+fn known_restart_warnings() -> [(Level, String); 10] {
     [
         // https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/1878:
         (
@@ -117,6 +117,10 @@ fn known_restart_warnings() -> [(Level, String); 9] {
         (
             Level::WARN,
             "Received error updating target height, stopping background task".to_string(),
+        ),
+        (
+            Level::WARN,
+            "Rewinding STF-info next_height_to_receive to stay contiguous with the latest verified aggregated proof".to_string(),
         ),
         // The node gets out of sync during the restart
         (

--- a/examples/demo-rollup/tests/restart/mod.rs
+++ b/examples/demo-rollup/tests/restart/mod.rs
@@ -1,2 +1,3 @@
 mod crash;
 mod graceful;
+mod proofs;

--- a/examples/demo-rollup/tests/restart/proofs.rs
+++ b/examples/demo-rollup/tests/restart/proofs.rs
@@ -106,8 +106,6 @@ async fn test_aggregated_proofs_after_restart_external_da() {
     // Phase 2: shut the rollup down and wait for the DA to advance by at least 3 blocks.
     let height_at_shutdown = da_service.get_head_block_header().await.unwrap().height() as u32;
 
-    println!("RESTART");
-
     let builder = test_rollup.shutdown().await.unwrap();
 
     da_service

--- a/examples/demo-rollup/tests/restart/proofs.rs
+++ b/examples/demo-rollup/tests/restart/proofs.rs
@@ -1,0 +1,126 @@
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use futures::StreamExt;
+use sov_demo_rollup::ExternalMockDemoRollup;
+use sov_full_node_configs::sequencer::SequencerKindConfig;
+use sov_mock_da::storable::rpc::{start_server, MockDaClientConfig};
+use sov_mock_da::storable::StorableMockDaService;
+use sov_mock_da::{BlockProducingConfig, MockAddress, MockDaConfig};
+use sov_modules_api::execution_mode::Native;
+use sov_modules_api::OperatingMode;
+use sov_rollup_interface::da::BlockHeaderTrait;
+use sov_rollup_interface::node::da::DaService;
+use sov_sequencer::preferred::RecoveryStrategy;
+use sov_stf_runner::processes::RollupProverConfig;
+use sov_test_utils::test_rollup::{RollupBuilder, TestRollup};
+use sov_test_utils::TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS;
+use tokio::sync::watch;
+
+use crate::test_helpers::test_genesis_source;
+
+const TEST_SEQ_DA_ADDRESS: MockAddress = MockAddress::new([0; 32]);
+const AGGREGATED_PROOF_BLOCK_JUMP: usize = 3;
+const PROOF_WAIT_TIMEOUT: Duration = Duration::from_secs(120);
+const OFFLINE_DA_BLOCKS: u32 = 3;
+
+async fn create_da_service_periodic() -> (StorableMockDaService, watch::Sender<()>, SocketAddr) {
+    let (shutdown_sender, shutdown_receiver) = tokio::sync::watch::channel(());
+    let mut da_config = MockDaConfig::instant_with_sender(TEST_SEQ_DA_ADDRESS);
+    da_config.block_producing = BlockProducingConfig::Periodic {
+        block_time_ms: TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS * 2,
+    };
+
+    let da_service = StorableMockDaService::from_config(da_config, shutdown_receiver).await;
+
+    let addr = start_server(da_service.clone(), "127.0.0.1", 0)
+        .await
+        .unwrap();
+
+    (da_service, shutdown_sender, addr)
+}
+
+async fn build_rollup_with_prover(
+    addr: SocketAddr,
+) -> RollupBuilder<ExternalMockDemoRollup<Native>> {
+    let genesis = test_genesis_source(OperatingMode::Zk);
+    let da_config = MockDaClientConfig {
+        url: format!("http://{addr}"),
+    };
+    RollupBuilder::new_with_external_da(genesis, da_config, None)
+        .await
+        .enable_prover()
+        .set_config(|c| {
+            c.blob_processing_timeout_secs = 300;
+            c.aggregated_proof_block_jump = AGGREGATED_PROOF_BLOCK_JUMP;
+            c.rollup_prover_config = RollupProverConfig::Prove;
+            if let SequencerKindConfig::Preferred(p) = &mut c.sequencer_config {
+                p.disable_state_root_consistency_checks = true;
+                p.num_cache_warmup_workers = 0;
+                p.recovery_strategy = RecoveryStrategy::TryToSave;
+                p.ideal_lag_behind_finalized_slot = 3;
+            }
+        })
+}
+
+async fn wait_for_aggregated_proofs(
+    test_rollup: &TestRollup<ExternalMockDemoRollup<Native>>,
+    count: usize,
+) {
+    let api_client = test_rollup.api_client().clone();
+    let mut proofs = api_client.subscribe_aggregated_proof().await.unwrap();
+    for i in 0..count {
+        let proof = tokio::time::timeout(PROOF_WAIT_TIMEOUT, proofs.next())
+            .await
+            .unwrap_or_else(|_| panic!("Timed out waiting for aggregated proof #{}", i + 1))
+            .expect("Aggregated proof stream ended unexpectedly")
+            .expect("Aggregated proof message was an error");
+        tracing::info!(proof_index = i + 1, ?proof, "Received aggregated proof",);
+    }
+}
+
+/// Integration test: external-DA rollup keeps processing aggregated proofs after a restart.
+///
+/// Scenario:
+///   1. Start the rollup against an external mock DA, wait for 3 aggregated proofs.
+///   2. Shut the rollup down for at least 3 DA blocks (the DA layer keeps producing while the rollup is offline).
+///   3. Restart the rollup on the same storage and verify aggregated proofs are still being produced.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_aggregated_proofs_after_restart_external_da() {
+    //sov_test_utils::logging::initialize_or_change_logging_with_filter("info,tower=off");
+
+    let (da_service, da_shutdown, addr) = create_da_service_periodic().await;
+    // Give the DA layer some headroom so the rollup doesn't immediately starve on startup.
+    da_service.wait_for_height(10).await.unwrap();
+
+    // Phase 1: start the rollup and wait for 3 aggregated proofs.
+    let test_rollup = build_rollup_with_prover(addr)
+        .await
+        .start_test_rollup()
+        .await
+        .unwrap();
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
+
+    wait_for_aggregated_proofs(&test_rollup, 3).await;
+
+    // Phase 2: shut the rollup down and wait for the DA to advance by at least 3 blocks.
+    let height_at_shutdown = da_service.get_head_block_header().await.unwrap().height() as u32;
+
+    println!("RESTART");
+
+    let builder = test_rollup.shutdown().await.unwrap();
+
+    da_service
+        .wait_for_height(height_at_shutdown + OFFLINE_DA_BLOCKS)
+        .await
+        .unwrap();
+
+    // Phase 3: restart on the same storage and confirm aggregated proofs keep flowing.
+    let test_rollup = builder.start_test_rollup().await.unwrap();
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
+
+    wait_for_aggregated_proofs(&test_rollup, 9).await;
+
+    let _ = test_rollup.shutdown().await;
+    let _ = da_shutdown.send(());
+}

--- a/examples/demo-rollup/tests/resync/mod.rs
+++ b/examples/demo-rollup/tests/resync/mod.rs
@@ -320,6 +320,7 @@ async fn test_rollup_resync() -> anyhow::Result<()> {
         (Level::WARN, "slow statement: execution time exceeded alert threshold".to_string()),
         // TODO - investigate: https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/2978
         (Level::WARN, "Received error updating target height, stopping background task".to_string()),
+        (Level::WARN, "The node has a higher sequence number than the sequencer, but we're very close to the chain tip, i.e. we don't expect to be simply syncing. This could mean there is another preferred sequencer running (which is not supported and will likely lead to issues), or you very recently restarted the node and there's still some in-flight blobs. Resyncing to the chain tip.".to_string()),
         // This is expected for the second resync: since we have batches in the sequencer DB, we
         // are indeed causing a delay for users
         (Level::WARN, "The sequencer must pause because the node has lagged behind the DA blockchain. This might lead to a brief downtime for users.".to_string()),


### PR DESCRIPTION
# Description

This PR makes the outer-VM aggregated proof pipeline survive a node restart. Before this change, after a restart, the prover would forget the previous aggregated proof, and either start a fresh aggregation that wasn't contiguous with what was already on disk, or fail recursive verification.                                                                                                                                                                                                                       

Core idea:        
                                                                                                                                                                                                           On startup, load the latest aggregated proof from the ledger DB, verify it, extract its public data, and seed two things with it:                                                                                                                           
  1. The outer VM host — so the next aggregation is recursively chained to the previous one.
  2. The STF-info channel — so the runner replays slots starting at previous_final_slot + 1.

Changes: 

  - On startup, load the latest aggregated proof from the ledger DB and feed it into the outer ZKVM host (mock + SP1) so that aggregation-continuity assertions hold across a restart.                                                                        
  - Use that proof's `final_slot_number` to anchor the STF-info channel at `final_slot + 1`.                                                                                                                                                            
  - Port `external_mock_rollup.rs` from Risc0 to `MockZkvm` so the new restart test runs without real proving.                                                                                                                                                

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551