### PR TITLE
Multisig solana v0 improvement

### DIFF
--- a/crates/module-system/sov-solana-offchain-auth/src/authentication/payload.rs
+++ b/crates/module-system/sov-solana-offchain-auth/src/authentication/payload.rs
@@ -33,6 +33,9 @@ pub struct SolanaOffchainSigningPayloadV0<R: TransactionCallable, S: Spec> {
     /// See [`sov_modules_api::capabilities::AuthorizationData::address_override`] for routing semantics.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub address_override: Option<S::Address>,
+    /// Message format version. Must be `0` for this struct.
+    #[serde(deserialize_with = "deserialize_version_0")]
+    pub version: u8,
 }
 
 impl<R, S> SolanaOffchainSigningPayloadV0<R, S>
@@ -89,6 +92,18 @@ pub struct SolanaOffchainSigningPayloadV1<R: TransactionCallable, S: Spec> {
     /// Message format version. Must be `1` for this struct.
     #[serde(deserialize_with = "deserialize_version_1")]
     pub version: u8,
+}
+
+fn deserialize_version_0<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<u8, D::Error> {
+    let v = <u8 as serde::Deserialize>::deserialize(deserializer)?;
+    if v != 0 {
+        return Err(serde::de::Error::custom(format!(
+            "expected message version 0, got {v}"
+        )));
+    }
+    Ok(v)
 }
 
 fn deserialize_version_1<'de, D: serde::Deserializer<'de>>(

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/main.rs
@@ -249,6 +249,7 @@ fn create_transfer_tx_json_with_address_override(
         details: unsigned_tx.details,
         chain_name: config_value!("CHAIN_NAME").to_string().try_into().unwrap(),
         address_override,
+        version: 0,
     };
 
     serde_json::to_string(&solana_unsigned_tx).unwrap()
@@ -354,7 +355,7 @@ async fn test_submit_ledger_signed_transaction() {
     // updated.)
     assert_eq!(
         transfer_json_tx,
-        r#"{"runtime_call":{"bank":{"transfer":{"to":"4zdwHNaEa5npHtRtaZ3RL1m6rptuQZ6RBLHG6cAyVHjL","coins":{"amount":"5000","token_id":"token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"}}}},"uniqueness":{"generation":0},"details":{"max_priority_fee_bips":0,"max_fee":"100000000000","gas_limit":[1000000000,1000000000],"chain_id":4321},"chain_name":"TestChain"}"#,
+        r#"{"runtime_call":{"bank":{"transfer":{"to":"4zdwHNaEa5npHtRtaZ3RL1m6rptuQZ6RBLHG6cAyVHjL","coins":{"amount":"5000","token_id":"token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7"}}}},"uniqueness":{"generation":0},"details":{"max_priority_fee_bips":0,"max_fee":"100000000000","gas_limit":[1000000000,1000000000],"chain_id":4321},"chain_name":"TestChain","version":0}"#,
         "JSON changed - re-sign on Ledger and update the hardcoded signature"
     );
     let encoded_tx = transfer_json_tx.as_bytes().to_vec();
@@ -364,7 +365,7 @@ async fn test_submit_ledger_signed_transaction() {
         .try_into()
         .unwrap();
     let signature: Ed25519Signature = bs58::decode(
-        "3GBYQrmcKtUiXAQLz2bUR55Kh7YfgUy2g199ePXYSUHbRHLAsdjcTctSrt98oiA79nZVQU79AbBpiKU23Z2UTstQ",
+        "3kY989YQ614HgcoToFeZp4rWggqzkpQJPeusDNoVRLt74X1goAaoF6LH8wXB8dwrvmjnxBNvSJq1LFpG3MBh6fAd",
     )
     .into_vec()
     .unwrap()
@@ -380,8 +381,8 @@ async fn test_submit_ledger_signed_transaction() {
     let message_str = bs58::encode(&signed_message_with_preamble).into_string();
     assert_eq!(
         message_str,
-        "45bxAZgjJHtL6EmowbCZiBduiwEePySEehCCaCVVJouRB7hQRL3qsv4PNmQvE9NVDfFKmfmVNaNS5a32X1fpSmjJVk19Dk9VSqLyYXxeVuGCZR4jCx7JTx1qbLHD3amNkHvmCnhkgLbT8HgkPwHZWPMeapAo2cL9N3CRzPMZFM5ikWb8yJXzFpCzBjsL1fkCtkDz2BoZPHAtrh5Zvhdae6W9Qypme1iUys8iu4A4e3mk6Nh2us2iLgPcEJhK7xsNxm66CxogjGnwBW3ioTfjRby9LHVzJwQ2dFLJT8kugres5xGG6PxKFNkhFRV4bPgYJvh4ZUUUZSWKkVeW4Ep3nH4BTn1N5WkouYWjKvhy54FCasbM8AyWYAyCnSpX5e8jFEN12rBzmq4HEEJxJY51rTULCEK8Uq2ZJKAe5yTXUisQRw1hZo5bQGku5DwfGyupyfiE6b78vm7uJvQcipLFBoDByrrwPRGhYXK3m8axmcDUFm2PiCpRfYSMk7kGsNn1LLD7D2EwovWDCVERVEB5zftfj6gx9ZeFeZi1c2PdUYsvhZjHdVEa8JVFmts5Q8hD1Wf53DjQAmCFa8GzTK1cekDN47ENFfPaPQsLRFTEXn",
-        "Multisig message bytes changed - re-sign on ledger and update the hardcoded signature"
+        "FspUdENNoCTH4VASSjcgC8cLUmq79qrXg2NPyYx6h6fw1fQvwpCCNFEC4VH3wVWYU3FKv54nNKE1guEqUDJ9cBv2R5aUDFiTiSt1uyTQMiacVcB9tknHJTWDKKkoYwiAqeLYvK2yACXfd8XpajNMk8FexFqv6jWXcwHyEBp9TVnrwqxTvXJkVUhVRXv1pkSPHL2ZwUNtb4b98YzuwjcPXiKmqfXZz1FRARFJPSdWoSsKihj7VUB9SLuDmVvQpuK4AhQbeJCbZfhAnu3BccvCYjX6YEKwejDkSApzCNZEeuRHDHcw4WtfMeTREkW3qQr98N1ZZY8mx3zoZ59EMnfwdfgTAM5LH2hLRZk6FxtXz9oLXPDFBzaa1K5ikjYtqGvgf3vzDWrTCH4cYAZXP6xvs9rAs5JYyWcwm2ToCSKvS2Qxe867XhBf5pNnDtieLwZjSByQJLM27w2RXeJ2FR7T7p2KphFeKxYEdR76JDuA58aXWtw8NvRHoVULnxMuj65epCipxnvWkFqALsUaSAeQMQV1U3v9PF8MJDHWpyENBF9YG66ZZf2NwrA3kRNGVm3F8hCJgnuiN3jxiZWgAMuqxX1eeY26WKufP63SwBXQbkE3Yo7nx5yfEMApRi",
+        "Ledger message bytes changed - re-sign on ledger and update the hardcoded signature"
     );
 
     let message = SolanaOffchainSpecCompliantEnvelope::<S> {
@@ -391,6 +392,17 @@ async fn test_submit_ledger_signed_transaction() {
 
     let raw_tx_bytes = borsh::to_vec(&message).unwrap();
 
+    {
+        let request = AcceptTx {
+            body: sov_sequencer::rest_api::Base64Blob {
+                blob: raw_tx_bytes.clone(),
+            },
+        };
+        println!(
+            "SINGLE_SIG LEDGER PAYLOAD: {}",
+            serde_json::to_string(&request).unwrap()
+        );
+    }
     let response = submit_tx(test_rollup.api_client(), raw_tx_bytes).await;
     assert!(
         response.status().is_success(),
@@ -425,6 +437,7 @@ async fn test_submit_raw_signed_message_transaction() {
     let tx_str = create_transfer_tx_json(Amount(10_000), RECIPIENT_ADDRESS);
     let encoded_tx = tx_str.as_bytes().to_vec();
     let signer = admin.private_key();
+    println!("SINGLE SIG SIGNER KEY: {}", hex::encode(signer));
     let pubkey = signer.pub_key();
     let signature = signer.sign(&encoded_tx);
 
@@ -436,6 +449,17 @@ async fn test_submit_raw_signed_message_transaction() {
     };
     let raw_tx_bytes = borsh::to_vec(&message).unwrap();
 
+    {
+        let request = AcceptTx {
+            body: sov_sequencer::rest_api::Base64Blob {
+                blob: raw_tx_bytes.clone(),
+            },
+        };
+        println!(
+            "SINGLE_SIG PAYLOAD: {}",
+            serde_json::to_string(&request).unwrap()
+        );
+    }
     let response = submit_tx(test_rollup.api_client(), raw_tx_bytes).await;
 
     assert!(
@@ -1556,6 +1580,7 @@ fn build_v0_payload(
         details: unsigned_tx.details,
         chain_name: config_value!("CHAIN_NAME").to_string().try_into().unwrap(),
         address_override,
+        version: 0,
     }
 }
 

--- a/typescript/packages/web3/src/rollup/solana-signable-rollup.test.ts
+++ b/typescript/packages/web3/src/rollup/solana-signable-rollup.test.ts
@@ -230,6 +230,7 @@ describe("SolanaSignableRollup", () => {
     const message = JSON.parse(new TextDecoder().decode(jsonBytes));
 
     expect(message.chain_name).toBe(demoRollupSchema.chain_data.chain_name);
+    expect(message.version).toBe(0);
   });
 
   it("should include address_override in Solana signed JSON when present", async () => {
@@ -286,9 +287,9 @@ describe("SolanaSignableRollup", () => {
       // These values were generated using the test_submit_raw_signed_message_transaction() test from the sov-solana-offchain-auth crate.
       // The signer private key was logged, and the serde serialization of the AcceptTx was logged.
       const privateKeyHex =
-        "4096e0037e7dc13c28730b01e303ea4679a05e019f68a5ee8aec6c1968cac707";
+        "2bf7a34f197040d49014e026aa35a61b094ad6b32d5ae86e769e777a51a83c5d";
       const expectedJson =
-        '{"body":{"body":"cAEAAHsicnVudGltZV9jYWxsIjp7ImJhbmsiOnsidHJhbnNmZXIiOnsidG8iOiI0emR3SE5hRWE1bnBIdFJ0YVozUkwxbTZycHR1UVo2UkJMSEc2Y0F5VkhqTCIsImNvaW5zIjp7ImFtb3VudCI6IjEwMDAwIiwidG9rZW5faWQiOiJ0b2tlbl8xbnlsMGUweXdlcmFnZnNhdHlndDI0em1kOGpycjJ2cXR2ZGZwdHpqaHhrZ3V6Mnh4eDN2czB5MDd1NyJ9fX19LCJ1bmlxdWVuZXNzIjp7ImdlbmVyYXRpb24iOjB9LCJkZXRhaWxzIjp7Im1heF9wcmlvcml0eV9mZWVfYmlwcyI6MCwibWF4X2ZlZSI6IjEwMDAwMDAwMDAwMCIsImdhc19saW1pdCI6WzEwMDAwMDAwMDAsMTAwMDAwMDAwMF0sImNoYWluX2lkIjo0MzIxfSwiY2hhaW5fbmFtZSI6IlRlc3RDaGFpbiJ9CwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwuMdhE5OjziHniAzu9qaFH0I50R93Apv2VgyONYPuLm3nN3Cr4cJwZ5ii6YYXxr7LsW3qcL0NAJfIvmUZroK+fuM18D3Hj+NsFn+nmN9jCjiWhjbQO1/79i365l424Erwg="}}';
+        '{"body":{"body":"fAEAAHsicnVudGltZV9jYWxsIjp7ImJhbmsiOnsidHJhbnNmZXIiOnsidG8iOiI0emR3SE5hRWE1bnBIdFJ0YVozUkwxbTZycHR1UVo2UkJMSEc2Y0F5VkhqTCIsImNvaW5zIjp7ImFtb3VudCI6IjEwMDAwIiwidG9rZW5faWQiOiJ0b2tlbl8xbnlsMGUweXdlcmFnZnNhdHlndDI0em1kOGpycjJ2cXR2ZGZwdHpqaHhrZ3V6Mnh4eDN2czB5MDd1NyJ9fX19LCJ1bmlxdWVuZXNzIjp7ImdlbmVyYXRpb24iOjB9LCJkZXRhaWxzIjp7Im1heF9wcmlvcml0eV9mZWVfYmlwcyI6MCwibWF4X2ZlZSI6IjEwMDAwMDAwMDAwMCIsImdhc19saW1pdCI6WzEwMDAwMDAwMDAsMTAwMDAwMDAwMF0sImNoYWluX2lkIjo0MzIxfSwiY2hhaW5fbmFtZSI6IlRlc3RDaGFpbiIsInZlcnNpb24iOjB9CwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwt0I7oBLzTClR8+NiHHPE6LyyQfcVTjHex79N5keSD1gm4KQIi9Wdvph88C+u2Y1i/1eZF9j5q2tRUY+QPqVw2BnwF+uFCpwdsmpqQQgi1DfY4dMMCxQzUFuhz7krpMtQI="}}';
 
       const mockClient = createMockClient({
         chainId: 4321,
@@ -361,9 +362,9 @@ describe("SolanaSignableRollup", () => {
       const knownPubkeyHex =
         "70248c99a1d39769831c99706948b9851585cba907a677d112f9a3694cbcb4cd";
       const knownSignatureHex =
-        "71204c3487b8e637cffaa5e9dc409efe2f1e98db6b557041181a368f4c487bbd407f72c43f08aa44b75f219e6fb3ce4681785dd72ee3eebe4e641ade8289370d";
+        "89941ccebc40db1daf60b0b392121616868000d4799d930d18f4eaff266cd560cf61c6bf62c97955f64b33cc0640718427d0dc0180cf65e9746b7522d7f6d20e";
       const expectedJson =
-        '{"body":{"body":"xAEAAP9zb2xhbmEgb2ZmY2hhaW4ACwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsAAXAkjJmh05dpgxyZcGlIuYUVhcupB6Z30RL5o2lMvLTNbwF7InJ1bnRpbWVfY2FsbCI6eyJiYW5rIjp7InRyYW5zZmVyIjp7InRvIjoiNHpkd0hOYUVhNW5wSHRSdGFaM1JMMW02cnB0dVFaNlJCTEhHNmNBeVZIakwiLCJjb2lucyI6eyJhbW91bnQiOiI1MDAwIiwidG9rZW5faWQiOiJ0b2tlbl8xbnlsMGUweXdlcmFnZnNhdHlndDI0em1kOGpycjJ2cXR2ZGZwdHpqaHhrZ3V6Mnh4eDN2czB5MDd1NyJ9fX19LCJ1bmlxdWVuZXNzIjp7ImdlbmVyYXRpb24iOjB9LCJkZXRhaWxzIjp7Im1heF9wcmlvcml0eV9mZWVfYmlwcyI6MCwibWF4X2ZlZSI6IjEwMDAwMDAwMDAwMCIsImdhc19saW1pdCI6WzEwMDAwMDAwMDAsMTAwMDAwMDAwMF0sImNoYWluX2lkIjo0MzIxfSwiY2hhaW5fbmFtZSI6IlRlc3RDaGFpbiJ9cSBMNIe45jfP+qXp3ECe/i8emNtrVXBBGBo2j0xIe71Af3LEPwiqRLdfIZ5vs85GgXhd1y7j7r5OZBregok3DQ=="}}';
+        '{"body":{"body":"0AEAAP9zb2xhbmEgb2ZmY2hhaW4ACwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsLCwsAAXAkjJmh05dpgxyZcGlIuYUVhcupB6Z30RL5o2lMvLTNewF7InJ1bnRpbWVfY2FsbCI6eyJiYW5rIjp7InRyYW5zZmVyIjp7InRvIjoiNHpkd0hOYUVhNW5wSHRSdGFaM1JMMW02cnB0dVFaNlJCTEhHNmNBeVZIakwiLCJjb2lucyI6eyJhbW91bnQiOiI1MDAwIiwidG9rZW5faWQiOiJ0b2tlbl8xbnlsMGUweXdlcmFnZnNhdHlndDI0em1kOGpycjJ2cXR2ZGZwdHpqaHhrZ3V6Mnh4eDN2czB5MDd1NyJ9fX19LCJ1bmlxdWVuZXNzIjp7ImdlbmVyYXRpb24iOjB9LCJkZXRhaWxzIjp7Im1heF9wcmlvcml0eV9mZWVfYmlwcyI6MCwibWF4X2ZlZSI6IjEwMDAwMDAwMDAwMCIsImdhc19saW1pdCI6WzEwMDAwMDAwMDAsMTAwMDAwMDAwMF0sImNoYWluX2lkIjo0MzIxfSwiY2hhaW5fbmFtZSI6IlRlc3RDaGFpbiIsInZlcnNpb24iOjB9iZQczrxA2x2vYLCzkhIWFoaAANR5nZMNGPTq/yZs1WDPYca/Ysl5VfZLM8wGQHGEJ9DcAYDPZel0a3Ui1/bSDg=="}}';
 
       const mockClient = createMockClient({
         chainId: 4321,

--- a/typescript/packages/web3/src/rollup/solana-signable-rollup.ts
+++ b/typescript/packages/web3/src/rollup/solana-signable-rollup.ts
@@ -30,6 +30,7 @@ export type SolanaOffchainSigningPayloadV0<RuntimeCall> = Omit<
   "address_override"
 > & {
   chain_name: string;
+  version: 0;
   /**
    * Signer-declared address override.
    * See `AuthorizationData::address_override` (Rust) for routing semantics.
@@ -40,14 +41,13 @@ export type SolanaOffchainSigningPayloadV0<RuntimeCall> = Omit<
 export type SolanaOffchainSigningPayloadV1<
   RuntimeCall,
   MultisigId = unknown,
-> = Omit<SolanaOffchainSigningPayloadV0<RuntimeCall>, "address_override"> & {
+> = Omit<SolanaOffchainSigningPayloadV0<RuntimeCall>, "version"> & {
   multisig_id: MultisigId;
   /**
    * Signer-declared address override.
    * See `AuthorizationData::address_override` (Rust) for routing semantics.
    */
-  address_override?: string;
-  version: number;
+  version: 1;
 };
 
 export type SolanaOffchainSimpleEnvelope = {
@@ -326,6 +326,7 @@ export class SolanaSignableRollup<RuntimeCall> {
         unsignedTx.address_override !== undefined && {
           address_override: unsignedTx.address_override,
         }),
+      version: 0,
     };
 
     // JSON serialize the Solana unsigned transaction

--- a/typescript/packages/web3/src/rollup/solana-signable-rollup.ts
+++ b/typescript/packages/web3/src/rollup/solana-signable-rollup.ts
@@ -30,6 +30,9 @@ export type SolanaOffchainSigningPayloadV0<RuntimeCall> = Omit<
   "address_override"
 > & {
   chain_name: string;
+  /**
+   * Message format version. Must be 0 for V0 payloads.
+   */
   version: 0;
   /**
    * Signer-declared address override.
@@ -44,8 +47,7 @@ export type SolanaOffchainSigningPayloadV1<
 > = Omit<SolanaOffchainSigningPayloadV0<RuntimeCall>, "version"> & {
   multisig_id: MultisigId;
   /**
-   * Signer-declared address override.
-   * See `AuthorizationData::address_override` (Rust) for routing semantics.
+   * Message format version. Must be 1 for V1 payloads.
    */
   version: 1;
 };


### PR DESCRIPTION
# Description

Adds a `"version": 0` field to the V0 solana-offchain JSON. This brings it in line with the normal UnsignedTransaction format which includes an enum discriminator byte for both formats, and makes it less ambiguous and more secure for the future (each version is explicitly marked, no assumptions are needed when the "version" field is missing).

Background: `"version: 1"` was added as part of adding V1 support to the solana authenticator, but V0 was left untouched because the V1 support addition was non-breaking. Now V0 is being brough inline with V1 and with the standard authenticator on this point as part of the multisig hard fork upgrade.

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] ~~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
