### PR TITLE
chore: do not build ZKVM guest in `check` job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,6 +105,8 @@ jobs:
     timeout-minutes: 60
     env:
       RUSTFLAGS: "-D warnings"
+      SKIP_GUEST_BUILD: "1"
+      SP1_SKIP_PROGRAM_BUILD: "true"
     steps:
       - uses: actions/checkout@v5
       - uses: namespacelabs/nscloud-cache-action@v1


### PR DESCRIPTION
# Description

So whole CI pipeline is faster.

Errors should be covered by:

* cargo hack covers clippy warnings
* README test will cover actual ZKVM compilation issues, such as native not supported calls to socket or fs.



- [x] Internal CI only change. ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All tests are passing

## Docs
No updates
