### PR TITLE
  Pipeline proof aggregation.

### DIFF
--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -139,6 +139,15 @@ fn default_eager_proof_submission() -> bool {
     true
 }
 
+impl<Address> ProofManagerConfig<Address> {
+    /// Number of prover threads required to fully pipeline aggregation:
+    /// `2 * aggregated_proof_block_jump + 1` covers inner proofs for the
+    /// current and next batch plus one outer-aggregation worker.
+    pub fn prover_thread_count(&self) -> usize {
+        2 * self.aggregated_proof_block_jump.get() + 1
+    }
+}
+
 /// Rollup Configuration
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[schemars(

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/mod.rs
@@ -75,17 +75,9 @@ where
         outer_vm: OuterVm::OuterHost,
         da_verifier: Da::Verifier,
         prover_address: Address,
+        num_threads: usize,
     ) -> Self {
-        let num_cpus = num_cpus::get();
-        assert!(num_cpus > 1, "Unable to create parallel prover service");
-
-        Self::new(
-            inner_vm,
-            outer_vm,
-            da_verifier,
-            num_cpus - 1,
-            prover_address,
-        )
+        Self::new(inner_vm, outer_vm, da_verifier, num_threads, prover_address)
     }
 }
 

--- a/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
@@ -425,6 +425,39 @@ where
                 .fetch_add(amount, Ordering::SeqCst),
         )
     }
+
+    /// Returns a cloneable handle that can advance `next_height_to_receive`
+    /// from a different task without requiring access to the full
+    /// [`Receiver`]. Used by the proof-aggregation pipeline to keep the
+    /// cursor advance co-located with the actual proof publication, while
+    /// the channel-draining `read_next` still happens on the intake task.
+    pub fn cursor_handle(&self) -> CursorHandle {
+        CursorHandle {
+            next_height_to_receive: self.next_height_to_receive.clone(),
+        }
+    }
+}
+
+/// A clonable handle over the [`Receiver`]'s `next_height_to_receive` cursor.
+///
+/// The cursor doubles as the prune cutoff for materialized STF infos
+/// (see `prune_entries`), so it MUST only be advanced over slots whose proofs
+/// have been durably published. Holding this handle in a non-receiver task
+/// lets the publish step do that advance without giving the task the rest of
+/// the [`Receiver`].
+#[derive(Clone)]
+pub struct CursorHandle {
+    next_height_to_receive: Arc<AtomicU64>,
+}
+
+impl CursorHandle {
+    /// Increment next height to receive by the requested amount, returning the previous value.
+    pub fn inc_next_height_to_receive_by(&self, amount: u64) -> SlotNumber {
+        SlotNumber::new_dangerous(
+            self.next_height_to_receive
+                .fetch_add(amount, Ordering::SeqCst),
+        )
+    }
 }
 
 #[cfg(test)]

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -1,4 +1,5 @@
 use std::num::NonZero;
+use std::sync::Arc;
 
 use backon::{BackoffBuilder, ExponentialBuilder};
 use sov_rollup_interface::da::BlockHeaderTrait;
@@ -6,13 +7,14 @@ use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
 use sov_rollup_interface::stf::ProofSender;
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, Duration};
 use types::{BlockProofInfo, BlockProofStatus, UnAggregatedProofList};
 
 use self::types::AggregateProofMetadata;
 use super::StateTransitionInfo;
-use crate::processes::{ProverService, Receiver};
+use crate::processes::{CursorHandle, ProverService, Receiver};
 
 mod types;
 
