### PR TITLE
`sov-timelock` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-04-30
+- #2798 (Non-breaking) Adds timelock support to the SDK. To use, add the `sov-timelock` module to the runtime, override the `timelock()` accessor on `HasCapabilities`, and then override `Runtime::timelock_for_callmessage` to match `CallMessage`s and return `TimelockPolicy` for those that should be timelocked. The module supports configurable cancellation policies, including delegating to a separate cancel address. See the `sov-timelock` module README for more details. Existing rollups do not need to do anything.
+
 # 2026-04-23
 - #2693 Adds new apis for statemap iteration at `/modules/{module}/state/{map_name}/items`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5754,7 +5754,6 @@ dependencies = [
  "sov-state",
  "sov-test-modules",
  "sov-test-utils",
- "sov-timelock",
  "sov-value-setter",
  "strum 0.26.3",
  "tempfile",
@@ -13033,6 +13032,11 @@ dependencies = [
  "serde_json",
  "sov-chain-state",
  "sov-modules-api",
+ "sov-test-modules",
+ "sov-test-utils",
+ "sov-timelock",
+ "sov-value-setter",
+ "strum 0.26.3",
  "thiserror 2.0.17",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13027,7 +13027,13 @@ name = "sov-timelock"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "borsh",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "sov-chain-state",
  "sov-modules-api",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/crates/module-system/module-implementations/integration-tests/Cargo.toml
+++ b/crates/module-system/module-implementations/integration-tests/Cargo.toml
@@ -49,7 +49,6 @@ sov-attester-incentives = { workspace = true, features = ["native"] }
 sov-chain-state = { workspace = true, features = ["native"] }
 sov-value-setter = { workspace = true, features = ["native"] }
 sov-test-modules = { workspace = true, features = ["native"] }
-sov-timelock = { workspace = true, features = ["native"] }
 sov-sequencer-registry = { workspace = true, features = ["native"] }
 sov-bank = { workspace = true, features = ["native"] }
 sov-accounts = { workspace = true, features = ["native"] }

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/timelock.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/timelock.rs
@@ -1,14 +1,20 @@
 use std::num::NonZeroU64;
 
-use sov_modules_api::capabilities::TimelockPolicy;
+use sov_modules_api::capabilities::{
+    calculate_timelock_proposal_id, TimelockPolicy, TimelockProposalHashData,
+    DEFAULT_EXPIRE_SECONDS_AFTER_UNLOCK,
+};
+use sov_modules_api::da::Time;
 use sov_modules_api::prelude::UnwrapInfallible;
+use sov_modules_api::EncodeCall;
 use sov_test_modules::hooks_count::TxHooksCount;
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
 use sov_test_utils::runtime::{TestRunner, ValueSetter};
 use sov_test_utils::{
     generate_optimistic_runtime_with_kernel, AsUser, TestUser, TransactionTestCase,
 };
-use sov_value_setter::{CallMessage, ValueSetterConfig};
+use sov_timelock::{CancellationPolicy, Timelock, TimelockKey};
+use sov_value_setter::{CallMessage as ValueSetterCallMessage, ValueSetterConfig};
 
 use crate::stf_blueprint::S;
 
@@ -22,7 +28,7 @@ generate_optimistic_runtime_with_kernel!(
     ],
     timelock_policy_wrapper: |call: &TimelockRuntimeCall<S>| {
         match call {
-            TimelockRuntimeCall::ValueSetter(CallMessage::SetValue { value: 7, .. }) => {
+            TimelockRuntimeCall::ValueSetter(ValueSetterCallMessage::SetValue { value: 7, .. }) => {
                 Some(TimelockPolicy {
                     unlock_seconds_from_proposal: NonZeroU64::new(60).unwrap(),
                     expire_seconds_after_unlock_override: Some(60),
@@ -54,21 +60,30 @@ fn setup() -> (TestUser<S>, TestRunner<RT, S>) {
         (),
     );
 
-    let runner = TestRunner::new_with_genesis(genesis.into_genesis_params(), RT::default());
+    let mut runner = TestRunner::new_with_genesis(genesis.into_genesis_params(), RT::default());
+    runner.config.freeze_time = Some(Time::from_secs(1_000));
 
     (admin, runner)
+}
+
+fn set_value_message(value: u32) -> ValueSetterCallMessage<S> {
+    ValueSetterCallMessage::SetValue { value, gas: None }
+}
+
+fn set_value_proposal_id(value: u32) -> sov_modules_api::capabilities::ProposalId {
+    let encoded = <RT as EncodeCall<ValueSetter<S>>>::encode_call(set_value_message(value));
+    calculate_timelock_proposal_id::<S>(TimelockProposalHashData::CallMessage(&encoded))
 }
 
 #[test]
 fn timelocked_call_registers_proposal_without_dispatching_call() {
     let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let proposal_id = set_value_proposal_id(7);
 
     runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(CallMessage::SetValue {
-            value: 7,
-            gas: None,
-        }),
-        assert: Box::new(|result, state| {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(move |result, state| {
             assert!(result.tx_receipt.is_successful());
             assert_eq!(
                 ValueSetter::<S>::default()
@@ -84,39 +99,270 @@ fn timelocked_call_registers_proposal_without_dispatching_call() {
                     .unwrap_infallible(),
                 Some(1)
             );
+            let condition = Timelock::<S>::default()
+                .timelocks
+                .get(
+                    &TimelockKey {
+                        address: admin_address,
+                        proposal_id,
+                    },
+                    state,
+                )
+                .unwrap_infallible()
+                .unwrap();
+            assert_eq!(condition.executable_from, 1_060);
+            assert_eq!(condition.executable_until, 1_120);
         }),
     });
 }
 
 #[test]
-fn repeated_timelocked_call_still_registers_without_dispatching_call() {
+fn repeated_timelocked_call_reverts_while_locked() {
     let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let proposal_id = set_value_proposal_id(7);
 
-    for count in 1..=2 {
-        runner.execute_transaction(TransactionTestCase {
-            input: admin.create_plain_message::<RT, ValueSetter<S>>(CallMessage::SetValue {
-                value: 7,
-                gas: None,
-            }),
-            assert: Box::new(move |result, state| {
-                assert!(result.tx_receipt.is_successful());
-                assert_eq!(
-                    ValueSetter::<S>::default()
-                        .value
-                        .get(state)
-                        .unwrap_infallible(),
-                    None
-                );
-                assert_eq!(
-                    TxHooksCount::<S>::default()
-                        .post_dispatch_tx_hook_count
-                        .get(state)
-                        .unwrap_infallible(),
-                    Some(count)
-                );
-            }),
-        });
-    }
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_reverted());
+            assert_eq!(
+                ValueSetter::<S>::default()
+                    .value
+                    .get(state)
+                    .unwrap_infallible(),
+                None
+            );
+            assert_eq!(
+                TxHooksCount::<S>::default()
+                    .post_dispatch_tx_hook_count
+                    .get(state)
+                    .unwrap_infallible(),
+                Some(1)
+            );
+            assert!(Timelock::<S>::default()
+                .timelocks
+                .get(
+                    &TimelockKey {
+                        address: admin_address,
+                        proposal_id,
+                    },
+                    state
+                )
+                .unwrap_infallible()
+                .is_some());
+        }),
+    });
+}
+
+#[test]
+fn unlocked_timelocked_call_dispatches_and_consumes_proposal() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let proposal_id = set_value_proposal_id(7);
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.config.freeze_time = Some(Time::from_secs(1_060));
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(
+                ValueSetter::<S>::default()
+                    .value
+                    .get(state)
+                    .unwrap_infallible(),
+                Some(7)
+            );
+            assert_eq!(
+                TxHooksCount::<S>::default()
+                    .post_dispatch_tx_hook_count
+                    .get(state)
+                    .unwrap_infallible(),
+                Some(2)
+            );
+            assert!(Timelock::<S>::default()
+                .timelocks
+                .get(
+                    &TimelockKey {
+                        address: admin_address,
+                        proposal_id,
+                    },
+                    state
+                )
+                .unwrap_infallible()
+                .is_none());
+        }),
+    });
+}
+
+#[test]
+fn owner_can_cancel_pending_proposal() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let proposal_id = set_value_proposal_id(7);
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::CancelUnlock {
+                call_message_hash: proposal_id,
+                address: None,
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert!(Timelock::<S>::default()
+                .timelocks
+                .get(
+                    &TimelockKey {
+                        address: admin_address,
+                        proposal_id,
+                    },
+                    state
+                )
+                .unwrap_infallible()
+                .is_none());
+        }),
+    });
+}
+
+#[test]
+fn cancellation_policy_updates_are_self_timelocked_after_initial_policy() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let initial_policy = CancellationPolicy::<S> {
+        authorized_canceller: admin_address,
+        policy_change_timelock_seconds: 60,
+    };
+    let replacement_policy = CancellationPolicy::<S> {
+        authorized_canceller: admin_address,
+        policy_change_timelock_seconds: 120,
+    };
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: initial_policy.clone(),
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: replacement_policy.clone(),
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .policies
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                Some(initial_policy)
+            );
+        }),
+    });
+
+    runner.config.freeze_time = Some(Time::from_secs(1_060));
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: replacement_policy.clone(),
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .policies
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                Some(replacement_policy)
+            );
+        }),
+    });
+}
+
+#[test]
+fn cancellation_policy_update_proposals_expire_after_default_window() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let initial_policy = CancellationPolicy::<S> {
+        authorized_canceller: admin_address,
+        policy_change_timelock_seconds: 60,
+    };
+    let replacement_policy = CancellationPolicy::<S> {
+        authorized_canceller: admin_address,
+        policy_change_timelock_seconds: 120,
+    };
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: initial_policy.clone(),
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: replacement_policy.clone(),
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    let expired_proposal_time =
+        i64::try_from(1_060 + DEFAULT_EXPIRE_SECONDS_AFTER_UNLOCK + 1).unwrap();
+    runner.config.freeze_time = Some(Time::from_secs(expired_proposal_time));
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: replacement_policy,
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_reverted());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .policies
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                Some(initial_policy)
+            );
+        }),
+    });
 }
 
 #[test]
@@ -124,10 +370,7 @@ fn untimelocked_call_dispatches_normally() {
     let (admin, mut runner) = setup();
 
     runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(CallMessage::SetValue {
-            value: 8,
-            gas: None,
-        }),
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(8)),
         assert: Box::new(|result, state| {
             assert!(result.tx_receipt.is_successful());
             assert_eq!(

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/timelock.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/timelock.rs
@@ -1,34 +1,28 @@
 use std::num::NonZeroU64;
 
-use sov_modules_api::capabilities::{
-    calculate_timelock_proposal_id, TimelockPolicy, TimelockProposalHashData,
-    DEFAULT_EXPIRE_SECONDS_AFTER_UNLOCK,
-};
-use sov_modules_api::da::Time;
+use sov_modules_api::capabilities::TimelockPolicy;
 use sov_modules_api::prelude::UnwrapInfallible;
-use sov_modules_api::EncodeCall;
-use sov_test_modules::hooks_count::TxHooksCount;
+use sov_modules_api::TxEffect;
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
 use sov_test_utils::runtime::{TestRunner, ValueSetter};
 use sov_test_utils::{
     generate_optimistic_runtime_with_kernel, AsUser, TestUser, TransactionTestCase,
 };
-use sov_timelock::{CancellationPolicy, Timelock, TimelockKey};
 use sov_value_setter::{CallMessage as ValueSetterCallMessage, ValueSetterConfig};
 
 use crate::stf_blueprint::S;
 
 generate_optimistic_runtime_with_kernel!(
-    TimelockRuntime <=
+    NoopTimelockRuntime <=
     kernel_type: sov_test_utils::runtime::BasicKernel<'a, S>,
     modules: [
-        value_setter: ValueSetter<S>,
-        tx_hooks_count: TxHooksCount<S>,
-        timelock: sov_timelock::Timelock<S>
+        value_setter: ValueSetter<S>
     ],
-    timelock_policy_wrapper: |call: &TimelockRuntimeCall<S>| {
+    timelock_policy_wrapper: |call: &NoopTimelockRuntimeCall<S>| {
         match call {
-            TimelockRuntimeCall::ValueSetter(ValueSetterCallMessage::SetValue { value: 7, .. }) => {
+            NoopTimelockRuntimeCall::ValueSetter(
+                ValueSetterCallMessage::SetValue { value: 7, .. }
+            ) => {
                 Some(TimelockPolicy {
                     unlock_seconds_from_proposal: NonZeroU64::new(60).unwrap(),
                     expire_seconds_after_unlock_override: Some(60),
@@ -39,7 +33,7 @@ generate_optimistic_runtime_with_kernel!(
     },
 );
 
-type RT = TimelockRuntime<S>;
+type RT = NoopTimelockRuntime<S>;
 
 fn setup() -> (TestUser<S>, TestRunner<RT, S>) {
     let genesis_config =
@@ -56,336 +50,36 @@ fn setup() -> (TestUser<S>, TestRunner<RT, S>) {
         ValueSetterConfig {
             admin: admin.address(),
         },
-        (),
-        (),
     );
 
-    let mut runner = TestRunner::new_with_genesis(genesis.into_genesis_params(), RT::default());
-    runner.config.freeze_time = Some(Time::from_secs(1_000));
+    let runner = TestRunner::new_with_genesis(genesis.into_genesis_params(), RT::default());
 
     (admin, runner)
 }
 
-fn set_value_message(value: u32) -> ValueSetterCallMessage<S> {
-    ValueSetterCallMessage::SetValue { value, gas: None }
-}
-
-fn set_value_proposal_id(value: u32) -> sov_modules_api::capabilities::ProposalId {
-    let encoded = <RT as EncodeCall<ValueSetter<S>>>::encode_call(set_value_message(value));
-    calculate_timelock_proposal_id::<S>(TimelockProposalHashData::CallMessage(&encoded))
-}
-
 #[test]
-fn timelocked_call_registers_proposal_without_dispatching_call() {
-    let (admin, mut runner) = setup();
-    let admin_address = admin.address();
-    let proposal_id = set_value_proposal_id(7);
-
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
-        assert: Box::new(move |result, state| {
-            assert!(result.tx_receipt.is_successful());
-            assert_eq!(
-                ValueSetter::<S>::default()
-                    .value
-                    .get(state)
-                    .unwrap_infallible(),
-                None
-            );
-            assert_eq!(
-                TxHooksCount::<S>::default()
-                    .post_dispatch_tx_hook_count
-                    .get(state)
-                    .unwrap_infallible(),
-                Some(1)
-            );
-            let condition = Timelock::<S>::default()
-                .timelocks
-                .get(
-                    &TimelockKey {
-                        address: admin_address,
-                        proposal_id,
-                    },
-                    state,
-                )
-                .unwrap_infallible()
-                .unwrap();
-            assert_eq!(condition.executable_from, 1_060);
-            assert_eq!(condition.executable_until, 1_120);
-        }),
-    });
-}
-
-#[test]
-fn repeated_timelocked_call_reverts_while_locked() {
-    let (admin, mut runner) = setup();
-    let admin_address = admin.address();
-    let proposal_id = set_value_proposal_id(7);
-
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
-        assert: Box::new(|result, _state| {
-            assert!(result.tx_receipt.is_successful());
-        }),
-    });
-
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
-        assert: Box::new(move |result, state| {
-            assert!(result.tx_receipt.is_reverted());
-            assert_eq!(
-                ValueSetter::<S>::default()
-                    .value
-                    .get(state)
-                    .unwrap_infallible(),
-                None
-            );
-            assert_eq!(
-                TxHooksCount::<S>::default()
-                    .post_dispatch_tx_hook_count
-                    .get(state)
-                    .unwrap_infallible(),
-                Some(1)
-            );
-            assert!(Timelock::<S>::default()
-                .timelocks
-                .get(
-                    &TimelockKey {
-                        address: admin_address,
-                        proposal_id,
-                    },
-                    state
-                )
-                .unwrap_infallible()
-                .is_some());
-        }),
-    });
-}
-
-#[test]
-fn unlocked_timelocked_call_dispatches_and_consumes_proposal() {
-    let (admin, mut runner) = setup();
-    let admin_address = admin.address();
-    let proposal_id = set_value_proposal_id(7);
-
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
-        assert: Box::new(|result, _state| {
-            assert!(result.tx_receipt.is_successful());
-        }),
-    });
-
-    runner.config.freeze_time = Some(Time::from_secs(1_060));
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
-        assert: Box::new(move |result, state| {
-            assert!(result.tx_receipt.is_successful());
-            assert_eq!(
-                ValueSetter::<S>::default()
-                    .value
-                    .get(state)
-                    .unwrap_infallible(),
-                Some(7)
-            );
-            assert_eq!(
-                TxHooksCount::<S>::default()
-                    .post_dispatch_tx_hook_count
-                    .get(state)
-                    .unwrap_infallible(),
-                Some(2)
-            );
-            assert!(Timelock::<S>::default()
-                .timelocks
-                .get(
-                    &TimelockKey {
-                        address: admin_address,
-                        proposal_id,
-                    },
-                    state
-                )
-                .unwrap_infallible()
-                .is_none());
-        }),
-    });
-}
-
-#[test]
-fn owner_can_cancel_pending_proposal() {
-    let (admin, mut runner) = setup();
-    let admin_address = admin.address();
-    let proposal_id = set_value_proposal_id(7);
-
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
-        assert: Box::new(|result, _state| {
-            assert!(result.tx_receipt.is_successful());
-        }),
-    });
-
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, Timelock<S>>(
-            sov_timelock::CallMessage::CancelUnlock {
-                call_message_hash: proposal_id,
-                address: None,
-            },
-        ),
-        assert: Box::new(move |result, state| {
-            assert!(result.tx_receipt.is_successful());
-            assert!(Timelock::<S>::default()
-                .timelocks
-                .get(
-                    &TimelockKey {
-                        address: admin_address,
-                        proposal_id,
-                    },
-                    state
-                )
-                .unwrap_infallible()
-                .is_none());
-        }),
-    });
-}
-
-#[test]
-fn cancellation_policy_updates_are_self_timelocked_after_initial_policy() {
-    let (admin, mut runner) = setup();
-    let admin_address = admin.address();
-    let initial_policy = CancellationPolicy::<S> {
-        authorized_canceller: admin_address,
-        policy_change_timelock_seconds: 60,
-    };
-    let replacement_policy = CancellationPolicy::<S> {
-        authorized_canceller: admin_address,
-        policy_change_timelock_seconds: 120,
-    };
-
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, Timelock<S>>(
-            sov_timelock::CallMessage::ModifyCancellationPolicy {
-                new_policy: initial_policy.clone(),
-            },
-        ),
-        assert: Box::new(|result, _state| {
-            assert!(result.tx_receipt.is_successful());
-        }),
-    });
-
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, Timelock<S>>(
-            sov_timelock::CallMessage::ModifyCancellationPolicy {
-                new_policy: replacement_policy.clone(),
-            },
-        ),
-        assert: Box::new(move |result, state| {
-            assert!(result.tx_receipt.is_successful());
-            assert_eq!(
-                Timelock::<S>::default()
-                    .policies
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
-                Some(initial_policy)
-            );
-        }),
-    });
-
-    runner.config.freeze_time = Some(Time::from_secs(1_060));
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, Timelock<S>>(
-            sov_timelock::CallMessage::ModifyCancellationPolicy {
-                new_policy: replacement_policy.clone(),
-            },
-        ),
-        assert: Box::new(move |result, state| {
-            assert!(result.tx_receipt.is_successful());
-            assert_eq!(
-                Timelock::<S>::default()
-                    .policies
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
-                Some(replacement_policy)
-            );
-        }),
-    });
-}
-
-#[test]
-fn cancellation_policy_update_proposals_expire_after_default_window() {
-    let (admin, mut runner) = setup();
-    let admin_address = admin.address();
-    let initial_policy = CancellationPolicy::<S> {
-        authorized_canceller: admin_address,
-        policy_change_timelock_seconds: 60,
-    };
-    let replacement_policy = CancellationPolicy::<S> {
-        authorized_canceller: admin_address,
-        policy_change_timelock_seconds: 120,
-    };
-
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, Timelock<S>>(
-            sov_timelock::CallMessage::ModifyCancellationPolicy {
-                new_policy: initial_policy.clone(),
-            },
-        ),
-        assert: Box::new(|result, _state| {
-            assert!(result.tx_receipt.is_successful());
-        }),
-    });
-
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, Timelock<S>>(
-            sov_timelock::CallMessage::ModifyCancellationPolicy {
-                new_policy: replacement_policy.clone(),
-            },
-        ),
-        assert: Box::new(|result, _state| {
-            assert!(result.tx_receipt.is_successful());
-        }),
-    });
-
-    let expired_proposal_time =
-        i64::try_from(1_060 + DEFAULT_EXPIRE_SECONDS_AFTER_UNLOCK + 1).unwrap();
-    runner.config.freeze_time = Some(Time::from_secs(expired_proposal_time));
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, Timelock<S>>(
-            sov_timelock::CallMessage::ModifyCancellationPolicy {
-                new_policy: replacement_policy,
-            },
-        ),
-        assert: Box::new(move |result, state| {
-            assert!(result.tx_receipt.is_reverted());
-            assert_eq!(
-                Timelock::<S>::default()
-                    .policies
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
-                Some(initial_policy)
-            );
-        }),
-    });
-}
-
-#[test]
-fn untimelocked_call_dispatches_normally() {
+fn timelocked_call_is_rejected_when_timelock_capability_is_unavailable() {
     let (admin, mut runner) = setup();
 
     runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(8)),
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(ValueSetterCallMessage::SetValue {
+            value: 7,
+            gas: None,
+        }),
         assert: Box::new(|result, state| {
-            assert!(result.tx_receipt.is_successful());
+            let TxEffect::Reverted(contents) = &result.tx_receipt else {
+                panic!("expected reverted transaction, got {:?}", result.tx_receipt);
+            };
+            assert!(contents
+                .reason
+                .to_string()
+                .contains("Timelocks are not available"));
             assert_eq!(
                 ValueSetter::<S>::default()
                     .value
                     .get(state)
                     .unwrap_infallible(),
-                Some(8)
-            );
-            assert_eq!(
-                TxHooksCount::<S>::default()
-                    .post_dispatch_tx_hook_count
-                    .get(state)
-                    .unwrap_infallible(),
-                Some(1)
+                None
             );
         }),
     });

--- a/crates/module-system/module-implementations/sov-timelock/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-timelock/Cargo.toml
@@ -15,7 +15,13 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+borsh = { workspace = true, features = ["rc"] }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sov-chain-state = { workspace = true }
 sov-modules-api = { workspace = true }
+thiserror = { workspace = true }
 
 [features]
 default = []

--- a/crates/module-system/module-implementations/sov-timelock/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-timelock/Cargo.toml
@@ -23,7 +23,14 @@ sov-chain-state = { workspace = true }
 sov-modules-api = { workspace = true }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+sov-test-modules = { workspace = true, features = ["native"] }
+sov-test-utils = { workspace = true }
+sov-timelock = { path = ".", version = "*", features = ["native"] }
+sov-value-setter = { workspace = true, features = ["native"] }
+strum = { workspace = true }
+
 [features]
 default = []
 arbitrary = ["sov-modules-api/arbitrary"]
-native = ["sov-modules-api/native"]
+native = ["sov-chain-state/native", "sov-modules-api/native"]

--- a/crates/module-system/module-implementations/sov-timelock/Cargo.toml
+++ b/crates/module-system/module-implementations/sov-timelock/Cargo.toml
@@ -32,5 +32,15 @@ strum = { workspace = true }
 
 [features]
 default = []
-arbitrary = ["sov-modules-api/arbitrary"]
-native = ["sov-chain-state/native", "sov-modules-api/native"]
+arbitrary = [
+	"sov-modules-api/arbitrary",
+	"sov-test-utils/arbitrary",
+	"sov-timelock/arbitrary"
+]
+native = [
+	"sov-chain-state/native",
+	"sov-modules-api/native",
+	"sov-test-modules/native",
+	"sov-timelock/native",
+	"sov-value-setter/native"
+]

--- a/crates/module-system/module-implementations/sov-timelock/README.md
+++ b/crates/module-system/module-implementations/sov-timelock/README.md
@@ -6,3 +6,246 @@ The module stores pending proposals by owner and proposal id, exposes runtime
 capability methods for registering and unlocking proposals, and provides
 user-callable messages for cancelling proposals and modifying cancellation
 policies.
