### PR TITLE
Add `prover-incentives` rejection and admin upgrade observability

### DIFF
--- a/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
@@ -279,6 +279,7 @@ impl<S: Spec> ProverIncentives<S> {
             prover_address,
             &ctx,
             is_admin,
+            execution_context,
             state,
         )?;
 
@@ -292,6 +293,7 @@ impl<S: Spec> ProverIncentives<S> {
                 if pending_admin_upgrade.is_some() {
                     crate::metrics::track_admin_upgrade_failure(
                         public_outputs.final_slot_number,
+                        execution_context,
                         crate::metrics::AdminUpgradeMetricReason::ProverPenalized,
                     );
                 }
@@ -305,7 +307,12 @@ impl<S: Spec> ProverIncentives<S> {
 
                 // Persist the upgrade only after the proof is fully accepted.
                 if let Some(upgrade) = pending_admin_upgrade {
-                    self.apply_admin_upgrade(public_outputs.final_slot_number, upgrade, state)?;
+                    self.apply_admin_upgrade(
+                        public_outputs.final_slot_number,
+                        upgrade,
+                        execution_context,
+                        state,
+                    )?;
                 }
 
                 // Only expose proofs that were fully accepted.
@@ -518,6 +525,7 @@ impl<S: Spec> ProverIncentives<S> {
         prover_address: &S::Address,
         ctx: &ProofContext<S>,
         is_admin: bool,
+        execution_context: ExecutionContext,
         state: &mut ST,
     ) -> Result<Option<AdminUpgrade<S>>, ProcessProofError> {
         if !ctx.is_admin_upgrade(public_outputs, is_admin) {
@@ -534,6 +542,7 @@ impl<S: Spec> ProverIncentives<S> {
             self.slash_prover(prover_address, state)?;
             crate::metrics::track_admin_upgrade_failure(
                 upgrade_slot,
+                execution_context,
                 crate::metrics::AdminUpgradeMetricReason::StaleAdminUpgrade,
             );
             return Err(ProcessProofError::ProverSlashedNoRevert(format!(
@@ -546,13 +555,27 @@ impl<S: Spec> ProverIncentives<S> {
             public_outputs.outer_vk_hash.clone(),
         ) {
             Ok(commitment) => commitment,
-            Err(_) => return self.slash_admin_for_invalid_vkey_hash(public_outputs, prover_address, state),
+            Err(_) => {
+                return self.slash_admin_for_invalid_vkey_hash(
+                    public_outputs,
+                    prover_address,
+                    execution_context,
+                    state,
+                );
+            }
         };
         let inner_code_commitment = match <<<S as Spec>::InnerZkvm as Zkvm>::Verifier as ZkVerifier>::CodeCommitment::try_from_hash(
             public_outputs.inner_vkey_hash.clone(),
         ) {
             Ok(commitment) => commitment,
-            Err(_) => return self.slash_admin_for_invalid_vkey_hash(public_outputs, prover_address, state),
+            Err(_) => {
+                return self.slash_admin_for_invalid_vkey_hash(
+                    public_outputs,
+                    prover_address,
+                    execution_context,
+                    state,
+                );
+            }
         };
 
         Ok(Some(AdminUpgrade::<S> {
@@ -570,6 +593,7 @@ impl<S: Spec> ProverIncentives<S> {
             <S::Storage as Storage>::Root,
         >,
         prover_address: &S::Address,
+        execution_context: ExecutionContext,
         state: &mut ST,
     ) -> Result<Option<AdminUpgrade<S>>, ProcessProofError> {
         tracing::debug!(
@@ -581,6 +605,7 @@ impl<S: Spec> ProverIncentives<S> {
         self.slash_prover(prover_address, state)?;
         crate::metrics::track_admin_upgrade_failure(
             public_outputs.final_slot_number,
+            execution_context,
             crate::metrics::AdminUpgradeMetricReason::InvalidAdminUpgradeVkeyHash,
         );
         Err(ProcessProofError::ProverSlashedNoRevert(format!(
@@ -593,6 +618,7 @@ impl<S: Spec> ProverIncentives<S> {
         &mut self,
         slot: SlotNumber,
         upgrade: AdminUpgrade<S>,
+        execution_context: ExecutionContext,
         state: &mut ST,
     ) -> Result<(), anyhow::Error> {
         self.admin_upgrades.set(&slot, &upgrade, state)?;
@@ -605,7 +631,7 @@ impl<S: Spec> ProverIncentives<S> {
             "Admin upgrade recorded"
         );
 
-        crate::metrics::track_admin_upgrade_success(slot);
+        crate::metrics::track_admin_upgrade_success(slot, execution_context);
 
         Ok(())
     }

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/capabilities.rs
@@ -128,6 +128,51 @@ impl<S: Spec> ProverIncentives<S> {
         AggregatedProofPublicData<S::Address, S::Da, <S::Storage as Storage>::Root>,
         ProcessProofError,
     > {
+        let result = self.process_proof_inner(proof, prover_address, execution_context, state);
+        if let Err(error) = &result {
+            Self::log_process_proof_error(prover_address, error);
+            crate::metrics::track_rejected_proof(execution_context, error);
+        }
+        result
+    }
+
+    fn log_process_proof_error(prover_address: &S::Address, error: &ProcessProofError) {
+        match error {
+            ProcessProofError::ProverSlashedNoRevert(reason) => {
+                tracing::warn!(
+                    %prover_address,
+                    %reason,
+                    "Prover slashed while processing proof"
+                );
+            }
+            ProcessProofError::ProverPenalizedNoRevert(reason) => {
+                tracing::warn!(
+                    %prover_address,
+                    %reason,
+                    "Prover penalized while processing proof"
+                );
+            }
+            _ => {
+                tracing::debug!(
+                    %prover_address,
+                    %error,
+                    "Proof rejected while processing proof"
+                );
+            }
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn process_proof_inner<ST: TxState<S> + GetGasPrice<Spec = S>>(
+        &mut self,
+        proof: &SerializedAggregatedProof,
+        prover_address: &S::Address,
+        execution_context: ExecutionContext,
+        state: &mut ST,
+    ) -> Result<
+        AggregatedProofPublicData<S::Address, S::Da, <S::Storage as Storage>::Root>,
+        ProcessProofError,
+    > {
         if !self.should_reward_fees(state) {
             return Err(ProcessProofError::InvalidOperatingMode);
         }
@@ -211,8 +256,6 @@ impl<S: Spec> ProverIncentives<S> {
             %public_outputs.final_slot_number,
             "Processing aggregated proof"
         );
-        #[cfg(not(feature = "native"))]
-        let _ = execution_context;
 
         // The expected origin state root and inner VK hash were already resolved
         // into `ctx` above; this binds the inner circuit (so a prover cannot
@@ -246,6 +289,12 @@ impl<S: Spec> ProverIncentives<S> {
         )? {
             Paycheck::Penalized => {
                 self.penalize_prover(old_balance, prover_address, state)?;
+                if pending_admin_upgrade.is_some() {
+                    crate::metrics::track_admin_upgrade_failure(
+                        public_outputs.final_slot_number,
+                        crate::metrics::AdminUpgradeMetricReason::ProverPenalized,
+                    );
+                }
                 // The state won't be reverted.
                 Err(ProcessProofError::ProverPenalizedNoRevert(
                     "Prover penalized".to_string(),
@@ -264,13 +313,10 @@ impl<S: Spec> ProverIncentives<S> {
                     .set(&public_outputs, state)
                     .map_err(Into::<anyhow::Error>::into)?;
 
-                #[cfg(feature = "native")]
-                sov_metrics::track_metrics(|tracker| {
-                    tracker.submit(crate::metrics::LatestVerifiedProofMetric {
-                        final_slot_number: public_outputs.final_slot_number.get(),
-                        execution_context: execution_context.str(),
-                    });
-                });
+                crate::metrics::track_latest_verified_proof(
+                    public_outputs.final_slot_number,
+                    execution_context,
+                );
 
                 Ok(public_outputs)
             }
@@ -486,6 +532,10 @@ impl<S: Spec> ProverIncentives<S> {
                 "Slashing admin: upgrade slot is not newer than latest recorded upgrade"
             );
             self.slash_prover(prover_address, state)?;
+            crate::metrics::track_admin_upgrade_failure(
+                upgrade_slot,
+                crate::metrics::AdminUpgradeMetricReason::StaleAdminUpgrade,
+            );
             return Err(ProcessProofError::ProverSlashedNoRevert(format!(
                 "Invalid output {}",
                 SlashingReason::StaleAdminUpgrade
@@ -529,6 +579,10 @@ impl<S: Spec> ProverIncentives<S> {
             "Slashing admin: upgrade proof committed to a malformed VK hash"
         );
         self.slash_prover(prover_address, state)?;
+        crate::metrics::track_admin_upgrade_failure(
+            public_outputs.final_slot_number,
+            crate::metrics::AdminUpgradeMetricReason::InvalidAdminUpgradeVkeyHash,
+        );
         Err(ProcessProofError::ProverSlashedNoRevert(format!(
             "Invalid output {}",
             SlashingReason::InvalidAdminUpgradeVkeyHash
@@ -550,6 +604,8 @@ impl<S: Spec> ProverIncentives<S> {
             inner_vkey_hash = ?upgrade.inner_code_commitment.to_hash(),
             "Admin upgrade recorded"
         );
+
+        crate::metrics::track_admin_upgrade_success(slot);
 
         Ok(())
     }

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/lib.rs
@@ -4,7 +4,6 @@ mod call;
 mod capabilities;
 mod event;
 mod genesis;
-#[cfg(feature = "native")]
 mod metrics;
 mod registration;
 

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/metrics.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/metrics.rs
@@ -1,25 +1,225 @@
-use std::io::Write;
+use sov_modules_api::ExecutionContext;
+use sov_rollup_interface::common::SlotNumber;
 
-use sov_metrics::Metric;
+use crate::capabilities::ProcessProofError;
 
-#[derive(Debug)]
-pub(crate) struct LatestVerifiedProofMetric {
-    pub final_slot_number: u64,
-    pub execution_context: &'static str,
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum AdminUpgradeMetricReason {
+    Recorded,
+    StaleAdminUpgrade,
+    InvalidAdminUpgradeVkeyHash,
+    ProverPenalized,
 }
 
-impl Metric for LatestVerifiedProofMetric {
-    fn measurement_name(&self) -> &'static str {
-        "sov_prover_incentives_latest_verified_proof"
+#[derive(Debug, Clone, Copy)]
+enum AdminUpgradeMetricStatus {
+    Success,
+    Failed,
+}
+
+pub(crate) fn track_latest_verified_proof(
+    final_slot_number: SlotNumber,
+    execution_context: ExecutionContext,
+) {
+    implementation::track_latest_verified_proof(final_slot_number, execution_context);
+}
+
+pub(crate) fn track_rejected_proof(execution_context: ExecutionContext, error: &ProcessProofError) {
+    implementation::track_rejected_proof(execution_context, error);
+}
+
+pub(crate) fn track_admin_upgrade_success(slot: SlotNumber) {
+    implementation::track_admin_upgrade(
+        slot,
+        AdminUpgradeMetricStatus::Success,
+        AdminUpgradeMetricReason::Recorded,
+    );
+}
+
+pub(crate) fn track_admin_upgrade_failure(slot: SlotNumber, reason: AdminUpgradeMetricReason) {
+    implementation::track_admin_upgrade(slot, AdminUpgradeMetricStatus::Failed, reason);
+}
+
+#[cfg(feature = "native")]
+mod implementation {
+    use std::io::Write;
+
+    use sov_metrics::Metric;
+    use sov_modules_api::ExecutionContext;
+    use sov_rollup_interface::common::SlotNumber;
+
+    use super::{AdminUpgradeMetricReason, AdminUpgradeMetricStatus};
+    use crate::capabilities::ProcessProofError;
+
+    #[derive(Debug)]
+    struct LatestVerifiedProofMetric {
+        final_slot_number: u64,
+        execution_context: &'static str,
     }
 
-    fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
-        write!(
-            buffer,
-            "{},context={} final_slot_number={}",
-            self.measurement_name(),
-            self.execution_context,
-            self.final_slot_number
-        )
+    impl Metric for LatestVerifiedProofMetric {
+        fn measurement_name(&self) -> &'static str {
+            "sov_prover_incentives_latest_verified_proof"
+        }
+
+        fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+            write!(
+                buffer,
+                "{},context={} final_slot_number={}",
+                self.measurement_name(),
+                self.execution_context,
+                self.final_slot_number
+            )
+        }
+    }
+
+    #[derive(Debug)]
+    struct RejectedProofMetric {
+        execution_context: &'static str,
+        reason: &'static str,
+    }
+
+    impl Metric for RejectedProofMetric {
+        fn measurement_name(&self) -> &'static str {
+            "sov_prover_incentives_rejected_proof"
+        }
+
+        fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+            write!(
+                buffer,
+                "{},context={},reason={} count=1i",
+                self.measurement_name(),
+                self.execution_context,
+                self.reason,
+            )
+        }
+    }
+
+    #[derive(Debug)]
+    struct AdminUpgradeMetric {
+        status: AdminUpgradeMetricStatus,
+        reason: AdminUpgradeMetricReason,
+        slot: u64,
+    }
+
+    impl Metric for AdminUpgradeMetric {
+        fn measurement_name(&self) -> &'static str {
+            "sov_prover_incentives_admin_upgrade"
+        }
+
+        fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+            write!(
+                buffer,
+                "{},status={},reason={} count=1i,slot={}i",
+                self.measurement_name(),
+                self.status.as_str(),
+                self.reason.as_str(),
+                self.slot,
+            )
+        }
+    }
+
+    pub(super) fn track_latest_verified_proof(
+        final_slot_number: SlotNumber,
+        execution_context: ExecutionContext,
+    ) {
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit(LatestVerifiedProofMetric {
+                final_slot_number: final_slot_number.get(),
+                execution_context: execution_context.str(),
+            });
+        });
+    }
+
+    pub(super) fn track_rejected_proof(
+        execution_context: ExecutionContext,
+        error: &ProcessProofError,
+    ) {
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit(RejectedProofMetric {
+                execution_context: execution_context.str(),
+                reason: rejected_proof_reason(error),
+            });
+        });
+    }
+
+    pub(super) fn track_admin_upgrade(
+        slot: SlotNumber,
+        status: AdminUpgradeMetricStatus,
+        reason: AdminUpgradeMetricReason,
+    ) {
+        sov_metrics::track_metrics(|tracker| {
+            tracker.submit(AdminUpgradeMetric {
+                status,
+                reason,
+                slot: slot.get(),
+            });
+        });
+    }
+
+    impl AdminUpgradeMetricStatus {
+        fn as_str(&self) -> &'static str {
+            match self {
+                Self::Success => "success",
+                Self::Failed => "failed",
+            }
+        }
+    }
+
+    impl AdminUpgradeMetricReason {
+        fn as_str(&self) -> &'static str {
+            match self {
+                Self::Recorded => "recorded",
+                Self::StaleAdminUpgrade => "stale_admin_upgrade",
+                Self::InvalidAdminUpgradeVkeyHash => "invalid_admin_upgrade_vkey_hash",
+                Self::ProverPenalized => "prover_penalized",
+            }
+        }
+    }
+
+    fn rejected_proof_reason(error: &ProcessProofError) -> &'static str {
+        match error {
+            ProcessProofError::TransferFailure(_) => "transfer_failure",
+            ProcessProofError::ProverSlashedNoRevert(_) => "prover_slashed",
+            ProcessProofError::ProverPenalizedNoRevert(_) => "prover_penalized",
+            ProcessProofError::ProverNotBonded => "prover_not_bonded",
+            ProcessProofError::BondNotHighEnough => "bond_not_high_enough",
+            ProcessProofError::StateAccessorError(_) => "state_accessor_error",
+            ProcessProofError::InvalidOperatingMode => "invalid_operating_mode",
+            ProcessProofError::ProofPrecedesLatestAdminUpgrade { .. } => {
+                "proof_precedes_latest_admin_upgrade"
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "native"))]
+mod implementation {
+    use sov_modules_api::ExecutionContext;
+    use sov_rollup_interface::common::SlotNumber;
+
+    use super::{AdminUpgradeMetricReason, AdminUpgradeMetricStatus};
+    use crate::capabilities::ProcessProofError;
+
+    pub(super) fn track_latest_verified_proof(
+        final_slot_number: SlotNumber,
+        execution_context: ExecutionContext,
+    ) {
+        let _ = (final_slot_number, execution_context);
+    }
+
+    pub(super) fn track_rejected_proof(
+        execution_context: ExecutionContext,
+        error: &ProcessProofError,
+    ) {
+        let _ = (execution_context, error);
+    }
+
+    pub(super) fn track_admin_upgrade(
+        slot: SlotNumber,
+        status: AdminUpgradeMetricStatus,
+        reason: AdminUpgradeMetricReason,
+    ) {
+        let _ = (slot, status, reason);
     }
 }

--- a/crates/module-system/module-implementations/sov-prover-incentives/src/metrics.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/src/metrics.rs
@@ -28,16 +28,26 @@ pub(crate) fn track_rejected_proof(execution_context: ExecutionContext, error: &
     implementation::track_rejected_proof(execution_context, error);
 }
 
-pub(crate) fn track_admin_upgrade_success(slot: SlotNumber) {
+pub(crate) fn track_admin_upgrade_success(slot: SlotNumber, execution_context: ExecutionContext) {
     implementation::track_admin_upgrade(
         slot,
+        execution_context,
         AdminUpgradeMetricStatus::Success,
         AdminUpgradeMetricReason::Recorded,
     );
 }
 
-pub(crate) fn track_admin_upgrade_failure(slot: SlotNumber, reason: AdminUpgradeMetricReason) {
-    implementation::track_admin_upgrade(slot, AdminUpgradeMetricStatus::Failed, reason);
+pub(crate) fn track_admin_upgrade_failure(
+    slot: SlotNumber,
+    execution_context: ExecutionContext,
+    reason: AdminUpgradeMetricReason,
+) {
+    implementation::track_admin_upgrade(
+        slot,
+        execution_context,
+        AdminUpgradeMetricStatus::Failed,
+        reason,
+    );
 }
 
 #[cfg(feature = "native")]
@@ -97,6 +107,7 @@ mod implementation {
 
     #[derive(Debug)]
     struct AdminUpgradeMetric {
+        execution_context: &'static str,
         status: AdminUpgradeMetricStatus,
         reason: AdminUpgradeMetricReason,
         slot: u64,
@@ -110,8 +121,9 @@ mod implementation {
         fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
             write!(
                 buffer,
-                "{},status={},reason={} count=1i,slot={}i",
+                "{},context={},status={},reason={} count=1i,slot={}i",
                 self.measurement_name(),
+                self.execution_context,
                 self.status.as_str(),
                 self.reason.as_str(),
                 self.slot,
@@ -145,11 +157,13 @@ mod implementation {
 
     pub(super) fn track_admin_upgrade(
         slot: SlotNumber,
+        execution_context: ExecutionContext,
         status: AdminUpgradeMetricStatus,
         reason: AdminUpgradeMetricReason,
     ) {
         sov_metrics::track_metrics(|tracker| {
             tracker.submit(AdminUpgradeMetric {
+                execution_context: execution_context.str(),
                 status,
                 reason,
                 slot: slot.get(),
@@ -170,25 +184,23 @@ mod implementation {
         fn as_str(&self) -> &'static str {
             match self {
                 Self::Recorded => "recorded",
-                Self::StaleAdminUpgrade => "stale_admin_upgrade",
-                Self::InvalidAdminUpgradeVkeyHash => "invalid_admin_upgrade_vkey_hash",
-                Self::ProverPenalized => "prover_penalized",
+                Self::StaleAdminUpgrade => "stale",
+                Self::InvalidAdminUpgradeVkeyHash => "bad_vkey",
+                Self::ProverPenalized => "penalized",
             }
         }
     }
 
     fn rejected_proof_reason(error: &ProcessProofError) -> &'static str {
         match error {
-            ProcessProofError::TransferFailure(_) => "transfer_failure",
-            ProcessProofError::ProverSlashedNoRevert(_) => "prover_slashed",
-            ProcessProofError::ProverPenalizedNoRevert(_) => "prover_penalized",
-            ProcessProofError::ProverNotBonded => "prover_not_bonded",
-            ProcessProofError::BondNotHighEnough => "bond_not_high_enough",
-            ProcessProofError::StateAccessorError(_) => "state_accessor_error",
-            ProcessProofError::InvalidOperatingMode => "invalid_operating_mode",
-            ProcessProofError::ProofPrecedesLatestAdminUpgrade { .. } => {
-                "proof_precedes_latest_admin_upgrade"
-            }
+            ProcessProofError::TransferFailure(_) => "transfer",
+            ProcessProofError::ProverSlashedNoRevert(_) => "slashed",
+            ProcessProofError::ProverPenalizedNoRevert(_) => "penalized",
+            ProcessProofError::ProverNotBonded => "unbonded",
+            ProcessProofError::BondNotHighEnough => "low_bond",
+            ProcessProofError::StateAccessorError(_) => "state",
+            ProcessProofError::InvalidOperatingMode => "bad_mode",
+            ProcessProofError::ProofPrecedesLatestAdminUpgrade { .. } => "stale_proof",
         }
     }
 }
@@ -217,9 +229,10 @@ mod implementation {
 
     pub(super) fn track_admin_upgrade(
         slot: SlotNumber,
+        execution_context: ExecutionContext,
         status: AdminUpgradeMetricStatus,
         reason: AdminUpgradeMetricReason,
     ) {
-        let _ = (slot, status, reason);
+        let _ = (slot, execution_context, status, reason);
     }
 }

--- a/examples/demo-rollup/tests/restart/graceful.rs
+++ b/examples/demo-rollup/tests/restart/graceful.rs
@@ -107,7 +107,7 @@ fn build_sleep_schedule(
     schedule
 }
 
-fn known_restart_warnings() -> [(Level, String); 9] {
+fn known_restart_warnings() -> [(Level, String); 10] {
     [
         // https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/1878:
         (
@@ -149,6 +149,11 @@ fn known_restart_warnings() -> [(Level, String); 9] {
         (
             Level::ERROR,
             "Error accepting transaction".to_string(),
+        ),
+        // Duplicate proof blobs can be replayed around restart boundaries.
+        (
+            Level::WARN,
+            "Prover penalized while processing proof".to_string(),
         ),
     ]
 }


### PR DESCRIPTION
# Description

Adds observability for `ProverIncentives::process_proof` outcomes:
  - Logs proof rejections, prover slashing, and prover penalties.
  - Emits `sov_prover_incentives_rejected_proof` metrics with rejection reason details.
  - Emits `sov_prover_incentives_admin_upgrade` metrics for successful and failed admin upgrade attempts.
  - Uses an enum for admin upgrade metric reasons.
  - Centralizes native/non-native metric handling in metrics.rs, with no-op helpers for non-native builds.

- [x] ~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Related to #2551




<img width="2986" height="1578" alt="image" src="https://github.com/user-attachments/assets/659099b6-62dd-4edc-81c0-16dd768aeb7e" />

