### PR TITLE
 SP1: support start_fresh_outer_proof_on_resync

### DIFF
--- a/crates/adapters/sp1/src/host.rs
+++ b/crates/adapters/sp1/src/host.rs
@@ -336,7 +336,12 @@ pub fn verifying_key_from_elf(elf: &[u8]) -> anyhow::Result<SP1VerifyingKey> {
 /// Computes the [`SP1MethodId`] (code commitment) for the given guest ELF.
 pub fn code_commitment_from_elf(elf: &[u8]) -> anyhow::Result<SP1MethodId> {
     let vk = verifying_key_from_elf(elf)?;
-    Ok(SP1MethodId(vk.hash_u32()))
+    Ok(code_commitment_from_verifying_key(&vk))
+}
+
+/// Computes the [`SP1MethodId`] (code commitment) for an already-derived verifying key.
+pub fn code_commitment_from_verifying_key(vk: &SP1VerifyingKey) -> SP1MethodId {
+    SP1MethodId(vk.hash_u32())
 }
 
 fn prover_and_pk(elf: &[u8]) -> anyhow::Result<(EnvProver, EnvProvingKey)> {

--- a/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/risc0/guest-celestia/Cargo.lock
@@ -4542,6 +4542,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode",
  "borsh",
  "bytes",
  "derive_more",

--- a/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-aggregation-mock/Cargo.lock
@@ -6213,6 +6213,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode",
  "borsh",
  "bytes",
  "derive_more 2.1.1",

--- a/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-celestia/Cargo.lock
@@ -6579,6 +6579,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode",
  "borsh",
  "bytes",
  "derive_more 2.1.1",

--- a/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
+++ b/examples/demo-rollup/provers/sp1/guest-mock/Cargo.lock
@@ -6203,6 +6203,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode",
  "borsh",
  "bytes",
  "derive_more 2.1.1",

--- a/examples/demo-rollup/src/lib.rs
+++ b/examples/demo-rollup/src/lib.rs
@@ -3,8 +3,16 @@
 //! See the README for more information.
 // TODO: #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
+use serde::de::DeserializeOwned;
 use sov_celestia_adapter::types::Namespace;
+use sov_db::ledger_db::LedgerDb;
 use sov_modules_api::macros::config_value;
+use sov_rollup_interface::common::SlotNumber;
+use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::zk::aggregated_proof::{
+    AggregatedProofPublicData, CodeCommitmentHash, SerializedAggregatedProof,
+};
+use sov_rollup_interface::zk::ZkVerifier;
 use std::str::FromStr;
 mod aggregated_proof;
 pub use aggregated_proof::read_latest_aggregated_proof;
@@ -48,4 +56,57 @@ fn eth_dev_signer() -> sov_ethereum::Signers {
         "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
     )
     .unwrap()])
+}
+
+/// Loads the latest persisted aggregated proof and reconciles it with the
+/// current inner/outer code commitments to decide what the outer prover should
+/// resume from.
+pub(crate) async fn get_persisted_outer_proof<Vm, Address, Da, Root>(
+    ledger_db: &LedgerDb,
+    inner_code_commitment_hash: CodeCommitmentHash,
+    outer_code_commitment_hash: CodeCommitmentHash,
+    start_fresh_outer_proof_on_resync: bool,
+) -> anyhow::Result<(Option<SerializedAggregatedProof>, Option<SlotNumber>)>
+where
+    Vm: ZkVerifier,
+    Da: DaSpec,
+    AggregatedProofPublicData<Address, Da, Root>: DeserializeOwned,
+{
+    let previous_proof = read_latest_aggregated_proof(ledger_db).await;
+
+    let previous_public_data = previous_proof
+        .as_ref()
+        .map(|proof| {
+            Vm::extract_public_data::<AggregatedProofPublicData<Address, Da, Root>>(
+                &proof.clone().to_serialized_zk_proof(),
+            )
+        })
+        .transpose()
+        .map_err(|e| {
+            anyhow::anyhow!("Failed to extract public data from persisted aggregated proof: {e:#}")
+        })?;
+
+    let latest_proof_final_slot = previous_public_data.as_ref().map(|p| p.final_slot_number);
+
+    if let (false, Some(prev)) = (
+        start_fresh_outer_proof_on_resync,
+        previous_public_data.as_ref(),
+    ) {
+        anyhow::ensure!(
+            inner_code_commitment_hash == prev.inner_vkey_hash,
+            "inner code commitment changed since last proof; pass start_fresh_outer_proof_on_resync to reset"
+        );
+        anyhow::ensure!(
+            outer_code_commitment_hash == prev.outer_vk_hash,
+            "outer code commitment changed since last proof; pass start_fresh_outer_proof_on_resync to reset"
+        );
+    }
+
+    let previous_outer_proof = if start_fresh_outer_proof_on_resync {
+        None
+    } else {
+        previous_proof
+    };
+
+    Ok((previous_outer_proof, latest_proof_final_slot))
 }

