### PR TITLE
Harden `prover-incentives` proof acceptance and reward accounting

### DIFF
--- a/crates/adapters/mock-zkvm/src/lib.rs
+++ b/crates/adapters/mock-zkvm/src/lib.rs
@@ -14,6 +14,9 @@ pub use host::MockZkvmHost;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 pub mod crypto;
+use sov_rollup_interface::common::strict_bincode_deserialize;
+use sov_rollup_interface::zk::aggregated_proof::common::SerializedPubValues;
+use sov_rollup_interface::zk::aggregated_proof::{CodeCommitmentDecodeError, CodeCommitmentHash};
 use sov_rollup_interface::zk::{CryptoSpec, SerializedZkProof, Zkvm};
 
 use crate::crypto::{Ed25519PublicKey, Ed25519Signature};
@@ -65,18 +68,19 @@ impl Zkvm for MockZkvm {
 pub struct MockCodeCommitment(pub [u8; 8]);
 
 impl sov_rollup_interface::zk::CodeCommitmentTrait for MockCodeCommitment {
-    fn to_hash(&self) -> sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash {
+    fn to_hash(&self) -> CodeCommitmentHash {
         // Pad the 8-byte mock commitment to 32 bytes to match the canonical hash layout.
-        let mut bytes = vec![0u8; 32];
+        let mut bytes = [0u8; CodeCommitmentHash::HASH_LEN];
         bytes[..8].copy_from_slice(&self.0);
-        sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash(bytes)
+        CodeCommitmentHash::from_u8_array(bytes)
     }
 
-    fn from_hash(hash: sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash) -> Self {
+    fn try_from_hash(hash: CodeCommitmentHash) -> Result<Self, CodeCommitmentDecodeError> {
+        let words = hash.to_u32_array()?;
         let mut bytes = [0u8; 8];
-        let len = hash.0.len().min(8);
-        bytes[..len].copy_from_slice(&hash.0[..len]);
-        Self(bytes)
+        bytes[..4].copy_from_slice(&words[0].to_be_bytes());
+        bytes[4..].copy_from_slice(&words[1].to_be_bytes());
+        Ok(Self(bytes))
     }
 }
 
@@ -112,7 +116,7 @@ impl MockProof {
 
     /// Bincode-decodes a proof from `bytes`.
     pub(crate) fn deserialize(bytes: &[u8]) -> bincode::Result<Self> {
-        bincode::deserialize(bytes)
+        strict_bincode_deserialize(bytes)
     }
 }
 
@@ -128,7 +132,7 @@ impl sov_rollup_interface::zk::ZkVerifier for MockZkVerifier {
     type Error = anyhow::Error;
 
     fn verify_with_pub_values<T: DeserializeOwned>(
-        public_values: &sov_rollup_interface::zk::aggregated_proof::common::SerializedPubValues,
+        public_values: &SerializedPubValues,
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         // The mock encodes a complete `MockProof` in `pub_values.pub_values` —
@@ -147,7 +151,7 @@ impl sov_rollup_interface::zk::ZkVerifier for MockZkVerifier {
                 "Code commitment mismatch: proof claims {claimed:?}, verifier expects {code_commitment:?}"
             );
         }
-        Ok(bincode::deserialize(&pub_data)?)
+        Ok(strict_bincode_deserialize(&pub_data)?)
     }
 
     fn verify_with_proof<T: DeserializeOwned>(
@@ -167,7 +171,7 @@ impl sov_rollup_interface::zk::ZkVerifier for MockZkVerifier {
                 "Code commitment mismatch: proof claims {claimed:?}, verifier expects {code_commitment:?}"
             );
         }
-        Ok(bincode::deserialize(&input)?)
+        Ok(strict_bincode_deserialize(&input)?)
     }
 
     fn extract_public_data<T: DeserializeOwned>(
@@ -176,7 +180,7 @@ impl sov_rollup_interface::zk::ZkVerifier for MockZkVerifier {
         let MockProof {
             pub_data: input, ..
         } = MockProof::deserialize(&serialized_proof.raw_proof)?;
-        Ok(bincode::deserialize(&input)?)
+        Ok(strict_bincode_deserialize(&input)?)
     }
 }
 

--- a/crates/adapters/risc0/src/lib.rs
+++ b/crates/adapters/risc0/src/lib.rs
@@ -10,6 +10,9 @@ use risc0_zkvm::Receipt;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use sov_rollup_interface::common::strict_bincode_deserialize;
+use sov_rollup_interface::zk::aggregated_proof::common::SerializedPubValues;
+use sov_rollup_interface::zk::aggregated_proof::{CodeCommitmentDecodeError, CodeCommitmentHash};
 use sov_rollup_interface::zk::SerializedZkProof;
 use sov_rollup_interface::zk::{CryptoSpec, ZkVerifier};
 use thiserror::Error;
@@ -32,12 +35,12 @@ pub mod metrics;
 pub struct Risc0MethodId([u32; 8]);
 
 impl sov_rollup_interface::zk::CodeCommitmentTrait for Risc0MethodId {
-    fn to_hash(&self) -> sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash {
-        sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash::from_u32_array(self.0)
+    fn to_hash(&self) -> CodeCommitmentHash {
+        CodeCommitmentHash::from_u32_array(self.0)
     }
 
-    fn from_hash(hash: sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash) -> Self {
-        Self(hash.to_u32_array())
+    fn try_from_hash(hash: CodeCommitmentHash) -> Result<Self, CodeCommitmentDecodeError> {
+        Ok(Self(hash.to_u32_array()?))
     }
 }
 
@@ -101,7 +104,7 @@ impl ZkVerifier for Risc0Verifier {
     type Error = anyhow::Error;
 
     fn verify_with_pub_values<T: DeserializeOwned>(
-        _public_values: &sov_rollup_interface::zk::aggregated_proof::common::SerializedPubValues,
+        _public_values: &SerializedPubValues,
         _code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         // Risc0's `verify_with_pub_values` is only meaningful inside the guest.
@@ -114,16 +117,16 @@ impl ZkVerifier for Risc0Verifier {
         serialized_proof: &SerializedZkProof,
         code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
-        let receipt: Receipt = bincode::deserialize(&serialized_proof.raw_proof)?;
+        let receipt: Receipt = strict_bincode_deserialize(&serialized_proof.raw_proof)?;
         receipt.verify(code_commitment.0)?;
-        Ok(bincode::deserialize(&receipt.journal.bytes)?)
+        Ok(strict_bincode_deserialize(&receipt.journal.bytes)?)
     }
 
     fn extract_public_data<T: DeserializeOwned>(
         serialized_proof: &SerializedZkProof,
     ) -> Result<T, Self::Error> {
-        let receipt: Receipt = bincode::deserialize(&serialized_proof.raw_proof)?;
-        Ok(bincode::deserialize(&receipt.journal.bytes)?)
+        let receipt: Receipt = strict_bincode_deserialize(&serialized_proof.raw_proof)?;
+        Ok(strict_bincode_deserialize(&receipt.journal.bytes)?)
     }
 }
 
@@ -151,7 +154,7 @@ impl ZkVerifier for Risc0Verifier {
     type Error = anyhow::Error;
 
     fn verify_with_pub_values<T: DeserializeOwned>(
-        _public_values: &sov_rollup_interface::zk::aggregated_proof::common::SerializedPubValues,
+        _public_values: &SerializedPubValues,
         _code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         // Implement this method once risc0 supports recursion: issue #633

--- a/crates/adapters/sp1/src/lib.rs
+++ b/crates/adapters/sp1/src/lib.rs
@@ -10,7 +10,9 @@ use crypto::{SP1PublicKey, SP1Signature};
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash;
+use sov_rollup_interface::common::strict_bincode_deserialize;
+use sov_rollup_interface::zk::aggregated_proof::common::SerializedPubValues;
+use sov_rollup_interface::zk::aggregated_proof::{CodeCommitmentDecodeError, CodeCommitmentHash};
 use sov_rollup_interface::zk::SerializedZkProof;
 use sov_rollup_interface::zk::{CryptoSpec, ZkVerifier};
 
@@ -41,8 +43,8 @@ impl sov_rollup_interface::zk::CodeCommitmentTrait for SP1MethodId {
         CodeCommitmentHash::from_u32_array(self.0)
     }
 
-    fn from_hash(hash: sov_rollup_interface::zk::aggregated_proof::CodeCommitmentHash) -> Self {
-        Self(hash.to_u32_array())
+    fn try_from_hash(hash: CodeCommitmentHash) -> Result<Self, CodeCommitmentDecodeError> {
+        Ok(Self(hash.to_u32_array()?))
     }
 }
 
@@ -110,7 +112,7 @@ impl ZkVerifier for SP1Verifier {
     type Error = anyhow::Error;
 
     fn verify_with_pub_values<T: DeserializeOwned>(
-        _public_values: &sov_rollup_interface::zk::aggregated_proof::common::SerializedPubValues,
+        _public_values: &SerializedPubValues,
         _code_commitment: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         // SP1's `verify_with_pub_values` is only meaningful inside the guest.
@@ -157,14 +159,16 @@ impl ZkVerifier for SP1Verifier {
             }
         }
 
-        Ok(bincode::deserialize(proof.public_values.as_slice())?)
+        Ok(strict_bincode_deserialize(proof.public_values.as_slice())?)
     }
 
     fn extract_public_data<T: DeserializeOwned>(
         serialized_proof: &SerializedZkProof,
     ) -> Result<T, Self::Error> {
-        let envelope: Sp1ProofEnvelope = bincode::deserialize(&serialized_proof.raw_proof)?;
-        Ok(bincode::deserialize(envelope.public_values.as_slice())?)
+        let envelope: Sp1ProofEnvelope = strict_bincode_deserialize(&serialized_proof.raw_proof)?;
+        Ok(strict_bincode_deserialize(
+            envelope.public_values.as_slice(),
+        )?)
     }
 }
 
@@ -192,14 +196,14 @@ impl ZkVerifier for SP1Verifier {
     type Error = anyhow::Error;
 
     fn verify_with_pub_values<T: DeserializeOwned>(
-        public_values: &sov_rollup_interface::zk::aggregated_proof::common::SerializedPubValues,
+        public_values: &SerializedPubValues,
         vkey_hash: &Self::CodeCommitment,
     ) -> Result<T, Self::Error> {
         use sha2::Digest;
         let public_values = &public_values.pub_values;
         let public_values_digest: [u8; 32] = sha2::Sha256::digest(public_values).into();
         sp1_zkvm::lib::verify::verify_sp1_proof(&vkey_hash.0, &public_values_digest);
-        Ok(bincode::deserialize(public_values)?)
+        Ok(strict_bincode_deserialize(public_values)?)
     }
 
     fn verify_with_proof<T: DeserializeOwned>(
@@ -215,7 +219,7 @@ impl ZkVerifier for SP1Verifier {
 
         let public_values_digest: [u8; 32] = sha2::Sha256::digest(&public_values).into();
         sp1_zkvm::lib::verify::verify_sp1_proof(&vkey_hash.0, &public_values_digest);
-        Ok(bincode::deserialize(&public_values)?)
+        Ok(strict_bincode_deserialize(&public_values)?)
     }
 
     fn extract_public_data<T: DeserializeOwned>(
@@ -223,7 +227,7 @@ impl ZkVerifier for SP1Verifier {
     ) -> Result<T, Self::Error> {
         let mut reader: &[u8] = &serialized_proof.raw_proof;
         let public_values: Vec<u8> = bincode::deserialize_from(&mut reader)?;
-        Ok(bincode::deserialize(&public_values)?)
+        Ok(strict_bincode_deserialize(&public_values)?)
     }
 }
 
@@ -232,8 +236,8 @@ impl ZkVerifier for SP1Verifier {
 pub fn decode_sp1_proof(
     serialized_proof: &SerializedZkProof,
 ) -> anyhow::Result<sp1_sdk::SP1ProofWithPublicValues> {
-    let envelope: Sp1ProofEnvelope = bincode::deserialize(&serialized_proof.raw_proof)?;
-    Ok(bincode::deserialize(&envelope.sp1_proof)?)
+    let envelope: Sp1ProofEnvelope = strict_bincode_deserialize(&serialized_proof.raw_proof)?;
+    Ok(strict_bincode_deserialize(&envelope.sp1_proof)?)
 }
 
 #[cfg(test)]

--- a/crates/bench/sp1-microbenches/guest-ed25519/Cargo.lock
+++ b/crates/bench/sp1-microbenches/guest-ed25519/Cargo.lock
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bech32",
  "borsh",
@@ -4285,7 +4285,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bech32",
  "borsh",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",

--- a/crates/bench/sp1-microbenches/guest-sha256/Cargo.lock
+++ b/crates/bench/sp1-microbenches/guest-sha256/Cargo.lock
@@ -1209,15 +1209,14 @@ dependencies = [
 
 [[package]]
 name = "nomt-core"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86909b9e6666306bb3878401e8fc8afe4bcd99771acf30d94ad0bab1c1173f9"
+checksum = "1c29af216422c69aeef84d7c20bb7638d442ec5016d93df53d1fb5152f7e4dc7"
 dependencies = [
  "arrayvec",
  "bitvec",
  "borsh",
  "digest",
- "hex",
  "ruint",
  "serde",
 ]
@@ -2133,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "arrayvec",
@@ -2153,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bech32",
  "borsh",
@@ -2167,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
@@ -591,14 +591,15 @@ impl<S: Spec> ProverIncentives<S> {
             }
         }
 
-        // We need to remove the reward once it is claimed
-        self.last_claimed_reward
-            .set(&max(first_available_reward, final_slot_num), state)
-            .map_err(Into::<anyhow::Error>::into)?;
-
         if first_claimed_reward > final_slot_num {
+            // Nothing in the proof's range was unclaimed, so the cursor must
+            // stay put — otherwise a stale proof would silently burn the next
+            // honest slot's reward.
             Ok(Paycheck::Penalized)
         } else {
+            self.last_claimed_reward
+                .set(&final_slot_num, state)
+                .map_err(Into::<anyhow::Error>::into)?;
             Ok(Paycheck::Rewarded(total_reward))
         }
     }

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
@@ -206,25 +206,13 @@ impl<S: Spec> ProverIncentives<S> {
             }
         };
 
-        self.latest_proof_succesfully_verified
-            .set(&public_outputs, state)
-            .map_err(Into::<anyhow::Error>::into)?;
-
-        #[cfg(feature = "native")]
-        sov_metrics::track_metrics(|tracker| {
-            tracker.submit(crate::metrics::LatestVerifiedProofMetric {
-                final_slot_number: public_outputs.final_slot_number.get(),
-                execution_context: execution_context.str(),
-            });
-        });
-        #[cfg(not(feature = "native"))]
-        let _ = execution_context;
-
         tracing::debug!(
             %public_outputs.initial_slot_number,
             %public_outputs.final_slot_number,
             "Processing aggregated proof"
         );
+        #[cfg(not(feature = "native"))]
+        let _ = execution_context;
 
         // The expected origin state root and inner VK hash were already resolved
         // into `ctx` above; this binds the inner circuit (so a prover cannot
@@ -243,7 +231,7 @@ impl<S: Spec> ProverIncentives<S> {
             )));
         }
 
-        let is_admin_upgrade = self.check_admin_upgrade_or_slash(
+        let pending_admin_upgrade = self.check_admin_upgrade_or_slash(
             &public_outputs,
             prover_address,
             &ctx,
@@ -267,9 +255,22 @@ impl<S: Spec> ProverIncentives<S> {
                 self.reward_prover(total_reward, prover_address, state)?;
 
                 // Persist the upgrade only after the proof is fully accepted.
-                if is_admin_upgrade {
-                    self.apply_admin_upgrade(&public_outputs, state)?;
+                if let Some(upgrade) = pending_admin_upgrade {
+                    self.apply_admin_upgrade(public_outputs.final_slot_number, upgrade, state)?;
                 }
+
+                // Only expose proofs that were fully accepted.
+                self.latest_proof_succesfully_verified
+                    .set(&public_outputs, state)
+                    .map_err(Into::<anyhow::Error>::into)?;
+
+                #[cfg(feature = "native")]
+                sov_metrics::track_metrics(|tracker| {
+                    tracker.submit(crate::metrics::LatestVerifiedProofMetric {
+                        final_slot_number: public_outputs.final_slot_number.get(),
+                        execution_context: execution_context.str(),
+                    });
+                });
 
                 Ok(public_outputs)
             }
@@ -332,9 +333,9 @@ impl<S: Spec> ProverIncentives<S> {
     /// prover claims in the proof's public outputs (extracted without cryptographic
     /// verification). Returns `None` for non-admin proofs, admin proofs whose bytes
     /// are too malformed to extract public outputs, or admin proofs whose claimed
-    /// `outer_vk_hash` is the wrong length for [`CodeCommitmentTrait::from_hash`] -
-    /// the caller then falls back to the currently-authorized commitment so
-    /// verification fails via the usual path rather than panicking.
+    /// `outer_vk_hash` fails [`CodeCommitmentTrait::try_from_hash`] - the caller
+    /// then falls back to the currently-authorized commitment so verification
+    /// fails via the usual path rather than panicking.
     #[allow(clippy::type_complexity)]
     fn admin_claimed_outer_commitment(
         claimed_outputs: Option<
@@ -347,17 +348,10 @@ impl<S: Spec> ProverIncentives<S> {
         }
         let claimed = claimed_outputs?;
 
-        // Production verifiers (SP1, Risc0) reconstruct their commitment via
-        // `to_u32_array`, which asserts a 32-byte hash. Reject malformed lengths
-        // here so we slash on `Verification failed` instead of panicking the STF.
-        if claimed.outer_vk_hash.0.len() != CodeCommitmentHash::HASH_LEN {
-            return None;
-        }
-        Some(
-            <<<S as Spec>::OuterZkvm as Zkvm>::Verifier as ZkVerifier>::CodeCommitment::from_hash(
-                claimed.outer_vk_hash.clone(),
-            ),
+        <<<S as Spec>::OuterZkvm as Zkvm>::Verifier as ZkVerifier>::CodeCommitment::try_from_hash(
+            claimed.outer_vk_hash.clone(),
         )
+        .ok()
     }
 
     /// Resolve every admin-state-derived value needed by the rest of
@@ -462,11 +456,12 @@ impl<S: Spec> ProverIncentives<S> {
             .expect("The genesis hash should be set at genesis"))
     }
 
-    /// Classifies an admin proof. Returns `true` if it is an upgrade (some
-    /// commitment or origin state root differs from current effective values) and
-    /// the target slot is strictly newer than the most recent recorded upgrade.
-    /// Returns `false` if the proof's outputs match current effective values
-    /// (i.e. it's a normal admin proof, not an upgrade).
+    /// Classifies an admin proof. Returns `Some(upgrade)` with the decoded
+    /// commitments ready to persist if the proof requests an upgrade and all
+    /// gates pass (target slot strictly newer than the latest recorded upgrade;
+    /// hash lengths decode under the verifier). Returns `None` for normal admin
+    /// proofs whose outputs already match current effective values. Slashes and
+    /// returns `Err` for stale upgrade slots or malformed VK hashes.
     fn check_admin_upgrade_or_slash<ST: TxState<S>>(
         &mut self,
         public_outputs: &AggregatedProofPublicData<
@@ -478,9 +473,9 @@ impl<S: Spec> ProverIncentives<S> {
         ctx: &ProofContext<S>,
         is_admin: bool,
         state: &mut ST,
-    ) -> Result<bool, ProcessProofError> {
+    ) -> Result<Option<AdminUpgrade<S>>, ProcessProofError> {
         if !ctx.is_admin_upgrade(public_outputs, is_admin) {
-            return Ok(false);
+            return Ok(None);
         }
 
         let upgrade_slot = public_outputs.final_slot_number;
@@ -497,44 +492,62 @@ impl<S: Spec> ProverIncentives<S> {
             )));
         }
 
-        Ok(true)
+        let outer_code_commitment = match <<<S as Spec>::OuterZkvm as Zkvm>::Verifier as ZkVerifier>::CodeCommitment::try_from_hash(
+            public_outputs.outer_vk_hash.clone(),
+        ) {
+            Ok(commitment) => commitment,
+            Err(_) => return self.slash_admin_for_invalid_vkey_hash(public_outputs, prover_address, state),
+        };
+        let inner_code_commitment = match <<<S as Spec>::InnerZkvm as Zkvm>::Verifier as ZkVerifier>::CodeCommitment::try_from_hash(
+            public_outputs.inner_vkey_hash.clone(),
+        ) {
+            Ok(commitment) => commitment,
+            Err(_) => return self.slash_admin_for_invalid_vkey_hash(public_outputs, prover_address, state),
+        };
+
+        Ok(Some(AdminUpgrade::<S> {
+            outer_code_commitment,
+            inner_code_commitment,
+            origin_state_root: public_outputs.origin_state_root.clone(),
+        }))
     }
 
-    /// Record the admin proof's claimed public outputs as a new upgrade entry in this
-    /// module's slot-keyed history. The proof has already been verified against the VK
-    /// it claims (reconstructed via `from_hash`), so these values become canonical for
-    /// proofs at or after this slot that pass the stale-proof cutoff. chain_state is
-    /// left untouched; effective values are read from this module's `admin_*` maps
-    /// when `latest_admin_upgrade_slot` is set.
-    fn apply_admin_upgrade<ST: TxState<S>>(
+    fn slash_admin_for_invalid_vkey_hash<ST: TxState<S>>(
         &mut self,
         public_outputs: &AggregatedProofPublicData<
             S::Address,
             S::Da,
             <S::Storage as Storage>::Root,
         >,
+        prover_address: &S::Address,
+        state: &mut ST,
+    ) -> Result<Option<AdminUpgrade<S>>, ProcessProofError> {
+        tracing::debug!(
+            outer_vk_hash_len = public_outputs.outer_vk_hash.len(),
+            inner_vkey_hash_len = public_outputs.inner_vkey_hash.len(),
+            expected = CodeCommitmentHash::HASH_LEN,
+            "Slashing admin: upgrade proof committed to a malformed VK hash"
+        );
+        self.slash_prover(prover_address, state)?;
+        Err(ProcessProofError::ProverSlashedNoRevert(format!(
+            "Invalid output {}",
+            SlashingReason::InvalidAdminUpgradeVkeyHash
+        )))
+    }
+
+    fn apply_admin_upgrade<ST: TxState<S>>(
+        &mut self,
+        slot: SlotNumber,
+        upgrade: AdminUpgrade<S>,
         state: &mut ST,
     ) -> Result<(), anyhow::Error> {
-        let slot = public_outputs.final_slot_number;
-
-        let upgrade = AdminUpgrade::<S> {
-            outer_code_commitment:
-                <<<S as Spec>::OuterZkvm as Zkvm>::Verifier as ZkVerifier>::CodeCommitment::from_hash(
-                    public_outputs.outer_vk_hash.clone(),
-                ),
-            inner_code_commitment:
-                <<<S as Spec>::InnerZkvm as Zkvm>::Verifier as ZkVerifier>::CodeCommitment::from_hash(
-                    public_outputs.inner_vkey_hash.clone(),
-                ),
-            origin_state_root: public_outputs.origin_state_root.clone(),
-        };
         self.admin_upgrades.set(&slot, &upgrade, state)?;
         self.latest_admin_upgrade_slot.set(&slot, state)?;
 
         tracing::info!(
             %slot,
-            ?public_outputs.outer_vk_hash,
-            ?public_outputs.inner_vkey_hash,
+            outer_vk_hash = ?upgrade.outer_code_commitment.to_hash(),
+            inner_vkey_hash = ?upgrade.inner_code_commitment.to_hash(),
             "Admin upgrade recorded"
         );
 
@@ -572,29 +585,26 @@ impl<S: Spec> ProverIncentives<S> {
 
         // Here the final rollup height is inclusive
         for slot_num in first_claimed_reward.range_inclusive(final_slot_num) {
-            // Check if the reward was already claimed
-
-            // If not, reward the prover with the block reward
-            // `get_historical_transitions` should always return `Some` because we are iterating over the range of `init_slot_num..=final_slot_num`
-            // whose integrity was checked beforehand.
-            if let Some(transition) = self
+            // `slot_at_height` must return `Some`: `check_proof_outputs`
+            // verified `final_slot_num` exists, and chain_state slot heights
+            // are contiguous, so every slot in this range must exist. A `None`
+            // here means that invariant has broken and reward accounting would
+            // silently under-pay — fail loud instead of skipping the slot.
+            let transition = self
                 .chain_state
                 .slot_at_height(slot_num, state)
                 .map_err(Into::<anyhow::Error>::into)?
-            {
-                // SAFETY: this cannot overflow, because that would require more than the entire token supply to be spent on gas
-                // *before* the prover claimed their reward, but gas fees are locked until the prover claims them.
-                let curr_reward = transition.gas_used().value(transition.gas_price());
-                total_reward = total_reward
-                    .checked_add(curr_reward)
-                    .expect("Gas token Overflow");
-            }
+                .expect("slot must exist: range bounded by verified final_slot_num");
+
+            // SAFETY: this cannot overflow, because that would require more than the entire token supply to be spent on gas
+            // *before* the prover claimed their reward, but gas fees are locked until the prover claims them.
+            let curr_reward = transition.gas_used().value(transition.gas_price());
+            total_reward = total_reward
+                .checked_add(curr_reward)
+                .expect("Gas token Overflow");
         }
 
         if first_claimed_reward > final_slot_num {
-            // Nothing in the proof's range was unclaimed, so the cursor must
-            // stay put — otherwise a stale proof would silently burn the next
-            // honest slot's reward.
             Ok(Paycheck::Penalized)
         } else {
             self.last_claimed_reward

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/event.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/event.rs
@@ -42,6 +42,11 @@ pub enum SlashingReason {
     /// than the most recent recorded admin upgrade. Accepting it would rewind the
     /// canonical commitments.
     StaleAdminUpgrade,
+
+    /// An admin-submitted upgrade proof committed to a verification key hash that
+    /// the verifier cannot decode (e.g. wrong length). A well-formed inner circuit
+    /// never emits such a hash.
+    InvalidAdminUpgradeVkeyHash,
 }
 
 #[derive(Debug, PartialEq, Clone, schemars::JsonSchema)]

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/lib.rs
@@ -82,7 +82,7 @@ pub struct ProverIncentives<S: Spec> {
     #[module]
     pub(crate) chain_state: sov_chain_state::ChainState<S>,
 
-    /// Public data from the most recently verified aggregated proof.
+    /// Public data from the most recently accepted aggregated proof.
     #[state]
     #[allow(clippy::type_complexity)]
     pub latest_proof_succesfully_verified:

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/admin_upgrade.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/admin_upgrade.rs
@@ -95,9 +95,9 @@ fn test_admin_bypass_outer_vk_hash_records_upgrade() {
     // value that round-trips losslessly under from_hash/to_hash.
     let new_outer_commitment = sov_mock_zkvm::MockCodeCommitment([0xcd; 8]);
     let new_outer_vk_hash = {
-        let mut bytes = vec![0u8; 32];
+        let mut bytes = [0u8; CodeCommitmentHash::HASH_LEN];
         bytes[..8].copy_from_slice(&[0xcd; 8]);
-        CodeCommitmentHash(bytes)
+        CodeCommitmentHash::from_u8_array(bytes)
     };
     aggregated_proof.outer_vk_hash = new_outer_vk_hash.clone();
     let expected_slot = aggregated_proof.final_slot_number;
@@ -139,9 +139,9 @@ fn test_admin_bypass_inner_vkey_hash_records_upgrade() {
     // MockCodeCommitment is 8 bytes wide and zero-pads to 32 in `to_hash`, so we use a
     // value that round-trips losslessly under from_hash/to_hash.
     let new_inner_vkey_hash = {
-        let mut bytes = vec![0u8; 32];
+        let mut bytes = [0u8; CodeCommitmentHash::HASH_LEN];
         bytes[..8].copy_from_slice(&[0xab; 8]);
-        CodeCommitmentHash(bytes)
+        CodeCommitmentHash::from_u8_array(bytes)
     };
     aggregated_proof.inner_vkey_hash = new_inner_vkey_hash.clone();
     let expected_slot = aggregated_proof.final_slot_number;
@@ -204,6 +204,7 @@ fn test_admin_matching_proof_does_not_record_upgrade() {
 #[test]
 fn test_admin_upgrade_not_recorded_on_penalized_proof() {
     let (mut runner, prover, mut first_proof) = prepare_admin_proof();
+    let last_valid_outputs = first_proof.clone();
     // First proof for slots 1->2: a normal (no-op) admin proof that claims the
     // reward and pins last_claimed_reward to slot 2.
     runner.execute_proof::<TestProverIncentives>(ProofTestCase {
@@ -249,6 +250,11 @@ fn test_admin_upgrade_not_recorded_on_penalized_proof() {
                     .unwrap()
                     .is_none(),
                 "Penalized admin proof must not write an admin_upgrades entry",
+            );
+            assert_eq!(
+                module.latest_proof_succesfully_verified.get(state).unwrap(),
+                Some(last_valid_outputs.clone()),
+                "Penalized proof must not replace the latest accepted proof",
             );
             // The admin is penalized (loses bond), not slashed; they remain
             // bonded after the deduction.
@@ -392,9 +398,9 @@ fn test_admin_upgrade_at_same_slot_is_slashed() {
         .unwrap();
     let new_outer_commitment = sov_mock_zkvm::MockCodeCommitment([0xef; 8]);
     second_proof.outer_vk_hash = {
-        let mut bytes = vec![0u8; 32];
+        let mut bytes = [0u8; CodeCommitmentHash::HASH_LEN];
         bytes[..8].copy_from_slice(&[0xef; 8]);
-        CodeCommitmentHash(bytes)
+        CodeCommitmentHash::from_u8_array(bytes)
     };
     let prover_address = prover.user_info.address();
 

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/non_admin_proof.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/non_admin_proof.rs
@@ -122,9 +122,9 @@ fn test_non_admin_invalid_inner_vkey_hash_slashed() {
         .unwrap();
 
     aggregated_proof.inner_vkey_hash = {
-        let mut bytes = vec![0u8; 32];
+        let mut bytes = [0u8; CodeCommitmentHash::HASH_LEN];
         bytes[..8].copy_from_slice(&[0xab; 8]);
-        CodeCommitmentHash(bytes)
+        CodeCommitmentHash::from_u8_array(bytes)
     };
     let prover_address = prover.user_info.address();
 

--- a/crates/module-system/sov-modules-api/src/proof_metadata.rs
+++ b/crates/module-system/sov-modules-api/src/proof_metadata.rs
@@ -48,6 +48,12 @@ impl<S: Spec> SerializeProofWithDetails<S> {
     fn unmetered_deserialize_inner(buf: &mut &[u8]) -> Result<Self, io::Error> {
         let signature = <ProofType as BorshDeserialize>::deserialize(buf)?;
         let pub_key = <TxDetails<S> as BorshDeserialize>::deserialize(buf)?;
+        if !buf.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Trailing bytes after proof blob",
+            ));
+        }
 
         Ok(Self {
             proof: signature,

--- a/crates/rollup-interface/src/common/mod.rs
+++ b/crates/rollup-interface/src/common/mod.rs
@@ -3,8 +3,10 @@
 mod hex_string;
 pub mod safe_vec;
 mod slot_numbering;
+mod strict_bincode;
 
 pub use hex_string::*;
 pub use safe_vec::SafeVec;
 pub use slot_numbering::*;
 pub use sov_universal_wallet::schema::safe_string::{SafeString, SizedSafeString};
+pub use strict_bincode::strict_bincode_deserialize;

--- a/crates/rollup-interface/src/common/strict_bincode.rs
+++ b/crates/rollup-interface/src/common/strict_bincode.rs
@@ -1,0 +1,59 @@
+//! Strict bincode deserialization helper.
+use bincode::Options as _;
+use serde::de::DeserializeOwned;
+
+/// Deserialize `bytes` into `T`, rejecting any trailing bytes.
+///
+/// Drop-in replacement for [`bincode::deserialize`] for cases where the
+/// payload length is supposed to match the encoded value exactly.
+pub fn strict_bincode_deserialize<T: DeserializeOwned>(bytes: &[u8]) -> bincode::Result<T> {
+    bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .with_limit(bytes.len() as u64)
+        .reject_trailing_bytes()
+        .deserialize(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_matches_default_bincode() {
+        let value: (u32, String) = (0x12345678, "hello".to_string());
+        let bytes = bincode::serialize(&value).unwrap();
+        let decoded: (u32, String) = strict_bincode_deserialize(&bytes).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn rejects_trailing_bytes() {
+        let bytes = bincode::serialize(&0x12345678u32).unwrap();
+        let mut padded = bytes.clone();
+        padded.push(0xff);
+
+        let lax: u32 = bincode::deserialize(&padded).unwrap();
+        assert_eq!(
+            lax, 0x12345678,
+            "sanity check: stock bincode must accept trailing bytes",
+        );
+
+        let strict: bincode::Result<u32> = strict_bincode_deserialize(&padded);
+        assert!(
+            strict.is_err(),
+            "strict_bincode_deserialize must reject trailing bytes",
+        );
+    }
+
+    #[test]
+    fn rejects_truncated_input() {
+        let bytes = bincode::serialize(&(0x12345678u32, 0xabcdu16)).unwrap();
+        let truncated = &bytes[..bytes.len() - 1];
+
+        let strict: bincode::Result<(u32, u16)> = strict_bincode_deserialize(truncated);
+        assert!(
+            strict.is_err(),
+            "strict_bincode_deserialize must reject truncated input",
+        );
+    }
+}

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/circuit.rs
@@ -50,7 +50,8 @@ where
         let public_data =
             V::verify_with_pub_values::<AggregatedProofPublicData<Address, Da, Root>>(
                 &prev_outer_proof_witness.public_values,
-                &<V::CodeCommitment as CodeCommitmentTrait>::from_hash(outer_vkey_hash.clone()),
+                &<V::CodeCommitment as CodeCommitmentTrait>::try_from_hash(outer_vkey_hash.clone())
+                    .expect("outer_vkey_hash must be a canonical CodeCommitmentHash"),
             )
             .unwrap_or_else(|error| panic!("Failed to verify aggregated proof: {error:?}"));
 
@@ -153,7 +154,8 @@ where
         let stf_public_data =
             V::verify_with_pub_values::<StateTransitionPublicData<Address, Da, Root>>(
                 &proof_input.public_values,
-                &<V::CodeCommitment as CodeCommitmentTrait>::from_hash(vkey_hash.clone()),
+                &<V::CodeCommitment as CodeCommitmentTrait>::try_from_hash(vkey_hash.clone())
+                    .expect("vkey_hash must be a canonical CodeCommitmentHash"),
             )
             .unwrap_or_else(|error| panic!("Failed to verify inner proof: {error:?}"));
 

--- a/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/aggregated_proof/mod.rs
@@ -11,7 +11,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 use super::{StateTransitionPublicData, ZkVerifier};
-use crate::common::SlotNumber;
+use crate::common::{SafeVec, SlotNumber};
 use crate::da::DaSpec;
 use crate::zk::SerializedZkProof;
 
@@ -39,46 +39,91 @@ pub struct BlockProof<Address, Da: DaSpec, Root> {
 
 /// A code commitment hash used to identify ZK circuits (both inner and outer).
 #[derive(Debug, Eq, PartialEq, BorshDeserialize, BorshSerialize, Serialize, Deserialize, Clone)]
-pub struct CodeCommitmentHash(pub Vec<u8>);
+pub struct CodeCommitmentHash(pub(crate) SafeVec<u8, 32>);
 
 impl Default for CodeCommitmentHash {
     fn default() -> Self {
         // We use [0u8; 32] to match the placeholder value in the chain_state genesis.
         // This remains the default until the full proof aggregation workflow is finalized.
-        Self(vec![0u8; 32])
+        Self::from_u8_array([0u8; Self::HASH_LEN])
     }
 }
 
+impl From<[u8; CodeCommitmentHash::HASH_LEN]> for CodeCommitmentHash {
+    fn from(bytes: [u8; CodeCommitmentHash::HASH_LEN]) -> Self {
+        Self::from_u8_array(bytes)
+    }
+}
+
+/// Error returned when decoding a [`CodeCommitmentHash`] into a concrete
+/// [`crate::zk::CodeCommitmentTrait`] implementation fails.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CodeCommitmentDecodeError {
+    /// The hash length did not match the adapter's expected length.
+    #[error("invalid code commitment hash length: expected {expected}, got {got}")]
+    InvalidLength {
+        /// Expected byte length (typically [`CodeCommitmentHash::HASH_LEN`]).
+        expected: usize,
+        /// Actual byte length supplied.
+        got: usize,
+    },
+}
+
 impl CodeCommitmentHash {
-    /// Canonical byte length expected by every [`crate::zk::CodeCommitmentTrait`]
-    /// implementation. Concrete adapters (Risc0, SP1) panic in [`Self::to_u32_array`]
-    /// when this invariant is violated, so callers reading hashes from untrusted
-    /// sources should reject mismatched lengths before invoking
-    /// [`crate::zk::CodeCommitmentTrait::from_hash`].
+    /// Canonical byte length expected by every
+    /// [`crate::zk::CodeCommitmentTrait`] implementation. Must match the
+    /// `SafeVec` capacity in the struct definition above.
     pub const HASH_LEN: usize = 32;
+
+    /// Byte length of the inner buffer. May be less than [`Self::HASH_LEN`]
+    /// for hashes decoded from untrusted bytes — the [`SafeVec`] only caps
+    /// the upper bound.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the inner buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Creates a [`CodeCommitmentHash`] from a `[u8; HASH_LEN]` array. This is
+    /// the infallible primary constructor — the fixed-size input statically
+    /// guarantees the inner `SafeVec` invariant.
+    pub fn from_u8_array(bytes: [u8; Self::HASH_LEN]) -> Self {
+        Self(
+            bytes
+                .to_vec()
+                .try_into()
+                .expect("HASH_LEN bytes always fit in SafeVec<u8, HASH_LEN>"),
+        )
+    }
 
     /// Creates a [`CodeCommitmentHash`] from a `[u32; 8]` array using big-endian byte order.
     /// This matches the representation used by SP1's `HashableKey::hash_bytes`.
     pub fn from_u32_array(arr: [u32; 8]) -> Self {
-        let mut bytes = Vec::with_capacity(32);
-        for word in arr {
-            bytes.extend_from_slice(&word.to_be_bytes());
+        let mut bytes = [0u8; Self::HASH_LEN];
+        for (idx, word) in arr.iter().enumerate() {
+            bytes[idx * 4..(idx + 1) * 4].copy_from_slice(&word.to_be_bytes());
         }
-        Self(bytes)
+        Self::from_u8_array(bytes)
     }
 
-    /// Converts this hash back to a `[u32; 8]` array using big-endian byte order.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the inner byte vector is not exactly 32 bytes long.
-    pub fn to_u32_array(&self) -> [u32; 8] {
-        assert_eq!(self.0.len(), 32, "CodeCommitmentHash must be 32 bytes");
+    /// Converts this hash back to a `[u32; 8]` array using big-endian byte
+    /// order, returning [`CodeCommitmentDecodeError::InvalidLength`] if the
+    /// byte count is not canonical.
+    pub fn to_u32_array(&self) -> Result<[u32; 8], CodeCommitmentDecodeError> {
+        if self.0.len() != Self::HASH_LEN {
+            return Err(CodeCommitmentDecodeError::InvalidLength {
+                expected: Self::HASH_LEN,
+                got: self.0.len(),
+            });
+        }
         let mut arr = [0u32; 8];
         for (idx, chunk) in self.0.chunks_exact(4).enumerate() {
             arr[idx] = u32::from_be_bytes(chunk.try_into().unwrap());
         }
-        arr
+        Ok(arr)
     }
 }
 

--- a/crates/rollup-interface/src/state_machine/zk/mod.rs
+++ b/crates/rollup-interface/src/state_machine/zk/mod.rs
@@ -122,7 +122,11 @@ pub trait CodeCommitmentTrait:
     fn to_hash(&self) -> aggregated_proof::CodeCommitmentHash;
 
     /// Constructs the code commitment from its canonical hash.
-    fn from_hash(hash: aggregated_proof::CodeCommitmentHash) -> Self;
+    fn try_from_hash(
+        hash: aggregated_proof::CodeCommitmentHash,
+    ) -> Result<Self, aggregated_proof::CodeCommitmentDecodeError>
+    where
+        Self: Sized;
 }
 
 /// A Zk proof system capable of proving and verifying arbitrary Rust code


### PR DESCRIPTION
# Description

This PR hardens proof decoding across the zk adapters and tightens the`prover-incentives` admin-upgrade / stale-proof paths.

  Main changes:
  - add `strict_bincode_deserialize` and switch proof/public-value decoding to reject trailing bytes
  - apply strict decoding on every relevant path
  - replace `CodeCommitmentTrait::from_hash` with `try_from_hash` so malformed commitment hashes fail cleanly instead of panicking
  - back `CodeCommitmentHash` with a bounded container and add canonical decode helpers
  - in `sov-prover-incentives`, only persist `latest_proof_succesfully_verified` and admin upgrades after the proof is fully accepted
  - slash admin upgrade proofs that commit to malformed VK hashes
  - keep `last_claimed_reward` unchanged for fully stale proofs instead of advancing the cursor
  - add / update tests around penalized admin proofs and accepted-proof tracking

  Behavior notes:
  -  stale proofs no longer advance `last_claimed_reward`
  - `latest_proof_succesfully_verified` now reflects the latest accepted proof, not merely a proof that verified before later rejection/penalty

- [ ] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
