### PR TITLE
Fix events list pagination

### DIFF
--- a/crates/full-node/sov-ledger-apis/src/lib.rs
+++ b/crates/full-node/sov-ledger-apis/src/lib.rs
@@ -37,6 +37,12 @@ use tokio::sync::watch;
 
 type PathMap = Path<HashMap<String, NumberOrHash>>;
 
+/// Maximum value of `page[cursor]` accepted on the prefix path of `list_events`.
+/// Bounds per-request work since the current implementation re-reads everything
+/// from event 0 on every page. Until prefix iteration is pushed down into the
+/// storage layer, deeper cursors are rejected with 400.
+const PREFIX_MAX_START: u64 = 10_000;
+
 /// Error to be returned when our bespoke path captures parser fails.
 fn bad_path_error(key: &str) -> Response {
     ErrorObject {
@@ -364,22 +370,31 @@ where
             PageSelection::First => 0,
             PageSelection::Last => return Err(errors::not_implemented_501()),
         };
+        let limit = pagination.size as usize;
+
         if let Some(prefix) = event_key_prefix_opt
             .as_ref()
             .map(|q| q.0.prefix.as_str())
-            .filter(|p| !p.is_empty() && start == 0)
+            .filter(|p| !p.is_empty())
         {
-            let events = Self::list_events_by_prefix_first_page(
-                &state.ledger,
-                prefix,
-                pagination.size as usize,
-            )
-            .await
-            .map_err(errors::database_error_response_500)?;
+            // Bound the per-request work on the prefix path. Cost scales with
+            // `start + limit` per matching key (see list_events_by_prefix), so an
+            // unbounded cursor lets a client force the node to read and sort
+            // arbitrarily large windows. Reject deep cursors until the prefix
+            // iteration is pushed down into the storage layer.
+            if start > PREFIX_MAX_START {
+                return Err(errors::bad_request_400(
+                    "prefix queries cannot paginate past this offset",
+                    format!("page[cursor] must be <= {PREFIX_MAX_START} when prefix is set; use a more selective prefix to narrow results"),
+                ));
+            }
+            let events = Self::list_events_by_prefix(&state.ledger, prefix, start, limit)
+                .await
+                .map_err(errors::database_error_response_500)?;
             return Ok(events.into());
         }
 
-        let end = start.saturating_add(pagination.size as u64);
+        let end = start.saturating_add(limit as u64);
         let nums = (start..end)
             .map(EventIdentifier::Number)
             .collect::<Vec<_>>();
@@ -390,20 +405,20 @@ where
             .map_err(errors::database_error_response_500)?
             .into_iter()
             .flatten()
-            .filter(|event| {
-                if let Some(prefix) = &event_key_prefix_opt {
-                    event.key.starts_with(&prefix.prefix)
-                } else {
-                    true
-                }
-            })
             .collect::<Vec<_>>();
         Ok(events.into())
     }
 
