### PR TITLE
Make NodeDiscovery resilient to missed PostgreSQL notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12137,6 +12137,7 @@ dependencies = [
  "reqwest 0.13.3",
  "serde",
  "sov-metrics",
+ "sov-test-utils",
  "sqlx",
  "thiserror 2.0.18",
  "time",

--- a/crates/utils/sov-proxy-utils/Cargo.toml
+++ b/crates/utils/sov-proxy-utils/Cargo.toml
@@ -21,6 +21,10 @@ serde = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 thiserror = { workspace = true }
 
+[dev-dependencies]
+sov-test-utils = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
 
 [lints]
 workspace = true

--- a/crates/utils/sov-proxy-utils/src/cluster_info_service.rs
+++ b/crates/utils/sov-proxy-utils/src/cluster_info_service.rs
@@ -4,6 +4,7 @@ use crate::node_discovery::ClusterInfo;
 use crate::node_discovery::ClusterUpdateNotifier;
 use crate::node_discovery::NodeDiscovery;
 use crate::node_discovery::NodeDiscoveryTask;
+use crate::node_discovery::DEFAULT_POLL_INTERVAL;
 use anyhow::{Context, Result};
 use std::time::Duration;
 
@@ -20,7 +21,11 @@ impl ClusterInfoService {
         max_age: Duration,
         notifier: Option<Box<dyn ClusterUpdateNotifier>>,
     ) -> Result<Self> {
-        let node_discovery = NodeDiscovery::connect(connection_string, max_age, notifier).await?;
+        install_panic_handler();
+
+        let node_discovery =
+            NodeDiscovery::connect(connection_string, max_age, DEFAULT_POLL_INTERVAL, notifier)
+                .await?;
         let node_checker = NodeChecker::new(node_discovery.receiver.clone())?;
 
         let node_discovery_task = node_discovery.spawn();
@@ -58,4 +63,25 @@ impl ClusterInfoService {
         self.node_discovery_task.handle.await??;
         Ok(())
     }
+}
+
+/// Installs a process-wide panic hook that terminates the process on any panic.
+///
+/// `tokio::spawn` catches panics at the task boundary: a panicking discovery
+/// task would silently stop while the rest of the process keeps running, with
+/// the failure surfacing only as a `JoinError` nobody awaits. This hook makes
+/// such a panic fatal — it still runs the default hook (so the panic message
+/// and backtrace are printed) and then exits with a non-zero status.
+///
+/// Installed only once, even if [`ClusterInfoService::spawn`] is called
+/// repeatedly.
+fn install_panic_handler() {
+    static INSTALL: std::sync::Once = std::sync::Once::new();
+    INSTALL.call_once(|| {
+        let default_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            default_hook(info);
+            std::process::exit(1);
+        }));
+    });
 }

--- a/crates/utils/sov-proxy-utils/src/cluster_info_service.rs
+++ b/crates/utils/sov-proxy-utils/src/cluster_info_service.rs
@@ -60,7 +60,7 @@ impl ClusterInfoService {
     // Waits for the background cluster-info tasks to finish.
     pub async fn join(self) -> anyhow::Result<()> {
         self.node_checker_task.handle.await?;
-        self.node_discovery_task.handle.await??;
+        self.node_discovery_task.handle.await?;
         Ok(())
     }
 }

