### PR TITLE
Clean up trait definitions for `resolve_context_` methods

### DIFF
--- a/crates/module-system/sov-capabilities/src/lib.rs
+++ b/crates/module-system/sov-capabilities/src/lib.rs
@@ -309,7 +309,7 @@ impl<S: Spec, T> TransactionAuthorizer<S> for StandardProvenRollupCapabilities<'
         auth_data: &AuthorizationData<S>,
         sequencer: &<S::Da as DaSpec>::Address,
         sequencer_rollup_address: S::Address,
-        state: &mut impl StateAccessor,
+        state: &mut impl StateReader<User>,
         sequencing_data: Option<Bytes>,
         execution_context: ExecutionContext,
         sequencer_type: SequencerType,
@@ -331,7 +331,7 @@ impl<S: Spec, T> TransactionAuthorizer<S> for StandardProvenRollupCapabilities<'
         &mut self,
         auth_data: &AuthorizationData<S>,
         sequencer: &<<S as Spec>::Da as DaSpec>::Address,
-        state: &mut impl StateAccessor,
+        state: &mut impl StateReader<User>,
         execution_context: ExecutionContext,
     ) -> anyhow::Result<Context<S>> {
         // On the unregistered path the sender pays its own sequencing, so the
@@ -375,7 +375,7 @@ impl<S: Spec, T> StandardProvenRollupCapabilities<'_, S, T> {
     fn resolve_authorized_sender(
         &mut self,
         auth_data: &AuthorizationData<S>,
-        state: &mut impl StateAccessor,
+        state: &mut impl StateReader<User>,
     ) -> anyhow::Result<S::Address> {
         match auth_data.address_override {
             Some(address_override) => {

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/authorization.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/authorization.rs
@@ -10,8 +10,10 @@ use sov_rollup_interface::stf::ExecutionContext;
 use sov_rollup_interface::{Bytes, TxHash};
 use sov_universal_wallet::UniversalWallet;
 
+use sov_state::User;
+
 use crate::transaction::Credentials;
-use crate::{Context, SequencerType, Spec, StateAccessor};
+use crate::{Context, SequencerType, Spec, StateAccessor, StateReader};
 
 /// Authorizes transactions to be executed.
 pub trait TransactionAuthorizer<S: Spec> {
@@ -21,7 +23,7 @@ pub trait TransactionAuthorizer<S: Spec> {
         auth_data: &AuthorizationData<S>,
         sequencer: &<<S as Spec>::Da as DaSpec>::Address,
         sequencer_rollup_address: S::Address,
-        state: &mut impl StateAccessor,
+        state: &mut impl StateReader<User>,
         sequencing_data: Option<Bytes>,
         execution_context: ExecutionContext,
         sequencer_type: SequencerType,
@@ -32,7 +34,7 @@ pub trait TransactionAuthorizer<S: Spec> {
         &mut self,
         auth_data: &AuthorizationData<S>,
         sequencer: &<<S as Spec>::Da as DaSpec>::Address,
-        state: &mut impl StateAccessor,
+        state: &mut impl StateReader<User>,
         execution_context: ExecutionContext,
     ) -> anyhow::Result<Context<S>>;
 
@@ -42,7 +44,7 @@ pub trait TransactionAuthorizer<S: Spec> {
         auth_data: &AuthorizationData<S>,
         context: &Context<S>,
         execution_context: &ExecutionContext,
-        state: &mut impl StateAccessor,
+        state: &mut impl StateReader<User>,
     ) -> anyhow::Result<()>;
 
     /// Marks a transaction as having been executed, preventing it from executing again.


### PR DESCRIPTION
# Description

After sov-accounts have removed state write on context resolution now we can tighten the trait.

---

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/384

## Testing
No updates

## Docs
No updates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->