### PR TITLE
fix: correct spelling errors in test files

### DIFF
--- a/crates/full-node/sov-blob-sender/tests/blob_sender.rs
+++ b/crates/full-node/sov-blob-sender/tests/blob_sender.rs
@@ -160,7 +160,7 @@ async fn blob_sender_shutdown_task() -> anyhow::Result<()> {
     subscriber.init();
 
     let deps = create_deps().await;
-    let (status_sender, mut status_reciever) = broadcast::channel(100);
+    let (status_sender, mut status_receiver) = broadcast::channel(100);
 
     let (mut blob_sender, handle) = create_blob_sender(
         Duration::from_secs(20),
@@ -180,7 +180,7 @@ async fn blob_sender_shutdown_task() -> anyhow::Result<()> {
     };
 
     // Wait for the blob task to start.
-    status_reciever.recv().await.unwrap();
+    status_receiver.recv().await.unwrap();
     deps.shutdown_sender.send(()).unwrap();
     handle.await.unwrap();
 

--- a/crates/full-node/sov-ethereum/tests/integration/evm/evm_balances.rs
+++ b/crates/full-node/sov-ethereum/tests/integration/evm/evm_balances.rs
@@ -8,45 +8,45 @@ use sov_test_utils::test_rollup::TestRollup;
 use crate::common::{setup_with_simple_storage, EVM_EXTENSION};
 use crate::runtime::EvmBlueprint;
 
-const RECIEVER_ADDR_STR: &str = "0x3FE0233e6cf3c9753fcB7449987EC49C88aDDE71";
+const RECEIVER_ADDR_STR: &str = "0x3FE0233e6cf3c9753fcB7449987EC49C88aDDE71";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn evm_test_balances() -> anyhow::Result<()> {
     let (test_rollup, evm_client, _) = setup_with_simple_storage(0, EVM_EXTENSION).await;
     let sender_address = evm_client.address();
 
-    let reciever_address = Address::from_str(RECIEVER_ADDR_STR).unwrap();
+    let receiver_address = Address::from_str(RECEIVER_ADDR_STR).unwrap();
 
     let (sender_bank_balance_start, sender_evm_balance_start) =
         get_balances(sender_address, &test_rollup, &evm_client).await;
 
-    let (reciever_bank_balance_start, reciever_evm_balance_start) =
-        get_balances(reciever_address, &test_rollup, &evm_client).await;
+    let (receiver_bank_balance_start, receiver_evm_balance_start) =
+        get_balances(receiver_address, &test_rollup, &evm_client).await;
 
     let eth_to_send = 2u128;
     evm_client
-        .send_eth(reciever_address, U256::from(eth_to_send))
+        .send_eth(receiver_address, U256::from(eth_to_send))
         .await;
     test_rollup.wait_for_rollup_height_advance_by(2).await;
 
     let (sender_bank_balance_end, sender_evm_balance_end) =
         get_balances(sender_address, &test_rollup, &evm_client).await;
 
-    let (reciever_bank_balance_end, reciever_evm_balance_end) =
-        get_balances(reciever_address, &test_rollup, &evm_client).await;
+    let (receiver_bank_balance_end, receiver_evm_balance_end) =
+        get_balances(receiver_address, &test_rollup, &evm_client).await;
 
     assert_eq!(sender_bank_balance_start, sender_evm_balance_start);
     assert_eq!(sender_bank_balance_end, sender_evm_balance_end);
     assert!(sender_bank_balance_start > sender_bank_balance_end + eth_to_send);
 
-    assert_eq!(reciever_bank_balance_start, reciever_evm_balance_start);
+    assert_eq!(receiver_bank_balance_start, receiver_evm_balance_start);
     assert_eq!(
-        reciever_bank_balance_start + eth_to_send,
-        reciever_bank_balance_end
+        receiver_bank_balance_start + eth_to_send,
+        receiver_bank_balance_end
     );
     assert_eq!(
-        reciever_evm_balance_start + eth_to_send,
-        reciever_evm_balance_end
+        receiver_evm_balance_start + eth_to_send,
+        receiver_evm_balance_end
     );
 
     Ok(())

--- a/examples/demo-rollup/stf/src/runtime.rs
+++ b/examples/demo-rollup/stf/src/runtime.rs
@@ -160,7 +160,7 @@ where
                     tracing::warn!(bucket_id = ?bucket_id, limit = ?limit, error = ?e, "EVM Failed to load bucket into pinned cache");
                 }
                 Ok(LoadBucketOutcome::NotSupportedByStorage) => {
-                    panic!("EVM Failed to load bucket into pinned cache because the storage doesn't support iteration. This means that pinning is configured but the rollup doesnt support it. Adjust your config or switch to NOMT");
+                    panic!("EVM Failed to load bucket into pinned cache because the storage doesn't support iteration. This means that pinning is configured but the rollup doesn't support it. Adjust your config or switch to NOMT");
                 }
                 Ok(LoadBucketOutcome::AlreadyPresent)
                 | Ok(LoadBucketOutcome::Loaded)


### PR DESCRIPTION
## Description
Fixed spelling errors in test files and error messages for improved code readability.

## Changes
- Corrected `reciever` → `receiver` (15+ occurrences in evm_balances.rs)
- Corrected `doesnt` → `doesn't` in runtime.rs panic message
- Corrected `status_reciever` → `status_receiver` in blob_sender.rs

## Files Modified
- `crates/full-node/sov-ethereum/tests/integration/evm/evm_balances.rs`
- `examples/demo-rollup/stf/src/runtime.rs`
- `crates/full-node/sov-blob-sender/tests/blob_sender.rs`

## Testing
- Verified all changes are variable/constant name corrections
- No functional changes to test logic