+
+## Runtime Integration
+
+Add `sov_timelock::Timelock` to the runtime, return it from the runtime's
+timelock capability accessor, and implement `timelock_for_callmessage` for the
+runtime calls that must be delayed.
+
+```rust,ignore
+use std::num::NonZeroU64;
+
+use sov_modules_api::capabilities::{TimelockCapability, TimelockPolicy};
+use sov_modules_api::Spec;
+
+pub struct Runtime<S: Spec> {
+    pub admin: my_admin_module::Admin<S>,
+    pub timelock: sov_timelock::Timelock<S>,
+    // Other modules...
+}
+
+impl<S: Spec> sov_modules_api::capabilities::HasCapabilities<S> for Runtime<S> {
+    // Existing capability implementation omitted.
+
+    fn timelock(&mut self) -> impl TimelockCapability<S> {
+        &mut self.timelock
+    }
+}
+
+impl<S: Spec> sov_modules_stf_blueprint::Runtime<S> for Runtime<S> {
+    // Other associated types and methods omitted.
+
+    fn timelock_for_callmessage(&self, call: &Self::Decodable) -> Option<TimelockPolicy> {
+        match call {
+            RuntimeCall::Admin(my_admin_module::CallMessage::RotateAdmin { .. }) => {
+                Some(TimelockPolicy {
+                    unlock_seconds_from_proposal: NonZeroU64::new(24 * 60 * 60).unwrap(),
+                    expire_seconds_after_unlock_override: None,
+                })
+            }
+            _ => None,
+        }
+    }
+}
+```
+
+If a runtime returns a timelock policy but does not provide a concrete timelock
+capability, the transaction is rejected with `TimelocksNotAvailable`. This keeps
+timelocks opt-in for runtimes that do not include `sov-timelock`.
+
+## Module-Owned Timelocks
+
+Modules may also depend directly on `sov-timelock` and enforce their own
+timelocks internally, instead of asking the runtime to match on their call
+messages in `timelock_for_callmessage`. This is useful when the timelock is a
+module invariant rather than a rollup-level policy. `sov-timelock` uses this
+pattern for `ModifyCancellationPolicy`.
+
+The module should encode the operation it wants to protect, wrap those bytes with
+`TimelockProposalData::custom_data(module_id, bytes)`, and call
+`register_or_try_unlock_proposal`. If the outcome is `Registered`, the module
+returns without applying the protected action. If the outcome is `Unlocked`, the
+module applies the action. The timelock module must still be part of the
+runtime; the dependent module takes a module reference to it with `#[module]`.
+
+```rust,no_run
+use std::num::NonZeroU64;
+
+use schemars::JsonSchema;
+use sov_modules_api::capabilities::{
+    TimelockCapability, TimelockPolicy, TimelockProposalData, TimelockProposalOutcome,
+};
+use sov_modules_api::macros::{serialize, UniversalWallet};
+use sov_modules_api::{
+    Context, CoreModuleError, Module, ModuleId, ModuleInfo, Spec, StateValue, TxState,
+};
+
+#[derive(Clone, ModuleInfo)]
+pub struct ExampleModule<S: Spec> {
+    #[id]
+    pub id: ModuleId,
+
+    #[state]
+    pub setup_mode_terminated: StateValue<bool>,
+
+    #[module]
+    pub timelock: sov_timelock::Timelock<S>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, JsonSchema, UniversalWallet)]
+#[serialize(Borsh, Serde)]
+pub enum CallMessage {
+    TerminateSetupMode {},
+}
+
+impl<S: Spec> Module for ExampleModule<S> {
+    type Spec = S;
+    type Config = ();
+    type CallMessage = CallMessage;
+    type Event = ();
+    type Error = sov_modules_api::Error;
+
+    fn call(
+        &mut self,
+        msg: Self::CallMessage,
+        context: &Context<S>,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), Self::Error> {
+        match msg {
+            CallMessage::TerminateSetupMode {} => self.terminate_setup_mode(context, state),
+        }
+    }
+}
+
+impl<S: Spec> ExampleModule<S> {
+    fn terminate_setup_mode(
+        &mut self,
+        context: &Context<S>,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), sov_modules_api::Error> {
+        let encoded_message = borsh::to_vec(&CallMessage::TerminateSetupMode {})
+            .map_err(|error| CoreModuleError::Generic(anyhow::anyhow!(error)))?;
+        let proposal_data = TimelockProposalData::custom_data(self.id, encoded_message);
+
+        let outcome = self.timelock.register_or_try_unlock_proposal(
+            context.sender(),
+            proposal_data,
+            TimelockPolicy {
+                unlock_seconds_from_proposal: NonZeroU64::new(24 * 60 * 60).unwrap(),
+                expire_seconds_after_unlock_override: None,
+            },
+            state,
+        )?;
+
+        match outcome {
+            TimelockProposalOutcome::Registered => {}
+            TimelockProposalOutcome::Unlocked => {
+                self.setup_mode_terminated
+                    .set(&true, state)
+                    .map_err(CoreModuleError::state_write)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+```
+
+The `CustomData` domain is separated from runtime call-message proposal data, so
+module-owned proposal ids cannot collide with runtime-managed timelocks.
+
+## Duplicate Proposals
+
+Simultaneous duplicate proposals are not supported. Proposals are keyed by
+`(owner_address, proposal_id)`, and the proposal id is derived from the encoded
+call message or module-owned custom proposal data. If the same owner submits the
+same timelocked call while it is already pending, the module treats it as an
+attempt to unlock the existing proposal, not as a request to create another one.
+
+Modules that need multiple simultaneous timelocks for otherwise identical
+actions should make their call messages intentionally malleable, for example by
+including a meaningless `nonce` or `salt` field purely to produce a distinct
+proposal hash.
+
+## Transaction UX
+
+For a timelocked runtime call, the proposal id is the hash of the encoded
+`Runtime::CallMessage`, not the hash of the raw transaction. Users submit the
+same call message twice, usually in two distinct signed transactions with fresh
+nonce or uniqueness metadata:
+
+1. The first transaction registers the call as a pending proposal and does not
+   dispatch the underlying call.
+2. A repeat transaction before the unlock time is rejected as still locked.
+3. A repeat transaction after the unlock time dispatches the underlying call and
+   consumes the proposal.
+4. A repeat transaction after the expiry window is rejected as expired. Expired
+   proposals can be removed with `CleanExpiredProposals`.
+
+```rust,ignore
+use sov_modules_api::capabilities::{
+    calculate_timelock_proposal_id, TimelockProposalData,
+};
+use sov_modules_api::EncodeCall;
+
+let call = RuntimeCall::Admin(my_admin_module::CallMessage::RotateAdmin {
+    new_admin,
+});
+
+let proposal_id = calculate_timelock_proposal_id::<S>(
+    &TimelockProposalData::call_message(Runtime::<S>::encode(&call)),
+);
+
+submit_transaction(call.clone()); // Registers the proposal.
+wait_until_unlock_time();
+submit_transaction(call); // Executes and consumes the proposal.
+```
+
+The default post-unlock expiry window is two days. A runtime policy can override
+that window with `expire_seconds_after_unlock_override`.
+
+## Cancelling Proposals
+
+The proposal owner can cancel a pending proposal by passing `address: None`.
+
+```rust,ignore
+let cancel = RuntimeCall::Timelock(sov_timelock::CallMessage::CancelProposal {
+    proposal_id,
+    address: None,
+});
+
+submit_transaction(cancel);
+```
+
+An authorized canceller can cancel on behalf of the owner by passing the owner's
+address explicitly.
+
+```rust,ignore
+let cancel = RuntimeCall::Timelock(sov_timelock::CallMessage::CancelProposal {
+    proposal_id,
+    address: Some(owner_address),
+});
+
+submit_transaction(cancel);
+```
+
+Users configure that authorized canceller with `ModifyCancellationPolicy`.
+
+```rust,ignore
+let update_policy =
+    RuntimeCall::Timelock(sov_timelock::CallMessage::ModifyCancellationPolicy {
+        new_policy: sov_timelock::CancellationPolicy {
+            authorized_canceller,
+            policy_change_timelock_seconds: 60 * 60,
+        },
+    });
+
+submit_transaction(update_policy);
+```
+
+If the current policy has `policy_change_timelock_seconds == 0`, the update is
+applied immediately. Otherwise, the policy update is itself timelocked: submit
+the same `ModifyCancellationPolicy` call once to register the update, then submit
+it again after the policy-change delay to apply it. Policy update proposals use
+the default expiry window.

--- a/crates/module-system/module-implementations/sov-timelock/README.md
+++ b/crates/module-system/module-implementations/sov-timelock/README.md
@@ -1,3 +1,8 @@
 # `sov-timelock`
 
-Minimal timelock capability module for Sovereign SDK runtimes.
+Timelock capability module for Sovereign SDK runtimes.
+
+The module stores pending proposals by owner and proposal id, exposes runtime
+capability methods for registering and unlocking proposals, and provides
+user-callable messages for cancelling proposals and modifying cancellation
+policies.

--- a/crates/module-system/module-implementations/sov-timelock/src/call.rs
+++ b/crates/module-system/module-implementations/sov-timelock/src/call.rs
@@ -1,0 +1,206 @@
+use std::num::NonZeroU64;
+
+use schemars::JsonSchema;
+use sov_modules_api::capabilities::{
+    ProposalId, TimelockCapability, TimelockError, TimelockPolicy, TimelockProposalData,
+    TimelockProposalOutcome,
+};
+use sov_modules_api::macros::{serialize, UniversalWallet};
+use sov_modules_api::{
+    Context, CoreModuleError, Error as ModuleError, EventEmitter, SafeVec, Spec, TxState,
+};
+
+use crate::{
+    CancellationPolicy, Error, Event, ProposalKey, Timelock, MAX_PROPOSAL_KEYS_PER_CLEANUP,
+};
+
+/// Calls supported by the timelock module.
+#[derive(Debug, PartialEq, Eq, Clone, JsonSchema, UniversalWallet)]
+#[serialize(Borsh, Serde)]
+#[serde(bound = "S: Spec")]
+#[schemars(bound = "S::Address: ::schemars::JsonSchema", rename = "CallMessage")]
+#[serde(rename_all = "snake_case")]
+pub enum CallMessage<S: Spec> {
+    /// Cancel a pending proposal.
+    CancelProposal {
+        /// Proposal id to cancel.
+        proposal_id: ProposalId,
+        /// Owner address. If absent, the sender is treated as the owner.
+        address: Option<S::Address>,
+    },
+    /// Modify the sender's cancellation policy.
+    ModifyCancellationPolicy {
+        /// New cancellation policy.
+        new_policy: CancellationPolicy<S>,
+    },
+    /// Clean expired proposals.
+    CleanExpiredProposals {
+        /// Proposal keys to clean.
+        proposal_keys: SafeVec<ProposalKey<S>, MAX_PROPOSAL_KEYS_PER_CLEANUP>,
+    },
+}
+
+impl<S: Spec> Timelock<S> {
+    pub(super) fn cancel_proposal(
+        &mut self,
+        proposal_id: ProposalId,
+        address: Option<S::Address>,
+        context: &Context<S>,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), Error<S>> {
+        let address = address.unwrap_or(*context.sender());
+        let key = ProposalKey::new(address, proposal_id);
+        let Some(pending_proposal) = self
+            .proposals
+            .get(&key, state)
+            .map_err(CoreModuleError::state_read)?
+        else {
+            return Err(TimelockError::ProposalNotFound.into());
+        };
+
+        if context.sender() != &address
+            && context.sender()
+                != &pending_proposal
+                    .unlock_condition
+                    .cancellation_policy
+                    .authorized_canceller
+        {
+            return Err(Error::UnauthorizedCanceller {
+                sender: *context.sender(),
+                address,
+                authorized_canceller: pending_proposal
+                    .unlock_condition
+                    .cancellation_policy
+                    .authorized_canceller,
+                proposal_id,
+            });
+        }
+
+        self.delete_proposal(&key, state)?;
+        self.emit_event(
+            state,
+            Event::ProposalCancelled {
+                address,
+                proposal_id,
+                cancelled_by: *context.sender(),
+            },
+        );
+        Ok(())
+    }
+
+    pub(super) fn clean_expired_proposals(
+        &mut self,
+        proposal_keys: SafeVec<ProposalKey<S>, MAX_PROPOSAL_KEYS_PER_CLEANUP>,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), Error<S>> {
+        let current_time = self.current_time_secs(state)?;
+        for key in proposal_keys {
+            let mut attempt_state = state.to_revertable();
+            match self.clean_expired_proposal(&key, current_time, &mut attempt_state) {
+                Ok(()) => {
+                    attempt_state.commit();
+                }
+                Err(Error::Timelock(TimelockError::ProposalNotFound))
+                | Err(Error::ProposalNotExpired { .. }) => {
+                    attempt_state.revert();
+                }
+                Err(error) => {
+                    attempt_state.revert();
+                    return Err(error);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn clean_expired_proposal(
+        &mut self,
+        key: &ProposalKey<S>,
+        current_time: u64,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), Error<S>> {
+        let Some(pending_proposal) = self
+            .proposals
+            .get(key, state)
+            .map_err(CoreModuleError::state_read)?
+        else {
+            return Err(TimelockError::ProposalNotFound.into());
+        };
+
+        if current_time <= pending_proposal.unlock_condition.executable_until {
+            return Err(Error::ProposalNotExpired {
+                proposal_key: key.clone(),
+                current_time,
+                executable_until: pending_proposal.unlock_condition.executable_until,
+            });
+        }
+
+        self.delete_proposal(key, state)?;
+        self.emit_event(
+            state,
+            Event::ExpiredProposalCleaned {
+                address: key.0,
+                proposal_id: key.1,
+            },
+        );
+
+        Ok(())
+    }
+
+    pub(super) fn modify_cancellation_policy(
+        &mut self,
+        new_policy: CancellationPolicy<S>,
+        context: &Context<S>,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), ModuleError> {
+        let current_policy = self
+            .cancellation_policy(context.sender(), state)
+            .map_err(ModuleError::from)?;
+        let Some(policy_change_timelock_seconds) =
+            NonZeroU64::new(current_policy.policy_change_timelock_seconds)
+        else {
+            self.policies
+                .set(context.sender(), &new_policy, state)
+                .map_err(CoreModuleError::state_write)
+                .map_err(ModuleError::from)?;
+            return Ok(());
+        };
+
+        let proposal_data = self
+            .policy_update_proposal_data(&new_policy)
+            .map_err(ModuleError::from)?;
+        let policy = TimelockPolicy {
+            unlock_seconds_from_proposal: policy_change_timelock_seconds,
+            expire_seconds_after_unlock_override: None,
+        };
+        match self.register_or_try_unlock_proposal(
+            context.sender(),
+            proposal_data,
+            policy,
+            state,
+        )? {
+            TimelockProposalOutcome::Registered => {}
+            TimelockProposalOutcome::Unlocked => {
+                self.policies
+                    .set(context.sender(), &new_policy, state)
+                    .map_err(CoreModuleError::state_write)
+                    .map_err(ModuleError::from)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn policy_update_proposal_data(
+        &self,
+        new_policy: &CancellationPolicy<S>,
+    ) -> Result<TimelockProposalData, Error<S>> {
+        let encoded_message = borsh::to_vec(&CallMessage::ModifyCancellationPolicy {
+            new_policy: new_policy.clone(),
+        })
+        .map_err(|error| CoreModuleError::Generic(anyhow::anyhow!(error)))?;
+
+        Ok(TimelockProposalData::custom_data(self.id, encoded_message))
+    }
+}

--- a/crates/module-system/module-implementations/sov-timelock/src/call.rs
+++ b/crates/module-system/module-implementations/sov-timelock/src/call.rs
@@ -95,20 +95,7 @@ impl<S: Spec> Timelock<S> {
     ) -> Result<(), Error<S>> {
         let current_time = self.current_time_secs(state)?;
         for key in proposal_keys {
-            let mut attempt_state = state.to_revertable();
-            match self.clean_expired_proposal(&key, current_time, &mut attempt_state) {
-                Ok(()) => {
-                    attempt_state.commit();
-                }
-                Err(Error::Timelock(TimelockError::ProposalNotFound))
-                | Err(Error::ProposalNotExpired { .. }) => {
-                    attempt_state.revert();
-                }
-                Err(error) => {
-                    attempt_state.revert();
-                    return Err(error);
-                }
-            }
+            self.clean_expired_proposal(&key, current_time, state)?;
         }
 
         Ok(())

--- a/crates/module-system/module-implementations/sov-timelock/src/error.rs
+++ b/crates/module-system/module-implementations/sov-timelock/src/error.rs
@@ -1,0 +1,98 @@
+use sov_modules_api::capabilities::{ProposalId, TimelockError};
+use sov_modules_api::{err_detail, CoreModuleError, ErrorContext, ErrorDetail, Spec};
+
+use crate::ProposalKey;
+
+/// Errors returned by the timelock module.
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[serde(
+    tag = "error_code",
+    rename_all = "snake_case",
+    bound = "S::Address: serde::Serialize"
+)]
+pub enum Error<S: Spec> {
+    /// A core module error occurred.
+    #[error(transparent)]
+    Core(#[from] CoreModuleError),
+    /// A timelock semantic error occurred.
+    #[error(transparent)]
+    Timelock(#[from] TimelockError),
+    /// The proposal already exists.
+    #[error("Proposal {proposal_id} already exists for address {address}")]
+    ProposalAlreadyExists {
+        /// Proposal owner.
+        address: S::Address,
+        /// Existing proposal id.
+        proposal_id: ProposalId,
+    },
+    /// The proposal owner already has the maximum number of pending proposals.
+    #[error(
+        "Address {address} already has the maximum of {max_pending_proposals} pending proposals"
+    )]
+    MaxPendingProposalsReached {
+        /// Proposal owner.
+        address: S::Address,
+        /// Maximum pending proposals per address.
+        max_pending_proposals: u32,
+    },
+    /// The proposal counter is inconsistent with the proposal map.
+    #[error(
+        "Proposal count for address {address} is inconsistent while deleting proposal {proposal_id}"
+    )]
+    ProposalCountUnderflow {
+        /// Proposal owner.
+        address: S::Address,
+        /// Proposal id being deleted.
+        proposal_id: ProposalId,
+    },
+    /// The proposal exists but has not expired yet.
+    #[error(
+        "Proposal {proposal_key} is not expired at current time {current_time}; executable until {executable_until}"
+    )]
+    ProposalNotExpired {
+        /// Proposal key.
+        proposal_key: ProposalKey<S>,
+        /// Current chain time in seconds.
+        current_time: u64,
+        /// Unix timestamp after which the proposal is expired.
+        executable_until: u64,
+    },
+    /// The sender is not authorized to cancel the proposal.
+    #[error(
+        "Address {sender} is not authorized to cancel proposal {proposal_id} for {address}; authorized canceller is {authorized_canceller}"
+    )]
+    UnauthorizedCanceller {
+        /// Transaction sender.
+        sender: S::Address,
+        /// Proposal owner.
+        address: S::Address,
+        /// Address authorized by the proposal's cancellation policy.
+        authorized_canceller: S::Address,
+        /// Proposal id.
+        proposal_id: ProposalId,
+    },
+    /// The current chain time is negative.
+    #[error("Current chain time {current_time} is before the Unix epoch")]
+    InvalidCurrentTime {
+        /// Current chain time in seconds.
+        current_time: i64,
+    },
+    /// Computing an unlock timestamp overflowed.
+    #[error(
+        "Timestamp overflow while computing unlock condition from current time {current_time}"
+    )]
+    TimestampOverflow {
+        /// Current chain time in seconds.
+        current_time: u64,
+    },
+}
+
+impl<S> ErrorDetail for Error<S>
+where
+    S: Spec,
+    S::Address: serde::Serialize,
+{
+    fn error_detail(&self) -> Result<ErrorContext, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(err_detail!(self))
+    }
+}

--- a/crates/module-system/module-implementations/sov-timelock/src/event.rs
+++ b/crates/module-system/module-implementations/sov-timelock/src/event.rs
@@ -1,0 +1,48 @@
+use schemars::JsonSchema;
+use sov_modules_api::capabilities::{ProposalId, TimelockProposalData};
+use sov_modules_api::macros::serialize;
+use sov_modules_api::Spec;
+
+/// Events emitted by the timelock module.
+#[derive(Debug, PartialEq, Eq, Clone, JsonSchema)]
+#[serialize(Borsh, Serde)]
+#[serde(bound = "S: Spec", rename_all = "snake_case")]
+#[schemars(bound = "S::Address: ::schemars::JsonSchema", rename = "Event")]
+pub enum Event<S: Spec> {
+    /// A proposal was registered and is pending unlock.
+    ProposalRegistered {
+        /// Proposal owner.
+        address: S::Address,
+        /// Proposal id.
+        proposal_id: ProposalId,
+        /// Full proposal data whose hash is the proposal id.
+        proposal_data: TimelockProposalData,
+        /// Unix timestamp at which the proposal becomes executable.
+        executable_from: u64,
+        /// Unix timestamp after which the proposal is expired.
+        executable_until: u64,
+    },
+    /// A proposal was unlocked and consumed for execution.
+    ProposalUnlocked {
+        /// Proposal owner.
+        address: S::Address,
+        /// Proposal id.
+        proposal_id: ProposalId,
+    },
+    /// A pending proposal was cancelled.
+    ProposalCancelled {
+        /// Proposal owner.
+        address: S::Address,
+        /// Proposal id.
+        proposal_id: ProposalId,
+        /// Address that cancelled the proposal.
+        cancelled_by: S::Address,
+    },
+    /// An expired proposal was cleaned.
+    ExpiredProposalCleaned {
+        /// Proposal owner.
+        address: S::Address,
+        /// Proposal id.
+        proposal_id: ProposalId,
+    },
+}

--- a/crates/module-system/module-implementations/sov-timelock/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-timelock/src/lib.rs
@@ -3,22 +3,249 @@
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
 
+use std::fmt::{Display, Formatter};
+use std::num::NonZeroU64;
+use std::str::FromStr;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use schemars::JsonSchema;
 use sov_modules_api::capabilities::{
-    ProposalId, TimelockCapability, TimelockError, TimelockPolicy,
+    calculate_timelock_proposal_id_metered, ProposalId, TimelockCapability, TimelockError,
+    TimelockPolicy, TimelockProposalHashData,
 };
+use sov_modules_api::macros::{serialize, UniversalWallet};
 use sov_modules_api::{
-    Context, DaSpec, Error, GenesisState, Module, ModuleId, ModuleInfo, ModuleRestApi,
-    NotInstantiable, Spec, TxState,
+    err_detail, Context, CoreModuleError, DaSpec, Error as ModuleError, ErrorContext, ErrorDetail,
+    GenesisState, Module, ModuleId, ModuleInfo, ModuleRestApi, Spec, StateMap, TxState,
 };
 
-/// Timelock module.
+/// Planned upper bound for per-address timelocks.
 ///
