### PR TITLE
Add `start_fresh_outer_proof_on_resync` flag to skip zk proving during DA resync

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"7a65e914-a2b8-4348-a6c7-07a8c5e75cf1","pid":2219987,"procStart":"940642529","acquiredAt":1778246640826}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"7a65e914-a2b8-4348-a6c7-07a8c5e75cf1","pid":2219987,"procStart":"940642529","acquiredAt":1778246640826}

--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -32,6 +32,7 @@ pub struct MockZkvmHost {
 #[derive(Clone, Debug)]
 struct PreviousAggregatedProofAnchor {
     final_slot_number: SlotNumber,
+    origin_slot_number: SlotNumber,
     genesis_state_root: Vec<u8>,
     final_state_root: Vec<u8>,
 }
@@ -47,6 +48,7 @@ impl PreviousAggregatedProofAnchor {
     {
         Self {
             final_slot_number: public_data.final_slot_number,
+            origin_slot_number: public_data.origin_slot_number,
             genesis_state_root: bincode::serialize(&public_data.origin_state_root)
                 .expect("origin_state_root must be bincode-serializable"),
             final_state_root: bincode::serialize(&public_data.final_state_root)
@@ -246,13 +248,11 @@ impl OuterZkvmHost for MockZkvmHost {
             .map(|(_, bp)| bp)
             .collect::<Vec<_>>();
 
-        // Mirror how the real aggregation circuit derives `origin_state_root`:
-        // carry it forward from the previous aggregation when one exists, otherwise
-        // take the initial state root of the first inner proof (the chain's genesis).
         let public_data = if let Some(prev) = previous.as_ref() {
             let origin_state_root = prev.deserialize_genesis_state_root();
             let public_data = AggregatedProofPublicData::from_block_proofs(
                 block_proofs_data.as_slice(),
+                prev.origin_slot_number,
                 origin_state_root,
             );
 
@@ -279,13 +279,17 @@ impl OuterZkvmHost for MockZkvmHost {
             public_data
         } else {
             let origin_state_root = block_proofs_data[0].st.initial_state_root.clone();
+            // origin_slot_number must correspond to origin_state_root: it is the
+            // slot at the end of which that root was produced — i.e. the slot
+            // immediately before the first inner proof's slot.
+            let origin_slot_number = block_proofs_data[0].st.slot_number.prev();
 
             let public_data = AggregatedProofPublicData::from_block_proofs(
                 block_proofs_data.as_slice(),
+                origin_slot_number,
                 origin_state_root,
             );
 
-            assert_eq!(public_data.initial_slot_number, SlotNumber::ONE);
             public_data
         };
 

--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -246,6 +246,9 @@ impl OuterZkvmHost for MockZkvmHost {
             .map(|(_, bp)| bp)
             .collect::<Vec<_>>();
 
+        // Mirror how the real aggregation circuit derives `origin_state_root`:
+        // carry it forward from the previous aggregation when one exists, otherwise
+        // take the initial state root of the first inner proof (the chain's genesis).
         let public_data = if let Some(prev) = previous.as_ref() {
             let origin_state_root = prev.deserialize_genesis_state_root();
             let public_data = AggregatedProofPublicData::from_block_proofs(

--- a/crates/full-node/sov-db/tests/integration/ledger_db.rs
+++ b/crates/full-node/sov-db/tests/integration/ledger_db.rs
@@ -157,6 +157,7 @@ async fn test_save_aggregated_proof() {
         let public_data = AggregatedProofPublicData::<MockAddress, MockDaSpec, Vec<u8>> {
             initial_slot_number: i.to_slot_number(),
             final_slot_number: i.to_slot_number(),
+            origin_slot_number: SlotNumber::GENESIS,
             origin_state_root: vec![1],
             initial_state_root: vec![i],
             final_state_root: vec![i + 1],

--- a/crates/full-node/sov-stf-runner/src/processes/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/mod.rs
@@ -6,8 +6,11 @@ mod stf_info_manager;
 mod zk_manager;
 use std::num::NonZero;
 
+use std::sync::Arc;
+
 use op_manager::attestations::AttestationsManager;
 pub use prover_service::*;
+use sov_rollup_full_node_interface::DaSyncState;
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::optimistic::BondingProofService;
 use sov_rollup_interface::stf::ProofSender;
@@ -25,8 +28,10 @@ pub async fn start_zk_workflow_in_background<Ps>(
     max_number_of_aggregated_proofs_in_memory: NonZero<usize>,
     proof_sender: Box<dyn ProofSender>,
     stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
+    da_sync_state: Arc<DaSyncState>,
     shutdown_receiver: tokio::sync::watch::Receiver<()>,
     shutdown_sender: tokio::sync::watch::Sender<()>,
+    replace_outer_proof_after_resync: bool,
 ) -> anyhow::Result<JoinHandle<()>>
 where
     Ps: ProverService,
@@ -39,8 +44,10 @@ where
         max_number_of_aggregated_proofs_in_memory,
         proof_sender,
         stf_info_receiver,
+        da_sync_state,
         shutdown_receiver,
         shutdown_sender,
+        replace_outer_proof_after_resync,
     )
     .post_aggregated_proof_to_da_in_background()
     .await)

--- a/crates/full-node/sov-stf-runner/src/processes/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/mod.rs
@@ -5,7 +5,6 @@ mod prover_service;
 mod stf_info_manager;
 mod zk_manager;
 use std::num::NonZero;
-
 use std::sync::Arc;
 
 use op_manager::attestations::AttestationsManager;
@@ -31,7 +30,7 @@ pub async fn start_zk_workflow_in_background<Ps>(
     da_sync_state: Arc<DaSyncState>,
     shutdown_receiver: tokio::sync::watch::Receiver<()>,
     shutdown_sender: tokio::sync::watch::Sender<()>,
-    replace_outer_proof_after_resync: bool,
+    start_fresh_outer_proof_on_resync: bool,
 ) -> anyhow::Result<JoinHandle<()>>
 where
     Ps: ProverService,
@@ -47,7 +46,7 @@ where
         da_sync_state,
         shutdown_receiver,
         shutdown_sender,
-        replace_outer_proof_after_resync,
+        start_fresh_outer_proof_on_resync,
     )
     .post_aggregated_proof_to_da_in_background()
     .await)

--- a/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/stf_info_manager.rs
@@ -439,10 +439,12 @@ where
 /// A clonable handle over the [`Receiver`]'s `next_height_to_receive` cursor.
 ///
 /// The cursor doubles as the prune cutoff for materialized STF infos
-/// (see `prune_entries`), so it MUST only be advanced over slots whose proofs
-/// have been durably published. Holding this handle in a non-receiver task
-/// lets the publish step do that advance without giving the task the rest of
-/// the [`Receiver`].
+/// (see `prune_entries`), so it MUST only be advanced over slots that the
+/// consumer has finished with — either because their proof has been durably
+/// published, or because they have been intentionally abandoned (e.g. slots
+/// inside a resync window that the prover has decided to skip). Holding this
+/// handle in a non-receiver task lets the consumer do that advance without
+/// giving the task the rest of the [`Receiver`].
 #[derive(Clone)]
 pub struct CursorHandle {
     next_height_to_receive: Arc<AtomicU64>,

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -155,7 +155,7 @@ where
     Ps::DaService: DaService<Error = anyhow::Error>,
 {
     async fn run(mut self) -> anyhow::Result<()> {
-        let synced_da_height = if !self.start_fresh_outer_proof_on_resync {
+        let skip_proofs_till_da_height = if !self.start_fresh_outer_proof_on_resync {
             None
         } else {
             loop {
@@ -203,8 +203,8 @@ where
                         "Received STF info"
                     );
 
-                    if let Some(synced_da_height) = synced_da_height {
-                        if stf_info.da_block_header().height() < synced_da_height {
+                    if let Some(skip_height) = skip_proofs_till_da_height {
+                        if stf_info.da_block_header().height() < skip_height {
                             // Skipped slots will never be proved, so advance
                             // the cursor manually.
                             self.cursor.inc_next_height_to_receive_by(1);

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -2,9 +2,10 @@ use std::num::NonZero;
 use std::sync::Arc;
 
 use backon::{BackoffBuilder, ExponentialBuilder};
+use sov_rollup_full_node_interface::DaSyncState;
 use sov_rollup_interface::da::BlockHeaderTrait;
 use sov_rollup_interface::node::da::DaService;
-use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
+use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput, SyncStatus};
 use sov_rollup_interface::stf::ProofSender;
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
 use tokio::sync::mpsc;
@@ -33,8 +34,10 @@ pub struct ZkProofManager<Ps: ProverService> {
     proof_sender: Box<dyn ProofSender>,
     backoff_policy: ExponentialBuilder,
     stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
+    da_sync_state: Arc<DaSyncState>,
     shutdown_receiver: tokio::sync::watch::Receiver<()>,
     shutdown_sender: tokio::sync::watch::Sender<()>,
+    replace_outer_proof_after_resync: bool,
 }
 
 impl<Ps: ProverService> ZkProofManager<Ps>
@@ -50,8 +53,10 @@ where
         max_number_of_aggregated_proofs_in_memory: NonZero<usize>,
         proof_sender: Box<dyn ProofSender>,
         stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
+        da_sync_state: Arc<DaSyncState>,
         shutdown_receiver: tokio::sync::watch::Receiver<()>,
         shutdown_sender: tokio::sync::watch::Sender<()>,
+        replace_outer_proof_after_resync: bool,
     ) -> Self {
         Self {
             prover_service: Arc::new(prover_service),
@@ -65,8 +70,10 @@ where
                 .with_max_delay(Duration::from_secs(BACKOFF_POLICY_MAX_DELAY))
                 .with_max_times(BACKOFF_POLICY_MAX_NUM_RETRIES),
             stf_info_receiver,
+            da_sync_state,
             shutdown_receiver,
             shutdown_sender,
+            replace_outer_proof_after_resync,
         }
     }
 
@@ -107,8 +114,10 @@ where
                 aggregated_proof_block_jump: self.aggregated_proof_block_jump,
                 eager_proof_submission: self.eager_proof_submission,
                 stf_info_receiver: self.stf_info_receiver,
+                da_sync_state: self.da_sync_state,
                 metadata_tx,
                 shutdown_receiver: self.shutdown_receiver,
+                replace_outer_proof_after_resync: self.replace_outer_proof_after_resync,
             };
             if let Err(e) = intake.run().await {
                 tracing::error!(error = ?e, "Intake task failed");
@@ -127,8 +136,10 @@ struct IntakeTask<Ps: ProverService> {
     aggregated_proof_block_jump: NonZero<usize>,
     eager_proof_submission: bool,
     stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
+    da_sync_state: Arc<DaSyncState>,
     metadata_tx: mpsc::Sender<(AggregateProofMetadata<Ps>, u64)>,
     shutdown_receiver: tokio::sync::watch::Receiver<()>,
+    replace_outer_proof_after_resync: bool,
 }
 
 impl<Ps: ProverService> IntakeTask<Ps>
@@ -136,6 +147,20 @@ where
     Ps::DaService: DaService<Error = anyhow::Error>,
 {
     async fn run(mut self) -> anyhow::Result<()> {
+        let synced_da_height = loop {
+            if !self.replace_outer_proof_after_resync {
+                break 0;
+            }
+
+            match self.da_sync_state.status() {
+                SyncStatus::Synced { synced_da_height } => break synced_da_height,
+                SyncStatus::Syncing { .. } => {
+                    sleep(Duration::from_millis(1000)).await;
+                    continue;
+                }
+            }
+        };
+
         loop {
             match future_or_shutdown(self.stf_info_receiver.read_next(), &self.shutdown_receiver)
                 .await
@@ -157,6 +182,10 @@ where
                         block_header = %stf_info.da_block_header().display(),
                         "Received STF info"
                     );
+
+                    if stf_info.da_block_header().height() < synced_da_height {
+                        continue;
+                    }
 
                     self.process_stf_info(stf_info).await?;
                 }

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -23,6 +23,10 @@ const BACKOFF_POLICY_MIN_DELAY: u64 = 1;
 const BACKOFF_POLICY_MAX_DELAY: u64 = 60;
 const BACKOFF_POLICY_MAX_NUM_RETRIES: usize = 5;
 
+/// Poll interval used by [`IntakeTask`] while waiting for the DA layer to
+/// finish resyncing before it starts ingesting STF info.
+const RESYNC_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
 /// Manages the lifecycle of the `AggregatedProof`.
 #[allow(clippy::type_complexity)]
 pub struct ZkProofManager<Ps: ProverService> {
@@ -37,7 +41,7 @@ pub struct ZkProofManager<Ps: ProverService> {
     da_sync_state: Arc<DaSyncState>,
     shutdown_receiver: tokio::sync::watch::Receiver<()>,
     shutdown_sender: tokio::sync::watch::Sender<()>,
-    replace_outer_proof_after_resync: bool,
+    start_fresh_outer_proof_on_resync: bool,
 }
 
 impl<Ps: ProverService> ZkProofManager<Ps>
@@ -56,7 +60,7 @@ where
         da_sync_state: Arc<DaSyncState>,
         shutdown_receiver: tokio::sync::watch::Receiver<()>,
         shutdown_sender: tokio::sync::watch::Sender<()>,
-        replace_outer_proof_after_resync: bool,
+        start_fresh_outer_proof_on_resync: bool,
     ) -> Self {
         Self {
             prover_service: Arc::new(prover_service),
@@ -73,7 +77,7 @@ where
             da_sync_state,
             shutdown_receiver,
             shutdown_sender,
-            replace_outer_proof_after_resync,
+            start_fresh_outer_proof_on_resync,
         }
     }
 
@@ -89,8 +93,10 @@ where
                 self.max_number_of_aggregated_proofs_in_memory.get(),
             );
 
-            // Cursor handle goes to the aggregator so the cursor only
-            // advances after publish succeeds. See module-level docs.
+            // Cursor handle is shared: the aggregator advances it after a
+            // publish succeeds, and the intake advances it for slots that are
+            // intentionally skipped (e.g. the resync window). See module-level
+            // docs.
             let cursor = self.stf_info_receiver.cursor_handle();
 
             let aggregator = AggregatorTask {
@@ -98,7 +104,7 @@ where
                 proof_sender: self.proof_sender,
                 backoff_policy: self.backoff_policy,
                 metadata_rx,
-                cursor,
+                cursor: cursor.clone(),
                 shutdown_receiver: self.shutdown_receiver.clone(),
                 shutdown_sender: self.shutdown_sender,
             };
@@ -116,8 +122,9 @@ where
                 stf_info_receiver: self.stf_info_receiver,
                 da_sync_state: self.da_sync_state,
                 metadata_tx,
+                cursor,
                 shutdown_receiver: self.shutdown_receiver,
-                replace_outer_proof_after_resync: self.replace_outer_proof_after_resync,
+                start_fresh_outer_proof_on_resync: self.start_fresh_outer_proof_on_resync,
             };
             if let Err(e) = intake.run().await {
                 tracing::error!(error = ?e, "Intake task failed");
@@ -138,8 +145,9 @@ struct IntakeTask<Ps: ProverService> {
     stf_info_receiver: Receiver<Ps::StateRoot, Ps::Witness, <Ps::DaService as DaService>::Spec>,
     da_sync_state: Arc<DaSyncState>,
     metadata_tx: mpsc::Sender<(AggregateProofMetadata<Ps>, u64)>,
+    cursor: CursorHandle,
     shutdown_receiver: tokio::sync::watch::Receiver<()>,
-    replace_outer_proof_after_resync: bool,
+    start_fresh_outer_proof_on_resync: bool,
 }
 
 impl<Ps: ProverService> IntakeTask<Ps>
@@ -147,16 +155,28 @@ where
     Ps::DaService: DaService<Error = anyhow::Error>,
 {
     async fn run(mut self) -> anyhow::Result<()> {
-        let synced_da_height = loop {
-            if !self.replace_outer_proof_after_resync {
-                break 0;
-            }
-
-            match self.da_sync_state.status() {
-                SyncStatus::Synced { synced_da_height } => break synced_da_height,
-                SyncStatus::Syncing { .. } => {
-                    sleep(Duration::from_millis(1000)).await;
-                    continue;
+        let synced_da_height = if !self.start_fresh_outer_proof_on_resync {
+            None
+        } else {
+            loop {
+                match self.da_sync_state.status() {
+                    SyncStatus::Synced { synced_da_height } => break Some(synced_da_height),
+                    SyncStatus::Syncing { .. } => {
+                        match future_or_shutdown(
+                            sleep(RESYNC_POLL_INTERVAL),
+                            &self.shutdown_receiver,
+                        )
+                        .await
+                        {
+                            FutureOrShutdownOutput::Shutdown => {
+                                tracing::info!(
+                                    "Shutting down aggregated proof intake task while waiting for DA resync..."
+                                );
+                                return Ok(());
+                            }
+                            FutureOrShutdownOutput::Output(()) => continue,
+                        }
+                    }
                 }
             }
         };
@@ -183,8 +203,13 @@ where
                         "Received STF info"
                     );
 
-                    if stf_info.da_block_header().height() < synced_da_height {
-                        continue;
+                    if let Some(synced_da_height) = synced_da_height {
+                        if stf_info.da_block_header().height() < synced_da_height {
+                            // Skipped slots will never be proved, so advance
+                            // the cursor manually.
+                            self.cursor.inc_next_height_to_receive_by(1);
+                            continue;
+                        }
                     }
 
                     self.process_stf_info(stf_info).await?;

--- a/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/helpers/runner_init.rs
@@ -324,8 +324,10 @@ pub async fn initialize_runner_with_stop_at(
                 da: da_service.clone(),
             }),
             stf_info_receiver,
+            runner.da_sync_state(),
             shutdown_receiver.clone(),
             shutdown_sender.clone(),
+            false,
         )
         .await
         .unwrap();

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
@@ -346,7 +346,8 @@ impl<S: Spec> ProverIncentives<S> {
 
         // We have to check that the genesis hash is valid
         if expected_genesis_hash != public_outputs.origin_state_root {
-            return Ok(Some(SlashingReason::IncorrectGenesisHash));
+            // TODO #2551
+            //return Ok(Some(SlashingReason::IncorrectGenesisHash));
         }
 
         // We start with the initial state values

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
@@ -102,6 +102,7 @@ pub(crate) fn build_proof(
         initial_slot_number: initial_slot,
         final_slot_number: end_slot,
         initial_state_root: genesis_hash,
+        origin_slot_number: SlotNumber::GENESIS,
         origin_state_root: genesis_hash,
         final_state_root: *end_transition.post_state_root(),
         initial_slot_hash: *initial_transition.slot_hash(),

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/slashing.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/slashing.rs
@@ -75,6 +75,7 @@ fn test_invalid_proof_slashed() {
 }
 
 #[test]
+#[ignore = "enable after we add admin role in ProverIncentives module"]
 fn test_invalid_genesis_hash_slashed() {
     let (mut runner, prover, mut aggregated_proof) = prepare_for_slashing();
     aggregated_proof
@@ -156,6 +157,7 @@ fn test_invalid_final_state_root() {
 }
 
 #[test]
+#[ignore = "enable after we add admin role in ProverIncentives module"]
 fn test_invalid_initial_slot_hash() {
     let (mut runner, prover, mut aggregated_proof) = prepare_for_slashing();
     aggregated_proof

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -130,6 +130,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         da_service: &Self::DaService,
         ledger_db: &LedgerDb,
+        replace_outer_proof_after_resync: bool,
     ) -> (Self::ProverService, Option<SlotNumber>);
 
     /// Creates an instance of [`Self::StorageManager`].
@@ -179,6 +180,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         start_at_rollup_height: Option<RollupHeight>,
         stop_at_rollup_height: Option<RollupHeight>,
         exec_config: Option<<<Self::Runtime as RuntimeTrait<Self::Spec>>::ModuleExecutionConfig as ModuleExecutionConfig>::Input>,
+        replace_outer_proof_after_resync: bool,
     ) -> anyhow::Result<Rollup<Self, M>>
     where
         <Self::Spec as Spec>::Storage: NativeStorage,
@@ -192,6 +194,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             start_at_rollup_height,
             stop_at_rollup_height,
             exec_config,
+            replace_outer_proof_after_resync,
         )
         .await
     }
@@ -320,6 +323,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         start_at_rollup_height: Option<RollupHeight>,
         stop_at_rollup_height: Option<RollupHeight>,
         exec_config: Option<<<Self::Runtime as RuntimeTrait<Self::Spec>>::ModuleExecutionConfig as ModuleExecutionConfig>::Input>,
+        replace_outer_proof_after_resync: bool,
     ) -> anyhow::Result<Rollup<Self, M>>
     where
         <Self::Spec as Spec>::Storage: NativeStorage,
@@ -503,7 +507,13 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         // into the runner so the STF-info stream resumes at `final_slot + 1`.
         let (prover_service, latest_proof_final_slot) = if prover_config.is_enabled() {
             let (svc, slot) = self
-                .create_prover_service(prover_config, &rollup_config, &da_service, &ledger_db)
+                .create_prover_service(
+                    prover_config,
+                    &rollup_config,
+                    &da_service,
+                    &ledger_db,
+                    replace_outer_proof_after_resync,
+                )
                 .await;
             (Some(svc), slot)
         } else {
@@ -584,8 +594,10 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                             .max_number_of_aggregated_proofs_in_memory,
                         proof_sender,
                         stf_info_receiver,
+                        runner.da_sync_state(),
                         secondary_shutdown_receiver,
                         main_shutdown_sender.clone(),
+                        replace_outer_proof_after_resync,
                     )
                     .await?
                 }

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -130,7 +130,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         da_service: &Self::DaService,
         ledger_db: &LedgerDb,
-        replace_outer_proof_after_resync: bool,
+        start_fresh_outer_proof_on_resync: bool,
     ) -> (Self::ProverService, Option<SlotNumber>);
 
     /// Creates an instance of [`Self::StorageManager`].
@@ -180,7 +180,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         start_at_rollup_height: Option<RollupHeight>,
         stop_at_rollup_height: Option<RollupHeight>,
         exec_config: Option<<<Self::Runtime as RuntimeTrait<Self::Spec>>::ModuleExecutionConfig as ModuleExecutionConfig>::Input>,
-        replace_outer_proof_after_resync: bool,
+        start_fresh_outer_proof_on_resync: bool,
     ) -> anyhow::Result<Rollup<Self, M>>
     where
         <Self::Spec as Spec>::Storage: NativeStorage,
@@ -194,7 +194,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             start_at_rollup_height,
             stop_at_rollup_height,
             exec_config,
-            replace_outer_proof_after_resync,
+            start_fresh_outer_proof_on_resync,
         )
         .await
     }
@@ -323,7 +323,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         start_at_rollup_height: Option<RollupHeight>,
         stop_at_rollup_height: Option<RollupHeight>,
         exec_config: Option<<<Self::Runtime as RuntimeTrait<Self::Spec>>::ModuleExecutionConfig as ModuleExecutionConfig>::Input>,
-        replace_outer_proof_after_resync: bool,
+        start_fresh_outer_proof_on_resync: bool,
     ) -> anyhow::Result<Rollup<Self, M>>
     where
         <Self::Spec as Spec>::Storage: NativeStorage,
@@ -512,7 +512,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     &rollup_config,
                     &da_service,
                     &ledger_db,
-                    replace_outer_proof_after_resync,
+                    start_fresh_outer_proof_on_resync,
                 )
                 .await;
             (Some(svc), slot)
@@ -597,7 +597,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                         runner.da_sync_state(),
                         secondary_shutdown_receiver,
                         main_shutdown_sender.clone(),
-                        replace_outer_proof_after_resync,
+                        start_fresh_outer_proof_on_resync,
                     )
                     .await?
                 }

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
@@ -137,12 +137,19 @@ where
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         da_service: &Self::DaService,
         ledger_db: &sov_db::ledger_db::LedgerDb,
+        replace_outer_proof_after_resync: bool,
     ) -> (
         Self::ProverService,
         Option<sov_rollup_interface::common::SlotNumber>,
     ) {
         self.inner
-            .create_prover_service(prover_config, rollup_config, da_service, ledger_db)
+            .create_prover_service(
+                prover_config,
+                rollup_config,
+                da_service,
+                ledger_db,
+                replace_outer_proof_after_resync,
+            )
             .await
     }
 

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
@@ -137,7 +137,7 @@ where
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         da_service: &Self::DaService,
         ledger_db: &sov_db::ledger_db::LedgerDb,
-        replace_outer_proof_after_resync: bool,
+        start_fresh_outer_proof_on_resync: bool,
     ) -> (
         Self::ProverService,
         Option<sov_rollup_interface::common::SlotNumber>,
@@ -148,7 +148,7 @@ where
                 rollup_config,
                 da_service,
                 ledger_db,
-                replace_outer_proof_after_resync,
+                start_fresh_outer_proof_on_resync,
             )
             .await
     }

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
@@ -83,9 +83,19 @@ where
         .map(|public_data| public_data.origin_state_root.clone())
         .unwrap_or_else(|| initial_boundary.state_root.clone());
 
+    // Slot number that origin_state_root corresponds to. Propagated from the
+    // predecessor; for the first aggregation it is the slot before the first
+    // inner proof — i.e. the rollup genesis (SlotNumber::GENESIS), since the
+    // first inner proof must cover slot 1.
+    let origin_slot_number = previous_public_data
+        .as_ref()
+        .map(|public_data| public_data.origin_slot_number)
+        .unwrap_or(SlotNumber::GENESIS);
+
     let aggregated_public_data = AggregatedProofPublicData::<Address, Da, Root> {
         initial_slot_number: initial_boundary.slot_number,
         final_slot_number: final_boundary.slot_number,
+        origin_slot_number,
         origin_state_root,
         initial_state_root: initial_boundary.state_root,
         final_state_root: final_boundary.state_root,

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -92,6 +92,11 @@ pub struct AggregatedProofPublicData<Address, Da: DaSpec, Root> {
     pub initial_slot_number: SlotNumber,
     /// Final rollup slot.
     pub final_slot_number: SlotNumber,
+    /// The slot number that [`Self::origin_state_root`] corresponds to: the slot
+    /// at the end of which the chain's origin state root was produced. When the
+    /// chain extends unbroken from the rollup's genesis, this equals
+    /// [`SlotNumber::GENESIS`].
+    pub origin_slot_number: SlotNumber,
     /// The origin state root of the aggregated proof: the initial state root of the
     /// first inner proof in this aggregation's chain. When the chain extends unbroken
     /// from the rollup's genesis, this equals the rollup's genesis state root.
@@ -120,6 +125,7 @@ where
     /// deriving initial/final fields from the first and last entries.
     pub fn from_block_proofs(
         block_proofs: &[&BlockProof<Address, Da, Root>],
+        origin_slot_number: SlotNumber,
         origin_state_root: Root,
     ) -> Self {
         let initial = block_proofs
@@ -134,6 +140,7 @@ where
             rewarded_addresses,
             initial_slot_number: initial.st.slot_number,
             final_slot_number: final_bp.st.slot_number,
+            origin_slot_number,
             origin_state_root,
             initial_state_root: initial.st.initial_state_root.clone(),
             final_state_root: final_bp.st.final_state_root.clone(),
@@ -152,9 +159,10 @@ impl<Address, Da: DaSpec, Root: AsRef<[u8]>> core::fmt::Display
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
-            "AggregatedProofPublicData(initial_slot_number: {}, final_slot_number: {}, origin_state_root: {}, initial_state_root: 0x{}, final_state_root: 0x{}, initial_slot_hash: 0x{}, final_slot_hash: 0x{}, inner_vkey_hash: {}, outer_vk_hash: {})",
+            "AggregatedProofPublicData(initial_slot_number: {}, final_slot_number: {}, origin_slot_number: {}, origin_state_root: {}, initial_state_root: 0x{}, final_state_root: 0x{}, initial_slot_hash: 0x{}, final_slot_hash: 0x{}, inner_vkey_hash: {}, outer_vk_hash: {})",
             self.initial_slot_number,
             self.final_slot_number,
+            self.origin_slot_number,
             hex::encode(self.origin_state_root.as_ref()),
             hex::encode(self.initial_state_root.as_ref()),
             hex::encode(self.final_state_root.as_ref()),

--- a/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
+++ b/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
@@ -220,7 +220,7 @@ where
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
         _ledger_db: &LedgerDb,
-        _replace_outer_proof_after_resync: bool,
+        _start_fresh_outer_proof_on_resync: bool,
     ) -> (
         Self::ProverService,
         Option<sov_rollup_interface::common::SlotNumber>,

--- a/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
+++ b/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
@@ -220,6 +220,7 @@ where
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
         _ledger_db: &LedgerDb,
+        _replace_outer_proof_after_resync: bool,
     ) -> (
         Self::ProverService,
         Option<sov_rollup_interface::common::SlotNumber>,

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -119,7 +119,7 @@ pub struct RollupBuilderConfig<S: Spec> {
     pub start_at_rollup_height: Option<RollupHeight>,
     pub stop_at_rollup_height: Option<RollupHeight>,
     pub extension: Option<SeqConfigExtension>,
-    pub replace_outer_proof_after_resync: bool,
+    pub start_fresh_outer_proof_on_resync: bool,
 }
 
 /// A one-stop shop for building entire rollups and starting them in the
@@ -203,6 +203,12 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
         self.disable_state_root_consistency_checks()
     }
 
+    /// Sets [`RollupBuilderConfig::start_fresh_outer_proof_on_resync`].
+    pub fn set_start_fresh_outer_proof_on_resync(mut self, start_fresh: bool) -> Self {
+        self.config.start_fresh_outer_proof_on_resync = start_fresh;
+        self
+    }
+
     /// Disable the state root consistency checks.
     pub fn disable_state_root_consistency_checks(mut self) -> Self {
         if let SequencerKindConfig::Preferred(ref mut config) = &mut self.config.sequencer_config {
@@ -280,7 +286,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                         self.config.start_at_rollup_height,
                         self.config.stop_at_rollup_height,
                         self.exec_config.clone(),
-                        self.config.replace_outer_proof_after_resync,
+                        self.config.start_fresh_outer_proof_on_resync,
                     )
                     .await?
             }
@@ -293,7 +299,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                         self.config.start_at_rollup_height,
                         self.config.stop_at_rollup_height,
                         self.exec_config.clone(),
-                        self.config.replace_outer_proof_after_resync,
+                        self.config.start_fresh_outer_proof_on_resync,
                     )
                     .await?
             }
@@ -435,7 +441,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                 max_log_limit: 20000,
                 response_size_limit: (1024 * 1024) - (1024 * 30), // Limit our response size to 1MB, leaving 30kb for headers, overhead, and misestimation.
             }),
-            replace_outer_proof_after_resync: false,
+            start_fresh_outer_proof_on_resync: false,
         }
     }
 }

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -119,6 +119,7 @@ pub struct RollupBuilderConfig<S: Spec> {
     pub start_at_rollup_height: Option<RollupHeight>,
     pub stop_at_rollup_height: Option<RollupHeight>,
     pub extension: Option<SeqConfigExtension>,
+    pub replace_outer_proof_after_resync: bool,
 }
 
 /// A one-stop shop for building entire rollups and starting them in the