-    async fn list_events_by_prefix_first_page(
+    // Assumes the prefix selects a small number of distinct event keys (typically
+    // 1-5). Cost per page is O(M * (start + limit)) event reads where M is the
+    // number of matching keys, so deep pagination over a broad prefix gets
+    // expensive. If that ever becomes a real workload, push prefix iteration into
+    // LedgerStateProviderExt with an opaque cursor backed by a RocksDB prefix scan
+    // so the cost becomes proportional to the answer size.
+    async fn list_events_by_prefix(
         ledger: &T,
         prefix: &str,
+        start: u64,
         limit: usize,
     ) -> Result<Vec<RuntimeEventResponse<E>>, T::Error> {
         let matching_keys = ledger
@@ -414,16 +429,25 @@ where
             .filter(|key| key.starts_with(prefix))
             .collect::<Vec<_>>();
 
+        let per_key_fetch = (start as usize).saturating_add(limit);
+
         let mut events = Vec::new();
         for event_key in matching_keys {
             let mut response = ledger
-                .get_events_by_key::<RuntimeEventResponse<E>>(&event_key, None, limit, None)
+                .get_events_by_key::<RuntimeEventResponse<E>>(
+                    &event_key,
+                    None,
+                    per_key_fetch,
+                    None,
+                )
                 .await?
                 .events_response;
             events.append(&mut response);
         }
 
         events.sort_by_key(|event| event.number);
+        let cut = events.partition_point(|event| event.number < start);
+        events.drain(..cut);
         events.truncate(limit);
         Ok(events)
     }

--- a/crates/full-node/sov-ledger-apis/src/lib.rs
+++ b/crates/full-node/sov-ledger-apis/src/lib.rs
@@ -93,7 +93,7 @@ pub struct LedgerState<T: LedgerStateProvider + Clone + Send + Sync + 'static> {
 
 impl<T, B, TxReceipt, E> LedgerRoutes<T, B, TxReceipt, E>
 where
-    T: LedgerStateProvider + LedgerStateProviderExt + Clone + Send + Sync + 'static,
+    T: LedgerStateProviderExt + Clone + Send + Sync + 'static,
     B: serde::Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     TxReceipt: TxReceiptContents,
     E: EventModuleName
@@ -434,12 +434,7 @@ where
         let mut events = Vec::new();
         for event_key in matching_keys {
             let mut response = ledger
-                .get_events_by_key::<RuntimeEventResponse<E>>(
-                    &event_key,
-                    None,
-                    per_key_fetch,
-                    None,
-                )
+                .get_events_by_key::<RuntimeEventResponse<E>>(&event_key, None, per_key_fetch, None)
                 .await?
                 .events_response;
             events.append(&mut response);

--- a/crates/full-node/sov-ledger-apis/src/lib.rs
+++ b/crates/full-node/sov-ledger-apis/src/lib.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use sov_db::schema::types::{BatchNumber, EventNumber, TxNumber};
 use sov_modules_api::da::Time;
+use sov_modules_api::rpc::LedgerStateProviderExt;
 pub use sov_modules_api::ApiTxEffect as TxEffect;
 use sov_modules_api::{EventModuleName, FullyBakedTx, RuntimeEventResponse};
 use sov_rest_utils::errors::ReportableWsError;
@@ -86,7 +87,7 @@ pub struct LedgerState<T: LedgerStateProvider + Clone + Send + Sync + 'static> {
 
 impl<T, B, TxReceipt, E> LedgerRoutes<T, B, TxReceipt, E>
 where
-    T: LedgerStateProvider + Clone + Send + Sync + 'static,
+    T: LedgerStateProvider + LedgerStateProviderExt + Clone + Send + Sync + 'static,
     B: serde::Serialize + DeserializeOwned + Clone + Send + Sync + 'static,
     TxReceipt: TxReceiptContents,
     E: EventModuleName
@@ -363,8 +364,23 @@ where
             PageSelection::First => 0,
             PageSelection::Last => return Err(errors::not_implemented_501()),
         };
+        if let Some(prefix) = event_key_prefix_opt
+            .as_ref()
+            .map(|q| q.0.prefix.as_str())
+            .filter(|p| !p.is_empty() && start == 0)
+        {
+            let events = Self::list_events_by_prefix_first_page(
+                &state.ledger,
+                prefix,
+                pagination.size as usize,
+            )
+            .await
+            .map_err(errors::database_error_response_500)?;
+            return Ok(events.into());
+        }
+
         let end = start.saturating_add(pagination.size as u64);
-        let nums = (start..=end)
+        let nums = (start..end)
             .map(EventIdentifier::Number)
             .collect::<Vec<_>>();
         let events = state
@@ -383,6 +399,33 @@ where
             })
             .collect::<Vec<_>>();
         Ok(events.into())