-/// The initial MVP exposes the timelock capability interface without storing proposals.
+/// This is not enforced by the two-map MVP because enforcing it efficiently requires
+/// tracking a per-address count or index.
+pub const MAX_USER_TIMELOCKS: u32 = 100;
+
+const TIMELOCK_KEY_PREFIX: &str = "addresses/";
+const TIMELOCK_KEY_SEPARATOR: &str = "/timelocks/";
+
+/// Storage key for a timelock proposal.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    BorshDeserialize,
+    BorshSerialize,
+    serde::Serialize,
+    serde::Deserialize,
+    JsonSchema,
+)]
+#[serde(bound = "S: Spec", deny_unknown_fields)]
+#[schemars(bound = "S::Address: ::schemars::JsonSchema", rename = "TimelockKey")]
+pub struct TimelockKey<S: Spec> {
+    /// Proposal owner.
+    pub address: S::Address,
+    /// Proposal id.
+    pub proposal_id: ProposalId,
+}
+
+impl<S: Spec> TimelockKey<S> {
+    fn new(address: S::Address, proposal_id: ProposalId) -> Self {
+        Self {
+            address,
+            proposal_id,
+        }
+    }
+}
+
+impl<S: Spec> Display for TimelockKey<S> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{TIMELOCK_KEY_PREFIX}{}{TIMELOCK_KEY_SEPARATOR}{}",
+            self.address, self.proposal_id
+        )
+    }
+}
+
+impl<S> FromStr for TimelockKey<S>
+where
+    S: Spec,
+    S::Address: FromStr<Err: Into<Box<dyn std::error::Error + Send + Sync + 'static>>>,
+{
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let Some(s) = s.strip_prefix(TIMELOCK_KEY_PREFIX) else {
+            anyhow::bail!("{s} is not a timelock key: missing '{TIMELOCK_KEY_PREFIX}' prefix");
+        };
+        let Some((address, proposal_id)) = s.rsplit_once(TIMELOCK_KEY_SEPARATOR) else {
+            anyhow::bail!(
+                "{s} is not a timelock key: missing '{TIMELOCK_KEY_SEPARATOR}' separator"
+            );
+        };
+
+        Ok(Self {
+            address: S::Address::from_str(address)
+                .map_err(|error| anyhow::Error::from_boxed(error.into()))?,
+            proposal_id: ProposalId::from_str(proposal_id)?,
+        })
+    }
+}
+
+/// Cancellation rules for proposals owned by an address.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    BorshDeserialize,
+    BorshSerialize,
+    serde::Serialize,
+    serde::Deserialize,
+    JsonSchema,
+    UniversalWallet,
+)]
+#[serde(bound = "S: Spec", deny_unknown_fields)]
+#[schemars(
+    bound = "S::Address: ::schemars::JsonSchema",
+    rename = "CancellationPolicy"
+)]
+pub struct CancellationPolicy<S: Spec> {
+    /// Address allowed to cancel proposals for this account when the cancel call specifies an owner.
+    pub authorized_canceller: S::Address,
+    /// Delay before policy updates take effect.
+    pub policy_change_timelock_seconds: u64,
+}
+
+/// Stored unlock condition for a pending proposal.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    BorshDeserialize,
+    BorshSerialize,
+    serde::Serialize,
+    serde::Deserialize,
+    JsonSchema,
+)]
+#[serde(bound = "S: Spec", deny_unknown_fields)]
+#[schemars(
+    bound = "S::Address: ::schemars::JsonSchema",
+    rename = "UnlockCondition"
+)]
+pub struct UnlockCondition<S: Spec> {
+    /// Unix timestamp at which the proposal becomes executable.
+    pub executable_from: u64,
+    /// Unix timestamp after which the proposal is expired.
+    pub executable_until: u64,
+    /// Cancellation policy snapshotted when the proposal was created.
+    pub cancellation_policy: CancellationPolicy<S>,
+}
+
+/// Calls supported by the timelock module.
+#[derive(Debug, PartialEq, Eq, Clone, JsonSchema, UniversalWallet)]
+#[serialize(Borsh, Serde)]
+#[serde(bound = "S: Spec")]
+#[schemars(bound = "S::Address: ::schemars::JsonSchema", rename = "CallMessage")]
+#[serde(rename_all = "snake_case")]
+pub enum CallMessage<S: Spec> {
+    /// Cancel a pending unlock.
+    CancelUnlock {
+        /// Proposal id to cancel.
+        call_message_hash: ProposalId,
+        /// Owner address. If absent, the sender is treated as the owner.
+        address: Option<S::Address>,
+    },
+    /// Modify the sender's cancellation policy.
+    ModifyCancellationPolicy {
+        /// New cancellation policy.
+        new_policy: CancellationPolicy<S>,
+    },
+}
+
+/// Errors returned by the timelock module.
+#[derive(Debug, thiserror::Error, serde::Serialize)]
+#[serde(
+    tag = "error_code",
+    rename_all = "snake_case",
+    bound = "S::Address: serde::Serialize"
+)]
+pub enum Error<S: Spec> {
+    /// A core module error occurred.
+    #[error(transparent)]
+    Core(#[from] CoreModuleError),
+    /// A timelock semantic error occurred.
+    #[error(transparent)]
+    Timelock(#[from] TimelockError),
+    /// The proposal already exists.
+    #[error("Timelock proposal {proposal_id} already exists for address {address}")]
+    ProposalAlreadyExists {
+        /// Proposal owner.
+        address: S::Address,
+        /// Existing proposal id.
+        proposal_id: ProposalId,
+    },
+    /// The sender is not authorized to cancel the proposal.
+    #[error(
+        "Address {sender} is not authorized to cancel timelock proposal {proposal_id} for {address}; authorized canceller is {authorized_canceller}"
+    )]
+    UnauthorizedCanceller {
+        /// Transaction sender.
+        sender: S::Address,
+        /// Proposal owner.
+        address: S::Address,
+        /// Address authorized by the proposal's cancellation policy.
+        authorized_canceller: S::Address,
+        /// Proposal id.
+        proposal_id: ProposalId,
+    },
+    /// The current chain time is negative.
+    #[error("Current chain time {current_time} is before the Unix epoch")]
+    InvalidCurrentTime {
+        /// Current chain time in seconds.
+        current_time: i64,
+    },
+    /// Computing an unlock timestamp overflowed.
+    #[error(
+        "Timestamp overflow while computing unlock condition from current time {current_time}"
+    )]
+    TimestampOverflow {
+        /// Current chain time in seconds.
+        current_time: u64,
+    },
+}
+
+impl<S> ErrorDetail for Error<S>
+where
+    S: Spec,
+    S::Address: serde::Serialize,
+{
+    fn error_detail(&self) -> Result<ErrorContext, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(err_detail!(self))
+    }
+}
+
+/// Timelock module.
 #[derive(Clone, ModuleInfo, ModuleRestApi)]
 pub struct Timelock<S: Spec> {
     /// The ID of the sov-timelock module.
     #[id]
     pub id: ModuleId,
+
+    /// Pending timelock proposals.
+    #[state]
+    pub timelocks: StateMap<TimelockKey<S>, UnlockCondition<S>>,
+
+    /// Cancellation policy per address.
+    #[state]
+    pub policies: StateMap<S::Address, CancellationPolicy<S>>,
+
+    /// Reference to the ChainState module.
+    #[module]
+    pub(crate) chain_state: sov_chain_state::ChainState<S>,
 
     #[phantom]
     phantom: std::marker::PhantomData<S>,
@@ -29,27 +256,38 @@ impl<S: Spec> Module for Timelock<S> {
 
     type Config = ();
 
-    type CallMessage = NotInstantiable;
+    type CallMessage = CallMessage<S>;
 
     type Event = ();
 
-    type Error = anyhow::Error;
+    type Error = ModuleError;
 
     fn genesis(
         &mut self,
         _genesis_rollup_header: &<<S as Spec>::Da as DaSpec>::BlockHeader,
         _config: &Self::Config,
         _state: &mut impl GenesisState<S>,
-    ) -> Result<(), Self::Error> {
+    ) -> anyhow::Result<()> {
         Ok(())
     }
 
     fn call(
         &mut self,
-        _msg: Self::CallMessage,
-        _context: &Context<S>,
-        _state: &mut impl TxState<S>,
+        msg: Self::CallMessage,
+        context: &Context<S>,
+        state: &mut impl TxState<S>,
     ) -> Result<(), Self::Error> {
+        match msg {
+            CallMessage::CancelUnlock {
+                call_message_hash,
+                address,
+            } => self
+                .cancel_unlock(call_message_hash, address, context, state)
+                .map_err(ModuleError::from)?,
+            CallMessage::ModifyCancellationPolicy { new_policy } => {
+                self.modify_cancellation_policy(new_policy, context, state)?;
+            }
+        }
         Ok(())
     }
 }
@@ -57,29 +295,236 @@ impl<S: Spec> Module for Timelock<S> {
 impl<S: Spec> TimelockCapability<S> for Timelock<S> {
     fn has_proposal(
         &self,
-        _address: &S::Address,
-        _proposal_id: &ProposalId,
-        _state: &mut impl TxState<S>,
-    ) -> Result<bool, Error> {
-        Ok(false)
+        address: &S::Address,
+        proposal_id: &ProposalId,
+        state: &mut impl TxState<S>,
+    ) -> Result<bool, ModuleError> {
+        Ok(self
+            .timelocks
+            .get(&TimelockKey::new(*address, *proposal_id), state)
+            .map_err(CoreModuleError::state_read)?
+            .is_some())
     }
 
     fn register_proposal(
         &mut self,
-        _address: &S::Address,
-        _proposal_id: ProposalId,
-        _policy: TimelockPolicy,
-        _state: &mut impl TxState<S>,
-    ) -> Result<(), Error> {
-        Ok(())
+        address: &S::Address,
+        proposal_id: ProposalId,
+        policy: TimelockPolicy,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), ModuleError> {
+        self.register_proposal_inner(address, proposal_id, policy, state)
+            .map_err(Into::into)
     }
 
     fn try_unlock_proposal(
         &mut self,
-        _address: &S::Address,
-        _proposal_id: &ProposalId,
-        _state: &mut impl TxState<S>,
-    ) -> Result<(), Error> {
-        Err(TimelockError::ProposalNotFound.into())
+        address: &S::Address,
+        proposal_id: &ProposalId,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), ModuleError> {
+        self.try_unlock_proposal_inner(address, proposal_id, state)
+            .map_err(Into::into)
+    }
+}
+
+impl<S: Spec> Timelock<S> {
+    fn current_time_secs(&self, state: &mut impl TxState<S>) -> Result<u64, Error<S>> {
+        let current_time = self
+            .chain_state
+            .get_time(state)
+            .map_err(CoreModuleError::state_read)?
+            .secs();
+
+        current_time
+            .try_into()
+            .map_err(|_| Error::InvalidCurrentTime { current_time })
+    }
+
+    fn cancellation_policy(
+        &self,
+        address: &S::Address,
+        state: &mut impl TxState<S>,
+    ) -> Result<CancellationPolicy<S>, Error<S>> {
+        Ok(self
+            .policies
+            .get(address, state)
+            .map_err(CoreModuleError::state_read)?
+            .unwrap_or(CancellationPolicy {
+                authorized_canceller: *address,
+                policy_change_timelock_seconds: 0,
+            }))
+    }
+
+    fn unlock_condition(
+        &self,
+        address: &S::Address,
+        policy: TimelockPolicy,
+        state: &mut impl TxState<S>,
+    ) -> Result<UnlockCondition<S>, Error<S>> {
+        let current_time = self.current_time_secs(state)?;
+        let executable_from = current_time
+            .checked_add(policy.unlock_seconds_from_proposal.get())
+            .ok_or(Error::TimestampOverflow { current_time })?;
+        let executable_until = executable_from
+            .checked_add(policy.expire_seconds_after_unlock())
+            .ok_or(Error::TimestampOverflow { current_time })?;
+
+        Ok(UnlockCondition {
+            executable_from,
+            executable_until,
+            cancellation_policy: self.cancellation_policy(address, state)?,
+        })
+    }
+
+    fn register_proposal_inner(
+        &mut self,
+        address: &S::Address,
+        proposal_id: ProposalId,
+        policy: TimelockPolicy,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), Error<S>> {
+        let key = TimelockKey::new(*address, proposal_id);
+        if self
+            .timelocks
+            .get(&key, state)
+            .map_err(CoreModuleError::state_read)?
+            .is_some()
+        {
+            return Err(Error::ProposalAlreadyExists {
+                address: *address,
+                proposal_id,
+            });
+        }
+
+        let unlock_condition = self.unlock_condition(address, policy, state)?;
+        self.timelocks
+            .set(&key, &unlock_condition, state)
+            .map_err(CoreModuleError::state_write)?;
+        Ok(())
+    }
+
+    fn try_unlock_proposal_inner(
+        &mut self,
+        address: &S::Address,
+        proposal_id: &ProposalId,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), Error<S>> {
+        let key = TimelockKey::new(*address, *proposal_id);
+        let Some(condition) = self
+            .timelocks
+            .get(&key, state)
+            .map_err(CoreModuleError::state_read)?
+        else {
+            return Err(TimelockError::ProposalNotFound.into());
+        };
+
+        let current_time = self.current_time_secs(state)?;
+        if current_time < condition.executable_from {
+            return Err(TimelockError::ProposalLocked.into());
+        }
+
+        if current_time > condition.executable_until {
+            return Err(TimelockError::ProposalExpired.into());
+        }
+
+        self.timelocks
+            .delete(&key, state)
+            .map_err(CoreModuleError::state_write)?;
+
+        Ok(())
+    }
+
+    fn cancel_unlock(
+        &mut self,
+        proposal_id: ProposalId,
+        address: Option<S::Address>,
+        context: &Context<S>,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), Error<S>> {
+        let address = address.unwrap_or(*context.sender());
+        let key = TimelockKey::new(address, proposal_id);
+        let Some(condition) = self
+            .timelocks
+            .get(&key, state)
+            .map_err(CoreModuleError::state_read)?
+        else {
+            return Err(TimelockError::ProposalNotFound.into());
+        };
+
+        if context.sender() != &address
+            && context.sender() != &condition.cancellation_policy.authorized_canceller
+        {
+            return Err(Error::UnauthorizedCanceller {
+                sender: *context.sender(),
+                address,
+                authorized_canceller: condition.cancellation_policy.authorized_canceller,
+                proposal_id,
+            });
+        }
+
+        self.timelocks
+            .delete(&key, state)
+            .map_err(CoreModuleError::state_write)?;
+        Ok(())
+    }
+
+    fn modify_cancellation_policy(
+        &mut self,
+        new_policy: CancellationPolicy<S>,
+        context: &Context<S>,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), ModuleError> {
+        let current_policy = self
+            .cancellation_policy(context.sender(), state)
+            .map_err(ModuleError::from)?;
+        let Some(policy_change_timelock_seconds) =
+            NonZeroU64::new(current_policy.policy_change_timelock_seconds)
+        else {
+            self.policies
+                .set(context.sender(), &new_policy, state)
+                .map_err(CoreModuleError::state_write)
+                .map_err(ModuleError::from)?;
+            return Ok(());
+        };
+
+        let proposal_id = self
+            .policy_update_proposal_id(&new_policy, state)
+            .map_err(ModuleError::from)?;
+        if self.has_proposal(context.sender(), &proposal_id, state)? {
+            self.try_unlock_proposal(context.sender(), &proposal_id, state)?;
+            self.policies
+                .set(context.sender(), &new_policy, state)
+                .map_err(CoreModuleError::state_write)
+                .map_err(ModuleError::from)?;
+        } else {
+            let policy = TimelockPolicy {
+                unlock_seconds_from_proposal: policy_change_timelock_seconds,
+                expire_seconds_after_unlock_override: None,
+            };
+            self.register_proposal(context.sender(), proposal_id, policy, state)?;
+        }
+
+        Ok(())
+    }
+
+    fn policy_update_proposal_id(
+        &self,
+        new_policy: &CancellationPolicy<S>,
+        state: &mut impl TxState<S>,
+    ) -> Result<ProposalId, Error<S>> {
+        let encoded_message = borsh::to_vec(&CallMessage::ModifyCancellationPolicy {
+            new_policy: new_policy.clone(),
+        })
+        .map_err(|error| CoreModuleError::Generic(anyhow::anyhow!(error)))?;
+
+        calculate_timelock_proposal_id_metered::<_, S>(
+            TimelockProposalHashData::CustomData {
+                module_id: &self.id,
+                data: &encoded_message,
+            },
+            state,
+        )
+        .map_err(|error| CoreModuleError::Generic(anyhow::anyhow!(error)).into())
     }
 }

--- a/crates/module-system/module-implementations/sov-timelock/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-timelock/src/lib.rs
@@ -20,12 +20,12 @@ use sov_modules_api::{
     TxState,
 };
 
-/// Maximum number of pending timelock proposals per address.
-pub const MAX_USER_TIMELOCKS: u32 = 128;
+/// Maximum number of pending proposals per address.
+pub const MAX_PENDING_PROPOSALS_PER_ADDRESS: u32 = 128;
 
-const TIMELOCK_KEY_SEPARATOR: &str = "/timelocks/";
+const PROPOSAL_KEY_SEPARATOR: &str = "/proposals/";
 
-/// Storage key for a timelock proposal.
+/// Storage key for a pending proposal.
 #[derive(
     Debug,
     Clone,
@@ -39,27 +39,27 @@ const TIMELOCK_KEY_SEPARATOR: &str = "/timelocks/";
     JsonSchema,
 )]
 #[serde(bound = "S: Spec", deny_unknown_fields)]
-#[schemars(bound = "S::Address: ::schemars::JsonSchema", rename = "TimelockKey")]
-pub struct TimelockKey<S: Spec>(
+#[schemars(bound = "S::Address: ::schemars::JsonSchema", rename = "ProposalKey")]
+pub struct ProposalKey<S: Spec>(
     /// Proposal owner.
     pub S::Address,
     /// Proposal id.
     pub ProposalId,
 );
 
-impl<S: Spec> TimelockKey<S> {
+impl<S: Spec> ProposalKey<S> {
     fn new(address: S::Address, proposal_id: ProposalId) -> Self {
         Self(address, proposal_id)
     }
 }
 
-impl<S: Spec> Display for TimelockKey<S> {
+impl<S: Spec> Display for ProposalKey<S> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}{TIMELOCK_KEY_SEPARATOR}{}", self.0, self.1)
+        write!(f, "{}{PROPOSAL_KEY_SEPARATOR}{}", self.0, self.1)
     }
 }
 
-impl<S> FromStr for TimelockKey<S>
+impl<S> FromStr for ProposalKey<S>
 where
     S: Spec,
     S::Address: FromStr<Err: Into<Box<dyn std::error::Error + Send + Sync + 'static>>>,
@@ -67,9 +67,9 @@ where
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let Some((address, proposal_id)) = s.rsplit_once(TIMELOCK_KEY_SEPARATOR) else {
+        let Some((address, proposal_id)) = s.rsplit_once(PROPOSAL_KEY_SEPARATOR) else {
             anyhow::bail!(
-                "{s} is not a timelock key: missing '{TIMELOCK_KEY_SEPARATOR}' separator"
+                "{s} is not a proposal key: missing '{PROPOSAL_KEY_SEPARATOR}' separator"
             );
         };
 
@@ -132,7 +132,7 @@ pub struct UnlockCondition<S: Spec> {
     pub cancellation_policy: CancellationPolicy<S>,
 }
 
-/// A pending timelock proposal and its unlock condition.
+/// A pending proposal and its unlock condition.
 #[derive(
     Debug,
     Clone,
@@ -147,9 +147,9 @@ pub struct UnlockCondition<S: Spec> {
 #[serde(bound = "S: Spec", deny_unknown_fields)]
 #[schemars(
     bound = "S::Address: ::schemars::JsonSchema",
-    rename = "PendingTimelock"
+    rename = "PendingProposal"
 )]
