### PR TITLE
Add admin role in `sov-prover-incentives`

### DIFF
--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -133,6 +133,15 @@ impl sov_rollup_interface::zk::ZkVerifier for MockZkVerifier {
             anyhow::bail!("Proof is not valid")
         }
     }
+
+    fn extract_public_data<T: DeserializeOwned>(
+        serialized_proof: &SerializedZkProof,
+    ) -> Result<T, Self::Error> {
+        let MockProof {
+            pub_data: input, ..
+        } = bincode::deserialize(&serialized_proof.raw_proof)?;
+        Ok(bincode::deserialize(&input)?)
+    }
 }
 
 #[cfg(test)]

--- a/crates/adapters/risc0/src/lib.rs
+++ b/crates/adapters/risc0/src/lib.rs
@@ -108,6 +108,13 @@ impl ZkVerifier for Risc0Verifier {
         receipt.verify(code_commitment.0)?;
         Ok(bincode::deserialize(&receipt.journal.bytes)?)
     }
+
+    fn extract_public_data<T: DeserializeOwned>(
+        serialized_proof: &SerializedZkProof,
+    ) -> Result<T, Self::Error> {
+        let receipt: Receipt = bincode::deserialize(&serialized_proof.raw_proof)?;
+        Ok(bincode::deserialize(&receipt.journal.bytes)?)
+    }
 }
 
 /// The Risc0 Zkvm.
@@ -144,6 +151,13 @@ impl ZkVerifier for Risc0Verifier {
     fn verify_with_proof<T: DeserializeOwned>(
         _serialized_proof: &SerializedZkProof,
         _code_commitment: &Self::CodeCommitment,
+    ) -> Result<T, Self::Error> {
+        // Implement this method once risc0 supports recursion: issue #633
+        todo!("Implement once risc0 supports recursion: https://github.com/Sovereign-Labs/sovereign-sdk/issues/633")
+    }
+
+    fn extract_public_data<T: DeserializeOwned>(
+        _serialized_proof: &SerializedZkProof,
     ) -> Result<T, Self::Error> {
         // Implement this method once risc0 supports recursion: issue #633
         todo!("Implement once risc0 supports recursion: https://github.com/Sovereign-Labs/sovereign-sdk/issues/633")

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -149,6 +149,13 @@ impl ZkVerifier for SP1Verifier {
 
         Ok(bincode::deserialize(proof.public_values.as_slice())?)
     }
+
+    fn extract_public_data<T: DeserializeOwned>(
+        serialized_proof: &SerializedZkProof,
+    ) -> Result<T, Self::Error> {
+        let envelope: Sp1ProofEnvelope = bincode::deserialize(&serialized_proof.raw_proof)?;
+        Ok(bincode::deserialize(envelope.public_values.as_slice())?)
+    }
 }
 
 /// The SP1 Zkvm.
@@ -198,6 +205,14 @@ impl ZkVerifier for SP1Verifier {
 
         let public_values_digest: [u8; 32] = sha2::Sha256::digest(&public_values).into();
         sp1_zkvm::lib::verify::verify_sp1_proof(&vkey_hash.0, &public_values_digest);
+        Ok(bincode::deserialize(&public_values)?)
+    }
+
+    fn extract_public_data<T: DeserializeOwned>(
+        serialized_proof: &SerializedZkProof,
+    ) -> Result<T, Self::Error> {
+        let mut reader: &[u8] = &serialized_proof.raw_proof;
+        let public_values: Vec<u8> = bincode::deserialize_from(&mut reader)?;
         Ok(bincode::deserialize(&public_values)?)
     }
 }

--- a/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
+++ b/crates/full-node/sov-stf-runner/src/processes/zk_manager/mod.rs
@@ -23,10 +23,6 @@ const BACKOFF_POLICY_MIN_DELAY: u64 = 1;
 const BACKOFF_POLICY_MAX_DELAY: u64 = 60;
 const BACKOFF_POLICY_MAX_NUM_RETRIES: usize = 5;
 
-/// Poll interval used by [`IntakeTask`] while waiting for the DA layer to
-/// finish resyncing before it starts ingesting STF info.
-const RESYNC_POLL_INTERVAL: Duration = Duration::from_millis(500);
-
 /// Manages the lifecycle of the `AggregatedProof`.
 #[allow(clippy::type_complexity)]
 pub struct ZkProofManager<Ps: ProverService> {
@@ -135,6 +131,18 @@ where
     }
 }
 
