### PR TITLE
fix(demo-rollup): fix assertions' inconsistencies

### DIFF
--- a/examples/demo-rollup/sov-benchmarks/src/node/rollup_coarse_measure.rs
+++ b/examples/demo-rollup/sov-benchmarks/src/node/rollup_coarse_measure.rs
@@ -45,12 +45,12 @@ fn print_times(
     table.printstd();
 
     assert!(
-        tps > MIN_TPS,
+        tps >= MIN_TPS,
         "TPS {tps} dropped below {MIN_TPS}, investigation is needed"
     );
     assert!(
-        tps < MAX_TPS,
-        "TPS {tps} reached unrealistic number {MAX_TPS}, investigation is needed"
+        tps <= MAX_TPS,
+        "TPS {tps} exceeded unrealistic number {MAX_TPS}, investigation is needed"
     );
 }
 

--- a/examples/demo-rollup/tests/restart/graceful.rs
+++ b/examples/demo-rollup/tests/restart/graceful.rs
@@ -696,7 +696,7 @@ async fn check_with_increasing_stf_infos(
                 .unwrap();
         assert!(
             slot.number > last_processed_slot_number,
-            "Received notification for slot n={} is lower than last seen: {}",
+            "Received notification for slot n={} is not greater than last seen: {}",
             slot.number,
             last_processed_slot_number
         );


### PR DESCRIPTION
# Description

In rollup_coarse_measure.rs, the message indicates tps should be >= MIN_TPS(fail when "below")  while the predicates require tps > MIN_TPS. According to const's definition(comments), it should be tps >= MIN_TPS. So the
`assert!(tps < MAX_TPS, "TPS {tps} reached unrealistic number {MAX_TPS}, investigation is needed");` should also be changed. 

In graceful.rs, the predicate requires slot.number > last_processed_slot_number while the message requires slot.number >= last_processed_slot_number(fail when "is lower than"). The message should be changed.

```rust
// Minimum TPS, below which it is considered an issue
const MIN_TPS: f64 = 1000.0;
// Number to check that rollup actually executed some transactions
const MAX_TPS: f64 = 30_000.0;
```

- [] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)