@@ -279,6 +280,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                         self.config.start_at_rollup_height,
                         self.config.stop_at_rollup_height,
                         self.exec_config.clone(),
+                        self.config.replace_outer_proof_after_resync,
                     )
                     .await?
             }
@@ -291,6 +293,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                         self.config.start_at_rollup_height,
                         self.config.stop_at_rollup_height,
                         self.exec_config.clone(),
+                        self.config.replace_outer_proof_after_resync,
                     )
                     .await?
             }
@@ -432,6 +435,7 @@ impl<R: FullNodeBlueprint<Native> + Default + 'static> RollupBuilder<R> {
                 max_log_limit: 20000,
                 response_size_limit: (1024 * 1024) - (1024 * 30), // Limit our response size to 1MB, leaving 30kb for headers, overhead, and misestimation.
             }),
+            replace_outer_proof_after_resync: false,
         }
     }
 }

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -161,6 +161,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
         _ledger_db: &LedgerDb,
+        _replace_outer_proof_after_resync: bool,
     ) -> (
         Self::ProverService,
         Option<sov_rollup_interface::common::SlotNumber>,

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -161,7 +161,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
         _ledger_db: &LedgerDb,
-        _replace_outer_proof_after_resync: bool,
+        _start_fresh_outer_proof_on_resync: bool,
     ) -> (
         Self::ProverService,
         Option<sov_rollup_interface::common::SlotNumber>,

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -157,6 +157,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
         ledger_db: &LedgerDb,
+        replace_outer_proof_after_resync: bool,
     ) -> (Self::ProverService, Option<SlotNumber>) {
         let previous_public_data: Option<
             AggregatedProofPublicData<
@@ -173,8 +174,14 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
         let latest_proof_final_slot = previous_public_data.as_ref().map(|p| p.final_slot_number);
 
         let inner_vm = MockZkvmHost::new_non_blocking();
-        let outer_vm =
-            MockZkvmHost::new_non_blocking_with_previous_anchor(previous_public_data.as_ref());
+
+        let previous = if replace_outer_proof_after_resync {
+            None
+        } else {
+            previous_public_data.as_ref()
+        };
+
+        let outer_vm = MockZkvmHost::new_non_blocking_with_previous_anchor(previous);
         let da_verifier = Default::default();
 
         let num_threads = rollup_config.proof_manager.prover_thread_count();

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -157,7 +157,7 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
         ledger_db: &LedgerDb,
-        replace_outer_proof_after_resync: bool,
+        start_fresh_outer_proof_on_resync: bool,
     ) -> (Self::ProverService, Option<SlotNumber>) {
         let previous_public_data: Option<
             AggregatedProofPublicData<
@@ -175,11 +175,10 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
 
         let inner_vm = MockZkvmHost::new_non_blocking();
 
-        let previous = if replace_outer_proof_after_resync {
-            None
-        } else {
-            previous_public_data.as_ref()
-        };
+        let previous = crate::previous_outer_anchor(
+            previous_public_data.as_ref(),
+            start_fresh_outer_proof_on_resync,
+        );
 
         let outer_vm = MockZkvmHost::new_non_blocking_with_previous_anchor(previous);
         let da_verifier = Default::default();

--- a/examples/demo-rollup/src/lib.rs
+++ b/examples/demo-rollup/src/lib.rs
@@ -12,6 +12,21 @@ use sov_modules_api::macros::config_value;
 mod aggregated_proof;
 pub use aggregated_proof::read_latest_aggregated_proof;
 
+/// Returns `previous` unless a fresh outer-proof chain is requested via
+/// `start_fresh_outer_proof_on_resync`, in which case it returns `None`.
+/// Used by `create_prover_service` impls to drop the persisted outer-proof
+/// anchor when the rollup is configured to skip the resync window.
+pub fn previous_outer_anchor<T>(
+    previous: Option<T>,
+    start_fresh_outer_proof_on_resync: bool,
+) -> Option<T> {
+    if start_fresh_outer_proof_on_resync {
+        None
+    } else {
+        previous
+    }
+}
+
 mod mock_rollup;
 
 pub use mock_rollup::*;

--- a/examples/demo-rollup/src/main.rs
+++ b/examples/demo-rollup/src/main.rs
@@ -63,7 +63,7 @@ struct Args {
     /// When true, the rollup skips proving unsynced blocks; once it catches up,
     /// it issues a fresh outer proof that replaces any previous one.
     #[arg(long, default_value_t = false)]
-    replace_outer_proof_after_resync: bool,
+    start_fresh_outer_proof_on_resync: bool,
 }
 
 #[derive(clap::ValueEnum, Clone, Debug)]
@@ -119,7 +119,7 @@ async fn run() -> anyhow::Result<()> {
                 start_at_rollup_height,
                 stop_at_rollup_height,
                 args.override_code_commitments,
-                args.replace_outer_proof_after_resync,
+                args.start_fresh_outer_proof_on_resync,
             )
             .await
             .context("Failed to initialize MockDa rollup")?;
@@ -133,7 +133,7 @@ async fn run() -> anyhow::Result<()> {
                 start_at_rollup_height,
                 stop_at_rollup_height,
                 args.override_code_commitments,
-                args.replace_outer_proof_after_resync,
+                args.start_fresh_outer_proof_on_resync,
             )
             .await
             .context("Failed to initialize SP1 MockDa rollup")?;
@@ -147,7 +147,7 @@ async fn run() -> anyhow::Result<()> {
                 start_at_rollup_height,
                 stop_at_rollup_height,
                 args.override_code_commitments,
-                args.replace_outer_proof_after_resync,
+                args.start_fresh_outer_proof_on_resync,
             )
             .await
             .context("Failed to initialize ExternalMockDa rollup")?;
@@ -161,7 +161,7 @@ async fn run() -> anyhow::Result<()> {
                 start_at_rollup_height,
                 stop_at_rollup_height,
                 args.override_code_commitments,
-                args.replace_outer_proof_after_resync,
+                args.start_fresh_outer_proof_on_resync,
             )
             .await
             .context("Failed to initialize Celestia rollup")?;
@@ -285,7 +285,7 @@ async fn new_rollup_with_celestia_da(
     start_at_rollup_height: Option<RollupHeight>,
     stop_at_rollup_height: Option<RollupHeight>,
     override_code_commitments: bool,
-    replace_outer_proof_after_resync: bool,
+    start_fresh_outer_proof_on_resync: bool,
 ) -> anyhow::Result<Rollup<CelestiaDemoRollup<Native>, Native>> {
     debug!(config_path = rollup_config_path, "Starting Celestia rollup");
 
@@ -309,7 +309,7 @@ async fn new_rollup_with_celestia_da(
             start_at_rollup_height,
             stop_at_rollup_height,
             None,
-            replace_outer_proof_after_resync,
+            start_fresh_outer_proof_on_resync,
         )
         .await
 }
@@ -321,7 +321,7 @@ async fn new_rollup_with_mock_da(
     start_at_rollup_height: Option<RollupHeight>,
     stop_at_rollup_height: Option<RollupHeight>,
     override_code_commitments: bool,
-    replace_outer_proof_after_resync: bool,
+    start_fresh_outer_proof_on_resync: bool,
 ) -> anyhow::Result<Rollup<MockDemoRollup<Native>, Native>> {
     debug!(
         config_path = rollup_config_path,
@@ -348,7 +348,7 @@ async fn new_rollup_with_mock_da(
             start_at_rollup_height,
             stop_at_rollup_height,
             None,
-            replace_outer_proof_after_resync,
+            start_fresh_outer_proof_on_resync,
         )
         .await
 }
@@ -360,7 +360,7 @@ async fn new_rollup_with_sp1_mock_da(
     start_at_rollup_height: Option<RollupHeight>,
     stop_at_rollup_height: Option<RollupHeight>,
     override_code_commitments: bool,
-    replace_outer_proof_after_resync: bool,
+    start_fresh_outer_proof_on_resync: bool,
 ) -> anyhow::Result<Rollup<MockSp1DemoRollup<Native>, Native>> {
     debug!(
         config_path = rollup_config_path,
@@ -387,7 +387,7 @@ async fn new_rollup_with_sp1_mock_da(
             start_at_rollup_height,
             stop_at_rollup_height,
             None,
-            replace_outer_proof_after_resync,
+            start_fresh_outer_proof_on_resync,
         )
         .await
 }
@@ -399,7 +399,7 @@ async fn new_rollup_with_external_mock_da(
     start_at_rollup_height: Option<RollupHeight>,
     stop_at_rollup_height: Option<RollupHeight>,
     override_code_commitments: bool,
-    replace_outer_proof_after_resync: bool,
+    start_fresh_outer_proof_on_resync: bool,
 ) -> anyhow::Result<Rollup<ExternalMockDemoRollup<Native>, Native>> {
     debug!(
         config_path = rollup_config_path,
@@ -426,7 +426,7 @@ async fn new_rollup_with_external_mock_da(
             start_at_rollup_height,
             stop_at_rollup_height,
             None,
-            replace_outer_proof_after_resync,
+            start_fresh_outer_proof_on_resync,
         )
         .await
 }

--- a/examples/demo-rollup/src/main.rs
+++ b/examples/demo-rollup/src/main.rs
@@ -59,6 +59,11 @@ struct Args {
     /// zkVM guest ELFs before starting the rollup.
     #[arg(long, default_value_t = false)]
     override_code_commitments: bool,
+
+    /// When true, the rollup skips proving unsynced blocks; once it catches up,
+    /// it issues a fresh outer proof that replaces any previous one.
+    #[arg(long, default_value_t = false)]
+    replace_outer_proof_after_resync: bool,
 }
 
 #[derive(clap::ValueEnum, Clone, Debug)]
@@ -114,6 +119,7 @@ async fn run() -> anyhow::Result<()> {
                 start_at_rollup_height,
                 stop_at_rollup_height,
                 args.override_code_commitments,
+                args.replace_outer_proof_after_resync,
             )
             .await
             .context("Failed to initialize MockDa rollup")?;
@@ -127,6 +133,7 @@ async fn run() -> anyhow::Result<()> {
                 start_at_rollup_height,
                 stop_at_rollup_height,
                 args.override_code_commitments,
+                args.replace_outer_proof_after_resync,
             )
             .await
             .context("Failed to initialize SP1 MockDa rollup")?;
@@ -140,6 +147,7 @@ async fn run() -> anyhow::Result<()> {
                 start_at_rollup_height,
                 stop_at_rollup_height,
                 args.override_code_commitments,
+                args.replace_outer_proof_after_resync,
             )
             .await
             .context("Failed to initialize ExternalMockDa rollup")?;
@@ -153,6 +161,7 @@ async fn run() -> anyhow::Result<()> {
                 start_at_rollup_height,
                 stop_at_rollup_height,
                 args.override_code_commitments,
+                args.replace_outer_proof_after_resync,
             )
             .await
             .context("Failed to initialize Celestia rollup")?;
@@ -276,6 +285,7 @@ async fn new_rollup_with_celestia_da(
     start_at_rollup_height: Option<RollupHeight>,
     stop_at_rollup_height: Option<RollupHeight>,
     override_code_commitments: bool,
+    replace_outer_proof_after_resync: bool,
 ) -> anyhow::Result<Rollup<CelestiaDemoRollup<Native>, Native>> {
     debug!(config_path = rollup_config_path, "Starting Celestia rollup");
 
@@ -299,6 +309,7 @@ async fn new_rollup_with_celestia_da(
             start_at_rollup_height,
             stop_at_rollup_height,
             None,
+            replace_outer_proof_after_resync,
         )
         .await
 }
@@ -310,6 +321,7 @@ async fn new_rollup_with_mock_da(
     start_at_rollup_height: Option<RollupHeight>,
     stop_at_rollup_height: Option<RollupHeight>,
     override_code_commitments: bool,
+    replace_outer_proof_after_resync: bool,
 ) -> anyhow::Result<Rollup<MockDemoRollup<Native>, Native>> {
     debug!(
         config_path = rollup_config_path,
@@ -336,6 +348,7 @@ async fn new_rollup_with_mock_da(
             start_at_rollup_height,
             stop_at_rollup_height,
             None,
+            replace_outer_proof_after_resync,
         )
         .await
 }
@@ -347,6 +360,7 @@ async fn new_rollup_with_sp1_mock_da(
     start_at_rollup_height: Option<RollupHeight>,
     stop_at_rollup_height: Option<RollupHeight>,
     override_code_commitments: bool,
+    replace_outer_proof_after_resync: bool,
 ) -> anyhow::Result<Rollup<MockSp1DemoRollup<Native>, Native>> {
     debug!(
         config_path = rollup_config_path,
@@ -373,6 +387,7 @@ async fn new_rollup_with_sp1_mock_da(
             start_at_rollup_height,
             stop_at_rollup_height,
             None,
+            replace_outer_proof_after_resync,
         )
         .await
 }
@@ -384,6 +399,7 @@ async fn new_rollup_with_external_mock_da(
     start_at_rollup_height: Option<RollupHeight>,
     stop_at_rollup_height: Option<RollupHeight>,
     override_code_commitments: bool,
+    replace_outer_proof_after_resync: bool,
 ) -> anyhow::Result<Rollup<ExternalMockDemoRollup<Native>, Native>> {
     debug!(
         config_path = rollup_config_path,
@@ -410,6 +426,7 @@ async fn new_rollup_with_external_mock_da(
             start_at_rollup_height,
             stop_at_rollup_height,
             None,
+            replace_outer_proof_after_resync,
         )
         .await
 }

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -155,7 +155,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
         ledger_db: &LedgerDb,
-        _replace_outer_proof_after_resync: bool,
+        start_fresh_outer_proof_on_resync: bool,
     ) -> (Self::ProverService, Option<SlotNumber>) {
         let previous_public_data: Option<
             AggregatedProofPublicData<
@@ -172,8 +172,13 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
         let latest_proof_final_slot = previous_public_data.as_ref().map(|p| p.final_slot_number);
 
         let inner_vm = MockZkvmHost::new_non_blocking();
-        let outer_vm =
-            MockZkvmHost::new_non_blocking_with_previous_anchor(previous_public_data.as_ref());
+
+        let previous = crate::previous_outer_anchor(
+            previous_public_data.as_ref(),
+            start_fresh_outer_proof_on_resync,
+        );
+
+        let outer_vm = MockZkvmHost::new_non_blocking_with_previous_anchor(previous);
         let da_verifier = Default::default();
 
         let num_threads = rollup_config.proof_manager.prover_thread_count();

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -155,6 +155,7 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
         ledger_db: &LedgerDb,
+        _replace_outer_proof_after_resync: bool,
     ) -> (Self::ProverService, Option<SlotNumber>) {
         let previous_public_data: Option<
             AggregatedProofPublicData<

--- a/examples/demo-rollup/src/mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/mock_sp1_rollup.rs
@@ -147,7 +147,7 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
         ledger_db: &LedgerDb,
-        _replace_outer_proof_after_resync: bool,
+        start_fresh_outer_proof_on_resync: bool,
     ) -> (Self::ProverService, Option<SlotNumber>) {
         let elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
         let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
@@ -167,6 +167,12 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
             .expect("Failed to create SP1Host from guest ELF");
 
         let inner_verifying_key = inner_vm.verifying_key().clone();
+
+        if start_fresh_outer_proof_on_resync {
+            panic!(
+                "`start_fresh_outer_proof_on_resync` is not supported for the SP1 mock rollup: todo #2551"
+            );
+        }
 
         let previous_aggregated_proof = read_latest_aggregated_proof(ledger_db).await;
 

--- a/examples/demo-rollup/src/mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/mock_sp1_rollup.rs
@@ -147,6 +147,7 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
         ledger_db: &LedgerDb,
+        _replace_outer_proof_after_resync: bool,
     ) -> (Self::ProverService, Option<SlotNumber>) {
         let elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
         let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;

--- a/examples/demo-rollup/tests/zk_proving/max_concurrent_proof_blobs.rs
+++ b/examples/demo-rollup/tests/zk_proving/max_concurrent_proof_blobs.rs
@@ -19,7 +19,7 @@ fn resume_proving() {
 #[tokio::test(flavor = "multi_thread")]
 async fn max_concurrent_proof() -> anyhow::Result<()> {
     let external_da = start_external_mock_da(TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING).await?;
-    let test_rollup = start_test_rollup(0, &external_da, 2).await?;
+    let test_rollup = start_test_rollup(0, &external_da, 2, false).await?;
 
     let mut aggregated_proof_subscription = test_rollup.subscribe_aggregated_proof().await?;
     let _ = aggregated_proof_subscription.next().await.unwrap().unwrap();

--- a/examples/demo-rollup/tests/zk_proving/mod.rs
+++ b/examples/demo-rollup/tests/zk_proving/mod.rs
@@ -1,4 +1,5 @@
 mod max_concurrent_proof_blobs;
+mod skip_proving_on_resync;
 
 use demo_stf::genesis_config::create_genesis_config;
 use futures::StreamExt;
@@ -37,6 +38,7 @@ pub async fn start_test_rollup(
     genesis_da_height: u64,
     external_da: &ExternalDa,
     max_concurrent_proof_blobs: usize,
+    replace_outer_proof_after_resync: bool,
 ) -> anyhow::Result<TestRollup<ExternalMockDemoRollup<Native>>> {
     // Make sure the DA has produced the genesis block before the rollup tries
     // to read from it.
@@ -68,6 +70,7 @@ pub async fn start_test_rollup(
         c.blob_processing_timeout_secs = 180;
         c.aggregated_proof_block_jump = 2;
         c.max_concurrent_proof_blobs = max_concurrent_proof_blobs;
+        c.replace_outer_proof_after_resync = replace_outer_proof_after_resync;
         if let SequencerKindConfig::Preferred(sequencer_config) = &mut c.sequencer_config {
             sequencer_config.batch_execution_time_limit_millis = TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS;
             sequencer_config.recovery_strategy = RecoveryStrategy::TryToSave;

--- a/examples/demo-rollup/tests/zk_proving/mod.rs
+++ b/examples/demo-rollup/tests/zk_proving/mod.rs
@@ -38,7 +38,7 @@ pub async fn start_test_rollup(
     genesis_da_height: u64,
     external_da: &ExternalDa,
     max_concurrent_proof_blobs: usize,
-    replace_outer_proof_after_resync: bool,
+    start_fresh_outer_proof_on_resync: bool,
 ) -> anyhow::Result<TestRollup<ExternalMockDemoRollup<Native>>> {
     // Make sure the DA has produced the genesis block before the rollup tries
     // to read from it.
@@ -70,7 +70,7 @@ pub async fn start_test_rollup(
         c.blob_processing_timeout_secs = 180;
         c.aggregated_proof_block_jump = 2;
         c.max_concurrent_proof_blobs = max_concurrent_proof_blobs;
-        c.replace_outer_proof_after_resync = replace_outer_proof_after_resync;
+        c.start_fresh_outer_proof_on_resync = start_fresh_outer_proof_on_resync;
         if let SequencerKindConfig::Preferred(sequencer_config) = &mut c.sequencer_config {
             sequencer_config.batch_execution_time_limit_millis = TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS;
             sequencer_config.recovery_strategy = RecoveryStrategy::TryToSave;

--- a/examples/demo-rollup/tests/zk_proving/skip_proving_on_resync.rs
+++ b/examples/demo-rollup/tests/zk_proving/skip_proving_on_resync.rs
@@ -1,0 +1,41 @@
+use futures::StreamExt;
+use sov_test_utils::TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING;
+
+use crate::external_mock_da::start_external_mock_da;
+use crate::zk_proving::start_test_rollup;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn skip_proving_on_resync() -> anyhow::Result<()> {
+    let external_da = start_external_mock_da(TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING).await?;
+    let test_rollup = start_test_rollup(3, &external_da, 20, false).await?;
+    let mut proof_sub = test_rollup.subscribe_aggregated_proof().await?;
+
+    for _ in 0..5 {
+        let _ = proof_sub.next().await.unwrap().unwrap();
+    }
+
+    let h = test_rollup.height().await;
+    println!("Start Height {}", h);
+    let builder = test_rollup.shutdown().await?;
+
+    let mut header_subscription = external_da.service.subscribe_finalized_header().await?;
+    for _ in 0..10 {
+        let header = header_subscription.next().await.unwrap().unwrap();
+        println!("Header {}", header.height)
+    }
+
+    let test_rollup = builder.start_test_rollup().await?;
+    let h = test_rollup.height().await;
+    println!("Start Height {}", h);
+
+    let mut proof_sub = test_rollup.subscribe_aggregated_proof().await?;
+
+    for _ in 0..5 {
+        let _ = proof_sub.next().await.unwrap().unwrap();
+    }
+
+    let h = test_rollup.height().await;
+    println!("End Height {}", h);
+
+    Ok(())
+}

--- a/examples/demo-rollup/tests/zk_proving/skip_proving_on_resync.rs
+++ b/examples/demo-rollup/tests/zk_proving/skip_proving_on_resync.rs
@@ -1,8 +1,12 @@
 use futures::StreamExt;
+use sov_demo_rollup::ExternalMockDemoRollup;
+use sov_modules_api::execution_mode::Native;
+use sov_rollup_interface::common::SlotNumber;
+use sov_test_utils::test_rollup::TestRollup;
 use sov_test_utils::TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING;
 
 use crate::external_mock_da::start_external_mock_da;
-use crate::zk_proving::start_test_rollup;
+use crate::zk_proving::{query_verified_proofs, start_test_rollup};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn skip_proving_on_resync() -> anyhow::Result<()> {
@@ -14,28 +18,22 @@ async fn skip_proving_on_resync() -> anyhow::Result<()> {
         let _ = proof_sub.next().await.unwrap().unwrap();
     }
 
-    let h = test_rollup.height().await;
-    println!("Start Height {}", h);
-    let builder = test_rollup.shutdown().await?;
+    let agg_pub_data = query_verified_proofs(&test_rollup).await?;
+    assert_eq!(agg_pub_data.origin_slot_number, SlotNumber::GENESIS);
 
-    let mut header_subscription = external_da.service.subscribe_finalized_header().await?;
-    for _ in 0..10 {
-        let header = header_subscription.next().await.unwrap().unwrap();
-        println!("Header {}", header.height)
-    }
+    let test_rollup = restart_with_start_fresh_outer_proof_on_resync(test_rollup).await?;
+    test_rollup.wait_for_rollup_height_advance_by(20).await;
 
-    let test_rollup = builder.start_test_rollup().await?;
-    let h = test_rollup.height().await;
-    println!("Start Height {}", h);
-
-    let mut proof_sub = test_rollup.subscribe_aggregated_proof().await?;
-
-    for _ in 0..5 {
-        let _ = proof_sub.next().await.unwrap().unwrap();
-    }
-
-    let h = test_rollup.height().await;
-    println!("End Height {}", h);
+    let agg_pub_data = query_verified_proofs(&test_rollup).await?;
+    assert!(agg_pub_data.origin_slot_number > SlotNumber::GENESIS);
 
     Ok(())
+}
+
+async fn restart_with_start_fresh_outer_proof_on_resync(
+    test_rollup: TestRollup<ExternalMockDemoRollup<Native>>,
+) -> anyhow::Result<TestRollup<ExternalMockDemoRollup<Native>>> {
+    let builder = test_rollup.shutdown().await?;
+    let builder = builder.set_start_fresh_outer_proof_on_resync(true);
+    builder.start_test_rollup().await
 }


### PR DESCRIPTION
# Description
This PR adds  two distinct features:
  1. `origin_slot_number propagation` — adds a new field to `AggregatedProofPublicData` that tracks which slot the `origin_state_root` corresponds to.
  2. `start_fresh_outer_proof_on_resync` flag — when set, the prover waits for the DA layer to finish resyncing, then skips proving any slots that fell inside the resync window and starts a fresh outer-proof chain (drops the persisted previous anchor). Plumbed from CLI args (main.rs) through `FullNodeBlueprint::create_prover_service`, `build_with_runtime`, `RollupBuilder`, and into `IntakeTask`
 
In the next PR, we will introduce an `admin` role in the P`roverIncentive` module to control who can trigger `start_fresh_outer_proof_on_resync`. For now, we have relaxed the `ProverIncentive` module to accept new proofs from any registered prover, but this will be restricted in the follow-up PR.


- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551