### PR TITLE
LedgerDb: more granular events subscription fetch

### DIFF
--- a/crates/full-node/sov-db/src/ledger_db/rpc.rs
+++ b/crates/full-node/sov-db/src/ledger_db/rpc.rs
@@ -404,22 +404,51 @@ impl LedgerRpcReader {
             return Ok(vec![]);
         }
 
-        let stored_events = self.get_event_range(&event_range).await?;
+        let stored_events = self
+            .db
+            .collect_in_range_async::<EventByNumber, EventNumber>(event_range.clone())
+            .await?;
         let mut events = if event_key_prefix_filter.is_some() {
             Vec::new()
         } else {
             Vec::with_capacity(stored_events.len())
         };
+        let mut expected_event_number = event_range.start.0;
 
-        for (offset, event) in stored_events.iter().enumerate() {
+        for (event_number, event) in &stored_events {
+            if event_number.0 != expected_event_number {
+                bail!(
+                    "Ledger DB corruption: missing event {:?} in slot `{:?}` while scanning range {:?}..{:?}",
+                    EventNumber(expected_event_number),
+                    slot_id,
+                    event_range.start,
+                    event_range.end,
+                );
+            }
+
             if let Some(prefix) = &event_key_prefix_filter {
                 if !event.key().inner().starts_with(prefix) {
+                    expected_event_number = expected_event_number
+                        .checked_add(1)
+                        .expect("event number overflow while scanning slot events");
                     continue;
                 }
             }
 
-            let event_number = event_range.start.0 + offset as u64;
-            events.push((event_number, event).try_into()?);
+            events.push((event_number.0, event).try_into()?);
+            expected_event_number = expected_event_number
+                .checked_add(1)
+                .expect("event number overflow while scanning slot events");
+        }
+
+        if expected_event_number != event_range.end.0 {
+            bail!(
+                "Ledger DB corruption: missing event {:?} in slot `{:?}` while scanning range {:?}..{:?}",
+                EventNumber(expected_event_number),
+                slot_id,
+                event_range.start,
+                event_range.end,
+            );
         }
 
         Ok(events)

--- a/crates/full-node/sov-db/src/ledger_db/rpc.rs
+++ b/crates/full-node/sov-db/src/ledger_db/rpc.rs
@@ -340,6 +340,72 @@ impl LedgerRpcReader {
         self.get_data_range::<EventByNumber, _, _>(range).await
     }
 
+    async fn get_filtered_slot_events<E>(
+        &self,
+        slot_id: &SlotIdentifier,
+        event_key_prefix_filter: Option<Vec<u8>>,
+    ) -> anyhow::Result<Vec<E>>
+    where
+        E: for<'a> TryFrom<(u64, &'a StoredEvent), Error = anyhow::Error> + Send + Sync,
+    {
+        let slot_not_found_err = || anyhow::anyhow!("Slot `{:?}` not found", slot_id);
+
+        let slot_num = self
+            .resolve_slot_identifier(slot_id)
+            .await?
+            .ok_or_else(slot_not_found_err)?;
+        let slot = self
+            .db
+            .get_async::<SlotByNumber>(&slot_num)
+            .await?
+            .ok_or_else(slot_not_found_err)?;
+
+        if slot.batches.start >= slot.batches.end {
+            return Ok(vec![]);
+        }
+
+        let batches = self.get_batch_range(&slot.batches).await?;
+        let (Some(first_batch), Some(last_batch)) = (batches.first(), batches.last()) else {
+            return Ok(vec![]);
+        };
+
+        if first_batch.txs.start >= last_batch.txs.end {
+            return Ok(vec![]);
+        }
+
+        let txs = self
+            .get_tx_range(&(first_batch.txs.start..last_batch.txs.end))
+            .await?;
+        let (Some(first_tx), Some(last_tx)) = (txs.first(), txs.last()) else {
+            return Ok(vec![]);
+        };
+
+        if first_tx.events.start >= last_tx.events.end {
+            return Ok(vec![]);
+        }
+
+        let event_range = first_tx.events.start..last_tx.events.end;
+        let stored_events = self.get_event_range(&event_range).await?;
+        let mut events = Vec::with_capacity(stored_events.len());
+
+        for (offset, event) in stored_events.iter().enumerate() {
+            if let Some(prefix) = &event_key_prefix_filter {
+                if !event.key().inner().starts_with(prefix) {
+                    continue;
+                }
+            }
+
+            let event_number = event_range
+                .start
+                .0
+                .checked_add(offset as u64)
+                .expect("Event number overflow while iterating slot events");
+            events.push((event_number, event).try_into()?);
+        }
+
+        Ok(events)
+    }
+
     pub(crate) async fn get_data_range<T, K, V>(
         &self,
         range: &std::ops::Range<K>,
@@ -675,55 +741,10 @@ impl LedgerStateProvider for LedgerDb {
             + Sync
             + DeserializeOwned,
     {
-        let slot_not_found_err = || anyhow::anyhow!("Slot `{:?}` not found", slot_id);
-
-        let slot_num = self
-            .resolve_slot_identifier(slot_id)
+        self.get_rpc_reader()
             .await?
-            .ok_or_else(slot_not_found_err)?;
-        let slot: SlotResponse<B, T, E> = self
-            .get_slot_by_number(slot_num, QueryMode::Full)
-            .await?
-            .ok_or_else(slot_not_found_err)?;
-
-        let batches = slot
-            .batches
-            .unwrap_or_default()
-            .into_iter()
-            .filter_map(|b| match b {
-                ItemOrHash::Full(b) => Some(b),
-                _ => None,
-            });
-        let txs = batches.flat_map(|b| {
-            b.txs
-                .unwrap_or_default()
-                .into_iter()
-                .filter_map(|t| match t {
-                    ItemOrHash::Full(t) => Some(t),
-                    _ => None,
-                })
-        });
-        let event_nums = txs.flat_map(|t| t.event_range);
-
-        let mut events = vec![];
-
-        let db = self.db.read().expect(DB_LOCK_POISONED).clone();
-        for event_num in event_nums {
-            let event = db
-                .get_async::<EventByNumber>(&EventNumber(event_num))
-                .await?
-                .ok_or_else(|| anyhow::anyhow!("Event not found but should be present"))?;
-
-            if let Some(prefix) = &event_key_prefix_filter {
-                if !event.key().inner().starts_with(prefix) {
-                    continue;
-                }
-            }
-
-            events.push((event_num, &event).try_into()?);
-        }
-
-        Ok(events)
+            .get_filtered_slot_events(slot_id, event_key_prefix_filter)
+            .await
     }
 
     // Get X by hash

--- a/crates/full-node/sov-db/src/ledger_db/rpc.rs
+++ b/crates/full-node/sov-db/src/ledger_db/rpc.rs
@@ -360,21 +360,56 @@ impl LedgerRpcReader {
             .await?
             .ok_or_else(slot_not_found_err)?;
 
-        let batches = self.get_batch_range(&slot.batches).await?;
-        let (Some(first_batch), Some(last_batch)) = (batches.first(), batches.last()) else {
+        if slot.batches.is_empty() {
             return Ok(vec![]);
-        };
+        }
 
-        let txs = self
-            .get_tx_range(&(first_batch.txs.start..last_batch.txs.end))
-            .await?;
-        let (Some(first_tx), Some(last_tx)) = (txs.first(), txs.last()) else {
+        let first_batch = self
+            .db
+            .get_async::<BatchByNumber>(&slot.batches.start)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("First batch not found in slot `{:?}`", slot_id))?;
+        let txs_end = if slot.batches.start + 1 == slot.batches.end {
+            first_batch.txs.end
+        } else {
+            self.db
+                .get_async::<BatchByNumber>(&(slot.batches.end - 1))
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("Last batch not found in slot `{:?}`", slot_id))?
+                .txs
+                .end
+        };
+        let txs_range = first_batch.txs.start..txs_end;
+        if txs_range.is_empty() {
             return Ok(vec![]);
-        };
+        }
 
-        let event_range = first_tx.events.start..last_tx.events.end;
+        let first_tx = self
+            .db
+            .get_async::<TxByNumber>(&txs_range.start)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("First tx not found in slot `{:?}`", slot_id))?;
+        let events_end = if txs_range.start + 1 == txs_range.end {
+            first_tx.events.end
+        } else {
+            self.db
+                .get_async::<TxByNumber>(&(txs_range.end - 1))
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("Last tx not found in slot `{:?}`", slot_id))?
+                .events
+                .end
+        };
+        let event_range = first_tx.events.start..events_end;
+        if event_range.is_empty() {
+            return Ok(vec![]);
+        }
+
         let stored_events = self.get_event_range(&event_range).await?;
