### PR TITLE
Add typed BlobSubmissionError variant to BlobSubmissionStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-05-09
+- #2839 (Minor breaking change, code) Adds a typed `Failed { error: BlobSubmissionError, will_retry: bool }` variant to `BlobSubmissionStatus`, plus a new `BlobSubmissionError` enum (`Submission`, `PublishTimeout`, `Reorg`, `FinalityCheck`, `MaxRetriesExhausted`). Internal blob-sender failure sites now emit `Failed` on the broadcast channel before retrying or shutting down, so observers can label retry / shutdown counts by cause. Downstream consumers that match on `BlobSubmissionStatus` exhaustively need to add a `Failed` arm.
+
 # 2026-05-05
 - #2808 **Breaking config change**: Adds a required `sequencer.max_concurrent_proof_blobs` field to rollup TOML configs, capping the number of proof blobs in flight on the DA layer. When the cap is reached, the ZK aggregator triggers a rollup shutdown.
 # 2026-04-20

--- a/crates/full-node/sov-blob-sender/src/lib.rs
+++ b/crates/full-node/sov-blob-sender/src/lib.rs
@@ -645,6 +645,14 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                                 ?blob_status,
                                 "BlobSender: unable to send blob. Shutting down."
                             );
+                            self.send_notification(BlobExecutionStatus {
+                                blob_submission_status: BlobSubmissionStatus::Failed {
+                                    error: BlobSubmissionError::Submission(format!("{err:?}")),
+                                    will_retry: false,
+                                },
+                                blob_selector_status: None,
+                            })
+                            .await;
                             let _ = self.shutdown_sender.send(());
                             return;
                         }
@@ -686,6 +694,16 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                                     %blob_hash,
                                     "Shutting down the rollup. Blob processing wasn't completed on time."
                                 );
+                                self.send_notification(BlobExecutionStatus {
+                                    blob_submission_status: BlobSubmissionStatus::Failed {
+                                        error: BlobSubmissionError::MaxRetriesExhausted {
+                                            retries_attempted: nb_of_retries_attempted as u32,
+                                        },
+                                        will_retry: false,
+                                    },
+                                    blob_selector_status: None,
+                                })
+                                .await;
                                 let _ = self.shutdown_sender.send(());
                                 return;
                             }
@@ -696,6 +714,16 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                                 attempted = nb_of_retries_attempted,
                                 max_attempts = MAX_NB_OF_BLOB_SUBMISSION_RETRIES,
                                 "Processing timeout: Blob status set from Published to MustSubmit.");
