### PR TITLE
 Add NodeDiscovery cluster update metric

### DIFF
--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -307,7 +307,7 @@ impl NodeDiscovery {
         let cluster_changed = membership_changed || leader_changed;
         self.iter = self.iter.wrapping_add(1);
 
-        let liveness_due = self.iter % LIVENESS_INTERVAL == 0;
+        let liveness_due = self.iter.is_multiple_of(LIVENESS_INTERVAL);
 
         tracing::debug!(info = ?info, membership_changed, leader_changed, "Last cluster info");
 

--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -12,6 +12,11 @@ pub use time::OffsetDateTime;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
+/// Re-emit the cluster update metric every Nth successful check even if the                                                                                                                                                                
+/// cluster is unchanged, so the absence of samples can be alerted on if the                                                                                                                                                                
+/// polling task dies silently.                                                                                                                                                                                                             
+const LIVENESS_INTERVAL: u64 = 5;
+
 /// Information about a registered node.
 #[derive(Debug, Clone, FromRow, PartialEq, Eq)]
 pub struct NodeInfo {
@@ -124,6 +129,7 @@ pub struct NodeDiscovery {
     notifier: Option<Box<dyn ClusterUpdateNotifier>>,
     sender: watch::Sender<ClusterInfo>,
     pub(crate) receiver: watch::Receiver<ClusterInfo>,
+    iter: u64,
 }
 
 impl NodeDiscovery {
@@ -179,6 +185,7 @@ impl NodeDiscovery {
             notifier,
             sender,
             receiver,
+            iter: 0,
         })
     }
 
@@ -297,45 +304,54 @@ impl NodeDiscovery {
 
         let membership_changed = self.prev_followers != followers;
         let leader_changed = self.prev_leader_id != leader_id;
+        let cluster_changed = membership_changed || leader_changed;
+        self.iter = self.iter.wrapping_add(1);
+
+        let liveness_due = self.iter % LIVENESS_INTERVAL == 0;
 
         tracing::debug!(info = ?info, membership_changed, leader_changed, "Last cluster info");
 
-        if !(membership_changed || leader_changed) {
+        if !(cluster_changed || liveness_due) {
             return Ok(());
         }
+
         let update_metric = ClusterUpdateMetric {
             current_leader: leader_id.clone(),
             followers: followers.iter().cloned().collect(),
+            cluster_changed,
         };
 
-        // Log membership changes
-        for node_id in followers.difference(&self.prev_followers) {
-            tracing::info!(node_id, "Node joined the followers");
-        }
-        for node_id in self.prev_followers.difference(&followers) {
-            tracing::info!(node_id, "Node left the followers");
+        if cluster_changed {
+            // Log membership changes
+            for node_id in followers.difference(&self.prev_followers) {
+                tracing::info!(node_id, "Node joined the followers");
+            }
+            for node_id in self.prev_followers.difference(&followers) {
+                tracing::info!(node_id, "Node left the followers");
+            }
+
+            // Log leader change
+            if leader_changed {
+                tracing::info!(
+                    old_leader = ?self.prev_leader_id,
+                    new_leader = ?leader_id,
+                    "Leader changed"
+                );
+            }
+
+            // Notify watchers that the cluster was updated.
+            if let Some(notifier) = &mut self.notifier {
+                notifier
+                    .on_cluster_update(&info)
+                    .await
+                    .map_err(HandleClusterUpdateError::Notify)?;
+            }
+
+            self.prev_followers = followers;
+            self.prev_leader_id = leader_id;
+            let _ = self.sender.send(info);
         }
 
-        // Log leader change
-        if leader_changed {
-            tracing::info!(
-                old_leader = ?self.prev_leader_id,
-                new_leader = ?leader_id,
-                "Leader changed"
-            );
-        }
-
-        // Notify watchers that the cluster was updated.
-        if let Some(notifier) = &mut self.notifier {
-            notifier
-                .on_cluster_update(&info)
-                .await
-                .map_err(HandleClusterUpdateError::Notify)?;
-        }
-
-        self.prev_followers = followers;
-        self.prev_leader_id = leader_id;
-        let _ = self.sender.send(info);
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(update_metric);
         });

--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -1,5 +1,5 @@
 //! Utilities for discovering cluster nodes from PostgreSQL and persisting snapshots.
-use crate::node_discovery_metrics::ClusterUpdateFailureMetric;
+use crate::node_discovery_metrics::{ClusterUpdateFailureMetric, ClusterUpdateMetric};
 use anyhow::Result;
 use async_trait::async_trait;
 use sqlx::postgres::{PgListener, PgPool};
@@ -303,6 +303,10 @@ impl NodeDiscovery {
         if !(membership_changed || leader_changed) {
             return Ok(());
         }
+        let update_metric = ClusterUpdateMetric {
+            current_leader: leader_id.clone(),
+            followers: followers.iter().cloned().collect(),
+        };
 
         // Log membership changes
         for node_id in followers.difference(&self.prev_followers) {
@@ -332,6 +336,9 @@ impl NodeDiscovery {
         self.prev_followers = followers;
         self.prev_leader_id = leader_id;
         let _ = self.sender.send(info);
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit(update_metric);
+        });
 
         Ok(())
     }

--- a/crates/utils/sov-proxy-utils/src/node_discovery_metrics.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery_metrics.rs
@@ -16,11 +16,7 @@ impl sov_metrics::Metric for ClusterUpdateMetric {
         // Leader and follower IDs are fields, not tags, because each distinct
         // tag value creates a new InfluxDB series and cluster membership can
         // change often enough to cause high-cardinality storage/query overhead.
-        write!(
-            buffer,
-            "{} count=1,current_leader=\"",
-            self.measurement_name(),
-        )?;
+        write!(buffer, "{} current_leader=\"", self.measurement_name(),)?;
         write_escaped_field_value(buffer, self.current_leader.as_deref().unwrap_or(""))?;
         write!(buffer, "\",followers=\"")?;
         write_escaped_field_value(buffer, &format!("{:?}", self.followers))?;

--- a/crates/utils/sov-proxy-utils/src/node_discovery_metrics.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery_metrics.rs
@@ -1,4 +1,32 @@
+use sov_metrics::write_escaped_field_value;
 use std::io::Write;
+
+#[derive(Debug)]
+pub(crate) struct ClusterUpdateMetric {
+    pub current_leader: Option<String>,
+    pub followers: Vec<String>,
+}
+
+impl sov_metrics::Metric for ClusterUpdateMetric {
+    fn measurement_name(&self) -> &'static str {
+        "sov_proxy_cluster_update"
+    }
+
+    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        // Leader and follower IDs are fields, not tags, because each distinct
+        // tag value creates a new InfluxDB series and cluster membership can
+        // change often enough to cause high-cardinality storage/query overhead.
+        write!(
+            buffer,
+            "{} count=1,current_leader=\"",
+            self.measurement_name(),
+        )?;
+        write_escaped_field_value(buffer, self.current_leader.as_deref().unwrap_or(""))?;
+        write!(buffer, "\",followers=\"")?;
+        write_escaped_field_value(buffer, &format!("{:?}", self.followers))?;
+        buffer.write_all(b"\"")
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct ClusterUpdateFailureMetric {

--- a/crates/utils/sov-proxy-utils/src/node_discovery_metrics.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery_metrics.rs
@@ -5,6 +5,9 @@ use std::io::Write;
 pub(crate) struct ClusterUpdateMetric {
     pub current_leader: Option<String>,
     pub followers: Vec<String>,
+    /// `true` if this emission reflects an actual membership or leader change;
+    /// `false` if it is a periodic liveness re-emit of the unchanged state.
+    pub cluster_changed: bool,
 }
 
 impl sov_metrics::Metric for ClusterUpdateMetric {
@@ -20,7 +23,7 @@ impl sov_metrics::Metric for ClusterUpdateMetric {
         write_escaped_field_value(buffer, self.current_leader.as_deref().unwrap_or("none"))?;
         write!(buffer, "\",followers=\"")?;
         write_escaped_field_value(buffer, &format!("{:?}", self.followers))?;
-        buffer.write_all(b"\"")
+        write!(buffer, "\",cluster_changed={}", self.cluster_changed)
     }
 }
 

--- a/crates/utils/sov-proxy-utils/src/node_discovery_metrics.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery_metrics.rs
@@ -17,7 +17,7 @@ impl sov_metrics::Metric for ClusterUpdateMetric {
         // tag value creates a new InfluxDB series and cluster membership can
         // change often enough to cause high-cardinality storage/query overhead.
         write!(buffer, "{} current_leader=\"", self.measurement_name(),)?;
-        write_escaped_field_value(buffer, self.current_leader.as_deref().unwrap_or(""))?;
+        write_escaped_field_value(buffer, self.current_leader.as_deref().unwrap_or("none"))?;
         write!(buffer, "\",followers=\"")?;
         write_escaped_field_value(buffer, &format!("{:?}", self.followers))?;
         buffer.write_all(b"\"")


### PR DESCRIPTION
# Description

Depends on #2905

  Adds a `sov_proxy_cluster_update` metric emitted whenever `NodeDiscovery` publishes an actual cluster change.

  The metric includes:
  - `current_leader`
  - `followers`

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


<img width="2730" height="1228" alt="image" src="https://github.com/user-attachments/assets/cf42bbbe-1b26-4d9f-b05e-276df2ae3e99" />

