### PR TITLE
 Bind aggregation slot range to inner-proof public data 

### DIFF
--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -6,11 +6,15 @@ use crate::{MockCodeCommitment, MockProof, MockZkGuest};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sov_rollup_interface::common::SlotNumber;
-use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec};
 use sov_rollup_interface::zk::aggregated_proof::{
     AggregatedProofPublicData, BlockProof, OuterZkvmHost, SerializedAggregatedProof,
 };
 use sov_rollup_interface::zk::SerializedZkProof;
+
+/// A DA block header paired with the inner-proof data covering that block.
+type HeaderWithBlockProof<Address, Da, Root> =
+    (<Da as DaSpec>::BlockHeader, BlockProof<Address, Da, Root>);
 
 /// A mock implementing the zkVM trait.
 #[derive(Clone)]
@@ -132,6 +136,44 @@ impl MockZkvmHost {
         })?)
     }
 
+    /// Mirrors the per-inner-proof continuity checks performed by the real
+    /// aggregation circuit. Verifies that consecutive `BlockProof.st` entries
+    /// have:
+    ///   1. slot numbers that increment by exactly one,
+    ///   2. a `slot_hash` matching the paired DA block header's hash,
+    ///   3. a `prev_hash` pointing at the predecessor DA block's hash,
+    ///   4. an `initial_state_root` equal to the predecessor's `final_state_root`.
+    fn check_inner_proof_chain<Address, Da: DaSpec, Root: PartialEq + Debug>(
+        headers_with_block_proofs: &[HeaderWithBlockProof<Address, Da, Root>],
+    ) {
+        let mut prev: Option<(SlotNumber, &Da::SlotHash, &Root)> = None;
+        for (index, (header, bp)) in headers_with_block_proofs.iter().enumerate() {
+            let header_hash = header.hash();
+            assert_eq!(
+                header_hash, bp.st.slot_hash,
+                "Slot hash mismatch at index {index}: DA block header hash doesn't match inner-proof public data",
+            );
+            if let Some((prev_slot, prev_hash, prev_state_root)) = prev {
+                let expected = prev_slot.next();
+                assert_eq!(
+                    bp.st.slot_number, expected,
+                    "Slot number discontinuity at index {index}: expected {expected}, got {}",
+                    bp.st.slot_number,
+                );
+                assert_eq!(
+                    prev_hash,
+                    &header.prev_hash(),
+                    "DA block chain broken at index {index}: prev_hash mismatch",
+                );
+                assert_eq!(
+                    &bp.st.initial_state_root, prev_state_root,
+                    "State root discontinuity at index {index}: previous final_state_root != current initial_state_root",
+                );
+            }
+            prev = Some((bp.st.slot_number, &bp.st.slot_hash, &bp.st.final_state_root));
+        }
+    }
+
     /// Sleeps for the duration (in milliseconds) read from `env_var`. Used in
     /// tests/soak runs to throttle the otherwise-instant mock prover. No-op
     /// if the env var is unset or not parseable.
@@ -180,6 +222,10 @@ impl OuterZkvmHost for MockZkvmHost {
         genesis_state_root: Root,
         headers_with_block_proofs: Vec<(Da::BlockHeader, BlockProof<Address, Da, Root>)>,
     ) -> anyhow::Result<SerializedAggregatedProof> {
+        // Mirror the checks performed by the real aggregation circuit
+        // (`run_aggregation_program` in sov-rollup-interface).
+        Self::check_inner_proof_chain(&headers_with_block_proofs);
+
         let block_proofs_data = headers_with_block_proofs
             .iter()
             .map(|(_, bp)| bp)

--- a/crates/full-node/sov-stf-runner/src/processes/op_manager/attestations.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/op_manager/attestations.rs
@@ -78,7 +78,7 @@ where
         &mut self,
         stf_info: StateTransitionInfo<StateRoot, Witness, Da>,
     ) -> anyhow::Result<()> {
-        let slot_number = stf_info.slot_number;
+        let slot_number = stf_info.slot_number();
         let witness = stf_info.witness();
 
         let attestation = Attestation {

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
@@ -111,8 +111,9 @@ where
             let StateTransitionInfo {
                 data,
                 aggregated_proofs,
-                slot_number,
             } = state_transition_info;
+
+            let slot_number = data.slot_number;
 
             let data = StateTransitionWitnessWithAddress {
                 stf_witness: data,
@@ -158,7 +159,6 @@ where
                             slot_hash: block_header_hash.clone(),
                             prover_address,
                         },
-                        slot_number,
                     });
 
                     prover_state.set_to_proved(block_header_hash, block_proof);

