### PR TITLE
Port NOMT fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-05-18
+- #2879 Updates NOMT crate version. **Breaking for existing ZK-rollups**. Proof type has changed.
+
 # 2026-05-11
 - #2847 Removes bincode support from `sov-risc0-adapter`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,12 +893,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
-dependencies = [
- "backtrace",
-]
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -3558,7 +3555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5131,6 +5128,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -6502,6 +6504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.0",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6943,11 +6954,10 @@ dependencies = [
 
 [[package]]
 name = "nomt"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cebfa5217b0c23f8088cdd2e9b8033db6ba49a968cfbf0a35433043b76b8f93"
+checksum = "8dc31b6dd2f30dc674b0bdeafbf3790eded499072eb17c79212f3dcfa31b0baf"
 dependencies = [
- "ahash",
  "anyhow",
  "bitvec",
  "borsh",
@@ -6960,10 +6970,10 @@ dependencies = [
  "io-uring",
  "libc",
  "loom",
- "lru 0.12.5",
+ "lru 0.18.0",
  "nomt-core",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.10.1",
  "serde",
  "slab",
  "thread_local",
@@ -6973,15 +6983,14 @@ dependencies = [
 
 [[package]]
 name = "nomt-core"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86909b9e6666306bb3878401e8fc8afe4bcd99771acf30d94ad0bab1c1173f9"
+checksum = "1c29af216422c69aeef84d7c20bb7638d442ec5016d93df53d1fb5152f7e4dc7"
 dependencies = [
  "arrayvec",
  "bitvec",
  "borsh",
  "digest 0.10.7",
- "hex",
  "ruint",
  "serde",
 ]
@@ -9693,14 +9702,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecb38f82477f20c5c3d62ef52d7c4e536e38ea9b73fb570a20c5cae0e14bcf6"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
  "borsh",
  "bytes",
  "fastrlp 0.3.1",
@@ -9715,7 +9725,7 @@ dependencies = [
  "rand 0.9.2",
  "rlp",
  "ruint-macro",
- "serde",
+ "serde_core",
  "valuable",
  "zeroize",
 ]
@@ -15259,9 +15269,6 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-dependencies = [
- "rand 0.9.2",
-]
 
 [[package]]
 name = "typed-arena"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,8 +209,8 @@ reltester = { git = "https://github.com/sovereign-labs/reltester.git", rev = "d6
 rockbound = { git = "https://github.com/sovereign-labs/rockbound", rev = "d8b270d399d0d355a19fbeedf9af009baee8ae66" }
 nmt-rs = { version = "0.2.5", features = ["serde", "borsh"] }
 # External dependencies
-nomt-core = { version = "1.0.3", default-features = false, features = ["borsh", "serde"] }
-nomt = { version = "1.0.3", default-features = false, features = ["borsh", "serde"] }
+nomt-core = { version = "1.0.4", default-features = false, features = ["borsh", "serde"] }
+nomt = { version = "1.0.4", default-features = false, features = ["borsh", "serde"] }
 concread = { version = "0.5.7" }
 
 anyhow = { version = "1.0.95" }

--- a/crates/full-node/sov-db-types/src/lib.rs
+++ b/crates/full-node/sov-db-types/src/lib.rs
@@ -490,7 +490,7 @@ impl SlotKey {
         }
     }
 
-    /// Craetes a test key with the given byte.
+    /// Creates a test key with the given byte.
     pub fn test_key(byte: u8) -> Self {
         Self {
             key: KeyContents::Inline(

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
@@ -704,12 +704,9 @@ impl<S: Spec> ProverIncentives<S> {
             return Ok(Some(SlashingReason::IncorrectFinalSlotHash));
         }
 
-        // TODO uncomment after NOMT bug is fixed: https://github.com/Sovereign-Labs/sovereign-sdk/pull/2739
-        /*
         if expected_final_transition.post_state_root() != &public_outputs.final_state_root {
             return Ok(Some(SlashingReason::IncorrectFinalStateRoot));
         }
-        */
 
         Ok(None)
     }

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/slashing.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/slashing.rs
@@ -136,7 +136,6 @@ fn test_invalid_final_slot_hash() {
 }
 
 #[test]
-#[ignore = "enable when NOMT bug fixed: https://github.com/Sovereign-Labs/sovereign-sdk/pull/2739"]
 fn test_invalid_final_state_root() {
     let (mut runner, prover, mut aggregated_proof) = prepare_for_slashing();
     aggregated_proof

--- a/crates/module-system/sov-state/src/nomt/mod.rs
+++ b/crates/module-system/sov-state/src/nomt/mod.rs
@@ -38,7 +38,7 @@ pub fn verify_storage_proof<S: MerkleProofSpec>(
                 .confirm_nonexistence(&key_path)
                 .map_err(|e| anyhow::anyhow!("Key out of scope: {:?}", e))?
             {
-                anyhow::bail!("Failed to verify non-existence of key");
+                anyhow::bail!("Failed to verify non-existence of key {key}");
             }
         }
         Some(slot_value) => {
@@ -52,7 +52,7 @@ pub fn verify_storage_proof<S: MerkleProofSpec>(
                 .confirm_value(&leaf)
                 .map_err(|e| anyhow::anyhow!("Key out of scope: {:?}", e))?
             {
-                anyhow::bail!("Failed to verify value for key");
+                anyhow::bail!("Failed to verify value for key {key}");
             }
         }
     }

--- a/crates/module-system/sov-state/src/nomt/mod.rs
+++ b/crates/module-system/sov-state/src/nomt/mod.rs
@@ -1,10 +1,8 @@
 //! Storage implementation based on [Nearly Optimal Merkle Tree(NOMT)](https://github.com/thrumdev/nomt/) implementation.
 
-use borsh::{BorshDeserialize, BorshSerialize};
 use nomt_core::hasher::BinaryHasher;
 use nomt_core::proof::MultiProof;
 use nomt_core::trie::{KeyPath, LeafData, Node, ValueHash};
-use serde::Serialize;
 use sov_rollup_interface::reexports::digest::Digest;
 
 use crate::{MerkleProofSpec, SlotKey, SlotValue, StateRoot, StorageProof, StorageRoot};
@@ -18,7 +16,7 @@ pub mod zk_storage;
 /// This is shared logic used by both Nomt-based storages.
 pub fn verify_storage_proof<S: MerkleProofSpec>(
     state_root: StorageRoot<S>,
-    proof: StorageProof<NomtMultiProof>,
+    proof: StorageProof<MultiProof>,
 ) -> anyhow::Result<(SlotKey, Option<SlotValue>)> {
     let StorageProof {
         key,
@@ -29,7 +27,7 @@ pub fn verify_storage_proof<S: MerkleProofSpec>(
     let root_node: Node = state_root.namespace_root(namespace);
 
     let verified =
-        nomt_core::proof::verify_multi_proof::<BinaryHasher<S::Hasher>>(&multi_proof.0, root_node)
+        nomt_core::proof::verify_multi_proof::<BinaryHasher<S::Hasher>>(&multi_proof, root_node)
             .map_err(|e| anyhow::anyhow!("Failed to verify proof: {:?}", e))?;
 
     let key_path: KeyPath = S::Hasher::digest(key.as_ref()).into();
@@ -61,39 +59,3 @@ pub fn verify_storage_proof<S: MerkleProofSpec>(
 
     Ok((key, value))
 }
-
-/// Wrapper around [`nomt_core::proof::MultiProof`] that implements `PartialEq`/`Eq`
-/// by manually comparing each of inner attributes of [`nomt_core::proof::MultiProof`]
-///
-/// This is necessary because `MultiProof` doesn't derive these traits.
-#[derive(Debug, Clone, Serialize, serde::Deserialize, BorshSerialize, BorshDeserialize)]
-pub struct NomtMultiProof(pub MultiProof);
-
-impl PartialEq for NomtMultiProof {
-    fn eq(&self, other: &Self) -> bool {
-        let this = &self.0;
-        let other = &other.0;
-
-        if this.paths.len() != other.paths.len() {
-            return false;
-        }
-
-        if this.siblings != other.siblings {
-            return false;
-        }
-
-        for (this_path, other_path) in this.paths.iter().zip(other.paths.iter()) {
-            if this_path.depth != other_path.depth {
-                return false;
-            }
-
-            if this_path.terminal != other_path.terminal {
-                return false;
-            }
-        }
-
-        true
-    }
-}
-
-impl Eq for NomtMultiProof {}

--- a/crates/module-system/sov-state/src/nomt/prover_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/prover_storage.rs
@@ -20,7 +20,6 @@ use sov_db::storage_manager::{
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::reexports::digest::Digest;
 
-use crate::nomt::NomtMultiProof;
 use crate::pinned_cache::PinnedCache;
 use crate::storage::ReadType;
 use crate::{
@@ -418,7 +417,7 @@ where
     fn get_with_proof_once<N: ProvableCompileTimeNamespace>(
         &self,
         proven_key: SlotKey,
-    ) -> Result<(StorageProof<NomtMultiProof>, SlotNumber, StorageRoot<S>), GetWithProofError> {
+    ) -> Result<(StorageProof<MultiProof>, SlotNumber, StorageRoot<S>), GetWithProofError> {
         let namespace = N::PROVABLE_NAMESPACE;
         // Fetch the latest root hash from the newest delta or the live table, whichever is newer.
         let (_, pre_fetch_state_root) =
@@ -463,7 +462,7 @@ where
             StorageProof {
                 key: proven_key,
                 value,
-                proof: NomtMultiProof(multi_proof),
+                proof: multi_proof,
                 namespace,
             },
             committed_slot_number,
@@ -610,7 +609,7 @@ where
 {
     type Hasher = S::Hasher;
     type Witness = S::Witness;
-    type Proof = NomtMultiProof;
+    type Proof = MultiProof;
     type Root = StorageRoot<S>;
     // These 2 are effectively the same thing, `StateUpdate` is not materialized, `ChangeSet` is materialized.
     type StateUpdate = NomtStateUpdate<S>;

--- a/crates/module-system/sov-state/src/nomt/zk_storage.rs
+++ b/crates/module-system/sov-state/src/nomt/zk_storage.rs
@@ -8,7 +8,6 @@ use nomt_core::trie::{KeyPath, LeafData, Node, ValueHash};
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::reexports::digest::Digest;
 
-use crate::nomt::NomtMultiProof;
 use crate::pinned_cache::PinnedCache;
 use crate::storage::ReadType;
 use crate::{
@@ -107,7 +106,7 @@ impl<S: MerkleProofSpec> NomtVerifierStorage<S> {
 impl<S: MerkleProofSpec> Storage for NomtVerifierStorage<S> {
     type Hasher = S::Hasher;
     type Witness = S::Witness;
-    type Proof = NomtMultiProof;
+    type Proof = MultiProof;
     type Root = StorageRoot<S>;
     type StateUpdate = ();
     type ChangeSet = ();

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
@@ -202,12 +202,11 @@ where
         // the predecessor's final_state_root, ensuring no gaps in the state
         // transition.
         {
-            if let Some(_expected_prev_state_root) = &expected_prev_state_root {
-                // TODO Fix NOMT bug.
-                // assert_eq!(
-                //     expected_prev_state_root, &stf_public_data.initial_state_root,
-                //     "State root discontinuity at index {index}: previous final_state_root != current initial_state_root"
-                // );
+            if let Some(expected_prev_state_root) = &expected_prev_state_root {
+                assert_eq!(
+                     expected_prev_state_root, &stf_public_data.initial_state_root,
+                     "State root discontinuity at index {index}: previous final_state_root != current initial_state_root"
+                 );
             }
 
             expected_prev_state_root = Some(stf_public_data.final_state_root.clone());

--- a/crates/utils/sov-rest-utils/src/sorting.rs
+++ b/crates/utils/sov-rest-utils/src/sorting.rs
@@ -113,9 +113,7 @@ mod tests {
     fn try_deserialize(query_params: &[(&str, &str)]) -> anyhow::Result<SortingQuery> {
         let uri = uri_with_query_params(query_params);
         Ok(Query::<SortingQuery>::try_from_uri(&uri)
-            .map_err(|e| {
-                anyhow::anyhow!("failed to parse sorting query string: {}", e.to_string())
-            })?
+            .map_err(|e| anyhow::anyhow!("failed to parse sorting query string: {e}"))?
             .0)
     }
 

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -58,8 +58,8 @@ async fn test_proof_generation() {
     let prover_address = default_prover_address();
 
     for witness in witnesses {
-        let _initial_state_root = witness.initial_state_root;
-        let _final_state_root = witness.final_state_root;
+        let initial_state_root = witness.initial_state_root;
+        let final_state_root = witness.final_state_root;
 
         let proof = generate_proof(&host, witness, prover_address).await;
         let proof_public_data = verify(&proof.proof, method_id.clone()).await;

--- a/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
+++ b/examples/demo-rollup/tests/prover/sp1_cpu_prover.rs
@@ -65,9 +65,8 @@ async fn test_proof_generation() {
         let proof_public_data = verify(&proof.proof, method_id.clone()).await;
 
         assert_eq!(proof_public_data.slot_hash, proof.da_block_header.hash());
-        // TODO: Uncomment after NOmt bug is solved: https://github.com/Sovereign-Labs/sovereign-sdk/pull/2739
-        //assert_eq!(proof_public_data.initial_state_root, initial_state_root);
-        //assert_eq!(proof_public_data.final_state_root, final_state_root);
+        assert_eq!(proof_public_data.initial_state_root, initial_state_root);
+        assert_eq!(proof_public_data.final_state_root, final_state_root);
         assert_eq!(proof_public_data.prover_address, prover_address);
     }
 }


### PR DESCRIPTION
# Description

Fixes NOMT MultiProof root derivation. 

* Update NOMT crates version
* Remove wrapper type, since `MultiProof` now can be used directly
* Re-enable tests and verification


---

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2514 

## Testing
All existing tests are passing. Un-ingored failed test

## Docs
No updates

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2879" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->