### PR TITLE
Ledger API: Do not collect all slots in RAM for finalized slot subscription

### DIFF
--- a/crates/full-node/sov-ledger-apis/src/lib.rs
+++ b/crates/full-node/sov-ledger-apis/src/lib.rs
@@ -839,15 +839,8 @@ where
                             tracing::trace!(
                                 from = %old_last,
                                 up_to_inc = %incoming_slot_num,
-                                "Going to notify about finalized slots"
-                            );
-                            tracing::trace!(
-                                from = %old_last,
-                                up_to_inc = %incoming_slot_num,
                                 "Created lazy websocket notification stream for finalized slots"
                             );
-                            // Returning `Some(...)` yields items to the *downstream*;
-                            // returning `None` would end the stream.
                             Some(
                                 futures::stream::iter(old_last.range_inclusive(incoming_slot_num))
                                     .then(move |slot_number| {

--- a/crates/full-node/sov-ledger-apis/src/lib.rs
+++ b/crates/full-node/sov-ledger-apis/src/lib.rs
@@ -836,42 +836,56 @@ where
 
                         let ledger = ledger.clone();
                         async move {
-                            let capacity =
-                                incoming_slot_num.saturating_sub(old_last.get()).get() as usize;
-                            let mut slots = Vec::with_capacity(capacity);
                             tracing::trace!(
                                 from = %old_last,
                                 up_to_inc = %incoming_slot_num,
                                 "Going to notify about finalized slots"
                             );
-                            for slot_number in old_last.range_inclusive(incoming_slot_num) {
-                                let slot_result = match ledger
-                                    .get_slot_by_number::<B, TxReceipt, RuntimeEventResponse<E>>(
-                                        slot_number,
-                                        query_mode,
-                                    )
-                                    .await
-                                {
-                                    Ok(Some(slot)) => Ok(Slot::<B, TxReceipt, E>::new(slot)),
-                                    Ok(None) => Err(WsLedgerError::SlotNotFound { slot: slot_number.get() }),
-                                    Err(err) => {
-                                        tracing::error!(
-                                            error = %err,
-                                            "Database error while fetching slot by number"
-                                        );
-                                        Err(WsLedgerError::SlotFetchFailed { slot: slot_number.get() })},
-                                };
-                                tracing::trace!(%slot_number, "Preparing slot result for sending to websocket");
-                                slots.push(slot_result);
-                            }
                             tracing::trace!(
                                 from = %old_last,
                                 up_to_inc = %incoming_slot_num,
-                                "Collected websocket notification about finalized slots"
+                                "Created lazy websocket notification stream for finalized slots"
                             );
                             // Returning `Some(...)` yields items to the *downstream*;
                             // returning `None` would end the stream.
-                            Some(futures::stream::iter(slots))
+                            Some(
+                                futures::stream::iter(old_last.range_inclusive(incoming_slot_num))
+                                    .then(move |slot_number| {
+                                        let ledger = ledger.clone();
+                                        async move {
+                                            let slot_result = match ledger
+                                                .get_slot_by_number::<
+                                                    B,
+                                                    TxReceipt,
+                                                    RuntimeEventResponse<E>,
+                                                >(slot_number, query_mode)
+                                                .await
+                                            {
+                                                Ok(Some(slot)) => {
+                                                    Ok(Slot::<B, TxReceipt, E>::new(slot))
+                                                }
+                                                Ok(None) => Err(WsLedgerError::SlotNotFound {
+                                                    slot: slot_number.get(),
+                                                }),
+                                                Err(err) => {
+                                                    tracing::error!(
+                                                        error = %err,
+                                                        "Database error while fetching slot by number"
+                                                    );
+                                                    Err(WsLedgerError::SlotFetchFailed {
+                                                        slot: slot_number.get(),
+                                                    })
+                                                }
+                                            };
+                                            tracing::trace!(
+                                                %slot_number,
+                                                "Prepared slot result for sending to websocket"
+                                            );
+                                            slot_result
+                                        }
+                                    })
+                                    .boxed(),
+                            )
                         }
                     },
                 )


### PR DESCRIPTION
# Description

Should prevent memory usage spikes in case if websocket client(s) skipped significant number of slots

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
All existing tests are passing

## Docs
No updates