-pub struct PendingTimelock<S: Spec> {
+pub struct PendingProposal<S: Spec> {
     /// Full proposal data whose hash is used as the proposal id.
     pub proposal_data: TimelockProposalData,
     /// Condition that must hold before the proposal may execute.
@@ -200,10 +200,10 @@ pub enum Event<S: Spec> {
 #[schemars(bound = "S::Address: ::schemars::JsonSchema", rename = "CallMessage")]
 #[serde(rename_all = "snake_case")]
 pub enum CallMessage<S: Spec> {
-    /// Cancel a pending unlock.
-    CancelUnlock {
+    /// Cancel a pending proposal.
+    CancelProposal {
         /// Proposal id to cancel.
-        call_message_hash: ProposalId,
+        proposal_id: ProposalId,
         /// Owner address. If absent, the sender is treated as the owner.
         address: Option<S::Address>,
     },
@@ -229,26 +229,28 @@ pub enum Error<S: Spec> {
     #[error(transparent)]
     Timelock(#[from] TimelockError),
     /// The proposal already exists.
-    #[error("Timelock proposal {proposal_id} already exists for address {address}")]
+    #[error("Proposal {proposal_id} already exists for address {address}")]
     ProposalAlreadyExists {
         /// Proposal owner.
         address: S::Address,
         /// Existing proposal id.
         proposal_id: ProposalId,
     },
-    /// The proposal owner already has the maximum number of pending timelocks.
-    #[error("Address {address} already has the maximum of {max_user_timelocks} pending timelock proposals")]
-    MaxUserTimelocksReached {
+    /// The proposal owner already has the maximum number of pending proposals.
+    #[error(
+        "Address {address} already has the maximum of {max_pending_proposals} pending proposals"
+    )]
+    MaxPendingProposalsReached {
         /// Proposal owner.
         address: S::Address,
-        /// Maximum pending timelocks per address.
-        max_user_timelocks: u32,
+        /// Maximum pending proposals per address.
+        max_pending_proposals: u32,
     },
     /// The proposal counter is inconsistent with the proposal map.
     #[error(
-        "Timelock count for address {address} is inconsistent while deleting proposal {proposal_id}"
+        "Proposal count for address {address} is inconsistent while deleting proposal {proposal_id}"
     )]
-    TimelockCountUnderflow {
+    ProposalCountUnderflow {
         /// Proposal owner.
         address: S::Address,
         /// Proposal id being deleted.
@@ -256,7 +258,7 @@ pub enum Error<S: Spec> {
     },
     /// The sender is not authorized to cancel the proposal.
     #[error(
-        "Address {sender} is not authorized to cancel timelock proposal {proposal_id} for {address}; authorized canceller is {authorized_canceller}"
+        "Address {sender} is not authorized to cancel proposal {proposal_id} for {address}; authorized canceller is {authorized_canceller}"
     )]
     UnauthorizedCanceller {
         /// Transaction sender.
@@ -301,13 +303,13 @@ pub struct Timelock<S: Spec> {
     #[id]
     pub id: ModuleId,
 
-    /// Pending timelock proposals.
+    /// Pending proposals.
     #[state]
-    pub timelocks: StateMap<TimelockKey<S>, PendingTimelock<S>>,
+    pub proposals: StateMap<ProposalKey<S>, PendingProposal<S>>,
 
-    /// Number of pending timelock proposals per address.
+    /// Number of pending proposals per address.
     #[state]
-    pub timelock_counts: StateMap<S::Address, u32>,
+    pub proposal_counts: StateMap<S::Address, u32>,
 
     /// Cancellation policy per address.
     #[state]
@@ -348,11 +350,11 @@ impl<S: Spec> Module for Timelock<S> {
         state: &mut impl TxState<S>,
     ) -> Result<(), Self::Error> {
         match msg {
-            CallMessage::CancelUnlock {
-                call_message_hash,
+            CallMessage::CancelProposal {
+                proposal_id,
                 address,
             } => self
-                .cancel_unlock(call_message_hash, address, context, state)
+                .cancel_proposal(proposal_id, address, context, state)
                 .map_err(ModuleError::from)?,
             CallMessage::ModifyCancellationPolicy { new_policy } => {
                 self.modify_cancellation_policy(new_policy, context, state)?;
@@ -373,9 +375,9 @@ impl<S: Spec> TimelockCapability<S> for Timelock<S> {
         let proposal_id = calculate_timelock_proposal_id_metered::<_, S>(&proposal_data, state)
             .map_err(|error| CoreModuleError::Generic(anyhow::anyhow!(error)))
             .map_err(ModuleError::from)?;
-        let key = TimelockKey::new(*address, proposal_id);
+        let key = ProposalKey::new(*address, proposal_id);
         if self
-            .timelocks
+            .proposals
             .get(&key, state)
             .map_err(CoreModuleError::state_read)?
             .is_some()
@@ -448,9 +450,9 @@ impl<S: Spec> Timelock<S> {
         policy: TimelockPolicy,
         state: &mut impl TxState<S>,
     ) -> Result<(), Error<S>> {
-        let key = TimelockKey::new(*address, proposal_id);
+        let key = ProposalKey::new(*address, proposal_id);
         if self
-            .timelocks
+            .proposals
             .get(&key, state)
             .map_err(CoreModuleError::state_read)?
             .is_some()
@@ -462,19 +464,19 @@ impl<S: Spec> Timelock<S> {
         }
 
         let unlock_condition = self.unlock_condition(address, policy, state)?;
-        let pending_timelock = PendingTimelock {
+        let pending_proposal = PendingProposal {
             proposal_data,
             unlock_condition,
         };
-        self.add_timelock(&key, &pending_timelock, state)?;
+        self.add_proposal(&key, &pending_proposal, state)?;
         self.emit_event(
             state,
             Event::ProposalRegistered {
                 address: *address,
                 proposal_id,
-                proposal_data: pending_timelock.proposal_data.clone(),
-                executable_from: pending_timelock.unlock_condition.executable_from,
-                executable_until: pending_timelock.unlock_condition.executable_until,
+                proposal_data: pending_proposal.proposal_data.clone(),
+                executable_from: pending_proposal.unlock_condition.executable_from,
+                executable_until: pending_proposal.unlock_condition.executable_until,
             },
         );
         Ok(())
@@ -486,9 +488,9 @@ impl<S: Spec> Timelock<S> {
         proposal_id: &ProposalId,
         state: &mut impl TxState<S>,
     ) -> Result<(), Error<S>> {
-        let key = TimelockKey::new(*address, *proposal_id);
-        let Some(pending_timelock) = self
-            .timelocks
+        let key = ProposalKey::new(*address, *proposal_id);
+        let Some(pending_proposal) = self
+            .proposals
             .get(&key, state)
             .map_err(CoreModuleError::state_read)?
         else {
@@ -496,15 +498,15 @@ impl<S: Spec> Timelock<S> {
         };
 
         let current_time = self.current_time_secs(state)?;
-        if current_time < pending_timelock.unlock_condition.executable_from {
+        if current_time < pending_proposal.unlock_condition.executable_from {
             return Err(TimelockError::ProposalLocked.into());
         }
 
-        if current_time > pending_timelock.unlock_condition.executable_until {
+        if current_time > pending_proposal.unlock_condition.executable_until {
             return Err(TimelockError::ProposalExpired.into());
         }
 
-        self.delete_timelock(&key, state)?;
+        self.delete_proposal(&key, state)?;
         self.emit_event(
             state,
             Event::ProposalUnlocked {
@@ -516,7 +518,7 @@ impl<S: Spec> Timelock<S> {
         Ok(())
     }
 
-    fn cancel_unlock(
+    fn cancel_proposal(
         &mut self,
         proposal_id: ProposalId,
         address: Option<S::Address>,
@@ -524,9 +526,9 @@ impl<S: Spec> Timelock<S> {
         state: &mut impl TxState<S>,
     ) -> Result<(), Error<S>> {
         let address = address.unwrap_or(*context.sender());
-        let key = TimelockKey::new(address, proposal_id);
-        let Some(pending_timelock) = self
-            .timelocks
+        let key = ProposalKey::new(address, proposal_id);
+        let Some(pending_proposal) = self
+            .proposals
             .get(&key, state)
             .map_err(CoreModuleError::state_read)?
         else {
@@ -535,7 +537,7 @@ impl<S: Spec> Timelock<S> {
 
         if context.sender() != &address
             && context.sender()
-                != &pending_timelock
+                != &pending_proposal
                     .unlock_condition
                     .cancellation_policy
                     .authorized_canceller
@@ -543,7 +545,7 @@ impl<S: Spec> Timelock<S> {
             return Err(Error::UnauthorizedCanceller {
                 sender: *context.sender(),
                 address,
-                authorized_canceller: pending_timelock
+                authorized_canceller: pending_proposal
                     .unlock_condition
                     .cancellation_policy
                     .authorized_canceller,
@@ -551,7 +553,7 @@ impl<S: Spec> Timelock<S> {
             });
         }
 
-        self.delete_timelock(&key, state)?;
+        self.delete_proposal(&key, state)?;
         self.emit_event(
             state,
             Event::ProposalCancelled {
@@ -563,62 +565,62 @@ impl<S: Spec> Timelock<S> {
         Ok(())
     }
 
-    fn add_timelock(
+    fn add_proposal(
         &mut self,
-        key: &TimelockKey<S>,
-        pending_timelock: &PendingTimelock<S>,
+        key: &ProposalKey<S>,
+        pending_proposal: &PendingProposal<S>,
         state: &mut impl TxState<S>,
     ) -> Result<(), Error<S>> {
         let count = self
-            .timelock_counts
+            .proposal_counts
             .get(&key.0, state)
             .map_err(CoreModuleError::state_read)?
             .unwrap_or_default();
 
-        if count >= MAX_USER_TIMELOCKS {
-            return Err(Error::MaxUserTimelocksReached {
+        if count >= MAX_PENDING_PROPOSALS_PER_ADDRESS {
+            return Err(Error::MaxPendingProposalsReached {
                 address: key.0,
-                max_user_timelocks: MAX_USER_TIMELOCKS,
+                max_pending_proposals: MAX_PENDING_PROPOSALS_PER_ADDRESS,
             });
         }
 
-        self.timelocks
-            .set(key, pending_timelock, state)
+        self.proposals
+            .set(key, pending_proposal, state)
             .map_err(CoreModuleError::state_write)?;
-        self.timelock_counts
+        self.proposal_counts
             .set(&key.0, &(count + 1), state)
             .map_err(CoreModuleError::state_write)?;
 
         Ok(())
     }
 
-    fn delete_timelock(
+    fn delete_proposal(
         &mut self,
-        key: &TimelockKey<S>,
+        key: &ProposalKey<S>,
         state: &mut impl TxState<S>,
     ) -> Result<(), Error<S>> {
         let Some(new_count) = self
-            .timelock_counts
+            .proposal_counts
             .get(&key.0, state)
             .map_err(CoreModuleError::state_read)?
             .unwrap_or_default()
             .checked_sub(1)
         else {
-            return Err(Error::TimelockCountUnderflow {
+            return Err(Error::ProposalCountUnderflow {
                 address: key.0,
                 proposal_id: key.1,
             });
         };
 
-        self.timelocks
+        self.proposals
             .delete(key, state)
             .map_err(CoreModuleError::state_write)?;
         if new_count == 0 {
-            self.timelock_counts
+            self.proposal_counts
                 .delete(&key.0, state)
                 .map_err(CoreModuleError::state_write)?;
         } else {
-            self.timelock_counts
+            self.proposal_counts
                 .set(&key.0, &new_count, state)
                 .map_err(CoreModuleError::state_write)?;
         }

--- a/crates/module-system/module-implementations/sov-timelock/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-timelock/src/lib.rs
@@ -3,8 +3,11 @@
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
 
+mod call;
+mod error;
+mod event;
+
 use std::fmt::{Display, Formatter};
-use std::num::NonZeroU64;
 use std::str::FromStr;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -13,12 +16,15 @@ use sov_modules_api::capabilities::{
     calculate_timelock_proposal_id_metered, ProposalId, TimelockCapability, TimelockError,
     TimelockPolicy, TimelockProposalData, TimelockProposalOutcome,
 };
-use sov_modules_api::macros::{serialize, UniversalWallet};
+use sov_modules_api::macros::UniversalWallet;
 use sov_modules_api::{
-    err_detail, Context, CoreModuleError, DaSpec, Error as ModuleError, ErrorContext, ErrorDetail,
-    EventEmitter, GenesisState, Module, ModuleId, ModuleInfo, ModuleRestApi, SafeVec, Spec,
-    StateMap, TxState,
+    Context, CoreModuleError, DaSpec, Error as ModuleError, EventEmitter, GenesisState, Module,
+    ModuleId, ModuleInfo, ModuleRestApi, Spec, StateMap, TxState,
 };
+
+pub use call::CallMessage;
+pub use error::Error;
+pub use event::Event;
 
 /// Maximum number of pending proposals per address.
 pub const MAX_PENDING_PROPOSALS_PER_ADDRESS: u32 = 128;
@@ -158,170 +164,6 @@ pub struct PendingProposal<S: Spec> {
     pub proposal_data: TimelockProposalData,
     /// Condition that must hold before the proposal may execute.
     pub unlock_condition: UnlockCondition<S>,
-}
-
-/// Events emitted by the timelock module.
-#[derive(Debug, PartialEq, Eq, Clone, JsonSchema)]
-#[serialize(Borsh, Serde)]
-#[serde(bound = "S: Spec", rename_all = "snake_case")]
-#[schemars(bound = "S::Address: ::schemars::JsonSchema", rename = "Event")]
-pub enum Event<S: Spec> {
-    /// A proposal was registered and is pending unlock.
-    ProposalRegistered {
-        /// Proposal owner.
-        address: S::Address,
-        /// Proposal id.
-        proposal_id: ProposalId,
-        /// Full proposal data whose hash is the proposal id.
-        proposal_data: TimelockProposalData,
-        /// Unix timestamp at which the proposal becomes executable.
-        executable_from: u64,
-        /// Unix timestamp after which the proposal is expired.
-        executable_until: u64,
-    },
-    /// A proposal was unlocked and consumed for execution.
-    ProposalUnlocked {
-        /// Proposal owner.
-        address: S::Address,
-        /// Proposal id.
-        proposal_id: ProposalId,
-    },
-    /// A pending proposal was cancelled.
-    ProposalCancelled {
-        /// Proposal owner.
-        address: S::Address,
-        /// Proposal id.
-        proposal_id: ProposalId,
-        /// Address that cancelled the proposal.
-        cancelled_by: S::Address,
-    },
-    /// An expired proposal was cleaned.
-    ExpiredProposalCleaned {
-        /// Proposal owner.
-        address: S::Address,
-        /// Proposal id.
-        proposal_id: ProposalId,
-    },
-}
-
-/// Calls supported by the timelock module.
-#[derive(Debug, PartialEq, Eq, Clone, JsonSchema, UniversalWallet)]
-#[serialize(Borsh, Serde)]
-#[serde(bound = "S: Spec")]
-#[schemars(bound = "S::Address: ::schemars::JsonSchema", rename = "CallMessage")]
-#[serde(rename_all = "snake_case")]
-pub enum CallMessage<S: Spec> {
-    /// Cancel a pending proposal.
-    CancelProposal {
-        /// Proposal id to cancel.
-        proposal_id: ProposalId,
-        /// Owner address. If absent, the sender is treated as the owner.
-        address: Option<S::Address>,
-    },
-    /// Modify the sender's cancellation policy.
-    ModifyCancellationPolicy {
-        /// New cancellation policy.
-        new_policy: CancellationPolicy<S>,
-    },
-    /// Clean expired proposals.
-    CleanExpiredProposals {
-        /// Proposal keys to clean.
-        proposal_keys: SafeVec<ProposalKey<S>, MAX_PROPOSAL_KEYS_PER_CLEANUP>,
-    },
-}
-
-/// Errors returned by the timelock module.
-#[derive(Debug, thiserror::Error, serde::Serialize)]
-#[serde(
-    tag = "error_code",
-    rename_all = "snake_case",
-    bound = "S::Address: serde::Serialize"
-)]
-pub enum Error<S: Spec> {
-    /// A core module error occurred.
-    #[error(transparent)]
-    Core(#[from] CoreModuleError),
-    /// A timelock semantic error occurred.
-    #[error(transparent)]
-    Timelock(#[from] TimelockError),
-    /// The proposal already exists.
-    #[error("Proposal {proposal_id} already exists for address {address}")]
-    ProposalAlreadyExists {
-        /// Proposal owner.
-        address: S::Address,
-        /// Existing proposal id.
-        proposal_id: ProposalId,
-    },
-    /// The proposal owner already has the maximum number of pending proposals.
-    #[error(
-        "Address {address} already has the maximum of {max_pending_proposals} pending proposals"
-    )]
-    MaxPendingProposalsReached {
-        /// Proposal owner.
-        address: S::Address,
-        /// Maximum pending proposals per address.
-        max_pending_proposals: u32,
-    },
-    /// The proposal counter is inconsistent with the proposal map.
-    #[error(
-        "Proposal count for address {address} is inconsistent while deleting proposal {proposal_id}"
-    )]
-    ProposalCountUnderflow {
-        /// Proposal owner.
-        address: S::Address,
-        /// Proposal id being deleted.
-        proposal_id: ProposalId,
-    },
-    /// The proposal exists but has not expired yet.
-    #[error(
-        "Proposal {proposal_key} is not expired at current time {current_time}; executable until {executable_until}"
-    )]
-    ProposalNotExpired {
-        /// Proposal key.
-        proposal_key: ProposalKey<S>,
-        /// Current chain time in seconds.
-        current_time: u64,
-        /// Unix timestamp after which the proposal is expired.
-        executable_until: u64,
-    },
-    /// The sender is not authorized to cancel the proposal.
-    #[error(
-        "Address {sender} is not authorized to cancel proposal {proposal_id} for {address}; authorized canceller is {authorized_canceller}"
-    )]
-    UnauthorizedCanceller {
-        /// Transaction sender.
-        sender: S::Address,
-        /// Proposal owner.
-        address: S::Address,
-        /// Address authorized by the proposal's cancellation policy.
-        authorized_canceller: S::Address,
-        /// Proposal id.
-        proposal_id: ProposalId,
-    },
-    /// The current chain time is negative.
-    #[error("Current chain time {current_time} is before the Unix epoch")]
-    InvalidCurrentTime {
-        /// Current chain time in seconds.
-        current_time: i64,
-    },
-    /// Computing an unlock timestamp overflowed.
-    #[error(
-        "Timestamp overflow while computing unlock condition from current time {current_time}"
-    )]
-    TimestampOverflow {
-        /// Current chain time in seconds.
-        current_time: u64,
-    },
-}
-
-impl<S> ErrorDetail for Error<S>
-where
-    S: Spec,
-    S::Address: serde::Serialize,
-{
-    fn error_detail(&self) -> Result<ErrorContext, Box<dyn std::error::Error + Send + Sync>> {
-        Ok(err_detail!(self))
-    }
 }
 
 /// Timelock module.
@@ -550,113 +392,6 @@ impl<S: Spec> Timelock<S> {
         Ok(())
     }
 
-    fn cancel_proposal(
-        &mut self,
-        proposal_id: ProposalId,
-        address: Option<S::Address>,
-        context: &Context<S>,
-        state: &mut impl TxState<S>,
-    ) -> Result<(), Error<S>> {
-        let address = address.unwrap_or(*context.sender());
-        let key = ProposalKey::new(address, proposal_id);
-        let Some(pending_proposal) = self
-            .proposals
-            .get(&key, state)
-            .map_err(CoreModuleError::state_read)?
-        else {
-            return Err(TimelockError::ProposalNotFound.into());
-        };
-
-        if context.sender() != &address
-            && context.sender()
-                != &pending_proposal
-                    .unlock_condition
-                    .cancellation_policy
-                    .authorized_canceller
-        {
-            return Err(Error::UnauthorizedCanceller {
-                sender: *context.sender(),
-                address,
-                authorized_canceller: pending_proposal
-                    .unlock_condition
-                    .cancellation_policy
-                    .authorized_canceller,
-                proposal_id,
-            });
-        }
-
-        self.delete_proposal(&key, state)?;
-        self.emit_event(
-            state,
-            Event::ProposalCancelled {
-                address,
-                proposal_id,
-                cancelled_by: *context.sender(),
-            },
-        );
-        Ok(())
-    }
-
-    fn clean_expired_proposals(
-        &mut self,
-        proposal_keys: SafeVec<ProposalKey<S>, MAX_PROPOSAL_KEYS_PER_CLEANUP>,
-        state: &mut impl TxState<S>,
-    ) -> Result<(), Error<S>> {
-        let current_time = self.current_time_secs(state)?;
-        for key in proposal_keys {
-            let mut attempt_state = state.to_revertable();
-            match self.clean_expired_proposal(&key, current_time, &mut attempt_state) {
-                Ok(()) => {
-                    attempt_state.commit();
-                }
-                Err(Error::Timelock(TimelockError::ProposalNotFound))
-                | Err(Error::ProposalNotExpired { .. }) => {
-                    attempt_state.revert();
-                }
-                Err(error) => {
-                    attempt_state.revert();
-                    return Err(error);
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    fn clean_expired_proposal(
-        &mut self,
-        key: &ProposalKey<S>,
-        current_time: u64,
-        state: &mut impl TxState<S>,
-    ) -> Result<(), Error<S>> {
-        let Some(pending_proposal) = self
-            .proposals
-            .get(key, state)
-            .map_err(CoreModuleError::state_read)?
-        else {
-            return Err(TimelockError::ProposalNotFound.into());
-        };
-
-        if current_time <= pending_proposal.unlock_condition.executable_until {
-            return Err(Error::ProposalNotExpired {
-                proposal_key: key.clone(),
-                current_time,
-                executable_until: pending_proposal.unlock_condition.executable_until,
-            });
-        }
-
-        self.delete_proposal(key, state)?;
-        self.emit_event(
-            state,
-            Event::ExpiredProposalCleaned {
-                address: key.0,
-                proposal_id: key.1,
-            },
-        );
-
-        Ok(())
-    }
-
     fn add_proposal(
         &mut self,
         key: &ProposalKey<S>,
@@ -718,61 +453,5 @@ impl<S: Spec> Timelock<S> {
         }
 
         Ok(())
-    }
-
-    fn modify_cancellation_policy(
-        &mut self,
-        new_policy: CancellationPolicy<S>,
-        context: &Context<S>,
-        state: &mut impl TxState<S>,
-    ) -> Result<(), ModuleError> {
-        let current_policy = self
-            .cancellation_policy(context.sender(), state)
-            .map_err(ModuleError::from)?;
-        let Some(policy_change_timelock_seconds) =
-            NonZeroU64::new(current_policy.policy_change_timelock_seconds)
-        else {
-            self.policies
-                .set(context.sender(), &new_policy, state)
-                .map_err(CoreModuleError::state_write)
-                .map_err(ModuleError::from)?;
-            return Ok(());
-        };
-
-        let proposal_data = self
-            .policy_update_proposal_data(&new_policy)
-            .map_err(ModuleError::from)?;
-        let policy = TimelockPolicy {
-            unlock_seconds_from_proposal: policy_change_timelock_seconds,
-            expire_seconds_after_unlock_override: None,
-        };
-        match self.register_or_try_unlock_proposal(
-            context.sender(),
-            proposal_data,
-            policy,
-            state,
-        )? {
-            TimelockProposalOutcome::Registered => {}
-            TimelockProposalOutcome::Unlocked => {
-                self.policies
-                    .set(context.sender(), &new_policy, state)
-                    .map_err(CoreModuleError::state_write)
-                    .map_err(ModuleError::from)?;
-            }
-        }
-
-        Ok(())
-    }
-
-    fn policy_update_proposal_data(
-        &self,
-        new_policy: &CancellationPolicy<S>,
-    ) -> Result<TimelockProposalData, Error<S>> {
-        let encoded_message = borsh::to_vec(&CallMessage::ModifyCancellationPolicy {
-            new_policy: new_policy.clone(),
-        })
-        .map_err(|error| CoreModuleError::Generic(anyhow::anyhow!(error)))?;
-
-        Ok(TimelockProposalData::custom_data(self.id, encoded_message))
     }
 }

--- a/crates/module-system/module-implementations/sov-timelock/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-timelock/src/lib.rs
@@ -10,8 +10,8 @@ use std::str::FromStr;
 use borsh::{BorshDeserialize, BorshSerialize};
 use schemars::JsonSchema;
 use sov_modules_api::capabilities::{
-    calculate_custom_timelock_proposal_id_metered, ProposalId, TimelockCapability, TimelockError,
-    TimelockPolicy, TimelockProposalOutcome,
+    calculate_timelock_proposal_id_metered, ProposalId, TimelockCapability, TimelockError,
+    TimelockPolicy, TimelockProposalData, TimelockProposalOutcome,
 };
 use sov_modules_api::macros::{serialize, UniversalWallet};
 use sov_modules_api::{
@@ -132,6 +132,30 @@ pub struct UnlockCondition<S: Spec> {
     pub cancellation_policy: CancellationPolicy<S>,
 }
 
+/// A pending timelock proposal and its unlock condition.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    BorshDeserialize,
+    BorshSerialize,
+    serde::Serialize,
+    serde::Deserialize,
+    JsonSchema,
+)]
+#[serde(bound = "S: Spec", deny_unknown_fields)]
+#[schemars(
+    bound = "S::Address: ::schemars::JsonSchema",
+    rename = "PendingTimelock"
+)]
+pub struct PendingTimelock<S: Spec> {
+    /// Full proposal data whose hash is used as the proposal id.
+    pub proposal_data: TimelockProposalData,
+    /// Condition that must hold before the proposal may execute.
+    pub unlock_condition: UnlockCondition<S>,
+}
+
 /// Events emitted by the timelock module.
 #[derive(Debug, PartialEq, Eq, Clone, JsonSchema)]
 #[serialize(Borsh, Serde)]
@@ -144,6 +168,8 @@ pub enum Event<S: Spec> {
         address: S::Address,
         /// Proposal id.
         proposal_id: ProposalId,
+        /// Full proposal data whose hash is the proposal id.
+        proposal_data: TimelockProposalData,
         /// Unix timestamp at which the proposal becomes executable.
         executable_from: u64,
         /// Unix timestamp after which the proposal is expired.
@@ -277,7 +303,7 @@ pub struct Timelock<S: Spec> {
 
     /// Pending timelock proposals.
     #[state]
-    pub timelocks: StateMap<TimelockKey<S>, UnlockCondition<S>>,
+    pub timelocks: StateMap<TimelockKey<S>, PendingTimelock<S>>,
 
     /// Number of pending timelock proposals per address.
     #[state]
@@ -340,10 +366,13 @@ impl<S: Spec> TimelockCapability<S> for Timelock<S> {
     fn register_or_try_unlock_proposal(
         &mut self,
         address: &S::Address,
-        proposal_id: ProposalId,
+        proposal_data: TimelockProposalData,
         policy: TimelockPolicy,
         state: &mut impl TxState<S>,
     ) -> Result<TimelockProposalOutcome, ModuleError> {
+        let proposal_id = calculate_timelock_proposal_id_metered::<_, S>(&proposal_data, state)
+            .map_err(|error| CoreModuleError::Generic(anyhow::anyhow!(error)))
+            .map_err(ModuleError::from)?;
         let key = TimelockKey::new(*address, proposal_id);
         if self
             .timelocks
@@ -355,7 +384,7 @@ impl<S: Spec> TimelockCapability<S> for Timelock<S> {
                 .map_err(ModuleError::from)?;
             Ok(TimelockProposalOutcome::Unlocked)
         } else {
-            self.register_proposal_inner(address, proposal_id, policy, state)
+            self.register_proposal_inner(address, proposal_id, proposal_data, policy, state)
                 .map_err(ModuleError::from)?;
             Ok(TimelockProposalOutcome::Registered)
         }
@@ -415,6 +444,7 @@ impl<S: Spec> Timelock<S> {
         &mut self,
         address: &S::Address,
         proposal_id: ProposalId,
+        proposal_data: TimelockProposalData,
         policy: TimelockPolicy,
         state: &mut impl TxState<S>,
     ) -> Result<(), Error<S>> {
@@ -432,14 +462,19 @@ impl<S: Spec> Timelock<S> {
         }
 
         let unlock_condition = self.unlock_condition(address, policy, state)?;
-        self.add_timelock(&key, &unlock_condition, state)?;
+        let pending_timelock = PendingTimelock {
+            proposal_data,
+            unlock_condition,
+        };
+        self.add_timelock(&key, &pending_timelock, state)?;
         self.emit_event(
             state,
             Event::ProposalRegistered {
                 address: *address,
                 proposal_id,
-                executable_from: unlock_condition.executable_from,
-                executable_until: unlock_condition.executable_until,
+                proposal_data: pending_timelock.proposal_data.clone(),
+                executable_from: pending_timelock.unlock_condition.executable_from,
+                executable_until: pending_timelock.unlock_condition.executable_until,
             },
         );
         Ok(())
@@ -452,7 +487,7 @@ impl<S: Spec> Timelock<S> {
         state: &mut impl TxState<S>,
     ) -> Result<(), Error<S>> {
         let key = TimelockKey::new(*address, *proposal_id);
-        let Some(condition) = self
+        let Some(pending_timelock) = self
             .timelocks
             .get(&key, state)
             .map_err(CoreModuleError::state_read)?
@@ -461,11 +496,11 @@ impl<S: Spec> Timelock<S> {
         };
 
         let current_time = self.current_time_secs(state)?;
-        if current_time < condition.executable_from {
+        if current_time < pending_timelock.unlock_condition.executable_from {
             return Err(TimelockError::ProposalLocked.into());
         }
 
-        if current_time > condition.executable_until {
+        if current_time > pending_timelock.unlock_condition.executable_until {
             return Err(TimelockError::ProposalExpired.into());
         }
 
@@ -490,7 +525,7 @@ impl<S: Spec> Timelock<S> {
     ) -> Result<(), Error<S>> {
         let address = address.unwrap_or(*context.sender());
         let key = TimelockKey::new(address, proposal_id);
-        let Some(condition) = self
+        let Some(pending_timelock) = self
             .timelocks
             .get(&key, state)
             .map_err(CoreModuleError::state_read)?
@@ -499,12 +534,19 @@ impl<S: Spec> Timelock<S> {
         };
 
         if context.sender() != &address
-            && context.sender() != &condition.cancellation_policy.authorized_canceller
+            && context.sender()
+                != &pending_timelock
+                    .unlock_condition
+                    .cancellation_policy
+                    .authorized_canceller
         {
             return Err(Error::UnauthorizedCanceller {
                 sender: *context.sender(),
                 address,
-                authorized_canceller: condition.cancellation_policy.authorized_canceller,
+                authorized_canceller: pending_timelock
+                    .unlock_condition
+                    .cancellation_policy
+                    .authorized_canceller,
                 proposal_id,
             });
         }
@@ -524,7 +566,7 @@ impl<S: Spec> Timelock<S> {
     fn add_timelock(
         &mut self,
         key: &TimelockKey<S>,
-        unlock_condition: &UnlockCondition<S>,
+        pending_timelock: &PendingTimelock<S>,
         state: &mut impl TxState<S>,
     ) -> Result<(), Error<S>> {
         let count = self
@@ -541,7 +583,7 @@ impl<S: Spec> Timelock<S> {
         }
 
         self.timelocks
-            .set(key, unlock_condition, state)
+            .set(key, pending_timelock, state)
             .map_err(CoreModuleError::state_write)?;
         self.timelock_counts
             .set(&key.0, &(count + 1), state)
@@ -603,14 +645,19 @@ impl<S: Spec> Timelock<S> {
             return Ok(());
         };
 
-        let proposal_id = self
-            .policy_update_proposal_id(&new_policy, state)
+        let proposal_data = self
+            .policy_update_proposal_data(&new_policy)
             .map_err(ModuleError::from)?;
         let policy = TimelockPolicy {
             unlock_seconds_from_proposal: policy_change_timelock_seconds,
             expire_seconds_after_unlock_override: None,
         };
-        match self.register_or_try_unlock_proposal(context.sender(), proposal_id, policy, state)? {
+        match self.register_or_try_unlock_proposal(
+            context.sender(),
+            proposal_data,
+            policy,
+            state,
+        )? {
             TimelockProposalOutcome::Registered => {}
             TimelockProposalOutcome::Unlocked => {
                 self.policies
@@ -623,17 +670,15 @@ impl<S: Spec> Timelock<S> {
         Ok(())
     }
 
-    fn policy_update_proposal_id(
+    fn policy_update_proposal_data(
         &self,
         new_policy: &CancellationPolicy<S>,
-        state: &mut impl TxState<S>,
-    ) -> Result<ProposalId, Error<S>> {
+    ) -> Result<TimelockProposalData, Error<S>> {
         let encoded_message = borsh::to_vec(&CallMessage::ModifyCancellationPolicy {
             new_policy: new_policy.clone(),
         })
         .map_err(|error| CoreModuleError::Generic(anyhow::anyhow!(error)))?;
 
-        calculate_custom_timelock_proposal_id_metered::<_, S>(&self.id, &encoded_message, state)
-            .map_err(|error| CoreModuleError::Generic(anyhow::anyhow!(error)).into())
+        Ok(TimelockProposalData::custom_data(self.id, encoded_message))
     }
 }

--- a/crates/module-system/module-implementations/sov-timelock/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-timelock/src/lib.rs
@@ -16,7 +16,8 @@ use sov_modules_api::capabilities::{
 use sov_modules_api::macros::{serialize, UniversalWallet};
 use sov_modules_api::{
     err_detail, Context, CoreModuleError, DaSpec, Error as ModuleError, ErrorContext, ErrorDetail,
-    GenesisState, Module, ModuleId, ModuleInfo, ModuleRestApi, Spec, StateMap, TxState,
+    EventEmitter, GenesisState, Module, ModuleId, ModuleInfo, ModuleRestApi, Spec, StateMap,
+    TxState,
 };
 
 /// Planned upper bound for per-address timelocks.
@@ -134,6 +135,41 @@ pub struct UnlockCondition<S: Spec> {
     pub cancellation_policy: CancellationPolicy<S>,
 }
 
+/// Events emitted by the timelock module.
+#[derive(Debug, PartialEq, Eq, Clone, JsonSchema)]
+#[serialize(Borsh, Serde)]
+#[serde(bound = "S: Spec", rename_all = "snake_case")]
+#[schemars(bound = "S::Address: ::schemars::JsonSchema", rename = "Event")]
+pub enum Event<S: Spec> {
+    /// A proposal was registered and is pending unlock.
+    ProposalRegistered {
+        /// Proposal owner.
+        address: S::Address,
+        /// Proposal id.
+        proposal_id: ProposalId,
+        /// Unix timestamp at which the proposal becomes executable.
+        executable_from: u64,
+        /// Unix timestamp after which the proposal is expired.
+        executable_until: u64,
+    },
+    /// A proposal was unlocked and consumed for execution.
+    ProposalUnlocked {
+        /// Proposal owner.
+        address: S::Address,
+        /// Proposal id.
+        proposal_id: ProposalId,
+    },
+    /// A pending proposal was cancelled.
+    ProposalCancelled {
+        /// Proposal owner.
+        address: S::Address,
+        /// Proposal id.
+        proposal_id: ProposalId,
+        /// Address that cancelled the proposal.
+        cancelled_by: S::Address,
+    },
+}
+
 /// Calls supported by the timelock module.
 #[derive(Debug, PartialEq, Eq, Clone, JsonSchema, UniversalWallet)]
 #[serialize(Borsh, Serde)]
@@ -247,7 +283,7 @@ impl<S: Spec> Module for Timelock<S> {
 
     type CallMessage = CallMessage<S>;
 
-    type Event = ();
+    type Event = Event<S>;
 
     type Error = ModuleError;
 
@@ -380,6 +416,15 @@ impl<S: Spec> Timelock<S> {
         self.timelocks
             .set(&key, &unlock_condition, state)
             .map_err(CoreModuleError::state_write)?;
+        self.emit_event(
+            state,
+            Event::ProposalRegistered {
+                address: *address,
+                proposal_id,
+                executable_from: unlock_condition.executable_from,
+                executable_until: unlock_condition.executable_until,
+            },
+        );
         Ok(())
     }
 
@@ -410,6 +455,13 @@ impl<S: Spec> Timelock<S> {
         self.timelocks
             .delete(&key, state)
             .map_err(CoreModuleError::state_write)?;
+        self.emit_event(
+            state,
+            Event::ProposalUnlocked {
+                address: *address,
+                proposal_id: *proposal_id,
+            },
+        );
 
         Ok(())
     }
@@ -445,6 +497,14 @@ impl<S: Spec> Timelock<S> {
         self.timelocks
             .delete(&key, state)
             .map_err(CoreModuleError::state_write)?;
+        self.emit_event(
+            state,
+            Event::ProposalCancelled {
+                address,
+                proposal_id,
+                cancelled_by: *context.sender(),
+            },
+        );
         Ok(())
     }
 

--- a/crates/module-system/module-implementations/sov-timelock/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-timelock/src/lib.rs
@@ -20,11 +20,8 @@ use sov_modules_api::{
     TxState,
 };
 
-/// Planned upper bound for per-address timelocks.
-///
-/// This is not enforced by the two-map MVP because enforcing it efficiently requires
-/// tracking a per-address count or index.
-pub const MAX_USER_TIMELOCKS: u32 = 100;
+/// Maximum number of pending timelock proposals per address.
+pub const MAX_USER_TIMELOCKS: u32 = 128;
 
 const TIMELOCK_KEY_SEPARATOR: &str = "/timelocks/";
 
@@ -213,6 +210,24 @@ pub enum Error<S: Spec> {
         /// Existing proposal id.
         proposal_id: ProposalId,
     },
+    /// The proposal owner already has the maximum number of pending timelocks.
+    #[error("Address {address} already has the maximum of {max_user_timelocks} pending timelock proposals")]
+    MaxUserTimelocksReached {
+        /// Proposal owner.
+        address: S::Address,
+        /// Maximum pending timelocks per address.
+        max_user_timelocks: u32,
+    },
+    /// The proposal counter is inconsistent with the proposal map.
+    #[error(
+        "Timelock count for address {address} is inconsistent while deleting proposal {proposal_id}"
+    )]
+    TimelockCountUnderflow {
+        /// Proposal owner.
+        address: S::Address,
+        /// Proposal id being deleted.
+        proposal_id: ProposalId,
+    },
     /// The sender is not authorized to cancel the proposal.
     #[error(
         "Address {sender} is not authorized to cancel timelock proposal {proposal_id} for {address}; authorized canceller is {authorized_canceller}"
@@ -263,6 +278,10 @@ pub struct Timelock<S: Spec> {
     /// Pending timelock proposals.
     #[state]
     pub timelocks: StateMap<TimelockKey<S>, UnlockCondition<S>>,
+
+    /// Number of pending timelock proposals per address.
+    #[state]
+    pub timelock_counts: StateMap<S::Address, u32>,
 
     /// Cancellation policy per address.
     #[state]
@@ -413,9 +432,7 @@ impl<S: Spec> Timelock<S> {
         }
 
         let unlock_condition = self.unlock_condition(address, policy, state)?;
-        self.timelocks
-            .set(&key, &unlock_condition, state)
-            .map_err(CoreModuleError::state_write)?;
+        self.add_timelock(&key, &unlock_condition, state)?;
         self.emit_event(
             state,
             Event::ProposalRegistered {
@@ -452,9 +469,7 @@ impl<S: Spec> Timelock<S> {
             return Err(TimelockError::ProposalExpired.into());
         }
 
-        self.timelocks
-            .delete(&key, state)
-            .map_err(CoreModuleError::state_write)?;
+        self.delete_timelock(&key, state)?;
         self.emit_event(
             state,
             Event::ProposalUnlocked {
@@ -494,9 +509,7 @@ impl<S: Spec> Timelock<S> {
             });
         }
 
-        self.timelocks
-            .delete(&key, state)
-            .map_err(CoreModuleError::state_write)?;
+        self.delete_timelock(&key, state)?;
         self.emit_event(
             state,
             Event::ProposalCancelled {
@@ -505,6 +518,69 @@ impl<S: Spec> Timelock<S> {
                 cancelled_by: *context.sender(),
             },
         );
+        Ok(())
+    }
+
+    fn add_timelock(
+        &mut self,
+        key: &TimelockKey<S>,
+        unlock_condition: &UnlockCondition<S>,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), Error<S>> {
+        let count = self
+            .timelock_counts
+            .get(&key.0, state)
+            .map_err(CoreModuleError::state_read)?
+            .unwrap_or_default();
+
+        if count >= MAX_USER_TIMELOCKS {
+            return Err(Error::MaxUserTimelocksReached {
+                address: key.0,
+                max_user_timelocks: MAX_USER_TIMELOCKS,
+            });
+        }
+
+        self.timelocks
+            .set(key, unlock_condition, state)
+            .map_err(CoreModuleError::state_write)?;
+        self.timelock_counts
+            .set(&key.0, &(count + 1), state)
+            .map_err(CoreModuleError::state_write)?;
+
+        Ok(())
+    }
+
+    fn delete_timelock(
+        &mut self,
+        key: &TimelockKey<S>,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), Error<S>> {
+        let Some(new_count) = self
+            .timelock_counts
+            .get(&key.0, state)
+            .map_err(CoreModuleError::state_read)?
+            .unwrap_or_default()
+            .checked_sub(1)
+        else {
+            return Err(Error::TimelockCountUnderflow {
+                address: key.0,
+                proposal_id: key.1,
+            });
+        };
+
+        self.timelocks
+            .delete(key, state)
+            .map_err(CoreModuleError::state_write)?;
+        if new_count == 0 {
+            self.timelock_counts
+                .delete(&key.0, state)
+                .map_err(CoreModuleError::state_write)?;
+        } else {
+            self.timelock_counts
+                .set(&key.0, &new_count, state)
+                .map_err(CoreModuleError::state_write)?;
+        }
+
         Ok(())
     }
 

--- a/crates/module-system/module-implementations/sov-timelock/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-timelock/src/lib.rs
@@ -25,7 +25,6 @@ use sov_modules_api::{
 /// tracking a per-address count or index.
 pub const MAX_USER_TIMELOCKS: u32 = 100;
 
-const TIMELOCK_KEY_PREFIX: &str = "addresses/";
 const TIMELOCK_KEY_SEPARATOR: &str = "/timelocks/";
 
 /// Storage key for a timelock proposal.
@@ -43,29 +42,22 @@ const TIMELOCK_KEY_SEPARATOR: &str = "/timelocks/";
 )]
 #[serde(bound = "S: Spec", deny_unknown_fields)]
 #[schemars(bound = "S::Address: ::schemars::JsonSchema", rename = "TimelockKey")]
-pub struct TimelockKey<S: Spec> {
+pub struct TimelockKey<S: Spec>(
     /// Proposal owner.
-    pub address: S::Address,
+    pub S::Address,
     /// Proposal id.
-    pub proposal_id: ProposalId,
-}
+    pub ProposalId,
+);
 
 impl<S: Spec> TimelockKey<S> {
     fn new(address: S::Address, proposal_id: ProposalId) -> Self {
-        Self {
-            address,
-            proposal_id,
-        }
+        Self(address, proposal_id)
     }
 }
 
 impl<S: Spec> Display for TimelockKey<S> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{TIMELOCK_KEY_PREFIX}{}{TIMELOCK_KEY_SEPARATOR}{}",
-            self.address, self.proposal_id
-        )
+        write!(f, "{}{TIMELOCK_KEY_SEPARATOR}{}", self.0, self.1)
     }
 }
 
@@ -77,20 +69,17 @@ where
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let Some(s) = s.strip_prefix(TIMELOCK_KEY_PREFIX) else {
-            anyhow::bail!("{s} is not a timelock key: missing '{TIMELOCK_KEY_PREFIX}' prefix");
-        };
         let Some((address, proposal_id)) = s.rsplit_once(TIMELOCK_KEY_SEPARATOR) else {
             anyhow::bail!(
                 "{s} is not a timelock key: missing '{TIMELOCK_KEY_SEPARATOR}' separator"
             );
         };
 
-        Ok(Self {
-            address: S::Address::from_str(address)
+        Ok(Self(
+            S::Address::from_str(address)
                 .map_err(|error| anyhow::Error::from_boxed(error.into()))?,
-            proposal_id: ProposalId::from_str(proposal_id)?,
-        })
+            ProposalId::from_str(proposal_id)?,
+        ))
     }
 }
 

--- a/crates/module-system/module-implementations/sov-timelock/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-timelock/src/lib.rs
@@ -10,8 +10,8 @@ use std::str::FromStr;
 use borsh::{BorshDeserialize, BorshSerialize};
 use schemars::JsonSchema;
 use sov_modules_api::capabilities::{
-    calculate_timelock_proposal_id_metered, ProposalId, TimelockCapability, TimelockError,
-    TimelockPolicy, TimelockProposalHashData,
+    calculate_custom_timelock_proposal_id_metered, ProposalId, TimelockCapability, TimelockError,
+    TimelockPolicy, TimelockProposalOutcome,
 };
 use sov_modules_api::macros::{serialize, UniversalWallet};
 use sov_modules_api::{
@@ -293,38 +293,28 @@ impl<S: Spec> Module for Timelock<S> {
 }
 
 impl<S: Spec> TimelockCapability<S> for Timelock<S> {
-    fn has_proposal(
-        &self,
-        address: &S::Address,
-        proposal_id: &ProposalId,
-        state: &mut impl TxState<S>,
-    ) -> Result<bool, ModuleError> {
-        Ok(self
-            .timelocks
-            .get(&TimelockKey::new(*address, *proposal_id), state)
-            .map_err(CoreModuleError::state_read)?
-            .is_some())
-    }
-
-    fn register_proposal(
+    fn register_or_try_unlock_proposal(
         &mut self,
         address: &S::Address,
         proposal_id: ProposalId,
         policy: TimelockPolicy,
         state: &mut impl TxState<S>,
-    ) -> Result<(), ModuleError> {
-        self.register_proposal_inner(address, proposal_id, policy, state)
-            .map_err(Into::into)
-    }
-
-    fn try_unlock_proposal(
-        &mut self,
-        address: &S::Address,
-        proposal_id: &ProposalId,
-        state: &mut impl TxState<S>,
-    ) -> Result<(), ModuleError> {
-        self.try_unlock_proposal_inner(address, proposal_id, state)
-            .map_err(Into::into)
+    ) -> Result<TimelockProposalOutcome, ModuleError> {
+        let key = TimelockKey::new(*address, proposal_id);
+        if self
+            .timelocks
+            .get(&key, state)
+            .map_err(CoreModuleError::state_read)?
+            .is_some()
+        {
+            self.try_unlock_proposal_inner(address, &proposal_id, state)
+                .map_err(ModuleError::from)?;
+            Ok(TimelockProposalOutcome::Unlocked)
+        } else {
+            self.register_proposal_inner(address, proposal_id, policy, state)
+                .map_err(ModuleError::from)?;
+            Ok(TimelockProposalOutcome::Registered)
+        }
     }
 }
 
@@ -491,18 +481,18 @@ impl<S: Spec> Timelock<S> {
         let proposal_id = self
             .policy_update_proposal_id(&new_policy, state)
             .map_err(ModuleError::from)?;
-        if self.has_proposal(context.sender(), &proposal_id, state)? {
-            self.try_unlock_proposal(context.sender(), &proposal_id, state)?;
-            self.policies
-                .set(context.sender(), &new_policy, state)
-                .map_err(CoreModuleError::state_write)
-                .map_err(ModuleError::from)?;
-        } else {
-            let policy = TimelockPolicy {
-                unlock_seconds_from_proposal: policy_change_timelock_seconds,
-                expire_seconds_after_unlock_override: None,
-            };
-            self.register_proposal(context.sender(), proposal_id, policy, state)?;
+        let policy = TimelockPolicy {
+            unlock_seconds_from_proposal: policy_change_timelock_seconds,
+            expire_seconds_after_unlock_override: None,
+        };
+        match self.register_or_try_unlock_proposal(context.sender(), proposal_id, policy, state)? {
+            TimelockProposalOutcome::Registered => {}
+            TimelockProposalOutcome::Unlocked => {
+                self.policies
+                    .set(context.sender(), &new_policy, state)
+                    .map_err(CoreModuleError::state_write)
+                    .map_err(ModuleError::from)?;
+            }
         }
 
         Ok(())
@@ -518,13 +508,7 @@ impl<S: Spec> Timelock<S> {
         })
         .map_err(|error| CoreModuleError::Generic(anyhow::anyhow!(error)))?;
 
-        calculate_timelock_proposal_id_metered::<_, S>(
-            TimelockProposalHashData::CustomData {
-                module_id: &self.id,
-                data: &encoded_message,
-            },
-            state,
-        )
-        .map_err(|error| CoreModuleError::Generic(anyhow::anyhow!(error)).into())
+        calculate_custom_timelock_proposal_id_metered::<_, S>(&self.id, &encoded_message, state)
+            .map_err(|error| CoreModuleError::Generic(anyhow::anyhow!(error)).into())
     }
 }

--- a/crates/module-system/module-implementations/sov-timelock/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-timelock/src/lib.rs
@@ -16,12 +16,15 @@ use sov_modules_api::capabilities::{
 use sov_modules_api::macros::{serialize, UniversalWallet};
 use sov_modules_api::{
     err_detail, Context, CoreModuleError, DaSpec, Error as ModuleError, ErrorContext, ErrorDetail,
-    EventEmitter, GenesisState, Module, ModuleId, ModuleInfo, ModuleRestApi, Spec, StateMap,
-    TxState,
+    EventEmitter, GenesisState, Module, ModuleId, ModuleInfo, ModuleRestApi, SafeVec, Spec,
+    StateMap, TxState,
 };
 
 /// Maximum number of pending proposals per address.
 pub const MAX_PENDING_PROPOSALS_PER_ADDRESS: u32 = 128;
+
+/// Maximum number of proposal keys accepted by a cleanup call.
+pub const MAX_PROPOSAL_KEYS_PER_CLEANUP: usize = 128;
 
 const PROPOSAL_KEY_SEPARATOR: &str = "/proposals/";
 
@@ -37,6 +40,7 @@ const PROPOSAL_KEY_SEPARATOR: &str = "/proposals/";
     serde::Serialize,
     serde::Deserialize,
     JsonSchema,
+    UniversalWallet,
 )]
 #[serde(bound = "S: Spec", deny_unknown_fields)]
 #[schemars(bound = "S::Address: ::schemars::JsonSchema", rename = "ProposalKey")]
@@ -191,6 +195,13 @@ pub enum Event<S: Spec> {
         /// Address that cancelled the proposal.
         cancelled_by: S::Address,
     },
+    /// An expired proposal was cleaned.
+    ExpiredProposalCleaned {
+        /// Proposal owner.
+        address: S::Address,
+        /// Proposal id.
+        proposal_id: ProposalId,
+    },
 }
 
 /// Calls supported by the timelock module.
@@ -211,6 +222,11 @@ pub enum CallMessage<S: Spec> {
     ModifyCancellationPolicy {
         /// New cancellation policy.
         new_policy: CancellationPolicy<S>,
+    },
+    /// Clean expired proposals.
+    CleanExpiredProposals {
+        /// Proposal keys to clean.
+        proposal_keys: SafeVec<ProposalKey<S>, MAX_PROPOSAL_KEYS_PER_CLEANUP>,
     },
 }
 
@@ -255,6 +271,18 @@ pub enum Error<S: Spec> {
         address: S::Address,
         /// Proposal id being deleted.
         proposal_id: ProposalId,
+    },
+    /// The proposal exists but has not expired yet.
+    #[error(
+        "Proposal {proposal_key} is not expired at current time {current_time}; executable until {executable_until}"
+    )]
+    ProposalNotExpired {
+        /// Proposal key.
+        proposal_key: ProposalKey<S>,
+        /// Current chain time in seconds.
+        current_time: u64,
+        /// Unix timestamp after which the proposal is expired.
+        executable_until: u64,
     },
     /// The sender is not authorized to cancel the proposal.
     #[error(
@@ -358,6 +386,10 @@ impl<S: Spec> Module for Timelock<S> {
                 .map_err(ModuleError::from)?,
             CallMessage::ModifyCancellationPolicy { new_policy } => {
                 self.modify_cancellation_policy(new_policy, context, state)?;
+            }
+            CallMessage::CleanExpiredProposals { proposal_keys } => {
+                self.clean_expired_proposals(proposal_keys, state)
+                    .map_err(ModuleError::from)?;
             }
         }
         Ok(())
@@ -562,6 +594,66 @@ impl<S: Spec> Timelock<S> {
                 cancelled_by: *context.sender(),
             },
         );
+        Ok(())
+    }
+
+    fn clean_expired_proposals(
+        &mut self,
+        proposal_keys: SafeVec<ProposalKey<S>, MAX_PROPOSAL_KEYS_PER_CLEANUP>,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), Error<S>> {
+        let current_time = self.current_time_secs(state)?;
+        for key in proposal_keys {
+            let mut attempt_state = state.to_revertable();
+            match self.clean_expired_proposal(&key, current_time, &mut attempt_state) {
+                Ok(()) => {
+                    attempt_state.commit();
+                }
+                Err(Error::Timelock(TimelockError::ProposalNotFound))
+                | Err(Error::ProposalNotExpired { .. }) => {
+                    attempt_state.revert();
+                }
+                Err(error) => {
+                    attempt_state.revert();
+                    return Err(error);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn clean_expired_proposal(
+        &mut self,
+        key: &ProposalKey<S>,
+        current_time: u64,
+        state: &mut impl TxState<S>,
+    ) -> Result<(), Error<S>> {
+        let Some(pending_proposal) = self
+            .proposals
+            .get(key, state)
+            .map_err(CoreModuleError::state_read)?
+        else {
+            return Err(TimelockError::ProposalNotFound.into());
+        };
+
+        if current_time <= pending_proposal.unlock_condition.executable_until {
+            return Err(Error::ProposalNotExpired {
+                proposal_key: key.clone(),
+                current_time,
+                executable_until: pending_proposal.unlock_condition.executable_until,
+            });
+        }
+
+        self.delete_proposal(key, state)?;
+        self.emit_event(
+            state,
+            Event::ExpiredProposalCleaned {
+                address: key.0,
+                proposal_id: key.1,
+            },
+        );
+
         Ok(())
     }
 

--- a/crates/module-system/module-implementations/sov-timelock/tests/integration/main.rs
+++ b/crates/module-system/module-implementations/sov-timelock/tests/integration/main.rs
@@ -1,0 +1,3 @@
+mod timelock;
+
+type S = sov_test_utils::TestSpec;

--- a/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
+++ b/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU64;
 use std::str::FromStr;
 
 use sov_modules_api::capabilities::{
-    calculate_timelock_proposal_id, ProposalId, TimelockPolicy, TimelockProposalHashData,
+    calculate_timelock_proposal_id, ProposalId, TimelockPolicy, TimelockProposalData,
     DEFAULT_EXPIRE_SECONDS_AFTER_UNLOCK,
 };
 use sov_modules_api::da::Time;
@@ -83,8 +83,12 @@ fn set_value_message(value: u32) -> ValueSetterCallMessage<S> {
 }
 
 fn set_value_proposal_id(value: u32) -> sov_modules_api::capabilities::ProposalId {
+    calculate_timelock_proposal_id::<S>(&set_value_proposal_data(value))
+}
+
+fn set_value_proposal_data(value: u32) -> TimelockProposalData {
     let encoded = <RT as EncodeCall<ValueSetter<S>>>::encode_call(set_value_message(value));
-    calculate_timelock_proposal_id::<S>(TimelockProposalHashData::CallMessage(&encoded))
+    TimelockProposalData::call_message(encoded)
 }
 
 #[test]
@@ -114,6 +118,7 @@ fn timelocked_call_registers_proposal_without_dispatching_call() {
                     TimelockEvent::ProposalRegistered {
                         address: admin_address,
                         proposal_id,
+                        proposal_data: set_value_proposal_data(7),
                         executable_from: 1_060,
                         executable_until: 1_120,
                     }
@@ -133,13 +138,14 @@ fn timelocked_call_registers_proposal_without_dispatching_call() {
                     .unwrap_infallible(),
                 Some(1)
             );
-            let condition = Timelock::<S>::default()
+            let pending_timelock = Timelock::<S>::default()
                 .timelocks
                 .get(&TimelockKey(admin_address, proposal_id), state)
                 .unwrap_infallible()
                 .unwrap();
-            assert_eq!(condition.executable_from, 1_060);
-            assert_eq!(condition.executable_until, 1_120);
+            assert_eq!(pending_timelock.proposal_data, set_value_proposal_data(7));
+            assert_eq!(pending_timelock.unlock_condition.executable_from, 1_060);
+            assert_eq!(pending_timelock.unlock_condition.executable_until, 1_120);
             assert_eq!(
                 Timelock::<S>::default()
                     .timelock_counts

--- a/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
+++ b/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
@@ -1,0 +1,399 @@
+use std::num::NonZeroU64;
+
+use sov_modules_api::capabilities::{
+    calculate_timelock_proposal_id, TimelockPolicy, TimelockProposalHashData,
+    DEFAULT_EXPIRE_SECONDS_AFTER_UNLOCK,
+};
+use sov_modules_api::da::Time;
+use sov_modules_api::prelude::UnwrapInfallible;
+use sov_modules_api::EncodeCall;
+use sov_test_modules::hooks_count::TxHooksCount;
+use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
+use sov_test_utils::runtime::{TestRunner, ValueSetter};
+use sov_test_utils::{
+    generate_optimistic_runtime_with_kernel, AsUser, TestUser, TransactionTestCase,
+};
+use sov_timelock::{CancellationPolicy, Timelock, TimelockKey};
+use sov_value_setter::{CallMessage as ValueSetterCallMessage, ValueSetterConfig};
+
+use crate::S;
+
+generate_optimistic_runtime_with_kernel!(
+    TimelockRuntime <=
+    kernel_type: sov_test_utils::runtime::BasicKernel<'a, S>,
+    modules: [
+        value_setter: ValueSetter<S>,
+        tx_hooks_count: TxHooksCount<S>,
+        timelock: sov_timelock::Timelock<S>
+    ],
+    timelock_policy_wrapper: |call: &TimelockRuntimeCall<S>| {
+        match call {
+            TimelockRuntimeCall::ValueSetter(ValueSetterCallMessage::SetValue { value: 7, .. }) => {
+                Some(TimelockPolicy {
+                    unlock_seconds_from_proposal: NonZeroU64::new(60).unwrap(),
+                    expire_seconds_after_unlock_override: Some(60),
+                })
+            }
+            _ => None,
+        }
+    },
+    timelock_capability: timelock_capability,
+);
+
+type RT = TimelockRuntime<S>;
+
+fn timelock_capability<SpecT: sov_modules_api::Spec>(
+    runtime: &mut TimelockRuntime<SpecT>,
+) -> &mut Timelock<SpecT> {
+    &mut runtime.timelock
+}
+
+fn setup() -> (TestUser<S>, TestRunner<RT, S>) {
+    let genesis_config =
+        HighLevelOptimisticGenesisConfig::generate().add_accounts_with_default_balance(1);
+
+    let admin = genesis_config
+        .additional_accounts()
+        .first()
+        .unwrap()
+        .clone();
+
+    let genesis = GenesisConfig::from_minimal_config(
+        genesis_config.into(),
+        ValueSetterConfig {
+            admin: admin.address(),
+        },
+        (),
+        (),
+    );
+
+    let mut runner = TestRunner::new_with_genesis(genesis.into_genesis_params(), RT::default());
+    runner.config.freeze_time = Some(Time::from_secs(1_000));
+
+    (admin, runner)
+}
+
+fn set_value_message(value: u32) -> ValueSetterCallMessage<S> {
+    ValueSetterCallMessage::SetValue { value, gas: None }
+}
+
+fn set_value_proposal_id(value: u32) -> sov_modules_api::capabilities::ProposalId {
+    let encoded = <RT as EncodeCall<ValueSetter<S>>>::encode_call(set_value_message(value));
+    calculate_timelock_proposal_id::<S>(TimelockProposalHashData::CallMessage(&encoded))
+}
+
+#[test]
+fn timelocked_call_registers_proposal_without_dispatching_call() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let proposal_id = set_value_proposal_id(7);
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(
+                ValueSetter::<S>::default()
+                    .value
+                    .get(state)
+                    .unwrap_infallible(),
+                None
+            );
+            assert_eq!(
+                TxHooksCount::<S>::default()
+                    .post_dispatch_tx_hook_count
+                    .get(state)
+                    .unwrap_infallible(),
+                Some(1)
+            );
+            let condition = Timelock::<S>::default()
+                .timelocks
+                .get(
+                    &TimelockKey {
+                        address: admin_address,
+                        proposal_id,
+                    },
+                    state,
+                )
+                .unwrap_infallible()
+                .unwrap();
+            assert_eq!(condition.executable_from, 1_060);
+            assert_eq!(condition.executable_until, 1_120);
+        }),
+    });
+}
+
+#[test]
+fn repeated_timelocked_call_reverts_while_locked() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let proposal_id = set_value_proposal_id(7);
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_reverted());
+            assert_eq!(
+                ValueSetter::<S>::default()
+                    .value
+                    .get(state)
+                    .unwrap_infallible(),
+                None
+            );
+            assert_eq!(
+                TxHooksCount::<S>::default()
+                    .post_dispatch_tx_hook_count
+                    .get(state)
+                    .unwrap_infallible(),
+                Some(1)
+            );
+            assert!(Timelock::<S>::default()
+                .timelocks
+                .get(
+                    &TimelockKey {
+                        address: admin_address,
+                        proposal_id,
+                    },
+                    state
+                )
+                .unwrap_infallible()
+                .is_some());
+        }),
+    });
+}
+
+#[test]
+fn unlocked_timelocked_call_dispatches_and_consumes_proposal() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let proposal_id = set_value_proposal_id(7);
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.config.freeze_time = Some(Time::from_secs(1_060));
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(
+                ValueSetter::<S>::default()
+                    .value
+                    .get(state)
+                    .unwrap_infallible(),
+                Some(7)
+            );
+            assert_eq!(
+                TxHooksCount::<S>::default()
+                    .post_dispatch_tx_hook_count
+                    .get(state)
+                    .unwrap_infallible(),
+                Some(2)
+            );
+            assert!(Timelock::<S>::default()
+                .timelocks
+                .get(
+                    &TimelockKey {
+                        address: admin_address,
+                        proposal_id,
+                    },
+                    state
+                )
+                .unwrap_infallible()
+                .is_none());
+        }),
+    });
+}
+
+#[test]
+fn owner_can_cancel_pending_proposal() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let proposal_id = set_value_proposal_id(7);
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::CancelUnlock {
+                call_message_hash: proposal_id,
+                address: None,
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert!(Timelock::<S>::default()
+                .timelocks
+                .get(
+                    &TimelockKey {
+                        address: admin_address,
+                        proposal_id,
+                    },
+                    state
+                )
+                .unwrap_infallible()
+                .is_none());
+        }),
+    });
+}
+
+#[test]
+fn cancellation_policy_updates_are_self_timelocked_after_initial_policy() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let initial_policy = CancellationPolicy::<S> {
+        authorized_canceller: admin_address,
+        policy_change_timelock_seconds: 60,
+    };
+    let replacement_policy = CancellationPolicy::<S> {
+        authorized_canceller: admin_address,
+        policy_change_timelock_seconds: 120,
+    };
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: initial_policy.clone(),
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: replacement_policy.clone(),
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .policies
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                Some(initial_policy)
+            );
+        }),
+    });
+
+    runner.config.freeze_time = Some(Time::from_secs(1_060));
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: replacement_policy.clone(),
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .policies
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                Some(replacement_policy)
+            );
+        }),
+    });
+}
+
+#[test]
+fn cancellation_policy_update_proposals_expire_after_default_window() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let initial_policy = CancellationPolicy::<S> {
+        authorized_canceller: admin_address,
+        policy_change_timelock_seconds: 60,
+    };
+    let replacement_policy = CancellationPolicy::<S> {
+        authorized_canceller: admin_address,
+        policy_change_timelock_seconds: 120,
+    };
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: initial_policy.clone(),
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: replacement_policy.clone(),
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    let expired_proposal_time =
+        i64::try_from(1_060 + DEFAULT_EXPIRE_SECONDS_AFTER_UNLOCK + 1).unwrap();
+    runner.config.freeze_time = Some(Time::from_secs(expired_proposal_time));
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: replacement_policy,
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_reverted());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .policies
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                Some(initial_policy)
+            );
+        }),
+    });
+}
+
+#[test]
+fn untimelocked_call_dispatches_normally() {
+    let (admin, mut runner) = setup();
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(8)),
+        assert: Box::new(|result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(
+                ValueSetter::<S>::default()
+                    .value
+                    .get(state)
+                    .unwrap_infallible(),
+                Some(8)
+            );
+            assert_eq!(
+                TxHooksCount::<S>::default()
+                    .post_dispatch_tx_hook_count
+                    .get(state)
+                    .unwrap_infallible(),
+                Some(1)
+            );
+        }),
+    });
+}