--- a/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/prover_service/parallel/prover.rs
@@ -154,6 +154,7 @@ where
                         st: StateTransitionPublicData::<Address, Da::Spec, StateRoot> {
                             initial_state_root,
                             final_state_root,
+                            slot_number,
                             slot_hash: block_header_hash.clone(),
                             prover_address,
                         },

--- a/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
@@ -26,21 +26,19 @@ pub struct StateTransitionInfo<StateRoot, Witness, Da: DaSpec> {
     pub(crate) data: StateTransitionWitness<StateRoot, Witness, Da>,
     /// Aggregated proofs processed while executing this transition, in verification order.
     pub(crate) aggregated_proofs: Vec<SerializedAggregatedProof>,
-    /// Rollup height.
-    pub(crate) slot_number: SlotNumber,
 }
 
 impl<StateRoot, Witness, Da: DaSpec> StateTransitionInfo<StateRoot, Witness, Da> {
     /// StateTransitionInfo constructor.
-    pub fn new(
-        data: StateTransitionWitness<StateRoot, Witness, Da>,
-        slot_number: SlotNumber,
-    ) -> Self {
+    pub fn new(data: StateTransitionWitness<StateRoot, Witness, Da>) -> Self {
         Self {
             data,
             aggregated_proofs: Vec::new(),
-            slot_number,
         }
+    }
+
+    pub(crate) fn slot_number(&self) -> SlotNumber {
+        self.data.slot_number
     }
 
     pub(crate) fn da_block_header(&self) -> &Da::BlockHeader {
@@ -321,7 +319,7 @@ where
         };
 
         // Materialize the changes to the database
-        let write_rollup_height = stf_info.slot_number;
+        let write_rollup_height = stf_info.slot_number();
 
         // Save the stf info in the db.
         let mut schema = ledger_db.materialize_stf_info(&stored_stf_info, write_rollup_height)?;
@@ -534,7 +532,7 @@ mod tests {
             for height in 1..=channel_size {
                 let stf_info = make_stf_info(height);
                 let schema_batch = sender.materialize_stf_info(&stf_info, &ledger_db).await?;
-                sender.notify(stf_info.slot_number, &ledger_db).await?;
+                sender.notify(stf_info.slot_number(), &ledger_db).await?;
                 storage_manager.commit(&schema_batch);
             }
         }
@@ -546,7 +544,7 @@ mod tests {
 
             for i in 1..=channel_size {
                 let stf_info = receiver.read_next().await?.unwrap();
-                assert_eq!(stf_info.slot_number.get(), i);
+                assert_eq!(stf_info.slot_number().get(), i);
             }
 
             assert_eq!(sender.get_oldest_slot_number(&ledger_db).await?.get(), 1);
@@ -559,7 +557,7 @@ mod tests {
 
             for i in 1..=channel_size {
                 let stf_info = receiver.read_next().await?.unwrap();
-                assert_eq!(stf_info.slot_number.get(), i);
+                assert_eq!(stf_info.slot_number().get(), i);
             }
 
             assert_eq!(sender.get_oldest_slot_number(&ledger_db).await?.get(), 1);
@@ -572,12 +570,12 @@ mod tests {
             let stf_info = make_stf_info(channel_size + 1);
             let schema_batch = sender.materialize_stf_info(&stf_info, &ledger_db).await?;
             storage_manager.commit(&schema_batch);
-            sender.notify(stf_info.slot_number, &ledger_db).await?;
+            sender.notify(stf_info.slot_number(), &ledger_db).await?;
 
             let stf_info = make_stf_info(channel_size + 2);
             let schema_batch = sender.materialize_stf_info(&stf_info, &ledger_db).await?;
             storage_manager.commit(&schema_batch);
-            sender.notify(stf_info.slot_number, &ledger_db).await?;
+            sender.notify(stf_info.slot_number(), &ledger_db).await?;
 
             assert_eq!(sender.get_oldest_slot_number(&ledger_db).await?.get(), 2);
         }
@@ -596,7 +594,7 @@ mod tests {
             .await?;
 
             let stf_info = receiver.read_next().await?.unwrap();
-            assert_eq!(stf_info.slot_number.get(), 3);
+            assert_eq!(stf_info.slot_number().get(), 3);
             assert_eq!(sender.get_oldest_slot_number(&ledger_db).await?.get(), 2);
         }
 
@@ -617,7 +615,7 @@ mod tests {
             let stf_info = make_stf_info(height);
             let schema_batch = sender.materialize_stf_info(&stf_info, &ledger_db).await?;
             storage_manager.commit(&schema_batch);
-            sender.notify(stf_info.slot_number, &ledger_db).await?;
+            sender.notify(stf_info.slot_number(), &ledger_db).await?;
         }
 
         // Read the data from the db.
@@ -627,7 +625,7 @@ mod tests {
                 .next_height_to_receive
                 .fetch_add(1, Ordering::SeqCst);
 
-            assert_eq!(stf_info.slot_number.get(), height);
+            assert_eq!(stf_info.slot_number().get(), height);
         }
         Ok(())
     }
@@ -644,7 +642,7 @@ mod tests {
             let stf_info = make_stf_info(height);
             let schema_batch = sender.materialize_stf_info(&stf_info, &ledger_db).await?;
             storage_manager.commit(&schema_batch);
-            sender.notify(stf_info.slot_number, &ledger_db).await?;
+            sender.notify(stf_info.slot_number(), &ledger_db).await?;
         }
 
         drop(sender);
@@ -655,7 +653,7 @@ mod tests {
                 .next_height_to_receive
                 .fetch_add(1, Ordering::SeqCst);
 
-            assert_eq!(stf_info.slot_number.get(), height);
+            assert_eq!(stf_info.slot_number().get(), height);
         }
 
         let stf_info = receiver.read_next().await;
@@ -687,7 +685,7 @@ mod tests {
                     .unwrap();
                 storage_manager.commit(&schema_batch);
                 sender
-                    .notify(stf_info.slot_number, &ledger_db)
+                    .notify(stf_info.slot_number(), &ledger_db)
                     .await
                     .unwrap();
             }
@@ -700,7 +698,7 @@ mod tests {
                 .next_height_to_receive
                 .fetch_add(1, Ordering::SeqCst);
 
-            assert_eq!(stf_info.slot_number.get(), height);
+            assert_eq!(stf_info.slot_number().get(), height);
         }
         Ok(())
     }
@@ -791,7 +789,7 @@ mod tests {
                 let stf_info = make_stf_info(height);
                 let schema_batch = sender.materialize_stf_info(&stf_info, &ledger_db).await?;
                 storage_manager.commit(&schema_batch);
-                sender.notify(stf_info.slot_number, &ledger_db).await?;
+                sender.notify(stf_info.slot_number(), &ledger_db).await?;
                 receiver.read_next().await?.unwrap();
                 receiver
                     .next_height_to_receive
@@ -848,34 +846,32 @@ mod tests {
     }
 
     fn make_stf_info(height: u64) -> StateTransitionInfo<Vec<u8>, Vec<u8>, MockDaSpec> {
-        StateTransitionInfo::new(
-            StateTransitionWitness {
-                initial_state_root: vec![1, 2, 3],
-                final_state_root: vec![3, 4, 5],
-                da_block_header: MockBlockHeader {
-                    prev_hash: [0; 32].into(),
-                    hash: MockHash([height as u8; 32]),
-                    height,
-                    time: Time::now(),
-                },
-                relevant_proofs: RelevantProofs {
-                    batch: DaProof {
-                        inclusion_proof: Default::default(),
-                        completeness_proof: Default::default(),
-                    },
-                    proof: DaProof {
-                        inclusion_proof: Default::default(),
-                        completeness_proof: Default::default(),
-                    },
-                },
-                relevant_blobs: RelevantBlobs {
-                    proof_blobs: vec![],
-                    batch_blobs: vec![],
-                },
-                witness: vec![],
+        StateTransitionInfo::new(StateTransitionWitness {
+            initial_state_root: vec![1, 2, 3],
+            final_state_root: vec![3, 4, 5],
+            da_block_header: MockBlockHeader {
+                prev_hash: [0; 32].into(),
+                hash: MockHash([height as u8; 32]),
+                height,
+                time: Time::now(),
             },
-            SlotNumber::new_dangerous(height),
-        )
+            relevant_proofs: RelevantProofs {
+                batch: DaProof {
+                    inclusion_proof: Default::default(),
+                    completeness_proof: Default::default(),
+                },
+                proof: DaProof {
+                    inclusion_proof: Default::default(),
+                    completeness_proof: Default::default(),
+                },
+            },
+            relevant_blobs: RelevantBlobs {
+                proof_blobs: vec![],
+                batch_blobs: vec![],
+            },
+            witness: vec![],
+            slot_number: SlotNumber::new_dangerous(height),
+        })
     }
 
     fn get_header_hash(stf_info: &StateTransitionInfo<Vec<u8>, Vec<u8>, MockDaSpec>) -> MockHash {

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -153,7 +153,7 @@ where
                         Some(stf_info) => stf_info,
                     };
                     tracing::trace!(
-                        slot_number = %stf_info.slot_number,
+                        slot_number = %stf_info.slot_number(),
                         block_header = %stf_info.da_block_header().display(),
                         "Received STF info"
                     );
@@ -175,7 +175,7 @@ where
         >,
     ) -> anyhow::Result<()> {
         let first_height_unproven = self.stf_info_receiver.next_height_to_receive();
-        let received_slot_number = stf_info.slot_number;
+        let received_slot_number = stf_info.slot_number();
 
         assert!(
             received_slot_number.get() >= first_height_unproven.get(),
@@ -185,7 +185,7 @@ where
         // We ensure that we're not trying to prove blocks that are being proven.
         // If that is not the case, we add the block to the queue.
         if first_height_unproven.saturating_add(self.proofs_to_create.current_proof_jump() as u64)
-            <= stf_info.slot_number
+            <= stf_info.slot_number()
         {
             let block_header = stf_info.da_block_header().clone();
             // Save the transition for later proving. This is temporarily redundant

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -662,6 +662,7 @@ where
                 relevant_proofs,
                 relevant_blobs,
                 witness: slot_result.witness,
+                slot_number: slot_result.slot_number,
             };
 
         let (aggregated_proofs, proof_receipts) =

--- a/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/mod.rs
@@ -398,7 +398,16 @@ where
         self.ledger_db.replace_reader(ledger_pre_state);
         self.verify_transition_witness_against_ledger_state(&transition_witness)?;
 
-        let slot_number = self.get_slot_number()?;
+        let slot_number = transition_witness.slot_number;
+        let ledger_slot_number = self.get_slot_number()?;
+        // `slot_number` is the kernel-emitted value (true_slot_number from the STF),
+        // committed in the witness. The ledger's next-slot counter must agree
+        // with it; otherwise host-side bookkeeping has drifted from execution and
+        // downstream aggregation would later diverge.
+        assert_eq!(
+            slot_number, ledger_slot_number,
+            "STF-emitted slot_number ({slot_number}) does not match ledger-derived slot_number ({ledger_slot_number})",
+        );
         let ledger_materialization_start = std::time::Instant::now();
         let mut ledger_change_set = self
             .ledger_db
@@ -438,7 +447,6 @@ where
             let stf_info = StateTransitionInfo {
                 data: transition_witness,
                 aggregated_proofs: all_aggregated_proofs,
-                slot_number,
             };
             let stf_info_schema = stf_info_sender
                 .materialize_stf_info(&stf_info, &self.ledger_db)

--- a/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
@@ -105,7 +105,7 @@ impl<Da: DaSpec> StateTransitionFunction<Da> for MockStf {
             }],
             discarded_blobs: Default::default(),
             witness: (),
-            rollup_height: RollupHeight::new(0),
+            rollup_height: RollupHeight::new(slot_header.height()),
             slot_number: SlotNumber::new(slot_header.height()),
         }
     }
@@ -196,7 +196,7 @@ async fn test_instant_finality() -> anyhow::Result<()> {
             sender.inc_next_height_to_receive();
         };
 
-        assert_eq!(height, finalized.slot_number.get());
+        assert_eq!(height, finalized.slot_number().get());
         assert_eq!(filtered_block.header, finalized.data.da_block_header);
         assert_eq!(state_root, finalized.data.initial_state_root);
         state_root.clone_from(&finalized.data.final_state_root);
@@ -1314,6 +1314,7 @@ async fn produce_synthetic_state_transition_witness<Da: DaService>(
         relevant_proofs,
         relevant_blobs,
         witness: (),
+        slot_number: SlotNumber::new(filtered_block.header().height()),
     };
 
     (change_set, transition_witness)

--- a/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
+++ b/crates/full-node/sov-stf-runner/src/state_manager/tests.rs
@@ -16,7 +16,7 @@ use sov_mock_da::{
 };
 use sov_modules_api::provable_height_tracker::InfiniteHeight;
 use sov_rollup_interface::common::{HexHash, RollupHeight, SlotNumber};
-use sov_rollup_interface::da::{DaSpec, RelevantBlobIters};
+use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec, RelevantBlobIters};
 use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
 use sov_rollup_interface::node::SyncStatus;
 use sov_rollup_interface::stf::GenesisParams;
@@ -89,7 +89,7 @@ impl<Da: DaSpec> StateTransitionFunction<Da> for MockStf {
         _pre_state_root: &Self::StateRoot,
         _base_state: Self::PreState,
         _witness: Self::Witness,
-        _slot_header: &Da::BlockHeader,
+        slot_header: &Da::BlockHeader,
         _relevant_blobs: RelevantBlobIters<&mut [<Da as DaSpec>::BlobTransaction]>,
         _execution_context: ExecutionContext,
     ) -> ApplySlotOutput<Da, Self> {
@@ -106,6 +106,7 @@ impl<Da: DaSpec> StateTransitionFunction<Da> for MockStf {
             discarded_blobs: Default::default(),
             witness: (),
             rollup_height: RollupHeight::new(0),
+            slot_number: SlotNumber::new(slot_header.height()),
         }
     }
 }

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/hash_stf.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/hash_stf.rs
@@ -5,7 +5,7 @@ use sov_mock_zkvm::{MockCodeCommitment, MockZkVerifier};
 use sov_modules_api::{
     AggregatedProofPublicData, ProofOutcome, ProofReceipt, ProofReceiptContents, Storage,
 };