--- a/examples/demo-rollup/src/lib.rs
+++ b/examples/demo-rollup/src/lib.rs
@@ -83,7 +83,7 @@ where
         })
         .transpose()
         .map_err(|e| {
-            anyhow::anyhow!("Failed to extract public data from persisted aggregated proof: {e:#}")
+            anyhow::anyhow!("Failed to extract public data from persisted aggregated proof: {e:?}")
         })?;
 
     let latest_proof_final_slot = previous_public_data.as_ref().map(|p| p.final_slot_number);

--- a/examples/demo-rollup/src/mock_helper.rs
+++ b/examples/demo-rollup/src/mock_helper.rs
@@ -16,13 +16,12 @@ use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::da::DaService;
 use sov_rollup_interface::zk::aggregated_proof::AggregatedProofPublicData;
-use sov_rollup_interface::zk::ZkVerifier;
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::{DefaultStorageSpec, Storage};
 use sov_stf_runner::processes::ParallelProverService;
 use sov_stf_runner::RollupConfig;
 
-use crate::read_latest_aggregated_proof;
+use crate::get_persisted_outer_proof;
 
 /// Hasher used by mock-da-backed demo rollups.
 pub type Hasher = <MockZkvmCryptoSpec as CryptoSpec>::Hasher;
@@ -103,42 +102,18 @@ where
 {
     let (inner_code_commitment, outer_code_commitment) = read_mock_code_commitments_from_env();
 
-    // Read the persisted proof.
-    let previous_proof = read_latest_aggregated_proof(ledger_db).await;
-    let previous_public_data: Option<MockAggregatedProofPublicData> =
-        match previous_proof.as_ref() {
-            None => None,
-            Some(proof) => Some(
-                MockZkVerifier::extract_public_data(&proof.clone().to_serialized_zk_proof())
-                    .map_err(|e| {
-                        anyhow::anyhow!(
-                            "Failed to extract public data from persisted aggregated proof: {e}"
-                        )
-                    })?,
-            ),
-        };
-
-    let latest_proof_final_slot = previous_public_data.as_ref().map(|p| p.final_slot_number);
-
-    if let (false, Some(prev)) = (
+    let (previous_outer_proof, latest_proof_final_slot) = get_persisted_outer_proof::<
+        MockZkVerifier,
+        MultiAddressEvmSolana,
+        MockDaSpec,
+        <NativeStorage as Storage>::Root,
+    >(
+        ledger_db,
+        inner_code_commitment.to_hash(),
+        outer_code_commitment.to_hash(),
         start_fresh_outer_proof_on_resync,
-        previous_public_data.as_ref(),
-    ) {
-        anyhow::ensure!(
-            inner_code_commitment.to_hash() == prev.inner_vkey_hash,
-            "inner code commitment changed since last proof; pass start_fresh_outer_proof_on_resync to reset"
-        );
-        anyhow::ensure!(
-            outer_code_commitment.to_hash() == prev.outer_vk_hash,
-            "outer code commitment changed since last proof; pass start_fresh_outer_proof_on_resync to reset"
-        );
-    }
-
-    let previous_outer_proof = if start_fresh_outer_proof_on_resync {
-        None
-    } else {
-        previous_proof
-    };
+    )
+    .await?;
 
     let inner_vm = MockZkvmHost::new_non_blocking().with_code_commitment(inner_code_commitment);
 

--- a/examples/demo-rollup/src/mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/mock_sp1_rollup.rs
@@ -11,7 +11,7 @@ use sov_mock_da::storable::StorableMockDaService;
 use sov_mock_da::MockDaSpec;
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::{Native, WitnessGeneration};
-use sov_modules_api::{CryptoSpec, NodeEndpoints, Spec};
+use sov_modules_api::{CodeCommitmentTrait, CryptoSpec, NodeEndpoints, Spec};
 use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
 use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
@@ -19,11 +19,8 @@ use sov_rollup_full_node_interface::StateUpdateReceiver;
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::da::DaSpec;
 use sov_rollup_interface::node::SyncStatus;
-use sov_rollup_interface::zk::aggregated_proof::{
-    AggregateProofVerifier, AggregatedProofPublicData,
-};
 use sov_sequencer::{ProofBlobSender, Sequencer};
-use sov_sp1_adapter::host::{SP1AggregationHost, SP1Host};
+use sov_sp1_adapter::host::{code_commitment_from_verifying_key, SP1AggregationHost, SP1Host};
 use sov_sp1_adapter::{SP1CryptoSpec, SP1MethodId, SP1Verifier, SP1};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::{DefaultStorageSpec, Storage};
@@ -31,8 +28,31 @@ use sov_stf_runner::processes::{ParallelProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
 
 use crate::eth_dev_signer;
-use crate::read_latest_aggregated_proof;
+use crate::get_persisted_outer_proof;
 use crate::solana_offchain_endpoint::solana_offchain_router;
+
+/// Output of [`build_sp1_inner_host`]: the inner [`SP1Host`] together with the
+/// inner and outer code commitments derived from the same setup pass.
+struct Sp1InnerHostBundle {
+    inner_host: SP1Host,
+    inner_code_commitment: SP1MethodId,
+    outer_code_commitment: SP1MethodId,
+}
+
+/// Runs the SP1 prover setup once per ELF and returns the inner host plus both
+/// code commitments. Callers that only need the commitments can drop
+/// `inner_host`; the setup cost is identical either way.
+fn build_sp1_inner_host(inner_elf: &[u8], outer_elf: &[u8]) -> anyhow::Result<Sp1InnerHostBundle> {
+    let outer_vk = Arc::new(sov_sp1_adapter::host::verifying_key_from_elf(outer_elf)?);
+    let outer_code_commitment = code_commitment_from_verifying_key(&outer_vk);
+    let inner_host = SP1Host::new(inner_elf, outer_vk)?;
+    let inner_code_commitment = code_commitment_from_verifying_key(inner_host.verifying_key());
+    Ok(Sp1InnerHostBundle {
+        inner_host,
+        inner_code_commitment,
+        outer_code_commitment,
+    })
+}
 
 /// Rollup with a [`ConfigurableSpec`] with [`MockDaSpec`] as Da spec, and [`SP1`] for both inner and outer vm
 #[derive(Default, Clone, Copy)]
@@ -152,31 +172,31 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
         let elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
         let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
 
-        let outer_verifying_key = tokio::task::spawn_blocking(move || {
-            sov_sp1_adapter::host::verifying_key_from_elf(agg_elf).map(Arc::new)
-        })
-        .await
-        .expect("Outer verifying key setup task panicked")
-        .expect("Failed to derive outer verifying key from aggregation guest ELF");
-
         // SP1's blocking CPU prover spins up its own tokio runtime during setup,
         // so it must be constructed off the async executor thread.
-        let inner_vm = tokio::task::spawn_blocking(move || SP1Host::new(elf, outer_verifying_key))
+        let Sp1InnerHostBundle {
+            inner_host: inner_vm,
+            inner_code_commitment,
+            outer_code_commitment,
+        } = tokio::task::spawn_blocking(move || build_sp1_inner_host(elf, agg_elf))
             .await
-            .expect("SP1Host setup task panicked")
-            .expect("Failed to create SP1Host from guest ELF");
+            .expect("SP1 host setup task panicked")?;
 
         let inner_verifying_key = inner_vm.verifying_key().clone();
 
-        if start_fresh_outer_proof_on_resync {
-            panic!(
-                "`start_fresh_outer_proof_on_resync` is not supported for the SP1 mock rollup: todo #2551"
-            );
-        }
+        let (previous_for_outer, latest_proof_final_slot) = get_persisted_outer_proof::<
+            SP1Verifier,
+            <Self::Spec as Spec>::Address,
+            MockDaSpec,
+            <<Self::Spec as Spec>::Storage as Storage>::Root,
+        >(
+            ledger_db,
+            inner_code_commitment.to_hash(),
+            outer_code_commitment.to_hash(),
+            start_fresh_outer_proof_on_resync,
+        )
+        .await?;
 
-        let previous_aggregated_proof = read_latest_aggregated_proof(ledger_db).await;
-
-        let previous_for_outer = previous_aggregated_proof.clone();
         let outer_vm = tokio::task::spawn_blocking(move || {
             SP1AggregationHost::new_with_previous_proof(
                 agg_elf,
@@ -187,19 +207,6 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
         })
         .await
         .expect("SP1AggregationHost setup task panicked");
-
-        // Validate the persisted proof and extract the `final_slot_number` so
-        // the runner can rewind the STF-info stream to `final_slot + 1`.
-        let latest_proof_final_slot = previous_aggregated_proof.as_ref().map(|proof| {
-            let public_data: AggregatedProofPublicData<
-                <Self::Spec as Spec>::Address,
-                MockDaSpec,
-                <<Self::Spec as Spec>::Storage as Storage>::Root,
-            > = AggregateProofVerifier::<SP1Verifier>::new(outer_vm.code_commitment())
-                .verify(proof)
-                .expect("Persisted aggregated proof failed verification");
-            public_data.final_slot_number
-        });
 
         let da_verifier = Default::default();
 
@@ -235,9 +242,12 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
         let inner_elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
         let outer_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
 
-        let inner = sov_sp1_adapter::host::code_commitment_from_elf(inner_elf)?;
-        let outer = sov_sp1_adapter::host::code_commitment_from_elf(outer_elf)?;
+        let Sp1InnerHostBundle {
+            inner_code_commitment,
+            outer_code_commitment,
+            ..
+        } = build_sp1_inner_host(inner_elf, outer_elf)?;
 
-        Ok((inner, outer))
+        Ok((inner_code_commitment, outer_code_commitment))
     }
 }


### PR DESCRIPTION
# Description


  - Implements `start_fresh_outer_proof_on_resync` for `MockSp1DemoRollup`, removing the panic stub in `create_prover_service` (todo #2551). When the flag is on we drop the persisted outer proof and start a fresh aggregation chain.
  - Extracts a shared `get_persisted_outer_proof::<Vm, …>` helper in `examples/demo-rollup/src/lib.rs`,
  - Adds `build_sp1_inner_host` in `mock_sp1_rollup.rs` that runs SP1's setup once per ELF and returns the inner `SP1Host` plus both code commitments. `


- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551