--- a/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
+++ b/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
@@ -14,7 +14,7 @@ use sov_test_utils::runtime::{TestRunner, ValueSetter};
 use sov_test_utils::{
     generate_optimistic_runtime_with_kernel, AsUser, TestUser, TransactionTestCase,
 };
-use sov_timelock::{CancellationPolicy, Timelock, TimelockKey};
+use sov_timelock::{CancellationPolicy, Event as TimelockEvent, Timelock, TimelockKey};
 use sov_value_setter::{CallMessage as ValueSetterCallMessage, ValueSetterConfig};
 
 use crate::S;
@@ -105,6 +105,17 @@ fn timelocked_call_registers_proposal_without_dispatching_call() {
         assert: Box::new(move |result, state| {
             assert!(result.tx_receipt.is_successful());
             assert_eq!(
+                result.events,
+                vec![TimelockRuntimeEvent::Timelock(
+                    TimelockEvent::ProposalRegistered {
+                        address: admin_address,
+                        proposal_id,
+                        executable_from: 1_060,
+                        executable_until: 1_120,
+                    }
+                )]
+            );
+            assert_eq!(
                 ValueSetter::<S>::default()
                     .value
                     .get(state)
@@ -187,6 +198,13 @@ fn unlocked_timelocked_call_dispatches_and_consumes_proposal() {
         input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
         assert: Box::new(move |result, state| {
             assert!(result.tx_receipt.is_successful());
+            assert!(result.events.iter().any(|event| {
+                event
+                    == &TimelockRuntimeEvent::Timelock(TimelockEvent::ProposalUnlocked {
+                        address: admin_address,
+                        proposal_id,
+                    })
+            }));
             assert_eq!(
                 ValueSetter::<S>::default()
                     .value
@@ -232,6 +250,16 @@ fn owner_can_cancel_pending_proposal() {
         ),
         assert: Box::new(move |result, state| {
             assert!(result.tx_receipt.is_successful());
+            assert_eq!(
+                result.events,
+                vec![TimelockRuntimeEvent::Timelock(
+                    TimelockEvent::ProposalCancelled {
+                        address: admin_address,
+                        proposal_id,
+                        cancelled_by: admin_address,
+                    }
+                )]
+            );
             assert!(Timelock::<S>::default()
                 .timelocks
                 .get(&TimelockKey(admin_address, proposal_id), state)

--- a/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
+++ b/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
@@ -14,7 +14,9 @@ use sov_test_utils::runtime::{TestRunner, ValueSetter};
 use sov_test_utils::{
     generate_optimistic_runtime_with_kernel, AsUser, TestUser, TransactionTestCase,
 };
-use sov_timelock::{CancellationPolicy, Event as TimelockEvent, Timelock, TimelockKey};
+use sov_timelock::{
+    CancellationPolicy, Event as TimelockEvent, Timelock, TimelockKey, MAX_USER_TIMELOCKS,
+};
 use sov_value_setter::{CallMessage as ValueSetterCallMessage, ValueSetterConfig};
 
 use crate::S;
@@ -29,7 +31,9 @@ generate_optimistic_runtime_with_kernel!(
     ],
     timelock_policy_wrapper: |call: &TimelockRuntimeCall<S>| {
         match call {
-            TimelockRuntimeCall::ValueSetter(ValueSetterCallMessage::SetValue { value: 7, .. }) => {
+            TimelockRuntimeCall::ValueSetter(ValueSetterCallMessage::SetValue { value, .. })
+                if *value == 7 || *value >= 100 =>
+            {
                 Some(TimelockPolicy {
                     unlock_seconds_from_proposal: NonZeroU64::new(60).unwrap(),
                     expire_seconds_after_unlock_override: Some(60),
@@ -136,6 +140,13 @@ fn timelocked_call_registers_proposal_without_dispatching_call() {
                 .unwrap();
             assert_eq!(condition.executable_from, 1_060);
             assert_eq!(condition.executable_until, 1_120);
+            assert_eq!(
+                Timelock::<S>::default()
+                    .timelock_counts
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                Some(1)
+            );
         }),
     });
 }
@@ -224,6 +235,13 @@ fn unlocked_timelocked_call_dispatches_and_consumes_proposal() {
                 .get(&TimelockKey(admin_address, proposal_id), state)
                 .unwrap_infallible()
                 .is_none());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .timelock_counts
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                None
+            );
         }),
     });
 }
@@ -263,6 +281,49 @@ fn owner_can_cancel_pending_proposal() {
             assert!(Timelock::<S>::default()
                 .timelocks
                 .get(&TimelockKey(admin_address, proposal_id), state)
+                .unwrap_infallible()
+                .is_none());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .timelock_counts
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                None
+            );
+        }),
+    });
+}
+
+#[test]
+fn registration_reverts_after_max_user_timelocks() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+
+    for value in 100..(100 + MAX_USER_TIMELOCKS) {
+        runner.execute_transaction(TransactionTestCase {
+            input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(value)),
+            assert: Box::new(|result, _state| {
+                assert!(result.tx_receipt.is_successful());
+            }),
+        });
+    }
+
+    let rejected_value = 100 + MAX_USER_TIMELOCKS;
+    let rejected_proposal_id = set_value_proposal_id(rejected_value);
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(rejected_value)),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_reverted());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .timelock_counts
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                Some(MAX_USER_TIMELOCKS)
+            );
+            assert!(Timelock::<S>::default()
+                .timelocks
+                .get(&TimelockKey(admin_address, rejected_proposal_id), state)
                 .unwrap_infallible()
                 .is_none());
         }),

