### PR TITLE
Fix state hash on dev

### DIFF
--- a/crates/module-system/module-implementations/sov-prover-incentives/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/lib.rs
@@ -48,12 +48,6 @@ pub struct ProverIncentives<S: Spec> {
     #[state]
     pub last_claimed_reward: StateValue<SlotNumber>,
 
-    /// Public data from the most recently verified aggregated proof.
-    #[state]
-    #[allow(clippy::type_complexity)]
-    pub latest_proof_succesfully_verified:
-        StateValue<AggregatedProofPublicData<S::Address, S::Da, <S::Storage as Storage>::Root>>,
-
     /// A penalty for provers who submit a proof for transitions that were already proven
     ///
     /// This quantity is expressed in gas units. When provers are penalized proofs, they will
@@ -68,6 +62,12 @@ pub struct ProverIncentives<S: Spec> {
     /// Reference to the Chain state module. Used to check the proof inputs
     #[module]
     pub(crate) chain_state: sov_chain_state::ChainState<S>,
+
+    /// Public data from the most recently verified aggregated proof.
+    #[state]
+    #[allow(clippy::type_complexity)]
+    pub latest_proof_succesfully_verified:
+        StateValue<AggregatedProofPublicData<S::Address, S::Da, <S::Storage as Storage>::Root>>,
 }
 
 impl<S: Spec> sov_modules_api::Module for ProverIncentives<S> {


### PR DESCRIPTION
# Description

Adjusts the changes from #2832 to make the new state item the last in the module. This keeps the state root hash the same and avoids compatibility breakage on dev.

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [ ] ~~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
