### PR TITLE
  Make prover thread count and aggregated-proof buffer configurable.

### DIFF
--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -134,7 +134,8 @@ pub struct ProofManagerConfig<Address> {
     #[serde(default = "default_eager_proof_submission")]
     pub eager_proof_submission: bool,
     /// Override for the number of prover threads. When `None`, defaults to
-    /// `2 * aggregated_proof_block_jump + 1`.
+    /// `2 * aggregated_proof_block_jump + 1`, which covers inner proofs for
+    /// the current and next batch plus one outer-aggregation worker.
     #[serde(default)]
     pub prover_thread_count_override: Option<NonZero<usize>>,
     /// Maximum number of completed aggregation windows that can be buffered in

--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -133,10 +133,15 @@ pub struct ProofManagerConfig<Address> {
     /// When false, submission is deferred until the batch is full, then submitted concurrently.
     #[serde(default = "default_eager_proof_submission")]
     pub eager_proof_submission: bool,
-    /// Number of prover threads. If unset, defaults to
-    /// `2 * aggregated_proof_block_jump + 1`, which fully pipelines aggregation.
+    /// Override for the number of prover threads. When `None`, defaults to
+    /// `2 * aggregated_proof_block_jump + 1`.
     #[serde(default)]
-    pub prover_thread_count: Option<NonZero<usize>>,
+    pub prover_thread_count_override: Option<NonZero<usize>>,
+    /// Maximum number of completed aggregation windows that can be buffered in
+    /// memory between the intake task and the aggregator task. When the
+    /// aggregator falls behind by this many windows, intake stalls and
+    /// back-pressure propagates upstream.
+    pub max_number_of_aggregated_proofs_in_memory: NonZero<usize>,
 }
 
 fn default_eager_proof_submission() -> bool {
@@ -148,7 +153,7 @@ impl<Address> ProofManagerConfig<Address> {
     /// `2 * aggregated_proof_block_jump + 1` — enough to cover inner proofs for the
     /// current and next batch plus one outer-aggregation worker.
     pub fn prover_thread_count(&self) -> usize {
-        self.prover_thread_count
+        self.prover_thread_count_override
             .map(|n| n.get())
             .unwrap_or_else(|| 2 * self.aggregated_proof_block_jump.get() + 1)
     }
@@ -231,8 +236,9 @@ mod tests {
             [proof_manager]
             aggregated_proof_block_jump = 22
             prover_address = "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
-            max_number_of_transitions_in_db = 1025
-            max_number_of_transitions_in_memory = 768
+            max_number_of_transitions_in_db = 1000
+            max_number_of_transitions_in_memory = 100
+            max_number_of_aggregated_proofs_in_memory = 5
             [sequencer]
             blob_processing_timeout_secs = 60
             max_batch_size_bytes = 1048576
@@ -274,8 +280,9 @@ mod tests {
             [proof_manager]
             aggregated_proof_block_jump = 22
             prover_address = "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
-            max_number_of_transitions_in_db = 1025
-            max_number_of_transitions_in_memory = 768
+            max_number_of_transitions_in_db = 1000
+            max_number_of_transitions_in_memory = 100
+            max_number_of_aggregated_proofs_in_memory = 5
             [sequencer]
             blob_processing_timeout_secs = 60
             max_batch_size_bytes = 1048576
@@ -327,8 +334,9 @@ mod tests {
             [proof_manager]
             aggregated_proof_block_jump = 22
             prover_address = "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
-            max_number_of_transitions_in_db = 1025
-            max_number_of_transitions_in_memory = 768
+            max_number_of_transitions_in_db = 1000
+            max_number_of_transitions_in_memory = 100
+            max_number_of_aggregated_proofs_in_memory = 5
             [sequencer]
             blob_processing_timeout_secs = 60
             max_batch_size_bytes = 1048576

--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -149,9 +149,7 @@ fn default_eager_proof_submission() -> bool {
 }
 
 impl<Address> ProofManagerConfig<Address> {
-    /// Number of prover threads. Returns the configured value when set, otherwise
-    /// `2 * aggregated_proof_block_jump + 1` — enough to cover inner proofs for the
-    /// current and next batch plus one outer-aggregation worker.
+    /// Number of prover threads.
     pub fn prover_thread_count(&self) -> usize {
         self.prover_thread_count_override
             .map(|n| n.get())

--- a/crates/full-node/full-node-configs/src/runner.rs
+++ b/crates/full-node/full-node-configs/src/runner.rs
@@ -133,6 +133,10 @@ pub struct ProofManagerConfig<Address> {
     /// When false, submission is deferred until the batch is full, then submitted concurrently.
     #[serde(default = "default_eager_proof_submission")]
     pub eager_proof_submission: bool,
+    /// Number of prover threads. If unset, defaults to
+    /// `2 * aggregated_proof_block_jump + 1`, which fully pipelines aggregation.
+    #[serde(default)]
+    pub prover_thread_count: Option<NonZero<usize>>,
 }
 
 fn default_eager_proof_submission() -> bool {
@@ -140,11 +144,13 @@ fn default_eager_proof_submission() -> bool {
 }
 
 impl<Address> ProofManagerConfig<Address> {
-    /// Number of prover threads required to fully pipeline aggregation:
-    /// `2 * aggregated_proof_block_jump + 1` covers inner proofs for the
+    /// Number of prover threads. Returns the configured value when set, otherwise
+    /// `2 * aggregated_proof_block_jump + 1` — enough to cover inner proofs for the
     /// current and next batch plus one outer-aggregation worker.
     pub fn prover_thread_count(&self) -> usize {
-        2 * self.aggregated_proof_block_jump.get() + 1
+        self.prover_thread_count
+            .map(|n| n.get())
+            .unwrap_or_else(|| 2 * self.aggregated_proof_block_jump.get() + 1)
     }
 }
 

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config.snap
@@ -50,10 +50,11 @@ expression: config
   "proof_manager": {
     "aggregated_proof_block_jump": 22,
     "prover_address": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
-    "max_number_of_transitions_in_db": 1025,
-    "max_number_of_transitions_in_memory": 768,
+    "max_number_of_transitions_in_db": 1000,
+    "max_number_of_transitions_in_memory": 100,
     "eager_proof_submission": true,
-    "prover_thread_count": null
+    "prover_thread_count_override": null,
+    "max_number_of_aggregated_proofs_in_memory": 5
   },
   "sequencer": {
     "automatic_batch_production": true,

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config.snap
@@ -52,7 +52,8 @@ expression: config
     "prover_address": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
     "max_number_of_transitions_in_db": 1025,
     "max_number_of_transitions_in_memory": 768,
-    "eager_proof_submission": true
+    "eager_proof_submission": true,
+    "prover_thread_count": null
   },
   "sequencer": {
     "automatic_batch_production": true,

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
@@ -50,10 +50,11 @@ expression: config
   "proof_manager": {
     "aggregated_proof_block_jump": 22,
     "prover_address": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
-    "max_number_of_transitions_in_db": 1025,
-    "max_number_of_transitions_in_memory": 768,
+    "max_number_of_transitions_in_db": 1000,
+    "max_number_of_transitions_in_memory": 100,
     "eager_proof_submission": true,
-    "prover_thread_count": null
+    "prover_thread_count_override": null,
+    "max_number_of_aggregated_proofs_in_memory": 5
   },
   "sequencer": {
     "automatic_batch_production": true,

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
@@ -52,7 +52,8 @@ expression: config
     "prover_address": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
     "max_number_of_transitions_in_db": 1025,
     "max_number_of_transitions_in_memory": 768,
-    "eager_proof_submission": true
+    "eager_proof_submission": true,
+    "prover_thread_count": null
   },
   "sequencer": {
     "automatic_batch_production": true,

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
@@ -50,10 +50,11 @@ expression: config
   "proof_manager": {
     "aggregated_proof_block_jump": 22,
     "prover_address": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
-    "max_number_of_transitions_in_db": 1025,
-    "max_number_of_transitions_in_memory": 768,
+    "max_number_of_transitions_in_db": 1000,
+    "max_number_of_transitions_in_memory": 100,
     "eager_proof_submission": true,
-    "prover_thread_count": null
+    "prover_thread_count_override": null,
+    "max_number_of_aggregated_proofs_in_memory": 5
   },
   "sequencer": {
     "automatic_batch_production": true,

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
@@ -52,7 +52,8 @@ expression: config
     "prover_address": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
     "max_number_of_transitions_in_db": 1025,
     "max_number_of_transitions_in_memory": 768,
-    "eager_proof_submission": true
+    "eager_proof_submission": true,
+    "prover_thread_count": null
   },
   "sequencer": {
     "automatic_batch_production": true,

--- a/crates/full-node/sov-stf-runner/src/processes/metrics.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/metrics.rs
@@ -39,6 +39,9 @@ pub(crate) struct ZkProofManagerMetrics {
     pub proofs_to_create: usize,
     /// The slot number of the most recently received state transition.
     pub slot_number: u64,
+    /// Number of pending aggregated-proof metadata items currently buffered in the
+    /// intake-to-aggregator channel (capacity `max_number_of_aggregated_proofs_in_memory`).
+    pub pending_agg_metadata: usize,
 }
 
 impl Metric for ZkProofManagerMetrics {
@@ -49,11 +52,12 @@ impl Metric for ZkProofManagerMetrics {
     fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
         write!(
             buffer,
-            "{} proving_lag={}i,proofs_to_create={}i,slot_number={}i",
+            "{} proving_lag={}i,proofs_to_create={}i,slot_number={}i,pending_agg_metadata={}i",
             self.measurement_name(),
             self.proving_lag,
             self.proofs_to_create,
             self.slot_number,
+            self.pending_agg_metadata,
         )
     }
 }

--- a/crates/full-node/sov-stf-runner/src/processes/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/mod.rs
@@ -17,10 +17,12 @@ use tokio::task::JoinHandle;
 pub use zk_manager::*;
 
 /// Starts a process that generates aggregated proofs in the background.
+#[allow(clippy::too_many_arguments)]
 pub async fn start_zk_workflow_in_background<Ps>(
     prover_service: Ps,
     aggregated_proof_block_jump: NonZero<usize>,
     eager_proof_submission: bool,
+    max_number_of_aggregated_proofs_in_memory: NonZero<usize>,
     proof_sender: Box<dyn ProofSender>,
     genesis_state_root: Ps::StateRoot,
     stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
@@ -34,6 +36,7 @@ where
         prover_service,
         aggregated_proof_block_jump,
         eager_proof_submission,
+        max_number_of_aggregated_proofs_in_memory,
         proof_sender,
         genesis_state_root,
         stf_info_receiver,

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -229,8 +229,7 @@ where
                 })?;
         }
 
-        let pending_agg_metadata =
-            self.metadata_tx.max_capacity() - self.metadata_tx.capacity();
+        let pending_agg_metadata = self.metadata_tx.max_capacity() - self.metadata_tx.capacity();
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(super::metrics::ZkProofManagerMetrics {
                 proving_lag: received_slot_number.get() - first_height_unproven.get(),

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -29,6 +29,7 @@ pub struct ZkProofManager<Ps: ProverService> {
     proofs_to_create: UnAggregatedProofList<Ps>,
     aggregated_proof_block_jump: NonZero<usize>,
     eager_proof_submission: bool,
+    max_number_of_aggregated_proofs_in_memory: NonZero<usize>,
     proof_sender: Box<dyn ProofSender>,
     backoff_policy: ExponentialBuilder,
     genesis_state_root: Ps::StateRoot,
@@ -46,6 +47,7 @@ where
         prover_service: Ps,
         aggregated_proof_block_jump: NonZero<usize>,
         eager_proof_submission: bool,
+        max_number_of_aggregated_proofs_in_memory: NonZero<usize>,
         proof_sender: Box<dyn ProofSender>,
         genesis_state_root: Ps::StateRoot,
         stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
@@ -56,6 +58,7 @@ where
             proofs_to_create: UnAggregatedProofList::new(),
             aggregated_proof_block_jump,
             eager_proof_submission,
+            max_number_of_aggregated_proofs_in_memory,
             proof_sender,
             backoff_policy: ExponentialBuilder::default()
                 .with_min_delay(Duration::from_secs(BACKOFF_POLICY_MIN_DELAY))
@@ -75,7 +78,9 @@ where
         tokio::spawn(async move {
             tracing::info!("Spawning an aggregated proof posting background task");
 
-            let (metadata_tx, metadata_rx) = mpsc::channel::<(AggregateProofMetadata<Ps>, u64)>(1);
+            let (metadata_tx, metadata_rx) = mpsc::channel::<(AggregateProofMetadata<Ps>, u64)>(
+                self.max_number_of_aggregated_proofs_in_memory.get(),
+            );
 
             // Cursor handle goes to the aggregator so the cursor only
             // advances after publish succeeds. See module-level docs.
@@ -211,11 +216,11 @@ where
             let metadata = self.proofs_to_create.take_oldest();
             let window_size = num_proofs_to_create as u64;
 
-            // 1-deep channel: blocks here only when the aggregator already
-            // has one window in flight AND a second buffered. While blocked,
-            // intake stops draining the STF-info mpsc, which propagates
-            // back-pressure upstream to the runner exactly as in the
-            // pre-pipelining design.
+            // Capacity is `max_number_of_aggregated_proofs_in_memory`: blocks
+            // here only once the aggregator has one window in flight AND that
+            // many windows buffered. While blocked, intake stops draining the
+            // STF-info mpsc, which propagates back-pressure upstream to the
+            // runner exactly as in the pre-pipelining design.
             self.metadata_tx
                 .send((metadata, window_size))
                 .await
@@ -236,9 +241,6 @@ where
     }
 }
 
-/// Aggregator side of [`ZkProofManager`]. Pulls completed windows from the
-/// 1-deep mpsc, runs the (necessarily serial) recursive aggregation, and
-/// publishes the resulting blob to DA.
 struct AggregatorTask<Ps: ProverService> {
     prover_service: Arc<Ps>,
     proof_sender: Box<dyn ProofSender>,

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -229,11 +229,14 @@ where
                 })?;
         }
 
+        let pending_agg_metadata =
+            self.metadata_tx.max_capacity() - self.metadata_tx.capacity();
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(super::metrics::ZkProofManagerMetrics {
                 proving_lag: received_slot_number.get() - first_height_unproven.get(),
                 proofs_to_create: self.proofs_to_create.current_proof_jump(),
                 slot_number: received_slot_number.get(),
+                pending_agg_metadata,
             });
         });
 

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -41,8 +41,16 @@ fn validate_proof_manager_config<Address>(
 ) -> anyhow::Result<()> {
     let aggregated_proof_block_jump = u64::try_from(config.aggregated_proof_block_jump.get())
         .context("aggregated_proof_block_jump does not fit in u64")?;
+    let buffered_windows = u64::try_from(config.max_number_of_aggregated_proofs_in_memory.get())
+        .context("max_number_of_aggregated_proofs_in_memory does not fit in u64")?;
+    // Windows resident across the pipeline: the one intake is filling, the one
+    // the aggregator is working on, plus `buffered_windows` queued in the
+    // intake→aggregator channel.
+    let pipelined_windows = buffered_windows
+        .checked_add(2)
+        .context("aggregated proof window count overflowed")?;
     let pipelined_backlog = aggregated_proof_block_jump
-        .checked_mul(3)
+        .checked_mul(pipelined_windows)
         .context("aggregated proof backlog overflowed")?;
     let required_transitions_in_db = config
         .max_number_of_transitions_in_memory
@@ -52,10 +60,11 @@ fn validate_proof_manager_config<Address>(
 
     anyhow::ensure!(
         config.max_number_of_transitions_in_db.get() >= required_transitions_in_db,
-        "Invalid proof manager config: `max_number_of_transitions_in_db` must be at least `max_number_of_transitions_in_memory + 3 * aggregated_proof_block_jump` for pipelined aggregated proof posting (got db={}, memory={}, jump={}, required={})",
+        "Invalid proof manager config: `max_number_of_transitions_in_db` must be at least `max_number_of_transitions_in_memory + (max_number_of_aggregated_proofs_in_memory + 2) * aggregated_proof_block_jump` for pipelined aggregated proof posting (got db={}, memory={}, jump={}, buffered={}, required={})",
         config.max_number_of_transitions_in_db,
         config.max_number_of_transitions_in_memory,
         config.aggregated_proof_block_jump,
+        config.max_number_of_aggregated_proofs_in_memory,
         required_transitions_in_db,
     );
 

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -417,6 +417,7 @@ pub fn rollup_config_with_da<Da: DaService<Config = MockDaConfig>>(
             max_number_of_transitions_in_db: NonZero::new(30).unwrap(),
             max_number_of_transitions_in_memory: NonZero::new(20).unwrap(),
             eager_proof_submission: true,
+            prover_thread_count: None,
         },
         sequencer: SequencerConfig {
             automatic_batch_production: true,

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -288,6 +288,9 @@ pub async fn initialize_runner(
             prover_service,
             rollup_config.proof_manager.aggregated_proof_block_jump,
             rollup_config.proof_manager.eager_proof_submission,
+            rollup_config
+                .proof_manager
+                .max_number_of_aggregated_proofs_in_memory,
             Box::new(MockProofSender {
                 da: da_service.clone(),
             }),
@@ -414,10 +417,11 @@ pub fn rollup_config_with_da<Da: DaService<Config = MockDaConfig>>(
         proof_manager: ProofManagerConfig {
             aggregated_proof_block_jump: NonZero::new(aggregated_proof_block_jump).unwrap(),
             prover_address: MockAddress::new([0u8; 32]),
-            max_number_of_transitions_in_db: NonZero::new(30).unwrap(),
-            max_number_of_transitions_in_memory: NonZero::new(20).unwrap(),
+            max_number_of_transitions_in_db: NonZero::new(1000).unwrap(),
+            max_number_of_transitions_in_memory: NonZero::new(100).unwrap(),
             eager_proof_submission: true,
-            prover_thread_count: None,
+            prover_thread_count_override: None,
+            max_number_of_aggregated_proofs_in_memory: NonZero::new(5).unwrap(),
         },
         sequencer: SequencerConfig {
             automatic_batch_production: true,

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -644,6 +644,7 @@
       "type": "object",
       "required": [
         "aggregated_proof_block_jump",
+        "max_number_of_aggregated_proofs_in_memory",
         "max_number_of_transitions_in_db",
         "max_number_of_transitions_in_memory",
         "prover_address"
@@ -659,6 +660,12 @@
           "description": "When true, proofs are submitted as each block arrives. When false, submission is deferred until the batch is full, then submitted concurrently.",
           "default": true,
           "type": "boolean"
+        },
+        "max_number_of_aggregated_proofs_in_memory": {
+          "description": "Maximum number of completed aggregation windows that can be buffered in memory between the intake task and the aggregator task. When the aggregator falls behind by this many windows, intake stalls and back-pressure propagates upstream.",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1.0
         },
         "max_number_of_transitions_in_db": {
           "description": "A number of state transition info entries are allowed to be stored in the database. When the number is exceeded, older entries are removed.",
@@ -679,6 +686,16 @@
               "$ref": "#/definitions/Address"
             }
           ]
+        },
+        "prover_thread_count_override": {
+          "description": "Override for the number of prover threads. When `None`, defaults to `2 * aggregated_proof_block_jump + 1`.",
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 1.0
         }
       }
     },

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -688,7 +688,7 @@
           ]
         },
         "prover_thread_count_override": {
-          "description": "Override for the number of prover threads. When `None`, defaults to `2 * aggregated_proof_block_jump + 1`.",
+          "description": "Override for the number of prover threads. When `None`, defaults to `2 * aggregated_proof_block_jump + 1`, which covers inner proofs for the current and next batch plus one outer-aggregation worker.",
           "default": null,
           "type": [
             "integer",

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -579,6 +579,9 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                         prover_service,
                         rollup_config.proof_manager.aggregated_proof_block_jump,
                         rollup_config.proof_manager.eager_proof_submission,
+                        rollup_config
+                            .proof_manager
+                            .max_number_of_aggregated_proofs_in_memory,
                         proof_sender,
                         genesis_state_root,
                         stf_info_receiver,

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -370,6 +370,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                 max_number_of_transitions_in_memory: NonZero::new(self.config.max_channel_size)
                     .unwrap(),
                 eager_proof_submission: true,
+                prover_thread_count: None,
             },
             sequencer: SequencerConfig {
                 automatic_batch_production: self.config.automatic_batch_production,

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -370,7 +370,8 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                 max_number_of_transitions_in_memory: NonZero::new(self.config.max_channel_size)
                     .unwrap(),
                 eager_proof_submission: true,
-                prover_thread_count: None,
+                prover_thread_count_override: None,
+                max_number_of_aggregated_proofs_in_memory: NonZero::new(5).unwrap(),
             },
             sequencer: SequencerConfig {
                 automatic_batch_production: self.config.automatic_batch_production,

--- a/examples/demo-rollup/configs/celestia_rollup_config.toml
+++ b/examples/demo-rollup/configs/celestia_rollup_config.toml
@@ -131,8 +131,9 @@ telegraf_address = "udp://127.0.0.1:8094"
 [proof_manager]
 aggregated_proof_block_jump = 10
 prover_address = "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
-max_number_of_transitions_in_db = 100
-max_number_of_transitions_in_memory = 30
+max_number_of_transitions_in_db = 1000
+max_number_of_transitions_in_memory = 100
+max_number_of_aggregated_proofs_in_memory = 5
 
 [sequencer]
 # This value is counted between sequencer receiving receipt from DA about inclusion till node has processed this blob.

--- a/examples/demo-rollup/configs/external_mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/external_mock_rollup_config.toml
@@ -53,8 +53,9 @@ telegraf_address = "udp://127.0.0.1:8094"
 [proof_manager]
 aggregated_proof_block_jump = 1
 prover_address = "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
-max_number_of_transitions_in_db = 100
-max_number_of_transitions_in_memory = 30
+max_number_of_transitions_in_db = 1000
+max_number_of_transitions_in_memory = 100
+max_number_of_aggregated_proofs_in_memory = 5
 
 [sequencer]
 blob_processing_timeout_secs = 3000

--- a/examples/demo-rollup/configs/mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/mock_rollup_config.toml
@@ -80,8 +80,9 @@ tokio_runtime_metrics_interval_millis = 500
 [proof_manager]
 aggregated_proof_block_jump = 1
 prover_address = "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
-max_number_of_transitions_in_db = 100
-max_number_of_transitions_in_memory = 30
+max_number_of_transitions_in_db = 1000
+max_number_of_transitions_in_memory = 100
+max_number_of_aggregated_proofs_in_memory = 5
 
 [sequencer]
 blob_processing_timeout_secs = 3000

--- a/examples/demo-rollup/configs/replica_external_mock_rollup_config.toml
+++ b/examples/demo-rollup/configs/replica_external_mock_rollup_config.toml
@@ -53,8 +53,9 @@ telegraf_address = "udp://127.0.0.1:8095"
 [proof_manager]
 aggregated_proof_block_jump = 1
 prover_address = "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
-max_number_of_transitions_in_db = 100
-max_number_of_transitions_in_memory = 30
+max_number_of_transitions_in_db = 1000
+max_number_of_transitions_in_memory = 100
+max_number_of_aggregated_proofs_in_memory = 5
 
 [sequencer]
 blob_processing_timeout_secs = 3000

--- a/examples/demo-rollup/hive/mock_rollup_config.toml
+++ b/examples/demo-rollup/hive/mock_rollup_config.toml
@@ -32,8 +32,9 @@ tokio_runtime_metrics_interval_millis = 500
 [proof_manager]
 aggregated_proof_block_jump = 1
 prover_address = "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
-max_number_of_transitions_in_db = 100
-max_number_of_transitions_in_memory = 30
+max_number_of_transitions_in_db = 1000
+max_number_of_transitions_in_memory = 100
+max_number_of_aggregated_proofs_in_memory = 5
 
 [sequencer]
 blob_processing_timeout_secs = 3000

--- a/typescript/examples/soak-testing/templates/rollup.toml
+++ b/typescript/examples/soak-testing/templates/rollup.toml
@@ -22,8 +22,9 @@ telegraf_address = "127.0.0.1:8094"
 [proof_manager]
 aggregated_proof_block_jump = 1
 prover_address = "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf"
-max_number_of_transitions_in_db = 100
-max_number_of_transitions_in_memory = 20
+max_number_of_transitions_in_db = 1000
+max_number_of_transitions_in_memory = 100
+max_number_of_aggregated_proofs_in_memory = 5
 
 
 [sequencer]


### PR DESCRIPTION
# Description

This PR introduces the folloing changes:

1. Add `prover_thread_count_override: Option<NonZero<usize>>` to `ProofManagerConfig`. When `None` (default), `prover_thread_count()` keeps its previous value of `2 * aggregated_proof_block_jump + 1`; when `Some(n)`, the override is used directly.
2. Add `max_number_of_aggregated_proofs_in_memory: NonZero<usize>` to `ProofManagerConfig` and thread it through `start_zk_workflow_in_background` → `ZkProofManager`. This becomes the capacity of the intake → aggregator mpsc (previously hardcoded to 1),
   so operators can let more completed aggregation windows queue in memory before back-pressure stalls intake.                                                                                                                                                
3. Update the runner's config validation: `max_number_of_transitions_in_db & max_number_of_transitions_in_memory`                                                                                                                                                                          
4. Set `max_number_of_aggregated_proofs_in_memory = 5` in the example/demo TOMLs and test rollup builders, and bump `max_number_of_transitions_in_db`/`_in_memory` accordingly so the new validation passes.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551