--- a/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
+++ b/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
@@ -32,6 +32,12 @@ generate_optimistic_runtime_with_kernel!(
     ],
     timelock_policy_wrapper: |call: &TimelockRuntimeCall<S>| {
         match call {
+            TimelockRuntimeCall::ValueSetter(ValueSetterCallMessage::SetValue { value: 9, .. }) => {
+                Some(TimelockPolicy {
+                    unlock_seconds_from_proposal: NonZeroU64::new(60).unwrap(),
+                    expire_seconds_after_unlock_override: Some(0),
+                })
+            }
             TimelockRuntimeCall::ValueSetter(ValueSetterCallMessage::SetValue { value, .. })
                 if *value == 7 || *value >= 100 =>
             {
@@ -264,6 +270,160 @@ fn unlocked_timelocked_call_dispatches_and_consumes_proposal() {
 }
 
 #[test]
+fn expired_timelocked_call_reverts_without_consuming_proposal() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let proposal_id = set_value_proposal_id(7);
+    let proposal_key = ProposalKey(admin_address, proposal_id);
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.config.freeze_time = Some(Time::from_secs(1_121));
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_reverted());
+            assert_eq!(
+                ValueSetter::<S>::default()
+                    .value
+                    .get(state)
+                    .unwrap_infallible(),
+                None
+            );
+            assert!(Timelock::<S>::default()
+                .proposals
+                .get(&proposal_key, state)
+                .unwrap_infallible()
+                .is_some());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .proposal_counts
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                Some(1)
+            );
+            assert_eq!(
+                TxHooksCount::<S>::default()
+                    .post_dispatch_tx_hook_count
+                    .get(state)
+                    .unwrap_infallible(),
+                Some(1)
+            );
+        }),
+    });
+}
+
+#[test]
+fn zero_expiry_policy_executes_at_exact_unlock_timestamp() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let proposal_id = set_value_proposal_id(9);
+    let proposal_key = ProposalKey(admin_address, proposal_id);
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(9)),
+        assert: Box::new({
+            let proposal_key = proposal_key.clone();
+            move |result, state| {
+                assert!(result.tx_receipt.is_successful());
+                assert_eq!(
+                    result.events,
+                    vec![TimelockRuntimeEvent::Timelock(
+                        TimelockEvent::ProposalRegistered {
+                            address: admin_address,
+                            proposal_id,
+                            proposal_data: set_value_proposal_data(9),
+                            executable_from: 1_060,
+                            executable_until: 1_060,
+                        }
+                    )]
+                );
+                let pending_proposal = Timelock::<S>::default()
+                    .proposals
+                    .get(&proposal_key, state)
+                    .unwrap_infallible()
+                    .unwrap();
+                assert_eq!(pending_proposal.unlock_condition.executable_from, 1_060);
+                assert_eq!(pending_proposal.unlock_condition.executable_until, 1_060);
+            }
+        }),
+    });
+
+    runner.config.freeze_time = Some(Time::from_secs(1_060));
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::CleanExpiredProposals {
+                proposal_keys: cleanup_keys(vec![proposal_key.clone()]),
+            },
+        ),
+        assert: Box::new({
+            let proposal_key = proposal_key.clone();
+            move |result, state| {
+                assert!(result.tx_receipt.is_successful());
+                assert_eq!(result.events, vec![]);
+                assert!(Timelock::<S>::default()
+                    .proposals
+                    .get(&proposal_key, state)
+                    .unwrap_infallible()
+                    .is_some());
+                assert_eq!(
+                    Timelock::<S>::default()
+                        .proposal_counts
+                        .get(&admin_address, state)
+                        .unwrap_infallible(),
+                    Some(1)
+                );
+                assert_eq!(
+                    ValueSetter::<S>::default()
+                        .value
+                        .get(state)
+                        .unwrap_infallible(),
+                    None
+                );
+            }
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(9)),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert!(result.events.iter().any(|event| {
+                event
+                    == &TimelockRuntimeEvent::Timelock(TimelockEvent::ProposalUnlocked {
+                        address: admin_address,
+                        proposal_id,
+                    })
+            }));
+            assert_eq!(
+                ValueSetter::<S>::default()
+                    .value
+                    .get(state)
+                    .unwrap_infallible(),
+                Some(9)
+            );
+            assert!(Timelock::<S>::default()
+                .proposals
+                .get(&proposal_key, state)
+                .unwrap_infallible()
+                .is_none());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .proposal_counts
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                None
+            );
+        }),
+    });
+}
+
+#[test]
 fn owner_can_cancel_pending_proposal() {
     let (admin, mut runner) = setup();
     let admin_address = admin.address();
@@ -298,6 +458,255 @@ fn owner_can_cancel_pending_proposal() {
             assert!(Timelock::<S>::default()
                 .proposals
                 .get(&ProposalKey(admin_address, proposal_id), state)
+                .unwrap_infallible()
+                .is_none());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .proposal_counts
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                None
+            );
+        }),
+    });
+}
+
+#[test]
+fn authorized_canceller_can_cancel_pending_proposal() {
+    let (users, mut runner) = setup_with_accounts(2);
+    let admin = users[0].clone();
+    let canceller = users[1].clone();
+    let admin_address = admin.address();
+    let canceller_address = canceller.address();
+    let proposal_id = set_value_proposal_id(7);
+    let cancellation_policy = CancellationPolicy::<S> {
+        authorized_canceller: canceller_address,
+        policy_change_timelock_seconds: 0,
+    };
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: cancellation_policy.clone(),
+            },
+        ),
+        assert: Box::new({
+            let cancellation_policy = cancellation_policy.clone();
+            move |result, state| {
+                assert!(result.tx_receipt.is_successful());
+                assert_eq!(
+                    Timelock::<S>::default()
+                        .policies
+                        .get(&admin_address, state)
+                        .unwrap_infallible(),
+                    Some(cancellation_policy)
+                );
+            }
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new({
+            let cancellation_policy = cancellation_policy.clone();
+            move |result, state| {
+                assert!(result.tx_receipt.is_successful());
+                let pending_proposal = Timelock::<S>::default()
+                    .proposals
+                    .get(&ProposalKey(admin_address, proposal_id), state)
+                    .unwrap_infallible()
+                    .unwrap();
+                assert_eq!(
+                    pending_proposal.unlock_condition.cancellation_policy,
+                    cancellation_policy
+                );
+            }
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: canceller.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::CancelProposal {
+                proposal_id,
+                address: Some(admin_address),
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(
+                result.events,
+                vec![TimelockRuntimeEvent::Timelock(
+                    TimelockEvent::ProposalCancelled {
+                        address: admin_address,
+                        proposal_id,
+                        cancelled_by: canceller_address,
+                    }
+                )]
+            );
+            assert!(Timelock::<S>::default()
+                .proposals
+                .get(&ProposalKey(admin_address, proposal_id), state)
+                .unwrap_infallible()
+                .is_none());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .proposal_counts
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                None
+            );
+        }),
+    });
+}
+
+#[test]
+fn proposals_snapshot_cancellation_policy_at_registration() {
+    let (users, mut runner) = setup_with_accounts(3);
+    let admin = users[0].clone();
+    let initial_canceller = users[1].clone();
+    let replacement_canceller = users[2].clone();
+    let admin_address = admin.address();
+    let initial_canceller_address = initial_canceller.address();
+    let replacement_canceller_address = replacement_canceller.address();
+    let proposal_id = set_value_proposal_id(7);
+    let proposal_key = ProposalKey(admin_address, proposal_id);
+    let initial_policy = CancellationPolicy::<S> {
+        authorized_canceller: initial_canceller_address,
+        policy_change_timelock_seconds: 0,
+    };
+    let replacement_policy = CancellationPolicy::<S> {
+        authorized_canceller: replacement_canceller_address,
+        policy_change_timelock_seconds: 0,
+    };
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: initial_policy.clone(),
+            },
+        ),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
+        assert: Box::new({
+            let initial_policy = initial_policy.clone();
+            let proposal_key = proposal_key.clone();
+            move |result, state| {
+                assert!(result.tx_receipt.is_successful());
+                let pending_proposal = Timelock::<S>::default()
+                    .proposals
+                    .get(&proposal_key, state)
+                    .unwrap_infallible()
+                    .unwrap();
+                assert_eq!(
+                    pending_proposal.unlock_condition.cancellation_policy,
+                    initial_policy
+                );
+                assert_eq!(
+                    Timelock::<S>::default()
+                        .proposal_counts
+                        .get(&admin_address, state)
+                        .unwrap_infallible(),
+                    Some(1)
+                );
+            }
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::ModifyCancellationPolicy {
+                new_policy: replacement_policy.clone(),
+            },
+        ),
+        assert: Box::new({
+            let initial_policy = initial_policy.clone();
+            let replacement_policy = replacement_policy.clone();
+            let proposal_key = proposal_key.clone();
+            move |result, state| {
+                assert!(result.tx_receipt.is_successful());
+                assert_eq!(
+                    Timelock::<S>::default()
+                        .policies
+                        .get(&admin_address, state)
+                        .unwrap_infallible(),
+                    Some(replacement_policy)
+                );
+                assert_eq!(
+                    Timelock::<S>::default()
+                        .proposals
+                        .get(&proposal_key, state)
+                        .unwrap_infallible()
+                        .unwrap()
+                        .unlock_condition
+                        .cancellation_policy,
+                    initial_policy
+                );
+            }
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: replacement_canceller.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::CancelProposal {
+                proposal_id,
+                address: Some(admin_address),
+            },
+        ),
+        assert: Box::new({
+            let replacement_policy = replacement_policy.clone();
+            let proposal_key = proposal_key.clone();
+            move |result, state| {
+                assert!(result.tx_receipt.is_reverted());
+                assert!(Timelock::<S>::default()
+                    .proposals
+                    .get(&proposal_key, state)
+                    .unwrap_infallible()
+                    .is_some());
+                assert_eq!(
+                    Timelock::<S>::default()
+                        .proposal_counts
+                        .get(&admin_address, state)
+                        .unwrap_infallible(),
+                    Some(1)
+                );
+                assert_eq!(
+                    Timelock::<S>::default()
+                        .policies
+                        .get(&admin_address, state)
+                        .unwrap_infallible(),
+                    Some(replacement_policy)
+                );
+            }
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: initial_canceller.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::CancelProposal {
+                proposal_id,
+                address: Some(admin_address),
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(
+                result.events,
+                vec![TimelockRuntimeEvent::Timelock(
+                    TimelockEvent::ProposalCancelled {
+                        address: admin_address,
+                        proposal_id,
+                        cancelled_by: initial_canceller_address,
+                    }
+                )]
+            );
+            assert!(Timelock::<S>::default()
+                .proposals
+                .get(&proposal_key, state)
                 .unwrap_infallible()
                 .is_none());
             assert_eq!(

--- a/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
+++ b/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
@@ -1,7 +1,8 @@
 use std::num::NonZeroU64;
+use std::str::FromStr;
 
 use sov_modules_api::capabilities::{
-    calculate_timelock_proposal_id, TimelockPolicy, TimelockProposalHashData,
+    calculate_timelock_proposal_id, ProposalId, TimelockPolicy, TimelockProposalHashData,
     DEFAULT_EXPIRE_SECONDS_AFTER_UNLOCK,
 };
 use sov_modules_api::da::Time;
@@ -83,6 +84,17 @@ fn set_value_proposal_id(value: u32) -> sov_modules_api::capabilities::ProposalI
 }
 
 #[test]
+fn timelock_key_display_roundtrips() {
+    let (admin, _runner) = setup();
+    let key = TimelockKey(admin.address(), ProposalId::new([1; 32]));
+    let encoded = key.to_string();
+
+    assert!(encoded.contains("/timelocks/"));
+    assert!(!encoded.starts_with("addresses/"));
+    assert_eq!(TimelockKey::<S>::from_str(&encoded).unwrap(), key);
+}
+
+#[test]
 fn timelocked_call_registers_proposal_without_dispatching_call() {
     let (admin, mut runner) = setup();
     let admin_address = admin.address();
@@ -108,13 +120,7 @@ fn timelocked_call_registers_proposal_without_dispatching_call() {
             );
             let condition = Timelock::<S>::default()
                 .timelocks
-                .get(
-                    &TimelockKey {
-                        address: admin_address,
-                        proposal_id,
-                    },
-                    state,
-                )
+                .get(&TimelockKey(admin_address, proposal_id), state)
                 .unwrap_infallible()
                 .unwrap();
             assert_eq!(condition.executable_from, 1_060);
@@ -156,13 +162,7 @@ fn repeated_timelocked_call_reverts_while_locked() {
             );
             assert!(Timelock::<S>::default()
                 .timelocks
-                .get(
-                    &TimelockKey {
-                        address: admin_address,
-                        proposal_id,
-                    },
-                    state
-                )
+                .get(&TimelockKey(admin_address, proposal_id), state)
                 .unwrap_infallible()
                 .is_some());
         }),
@@ -203,13 +203,7 @@ fn unlocked_timelocked_call_dispatches_and_consumes_proposal() {
             );
             assert!(Timelock::<S>::default()
                 .timelocks
-                .get(
-                    &TimelockKey {
-                        address: admin_address,
-                        proposal_id,
-                    },
-                    state
-                )
+                .get(&TimelockKey(admin_address, proposal_id), state)
                 .unwrap_infallible()
                 .is_none());
         }),
@@ -240,13 +234,7 @@ fn owner_can_cancel_pending_proposal() {
             assert!(result.tx_receipt.is_successful());
             assert!(Timelock::<S>::default()
                 .timelocks
-                .get(
-                    &TimelockKey {
-                        address: admin_address,
-                        proposal_id,
-                    },
-                    state
-                )
+                .get(&TimelockKey(admin_address, proposal_id), state)
                 .unwrap_infallible()
                 .is_none());
         }),

--- a/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
+++ b/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
@@ -324,8 +324,7 @@ fn zero_expiry_policy_executes_at_exact_unlock_timestamp() {
         assert: Box::new({
             let proposal_key = proposal_key.clone();
             move |result, state| {
-                assert!(result.tx_receipt.is_successful());
-                assert_eq!(result.events, vec![]);
+                assert!(result.tx_receipt.is_reverted());
                 assert!(pending_proposal(state, &proposal_key).is_some());
                 assert_eq!(proposal_count(state, &admin_address), Some(1));
                 assert_eq!(stored_value(state), None);
@@ -627,12 +626,11 @@ fn expired_proposals_can_be_batch_cleaned_without_owner_permission() {
 }
 
 #[test]
-fn cleanup_skips_unexpired_and_missing_proposals() {
+fn cleanup_reverts_on_unexpired_or_missing_proposals() {
     let (admin, mut runner) = setup();
     let admin_address = admin.address();
     let expired_proposal_key = set_value_proposal_key(admin_address, 100);
     let unexpired_proposal_key = set_value_proposal_key(admin_address, 101);
-    let expired_proposal_id = expired_proposal_key.1;
     let missing_proposal_key = ProposalKey(admin_address, ProposalId::new([9; 32]));
 
     register_set_value_proposal(&mut runner, &admin, 100);
@@ -647,24 +645,35 @@ fn cleanup_skips_unexpired_and_missing_proposals() {
                 proposal_keys: cleanup_keys(vec![
                     expired_proposal_key.clone(),
                     unexpired_proposal_key.clone(),
+                ]),
+            },
+        ),
+        assert: Box::new({
+            let expired_proposal_key = expired_proposal_key.clone();
+            let unexpired_proposal_key = unexpired_proposal_key.clone();
+            move |result, state| {
+                assert!(result.tx_receipt.is_reverted());
+                assert!(pending_proposal(state, &expired_proposal_key).is_some());
+                assert!(pending_proposal(state, &unexpired_proposal_key).is_some());
+                assert_eq!(proposal_count(state, &admin_address), Some(2));
+            }
+        }),
+    });
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::CleanExpiredProposals {
+                proposal_keys: cleanup_keys(vec![
+                    expired_proposal_key.clone(),
                     missing_proposal_key,
                 ]),
             },
         ),
         assert: Box::new(move |result, state| {
-            assert!(result.tx_receipt.is_successful());
-            assert_eq!(
-                result.events,
-                vec![TimelockRuntimeEvent::Timelock(
-                    TimelockEvent::ExpiredProposalCleaned {
-                        address: admin_address,
-                        proposal_id: expired_proposal_id,
-                    }
-                )]
-            );
-            assert!(pending_proposal(state, &expired_proposal_key).is_none());
+            assert!(result.tx_receipt.is_reverted());
+            assert!(pending_proposal(state, &expired_proposal_key).is_some());
             assert!(pending_proposal(state, &unexpired_proposal_key).is_some());
-            assert_eq!(proposal_count(state, &admin_address), Some(1));
+            assert_eq!(proposal_count(state, &admin_address), Some(2));
         }),
     });
 }

--- a/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
+++ b/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
@@ -7,7 +7,7 @@ use sov_modules_api::capabilities::{
 };
 use sov_modules_api::da::Time;
 use sov_modules_api::prelude::UnwrapInfallible;
-use sov_modules_api::EncodeCall;
+use sov_modules_api::{EncodeCall, SafeVec};
 use sov_test_modules::hooks_count::TxHooksCount;
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
 use sov_test_utils::runtime::{TestRunner, ValueSetter};
@@ -16,7 +16,7 @@ use sov_test_utils::{
 };
 use sov_timelock::{
     CancellationPolicy, Event as TimelockEvent, ProposalKey, Timelock,
-    MAX_PENDING_PROPOSALS_PER_ADDRESS,
+    MAX_PENDING_PROPOSALS_PER_ADDRESS, MAX_PROPOSAL_KEYS_PER_CLEANUP,
 };
 use sov_value_setter::{CallMessage as ValueSetterCallMessage, ValueSetterConfig};
 
@@ -54,15 +54,12 @@ fn timelock_capability<SpecT: sov_modules_api::Spec>(
     &mut runtime.timelock
 }
 
-fn setup() -> (TestUser<S>, TestRunner<RT, S>) {
-    let genesis_config =
-        HighLevelOptimisticGenesisConfig::generate().add_accounts_with_default_balance(1);
+fn setup_with_accounts(account_count: usize) -> (Vec<TestUser<S>>, TestRunner<RT, S>) {
+    let genesis_config = HighLevelOptimisticGenesisConfig::generate()
+        .add_accounts_with_default_balance(account_count);
 
-    let admin = genesis_config
-        .additional_accounts()
-        .first()
-        .unwrap()
-        .clone();
+    let users = genesis_config.additional_accounts().to_vec();
+    let admin = users.first().unwrap().clone();
 
     let genesis = GenesisConfig::from_minimal_config(
         genesis_config.into(),
@@ -75,6 +72,13 @@ fn setup() -> (TestUser<S>, TestRunner<RT, S>) {
 
     let mut runner = TestRunner::new_with_genesis(genesis.into_genesis_params(), RT::default());
     runner.config.freeze_time = Some(Time::from_secs(1_000));
+
+    (users, runner)
+}
+
+fn setup() -> (TestUser<S>, TestRunner<RT, S>) {
+    let (mut users, runner) = setup_with_accounts(1);
+    let admin = users.pop().unwrap();
 
     (admin, runner)
 }
@@ -90,6 +94,12 @@ fn set_value_proposal_id(value: u32) -> sov_modules_api::capabilities::ProposalI
 fn set_value_proposal_data(value: u32) -> TimelockProposalData {
     let encoded = <RT as EncodeCall<ValueSetter<S>>>::encode_call(set_value_message(value));
     TimelockProposalData::call_message(encoded)
+}
+
+fn cleanup_keys(
+    keys: Vec<ProposalKey<S>>,
+) -> SafeVec<ProposalKey<S>, MAX_PROPOSAL_KEYS_PER_CLEANUP> {
+    SafeVec::try_from(keys).unwrap()
 }
 
 #[test]
@@ -296,6 +306,136 @@ fn owner_can_cancel_pending_proposal() {
                     .get(&admin_address, state)
                     .unwrap_infallible(),
                 None
+            );
+        }),
+    });
+}
+
+#[test]
+fn expired_proposals_can_be_batch_cleaned_without_owner_permission() {
+    let (users, mut runner) = setup_with_accounts(2);
+    let admin = users[0].clone();
+    let cleaner = users[1].clone();
+    let admin_address = admin.address();
+    let first_proposal_id = set_value_proposal_id(100);
+    let second_proposal_id = set_value_proposal_id(101);
+
+    for value in [100, 101] {
+        runner.execute_transaction(TransactionTestCase {
+            input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(value)),
+            assert: Box::new(|result, _state| {
+                assert!(result.tx_receipt.is_successful());
+            }),
+        });
+    }
+
+    runner.config.freeze_time = Some(Time::from_secs(1_121));
+    let proposal_keys = cleanup_keys(vec![
+        ProposalKey(admin_address, first_proposal_id),
+        ProposalKey(admin_address, second_proposal_id),
+    ]);
+    runner.execute_transaction(TransactionTestCase {
+        input: cleaner.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::CleanExpiredProposals {
+                proposal_keys: proposal_keys.clone(),
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(
+                result.events,
+                vec![
+                    TimelockRuntimeEvent::Timelock(TimelockEvent::ExpiredProposalCleaned {
+                        address: admin_address,
+                        proposal_id: first_proposal_id,
+                    }),
+                    TimelockRuntimeEvent::Timelock(TimelockEvent::ExpiredProposalCleaned {
+                        address: admin_address,
+                        proposal_id: second_proposal_id,
+                    }),
+                ]
+            );
+            for proposal_key in proposal_keys {
+                assert!(Timelock::<S>::default()
+                    .proposals
+                    .get(&proposal_key, state)
+                    .unwrap_infallible()
+                    .is_none());
+            }
+            assert_eq!(
+                Timelock::<S>::default()
+                    .proposal_counts
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                None
+            );
+        }),
+    });
+}
+
+#[test]
+fn cleanup_skips_unexpired_and_missing_proposals() {
+    let (admin, mut runner) = setup();
+    let admin_address = admin.address();
+    let expired_proposal_id = set_value_proposal_id(100);
+    let unexpired_proposal_id = set_value_proposal_id(101);
+    let expired_proposal_key = ProposalKey(admin_address, expired_proposal_id);
+    let unexpired_proposal_key = ProposalKey(admin_address, unexpired_proposal_id);
+    let missing_proposal_key = ProposalKey(admin_address, ProposalId::new([9; 32]));
+
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(100)),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.config.freeze_time = Some(Time::from_secs(1_061));
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(101)),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
+
+    runner.config.freeze_time = Some(Time::from_secs(1_121));
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Timelock<S>>(
+            sov_timelock::CallMessage::CleanExpiredProposals {
+                proposal_keys: cleanup_keys(vec![
+                    expired_proposal_key.clone(),
+                    unexpired_proposal_key.clone(),
+                    missing_proposal_key,
+                ]),
+            },
+        ),
+        assert: Box::new(move |result, state| {
+            assert!(result.tx_receipt.is_successful());
+            assert_eq!(
+                result.events,
+                vec![TimelockRuntimeEvent::Timelock(
+                    TimelockEvent::ExpiredProposalCleaned {
+                        address: admin_address,
+                        proposal_id: expired_proposal_id,
+                    }
+                )]
+            );
+            assert!(Timelock::<S>::default()
+                .proposals
+                .get(&expired_proposal_key, state)
+                .unwrap_infallible()
+                .is_none());
+            assert!(Timelock::<S>::default()
+                .proposals
+                .get(&unexpired_proposal_key, state)
+                .unwrap_infallible()
+                .is_some());
+            assert_eq!(
+                Timelock::<S>::default()
+                    .proposal_counts
+                    .get(&admin_address, state)
+                    .unwrap_infallible(),
+                Some(1)
             );
         }),
     });

--- a/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
+++ b/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
@@ -15,7 +15,8 @@ use sov_test_utils::{
     generate_optimistic_runtime_with_kernel, AsUser, TestUser, TransactionTestCase,
 };
 use sov_timelock::{
-    CancellationPolicy, Event as TimelockEvent, Timelock, TimelockKey, MAX_USER_TIMELOCKS,
+    CancellationPolicy, Event as TimelockEvent, ProposalKey, Timelock,
+    MAX_PENDING_PROPOSALS_PER_ADDRESS,
 };
 use sov_value_setter::{CallMessage as ValueSetterCallMessage, ValueSetterConfig};
 
@@ -92,14 +93,14 @@ fn set_value_proposal_data(value: u32) -> TimelockProposalData {
 }
 
 #[test]
-fn timelock_key_display_roundtrips() {
+fn proposal_key_display_roundtrips() {
     let (admin, _runner) = setup();
-    let key = TimelockKey(admin.address(), ProposalId::new([1; 32]));
+    let key = ProposalKey(admin.address(), ProposalId::new([1; 32]));
     let encoded = key.to_string();
 
-    assert!(encoded.contains("/timelocks/"));
+    assert!(encoded.contains("/proposals/"));
     assert!(!encoded.starts_with("addresses/"));
-    assert_eq!(TimelockKey::<S>::from_str(&encoded).unwrap(), key);
+    assert_eq!(ProposalKey::<S>::from_str(&encoded).unwrap(), key);
 }
 
 #[test]
@@ -138,17 +139,17 @@ fn timelocked_call_registers_proposal_without_dispatching_call() {
                     .unwrap_infallible(),
                 Some(1)
             );
-            let pending_timelock = Timelock::<S>::default()
-                .timelocks
-                .get(&TimelockKey(admin_address, proposal_id), state)
+            let pending_proposal = Timelock::<S>::default()
+                .proposals
+                .get(&ProposalKey(admin_address, proposal_id), state)
                 .unwrap_infallible()
                 .unwrap();
-            assert_eq!(pending_timelock.proposal_data, set_value_proposal_data(7));
-            assert_eq!(pending_timelock.unlock_condition.executable_from, 1_060);
-            assert_eq!(pending_timelock.unlock_condition.executable_until, 1_120);
+            assert_eq!(pending_proposal.proposal_data, set_value_proposal_data(7));
+            assert_eq!(pending_proposal.unlock_condition.executable_from, 1_060);
+            assert_eq!(pending_proposal.unlock_condition.executable_until, 1_120);
             assert_eq!(
                 Timelock::<S>::default()
-                    .timelock_counts
+                    .proposal_counts
                     .get(&admin_address, state)
                     .unwrap_infallible(),
                 Some(1)
@@ -189,8 +190,8 @@ fn repeated_timelocked_call_reverts_while_locked() {
                 Some(1)
             );
             assert!(Timelock::<S>::default()
-                .timelocks
-                .get(&TimelockKey(admin_address, proposal_id), state)
+                .proposals
+                .get(&ProposalKey(admin_address, proposal_id), state)
                 .unwrap_infallible()
                 .is_some());
         }),
