### PR TITLE
Versioned state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Temporary section for maintaining breaking changes from individual PRs, which wi
   * The `UnsignedTransaction` type, and multiple member methods of `Transaction`, have changed. Our client SDKs have been updated, but for users manually constructing an UnsignedTransaction in Rust, we recommend explicitly using `UnsignedTransactionV0`. For creating a multisig, use `UnsignedTransactionV0::to_multisig_tx()`.
   * The CHAIN_HASH has changed.
   * The `Generation` uniqueness (replay protection) mechanism has been amended to fix a transaction hash malleability vulnerability with V1 transactions. New, non-malleable hashes are used to prevent replay. **If the rollup has had public V1 transactions submitted**, a migration script must increment the current generation of every user that has submitted a V1 transaction by `PAST_TRANSACTION_GENERATIONS` to invalidate prior existing hashes. No action is needed if there are no users with a prior V1 submission.
+  * Hard fork version tracking: a new `chain_state.state_version` state item has been added, and a corresponding `STATE_VERSION` entry in constants.toml. These must match for the rollup to start. The binary `STATE_VERSION` will be incremented on breaking hard forks. On genesis, the state value must be initialised to the starting rollup binary's version, and it will subsequently be incremented by migrations between versions.
 
 # 2026-04-01
 - #2670 **Breaking change** Remove `InnerVm` and `OuterVm` generic type parameters from `StateTransitionFunction` trait and all downstream types.

--- a/constants.testing.toml
+++ b/constants.testing.toml
@@ -9,6 +9,7 @@ freeze = [1, 1]
 # We use the ID 4321 for demo purposes. Change this value before deploying!
 CHAIN_ID = 4321
 CHAIN_NAME = "TestChain"
+STATE_VERSION = 1
 CHAIN_HASH_OVERRIDES = []
 # The number of bytes a transaction can have.
 MAX_TX_SIZE=1_048_576

--- a/constants.toml
+++ b/constants.toml
@@ -10,6 +10,9 @@ freeze = [1, 1]
 # We use the ID 4321 for demo purposes. Change this value before deploying!
 CHAIN_ID = 4321
 CHAIN_NAME = "TestChain"
+# The global on-chain state schema version expected by this binary.
+# Increment this whenever an SDK upgrade requires an out-of-band state migration.
+STATE_VERSION = 1
 
 # Chain hash overrides by rollup block height range.
 # When the rollup schema changes (e.g., adding a new transaction type), the CHAIN_HASH changes.

--- a/constants.toml
+++ b/constants.toml
@@ -10,7 +10,9 @@ freeze = [1, 1]
 # We use the ID 4321 for demo purposes. Change this value before deploying!
 CHAIN_ID = 4321
 CHAIN_NAME = "TestChain"
-# The global on-chain state schema version expected by this binary.
+# The global on-chain Sovereign state version expected by this binary.
+# This must match the `sov_chain_state::state_version` value in the current on-disk state. The compiled
+# rollup will refuse to run if there is a mismatch.
 # Increment this whenever an SDK upgrade requires an out-of-band state migration.
 STATE_VERSION = 1
 

