### PR TITLE
mock-zkvm: enforce real aggregation constraints in the mock host

### DIFF
--- a/crates/adapters/mock-zkvm/src/guest.rs
+++ b/crates/adapters/mock-zkvm/src/guest.rs
@@ -1,17 +1,52 @@
+use std::sync::Mutex;
+
 use serde::Serialize;
 
 use crate::MockZkVerifier;
+
 /// A mock implementing the Guest.
 #[derive(Default)]
-pub struct MockZkGuest {}
+pub struct MockZkGuest {
+    hint: Mutex<Option<Vec<u8>>>,
+    committed: Mutex<Option<Vec<u8>>>,
+}
+
+impl MockZkGuest {
+    /// Construct a guest seeded with a single bincode-serialized hint.
+    pub fn with_hint(hint: Vec<u8>) -> Self {
+        Self {
+            hint: Mutex::new(Some(hint)),
+            committed: Mutex::new(None),
+        }
+    }
+
+    /// Drain the bytes committed by [`Self::commit`]. Returns `None` if
+    /// `commit` was never called.
+    pub fn take_committed_bytes(&self) -> Option<Vec<u8>> {
+        self.committed
+            .lock()
+            .expect("MockZkGuest committed mutex poisoned")
+            .take()
+    }
+}
 
 impl sov_rollup_interface::zk::ZkvmGuest for MockZkGuest {
     type Verifier = MockZkVerifier;
     fn read_from_host<T: serde::de::DeserializeOwned>(&self) -> T {
-        unimplemented!()
+        let bytes = self
+            .hint
+            .lock()
+            .expect("MockZkGuest hint mutex poisoned")
+            .take()
+            .expect("MockZkGuest has no hint to read; call `with_hint` first");
+        bincode::deserialize(&bytes).expect("failed to deserialize MockZkGuest hint")
     }
 
-    fn commit<T: Serialize>(&self, _item: &T) {
-        unimplemented!()
+    fn commit<T: Serialize>(&self, item: &T) {
+        let bytes = bincode::serialize(item).expect("failed to serialize MockZkGuest commit");
+        *self
+            .committed
+            .lock()
+            .expect("MockZkGuest committed mutex poisoned") = Some(bytes);
     }
 }

--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -165,15 +165,18 @@ impl sov_rollup_interface::zk::ZkvmHost for MockZkvmHost {
 
     fn add_hint_deferred_and_run<T: Serialize>(
         &mut self,
-        item: &T,
+        _item: &T,
         _agg_proofs: Vec<SerializedAggregatedProof>,
     ) -> anyhow::Result<SerializedZkProof> {
+        // Mirror SP1: a proof commits whatever the guest commits, not the hint.
+        // With no guest execution, the mock has nothing to commit, so the
+        // inner proof carries empty public data. The aggregation step gets
+        // the canonical public output side-band via `BlockProof::st`.
         Self::maybe_mock_sleep("SOV_MOCK_PROVE_SLEEP_MS");
-        let pub_data = bincode::serialize(item)?;
         if self.wait_for_proof {
             self.notification_manager.wait();
         }
-        let raw_proof = Self::valid_mock_proof_bytes(pub_data, self.code_commitment.clone())?;
+        let raw_proof = Self::valid_mock_proof_bytes(Vec::new(), self.code_commitment.clone())?;
         Ok(SerializedZkProof { raw_proof })
     }
 }

--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -106,14 +106,6 @@ impl MockZkvmHost {
         SerializedZkProof { raw_proof }
     }
 
-    fn add_hint_and_run_inner<T: Serialize>(&self, item: &T) -> anyhow::Result<Vec<u8>> {
-        let pub_data = bincode::serialize(item)?;
-        if self.wait_for_proof {
-            self.notification_manager.wait();
-        }
-        Self::valid_mock_proof_bytes(pub_data, self.code_commitment.clone())
-    }
-
     /// Bincode-encodes a [`MockProof`] with `is_valid: true` and the given public-data bytes and commitment.
     fn valid_mock_proof_bytes(
         pub_data: Vec<u8>,
@@ -177,8 +169,12 @@ impl sov_rollup_interface::zk::ZkvmHost for MockZkvmHost {
         _agg_proofs: Vec<SerializedAggregatedProof>,
     ) -> anyhow::Result<SerializedZkProof> {
         Self::maybe_mock_sleep("SOV_MOCK_PROVE_SLEEP_MS");
-        self.add_hint_and_run_inner(item)
-            .map(|raw_proof| SerializedZkProof { raw_proof })
+        let pub_data = bincode::serialize(item)?;
+        if self.wait_for_proof {
+            self.notification_manager.wait();
+        }
+        let raw_proof = Self::valid_mock_proof_bytes(pub_data, self.code_commitment.clone())?;
+        Ok(SerializedZkProof { raw_proof })
     }
 }
 

--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -205,10 +205,8 @@ impl OuterZkvmHost for MockZkvmHost {
         for (header, bp) in headers_with_block_proofs {
             let recovered = MockProof::deserialize(&bp.proof.raw_proof)
                 .expect("inner proof must be a bincode-encoded MockProof");
-            let pub_values = Self::valid_mock_proof_bytes(
-                bincode::serialize(&bp.st)?,
-                recovered.code_commitment,
-            )?;
+            let pub_values =
+                Self::valid_mock_proof_bytes(bp.st.serialize()?, recovered.code_commitment)?;
             proof_inputs.push(DeferredProofInput::<Da> {
                 public_values: SerializedPubValues { pub_values },
                 da_block_header: header,

--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -5,10 +5,13 @@ use crate::notifier::NotificationManager;
 use crate::{MockCodeCommitment, MockProof, MockZkGuest};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use sov_rollup_interface::common::SlotNumber;
-use sov_rollup_interface::da::{BlockHeaderTrait, DaSpec};
+use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::zk::aggregated_proof::circuit::run_aggregation_program;
+use sov_rollup_interface::zk::aggregated_proof::common::{
+    AggregatedProofWitness, DeferredProofInput, PreviousOuterProofWitness, SerializedPubValues,
+};
 use sov_rollup_interface::zk::aggregated_proof::{
-    AggregatedProofPublicData, BlockProof, OuterZkvmHost, SerializedAggregatedProof,
+    BlockProof, OuterZkvmHost, SerializedAggregatedProof,
 };
 use sov_rollup_interface::zk::{CodeCommitmentTrait, SerializedZkProof};
 
@@ -21,52 +24,10 @@ type HeaderWithBlockProof<Address, Da, Root> =
 pub struct MockZkvmHost {
     notification_manager: NotificationManager,
     wait_for_proof: bool,
-    /// Anchor extracted from the most recently produced aggregated proof.
-    /// Shared across clones so that continuity assertions in
-    /// [`OuterZkvmHost::run_proof_aggregation`] hold across the whole prover
-    /// service.
-    previous_anchor: Arc<Mutex<Option<PreviousAggregatedProofAnchor>>>,
+    /// Most-recently-produced outer aggregated proof.
+    previous_outer_proof: Arc<Mutex<Option<SerializedAggregatedProof>>>,
     /// Commitment this host stamps into proofs.
     code_commitment: MockCodeCommitment,
-}
-
-/// Continuity anchor extracted from a previously produced aggregated proof.
-#[derive(Clone, Debug)]
-struct PreviousAggregatedProofAnchor {
-    final_slot_number: SlotNumber,
-    origin_slot_number: SlotNumber,
-    genesis_state_root: Vec<u8>,
-    final_state_root: Vec<u8>,
-}
-
-impl PreviousAggregatedProofAnchor {
-    fn from_public_data<Address, Da, Root>(
-        public_data: &AggregatedProofPublicData<Address, Da, Root>,
-    ) -> Self
-    where
-        Address: Serialize,
-        Da: DaSpec,
-        Root: Serialize,
-    {
-        Self {
-            final_slot_number: public_data.final_slot_number,
-            origin_slot_number: public_data.origin_slot_number,
-            genesis_state_root: bincode::serialize(&public_data.origin_state_root)
-                .expect("origin_state_root must be bincode-serializable"),
-            final_state_root: bincode::serialize(&public_data.final_state_root)
-                .expect("final_state_root must be bincode-serializable"),
-        }
-    }
-
-    fn deserialize_genesis_state_root<Root: DeserializeOwned>(&self) -> Root {
-        bincode::deserialize(&self.genesis_state_root)
-            .expect("genesis_state_root must be bincode-deserializable")
-    }
-
-    fn deserialize_final_state_root<Root: DeserializeOwned>(&self) -> Root {
-        bincode::deserialize(&self.final_state_root)
-            .expect("final_state_root must be bincode-deserializable")
-    }
 }
 
 impl MockZkvmHost {
@@ -75,7 +36,7 @@ impl MockZkvmHost {
         Self {
             wait_for_proof: true,
             notification_manager: Default::default(),
-            previous_anchor: Arc::new(Mutex::new(None)),
+            previous_outer_proof: Arc::new(Mutex::new(None)),
             code_commitment: MockCodeCommitment::default(),
         }
     }
@@ -85,29 +46,21 @@ impl MockZkvmHost {
         Self {
             wait_for_proof: false,
             notification_manager: Default::default(),
-            previous_anchor: Arc::new(Mutex::new(None)),
+            previous_outer_proof: Arc::new(Mutex::new(None)),
             code_commitment: MockCodeCommitment::default(),
         }
     }
 
-    /// Like [`Self::new_non_blocking`], but seeded with the public data of the
-    /// latest verified aggregated proof previously persisted in the ledger DB
-    /// so that continuity assertions in
-    /// [`OuterZkvmHost::run_proof_aggregation`] survive a node restart.
-    pub fn new_non_blocking_with_previous_anchor<Address, Da, Root>(
-        previous_public_data: Option<&AggregatedProofPublicData<Address, Da, Root>>,
-    ) -> Self
-    where
-        Address: Serialize,
-        Da: DaSpec,
-        Root: Serialize,
-    {
-        let previous_anchor =
-            previous_public_data.map(PreviousAggregatedProofAnchor::from_public_data);
+    /// Like [`Self::new_non_blocking`], but seeded with the
+    /// most-recently-produced [`SerializedAggregatedProof`] so the recursive
+    /// aggregation circuit can verify continuity across a node restart.
+    pub fn new_non_blocking_with_previous_outer_proof(
+        previous: Option<SerializedAggregatedProof>,
+    ) -> Self {
         Self {
             wait_for_proof: false,
             notification_manager: Default::default(),
-            previous_anchor: Arc::new(Mutex::new(previous_anchor)),
+            previous_outer_proof: Arc::new(Mutex::new(previous)),
             code_commitment: MockCodeCommitment::default(),
         }
     }
@@ -157,49 +110,19 @@ impl MockZkvmHost {
         if self.wait_for_proof {
             self.notification_manager.wait();
         }
+        Self::valid_mock_proof_bytes(pub_data, self.code_commitment.clone())
+    }
+
+    /// Bincode-encodes a [`MockProof`] with `is_valid: true` and the given public-data bytes and commitment.
+    fn valid_mock_proof_bytes(
+        pub_data: Vec<u8>,
+        code_commitment: MockCodeCommitment,
+    ) -> anyhow::Result<Vec<u8>> {
         Ok(bincode::serialize(&MockProof {
             is_valid: true,
             pub_data,
-            code_commitment: self.code_commitment.clone(),
+            code_commitment,
         })?)
-    }
-
-    /// Mirrors the per-inner-proof continuity checks performed by the real
-    /// aggregation circuit. Verifies that consecutive `BlockProof.st` entries
-    /// have:
-    ///   1. slot numbers that increment by exactly one,
-    ///   2. a `slot_hash` matching the paired DA block header's hash,
-    ///   3. a `prev_hash` pointing at the predecessor DA block's hash,
-    ///   4. an `initial_state_root` equal to the predecessor's `final_state_root`.
-    fn check_inner_proof_chain<Address, Da: DaSpec, Root: PartialEq + Debug>(
-        headers_with_block_proofs: &[HeaderWithBlockProof<Address, Da, Root>],
-    ) {
-        let mut prev: Option<(SlotNumber, &Da::SlotHash, &Root)> = None;
-        for (index, (header, bp)) in headers_with_block_proofs.iter().enumerate() {
-            let header_hash = header.hash();
-            assert_eq!(
-                header_hash, bp.st.slot_hash,
-                "Slot hash mismatch at index {index}: DA block header hash doesn't match inner-proof public data",
-            );
-            if let Some((prev_slot, prev_hash, prev_state_root)) = prev {
-                let expected = prev_slot.next();
-                assert_eq!(
-                    bp.st.slot_number, expected,
-                    "Slot number discontinuity at index {index}: expected {expected}, got {}",
-                    bp.st.slot_number,
-                );
-                assert_eq!(
-                    prev_hash,
-                    &header.prev_hash(),
-                    "DA block chain broken at index {index}: prev_hash mismatch",
-                );
-                assert_eq!(
-                    &bp.st.initial_state_root, prev_state_root,
-                    "State root discontinuity at index {index}: previous final_state_root != current initial_state_root",
-                );
-            }
-            prev = Some((bp.st.slot_number, &bp.st.slot_hash, &bp.st.final_state_root));
-        }
     }
 
     /// Sleeps for the duration (in milliseconds) read from `env_var`. Used in
@@ -224,13 +147,10 @@ impl MockZkvmHost {
     }
 
     /// Recovers the inner-guest commitment from the inner proofs being aggregated.
-    fn inner_vkey_hash_from_block_proofs<Address, Da: DaSpec, Root>(
-        block_proofs: &[&BlockProof<Address, Da, Root>],
+    fn inner_vkey_hash_from_proof(
+        proof: &SerializedZkProof,
     ) -> sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash {
-        let first = block_proofs
-            .first()
-            .expect("at least one inner proof is required for aggregation");
-        let mock_proof: MockProof = bincode::deserialize(&first.proof.raw_proof)
+        let mock_proof: MockProof = bincode::deserialize(&proof.raw_proof)
             .expect("inner proof must be a bincode-encoded MockProof");
         mock_proof.code_commitment.to_hash()
     }
@@ -262,91 +182,83 @@ impl sov_rollup_interface::zk::ZkvmHost for MockZkvmHost {
 
 impl OuterZkvmHost for MockZkvmHost {
     fn run_proof_aggregation<
-        Address: Serialize + Clone,
+        Address: Serialize + DeserializeOwned + Clone,
         Da: DaSpec,
         Root: Serialize + DeserializeOwned + Clone + PartialEq + Debug,
     >(
         &self,
-        headers_with_block_proofs: Vec<(Da::BlockHeader, BlockProof<Address, Da, Root>)>,
+        headers_with_block_proofs: Vec<HeaderWithBlockProof<Address, Da, Root>>,
     ) -> anyhow::Result<SerializedAggregatedProof> {
         Self::maybe_mock_sleep("SOV_MOCK_AGGREGATION_SLEEP_MS");
         Self::wait_while_stop_proving("SOV_MOCK_AGGREGATION_GATE");
 
-        let mut previous = self
-            .previous_anchor
+        let mut previous_outer_proof = self
+            .previous_outer_proof
             .lock()
-            .expect("previous_anchor mutex was poisoned");
+            .expect("previous_outer_proof mutex was poisoned");
 
-        // Mirror the checks performed by the real aggregation circuit
-        // (`run_aggregation_program` in sov-rollup-interface).
-        Self::check_inner_proof_chain(&headers_with_block_proofs);
+        let first = headers_with_block_proofs
+            .first()
+            .expect("at least one inner proof is required for aggregation");
+        let inner_vkey_hash = Self::inner_vkey_hash_from_proof(&first.1.proof);
+        let outer_vkey_hash = self.code_commitment.to_hash();
 
-        let block_proofs_data = headers_with_block_proofs
-            .iter()
-            .map(|(_, bp)| bp)
-            .collect::<Vec<_>>();
+        let mut proof_inputs = Vec::with_capacity(headers_with_block_proofs.len());
+        for (header, bp) in headers_with_block_proofs {
+            let recovered: MockProof = bincode::deserialize(&bp.proof.raw_proof)
+                .expect("inner proof must be a bincode-encoded MockProof");
+            let pub_values = Self::valid_mock_proof_bytes(
+                bincode::serialize(&bp.st)?,
+                recovered.code_commitment,
+            )?;
+            proof_inputs.push(DeferredProofInput::<Da> {
+                public_values: SerializedPubValues { pub_values },
+                da_block_header: header,
+            });
+        }
 
-        let inner_vkey_hash = Self::inner_vkey_hash_from_block_proofs(&block_proofs_data);
-        let outer_vk_hash = self.code_commitment.to_hash();
+        let prev_outer_proof_witness =
+            previous_outer_proof
+                .as_ref()
+                .map(|prev| PreviousOuterProofWitness {
+                    public_values: SerializedPubValues {
+                        pub_values: prev.raw_aggregated_proof.clone(),
+                    },
+                });
 
-        let public_data = if let Some(prev) = previous.as_ref() {
-            let origin_state_root = prev.deserialize_genesis_state_root();
-            let public_data = AggregatedProofPublicData::from_block_proofs(
-                block_proofs_data.as_slice(),
-                prev.origin_slot_number,
-                origin_state_root,
-                inner_vkey_hash.clone(),
-                outer_vk_hash.clone(),
-            );
-
-            assert_eq!(
-                public_data.initial_slot_number,
-                prev.final_slot_number.next(),
-                "Aggregated proof continuity violated: new aggregation starts at slot {} but previous aggregation ended at slot {}",
-                public_data.initial_slot_number,
-                prev.final_slot_number,
-            );
-
-            let prev_genesis_state_root: Root = prev.deserialize_genesis_state_root();
-            let prev_final_state_root: Root = prev.deserialize_final_state_root();
-
-            assert_eq!(
-                public_data.origin_state_root, prev_genesis_state_root,
-                "Aggregated proof continuity violated: origin_state_root differs from previous aggregation",
-            );
-            assert_eq!(
-                public_data.initial_state_root, prev_final_state_root,
-                "Aggregated proof continuity violated: new initial_state_root does not match previous final_state_root",
-            );
-
-            public_data
-        } else {
-            let origin_state_root = block_proofs_data[0].st.initial_state_root.clone();
-            // origin_slot_number must correspond to origin_state_root: it is the
-            // slot at the end of which that root was produced — i.e. the slot
-            // immediately before the first inner proof's slot.
-            let origin_slot_number = block_proofs_data[0].st.slot_number.prev();
-
-            let public_data = AggregatedProofPublicData::from_block_proofs(
-                block_proofs_data.as_slice(),
-                origin_slot_number,
-                origin_state_root,
-                inner_vkey_hash,
-                outer_vk_hash,
-            );
-
-            public_data
+        let witness = AggregatedProofWitness::<Da> {
+            proof_inputs,
+            inner_vkey_hash,
+            outer_vkey_hash,
+            prev_outer_proof_witness,
         };
 
-        let serialized = self
-            .add_hint_and_run_inner(&public_data)
-            .map(|raw_aggregated_proof| SerializedAggregatedProof {
-                raw_aggregated_proof,
-            })?;
+        let serialized_witness = bincode::serialize(&witness)?;
+        let guest = MockZkGuest::with_hint(serialized_witness);
 
-        *previous = Some(PreviousAggregatedProofAnchor::from_public_data(
-            &public_data,
-        ));
+        // Runs the shared aggregation circuit natively: verifies inner proofs
+        // and the previous outer proof, asserts within-aggregation DA/state
+        // continuity, and commits the new `AggregatedProofPublicData` into
+        // the guest's commit slot.
+        run_aggregation_program::<Address, Da, Root, crate::MockZkVerifier, MockZkGuest>(&guest);
+
+        let committed_public_data = guest
+            .take_committed_bytes()
+            .expect("aggregation circuit must commit its public data");
+
+        if self.wait_for_proof {
+            self.notification_manager.wait();
+        }
+
+        let serialized = SerializedAggregatedProof {
+            raw_aggregated_proof: Self::valid_mock_proof_bytes(
+                committed_public_data,
+                self.code_commitment.clone(),
+            )?,
+        };
+
+        *previous_outer_proof = Some(serialized.clone());
+
         Ok(serialized)
     }
 }

--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -96,11 +96,12 @@ impl MockZkvmHost {
         code_commitment: MockCodeCommitment,
     ) -> SerializedZkProof {
         let data = bincode::serialize(&transition).unwrap();
-        let raw_proof = bincode::serialize(&MockProof {
+        let raw_proof = MockProof {
             is_valid,
             pub_data: data,
             code_commitment,
-        })
+        }
+        .serialize()
         .unwrap();
         SerializedZkProof { raw_proof }
     }
@@ -118,11 +119,12 @@ impl MockZkvmHost {
         pub_data: Vec<u8>,
         code_commitment: MockCodeCommitment,
     ) -> anyhow::Result<Vec<u8>> {
-        Ok(bincode::serialize(&MockProof {
+        Ok(MockProof {
             is_valid: true,
             pub_data,
             code_commitment,
-        })?)
+        }
+        .serialize()?)
     }
 
     /// Sleeps for the duration (in milliseconds) read from `env_var`. Used in
@@ -150,7 +152,7 @@ impl MockZkvmHost {
     fn inner_vkey_hash_from_proof(
         proof: &SerializedZkProof,
     ) -> sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash {
-        let mock_proof: MockProof = bincode::deserialize(&proof.raw_proof)
+        let mock_proof = MockProof::deserialize(&proof.raw_proof)
             .expect("inner proof must be a bincode-encoded MockProof");
         mock_proof.code_commitment.to_hash()
     }
@@ -205,7 +207,7 @@ impl OuterZkvmHost for MockZkvmHost {
 
         let mut proof_inputs = Vec::with_capacity(headers_with_block_proofs.len());
         for (header, bp) in headers_with_block_proofs {
-            let recovered: MockProof = bincode::deserialize(&bp.proof.raw_proof)
+            let recovered = MockProof::deserialize(&bp.proof.raw_proof)
                 .expect("inner proof must be a bincode-encoded MockProof");
             let pub_values = Self::valid_mock_proof_bytes(
                 bincode::serialize(&bp.st)?,

--- a/crates/adapters/mock-zkvm/src/host.rs
+++ b/crates/adapters/mock-zkvm/src/host.rs
@@ -168,7 +168,6 @@ impl sov_rollup_interface::zk::ZkvmHost for MockZkvmHost {
         _item: &T,
         _agg_proofs: Vec<SerializedAggregatedProof>,
     ) -> anyhow::Result<SerializedZkProof> {
-        // Mirror SP1: a proof commits whatever the guest commits, not the hint.
         // With no guest execution, the mock has nothing to commit, so the
         // inner proof carries empty public data. The aggregation step gets
         // the canonical public output side-band via `BlockProof::st`.

--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -202,19 +202,12 @@ mod tests {
 
     #[test]
     fn test_mock_vm() -> anyhow::Result<()> {
-        let pub_data = TestPublicData {
-            hint: "Test".to_owned(),
-        };
-
         let mut vm = MockZkvmHost::new();
         vm.make_proof();
-        let proof = vm
-            .add_hint_deferred_and_run(&pub_data, Default::default())
-            .unwrap();
-        let verified_pub_data =
-            MockZkVerifier::verify_with_proof::<TestPublicData>(&proof, &Default::default())?;
-
-        assert_eq!(verified_pub_data, pub_data);
+        // Inner mock proofs commit nothing (no guest to derive public output
+        // from the hint); verification asserts validity + matching commitment.
+        let proof = vm.add_hint_deferred_and_run(&(), Default::default())?;
+        MockZkVerifier::verify_with_proof::<()>(&proof, &Default::default())?;
         Ok(())
     }
 
@@ -238,16 +231,10 @@ mod tests {
     #[test]
     fn test_verify_accepts_matching_code_commitment() -> anyhow::Result<()> {
         let commitment = MockCodeCommitment(*b"binary01");
-        let pub_data = TestPublicData {
-            hint: "match".to_owned(),
-        };
-
         let mut vm = MockZkvmHost::new().with_code_commitment(commitment.clone());
         vm.make_proof();
-        let proof = vm.add_hint_deferred_and_run(&pub_data, Default::default())?;
-
-        let verified = MockZkVerifier::verify_with_proof::<TestPublicData>(&proof, &commitment)?;
-        assert_eq!(verified, pub_data);
+        let proof = vm.add_hint_deferred_and_run(&(), Default::default())?;
+        MockZkVerifier::verify_with_proof::<()>(&proof, &commitment)?;
         Ok(())
     }
 
@@ -255,17 +242,14 @@ mod tests {
     fn test_verify_rejects_mismatched_code_commitment() {
         let v1 = MockCodeCommitment(*b"binary01");
         let v2 = MockCodeCommitment(*b"binary02");
-        let pub_data = TestPublicData {
-            hint: "mismatch".to_owned(),
-        };
 
-        let mut vm = MockZkvmHost::new().with_code_commitment(v1.clone());
+        let mut vm = MockZkvmHost::new().with_code_commitment(v1);
         vm.make_proof();
         let proof = vm
-            .add_hint_deferred_and_run(&pub_data, Default::default())
+            .add_hint_deferred_and_run(&(), Default::default())
             .unwrap();
 
-        let err = MockZkVerifier::verify_with_proof::<TestPublicData>(&proof, &v2).unwrap_err();
+        let err = MockZkVerifier::verify_with_proof::<()>(&proof, &v2).unwrap_err();
         assert!(
             err.to_string().contains("Code commitment mismatch"),
             "expected commitment-mismatch error, got: {err}"

--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -113,12 +113,27 @@ impl sov_rollup_interface::zk::ZkVerifier for MockZkVerifier {
 
     type Error = anyhow::Error;
 
-    #[cfg(target_os = "zkvm")]
     fn verify_with_pub_values<T: DeserializeOwned>(
-        _public_values: &sov_rollup_interface::zk::aggregated_proof::common::SerializedPubValues,
-        _code_commitment: &Self::CodeCommitment,
+        public_values: &sov_rollup_interface::zk::aggregated_proof::common::SerializedPubValues,
+        code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
-        todo!("MockZkVerifier does not support `verify_with_pub_values`")
+        // The mock encodes a complete `MockProof` in `pub_values.pub_values` —
+        // mirroring SP1's deferred-proof channel, but in-band so the circuit
+        // can run natively.
+        let MockProof {
+            is_valid,
+            pub_data,
+            code_commitment: claimed,
+        } = bincode::deserialize(&public_values.pub_values)?;
+        if !is_valid {
+            anyhow::bail!("Proof is not valid");
+        }
+        if &claimed != code_commitment {
+            anyhow::bail!(
+                "Code commitment mismatch: proof claims {claimed:?}, verifier expects {code_commitment:?}"
+            );
+        }
+        Ok(bincode::deserialize(&pub_data)?)
     }
 
     fn verify_with_proof<T: DeserializeOwned>(

--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -102,6 +102,18 @@ struct MockProof {
     code_commitment: MockCodeCommitment,
 }
 
+impl MockProof {
+    /// Bincode-encodes this proof.
+    pub(crate) fn serialize(&self) -> bincode::Result<Vec<u8>> {
+        bincode::serialize(self)
+    }
+
+    /// Bincode-decodes a proof from `bytes`.
+    pub(crate) fn deserialize(bytes: &[u8]) -> bincode::Result<Self> {
+        bincode::deserialize(bytes)
+    }
+}
+
 /// The verifier for mock zk proofs.
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct MockZkVerifier;
@@ -124,7 +136,7 @@ impl sov_rollup_interface::zk::ZkVerifier for MockZkVerifier {
             is_valid,
             pub_data,
             code_commitment: claimed,
-        } = bincode::deserialize(&public_values.pub_values)?;
+        } = MockProof::deserialize(&public_values.pub_values)?;
         if !is_valid {
             anyhow::bail!("Proof is not valid");
         }
@@ -144,7 +156,7 @@ impl sov_rollup_interface::zk::ZkVerifier for MockZkVerifier {
             is_valid,
             pub_data: input,
             code_commitment: claimed,
-        } = bincode::deserialize(&serialized_proof.raw_proof)?;
+        } = MockProof::deserialize(&serialized_proof.raw_proof)?;
         if !is_valid {
             anyhow::bail!("Proof is not valid");
         }
@@ -161,7 +173,7 @@ impl sov_rollup_interface::zk::ZkVerifier for MockZkVerifier {
     ) -> Result<T, Self::Error> {
         let MockProof {
             pub_data: input, ..
-        } = bincode::deserialize(&serialized_proof.raw_proof)?;
+        } = MockProof::deserialize(&serialized_proof.raw_proof)?;
         Ok(bincode::deserialize(&input)?)
     }
 }

--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -103,7 +103,9 @@ struct MockProof {
 }
 
 impl MockProof {
-    /// Bincode-encodes this proof.
+    /// Bincode-encodes this proof. Only the native host path produces
+    /// `MockProof`s; verifiers read them via [`Self::deserialize`].
+    #[cfg(feature = "native")]
     pub(crate) fn serialize(&self) -> bincode::Result<Vec<u8>> {
         bincode::serialize(self)
     }

--- a/crates/adapters/risc0/src/lib.rs
+++ b/crates/adapters/risc0/src/lib.rs
@@ -100,6 +100,16 @@ impl ZkVerifier for Risc0Verifier {
     type CryptoSpec = Risc0CryptoSpec;
     type Error = anyhow::Error;
 
+    fn verify_with_pub_values<T: DeserializeOwned>(
+        _public_values: &sov_rollup_interface::zk::aggregated_proof::common::SerializedPubValues,
+        _code_commitment: &Self::CodeCommitment,
+    ) -> Result<T, Self::Error> {
+        // Risc0's `verify_with_pub_values` is only meaningful inside the guest.
+        unimplemented!(
+            "Risc0Verifier::verify_with_pub_values is only available inside the zkvm guest"
+        )
+    }
+
     fn verify_with_proof<T: DeserializeOwned>(
         serialized_proof: &SerializedZkProof,
         code_commitment: &Self::CodeCommitment,

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -109,6 +109,16 @@ impl ZkVerifier for SP1Verifier {
     type CryptoSpec = SP1CryptoSpec;
     type Error = anyhow::Error;
 
+    fn verify_with_pub_values<T: DeserializeOwned>(
+        _public_values: &sov_rollup_interface::zk::aggregated_proof::common::SerializedPubValues,
+        _code_commitment: &Self::CodeCommitment,
+    ) -> Result<T, Self::Error> {
+        // SP1's `verify_with_pub_values` is only meaningful inside the guest.
+        unimplemented!(
+            "SP1Verifier::verify_with_pub_values is only available inside the zkvm guest"
+        )
+    }
+
     fn verify_with_proof<T: DeserializeOwned>(
         serialized_proof: &SerializedZkProof,
         code_commitment: &Self::CodeCommitment,

--- a/crates/full-node/sov-stf-runner/tests/integration/prover_service/parallel.rs
+++ b/crates/full-node/sov-stf-runner/tests/integration/prover_service/parallel.rs
@@ -82,9 +82,9 @@ async fn test_prover_status_busy() -> anyhow::Result<()> {
         ..
     } = make_new_prover();
 
-    let headers: Vec<_> = (0..num_worker_threads)
-        .map(|height| make_header(MockHash::from([(height + 1) as u8; 32]), height as u64))
-        .collect();
+    // Headers must form a DA hash chain so consecutive single-header
+    // aggregations satisfy the circuit's cross-aggregation continuity check.
+    let headers = make_chained_headers(num_worker_threads);
 
     // Saturate the prover.
     for header in &headers {

--- a/crates/rollup-interface/Cargo.toml
+++ b/crates/rollup-interface/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true }
 async-trait = { workspace = true }
 backon = { workspace = true, optional = true }
+bincode = { workspace = true }
 borsh = { workspace = true, features = ["bytes"] }
 bytes = { workspace = true, features = ["serde"] }
 derive_more = { workspace = true, features = [
@@ -51,7 +52,6 @@ proptest-derive = { workspace = true }
 serde_json = { workspace = true }
 jsonschema = { workspace = true }
 schemars = { workspace = true }
-bincode = { workspace = true }
 sov-rollup-interface = { path = ".", features = ["native", "arbitrary"] }
 test-strategy = { workspace = true }
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
@@ -29,7 +29,7 @@ type VerifyResult<Address, Da, Root> = VerifiedProofData<Address, <Da as DaSpec>
 /// Runs the aggregation circuit: reads a witness from the host, verifies inner
 /// proofs and an optional previous outer proof, checks DA and state-root
 /// continuity, then commits [`AggregatedProofPublicData`] as the public output.
-pub fn run_aggregation_program<Address, Da, Root, V, G>(guest: G)
+pub fn run_aggregation_program<Address, Da, Root, V, G>(guest: &G)
 where
     Address: Clone + Serialize + DeserializeOwned,
     Da: DaSpec,
@@ -76,21 +76,25 @@ where
     } = verified_proof_data;
 
     // Propagate the origin state root forward through recursive aggregations.
-    // For the very first aggregation, the origin root is the initial state root
-    // of the first inner proof (i.e. the state root at chain genesis).
+    // For the very first aggregation (no predecessor), the origin root is the
+    // initial state root of the first inner proof.
     let origin_state_root = previous_public_data
         .as_ref()
         .map(|public_data| public_data.origin_state_root.clone())
         .unwrap_or_else(|| initial_boundary.state_root.clone());
 
     // Slot number that origin_state_root corresponds to. Propagated from the
-    // predecessor; for the first aggregation it is the slot before the first
-    // inner proof — i.e. the rollup genesis (SlotNumber::GENESIS), since the
-    // first inner proof must cover slot 1.
+    // predecessor when one exists; otherwise it is the slot immediately
+    // before the first inner proof. For a chain rooted at rollup genesis the
+    // first inner proof covers slot 1 and this evaluates to GENESIS, but the
+    // circuit doesn't itself enforce that — a chain that starts mid-flight
+    // (e.g. after a prover-service resync that intentionally skipped earlier
+    // slots) will produce an aggregation with `origin_slot_number > GENESIS`,
+    // which downstream consumers can use to detect the discontinuity.
     let origin_slot_number = previous_public_data
         .as_ref()
         .map(|public_data| public_data.origin_slot_number)
-        .unwrap_or(SlotNumber::GENESIS);
+        .unwrap_or_else(|| initial_boundary.slot_number.prev());
 
     let aggregated_public_data = AggregatedProofPublicData::<Address, Da, Root> {
         initial_slot_number: initial_boundary.slot_number,
@@ -155,19 +159,20 @@ where
 
         let current_slot_number = stf_public_data.slot_number;
 
-        // Slots advance 1:1 with DA blocks on the canonical fork, so each
-        // consecutive inner proof must increment the slot number by exactly one.
-        // For the very first aggregation (no predecessor), the first inner proof
-        // must cover slot 1 — slot 0 is the rollup genesis state and has no
-        // associated state transition / inner proof.
-        let expected = match expected_prev_slot_number {
-            Some(prev) => prev.next(),
-            None => SlotNumber::ONE,
-        };
-        assert_eq!(
-            current_slot_number, expected,
-            "Slot number discontinuity at index {index}: expected {expected}, got {current_slot_number}",
-        );
+        // Within a single aggregation, consecutive inner proofs must increment
+        // the slot number by exactly one — slots advance 1:1 with DA blocks on
+        // the canonical fork. When there's no predecessor outer proof, the
+        // first inner proof can start at any slot (the rollup may legitimately
+        // resume mid-flight after a resync that skipped earlier slots); the
+        // aggregation's `origin_slot_number` will reflect where this chain
+        // segment begins.
+        if let Some(prev) = expected_prev_slot_number {
+            let expected = prev.next();
+            assert_eq!(
+                current_slot_number, expected,
+                "Slot number discontinuity at index {index}: expected {expected}, got {current_slot_number}",
+            );
+        }
         expected_prev_slot_number = Some(current_slot_number);
 
         // Verify DA block hash-chain continuity: each block's prev_hash must equal

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -1,6 +1,5 @@
 //! Defines types that are related to the `AggregatedProof`.
 /// Core aggregation circuit logic.
-#[cfg(target_os = "zkvm")]
 pub mod circuit;
 /// Common types shared between the aggregated proof program and the host script.
 pub mod common;
@@ -20,7 +19,7 @@ use crate::zk::SerializedZkProof;
 pub trait OuterZkvmHost: Clone + Send + Sync + 'static {
     /// Aggregates per-block inner proofs into a single serialized aggregated proof.
     fn run_proof_aggregation<
-        Address: Serialize + Clone,
+        Address: Serialize + DeserializeOwned + Clone,
         Da: DaSpec,
         Root: Serialize + DeserializeOwned + Clone + PartialEq + core::fmt::Debug,
     >(
@@ -122,43 +121,6 @@ pub struct AggregatedProofPublicData<Address, Da: DaSpec, Root> {
     pub outer_vk_hash: CodeCommitmentHash,
     /// These are the addresses of the provers who proved individual blocks.
     pub rewarded_addresses: Vec<Address>,
-}
-
-impl<Address: Clone, Da: DaSpec, Root: Clone> AggregatedProofPublicData<Address, Da, Root>
-where
-    Da::SlotHash: Clone,
-{
-    /// Constructs an [`AggregatedProofPublicData`] from a slice of [`BlockProof`] references,
-    /// deriving initial/final fields from the first and last entries.
-    pub fn from_block_proofs(
-        block_proofs: &[&BlockProof<Address, Da, Root>],
-        origin_slot_number: SlotNumber,
-        origin_state_root: Root,
-        inner_vkey_hash: CodeCommitmentHash,
-        outer_vk_hash: CodeCommitmentHash,
-    ) -> Self {
-        let initial = block_proofs
-            .first()
-            .expect("block_proofs must not be empty");
-        let final_bp = block_proofs.last().expect("block_proofs must not be empty");
-        let rewarded_addresses = block_proofs
-            .iter()
-            .map(|bp| bp.st.prover_address.clone())
-            .collect();
-        Self {
-            rewarded_addresses,
-            initial_slot_number: initial.st.slot_number,
-            final_slot_number: final_bp.st.slot_number,
-            origin_slot_number,
-            origin_state_root,
-            initial_state_root: initial.st.initial_state_root.clone(),
-            final_state_root: final_bp.st.final_state_root.clone(),
-            initial_slot_hash: initial.st.slot_hash.clone(),
-            final_slot_hash: final_bp.st.slot_hash.clone(),
-            inner_vkey_hash,
-            outer_vk_hash,
-        }
-    }
 }
 
 impl<Address, Da: DaSpec, Root: AsRef<[u8]>> core::fmt::Display

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -144,7 +144,6 @@ pub trait ZkVerifier: Default + Clone + Send + Sync + 'static {
     /// supplies the serialized public values the proof is expected to commit
     /// to, along with the code commitment identifying which program was
     /// proven.
-    #[cfg(target_os = "zkvm")]
     fn verify_with_pub_values<T: DeserializeOwned>(
         pub_values: &aggregated_proof::common::SerializedPubValues,
         code_commitment: &Self::CodeCommitment,

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -220,6 +220,18 @@ pub struct StateTransitionPublicData<Address, Da: DaSpec, Root> {
     pub prover_address: Address,
 }
 
+impl<Address, Da: DaSpec, Root> StateTransitionPublicData<Address, Da, Root> {
+    /// Bincode-encodes this public data.
+    pub fn serialize(&self) -> bincode::Result<Vec<u8>>
+    where
+        Address: Serialize,
+        Root: Serialize,
+        Da::SlotHash: Serialize,
+    {
+        bincode::serialize(self)
+    }
+}
+
 #[derive(Serialize, Deserialize, UniversalWallet)]
 // Prevent serde from generating spurious trait bounds. The correct serde bounds are already enforced by the
 // StateTransitionFunction, DA, and Zkvm traits.

--- a/examples/demo-rollup/provers/sp1/guest-aggregation-mock/src/main.rs
+++ b/examples/demo-rollup/provers/sp1/guest-aggregation-mock/src/main.rs
@@ -21,5 +21,5 @@ pub fn main() {
         <<ProgramSpec as Spec>::Storage as Storage>::Root,
         SP1Verifier,
         SP1Guest,
-    >(guest);
+    >(&guest);
 }

--- a/examples/demo-rollup/src/mock_helper.rs
+++ b/examples/demo-rollup/src/mock_helper.rs
@@ -103,46 +103,46 @@ where
 {
     let (inner_code_commitment, outer_code_commitment) = read_mock_code_commitments_from_env();
 
-    // Extract the persisted proof's public data without re-verifying
-    // its commitment. The commitment may have legitimately rotated
-    // since the proof was written (e.g. a guest-binary upgrade), but
-    // we still need its `final_slot_number` to anchor the STF-info
-    // stream so the next aggregation is contiguous with what's on
-    // disk.
+    // Read the persisted proof.
+    let previous_proof = read_latest_aggregated_proof(ledger_db).await;
     let previous_public_data: Option<MockAggregatedProofPublicData> =
-        match read_latest_aggregated_proof(ledger_db).await {
+        match previous_proof.as_ref() {
             None => None,
             Some(proof) => Some(
-                MockZkVerifier::extract_public_data(&proof.to_serialized_zk_proof()).map_err(
-                    |e| {
+                MockZkVerifier::extract_public_data(&proof.clone().to_serialized_zk_proof())
+                    .map_err(|e| {
                         anyhow::anyhow!(
                             "Failed to extract public data from persisted aggregated proof: {e}"
                         )
-                    },
-                )?,
+                    })?,
             ),
         };
 
     let latest_proof_final_slot = previous_public_data.as_ref().map(|p| p.final_slot_number);
 
-    let previous = previous_public_data
-        .as_ref()
-        .filter(|_| !start_fresh_outer_proof_on_resync);
-
-    if let Some(previous) = previous {
+    if let (false, Some(prev)) = (
+        start_fresh_outer_proof_on_resync,
+        previous_public_data.as_ref(),
+    ) {
         anyhow::ensure!(
-            inner_code_commitment.to_hash() == previous.inner_vkey_hash,
+            inner_code_commitment.to_hash() == prev.inner_vkey_hash,
             "inner code commitment changed since last proof; pass start_fresh_outer_proof_on_resync to reset"
         );
         anyhow::ensure!(
-            outer_code_commitment.to_hash() == previous.outer_vk_hash,
+            outer_code_commitment.to_hash() == prev.outer_vk_hash,
             "outer code commitment changed since last proof; pass start_fresh_outer_proof_on_resync to reset"
         );
     }
 
+    let previous_outer_proof = if start_fresh_outer_proof_on_resync {
+        None
+    } else {
+        previous_proof
+    };
+
     let inner_vm = MockZkvmHost::new_non_blocking().with_code_commitment(inner_code_commitment);
 
-    let outer_vm = MockZkvmHost::new_non_blocking_with_previous_anchor(previous)
+    let outer_vm = MockZkvmHost::new_non_blocking_with_previous_outer_proof(previous_outer_proof)
         .with_code_commitment(outer_code_commitment);
     let prover = ParallelProverService::new_with_default_workers(
         inner_vm,

--- a/examples/demo-rollup/tests/zk_proving/commitment_rotation.rs
+++ b/examples/demo-rollup/tests/zk_proving/commitment_rotation.rs
@@ -39,10 +39,13 @@ async fn code_commitment_rotation_requires_fresh_start() -> anyhow::Result<()> {
         .start_test_rollup()
         .await;
 
-    assert!(res.is_err());
+    assert!(
+        res.is_err(),
+        "expected resume to fail under rotated commitments"
+    );
 
     // With start_fresh_outer_proof_on_resync = true, startup drops the previous
-    // outer-proof anchor and begins a fresh aggregation chain under the rotated
+    // outer-proof and begins a fresh aggregation chain under the rotated
     // commitments — no vkey-hash check, so this restart succeeds.
     let test_rollup = builder
         .set_config(|c| {


### PR DESCRIPTION
# Description

 Before this PR, `MockZkvmHost::run_proof_aggregation` was a hand-rolled reimplementation of `run_aggregation_program`: same constraints (slot/DA/state continuity), but maintained in two places. Now the mock executes the shared circuit verbatim — only the `ZkVerifier` and `ZkvmGuest` impls differ from SP1.

Changes:

1. Lifted `#[cfg(target_os = "zkvm")]` from `aggregated_proof::circuit` and `ZkVerifier::verify_with_pub_values` so the shared circuit is callable on native.

2.  The shared circuit previously assumed every aggregation chain roots at rollup genesis. Two checks encoded that assumption, both fired only when the aggregation has no predecessor outer proof:
   - Slot assertion. `verify_proof_chain` asserted `first_inner_slot == SlotNumber::ONE`.
  - Origin default. run_aggregation_program set the new aggregation's o`rigin_slot_number = SlotNumber::GENESIS`.

This PR relaxes both: the slot assertion is dropped when no predecessor exists, and o`rigin_slot_number` defaults to `first_inner_slot.prev()` instead. 
The motivation is  `start_fresh_outer_proof_on_resync`: when a node resumes with that flag, the prover service intentionally drops the on-disk anchor and begins a new chain at the current slot, which the old assertion forbade

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551