@@ -237,13 +238,13 @@ fn unlocked_timelocked_call_dispatches_and_consumes_proposal() {
                 Some(2)
             );
             assert!(Timelock::<S>::default()
-                .timelocks
-                .get(&TimelockKey(admin_address, proposal_id), state)
+                .proposals
+                .get(&ProposalKey(admin_address, proposal_id), state)
                 .unwrap_infallible()
                 .is_none());
             assert_eq!(
                 Timelock::<S>::default()
-                    .timelock_counts
+                    .proposal_counts
                     .get(&admin_address, state)
                     .unwrap_infallible(),
                 None
@@ -267,8 +268,8 @@ fn owner_can_cancel_pending_proposal() {
 
     runner.execute_transaction(TransactionTestCase {
         input: admin.create_plain_message::<RT, Timelock<S>>(
-            sov_timelock::CallMessage::CancelUnlock {
-                call_message_hash: proposal_id,
+            sov_timelock::CallMessage::CancelProposal {
+                proposal_id,
                 address: None,
             },
         ),
@@ -285,13 +286,13 @@ fn owner_can_cancel_pending_proposal() {
                 )]
             );
             assert!(Timelock::<S>::default()
-                .timelocks
-                .get(&TimelockKey(admin_address, proposal_id), state)
+                .proposals
+                .get(&ProposalKey(admin_address, proposal_id), state)
                 .unwrap_infallible()
                 .is_none());
             assert_eq!(
                 Timelock::<S>::default()
-                    .timelock_counts
+                    .proposal_counts
                     .get(&admin_address, state)
                     .unwrap_infallible(),
                 None
@@ -301,11 +302,11 @@ fn owner_can_cancel_pending_proposal() {
 }
 
 #[test]
-fn registration_reverts_after_max_user_timelocks() {
+fn registration_reverts_after_max_pending_proposals() {
     let (admin, mut runner) = setup();
     let admin_address = admin.address();
 
-    for value in 100..(100 + MAX_USER_TIMELOCKS) {
+    for value in 100..(100 + MAX_PENDING_PROPOSALS_PER_ADDRESS) {
         runner.execute_transaction(TransactionTestCase {
             input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(value)),
             assert: Box::new(|result, _state| {
@@ -314,7 +315,7 @@ fn registration_reverts_after_max_user_timelocks() {
         });
     }
 
-    let rejected_value = 100 + MAX_USER_TIMELOCKS;
+    let rejected_value = 100 + MAX_PENDING_PROPOSALS_PER_ADDRESS;
     let rejected_proposal_id = set_value_proposal_id(rejected_value);
     runner.execute_transaction(TransactionTestCase {
         input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(rejected_value)),
@@ -322,14 +323,14 @@ fn registration_reverts_after_max_user_timelocks() {
             assert!(result.tx_receipt.is_reverted());
             assert_eq!(
                 Timelock::<S>::default()
-                    .timelock_counts
+                    .proposal_counts
                     .get(&admin_address, state)
                     .unwrap_infallible(),
-                Some(MAX_USER_TIMELOCKS)
+                Some(MAX_PENDING_PROPOSALS_PER_ADDRESS)
             );
             assert!(Timelock::<S>::default()
-                .timelocks
-                .get(&TimelockKey(admin_address, rejected_proposal_id), state)
+                .proposals
+                .get(&ProposalKey(admin_address, rejected_proposal_id), state)
                 .unwrap_infallible()
                 .is_none());
         }),

--- a/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
+++ b/crates/module-system/module-implementations/sov-timelock/tests/integration/timelock.rs
@@ -7,7 +7,7 @@ use sov_modules_api::capabilities::{
 };
 use sov_modules_api::da::Time;
 use sov_modules_api::prelude::UnwrapInfallible;
-use sov_modules_api::{EncodeCall, SafeVec};
+use sov_modules_api::{ApiStateAccessor, EncodeCall, SafeVec};
 use sov_test_modules::hooks_count::TxHooksCount;
 use sov_test_utils::runtime::genesis::optimistic::HighLevelOptimisticGenesisConfig;
 use sov_test_utils::runtime::{TestRunner, ValueSetter};
@@ -15,7 +15,7 @@ use sov_test_utils::{
     generate_optimistic_runtime_with_kernel, AsUser, TestUser, TransactionTestCase,
 };
 use sov_timelock::{
-    CancellationPolicy, Event as TimelockEvent, ProposalKey, Timelock,
+    CancellationPolicy, Event as TimelockEvent, PendingProposal, ProposalKey, Timelock,
     MAX_PENDING_PROPOSALS_PER_ADDRESS, MAX_PROPOSAL_KEYS_PER_CLEANUP,
 };
 use sov_value_setter::{CallMessage as ValueSetterCallMessage, ValueSetterConfig};
@@ -97,15 +97,75 @@ fn set_value_proposal_id(value: u32) -> sov_modules_api::capabilities::ProposalI
     calculate_timelock_proposal_id::<S>(&set_value_proposal_data(value))
 }
 
+fn set_value_proposal_key(
+    address: <S as sov_modules_api::Spec>::Address,
+    value: u32,
+) -> ProposalKey<S> {
+    ProposalKey(address, set_value_proposal_id(value))
+}
+
 fn set_value_proposal_data(value: u32) -> TimelockProposalData {
     let encoded = <RT as EncodeCall<ValueSetter<S>>>::encode_call(set_value_message(value));
     TimelockProposalData::call_message(encoded)
+}
+
+fn register_set_value_proposal(runner: &mut TestRunner<RT, S>, user: &TestUser<S>, value: u32) {
+    runner.execute_transaction(TransactionTestCase {
+        input: user.create_plain_message::<RT, ValueSetter<S>>(set_value_message(value)),
+        assert: Box::new(|result, _state| {
+            assert!(result.tx_receipt.is_successful());
+        }),
+    });
 }
 
 fn cleanup_keys(
     keys: Vec<ProposalKey<S>>,
 ) -> SafeVec<ProposalKey<S>, MAX_PROPOSAL_KEYS_PER_CLEANUP> {
     SafeVec::try_from(keys).unwrap()
+}
+
+fn stored_value(state: &mut ApiStateAccessor<S>) -> Option<u32> {
+    ValueSetter::<S>::default()
+        .value
+        .get(state)
+        .unwrap_infallible()
+}
+
+fn pending_proposal(
+    state: &mut ApiStateAccessor<S>,
+    key: &ProposalKey<S>,
+) -> Option<PendingProposal<S>> {
+    Timelock::<S>::default()
+        .proposals
+        .get(key, state)
+        .unwrap_infallible()
+}
+
+fn proposal_count(
+    state: &mut ApiStateAccessor<S>,
+    address: &<S as sov_modules_api::Spec>::Address,
+) -> Option<u32> {
+    Timelock::<S>::default()
+        .proposal_counts
+        .get(address, state)
+        .unwrap_infallible()
+}
+
+fn stored_cancellation_policy(
+    state: &mut ApiStateAccessor<S>,
+    address: &<S as sov_modules_api::Spec>::Address,
+) -> Option<CancellationPolicy<S>> {
+    Timelock::<S>::default()
+        .policies
+        .get(address, state)
+        .unwrap_infallible()
+}
+
+fn post_dispatch_count(state: &mut ApiStateAccessor<S>) -> Option<u32> {
+    TxHooksCount::<S>::default()
+        .post_dispatch_tx_hook_count
+        .get(state)
+        .unwrap_infallible()
 }
 
 #[test]
@@ -123,7 +183,8 @@ fn proposal_key_display_roundtrips() {
 fn timelocked_call_registers_proposal_without_dispatching_call() {
     let (admin, mut runner) = setup();
     let admin_address = admin.address();
-    let proposal_id = set_value_proposal_id(7);
+    let proposal_key = set_value_proposal_key(admin_address, 7);
+    let proposal_id = proposal_key.1;
 
     runner.execute_transaction(TransactionTestCase {
         input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
@@ -141,35 +202,13 @@ fn timelocked_call_registers_proposal_without_dispatching_call() {
                     }
                 )]
             );
-            assert_eq!(
-                ValueSetter::<S>::default()
-                    .value
-                    .get(state)
-                    .unwrap_infallible(),
-                None
-            );
-            assert_eq!(
-                TxHooksCount::<S>::default()
-                    .post_dispatch_tx_hook_count
-                    .get(state)
-                    .unwrap_infallible(),
-                Some(1)
-            );
-            let pending_proposal = Timelock::<S>::default()
-                .proposals
-                .get(&ProposalKey(admin_address, proposal_id), state)
-                .unwrap_infallible()
-                .unwrap();
-            assert_eq!(pending_proposal.proposal_data, set_value_proposal_data(7));
-            assert_eq!(pending_proposal.unlock_condition.executable_from, 1_060);
-            assert_eq!(pending_proposal.unlock_condition.executable_until, 1_120);
-            assert_eq!(
-                Timelock::<S>::default()
-                    .proposal_counts
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
-                Some(1)
-            );
+            assert_eq!(stored_value(state), None);
+            assert_eq!(post_dispatch_count(state), Some(1));
+            let proposal = pending_proposal(state, &proposal_key).unwrap();
+            assert_eq!(proposal.proposal_data, set_value_proposal_data(7));
+            assert_eq!(proposal.unlock_condition.executable_from, 1_060);
+            assert_eq!(proposal.unlock_condition.executable_until, 1_120);
+            assert_eq!(proposal_count(state, &admin_address), Some(1));
         }),
     });
 }
@@ -178,38 +217,17 @@ fn timelocked_call_registers_proposal_without_dispatching_call() {
 fn repeated_timelocked_call_reverts_while_locked() {
     let (admin, mut runner) = setup();
     let admin_address = admin.address();
-    let proposal_id = set_value_proposal_id(7);
+    let proposal_key = set_value_proposal_key(admin_address, 7);
 
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
-        assert: Box::new(|result, _state| {
-            assert!(result.tx_receipt.is_successful());
-        }),
-    });
+    register_set_value_proposal(&mut runner, &admin, 7);
 
     runner.execute_transaction(TransactionTestCase {
         input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
         assert: Box::new(move |result, state| {
             assert!(result.tx_receipt.is_reverted());
-            assert_eq!(
-                ValueSetter::<S>::default()
-                    .value
-                    .get(state)
-                    .unwrap_infallible(),
-                None
-            );
-            assert_eq!(
-                TxHooksCount::<S>::default()
-                    .post_dispatch_tx_hook_count
-                    .get(state)
-                    .unwrap_infallible(),
-                Some(1)
-            );
-            assert!(Timelock::<S>::default()
-                .proposals
-                .get(&ProposalKey(admin_address, proposal_id), state)
-                .unwrap_infallible()
-                .is_some());
+            assert_eq!(stored_value(state), None);
+            assert_eq!(post_dispatch_count(state), Some(1));
+            assert!(pending_proposal(state, &proposal_key).is_some());
         }),
     });
 }
@@ -218,14 +236,10 @@ fn repeated_timelocked_call_reverts_while_locked() {
 fn unlocked_timelocked_call_dispatches_and_consumes_proposal() {
     let (admin, mut runner) = setup();
     let admin_address = admin.address();
-    let proposal_id = set_value_proposal_id(7);
+    let proposal_key = set_value_proposal_key(admin_address, 7);
+    let proposal_id = proposal_key.1;
 
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
-        assert: Box::new(|result, _state| {
-            assert!(result.tx_receipt.is_successful());
-        }),
-    });
+    register_set_value_proposal(&mut runner, &admin, 7);
 
     runner.config.freeze_time = Some(Time::from_secs(1_060));
     runner.execute_transaction(TransactionTestCase {
@@ -239,32 +253,10 @@ fn unlocked_timelocked_call_dispatches_and_consumes_proposal() {
                         proposal_id,
                     })
             }));
-            assert_eq!(
-                ValueSetter::<S>::default()
-                    .value
-                    .get(state)
-                    .unwrap_infallible(),
-                Some(7)
-            );
-            assert_eq!(
-                TxHooksCount::<S>::default()
-                    .post_dispatch_tx_hook_count
-                    .get(state)
-                    .unwrap_infallible(),
-                Some(2)
-            );
-            assert!(Timelock::<S>::default()
-                .proposals
-                .get(&ProposalKey(admin_address, proposal_id), state)
-                .unwrap_infallible()
-                .is_none());
-            assert_eq!(
-                Timelock::<S>::default()
-                    .proposal_counts
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
-                None
-            );
+            assert_eq!(stored_value(state), Some(7));
+            assert_eq!(post_dispatch_count(state), Some(2));
+            assert!(pending_proposal(state, &proposal_key).is_none());
+            assert_eq!(proposal_count(state, &admin_address), None);
         }),
     });
 }
@@ -273,47 +265,19 @@ fn unlocked_timelocked_call_dispatches_and_consumes_proposal() {
 fn expired_timelocked_call_reverts_without_consuming_proposal() {
     let (admin, mut runner) = setup();
     let admin_address = admin.address();
-    let proposal_id = set_value_proposal_id(7);
-    let proposal_key = ProposalKey(admin_address, proposal_id);
+    let proposal_key = set_value_proposal_key(admin_address, 7);
 
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
-        assert: Box::new(|result, _state| {
-            assert!(result.tx_receipt.is_successful());
-        }),
-    });
+    register_set_value_proposal(&mut runner, &admin, 7);
 
     runner.config.freeze_time = Some(Time::from_secs(1_121));
     runner.execute_transaction(TransactionTestCase {
         input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
         assert: Box::new(move |result, state| {
             assert!(result.tx_receipt.is_reverted());
-            assert_eq!(
-                ValueSetter::<S>::default()
-                    .value
-                    .get(state)
-                    .unwrap_infallible(),
-                None
-            );
-            assert!(Timelock::<S>::default()
-                .proposals
-                .get(&proposal_key, state)
-                .unwrap_infallible()
-                .is_some());
-            assert_eq!(
-                Timelock::<S>::default()
-                    .proposal_counts
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
-                Some(1)
-            );
-            assert_eq!(
-                TxHooksCount::<S>::default()
-                    .post_dispatch_tx_hook_count
-                    .get(state)
-                    .unwrap_infallible(),
-                Some(1)
-            );
+            assert_eq!(stored_value(state), None);
+            assert!(pending_proposal(state, &proposal_key).is_some());
+            assert_eq!(proposal_count(state, &admin_address), Some(1));
+            assert_eq!(post_dispatch_count(state), Some(1));
         }),
     });
 }
@@ -322,8 +286,8 @@ fn expired_timelocked_call_reverts_without_consuming_proposal() {
 fn zero_expiry_policy_executes_at_exact_unlock_timestamp() {
     let (admin, mut runner) = setup();
     let admin_address = admin.address();
-    let proposal_id = set_value_proposal_id(9);
-    let proposal_key = ProposalKey(admin_address, proposal_id);
+    let proposal_key = set_value_proposal_key(admin_address, 9);
+    let proposal_id = proposal_key.1;
 
     runner.execute_transaction(TransactionTestCase {
         input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(9)),
@@ -343,13 +307,9 @@ fn zero_expiry_policy_executes_at_exact_unlock_timestamp() {
                         }
                     )]
                 );
-                let pending_proposal = Timelock::<S>::default()
-                    .proposals
-                    .get(&proposal_key, state)
-                    .unwrap_infallible()
-                    .unwrap();
-                assert_eq!(pending_proposal.unlock_condition.executable_from, 1_060);
-                assert_eq!(pending_proposal.unlock_condition.executable_until, 1_060);
+                let proposal = pending_proposal(state, &proposal_key).unwrap();
+                assert_eq!(proposal.unlock_condition.executable_from, 1_060);
+                assert_eq!(proposal.unlock_condition.executable_until, 1_060);
             }
         }),
     });
@@ -366,25 +326,9 @@ fn zero_expiry_policy_executes_at_exact_unlock_timestamp() {
             move |result, state| {
                 assert!(result.tx_receipt.is_successful());
                 assert_eq!(result.events, vec![]);
-                assert!(Timelock::<S>::default()
-                    .proposals
-                    .get(&proposal_key, state)
-                    .unwrap_infallible()
-                    .is_some());
-                assert_eq!(
-                    Timelock::<S>::default()
-                        .proposal_counts
-                        .get(&admin_address, state)
-                        .unwrap_infallible(),
-                    Some(1)
-                );
-                assert_eq!(
-                    ValueSetter::<S>::default()
-                        .value
-                        .get(state)
-                        .unwrap_infallible(),
-                    None
-                );
+                assert!(pending_proposal(state, &proposal_key).is_some());
+                assert_eq!(proposal_count(state, &admin_address), Some(1));
+                assert_eq!(stored_value(state), None);
             }
         }),
     });
@@ -400,25 +344,9 @@ fn zero_expiry_policy_executes_at_exact_unlock_timestamp() {
                         proposal_id,
                     })
             }));
-            assert_eq!(
-                ValueSetter::<S>::default()
-                    .value
-                    .get(state)
-                    .unwrap_infallible(),
-                Some(9)
-            );
-            assert!(Timelock::<S>::default()
-                .proposals
-                .get(&proposal_key, state)
-                .unwrap_infallible()
-                .is_none());
-            assert_eq!(
-                Timelock::<S>::default()
-                    .proposal_counts
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
-                None
-            );
+            assert_eq!(stored_value(state), Some(9));
+            assert!(pending_proposal(state, &proposal_key).is_none());
+            assert_eq!(proposal_count(state, &admin_address), None);
         }),
     });
 }
@@ -427,14 +355,10 @@ fn zero_expiry_policy_executes_at_exact_unlock_timestamp() {
 fn owner_can_cancel_pending_proposal() {
     let (admin, mut runner) = setup();
     let admin_address = admin.address();
-    let proposal_id = set_value_proposal_id(7);
+    let proposal_key = set_value_proposal_key(admin_address, 7);
+    let proposal_id = proposal_key.1;
 
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
-        assert: Box::new(|result, _state| {
-            assert!(result.tx_receipt.is_successful());
-        }),
-    });
+    register_set_value_proposal(&mut runner, &admin, 7);
 
     runner.execute_transaction(TransactionTestCase {
         input: admin.create_plain_message::<RT, Timelock<S>>(
@@ -455,18 +379,8 @@ fn owner_can_cancel_pending_proposal() {
                     }
                 )]
             );
-            assert!(Timelock::<S>::default()
-                .proposals
-                .get(&ProposalKey(admin_address, proposal_id), state)
-                .unwrap_infallible()
-                .is_none());
-            assert_eq!(
-                Timelock::<S>::default()
-                    .proposal_counts
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
-                None
-            );
+            assert!(pending_proposal(state, &proposal_key).is_none());
+            assert_eq!(proposal_count(state, &admin_address), None);
         }),
     });
 }
@@ -478,7 +392,8 @@ fn authorized_canceller_can_cancel_pending_proposal() {
     let canceller = users[1].clone();
     let admin_address = admin.address();
     let canceller_address = canceller.address();
-    let proposal_id = set_value_proposal_id(7);
+    let proposal_key = set_value_proposal_key(admin_address, 7);
+    let proposal_id = proposal_key.1;
     let cancellation_policy = CancellationPolicy::<S> {
         authorized_canceller: canceller_address,
         policy_change_timelock_seconds: 0,
@@ -495,10 +410,7 @@ fn authorized_canceller_can_cancel_pending_proposal() {
             move |result, state| {
                 assert!(result.tx_receipt.is_successful());
                 assert_eq!(
-                    Timelock::<S>::default()
-                        .policies
-                        .get(&admin_address, state)
-                        .unwrap_infallible(),
+                    stored_cancellation_policy(state, &admin_address),
                     Some(cancellation_policy)
                 );
             }
@@ -509,15 +421,12 @@ fn authorized_canceller_can_cancel_pending_proposal() {
         input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(7)),
         assert: Box::new({
             let cancellation_policy = cancellation_policy.clone();
+            let proposal_key = proposal_key.clone();
             move |result, state| {
                 assert!(result.tx_receipt.is_successful());
-                let pending_proposal = Timelock::<S>::default()
-                    .proposals
-                    .get(&ProposalKey(admin_address, proposal_id), state)
-                    .unwrap_infallible()
-                    .unwrap();
+                let proposal = pending_proposal(state, &proposal_key).unwrap();
                 assert_eq!(
-                    pending_proposal.unlock_condition.cancellation_policy,
+                    proposal.unlock_condition.cancellation_policy,
                     cancellation_policy
                 );
             }
@@ -543,18 +452,8 @@ fn authorized_canceller_can_cancel_pending_proposal() {
                     }
                 )]
             );
-            assert!(Timelock::<S>::default()
-                .proposals
-                .get(&ProposalKey(admin_address, proposal_id), state)
-                .unwrap_infallible()
-                .is_none());
-            assert_eq!(
-                Timelock::<S>::default()
-                    .proposal_counts
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
-                None
-            );
+            assert!(pending_proposal(state, &proposal_key).is_none());
+            assert_eq!(proposal_count(state, &admin_address), None);
         }),
     });
 }
@@ -568,8 +467,8 @@ fn proposals_snapshot_cancellation_policy_at_registration() {
     let admin_address = admin.address();
     let initial_canceller_address = initial_canceller.address();
     let replacement_canceller_address = replacement_canceller.address();
-    let proposal_id = set_value_proposal_id(7);
-    let proposal_key = ProposalKey(admin_address, proposal_id);
+    let proposal_key = set_value_proposal_key(admin_address, 7);
+    let proposal_id = proposal_key.1;
     let initial_policy = CancellationPolicy::<S> {
         authorized_canceller: initial_canceller_address,
         policy_change_timelock_seconds: 0,
@@ -597,22 +496,12 @@ fn proposals_snapshot_cancellation_policy_at_registration() {
             let proposal_key = proposal_key.clone();
             move |result, state| {
                 assert!(result.tx_receipt.is_successful());
-                let pending_proposal = Timelock::<S>::default()
-                    .proposals
-                    .get(&proposal_key, state)
-                    .unwrap_infallible()
-                    .unwrap();
+                let proposal = pending_proposal(state, &proposal_key).unwrap();
                 assert_eq!(
-                    pending_proposal.unlock_condition.cancellation_policy,
+                    proposal.unlock_condition.cancellation_policy,
                     initial_policy
                 );
-                assert_eq!(
-                    Timelock::<S>::default()
-                        .proposal_counts
-                        .get(&admin_address, state)
-                        .unwrap_infallible(),
-                    Some(1)
-                );
+                assert_eq!(proposal_count(state, &admin_address), Some(1));
             }
         }),
     });
@@ -630,17 +519,11 @@ fn proposals_snapshot_cancellation_policy_at_registration() {
             move |result, state| {
                 assert!(result.tx_receipt.is_successful());
                 assert_eq!(
-                    Timelock::<S>::default()
-                        .policies
-                        .get(&admin_address, state)
-                        .unwrap_infallible(),
+                    stored_cancellation_policy(state, &admin_address),
                     Some(replacement_policy)
                 );
                 assert_eq!(
-                    Timelock::<S>::default()
-                        .proposals
-                        .get(&proposal_key, state)
-                        .unwrap_infallible()
+                    pending_proposal(state, &proposal_key)
                         .unwrap()
                         .unlock_condition
                         .cancellation_policy,
@@ -662,23 +545,10 @@ fn proposals_snapshot_cancellation_policy_at_registration() {
             let proposal_key = proposal_key.clone();
             move |result, state| {
                 assert!(result.tx_receipt.is_reverted());
-                assert!(Timelock::<S>::default()
-                    .proposals
-                    .get(&proposal_key, state)
-                    .unwrap_infallible()
-                    .is_some());
+                assert!(pending_proposal(state, &proposal_key).is_some());
+                assert_eq!(proposal_count(state, &admin_address), Some(1));
                 assert_eq!(
-                    Timelock::<S>::default()
-                        .proposal_counts
-                        .get(&admin_address, state)
-                        .unwrap_infallible(),
-                    Some(1)
-                );
-                assert_eq!(
-                    Timelock::<S>::default()
-                        .policies
-                        .get(&admin_address, state)
-                        .unwrap_infallible(),
+                    stored_cancellation_policy(state, &admin_address),
                     Some(replacement_policy)
                 );
             }
@@ -704,18 +574,8 @@ fn proposals_snapshot_cancellation_policy_at_registration() {
                     }
                 )]
             );
-            assert!(Timelock::<S>::default()
-                .proposals
-                .get(&proposal_key, state)
-                .unwrap_infallible()
-                .is_none());
-            assert_eq!(
-                Timelock::<S>::default()
-                    .proposal_counts
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
-                None
-            );
+            assert!(pending_proposal(state, &proposal_key).is_none());
+            assert_eq!(proposal_count(state, &admin_address), None);
         }),
     });
 }
@@ -726,23 +586,17 @@ fn expired_proposals_can_be_batch_cleaned_without_owner_permission() {
     let admin = users[0].clone();
     let cleaner = users[1].clone();
     let admin_address = admin.address();
-    let first_proposal_id = set_value_proposal_id(100);
-    let second_proposal_id = set_value_proposal_id(101);
+    let first_proposal_key = set_value_proposal_key(admin_address, 100);
+    let second_proposal_key = set_value_proposal_key(admin_address, 101);
+    let first_proposal_id = first_proposal_key.1;
+    let second_proposal_id = second_proposal_key.1;
 
     for value in [100, 101] {
-        runner.execute_transaction(TransactionTestCase {
-            input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(value)),
-            assert: Box::new(|result, _state| {
-                assert!(result.tx_receipt.is_successful());
-            }),
-        });
+        register_set_value_proposal(&mut runner, &admin, value);
     }
 
     runner.config.freeze_time = Some(Time::from_secs(1_121));
-    let proposal_keys = cleanup_keys(vec![
-        ProposalKey(admin_address, first_proposal_id),
-        ProposalKey(admin_address, second_proposal_id),
-    ]);
+    let proposal_keys = cleanup_keys(vec![first_proposal_key, second_proposal_key]);
     runner.execute_transaction(TransactionTestCase {
         input: cleaner.create_plain_message::<RT, Timelock<S>>(
             sov_timelock::CallMessage::CleanExpiredProposals {
@@ -765,19 +619,9 @@ fn expired_proposals_can_be_batch_cleaned_without_owner_permission() {
                 ]
             );
             for proposal_key in proposal_keys {
-                assert!(Timelock::<S>::default()
-                    .proposals
-                    .get(&proposal_key, state)
-                    .unwrap_infallible()
-                    .is_none());
+                assert!(pending_proposal(state, &proposal_key).is_none());
             }
-            assert_eq!(
-                Timelock::<S>::default()
-                    .proposal_counts
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
-                None
-            );
+            assert_eq!(proposal_count(state, &admin_address), None);
         }),
     });
 }
@@ -786,26 +630,15 @@ fn expired_proposals_can_be_batch_cleaned_without_owner_permission() {
 fn cleanup_skips_unexpired_and_missing_proposals() {
     let (admin, mut runner) = setup();
     let admin_address = admin.address();
-    let expired_proposal_id = set_value_proposal_id(100);
-    let unexpired_proposal_id = set_value_proposal_id(101);
-    let expired_proposal_key = ProposalKey(admin_address, expired_proposal_id);
-    let unexpired_proposal_key = ProposalKey(admin_address, unexpired_proposal_id);
+    let expired_proposal_key = set_value_proposal_key(admin_address, 100);
+    let unexpired_proposal_key = set_value_proposal_key(admin_address, 101);
+    let expired_proposal_id = expired_proposal_key.1;
     let missing_proposal_key = ProposalKey(admin_address, ProposalId::new([9; 32]));
 
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(100)),
-        assert: Box::new(|result, _state| {
-            assert!(result.tx_receipt.is_successful());
-        }),
-    });
+    register_set_value_proposal(&mut runner, &admin, 100);
 
     runner.config.freeze_time = Some(Time::from_secs(1_061));
-    runner.execute_transaction(TransactionTestCase {
-        input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(101)),
-        assert: Box::new(|result, _state| {
-            assert!(result.tx_receipt.is_successful());
-        }),
-    });
+    register_set_value_proposal(&mut runner, &admin, 101);
 
     runner.config.freeze_time = Some(Time::from_secs(1_121));
     runner.execute_transaction(TransactionTestCase {
@@ -829,23 +662,9 @@ fn cleanup_skips_unexpired_and_missing_proposals() {
                     }
                 )]
             );
-            assert!(Timelock::<S>::default()
-                .proposals
-                .get(&expired_proposal_key, state)
-                .unwrap_infallible()
-                .is_none());
-            assert!(Timelock::<S>::default()
-                .proposals
-                .get(&unexpired_proposal_key, state)
-                .unwrap_infallible()
-                .is_some());
-            assert_eq!(
-                Timelock::<S>::default()
-                    .proposal_counts
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
-                Some(1)
-            );
+            assert!(pending_proposal(state, &expired_proposal_key).is_none());
+            assert!(pending_proposal(state, &unexpired_proposal_key).is_some());
+            assert_eq!(proposal_count(state, &admin_address), Some(1));
         }),
     });
 }
@@ -856,32 +675,20 @@ fn registration_reverts_after_max_pending_proposals() {
     let admin_address = admin.address();
 
     for value in 100..(100 + MAX_PENDING_PROPOSALS_PER_ADDRESS) {
-        runner.execute_transaction(TransactionTestCase {
-            input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(value)),
-            assert: Box::new(|result, _state| {
-                assert!(result.tx_receipt.is_successful());
-            }),
-        });
+        register_set_value_proposal(&mut runner, &admin, value);
     }
 
     let rejected_value = 100 + MAX_PENDING_PROPOSALS_PER_ADDRESS;
-    let rejected_proposal_id = set_value_proposal_id(rejected_value);
+    let rejected_proposal_key = set_value_proposal_key(admin_address, rejected_value);
     runner.execute_transaction(TransactionTestCase {
         input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(rejected_value)),
         assert: Box::new(move |result, state| {
             assert!(result.tx_receipt.is_reverted());
             assert_eq!(
-                Timelock::<S>::default()
-                    .proposal_counts
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
+                proposal_count(state, &admin_address),
                 Some(MAX_PENDING_PROPOSALS_PER_ADDRESS)
             );
-            assert!(Timelock::<S>::default()
-                .proposals
-                .get(&ProposalKey(admin_address, rejected_proposal_id), state)
-                .unwrap_infallible()
-                .is_none());
+            assert!(pending_proposal(state, &rejected_proposal_key).is_none());
         }),
     });
 }
