### PR TITLE
Attempt to fix flaky `test_gas_limit_update`

### DIFF
--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -2431,10 +2431,12 @@ async fn test_gas_limit_update() {
 
     // 4. Main loop Submit a tx and save the receipt. Then, force close the batch and produce a block.
     for i in 0..20_u64 {
-        // 4.1 Submit a tx and save the receipt.
+        // 4.1 Submit a tx and save the receipt. Use the retrying client so that transient
+        //     `WaitingOnBlobSender` 503s from blob-sender backpressure are retried with backoff
+        //     instead of failing the test outright (one historical Mode-C failure mode).
         let receipt = test_rollup
             .api_client()
-            .send_raw_tx_to_sequencer(&tx_set_value_nonce::<TestRuntime<TestSpec>>(
+            .send_raw_tx_to_sequencer_with_retry(&tx_set_value_nonce::<TestRuntime<TestSpec>>(
                 &admin.private_key,
                 nonce,
                 i,
@@ -2487,14 +2489,49 @@ async fn test_gas_limit_update() {
         }
     }
 
-    // 5. Produce more blocks to ensure the ledger DB finishes populating. Save the ledger DB contents.
-    for _ in 0..10 {
+    // 5. Drain the blob-sender pipeline: produce DA blocks until every sequencer-accepted tx has
+    //    appeared in a slot, or we've produced an unreasonable number of blocks. Under load, the
+    //    `force_close_batch + produce_block` pattern in the loop can produce empty DA blocks while
+    //    the just-closed batch is still on its way to DA, so the tx appears in a later block.
+    //    Observe the base fee along the way too — when previously-pending batches finally land, the
+    //    gas_used in those rollup blocks pushes the base fee above 7, and we may only see that rise
+    //    during the drain (not the main loop).
+    let expected_tx_count = sequencer_receipts.len();
+    let mut drain_blocks = 0u32;
+    while ledger_receipts.len() < expected_tx_count {
         test_rollup.da_service.produce_block_now().await.unwrap();
+        drain_blocks += 1;
         let slot = slot_subscription.next().await.unwrap().unwrap();
         for batch in slot.batches {
             for tx in batch.txs {
                 ledger_receipts.push(tx);
             }
+        }
+        let drain_height = test_rollup.height().await.get();
+        if drain_height > CHANGE_GAS_LIMIT_AFTER_HEIGHT as u64 {
+            let base_fee_per_gas = test_rollup
+                .client
+                .http_get("/rollup/base-fee-per-gas/latest")
+                .await
+                .unwrap();
+            let current_base_fee = base_fee_per_gas
+                .trim()
+                .trim_start_matches(r#"{"base_fee_per_gas":[""#)
+                .split('"')
+                .next()
+                .unwrap()
+                .parse::<u64>()
+                .unwrap_or_else(|_| panic!("Failed to parse base fee per gas: {base_fee_per_gas}"));
+            if current_base_fee > max_base_fee_per_gas_observed_after_update {
+                max_base_fee_per_gas_observed_after_update = current_base_fee;
+            }
+        }
+        if drain_blocks > 60 {
+            panic!(
+                "Produced 60 drain blocks but only collected {} of {} expected txs in the ledger",
+                ledger_receipts.len(),
+                expected_tx_count
+            );
         }
     }
 


### PR DESCRIPTION
# The fix

1. **`send_raw_tx_to_sequencer → send_raw_tx_to_sequencer_with_retry`** — Eliminates: the panic Tx N failed with error: ... 503 Service Unavailable WaitingOnBlobSender. This fires when the sequencer's in-flight batch-blob counter saturates at TEST_MAX_CONCURRENT_BATCH_BLOBS = 16  because the test creates batches via `force_close_batch` faster than the blob-sender drains them to "Finalized + Accepted". The retry helper transparently waits for the cap to drop before letting the tx submission succeed.
2. **Replace the fixed 10-block post-loop with a drain loop** that produces DA blocks until every sequencer-accepted tx has appeared in a slot (bounded at 60 blocks for safety). Under load, force_close_batch + produce_block sometimes produces empty DA blocks while the just-closed batch is still in flight; the tx lands later. The drain ensures ledger and sequencer counts match
3. Observe base_fee_per_gas inside the drain loop in addition to the main loop.  
   **Eliminates**: the panic Max observed base fee per gas after update must be greater than The base fee can only rise above 7 once a rollup block contains a post-gas-limit-change tx with gas_used > gas_target (33k vs 25k after the override kicks in). When batches arrive late, the main loop's observations land on rollup blocks with gas_used = 0, so the base fee sits at its empirical floor of 7 (the EIP-1559 decrease delta truncates to 0 there and stops moving  see crates/module-system/module-implementations/sov-chain-state/src/gas.rs:188-195). Only when the late-arriving batches finally land — during the drain — does the gas_used push the base fee up, and observing there catches that rise

No production code is changed; the underlying race in force_close_batch / tenderly_produce_blocks is still there, but the test is now resilient to it.

## What Claude learned along the way

It went down two wrong paths before landing here — both worth flagging:
- A wait_for_next_published_batch_blob helper (consuming events from subscribe_to_blobs_from_blob_sender) felt elegant but actually made the test worse (~95% failure rate). Setup-phase events buffered in the WS subscription throw off the 1:1 iteration ↔ Published-event matching.
- A "produce DA blocks until our tx lands by hash" loop pushed the test into a regime where many empty blocks separated tx blocks, killing the EIP-1559 rise. The base-fee dynamics in this test are surprisingly sensitive to tx density.

The retry-and-drain approach succeeds because it keeps the original force_close + 1 DA block per iter cadence intact and only patches the failure modes externally.

---

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
Updates only test code

## Docs
No update