### PR TITLE
mock-zkvm: make code commitment configurable to simulate guest upgrades

### DIFF
--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -10,7 +10,7 @@ use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec};
 use sov_rollup_interface::zk::aggregated_proof::{
     AggregatedProofPublicData, BlockProof, OuterZkvmHost, SerializedAggregatedProof,
 };
-use sov_rollup_interface::zk::SerializedZkProof;
+use sov_rollup_interface::zk::{CodeCommitmentTrait, SerializedZkProof};
 
 /// A DA block header paired with the inner-proof data covering that block.
 type HeaderWithBlockProof<Address, Da, Root> =
@@ -26,6 +26,11 @@ pub struct MockZkvmHost {
     /// [`OuterZkvmHost::run_proof_aggregation`] hold across the whole prover
     /// service.
     previous_anchor: Arc<Mutex<Option<PreviousAggregatedProofAnchor>>>,
+    /// Commitment this host stamps into proofs it produces and reports via
+    /// [`sov_rollup_interface::zk::ZkvmHost::code_commitment`]. Defaults to
+    /// [`MockCodeCommitment::default`]; override with
+    /// [`Self::with_code_commitment`] to simulate a guest-binary upgrade.
+    code_commitment: MockCodeCommitment,
 }
 
 /// Continuity anchor extracted from a previously produced aggregated proof.
@@ -74,6 +79,7 @@ impl MockZkvmHost {
             wait_for_proof: true,
             notification_manager: Default::default(),
             previous_anchor: Arc::new(Mutex::new(None)),
+            code_commitment: MockCodeCommitment::default(),
         }
     }
 
@@ -83,6 +89,7 @@ impl MockZkvmHost {
             wait_for_proof: false,
             notification_manager: Default::default(),
             previous_anchor: Arc::new(Mutex::new(None)),
+            code_commitment: MockCodeCommitment::default(),
         }
     }
 
@@ -104,7 +111,14 @@ impl MockZkvmHost {
             wait_for_proof: false,
             notification_manager: Default::default(),
             previous_anchor: Arc::new(Mutex::new(previous_anchor)),
+            code_commitment: MockCodeCommitment::default(),
         }
+    }
+
+    /// Override the [`MockCodeCommitment`] this host stamps into produced proofs.
+    pub fn with_code_commitment(mut self, code_commitment: MockCodeCommitment) -> Self {
+        self.code_commitment = code_commitment;
+        self
     }
 
     /// Simulates zk proof generation.
@@ -113,15 +127,29 @@ impl MockZkvmHost {
         self.notification_manager.notify();
     }
 