@@ -919,10 +726,7 @@ fn cancellation_policy_updates_are_self_timelocked_after_initial_policy() {
         assert: Box::new(move |result, state| {
             assert!(result.tx_receipt.is_successful());
             assert_eq!(
-                Timelock::<S>::default()
-                    .policies
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
+                stored_cancellation_policy(state, &admin_address),
                 Some(initial_policy)
             );
         }),
@@ -938,10 +742,7 @@ fn cancellation_policy_updates_are_self_timelocked_after_initial_policy() {
         assert: Box::new(move |result, state| {
             assert!(result.tx_receipt.is_successful());
             assert_eq!(
-                Timelock::<S>::default()
-                    .policies
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
+                stored_cancellation_policy(state, &admin_address),
                 Some(replacement_policy)
             );
         }),
@@ -995,10 +796,7 @@ fn cancellation_policy_update_proposals_expire_after_default_window() {
         assert: Box::new(move |result, state| {
             assert!(result.tx_receipt.is_reverted());
             assert_eq!(
-                Timelock::<S>::default()
-                    .policies
-                    .get(&admin_address, state)
-                    .unwrap_infallible(),
+                stored_cancellation_policy(state, &admin_address),
                 Some(initial_policy)
             );
         }),
@@ -1013,20 +811,8 @@ fn untimelocked_call_dispatches_normally() {
         input: admin.create_plain_message::<RT, ValueSetter<S>>(set_value_message(8)),
         assert: Box::new(|result, state| {
             assert!(result.tx_receipt.is_successful());
-            assert_eq!(
-                ValueSetter::<S>::default()
-                    .value
-                    .get(state)
-                    .unwrap_infallible(),
-                Some(8)
-            );
-            assert_eq!(
-                TxHooksCount::<S>::default()
-                    .post_dispatch_tx_hook_count
-                    .get(state)
-                    .unwrap_infallible(),
-                Some(1)
-            );
+            assert_eq!(stored_value(state), Some(8));
+            assert_eq!(post_dispatch_count(state), Some(1));
         }),
     });
 }

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/timelock.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/timelock.rs
@@ -2,9 +2,14 @@
 
 use std::num::NonZeroU64;
 
+use borsh::BorshSerialize;
 use serde::{Deserialize, Serialize};
 
-use crate::{err_detail, Error, ErrorContext, ErrorDetail, HexHash, Spec, TxState};
+use super::{calculate_hash, calculate_hash_metered};
+use crate::{
+    err_detail, Error, ErrorContext, ErrorDetail, GasMeter, GasMeteringError, HexHash, ModuleId,
+    Spec, TxState,
+};
 
 /// Identifier for a timelock proposal.
 ///
@@ -13,6 +18,41 @@ pub type ProposalId = HexHash;
 
 /// Default number of seconds after unlock during which a proposal may be executed.
 pub const DEFAULT_EXPIRE_SECONDS_AFTER_UNLOCK: u64 = 86_400 * 2; // 2 days
+
+/// Domain-separated data used to compute timelock proposal ids.
+#[derive(BorshSerialize)]
+pub enum TimelockProposalHashData<'a> {
+    /// Encoded runtime call message bytes.
+    CallMessage(&'a [u8]),
+    /// Module-owned custom proposal bytes.
+    CustomData {
+        /// Module owning the custom proposal.
+        module_id: &'a ModuleId,
+        /// Encoded module-specific proposal payload.
+        data: &'a [u8],
+    },
+}
+
+/// Calculates a timelock proposal id and charges gas for hashing.
+///
+/// The input is domain-separated so runtime call messages cannot overlap with
+/// module-owned custom proposal payloads.
+pub fn calculate_timelock_proposal_id_metered<G: GasMeter<Spec = S>, S: Spec>(
+    data: TimelockProposalHashData<'_>,
+    gas_meter: &mut G,
+) -> Result<ProposalId, GasMeteringError<S::Gas>> {
+    let encoded_data = borsh::to_vec(&data).expect("Serialization to vec is infallible");
+    calculate_hash_metered::<G, S>(&encoded_data, gas_meter)
+}
+
+/// Calculates a timelock proposal id without charging gas.
+///
+/// This helper is intended for tests and clients that need to derive the same proposal id
+/// outside transaction execution.
+pub fn calculate_timelock_proposal_id<S: Spec>(data: TimelockProposalHashData<'_>) -> ProposalId {
+    let encoded_data = borsh::to_vec(&data).expect("Serialization to vec is infallible");
+    calculate_hash::<S>(&encoded_data)
+}
 
 /// Timelock policy returned by a runtime for call messages that must be delayed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/timelock.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/timelock.rs
@@ -45,6 +45,18 @@ pub fn calculate_timelock_proposal_id_metered<G: GasMeter<Spec = S>, S: Spec>(
     calculate_hash_metered::<G, S>(&encoded_data, gas_meter)
 }
 
+/// Calculates a module-owned custom timelock proposal id and charges gas for hashing.
+pub fn calculate_custom_timelock_proposal_id_metered<G: GasMeter<Spec = S>, S: Spec>(
+    module_id: &ModuleId,
+    data: &[u8],
+    gas_meter: &mut G,
+) -> Result<ProposalId, GasMeteringError<S::Gas>> {
+    calculate_timelock_proposal_id_metered::<G, S>(
+        TimelockProposalHashData::CustomData { module_id, data },
+        gas_meter,
+    )
+}
+
 /// Calculates a timelock proposal id without charging gas.
 ///
 /// This helper is intended for tests and clients that need to derive the same proposal id
@@ -52,6 +64,17 @@ pub fn calculate_timelock_proposal_id_metered<G: GasMeter<Spec = S>, S: Spec>(
 pub fn calculate_timelock_proposal_id<S: Spec>(data: TimelockProposalHashData<'_>) -> ProposalId {
     let encoded_data = borsh::to_vec(&data).expect("Serialization to vec is infallible");
     calculate_hash::<S>(&encoded_data)
+}
+
+/// Calculates a module-owned custom timelock proposal id without charging gas.
+///
+/// This helper is intended for tests and clients that need to derive the same proposal id
+/// outside transaction execution.
+pub fn calculate_custom_timelock_proposal_id<S: Spec>(
+    module_id: &ModuleId,
+    data: &[u8],
+) -> ProposalId {
+    calculate_timelock_proposal_id::<S>(TimelockProposalHashData::CustomData { module_id, data })
 }
 
 /// Timelock policy returned by a runtime for call messages that must be delayed.
@@ -73,6 +96,15 @@ impl TimelockPolicy {
         self.expire_seconds_after_unlock_override
             .unwrap_or(DEFAULT_EXPIRE_SECONDS_AFTER_UNLOCK)
     }
+}
+
+/// Outcome of registering or unlocking a timelock proposal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TimelockProposalOutcome {
+    /// The proposal did not exist and has been registered.
+    Registered,
+    /// The proposal existed, was unlocked, and has been consumed.
+    Unlocked,
 }
 
 /// Errors returned when trying to unlock a timelock proposal.
@@ -104,88 +136,36 @@ impl ErrorDetail for TimelockError {
 /// Methods return [`crate::Error`] so semantic timelock failures and state/gas access
 /// failures can use the same error path as [`crate::DispatchCall::dispatch_call`].
 pub trait TimelockCapability<S: Spec> {
-    /// Returns true if the proposal exists for the provided address.
-    fn has_proposal(
-        &self,
-        address: &S::Address,
-        proposal_id: &ProposalId,
-        state: &mut impl TxState<S>,
-    ) -> Result<bool, Error>;
-
-    /// Registers a new proposal for the provided address.
-    fn register_proposal(
+    /// Registers a proposal if it does not exist, or tries to unlock and consume an existing proposal.
+    fn register_or_try_unlock_proposal(
         &mut self,
         address: &S::Address,
         proposal_id: ProposalId,
         policy: TimelockPolicy,
         state: &mut impl TxState<S>,
-    ) -> Result<(), Error>;
-
-    /// Tries to unlock a proposal, consuming it if unlocking succeeds.
-    fn try_unlock_proposal(
-        &mut self,
-        address: &S::Address,
-        proposal_id: &ProposalId,
-        state: &mut impl TxState<S>,
-    ) -> Result<(), Error>;
+    ) -> Result<TimelockProposalOutcome, Error>;
 }
 
 impl<S: Spec> TimelockCapability<S> for () {
-    fn has_proposal(
-        &self,
-        _address: &S::Address,
-        _proposal_id: &ProposalId,
-        _state: &mut impl TxState<S>,
-    ) -> Result<bool, Error> {
-        Ok(false)
-    }
-
-    fn register_proposal(
+    fn register_or_try_unlock_proposal(
         &mut self,
         _address: &S::Address,
         _proposal_id: ProposalId,
         _policy: TimelockPolicy,
         _state: &mut impl TxState<S>,
-    ) -> Result<(), Error> {
+    ) -> Result<TimelockProposalOutcome, Error> {
         Err(TimelockError::TimelocksNotAvailable.into())
-    }
-
-    fn try_unlock_proposal(
-        &mut self,
-        _address: &S::Address,
-        _proposal_id: &ProposalId,
-        _state: &mut impl TxState<S>,
-    ) -> Result<(), Error> {
-        Err(TimelockError::ProposalNotFound.into())
     }
 }
 
 impl<S: Spec, T: TimelockCapability<S> + ?Sized> TimelockCapability<S> for &mut T {
-    fn has_proposal(
-        &self,
-        address: &S::Address,
-        proposal_id: &ProposalId,
-        state: &mut impl TxState<S>,
-    ) -> Result<bool, Error> {
-        (**self).has_proposal(address, proposal_id, state)
-    }
-
-    fn register_proposal(
+    fn register_or_try_unlock_proposal(
         &mut self,
         address: &S::Address,
         proposal_id: ProposalId,
         policy: TimelockPolicy,
         state: &mut impl TxState<S>,
-    ) -> Result<(), Error> {
-        (**self).register_proposal(address, proposal_id, policy, state)
-    }
-
-    fn try_unlock_proposal(
-        &mut self,
-        address: &S::Address,
-        proposal_id: &ProposalId,
-        state: &mut impl TxState<S>,
-    ) -> Result<(), Error> {
-        (**self).try_unlock_proposal(address, proposal_id, state)
+    ) -> Result<TimelockProposalOutcome, Error> {
+        (**self).register_or_try_unlock_proposal(address, proposal_id, policy, state)
     }
 }

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/timelock.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/timelock.rs
@@ -2,13 +2,14 @@
 
 use std::num::NonZeroU64;
 
-use borsh::BorshSerialize;
+use borsh::{BorshDeserialize, BorshSerialize};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::{calculate_hash, calculate_hash_metered};
 use crate::{
-    err_detail, Error, ErrorContext, ErrorDetail, GasMeter, GasMeteringError, HexHash, ModuleId,
-    Spec, TxState,
+    err_detail, Error, ErrorContext, ErrorDetail, GasMeter, GasMeteringError, HexHash, HexString,
+    ModuleId, Spec, TxState,
 };
 
 /// Identifier for a timelock proposal.
@@ -19,18 +20,49 @@ pub type ProposalId = HexHash;
 /// Default number of seconds after unlock during which a proposal may be executed.
 pub const DEFAULT_EXPIRE_SECONDS_AFTER_UNLOCK: u64 = 86_400 * 2; // 2 days
 
-/// Domain-separated data used to compute timelock proposal ids.
-#[derive(BorshSerialize)]
-pub enum TimelockProposalHashData<'a> {
+/// Domain-separated proposal data used to compute timelock proposal ids.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    BorshDeserialize,
+    BorshSerialize,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TimelockProposalData {
     /// Encoded runtime call message bytes.
-    CallMessage(&'a [u8]),
+    CallMessage {
+        /// Encoded runtime call message bytes.
+        data: HexString,
+    },
     /// Module-owned custom proposal bytes.
     CustomData {
         /// Module owning the custom proposal.
-        module_id: &'a ModuleId,
+        module_id: ModuleId,
         /// Encoded module-specific proposal payload.
-        data: &'a [u8],
+        data: HexString,
     },
+}
+
+impl TimelockProposalData {
+    /// Creates proposal data for an encoded runtime call message.
+    pub fn call_message(data: impl Into<Vec<u8>>) -> Self {
+        Self::CallMessage {
+            data: HexString::new(data.into()),
+        }
+    }
+
+    /// Creates module-owned custom proposal data.
+    pub fn custom_data(module_id: ModuleId, data: impl Into<Vec<u8>>) -> Self {
+        Self::CustomData {
+            module_id,
+            data: HexString::new(data.into()),
+        }
+    }
 }
 
 /// Calculates a timelock proposal id and charges gas for hashing.
@@ -38,10 +70,10 @@ pub enum TimelockProposalHashData<'a> {
 /// The input is domain-separated so runtime call messages cannot overlap with
 /// module-owned custom proposal payloads.
 pub fn calculate_timelock_proposal_id_metered<G: GasMeter<Spec = S>, S: Spec>(
-    data: TimelockProposalHashData<'_>,
+    data: &TimelockProposalData,
     gas_meter: &mut G,
 ) -> Result<ProposalId, GasMeteringError<S::Gas>> {
-    let encoded_data = borsh::to_vec(&data).expect("Serialization to vec is infallible");
+    let encoded_data = borsh::to_vec(data).expect("Serialization to vec is infallible");
     calculate_hash_metered::<G, S>(&encoded_data, gas_meter)
 }
 
@@ -51,18 +83,16 @@ pub fn calculate_custom_timelock_proposal_id_metered<G: GasMeter<Spec = S>, S: S
     data: &[u8],
     gas_meter: &mut G,
 ) -> Result<ProposalId, GasMeteringError<S::Gas>> {
-    calculate_timelock_proposal_id_metered::<G, S>(
-        TimelockProposalHashData::CustomData { module_id, data },
-        gas_meter,
-    )
+    let proposal_data = TimelockProposalData::custom_data(*module_id, data);
+    calculate_timelock_proposal_id_metered::<G, S>(&proposal_data, gas_meter)
 }
 
 /// Calculates a timelock proposal id without charging gas.
 ///
 /// This helper is intended for tests and clients that need to derive the same proposal id
 /// outside transaction execution.
-pub fn calculate_timelock_proposal_id<S: Spec>(data: TimelockProposalHashData<'_>) -> ProposalId {
-    let encoded_data = borsh::to_vec(&data).expect("Serialization to vec is infallible");
+pub fn calculate_timelock_proposal_id<S: Spec>(data: &TimelockProposalData) -> ProposalId {
+    let encoded_data = borsh::to_vec(data).expect("Serialization to vec is infallible");
     calculate_hash::<S>(&encoded_data)
 }
 
@@ -74,7 +104,7 @@ pub fn calculate_custom_timelock_proposal_id<S: Spec>(
     module_id: &ModuleId,
     data: &[u8],
 ) -> ProposalId {
-    calculate_timelock_proposal_id::<S>(TimelockProposalHashData::CustomData { module_id, data })
+    calculate_timelock_proposal_id::<S>(&TimelockProposalData::custom_data(*module_id, data))
 }
 
 /// Timelock policy returned by a runtime for call messages that must be delayed.
@@ -86,7 +116,7 @@ pub struct TimelockPolicy {
     /// [`DEFAULT_EXPIRE_SECONDS_AFTER_UNLOCK`] is used.
     ///
     /// Caution: an override of `0` has no special meaning, and the proposal will be executable
-    /// only at its exact unlock timestamp. Take care to set reasonable expiraty delays.
+    /// only at its exact unlock timestamp. Take care to set reasonable expiry windows.
     pub expire_seconds_after_unlock_override: Option<u64>,
 }
 
@@ -140,7 +170,7 @@ pub trait TimelockCapability<S: Spec> {
     fn register_or_try_unlock_proposal(
         &mut self,
         address: &S::Address,
-        proposal_id: ProposalId,
+        proposal_data: TimelockProposalData,
         policy: TimelockPolicy,
         state: &mut impl TxState<S>,
     ) -> Result<TimelockProposalOutcome, Error>;
@@ -150,7 +180,7 @@ impl<S: Spec> TimelockCapability<S> for () {
     fn register_or_try_unlock_proposal(
         &mut self,
         _address: &S::Address,
-        _proposal_id: ProposalId,
+        _proposal_data: TimelockProposalData,
         _policy: TimelockPolicy,
         _state: &mut impl TxState<S>,
     ) -> Result<TimelockProposalOutcome, Error> {
@@ -162,10 +192,10 @@ impl<S: Spec, T: TimelockCapability<S> + ?Sized> TimelockCapability<S> for &mut 
     fn register_or_try_unlock_proposal(
         &mut self,
         address: &S::Address,
-        proposal_id: ProposalId,
+        proposal_data: TimelockProposalData,
         policy: TimelockPolicy,
         state: &mut impl TxState<S>,
     ) -> Result<TimelockProposalOutcome, Error> {
-        (**self).register_or_try_unlock_proposal(address, proposal_id, policy, state)
+        (**self).register_or_try_unlock_proposal(address, proposal_data, policy, state)
     }
 }

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/common.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/common.rs
@@ -1,6 +1,7 @@
 use borsh::BorshDeserialize;
 use sov_modules_api::capabilities::{
-    calculate_hash_metered, HasCapabilities, SequencingDataHandler, TimelockCapability,
+    calculate_timelock_proposal_id_metered, HasCapabilities, SequencingDataHandler,
+    TimelockCapability, TimelockProposalHashData,
 };
 use sov_modules_api::capabilities::{AuthenticationError, AuthenticationOutput, FatalError};
 use sov_modules_api::transaction::AuthenticatedTransactionData;
@@ -140,8 +141,11 @@ fn attempt_tx<S: Spec, RT: Runtime<S>, I: StateProvider<S>>(
 
     if let Some(policy) = runtime.timelock_for_callmessage(&message) {
         let encoded_message = RT::encode(&message);
-        let proposal_id = calculate_hash_metered::<_, S>(&encoded_message, state)
-            .map_err(|error| Error::from(anyhow::anyhow!(error)))?;
+        let proposal_id = calculate_timelock_proposal_id_metered::<_, S>(
+            TimelockProposalHashData::CallMessage(&encoded_message),
+            state,
+        )
+        .map_err(|error| Error::from(anyhow::anyhow!(error)))?;
         let proposal_exists = {
             let timelock = runtime.timelock();
             timelock.has_proposal(ctx.sender(), &proposal_id, state)?

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/common.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/common.rs
@@ -1,9 +1,9 @@
 use borsh::BorshDeserialize;
-use sov_modules_api::capabilities::{
-    calculate_timelock_proposal_id_metered, HasCapabilities, SequencingDataHandler,
-    TimelockCapability, TimelockProposalHashData, TimelockProposalOutcome,
-};
 use sov_modules_api::capabilities::{AuthenticationError, AuthenticationOutput, FatalError};
+use sov_modules_api::capabilities::{
+    HasCapabilities, SequencingDataHandler, TimelockCapability, TimelockProposalData,
+    TimelockProposalOutcome,
+};
 use sov_modules_api::transaction::AuthenticatedTransactionData;
 use sov_modules_api::{
     BatchSequencerReceipt, Context, DispatchCall, Error, IgnoredTransactionReceipt, Spec,
@@ -140,16 +140,14 @@ fn attempt_tx<S: Spec, RT: Runtime<S>, I: StateProvider<S>>(
     runtime.pre_dispatch_tx_hook(tx, state)?;
 
     if let Some(policy) = runtime.timelock_for_callmessage(&message) {
-        let encoded_message = RT::encode(&message);
-        let proposal_id = calculate_timelock_proposal_id_metered::<_, S>(
-            TimelockProposalHashData::CallMessage(&encoded_message),
-            state,
-        )
-        .map_err(|error| Error::from(anyhow::anyhow!(error)))?;
-
         let outcome = {
             let mut timelock = runtime.timelock();
-            timelock.register_or_try_unlock_proposal(ctx.sender(), proposal_id, policy, state)?
+            timelock.register_or_try_unlock_proposal(
+                ctx.sender(),
+                TimelockProposalData::call_message(RT::encode(&message)),
+                policy,
+                state,
+            )?
         };
         match outcome {
             TimelockProposalOutcome::Registered => {}

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/common.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/common.rs
@@ -1,7 +1,7 @@
 use borsh::BorshDeserialize;
 use sov_modules_api::capabilities::{
     calculate_timelock_proposal_id_metered, HasCapabilities, SequencingDataHandler,
-    TimelockCapability, TimelockProposalHashData,
+    TimelockCapability, TimelockProposalHashData, TimelockProposalOutcome,
 };
 use sov_modules_api::capabilities::{AuthenticationError, AuthenticationOutput, FatalError};
 use sov_modules_api::transaction::AuthenticatedTransactionData;
@@ -146,20 +146,14 @@ fn attempt_tx<S: Spec, RT: Runtime<S>, I: StateProvider<S>>(
             state,
         )
         .map_err(|error| Error::from(anyhow::anyhow!(error)))?;
-        let proposal_exists = {
-            let timelock = runtime.timelock();
-            timelock.has_proposal(ctx.sender(), &proposal_id, state)?
-        };
 
-        if proposal_exists {
-            {
-                let mut timelock = runtime.timelock();
-                timelock.try_unlock_proposal(ctx.sender(), &proposal_id, state)?;
-            }
-            runtime.dispatch_call(message, state, ctx)?;
-        } else {
+        let outcome = {
             let mut timelock = runtime.timelock();
-            timelock.register_proposal(ctx.sender(), proposal_id, policy, state)?;
+            timelock.register_or_try_unlock_proposal(ctx.sender(), proposal_id, policy, state)?
+        };
+        match outcome {
+            TimelockProposalOutcome::Registered => {}
+            TimelockProposalOutcome::Unlocked => runtime.dispatch_call(message, state, ctx)?,
         }
     } else {
         runtime.dispatch_call(message, state, ctx)?;

--- a/crates/utils/sov-test-utils/src/runtime/macros.rs
+++ b/crates/utils/sov-test-utils/src/runtime/macros.rs
@@ -22,7 +22,6 @@ macro_rules! generate_runtime_without_capabilities {
         $(, transaction_priority_wrapper: $transaction_priority_wrapper_expr:expr)?
         // Optional: A wrapper expression for custom transaction timelock policy logic.
         // Expected signature for the expression: `fn(&Self::Decodable) -> Option<TimelockPolicy>`.
-        // If provided, the runtime must include a module named `timelock`.
         $(, timelock_policy_wrapper: $timelock_policy_wrapper_expr:expr)?
         $(, populate_pinned_cache_fn: $populate_pinned_cache_fn_expr:expr)?
         // optional final comma for the entire argument block
@@ -243,9 +242,9 @@ macro_rules! generate_runtime_without_capabilities {
 #[macro_export]
 macro_rules! __impl_runtime_timelock_capability {
     () => {};
-    ($timelock_policy_wrapper_expr:expr) => {
+    ($timelock_capability_expr:expr) => {
         fn timelock(&mut self) -> impl ::sov_modules_api::capabilities::TimelockCapability<S> {
-            &mut self.timelock
+            ($timelock_capability_expr)(self)
         }
     };
 }
@@ -267,6 +266,10 @@ macro_rules! generate_runtime {
         auth_call_wrapper: $auth_wrapper:expr
         $(, transaction_delay_ms_wrapper: $transaction_delay_ms_wrapper_expr:expr)?
         $(, timelock_policy_wrapper: $timelock_policy_wrapper_expr:expr)?
+        // Optional: An accessor for a concrete timelock capability.
+        // Expected signature for the expression: `fn(&mut Self) -> impl TimelockCapability<S>`.
+        // If not provided, the runtime uses the default no-op timelock capability.
+        $(, timelock_capability: $timelock_capability_expr:expr)?
         $(, populate_pinned_cache_fn: $populate_pinned_cache_fn_expr:expr)?
         // optional final comma
         $(,)?
@@ -308,7 +311,7 @@ macro_rules! generate_runtime {
                 )
             }
 
-            $crate::__impl_runtime_timelock_capability!($($timelock_policy_wrapper_expr)?);
+            $crate::__impl_runtime_timelock_capability!($($timelock_capability_expr)?);
         }
     };
     (
@@ -323,6 +326,10 @@ macro_rules! generate_runtime {
         $(, transaction_delay_ms_wrapper: $transaction_delay_ms_wrapper_expr:expr)?
         $(, transaction_priority_wrapper: $transaction_priority_wrapper_expr:expr)?
         $(, timelock_policy_wrapper: $timelock_policy_wrapper_expr:expr)?
+        // Optional: An accessor for a concrete timelock capability.
+        // Expected signature for the expression: `fn(&mut Self) -> impl TimelockCapability<S>`.
+        // If not provided, the runtime uses the default no-op timelock capability.
+        $(, timelock_capability: $timelock_capability_expr:expr)?
         $(, populate_pinned_cache_fn: $populate_pinned_cache_fn_expr:expr)?
         // optional final comma
         $(,)?
@@ -366,7 +373,7 @@ macro_rules! generate_runtime {
                 )
             }
 
-            $crate::__impl_runtime_timelock_capability!($($timelock_policy_wrapper_expr)?);
+            $crate::__impl_runtime_timelock_capability!($($timelock_capability_expr)?);
         }
     }
 }
@@ -398,6 +405,10 @@ macro_rules! generate_optimistic_runtime_with_kernel {
         $(, transaction_delay_ms_wrapper: $transaction_delay_ms_wrapper_expr:expr)?
         $(, transaction_priority_wrapper: $transaction_priority_wrapper_expr:expr)?
         $(, timelock_policy_wrapper: $timelock_policy_wrapper_expr:expr)?
+        // Optional: An accessor for a concrete timelock capability.
+        // Expected signature for the expression: `fn(&mut Self) -> impl TimelockCapability<S>`.
+        // If not provided, the runtime uses the default no-op timelock capability.
+        $(, timelock_capability: $timelock_capability_expr:expr)?
         $(, populate_pinned_cache_fn: $populate_pinned_cache_fn_expr:expr)?
         $(,)? // Optional trailing comma for the module list or wrapper
     ) => {
@@ -413,6 +424,7 @@ macro_rules! generate_optimistic_runtime_with_kernel {
             $(, transaction_delay_ms_wrapper: $transaction_delay_ms_wrapper_expr)?
             $(, transaction_priority_wrapper: $transaction_priority_wrapper_expr)?
             $(, timelock_policy_wrapper: $timelock_policy_wrapper_expr)?
+            $(, timelock_capability: $timelock_capability_expr)?
             $(, populate_pinned_cache_fn: $populate_pinned_cache_fn_expr)?
         }
     };


### PR DESCRIPTION
# Description

Implements `sov-timelock` for timelock support.

Main things to review:
1. The `TimelockCapablity` introduced in a previous PR has been simplified, since a single method makes the timelock state machine more ergonomic to use. Changes in `sov-modules-api/runtime/capabilities/timelock.rs` and `stf-blueprint/src/sequencer_mode/common.rs`.
2. The `sov-timelock` module itself, main logic being in lib.rs and call.rs.

`sov-timelock` stores timelocked proposals keyed by `(Address, ProposalId)`. The ProposalId is a domain-separated hash so we can support both Runtime::Decodable callmessages, and separately arbitrary module-owned data; the latter is used in `sov-timelock` to implement a timelock on the `ModifyCancellationPolicy` callmessage.

We also track the number of timelocks per user in a separate state item, to enforce the `MAX_PENDING_PROPOSALS_PER_ADDRESS` upper bound.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