@@ -23,7 +25,7 @@ const BACKOFF_POLICY_MAX_NUM_RETRIES: usize = 5;
 /// Manages the lifecycle of the `AggregatedProof`.
 #[allow(clippy::type_complexity)]
 pub struct ZkProofManager<Ps: ProverService> {
-    prover_service: Ps,
+    prover_service: Arc<Ps>,
     proofs_to_create: UnAggregatedProofList<Ps>,
     aggregated_proof_block_jump: NonZero<usize>,
     eager_proof_submission: bool,
@@ -50,7 +52,7 @@ where
         shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> Self {
         Self {
-            prover_service,
+            prover_service: Arc::new(prover_service),
             proofs_to_create: UnAggregatedProofList::new(),
             aggregated_proof_block_jump,
             eager_proof_submission,
@@ -65,76 +67,76 @@ where
         }
     }
 
-    async fn create_aggregate_proof_with_retries(
-        &self,
-        mut metadata: AggregateProofMetadata<Ps>,
-        prover_service: &Ps,
-        genesis_state_root: &Ps::StateRoot,
-    ) -> anyhow::Result<SerializedAggregatedProof> {
-        let mut attempt_num = 1u32;
-        let mut backoff_iter = self.backoff_policy.build();
-
-        loop {
-            let maybe_backoff_duration = backoff_iter.next();
-
-            match metadata.prove(prover_service, genesis_state_root).await {
-                Ok(proof) => return Ok(proof),
-                Err((returned_metadata, error)) => {
-                    let error_message = format!("Failed to generate aggregate proof: {error}");
-
-                    if error_message.contains("Elf parse error") {
-                        // NOTE We exit early on this error since it means the we've failed to find/parse
-                        // the zk circuit, and there's no recovering from that.
-                        tracing::error!("Fatal error: {error_message}");
-                        tracing::error!(
-                            "Please check your zk circuit ELF file was built correctly!"
-                        );
-                        anyhow::bail!(error)
-                    };
-
-                    if error_message.contains("Outer network proving") {
-                        tracing::error!("Fatal error: {error_message}");
-                        anyhow::bail!(error)
-                    };
-
-                    tracing::error!(error_message);
-                    match maybe_backoff_duration {
-                        None => {
-                            tracing::warn!("Maximum number of retries exhausted - exiting");
-                            anyhow::bail!(error)
-                        }
-                        Some(duration) => {
-                            tracing::info!("Retrying generation of aggregate proof in {}s, attempt {attempt_num} of {}...", duration.as_secs(), BACKOFF_POLICY_MAX_NUM_RETRIES);
-                            attempt_num += 1;
-                            sleep(duration).await;
-                            metadata = returned_metadata;
-                            continue;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /// Starts a background task for `AggregatedProof` generation.
+    /// Spawns the intake and aggregator background tasks.
+    ///
+    /// Returns a single supervisor handle that resolves once both tasks
+    /// terminate.
     pub async fn post_aggregated_proof_to_da_in_background(self) -> JoinHandle<()> {
         tokio::spawn(async move {
             tracing::info!("Spawning an aggregated proof posting background task");
-            if let Err(e) = self.post_aggregated_proof_to_da_when_ready().await {
-                tracing::error!(error = ?e, "Failed to post aggregated proof to DA");
+
+            let (metadata_tx, metadata_rx) = mpsc::channel::<(AggregateProofMetadata<Ps>, u64)>(1);
+
+            // Cursor handle goes to the aggregator so the cursor only
+            // advances after publish succeeds. See module-level docs.
+            let cursor = self.stf_info_receiver.cursor_handle();
+
+            let aggregator = AggregatorTask {
+                prover_service: self.prover_service.clone(),
+                proof_sender: self.proof_sender,
+                backoff_policy: self.backoff_policy,
+                genesis_state_root: self.genesis_state_root.clone(),
+                metadata_rx,
+                cursor,
+                shutdown_receiver: self.shutdown_receiver.clone(),
+            };
+            let aggregator_handle = tokio::spawn(async move {
+                if let Err(e) = aggregator.run().await {
+                    tracing::error!(error = ?e, "Aggregator task failed");
+                }
+            });
+
+            let intake = IntakeTask {
+                prover_service: self.prover_service,
+                proofs_to_create: self.proofs_to_create,
+                aggregated_proof_block_jump: self.aggregated_proof_block_jump,
+                eager_proof_submission: self.eager_proof_submission,
+                stf_info_receiver: self.stf_info_receiver,
+                metadata_tx,
+                shutdown_receiver: self.shutdown_receiver,
+            };
+            if let Err(e) = intake.run().await {
+                tracing::error!(error = ?e, "Intake task failed");
             }
+
+            let _ = aggregator_handle.await;
         })
     }
+}
 
-    /// Attempts to generate an `AggregatedProof` and then posts it to DA.
-    /// The proof is created only when there are enough of inner proofs in the `ProverService` queue.
-    async fn post_aggregated_proof_to_da_when_ready(mut self) -> anyhow::Result<()> {
+/// Per-slot intake side of [`ZkProofManager`]. See the type-level docs for
+/// how it cooperates with [`AggregatorTask`].
+struct IntakeTask<Ps: ProverService> {
+    prover_service: Arc<Ps>,
+    proofs_to_create: UnAggregatedProofList<Ps>,
+    aggregated_proof_block_jump: NonZero<usize>,
+    eager_proof_submission: bool,
+    stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
+    metadata_tx: mpsc::Sender<(AggregateProofMetadata<Ps>, u64)>,
+    shutdown_receiver: tokio::sync::watch::Receiver<()>,
+}
+
+impl<Ps: ProverService> IntakeTask<Ps>
+where
+    Ps::DaService: DaService<Error = anyhow::Error>,
+{
+    async fn run(mut self) -> anyhow::Result<()> {
         loop {
             match future_or_shutdown(self.stf_info_receiver.read_next(), &self.shutdown_receiver)
                 .await
             {
                 FutureOrShutdownOutput::Shutdown => {
-                    tracing::info!("Shutting down aggregated proof posting task...");
+                    tracing::info!("Shutting down aggregated proof intake task...");
                     break;
                 }
                 FutureOrShutdownOutput::Output(stf_info_result) => {
@@ -148,17 +150,17 @@ where
                     tracing::trace!(
                         slot_number = %stf_info.slot_number,
                         block_header = %stf_info.da_block_header().display(),
-                        "Received STF info");
+                        "Received STF info"
+                    );
 
                     self.process_stf_info(stf_info).await?;
                 }
             }
         }
-        tracing::debug!("Aggregated proofs posting task has been completed");
+        tracing::debug!("Aggregated proofs intake task has been completed");
         Ok(())
     }
 
-    /// Processes current STF info and optionally published aggregated proof to DA.
     async fn process_stf_info(
         &mut self,
         stf_info: StateTransitionInfo<
@@ -174,8 +176,6 @@ where
             received_slot_number.get() >= first_height_unproven.get(),
             "Received slot {received_slot_number} is behind first unproven height {first_height_unproven}"
         );
-
-        let prover_service = &self.prover_service;
 
         // We ensure that we're not trying to prove blocks that are being proven.
         // If that is not the case, we add the block to the queue.
@@ -198,25 +198,86 @@ where
         if self.eager_proof_submission {
             self.proofs_to_create
                 .oldest_mut()
-                .prove_any_unproven_blocks(prover_service)
+                .prove_any_unproven_blocks(&*self.prover_service)
                 .await;
         }
 
         let num_proofs_to_create = self.proofs_to_create.current_proof_jump();
 
-        // If we've covered enough blocks for the aggregate proof, generate and submit it to DA
+        // If we've covered enough blocks for the aggregate proof, hand the
+        // window off to the aggregator task.
         if num_proofs_to_create >= self.aggregated_proof_block_jump.get() {
             self.proofs_to_create.close_newest_proof();
             let metadata = self.proofs_to_create.take_oldest();
+            let window_size = num_proofs_to_create as u64;
+
+            // 1-deep channel: blocks here only when the aggregator already
+            // has one window in flight AND a second buffered. While blocked,
+            // intake stops draining the STF-info mpsc, which propagates
+            // back-pressure upstream to the runner exactly as in the
+            // pre-pipelining design.
+            self.metadata_tx
+                .send((metadata, window_size))
+                .await
+                .map_err(|_| {
+                    anyhow::anyhow!("Aggregator task has terminated; cannot send metadata")
+                })?;
+        }
+
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit(super::metrics::ZkProofManagerMetrics {
+                proving_lag: received_slot_number.get() - first_height_unproven.get(),
+                proofs_to_create: self.proofs_to_create.current_proof_jump(),
+                slot_number: received_slot_number.get(),
+            });
+        });
+
+        Ok(())
+    }
+}
+
+/// Aggregator side of [`ZkProofManager`]. Pulls completed windows from the
+/// 1-deep mpsc, runs the (necessarily serial) recursive aggregation, and
+/// publishes the resulting blob to DA.
+struct AggregatorTask<Ps: ProverService> {
+    prover_service: Arc<Ps>,
+    proof_sender: Box<dyn ProofSender>,
+    backoff_policy: ExponentialBuilder,
+    genesis_state_root: Ps::StateRoot,
+    metadata_rx: mpsc::Receiver<(AggregateProofMetadata<Ps>, u64)>,
+    cursor: CursorHandle,
+    shutdown_receiver: tokio::sync::watch::Receiver<()>,
+}
+
+impl<Ps: ProverService> AggregatorTask<Ps>
+where
+    Ps::DaService: DaService<Error = anyhow::Error>,
+{
+    async fn run(mut self) -> anyhow::Result<()> {
+        loop {
+            let (metadata, window_size) =
+                match future_or_shutdown(self.metadata_rx.recv(), &self.shutdown_receiver).await {
+                    FutureOrShutdownOutput::Shutdown => {
+                        tracing::info!("Shutting down aggregator task...");
+                        break;
+                    }
+                    FutureOrShutdownOutput::Output(None) => {
+                        // Intake side dropped its sender (clean shutdown or
+                        // intake error).
+                        tracing::debug!("Intake task closed metadata channel; aggregator exiting");
+                        break;
+                    }
+                    FutureOrShutdownOutput::Output(Some(item)) => item,
+                };
 
             let proving_start = std::time::Instant::now();
-            let agg_proof = self
-                .create_aggregate_proof_with_retries(
-                    metadata,
-                    prover_service,
-                    &self.genesis_state_root,
-                )
-                .await?;
+            let agg_proof = create_aggregate_proof_with_retries(
+                metadata,
+                &*self.prover_service,
+                &self.genesis_state_root,
+                &self.backoff_policy,
+            )
+            .await?;
             let aggregation_duration = proving_start.elapsed();
 
             sov_metrics::track_metrics(|tracker| {
@@ -234,19 +295,58 @@ where
                 .publish_proof_blob_with_metadata(agg_proof)
                 .await?;
 
-            // Update the next height to receive
-            self.stf_info_receiver
-                .inc_next_height_to_receive_by(num_proofs_to_create as u64);
+            self.cursor.inc_next_height_to_receive_by(window_size);
         }
-
-        sov_metrics::track_metrics(|tracker| {
-            tracker.submit(super::metrics::ZkProofManagerMetrics {
-                proving_lag: received_slot_number.get() - first_height_unproven.get(),
-                proofs_to_create: self.proofs_to_create.current_proof_jump(),
-                slot_number: received_slot_number.get(),
-            });
-        });
-
+        tracing::debug!("Aggregator task has been completed");
         Ok(())
+    }
+}
+
+async fn create_aggregate_proof_with_retries<Ps: ProverService>(
+    mut metadata: AggregateProofMetadata<Ps>,
+    prover_service: &Ps,
+    genesis_state_root: &Ps::StateRoot,
+    backoff_policy: &ExponentialBuilder,
+) -> anyhow::Result<SerializedAggregatedProof> {
+    let mut attempt_num = 1u32;
+    let mut backoff_iter = backoff_policy.build();
+
+    loop {
+        let maybe_backoff_duration = backoff_iter.next();
+
+        match metadata.prove(prover_service, genesis_state_root).await {
+            Ok(proof) => return Ok(proof),
+            Err((returned_metadata, error)) => {
+                let error_message = format!("Failed to generate aggregate proof: {error}");
+
+                if error_message.contains("Elf parse error") {
+                    // NOTE We exit early on this error since it means the we've failed to find/parse
+                    // the zk circuit, and there's no recovering from that.
+                    tracing::error!("Fatal error: {error_message}");
+                    tracing::error!("Please check your zk circuit ELF file was built correctly!");
+                    anyhow::bail!(error)
+                };
+
+                if error_message.contains("Outer network proving") {
+                    tracing::error!("Fatal error: {error_message}");
+                    anyhow::bail!(error)
+                };
+
+                tracing::error!(error_message);
+                match maybe_backoff_duration {
+                    None => {
+                        tracing::warn!("Maximum number of retries exhausted - exiting");
+                        anyhow::bail!(error)
+                    }
+                    Some(duration) => {
+                        tracing::info!("Retrying generation of aggregate proof in {}s, attempt {attempt_num} of {}...", duration.as_secs(), BACKOFF_POLICY_MAX_NUM_RETRIES);
+                        attempt_num += 1;
+                        sleep(duration).await;
+                        metadata = returned_metadata;
+                        continue;
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -36,7 +36,9 @@ type GenesisParams<ST, Da> = <ST as StateTransitionFunction<Da>>::GenesisParams;
 
 type NextDaHeightToProcess = u64;
 
-fn validate_proof_manager_config<Address>(config: ProofManagerConfig<Address>) -> anyhow::Result<()> {
+fn validate_proof_manager_config<Address>(
+    config: &ProofManagerConfig<Address>,
+) -> anyhow::Result<()> {
     let aggregated_proof_block_jump = u64::try_from(config.aggregated_proof_block_jump.get())
         .context("aggregated_proof_block_jump does not fit in u64")?;
     let pipelined_backlog = aggregated_proof_block_jump
@@ -193,7 +195,7 @@ where
             "Initializing StfRunner");
 
         let (stf_info_sender, stf_info_receiver) = if let Some(config) = pm_config {
-            validate_proof_manager_config(config)?;
+            validate_proof_manager_config(&config)?;
             let channel = new_stf_info_channel(
                 ledger_db.clone(),
                 config.max_number_of_transitions_in_memory,

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -36,6 +36,30 @@ type GenesisParams<ST, Da> = <ST as StateTransitionFunction<Da>>::GenesisParams;
 
 type NextDaHeightToProcess = u64;
 
+fn validate_proof_manager_config<Address>(config: ProofManagerConfig<Address>) -> anyhow::Result<()> {
+    let aggregated_proof_block_jump = u64::try_from(config.aggregated_proof_block_jump.get())
+        .context("aggregated_proof_block_jump does not fit in u64")?;
+    let pipelined_backlog = aggregated_proof_block_jump
+        .checked_mul(3)
+        .context("aggregated proof backlog overflowed")?;
+    let required_transitions_in_db = config
+        .max_number_of_transitions_in_memory
+        .get()
+        .checked_add(pipelined_backlog)
+        .context("required STF info DB capacity overflowed")?;
+
+    anyhow::ensure!(
+        config.max_number_of_transitions_in_db.get() >= required_transitions_in_db,
+        "Invalid proof manager config: `max_number_of_transitions_in_db` must be at least `max_number_of_transitions_in_memory + 3 * aggregated_proof_block_jump` for pipelined aggregated proof posting (got db={}, memory={}, jump={}, required={})",
+        config.max_number_of_transitions_in_db,
+        config.max_number_of_transitions_in_memory,
+        config.aggregated_proof_block_jump,
+        required_transitions_in_db,
+    );
+
+    Ok(())
+}
+
 /// Combines `DaService` with `StateTransitionFunction` and "runs" the rollup.
 #[allow(clippy::type_complexity)]
 pub struct StateTransitionRunner<Stf, Sm, Da>
@@ -169,6 +193,7 @@ where
             "Initializing StfRunner");
 
         let (stf_info_sender, stf_info_receiver) = if let Some(config) = pm_config {
+            validate_proof_manager_config(config)?;
             let channel = new_stf_info_channel(
                 ledger_db.clone(),
                 config.max_number_of_transitions_in_memory,

--- a/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
+++ b/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
@@ -80,6 +80,7 @@ where
             outer_vm,
             Default::default(),
             rollup_config.proof_manager.prover_address,
+            5,
         )
     }
 }

--- a/examples/demo-rollup/sov-benchmarks/src/bench_runner/mod.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/bench_runner/mod.rs
@@ -77,6 +77,7 @@ where
             outer_vm,
             Default::default(),
             rollup_config.proof_manager.prover_address,
+            5,
         )
     }
 }

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -176,11 +176,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
 
         let da_verifier = CelestiaVerifier::new(rollup_params);
 
-        let num_threads = rollup_config
-            .proof_manager
-            .aggregated_proof_block_jump
-            .get()
-            + 1;
+        let num_threads = rollup_config.proof_manager.prover_thread_count();
 
         let prover = ParallelProverService::new_with_default_workers(
             inner_vm,

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -176,11 +176,18 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
 
         let da_verifier = CelestiaVerifier::new(rollup_params);
 
+        let num_threads = rollup_config
+            .proof_manager
+            .aggregated_proof_block_jump
+            .get()
+            + 1;
+
         let prover = ParallelProverService::new_with_default_workers(
             inner_vm,
             outer_vm,
             da_verifier,
             rollup_config.proof_manager.prover_address,
+            num_threads,
         );
 
         (prover, None)

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -177,11 +177,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
             MockZkvmHost::new_non_blocking_with_previous_anchor(previous_public_data.as_ref());
         let da_verifier = Default::default();
 
-        let num_threads = rollup_config
-            .proof_manager
-            .aggregated_proof_block_jump
-            .get()
-            + 1;
+        let num_threads = rollup_config.proof_manager.prover_thread_count();
         let prover = ParallelProverService::new_with_default_workers(
             inner_vm,
             outer_vm,

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -177,11 +177,17 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
             MockZkvmHost::new_non_blocking_with_previous_anchor(previous_public_data.as_ref());
         let da_verifier = Default::default();
 
+        let num_threads = rollup_config
+            .proof_manager
+            .aggregated_proof_block_jump
+            .get()
+            + 1;
         let prover = ParallelProverService::new_with_default_workers(
             inner_vm,
             outer_vm,
             da_verifier,
             rollup_config.proof_manager.prover_address,
+            num_threads,
         );
 
         (prover, latest_proof_final_slot)

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -175,11 +175,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
             MockZkvmHost::new_non_blocking_with_previous_anchor(previous_public_data.as_ref());
         let da_verifier = Default::default();
 
-        let num_threads = rollup_config
-            .proof_manager
-            .aggregated_proof_block_jump
-            .get()
-            + 1;
+        let num_threads = rollup_config.proof_manager.prover_thread_count();
 
         let prover = ParallelProverService::new_with_default_workers(
             inner_vm,

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -175,11 +175,18 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
             MockZkvmHost::new_non_blocking_with_previous_anchor(previous_public_data.as_ref());
         let da_verifier = Default::default();
 
+        let num_threads = rollup_config
+            .proof_manager
+            .aggregated_proof_block_jump
+            .get()
+            + 1;
+
         let prover = ParallelProverService::new_with_default_workers(
             inner_vm,
             outer_vm,
             da_verifier,
             rollup_config.proof_manager.prover_address,
+            num_threads,
         );
 
         (prover, latest_proof_final_slot)

--- a/examples/demo-rollup/src/mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/mock_sp1_rollup.rs
@@ -196,11 +196,17 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
 
         let da_verifier = Default::default();
 
+        let num_threads = 2 * rollup_config
+            .proof_manager
+            .aggregated_proof_block_jump
+            .get()
+            + 1;
         let prover = ParallelProverService::new_with_default_workers(
             inner_vm,
             outer_vm,
             da_verifier,
             rollup_config.proof_manager.prover_address,
+            num_threads,
         );
 
         (prover, latest_proof_final_slot)

--- a/examples/demo-rollup/src/mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/mock_sp1_rollup.rs
@@ -196,11 +196,7 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
 
         let da_verifier = Default::default();
 
-        let num_threads = 2 * rollup_config
-            .proof_manager
-            .aggregated_proof_block_jump
-            .get()
-            + 1;
+        let num_threads = rollup_config.proof_manager.prover_thread_count();
         let prover = ParallelProverService::new_with_default_workers(
             inner_vm,
             outer_vm,

--- a/examples/demo-rollup/tests/prover/parallel.rs
+++ b/examples/demo-rollup/tests/prover/parallel.rs
@@ -65,6 +65,7 @@ async fn test_parallel_proof_generation() {
         outer_vm,
         da_verifier,
         prover_address,
+        3,
     );
 
     let (genesis_state_root, witnesses) = super::generate_witnesses().await;


### PR DESCRIPTION
# Description

 This PR pipelines the aggregated-proof workflow so the prover can keep ingesting STF infos while the previous aggregation/publication is in flight.

Before this change, the flow was more serialized than it needed to be.
Assume aggregated_proof_block_jump = 5:

  1. For each proof window, we would submit up to 5 batch-proof jobs.
  2. Once those 5 batch proofs were finished, we would start aggregate-proof generation.
  3. Only after aggregate-proof generation completed would we start submitting the next 5 batch proofs.

  The key observation is that steps 2 and 3 do not actually depend on each other. While one aggregate proof is being generated and published, we can already start proving the next batch window. This PR fixes exactly that: ZkProofManager now overlaps
  batch-proof production with aggregate-proof generation, so both stages can run in parallel.

  This PR also changes the worker-count logic to num_threads = 2 * aggregated_proof_block_jump + 1.

  Previously, num_threads defaulted to num_cpus, which on the dev machine was 97. That was too aggressive for the network prover: the remote service could not keep up, and we were frequently hitting invalid nonce errors due to excessive parallel
  submissions.

  With aggregated_proof_block_jump = 5, the new setting gives num_threads = 11, so we submit at most 11 proving jobs in parallel. That has been a much more reasonable limit so far, though this value is still a tuning parameter and can be adjusted further
  if needed.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551 