### PR TITLE
Preferred Sequencer: deregister on graceful shutdown

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
@@ -127,6 +127,13 @@ impl HeartBeatTask {
         }
     }
 
+    // Logs the shutdown and best-effort deregisters this node. Shared by every task
+    // loop so all graceful-shutdown paths deregister in exactly one place.
+    async fn shutdown_and_deregister(&self, task: &str) {
+        info!(node_id = %self.node_id, task, "Shutdown signal received; stopping task and deregistering node");
+        self.deregister_on_shutdown().await;
+    }
+
     // Spawns a task for the current leader to maintain leadership.
     //
     // Periodically refreshes leadership. If leadership is lost or the database
@@ -139,8 +146,7 @@ impl HeartBeatTask {
             loop {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
-                        info!("Shutdown signal received, stopping heartbeat task and deregistering node");
-                        self.deregister_on_shutdown().await;
+                        self.shutdown_and_deregister("leader heartbeat").await;
                         return;
                     }
                     FutureOrShutdownOutput::Output(_) => {
@@ -185,8 +191,7 @@ impl HeartBeatTask {
             loop {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
-                        info!("Shutdown signal received, stopping election task and deregistering node.");
-                        self.deregister_on_shutdown().await;
+                        self.shutdown_and_deregister("replica election").await;
                         return;
                     }
                     FutureOrShutdownOutput::Output(_) => {
@@ -235,8 +240,7 @@ impl HeartBeatTask {
             loop {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
-                        info!("Shutdown signal received, stopping registration task and deregistering node.");
-                        self.deregister_on_shutdown().await;
+                        self.shutdown_and_deregister("replica registration").await;
                         return;
                     }
                     FutureOrShutdownOutput::Output(_) => match self.register_node().await {

--- a/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
@@ -92,20 +92,18 @@ impl HeartBeatTask {
         Ok(())
     }
 
-    // Best-effort: deletes this node's rows from `sequencer_leader` and `nodes` on
-    // graceful shutdown so replicas can take over without waiting for the staleness
-    // filter / leader timeout to expire. Errors and timeouts are logged, never
-    // propagated — the task is already exiting and the staleness filter is the
-    // backstop for cases where this can't run (SIGKILL, OOM, DB unreachable, etc.).
+    // Best-effort: deletes this node's row from `nodes` on graceful shutdown so
+    // DbElected replicas can take over without waiting for the leader timeout.
+    // Errors and timeouts are logged, never propagated — the task is already
+    // exiting and the staleness filter is the backstop for cases where this
+    // can't run (SIGKILL, OOM, DB unreachable, etc.).
     //
     // Hard-bounded by `SHUTDOWN_DEREGISTER_TIMEOUT` so a stalled DB connection cannot
     // delay graceful shutdown, regardless of the inner retry budget.
     //
-    // Deleting `sequencer_leader` opens a brief window where in-flight writes from
-    // the block executor (guarded by `is_leader($node_id)` in SQL) can land as
-    // `ReplicaDisallowed`. This is benign — the node is already shutting down — and
-    // `PreferredSequencerDb::check_replica_err` downgrades those errors during
-    // shutdown so they don't surface as "primary has become a replica".
+    // `sequencer_leader` is deliberately preserved until a replacement takes
+    // over, so in-flight writes guarded by `is_leader($node_id)` can still
+    // complete during the handoff window.
     async fn deregister_on_shutdown(&self) {
         const SHUTDOWN_DEREGISTER_TIMEOUT: Duration = Duration::from_millis(500);
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
@@ -20,6 +20,7 @@ use tracing::{error, info, warn};
 use super::SequencerRole;
 
 use super::postgres::PostgresBackend;
+use crate::preferred::executor_events::SIDE_EFFECTS_DRAIN_TIMEOUT;
 use crate::preferred::exit_rollup;
 
 /// Manages periodic heartbeat and optional leadership election for a sequencer node.
@@ -34,7 +35,7 @@ pub struct HeartBeatTask {
     shutdown_receiver: watch::Receiver<()>,
     postgres_config: PostgresConfig,
     heartbeat_interval: Duration,
-    side_effects_drained_receiver: Option<oneshot::Receiver<()>>,
+    side_effects_drained_receiver: oneshot::Receiver<()>,
 }
 
 impl HeartBeatTask {
@@ -55,7 +56,7 @@ impl HeartBeatTask {
             shutdown_receiver,
             postgres_config,
             heartbeat_interval,
-            side_effects_drained_receiver: Some(side_effects_drained_receiver),
+            side_effects_drained_receiver,
         })
     }
 
@@ -95,64 +96,20 @@ impl HeartBeatTask {
         Ok(())
     }
 
-    // Best-effort: deletes this node's row from `nodes` on graceful shutdown so
-    // DbElected replicas can take over without waiting for the leader timeout.
-    // Errors and timeouts are logged, never propagated — the task is already
-    // exiting and the staleness filter is the backstop for cases where this
-    // can't run (SIGKILL, OOM, DB unreachable, etc.).
-    //
-    // Hard-bounded by `SHUTDOWN_DEREGISTER_TIMEOUT` so a stalled DB connection cannot
-    // delay graceful shutdown, regardless of the inner retry budget.
-    //
-    // `sequencer_leader` is deliberately preserved until a replacement takes
-    // over, so in-flight writes guarded by `is_leader($node_id)` can still
-    // complete during the handoff window.
-    async fn deregister_on_shutdown(&self) {
-        const SHUTDOWN_DEREGISTER_TIMEOUT: Duration = Duration::from_millis(500);
-
-        match tokio::time::timeout(
-            SHUTDOWN_DEREGISTER_TIMEOUT,
-            self.backend.deregister_node_on_shutdown(),
+    // Logs the shutdown, waits for the side effects task to confirm it has drained,
+    // then best-effort deregisters this node. Shared by every task loop so all
+    // graceful-shutdown paths deregister in exactly one place.
+    async fn shutdown_and_deregister(self, task: &str) {
+        info!(node_id = %self.node_id, task, "Shutdown signal received; stopping task and waiting for side effects to drain before deregistering node");
+        if wait_for_side_effects_to_drain_signal(
+            &self.node_id,
+            self.side_effects_drained_receiver,
+            SIDE_EFFECTS_DRAIN_TIMEOUT,
         )
         .await
         {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => warn!(
-                node_id = %self.node_id,
-                error = ?e,
-                "Failed to delete node registration on shutdown; row will age out via staleness filter."
-            ),
-            Err(_) => warn!(
-                node_id = %self.node_id,
-                timeout_ms = SHUTDOWN_DEREGISTER_TIMEOUT.as_millis() as u64,
-                "Timed out deleting node registration on shutdown; row will age out via staleness filter."
-            ),
+            deregister_on_shutdown(&self.backend, &self.node_id).await;
         }
-    }
-
-    async fn wait_for_side_effects_to_drain(&mut self) -> bool {
-        const SIDE_EFFECTS_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
-
-        let Some(receiver) = self.side_effects_drained_receiver.take() else {
-            warn!(
-                node_id = %self.node_id,
-                "Side effects drain receiver already consumed; skipping node deregistration."
-            );
-            return false;
-        };
-
-        wait_for_side_effects_to_drain_signal(&self.node_id, receiver, SIDE_EFFECTS_DRAIN_TIMEOUT)
-            .await
-    }
-
-    // Logs the shutdown and best-effort deregisters this node. Shared by every task
-    // loop so all graceful-shutdown paths deregister in exactly one place.
-    async fn shutdown_and_deregister(mut self, task: &str) {
-        info!(node_id = %self.node_id, task, "Shutdown signal received; stopping task and waiting for side effects to drain before deregistering node");
-        if !self.wait_for_side_effects_to_drain().await {
-            return;
-        }
-        self.deregister_on_shutdown().await;
     }
 
     // Spawns a task for the current leader to maintain leadership.
@@ -277,6 +234,41 @@ impl HeartBeatTask {
                 }
             }
         })
+    }
+}
+
+// Best-effort: deletes this node's row from `nodes` on graceful shutdown so
+// DbElected replicas can take over without waiting for the leader timeout.
+// Errors and timeouts are logged, never propagated — the task is already
+// exiting and the staleness filter is the backstop for cases where this
+// can't run (SIGKILL, OOM, DB unreachable, etc.).
+//
+// Hard-bounded by `SHUTDOWN_DEREGISTER_TIMEOUT` so a stalled DB connection cannot
+// delay graceful shutdown, regardless of the inner retry budget.
+//
+// `sequencer_leader` is deliberately preserved until a replacement takes
+// over, so in-flight writes guarded by `is_leader($node_id)` can still
+// complete during the handoff window.
+async fn deregister_on_shutdown(backend: &PostgresBackend, node_id: &str) {
+    const SHUTDOWN_DEREGISTER_TIMEOUT: Duration = Duration::from_millis(500);
+
+    match tokio::time::timeout(
+        SHUTDOWN_DEREGISTER_TIMEOUT,
+        backend.deregister_node_on_shutdown(),
+    )
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => warn!(
+            node_id,
+            error = ?e,
+            "Failed to delete node registration on shutdown; row will age out via staleness filter."
+        ),
+        Err(_) => warn!(
+            node_id,
+            timeout_ms = SHUTDOWN_DEREGISTER_TIMEOUT.as_millis() as u64,
+            "Timed out deleting node registration on shutdown; row will age out via staleness filter."
+        ),
     }
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
@@ -13,14 +13,13 @@ use std::time::Duration;
 use anyhow::Result;
 use sov_full_node_configs::sequencer::{ConfiguredNodeRole, PostgresConfig};
 use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
-use tokio::sync::{oneshot, watch};
+use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
 use super::SequencerRole;
 
 use super::postgres::PostgresBackend;
-use crate::preferred::executor_events::SIDE_EFFECTS_DRAIN_TIMEOUT;
 use crate::preferred::exit_rollup;
 
 /// Manages periodic heartbeat and optional leadership election for a sequencer node.
@@ -35,7 +34,6 @@ pub struct HeartBeatTask {
     shutdown_receiver: watch::Receiver<()>,
     postgres_config: PostgresConfig,
     heartbeat_interval: Duration,
-    side_effects_drained_receiver: oneshot::Receiver<()>,
 }
 
 impl HeartBeatTask {
@@ -44,7 +42,6 @@ impl HeartBeatTask {
         shutdown_sender: watch::Sender<()>,
         bind_addr: SocketAddr,
         heartbeat_interval: Duration,
-        side_effects_drained_receiver: oneshot::Receiver<()>,
     ) -> Result<Self> {
         let backend = PostgresBackend::connect(&postgres_config, bind_addr).await?;
         let shutdown_receiver = shutdown_sender.subscribe();
@@ -56,7 +53,6 @@ impl HeartBeatTask {
             shutdown_receiver,
             postgres_config,
             heartbeat_interval,
-            side_effects_drained_receiver,
         })
     }
 
@@ -96,22 +92,6 @@ impl HeartBeatTask {
         Ok(())
     }
 
-    // Logs the shutdown, waits for the side effects task to confirm it has drained,
-    // then best-effort deregisters this node. Shared by every task loop so all
-    // graceful-shutdown paths deregister in exactly one place.
-    async fn shutdown_and_deregister(self, task: &str) {
-        info!(node_id = %self.node_id, task, "Shutdown signal received; stopping task and waiting for side effects to drain before deregistering node");
-        if wait_for_side_effects_to_drain_signal(
-            &self.node_id,
-            self.side_effects_drained_receiver,
-            SIDE_EFFECTS_DRAIN_TIMEOUT,
-        )
-        .await
-        {
-            deregister_on_shutdown(&self.backend, &self.node_id).await;
-        }
-    }
-
     // Spawns a task for the current leader to maintain leadership.
     //
     // Periodically refreshes leadership. If leadership is lost or the database
@@ -124,7 +104,7 @@ impl HeartBeatTask {
             loop {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
-                        self.shutdown_and_deregister("leader heartbeat").await;
+                        info!(node_id = %self.node_id, task = "leader heartbeat", "Shutdown signal received; stopping task");
                         return;
                     }
                     FutureOrShutdownOutput::Output(_) => {
@@ -169,7 +149,7 @@ impl HeartBeatTask {
             loop {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
-                        self.shutdown_and_deregister("replica election").await;
+                        info!(node_id = %self.node_id, task = "replica election", "Shutdown signal received; stopping task");
                         return;
                     }
                     FutureOrShutdownOutput::Output(_) => {
@@ -179,10 +159,8 @@ impl HeartBeatTask {
                                     node_id = %self.node_id,
                                     "Replica acquired leadership! Exiting to restart as leader."
                                 );
-                                // Intentionally no `deregister_on_shutdown` here: this node
-                                // will restart as leader with the same node_id and re-UPSERT
-                                // the same row, so we want the registration to persist across
-                                // the restart instead of being briefly deleted and re-inserted.
+                                // Keep this node row in place: this node will restart
+                                // as leader with the same node_id and re-UPSERT the same row.
                                 let _ = self.shutdown_sender.send(());
                                 break;
                             }
@@ -218,7 +196,7 @@ impl HeartBeatTask {
             loop {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
-                        self.shutdown_and_deregister("replica registration").await;
+                        info!(node_id = %self.node_id, task = "replica registration", "Shutdown signal received; stopping task");
                         return;
                     }
                     FutureOrShutdownOutput::Output(_) => match self.register_node().await {
@@ -234,92 +212,5 @@ impl HeartBeatTask {
                 }
             }
         })
-    }
-}
-
-// Best-effort: deletes this node's row from `nodes` on graceful shutdown so
-// DbElected replicas can take over without waiting for the leader timeout.
-// Errors and timeouts are logged, never propagated — the task is already
-// exiting and the staleness filter is the backstop for cases where this
-// can't run (SIGKILL, OOM, DB unreachable, etc.).
-//
-// Hard-bounded by `SHUTDOWN_DEREGISTER_TIMEOUT` so a stalled DB connection cannot
-// delay graceful shutdown, regardless of the inner retry budget.
-//
-// `sequencer_leader` is deliberately preserved until a replacement takes
-// over, so in-flight writes guarded by `is_leader($node_id)` can still
-// complete during the handoff window.
-async fn deregister_on_shutdown(backend: &PostgresBackend, node_id: &str) {
-    const SHUTDOWN_DEREGISTER_TIMEOUT: Duration = Duration::from_millis(500);
-
-    match tokio::time::timeout(
-        SHUTDOWN_DEREGISTER_TIMEOUT,
-        backend.deregister_node_on_shutdown(),
-    )
-    .await
-    {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => warn!(
-            node_id,
-            error = ?e,
-            "Failed to delete node registration on shutdown; row will age out via staleness filter."
-        ),
-        Err(_) => warn!(
-            node_id,
-            timeout_ms = SHUTDOWN_DEREGISTER_TIMEOUT.as_millis() as u64,
-            "Timed out deleting node registration on shutdown; row will age out via staleness filter."
-        ),
-    }
-}
-
-async fn wait_for_side_effects_to_drain_signal(
-    node_id: &str,
-    receiver: oneshot::Receiver<()>,
-    timeout: Duration,
-) -> bool {
-    match tokio::time::timeout(timeout, receiver).await {
-        Ok(Ok(())) => true,
-        Ok(Err(_)) => {
-            warn!(
-                node_id,
-                "Side effects task exited before confirming clean drain; skipping node deregistration."
-            );
-            false
-        }
-        Err(_) => {
-            warn!(
-                node_id,
-                timeout_ms = timeout.as_millis() as u64,
-                "Timed out waiting for side effects to drain; skipping node deregistration."
-            );
-            false
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn side_effects_drain_signal_allows_deregistration() {
-        let (sender, receiver) = oneshot::channel();
-        sender.send(()).unwrap();
-
-        assert!(
-            wait_for_side_effects_to_drain_signal("node_id", receiver, Duration::from_millis(10),)
-                .await
-        );
-    }
-
-    #[tokio::test]
-    async fn dropped_side_effects_drain_signal_blocks_deregistration() {
-        let (sender, receiver) = oneshot::channel();
-        drop(sender);
-
-        assert!(
-            !wait_for_side_effects_to_drain_signal("node_id", receiver, Duration::from_millis(10),)
-                .await
-        );
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
@@ -92,6 +92,37 @@ impl HeartBeatTask {
         Ok(())
     }
 
+    // Best-effort: deletes this node's row from the `nodes` table on graceful shutdown
+    // so discovery learns of its departure immediately instead of waiting for the
+    // `last_updated` staleness filter to expire. Errors and timeouts are logged, never
+    // propagated — the task is already exiting and the staleness filter is the backstop
+    // for cases where this can't run (SIGKILL, OOM, DB unreachable, etc.).
+    //
+    // Hard-bounded by `SHUTDOWN_DEREGISTER_TIMEOUT` so a stalled DB connection cannot
+    // delay graceful shutdown, regardless of the inner retry budget.
+    async fn deregister_on_shutdown(&self) {
+        const SHUTDOWN_DEREGISTER_TIMEOUT: Duration = Duration::from_millis(500);
+
+        match tokio::time::timeout(
+            SHUTDOWN_DEREGISTER_TIMEOUT,
+            self.backend.delete_node_registration(),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => warn!(
+                node_id = %self.node_id,
+                error = ?e,
+                "Failed to delete node registration on shutdown; row will age out via staleness filter."
+            ),
+            Err(_) => warn!(
+                node_id = %self.node_id,
+                timeout_ms = SHUTDOWN_DEREGISTER_TIMEOUT.as_millis() as u64,
+                "Timed out deleting node registration on shutdown; row will age out via staleness filter."
+            ),
+        }
+    }
+
     // Spawns a task for the current leader to maintain leadership.
     //
     // Periodically refreshes leadership. If leadership is lost or the database
@@ -104,7 +135,8 @@ impl HeartBeatTask {
             loop {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
-                        info!("Shutdown signal received, stopping heartbeat task");
+                        info!("Shutdown signal received, stopping heartbeat task and removing registration");
+                        self.deregister_on_shutdown().await;
                         return;
                     }
                     FutureOrShutdownOutput::Output(_) => {
@@ -150,6 +182,7 @@ impl HeartBeatTask {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
                         info!("Shutdown signal received, stopping election task.");
+                        self.deregister_on_shutdown().await;
                         return;
                     }
                     FutureOrShutdownOutput::Output(_) => {
@@ -195,6 +228,7 @@ impl HeartBeatTask {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
                         info!("Shutdown signal received, stopping registration task.");
+                        self.deregister_on_shutdown().await;
                         return;
                     }
                     FutureOrShutdownOutput::Output(_) => match self.register_node().await {

--- a/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use anyhow::Result;
 use sov_full_node_configs::sequencer::{ConfiguredNodeRole, PostgresConfig};
 use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
-use tokio::sync::watch;
+use tokio::sync::{oneshot, watch};
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
@@ -21,6 +21,29 @@ use super::SequencerRole;
 
 use super::postgres::PostgresBackend;
 use crate::preferred::exit_rollup;
+
+pub(crate) type HeartbeatStoppedSender = oneshot::Sender<()>;
+pub(crate) type HeartbeatStoppedReceiver = oneshot::Receiver<()>;
+
+pub(crate) fn heartbeat_stopped_channel() -> (HeartbeatStoppedSender, HeartbeatStoppedReceiver) {
+    oneshot::channel()
+}
+
+struct HeartbeatStoppedGuard(Option<HeartbeatStoppedSender>);
+
+impl HeartbeatStoppedGuard {
+    fn new(sender: Option<HeartbeatStoppedSender>) -> Self {
+        Self(sender)
+    }
+}
+
+impl Drop for HeartbeatStoppedGuard {
+    fn drop(&mut self) {
+        if let Some(sender) = self.0.take() {
+            let _ = sender.send(());
+        }
+    }
+}
 
 /// Manages periodic heartbeat and optional leadership election for a sequencer node.
 ///
@@ -34,6 +57,7 @@ pub struct HeartBeatTask {
     shutdown_receiver: watch::Receiver<()>,
     postgres_config: PostgresConfig,
     heartbeat_interval: Duration,
+    stopped_sender: Option<HeartbeatStoppedSender>,
 }
 
 impl HeartBeatTask {
@@ -42,6 +66,7 @@ impl HeartBeatTask {
         shutdown_sender: watch::Sender<()>,
         bind_addr: SocketAddr,
         heartbeat_interval: Duration,
+        stopped_sender: Option<HeartbeatStoppedSender>,
     ) -> Result<Self> {
         let backend = PostgresBackend::connect(&postgres_config, bind_addr).await?;
         let shutdown_receiver = shutdown_sender.subscribe();
@@ -53,6 +78,7 @@ impl HeartBeatTask {
             shutdown_receiver,
             postgres_config,
             heartbeat_interval,
+            stopped_sender,
         })
     }
 
@@ -96,8 +122,10 @@ impl HeartBeatTask {
     //
     // Periodically refreshes leadership. If leadership is lost or the database
     // becomes unreachable, triggers a graceful shutdown.  .
-    fn spawn_leader_heartbeat_task(self) -> JoinHandle<()> {
+    fn spawn_leader_heartbeat_task(mut self) -> JoinHandle<()> {
+        let stopped_sender = self.stopped_sender.take();
         tokio::spawn(async move {
+            let _stopped_guard = HeartbeatStoppedGuard::new(stopped_sender);
             info!(node_id = %self.node_id, address = %self.backend.node_address, "Starting leader heartbeat task");
             let mut interval = tokio::time::interval(self.heartbeat_interval);
 
@@ -141,8 +169,10 @@ impl HeartBeatTask {
     //
     // Periodically attempts to acquire leadership. If successful, triggers
     // a shutdown so the node can restart as the new leader.
-    fn spawn_replica_heartbeat_task(self) -> JoinHandle<()> {
+    fn spawn_replica_heartbeat_task(mut self) -> JoinHandle<()> {
+        let stopped_sender = self.stopped_sender.take();
         tokio::spawn(async move {
+            let _stopped_guard = HeartbeatStoppedGuard::new(stopped_sender);
             info!(node_id = %self.node_id, address = %self.backend.node_address, "Starting replica election task");
             let mut interval = tokio::time::interval(self.heartbeat_interval);
 
@@ -188,8 +218,10 @@ impl HeartBeatTask {
     //
     // Periodically updates the node's entry in the `nodes` table without
     // competing for leadership. Failures are logged but don't cause shutdown.
-    fn spawn_node_registration_task(self) -> JoinHandle<()> {
+    fn spawn_node_registration_task(mut self) -> JoinHandle<()> {
+        let stopped_sender = self.stopped_sender.take();
         tokio::spawn(async move {
+            let _stopped_guard = HeartbeatStoppedGuard::new(stopped_sender);
             info!(node_id = %self.node_id, address = %self.backend.node_address, "Starting replica registration task.");
             let mut interval = tokio::time::interval(self.heartbeat_interval);
 
@@ -212,5 +244,21 @@ impl HeartBeatTask {
                 }
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stopped_guard_notifies_receiver_on_drop() {
+        let (sender, mut receiver) = heartbeat_stopped_channel();
+
+        {
+            let _guard = HeartbeatStoppedGuard::new(Some(sender));
+        }
+
+        assert!(matches!(receiver.try_recv(), Ok(())));
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 use anyhow::Result;
 use sov_full_node_configs::sequencer::{ConfiguredNodeRole, PostgresConfig};
 use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
-use tokio::sync::watch;
+use tokio::sync::{oneshot, watch};
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
 
@@ -34,6 +34,7 @@ pub struct HeartBeatTask {
     shutdown_receiver: watch::Receiver<()>,
     postgres_config: PostgresConfig,
     heartbeat_interval: Duration,
+    side_effects_drained_receiver: Option<oneshot::Receiver<()>>,
 }
 
 impl HeartBeatTask {
@@ -42,6 +43,7 @@ impl HeartBeatTask {
         shutdown_sender: watch::Sender<()>,
         bind_addr: SocketAddr,
         heartbeat_interval: Duration,
+        side_effects_drained_receiver: oneshot::Receiver<()>,
     ) -> Result<Self> {
         let backend = PostgresBackend::connect(&postgres_config, bind_addr).await?;
         let shutdown_receiver = shutdown_sender.subscribe();
@@ -53,6 +55,7 @@ impl HeartBeatTask {
             shutdown_receiver,
             postgres_config,
             heartbeat_interval,
+            side_effects_drained_receiver: Some(side_effects_drained_receiver),
         })
     }
 
@@ -127,10 +130,28 @@ impl HeartBeatTask {
         }
     }
 
+    async fn wait_for_side_effects_to_drain(&mut self) -> bool {
+        const SIDE_EFFECTS_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+        let Some(receiver) = self.side_effects_drained_receiver.take() else {
+            warn!(
+                node_id = %self.node_id,
+                "Side effects drain receiver already consumed; skipping node deregistration."
+            );
+            return false;
+        };
+
+        wait_for_side_effects_to_drain_signal(&self.node_id, receiver, SIDE_EFFECTS_DRAIN_TIMEOUT)
+            .await
+    }
+
     // Logs the shutdown and best-effort deregisters this node. Shared by every task
     // loop so all graceful-shutdown paths deregister in exactly one place.
-    async fn shutdown_and_deregister(&self, task: &str) {
-        info!(node_id = %self.node_id, task, "Shutdown signal received; stopping task and deregistering node");
+    async fn shutdown_and_deregister(mut self, task: &str) {
+        info!(node_id = %self.node_id, task, "Shutdown signal received; stopping task and waiting for side effects to drain before deregistering node");
+        if !self.wait_for_side_effects_to_drain().await {
+            return;
+        }
         self.deregister_on_shutdown().await;
     }
 
@@ -256,5 +277,57 @@ impl HeartBeatTask {
                 }
             }
         })
+    }
+}
+
+async fn wait_for_side_effects_to_drain_signal(
+    node_id: &str,
+    receiver: oneshot::Receiver<()>,
+    timeout: Duration,
+) -> bool {
+    match tokio::time::timeout(timeout, receiver).await {
+        Ok(Ok(())) => true,
+        Ok(Err(_)) => {
+            warn!(
+                node_id,
+                "Side effects task exited before confirming clean drain; skipping node deregistration."
+            );
+            false
+        }
+        Err(_) => {
+            warn!(
+                node_id,
+                timeout_ms = timeout.as_millis() as u64,
+                "Timed out waiting for side effects to drain; skipping node deregistration."
+            );
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn side_effects_drain_signal_allows_deregistration() {
+        let (sender, receiver) = oneshot::channel();
+        sender.send(()).unwrap();
+
+        assert!(
+            wait_for_side_effects_to_drain_signal("node_id", receiver, Duration::from_millis(10),)
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn dropped_side_effects_drain_signal_blocks_deregistration() {
+        let (sender, receiver) = oneshot::channel();
+        drop(sender);
+
+        assert!(
+            !wait_for_side_effects_to_drain_signal("node_id", receiver, Duration::from_millis(10),)
+                .await
+        );
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
@@ -105,7 +105,7 @@ impl HeartBeatTask {
 
         match tokio::time::timeout(
             SHUTDOWN_DEREGISTER_TIMEOUT,
-            self.backend.delete_node_registration(),
+            self.backend.deregister_node_on_shutdown(),
         )
         .await
         {
@@ -135,7 +135,7 @@ impl HeartBeatTask {
             loop {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
-                        info!("Shutdown signal received, stopping heartbeat task and removing registration");
+                        info!("Shutdown signal received, stopping heartbeat task and deregistering node");
                         self.deregister_on_shutdown().await;
                         return;
                     }
@@ -181,7 +181,7 @@ impl HeartBeatTask {
             loop {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
-                        info!("Shutdown signal received, stopping election task.");
+                        info!("Shutdown signal received, stopping election task and deregistering node.");
                         self.deregister_on_shutdown().await;
                         return;
                     }
@@ -192,6 +192,10 @@ impl HeartBeatTask {
                                     node_id = %self.node_id,
                                     "Replica acquired leadership! Exiting to restart as leader."
                                 );
+                                // Intentionally no `deregister_on_shutdown` here: this node
+                                // will restart as leader with the same node_id and re-UPSERT
+                                // the same row, so we want the registration to persist across
+                                // the restart instead of being briefly deleted and re-inserted.
                                 let _ = self.shutdown_sender.send(());
                                 break;
                             }
@@ -227,7 +231,7 @@ impl HeartBeatTask {
             loop {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
-                        info!("Shutdown signal received, stopping registration task.");
+                        info!("Shutdown signal received, stopping registration task and deregistering node.");
                         self.deregister_on_shutdown().await;
                         return;
                     }

--- a/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
@@ -92,14 +92,20 @@ impl HeartBeatTask {
         Ok(())
     }
 
-    // Best-effort: deletes this node's row from the `nodes` table on graceful shutdown
-    // so discovery learns of its departure immediately instead of waiting for the
-    // `last_updated` staleness filter to expire. Errors and timeouts are logged, never
-    // propagated — the task is already exiting and the staleness filter is the backstop
-    // for cases where this can't run (SIGKILL, OOM, DB unreachable, etc.).
+    // Best-effort: deletes this node's rows from `sequencer_leader` and `nodes` on
+    // graceful shutdown so replicas can take over without waiting for the staleness
+    // filter / leader timeout to expire. Errors and timeouts are logged, never
+    // propagated — the task is already exiting and the staleness filter is the
+    // backstop for cases where this can't run (SIGKILL, OOM, DB unreachable, etc.).
     //
     // Hard-bounded by `SHUTDOWN_DEREGISTER_TIMEOUT` so a stalled DB connection cannot
     // delay graceful shutdown, regardless of the inner retry budget.
+    //
+    // Deleting `sequencer_leader` opens a brief window where in-flight writes from
+    // the block executor (guarded by `is_leader($node_id)` in SQL) can land as
+    // `ReplicaDisallowed`. This is benign — the node is already shutting down — and
+    // `PreferredSequencerDb::check_replica_err` downgrades those errors during
+    // shutdown so they don't surface as "primary has become a replica".
     async fn deregister_on_shutdown(&self) {
         const SHUTDOWN_DEREGISTER_TIMEOUT: Duration = Duration::from_millis(500);
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -539,6 +539,7 @@ impl SequencerRole {
 pub(crate) struct PreferredSequencerDb {
     backend: Option<Box<dyn DbBackend>>,
     shutdown_sender: watch::Sender<()>,
+    shutdown_receiver: watch::Receiver<()>,
 }
 
 impl PreferredSequencerDb {
@@ -593,10 +594,12 @@ impl PreferredSequencerDb {
                 )
             }
         };
+        let shutdown_receiver = shutdown_sender.subscribe();
         Ok((
             Self {
                 backend,
                 shutdown_sender,
+                shutdown_receiver,
             },
             role,
         ))
@@ -638,6 +641,19 @@ impl PreferredSequencerDb {
                     self_node_id,
                     operation,
                 }) => {
+                    // See `check_replica_err`: a ReplicaDisallowed observed after
+                    // shutdown was signaled is the expected aftermath of leader
+                    // deregistration, not a genuine leadership loss.
+                    if self.shutdown_receiver.has_changed().unwrap_or(true) {
+                        tracing::debug!(
+                            %self_node_id,
+                            %operation,
+                            "Initial DB read rejected after leader deregistration during graceful shutdown.",
+                        );
+                        return Err(anyhow::anyhow!(
+                            "Initial DB read rejected during shutdown (operation: {operation})"
+                        ));
+                    }
                     tracing::error!(
                         %self_node_id,
                         %operation,
@@ -724,6 +740,20 @@ impl PreferredSequencerDb {
                 self_node_id,
                 operation,
             } => {
+                // During graceful shutdown the leader heartbeat task deletes the
+                // `sequencer_leader` row, which causes any in-flight write guarded
+                // by `is_leader($node_id)` to land as `ReplicaDisallowed`. Treat
+                // this as an expected drain symptom instead of a leadership loss.
+                if self.shutdown_receiver.has_changed().unwrap_or(true) {
+                    tracing::debug!(
+                        %self_node_id,
+                        %operation,
+                        "DB write rejected after leader deregistration during graceful shutdown.",
+                    );
+                    return anyhow::anyhow!(
+                        "DB write rejected during shutdown (operation: {operation})"
+                    );
+                }
                 tracing::error!(
                     %self_node_id,
                     %operation,

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -539,7 +539,6 @@ impl SequencerRole {
 pub(crate) struct PreferredSequencerDb {
     backend: Option<Box<dyn DbBackend>>,
     shutdown_sender: watch::Sender<()>,
-    shutdown_receiver: watch::Receiver<()>,
 }
 
 impl PreferredSequencerDb {
@@ -594,12 +593,10 @@ impl PreferredSequencerDb {
                 )
             }
         };
-        let shutdown_receiver = shutdown_sender.subscribe();
         Ok((
             Self {
                 backend,
                 shutdown_sender,
-                shutdown_receiver,
             },
             role,
         ))
@@ -641,19 +638,6 @@ impl PreferredSequencerDb {
                     self_node_id,
                     operation,
                 }) => {
-                    // See `check_replica_err`: a ReplicaDisallowed observed after
-                    // shutdown was signaled is the expected aftermath of leader
-                    // deregistration, not a genuine leadership loss.
-                    if self.shutdown_receiver.has_changed().unwrap_or(true) {
-                        tracing::debug!(
-                            %self_node_id,
-                            %operation,
-                            "Initial DB read rejected after leader deregistration during graceful shutdown.",
-                        );
-                        return Err(anyhow::anyhow!(
-                            "Initial DB read rejected during shutdown (operation: {operation})"
-                        ));
-                    }
                     tracing::error!(
                         %self_node_id,
                         %operation,
@@ -740,20 +724,6 @@ impl PreferredSequencerDb {
                 self_node_id,
                 operation,
             } => {
-                // During graceful shutdown the leader heartbeat task deletes the
-                // `sequencer_leader` row, which causes any in-flight write guarded
-                // by `is_leader($node_id)` to land as `ReplicaDisallowed`. Treat
-                // this as an expected drain symptom instead of a leadership loss.
-                if self.shutdown_receiver.has_changed().unwrap_or(true) {
-                    tracing::debug!(
-                        %self_node_id,
-                        %operation,
-                        "DB write rejected after leader deregistration during graceful shutdown.",
-                    );
-                    return anyhow::anyhow!(
-                        "DB write rejected during shutdown (operation: {operation})"
-                    );
-                }
                 tracing::error!(
                     %self_node_id,
                     %operation,

--- a/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/mod.rs
@@ -33,6 +33,7 @@ use std::net::SocketAddr;
 use std::num::NonZero;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{mpsc, watch};
 
 use crate::common::WithCachedTxHashes;
@@ -130,6 +131,10 @@ pub trait DbBackend: Send + Sync + 'static {
     /// This method exists because the sequencer has no use for data that is
     /// already finalized.
     async fn prune(&mut self, up_to_including: SequenceNumber) -> Result<(), DbError>;
+
+    async fn deregister_node_on_shutdown(&mut self) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// The return type of `DbBackend::current_data()`.
@@ -778,6 +783,35 @@ impl PreferredSequencerDb {
             }
         }
         Ok(())
+    }
+
+    pub(crate) async fn deregister_node_on_shutdown_best_effort(&mut self) {
+        const SHUTDOWN_DEREGISTER_TIMEOUT: Duration = Duration::from_millis(500);
+
+        let Some(backend) = &mut self.backend else {
+            return;
+        };
+
+        match tokio::time::timeout(
+            SHUTDOWN_DEREGISTER_TIMEOUT,
+            backend.deregister_node_on_shutdown(),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                tracing::warn!(
+                    error = ?error,
+                    "Failed to delete node registration on shutdown; row will age out via staleness filter."
+                );
+            }
+            Err(_) => {
+                tracing::warn!(
+                    timeout_ms = SHUTDOWN_DEREGISTER_TIMEOUT.as_millis() as u64,
+                    "Timed out deleting node registration on shutdown; row will age out via staleness filter."
+                );
+            }
+        }
     }
 
     async fn debug_assert_in_progress_batch_is_none(

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -632,6 +632,11 @@ impl DbBackend for PostgresBackend {
 
         Ok(())
     }
+
+    async fn deregister_node_on_shutdown(&mut self) -> anyhow::Result<()> {
+        PostgresBackend::deregister_node_on_shutdown(self).await
+    }
+
     async fn read_in_progress_batch(&self) -> anyhow::Result<Option<InProgressBatch>, DbError> {
         let mut tx = self.pool.begin().await?;
         let maybe_leader = self.get_sequencer_leader_inner(&mut tx).await?;

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -362,22 +362,14 @@ impl PostgresBackend {
             .with_factor(10.0)
             .with_max_times(2);
 
+        // Single statement → no explicit transaction (matches `begin_rollup_block`).
         run_with_retries!(
             &shutdown_backoff,
-            self.deregister_node_on_shutdown_in_tx(),
+            sqlx::query("DELETE FROM nodes WHERE node_id = $1")
+                .bind(&self.node_id)
+                .execute(&self.pool),
             "postgres_db_backend_deregister_node_on_shutdown"
-        )
-    }
-
-    async fn deregister_node_on_shutdown_in_tx(&self) -> anyhow::Result<()> {
-        let mut tx: sqlx::Transaction<'_, Postgres> = self.pool.begin().await?;
-
-        sqlx::query("DELETE FROM nodes WHERE node_id = $1")
-            .bind(&self.node_id)
-            .execute(&mut *tx)
-            .await?;
-
-        tx.commit().await?;
+        )?;
         Ok(())
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -367,14 +367,6 @@ impl PostgresBackend {
     async fn deregister_node_on_shutdown_in_tx(&self) -> anyhow::Result<()> {
         let mut tx: sqlx::Transaction<'_, Postgres> = self.pool.begin().await?;
 
-        sqlx::query(
-            "DELETE FROM sequencer_leader
-             WHERE singleton = 1 AND node_id = $1",
-        )
-        .bind(&self.node_id)
-        .execute(&mut *tx)
-        .await?;
-
         sqlx::query("DELETE FROM nodes WHERE node_id = $1")
             .bind(&self.node_id)
             .execute(&mut *tx)

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -298,7 +298,9 @@ impl PostgresBackend {
 
         // Leadership update logic:
         // 1. Same node can always refresh its heartbeat
-        // 2. Different node can only take over if BOTH:
+        // 2. Different node can take over immediately if the current leader has
+        //    gracefully deregistered its node row.
+        // 3. Otherwise, different node can only take over if BOTH:
         //    - The current leader has timed out (no heartbeat within leader_timeout)
         //    - The grace period since leader_acquired_at has passed (prevents rapid flapping)
         let res = sqlx::query_as::<_, SequencerLeader>(
@@ -315,6 +317,9 @@ impl PostgresBackend {
                         END
                     WHERE
                         sequencer_leader.node_id = EXCLUDED.node_id
+                        OR NOT EXISTS (
+                            SELECT 1 FROM nodes WHERE nodes.node_id = sequencer_leader.node_id
+                        )
                         OR (
                             sequencer_leader.last_updated < EXCLUDED.last_updated - ($2 * INTERVAL '1 millisecond')
                             AND sequencer_leader.leader_acquired_at < EXCLUDED.last_updated - ($3 * INTERVAL '1 millisecond')

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -348,6 +348,34 @@ impl PostgresBackend {
         Ok(())
     }
 
+    /// Deletes this node's row from the `nodes` table.
+    ///
+    /// Used during graceful shutdown to remove the node from discovery immediately,
+    /// rather than waiting for its heartbeat to age out via the `last_updated`
+    /// staleness filter. The existing `notify_nodes_changes` trigger propagates the
+    /// DELETE to `node_discovery` subscribers, so departure is observed in real time.
+    ///
+    /// Uses a deliberately short retry budget (2 retries, ~110ms total of sleeps)
+    /// rather than the shared `self.backoff_policy` so a DB outage cannot stall
+    /// graceful shutdown. The staleness filter in node discovery is the backstop
+    /// when this call ultimately fails.
+    pub(crate) async fn delete_node_registration(&self) -> anyhow::Result<()> {
+        let shutdown_backoff = ExponentialBuilder::default()
+            .with_min_delay(Duration::from_millis(10))
+            .with_max_delay(Duration::from_millis(100))
+            .with_factor(10.0)
+            .with_max_times(2);
+
+        run_with_retries!(
+            &shutdown_backoff,
+            sqlx::query("DELETE FROM nodes WHERE node_id = $1")
+                .bind(&self.node_id)
+                .execute(&self.pool),
+            "postgres_db_backend_delete_node_registration"
+        )?;
+        Ok(())
+    }
+
     async fn prune_inner(
         &self,
         prune_up_to_including: SequenceNumber,

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -349,8 +349,16 @@ impl PostgresBackend {
     }
 
     pub(crate) async fn deregister_node_on_shutdown(&self) -> anyhow::Result<()> {
+        // Deliberately tight: graceful shutdown must not stall on a slow DB.
+        // The staleness filter in node discovery is the backstop if we fail.
+        let shutdown_backoff = ExponentialBuilder::default()
+            .with_min_delay(Duration::from_millis(10))
+            .with_max_delay(Duration::from_millis(100))
+            .with_factor(10.0)
+            .with_max_times(2);
+
         run_with_retries!(
-            &self.backoff_policy,
+            &shutdown_backoff,
             self.deregister_node_on_shutdown_in_tx(),
             "postgres_db_backend_deregister_node_on_shutdown"
         )

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -348,31 +348,31 @@ impl PostgresBackend {
         Ok(())
     }
 
-    /// Deletes this node's row from the `nodes` table.
-    ///
-    /// Used during graceful shutdown to remove the node from discovery immediately,
-    /// rather than waiting for its heartbeat to age out via the `last_updated`
-    /// staleness filter. The existing `notify_nodes_changes` trigger propagates the
-    /// DELETE to `node_discovery` subscribers, so departure is observed in real time.
-    ///
-    /// Uses a deliberately short retry budget (2 retries, ~110ms total of sleeps)
-    /// rather than the shared `self.backoff_policy` so a DB outage cannot stall
-    /// graceful shutdown. The staleness filter in node discovery is the backstop
-    /// when this call ultimately fails.
-    pub(crate) async fn delete_node_registration(&self) -> anyhow::Result<()> {
-        let shutdown_backoff = ExponentialBuilder::default()
-            .with_min_delay(Duration::from_millis(10))
-            .with_max_delay(Duration::from_millis(100))
-            .with_factor(10.0)
-            .with_max_times(2);
-
+    pub(crate) async fn deregister_node_on_shutdown(&self) -> anyhow::Result<()> {
         run_with_retries!(
-            &shutdown_backoff,
-            sqlx::query("DELETE FROM nodes WHERE node_id = $1")
-                .bind(&self.node_id)
-                .execute(&self.pool),
-            "postgres_db_backend_delete_node_registration"
-        )?;
+            &self.backoff_policy,
+            self.deregister_node_on_shutdown_in_tx(),
+            "postgres_db_backend_deregister_node_on_shutdown"
+        )
+    }
+
+    async fn deregister_node_on_shutdown_in_tx(&self) -> anyhow::Result<()> {
+        let mut tx: sqlx::Transaction<'_, Postgres> = self.pool.begin().await?;
+
+        sqlx::query(
+            "DELETE FROM sequencer_leader
+             WHERE singleton = 1 AND node_id = $1",
+        )
+        .bind(&self.node_id)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query("DELETE FROM nodes WHERE node_id = $1")
+            .bind(&self.node_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
         Ok(())
     }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
@@ -352,6 +352,68 @@ async fn test_retry_sensitive_writes_are_idempotent() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_delete_node_registration_removes_only_target() {
+    let Some(postgres) = setup_test_postgres().await else {
+        return;
+    };
+
+    // Two replicas registered side-by-side; only the targeted row should be removed.
+    let alice = DB::new(
+        &postgres,
+        String::from("alice"),
+        ConfiguredNodeRole::Replica,
+    )
+    .await;
+    let bob = DB::new(&postgres, String::from("bob"), ConfiguredNodeRole::Replica).await;
+
+    alice.backend.heartbeat(None).await.unwrap();
+    bob.backend.heartbeat(None).await.unwrap();
+    assert_eq!(
+        count_nodes(&alice).await,
+        2,
+        "Both replicas should be registered after their heartbeats."
+    );
+
+    alice.backend.delete_node_registration().await.unwrap();
+    assert_eq!(
+        count_nodes(&alice).await,
+        1,
+        "Only one row should remain after alice deregisters."
+    );
+    assert!(
+        !node_exists(&alice, "alice").await,
+        "Alice's row should be removed."
+    );
+    assert!(
+        node_exists(&alice, "bob").await,
+        "Bob's row should be untouched."
+    );
+
+    // Idempotent: deleting an already-absent row is a no-op.
+    alice.backend.delete_node_registration().await.unwrap();
+    assert_eq!(
+        count_nodes(&alice).await,
+        1,
+        "Second delete should be a no-op."
+    );
+}
+
+async fn count_nodes(db: &DB) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM nodes")
+        .fetch_one(&db.backend.pool)
+        .await
+        .unwrap()
+}
+
+async fn node_exists(db: &DB, node_id: &str) -> bool {
+    sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM nodes WHERE node_id = $1)")
+        .bind(node_id)
+        .fetch_one(&db.backend.pool)
+        .await
+        .unwrap()
+}
+
 async fn count_events(db: &DB, sequence_number: SequenceNumber, event_type: &str) -> i64 {
     sqlx::query_scalar(
         "SELECT COUNT(*)

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
@@ -109,6 +109,52 @@ async fn test_db_operations_leader() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_deregistered_leader_can_finish_guarded_writes_before_takeover() {
+    let Some(postgres) = setup_test_postgres().await else {
+        return;
+    };
+
+    let db = &mut DB::new(
+        &postgres,
+        String::from("node_id_1"),
+        ConfiguredNodeRole::Leader,
+    )
+    .await;
+    db.maybe_update_leader().await.unwrap();
+
+    db.backend.deregister_node_on_shutdown().await.unwrap();
+    assert!(!node_exists(db, "node_id_1").await);
+
+    let sequence_number = 1;
+    let batch_to_store = batch_to_store(sequence_number);
+
+    db.as_mut()
+        .begin_rollup_block(batch_to_store)
+        .await
+        .unwrap();
+
+    db.as_mut()
+        .add_tx(
+            sequence_number,
+            0,
+            FullyBakedTx::new(vec![1, 2, 3]),
+            TxHash::new([1; 32]),
+        )
+        .await
+        .unwrap();
+
+    db.as_mut().end_rollup_block(batch_to_store).await.unwrap();
+
+    let data = db.as_mut().current_data().await.unwrap();
+    assert_eq!(data.completed_blobs.len(), 1);
+    let ReadBlob::Batch(batch) = &data.completed_blobs[0] else {
+        panic!("Completed blob must be a batch");
+    };
+    assert_eq!(batch.sequence_number, sequence_number);
+    assert_eq!(batch.txs.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_db_operations_replica() {
     let Some(postgres) = setup_test_postgres().await else {
         return;

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
@@ -452,14 +452,6 @@ async fn count_nodes(db: &DB) -> i64 {
         .unwrap()
 }
 
-async fn node_exists(db: &DB, node_id: &str) -> bool {
-    sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM nodes WHERE node_id = $1)")
-        .bind(node_id)
-        .fetch_one(&db.backend.pool)
-        .await
-        .unwrap()
-}
-
 async fn count_events(db: &DB, sequence_number: SequenceNumber, event_type: &str) -> i64 {
     sqlx::query_scalar(
         "SELECT COUNT(*)

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
@@ -353,7 +353,7 @@ async fn test_retry_sensitive_writes_are_idempotent() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_delete_node_registration_removes_only_target() {
+async fn test_shutdown_deregistration_removes_only_target() {
     let Some(postgres) = setup_test_postgres().await else {
         return;
     };
@@ -375,7 +375,7 @@ async fn test_delete_node_registration_removes_only_target() {
         "Both replicas should be registered after their heartbeats."
     );
 
-    alice.backend.delete_node_registration().await.unwrap();
+    alice.backend.deregister_node_on_shutdown().await.unwrap();
     assert_eq!(
         count_nodes(&alice).await,
         1,
@@ -391,7 +391,7 @@ async fn test_delete_node_registration_removes_only_target() {
     );
 
     // Idempotent: deleting an already-absent row is a no-op.
-    alice.backend.delete_node_registration().await.unwrap();
+    alice.backend.deregister_node_on_shutdown().await.unwrap();
     assert_eq!(
         count_nodes(&alice).await,
         1,

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/leader_election.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/leader_election.rs
@@ -271,7 +271,7 @@ async fn test_leader_grace_period() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_shutdown_deregistration_preserves_leader() {
+async fn test_shutdown_deregistration_allows_immediate_takeover_without_clearing_leader() {
     let Some(postgres) = setup_test_postgres().await else {
         return;
     };
@@ -285,7 +285,7 @@ async fn test_shutdown_deregistration_preserves_leader() {
     let db_2 = DB::new(
         &postgres,
         String::from("node_2"),
-        ConfiguredNodeRole::Replica,
+        ConfiguredNodeRole::DbElected,
     )
     .await;
 
@@ -300,6 +300,13 @@ async fn test_shutdown_deregistration_preserves_leader() {
     );
     assert!(!node_exists(&db_2, "node_1").await);
     assert!(node_exists(&db_2, "node_2").await);
+
+    let leader_2 = db_2.maybe_update_leader().await.unwrap();
+    assert_eq!(leader_2.node_id, "node_2");
+    assert_eq!(
+        db_2.get_sequencer_leader().await.unwrap(),
+        Some(String::from("node_2"))
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/leader_election.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/leader_election.rs
@@ -365,11 +365,3 @@ async fn test_shutdown_deregistration_is_idempotent() {
     );
     assert!(!node_exists(&db, "node_1").await);
 }
-
-async fn node_exists(db: &DB, node_id: &str) -> bool {
-    sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM nodes WHERE node_id = $1)")
-        .bind(node_id)
-        .fetch_one(&db.backend.pool)
-        .await
-        .unwrap()
-}

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/leader_election.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/leader_election.rs
@@ -269,3 +269,94 @@ async fn test_leader_grace_period() {
     );
     assert_eq!(result.unwrap().node_id, "node_2");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_shutdown_deregistration_clears_leader_before_removing_node() {
+    let Some(postgres) = setup_test_postgres().await else {
+        return;
+    };
+
+    let db_1 = DB::new(
+        &postgres,
+        String::from("node_1"),
+        ConfiguredNodeRole::Leader,
+    )
+    .await;
+    let db_2 = DB::new(
+        &postgres,
+        String::from("node_2"),
+        ConfiguredNodeRole::Replica,
+    )
+    .await;
+
+    db_1.maybe_update_leader().await.unwrap();
+    assert!(db_2.maybe_update_leader().await.is_none());
+
+    db_1.backend.deregister_node_on_shutdown().await.unwrap();
+
+    assert_eq!(db_2.get_sequencer_leader().await.unwrap(), None);
+    assert!(!node_exists(&db_2, "node_1").await);
+    assert!(node_exists(&db_2, "node_2").await);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_shutdown_deregistration_keeps_other_leader() {
+    let Some(postgres) = setup_test_postgres().await else {
+        return;
+    };
+
+    let leader = DB::new(
+        &postgres,
+        String::from("leader"),
+        ConfiguredNodeRole::Leader,
+    )
+    .await;
+    let replica = DB::new(
+        &postgres,
+        String::from("replica"),
+        ConfiguredNodeRole::Replica,
+    )
+    .await;
+
+    leader.maybe_update_leader().await.unwrap();
+    assert!(replica.maybe_update_leader().await.is_none());
+
+    replica.backend.deregister_node_on_shutdown().await.unwrap();
+
+    assert_eq!(
+        leader.get_sequencer_leader().await.unwrap(),
+        Some(String::from("leader"))
+    );
+    assert!(node_exists(&leader, "leader").await);
+    assert!(!node_exists(&leader, "replica").await);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_shutdown_deregistration_is_idempotent() {
+    let Some(postgres) = setup_test_postgres().await else {
+        return;
+    };
+
+    let db = DB::new(
+        &postgres,
+        String::from("node_1"),
+        ConfiguredNodeRole::Leader,
+    )
+    .await;
+
+    db.maybe_update_leader().await.unwrap();
+
+    db.backend.deregister_node_on_shutdown().await.unwrap();
+    db.backend.deregister_node_on_shutdown().await.unwrap();
+
+    assert_eq!(db.get_sequencer_leader().await.unwrap(), None);
+    assert!(!node_exists(&db, "node_1").await);
+}
+
+async fn node_exists(db: &DB, node_id: &str) -> bool {
+    sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM nodes WHERE node_id = $1)")
+        .bind(node_id)
+        .fetch_one(&db.backend.pool)
+        .await
+        .unwrap()
+}

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/leader_election.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/leader_election.rs
@@ -271,7 +271,7 @@ async fn test_leader_grace_period() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_shutdown_deregistration_clears_leader_before_removing_node() {
+async fn test_shutdown_deregistration_preserves_leader() {
     let Some(postgres) = setup_test_postgres().await else {
         return;
     };
@@ -294,7 +294,10 @@ async fn test_shutdown_deregistration_clears_leader_before_removing_node() {
 
     db_1.backend.deregister_node_on_shutdown().await.unwrap();
 
-    assert_eq!(db_2.get_sequencer_leader().await.unwrap(), None);
+    assert_eq!(
+        db_2.get_sequencer_leader().await.unwrap(),
+        Some(String::from("node_1"))
+    );
     assert!(!node_exists(&db_2, "node_1").await);
     assert!(node_exists(&db_2, "node_2").await);
 }
@@ -349,7 +352,10 @@ async fn test_shutdown_deregistration_is_idempotent() {
     db.backend.deregister_node_on_shutdown().await.unwrap();
     db.backend.deregister_node_on_shutdown().await.unwrap();
 
-    assert_eq!(db.get_sequencer_leader().await.unwrap(), None);
+    assert_eq!(
+        db.get_sequencer_leader().await.unwrap(),
+        Some(String::from("node_1"))
+    );
     assert!(!node_exists(&db, "node_1").await);
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/mod.rs
@@ -110,3 +110,11 @@ impl DB {
         Ok(res)
     }
 }
+
+pub(super) async fn node_exists(db: &DB, node_id: &str) -> bool {
+    sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM nodes WHERE node_id = $1)")
+        .bind(node_id)
+        .fetch_one(&db.backend.pool)
+        .await
+        .unwrap()
+}

--- a/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
@@ -18,7 +18,12 @@ use crate::preferred::{PreferredBlobToReplay, PreferredProofToReplay};
 use crate::{PreferredProofDataBytes, SlotNumber};
 
 const MAX_EXECUTOR_EVENT_QUEUE_DEPTH: usize = 1000;
-const SIDE_EFFECTS_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+/// How long any shutdown path waits for the side effects task to process the
+/// [`ExecutorEvent::DrainAndShutdown`] barrier. Shared by the sender side here
+/// and by the heartbeat task that deregisters the node once the drain completes,
+/// so the two waits cannot silently drift apart.
+pub(crate) const SIDE_EFFECTS_DRAIN_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(5);
 
 pub(crate) struct ExecutorEventsSender<S: Spec, Rt: Runtime<S>> {
     events_sender: mpsc::Sender<ExecutorEvent<S, Rt>>,

--- a/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
@@ -18,6 +18,7 @@ use crate::preferred::{PreferredBlobToReplay, PreferredProofToReplay};
 use crate::{PreferredProofDataBytes, SlotNumber};
 
 const MAX_EXECUTOR_EVENT_QUEUE_DEPTH: usize = 1000;
+const SIDE_EFFECTS_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 pub(crate) struct ExecutorEventsSender<S: Spec, Rt: Runtime<S>> {
     events_sender: mpsc::Sender<ExecutorEvent<S, Rt>>,
@@ -69,6 +70,59 @@ impl<S: Spec, Rt: Runtime<S>> ExecutorEventsSender<S, Rt> {
         sov_metrics::track_metrics(|t| {
             t.submit(metrics);
         });
+    }
+
+    pub(crate) async fn drain_and_shutdown(&self) -> bool {
+        let (ack_sender, ack_receiver) = oneshot::channel();
+        let event = ExecutorEvent::DrainAndShutdown { ack: ack_sender };
+
+        match self.events_sender.try_send(event) {
+            Ok(()) => {}
+            Err(TrySendError::Full(event)) => {
+                let send_result = tokio::time::timeout(
+                    SIDE_EFFECTS_DRAIN_TIMEOUT,
+                    self.events_sender.send(event),
+                )
+                .await;
+                match send_result {
+                    Ok(Ok(())) => {}
+                    Ok(Err(_)) => {
+                        tracing::warn!(
+                            "Side effects task exited before shutdown drain barrier was sent"
+                        );
+                        return false;
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            timeout_ms = SIDE_EFFECTS_DRAIN_TIMEOUT.as_millis() as u64,
+                            "Timed out sending side effects drain barrier during shutdown"
+                        );
+                        return false;
+                    }
+                }
+            }
+            Err(TrySendError::Closed(_)) => {
+                tracing::warn!("Side effects task exited before shutdown drain barrier was sent");
+                return false;
+            }
+        }
+
+        match tokio::time::timeout(SIDE_EFFECTS_DRAIN_TIMEOUT, ack_receiver).await {
+            Ok(Ok(())) => true,
+            Ok(Err(_)) => {
+                tracing::warn!(
+                    "Side effects task exited before acknowledging shutdown drain barrier"
+                );
+                false
+            }
+            Err(_) => {
+                tracing::warn!(
+                    timeout_ms = SIDE_EFFECTS_DRAIN_TIMEOUT.as_millis() as u64,
+                    "Timed out waiting for side effects drain barrier acknowledgment"
+                );
+                false
+            }
+        }
     }
 
     /// Send a notification of an accepted tx. Return a receiver that will receive the confirmation.
@@ -378,6 +432,8 @@ where
         next_tx_number: u64,
         oneshot_sender: oneshot::Sender<()>,
     },
+    /// Stop the side effects task after all preceding events have been flushed.
+    DrainAndShutdown { ack: oneshot::Sender<()> },
 }
 
 pub(crate) struct AcceptedTxEventContents<S: Spec, Rt: Runtime<S>> {
@@ -386,4 +442,42 @@ pub(crate) struct AcceptedTxEventContents<S: Spec, Rt: Runtime<S>> {
     pub oneshot_sender: oneshot::Sender<AcceptedTx<Confirmation<S, Rt>>>,
     pub sequence_number: SequenceNumber,
     pub tx_idx_within_batch: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use sov_test_utils::{generate_optimistic_runtime, TestSpec as S};
+
+    use super::*;
+
+    generate_optimistic_runtime!(TestRuntime <= );
+
+    #[tokio::test]
+    async fn drain_and_shutdown_sends_barrier_and_waits_for_ack() {
+        let (shutdown_sender, _) = watch::channel(());
+        let cache = BlobsCache::new(Default::default(), None, shutdown_sender.clone());
+        let (executor_events_sender, mut executor_events_receiver) =
+            ExecutorEventsSender::<S, TestRuntime<S>>::new(shutdown_sender, cache);
+
+        let side_effects = tokio::spawn(async move {
+            match executor_events_receiver.recv().await.unwrap() {
+                ExecutorEvent::DrainAndShutdown { ack } => ack.send(()).unwrap(),
+                _ => panic!("Expected drain-and-shutdown barrier"),
+            }
+        });
+
+        assert!(executor_events_sender.drain_and_shutdown().await);
+        side_effects.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn drain_and_shutdown_returns_false_if_receiver_dropped() {
+        let (shutdown_sender, _) = watch::channel(());
+        let cache = BlobsCache::new(Default::default(), None, shutdown_sender.clone());
+        let (executor_events_sender, executor_events_receiver) =
+            ExecutorEventsSender::<S, TestRuntime<S>>::new(shutdown_sender, cache);
+        drop(executor_events_receiver);
+
+        assert!(!executor_events_sender.drain_and_shutdown().await);
+    }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/executor_events.rs
@@ -18,12 +18,6 @@ use crate::preferred::{PreferredBlobToReplay, PreferredProofToReplay};
 use crate::{PreferredProofDataBytes, SlotNumber};
 
 const MAX_EXECUTOR_EVENT_QUEUE_DEPTH: usize = 1000;
-/// How long any shutdown path waits for the side effects task to process the
-/// [`ExecutorEvent::DrainAndShutdown`] barrier. Shared by the sender side here
-/// and by the heartbeat task that deregisters the node once the drain completes,
-/// so the two waits cannot silently drift apart.
-pub(crate) const SIDE_EFFECTS_DRAIN_TIMEOUT: std::time::Duration =
-    std::time::Duration::from_secs(5);
 
 pub(crate) struct ExecutorEventsSender<S: Spec, Rt: Runtime<S>> {
     events_sender: mpsc::Sender<ExecutorEvent<S, Rt>>,
@@ -75,59 +69,6 @@ impl<S: Spec, Rt: Runtime<S>> ExecutorEventsSender<S, Rt> {
         sov_metrics::track_metrics(|t| {
             t.submit(metrics);
         });
-    }
-
-    pub(crate) async fn drain_and_shutdown(&self) -> bool {
-        let (ack_sender, ack_receiver) = oneshot::channel();
-        let event = ExecutorEvent::DrainAndShutdown { ack: ack_sender };
-
-        match self.events_sender.try_send(event) {
-            Ok(()) => {}
-            Err(TrySendError::Full(event)) => {
-                let send_result = tokio::time::timeout(
-                    SIDE_EFFECTS_DRAIN_TIMEOUT,
-                    self.events_sender.send(event),
-                )
-                .await;
-                match send_result {
-                    Ok(Ok(())) => {}
-                    Ok(Err(_)) => {
-                        tracing::warn!(
-                            "Side effects task exited before shutdown drain barrier was sent"
-                        );
-                        return false;
-                    }
-                    Err(_) => {
-                        tracing::warn!(
-                            timeout_ms = SIDE_EFFECTS_DRAIN_TIMEOUT.as_millis() as u64,
-                            "Timed out sending side effects drain barrier during shutdown"
-                        );
-                        return false;
-                    }
-                }
-            }
-            Err(TrySendError::Closed(_)) => {
-                tracing::warn!("Side effects task exited before shutdown drain barrier was sent");
-                return false;
-            }
-        }
-
-        match tokio::time::timeout(SIDE_EFFECTS_DRAIN_TIMEOUT, ack_receiver).await {
-            Ok(Ok(())) => true,
-            Ok(Err(_)) => {
-                tracing::warn!(
-                    "Side effects task exited before acknowledging shutdown drain barrier"
-                );
-                false
-            }
-            Err(_) => {
-                tracing::warn!(
-                    timeout_ms = SIDE_EFFECTS_DRAIN_TIMEOUT.as_millis() as u64,
-                    "Timed out waiting for side effects drain barrier acknowledgment"
-                );
-                false
-            }
-        }
     }
 
     /// Send a notification of an accepted tx. Return a receiver that will receive the confirmation.
@@ -437,8 +378,6 @@ where
         next_tx_number: u64,
         oneshot_sender: oneshot::Sender<()>,
     },
-    /// Stop the side effects task after all preceding events have been flushed.
-    DrainAndShutdown { ack: oneshot::Sender<()> },
 }
 
 pub(crate) struct AcceptedTxEventContents<S: Spec, Rt: Runtime<S>> {
@@ -447,42 +386,4 @@ pub(crate) struct AcceptedTxEventContents<S: Spec, Rt: Runtime<S>> {
     pub oneshot_sender: oneshot::Sender<AcceptedTx<Confirmation<S, Rt>>>,
     pub sequence_number: SequenceNumber,
     pub tx_idx_within_batch: u64,
-}
-
-#[cfg(test)]
-mod tests {
-    use sov_test_utils::{generate_optimistic_runtime, TestSpec as S};
-
-    use super::*;
-
-    generate_optimistic_runtime!(TestRuntime <= );
-
-    #[tokio::test]
-    async fn drain_and_shutdown_sends_barrier_and_waits_for_ack() {
-        let (shutdown_sender, _) = watch::channel(());
-        let cache = BlobsCache::new(Default::default(), None, shutdown_sender.clone());
-        let (executor_events_sender, mut executor_events_receiver) =
-            ExecutorEventsSender::<S, TestRuntime<S>>::new(shutdown_sender, cache);
-
-        let side_effects = tokio::spawn(async move {
-            match executor_events_receiver.recv().await.unwrap() {
-                ExecutorEvent::DrainAndShutdown { ack } => ack.send(()).unwrap(),
-                _ => panic!("Expected drain-and-shutdown barrier"),
-            }
-        });
-
-        assert!(executor_events_sender.drain_and_shutdown().await);
-        side_effects.await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn drain_and_shutdown_returns_false_if_receiver_dropped() {
-        let (shutdown_sender, _) = watch::channel(());
-        let cache = BlobsCache::new(Default::default(), None, shutdown_sender.clone());
-        let (executor_events_sender, executor_events_receiver) =
-            ExecutorEventsSender::<S, TestRuntime<S>>::new(shutdown_sender, cache);
-        drop(executor_events_receiver);
-
-        assert!(!executor_events_sender.drain_and_shutdown().await);
-    }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::preferred::db::heartbeat_task::HeartBeatTask;
+use crate::preferred::db::heartbeat_task::{heartbeat_stopped_channel, HeartBeatTask};
 use crate::preferred::db::SequencerRole;
 use anyhow::Context;
 use anyhow::Result;
@@ -192,6 +192,16 @@ where
         let synchronized_state_task = synchronized_state.start().await;
         handles.push(synchronized_state_task);
 
+        let (heartbeat_stopped_sender, heartbeat_stopped_receiver) =
+            if matches!(seq_role, SequencerRole::BatchProducer)
+                && preferred_config.postgres_config.is_some()
+            {
+                let (sender, receiver) = heartbeat_stopped_channel();
+                (Some(sender), Some(receiver))
+            } else {
+                (None, None)
+            };
+
         let side_effects_task = SideEffectsTask {
             checkpoint_sender,
             blob_sender,
@@ -200,6 +210,7 @@ where
             api_ledger_db,
             shutdown_sender: shutdown_sender.clone(),
             transaction_cache: cached_txs.write_handle(),
+            heartbeat_stopped_receiver,
         }
         .spawn();
         handles.push(side_effects_task);
@@ -258,6 +269,7 @@ where
                 shutdown_sender.clone(),
                 bind_addr,
                 postgres_config.leader_election.heartbeat_interval(),
+                heartbeat_stopped_sender,
             )
             .await?;
             let heartbeat_handle = heartbeat_task.spawn(seq_role).await;

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{broadcast, mpsc, watch};
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 use tracing::debug;
 
@@ -130,6 +130,7 @@ where
 
         let (executor_events_sender, executor_events_receiver) =
             ExecutorEventsSender::new(shutdown_sender.clone(), db_cache);
+        let (side_effects_drained_sender, side_effects_drained_receiver) = oneshot::channel();
 
         let in_flight_batch_blobs = blob_sender.nb_of_in_flight_batch_blobs();
         let in_flight_proof_blobs = blob_sender.nb_of_in_flight_proof_blobs();
@@ -200,6 +201,7 @@ where
             api_ledger_db,
             shutdown_sender: shutdown_sender.clone(),
             transaction_cache: cached_txs.write_handle(),
+            side_effects_drained_sender,
         }
         .spawn();
         handles.push(side_effects_task);
@@ -258,6 +260,7 @@ where
                 shutdown_sender.clone(),
                 bind_addr,
                 postgres_config.leader_election.heartbeat_interval(),
+                side_effects_drained_receiver,
             )
             .await?;
             let heartbeat_handle = heartbeat_task.spawn(seq_role).await;

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{broadcast, mpsc, oneshot, watch};
+use tokio::sync::{broadcast, mpsc, watch};
 use tokio::task::JoinHandle;
 use tracing::debug;
 
@@ -130,7 +130,6 @@ where
 
         let (executor_events_sender, executor_events_receiver) =
             ExecutorEventsSender::new(shutdown_sender.clone(), db_cache);
-        let (side_effects_drained_sender, side_effects_drained_receiver) = oneshot::channel();
 
         let in_flight_batch_blobs = blob_sender.nb_of_in_flight_batch_blobs();
         let in_flight_proof_blobs = blob_sender.nb_of_in_flight_proof_blobs();
@@ -201,7 +200,6 @@ where
             api_ledger_db,
             shutdown_sender: shutdown_sender.clone(),
             transaction_cache: cached_txs.write_handle(),
-            side_effects_drained_sender,
         }
         .spawn();
         handles.push(side_effects_task);
@@ -260,7 +258,6 @@ where
                 shutdown_sender.clone(),
                 bind_addr,
                 postgres_config.leader_election.heartbeat_interval(),
-                side_effects_drained_receiver,
             )
             .await?;
             let heartbeat_handle = heartbeat_task.spawn(seq_role).await;

--- a/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
@@ -333,10 +333,10 @@ where
     }
 
     async fn receive_and_process_events(
-        &mut self,
+        mut self,
         mut event_queue: VecDeque<ExecutorEvent<S, Rt>>,
         max_queue_size: usize,
-    ) -> bool {
+    ) {
         while let Some(event) = self.executor_events_receiver.recv().await {
             event_queue.push_back(event);
             while event_queue.len() < max_queue_size {
@@ -350,30 +350,31 @@ where
             while !event_queue.is_empty() {
                 match self.handle_executor_event(&mut event_queue).await {
                     Ok(SideEffectsEventOutcome::Continue) => {}
-                    Ok(SideEffectsEventOutcome::DrainedAndShutdown) => return true,
+                    Ok(SideEffectsEventOutcome::DrainedAndShutdown) => {
+                        // The drain barrier is the last event we process: every
+                        // preceding side effect is now flushed, so signal the
+                        // heartbeat task that it is safe to deregister this node.
+                        let _ = self.side_effects_drained_sender.send(());
+                        return;
+                    }
                     Err(e) => {
                         tracing::error!(error = ?e, "Error handling executor event");
                         // If we've already started shutting down, this might fail - but then we're happy.
                         let _ = self.shutdown_sender.send(());
-                        return false;
+                        return;
                     }
                 }
             }
         }
-        false
     }
 
-    pub(crate) fn spawn(mut self) -> JoinHandle<()> {
+    pub(crate) fn spawn(self) -> JoinHandle<()> {
         // We use a queue so that we can batch insert txs.
         let max_queue_size = self.executor_events_receiver.max_capacity();
         let event_queue = VecDeque::with_capacity(max_queue_size);
         tokio::spawn(async move {
-            if self
-                .receive_and_process_events(event_queue, max_queue_size)
-                .await
-            {
-                let _ = self.side_effects_drained_sender.send(());
-            }
+            self.receive_and_process_events(event_queue, max_queue_size)
+                .await;
         })
     }
 }

--- a/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use sov_modules_api::{ConcurrentStateCheckpoint, Runtime, Spec, StateCheckpoint};
 use sov_rollup_interface::node::da::DaService;
 use std::sync::Arc;
-use tokio::sync::{mpsc, oneshot, watch};
+use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 use tracing::{debug, enabled, error, warn, Level};
 
@@ -32,12 +32,6 @@ where
     pub executor_events_receiver: mpsc::Receiver<ExecutorEvent<S, Rt>>,
     pub shutdown_sender: watch::Sender<()>,
     pub transaction_cache: TxResultWriter<S, Rt>,
-    pub side_effects_drained_sender: oneshot::Sender<()>,
-}
-
-enum SideEffectsEventOutcome {
-    Continue,
-    DrainedAndShutdown,
 }
 
 impl<S, Rt, Da> SideEffectsTask<S, Rt, Da>
@@ -160,14 +154,14 @@ where
     async fn handle_executor_event(
         &mut self,
         event_queue: &mut VecDeque<ExecutorEvent<S, Rt>>,
-    ) -> Result<SideEffectsEventOutcome> {
+    ) -> Result<()> {
         let queue_size_before = event_queue.len();
         let next_event = event_queue
             .pop_front()
             .expect("Tried to pop from empty event queue. This is a bug, please report it");
         let event_type: &'static str = (&next_event).into();
         let start_time = std::time::Instant::now();
-        let outcome = match next_event {
+        match next_event {
             ExecutorEvent::AcceptedTx(contents) => {
                 let sequence_number = contents.sequence_number;
                 let tx_idx_within_batch = contents.tx_idx_within_batch;
@@ -209,7 +203,6 @@ where
                     let _ = oneshot.send(tx.clone());
                     self.transaction_cache.insert(tx).await;
                 }
-                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::CloseBatch {
                 batch,
@@ -227,7 +220,6 @@ where
                 for tx in forced_txs {
                     self.transaction_cache.insert(tx).await;
                 }
-                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::StartBatch {
                 visible_slot_number_after_increase,
@@ -245,7 +237,6 @@ where
                     )
                     .await?;
                 self.update_api_state(new_checkpoint);
-                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::TriggerRecovery {
                 blobs_to_flush,
@@ -264,7 +255,6 @@ where
                 }
                 self.trigger_recovery(blobs_to_flush, recovery_strategy)
                     .await?;
-                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::PublishProofBlob(blob_id, data, sequence_number) => {
                 self.db
@@ -273,12 +263,10 @@ where
                 self.blob_sender
                     .publish_proof(data, sequence_number, blob_id)
                     .await?;
-                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::ForceUpdateApiState(new_checkpoint) => {
                 Self::maybe_delay_api_state_update_for_tests().await;
                 self.update_api_state(new_checkpoint);
-                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::UpdateApiLedger {
                 ledger_reader,
@@ -293,16 +281,13 @@ where
                     next_tx_number,
                 )
                 .await;
-                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::PruneDb(sequence_number) => {
                 self.db.prune_db(sequence_number).await?;
-                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::UpdateStateForRecovery(checkpoint) => {
                 Self::maybe_delay_api_state_update_for_tests().await;
                 self.update_api_state(checkpoint);
-                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::FlushTransactionsCache {
                 next_tx_number,
@@ -312,11 +297,6 @@ where
                     .clean_and_overwrite_next_tx_number(next_tx_number)
                     .await;
                 let _ = oneshot_sender.send(());
-                SideEffectsEventOutcome::Continue
-            }
-            ExecutorEvent::DrainAndShutdown { ack } => {
-                let _ = ack.send(());
-                SideEffectsEventOutcome::DrainedAndShutdown
             }
         };
         let queue_size_after = event_queue.len();
@@ -329,7 +309,7 @@ where
                 batch_size,
             });
         });
-        Ok(outcome)
+        Ok(())
     }
 
     async fn receive_and_process_events(
@@ -348,24 +328,19 @@ where
             }
 
             while !event_queue.is_empty() {
-                match self.handle_executor_event(&mut event_queue).await {
-                    Ok(SideEffectsEventOutcome::Continue) => {}
-                    Ok(SideEffectsEventOutcome::DrainedAndShutdown) => {
-                        // The drain barrier is the last event we process: every
-                        // preceding side effect is now flushed, so signal the
-                        // heartbeat task that it is safe to deregister this node.
-                        let _ = self.side_effects_drained_sender.send(());
-                        return;
-                    }
-                    Err(e) => {
-                        tracing::error!(error = ?e, "Error handling executor event");
-                        // If we've already started shutting down, this might fail - but then we're happy.
-                        let _ = self.shutdown_sender.send(());
-                        return;
-                    }
+                if let Err(e) = self.handle_executor_event(&mut event_queue).await {
+                    tracing::error!(error = ?e, "Error handling executor event");
+                    // If we've already started shutting down, this might fail - but then we're happy.
+                    let _ = self.shutdown_sender.send(());
+                    return;
                 }
             }
         }
+
+        tracing::debug!(
+            "Executor event sender dropped after side effects drained; deregistering node if applicable"
+        );
+        self.db.deregister_node_on_shutdown_best_effort().await;
     }
 
     pub(crate) fn spawn(self) -> JoinHandle<()> {
@@ -487,24 +462,6 @@ mod tests {
             // We should get back the event that we passed and no others. The queue should be untouched
             assert_eq!(drained_txs.len(), 1);
             assert_eq!(event_queue.len(), 2);
-        }
-
-        // Test that a shutdown drain barrier is not batched with accepted txs.
-        {
-            let first_event = create_accepted_tx_event(0);
-            let second_event = create_accepted_tx_event(1);
-            let (ack, _) = oneshot::channel();
-            let mut event_queue =
-                vec![ExecutorEvent::DrainAndShutdown { ack }, second_event].into();
-            let drained_txs =
-                drain_consecutive_accepted_txs(extract_contents(first_event), &mut event_queue);
-
-            assert_eq!(drained_txs.len(), 1);
-            assert_eq!(event_queue.len(), 2);
-            match event_queue.pop_front().unwrap() {
-                ExecutorEvent::DrainAndShutdown { .. } => {}
-                _ => panic!("Expected drain-and-shutdown barrier"),
-            }
         }
 
         // test a large queue size

--- a/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
@@ -10,6 +10,7 @@ use tracing::{debug, enabled, error, warn, Level};
 
 use super::executor_events::ExecutorEvent;
 use crate::metrics::PreferredSequencerExecutorEventMetrics;
+use crate::preferred::db::heartbeat_task::HeartbeatStoppedReceiver;
 use crate::preferred::db::BatchToStore;
 use crate::preferred::executor_events::AcceptedTxEventContents;
 use crate::preferred::transaction_subscriptions::TxResultWriter;
@@ -32,6 +33,7 @@ where
     pub executor_events_receiver: mpsc::Receiver<ExecutorEvent<S, Rt>>,
     pub shutdown_sender: watch::Sender<()>,
     pub transaction_cache: TxResultWriter<S, Rt>,
+    pub heartbeat_stopped_receiver: Option<HeartbeatStoppedReceiver>,
 }
 
 impl<S, Rt, Da> SideEffectsTask<S, Rt, Da>
@@ -337,8 +339,10 @@ where
             }
         }
 
+        tracing::debug!("Executor event sender dropped after side effects drained");
+        wait_for_heartbeat_task_to_stop(self.heartbeat_stopped_receiver.take()).await;
         tracing::debug!(
-            "Executor event sender dropped after side effects drained; deregistering node if applicable"
+            "Side effects drained and heartbeat stopped; deregistering node if applicable"
         );
         self.db.deregister_node_on_shutdown_best_effort().await;
     }
@@ -369,6 +373,17 @@ fn drain_consecutive_accepted_txs<S: Spec, Rt: Runtime<S>>(
         }
     }
     txs_to_insert
+}
+
+async fn wait_for_heartbeat_task_to_stop(
+    heartbeat_stopped_receiver: Option<HeartbeatStoppedReceiver>,
+) {
+    let Some(heartbeat_stopped_receiver) = heartbeat_stopped_receiver else {
+        return;
+    };
+
+    tracing::debug!("Waiting for heartbeat task to stop before deregistering node");
+    let _ = heartbeat_stopped_receiver.await;
 }
 
 #[cfg(test)]
@@ -425,6 +440,21 @@ mod tests {
                 _ => panic!("Expected AcceptedTx event"),
             }
         }
+    }
+
+    #[tokio::test]
+    async fn waits_for_heartbeat_stop_before_barrier_returns() {
+        let (sender, receiver) = oneshot::channel();
+        let wait = wait_for_heartbeat_task_to_stop(Some(receiver));
+        tokio::pin!(wait);
+
+        tokio::select! {
+            () = &mut wait => panic!("Heartbeat stop barrier returned before heartbeat stopped"),
+            () = tokio::task::yield_now() => {}
+        }
+
+        let _ = sender.send(());
+        wait.await;
     }
 
     #[tokio::test]

--- a/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/side_effects.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use sov_modules_api::{ConcurrentStateCheckpoint, Runtime, Spec, StateCheckpoint};
 use sov_rollup_interface::node::da::DaService;
 use std::sync::Arc;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 use tracing::{debug, enabled, error, warn, Level};
 
@@ -32,6 +32,12 @@ where
     pub executor_events_receiver: mpsc::Receiver<ExecutorEvent<S, Rt>>,
     pub shutdown_sender: watch::Sender<()>,
     pub transaction_cache: TxResultWriter<S, Rt>,
+    pub side_effects_drained_sender: oneshot::Sender<()>,
+}
+
+enum SideEffectsEventOutcome {
+    Continue,
+    DrainedAndShutdown,
 }
 
 impl<S, Rt, Da> SideEffectsTask<S, Rt, Da>
@@ -154,14 +160,14 @@ where
     async fn handle_executor_event(
         &mut self,
         event_queue: &mut VecDeque<ExecutorEvent<S, Rt>>,
-    ) -> Result<()> {
+    ) -> Result<SideEffectsEventOutcome> {
         let queue_size_before = event_queue.len();
         let next_event = event_queue
             .pop_front()
             .expect("Tried to pop from empty event queue. This is a bug, please report it");
         let event_type: &'static str = (&next_event).into();
         let start_time = std::time::Instant::now();
-        match next_event {
+        let outcome = match next_event {
             ExecutorEvent::AcceptedTx(contents) => {
                 let sequence_number = contents.sequence_number;
                 let tx_idx_within_batch = contents.tx_idx_within_batch;
@@ -203,6 +209,7 @@ where
                     let _ = oneshot.send(tx.clone());
                     self.transaction_cache.insert(tx).await;
                 }
+                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::CloseBatch {
                 batch,
@@ -220,6 +227,7 @@ where
                 for tx in forced_txs {
                     self.transaction_cache.insert(tx).await;
                 }
+                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::StartBatch {
                 visible_slot_number_after_increase,
@@ -237,6 +245,7 @@ where
                     )
                     .await?;
                 self.update_api_state(new_checkpoint);
+                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::TriggerRecovery {
                 blobs_to_flush,
@@ -255,6 +264,7 @@ where
                 }
                 self.trigger_recovery(blobs_to_flush, recovery_strategy)
                     .await?;
+                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::PublishProofBlob(blob_id, data, sequence_number) => {
                 self.db
@@ -263,10 +273,12 @@ where
                 self.blob_sender
                     .publish_proof(data, sequence_number, blob_id)
                     .await?;
+                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::ForceUpdateApiState(new_checkpoint) => {
                 Self::maybe_delay_api_state_update_for_tests().await;
                 self.update_api_state(new_checkpoint);
+                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::UpdateApiLedger {
                 ledger_reader,
@@ -281,13 +293,16 @@ where
                     next_tx_number,
                 )
                 .await;
+                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::PruneDb(sequence_number) => {
                 self.db.prune_db(sequence_number).await?;
+                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::UpdateStateForRecovery(checkpoint) => {
                 Self::maybe_delay_api_state_update_for_tests().await;
                 self.update_api_state(checkpoint);
+                SideEffectsEventOutcome::Continue
             }
             ExecutorEvent::FlushTransactionsCache {
                 next_tx_number,
@@ -297,8 +312,13 @@ where
                     .clean_and_overwrite_next_tx_number(next_tx_number)
                     .await;
                 let _ = oneshot_sender.send(());
+                SideEffectsEventOutcome::Continue
             }
-        }
+            ExecutorEvent::DrainAndShutdown { ack } => {
+                let _ = ack.send(());
+                SideEffectsEventOutcome::DrainedAndShutdown
+            }
+        };
         let queue_size_after = event_queue.len();
         let batch_size = queue_size_before - queue_size_after;
         let duration = start_time.elapsed();
@@ -309,14 +329,14 @@ where
                 batch_size,
             });
         });
-        Ok(())
+        Ok(outcome)
     }
 
     async fn receive_and_process_events(
         &mut self,
         mut event_queue: VecDeque<ExecutorEvent<S, Rt>>,
         max_queue_size: usize,
-    ) {
+    ) -> bool {
         while let Some(event) = self.executor_events_receiver.recv().await {
             event_queue.push_back(event);
             while event_queue.len() < max_queue_size {
@@ -328,14 +348,19 @@ where
             }
 
             while !event_queue.is_empty() {
-                if let Err(e) = self.handle_executor_event(&mut event_queue).await {
-                    tracing::error!(error = ?e, "Error handling executor event");
-                    // If we've already started shutting down, this might fail - but then we're happy.
-                    let _ = self.shutdown_sender.send(());
-                    break;
+                match self.handle_executor_event(&mut event_queue).await {
+                    Ok(SideEffectsEventOutcome::Continue) => {}
+                    Ok(SideEffectsEventOutcome::DrainedAndShutdown) => return true,
+                    Err(e) => {
+                        tracing::error!(error = ?e, "Error handling executor event");
+                        // If we've already started shutting down, this might fail - but then we're happy.
+                        let _ = self.shutdown_sender.send(());
+                        return false;
+                    }
                 }
             }
         }
+        false
     }
 
     pub(crate) fn spawn(mut self) -> JoinHandle<()> {
@@ -343,8 +368,12 @@ where
         let max_queue_size = self.executor_events_receiver.max_capacity();
         let event_queue = VecDeque::with_capacity(max_queue_size);
         tokio::spawn(async move {
-            self.receive_and_process_events(event_queue, max_queue_size)
-                .await;
+            if self
+                .receive_and_process_events(event_queue, max_queue_size)
+                .await
+            {
+                let _ = self.side_effects_drained_sender.send(());
+            }
         })
     }
 }
@@ -457,6 +486,24 @@ mod tests {
             // We should get back the event that we passed and no others. The queue should be untouched
             assert_eq!(drained_txs.len(), 1);
             assert_eq!(event_queue.len(), 2);
+        }
+
+        // Test that a shutdown drain barrier is not batched with accepted txs.
+        {
+            let first_event = create_accepted_tx_event(0);
+            let second_event = create_accepted_tx_event(1);
+            let (ack, _) = oneshot::channel();
+            let mut event_queue =
+                vec![ExecutorEvent::DrainAndShutdown { ack }, second_event].into();
+            let drained_txs =
+                drain_consecutive_accepted_txs(extract_contents(first_event), &mut event_queue);
+
+            assert_eq!(drained_txs.len(), 1);
+            assert_eq!(event_queue.len(), 2);
+            match event_queue.pop_front().unwrap() {
+                ExecutorEvent::DrainAndShutdown { .. } => {}
+                _ => panic!("Expected drain-and-shutdown barrier"),
+            }
         }
 
         // test a large queue size

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -35,6 +35,7 @@ use sov_modules_api::capabilities::{RollupHeight, SequencingDataHandler};
 use sov_modules_api::state::{ApiStateAccessor, ConcurrentStateCheckpoint};
 use sov_modules_api::{FullyBakedTx, Runtime, Spec, StateCheckpoint, VersionReader};
 use sov_rollup_full_node_interface::StateUpdateInfo;
+use sov_rollup_interface::node::{future_or_shutdown, FutureOrShutdownOutput};
 use sov_state::Storage;
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -172,12 +173,14 @@ where
 
                 // If we don't have any more messages to process, yield until a message becomes available
                 if self.heap.is_empty() {
-                    let msg = tokio::select! {
-                        msg = self.message_receiver.recv() => msg,
-                        changed = self.inner.shutdown_receiver.changed() => {
-                            if changed.is_err() {
-                                tracing::debug!("Shutdown sender dropped while sequencer state was idle");
-                            }
+                    let msg = match future_or_shutdown(
+                        self.message_receiver.recv(),
+                        &self.inner.shutdown_receiver,
+                    )
+                    .await
+                    {
+                        FutureOrShutdownOutput::Output(msg) => msg,
+                        FutureOrShutdownOutput::Shutdown => {
                             self.drain_side_effects_on_shutdown().await;
                             return;
                         }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -104,16 +104,6 @@ where
         self.heap.len() >= Self::MAX_HEAP_SIZE
     }
 
-    async fn drain_side_effects_on_shutdown(&self) {
-        if self.inner.executor_events_sender.drain_and_shutdown().await {
-            tracing::debug!("Side effects drained before sequencer state shutdown");
-        } else {
-            tracing::warn!(
-                "Sequencer state shut down before side effects drain could be confirmed"
-            );
-        }
-    }
-
     pub(crate) async fn start(mut self) -> JoinHandle<()> {
         tokio::spawn(async move {
             let mut index = 0;
@@ -160,7 +150,6 @@ where
                     if let Err(e) = self.handle_next_message(msg).await {
                         match e {
                             SequencerStateUpdatorError::Shutdown => {
-                                self.drain_side_effects_on_shutdown().await;
                                 return;
                             }
                             SequencerStateUpdatorError::Unexpected => {
@@ -181,7 +170,6 @@ where
                     {
                         FutureOrShutdownOutput::Output(msg) => msg,
                         FutureOrShutdownOutput::Shutdown => {
-                            self.drain_side_effects_on_shutdown().await;
                             return;
                         }
                     };

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -103,6 +103,16 @@ where
         self.heap.len() >= Self::MAX_HEAP_SIZE
     }
 
+    async fn drain_side_effects_on_shutdown(&self) {
+        if self.inner.executor_events_sender.drain_and_shutdown().await {
+            tracing::debug!("Side effects drained before sequencer state shutdown");
+        } else {
+            tracing::warn!(
+                "Sequencer state shut down before side effects drain could be confirmed"
+            );
+        }
+    }
+
     pub(crate) async fn start(mut self) -> JoinHandle<()> {
         tokio::spawn(async move {
             let mut index = 0;
@@ -149,6 +159,7 @@ where
                     if let Err(e) = self.handle_next_message(msg).await {
                         match e {
                             SequencerStateUpdatorError::Shutdown => {
+                                self.drain_side_effects_on_shutdown().await;
                                 return;
                             }
                             SequencerStateUpdatorError::Unexpected => {
@@ -161,7 +172,17 @@ where
 
                 // If we don't have any more messages to process, yield until a message becomes available
                 if self.heap.is_empty() {
-                    let Some(msg) = self.message_receiver.recv().await else {
+                    let msg = tokio::select! {
+                        msg = self.message_receiver.recv() => msg,
+                        changed = self.inner.shutdown_receiver.changed() => {
+                            if changed.is_err() {
+                                tracing::debug!("Shutdown sender dropped while sequencer state was idle");
+                            }
+                            self.drain_side_effects_on_shutdown().await;
+                            return;
+                        }
+                    };
+                    let Some(msg) = msg else {
                         break;
                     };
                     assert!(

--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -230,6 +230,9 @@ impl NodeDiscovery {
             }
         }
 
+        // A `leader_id` with no matching node row is expected, not an error: a leader
+        // that gracefully shuts down deletes its `nodes` row while `sequencer_leader`
+        // still points at it. Callers treat `leader: None` as "no routable leader yet".
         Ok(ClusterInfo { leader, followers })
     }
 

--- a/crates/utils/sov-proxy-utils/src/node_discovery.rs
+++ b/crates/utils/sov-proxy-utils/src/node_discovery.rs
@@ -230,12 +230,6 @@ impl NodeDiscovery {
             }
         }
 
-        if let Some(leader_id) = &leader_id {
-            if leader.is_none() {
-                anyhow::bail!("Leader is missing from the Nodes table. leader_id: {leader_id}, followers: {followers:?}");
-            }
-        }
-
         Ok(ClusterInfo { leader, followers })
     }
 
@@ -425,7 +419,7 @@ mod tests {
     }
 
     #[test]
-    fn cluster_errors_when_leader_not_in_nodes() {
+    fn cluster_treats_missing_leader_node_as_no_routable_leader() {
         let ts = test_timestamp();
         let result = NodeDiscovery::cluster(
             Some("missing_leader".to_string()),
@@ -435,10 +429,10 @@ mod tests {
             ],
         );
 
-        let err = result.unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("Leader is missing from the Nodes table."));
+        let cluster = result.unwrap();
+        assert!(cluster.leader.is_none());
+        assert!(cluster.has_follower("node1"));
+        assert!(cluster.has_follower("node2"));
     }
 
     #[test]


### PR DESCRIPTION
# Description

This should minimize failed requests during regular deployment, because node-discovery service will immediately exclude stopping service from nginx

----

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
Add unit test

## Docs
No updates