-    /// Create a proof for MockZkvm
+    /// Create a proof for MockZkvm.
     pub fn create_serialized_proof<T: Serialize>(
         is_valid: bool,
         transition: T,
+    ) -> SerializedZkProof {
+        Self::create_serialized_proof_with_commitment(
+            is_valid,
+            transition,
+            MockCodeCommitment::default(),
+        )
+    }
+
+    /// Create a proof that pins itself to the given [`MockCodeCommitment`].
+    pub fn create_serialized_proof_with_commitment<T: Serialize>(
+        is_valid: bool,
+        transition: T,
+        code_commitment: MockCodeCommitment,
     ) -> SerializedZkProof {
         let data = bincode::serialize(&transition).unwrap();
         let raw_proof = bincode::serialize(&MockProof {
             is_valid,
             pub_data: data,
+            code_commitment,
         })
         .unwrap();
         SerializedZkProof { raw_proof }
@@ -135,6 +163,7 @@ impl MockZkvmHost {
         Ok(bincode::serialize(&MockProof {
             is_valid: true,
             pub_data,
+            code_commitment: self.code_commitment.clone(),
         })?)
     }
 
@@ -196,6 +225,18 @@ impl MockZkvmHost {
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
     }
+
+    /// Recovers the inner-guest commitment from the inner proofs being aggregated.
+    fn inner_vkey_hash_from_block_proofs<Address, Da: DaSpec, Root>(
+        block_proofs: &[&BlockProof<Address, Da, Root>],
+    ) -> sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash {
+        let first = block_proofs
+            .first()
+            .expect("at least one inner proof is required for aggregation");
+        let mock_proof: MockProof = bincode::deserialize(&first.proof.raw_proof)
+            .expect("inner proof must be a bincode-encoded MockProof");
+        mock_proof.code_commitment.to_hash()
+    }
 }
 
 impl Default for MockZkvmHost {
@@ -208,7 +249,7 @@ impl sov_rollup_interface::zk::ZkvmHost for MockZkvmHost {
     type Guest = MockZkGuest;
 
     fn code_commitment(&self) -> anyhow::Result<<<Self::Guest as sov_rollup_interface::zk::ZkvmGuest>::Verifier as sov_rollup_interface::zk::ZkVerifier>::CodeCommitment>{
-        Ok(MockCodeCommitment::default())
+        Ok(self.code_commitment.clone())
     }
 
     fn add_hint_deferred_and_run<T: Serialize>(
@@ -248,12 +289,17 @@ impl OuterZkvmHost for MockZkvmHost {
             .map(|(_, bp)| bp)
             .collect::<Vec<_>>();
 
+        let inner_vkey_hash = Self::inner_vkey_hash_from_block_proofs(&block_proofs_data);
+        let outer_vk_hash = self.code_commitment.to_hash();
+
         let public_data = if let Some(prev) = previous.as_ref() {
             let origin_state_root = prev.deserialize_genesis_state_root();
             let public_data = AggregatedProofPublicData::from_block_proofs(
                 block_proofs_data.as_slice(),
                 prev.origin_slot_number,
                 origin_state_root,
+                inner_vkey_hash.clone(),
+                outer_vk_hash.clone(),
             );
 
             assert_eq!(
@@ -288,6 +334,8 @@ impl OuterZkvmHost for MockZkvmHost {
                 block_proofs_data.as_slice(),
                 origin_slot_number,
                 origin_state_root,
+                inner_vkey_hash,
+                outer_vk_hash,
             );
 
             public_data

--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -26,10 +26,7 @@ pub struct MockZkvmHost {
     /// [`OuterZkvmHost::run_proof_aggregation`] hold across the whole prover
     /// service.
     previous_anchor: Arc<Mutex<Option<PreviousAggregatedProofAnchor>>>,
-    /// Commitment this host stamps into proofs it produces and reports via
-    /// [`sov_rollup_interface::zk::ZkvmHost::code_commitment`]. Defaults to
-    /// [`MockCodeCommitment::default`]; override with
-    /// [`Self::with_code_commitment`] to simulate a guest-binary upgrade.
+    /// Commitment this host stamps into proofs.
     code_commitment: MockCodeCommitment,
 }
 

--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -98,6 +98,8 @@ struct MockProof {
     is_valid: bool,
     /// Public input.
     pub_data: Vec<u8>,
+    /// The commitment.
+    code_commitment: MockCodeCommitment,
 }
 
 /// The verifier for mock zk proofs.
@@ -121,17 +123,22 @@ impl sov_rollup_interface::zk::ZkVerifier for MockZkVerifier {
 
     fn verify_with_proof<T: DeserializeOwned>(
         serialized_proof: &SerializedZkProof,
-        _code_commitment: &Self::CodeCommitment,
+        code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         let MockProof {
             is_valid,
             pub_data: input,
+            code_commitment: claimed,
         } = bincode::deserialize(&serialized_proof.raw_proof)?;
-        if is_valid {
-            Ok(bincode::deserialize(&input)?)
-        } else {
-            anyhow::bail!("Proof is not valid")
+        if !is_valid {
+            anyhow::bail!("Proof is not valid");
         }
+        if &claimed != code_commitment {
+            anyhow::bail!(
+                "Code commitment mismatch: proof claims {claimed:?}, verifier expects {code_commitment:?}"
+            );
+        }
+        Ok(bincode::deserialize(&input)?)
     }
 
     fn extract_public_data<T: DeserializeOwned>(
@@ -151,7 +158,7 @@ mod tests {
 
     use super::*;
 
-    #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+    #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
     struct TestPublicData {
         hint: String,
     }
@@ -199,5 +206,42 @@ mod tests {
         assert!(verified_pub_data.is_err());
 
         Ok(())
+    }
+
+    #[test]
+    fn test_verify_accepts_matching_code_commitment() -> anyhow::Result<()> {
+        let commitment = MockCodeCommitment(*b"binary01");
+        let pub_data = TestPublicData {
+            hint: "match".to_owned(),
+        };
+
+        let mut vm = MockZkvmHost::new().with_code_commitment(commitment.clone());
+        vm.make_proof();
+        let proof = vm.add_hint_deferred_and_run(&pub_data, Default::default())?;
+
+        let verified = MockZkVerifier::verify_with_proof::<TestPublicData>(&proof, &commitment)?;
+        assert_eq!(verified, pub_data);
+        Ok(())
+    }
+
+    #[test]
+    fn test_verify_rejects_mismatched_code_commitment() {
+        let v1 = MockCodeCommitment(*b"binary01");
+        let v2 = MockCodeCommitment(*b"binary02");
+        let pub_data = TestPublicData {
+            hint: "mismatch".to_owned(),
+        };
+
+        let mut vm = MockZkvmHost::new().with_code_commitment(v1.clone());
+        vm.make_proof();
+        let proof = vm
+            .add_hint_deferred_and_run(&pub_data, Default::default())
+            .unwrap();
+
+        let err = MockZkVerifier::verify_with_proof::<TestPublicData>(&proof, &v2).unwrap_err();
+        assert!(
+            err.to_string().contains("Code commitment mismatch"),
+            "expected commitment-mismatch error, got: {err}"
+        );
     }
 }

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/admin_upgrade.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/admin_upgrade.rs
@@ -398,9 +398,6 @@ fn test_admin_upgrade_at_same_slot_is_slashed() {
     };
     let prover_address = prover.user_info.address();
 
-    // Stamp the mutated commitment into the proof bytes so the admin-path
-    // verifier (which rebuilds its commitment from `outer_vk_hash`) accepts
-    // the proof and execution reaches the stale-upgrade check.
     runner.execute_proof::<TestProverIncentives>(ProofTestCase {
         input: ProofInput(serialize_proof_with_commitment(
             second_proof,

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/admin_upgrade.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/admin_upgrade.rs
@@ -9,7 +9,8 @@ use sov_test_utils::runtime::TestRunner;
 use sov_test_utils::{assert_matches, ProofInput, ProofTestCase, TestProver, TestSpec};
 
 use crate::helpers::{
-    build_proof, consume_gas_tx_for_signer, serialize_proof, setup, TestProverIncentives, RT,
+    build_proof, consume_gas_tx_for_signer, serialize_proof, serialize_proof_with_commitment,
+    setup, TestProverIncentives, RT,
 };
 
 type S = TestSpec;
@@ -92,6 +93,7 @@ fn test_admin_bypass_outer_vk_hash_records_upgrade() {
     let (mut runner, _prover, mut aggregated_proof) = prepare_admin_proof();
     // MockCodeCommitment is 8 bytes wide and zero-pads to 32 in `to_hash`, so we use a
     // value that round-trips losslessly under from_hash/to_hash.
+    let new_outer_commitment = sov_mock_zkvm::MockCodeCommitment([0xcd; 8]);
     let new_outer_vk_hash = {
         let mut bytes = vec![0u8; 32];
         bytes[..8].copy_from_slice(&[0xcd; 8]);
@@ -100,8 +102,13 @@ fn test_admin_bypass_outer_vk_hash_records_upgrade() {
     aggregated_proof.outer_vk_hash = new_outer_vk_hash.clone();
     let expected_slot = aggregated_proof.final_slot_number;
 
+    // Stamp the new commitment into the proof bytes so the admin-path verifier
+    // (which rebuilds its commitment from `outer_vk_hash`) accepts the proof.
     runner.execute_proof::<TestProverIncentives>(ProofTestCase {
-        input: ProofInput(serialize_proof(aggregated_proof)),
+        input: ProofInput(serialize_proof_with_commitment(
+            aggregated_proof,
+            new_outer_commitment,
+        )),
         assert: Box::new(move |result, state| {
             assert_matches!(
                 result.proof_receipt.unwrap().outcome,
@@ -383,6 +390,7 @@ fn test_admin_upgrade_at_same_slot_is_slashed() {
             )
         })
         .unwrap();
+    let new_outer_commitment = sov_mock_zkvm::MockCodeCommitment([0xef; 8]);
     second_proof.outer_vk_hash = {
         let mut bytes = vec![0u8; 32];
         bytes[..8].copy_from_slice(&[0xef; 8]);
@@ -390,8 +398,14 @@ fn test_admin_upgrade_at_same_slot_is_slashed() {
     };
     let prover_address = prover.user_info.address();
 
+    // Stamp the mutated commitment into the proof bytes so the admin-path
+    // verifier (which rebuilds its commitment from `outer_vk_hash`) accepts
+    // the proof and execution reaches the stale-upgrade check.
     runner.execute_proof::<TestProverIncentives>(ProofTestCase {
-        input: ProofInput(serialize_proof(second_proof)),
+        input: ProofInput(serialize_proof_with_commitment(
+            second_proof,
+            new_outer_commitment,
+        )),
         assert: Box::new(move |result, state| {
             assert_matches!(
                 &result.proof_receipt.unwrap().outcome,

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/helpers.rs
@@ -128,12 +128,20 @@ pub(crate) fn consume_gas_tx_for_signer(signer: &TestUser<S>) -> TransactionType
 }
 
 pub(crate) fn serialize_proof<T: Serialize>(agg_proof: T) -> Vec<u8> {
-    let proof = sov_mock_zkvm::MockZkvmHost::create_serialized_proof(true, agg_proof);
+    serialize_proof_with_commitment(agg_proof, sov_mock_zkvm::MockCodeCommitment::default())
+}
+
+pub(crate) fn serialize_proof_with_commitment<T: Serialize>(
+    agg_proof: T,
+    commitment: sov_mock_zkvm::MockCodeCommitment,
+) -> Vec<u8> {
+    let proof = sov_mock_zkvm::MockZkvmHost::create_serialized_proof_with_commitment(
+        true, agg_proof, commitment,
+    );
     let serialized_proof = SerializedAggregatedProof {
         raw_aggregated_proof: proof.raw_proof,
     };
 
-    // Double serialzie because the blob selector deserialize a Vec<u8> and then that in turn gets deserialized by the STF
     borsh::to_vec(
         &serialize_proof_blob_with_metadata::<S>(serialized_proof)
             .unwrap()

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/mod.rs
@@ -131,7 +131,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
         da_service: &Self::DaService,
         ledger_db: &LedgerDb,
         start_fresh_outer_proof_on_resync: bool,
-    ) -> (Self::ProverService, Option<SlotNumber>);
+    ) -> anyhow::Result<(Self::ProverService, Option<SlotNumber>)>;
 
     /// Creates an instance of [`Self::StorageManager`].
     /// Panics if initialization fails.
@@ -514,7 +514,7 @@ pub trait FullNodeBlueprint<M: ExecutionMode>: RollupBlueprint<M> {
                     &ledger_db,
                     start_fresh_outer_proof_on_resync,
                 )
-                .await;
+                .await?;
             (Some(svc), slot)
         } else {
             (None, None)

--- a/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
+++ b/crates/module-system/sov-solana-offchain-auth/tests/integration/blueprint.rs
@@ -138,10 +138,10 @@ where
         da_service: &Self::DaService,
         ledger_db: &sov_db::ledger_db::LedgerDb,
         start_fresh_outer_proof_on_resync: bool,
-    ) -> (
+    ) -> anyhow::Result<(
         Self::ProverService,
         Option<sov_rollup_interface::common::SlotNumber>,
-    ) {
+    )> {
         self.inner
             .create_prover_service(
                 prover_config,

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -134,6 +134,8 @@ where
         block_proofs: &[&BlockProof<Address, Da, Root>],
         origin_slot_number: SlotNumber,
         origin_state_root: Root,
+        inner_vkey_hash: CodeCommitmentHash,
+        outer_vk_hash: CodeCommitmentHash,
     ) -> Self {
         let initial = block_proofs
             .first()
@@ -153,9 +155,8 @@ where
             final_state_root: final_bp.st.final_state_root.clone(),
             initial_slot_hash: initial.st.slot_hash.clone(),
             final_slot_hash: final_bp.st.slot_hash.clone(),
-            // This is used only for mock proving and matches the values in the chain_state genesis.
-            inner_vkey_hash: CodeCommitmentHash::default(),
-            outer_vk_hash: CodeCommitmentHash::default(),
+            inner_vkey_hash,
+            outer_vk_hash,
         }
     }
 }

--- a/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
+++ b/crates/utils/sov-test-utils/src/rt_agnostic_blueprint.rs
@@ -221,11 +221,11 @@ where
         _da_service: &Self::DaService,
         _ledger_db: &LedgerDb,
         _start_fresh_outer_proof_on_resync: bool,
-    ) -> (
+    ) -> anyhow::Result<(
         Self::ProverService,
         Option<sov_rollup_interface::common::SlotNumber>,
-    ) {
-        (Prover::create(prover_config, rollup_config).await, None)
+    )> {
+        Ok((Prover::create(prover_config, rollup_config).await, None))
     }
 
     fn create_storage_manager(

--- a/crates/utils/sov-test-utils/src/test_rollup.rs
+++ b/crates/utils/sov-test-utils/src/test_rollup.rs
@@ -751,12 +751,14 @@ where
     }
 
     /// Waits for the rollup to shutdown.
-    pub async fn wait_for_rollup_to_shutdown(self, t: tokio::time::Duration) {
+    pub async fn wait_for_rollup_to_shutdown(self, t: tokio::time::Duration) -> RollupBuilder<R> {
         timeout(t, self.rollup_task)
             .await
             .expect("Failed to join rollup task before timeout.")
             .expect("Rollup task panicked.")
             .expect("Rollup execution returned an error.");
+
+        self.builder
     }
 
     /// Waits for the rollup to shutdown without panicking on timeout.

--- a/examples/demo-rollup/src/celestia_rollup.rs
+++ b/examples/demo-rollup/src/celestia_rollup.rs
@@ -162,10 +162,10 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
         _da_service: &Self::DaService,
         _ledger_db: &LedgerDb,
         _start_fresh_outer_proof_on_resync: bool,
-    ) -> (
+    ) -> anyhow::Result<(
         Self::ProverService,
         Option<sov_rollup_interface::common::SlotNumber>,
-    ) {
+    )> {
         let inner_vm = Risc0Host::new(risc0::ROLLUP_ELF);
 
         let outer_vm = MockZkvmHost::new_non_blocking();
@@ -187,7 +187,7 @@ impl FullNodeBlueprint<Native> for CelestiaDemoRollup<Native> {
             num_threads,
         );
 
-        (prover, None)
+        Ok((prover, None))
     }
 
     fn create_storage_manager(

--- a/examples/demo-rollup/src/external_mock_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_rollup.rs
@@ -9,36 +9,25 @@ use sov_db::storage_manager::NomtStorageManager;
 use sov_ethereum::EthRpcConfig;
 use sov_mock_da::storable::rpc::StorableMockDaClient;
 use sov_mock_da::MockDaSpec;
-use sov_mock_zkvm::{
-    MockCodeCommitment, MockZkVerifier, MockZkvm, MockZkvmCryptoSpec, MockZkvmHost,
-};
+use sov_mock_zkvm::{MockCodeCommitment, MockZkvm, MockZkvmCryptoSpec};
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::{Native, WitnessGeneration};
-use sov_modules_api::CryptoSpec;
 use sov_modules_api::{NodeEndpoints, Spec, Storage};
 use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
 use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
 use sov_rollup_full_node_interface::StateUpdateReceiver;
 use sov_rollup_interface::common::SlotNumber;
-use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::SyncStatus;
-use sov_rollup_interface::zk::aggregated_proof::{
-    AggregateProofVerifier, AggregatedProofPublicData,
-};
 use sov_sequencer::{ProofBlobSender, Sequencer};
-use sov_state::nomt::prover_storage::NomtProverStorage;
-use sov_state::DefaultStorageSpec;
 use sov_stf_runner::processes::{ParallelProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
 
 use crate::eth_dev_signer;
-use crate::read_latest_aggregated_proof;
 use crate::solana_offchain_endpoint::solana_offchain_router;
-
-type Hasher = <MockZkvmCryptoSpec as CryptoSpec>::Hasher;
-type NativeStorage =
-    NomtProverStorage<DefaultStorageSpec<Hasher>, <MockDaSpec as DaSpec>::SlotHash>;
+use crate::{
+    create_mock_prover_service, read_mock_code_commitments_from_env, Hasher, NativeStorage,
+};
 
 /// The default spec of the rollup
 pub type ExternalMockRollupSpec<M> = ConfigurableSpec<
@@ -158,41 +147,9 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
         _da_service: &Self::DaService,
         ledger_db: &LedgerDb,
         start_fresh_outer_proof_on_resync: bool,
-    ) -> (Self::ProverService, Option<SlotNumber>) {
-        let previous_public_data: Option<
-            AggregatedProofPublicData<
-                <Self::Spec as Spec>::Address,
-                MockDaSpec,
-                <<Self::Spec as Spec>::Storage as Storage>::Root,
-            >,
-        > = read_latest_aggregated_proof(ledger_db).await.map(|proof| {
-            AggregateProofVerifier::<MockZkVerifier>::new(MockCodeCommitment::default())
-                .verify(&proof)
-                .expect("Persisted aggregated proof failed verification")
-        });
-
-        let latest_proof_final_slot = previous_public_data.as_ref().map(|p| p.final_slot_number);
-
-        let inner_vm = MockZkvmHost::new_non_blocking();
-
-        let previous = crate::previous_outer_anchor(
-            previous_public_data.as_ref(),
-            start_fresh_outer_proof_on_resync,
-        );
-
-        let outer_vm = MockZkvmHost::new_non_blocking_with_previous_anchor(previous);
-        let da_verifier = Default::default();
-
-        let num_threads = rollup_config.proof_manager.prover_thread_count();
-        let prover = ParallelProverService::new_with_default_workers(
-            inner_vm,
-            outer_vm,
-            da_verifier,
-            rollup_config.proof_manager.prover_address,
-            num_threads,
-        );
-
-        (prover, latest_proof_final_slot)
+    ) -> anyhow::Result<(Self::ProverService, Option<SlotNumber>)> {
+        create_mock_prover_service(rollup_config, ledger_db, start_fresh_outer_proof_on_resync)
+            .await
     }
 
     fn create_storage_manager(
@@ -212,8 +169,6 @@ impl FullNodeBlueprint<Native> for ExternalMockDemoRollup<Native> {
     }
 
     fn compute_code_commitments() -> anyhow::Result<(MockCodeCommitment, MockCodeCommitment)> {
-        // MockZkvm has no ELF to derive a commitment from — the default zero
-        // commitment matches what `MockZkvmHost::code_commitment` returns.
-        Ok((MockCodeCommitment::default(), MockCodeCommitment::default()))
+        Ok(read_mock_code_commitments_from_env())
     }
 }

--- a/examples/demo-rollup/src/lib.rs
+++ b/examples/demo-rollup/src/lib.rs
@@ -3,52 +3,31 @@
 //! See the README for more information.
 // TODO: #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
-
-use std::str::FromStr;
-
 use sov_celestia_adapter::types::Namespace;
 use sov_modules_api::macros::config_value;
-
+use std::str::FromStr;
 mod aggregated_proof;
 pub use aggregated_proof::read_latest_aggregated_proof;
-
-/// Returns `previous` unless a fresh outer-proof chain is requested via
-/// `start_fresh_outer_proof_on_resync`, in which case it returns `None`.
-/// Used by `create_prover_service` impls to drop the persisted outer-proof
-/// anchor when the rollup is configured to skip the resync window.
-pub fn previous_outer_anchor<T>(
-    previous: Option<T>,
-    start_fresh_outer_proof_on_resync: bool,
-) -> Option<T> {
-    if start_fresh_outer_proof_on_resync {
-        None
-    } else {
-        previous
-    }
-}
-
+mod mock_helper;
+pub use mock_helper::{
+    create_mock_prover_service, read_mock_code_commitments_from_env, set_inner_code_commitment_env,
+    set_outer_code_commitment_env, Hasher, MockAggregatedProofPublicData, NativeStorage,
+};
 mod mock_rollup;
-
 pub use mock_rollup::*;
-
 mod mock_sp1_rollup;
 pub use mock_sp1_rollup::*;
-
 mod chain_state_override;
 pub use chain_state_override::override_code_commitments_in_chain_state;
-
 mod celestia_rollup;
 pub use celestia_rollup::*;
-
 mod external_mock_rollup;
 pub use external_mock_rollup::*;
-
 mod solana_offchain_endpoint;
 
 /// The rollup stores its data in the namespace b"sov-test" on Celestia
 /// You can change this constant by modifying BATCH_NAMESPACE in constants.toml
 pub const ROLLUP_BATCH_NAMESPACE: Namespace = Namespace::const_v0(config_value!("BATCH_NAMESPACE"));
-
 /// The rollup stores the zk proofs in the namespace b"sov-test-p" on Celestia.
 /// You can change this constant by modifying PROOF_NAMESPACE in constants.toml
 pub const ROLLUP_PROOF_NAMESPACE: Namespace = Namespace::const_v0(config_value!("PROOF_NAMESPACE"));

--- a/examples/demo-rollup/src/mock_helper.rs
+++ b/examples/demo-rollup/src/mock_helper.rs
@@ -1,0 +1,156 @@
+//! Helpers shared between the mock-da-backed demo rollups
+//! ([`crate::MockDemoRollup`] and [`crate::ExternalMockDemoRollup`]).
+//!
+//! Centralizes the bits their `create_prover_service` / `compute_code_commitments`
+//! impls have in common: env-driven code commitments, the `Hasher` / `NativeStorage`
+//! type aliases, and assembly of the [`ParallelProverService`].
+
+use demo_stf::MultiAddressEvmSolana;
+use sov_db::ledger_db::LedgerDb;
+use sov_mock_da::MockDaSpec;
+use sov_mock_zkvm::{
+    MockCodeCommitment, MockZkVerifier, MockZkvm, MockZkvmCryptoSpec, MockZkvmHost,
+};
+use sov_modules_api::{CodeCommitmentTrait, CryptoSpec};
+use sov_rollup_interface::common::SlotNumber;
+use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::node::da::DaService;
+use sov_rollup_interface::zk::aggregated_proof::AggregatedProofPublicData;
+use sov_rollup_interface::zk::ZkVerifier;
+use sov_state::nomt::prover_storage::NomtProverStorage;
+use sov_state::{DefaultStorageSpec, Storage};
+use sov_stf_runner::processes::ParallelProverService;
+use sov_stf_runner::RollupConfig;
+
+use crate::read_latest_aggregated_proof;
+
+/// Hasher used by mock-da-backed demo rollups.
+pub type Hasher = <MockZkvmCryptoSpec as CryptoSpec>::Hasher;
+
+/// Native storage type for mock-da-backed demo rollups.
+pub type NativeStorage =
+    NomtProverStorage<DefaultStorageSpec<Hasher>, <MockDaSpec as DaSpec>::SlotHash>;
+
+/// Aggregated-proof public data shape shared by the mock-da-backed demo rollups.
+pub type MockAggregatedProofPublicData =
+    AggregatedProofPublicData<MultiAddressEvmSolana, MockDaSpec, <NativeStorage as Storage>::Root>;
+
+/// [`ParallelProverService`] shape shared by the mock-da-backed demo rollups,
+/// parameterized only over the concrete DA service.
+pub type MockParallelProverService<Da> = ParallelProverService<
+    MultiAddressEvmSolana,
+    <NativeStorage as Storage>::Root,
+    <NativeStorage as Storage>::Witness,
+    Da,
+    MockZkvm,
+    MockZkvm,
+>;
+
+/// Env var carrying the inner mock code commitment.
+const MOCK_INNER_CODE_COMMITMENT_ENV: &str = "SOV_MOCK_INNER_CODE_COMMITMENT";
+
+/// Env var carrying the outer mock code commitment.
+const MOCK_OUTER_CODE_COMMITMENT_ENV: &str = "SOV_MOCK_OUTER_CODE_COMMITMENT";
+
+/// Reads inner and outer mock code commitments from
+/// [`MOCK_INNER_CODE_COMMITMENT_ENV`] and [`MOCK_OUTER_CODE_COMMITMENT_ENV`],
+/// falling back to [`MockCodeCommitment::default`] when unset.
+pub fn read_mock_code_commitments_from_env() -> (MockCodeCommitment, MockCodeCommitment) {
+    let inner = mock_code_commitment_from_env(MOCK_INNER_CODE_COMMITMENT_ENV).unwrap_or_default();
+    let outer = mock_code_commitment_from_env(MOCK_OUTER_CODE_COMMITMENT_ENV).unwrap_or_default();
+    (inner, outer)
+}
+
+/// Test-only helper: sets [`MOCK_INNER_CODE_COMMITMENT_ENV`].
+pub fn set_inner_code_commitment_env(commitment: MockCodeCommitment) {
+    std::env::set_var(MOCK_INNER_CODE_COMMITMENT_ENV, commitment_hex(&commitment));
+}
+
+/// Test-only helper: sets [`MOCK_OUTER_CODE_COMMITMENT_ENV`].
+pub fn set_outer_code_commitment_env(commitment: MockCodeCommitment) {
+    std::env::set_var(MOCK_OUTER_CODE_COMMITMENT_ENV, commitment_hex(&commitment));
+}
+
+fn commitment_hex(commitment: &MockCodeCommitment) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(commitment.0.len() * 2);
+    for byte in &commitment.0 {
+        write!(&mut out, "{byte:02x}").expect("writing to String never fails");
+    }
+    out
+}
+
+/// Reads a [`MockCodeCommitment`] from `env_var`. Assumes the value was
+/// written by [`commitment_hex`] (16 lowercase hex chars, no prefix). Returns
+/// `None` if the variable is unset; panics if set but unparseable.
+fn mock_code_commitment_from_env(env_var: &str) -> Option<MockCodeCommitment> {
+    let raw = std::env::var(env_var).ok()?;
+    let n = u64::from_str_radix(&raw, 16).unwrap_or_else(|e| {
+        panic!("{env_var}: expected output of commitment_hex, got {raw:?}: {e}")
+    });
+    Some(MockCodeCommitment(n.to_be_bytes()))
+}
+
+/// Shared `create_prover_service` body for the mock-da-backed demo rollups.
+pub async fn create_mock_prover_service<Da>(
+    rollup_config: &RollupConfig<MultiAddressEvmSolana, Da>,
+    ledger_db: &LedgerDb,
+    start_fresh_outer_proof_on_resync: bool,
+) -> anyhow::Result<(MockParallelProverService<Da>, Option<SlotNumber>)>
+where
+    Da: DaService,
+    Da::Verifier: Default,
+{
+    let (inner_code_commitment, outer_code_commitment) = read_mock_code_commitments_from_env();
+
+    // Extract the persisted proof's public data without re-verifying
+    // its commitment. The commitment may have legitimately rotated
+    // since the proof was written (e.g. a guest-binary upgrade), but
+    // we still need its `final_slot_number` to anchor the STF-info
+    // stream so the next aggregation is contiguous with what's on
+    // disk.
+    let previous_public_data: Option<MockAggregatedProofPublicData> =
+        match read_latest_aggregated_proof(ledger_db).await {
+            None => None,
+            Some(proof) => Some(
+                MockZkVerifier::extract_public_data(&proof.to_serialized_zk_proof()).map_err(
+                    |e| {
+                        anyhow::anyhow!(
+                            "Failed to extract public data from persisted aggregated proof: {e}"
+                        )
+                    },
+                )?,
+            ),
+        };
+
+    let latest_proof_final_slot = previous_public_data.as_ref().map(|p| p.final_slot_number);
+
+    let previous = previous_public_data
+        .as_ref()
+        .filter(|_| !start_fresh_outer_proof_on_resync);
+
+    if let Some(previous) = previous {
+        anyhow::ensure!(
+            inner_code_commitment.to_hash() == previous.inner_vkey_hash,
+            "inner code commitment changed since last proof; pass start_fresh_outer_proof_on_resync to reset"
+        );
+        anyhow::ensure!(
+            outer_code_commitment.to_hash() == previous.outer_vk_hash,
+            "outer code commitment changed since last proof; pass start_fresh_outer_proof_on_resync to reset"
+        );
+    }
+
+    let inner_vm = MockZkvmHost::new_non_blocking().with_code_commitment(inner_code_commitment);
+
+    let outer_vm = MockZkvmHost::new_non_blocking_with_previous_anchor(previous)
+        .with_code_commitment(outer_code_commitment);
+    let prover = ParallelProverService::new_with_default_workers(
+        inner_vm,
+        outer_vm,
+        Da::Verifier::default(),
+        rollup_config.proof_manager.prover_address,
+        rollup_config.proof_manager.prover_thread_count(),
+    );
+
+    Ok((prover, latest_proof_final_slot))
+}

--- a/examples/demo-rollup/src/mock_rollup.rs
+++ b/examples/demo-rollup/src/mock_rollup.rs
@@ -9,41 +9,32 @@ use sov_db::storage_manager::NomtStorageManager;
 use sov_ethereum::EthRpcConfig;
 use sov_mock_da::storable::StorableMockDaService;
 use sov_mock_da::MockDaSpec;
-use sov_mock_zkvm::{
-    MockCodeCommitment, MockZkVerifier, MockZkvm, MockZkvmCryptoSpec, MockZkvmHost,
-};
+use sov_mock_zkvm::{MockCodeCommitment, MockZkvm, MockZkvmCryptoSpec};
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::{Native, WitnessGeneration};
-use sov_modules_api::{CryptoSpec, NodeEndpoints, Spec};
+use sov_modules_api::{NodeEndpoints, Spec};
 use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
 use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
 use sov_rollup_full_node_interface::StateUpdateReceiver;
 use sov_rollup_interface::common::SlotNumber;
-use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::SyncStatus;
-use sov_rollup_interface::zk::aggregated_proof::{
-    AggregateProofVerifier, AggregatedProofPublicData,
-};
 use sov_sequencer::{ProofBlobSender, Sequencer};
-use sov_state::nomt::prover_storage::NomtProverStorage;
-use sov_state::{DefaultStorageSpec, Storage};
+use sov_state::Storage;
 use sov_stf_runner::processes::{ParallelProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
 
 use crate::eth_dev_signer;
-use crate::read_latest_aggregated_proof;
 use crate::solana_offchain_endpoint::solana_offchain_router;
+use crate::{
+    create_mock_prover_service, read_mock_code_commitments_from_env, Hasher, NativeStorage,
+};
 
 /// Rollup with a [`ConfigurableSpec`] with [`MockDaSpec`] as Da spec, [`MockZkvm`] inner vm and [`MockZkvm`] for outer vm
 #[derive(Default, Clone, Copy)]
 pub struct MockDemoRollup<M> {
     phantom: std::marker::PhantomData<M>,
 }
-
-type Hasher = <MockZkvmCryptoSpec as CryptoSpec>::Hasher;
-type NativeStorage =
-    NomtProverStorage<DefaultStorageSpec<Hasher>, <MockDaSpec as DaSpec>::SlotHash>;
 
 /// The default spec of the rollup
 pub type MockRollupSpec<M> = ConfigurableSpec<
@@ -156,42 +147,9 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
         _da_service: &Self::DaService,
         ledger_db: &LedgerDb,
         start_fresh_outer_proof_on_resync: bool,
-    ) -> (Self::ProverService, Option<SlotNumber>) {
-        let previous_public_data: Option<
-            AggregatedProofPublicData<
-                <Self::Spec as Spec>::Address,
-                MockDaSpec,
-                <<Self::Spec as Spec>::Storage as Storage>::Root,
-            >,
-        > = read_latest_aggregated_proof(ledger_db).await.map(|proof| {
-            AggregateProofVerifier::<MockZkVerifier>::new(MockCodeCommitment::default())
-                .verify(&proof)
-                .expect("Persisted aggregated proof failed verification")
-        });
-
-        let latest_proof_final_slot = previous_public_data.as_ref().map(|p| p.final_slot_number);
-
-        let inner_vm = MockZkvmHost::new_non_blocking();
-
-        let previous = crate::previous_outer_anchor(
-            previous_public_data.as_ref(),
-            start_fresh_outer_proof_on_resync,
-        );
-
-        let outer_vm = MockZkvmHost::new_non_blocking_with_previous_anchor(previous);
-        let da_verifier = Default::default();
-
-        let num_threads = rollup_config.proof_manager.prover_thread_count();
-
-        let prover = ParallelProverService::new_with_default_workers(
-            inner_vm,
-            outer_vm,
-            da_verifier,
-            rollup_config.proof_manager.prover_address,
-            num_threads,
-        );
-
-        (prover, latest_proof_final_slot)
+    ) -> anyhow::Result<(Self::ProverService, Option<SlotNumber>)> {
+        create_mock_prover_service(rollup_config, ledger_db, start_fresh_outer_proof_on_resync)
+            .await
     }
 
     fn create_storage_manager(
@@ -211,8 +169,6 @@ impl FullNodeBlueprint<Native> for MockDemoRollup<Native> {
     }
 
     fn compute_code_commitments() -> anyhow::Result<(MockCodeCommitment, MockCodeCommitment)> {
-        // MockZkvm has no ELF to derive a commitment from — the default zero
-        // commitment matches what `MockZkvmHost::code_commitment` returns.
-        Ok((MockCodeCommitment::default(), MockCodeCommitment::default()))
+        Ok(read_mock_code_commitments_from_env())
     }
 }

--- a/examples/demo-rollup/src/mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/mock_sp1_rollup.rs
@@ -148,7 +148,7 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
         _da_service: &Self::DaService,
         ledger_db: &LedgerDb,
         start_fresh_outer_proof_on_resync: bool,
-    ) -> (Self::ProverService, Option<SlotNumber>) {
+    ) -> anyhow::Result<(Self::ProverService, Option<SlotNumber>)> {
         let elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
         let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
 
@@ -212,7 +212,7 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
             num_threads,
         );
 
-        (prover, latest_proof_final_slot)
+        Ok((prover, latest_proof_final_slot))
     }
 
     fn create_storage_manager(

--- a/examples/demo-rollup/tests/zk_proving/commitment_rotation.rs
+++ b/examples/demo-rollup/tests/zk_proving/commitment_rotation.rs
@@ -1,0 +1,66 @@
+use crate::external_mock_da::start_external_mock_da;
+use crate::zk_proving::start_test_rollup;
+use anyhow::Context;
+use futures::StreamExt;
+use sov_demo_rollup::{set_inner_code_commitment_env, set_outer_code_commitment_env};
+use sov_mock_zkvm::MockCodeCommitment;
+use sov_modules_api::capabilities::RollupHeight;
+use sov_test_utils::TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING;
+use std::time::Duration;
+
+const STOP_AT: u64 = 20;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn code_commitment_rotation_requires_fresh_start() -> anyhow::Result<()> {
+    let external_da = start_external_mock_da(TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING).await?;
+
+    // Phase 1 — env vars unset, defaults everywhere. Runner self-shuts at STOP_AT.
+    let test_rollup =
+        start_test_rollup(3, &external_da, 20, false, Some(RollupHeight::new(STOP_AT))).await?;
+
+    let builder = test_rollup
+        .wait_for_rollup_to_shutdown(Duration::from_secs(60))
+        .await;
+
+    // Phase 2 — rotate commitments and restart on the same storage.
+    set_inner_code_commitment_env(MockCodeCommitment([0x01; 8]));
+    set_outer_code_commitment_env(MockCodeCommitment([0x02; 8]));
+
+    // This is an error because the persisted aggregated proof was stamped with the
+    // default code commitments, and the rotated env vars no longer match its
+    // inner/outer vkey hashes — startup refuses to resume on top of a proof it can't
+    // verify against the current commitments.
+    let res = builder
+        .clone()
+        .set_config(|c| {
+            c.start_at_rollup_height = Some(RollupHeight::new(STOP_AT + 1));
+            c.stop_at_rollup_height = None;
+        })
+        .start_test_rollup()
+        .await;
+
+    assert!(res.is_err());
+
+    // With start_fresh_outer_proof_on_resync = true, startup drops the previous
+    // outer-proof anchor and begins a fresh aggregation chain under the rotated
+    // commitments — no vkey-hash check, so this restart succeeds.
+    let test_rollup = builder
+        .set_config(|c| {
+            c.start_at_rollup_height = Some(RollupHeight::new(STOP_AT + 1));
+            c.stop_at_rollup_height = None;
+            c.start_fresh_outer_proof_on_resync = true;
+        })
+        .start_test_rollup()
+        .await?;
+
+    let mut proof_sub = test_rollup.subscribe_aggregated_proof().await.unwrap();
+
+    for i in 0..5 {
+        tokio::time::timeout(Duration::from_secs(20), proof_sub.next())
+            .await
+            .with_context(|| format!("no aggregated proof within 60s on iter={i}"))?
+            .context("proof error")??;
+    }
+
+    Ok(())
+}

--- a/examples/demo-rollup/tests/zk_proving/max_concurrent_proof_blobs.rs
+++ b/examples/demo-rollup/tests/zk_proving/max_concurrent_proof_blobs.rs
@@ -19,7 +19,7 @@ fn resume_proving() {
 #[tokio::test(flavor = "multi_thread")]
 async fn max_concurrent_proof() -> anyhow::Result<()> {
     let external_da = start_external_mock_da(TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING).await?;
-    let test_rollup = start_test_rollup(0, &external_da, 2, false).await?;
+    let test_rollup = start_test_rollup(0, &external_da, 2, false, None).await?;
 
     let mut aggregated_proof_subscription = test_rollup.subscribe_aggregated_proof().await?;
     let _ = aggregated_proof_subscription.next().await.unwrap().unwrap();

--- a/examples/demo-rollup/tests/zk_proving/mod.rs
+++ b/examples/demo-rollup/tests/zk_proving/mod.rs
@@ -1,3 +1,4 @@
+mod commitment_rotation;
 mod max_concurrent_proof_blobs;
 mod skip_proving_on_resync;
 
@@ -39,6 +40,7 @@ pub async fn start_test_rollup(
     external_da: &ExternalDa,
     max_concurrent_proof_blobs: usize,
     start_fresh_outer_proof_on_resync: bool,
+    stop_at_rollup_height: Option<sov_modules_api::capabilities::RollupHeight>,
 ) -> anyhow::Result<TestRollup<ExternalMockDemoRollup<Native>>> {
     // Make sure the DA has produced the genesis block before the rollup tries
     // to read from it.
@@ -71,6 +73,7 @@ pub async fn start_test_rollup(
         c.aggregated_proof_block_jump = 2;
         c.max_concurrent_proof_blobs = max_concurrent_proof_blobs;
         c.start_fresh_outer_proof_on_resync = start_fresh_outer_proof_on_resync;
+        c.stop_at_rollup_height = stop_at_rollup_height;
         if let SequencerKindConfig::Preferred(sequencer_config) = &mut c.sequencer_config {
             sequencer_config.batch_execution_time_limit_millis = TEST_DEFAULT_MOCK_DA_BLOCK_TIME_MS;
             sequencer_config.recovery_strategy = RecoveryStrategy::TryToSave;

--- a/examples/demo-rollup/tests/zk_proving/skip_proving_on_resync.rs
+++ b/examples/demo-rollup/tests/zk_proving/skip_proving_on_resync.rs
@@ -11,7 +11,7 @@ use crate::zk_proving::{query_verified_proofs, start_test_rollup};
 #[tokio::test(flavor = "multi_thread")]
 async fn skip_proving_on_resync() -> anyhow::Result<()> {
     let external_da = start_external_mock_da(TEST_DEFAULT_MOCK_DA_PERIODIC_PRODUCING).await?;
-    let test_rollup = start_test_rollup(3, &external_da, 20, false).await?;
+    let test_rollup = start_test_rollup(3, &external_da, 20, false, None).await?;
     let mut proof_sub = test_rollup.subscribe_aggregated_proof().await?;
 
     for _ in 0..5 {


### PR DESCRIPTION
# Description

This PR makes mock proving behave more like the real zk backends by carrying explicit code commitments through proof production, aggregation, and prover startup.

Changes:
  - Mock proofs now carry the code commitment they were produced with, and mock verification now enforces that commitment instead of treating all mock proofs as interchangeable.
  - The mock demo rollups now share a single prover-setup path that reads inner and outer mock commitments from environment variables and threads those values through proof creation and aggregated proof metadata.
  - On restart, the prover now inspects the latest persisted aggregated proof before resuming. If the stored proof was produced under different commitments, startup refuses to continue from that chain unless `start_fresh_outer_proof_on_resync` is
  enabled. The tests cover both commitment mismatches and the fresh-start recovery path.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551