-use sov_rollup_interface::common::RollupHeight;
+use sov_rollup_interface::common::{RollupHeight, SlotNumber};
 use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait, DaSpec, RelevantBlobIters};
 use sov_rollup_interface::stf::{ApplySlotOutput, GenesisParams, StateTransitionFunction};
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
@@ -222,6 +222,7 @@ impl<Da: DaSpec> StateTransitionFunction<Da> for HashStf {
             discarded_blobs: vec![],
             witness,
             rollup_height: RollupHeight::new(slot_header.height()),
+            slot_number: SlotNumber::new(slot_header.height()),
         }
     }
 }

--- a/crates/full-node/sov-stf-runner/tests/integration/prover_service/mod.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/prover_service/mod.rs
@@ -13,42 +13,60 @@ type StateRoot = Vec<u8>;
 type Address = Vec<u8>;
 
 fn make_header(header_hash: MockHash, height: u64) -> MockBlockHeader {
+    make_header_with_prev(header_hash, [0; 32].into(), height)
+}
+
+fn make_header_with_prev(
+    header_hash: MockHash,
+    prev_hash: MockHash,
+    height: u64,
+) -> MockBlockHeader {
     MockBlockHeader {
-        prev_hash: [0; 32].into(),
+        prev_hash,
         hash: header_hash,
         height,
         time: Time::now(),
     }
 }
 
