### PR TITLE
Revert #2851: restore hash charging in sig verification

### DIFF
--- a/crates/module-system/sov-modules-api/src/gas/metered_utils.rs
+++ b/crates/module-system/sov-modules-api/src/gas/metered_utils.rs
@@ -199,6 +199,21 @@ fn charge_gas_for_sig_inner<GU: Gas, Meter: GasMeter<Spec: Spec<Gas = GU>>>(
         )
         .map_err(MeteredSigVerificationError::GasError)?;
 
+    meter
+        .charge_gas(<Meter::Spec as GasSpec>::gas_to_charge_hash_update())
+        .map_err(MeteredSigVerificationError::GasError)?;
+
+    meter
+        .charge_linear_gas(
+            <Meter::Spec as GasSpec>::gas_to_charge_per_byte_hash_update(),
+            msg_len.try_into().map_err(|e: TryFromIntError| {
+                MeteredSigVerificationError::GasError(MeteringError::<Meter>::Overflow(
+                    e.to_string(),
+                ))
+            })?,
+        )
+        .map_err(MeteredSigVerificationError::GasError)?;
+
     Ok(())
 }
 

--- a/crates/module-system/sov-modules-api/src/gas/tests/metered_utils.rs
+++ b/crates/module-system/sov-modules-api/src/gas/tests/metered_utils.rs
@@ -101,6 +101,14 @@ fn test_metered_signature() {
                 .unwrap(),
         )
         .unwrap()
+        .checked_combine(S::gas_to_charge_hash_update())
+        .unwrap()
+        .checked_combine(
+            S::gas_to_charge_per_byte_hash_update()
+                .checked_scalar_product(TEST_DATA.len() as u64)
+                .unwrap(),
+        )
+        .unwrap()
         .value(TEST_GAS_PRICE);
 
     let mut ws = create_working_set(remaining_funds, &TEST_GAS_PRICE);


### PR DESCRIPTION
## Summary

- Reverts c944984 (#2851), which removed the `gas_to_charge_hash_update` and `gas_to_charge_per_byte_hash_update` charges from `charge_gas_for_sig_inner`.
- The hash-charging removal will land via `theodore/multisig-upgrade` instead — see companion PR.