+    }
+
+    async fn list_events_by_prefix_first_page(
+        ledger: &T,
+        prefix: &str,
+        limit: usize,
+    ) -> Result<Vec<RuntimeEventResponse<E>>, T::Error> {
+        let matching_keys = ledger
+            .get_event_key_counts()
+            .await?
+            .into_iter()
+            .map(|(key, _)| key)
+            .filter(|key| key.starts_with(prefix))
+            .collect::<Vec<_>>();
+
+        let mut events = Vec::new();
+        for event_key in matching_keys {
+            let mut response = ledger
+                .get_events_by_key::<RuntimeEventResponse<E>>(&event_key, None, limit, None)
+                .await?
+                .events_response;
+            events.append(&mut response);
+        }
+
+        events.sort_by_key(|event| event.number);
+        events.truncate(limit);
+        Ok(events)
     }
 
     async fn get_latest_event(

--- a/crates/full-node/sov-ledger-apis/tests/integration/main.rs
+++ b/crates/full-node/sov-ledger-apis/tests/integration/main.rs
@@ -396,6 +396,49 @@ async fn get_event() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn list_events_respects_page_size() {
+    let ledger_service = LedgerTestService::new(LedgerTestServiceData::Simple)
+        .await
+        .unwrap();
+    let addr = ledger_service.axum_handle.listening().await.unwrap();
+
+    let events: serde_json::Value = reqwest::get(format!(
+        "http://{addr}/ledger/events?page=first&page[size]=1"
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+
+    let events = events.as_array().unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["number"].as_u64(), Some(0));
+    assert_eq!(events[0]["key"].as_str(), Some("foo0"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_events_prefix_reads_past_first_raw_page() {
+    let ledger_service = LedgerTestService::new(LedgerTestServiceData::Complex)
+        .await
+        .unwrap();
+    let addr = ledger_service.axum_handle.listening().await.unwrap();
+
+    let events: serde_json::Value =
+        reqwest::get(format!("http://{addr}/ledger/events?prefix=foo100"))
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+
+    let events = events.as_array().unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["number"].as_u64(), Some(200));
+    assert_eq!(events[0]["key"].as_str(), Some("foo100"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn get_latest_aggregated_proof() {
     let response = ledger_response_body(|client| async move {
         client

--- a/crates/full-node/sov-ledger-apis/tests/integration/main.rs
+++ b/crates/full-node/sov-ledger-apis/tests/integration/main.rs
@@ -439,6 +439,61 @@ async fn list_events_prefix_reads_past_first_raw_page() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn list_events_prefix_rejects_deep_cursor() {
+    let ledger_service = LedgerTestService::new(LedgerTestServiceData::Complex)
+        .await
+        .unwrap();
+    let addr = ledger_service.axum_handle.listening().await.unwrap();
+
+    let response = reqwest::get(format!(
+        "http://{addr}/ledger/events?prefix=foo&page=next&page[cursor]=10001&page[size]=10"
+    ))
+    .await
+    .unwrap();
+    assert_eq!(response.status(), 400);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn list_events_prefix_paginates() {
+    let ledger_service = LedgerTestService::new(LedgerTestServiceData::Complex)
+        .await
+        .unwrap();
+    let addr = ledger_service.axum_handle.listening().await.unwrap();
+
+    // Complex fixture emits foo{N} at event number 2N for N in 0..266.
+    let page1: serde_json::Value = reqwest::get(format!(
+        "http://{addr}/ledger/events?prefix=foo&page=first&page[size]=5"
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+    let page1 = page1.as_array().unwrap();
+    let page1_numbers = page1
+        .iter()
+        .map(|e| e["number"].as_u64().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(page1_numbers, vec![0, 2, 4, 6, 8]);
+
+    let next_cursor = page1_numbers.last().unwrap() + 1;
+    let page2: serde_json::Value = reqwest::get(format!(
+        "http://{addr}/ledger/events?prefix=foo&page=next&page[cursor]={next_cursor}&page[size]=5"
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+    let page2 = page2.as_array().unwrap();
+    let page2_numbers = page2
+        .iter()
+        .map(|e| e["number"].as_u64().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(page2_numbers, vec![10, 12, 14, 16, 18]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn get_latest_aggregated_proof() {
     let response = ledger_response_body(|client| async move {
         client


### PR DESCRIPTION
# Description

Fixes issue where events that should have been returned from the list endpoints were omitted when using a prefix. This is because we retrieved the page first (i.e the first ANY 25 events) and then applied the prefix filtering.

The implementation here is a stop-gap and is not performant. A cap of `10_000` for the page cursor has been added to prevent ddosing events that have a lot of entries (i.e on bullet). The real solution is to use the db layer to perform filtering which requires refactoring/breaking changes to our current pagination cursors: https://github.com/Sovereign-Labs/sovereign-sdk/issues/2811

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