+                            self.send_notification(BlobExecutionStatus {
+                                blob_submission_status: BlobSubmissionStatus::Failed {
+                                    error: BlobSubmissionError::PublishTimeout {
+                                        retries_attempted: nb_of_retries_attempted as u32,
+                                    },
+                                    will_retry: true,
+                                },
+                                blob_selector_status: None,
+                            })
+                            .await;
                             blob_status = BlobExecutionStatus {
                                 blob_submission_status: BlobSubmissionStatus::MustSubmit,
                                 blob_selector_status: None,
@@ -709,8 +737,15 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                             .await
                         {
                             Ok(finality_status) => finality_status,
-                            // Error is logged inside the method
-                            Err(_) => {
+                            Err(e) => {
+                                self.send_notification(BlobExecutionStatus {
+                                    blob_submission_status: BlobSubmissionStatus::Failed {
+                                        error: BlobSubmissionError::FinalityCheck(format!("{e:?}")),
+                                        will_retry: false,
+                                    },
+                                    blob_selector_status: None,
+                                })
+                                .await;
                                 // If we can't check the finality status, we shut down.
                                 let _ = self.shutdown_sender.send(());
                                 return;
@@ -761,7 +796,15 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                             .await
                         {
                             Ok(finality_status) => finality_status,
-                            Err(_) => {
+                            Err(e) => {
+                                self.send_notification(BlobExecutionStatus {
+                                    blob_submission_status: BlobSubmissionStatus::Failed {
+                                        error: BlobSubmissionError::FinalityCheck(format!("{e:?}")),
+                                        will_retry: false,
+                                    },
+                                    blob_selector_status: None,
+                                })
+                                .await;
                                 // If we can't check the finality status, we shut down.
                                 let _ = self.shutdown_sender.send(());
                                 return;
@@ -792,6 +835,14 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                                     "Re-org detected; resubmitting blob"
                                 );
 
+                                self.send_notification(BlobExecutionStatus {
+                                    blob_submission_status: BlobSubmissionStatus::Failed {
+                                        error: BlobSubmissionError::Reorg,
+                                        will_retry: true,
+                                    },
+                                    blob_selector_status: None,
+                                })
+                                .await;
                                 trace!(%blob_id, %receipt, "Blob status set from Processed to MustSubmit.");
                                 blob_status = BlobExecutionStatus {
                                     blob_submission_status: BlobSubmissionStatus::MustSubmit,
@@ -801,6 +852,20 @@ impl<Da: DaService, FM: FinalizationManager> TaskState<Da, FM> {
                             }
                         }
                     }
+                }
+                BlobSubmissionStatus::Failed { error, will_retry } => {
+                    // Failed is a transient notification, not an entry state.
+                    // If it lands here, fall back to MustSubmit and warn.
+                    tracing::warn!(
+                        ?blob_id,
+                        ?error,
+                        will_retry,
+                        "BlobSubmissionStatus::Failed observed as loop entry state",
+                    );
+                    blob_status = BlobExecutionStatus {
+                        blob_submission_status: BlobSubmissionStatus::MustSubmit,
+                        blob_selector_status: None,
+                    };
                 }
                 BlobSubmissionStatus::Finalized { receipt, .. } => {
                     match blob_status.blob_selector_status {
@@ -880,6 +945,43 @@ pub enum BlobSelectorStatus {
     Accepted,
 }
 
+/// Categorised failure paired with a [`BlobSubmissionStatus::Failed`].
+#[derive(derive_more::Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum BlobSubmissionError {
+    /// DA submission RPC returned an error.
+    Submission(String),
+    /// Inclusion not seen within the publish deadline.
+    PublishTimeout { retries_attempted: u32 },
+    /// DA re-organised away from the published blob.
+    Reorg,
+    /// Querying DA for finality status failed.
+    FinalityCheck(String),
+    /// [`MAX_NB_OF_BLOB_SUBMISSION_RETRIES`] reached; rollup shutdown.
+    MaxRetriesExhausted { retries_attempted: u32 },
+}
+
+impl std::fmt::Display for BlobSubmissionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BlobSubmissionError::Submission(msg) => write!(f, "submission failed: {msg}"),
+            BlobSubmissionError::PublishTimeout { retries_attempted } => {
+                write!(
+                    f,
+                    "publish timeout (retries attempted: {retries_attempted})"
+                )
+            }
+            BlobSubmissionError::Reorg => write!(f, "DA re-org detected"),
+            BlobSubmissionError::FinalityCheck(msg) => {
+                write!(f, "finality check failed: {msg}")
+            }
+            BlobSubmissionError::MaxRetriesExhausted { retries_attempted } => write!(
+                f,
+                "max retries exhausted ({retries_attempted}); rollup shutting down"
+            ),
+        }
+    }
+}
+
 #[derive(derive_more::Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[debug(bounds())]
 #[serde(bound = "Da: DaSpec")]
@@ -893,6 +995,12 @@ pub enum BlobSubmissionStatus<Da: DaSpec> {
     },
     Finalized {
         receipt: SubmitBlobReceipt<Da::TransactionId>,
+    },
+    /// Submission attempt failed. `will_retry = true` means the blob will be
+    /// resubmitted; `false` means the rollup is shutting down.
+    Failed {
+        error: BlobSubmissionError,
+        will_retry: bool,
     },
 }
 

--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use sov_blob_sender::{
     BlobExecutionStatus, BlobInternalId, BlobSelectorStatus, BlobSender, BlobSenderHooks,
-    BlobSubmissionStatus, FinalizationManager,
+    BlobSubmissionError, BlobSubmissionStatus, FinalizationManager,
 };
 use sov_mock_da::storable::layer::StorableMockDaLayer;
 use sov_mock_da::storable::StorableMockDaService;
@@ -316,6 +316,72 @@ async fn blob_sender_exit_if_blob_not_processed() -> anyhow::Result<()> {
         log.contains(pattern),
         "Pattern '{pattern}' not found in '{log}'"
     );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn blob_sender_emits_failed_status_before_max_retries_shutdown() -> anyhow::Result<()> {
+    let deps = create_deps().await;
+    let (status_sender, mut status_receiver) = broadcast::channel(100);
+    let mut shutdown_receiver = deps.shutdown_sender.subscribe();
+
+    let (mut blob_sender, _blob_sender_handle) = create_blob_sender(
+        Duration::from_secs(1),
+        &deps,
+        Some(status_sender),
+        BlobSelectorStatus::Accepted,
+    )
+    .await;
+
+    let blob_id = 21u8;
+    let data = Arc::new([blob_id, 2, 3, 4, 5]);
+    blob_sender
+        .publish_batch_blob(data, blob_id as BlobInternalId)
+        .await?;
+
+    let observed_failed = tokio::select! {
+        _ = shutdown_receiver.changed() => {
+            let mut found = false;
+            while let Ok(status) = status_receiver.try_recv() {
+                if matches!(
+                    status.blob_submission_status,
+                    BlobSubmissionStatus::Failed {
+                        error: BlobSubmissionError::MaxRetriesExhausted { .. },
+                        will_retry: false,
+                    }
+                ) {
+                    found = true;
+                    break;
+                }
+            }
+            found
+        }
+        result = async {
+            loop {
+                match status_receiver.recv().await {
+                    Ok(status) => {
+                        if matches!(
+                            status.blob_submission_status,
+                            BlobSubmissionStatus::Failed {
+                                error: BlobSubmissionError::MaxRetriesExhausted { .. },
+                                will_retry: false,
+                            }
+                        ) {
+                            return true;
+                        }
+                    }
+                    Err(_) => return false,
+                }
+            }
+        } => result,
+    };
+
+    assert!(
+        observed_failed,
+        "expected a Failed{{ MaxRetriesExhausted, will_retry: false }} status \
+         on the broadcast before shutdown"
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
# Description

Adds a typed `Failed` variant to `BlobSubmissionStatus` paired with a new `BlobSubmissionError` enum, so observers subscribed to the blob-sender broadcast can label retry / shutdown counts by cause. Before this change, internal failures were either silently retried or led to a logged-then-shutdown with no observable signal partners could put on a Prometheus counter.

```rust
pub enum BlobSubmissionError {
    Submission(String),
    PublishTimeout { retries_attempted: u32 },
    Reorg,
    FinalityCheck(String),
    MaxRetriesExhausted { retries_attempted: u32 },
}

pub enum BlobSubmissionStatus<Da: DaSpec> {
    MustSubmit,
    Published { ... },
    Processed { ... },
    Finalized { ... },
    Failed { error: BlobSubmissionError, will_retry: bool },  // NEW
}
```

5 internal failure sites in `BlobSender::manage_blob_submission_inside_task` now emit `Failed` through the existing `send_notification` channel before the existing retry-or-shutdown action runs. No new transport or hook trait, just typed plumbing through what the broadcast already carries.

Picked Option A (typed enum on `BlobSubmissionStatus`) over Option B (`on_failed_blob` hook) per the reply on #2828 ("Happy to enumerate a status, PR welcome").

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. *(Adds a new enum variant; existing match sites in this crate were updated. Will add a CHANGELOG entry once the PR number is assigned.)*
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. *(No `Cargo.toml` changes.)*

## Linked Issues
- Fixes #2828

## Testing

One new integration test in `tests/blob_sender.rs`: `blob_sender_emits_failed_status_before_max_retries_shutdown`. Drives a blob to `MAX_NB_OF_BLOB_SUBMISSION_RETRIES`, asserts a `Failed { MaxRetriesExhausted, will_retry: false }` notification fires on the broadcast before the shutdown signal. Passes locally.

Verified with `cargo fmt --check`, `cargo check --workspace` (excluding prover crates that need risc0/sp1 toolchains I don't have locally), `cargo clippy -p sov-blob-sender --all-targets --all-features -- -A clippy::too_many_arguments -D warnings`, and the new test under `cargo test -p sov-blob-sender --test blob_sender`.

Two pre-existing issues to flag (neither caused by this PR):

1. The blob_sender test suite has a pre-existing `tracing_subscriber` race. Two tests (`blob_sender_shutdown_task` and `blob_sender_exit_if_blob_not_processed`) both call `subscriber.init()` which sets a global; they collide when run in parallel. I confirmed this fails the same way without my new test added (5 passed, 2 failed either way). Probably a `set_default()` switch in a separate PR.

2. Same zepter 1.88 cyclic-feature fix in `crates/universal-wallet/schema/Cargo.toml` that we encountered on #2838. Reverted in this PR for the same reason (zepter adds bare `"serde"` to the `serde` feature, but `serde` is also an optional dep in that crate, which creates a self-cycle). The right fix is `"dep:serde"`.

## Docs

Doc comments on `BlobSubmissionError`, the `Failed` variant, and the failure-site code paths match the surrounding terse style. No public-API docs change beyond the new enum and the new variant on the existing one.