### PR TITLE
Replace HTTP 503 "Other" Message with more descriptive variant

### DIFF
--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -481,8 +481,8 @@ where
                 Ok(result)
             }
             Err(e) => match e {
-                AcceptTxError::SequencerOverloaded503 => {
-                    return Err(sequencer_overloaded_503("Other"));
+                AcceptTxError::SequencerOverloaded503(reason) => {
+                    return Err(sequencer_overloaded_503(reason));
                 }
                 AcceptTxError::NotFullySynced(details) => {
                     return Err(error_not_fully_synced(details))

--- a/crates/full-node/sov-sequencer/src/preferred/nonce_buffer_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/nonce_buffer_task.rs
@@ -464,7 +464,10 @@ impl<E: TxExecutionBackend<S, Rt> + Clone + Send + Sync + 'static, S: Spec, Rt: 
         }
     }
 
-    fn drain_and_reject_all_txs(&mut self, reject_error: fn() -> TransactionReceiverResult<S, Rt>) {
+    fn drain_and_reject_all_txs(
+        &mut self,
+        reject_error: impl Fn() -> TransactionReceiverResult<S, Rt>,
+    ) {
         while let Ok(input) = self.buffer_input.try_recv() {
             match input {
                 NonceBufferInput::NewTx { result_sender, .. } => {
@@ -640,8 +643,9 @@ impl<E: TxExecutionBackend<S, Rt> + Clone + Send + Sync + 'static, S: Spec, Rt: 
                                             if self.execution_backend.get_current_executor_tx_queue_id()
                                                 > original_tx_queue_id
                                             {
-                                                let _ = result_sender.send(wipe_reject_error());
-                                                self.drain_and_reject_all_txs(wipe_reject_error::<S, Rt>);
+                                                let reason = "Executor queue advanced after downtime";
+                                                let _ = result_sender.send(wipe_reject_error(reason));
+                                                self.drain_and_reject_all_txs(|| wipe_reject_error::<S, Rt>(reason));
                                                 continue;
                                             }
                                             queue.non_persisted.mark_inflight(tx_nonce);
@@ -705,7 +709,11 @@ impl<E: TxExecutionBackend<S, Rt> + Clone + Send + Sync + 'static, S: Spec, Rt: 
                                     // sequencer anyway so we wipe everything.
                                     if is_notready_error(&tx_result) {
                                         let _ = result_sender.send(tx_result);
-                                        self.drain_and_reject_all_txs(wipe_reject_error::<S, Rt>);
+                                        self.drain_and_reject_all_txs(|| {
+                                            wipe_reject_error::<S, Rt>(
+                                                "Sequencer not ready; nonce buffer wiped",
+                                            )
+                                        });
                                         continue;
                                     }
 
@@ -796,11 +804,15 @@ impl<E: TxExecutionBackend<S, Rt> + Clone + Send + Sync + 'static, S: Spec, Rt: 
                     match forced_tx_batch {
                         Ok(notification) => {
                             tracing::info!(?notification, "Wiping nonce buffer after forced batch execution");
-                            self.drain_and_reject_all_txs(wipe_reject_error::<S, Rt>);
+                            self.drain_and_reject_all_txs(|| {
+                                wipe_reject_error::<S, Rt>("Nonce buffer wiped after forced batch")
+                            });
                         }
                         Err(broadcast::error::RecvError::Lagged(skipped)) => {
                             tracing::warn!(skipped, "Forced batch notifications lagged; wiping nonce buffer");
-                            self.drain_and_reject_all_txs(wipe_reject_error::<S, Rt>);
+                            self.drain_and_reject_all_txs(|| {
+                                wipe_reject_error::<S, Rt>("Forced batch notifications lagged")
+                            });
                         }
                         Err(broadcast::error::RecvError::Closed) => {
                             wipe_closed = true;
@@ -1002,8 +1014,10 @@ fn err_invalid_nonce<S: Spec, Rt: Runtime<S>>(
     ))))
 }
 
-fn wipe_reject_error<S: Spec, Rt: Runtime<S>>() -> TransactionReceiverResult<S, Rt> {
-    Ok(Err(AcceptTxError::SequencerOverloaded503))
+fn wipe_reject_error<S: Spec, Rt: Runtime<S>>(
+    reason: &'static str,
+) -> TransactionReceiverResult<S, Rt> {
+    Ok(Err(AcceptTxError::SequencerOverloaded503(reason)))
 }
 
 fn shutdown_reject_error<S: Spec, Rt: Runtime<S>>() -> TransactionReceiverResult<S, Rt> {
@@ -1018,7 +1032,7 @@ fn is_notready_error<S: Spec, Rt: Runtime<S>>(result: &TransactionReceiverResult
             Err(accept_tx_error) => match accept_tx_error {
                 AcceptTxError::NotFullySynced(_) => true,
                 AcceptTxError::ReplicaMode
-                | AcceptTxError::SequencerOverloaded503
+                | AcceptTxError::SequencerOverloaded503(_)
                 | AcceptTxError::BatchError { .. }
                 | AcceptTxError::NewTxError(_)
                 | AcceptTxError::RateLimiter(_) => false,
@@ -1667,7 +1681,7 @@ mod tests {
                     let err = inner.expect_err(&format!("Expected tx {i} to fail with rejection"));
 
                     assert!(
-                        matches!(err, AcceptTxError::SequencerOverloaded503),
+                        matches!(err, AcceptTxError::SequencerOverloaded503(_)),
                         "Tx {i}: Expected SequencerOverloaded503 rejection, got: {err:?}"
                     );
                 }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
@@ -262,7 +262,7 @@ type AcceptTxRet<S, Rt> =
 
 #[derive(Debug)]
 pub(crate) enum AcceptTxError<S: Spec> {
-    SequencerOverloaded503,
+    SequencerOverloaded503(&'static str),
     NotFullySynced(SequencerNotReadyDetails),
     BatchError {
         batch_creation_error: BatchCreationError,

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -132,7 +132,7 @@ where
                         if let Message::AcceptTx { resp, .. } = lowest_priority_msg {
                             self.send_response(
                                 resp,
-                                Err(AcceptTxError::SequencerOverloaded503),
+                                Err(AcceptTxError::SequencerOverloaded503("Message heap full")),
                                 "accept_tx",
                             )
                             .await;
@@ -902,7 +902,9 @@ where
         let new_tx_queue_id = inner.tx_queue_id.load(Ordering::Acquire);
         if new_tx_queue_id != original_tx_queue_id {
             tracing::debug!(%tx_hash, "Transaction was queued before downtime. Dropping.");
-            return Err(AcceptTxError::SequencerOverloaded503);
+            return Err(AcceptTxError::SequencerOverloaded503(
+                "Transaction queued before downtime",
+            ));
         }
 
         inner


### PR DESCRIPTION
# Description

Currently if sequencer is overloaded, we return error for tx:

```
 server returned an error response: error code -32003: 503 Service Unavailable - 'The sequencer is temporarily overloaded. Try again in a few seconds'
  ({"reason": String("Other")})
```

That gives high level overview why tx has been rejected, but misses the details.

This PR propagates actual reasons, so it should be easier to investigate if that happens in production or reported by customer


- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
Existing tests are passing

## Docs
No updates
