### PR TITLE
Simplify `generate_precompile_set!` macro 

### DIFF
--- a/crates/module-system/module-implementations/sov-evm/src/precompiles/mod.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/precompiles/mod.rs
@@ -16,7 +16,7 @@ pub use bank_balance::{BankBalancePrecompile, BANK_BALANCE_PRECOMPILE_ADDRESS};
 pub use sequencing_timestamp::{
     SequencingTimestampPrecompile, SEQUENCING_TIMESTAMP_PRECOMPILE_ADDRESS,
 };
-pub use traits::{EvmPrecompile, EvmPrecompileSet, NoCustomPrecompiles, __private};
+pub use traits::{EvmPrecompile, EvmPrecompileSet, NoCustomPrecompiles};
 
 /// Result type for Sovereign precompile execution.
 pub type PrecompileResult = Result<PrecompileOutput, PrecompileError>;

--- a/crates/module-system/module-implementations/sov-evm/src/precompiles/traits.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/precompiles/traits.rs
@@ -57,11 +57,6 @@ impl<S: Spec> EvmPrecompileSet<S> for NoCustomPrecompiles<S> {
     }
 }
 
-#[doc(hidden)]
-pub mod __private {
-    pub use sov_modules_api::{Spec, TxState};
-}
-
 /// Generates an [`EvmPrecompileSet`] from a flat list of individual [`EvmPrecompile`]s.
 ///
 /// The generated set owns one instance of each listed precompile and derives its static address
@@ -76,20 +71,20 @@ macro_rules! generate_precompile_set {
     ) => {
         $(#[$meta])*
         #[derive(Clone, Default)]
-        $vis struct $name<$spec: $crate::precompiles::__private::Spec> {
+        $vis struct $name<$spec: ::sov_modules_api::Spec> {
             $($field: $precompile,)*
         }
 
         impl<$spec> $crate::precompiles::EvmPrecompileSet<$spec> for $name<$spec>
         where
-            $spec: $crate::precompiles::__private::Spec,
+            $spec: ::sov_modules_api::Spec,
             $($precompile: $crate::precompiles::EvmPrecompile<$spec>,)*
         {
             const ADDRESSES: &'static [$crate::precompiles::Address] = &[
                 $(<$precompile as $crate::precompiles::EvmPrecompile<$spec>>::ADDRESS,)*
             ];
 
-            fn execute<ST: $crate::precompiles::__private::TxState<$spec>>(
+            fn execute<ST: ::sov_modules_api::TxState<$spec>>(
                 &self,
                 address: $crate::precompiles::Address,
                 input: &[u8],


### PR DESCRIPTION
# Description

By removing the `__private` export and referencing `::sov_modules_api` directly in the generated output. This is safe in almost any sane usage since sov_modules_api will be a dependency in any rollup or stf crate, and avoids some cargo fmt issues.

- [ ] ~~I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.~~
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
