### PR TITLE
Clean up `EVM_RECEIPT_ACTUAL_FEE_HEIGHT`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ Temporary section for maintaining breaking changes from individual PRs, which wi
   * The `UnsignedTransaction` type, and multiple member methods of `Transaction`, have changed. Our client SDKs have been updated, but for users manually constructing an UnsignedTransaction in Rust, we recommend explicitly using `UnsignedTransactionV0`. For creating a multisig, use `UnsignedTransactionV0::to_multisig_tx()`.
   * The CHAIN_HASH has changed.
   * The `Generation` uniqueness (replay protection) mechanism has been amended to fix a transaction hash malleability vulnerability with V1 transactions. New, non-malleable hashes are used to prevent replay. **If the rollup has had public V1 transactions submitted**, a migration script must increment the current generation of every user that has submitted a V1 transaction by `PAST_TRANSACTION_GENERATIONS` to invalidate prior existing hashes. No action is needed if there are no users with a prior V1 submission.
-- #PR_NUMBER **Breaking change**: for EVM rollups only: removes the `EVM_RECEIPT_ACTUAL_FEE_HEIGHT` constant.
+- #2904 **Breaking change**: for EVM rollups only: removes the `EVM_RECEIPT_ACTUAL_FEE_HEIGHT` constant.
   Receipt `effectiveGasPrice` and projected `gasUsed` are now unconditionally derived from the actual metered fee. 
   Forks that had set this to a non-zero future activation height must migrate; the new behavior is mandatory.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ Temporary section for maintaining breaking changes from individual PRs, which wi
   * The `UnsignedTransaction` type, and multiple member methods of `Transaction`, have changed. Our client SDKs have been updated, but for users manually constructing an UnsignedTransaction in Rust, we recommend explicitly using `UnsignedTransactionV0`. For creating a multisig, use `UnsignedTransactionV0::to_multisig_tx()`.
   * The CHAIN_HASH has changed.
   * The `Generation` uniqueness (replay protection) mechanism has been amended to fix a transaction hash malleability vulnerability with V1 transactions. New, non-malleable hashes are used to prevent replay. **If the rollup has had public V1 transactions submitted**, a migration script must increment the current generation of every user that has submitted a V1 transaction by `PAST_TRANSACTION_GENERATIONS` to invalidate prior existing hashes. No action is needed if there are no users with a prior V1 submission.
+- #PR_NUMBER **Breaking change**: for EVM rollups only: removes the `EVM_RECEIPT_ACTUAL_FEE_HEIGHT` constant.
+  Receipt `effectiveGasPrice` and projected `gasUsed` are now unconditionally derived from the actual metered fee. 
+  Forks that had set this to a non-zero future activation height must migrate; the new behavior is mandatory.
 
 # 2026-04-01
 - #2670 **Breaking change** Remove `InnerVm` and `OuterVm` generic type parameters from `StateTransitionFunction` trait and all downstream types.

--- a/constants.testing.toml
+++ b/constants.testing.toml
@@ -19,9 +19,6 @@ EVM_BLOCK_PRUNING_THRESHOLD = 10000
 EVM_GAS_METERING_MODE = "Rollup"
 # After this evm block height, the max_fee check will be enforced.
 EVM_MAX_FEE_CHECK_HEIGHT = 0
-# After this evm block height, RPC receipts derive effectiveGasPrice
-# from the actual fee charged by the Sovereign gas meter.
-EVM_RECEIPT_ACTUAL_FEE_HEIGHT = 0
 # How many rollup blocks to wait before terminating setup mode. While setup mode is enabled,
 # the rollup does not charge gas. This is useful when initializing the rollup with a bridged gas token.
 SETUP_MODE_TERMINATION_HEIGHT = 0 # Disable setup mode entirely by default.

--- a/constants.toml
+++ b/constants.toml
@@ -46,9 +46,6 @@ EVM_BLOCK_PRUNING_THRESHOLD = 10000
 EVM_GAS_METERING_MODE = "Rollup"
 # After this evm block height, the max_fee check will be enforced.
 EVM_MAX_FEE_CHECK_HEIGHT = 0
