### PR TITLE
Adds a new rollup variant that combines the SP1 zkVM with the external mock-DA 

### DIFF
--- a/crates/full-node/sov-metrics/src/influxdb/mod.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/mod.rs
@@ -270,6 +270,9 @@ mod tests {
         let start = timestamp();
         tracker.track_runner_metrics(RunnerMetrics {
             da_height: 12333,
+            rollup_height: 8421,
+            start_at_rollup_height: None,
+            stop_at_rollup_height: None,
             sync_distance: 55768,
             get_block_time: std::time::Duration::from_millis(1000),
             batches_processed: 2084,

--- a/crates/full-node/sov-metrics/src/influxdb/tracker.rs
+++ b/crates/full-node/sov-metrics/src/influxdb/tracker.rs
@@ -93,6 +93,9 @@ impl MetricsTracker {
         let timestamp = timestamp();
         let RunnerMetrics {
             da_height: da_height_processed,
+            rollup_height,
+            start_at_rollup_height,
+            stop_at_rollup_height,
             sync_distance,
             get_block_time,
             batches_processed,
@@ -111,6 +114,9 @@ impl MetricsTracker {
             timestamp,
             RunnerDaMetrics {
                 da_height: da_height_processed,
+                rollup_height,
+                start_at_rollup_height,
+                stop_at_rollup_height,
                 sync_distance,
                 get_block_time,
             },
@@ -153,6 +159,12 @@ pub fn timestamp() -> u128 {
 pub struct RunnerMetrics {
     /// DA height processed in this iteration.
     pub da_height: u64,
+    /// Rollup height produced in this iteration.
+    pub rollup_height: u64,
+    /// Configured rollup height the runner started syncing from, if set.
+    pub start_at_rollup_height: Option<u64>,
+    /// Configured rollup height the runner should stop at, if set.
+    pub stop_at_rollup_height: Option<u64>,
     /// Distance between processed DA height and DA head.
     pub sync_distance: i64,
     /// Time it took to fetch given block from DA layer.
@@ -187,6 +199,9 @@ pub struct RunnerMetrics {
 #[derive(Debug)]
 pub(crate) struct RunnerDaMetrics {
     pub da_height: u64,
+    pub rollup_height: u64,
+    pub start_at_rollup_height: Option<u64>,
+    pub stop_at_rollup_height: Option<u64>,
     pub sync_distance: i64,
     pub get_block_time: std::time::Duration,
 }
@@ -322,12 +337,20 @@ impl Metric for RunnerDaMetrics {
     fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
         write!(
             buffer,
-            "{} da_height={},sync_distance={},get_block_time_ms={}",
+            "{} da_height={},rollup_height={},sync_distance={},get_block_time_ms={}",
             self.measurement_name(),
             self.da_height,
+            self.rollup_height,
             self.sync_distance,
             self.get_block_time.as_millis(),
-        )
+        )?;
+        if let Some(h) = self.start_at_rollup_height {
+            write!(buffer, ",start_at_rollup_height={h}")?;
+        }
+        if let Some(h) = self.stop_at_rollup_height {
+            write!(buffer, ",stop_at_rollup_height={h}")?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/full-node/sov-stf-runner/src/runner.rs
+++ b/crates/full-node/sov-stf-runner/src/runner.rs
@@ -700,6 +700,9 @@ where
             let point = RunnerMetrics {
                 sync_distance: target_da_height as i64 - synced_da_height as i64,
                 da_height: next_da_height,
+                rollup_height: slot_result.rollup_height.get(),
+                start_at_rollup_height: start_at_rollup_height.as_ref().map(|h| h.get()),
+                stop_at_rollup_height: stop_at_rollup_height.as_ref().map(|h| h.get()),
                 get_block_time,
                 batches_processed: batch_count,
                 batch_bytes_processed,

--- a/examples/demo-rollup/src/external_mock_sp1_rollup.rs
+++ b/examples/demo-rollup/src/external_mock_sp1_rollup.rs
@@ -7,7 +7,7 @@ use sov_address::{EthereumAddress, FromVmAddress};
 use sov_db::ledger_db::LedgerDb;
 use sov_db::storage_manager::NomtStorageManager;
 use sov_ethereum::EthRpcConfig;
-use sov_mock_da::storable::StorableMockDaService;
+use sov_mock_da::storable::rpc::StorableMockDaClient;
 use sov_mock_da::MockDaSpec;
 use sov_modules_api::configurable_spec::ConfigurableSpec;
 use sov_modules_api::execution_mode::{Native, WitnessGeneration};
@@ -30,14 +30,14 @@ use crate::sp1_helper::{
     Sp1ProverService,
 };
 
-/// Rollup with a [`ConfigurableSpec`] with [`MockDaSpec`] as Da spec, and [`SP1`] for both inner and outer vm
+/// SP1 rollup wired to the external `mock-da-server` over RPC.
 #[derive(Default, Clone, Copy)]
-pub struct MockSp1DemoRollup<M> {
+pub struct ExternalMockSp1DemoRollup<M> {
     phantom: std::marker::PhantomData<M>,
 }
 
-/// The default spec of the rollup
-pub type MockSp1RollupSpec<M> = ConfigurableSpec<
+/// The default spec of the rollup.
+pub type ExternalMockSp1RollupSpec<M> = ConfigurableSpec<
     MockDaSpec,
     SP1,
     SP1,
@@ -47,27 +47,27 @@ pub type MockSp1RollupSpec<M> = ConfigurableSpec<
     Sp1NativeStorage,
 >;
 
-impl RollupBlueprint<Native> for MockSp1DemoRollup<Native>
+impl RollupBlueprint<Native> for ExternalMockSp1DemoRollup<Native>
 where
-    MockSp1RollupSpec<Native>: PluggableSpec,
-    <MockSp1RollupSpec<Native> as Spec>::Address: FromVmAddress<EthereumAddress>,
+    ExternalMockSp1RollupSpec<Native>: PluggableSpec,
+    <ExternalMockSp1RollupSpec<Native> as Spec>::Address: FromVmAddress<EthereumAddress>,
 {
-    type Spec = MockSp1RollupSpec<Native>;
+    type Spec = ExternalMockSp1RollupSpec<Native>;
     type Runtime = Runtime<Self::Spec>;
 }
 
-impl RollupBlueprint<WitnessGeneration> for MockSp1DemoRollup<WitnessGeneration>
+impl RollupBlueprint<WitnessGeneration> for ExternalMockSp1DemoRollup<WitnessGeneration>
 where
-    MockSp1RollupSpec<WitnessGeneration>: PluggableSpec,
-    <MockSp1RollupSpec<WitnessGeneration> as Spec>::Address: FromVmAddress<EthereumAddress>,
+    ExternalMockSp1RollupSpec<WitnessGeneration>: PluggableSpec,
+    <ExternalMockSp1RollupSpec<WitnessGeneration> as Spec>::Address: FromVmAddress<EthereumAddress>,
 {
-    type Spec = MockSp1RollupSpec<WitnessGeneration>;
+    type Spec = ExternalMockSp1RollupSpec<WitnessGeneration>;
     type Runtime = Runtime<Self::Spec>;
 }
 
 #[async_trait]
-impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
-    type DaService = StorableMockDaService;
+impl FullNodeBlueprint<Native> for ExternalMockSp1DemoRollup<Native> {
+    type DaService = StorableMockDaClient;
 
     type StorageManager = NomtStorageManager<MockDaSpec, Sp1Hasher, Sp1NativeStorage>;
 
@@ -128,9 +128,10 @@ impl FullNodeBlueprint<Native> for MockSp1DemoRollup<Native> {
     async fn create_da_service(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        _shutdown_receiver: tokio::sync::watch::Receiver<()>,
     ) -> Self::DaService {
-        StorableMockDaService::from_config(rollup_config.da.clone(), shutdown_receiver).await
+        StorableMockDaClient::from_config(rollup_config.da.clone())
+            .expect("Failed to create da service")
     }
 
     async fn create_prover_service(

--- a/examples/demo-rollup/src/lib.rs
+++ b/examples/demo-rollup/src/lib.rs
@@ -23,8 +23,8 @@ pub use mock_helper::{
 };
 mod mock_rollup;
 pub use mock_rollup::*;
-mod sp1_helper;
 mod mock_sp1_rollup;
+mod sp1_helper;
 pub use mock_sp1_rollup::*;
 mod external_mock_sp1_rollup;
 pub use external_mock_sp1_rollup::*;

--- a/examples/demo-rollup/src/lib.rs
+++ b/examples/demo-rollup/src/lib.rs
@@ -23,8 +23,11 @@ pub use mock_helper::{
 };
 mod mock_rollup;
 pub use mock_rollup::*;
+mod sp1_helper;
 mod mock_sp1_rollup;
 pub use mock_sp1_rollup::*;
+mod external_mock_sp1_rollup;
+pub use external_mock_sp1_rollup::*;
 mod chain_state_override;
 pub use chain_state_override::override_code_commitments_in_chain_state;
 mod celestia_rollup;

--- a/examples/demo-rollup/src/main.rs
+++ b/examples/demo-rollup/src/main.rs
@@ -12,7 +12,7 @@ use sov_db::config::{
 };
 use sov_demo_rollup::{
     override_code_commitments_in_chain_state, CelestiaDemoRollup, ExternalMockDemoRollup,
-    MockDemoRollup, MockSp1DemoRollup,
+    ExternalMockSp1DemoRollup, MockDemoRollup, MockSp1DemoRollup,
 };
 use sov_mock_da::storable::rpc::StorableMockDaClient;
 use sov_mock_da::storable::StorableMockDaService;
@@ -153,6 +153,20 @@ async fn run() -> anyhow::Result<()> {
             .context("Failed to initialize ExternalMockDa rollup")?;
             rollup.run().await
         }
+        (SupportedDaLayer::ExternalMock, SupportedZkVm::Sp1) => {
+            let rollup = new_rollup_with_external_mock_sp1_da(
+                &GenesisPaths::from_dir(&args.genesis_config_dir),
+                rollup_config_path,
+                prover_config,
+                start_at_rollup_height,
+                stop_at_rollup_height,
+                args.override_code_commitments,
+                args.start_fresh_outer_proof_on_resync,
+            )
+            .await
+            .context("Failed to initialize SP1 ExternalMockDa rollup")?;
+            rollup.run().await
+        }
         (SupportedDaLayer::Celestia, SupportedZkVm::Mock) => {
             let rollup = new_rollup_with_celestia_da(
                 &GenesisPaths::from_dir(&args.genesis_config_dir),
@@ -169,7 +183,7 @@ async fn run() -> anyhow::Result<()> {
         }
         (da, SupportedZkVm::Sp1) => {
             anyhow::bail!(
-                "zk_vm=sp1 is only compatible with da_layer=mock (got da_layer={:?})",
+                "zk_vm=sp1 is only compatible with da_layer=mock or da_layer=external-mock (got da_layer={:?})",
                 da
             );
         }
@@ -379,6 +393,45 @@ async fn new_rollup_with_sp1_mock_da(
         })?;
 
     let mock_rollup = MockSp1DemoRollup::<Native>::default();
+    mock_rollup
+        .create_new_rollup(
+            rt_genesis_paths,
+            rollup_config,
+            prover_config,
+            start_at_rollup_height,
+            stop_at_rollup_height,
+            None,
+            start_fresh_outer_proof_on_resync,
+        )
+        .await
+}
+
+async fn new_rollup_with_external_mock_sp1_da(
+    rt_genesis_paths: &GenesisPaths,
+    rollup_config_path: &str,
+    prover_config: RollupProverConfig,
+    start_at_rollup_height: Option<RollupHeight>,
+    stop_at_rollup_height: Option<RollupHeight>,
+    override_code_commitments: bool,
+    start_fresh_outer_proof_on_resync: bool,
+) -> anyhow::Result<Rollup<ExternalMockSp1DemoRollup<Native>, Native>> {
+    debug!(
+        config_path = rollup_config_path,
+        "Starting rollup on external-mock DA with SP1 zkVM"
+    );
+
+    apply_code_commitments_override::<ExternalMockSp1DemoRollup<Native>>(
+        rt_genesis_paths,
+        override_code_commitments,
+    )
+    .await?;
+
+    let rollup_config: RollupConfig<MultiAddressEvmSolana, StorableMockDaClient> =
+        from_toml_path(rollup_config_path).with_context(|| {
+            format!("Failed to read rollup configuration from {rollup_config_path}")
+        })?;
+
+    let mock_rollup = ExternalMockSp1DemoRollup::<Native>::default();
     mock_rollup
         .create_new_rollup(
             rt_genesis_paths,

--- a/examples/demo-rollup/src/sp1_helper.rs
+++ b/examples/demo-rollup/src/sp1_helper.rs
@@ -99,8 +99,12 @@ where
     .await?;
 
     let outer_vm = tokio::task::spawn_blocking(move || {
-        SP1AggregationHost::new_with_previous_proof(agg_elf, inner_verifying_key, previous_for_outer)
-            .expect("Failed to create SP1AggregationHost from aggregation guest ELF")
+        SP1AggregationHost::new_with_previous_proof(
+            agg_elf,
+            inner_verifying_key,
+            previous_for_outer,
+        )
+        .expect("Failed to create SP1AggregationHost from aggregation guest ELF")
     })
     .await
     .expect("SP1AggregationHost setup task panicked");

--- a/examples/demo-rollup/src/sp1_helper.rs
+++ b/examples/demo-rollup/src/sp1_helper.rs
@@ -1,0 +1,135 @@
+//! Shared SP1 setup and prover-service construction for the SP1 demo rollups.
+
+use std::sync::Arc;
+
+use demo_stf::MultiAddressEvmSolana;
+use sov_db::ledger_db::LedgerDb;
+use sov_mock_da::MockDaSpec;
+use sov_modules_api::{CodeCommitmentTrait, CryptoSpec};
+use sov_rollup_interface::common::SlotNumber;
+use sov_rollup_interface::da::DaSpec;
+use sov_rollup_interface::node::da::DaService;
+use sov_sp1_adapter::host::{code_commitment_from_verifying_key, SP1AggregationHost, SP1Host};
+use sov_sp1_adapter::{SP1CryptoSpec, SP1MethodId, SP1Verifier, SP1};
+use sov_state::nomt::prover_storage::NomtProverStorage;
+use sov_state::{DefaultStorageSpec, Storage};
+use sov_stf_runner::processes::ParallelProverService;
+use sov_stf_runner::RollupConfig;
+
+use crate::get_persisted_outer_proof;
+
+pub(crate) type Sp1Hasher = <SP1CryptoSpec as CryptoSpec>::Hasher;
+pub(crate) type Sp1NativeStorage =
+    NomtProverStorage<DefaultStorageSpec<Sp1Hasher>, <MockDaSpec as DaSpec>::SlotHash>;
+
+/// Output of [`build_sp1_inner_host`]: the inner [`SP1Host`] together with the
+/// inner and outer code commitments derived from the same setup pass.
+pub(crate) struct Sp1InnerHostBundle {
+    pub(crate) inner_host: SP1Host,
+    pub(crate) inner_code_commitment: SP1MethodId,
+    pub(crate) outer_code_commitment: SP1MethodId,
+}
+
+/// Runs the SP1 prover setup once per ELF and returns the inner host plus both
+/// code commitments. Callers that only need the commitments can drop
+/// `inner_host`; the setup cost is identical either way.
+pub(crate) fn build_sp1_inner_host(
+    inner_elf: &[u8],
+    outer_elf: &[u8],
+) -> anyhow::Result<Sp1InnerHostBundle> {
+    let outer_vk = Arc::new(sov_sp1_adapter::host::verifying_key_from_elf(outer_elf)?);
+    let outer_code_commitment = code_commitment_from_verifying_key(&outer_vk);
+    let inner_host = SP1Host::new(inner_elf, outer_vk)?;
+    let inner_code_commitment = code_commitment_from_verifying_key(inner_host.verifying_key());
+    Ok(Sp1InnerHostBundle {
+        inner_host,
+        inner_code_commitment,
+        outer_code_commitment,
+    })
+}
+
+/// Concrete prover-service type used by both SP1 mock rollup variants.
+pub(crate) type Sp1ProverService<Da> = ParallelProverService<
+    MultiAddressEvmSolana,
+    <Sp1NativeStorage as Storage>::Root,
+    <Sp1NativeStorage as Storage>::Witness,
+    Da,
+    SP1,
+    SP1,
+>;
+
+/// Shared body of `FullNodeBlueprint::create_prover_service` for the SP1 mock
+/// rollups. Builds the inner+outer SP1 hosts off the async runtime, reconciles
+/// the persisted outer proof, and constructs the [`ParallelProverService`].
+pub(crate) async fn create_sp1_prover_service<Da>(
+    rollup_config: &RollupConfig<MultiAddressEvmSolana, Da>,
+    ledger_db: &LedgerDb,
+    start_fresh_outer_proof_on_resync: bool,
+) -> anyhow::Result<(Sp1ProverService<Da>, Option<SlotNumber>)>
+where
+    Da: DaService<Spec = MockDaSpec>,
+    Da::Verifier: Default,
+{
+    let elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
+    let agg_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
+
+    // SP1's blocking CPU prover spins up its own tokio runtime during setup,
+    // so it must be constructed off the async executor thread.
+    let Sp1InnerHostBundle {
+        inner_host: inner_vm,
+        inner_code_commitment,
+        outer_code_commitment,
+    } = tokio::task::spawn_blocking(move || build_sp1_inner_host(elf, agg_elf))
+        .await
+        .expect("SP1 host setup task panicked")?;
+
+    let inner_verifying_key = inner_vm.verifying_key().clone();
+
+    let (previous_for_outer, latest_proof_final_slot) = get_persisted_outer_proof::<
+        SP1Verifier,
+        MultiAddressEvmSolana,
+        MockDaSpec,
+        <Sp1NativeStorage as Storage>::Root,
+    >(
+        ledger_db,
+        inner_code_commitment.to_hash(),
+        outer_code_commitment.to_hash(),
+        start_fresh_outer_proof_on_resync,
+    )
+    .await?;
+
+    let outer_vm = tokio::task::spawn_blocking(move || {
+        SP1AggregationHost::new_with_previous_proof(agg_elf, inner_verifying_key, previous_for_outer)
+            .expect("Failed to create SP1AggregationHost from aggregation guest ELF")
+    })
+    .await
+    .expect("SP1AggregationHost setup task panicked");
+
+    let da_verifier = Default::default();
+
+    let num_threads = rollup_config.proof_manager.prover_thread_count();
+    let prover = ParallelProverService::new_with_default_workers(
+        inner_vm,
+        outer_vm,
+        da_verifier,
+        rollup_config.proof_manager.prover_address,
+        num_threads,
+    );
+
+    Ok((prover, latest_proof_final_slot))
+}
+
+/// Shared body of `FullNodeBlueprint::compute_code_commitments` for the SP1
+/// mock rollups.
+pub(crate) fn compute_sp1_code_commitments() -> anyhow::Result<(SP1MethodId, SP1MethodId)> {
+    let inner_elf: &[u8] = *sp1::SP1_GUEST_MOCK_ELF;
+    let outer_elf: &[u8] = *sp1::SP1_GUEST_AGGREGATION_MOCK_ELF;
+
+    let Sp1InnerHostBundle {
+        inner_code_commitment,
+        outer_code_commitment,
+        ..
+    } = build_sp1_inner_host(inner_elf, outer_elf)?;
+
+    Ok((inner_code_commitment, outer_code_commitment))
+}


### PR DESCRIPTION
# Description

This PR adds a new rollup variant that combines the SP1 zkVM with the external mock-DA backend.

  - Add `ExternalMockSp1DemoRollup` so the demo rollup can run SP1 against the external `mock-da-server`. Wired into `main.rs` under `(ExternalMock, Sp1)`.
  - Extract shared SP1 setup into `sp1_helper.rs` so both SP1 rollup variants share one code path.
  - Emit `rollup_height` / `start_at_rollup_height` / `stop_at_rollup_height` in the InfluxDB runner metrics.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551