+/// Builds a vector of `count` headers where each header's `prev_hash` points
+/// at the previous header's `hash`. Required when feeding multiple headers
+/// into proof aggregation, which now enforces DA hash-chain continuity.
+pub(crate) fn make_chained_headers(count: usize) -> Vec<MockBlockHeader> {
+    (0..count)
+        .map(|height| {
+            let hash = MockHash::from([(height + 1) as u8; 32]);
+            let prev_hash = MockHash::from([(height) as u8; 32]);
+            make_header_with_prev(hash, prev_hash, height as u64)
+        })
+        .collect()
+}
+
 fn make_transition_info(
     da_block_header: MockBlockHeader,
 ) -> StateTransitionInfo<StateRoot, Vec<u8>, MockDaSpec> {
-    let height = da_block_header.height + 1;
-
-    StateTransitionInfo::new(
-        StateTransitionWitness {
-            initial_state_root: Vec::default(),
-            final_state_root: Vec::default(),
-            da_block_header,
-            relevant_proofs: RelevantProofs {
-                batch: DaProof {
-                    inclusion_proof: Default::default(),
-                    completeness_proof: Default::default(),
-                },
-                proof: DaProof {
-                    inclusion_proof: Default::default(),
-                    completeness_proof: Default::default(),
-                },
+    let slot_number = SlotNumber::new_dangerous(da_block_header.height + 1);
+    StateTransitionInfo::new(StateTransitionWitness {
+        initial_state_root: Vec::default(),
+        final_state_root: Vec::default(),
+        da_block_header,
+        relevant_proofs: RelevantProofs {
+            batch: DaProof {
+                inclusion_proof: Default::default(),
+                completeness_proof: Default::default(),
             },
-            relevant_blobs: RelevantBlobs {
-                proof_blobs: vec![],
-                batch_blobs: vec![],
+            proof: DaProof {
+                inclusion_proof: Default::default(),
+                completeness_proof: Default::default(),
             },
-            witness: vec![],
         },
-        SlotNumber::new_dangerous(height),
-    )
+        relevant_blobs: RelevantBlobs {
+            proof_blobs: vec![],
+            batch_blobs: vec![],
+        },
+        witness: vec![],
+        slot_number,
+    })
 }
 
 async fn wait_for_aggregated_proof<

--- a/crates/full-node/sov-stf-runner/tests/integration/prover_service/parallel.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/prover_service/parallel.rs
@@ -7,7 +7,10 @@ use sov_stf_runner::processes::{
     ProverServiceError,
 };
 
-use super::{make_header, make_transition_info, wait_for_aggregated_proof, Address, StateRoot};
+use super::{
+    make_chained_headers, make_header, make_transition_info, wait_for_aggregated_proof, Address,
+    StateRoot,
+};
 use crate::helpers::genesis_state_root;
 
 struct TestProver {
@@ -202,9 +205,7 @@ async fn test_aggregated_proof() -> Result<(), ProverServiceError> {
         ..
     } = make_new_prover();
 
-    let headers: Vec<_> = (0..total_nb_of_blocks)
-        .map(|height| make_header(MockHash::from([height as u8; 32]), height as u64))
-        .collect();
+    let headers: Vec<_> = make_chained_headers(total_nb_of_blocks);
 
     let genesis_state_root = genesis_state_root();
 

--- a/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/helpers.rs
@@ -264,6 +264,7 @@ pub(crate) fn build_challenge(
     > = StateTransitionPublicData {
         initial_state_root: *current_transition.slot().prev_state_root(),
         final_state_root: *current_transition.post_state_root(),
+        slot_number: challenge_slot,
         slot_hash: *current_transition.slot().slot_hash(),
         prover_address,
     };

--- a/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -572,6 +572,7 @@ where
             .finalize_chain_state(&total_gas, &mut kernel_state_accessor);
 
         let rollup_height = state.rollup_height_to_access();
+        let slot_number = runtime.kernel().accessor(&mut state).true_slot_number();
         let (state_root, witness, change_set) = {
             // We can't use `if cfg!` here because `materialize_slot` returns different types in native and non-native mode.
             // So we structure this code to make it obvious that we're handling both cases.
@@ -615,6 +616,7 @@ where
             discarded_blobs,
             witness,
             rollup_height,
+            slot_number,
         }
     }
 

--- a/crates/rollup-interface/src/state_machine/stf/mod.rs
+++ b/crates/rollup-interface/src/state_machine/stf/mod.rs
@@ -27,8 +27,8 @@ pub use transaction::*;
 pub use verifier::StateTransitionVerifier;
 
 use super::optimistic::Attestation;
-use crate::common::{HexHash, RollupHeight};
 use crate::common::SlotNumber;
+use crate::common::{HexHash, RollupHeight};
 use crate::da::{DaSpec, RelevantBlobIters};
 use crate::zk::aggregated_proof::{AggregatedProofPublicData, SerializedAggregatedProof};
 use crate::zk::StateTransitionPublicData;

--- a/crates/rollup-interface/src/state_machine/stf/mod.rs
+++ b/crates/rollup-interface/src/state_machine/stf/mod.rs
@@ -28,6 +28,7 @@ pub use verifier::StateTransitionVerifier;
 
 use super::optimistic::Attestation;
 use crate::common::{HexHash, RollupHeight};
+use crate::common::SlotNumber;
 use crate::da::{DaSpec, RelevantBlobIters};
 use crate::zk::aggregated_proof::{AggregatedProofPublicData, SerializedAggregatedProof};
 use crate::zk::StateTransitionPublicData;
@@ -329,6 +330,8 @@ pub struct ApplySlotOutputInner<Root, ChangeSet, BR, PR, Witness> {
     pub witness: Witness,
     /// The rollup height before applying the changes.
     pub rollup_height: RollupHeight,
+    /// The canonical slot number of the transition within the rollup's DA fork.
+    pub slot_number: SlotNumber,
 }
 
 /// The result of applying a slot to current state.

--- a/crates/rollup-interface/src/state_machine/stf/verifier.rs
+++ b/crates/rollup-interface/src/state_machine/stf/verifier.rs
@@ -48,13 +48,16 @@ where
             data.relevant_blobs.as_iters(),
             ExecutionContext::Node,
         );
-        let final_state_root = result.state_root;
-        let slot_number = result.slot_number;
+
+        assert_eq!(
+            data.slot_number, result.slot_number,
+            "Witness slot_number, does not match STF-emitted slot_number."
+        );
 
         let out: StateTransitionPublicData<Stf::Address, Da::Spec, _> = StateTransitionPublicData {
             initial_state_root: data.initial_state_root,
-            final_state_root,
-            slot_number,
+            final_state_root: result.state_root,
+            slot_number: result.slot_number,
             slot_hash: data.da_block_header.hash(),
             prover_address,
         };

--- a/crates/rollup-interface/src/state_machine/stf/verifier.rs
+++ b/crates/rollup-interface/src/state_machine/stf/verifier.rs
@@ -48,10 +48,13 @@ where
             data.relevant_blobs.as_iters(),
             ExecutionContext::Node,
         );
+        let final_state_root = result.state_root;
+        let slot_number = result.slot_number;
 
         let out: StateTransitionPublicData<Stf::Address, Da::Spec, _> = StateTransitionPublicData {
             initial_state_root: data.initial_state_root,
-            final_state_root: result.state_root,
+            final_state_root,
+            slot_number,
             slot_hash: data.da_block_header.hash(),
             prover_address,
         };

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
@@ -123,6 +123,9 @@ where
     let mut expected_prev_state_root =
         previous_agg_proof_public_data.map(|public_data| public_data.final_state_root.clone());
 
+    let mut expected_prev_slot_number =
+        previous_agg_proof_public_data.map(|public_data| public_data.final_slot_number);
+
     // We intentionally scope the output to the current set of inner proofs only.
     // The predecessor proof is verified for chain continuity, but its slot range
     // and rewards are not carried forward — each aggregation covers only the
@@ -141,6 +144,21 @@ where
             .unwrap_or_else(|error| panic!("Failed to verify inner proof: {error:?}"));
 
         let current_slot_number = stf_public_data.slot_number;
+
+        // Slots advance 1:1 with DA blocks on the canonical fork, so each
+        // consecutive inner proof must increment the slot number by exactly one.
+        // For the very first aggregation (no predecessor), the first inner proof
+        // must cover slot 1 — slot 0 is the rollup genesis state and has no
+        // associated state transition / inner proof.
+        let expected = match expected_prev_slot_number {
+            Some(prev) => prev.next(),
+            None => SlotNumber::ONE,
+        };
+        assert_eq!(
+            current_slot_number, expected,
+            "Slot number discontinuity at index {index}: expected {expected}, got {current_slot_number}",
+        );
+        expected_prev_slot_number = Some(current_slot_number);
 
         // Verify DA block hash-chain continuity: each block's prev_hash must equal
         // the predecessor's hash. Also cross-check that the DA header hash matches

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
@@ -140,7 +140,7 @@ where
             )
             .unwrap_or_else(|error| panic!("Failed to verify inner proof: {error:?}"));
 
-        let current_slot_number = SlotNumber::new(proof_input.da_block_header.height());
+        let current_slot_number = stf_public_data.slot_number;
 
         // Verify DA block hash-chain continuity: each block's prev_hash must equal
         // the predecessor's hash. Also cross-check that the DA header hash matches

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -35,8 +35,6 @@ pub trait OuterZkvmHost: Clone + Send + Sync + 'static {
 pub struct BlockProof<Address, Da: DaSpec, Root> {
     /// The raw proof bytes.
     pub proof: SerializedZkProof,
-    /// The slot number this proof covers.
-    pub slot_number: SlotNumber,
     /// The state transition public data for this block.
     pub st: StateTransitionPublicData<Address, Da, Root>,
 }
@@ -91,9 +89,9 @@ impl core::fmt::Display for CodeCommitmentHash {
 /// Public data of an aggregated proof.
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone)]
 pub struct AggregatedProofPublicData<Address, Da: DaSpec, Root> {
-    /// Initial rollup height.
+    /// Initial rollup slot.
     pub initial_slot_number: SlotNumber,
-    /// Final rollup height.
+    /// Final rollup slot.
     pub final_slot_number: SlotNumber,
     /// The genesis state root of the aggregated proof.
     pub genesis_state_root: Root,
@@ -133,8 +131,8 @@ where
             .collect();
         Self {
             rewarded_addresses,
-            initial_slot_number: initial.slot_number,
-            final_slot_number: final_bp.slot_number,
+            initial_slot_number: initial.st.slot_number,
+            final_slot_number: final_bp.st.slot_number,
             genesis_state_root,
             initial_state_root: initial.st.initial_state_root.clone(),
             final_state_root: final_bp.st.final_state_root.clone(),

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -18,6 +18,7 @@ use sov_universal_wallet::UniversalWallet;
 
 use crate::crypto::{PublicKey, Signature};
 use crate::da::{DaSpec, RelevantBlobs, RelevantProofs};
+use crate::common::SlotNumber;
 use crate::zk::aggregated_proof::SerializedAggregatedProof;
 
 /// The `CryptoSpec` trait configures the cryptographic primitives used by a particular instance of a rollup.
@@ -195,6 +196,8 @@ pub struct StateTransitionPublicData<Address, Da: DaSpec, Root> {
         deserialize = "Root: borsh::de::BorshDeserialize"
     ))]
     pub final_state_root: Root,