-        let mut events = Vec::with_capacity(stored_events.len());
+        let mut events = if event_key_prefix_filter.is_some() {
+            Vec::new()
+        } else {
+            Vec::with_capacity(stored_events.len())
+        };
 
         for (offset, event) in stored_events.iter().enumerate() {
             if let Some(prefix) = &event_key_prefix_filter {

--- a/crates/full-node/sov-db/src/ledger_db/rpc.rs
+++ b/crates/full-node/sov-db/src/ledger_db/rpc.rs
@@ -360,18 +360,10 @@ impl LedgerRpcReader {
             .await?
             .ok_or_else(slot_not_found_err)?;
 
-        if slot.batches.start >= slot.batches.end {
-            return Ok(vec![]);
-        }
-
         let batches = self.get_batch_range(&slot.batches).await?;
         let (Some(first_batch), Some(last_batch)) = (batches.first(), batches.last()) else {
             return Ok(vec![]);
         };
-
-        if first_batch.txs.start >= last_batch.txs.end {
-            return Ok(vec![]);
-        }
 
         let txs = self
             .get_tx_range(&(first_batch.txs.start..last_batch.txs.end))
@@ -379,10 +371,6 @@ impl LedgerRpcReader {
         let (Some(first_tx), Some(last_tx)) = (txs.first(), txs.last()) else {
             return Ok(vec![]);
         };
-
-        if first_tx.events.start >= last_tx.events.end {
-            return Ok(vec![]);
-        }
 
         let event_range = first_tx.events.start..last_tx.events.end;
         let stored_events = self.get_event_range(&event_range).await?;
@@ -395,11 +383,7 @@ impl LedgerRpcReader {
                 }
             }
 
-            let event_number = event_range
-                .start
-                .0
-                .checked_add(offset as u64)
-                .expect("Event number overflow while iterating slot events");
+            let event_number = event_range.start.0 + offset as u64;
             events.push((event_number, event).try_into()?);
         }
 

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -5,7 +5,7 @@ use sov_db::schema::types::StoredStfInfo;
 use sov_mock_da::{MockAddress, MockBlob, MockBlock, MockDaSpec, MockHash};
 use sov_mock_zkvm::MockZkvmHost;
 use sov_rollup_interface::common::{HexHash, IntoSlotNumber, SlotNumber};
-use sov_rollup_interface::node::ledger_api::LedgerStateProvider;
+use sov_rollup_interface::node::ledger_api::{LedgerStateProvider, SlotIdentifier};
 use sov_rollup_interface::stf::{BatchReceipt, BlobDiscardReason, TransactionReceipt, TxEffect};
 use sov_rollup_interface::stf::{DiscardedBlob, StoredEvent};
 use sov_rollup_interface::zk::aggregated_proof::{
@@ -16,6 +16,24 @@ use sov_test_utils::ledger_db::sov_api_spec::types::IntOrHash;
 use sov_test_utils::ledger_db::{LedgerTestService, LedgerTestServiceData};
 use sov_test_utils::storage::SimpleLedgerStorageManager;
 use sov_test_utils::TestTxReceiptContents;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct TestEventKeyOnly {
+    number: u64,
+    key: String,
+}
+
+impl TryFrom<(u64, &StoredEvent)> for TestEventKeyOnly {
+    type Error = anyhow::Error;
+
+    fn try_from((number, event): (u64, &StoredEvent)) -> Result<Self, Self::Error> {
+        Ok(Self {
+            number,
+            key: String::from_utf8(event.key().inner().clone())
+                .unwrap_or_else(|_| hex::encode(event.key().inner())),
+        })
+    }
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_filtered_slot_events() {
@@ -48,6 +66,50 @@ async fn get_filtered_slot_events() {
     assert_eq!(events.len(), 2);
     assert_eq!(events[0].key, "foo0");
     assert_eq!(events[1].key, "bar0");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_filtered_slot_events_empty_tx_events() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
+    let ledger_storage = storage_manager.create_ledger_storage();
+    let ledger_db = LedgerDb::with_reader(ledger_storage).unwrap();
+
+    let schema_batch = create_slot_with_keys(0, &[], &ledger_db);
+    storage_manager.commit(&schema_batch);
+
+    let events = ledger_db
+        .get_filtered_slot_events::<i32, TestTxReceiptContents, TestEventKeyOnly>(
+            &SlotIdentifier::Number(0.to_slot_number()),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(events.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_filtered_slot_events_direct_prefix_filter() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
+    let ledger_storage = storage_manager.create_ledger_storage();
+    let ledger_db = LedgerDb::with_reader(ledger_storage).unwrap();
+
+    let schema_batch = create_slot_with_keys(0, &["foo0", "bar0"], &ledger_db);
+    storage_manager.commit(&schema_batch);
+
+    let events = ledger_db
+        .get_filtered_slot_events::<i32, TestTxReceiptContents, TestEventKeyOnly>(
+            &SlotIdentifier::Number(0.to_slot_number()),
+            Some(b"bar0".to_vec()),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].number, 1);
+    assert_eq!(events[0].key, "bar0");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -17,7 +17,7 @@ use sov_test_utils::ledger_db::{LedgerTestService, LedgerTestServiceData};
 use sov_test_utils::storage::SimpleLedgerStorageManager;
 use sov_test_utils::TestTxReceiptContents;
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 struct TestEventKeyOnly {
     number: u64,
     key: String,

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -1,7 +1,10 @@
 use futures::StreamExt;
 use rockbound::SchemaBatch;
 use sov_db::ledger_db::{LedgerDb, SlotCommit};
-use sov_db::schema::types::StoredStfInfo;
+use sov_db::schema::types::{EventNumber, StoredStfInfo};
+use sov_db::{
+    define_table_with_seek_key_codec, define_table_without_codec, impl_borsh_value_codec,
+};
 use sov_mock_da::{MockAddress, MockBlob, MockBlock, MockDaSpec, MockHash};
 use sov_mock_zkvm::MockZkvmHost;
 use sov_rollup_interface::common::{HexHash, IntoSlotNumber, SlotNumber};
@@ -16,6 +19,8 @@ use sov_test_utils::ledger_db::sov_api_spec::types::IntOrHash;
 use sov_test_utils::ledger_db::{LedgerTestService, LedgerTestServiceData};
 use sov_test_utils::storage::SimpleLedgerStorageManager;
 use sov_test_utils::TestTxReceiptContents;
+
+define_table_with_seek_key_codec!((EventByNumber) EventNumber => StoredEvent);
 
 #[derive(Debug, serde::Deserialize)]
 struct TestEventKeyOnly;
@@ -80,6 +85,37 @@ async fn get_filtered_slot_events_when_tx_has_no_events() {
         .unwrap();
 
     assert!(events.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_filtered_slot_events_fail_on_missing_event_row() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
+    let ledger_storage = storage_manager.create_ledger_storage();
+    let db = storage_manager.get_db();
+    let ledger_db = LedgerDb::with_reader(ledger_storage).unwrap();
+
+    let schema_batch = create_slot_with_keys(0, &["foo0", "bar0", "baz0"], &ledger_db);
+    storage_manager.commit(&schema_batch);
+
+    let mut delete_batch = SchemaBatch::new();
+    delete_batch
+        .delete::<EventByNumber>(&EventNumber(1))
+        .unwrap();
+    db.write_schemas(&delete_batch).unwrap();
+
+    let err = ledger_db
+        .get_filtered_slot_events::<i32, TestTxReceiptContents, TestEventKeyOnly>(
+            &SlotIdentifier::Number(0.to_slot_number()),
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("missing event"),
+        "unexpected error: {err:#}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -18,20 +18,13 @@ use sov_test_utils::storage::SimpleLedgerStorageManager;
 use sov_test_utils::TestTxReceiptContents;
 
 #[derive(Debug, serde::Deserialize)]
-struct TestEventKeyOnly {
-    number: u64,
-    key: String,
-}
+struct TestEventKeyOnly;
 
 impl TryFrom<(u64, &StoredEvent)> for TestEventKeyOnly {
     type Error = anyhow::Error;
 
-    fn try_from((number, event): (u64, &StoredEvent)) -> Result<Self, Self::Error> {
-        Ok(Self {
-            number,
-            key: String::from_utf8(event.key().inner().clone())
-                .unwrap_or_else(|_| hex::encode(event.key().inner())),
-        })
+    fn try_from(_: (u64, &StoredEvent)) -> Result<Self, Self::Error> {
+        Ok(Self)
     }
 }
 
@@ -69,7 +62,7 @@ async fn get_filtered_slot_events() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn get_filtered_slot_events_empty_tx_events() {
+async fn get_filtered_slot_events_when_tx_has_no_events() {
     let temp_dir = tempfile::tempdir().unwrap();
     let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
     let ledger_storage = storage_manager.create_ledger_storage();
@@ -87,29 +80,6 @@ async fn get_filtered_slot_events_empty_tx_events() {
         .unwrap();
 
     assert!(events.is_empty());
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn get_filtered_slot_events_direct_prefix_filter() {
-    let temp_dir = tempfile::tempdir().unwrap();
-    let mut storage_manager = SimpleLedgerStorageManager::new(temp_dir.path());
-    let ledger_storage = storage_manager.create_ledger_storage();
-    let ledger_db = LedgerDb::with_reader(ledger_storage).unwrap();
-
-    let schema_batch = create_slot_with_keys(0, &["foo0", "bar0"], &ledger_db);
-    storage_manager.commit(&schema_batch);
-
-    let events = ledger_db
-        .get_filtered_slot_events::<i32, TestTxReceiptContents, TestEventKeyOnly>(
-            &SlotIdentifier::Number(0.to_slot_number()),
-            Some(b"bar0".to_vec()),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(events.len(), 1);
-    assert_eq!(events[0].number, 1);
-    assert_eq!(events[0].key, "bar0");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
# Description

For each slot notification, it calls get_filtered_slot_events, which first loads the whole slot in `QueryMode::Full` and then builds another Vec of events.

Instead of materializing full slots, only detect boundaries for txs and materialize events based on that.

It no longer materializes a full `SlotResponse` in `QueryMode::Full`, so the websocket route keeps the same payload shape while avoiding the expensive parent-object expansion.

Another fix: propagate error on corrupted event ids instead of returning wrong data


- [x] Internal change ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existing test should pass

## Docs
No updates
