### PR TITLE
Remove hash gas charging from sig verification gas charges

### DIFF
--- a/crates/module-system/sov-modules-api/src/gas/metered_utils.rs
+++ b/crates/module-system/sov-modules-api/src/gas/metered_utils.rs
@@ -199,21 +199,6 @@ fn charge_gas_for_sig_inner<GU: Gas, Meter: GasMeter<Spec: Spec<Gas = GU>>>(
         )
         .map_err(MeteredSigVerificationError::GasError)?;
 
-    meter
-        .charge_gas(<Meter::Spec as GasSpec>::gas_to_charge_hash_update())
-        .map_err(MeteredSigVerificationError::GasError)?;
-
-    meter
-        .charge_linear_gas(
-            <Meter::Spec as GasSpec>::gas_to_charge_per_byte_hash_update(),
-            msg_len.try_into().map_err(|e: TryFromIntError| {
-                MeteredSigVerificationError::GasError(MeteringError::<Meter>::Overflow(
-                    e.to_string(),
-                ))
-            })?,
-        )
-        .map_err(MeteredSigVerificationError::GasError)?;
-
     Ok(())
 }
 

--- a/crates/module-system/sov-modules-api/src/gas/tests/metered_utils.rs
+++ b/crates/module-system/sov-modules-api/src/gas/tests/metered_utils.rs
@@ -101,14 +101,6 @@ fn test_metered_signature() {
                 .unwrap(),
         )
         .unwrap()
-        .checked_combine(S::gas_to_charge_hash_update())
-        .unwrap()
-        .checked_combine(
-            S::gas_to_charge_per_byte_hash_update()
-                .checked_scalar_product(TEST_DATA.len() as u64)
-                .unwrap(),
-        )
-        .unwrap()
         .value(TEST_GAS_PRICE);
 
     let mut ws = create_working_set(remaining_funds, &TEST_GAS_PRICE);


### PR DESCRIPTION
# Description

Removes charging gas for hashing from signature verification. The gas charged for signature verification hashing will be included in the signature verification gas costs.

This change is needed because the hasher defined on `CryptoSpec` might not match the one used by the sig scheme, i.e we currently use Sha256 by default but ed25519 uses Sha512. And to a lesser extent, makes setting gas constants for sig verification easier because we dont need to subtract the hashing gas cost constant

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2846

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