+    /// The canonical slot number of the transition within the rollup's DA fork.
+    pub slot_number: SlotNumber,
     /// The slot hash of the state transition
     #[borsh(bound(
         serialize = "<Da as DaSpec>::SlotHash: borsh::ser::BorshSerialize",

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -16,9 +16,9 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sov_universal_wallet::UniversalWallet;
 
+use crate::common::SlotNumber;
 use crate::crypto::{PublicKey, Signature};
 use crate::da::{DaSpec, RelevantBlobs, RelevantProofs};
-use crate::common::SlotNumber;
 use crate::zk::aggregated_proof::SerializedAggregatedProof;
 
 /// The `CryptoSpec` trait configures the cryptographic primitives used by a particular instance of a rollup.
@@ -227,6 +227,8 @@ pub struct StateTransitionWitness<StateRoot, Witness, Da: DaSpec> {
     pub relevant_blobs: RelevantBlobs<<Da as DaSpec>::BlobTransaction>,
     /// The witness for the state transition
     pub witness: Witness,
+    /// The canonical slot number of the transition within the rollup's DA fork.
+    pub slot_number: SlotNumber,
 }
 
 #[derive(Serialize, Deserialize, UniversalWallet)]

--- a/examples/demo-rollup/tests/prover/mod.rs
+++ b/examples/demo-rollup/tests/prover/mod.rs
@@ -125,6 +125,7 @@ pub(super) async fn generate_witnesses() -> (ProofStateRoot, Vec<StfWitness>) {
             witness: result.witness,
             relevant_blobs,
             final_state_root: result.state_root,
+            slot_number: result.slot_number,
         });
 
         prev_state_root = result.state_root;