+/// Tracks the resync skip-window state machine for the proof intake.
+enum ResyncState {
+    /// `start_fresh_outer_proof_on_resync` is disabled; always prove.
+    Disabled,
+    /// Flag enabled, DA still `Syncing`. Skip-advance every slot so the runner
+    /// can keep pushing transitions and sync can complete. Cutoff not yet captured.
+    AwaitingSync,
+    /// Flag enabled, first `Synced` observed at this DA height. Skip slots below
+    /// this height (they were drained but never proved); prove slots at or above.
+    SkipBelow(u64),
+}
+
 /// Per-slot intake side of [`ZkProofManager`]. See the type-level docs for
 /// how it cooperates with [`AggregatorTask`].
 struct IntakeTask<Ps: ProverService> {
@@ -155,30 +163,10 @@ where
     Ps::DaService: DaService<Error = anyhow::Error>,
 {
     async fn run(mut self) -> anyhow::Result<()> {
-        let skip_proofs_till_da_height = if !self.start_fresh_outer_proof_on_resync {
-            None
+        let mut resync_state = if self.start_fresh_outer_proof_on_resync {
+            ResyncState::AwaitingSync
         } else {
-            loop {
-                match self.da_sync_state.status() {
-                    SyncStatus::Synced { synced_da_height } => break Some(synced_da_height),
-                    SyncStatus::Syncing { .. } => {
-                        match future_or_shutdown(
-                            sleep(RESYNC_POLL_INTERVAL),
-                            &self.shutdown_receiver,
-                        )
-                        .await
-                        {
-                            FutureOrShutdownOutput::Shutdown => {
-                                tracing::info!(
-                                    "Shutting down aggregated proof intake task while waiting for DA resync..."
-                                );
-                                return Ok(());
-                            }
-                            FutureOrShutdownOutput::Output(()) => continue,
-                        }
-                    }
-                }
-            }
+            ResyncState::Disabled
         };
 
         loop {
@@ -203,7 +191,28 @@ where
                         "Received STF info"
                     );
 
-                    if let Some(skip_height) = skip_proofs_till_da_height {
+                    // If still observing resync, try to capture the cutoff. Until the DA
+                    // layer reports `Synced` at least once, skip-advance the current slot
+                    // unconditionally — this drains the channel so the runner can keep
+                    // producing.
+                    if matches!(resync_state, ResyncState::AwaitingSync) {
+                        match self.da_sync_state.status() {
+                            SyncStatus::Syncing { .. } => {
+                                self.cursor.inc_next_height_to_receive_by(1);
+                                continue;
+                            }
+                            SyncStatus::Synced { synced_da_height } => {
+                                tracing::info!(
+                                    %synced_da_height,
+                                    "DA resync complete; recording skip cutoff for proof intake"
+                                );
+                                resync_state = ResyncState::SkipBelow(synced_da_height);
+                                // fall through; this slot may still be below the cutoff.
+                            }
+                        }
+                    }
+
+                    if let ResyncState::SkipBelow(skip_height) = resync_state {
                         if stf_info.da_block_header().height() < skip_height {
                             // Skipped slots will never be proved, so advance
                             // the cursor manually.

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
@@ -3,16 +3,16 @@ use std::cmp::max;
 use sov_bank::{config_gas_token_id, Amount, Coins, IntoPayable};
 use sov_modules_api::registration_lib::StakeRegistration;
 use sov_modules_api::{
-    AggregatedProofPublicData, ExecutionContext, Gas, GasSpec, GetGasPrice, InvalidProofError,
-    SerializedAggregatedProof, Spec, StateReader, Storage, TxState, VersionReader, ZkVerifier,
-    Zkvm,
+    AggregatedProofPublicData, CodeCommitmentFor, CodeCommitmentHash, CodeCommitmentTrait,
+    ExecutionContext, Gas, GasSpec, GetGasPrice, InvalidProofError, SerializedAggregatedProof,
+    Spec, StateReader, Storage, TxState, VersionReader, ZkVerifier, Zkvm,
 };
 use sov_rollup_interface::common::SlotNumber;
 use sov_state::Kernel;
 use thiserror::Error;
 
 use crate::event::SlashingReason;
-use crate::ProverIncentives;
+use crate::{AdminUpgrade, ProverIncentives};
 
 /// Error raised while processing the aggregated proof.
 #[derive(Debug, Error)]
@@ -39,6 +39,15 @@ pub enum ProcessProofError {
 
     #[error("Prover incentives called with invalid operating mode")]
     InvalidOperatingMode,
+
+    #[error(
+        "Proof range [{initial_slot_number}, {final_slot_number}] starts before latest admin upgrade slot {latest_admin_upgrade_slot}"
+    )]
+    ProofPrecedesLatestAdminUpgrade {
+        initial_slot_number: SlotNumber,
+        final_slot_number: SlotNumber,
+        latest_admin_upgrade_slot: SlotNumber,
+    },
 }
 
 impl From<ProcessProofError> for InvalidProofError {
@@ -52,7 +61,8 @@ impl From<ProcessProofError> for InvalidProofError {
             }
             ProcessProofError::ProverNotBonded
             | ProcessProofError::BondNotHighEnough
-            | ProcessProofError::InvalidOperatingMode => {
+            | ProcessProofError::InvalidOperatingMode
+            | ProcessProofError::ProofPrecedesLatestAdminUpgrade { .. } => {
                 InvalidProofError::PreconditionNotMet(error.to_string())
             }
             ProcessProofError::StateAccessorError(e) => {
@@ -66,6 +76,43 @@ impl From<ProcessProofError> for InvalidProofError {
 enum Paycheck {
     Penalized,
     Rewarded(Amount),
+}
+
+/// Pre-resolved values needed by every step of proof processing.
+struct ProofContext<S: Spec> {
+    /// Outer code commitment to verify the proof against.
+    outer_code_commitment: CodeCommitmentFor<S::OuterZkvm>,
+    /// Hash of the *currently-authorized* outer commitment (always derived from
+    /// the latest admin upgrade or genesis).
+    effective_outer_vk_hash: CodeCommitmentHash,
+    /// Currently-authorized origin state root.
+    expected_origin_state_root: <S::Storage as Storage>::Root,
+    /// Hash of the currently-authorized inner commitment.
+    expected_inner_vkey_hash: CodeCommitmentHash,
+    /// Slot of the most recent admin upgrade, if any.
+    latest_admin_upgrade_slot: Option<SlotNumber>,
+}
+
+impl<S: Spec> ProofContext<S> {
+    /// Returns `true` if `is_admin` is set AND `public_outputs` differ from
+    /// the currently-authorized commitment/origin values — i.e. the proof is
+    /// requesting an admin upgrade rather than being a normal admin proof.
+    /// For non-admin proofs the same divergence is a slashing condition in
+    /// `check_proof_outputs`, not an upgrade — hence the `is_admin` gate here.
+    fn is_admin_upgrade(
+        &self,
+        public_outputs: &AggregatedProofPublicData<
+            S::Address,
+            S::Da,
+            <S::Storage as Storage>::Root,
+        >,
+        is_admin: bool,
+    ) -> bool {
+        is_admin
+            && (self.effective_outer_vk_hash != public_outputs.outer_vk_hash
+                || self.expected_inner_vkey_hash != public_outputs.inner_vkey_hash
+                || self.expected_origin_state_root != public_outputs.origin_state_root)
+    }
 }
 
 impl<S: Spec> ProverIncentives<S> {
@@ -106,12 +153,6 @@ impl<S: Spec> ProverIncentives<S> {
             return Err(ProcessProofError::BondNotHighEnough);
         };
 
-        let code_commitment = self
-            .chain_state
-            .outer_code_commitment(state)
-            .map_err(Into::<anyhow::Error>::into)?
-            .expect("The code commitment should be set at genesis");
-
         state
             .charge_gas(<S as GasSpec>::fixed_gas_to_charge_per_proof())
             .map_err(Into::<anyhow::Error>::into)?;
@@ -127,11 +168,30 @@ impl<S: Spec> ProverIncentives<S> {
             )
             .map_err(Into::<anyhow::Error>::into)?;
 
+        let is_admin = self
+            .admin
+            .get(state)
+            .map_err(Into::<anyhow::Error>::into)?
+            .as_ref()
+            == Some(prover_address);
+
+        // Extract the (untrusted) public outputs.
+        let claimed_outputs = Self::claimed_public_outputs(proof);
+
+        // Resolve every admin-state-derived value (outer commitment for
+        // verification, effective hashes for slashing/upgrade checks, latest
+        // upgrade slot) in one shot so downstream helpers don't re-read state.
+        let ctx = self.proof_context(claimed_outputs.as_ref(), is_admin, state)?;
+
+        Self::reject_stale_proof_before_latest_admin_upgrade(claimed_outputs.as_ref(), &ctx)?;
+
         // Don't return an error for invalid proofs - those are expected and shouldn't cause reverts.
-        let verification_result =
-            <<S as Spec>::OuterZkvm as Zkvm>::Verifier::verify_with_proof::<
-                AggregatedProofPublicData<S::Address, S::Da, <S::Storage as Storage>::Root>,
-            >(&proof.clone().to_serialized_zk_proof(), &code_commitment);
+        let verification_result = <<S as Spec>::OuterZkvm as Zkvm>::Verifier::verify_with_proof::<
+            AggregatedProofPublicData<S::Address, S::Da, <S::Storage as Storage>::Root>,
+        >(
+            &proof.clone().to_serialized_zk_proof(),
+            &ctx.outer_code_commitment,
+        );
 
         let public_outputs = match verification_result {
             Ok(public_outputs) => public_outputs,
@@ -166,32 +226,12 @@ impl<S: Spec> ProverIncentives<S> {
             "Processing aggregated proof"
         );
 
-        // TODO #2551: We don’t handle real inner_code_commitment yet. Re-enable it at the end of #2551.
-        /*
-                // Bind the inner circuit: the aggregation program reads `inner_vkey_hash`
-                // from host advice, so without this check a prover could verify inner
-                // proofs against an arbitrary inner VK. The outer VK proof alone no
-                // longer transitively pins the inner circuit.
-                let inner_code_commitment = self
-                    .chain_state
-                    .inner_code_commitment(state)
-                    .map_err(Into::<anyhow::Error>::into)?
-                    .expect("The inner code commitment should be set at genesis");
-
-                if &inner_code_commitment.to_hash()? != &public_outputs.inner_vkey_hash {
-                    tracing::debug!(
-                        slashing_reason = ?SlashingReason::IncorrectInnerVkeyHash,
-                        "Slashing prover"
-                    );
-                    self.slash_prover(prover_address, state)?;
-                    return Err(ProcessProofError::ProverSlashedNoRevert(format!(
-                        "Invalid output {}",
-                        SlashingReason::IncorrectInnerVkeyHash
-                    )));
-                }
-        */
+        // The expected origin state root and inner VK hash were already resolved
+        // into `ctx` above; this binds the inner circuit (so a prover cannot
+        // verify inner proofs against an arbitrary inner VK) and enforces the
+        // origin state root - both stale above when admin upgrades are accepted.
         if let Some(slashing_reason) = self
-            .check_proof_outputs(&public_outputs, state)
+            .check_proof_outputs(&public_outputs, &ctx, is_admin, state)
             .map_err(Into::<anyhow::Error>::into)?
         {
             tracing::debug!(?slashing_reason, "Slashing prover");
@@ -202,6 +242,14 @@ impl<S: Spec> ProverIncentives<S> {
                 "Invalid output {slashing_reason}"
             )));
         }
+
+        let is_admin_upgrade = self.check_admin_upgrade_or_slash(
+            &public_outputs,
+            prover_address,
+            &ctx,
+            is_admin,
+            state,
+        )?;
 
         match self.calculate_reward_and_remove(
             public_outputs.initial_slot_number,
@@ -217,9 +265,280 @@ impl<S: Spec> ProverIncentives<S> {
             }
             Paycheck::Rewarded(total_reward) => {
                 self.reward_prover(total_reward, prover_address, state)?;
+
+                // Persist the upgrade only after the proof is fully accepted.
+                if is_admin_upgrade {
+                    self.apply_admin_upgrade(&public_outputs, state)?;
+                }
+
                 Ok(public_outputs)
             }
         }
+    }
+
+    /// Extract the proof's claimed public outputs without cryptographic
+    /// verification. Callers must treat the result as untrusted metadata.
+    #[allow(clippy::type_complexity)]
+    fn claimed_public_outputs(
+        proof: &SerializedAggregatedProof,
+    ) -> Option<AggregatedProofPublicData<S::Address, S::Da, <S::Storage as Storage>::Root>> {
+        <<S as Spec>::OuterZkvm as Zkvm>::Verifier::extract_public_data::<
+            AggregatedProofPublicData<S::Address, S::Da, <S::Storage as Storage>::Root>,
+        >(&proof.clone().to_serialized_zk_proof())
+        .ok()
+    }
+
+    /// Reject proofs whose claimed range starts before the latest admin upgrade
+    /// slot. This is an explicit cutoff: once an upgrade is accepted, pre-upgrade
+    /// ranges are stale and should be dropped without slashing.
+    ///
+    /// The slot range comes from unverified public data, so this helper is only
+    /// used for a non-punitive early return. Proofs that fail extraction still
+    /// fall through to normal verification and can be slashed there.
+    #[allow(clippy::type_complexity)]
+    fn reject_stale_proof_before_latest_admin_upgrade(
+        claimed_outputs: Option<
+            &AggregatedProofPublicData<S::Address, S::Da, <S::Storage as Storage>::Root>,
+        >,
+        ctx: &ProofContext<S>,
+    ) -> Result<(), ProcessProofError> {
+        let Some(latest_admin_upgrade_slot) = ctx.latest_admin_upgrade_slot else {
+            return Ok(());
+        };
+
+        let Some(claimed_outputs) = claimed_outputs else {
+            return Ok(());
+        };
+
+        if claimed_outputs.initial_slot_number >= latest_admin_upgrade_slot {
+            return Ok(());
+        }
+
+        tracing::debug!(
+            initial_slot_number = %claimed_outputs.initial_slot_number,
+            final_slot_number = %claimed_outputs.final_slot_number,
+            %latest_admin_upgrade_slot,
+            "Rejecting proof whose claimed range starts before latest admin upgrade slot",
+        );
+
+        Err(ProcessProofError::ProofPrecedesLatestAdminUpgrade {
+            initial_slot_number: claimed_outputs.initial_slot_number,
+            final_slot_number: claimed_outputs.final_slot_number,
+            latest_admin_upgrade_slot,
+        })
+    }
+
+    /// For admin proofs, reconstruct the outer code commitment from the VK hash the
+    /// prover claims in the proof's public outputs (extracted without cryptographic
+    /// verification). Returns `None` for non-admin proofs, admin proofs whose bytes
+    /// are too malformed to extract public outputs, or admin proofs whose claimed
+    /// `outer_vk_hash` is the wrong length for [`CodeCommitmentTrait::from_hash`] -
+    /// the caller then falls back to the currently-authorized commitment so
+    /// verification fails via the usual path rather than panicking.
+    #[allow(clippy::type_complexity)]
+    fn admin_claimed_outer_commitment(
+        claimed_outputs: Option<
+            &AggregatedProofPublicData<S::Address, S::Da, <S::Storage as Storage>::Root>,
+        >,
+        is_admin: bool,
+    ) -> Option<CodeCommitmentFor<S::OuterZkvm>> {
+        if !is_admin {
+            return None;
+        }
+        let claimed = claimed_outputs?;
+
+        // Production verifiers (SP1, Risc0) reconstruct their commitment via
+        // `to_u32_array`, which asserts a 32-byte hash. Reject malformed lengths
+        // here so we slash on `Verification failed` instead of panicking the STF.
+        if claimed.outer_vk_hash.0.len() != CodeCommitmentHash::HASH_LEN {
+            return None;
+        }
+        Some(
+            <<<S as Spec>::OuterZkvm as Zkvm>::Verifier as ZkVerifier>::CodeCommitment::from_hash(
+                claimed.outer_vk_hash.clone(),
+            ),
+        )
+    }
+
+    /// Resolve every admin-state-derived value needed by the rest of
+    /// [`Self::process_proof`] in a single state read.
+    #[allow(clippy::type_complexity)]
+    fn proof_context<ST: TxState<S>>(
+        &self,
+        claimed_outputs: Option<
+            &AggregatedProofPublicData<S::Address, S::Da, <S::Storage as Storage>::Root>,
+        >,
+        is_admin: bool,
+        state: &mut ST,
+    ) -> Result<ProofContext<S>, anyhow::Error> {
+        let latest_admin_upgrade = self.latest_admin_upgrade(state)?;
+        let latest_admin_upgrade_slot = latest_admin_upgrade.as_ref().map(|(slot, _)| *slot);
+        let latest_admin_upgrade_value = latest_admin_upgrade.as_ref().map(|(_, upgrade)| upgrade);
+
+        let effective_outer =
+            self.effective_outer_code_commitment(latest_admin_upgrade_value, state)?;
+
+        let effective_outer_vk_hash = effective_outer.to_hash();
+
+        let outer_code_commitment = Self::admin_claimed_outer_commitment(claimed_outputs, is_admin)
+            .unwrap_or(effective_outer);
+
+        let expected_origin_state_root =
+            self.effective_origin_state_root(latest_admin_upgrade_value, state)?;
+
+        let expected_inner_vkey_hash = self
+            .effective_inner_code_commitment(latest_admin_upgrade_value, state)?
+            .to_hash();
+
+        Ok(ProofContext {
+            outer_code_commitment,
+            effective_outer_vk_hash,
+            expected_origin_state_root,
+            expected_inner_vkey_hash,
+            latest_admin_upgrade_slot,
+        })
+    }
+
+    /// Returns the slot and entry of the most recent admin upgrade, if any.
+    fn latest_admin_upgrade<ST: TxState<S>>(
+        &self,
+        state: &mut ST,
+    ) -> Result<Option<(SlotNumber, AdminUpgrade<S>)>, anyhow::Error> {
+        let Some(slot) = self.latest_admin_upgrade_slot.get(state)? else {
+            return Ok(None);
+        };
+        let upgrade = self
+            .admin_upgrades
+            .get(&slot, state)?
+            .expect("latest_admin_upgrade_slot points to a missing entry");
+        Ok(Some((slot, upgrade)))
+    }
+
+    /// Returns the outer code commitment to use when verifying proofs. Falls back to
+    /// chain_state's genesis value if no admin upgrade has been recorded.
+    fn effective_outer_code_commitment<ST: TxState<S>>(
+        &self,
+        latest_admin_upgrade: Option<&AdminUpgrade<S>>,
+        state: &mut ST,
+    ) -> Result<CodeCommitmentFor<S::OuterZkvm>, anyhow::Error> {
+        if let Some(upgrade) = latest_admin_upgrade {
+            return Ok(upgrade.outer_code_commitment.clone());
+        }
+        Ok(self
+            .chain_state
+            .outer_code_commitment(state)?
+            .expect("The code commitment should be set at genesis"))
+    }
+
+    /// Returns the inner code commitment to use when validating proof outputs. Falls
+    /// back to chain_state's genesis value if no admin upgrade has been recorded.
+    fn effective_inner_code_commitment<ST: TxState<S>>(
+        &self,
+        latest_admin_upgrade: Option<&AdminUpgrade<S>>,
+        state: &mut ST,
+    ) -> Result<CodeCommitmentFor<S::InnerZkvm>, anyhow::Error> {
+        if let Some(upgrade) = latest_admin_upgrade {
+            return Ok(upgrade.inner_code_commitment.clone());
+        }
+        Ok(self
+            .chain_state
+            .inner_code_commitment(state)?
+            .expect("The inner code commitment should be set at genesis"))
+    }
+
+    /// Returns the origin state root to enforce on proofs. Falls back to chain_state's
+    /// slot-derived genesis hash if no admin upgrade has been recorded.
+    fn effective_origin_state_root<ST: TxState<S>>(
+        &self,
+        latest_admin_upgrade: Option<&AdminUpgrade<S>>,
+        state: &mut ST,
+    ) -> Result<<S::Storage as Storage>::Root, anyhow::Error> {
+        if let Some(upgrade) = latest_admin_upgrade {
+            return Ok(upgrade.origin_state_root.clone());
+        }
+        Ok(self
+            .chain_state
+            .get_genesis_hash(state)?
+            .expect("The genesis hash should be set at genesis"))
+    }
+
+    /// Classifies an admin proof. Returns `true` if it is an upgrade (some
+    /// commitment or origin state root differs from current effective values) and
+    /// the target slot is strictly newer than the most recent recorded upgrade.
+    /// Returns `false` if the proof's outputs match current effective values
+    /// (i.e. it's a normal admin proof, not an upgrade).
+    fn check_admin_upgrade_or_slash<ST: TxState<S>>(
+        &mut self,
+        public_outputs: &AggregatedProofPublicData<
+            S::Address,
+            S::Da,
+            <S::Storage as Storage>::Root,
+        >,
+        prover_address: &S::Address,
+        ctx: &ProofContext<S>,
+        is_admin: bool,
+        state: &mut ST,
+    ) -> Result<bool, ProcessProofError> {
+        if !ctx.is_admin_upgrade(public_outputs, is_admin) {
+            return Ok(false);
+        }
+
+        let upgrade_slot = public_outputs.final_slot_number;
+        if matches!(ctx.latest_admin_upgrade_slot, Some(current) if upgrade_slot <= current) {
+            tracing::debug!(
+                %upgrade_slot,
+                latest = ?ctx.latest_admin_upgrade_slot,
+                "Slashing admin: upgrade slot is not newer than latest recorded upgrade"
+            );
+            self.slash_prover(prover_address, state)?;
+            return Err(ProcessProofError::ProverSlashedNoRevert(format!(
+                "Invalid output {}",
+                SlashingReason::StaleAdminUpgrade
+            )));
+        }
+
+        Ok(true)
+    }
+
+    /// Record the admin proof's claimed public outputs as a new upgrade entry in this
+    /// module's slot-keyed history. The proof has already been verified against the VK
+    /// it claims (reconstructed via `from_hash`), so these values become canonical for
+    /// proofs at or after this slot that pass the stale-proof cutoff. chain_state is
+    /// left untouched; effective values are read from this module's `admin_*` maps
+    /// when `latest_admin_upgrade_slot` is set.
+    fn apply_admin_upgrade<ST: TxState<S>>(
+        &mut self,
+        public_outputs: &AggregatedProofPublicData<
+            S::Address,
+            S::Da,
+            <S::Storage as Storage>::Root,
+        >,
+        state: &mut ST,
+    ) -> Result<(), anyhow::Error> {
+        let slot = public_outputs.final_slot_number;
+
+        let upgrade = AdminUpgrade::<S> {
+            outer_code_commitment:
+                <<<S as Spec>::OuterZkvm as Zkvm>::Verifier as ZkVerifier>::CodeCommitment::from_hash(
+                    public_outputs.outer_vk_hash.clone(),
+                ),
+            inner_code_commitment:
+                <<<S as Spec>::InnerZkvm as Zkvm>::Verifier as ZkVerifier>::CodeCommitment::from_hash(
+                    public_outputs.inner_vkey_hash.clone(),
+                ),
+            origin_state_root: public_outputs.origin_state_root.clone(),
+        };
+        self.admin_upgrades.set(&slot, &upgrade, state)?;
+        self.latest_admin_upgrade_slot.set(&slot, state)?;
+
+        tracing::info!(
+            %slot,
+            ?public_outputs.outer_vk_hash,
+            ?public_outputs.inner_vkey_hash,
+            "Admin upgrade recorded"
+        );
+
+        Ok(())
     }
 
     fn slash_prover(
@@ -337,17 +656,19 @@ impl<S: Spec> ProverIncentives<S> {
             S::Da,
             <S::Storage as Storage>::Root,
         >,
+        ctx: &ProofContext<S>,
+        is_admin: bool,
         state: &mut ST,
     ) -> Result<Option<SlashingReason>, ST::Error> {
-        let expected_genesis_hash = self
-            .chain_state
-            .get_genesis_hash(state)?
-            .expect("The genesis hash should be set at genesis");
+        // The admin prover is allowed to submit proofs that do not match the current
+        // origin state root or inner VK hash; admin upgrades replace the stored values
+        // post-verification.
+        if !is_admin && ctx.expected_origin_state_root != public_outputs.origin_state_root {
+            return Ok(Some(SlashingReason::IncorrectGenesisHash));
+        }
 
-        // We have to check that the genesis hash is valid
-        if expected_genesis_hash != public_outputs.origin_state_root {
-            // TODO #2551
-            //return Ok(Some(SlashingReason::IncorrectGenesisHash));
+        if !is_admin && ctx.expected_inner_vkey_hash != public_outputs.inner_vkey_hash {
+            return Ok(Some(SlashingReason::IncorrectInnerVkeyHash));
         }
 
         // We start with the initial state values

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/event.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/event.rs
@@ -37,6 +37,11 @@ pub enum SlashingReason {
     /// The inner verification key hash committed in the proof does not match the
     /// chain's expected inner code commitment.
     IncorrectInnerVkeyHash,
+
+    /// An admin-submitted upgrade proof targets a slot that is not strictly newer
+    /// than the most recent recorded admin upgrade. Accepting it would rewind the
+    /// canonical commitments.
+    StaleAdminUpgrade,
 }
 
 #[derive(Debug, PartialEq, Clone, schemars::JsonSchema)]

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/genesis.rs
@@ -26,6 +26,8 @@ pub struct ProverIncentivesConfig<S: Spec> {
     pub proving_penalty: S::Gas,
     /// The minimum bond for a prover.
     pub minimum_bond: S::Gas,
+    /// The admin prover address.
+    pub admin: S::Address,
     /// A list of initial provers and their bonded amount.
     pub initial_provers: Vec<(S::Address, Amount)>,
 }
@@ -61,6 +63,7 @@ impl<S: Spec> ProverIncentives<S> {
             self.register_staker(prover, prover, *bond, state)?;
         }
         self.minimum_bond.set(&config.minimum_bond, state)?;
+        self.admin.set(&config.admin, state)?;
 
         Ok(())
     }

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/genesis.rs
@@ -26,8 +26,11 @@ pub struct ProverIncentivesConfig<S: Spec> {
     pub proving_penalty: S::Gas,
     /// The minimum bond for a prover.
     pub minimum_bond: S::Gas,
-    /// The admin prover address.
-    pub admin: S::Address,
+    /// The admin prover address. When `None`, no admin role is configured for this
+    /// deployment and admin-only paths (e.g. genesis-hash bypass, rollup upgrades) are
+    /// inaccessible.
+    #[serde(default)]
+    pub admin: Option<S::Address>,
     /// A list of initial provers and their bonded amount.
     pub initial_provers: Vec<(S::Address, Amount)>,
 }
@@ -63,7 +66,9 @@ impl<S: Spec> ProverIncentives<S> {
             self.register_staker(prover, prover, *bond, state)?;
         }
         self.minimum_bond.set(&config.minimum_bond, state)?;
-        self.admin.set(&config.admin, state)?;
+        if let Some(admin) = &config.admin {
+            self.admin.set(admin, state)?;
+        }
 
         Ok(())
     }

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/lib.rs
@@ -10,17 +10,36 @@ mod registration;
 
 pub use call::*;
 pub use genesis::*;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 use sov_bank::Amount;
 use sov_modules_api::runtime::OperatingMode;
 use sov_modules_api::{
-    AggregatedProofPublicData, Context, DaSpec, Gas, GenesisState, GetGasPrice, ModuleId,
-    ModuleInfo, ModuleRestApi, Spec, StateMap, StateReader, StateValue, TxState,
+    AggregatedProofPublicData, CodeCommitmentFor, Context, DaSpec, Gas, GenesisState, GetGasPrice,
+    ModuleId, ModuleInfo, ModuleRestApi, Spec, StateMap, StateReader, StateValue, TxState,
 };
 use sov_rollup_interface::common::SlotNumber;
+use sov_state::codec::BcsCodec;
 use sov_state::Storage;
 use sov_state::User;
 
 pub use crate::event::Event;
+
+/// A snapshot of the rollup values that an admin upgrade replaces. Stored once per
+/// upgrade, keyed by the proof's `final_slot_number`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "CodeCommitmentFor<S::OuterZkvm>: Serialize, CodeCommitmentFor<S::InnerZkvm>: Serialize, <S::Storage as Storage>::Root: Serialize",
+    deserialize = "CodeCommitmentFor<S::OuterZkvm>: DeserializeOwned, CodeCommitmentFor<S::InnerZkvm>: DeserializeOwned, <S::Storage as Storage>::Root: DeserializeOwned",
+))]
+pub struct AdminUpgrade<S: Spec> {
+    /// The outer code commitment claimed by the admin proof's public outputs.
+    pub outer_code_commitment: CodeCommitmentFor<S::OuterZkvm>,
+    /// The inner code commitment claimed by the admin proof's public outputs.
+    pub inner_code_commitment: CodeCommitmentFor<S::InnerZkvm>,
+    /// The origin state root claimed by the admin proof's public outputs.
+    pub origin_state_root: <S::Storage as Storage>::Root,
+}
 
 /// A new module:
 /// - Must derive `ModuleInfo`
@@ -72,6 +91,17 @@ pub struct ProverIncentives<S: Spec> {
     /// The admin prover address.
     #[state]
     pub admin: StateValue<S::Address>,
+
+    /// History of admin upgrades keyed by the final slot number of the admin proof
+    /// that introduced the upgrade. Each entry carries the new outer + inner code
+    /// commitments and the new origin state root that become canonical from that
+    /// slot onward.
+    #[state]
+    pub admin_upgrades: StateMap<SlotNumber, AdminUpgrade<S>, BcsCodec>,
+
+    /// The final slot number of the most recent admin upgrade.
+    #[state]
+    pub latest_admin_upgrade_slot: StateValue<SlotNumber>,
 }
 
 impl<S: Spec> sov_modules_api::Module for ProverIncentives<S> {

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/lib.rs
@@ -68,6 +68,10 @@ pub struct ProverIncentives<S: Spec> {
     #[allow(clippy::type_complexity)]
     pub latest_proof_succesfully_verified:
         StateValue<AggregatedProofPublicData<S::Address, S::Da, <S::Storage as Storage>::Root>>,
+
+    /// The admin prover address.
+    #[state]
+    pub admin: StateValue<S::Address>,
 }
 
 impl<S: Spec> sov_modules_api::Module for ProverIncentives<S> {

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/admin_upgrade.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/admin_upgrade.rs
@@ -1,0 +1,430 @@
+//! Tests for the admin bypass + upgrade flow in [`ProverIncentives`].
+
+use sov_modules_api::{
+    AggregatedProofPublicData, CodeCommitmentHash, CodeCommitmentTrait, ProofOutcome, Spec,
+};
+use sov_rollup_interface::common::IntoSlotNumber;
+use sov_state::Storage;
+use sov_test_utils::runtime::TestRunner;
+use sov_test_utils::{assert_matches, ProofInput, ProofTestCase, TestProver, TestSpec};
+
+use crate::helpers::{
+    build_proof, consume_gas_tx_for_signer, serialize_proof, setup, TestProverIncentives, RT,
+};
+
+type S = TestSpec;
+
+#[allow(clippy::type_complexity)]
+fn prepare_admin_proof() -> (
+    TestRunner<RT, S>,
+    TestProver<S>,
+    AggregatedProofPublicData<
+        <S as Spec>::Address,
+        <S as Spec>::Da,
+        <<S as Spec>::Storage as Storage>::Root,
+    >,
+) {
+    let (mut runner, prover, other_user) = setup();
+
+    for _ in 0..3 {
+        runner.execute(consume_gas_tx_for_signer(&other_user));
+    }
+
+    let aggregated_proof = runner
+        .query_visible_state(|state| {
+            build_proof(
+                state,
+                1.to_slot_number(),
+                2.to_slot_number(),
+                prover.user_info.address(),
+            )
+        })
+        .unwrap();
+
+    (runner, prover, aggregated_proof)
+}
+
+/// Admin proofs with a new `origin_state_root` are NOT slashed for
+/// `IncorrectGenesisHash` — instead, the new value is recorded as an admin
+/// upgrade keyed by `final_slot_number`, and the pointer advances.
+#[test]
+fn test_admin_bypass_genesis_hash_records_upgrade() {
+    let (mut runner, _prover, mut aggregated_proof) = prepare_admin_proof();
+    // Force origin_state_root to differ from chain_state's genesis hash.
+    aggregated_proof
+        .origin_state_root
+        .clone_from(&aggregated_proof.final_state_root);
+
+    let expected_slot = aggregated_proof.final_slot_number;
+    let expected_origin = aggregated_proof.origin_state_root;
+
+    runner.execute_proof::<TestProverIncentives>(ProofTestCase {
+        input: ProofInput(serialize_proof(aggregated_proof)),
+        assert: Box::new(move |result, state| {
+            assert_matches!(
+                result.proof_receipt.unwrap().outcome,
+                ProofOutcome::Valid { .. }
+            );
+
+            let module = TestProverIncentives::default();
+            assert_eq!(
+                module.latest_admin_upgrade_slot.get(state).unwrap(),
+                Some(expected_slot),
+                "latest_admin_upgrade_slot should advance to the proof's final slot",
+            );
+            let upgrade = module
+                .admin_upgrades
+                .get(&expected_slot, state)
+                .unwrap()
+                .expect("upgrade entry should be recorded at the proof's final slot");
+            assert_eq!(upgrade.origin_state_root, expected_origin);
+        }),
+    });
+}
+
+/// Admin proofs with a new `outer_vk_hash` are NOT slashed for verification
+/// failure — the outer commitment is reconstructed from the claimed hash, the
+/// proof is verified against it, and the new commitment is recorded. This is
+/// the most consequential rotation path: it changes which proofs count as
+/// valid from this slot onward.
+#[test]
+fn test_admin_bypass_outer_vk_hash_records_upgrade() {
+    let (mut runner, _prover, mut aggregated_proof) = prepare_admin_proof();
+    // MockCodeCommitment is 8 bytes wide and zero-pads to 32 in `to_hash`, so we use a
+    // value that round-trips losslessly under from_hash/to_hash.
+    let new_outer_vk_hash = {
+        let mut bytes = vec![0u8; 32];
+        bytes[..8].copy_from_slice(&[0xcd; 8]);
+        CodeCommitmentHash(bytes)
+    };
+    aggregated_proof.outer_vk_hash = new_outer_vk_hash.clone();
+    let expected_slot = aggregated_proof.final_slot_number;
+
+    runner.execute_proof::<TestProverIncentives>(ProofTestCase {
+        input: ProofInput(serialize_proof(aggregated_proof)),
+        assert: Box::new(move |result, state| {
+            assert_matches!(
+                result.proof_receipt.unwrap().outcome,
+                ProofOutcome::Valid { .. }
+            );
+
+            let module = TestProverIncentives::default();
+            assert_eq!(
+                module.latest_admin_upgrade_slot.get(state).unwrap(),
+                Some(expected_slot),
+                "latest_admin_upgrade_slot should advance to the proof's final slot",
+            );
+            let upgrade = module
+                .admin_upgrades
+                .get(&expected_slot, state)
+                .unwrap()
+                .expect("upgrade entry should be recorded at the proof's final slot");
+            assert_eq!(upgrade.outer_code_commitment.to_hash(), new_outer_vk_hash);
+        }),
+    });
+}
+
+/// Admin proofs with a new `inner_vkey_hash` are NOT slashed for
+/// `IncorrectInnerVkeyHash` — instead, the new inner commitment is recorded.
+#[test]
+fn test_admin_bypass_inner_vkey_hash_records_upgrade() {
+    let (mut runner, _prover, mut aggregated_proof) = prepare_admin_proof();
+    // MockCodeCommitment is 8 bytes wide and zero-pads to 32 in `to_hash`, so we use a
+    // value that round-trips losslessly under from_hash/to_hash.
+    let new_inner_vkey_hash = {
+        let mut bytes = vec![0u8; 32];
+        bytes[..8].copy_from_slice(&[0xab; 8]);
+        CodeCommitmentHash(bytes)
+    };
+    aggregated_proof.inner_vkey_hash = new_inner_vkey_hash.clone();
+    let expected_slot = aggregated_proof.final_slot_number;
+
+    runner.execute_proof::<TestProverIncentives>(ProofTestCase {
+        input: ProofInput(serialize_proof(aggregated_proof)),
+        assert: Box::new(move |result, state| {
+            assert_matches!(
+                result.proof_receipt.unwrap().outcome,
+                ProofOutcome::Valid { .. }
+            );
+
+            let module = TestProverIncentives::default();
+            let upgrade = module
+                .admin_upgrades
+                .get(&expected_slot, state)
+                .unwrap()
+                .expect("upgrade entry should be recorded");
+            assert_eq!(upgrade.inner_code_commitment.to_hash(), new_inner_vkey_hash,);
+        }),
+    });
+}
+
+/// An admin proof whose public outputs already match the current effective
+/// values is a normal proof, not an upgrade — no map entry should be added
+/// and the latest-pointer should remain unset.
+#[test]
+fn test_admin_matching_proof_does_not_record_upgrade() {
+    let (mut runner, _prover, aggregated_proof) = prepare_admin_proof();
+    let final_slot = aggregated_proof.final_slot_number;
+
+    runner.execute_proof::<TestProverIncentives>(ProofTestCase {
+        input: ProofInput(serialize_proof(aggregated_proof)),
+        assert: Box::new(move |result, state| {
+            assert_matches!(
+                result.proof_receipt.unwrap().outcome,
+                ProofOutcome::Valid { .. }
+            );
+
+            let module = TestProverIncentives::default();
+            assert_eq!(
+                module.latest_admin_upgrade_slot.get(state).unwrap(),
+                None,
+                "no upgrade should be recorded for a matching admin proof",
+            );
+            assert!(module
+                .admin_upgrades
+                .get(&final_slot, state)
+                .unwrap()
+                .is_none());
+        }),
+    });
+}
+
+/// An admin proof that *would* be an upgrade (its public outputs differ from
+/// current effective values) but whose slot range has already been claimed
+/// (Penalized) must NOT mutate the upgrade history: persisting the upgrade
+/// while the proof itself is rejected would desync chain state from off-chain
+/// prover state across restarts.
+#[test]
+fn test_admin_upgrade_not_recorded_on_penalized_proof() {
+    let (mut runner, prover, mut first_proof) = prepare_admin_proof();
+    // First proof for slots 1->2: a normal (no-op) admin proof that claims the
+    // reward and pins last_claimed_reward to slot 2.
+    runner.execute_proof::<TestProverIncentives>(ProofTestCase {
+        input: ProofInput(serialize_proof(first_proof.clone())),
+        assert: Box::new(move |result, _state| {
+            assert_matches!(
+                result.proof_receipt.unwrap().outcome,
+                ProofOutcome::Valid { .. }
+            );
+        }),
+    });
+
+    // Rebuild the same range with a mutated origin_state_root so the admin
+    // proof looks like an upgrade attempt - but for an already-claimed range,
+    // so `calculate_reward_and_remove` should return Penalized.
+    first_proof
+        .origin_state_root
+        .clone_from(&first_proof.final_state_root);
+    let prover_address = prover.user_info.address();
+    let final_slot = first_proof.final_slot_number;
+
+    runner.execute_proof::<TestProverIncentives>(ProofTestCase {
+        input: ProofInput(serialize_proof(first_proof)),
+        assert: Box::new(move |result, state| {
+            assert_matches!(
+                &result.proof_receipt.unwrap().outcome,
+                ProofOutcome::Invalid(e, _) if matches!(
+                    e,
+                    sov_modules_api::InvalidProofError::ProverPenalized(_)
+                )
+            );
+
+            let module = TestProverIncentives::default();
+            assert_eq!(
+                module.latest_admin_upgrade_slot.get(state).unwrap(),
+                None,
+                "Penalized admin proof must not advance latest_admin_upgrade_slot",
+            );
+            assert!(
+                module
+                    .admin_upgrades
+                    .get(&final_slot, state)
+                    .unwrap()
+                    .is_none(),
+                "Penalized admin proof must not write an admin_upgrades entry",
+            );
+            // The admin is penalized (loses bond), not slashed; they remain
+            // bonded after the deduction.
+            assert!(module
+                .bonded_provers
+                .get(&prover_address, state)
+                .unwrap()
+                .is_some());
+        }),
+    });
+}
+
+/// Once an admin upgrade is accepted, any later-submitted proof whose claimed
+/// range starts before the upgrade slot is stale and must be rejected without
+/// slashing, even if its final slot is newer than the cutoff.
+#[test]
+fn wh() {
+    let (mut runner, prover, mut first_proof) = prepare_admin_proof();
+    first_proof
+        .origin_state_root
+        .clone_from(&first_proof.final_state_root);
+    let upgrade_slot = first_proof.final_slot_number;
+    let first_origin = first_proof.origin_state_root;
+
+    // First admin upgrade succeeds and pins `latest_admin_upgrade_slot` to slot 2.
+    runner.execute_proof::<TestProverIncentives>(ProofTestCase {
+        input: ProofInput(serialize_proof(first_proof)),
+        assert: Box::new(move |result, _state| {
+            assert_matches!(
+                result.proof_receipt.unwrap().outcome,
+                ProofOutcome::Valid { .. }
+            );
+        }),
+    });
+
+    for _ in 0..2 {
+        runner.execute(consume_gas_tx_for_signer(&prover.user_info));
+    }
+
+    // Build a proof that crosses the cutoff. It is syntactically valid but its
+    // claimed range still begins before the accepted upgrade slot, so it should
+    // be rejected as stale before any slashing path runs.
+    let stale_proof = runner
+        .query_visible_state(|state| {
+            build_proof(
+                state,
+                1.to_slot_number(),
+                4.to_slot_number(),
+                prover.user_info.address(),
+            )
+        })
+        .unwrap();
+    let prover_address = prover.user_info.address();
+    let stale_final_slot = stale_proof.final_slot_number;
+    let expected_reason = format!(
+        "Proof range [1, {}] starts before latest admin upgrade slot {}",
+        stale_final_slot, upgrade_slot
+    );
+
+    runner.execute_proof::<TestProverIncentives>(ProofTestCase {
+        input: ProofInput(serialize_proof(stale_proof)),
+        assert: Box::new(move |result, state| {
+            assert_matches!(
+                &result.proof_receipt.unwrap().outcome,
+                ProofOutcome::Invalid(e, _) if matches!(
+                    e,
+                    sov_modules_api::InvalidProofError::PreconditionNotMet(reason)
+                        if reason == &expected_reason
+                )
+            );
+
+            let module = TestProverIncentives::default();
+            assert!(
+                module
+                    .bonded_provers
+                    .get(&prover_address, state)
+                    .unwrap()
+                    .is_some(),
+                "stale pre-upgrade proof must not slash the prover",
+            );
+            assert_eq!(
+                module.latest_admin_upgrade_slot.get(state).unwrap(),
+                Some(upgrade_slot),
+            );
+            let recorded = module
+                .admin_upgrades
+                .get(&upgrade_slot, state)
+                .unwrap()
+                .unwrap();
+            assert_eq!(recorded.origin_state_root, first_origin);
+            assert!(
+                module
+                    .admin_upgrades
+                    .get(&stale_final_slot, state)
+                    .unwrap()
+                    .is_none(),
+                "stale proof must not create a newer upgrade entry",
+            );
+        }),
+    });
+}
+
+/// An admin proof that *would* be an upgrade but targets a `final_slot_number`
+/// that is not strictly newer than the most recent recorded upgrade must be
+/// slashed for `StaleAdminUpgrade`. Accepting it would rewind the canonical
+/// commitments to an older slot, so this path is security-critical.
+#[test]
+fn test_admin_upgrade_at_same_slot_is_slashed() {
+    let (mut runner, prover, mut first_proof) = prepare_admin_proof();
+    first_proof
+        .origin_state_root
+        .clone_from(&first_proof.final_state_root);
+    let upgrade_slot = first_proof.final_slot_number;
+    let first_origin = first_proof.origin_state_root;
+
+    // First admin upgrade pins `latest_admin_upgrade_slot` to `upgrade_slot`.
+    runner.execute_proof::<TestProverIncentives>(ProofTestCase {
+        input: ProofInput(serialize_proof(first_proof)),
+        assert: Box::new(move |result, _state| {
+            assert_matches!(
+                result.proof_receipt.unwrap().outcome,
+                ProofOutcome::Valid { .. }
+            );
+        }),
+    });
+
+    // Build a second admin proof for [upgrade_slot, upgrade_slot]. Its initial
+    // slot satisfies the stale-proof cutoff (>= latest_admin_upgrade_slot), but
+    // its final slot is not strictly newer than the recorded upgrade. Mutating
+    // `outer_vk_hash` makes it look like an upgrade attempt so the stale-slot
+    // check fires.
+    let mut second_proof = runner
+        .query_visible_state(|state| {
+            build_proof(
+                state,
+                upgrade_slot,
+                upgrade_slot,
+                prover.user_info.address(),
+            )
+        })
+        .unwrap();
+    second_proof.outer_vk_hash = {
+        let mut bytes = vec![0u8; 32];
+        bytes[..8].copy_from_slice(&[0xef; 8]);
+        CodeCommitmentHash(bytes)
+    };
+    let prover_address = prover.user_info.address();
+
+    runner.execute_proof::<TestProverIncentives>(ProofTestCase {
+        input: ProofInput(serialize_proof(second_proof)),
+        assert: Box::new(move |result, state| {
+            assert_matches!(
+                &result.proof_receipt.unwrap().outcome,
+                ProofOutcome::Invalid(e, _) if matches!(
+                    e,
+                    sov_modules_api::InvalidProofError::ProverSlashed(reason)
+                        if reason == "Invalid output StaleAdminUpgrade"
+                )
+            );
+
+            let module = TestProverIncentives::default();
+            assert!(
+                module
+                    .bonded_provers
+                    .get(&prover_address, state)
+                    .unwrap()
+                    .is_none(),
+                "admin must be slashed on a stale upgrade attempt",
+            );
+            assert_eq!(
+                module.latest_admin_upgrade_slot.get(state).unwrap(),
+                Some(upgrade_slot),
+                "stale upgrade must not advance latest_admin_upgrade_slot",
+            );
+            let recorded = module
+                .admin_upgrades
+                .get(&upgrade_slot, state)
+                .unwrap()
+                .expect("first upgrade should still be recorded");
+            assert_eq!(
+                recorded.origin_state_root, first_origin,
+                "first upgrade's recorded origin must not be overwritten",
+            );
+        }),
+    });
+}

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
@@ -101,7 +101,10 @@ pub(crate) fn build_proof(
     Ok(AggregatedProofPublicData {
         initial_slot_number: initial_slot,
         final_slot_number: end_slot,
-        initial_state_root: genesis_hash,
+        // For slot 1 this equals `genesis_hash`; for later slots it's the post-state of the
+        // previous slot. Reading it from the initial transition keeps the helper correct
+        // for any `initial_slot`, not just slot 1.
+        initial_state_root: *initial_transition.prev_state_root(),
         origin_slot_number: SlotNumber::GENESIS,
         origin_state_root: genesis_hash,
         final_state_root: *end_transition.post_state_root(),

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/main.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/main.rs
@@ -1,5 +1,7 @@
+mod admin_upgrade;
 mod bond;
 mod helpers;
+mod non_admin_proof;
 mod proofs;
 mod slashing;
 mod wallet;

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/non_admin_proof.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/non_admin_proof.rs
@@ -1,0 +1,151 @@
+//! Tests for the non-admin proof submission path in [`ProverIncentives`].
+//!
+//! These exercise the slashing checks that the admin role bypasses: when
+//! `prover_incentives.admin` is unset, the sequencer who submits proofs is
+//! treated like any other prover and is slashed on output mismatches.
+
+use sov_modules_api::{CodeCommitmentHash, InvalidProofError, ProofOutcome};
+use sov_rollup_interface::common::IntoSlotNumber;
+use sov_test_utils::runtime::genesis::zk::config::HighLevelZkGenesisConfig;
+use sov_test_utils::runtime::genesis::zk::MinimalZkGenesisConfig;
+use sov_test_utils::runtime::TestRunner;
+use sov_test_utils::{assert_matches, ProofInput, ProofTestCase, TestProver, TestSpec, TestUser};
+use sov_value_setter::ValueSetterConfig;
+
+use crate::helpers::{
+    build_proof, consume_gas_tx_for_signer, serialize_proof, TestProverIncentives, RT,
+};
+
+type S = TestSpec;
+
+fn setup_without_admin() -> (TestRunner<RT, S>, TestProver<S>, TestUser<S>) {
+    let high_level = HighLevelZkGenesisConfig::<S>::generate_with_additional_accounts(1);
+    let unbonded_user = high_level.additional_accounts().first().unwrap().clone();
+    let prover = high_level.initial_prover.clone();
+
+    let mut minimal: MinimalZkGenesisConfig<S> = high_level.into();
+    minimal.config.prover_incentives.admin = None;
+
+    let genesis_config = crate::helpers::GenesisConfig::from_minimal_config(
+        minimal,
+        ValueSetterConfig {
+            admin: prover.user_info.address(),
+        },
+    );
+    let runner = TestRunner::new_with_genesis(
+        genesis_config.into_genesis_params(),
+        crate::helpers::TestRuntime::default(),
+    );
+
+    (runner, prover, unbonded_user)
+}
+
+/// A proof whose `origin_state_root` differs from chain_state's genesis hash
+/// must be slashed for `IncorrectGenesisHash`, and no admin upgrade entry
+/// should be recorded.
+#[test]
+fn test_non_admin_invalid_genesis_hash_slashed() {
+    let (mut runner, prover, other_user) = setup_without_admin();
+    for _ in 0..3 {
+        runner.execute(consume_gas_tx_for_signer(&other_user));
+    }
+    let mut aggregated_proof = runner
+        .query_visible_state(|state| {
+            build_proof(
+                state,
+                1.to_slot_number(),
+                2.to_slot_number(),
+                prover.user_info.address(),
+            )
+        })
+        .unwrap();
+
+    aggregated_proof
+        .origin_state_root
+        .clone_from(&aggregated_proof.final_state_root);
+
+    let prover_address = prover.user_info.address();
+    let final_slot = aggregated_proof.final_slot_number;
+
+    runner.execute_proof::<TestProverIncentives>(ProofTestCase {
+        input: ProofInput(serialize_proof(aggregated_proof)),
+        assert: Box::new(move |result, state| {
+            assert_matches!(
+                &result.proof_receipt.unwrap().outcome,
+                ProofOutcome::Invalid(e, _) if matches!(
+                    e,
+                    InvalidProofError::ProverSlashed(reason)
+                        if reason == "Invalid output IncorrectGenesisHash"
+                )
+            );
+
+            let module = TestProverIncentives::default();
+            assert!(
+                module
+                    .bonded_provers
+                    .get(&prover_address, state)
+                    .unwrap()
+                    .is_none(),
+                "non-admin should be removed from bonded_provers on slash",
+            );
+            assert_eq!(
+                module.latest_admin_upgrade_slot.get(state).unwrap(),
+                None,
+                "no upgrade should be recorded when the sender is not the admin",
+            );
+            assert!(module
+                .admin_upgrades
+                .get(&final_slot, state)
+                .unwrap()
+                .is_none());
+        }),
+    });
+}
+
+/// A proof whose `inner_vkey_hash` differs from chain_state's inner code
+/// commitment must be slashed for `IncorrectInnerVkeyHash`.
+#[test]
+fn test_non_admin_invalid_inner_vkey_hash_slashed() {
+    let (mut runner, prover, other_user) = setup_without_admin();
+    for _ in 0..3 {
+        runner.execute(consume_gas_tx_for_signer(&other_user));
+    }
+    let mut aggregated_proof = runner
+        .query_visible_state(|state| {
+            build_proof(
+                state,
+                1.to_slot_number(),
+                2.to_slot_number(),
+                prover.user_info.address(),
+            )
+        })
+        .unwrap();
+
+    aggregated_proof.inner_vkey_hash = {
+        let mut bytes = vec![0u8; 32];
+        bytes[..8].copy_from_slice(&[0xab; 8]);
+        CodeCommitmentHash(bytes)
+    };
+    let prover_address = prover.user_info.address();
+
+    runner.execute_proof::<TestProverIncentives>(ProofTestCase {
+        input: ProofInput(serialize_proof(aggregated_proof)),
+        assert: Box::new(move |result, state| {
+            assert_matches!(
+                &result.proof_receipt.unwrap().outcome,
+                ProofOutcome::Invalid(e, _) if matches!(
+                    e,
+                    InvalidProofError::ProverSlashed(reason)
+                        if reason == "Invalid output IncorrectInnerVkeyHash"
+                )
+            );
+
+            let module = TestProverIncentives::default();
+            assert!(module
+                .bonded_provers
+                .get(&prover_address, state)
+                .unwrap()
+                .is_none());
+        }),
+    });
+}

--- a/crates/module-system/module-schemas/genesis-schemas/sov-prover-incentives.json
+++ b/crates/module-system/module-schemas/genesis-schemas/sov-prover-incentives.json
@@ -5,8 +5,16 @@
   "type": "object",
   "properties": {
     "admin": {
-      "description": "The admin prover address.",
-      "$ref": "#/$defs/Address"
+      "description": "The admin prover address. When `None`, no admin role is configured for this\ndeployment and admin-only paths (e.g. genesis-hash bypass, rollup upgrades) are\ninaccessible.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Address"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
     },
     "initial_provers": {
       "description": "A list of initial provers and their bonded amount.",
@@ -38,7 +46,6 @@
   "required": [
     "proving_penalty",
     "minimum_bond",
-    "admin",
     "initial_provers"
   ],
   "$defs": {

--- a/crates/module-system/module-schemas/genesis-schemas/sov-prover-incentives.json
+++ b/crates/module-system/module-schemas/genesis-schemas/sov-prover-incentives.json
@@ -4,6 +4,10 @@
   "description": "Configuration of the prover incentives module. Specifies the minimum bond, the commitment to\nthe allowed verifier method and a set of initial provers with their\nbonding amount.",
   "type": "object",
   "properties": {
+    "admin": {
+      "description": "The admin prover address.",
+      "$ref": "#/$defs/Address"
+    },
     "initial_provers": {
       "description": "A list of initial provers and their bonded amount.",
       "type": "array",
@@ -34,6 +38,7 @@
   "required": [
     "proving_penalty",
     "minimum_bond",
+    "admin",
     "initial_provers"
   ],
   "$defs": {

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -51,6 +51,13 @@ impl Default for CodeCommitmentHash {
 }
 
 impl CodeCommitmentHash {
+    /// Canonical byte length expected by every [`crate::zk::CodeCommitmentTrait`]
+    /// implementation. Concrete adapters (Risc0, SP1) panic in [`Self::to_u32_array`]
+    /// when this invariant is violated, so callers reading hashes from untrusted
+    /// sources should reject mismatched lengths before invoking
+    /// [`crate::zk::CodeCommitmentTrait::from_hash`].
+    pub const HASH_LEN: usize = 32;
+
     /// Creates a [`CodeCommitmentHash`] from a `[u32; 8]` array using big-endian byte order.
     /// This matches the representation used by SP1's `HashableKey::hash_bytes`.
     pub fn from_u32_array(arr: [u32; 8]) -> Self {

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -156,6 +156,18 @@ pub trait ZkVerifier: Default + Clone + Send + Sync + 'static {
         serialized_proof: &SerializedZkProof,
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error>;
+
+    /// Deserialize the claimed public outputs from a serialized proof WITHOUT performing
+    /// cryptographic verification.
+    ///
+    /// The returned value reflects only what the prover *claims* the outputs are. It must
+    /// be treated as untrusted until a corresponding [`Self::verify_with_proof`] call
+    /// succeeds against an appropriate code commitment. Useful when the caller needs the
+    /// claimed outputs to decide which code commitment to verify against (e.g. admin-
+    /// initiated rollup upgrades where the verification key itself is being rotated).
+    fn extract_public_data<T: DeserializeOwned>(
+        serialized_proof: &SerializedZkProof,
+    ) -> Result<T, Self::Error>;
 }
 
 /// A trait which is accessible from within a zkVM program.

--- a/crates/utils/sov-test-utils/src/runtime/genesis/operator/mod.rs
+++ b/crates/utils/sov-test-utils/src/runtime/genesis/operator/mod.rs
@@ -147,6 +147,7 @@ impl<S: Spec> MinimalOperatorGenesisConfig<S> {
                 prover_incentives: ProverIncentivesConfig {
                     minimum_bond: default_user_stake,
                     proving_penalty: { default_user_stake.scalar_division(2) },
+                    admin: placeholder.address(),
                     initial_provers: vec![(placeholder.address(), placeholder.balance())],
                 },
 

--- a/crates/utils/sov-test-utils/src/runtime/genesis/operator/mod.rs
+++ b/crates/utils/sov-test-utils/src/runtime/genesis/operator/mod.rs
@@ -147,7 +147,7 @@ impl<S: Spec> MinimalOperatorGenesisConfig<S> {
                 prover_incentives: ProverIncentivesConfig {
                     minimum_bond: default_user_stake,
                     proving_penalty: { default_user_stake.scalar_division(2) },
-                    admin: placeholder.address(),
+                    admin: Some(placeholder.address()),
                     initial_provers: vec![(placeholder.address(), placeholder.balance())],
                 },
 

--- a/crates/utils/sov-test-utils/src/runtime/genesis/optimistic/config.rs
+++ b/crates/utils/sov-test-utils/src/runtime/genesis/optimistic/config.rs
@@ -248,7 +248,7 @@ impl<S: Spec> MinimalOptimisticGenesisConfig<S> {
                 prover_incentives: ProverIncentivesConfig {
                     minimum_bond: default_user_stake,
                     proving_penalty: { default_user_stake.scalar_division(2) },
-                    admin: placeholder.address(),
+                    admin: Some(placeholder.address()),
                     initial_provers: vec![(placeholder.address(), placeholder.balance())],
                 },
 

--- a/crates/utils/sov-test-utils/src/runtime/genesis/optimistic/config.rs
+++ b/crates/utils/sov-test-utils/src/runtime/genesis/optimistic/config.rs
@@ -248,6 +248,7 @@ impl<S: Spec> MinimalOptimisticGenesisConfig<S> {
                 prover_incentives: ProverIncentivesConfig {
                     minimum_bond: default_user_stake,
                     proving_penalty: { default_user_stake.scalar_division(2) },
+                    admin: placeholder.address(),
                     initial_provers: vec![(placeholder.address(), placeholder.balance())],
                 },
 

--- a/crates/utils/sov-test-utils/src/runtime/genesis/optimistic/tests.rs
+++ b/crates/utils/sov-test-utils/src/runtime/genesis/optimistic/tests.rs
@@ -160,7 +160,7 @@ fn create_test_rt_genesis_config<S: Spec>(
         prover_incentives: ProverIncentivesConfig {
             minimum_bond: user_stake,
             proving_penalty: { user_stake.scalar_division(2) },
-            admin: prover_placeholder.address(),
+            admin: Some(prover_placeholder.address()),
             initial_provers: vec![(prover_placeholder.address(), prover_placeholder.balance())],
         },
         bank: BankConfig {

--- a/crates/utils/sov-test-utils/src/runtime/genesis/optimistic/tests.rs
+++ b/crates/utils/sov-test-utils/src/runtime/genesis/optimistic/tests.rs
@@ -160,6 +160,7 @@ fn create_test_rt_genesis_config<S: Spec>(
         prover_incentives: ProverIncentivesConfig {
             minimum_bond: user_stake,
             proving_penalty: { user_stake.scalar_division(2) },
+            admin: prover_placeholder.address(),
             initial_provers: vec![(prover_placeholder.address(), prover_placeholder.balance())],
         },
         bank: BankConfig {

--- a/crates/utils/sov-test-utils/src/runtime/genesis/zk/config.rs
+++ b/crates/utils/sov-test-utils/src/runtime/genesis/zk/config.rs
@@ -170,7 +170,7 @@ impl<S: Spec> MinimalZkGenesisConfig<S> {
                 prover_incentives: ProverIncentivesConfig {
                     minimum_bond: default_user_stake,
                     proving_penalty: { default_user_stake.scalar_division(2) },
-                    admin: initial_prover.as_user().address(),
+                    admin: Some(initial_prover.as_user().address()),
                     initial_provers: vec![(
                         initial_prover.as_user().address(),
                         initial_prover.bond,

--- a/crates/utils/sov-test-utils/src/runtime/genesis/zk/config.rs
+++ b/crates/utils/sov-test-utils/src/runtime/genesis/zk/config.rs
@@ -170,6 +170,7 @@ impl<S: Spec> MinimalZkGenesisConfig<S> {
                 prover_incentives: ProverIncentivesConfig {
                     minimum_bond: default_user_stake,
                     proving_penalty: { default_user_stake.scalar_division(2) },
+                    admin: initial_prover.as_user().address(),
                     initial_provers: vec![(
                         initial_prover.as_user().address(),
                         initial_prover.bond,

--- a/examples/test-data/genesis/demo/celestia/prover_incentives.json
+++ b/examples/test-data/genesis/demo/celestia/prover_incentives.json
@@ -1,6 +1,7 @@
 {
     "proving_penalty": [10, 10],
     "minimum_bond": [1000, 1000],
+    "admin": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
     "initial_provers": [
         [
             "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",

--- a/examples/test-data/genesis/demo/mock/prover_incentives.json
+++ b/examples/test-data/genesis/demo/mock/prover_incentives.json
@@ -1,6 +1,7 @@
 {
     "proving_penalty": [10, 10],
     "minimum_bond": [1000, 1000],
+    "admin": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
     "initial_provers": [
         [
             "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",

--- a/examples/test-data/genesis/integration-tests/prover_incentives.json
+++ b/examples/test-data/genesis/integration-tests/prover_incentives.json
@@ -1,6 +1,7 @@
 {
     "proving_penalty": [10, 10],
     "minimum_bond": [1000, 1000],
+    "admin": "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
     "initial_provers": [
         [
             "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",


### PR DESCRIPTION
# Description

This PR introduces an `admin prover` role in `sov-prover-incentives` that can:
The most relevant changes are in `sov-prover-incentives/capabilities`.

  1. Bypass the `IncorrectGenesisHash` and `IncorrectInnerVkeyHash` slashing checks.
  2. Trigger rollup upgrades by submitting a proof whose `outer_vk_hash`, `inner_vkey_hash`, or `origin_state_root` differs from the current effective values. The new values are recorded as an `AdminUpgrade` keyed by final_slot_number, becoming canonical for subsequent proofs.
  3. Rotate the outer verification key — the admin's claimed `outer_vk_hash` is reconstructed via CodeCommitmentTrait::from_hash and the proof is verified against that commitment (rather than the chain-state one).

  Supporting infrastructure: a new `ZkVerifier::extract_public_data` method (extracts public outputs without cryptographic verification) plus implementations for MockZkVerifier, Risc0Verifier, SP1Verifier. Two new integration test modules with thorough coverage.


- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551
