### PR TITLE
EVM subscription test: Allow same second blocks

### DIFF
--- a/crates/full-node/sov-ethereum/tests/integration/evm/evm_subscribe.rs
+++ b/crates/full-node/sov-ethereum/tests/integration/evm/evm_subscribe.rs
@@ -63,7 +63,8 @@ async fn evm_test_log_subscription() {
         // Verify that the block timestamp increases along with the block number.
         if block_nr_from_log > block_nr {
             let block_timestamp_from_log = log.block_timestamp.unwrap();
-            assert!(block_timestamp_from_log > time_stamp);
+            // More relaxed that standard Ethereum L1, as Sovereign Rollup might create batches faster than 1 second.
+            assert!(block_timestamp_from_log >= time_stamp);
             time_stamp = block_timestamp_from_log;
             block_nr = block_nr_from_log;
         }


### PR DESCRIPTION
# Description

To reduce flakiness in CI


----

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
1 test has been updated

## Docs
No updates

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/sovereign-sdk/pull/2915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->