--- a/crates/module-system/module-implementations/sov-chain-state/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/genesis.rs
@@ -32,17 +32,13 @@ pub struct ChainStateConfig<S: Spec> {
     /// The height of the first DA block.
     pub genesis_da_height: u64,
 
-    /// The global on-chain state schema version.
-    #[serde(default = "default_state_version")]
+    /// The version of Sovereign SDK consensus the rollup will run at genesis.
+    #[serde(default)]
     pub state_version: u64,
 
     /// The admin address. This address is allowed to terminate setup mode early.
     #[serde(default)]
     pub admin: Option<S::Address>,
-}
-
-fn default_state_version() -> u64 {
-    0
 }
 
 impl<S: Spec> ChainState<S> {

--- a/crates/module-system/module-implementations/sov-chain-state/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/genesis.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use sov_modules_api::capabilities::RollupHeight;
 use sov_modules_api::da::{BlockHeaderTrait, Time};
+use sov_modules_api::macros::config_value;
 use sov_modules_api::{
     CodeCommitmentFor, DaSpec, Gas, GasSpec, GenesisState, Module, OperatingMode, Spec,
 };
@@ -32,9 +33,17 @@ pub struct ChainStateConfig<S: Spec> {
     /// The height of the first DA block.
     pub genesis_da_height: u64,
 
+    /// The global on-chain state schema version.
+    #[serde(default = "default_state_version")]
+    pub state_version: u64,
+
     /// The admin address. This address is allowed to terminate setup mode early.
     #[serde(default)]
     pub admin: Option<S::Address>,
+}
+
+fn default_state_version() -> u64 {
+    config_value!("STATE_VERSION")
 }
 
 impl<S: Spec> ChainState<S> {
@@ -48,6 +57,7 @@ impl<S: Spec> ChainState<S> {
             current_time = ?config.current_time,
             operating_mode = ?config.operating_mode,
             genesis_da_height = %config.genesis_da_height,
+            state_version = %config.state_version,
             inner_code_commitment = ?config.inner_code_commitment,
             outer_code_commitment = ?config.outer_code_commitment,
             admin = ?config.admin,
@@ -88,6 +98,8 @@ impl<S: Spec> ChainState<S> {
 
         self.genesis_da_height
             .set(&config.genesis_da_height, state)?;
+
+        self.state_version.set(&config.state_version, state)?;
 
         self.slots.set_true_current(
             &SlotInformation::new(

--- a/crates/module-system/module-implementations/sov-chain-state/src/genesis.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/genesis.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use sov_modules_api::capabilities::RollupHeight;
 use sov_modules_api::da::{BlockHeaderTrait, Time};
-use sov_modules_api::macros::config_value;
 use sov_modules_api::{
     CodeCommitmentFor, DaSpec, Gas, GasSpec, GenesisState, Module, OperatingMode, Spec,
 };
@@ -43,7 +42,7 @@ pub struct ChainStateConfig<S: Spec> {
 }
 
 fn default_state_version() -> u64 {
-    config_value!("STATE_VERSION")
+    0
 }
 
 impl<S: Spec> ChainState<S> {

--- a/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -256,6 +256,12 @@ pub struct ChainState<S: Spec> {
     /// The current time in nanoseconds, as reported by the timing oracle.
     #[state]
     oracle_time_nanos: StateValue<u128>,
+
+    /// The global on-chain state schema version.
+    ///
+    /// This value is appended to preserve the discriminants of existing chain-state items.
+    #[state]
+    state_version: StateValue<u64>,
 }
 
 impl<S: Spec> ChainState<S> {
@@ -463,6 +469,16 @@ impl<S: Spec> ChainState<S> {
         state: &mut Accessor,
     ) -> Result<Option<u64>, <Accessor as StateReader<User>>::Error> {
         self.genesis_da_height.get(state)
+    }
+
+    /// Return the global on-chain state schema version.
+    ///
+    /// Existing state created before this field was introduced defaults to version 0.
+    pub fn state_version<Accessor: StateReader<User>>(
+        &self,
+        state: &mut Accessor,
+    ) -> Result<u64, Accessor::Error> {
+        Ok(self.state_version.get(state)?.unwrap_or(0))
     }
 
     /// Returns the last visible slot processed by the module.

--- a/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -42,6 +42,8 @@ use sov_modules_api::{DaSpec, Gas, KernelStateValue, Module, StateValue, Version
 use sov_rollup_interface::common::{SlotNumber, VisibleSlotNumber};
 use sov_state::codec::BcsCodec;
 use sov_state::namespaces::Kernel;
+#[cfg(feature = "native")]
+use sov_state::Accessory;
 use sov_state::{Storage, User};
 use tracing::trace;
 
@@ -261,7 +263,7 @@ pub struct ChainState<S: Spec> {
     /// This value is incremented on hard forks of the Sovereign SDK. It is used to ensure that
     /// versioned rollup binaries match the on-disk state corresponding to their consensus version.
     #[state]
-    state_version: StateValue<u64>,
+    state_version: AccessoryStateValue<u64>,
 }
 
 impl<S: Spec> ChainState<S> {
@@ -474,7 +476,8 @@ impl<S: Spec> ChainState<S> {
     /// Return the global on-chain state schema version.
     ///
     /// Existing state created before this field was introduced defaults to version 0.
-    pub fn state_version<Accessor: StateReader<User>>(
+    #[cfg(feature = "native")]
+    pub fn state_version<Accessor: StateReader<Accessory>>(
         &self,
         state: &mut Accessor,
     ) -> Result<u64, Accessor::Error> {

--- a/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -42,8 +42,6 @@ use sov_modules_api::{DaSpec, Gas, KernelStateValue, Module, StateValue, Version
 use sov_rollup_interface::common::{SlotNumber, VisibleSlotNumber};
 use sov_state::codec::BcsCodec;
 use sov_state::namespaces::Kernel;
-#[cfg(feature = "native")]
-use sov_state::Accessory;
 use sov_state::{Storage, User};
 use tracing::trace;
 
@@ -477,7 +475,7 @@ impl<S: Spec> ChainState<S> {
     ///
     /// Existing state created before this field was introduced defaults to version 0.
     #[cfg(feature = "native")]
-    pub fn state_version<Accessor: StateReader<Accessory>>(
+    pub fn state_version<Accessor: StateReader<sov_state::Accessory>>(
         &self,
         state: &mut Accessor,
     ) -> Result<u64, Accessor::Error> {

--- a/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -257,9 +257,9 @@ pub struct ChainState<S: Spec> {
     #[state]
     oracle_time_nanos: StateValue<u128>,
 
-    /// The global on-chain state schema version.
-    ///
-    /// This value is appended to preserve the discriminants of existing chain-state items.
+    /// The global Sovereign SDK version of the rollup.
+    /// This value is incremented on hard forks of the Sovereign SDK. It is used to ensure that
+    /// versioned rollup binaries match the on-disk state corresponding to their consensus version.
     #[state]
     state_version: StateValue<u64>,
 }

--- a/crates/module-system/module-implementations/sov-chain-state/src/tests/config.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/tests/config.rs
@@ -1,5 +1,4 @@
 use sov_modules_api::da::Time;
-use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::serde_json;
 use sov_test_utils::TestSpec;
 
@@ -12,7 +11,7 @@ fn test_config_serialization() {
         current_time: time,
         operating_mode: OperatingMode::Zk,
         genesis_da_height: 0,
-        state_version: config_value!("STATE_VERSION"),
+        state_version: 0,
         inner_code_commitment: Default::default(),
         outer_code_commitment: Default::default(),
         admin: None,

--- a/crates/module-system/module-implementations/sov-chain-state/src/tests/config.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/tests/config.rs
@@ -1,4 +1,5 @@
 use sov_modules_api::da::Time;
+use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::serde_json;
 use sov_test_utils::TestSpec;
 
@@ -11,6 +12,7 @@ fn test_config_serialization() {
         current_time: time,
         operating_mode: OperatingMode::Zk,
         genesis_da_height: 0,
+        state_version: config_value!("STATE_VERSION"),
         inner_code_commitment: Default::default(),
         outer_code_commitment: Default::default(),
         admin: None,

--- a/crates/module-system/sov-kernels/src/basic.rs
+++ b/crates/module-system/sov-kernels/src/basic.rs
@@ -16,8 +16,6 @@ use sov_modules_api::{
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::RelevantBlobIters;
 use sov_rollup_interface::stf::DiscardedBlob;
-#[cfg(feature = "native")]
-use sov_state::Accessory;
 use sov_state::{Kernel, Storage, User};
 
 /// The simplest imaginable kernel. It does not do any batching or reordering of blobs.
@@ -227,7 +225,7 @@ impl<S: Spec> sov_modules_api::capabilities::ChainState for BasicKernel<'_, S> {
     }
 
     #[cfg(feature = "native")]
-    fn state_version<Reader: StateReader<Accessory, Error = Infallible>>(
+    fn state_version<Reader: StateReader<sov_state::Accessory, Error = Infallible>>(
         &self,
         state: &mut Reader,
     ) -> u64 {

--- a/crates/module-system/sov-kernels/src/basic.rs
+++ b/crates/module-system/sov-kernels/src/basic.rs
@@ -16,6 +16,8 @@ use sov_modules_api::{
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::RelevantBlobIters;
 use sov_rollup_interface::stf::DiscardedBlob;
+#[cfg(feature = "native")]
+use sov_state::Accessory;
 use sov_state::{Kernel, Storage, User};
 
 /// The simplest imaginable kernel. It does not do any batching or reordering of blobs.
@@ -224,7 +226,8 @@ impl<S: Spec> sov_modules_api::capabilities::ChainState for BasicKernel<'_, S> {
         self.chain_state.operating_mode(state).unwrap_infallible()
     }
 
-    fn state_version<Reader: StateReader<User, Error = Infallible>>(
+    #[cfg(feature = "native")]
+    fn state_version<Reader: StateReader<Accessory, Error = Infallible>>(
         &self,
         state: &mut Reader,
     ) -> u64 {

--- a/crates/module-system/sov-kernels/src/basic.rs
+++ b/crates/module-system/sov-kernels/src/basic.rs
@@ -224,6 +224,13 @@ impl<S: Spec> sov_modules_api::capabilities::ChainState for BasicKernel<'_, S> {
         self.chain_state.operating_mode(state).unwrap_infallible()
     }
 
+    fn state_version<Reader: StateReader<User, Error = Infallible>>(
+        &self,
+        state: &mut Reader,
+    ) -> u64 {
+        self.chain_state.state_version(state).unwrap_infallible()
+    }
+
     #[cfg(feature = "native")]
     fn test_only_set_rollup_height_for_genesis(
         &mut self,

--- a/crates/module-system/sov-kernels/src/soft_confirmations.rs
+++ b/crates/module-system/sov-kernels/src/soft_confirmations.rs
@@ -14,8 +14,6 @@ use sov_modules_api::{
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::RelevantBlobIters;
 use sov_rollup_interface::stf::DiscardedBlob;
-#[cfg(feature = "native")]
-use sov_state::Accessory;
 use sov_state::{Kernel, Storage, User};
 use std::convert::Infallible;
 
@@ -217,7 +215,7 @@ impl<S: Spec> sov_modules_api::capabilities::ChainState for SoftConfirmationsKer
     }
 
     #[cfg(feature = "native")]
-    fn state_version<Reader: StateReader<Accessory, Error = Infallible>>(
+    fn state_version<Reader: StateReader<sov_state::Accessory, Error = Infallible>>(
         &self,
         state: &mut Reader,
     ) -> u64 {

--- a/crates/module-system/sov-kernels/src/soft_confirmations.rs
+++ b/crates/module-system/sov-kernels/src/soft_confirmations.rs
@@ -214,6 +214,13 @@ impl<S: Spec> sov_modules_api::capabilities::ChainState for SoftConfirmationsKer
         self.chain_state.operating_mode(state).unwrap_infallible()
     }
 
+    fn state_version<Reader: StateReader<User, Error = Infallible>>(
+        &self,
+        state: &mut Reader,
+    ) -> u64 {
+        self.chain_state.state_version(state).unwrap_infallible()
+    }
+
     #[cfg(feature = "native")]
     fn test_only_set_rollup_height_for_genesis(
         &mut self,

--- a/crates/module-system/sov-kernels/src/soft_confirmations.rs
+++ b/crates/module-system/sov-kernels/src/soft_confirmations.rs
@@ -14,6 +14,8 @@ use sov_modules_api::{
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::RelevantBlobIters;
 use sov_rollup_interface::stf::DiscardedBlob;
+#[cfg(feature = "native")]
+use sov_state::Accessory;
 use sov_state::{Kernel, Storage, User};
 use std::convert::Infallible;
 
@@ -214,7 +216,8 @@ impl<S: Spec> sov_modules_api::capabilities::ChainState for SoftConfirmationsKer
         self.chain_state.operating_mode(state).unwrap_infallible()
     }
 
-    fn state_version<Reader: StateReader<User, Error = Infallible>>(
+    #[cfg(feature = "native")]
+    fn state_version<Reader: StateReader<Accessory, Error = Infallible>>(
         &self,
         state: &mut Reader,
     ) -> u64 {

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/chain_state.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/chain_state.rs
@@ -2,8 +2,6 @@ use std::convert::Infallible;
 
 use sov_rollup_interface::common::VisibleSlotNumber;
 use sov_rollup_interface::da::DaSpec;
-#[cfg(feature = "native")]
-use sov_state::Accessory;
 use sov_state::{Kernel, Storage, User};
 
 use super::RollupHeight;
@@ -114,7 +112,7 @@ pub trait ChainState {
 
     /// Returns the global on-chain state schema version.
     #[cfg(feature = "native")]
-    fn state_version<Reader: StateReader<Accessory, Error = Infallible>>(
+    fn state_version<Reader: StateReader<sov_state::Accessory, Error = Infallible>>(
         &self,
         state: &mut Reader,
     ) -> u64;

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/chain_state.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/chain_state.rs
@@ -2,6 +2,8 @@ use std::convert::Infallible;
 
 use sov_rollup_interface::common::VisibleSlotNumber;
 use sov_rollup_interface::da::DaSpec;
+#[cfg(feature = "native")]
+use sov_state::Accessory;
 use sov_state::{Kernel, Storage, User};
 
 use super::RollupHeight;
@@ -111,7 +113,8 @@ pub trait ChainState {
     ) -> OperatingMode;
 
     /// Returns the global on-chain state schema version.
-    fn state_version<Reader: StateReader<User, Error = Infallible>>(
+    #[cfg(feature = "native")]
+    fn state_version<Reader: StateReader<Accessory, Error = Infallible>>(
         &self,
         state: &mut Reader,
     ) -> u64;

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/chain_state.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/chain_state.rs
@@ -110,6 +110,12 @@ pub trait ChainState {
         state: &mut Reader,
     ) -> OperatingMode;
 
+    /// Returns the global on-chain state schema version.
+    fn state_version<Reader: StateReader<User, Error = Infallible>>(
+        &self,
+        state: &mut Reader,
+    ) -> u64;
+
     /// Returns the visible root hash accessible at the requested rollup height using the accessory state.
     ///
     /// ## Note

--- a/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/rpc_gen_associated_types.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/rpc_gen_associated_types.rs
@@ -145,6 +145,7 @@ fn associated_types() {
         inner_code_commitment: Default::default(),
         outer_code_commitment: Default::default(),
         genesis_da_height: 0,
+        state_version: 1,
         admin: None,
     };
     let config = GenesisConfig::new(chain_state_config, 22);

--- a/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/rpc_gen_associated_types_nested.rs
+++ b/crates/module-system/sov-modules-macros/tests/integration/rpc_gen/rpc_gen_associated_types_nested.rs
@@ -169,6 +169,7 @@ fn associated_types_nested() {
         inner_code_commitment: Default::default(),
         outer_code_commitment: Default::default(),
         genesis_da_height: 0,
+        state_version: 1,
         admin: None,
     };
     let config = GenesisConfig::new(chain_state_config, 22);

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -653,7 +653,9 @@ where
     RT: RuntimeTrait<S>,
 {
     let compiled_state_version: u64 = sov_modules_api::macros::config_value!("STATE_VERSION");
-    let on_disk_state_version = runtime.chain_state().state_version(state);
+    let on_disk_state_version = runtime
+        .chain_state()
+        .state_version(&mut state.accessory_state());
 
     anyhow::ensure!(
         on_disk_state_version == compiled_state_version,

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -8,7 +8,9 @@ use async_trait::async_trait;
 pub use endpoints::*;
 use sov_db::ledger_db::LedgerDb;
 use sov_db::schema::{DeltaReader, SchemaBatch};
-use sov_modules_api::capabilities::{HasCapabilities, HasKernel, ProofProcessor, RollupHeight};
+use sov_modules_api::capabilities::{
+    ChainState as _, HasCapabilities, HasKernel, ProofProcessor, RollupHeight,
+};
 use sov_modules_api::execution_mode::ExecutionMode;
 use sov_modules_api::provable_height_tracker::MaximumProvableHeight;
 use sov_modules_api::rest::ApiState;
@@ -470,8 +472,9 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                 .await?;
 
         let mut rt = Self::Runtime::default();
-        let checkpoint = StateCheckpoint::new(prover_storage, &rt.kernel(), None);
+        let mut checkpoint = StateCheckpoint::new(prover_storage, &rt.kernel(), None);
         let current_height = checkpoint.rollup_height_to_access();
+        validate_state_version::<Self::Spec, Self::Runtime>(&mut rt, &mut checkpoint)?;
 
         validate_heights(
             current_height,
@@ -639,6 +642,25 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
             genesis_slot_number: genesis_da_height,
         })
     }
+}
+
+fn validate_state_version<S, RT>(
+    runtime: &mut RT,
+    state: &mut StateCheckpoint<S>,
+) -> anyhow::Result<()>
+where
+    S: Spec,
+    RT: RuntimeTrait<S>,
+{
+    let compiled_state_version: u64 = sov_modules_api::macros::config_value!("STATE_VERSION");
+    let on_disk_state_version = runtime.chain_state().state_version(state);
+
+    anyhow::ensure!(
+        on_disk_state_version == compiled_state_version,
+        "State version mismatch: on-disk state has version {on_disk_state_version}, but this binary was compiled with STATE_VERSION {compiled_state_version}. Run the appropriate migration binary or use a matching rollup binary."
+    );
+
+    Ok(())
 }
 
 fn validate_heights(

--- a/crates/utils/sov-test-utils/src/runtime/genesis/mod.rs
+++ b/crates/utils/sov-test-utils/src/runtime/genesis/mod.rs
@@ -170,6 +170,7 @@ impl<S: Spec> BasicGenesisConfig<S> {
         ChainStateConfig {
             current_time: Default::default(),
             genesis_da_height: 0,
+            state_version: sov_modules_api::macros::config_value!("STATE_VERSION"),
             operating_mode,
             inner_code_commitment,
             outer_code_commitment,

--- a/crates/utils/sov-test-utils/src/runtime/genesis/optimistic/tests.rs
+++ b/crates/utils/sov-test-utils/src/runtime/genesis/optimistic/tests.rs
@@ -186,6 +186,7 @@ fn create_test_rt_genesis_config<S: Spec>(
         chain_state: ChainStateConfig {
             current_time: Default::default(),
             genesis_da_height: 0,
+            state_version: sov_modules_api::macros::config_value!("STATE_VERSION"),
             operating_mode: sov_modules_api::OperatingMode::Optimistic,
             inner_code_commitment,
             outer_code_commitment,

--- a/crates/utils/sov-test-utils/tests/integration/test_rollup.rs
+++ b/crates/utils/sov-test-utils/tests/integration/test_rollup.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use sov_modules_api::macros::config_value;
 use sov_modules_api::Runtime;
 use sov_modules_rollup_blueprint::logging::initialize_logging;
 use sov_modules_stf_blueprint::GenesisParams;
@@ -16,6 +17,72 @@ use tempfile::TempDir;
 generate_optimistic_runtime!(TestRuntime <=);
 
 type TestBlueprint = RtAgnosticBlueprint<TestSpec, TestRuntime<TestSpec>>;
+
+fn genesis_params_with_state_version(
+    state_version: u64,
+) -> GenesisParams<<TestRuntime<TestSpec> as Runtime<TestSpec>>::GenesisConfig> {
+    let mut runtime =
+        <TestRuntime<TestSpec> as Runtime<TestSpec>>::GenesisConfig::from_minimal_config(
+            HighLevelOptimisticGenesisConfig::generate().into(),
+        );
+    runtime.chain_state.state_version = state_version;
+    GenesisParams { runtime }
+}
+
+fn rollup_builder_with_state_version(state_version: u64) -> RollupBuilder<TestBlueprint> {
+    RollupBuilder::<TestBlueprint>::new(
+        GenesisSource::CustomParams(genesis_params_with_state_version(state_version)),
+        TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING,
+        1,
+    )
+    .set_config(|c| {
+        c.rollup_prover_config = RollupProverConfig::Disabled;
+    })
+    .with_standard_sequencer()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rollup_startup_accepts_matching_state_version() {
+    let _guard = initialize_logging();
+    let state_version: u64 = config_value!("STATE_VERSION");
+
+    let test_rollup = rollup_builder_with_state_version(state_version)
+        .start_test_rollup()
+        .await
+        .unwrap();
+
+    test_rollup.shutdown().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rollup_startup_rejects_mismatched_state_version() {
+    let _guard = initialize_logging();
+    let expected_state_version: u64 = config_value!("STATE_VERSION");
+    let mismatched_state_version = expected_state_version + 1;
+
+    let Err(err) = rollup_builder_with_state_version(mismatched_state_version)
+        .start_test_rollup()
+        .await
+    else {
+        panic!("rollup startup unexpectedly succeeded with a mismatched state version");
+    };
+    let err = format!("{err:#}");
+
+    assert!(
+        err.contains("State version mismatch"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        err.contains(&format!(
+            "on-disk state has version {mismatched_state_version}"
+        )),
+        "unexpected error: {err}"
+    );
+    assert!(
+        err.contains(&format!("STATE_VERSION {expected_state_version}")),
+        "unexpected error: {err}"
+    );
+}
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "Fails too often on my machine"]

--- a/examples/test-data/genesis/demo/celestia/chain_state.json
+++ b/examples/test-data/genesis/demo/celestia/chain_state.json
@@ -3,5 +3,6 @@
     "operating_mode": "operator",
     "inner_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
     "outer_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
-    "genesis_da_height": 3
+    "genesis_da_height": 3,
+    "state_version": 1
 }

--- a/examples/test-data/genesis/demo/mock/chain_state.json
+++ b/examples/test-data/genesis/demo/mock/chain_state.json
@@ -3,5 +3,6 @@
     "operating_mode": "zk",
     "inner_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
     "outer_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
-    "genesis_da_height": 0
+    "genesis_da_height": 0,
+    "state_version": 1
 }

--- a/examples/test-data/genesis/integration-tests/chain_state_op.json
+++ b/examples/test-data/genesis/integration-tests/chain_state_op.json
@@ -3,5 +3,6 @@
     "operating_mode": "optimistic",
     "inner_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
     "outer_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
-    "genesis_da_height": 0
+    "genesis_da_height": 0,
+    "state_version": 1
 }

--- a/examples/test-data/genesis/integration-tests/chain_state_operator.json
+++ b/examples/test-data/genesis/integration-tests/chain_state_operator.json
@@ -3,5 +3,6 @@
     "operating_mode": "operator",
     "inner_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
     "outer_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
-    "genesis_da_height": 0
+    "genesis_da_height": 0,
+    "state_version": 1
 }

--- a/examples/test-data/genesis/integration-tests/chain_state_zk.json
+++ b/examples/test-data/genesis/integration-tests/chain_state_zk.json
@@ -3,5 +3,6 @@
     "operating_mode": "zk",
     "inner_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
     "outer_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
-    "genesis_da_height": 0
+    "genesis_da_height": 0,
+    "state_version": 1
 }


### PR DESCRIPTION
# Description

* Adds a `state_version` state item to sov-chain-state. Initialized at genesis and then updated on every hard fork upgrade.
* Adds a similar constant to `constants.toml`. This is then used on startup to make sure the running rollup binary corresponds to the on-disk state.

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] ~I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)~

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
