### PR TITLE
Start the nightly test run at 2am UTC instead of 5am

### DIFF
--- a/.github/workflows/acceptance_test_trigger.yml
+++ b/.github/workflows/acceptance_test_trigger.yml
@@ -2,8 +2,8 @@ name: Trigger Acceptance Tests
 
 on:
   schedule:
-    # Nightly at 5am UTC
-    - cron: "0 5 * * *"
+    # Nightly at 2am UTC
+    - cron: "0 2 * * *"
   # Can be triggered manually
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
# Description

The tests take a while to run and 5am is quite a late start, especially during daylight saving hours. Right now the tests are barely completing before standup.

Also, documentation says this should correspond go the UTC timezone, but the server logs show it triggering at 6am UTC. Strange, but not a big issue - still makes it even more worthwhile to push the configured start time earlier.

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [ ] ~~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