--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -73,6 +73,8 @@ impl NodeDiscoveryTask {
 
 #[derive(Debug, thiserror::Error)]
 enum HandleClusterUpdateError {
+    #[error("Failed to connect to the cluster database")]
+    Connect(#[source] anyhow::Error),
     #[error("Failed to fetch cluster info")]
     GetClusterInfo(#[source] anyhow::Error),
     #[error("Failed to notify on cluster update")]
@@ -84,20 +86,26 @@ enum HandleClusterUpdateError {
 impl HandleClusterUpdateError {
     fn stage(&self) -> &'static str {
         match self {
+            Self::Connect(_) => "connect",
             Self::GetClusterInfo(_) => "get_cluster_info",
             Self::Notify(_) => "notify",
             Self::RecvNotification(_) => "recv_notification",
         }
     }
 
-    /// Logs the failure, records a failure metric, and backs off before the
-    /// caller's next retry.
-    async fn report_and_backoff(&self) {
+    /// Logs the failure and records a failure metric.
+    fn report(&self) {
         let stage = self.stage();
         tracing::warn!(stage, error = ?self, "Cluster update failed");
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(ClusterUpdateFailureMetric { stage });
         });
+    }
+
+    /// Logs the failure, records a failure metric, and backs off before the
+    /// caller's next retry.
+    async fn report_and_backoff(&self) {
+        self.report();
         tokio::time::sleep(Duration::from_millis(1000)).await;
     }
 }
@@ -126,6 +134,21 @@ impl NodeDiscovery {
     ///
     /// Returns a [`NodeDiscovery`] ready to subscribe for cluster updates.
     pub async fn connect(
+        connection_string: &str,
+        max_age: Duration,
+        poll_interval: Duration,
+        notifier: Option<Box<dyn ClusterUpdateNotifier>>,
+    ) -> Result<Self> {
+        Self::try_connect(connection_string, max_age, poll_interval, notifier)
+            .await
+            .map_err(|error| {
+                let error = HandleClusterUpdateError::Connect(error);
+                error.report();
+                anyhow::Error::new(error)
+            })
+    }
+
+    async fn try_connect(
         connection_string: &str,
         max_age: Duration,
         poll_interval: Duration,

--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -88,9 +88,13 @@ impl HandleClusterUpdateError {
     }
 }
 
+/// Default upper bound on how long to wait before re-polling cluster info.
+pub(crate) const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(3);
+
 /// Client for querying cluster information from the database.
 pub struct NodeDiscovery {
     max_age: Duration,
+    poll_interval: Duration,
     pool: PgPool,
     listener: PgListener,
     prev_followers: BTreeSet<String>,
@@ -110,6 +114,7 @@ impl NodeDiscovery {
     pub async fn connect(
         connection_string: &str,
         max_age: Duration,
+        poll_interval: Duration,
         notifier: Option<Box<dyn ClusterUpdateNotifier>>,
     ) -> Result<Self> {
         tracing::info!("Connecting to database.");
@@ -129,6 +134,7 @@ impl NodeDiscovery {
 
         Ok(Self {
             max_age,
+            poll_interval,
             pool,
             listener,
             prev_followers: BTreeSet::new(),
@@ -205,8 +211,8 @@ impl NodeDiscovery {
                     tokio::time::sleep(Duration::from_millis(1000)).await;
                 }
 
-                // Wait for at least one notification.
-                self.listener.recv().await?;
+                // Wait for the next change signal, or re-poll after poll_interval.
+                self.recv_notification().await;
 
                 // Drain any additional pending notifications.
                 while self.listener.next_buffered().is_some() {}
@@ -214,6 +220,42 @@ impl NodeDiscovery {
         });
 
         NodeDiscoveryTask { receiver, handle }
+    }
+
+    /// Waits once for the next cluster change signal before returning to the
+    /// caller's loop, which always re-polls cluster info.
+    async fn recv_notification(&mut self) {
+        let poll_interval = self.poll_interval;
+        match tokio::time::timeout(poll_interval, self.listener.try_recv()).await {
+            // A notification arrived — re-poll.
+            Ok(Ok(Some(_))) => {}
+            // The listener connection dropped and was re-established. Any
+            // notifications sent before LISTEN was restored may have been lost,
+            // so re-poll cluster info immediately instead of waiting for the
+            // next poll interval.
+            Ok(Ok(None)) => {
+                tracing::debug!(
+                    "Cluster notification listener reconnected after connection loss, re-polling"
+                );
+            }
+            // No notification arrived within `poll_interval`. This is expected
+            // when the cluster is quiet; we re-poll anyway to bound staleness.
+            Err(_) => {
+                tracing::debug!(
+                    ?poll_interval,
+                    "No cluster notification received within the poll interval, re-polling"
+                );
+            }
+            Ok(Err(error)) => {
+                tracing::warn!(?error, "Failed to receive cluster notification, retrying");
+                sov_metrics::track_metrics(|tracker| {
+                    tracker.submit(ClusterUpdateFailureMetric {
+                        stage: "recv_notification",
+                    });
+                });
+                tokio::time::sleep(Duration::from_millis(1000)).await;
+            }
+        }
     }
 
     async fn handle_cluster_update(&mut self) -> Result<(), HandleClusterUpdateError> {

--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -62,7 +62,7 @@ pub trait ClusterUpdateNotifier: Send + Sync + 'static {
 /// Handle returned when subscribing to cluster updates.
 pub struct NodeDiscoveryTask {
     pub receiver: watch::Receiver<ClusterInfo>,
-    pub(crate) handle: JoinHandle<anyhow::Result<()>>,
+    pub(crate) handle: JoinHandle<()>,
 }
 
 impl NodeDiscoveryTask {

--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -270,7 +270,7 @@ impl NodeDiscovery {
         let membership_changed = self.prev_followers != followers;
         let leader_changed = self.prev_leader_id != leader_id;
 
-        tracing::trace!(info = ?info, membership_changed, leader_changed, "Last cluster info");
+        tracing::debug!(info = ?info, membership_changed, leader_changed, "Last cluster info");
 
         if !(membership_changed || leader_changed) {
             return Ok(());

--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -77,6 +77,8 @@ enum HandleClusterUpdateError {
     GetClusterInfo(#[source] anyhow::Error),
     #[error("Failed to notify on cluster update")]
     Notify(#[source] anyhow::Error),
+    #[error("Failed to receive cluster notification")]
+    RecvNotification(#[source] anyhow::Error),
 }
 
 impl HandleClusterUpdateError {
@@ -84,7 +86,19 @@ impl HandleClusterUpdateError {
         match self {
             Self::GetClusterInfo(_) => "get_cluster_info",
             Self::Notify(_) => "notify",
+            Self::RecvNotification(_) => "recv_notification",
         }
+    }
+
+    /// Logs the failure, records a failure metric, and backs off before the
+    /// caller's next retry.
+    async fn report_and_backoff(&self) {
+        let stage = self.stage();
+        tracing::warn!(stage, error = ?self, "Cluster update failed");
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit(ClusterUpdateFailureMetric { stage });
+        });
+        tokio::time::sleep(Duration::from_millis(1000)).await;
     }
 }
 
@@ -202,17 +216,13 @@ impl NodeDiscovery {
         let handle = tokio::spawn(async move {
             loop {
                 if let Err(error) = self.handle_cluster_update().await {
-                    let stage = error.stage();
-
-                    tracing::warn!(stage, ?error, "Cluster update failed");
-                    sov_metrics::track_metrics(|tracker| {
-                        tracker.submit(ClusterUpdateFailureMetric { stage });
-                    });
-                    tokio::time::sleep(Duration::from_millis(1000)).await;
+                    error.report_and_backoff().await;
                 }
 
                 // Wait for the next change signal, or re-poll after poll_interval.
-                self.recv_notification().await;
+                if let Err(error) = self.recv_notification().await {
+                    error.report_and_backoff().await;
+                }
 
                 // Drain any additional pending notifications.
                 while self.listener.next_buffered().is_some() {}
@@ -224,7 +234,7 @@ impl NodeDiscovery {
 
     /// Waits once for the next cluster change signal before returning to the
     /// caller's loop, which always re-polls cluster info.
-    async fn recv_notification(&mut self) {
+    async fn recv_notification(&mut self) -> Result<(), HandleClusterUpdateError> {
         let poll_interval = self.poll_interval;
         match tokio::time::timeout(poll_interval, self.listener.try_recv()).await {
             // A notification arrived — re-poll.
@@ -247,15 +257,10 @@ impl NodeDiscovery {
                 );
             }
             Ok(Err(error)) => {
-                tracing::warn!(?error, "Failed to receive cluster notification, retrying");
-                sov_metrics::track_metrics(|tracker| {
-                    tracker.submit(ClusterUpdateFailureMetric {
-                        stage: "recv_notification",
-                    });
-                });
-                tokio::time::sleep(Duration::from_millis(1000)).await;
+                return Err(HandleClusterUpdateError::RecvNotification(error.into()));
             }
         }
+        Ok(())
     }
 
     async fn handle_cluster_update(&mut self) -> Result<(), HandleClusterUpdateError> {

--- a/crates/utils/sov-proxy-utils/tests/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/tests/node_discovery.rs
@@ -1,0 +1,165 @@
+//! Integration tests for [`NodeDiscovery`] against a real PostgreSQL instance.
+
+use std::time::Duration;
+
+use sov_proxy_utils::{NodeDiscovery, NodeDiscoveryTask};
+use sov_test_utils::postgres::{
+    connection_string_from_postgres_container, create_postgres_container, ContainerAsync,
+    CreatePostgresError, Postgres,
+};
+use sov_test_utils::sov_toxi_proxi_image::ToxiProxySetup;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+
+/// The sequencer's production migrations.
+const MIGRATIONS: &[&str] = &[
+    include_str!(
+        "../../../full-node/sov-sequencer/src/preferred/db/postgres/migrations/001_init.sql"
+    ),
+    include_str!(
+        "../../../full-node/sov-sequencer/src/preferred/db/postgres/migrations/002_nodes.sql"
+    ),
+    include_str!(
+        "../../../full-node/sov-sequencer/src/preferred/db/postgres/migrations/003_unique_tx_events.sql"
+    ),
+];
+
+/// Spins up a Postgres container with [`MIGRATIONS`] applied.
+///
+/// Returns `None` when Docker is unavailable so the test can skip cleanly. The
+/// returned [`ContainerAsync`] must be kept alive for the whole test: dropping
+/// it stops the database.
+async fn setup() -> Option<(ContainerAsync<Postgres>, String, PgPool)> {
+    let container = match create_postgres_container().await {
+        Ok(container) => container,
+        Err(CreatePostgresError::DockerNotSupported) => return None,
+        Err(CreatePostgresError::DockerError(e)) => {
+            panic!("Failed to create Postgres container: {e}");
+        }
+    };
+
+    let connection_string = connection_string_from_postgres_container(&container)
+        .await
+        .expect("Failed to build connection string");
+
+    let writer = PgPoolOptions::new()
+        .connect(&connection_string)
+        .await
+        .expect("Failed to connect writer pool");
+
+    for migration in MIGRATIONS {
+        sqlx::raw_sql(migration)
+            .execute(&writer)
+            .await
+            .expect("Failed to apply migration");
+    }
+
+    Some((container, connection_string, writer))
+}
+
+/// Inserts a node into the `nodes` table with a fresh heartbeat.
+async fn insert_node(pool: &PgPool, node_id: &str, address: &str) {
+    sqlx::query("INSERT INTO nodes (node_id, address, last_updated) VALUES ($1, $2, NOW())")
+        .bind(node_id)
+        .bind(address)
+        .execute(pool)
+        .await
+        .expect("Failed to insert node");
+}
+
+/// Waits for the discovery task to publish a cluster info update.
+async fn wait_for_change(task: &mut NodeDiscoveryTask) {
+    tokio::time::timeout(Duration::from_secs(20), task.receiver.changed())
+        .await
+        .expect("Timed out waiting for a cluster info update")
+        .expect("Cluster info watch channel closed");
+}
+
+/// Starts toxiproxy in front of Postgres and spawns a [`NodeDiscovery`] task that connects through it.
+async fn start_proxied_discovery(
+    connection_string: &str,
+    poll_interval: Duration,
+) -> (ToxiProxySetup, NodeDiscoveryTask) {
+    let toxiproxy = ToxiProxySetup::start_for_postgres(connection_string).await;
+
+    let task = NodeDiscovery::connect(
+        toxiproxy.proxied_postgres_connection_string(),
+        Duration::from_secs(300), // max_age: keep nodes well within the window.
+        poll_interval,
+        None,
+    )
+    .await
+    .expect("Failed to connect NodeDiscovery")
+    .spawn();
+
+    (toxiproxy, task)
+}
+
+/// A membership change made while no notification reaches `NodeDiscovery` is
+/// still discovered, because it re-polls cluster info every `poll_interval`.
+#[tokio::test(flavor = "multi_thread")]
+async fn discovers_membership_change_without_notification() {
+    let Some((_container, connection_string, writer)) = setup().await else {
+        return; // Docker unavailable — skip.
+    };
+
+    // poll_interval is short, to keep the test fast.
+    let (toxiproxy, mut task) =
+        start_proxied_discovery(&connection_string, Duration::from_millis(500)).await;
+
+    // Baseline: a node inserted while the connection is healthy is discovered via the NOTIFY trigger.
+    insert_node(&writer, "node_a", "127.0.0.1:9001").await;
+    wait_for_change(&mut task).await;
+    assert!(
+        task.receiver.borrow_and_update().has_follower("node_a"),
+        "node inserted with a healthy connection should be discovered"
+    );
+
+    // Sever NodeDiscovery's connection, change membership while it is severed so
+    // the NOTIFY never reaches its listener, then heal the connection. The lost
+    // notification cannot be replayed, so only the periodic poll can surface
+    // this change.
+    toxiproxy.set_postgres_partition(true).await;
+    insert_node(&writer, "node_b", "127.0.0.1:9002").await;
+    toxiproxy.set_postgres_partition(false).await;
+    wait_for_change(&mut task).await;
+    assert!(
+        task.receiver.borrow_and_update().has_follower("node_b"),
+        "node added without a notification should be discovered via the periodic poll"
+    );
+
+    task.abort();
+    toxiproxy.shutdown();
+}
+
+/// The discovery task survives losing its database connection: it reconnects
+/// and keeps reporting cluster changes instead of exiting.
+#[tokio::test(flavor = "multi_thread")]
+async fn survives_database_connection_loss() {
+    let Some((_container, connection_string, writer)) = setup().await else {
+        return; // Docker unavailable — skip.
+    };
+
+    // poll_interval is effectively disabled, so recovery is exercised purely by
+    // the reconnect path rather than the periodic poll.
+    let (toxiproxy, mut task) =
+        start_proxied_discovery(&connection_string, Duration::from_secs(100000)).await;
+
+    insert_node(&writer, "node_a", "127.0.0.1:9001").await;
+    wait_for_change(&mut task).await;
+
+    // Sever the connection, the same as an abrupt network outage.
+    toxiproxy.set_postgres_partition(true).await;
+    toxiproxy.set_postgres_partition(false).await;
+
+    // The task must reconnect rather than exit, and keep discovering nodes.
+    insert_node(&writer, "node_b", "127.0.0.1:9002").await;
+    wait_for_change(&mut task).await;
+    assert!(
+        task.receiver.borrow_and_update().has_follower("node_b"),
+        "discovery task should recover from connection loss and keep discovering nodes"
+    );
+
+    task.abort();
+    toxiproxy.shutdown();
+}

--- a/crates/utils/sov-test-utils/src/sov_toxi_proxi_image.rs
+++ b/crates/utils/sov-test-utils/src/sov_toxi_proxi_image.rs
@@ -58,7 +58,7 @@ pub struct ToxiProxySetup {
     container: ContainerAsync<SovToxiProxiImage>,
     client: reqwest::Client,
     api_base_url: String,
-    proxied_da_addr: SocketAddr,
+    proxied_da_addr: Option<SocketAddr>,
     proxied_postgres_connection_string: String,
 }
 
@@ -68,6 +68,17 @@ impl ToxiProxySetup {
         postgres_connection_string: &str,
         da_upstream_port: u16,
     ) -> Self {
+        Self::start(postgres_connection_string, Some(da_upstream_port)).await
+    }
+
+    /// Starts toxiproxy with only a Postgres proxy.
+    pub async fn start_for_postgres(postgres_connection_string: &str) -> Self {
+        Self::start(postgres_connection_string, None).await
+    }
+
+    /// Starts toxiproxy with a Postgres proxy, plus a DA proxy when
+    /// `da_upstream_port` is `Some`.
+    async fn start(postgres_connection_string: &str, da_upstream_port: Option<u16>) -> Self {
         prepull_image_best_effort(SovToxiProxiImage).await;
 
         let toxiproxy = SovToxiProxiImage
@@ -95,10 +106,6 @@ impl ToxiProxySetup {
             .get_host_port_ipv4(TOXIPROXY_POSTGRES_PORT.tcp())
             .await
             .expect("Failed to map toxiproxy postgres port");
-        let toxiproxy_da_port = toxiproxy
-            .get_host_port_ipv4(TOXIPROXY_DA_PORT.tcp())
-            .await
-            .expect("Failed to map toxiproxy DA port");
 
         let client = reqwest::Client::builder()
             .timeout(TOXIPROXY_HTTP_REQUEST_TIMEOUT)
@@ -109,17 +116,28 @@ impl ToxiProxySetup {
 
         let postgres_port = Self::parse_postgres_port(postgres_connection_string);
         Self::create_postgres_proxy(&client, &api_base_url, postgres_port).await;
-        Self::create_da_proxy(&client, &api_base_url, da_upstream_port).await;
 
         let proxied_postgres_connection_string = Self::build_proxy_connection_string(
             postgres_connection_string,
             &toxiproxy_host,
             toxiproxy_postgres_port,
         );
-        let proxied_da_addr = SocketAddr::new(
-            Self::resolve_proxy_host_ip(&toxiproxy_host),
-            toxiproxy_da_port,
-        );
+
+        // The DA proxy is only created when the caller has DA traffic to route.
+        let proxied_da_addr = match da_upstream_port {
+            Some(da_upstream_port) => {
+                Self::create_da_proxy(&client, &api_base_url, da_upstream_port).await;
+                let toxiproxy_da_port = toxiproxy
+                    .get_host_port_ipv4(TOXIPROXY_DA_PORT.tcp())
+                    .await
+                    .expect("Failed to map toxiproxy DA port");
+                Some(SocketAddr::new(
+                    Self::resolve_proxy_host_ip(&toxiproxy_host),
+                    toxiproxy_da_port,
+                ))
+            }
+            None => None,
+        };
 
         Self {
             container: toxiproxy,
@@ -165,6 +183,7 @@ impl ToxiProxySetup {
     /// Returns the DA endpoint that points at toxiproxy.
     pub fn proxied_da_addr(&self) -> SocketAddr {
         self.proxied_da_addr
+            .expect("DA proxy was not configured; create the setup with start_for_postgres_and_da")
     }
 
     /// Returns the Postgres connection string rewritten to point at toxiproxy.


### PR DESCRIPTION
# Description
`NodeDiscovery` previously blocked on `PgListener::recv()` and only re-polled cluster info when a PostgreSQL `NOTIFY` arrived. If a notification was dropped, e.g., the listener connection was severed while membership changed, the change was never observed, and a listener error would terminate the discovery task entirely.

This PR makes discovery resilient:
1. `NodeDiscovery::connect` now takes a `poll_interval`. The discovery loop waits
    *up to* that interval for a notification via `timeout(poll_interval, try_recv())`
    and then re-polls regardless, bounding how stale cluster info can get.
2. A reconnect (`try_recv` returning `None`) triggers an immediate re-poll, since
    notifications sent before `LISTEN` was restored may have been lost.
3. Listener errors are now logged + metered and retried instead of killing the
    task, so discovery survives database connection loss.
4. `ClusterInfoService` passes a `DEFAULT_POLL_INTERVAL` of 3s.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)
