### PR TITLE
  Add optional sleep throttle for mock provers

### DIFF
--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -131,6 +131,19 @@ impl MockZkvmHost {
             pub_data,
         })?)
     }
+
+    /// Sleeps for the duration (in milliseconds) read from `env_var`. Used in
+    /// tests/soak runs to throttle the otherwise-instant mock prover. No-op
+    /// if the env var is unset or not parseable.
+    fn maybe_mock_sleep(env_var: &str) {
+        let Some(ms) = std::env::var(env_var)
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+        else {
+            return;
+        };
+        std::thread::sleep(std::time::Duration::from_millis(ms));
+    }
 }
 
 impl Default for MockZkvmHost {
@@ -151,6 +164,7 @@ impl sov_rollup_interface::zk::ZkvmHost for MockZkvmHost {
         item: &T,
         _agg_proofs: Vec<SerializedAggregatedProof>,
     ) -> anyhow::Result<SerializedZkProof> {
+        Self::maybe_mock_sleep("MOCK_PROVE_SLEEP_MS");
         self.add_hint_and_run_inner(item)
             .map(|raw_proof| SerializedZkProof { raw_proof })
     }
@@ -175,6 +189,8 @@ impl OuterZkvmHost for MockZkvmHost {
             block_proofs_data.as_slice(),
             genesis_state_root,
         );
+
+        Self::maybe_mock_sleep("MOCK_AGGREGATION_SLEEP_MS");
 
         let mut previous = self
             .previous_anchor

--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -164,7 +164,7 @@ impl sov_rollup_interface::zk::ZkvmHost for MockZkvmHost {
         item: &T,
         _agg_proofs: Vec<SerializedAggregatedProof>,
     ) -> anyhow::Result<SerializedZkProof> {
-        Self::maybe_mock_sleep("MOCK_PROVE_SLEEP_MS");
+        Self::maybe_mock_sleep("SOV_MOCK_PROVE_SLEEP_MS");
         self.add_hint_and_run_inner(item)
             .map(|raw_proof| SerializedZkProof { raw_proof })
     }
@@ -190,7 +190,7 @@ impl OuterZkvmHost for MockZkvmHost {
             genesis_state_root,
         );
 
-        Self::maybe_mock_sleep("MOCK_AGGREGATION_SLEEP_MS");
+        Self::maybe_mock_sleep("SOV_MOCK_AGGREGATION_SLEEP_MS");
 
         let mut previous = self
             .previous_anchor

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -318,7 +318,7 @@ impl ZkvmHost for SP1Host {
         item: &T,
         agg_proofs: Vec<SerializedAggregatedProof>,
     ) -> anyhow::Result<SerializedZkProof> {
-        self.prover.maybe_mock_sleep("SOV_SP1_MOCK_PROVE_SLEEP_MS");
+        self.prover.maybe_mock_sleep("MOCK_PROVE_SLEEP_MS");
         self.add_hint_deferred_and_run_helper(item, agg_proofs)
     }
 
@@ -347,7 +347,7 @@ impl OuterZkvmHost for SP1AggregationHost {
 
         self.inner
             .prover
-            .maybe_mock_sleep("SOV_SP1_MOCK_AGGREGATION_SLEEP_MS");
+            .maybe_mock_sleep("MOCK_AGGREGATION_SLEEP_MS");
         self.run(proofs_and_headers)
     }
 }

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -176,6 +176,23 @@ impl SP1Prover {
         SP1MethodId(self.pk.verifying_key().hash_u32())
     }
 
+    /// Sleeps for the duration (in milliseconds) read from `env_var`, but only
+    /// when running under the SP1 mock backend. Used in tests/soak runs to
+    /// throttle the otherwise-instant mock prover. No-op if the env var is
+    /// unset or not parseable, or if the prover is not a mock.
+    fn maybe_mock_sleep(&self, env_var: &str) {
+        if !matches!(&self.prover, &EnvProver::Mock(_)) {
+            return;
+        }
+        let Some(ms) = std::env::var(env_var)
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+        else {
+            return;
+        };
+        std::thread::sleep(std::time::Duration::from_millis(ms));
+    }
+
     fn add_proof_helper(
         &self,
         stdin: &mut SP1Stdin,
@@ -301,6 +318,7 @@ impl ZkvmHost for SP1Host {
         item: &T,
         agg_proofs: Vec<SerializedAggregatedProof>,
     ) -> anyhow::Result<SerializedZkProof> {
+        self.prover.maybe_mock_sleep("SOV_SP1_MOCK_PROVE_SLEEP_MS");
         self.add_hint_deferred_and_run_helper(item, agg_proofs)
     }
 
@@ -327,6 +345,9 @@ impl OuterZkvmHost for SP1AggregationHost {
             })
             .collect();
 
+        self.inner
+            .prover
+            .maybe_mock_sleep("SOV_SP1_MOCK_AGGREGATION_SLEEP_MS");
         self.run(proofs_and_headers)
     }
 }

--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -318,7 +318,7 @@ impl ZkvmHost for SP1Host {
         item: &T,
         agg_proofs: Vec<SerializedAggregatedProof>,
     ) -> anyhow::Result<SerializedZkProof> {
-        self.prover.maybe_mock_sleep("MOCK_PROVE_SLEEP_MS");
+        self.prover.maybe_mock_sleep("SOV_MOCK_PROVE_SLEEP_MS");
         self.add_hint_deferred_and_run_helper(item, agg_proofs)
     }
 
@@ -347,7 +347,7 @@ impl OuterZkvmHost for SP1AggregationHost {
 
         self.inner
             .prover
-            .maybe_mock_sleep("MOCK_AGGREGATION_SLEEP_MS");
+            .maybe_mock_sleep("SOV_MOCK_AGGREGATION_SLEEP_MS");
         self.run(proofs_and_headers)
     }
 }


### PR DESCRIPTION
# Description

This PR introduces the following changes: 
  - Adds `maybe_mock_sleep` helper to both `MockZkvmHost` and SP1's mock backend that sleeps for a duration read from an env var before proving/aggregating.
  - `MOCK_PROVE_SLEEP_MS` throttles inner proof generation; `MOCK_AGGREGATION_SLEEP_MS` throttles outer aggregation.                                                                                                                                          
  - No-op when the env var is unset/unparseable, or (for SP1) when not running under `EnvProver::Mock`. Real provers are unaffected.  

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to # (issue) 