-# After this evm block height, RPC receipts derive effectiveGasPrice
-# from the actual fee charged by the Sovereign gas meter.
-EVM_RECEIPT_ACTUAL_FEE_HEIGHT = 0
 # How many rollup blocks to wait before terminating setup mode. While setup mode is enabled,
 # the rollup does not charge gas. This is useful when initializing the rollup with a bridged gas token.
 SETUP_MODE_TERMINATION_HEIGHT = 0 # Disable setup mode entirely by default.

--- a/crates/module-system/module-implementations/sov-evm/AGENTS.md
+++ b/crates/module-system/module-implementations/sov-evm/AGENTS.md
@@ -53,7 +53,6 @@ If you touch fee context, validate all of these together:
 
 ### 1.5 Actual-fee projection invariants
 
-- Activation gate must stay shared via `src/sov_fee_and_gas_utils.rs:is_actual_fee_projection_height_active` for both receipt projection and RPC effective-gas-price projection.
 - Receipt-side gas projection must support non-uniform gas-price dimensions by computing `ceil(gas_value / gas_price[0])` with checked integer arithmetic.
 - Treat `GasInfo` as the source of truth: `gas_value` must equal `gas_used · gas_price`. Any divergence is a bug, not alternate fee semantics.
 - `gas_price[0]` is the canonical EVM gas price/base fee value. Block header `base_fee_per_gas` must represent the same value exactly (no clamping/truncation). Any mismatch is a bug.

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/block_resolution.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/block_resolution.rs
@@ -170,12 +170,9 @@ where
         );
         let fee_paid = self.receipt_fee(tx_idx, state);
         if let Some((receipt, _)) = self.receipt(tx_idx, state) {
-            if let Some(actual_effective_gas_price) = maybe_actual_effective_gas_price(
-                block_number,
-                receipt.gas_used,
-                fee_paid,
-                base_fee_per_gas,
-            ) {
+            if let Some(actual_effective_gas_price) =
+                maybe_actual_effective_gas_price(receipt.gas_used, fee_paid, base_fee_per_gas)
+            {
                 tx_rpc.effective_gas_price = Some(actual_effective_gas_price);
             }
         }

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/receipt_builder.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/receipt_builder.rs
@@ -7,15 +7,13 @@ use sov_rpc_eth_types::LogWithExecutionTimestamp;
 
 use crate::evm::primitive_types::{Receipt, TransactionSigned, TxSignedAndRecovered};
 use crate::primitive_types::MaybeSealedBlock;
-use crate::sov_fee_and_gas_utils::is_actual_fee_projection_height_active;
 
 pub(crate) fn maybe_actual_effective_gas_price(
-    block_number: u64,
     gas_used: u64,
     fee_paid: Option<Amount>,
     base_fee_per_gas: Option<u64>,
 ) -> Option<u128> {
-    if !is_actual_fee_projection_height_active(block_number) || gas_used == 0 {
+    if gas_used == 0 {
         return None;
     }
 
@@ -90,10 +88,9 @@ pub(crate) fn build_rpc_receipt(
         .inner()
         .effective_gas_price(block.maybe_partial_header().base_fee_per_gas);
 
-    // Once activated, keep zero-fee semantics from metered metadata and otherwise
+    // Keep zero-fee semantics from metered metadata and otherwise
     // report the primary gas-price dimension (EVM base fee from header).
     let effective_gas_price = maybe_actual_effective_gas_price(
-        block.number(),
         receipt.gas_used,
         fee_paid,
         block.maybe_partial_header().base_fee_per_gas,
@@ -119,70 +116,28 @@ pub(crate) fn build_rpc_receipt(
 
 #[cfg(test)]
 mod tests {
-    use sov_modules_api::macros::config_value;
-
     use super::*;
 
     #[test]
     fn maybe_actual_effective_gas_price_uses_zero_paid_fee() {
-        let activation_height: u64 = config_value!("EVM_RECEIPT_ACTUAL_FEE_HEIGHT");
-        let active_block = activation_height
-            .checked_add(1)
-            .expect("activation height must be strictly below u64::MAX");
-
         assert_eq!(
-            maybe_actual_effective_gas_price(active_block, 21_000, Some(Amount::ZERO), Some(123)),
+            maybe_actual_effective_gas_price(21_000, Some(Amount::ZERO), Some(123)),
             Some(0)
         );
     }
 
     #[test]
-    fn maybe_actual_effective_gas_price_ignores_zero_paid_fee_before_activation() {
-        let activation_height: u64 = config_value!("EVM_RECEIPT_ACTUAL_FEE_HEIGHT");
-
-        assert_eq!(
-            maybe_actual_effective_gas_price(
-                activation_height,
-                21_000,
-                Some(Amount::ZERO),
-                Some(123),
-            ),
-            None
-        );
-    }
-
-    #[test]
     fn maybe_actual_effective_gas_price_uses_base_fee_for_non_zero_paid_fee() {
-        let activation_height: u64 = config_value!("EVM_RECEIPT_ACTUAL_FEE_HEIGHT");
-        let active_block = activation_height
-            .checked_add(1)
-            .expect("activation height must be strictly below u64::MAX");
-
         assert_eq!(
-            maybe_actual_effective_gas_price(
-                active_block,
-                21_000,
-                Some(Amount::new(100_000)),
-                Some(42),
-            ),
+            maybe_actual_effective_gas_price(21_000, Some(Amount::new(100_000)), Some(42)),
             Some(42)
         );
     }
 
     #[test]
     fn maybe_actual_effective_gas_price_falls_back_when_base_fee_missing() {
-        let activation_height: u64 = config_value!("EVM_RECEIPT_ACTUAL_FEE_HEIGHT");
-        let active_block = activation_height
-            .checked_add(1)
-            .expect("activation height must be strictly below u64::MAX");
-
         assert_eq!(
-            maybe_actual_effective_gas_price(
-                active_block,
-                21_000,
-                Some(Amount::new(100_000)),
-                None,
-            ),
+            maybe_actual_effective_gas_price(21_000, Some(Amount::new(100_000)), None),
             None
         );
     }

--- a/crates/module-system/module-implementations/sov-evm/src/sov_fee_and_gas_utils.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/sov_fee_and_gas_utils.rs
@@ -35,10 +35,6 @@ where
     S: Spec,
 {
     let tx_fee_paid = gas_info.gas_value;
-    if !is_actual_fee_projection_height_active(receipt.block_number) {
-        return Ok(None);
-    }
-
     if tx_fee_paid == sov_bank::Amount::ZERO {
         return Ok(None);
     }
@@ -115,13 +111,6 @@ pub(crate) fn derive_receipt_gas_used_from_actual_fee<GU: Gas>(
     Ok(projected_gas_used)
 }
 
-/// Returns true once actual-fee projection is enabled for `block_number`.
-/// Keep non-height guards in callers; only the activation-height boundary is shared here.
-pub(crate) fn is_actual_fee_projection_height_active(block_number: u64) -> bool {
-    let apply_actual_fee_after_height: u64 = config_value!("EVM_RECEIPT_ACTUAL_FEE_HEIGHT");
-    block_number > apply_actual_fee_after_height
-}
-
 /// Returns true once the EIP-1559 max-fee-per-gas check is enabled for `block_number`.
 /// Keep non-height guards (e.g. the admin kill-switch) in callers; only the
 /// activation-height boundary is shared here.
@@ -146,26 +135,6 @@ mod tests {
             gas_used,
             gas_price,
         }
-    }
-
-    #[test]
-    fn actual_fee_height_inactive_at_genesis_block() {
-        assert!(!is_actual_fee_projection_height_active(0));
-    }
-
-    #[test]
-    fn actual_fee_height_inactive_at_activation_height() {
-        let activation_height: u64 = config_value!("EVM_RECEIPT_ACTUAL_FEE_HEIGHT");
-        assert!(!is_actual_fee_projection_height_active(activation_height));
-    }
-
-    #[test]
-    fn actual_fee_height_active_after_activation_height() {
-        let activation_height: u64 = config_value!("EVM_RECEIPT_ACTUAL_FEE_HEIGHT");
-        let first_active_block = activation_height
-            .checked_add(1)
-            .expect("activation height must be strictly below u64::MAX");
-        assert!(is_actual_fee_projection_height_active(first_active_block));
     }
 
     #[test]

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/helpers.rs
@@ -29,14 +29,6 @@ pub(crate) fn set_max_fee_check_height(height: u64) {
     );
 }
 
-/// Sets the block height after which receipt effective gas price is derived from actual charged fee.
-pub(crate) fn set_receipt_actual_fee_height(height: u64) {
-    std::env::set_var(
-        "SOV_TEST_CONST_OVERRIDE_EVM_RECEIPT_ACTUAL_FEE_HEIGHT",
-        height.to_string(),
-    );
-}
-
 pub(crate) struct EvmAccount(SecretKey);
 
 impl EvmAccount {

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/rpc_basefee.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/rpc_basefee.rs
@@ -1,6 +1,4 @@
-use crate::helpers::{
-    create_transfer_tx, set_max_fee_check_height, set_receipt_actual_fee_height, setup, EvmAccount,
-};
+use crate::helpers::{create_transfer_tx, set_max_fee_check_height, setup, EvmAccount};
 use crate::runtime::{RT, S};
 use alloy_consensus::{TxEip1559, TypedTransaction};
 use alloy_eips::eip1559::MIN_PROTOCOL_BASE_FEE;
@@ -259,7 +257,6 @@ fn test_eth_estimate_gas_large_access_list_underestimates_executed_receipt() {
     const TARGET_GAS_LIMIT: u64 = 10_000_000;
 
     set_max_fee_check_height(0);
-    set_receipt_actual_fee_height(0);
 
     let (mut runner, account, recipient, _) = setup();
     runner.execute(create_transfer_tx(0, &account, &recipient, 1).tx);
@@ -314,64 +311,6 @@ fn test_eth_estimate_gas_large_access_list_underestimates_executed_receipt() {
             receipt.gas_used
         );
     });
-}
-
-#[test]
-fn test_eth_estimate_gas_historical_block_below_receipt_projection_height_skips_projection() {
-    const EVM_RECEIPT_ACTUAL_FEE_HEIGHT: u64 = 3;
-    const HISTORICAL_BLOCK: u64 = 1;
-
-    set_max_fee_check_height(0);
-    set_receipt_actual_fee_height(EVM_RECEIPT_ACTUAL_FEE_HEIGHT);
-
-    let (mut runner, account, recipient, _) = setup();
-    runner.execute(create_transfer_tx(0, &account, &recipient, 1).tx);
-    runner.advance_slots((EVM_RECEIPT_ACTUAL_FEE_HEIGHT + 1) as usize);
-
-    let request = TransactionRequest {
-        from: Some(account.address()),
-        to: Some(TxKind::Call(recipient.address())),
-        max_fee_per_gas: Some((MIN_PROTOCOL_BASE_FEE as u128) * 10),
-        max_priority_fee_per_gas: Some(0),
-        ..Default::default()
-    };
-
-    let (historical_estimate, latest_estimate) = runner.query_visible_state(|state| {
-        let evm = Evm::<S>::default();
-        let live_block_number = evm.block_number(state).unwrap().to::<u64>();
-        assert!(
-            live_block_number > EVM_RECEIPT_ACTUAL_FEE_HEIGHT,
-            "test precondition failed: live height {live_block_number} must be above EVM_RECEIPT_ACTUAL_FEE_HEIGHT={EVM_RECEIPT_ACTUAL_FEE_HEIGHT}"
-        );
-
-        let historical_estimate = evm
-            .eth_estimate_gas_helper(
-                request.clone(),
-                Some(BlockId::number(HISTORICAL_BLOCK)),
-                None,
-                Some(low_base_fee_override()),
-                state,
-            )
-            .unwrap()
-            .to::<u64>();
-        let latest_estimate = evm
-            .eth_estimate_gas_helper(
-                request,
-                Some(BlockId::latest()),
-                None,
-                Some(low_base_fee_override()),
-                state,
-            )
-            .unwrap()
-            .to::<u64>();
-
-        (historical_estimate, latest_estimate)
-    });
-
-    assert!(
-        latest_estimate > historical_estimate,
-        "historical eth_estimateGas for block {HISTORICAL_BLOCK}, which is below EVM_RECEIPT_ACTUAL_FEE_HEIGHT={EVM_RECEIPT_ACTUAL_FEE_HEIGHT}, should skip fee projection while latest uses it; historical_estimate={historical_estimate}, latest_estimate={latest_estimate}"
-    );
 }
 
 #[test]

--- a/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
+++ b/crates/module-system/module-implementations/sov-evm/tests/integration/transactions.rs
@@ -68,7 +68,6 @@ fn test_simple_transfer() {
 
 #[test]
 fn test_receipt_fee_matches_balance_delta() {
-    set_receipt_actual_fee_height(0);
     let (mut runner, from, to, _) = setup();
     let value = 1u128;
     let transfer = create_transfer_tx_with_fee_params(
@@ -110,7 +109,6 @@ fn test_receipt_fee_matches_balance_delta() {
 
 #[test]
 fn test_block_receipt_fee_matches_balance_delta() {
-    set_receipt_actual_fee_height(0);
     let (mut runner, from, to, _) = setup();
     let value = 1u128;
     let transfer = create_transfer_tx_with_fee_params(
@@ -150,47 +148,6 @@ fn test_block_receipt_fee_matches_balance_delta() {
                 actual_fee,
                 implied_fee,
                 receipt.effective_gas_price,
-            );
-        }),
-    });
-}
-
-#[test]
-fn test_receipt_uses_eip1559_formula_before_activation_height() {
-    set_receipt_actual_fee_height(1_000_000);
-    let (mut runner, from, to, _) = setup();
-    let value = 1u128;
-    let transfer = create_transfer_tx_with_fee_params(
-        0,
-        &from,
-        &to,
-        value,
-        MIN_PROTOCOL_BASE_FEE as u128 * 2,
-        0,
-    );
-
-    let evm = Evm::<S>::default();
-    runner.execute_transaction(TransactionTestCase {
-        input: transfer.tx,
-        assert: Box::new(move |_ctx, state| {
-            let sender_balance_after = evm.get_balance(from.address(), None, state).unwrap();
-            let receipt = evm
-                .get_transaction_receipt(transfer.hash, state)
-                .unwrap()
-                .expect("receipt should exist");
-
-            let implied_fee =
-                U256::from(receipt.gas_used) * U256::from(receipt.effective_gas_price);
-            let actual_fee = U256::from(TEST_DEFAULT_USER_BALANCE.0)
-                .checked_sub(U256::from(value))
-                .and_then(|balance_after_value| {
-                    balance_after_value.checked_sub(sender_balance_after)
-                })
-                .expect("sender balance should decrease by transfer value and a fee");
-
-            assert_ne!(
-                actual_fee, implied_fee,
-                "before activation height receipts should follow legacy EIP-1559 projection",
             );
         }),
     });


### PR DESCRIPTION
# Description

 For every tx whose block is in H_2458 .. H_act, effectiveGasPrice flips from EIP-1559 derived (priority_fee + base_fee) to:

- 0 if receipt_fees[tx_idx] == 0
- block.header.base_fee_per_gas otherwise

### Endpoints affected (same field, same rule):

- eth_getTransactionReceipt → effectiveGasPrice
- eth_getBlockReceipts → receipts[*].effectiveGasPrice
- eth_getTransactionByHash → effectiveGasPrice
- eth_getBlockByNumber(fullTxs=true) → transactions[*].effectiveGasPrice
- eth_getBlockByHash(fullTxs=true) → transactions[*].effectiveGasPrice
- eth_estimateGas Affected for any Block that predates activation height

---
- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
All existing tests are passing

## Docs
No updates