--- a/examples/demo-rollup/tests/prover/parallel.rs
+++ b/examples/demo-rollup/tests/prover/parallel.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use sov_mock_da::{MockDaService, MockDaSpec};
 use sov_modules_api::{AggregatedProofPublicData, Spec, Storage, ZkVerifier};
-use sov_rollup_interface::common::SlotNumber;
 use sov_sp1_adapter::host::{SP1AggregationHost, SP1Host};
 use sov_sp1_adapter::{SP1Verifier, SP1};
 use sov_stf_runner::processes::{
@@ -75,8 +74,7 @@ async fn test_parallel_proof_generation() {
     for (i, witness) in witnesses.into_iter().enumerate() {
         block_headers.push(witness.da_block_header.clone());
 
-        let slot_number = SlotNumber::new(i as u64 + 1);
-        let state_transition_info = StateTransitionInfo::new(witness, slot_number);
+        let state_transition_info = StateTransitionInfo::new(witness);
 
         let status = prover_service
             .prove(state_transition_info)

--- a/examples/demo-simple-stf/src/lib.rs
+++ b/examples/demo-simple-stf/src/lib.rs
@@ -127,7 +127,7 @@ impl<Da: DaSpec> StateTransitionFunction<Da> for CheckHashPreimageStf {
             batch_receipts: receipts,
             discarded_blobs: Default::default(),
             witness: (),
-            rollup_height: RollupHeight::new(0),
+            rollup_height: RollupHeight::new(slot_header.height()),
             slot_number: SlotNumber::new(slot_header.height()),
         }
     }

--- a/examples/demo-simple-stf/src/lib.rs
+++ b/examples/demo-simple-stf/src/lib.rs
@@ -3,8 +3,8 @@
 use std::fmt::Display;
 
 use sha2::Digest;
-use sov_rollup_interface::common::RollupHeight;
-use sov_rollup_interface::da::{BlobReaderTrait, DaSpec, RelevantBlobIters};
+use sov_rollup_interface::common::{RollupHeight, SlotNumber};
+use sov_rollup_interface::da::{BlobReaderTrait, BlockHeaderTrait, DaSpec, RelevantBlobIters};
 use sov_rollup_interface::stf::GenesisParams as GenesisParamsTrait;
 use sov_rollup_interface::stf::{ApplySlotOutput, BatchReceipt, StateTransitionFunction};
 
@@ -90,7 +90,7 @@ impl<Da: DaSpec> StateTransitionFunction<Da> for CheckHashPreimageStf {
         _pre_state_root: &Root,
         _base_state: Self::PreState,
         _witness: Self::Witness,
-        _slot_header: &Da::BlockHeader,
+        slot_header: &Da::BlockHeader,
         relevant_blobs: RelevantBlobIters<&mut [Da::BlobTransaction]>,
         _execution_context: sov_rollup_interface::stf::ExecutionContext,
     ) -> ApplySlotOutput<Da, Self> {
@@ -128,6 +128,7 @@ impl<Da: DaSpec> StateTransitionFunction<Da> for CheckHashPreimageStf {
             discarded_blobs: Default::default(),
             witness: (),
             rollup_height: RollupHeight::new(0),
+            slot_number: SlotNumber::new(slot_header.height()),
         }
     }
 }


### PR DESCRIPTION
# Description

 Previously, `aggregated_proof/circuit.rs` initialized `current_slot_number` from `da_block_header.height()`. That is incorrect, because rollup slot numbers are not generally equal to raw DA heights; it only appeared to work in tests because the rollup was deployed at DA genesis. This PR fixes the issue by propagating the STF-derived slot number through the proof pipeline and using that value in the aggregation circuit.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551