### PR TITLE
Remove `CHANGE_GAS_LIMIT_AFTER_HEIGHT`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Temporary section for maintaining breaking changes from individual PRs, which wi
 - #2904 **Breaking change**: for EVM rollups only: removes the `EVM_RECEIPT_ACTUAL_FEE_HEIGHT` constant.
   Receipt `effectiveGasPrice` and projected `gasUsed` are now unconditionally derived from the actual metered fee. 
   Forks that had set this to a non-zero future activation height must migrate; the new behavior is mandatory.
+- #2934 **Breaking Change**: Removes the `CHANGE_GAS_LIMIT_AFTER_HEIGHT` gas-limit fork. The `INITIAL_GAS_LIMIT` and `UPDATED_GAS_LIMIT` constants are replaced by a single `BLOCK_GAS_LIMIT` constant (test override env var `SOV_TEST_CONST_OVERRIDE_INITIAL_GAS_LIMIT` → `SOV_TEST_CONST_OVERRIDE_BLOCK_GAS_LIMIT`). Removes the `sequencer.height_for_gas_limit_computation` rate-limiter config field and the `ChainStateCapability::block_gas_limit` / `ChainState::block_gas_limit{,_at}` methods (use `<S as GasSpec>::block_gas_limit()` instead). The block gas limit is now constant for all heights; the per-block sequencer safeguards (preferred-sequencer pre-exec escrow, zero-bond preferred-sequencer penalization, and the slot-gas-limit pre-check) remain unconditionally enabled.
 
 # 2026-04-01
 - #2670 **Breaking change** Remove `InnerVm` and `OuterVm` generic type parameters from `StateTransitionFunction` trait and all downstream types.

--- a/constants.testing.toml
+++ b/constants.testing.toml
@@ -121,10 +121,8 @@ FIXED_GAS_TO_CHARGE_PER_PROOF = [100, 100]
 # The portion that is not burned is awarded to provers and/or attesters on the network.
 PERCENT_BASE_FEE_TO_BURN = 10
 # --- Gas fee adjustment parameters: See https://eips.ethereum.org/EIPS/eip-1559 for a detailed description ---
-# The initial gas limit of the rollup.
-INITIAL_GAS_LIMIT = [100_000_000_000, 100_000_000_000]
-UPDATED_GAS_LIMIT = [100_000_000_000, 100_000_000_000]
-CHANGE_GAS_LIMIT_AFTER_HEIGHT = 9223372036854775807
+# The gas limit applied to every rollup block.
+BLOCK_GAS_LIMIT = [100_000_000_000, 100_000_000_000]
 # The initial "base fee" that every transaction emits when executed.
 INITIAL_BASE_FEE_PER_GAS = [10, 10]
 # The maximum change denominator of the base fee.

--- a/constants.toml
+++ b/constants.toml
@@ -159,10 +159,8 @@ GAS_TO_CHARGE_PER_PROOF_BYTE = [1, 1]
 FIXED_GAS_TO_CHARGE_PER_PROOF = [100, 100]
 
 # --- Gas fee adjustment parameters: See https://eips.ethereum.org/EIPS/eip-1559 for a detailed description ---
-# The initial gas limit of the rollup.
-INITIAL_GAS_LIMIT = [100_000_000_000, 100_000_000_000]
-UPDATED_GAS_LIMIT = [100_000_000_000, 100_000_000_000]
-CHANGE_GAS_LIMIT_AFTER_HEIGHT = 9223372036854775807
+# The gas limit applied to every rollup block.
+BLOCK_GAS_LIMIT = [100_000_000_000, 100_000_000_000]
 # The initial "base fee" that every transaction emits when executed.
 INITIAL_BASE_FEE_PER_GAS = [10, 10]
 # The maximum change denominator of the base fee.

--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -2,7 +2,6 @@ use std::{net::IpAddr, num::NonZero};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use sov_rollup_interface::common::RollupHeight;
 
 /// See [`SequencerConfig::sequencer_kind_config`].
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
@@ -350,24 +349,6 @@ pub struct SovRateLimiterConfig<Address: Copy> {
     #[serde(deserialize_with = "deserialize_ip_custom_limits")]
     #[schemars(with = "Vec<(IpAddrOrNet, Limits)>")]
     pub ip_custom_limits: Vec<(ipnet::IpNet, Limits)>,
-    /// Rate limiting on gas is currently disabled, so this param has no impact on runtime behavior.
-    ///
-    /// This height is used to statically compute the gas limit for the rate limiter. (If this value is less than or equal to CHANGE_GAS_LIMIT_AFTER_HEIGHT in constants.toml,
-    /// the gas limit will *always* be computed using the initial gas limit for rate limiting. If it is greater, the gas limit will be computed using the updated gas limit.)
-    /// Even after rate limiting based on gas is enabled, you can safely change this param at any time since it only impacts off-chain code.
-    #[serde(
-        default = "default_height_for_gas_limit_computation",
-        skip_serializing_if = "height_is_max"
-    )]
-    pub height_for_gas_limit_computation: RollupHeight,
-}
-
-fn default_height_for_gas_limit_computation() -> RollupHeight {
-    RollupHeight::MAX
-}
-
-fn height_is_max(height: &RollupHeight) -> bool {
-    *height == RollupHeight::MAX
 }
 
 /// Schema-only mirror of the wire form accepted by [`deserialize_ip_custom_limits`]: a bare IP

--- a/crates/full-node/sov-ethereum/tests/integration/evm/evm_fee_history.rs
+++ b/crates/full-node/sov-ethereum/tests/integration/evm/evm_fee_history.rs
@@ -7,7 +7,7 @@
 
 use alloy::network::TransactionBuilder;
 use alloy::signers::local::PrivateKeySigner;
-use alloy_primitives::{Address, B256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{DynProvider, Provider};
 use alloy_rpc_types_eth::{
     BlockNumberOrTag, BlockTransactions, TransactionReceipt, TransactionRequest,
@@ -16,16 +16,17 @@ use serde::Deserialize;
 
 use sov_cli::NodeClient;
 use sov_eth_client::SimpleStorageClient;
-use sov_modules_api::{GasPrice, GasUnit};
+use sov_evm::{ChainSpecUpdate, EvmRuntimeConfigUpdate};
+use sov_modules_api::{CryptoSpec, GasPrice, GasUnit, Spec};
 use sov_test_utils::test_rollup::TestRollup;
 
 use crate::common::{
-    alloy_client, create_simple_storage_client, deploy_contract_check,
+    alloy_client, alloy_client_with_signer, create_simple_storage_client, deploy_contract_check,
     estimate_gas_and_check_affordability, set_value_check, setup_test_rollup,
-    setup_test_rollup_with_ideal_lag, EVM_EXTENSION, HIGH_MAX_FEE_PER_GAS,
+    setup_test_rollup_with_admin_key, setup_test_rollup_with_ideal_lag, EVM_EXTENSION,
     HIGH_PRIORITY_FEE_PER_GAS, MAX_FEE_PER_GAS, SENDER_PRIV_KEY,
 };
-use crate::runtime::EvmBlueprint;
+use crate::runtime::{EvmBlueprint, EvmTestSpec};
 
 /// Mirror of the EVM genesis values used by `default_genesis()` (see
 /// `crate::common::genesis`). Inlined so the test does not depend on
@@ -223,48 +224,6 @@ async fn send_high_fee_set_value(
         .send_tx_and_wait_finalized(tx)
         .await
         .map_err(|err| anyhow::anyhow!(err.to_string()))
-}
-
-fn override_rollup_gas_limit_transition(
-    initial_gas_limit: u64,
-    updated_gas_limit: u64,
-    change_after_height: u64,
-) {
-    std::env::set_var(
-        "SOV_TEST_CONST_OVERRIDE_INITIAL_GAS_LIMIT",
-        format!("[{initial_gas_limit},{initial_gas_limit}]"),
-    );
-    std::env::set_var(
-        "SOV_TEST_CONST_OVERRIDE_UPDATED_GAS_LIMIT",
-        format!("[{updated_gas_limit},{updated_gas_limit}]"),
-    );
-    std::env::set_var(
-        "SOV_TEST_CONST_OVERRIDE_CHANGE_GAS_LIMIT_AFTER_HEIGHT",
-        change_after_height.to_string(),
-    );
-}
-
-async fn send_high_fee_transfer(
-    client: &DynProvider,
-    nonce: u64,
-) -> anyhow::Result<TransactionReceipt> {
-    send_high_fee_transfer_with_gas_limit(client, nonce, 1_000_000).await
-}
-
-async fn send_high_fee_transfer_with_gas_limit(
-    client: &DynProvider,
-    nonce: u64,
-    gas_limit: u64,
-) -> anyhow::Result<TransactionReceipt> {
-    let tx = TransactionRequest::default()
-        .with_to(Address::ZERO)
-        .with_nonce(nonce)
-        .with_value(alloy_primitives::U256::ZERO)
-        .with_gas_limit(gas_limit)
-        .with_max_fee_per_gas(HIGH_MAX_FEE_PER_GAS)
-        .with_max_priority_fee_per_gas(HIGH_PRIORITY_FEE_PER_GAS);
-    let pending = client.send_transaction(tx).await?;
-    Ok(pending.get_receipt().await?)
 }
 
 // ==================== Test Setup Helpers ====================
@@ -1350,134 +1309,6 @@ async fn test_fee_history_block_with_tx_nonzero_ratio() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Regression: each gas_used_ratio entry must use that block's gas limit across a gas-limit transition.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_fee_history_gas_used_ratio_uses_per_block_limit_across_transition(
-) -> anyhow::Result<()> {
-    const INITIAL_GAS_LIMIT: u64 = 100_000_000_000;
-    const UPDATED_GAS_LIMIT: u64 = 50_000_000_000;
-    const CHANGE_GAS_LIMIT_AFTER_HEIGHT: u64 = 10;
-
-    override_rollup_gas_limit_transition(
-        INITIAL_GAS_LIMIT,
-        UPDATED_GAS_LIMIT,
-        CHANGE_GAS_LIMIT_AFTER_HEIGHT,
-    );
-
-    let rollup = setup_test_rollup(0, EVM_EXTENSION).await;
-    let client = alloy_client(rollup.http_addr);
-
-    let target_pre_boundary_height = CHANGE_GAS_LIMIT_AFTER_HEIGHT.saturating_sub(2);
-    let current_height = rollup.height().await.get();
-    assert!(
-        current_height <= target_pre_boundary_height,
-        "test precondition failed: startup height {current_height} already exceeded target pre-boundary height {target_pre_boundary_height}"
-    );
-    rollup.wait_for_height(target_pre_boundary_height).await;
-
-    let signer: PrivateKeySigner = SENDER_PRIV_KEY.parse()?;
-    let mut nonce = client.get_transaction_count(signer.address()).await?;
-    let mut tx_blocks = Vec::new();
-
-    // Send transactions in blocks on both sides of the fee boundary (so that eth_feeHistory will have nonzero ratios)
-    for _ in 0..6 {
-        let receipt = send_high_fee_transfer(&client, nonce).await?;
-        rollup.wait_for_rollup_height_advance_by(1).await;
-        nonce = nonce.saturating_add(1);
-        tx_blocks.push(
-            receipt
-                .block_number
-                .expect("transfer receipt should include block number"),
-        );
-
-        let has_pre_change = tx_blocks
-            .iter()
-            .any(|&block| block <= CHANGE_GAS_LIMIT_AFTER_HEIGHT);
-        let has_post_change = tx_blocks
-            .iter()
-            .any(|&block| block > CHANGE_GAS_LIMIT_AFTER_HEIGHT);
-        if has_pre_change && has_post_change {
-            break;
-        }
-    }
-
-    let pre_change_block = tx_blocks
-        .iter()
-        .copied()
-        .filter(|&block| block <= CHANGE_GAS_LIMIT_AFTER_HEIGHT)
-        .max()
-        .expect("expected at least one tx-bearing block at or before the change height");
-    let post_change_block = tx_blocks
-        .iter()
-        .copied()
-        .find(|&block| block > CHANGE_GAS_LIMIT_AFTER_HEIGHT)
-        .expect("expected at least one tx-bearing block after the change height");
-
-    let block_count = post_change_block
-        .saturating_sub(pre_change_block)
-        .saturating_add(1);
-    let fee_history = client
-        .get_fee_history(
-            block_count,
-            BlockNumberOrTag::Number(post_change_block),
-            &[],
-        )
-        .await?;
-
-    assert_eq!(
-        fee_history.oldest_block, pre_change_block,
-        "feeHistory range should start at the last tx-bearing block before the gas-limit change"
-    );
-
-    let pre_change_idx = 0usize;
-    let post_change_idx: usize = post_change_block
-        .saturating_sub(pre_change_block)
-        .try_into()
-        .expect("block distance should fit in usize");
-
-    let pre_change_gas_used = total_gas_used_from_receipts(&client, pre_change_block).await?;
-    let post_change_gas_used = total_gas_used_from_receipts(&client, post_change_block).await?;
-    assert!(
-        pre_change_gas_used > 0,
-        "pre-change block should contain a transaction"
-    );
-    assert!(
-        post_change_gas_used > 0,
-        "post-change block should contain a transaction"
-    );
-
-    let observed_pre_change_ratio: f64 = fee_history.gas_used_ratio[pre_change_idx];
-    let observed_post_change_ratio: f64 = fee_history.gas_used_ratio[post_change_idx];
-    assert!(
-        observed_post_change_ratio > observed_pre_change_ratio,
-        "post-change gas_used_ratio should increase when the gas limit is reduced"
-    );
-
-    let observed_ratio_change = observed_pre_change_ratio / observed_post_change_ratio;
-    let expected_ratio_change = (pre_change_gas_used as f64 / post_change_gas_used as f64)
-        * (UPDATED_GAS_LIMIT as f64 / INITIAL_GAS_LIMIT as f64);
-    assert_float_eq(
-        observed_ratio_change,
-        expected_ratio_change,
-        "gas_used_ratio change across gas-limit transition",
-    );
-    assert!(
-        observed_ratio_change < 0.6,
-        "gas_used_ratio before/after should reflect the gas-limit drop, got {observed_ratio_change}"
-    );
-
-    // `wrong_shared_denominator_ratio_change` is the ratio of gas_used across the two blocks. If the gas limit hadn't changed,
-    // the rateio of `fee_ratio_before / fee_ratio_after` would be equal to this value. We want to assert that it *has* changed
-    let wrong_shared_denominator_ratio_change =
-        pre_change_gas_used as f64 / post_change_gas_used as f64;
-    assert!(
-        (observed_ratio_change - wrong_shared_denominator_ratio_change).abs() > 1e-12, // Float not equals check
-        "gas_used_ratio change should include the gas-limit transition, not just the gas-used change"
-    );
-
-    Ok(())
-}
-
 /// TC30: Multiple transactions across blocks show distinct ratios
 ///
 /// This test verifies that blocks with transactions show non-zero gas_used_ratio.
@@ -2057,4 +1888,125 @@ async fn test_fee_history_heavy_gas_usage() -> anyhow::Result<()> {
     assert_gas_ratios_valid(&fee_history.gas_used_ratio);
 
     Ok(())
+}
+
+/// Regression: `eth_feeHistory` must compute each block's `gasUsedRatio` against *that block's*
+/// stored gas limit, not the current runtime constant. We drive a gas-limit change through the EVM
+/// admin config update (not the removed `CHANGE_GAS_LIMIT_AFTER_HEIGHT` fork) and assert that every
+/// block's ratio equals `gas_used / eth_getBlockByNumber(block).gasLimit` across the change.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fee_history_gas_used_ratio_uses_per_block_limit() -> anyhow::Result<()> {
+    // Clearly different from the genesis EVM block gas limit and above MIN_BLOCK_GAS_LIMIT (5M).
+    const NEW_BLOCK_GAS_LIMIT: u64 = 0x1_2345_6700; // 4_886_718_208
+
+    let (rollup, admin_key) = setup_test_rollup_with_admin_key(0, EVM_EXTENSION).await;
+    let client = alloy_client_with_signer(rollup.http_addr, SENDER_PRIV_KEY);
+    rollup.wait_for_sequencer_ready().await.unwrap();
+
+    // 1. A transaction under the original (genesis) gas limit.
+    let pre_block = send_transfer_get_block(&client).await?;
+    let pre_limit = get_block_gas_limit(&client, pre_block).await?;
+    assert_ne!(
+        pre_limit, NEW_BLOCK_GAS_LIMIT,
+        "test precondition: the new limit must differ from the genesis limit"
+    );
+
+    // 2. Change the EVM block gas limit via an admin runtime-config update.
+    update_block_gas_limit(&rollup, &admin_key, NEW_BLOCK_GAS_LIMIT).await?;
+
+    // Wait until freshly produced blocks reflect the new limit.
+    let mut applied = false;
+    for _ in 0..30 {
+        rollup.wait_for_rollup_height_advance_by(1).await;
+        let latest = client.get_block_number().await?;
+        if get_block_gas_limit(&client, latest).await? == NEW_BLOCK_GAS_LIMIT {
+            applied = true;
+            break;
+        }
+    }
+    assert!(applied, "EVM block gas limit update did not take effect");
+
+    // 3. A transaction under the updated gas limit (non-zero gas_used so the denominator matters).
+    let post_block = send_transfer_get_block(&client).await?;
+    assert_eq!(
+        get_block_gas_limit(&client, post_block).await?,
+        NEW_BLOCK_GAS_LIMIT
+    );
+
+    // 4. Query fee history spanning both blocks; every ratio must use the block's own limit.
+    let block_count = post_block - pre_block + 1;
+    let fee_history = client
+        .get_fee_history(block_count, BlockNumberOrTag::Number(post_block), &[])
+        .await?;
+    let oldest = fee_history.oldest_block;
+    assert!(
+        oldest <= pre_block,
+        "fee history (oldest {oldest}) should cover the pre-update block {pre_block}"
+    );
+
+    let (mut saw_pre, mut saw_post) = (false, false);
+    for (i, ratio) in fee_history.gas_used_ratio.iter().enumerate() {
+        let n = oldest + i as u64;
+        let limit = get_block_gas_limit(&client, n).await?;
+        let gas_used = total_gas_used_from_receipts(&client, n).await?;
+        let expected = gas_used as f64 / limit as f64;
+        assert_float_eq(
+            *ratio,
+            expected,
+            &format!("gas_used_ratio for block {n} must use that block's own gas limit ({limit})"),
+        );
+        saw_pre |= limit == pre_limit;
+        saw_post |= limit == NEW_BLOCK_GAS_LIMIT;
+    }
+    assert!(
+        saw_pre && saw_post,
+        "fee history range must span the gas-limit change to be a meaningful regression test"
+    );
+
+    Ok(())
+}
+
+/// Sends a zero-value transfer and returns the block number it landed in.
+async fn send_transfer_get_block(client: &DynProvider) -> anyhow::Result<u64> {
+    let signer: PrivateKeySigner = SENDER_PRIV_KEY.parse()?;
+    let nonce = client.get_transaction_count(signer.address()).await?;
+    let tx = TransactionRequest::default()
+        .with_to(Address::ZERO)
+        .with_nonce(nonce)
+        .with_value(U256::ZERO)
+        .with_max_fee_per_gas(MAX_FEE_PER_GAS)
+        .with_max_priority_fee_per_gas(HIGH_PRIORITY_FEE_PER_GAS)
+        .with_gas_limit(100_000);
+    let receipt = client.send_transaction(tx).await?.get_receipt().await?;
+    receipt
+        .block_number
+        .ok_or_else(|| anyhow::anyhow!("transfer receipt should include a block number"))
+}
+
+/// Reads a block's stored gas limit (the value `eth_getBlockByNumber` reports).
+async fn get_block_gas_limit(client: &DynProvider, block_number: u64) -> anyhow::Result<u64> {
+    let block = client
+        .get_block_by_number(BlockNumberOrTag::Number(block_number))
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("block {block_number} should exist"))?;
+    Ok(block.header.gas_limit)
+}
+
+/// Changes the EVM block gas limit via an admin `UpdateRuntimeConfig` call.
+async fn update_block_gas_limit(
+    rollup: &TestRollup<EvmBlueprint>,
+    admin_key: &<<EvmTestSpec as Spec>::CryptoSpec as CryptoSpec>::PrivateKey,
+    new_block_gas_limit: u64,
+) -> anyhow::Result<()> {
+    let update = EvmRuntimeConfigUpdate::<EvmTestSpec> {
+        new_hardfork: None,
+        new_contract_creation_policy: None,
+        chain_spec_update: Some(ChainSpecUpdate {
+            new_limit_contract_code_size: None,
+            new_block_gas_limit: Some(new_block_gas_limit),
+            new_tx_gas_limit: None,
+        }),
+        new_admin: None,
+    };
+    super::send_evm_runtime_config_update(rollup, admin_key, update).await
 }

--- a/crates/full-node/sov-ethereum/tests/integration/evm/evm_max_fee_validation.rs
+++ b/crates/full-node/sov-ethereum/tests/integration/evm/evm_max_fee_validation.rs
@@ -5,16 +5,14 @@ use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::{Address, U256};
 use alloy_provider::DynProvider;
 use alloy_rpc_types_eth::TransactionInput;
-use sov_evm::{CallMessage, EvmRuntimeConfigUpdate};
-use sov_modules_api::transaction::Transaction;
+use sov_evm::EvmRuntimeConfigUpdate;
 use sov_modules_api::{CryptoSpec, Spec};
-use sov_test_utils::default_test_signed_transaction_with_nonce;
 use sov_test_utils::test_rollup::TestRollup;
 
 use crate::common::{
     alloy_client_with_signer, setup_test_rollup_with_admin_key, EVM_EXTENSION, SENDER_PRIV_KEY,
 };
-use crate::runtime::{EvmBlueprint, EvmTestSpec, TestRuntime, TestRuntimeCall};
+use crate::runtime::{EvmBlueprint, EvmTestSpec};
 
 const GAS_LIMIT: u64 = 100_000;
 
@@ -174,19 +172,5 @@ async fn disable_max_fee_check(
     admin_key: &AdminPrivateKey,
 ) -> anyhow::Result<()> {
     let update = EvmRuntimeConfigUpdate::<EvmTestSpec>::empty();
-    let msg = TestRuntimeCall::<EvmTestSpec>::Evm(CallMessage::UpdateRuntimeConfig(update));
-
-    let chain_hash =
-        <TestRuntime<EvmTestSpec> as sov_modules_stf_blueprint::Runtime<EvmTestSpec>>::CHAIN_HASH;
-
-    let tx: Transaction<TestRuntime<EvmTestSpec>, EvmTestSpec> =
-        default_test_signed_transaction_with_nonce(admin_key, &msg, 0, &chain_hash);
-
-    rollup
-        .client
-        .client
-        .send_tx_to_sequencer_with_retry(&tx)
-        .await?;
-
-    Ok(())
+    super::send_evm_runtime_config_update(rollup, admin_key, update).await
 }

--- a/crates/full-node/sov-ethereum/tests/integration/evm/evm_rate_limit.rs
+++ b/crates/full-node/sov-ethereum/tests/integration/evm/evm_rate_limit.rs
@@ -9,7 +9,6 @@ use alloy_provider::DynProvider;
 use alloy_rpc_types_eth::TransactionInput;
 use reqwest::header::{HeaderMap, HeaderValue};
 use sov_full_node_configs::sequencer::Limits;
-use sov_rollup_interface::common::RollupHeight;
 use sov_sequencer::SovRateLimiterConfig;
 
 use crate::common::{
@@ -38,7 +37,6 @@ async fn evm_test_rate_limit() -> anyhow::Result<()> {
         max_nb_of_concurrent_users_in_rate_limiter: 1000,
         max_requests_per_second: 1,
         address_custom_limits: Vec::default(),
-        height_for_gas_limit_computation: RollupHeight::GENESIS,
         ip_custom_limits: Vec::default(),
     };
 

--- a/crates/full-node/sov-ethereum/tests/integration/evm/mod.rs
+++ b/crates/full-node/sov-ethereum/tests/integration/evm/mod.rs
@@ -1,3 +1,11 @@
+use sov_evm::{CallMessage, EvmRuntimeConfigUpdate};
+use sov_modules_api::transaction::Transaction;
+use sov_modules_api::{CryptoSpec, Spec};
+use sov_test_utils::default_test_signed_transaction_with_nonce;
+use sov_test_utils::test_rollup::TestRollup;
+
+use crate::runtime::{EvmBlueprint, EvmTestSpec, TestRuntime, TestRuntimeCall};
+
 mod evm_account_abstraction;
 mod evm_balances;
 mod evm_basefee;
@@ -30,3 +38,25 @@ mod evm_tracing;
 mod evm_tx;
 mod evm_tx_type;
 mod evm_ws_watch;
+
+/// Signs an EVM `UpdateRuntimeConfig` admin call with `admin_key` and sends it to the sequencer.
+///
+/// Shared by the EVM integration tests that drive runtime-config changes (e.g. disabling the
+/// max-fee check or updating the block gas limit); they differ only in the `update` payload.
+async fn send_evm_runtime_config_update(
+    rollup: &TestRollup<EvmBlueprint>,
+    admin_key: &<<EvmTestSpec as Spec>::CryptoSpec as CryptoSpec>::PrivateKey,
+    update: EvmRuntimeConfigUpdate<EvmTestSpec>,
+) -> anyhow::Result<()> {
+    let msg = TestRuntimeCall::<EvmTestSpec>::Evm(CallMessage::UpdateRuntimeConfig(update));
+    let chain_hash =
+        <TestRuntime<EvmTestSpec> as sov_modules_stf_blueprint::Runtime<EvmTestSpec>>::CHAIN_HASH;
+    let tx: Transaction<TestRuntime<EvmTestSpec>, EvmTestSpec> =
+        default_test_signed_transaction_with_nonce(admin_key, &msg, 0, &chain_hash);
+    rollup
+        .client
+        .client
+        .send_tx_to_sequencer_with_retry(&tx)
+        .await?;
+    Ok(())
+}

--- a/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/block_executor.rs
@@ -13,8 +13,8 @@ use sov_modules_api::capabilities::{
 };
 use sov_modules_api::macros::config_value;
 use sov_modules_api::{
-    call_message_repr, Amount, BlobDataWithId, ChangeSet, DaSpec, ExecutionContext, FullyBakedTx,
-    Gas, GasSpec, HexString, KernelStateAccessor, NoOpControlFlow, RejectReason, Runtime,
+    call_message_repr, BlobDataWithId, ChangeSet, DaSpec, ExecutionContext, FullyBakedTx, Gas,
+    GasSpec, HexString, KernelStateAccessor, NoOpControlFlow, RejectReason, Runtime,
     RuntimeEventProcessor, RuntimeEventResponse, SelectedBlob, Spec, StateCheckpoint,
     TransactionReceipt, TxChangeSet, TxHash, VersionReader, VisibleSlotNumber,
 };
@@ -930,13 +930,7 @@ where
     let standard_gas_escrow = S::max_tx_check_costs()
         .checked_value(next_gas_price)
         .expect("Gas price overflow! This is a bug, please report it.");
-    let needed_gas_escrow_for_preferred_sequencer =
-    // The blob sender decides what the gas limit should be *before* we call `increment_rollup_height`. Use the same height
-        if old_rollup_height > <S as GasSpec>::change_gas_limit_after_height() {
-            Amount::ZERO
-        } else {
-            standard_gas_escrow
-        };
+    let needed_gas_escrow_for_preferred_sequencer = standard_gas_escrow;
     kernel.escrow_funds_for_preferred_sequencer(needed_gas_escrow_for_preferred_sequencer, &mut accessor).expect("Failed to escrow funds for the preferred sequencer. The sequencer is too low on funds, which could cause soft confirmations to be invalidated. Increase your bond and restart the sequencer.");
 
     let blob_selector_output = {

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
@@ -8,7 +8,6 @@ use resource::*;
 use sov_full_node_configs::sequencer::{Limits, SovRateLimiterConfig};
 use sov_modules_api::BasicAddress;
 use sov_modules_api::{CredentialId, Spec};
-use sov_rollup_interface::common::RollupHeight;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::{
@@ -16,6 +15,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::preferred::sync_sequencer_state::comfortable_gas_limit;
 const TTL_MULTIPLIER: u32 = 5;
 
 #[derive(Debug)]
@@ -141,9 +141,8 @@ fn calculate_limits<S: Spec>(
     max_requests_per_second: u64,
     batch_execution_time_limit: Duration,
     max_batch_size_bytes: usize,
-    height_for_gas_limit_computation: RollupHeight,
 ) -> RateLimiterConfig<S> {
-    let max_gas = comfortable_gas_limit_for_height::<S>(height_for_gas_limit_computation);
+    let max_gas = comfortable_gas_limit::<S>();
     let batch_execution_time_limit_millis = batch_execution_time_limit
         .as_millis()
         .try_into()
@@ -214,7 +213,6 @@ fn to_limiter_config_map<K: Eq + Hash, S: Spec>(
     max_requests_per_second: u64,
     batch_execution_time_limit: Duration,
     max_batch_size_bytes: usize,
-    height_for_gas_limit_computation: RollupHeight,
     v: Vec<(K, Limits)>,
 ) -> HashMap<K, RateLimiterConfig<S>> {
     v.into_iter()
@@ -226,7 +224,6 @@ fn to_limiter_config_map<K: Eq + Hash, S: Spec>(
                     max_requests_per_second,
                     batch_execution_time_limit,
                     max_batch_size_bytes,
-                    height_for_gas_limit_computation,
                 ),
             )
         })
@@ -265,14 +262,12 @@ fn limits<S: Spec>(
         sov_config.max_requests_per_second,
         batch_execution_time_limit,
         max_batch_size_bytes,
-        sov_config.height_for_gas_limit_computation,
     );
 
     let addrs = to_limiter_config_map::<S::Address, S>(
         sov_config.max_requests_per_second,
         batch_execution_time_limit,
         max_batch_size_bytes,
-        sov_config.height_for_gas_limit_computation,
         sov_config.address_custom_limits,
     );
 
@@ -288,7 +283,6 @@ fn limits<S: Spec>(
         sov_config.max_requests_per_second,
         batch_execution_time_limit,
         max_batch_size_bytes,
-        sov_config.height_for_gas_limit_computation,
         ip_custom_limits,
     );
 
@@ -533,13 +527,8 @@ mod tests {
         };
 
         let max_batch_exec_time = 6000;
-        let rate_limiter_config = calculate_limits::<TestSpec>(
-            limits,
-            10000,
-            Duration::from_millis(max_batch_exec_time),
-            6000000,
-            RollupHeight::GENESIS,
-        );
+        let rate_limiter_config =
+            calculate_limits::<TestSpec>(limits, 10000, Duration::from_millis(max_batch_exec_time), 6000000);
 
         let max_allowed_resources_per_key = rate_limiter_config.max_allowed_resources;
 

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
@@ -1,7 +1,7 @@
 mod limiter;
 mod resource;
 
-use crate::preferred::sync_sequencer_state::comfortable_gas_limit_for_height;
+use crate::preferred::sync_sequencer_state::comfortable_gas_limit;
 pub(crate) use limiter::ResourceUsed;
 use limiter::*;
 use resource::*;
@@ -15,7 +15,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::preferred::sync_sequencer_state::comfortable_gas_limit;
 const TTL_MULTIPLIER: u32 = 5;
 
 #[derive(Debug)]
@@ -527,8 +526,12 @@ mod tests {
         };
 
         let max_batch_exec_time = 6000;
-        let rate_limiter_config =
-            calculate_limits::<TestSpec>(limits, 10000, Duration::from_millis(max_batch_exec_time), 6000000);
+        let rate_limiter_config = calculate_limits::<TestSpec>(
+            limits,
+            10000,
+            Duration::from_millis(max_batch_exec_time),
+            6000000,
+        );
 
         let max_allowed_resources_per_key = rate_limiter_config.max_allowed_resources;
 
@@ -556,7 +559,6 @@ mod tests {
             1000,
             Duration::from_millis(6000),
             6_000_000,
-            RollupHeight::GENESIS,
         );
         assert_eq!(config.max_allowed_resources.inner.req_counter, 60);
     }
@@ -573,7 +575,6 @@ mod tests {
             1000,
             Duration::from_millis(100),
             6_000_000,
-            RollupHeight::GENESIS,
         );
         assert_eq!(config.max_allowed_resources.inner.req_counter, 1);
     }
@@ -590,7 +591,6 @@ mod tests {
             1000,
             Duration::from_millis(100),
             6_000_000,
-            RollupHeight::GENESIS,
         );
         assert_eq!(config.max_allowed_resources.inner.req_counter, 0);
     }
@@ -607,7 +607,6 @@ mod tests {
             0,
             Duration::from_millis(100),
             6_000_000,
-            RollupHeight::GENESIS,
         );
         assert_eq!(config.max_allowed_resources.inner.req_counter, 0);
     }
@@ -812,7 +811,6 @@ mod tests {
                 resources_per_bucket: 5,
                 refill_rate: 1,
             },
-            height_for_gas_limit_computation: RollupHeight::GENESIS,
             address_custom_limits: Vec::default(),
             ip_custom_limits: vec![
                 (
@@ -846,7 +844,6 @@ mod tests {
             max_requests_per_second: 1000,
             max_nb_of_concurrent_users_in_rate_limiter: 1000,
             default_limits: limits,
-            height_for_gas_limit_computation: RollupHeight::GENESIS,
             address_custom_limits: Vec::default(),
             ip_custom_limits: vec![
                 ("10.0.0.0/24".parse().unwrap(), limits),
@@ -931,7 +928,6 @@ mod tests {
                 resources_per_bucket: 5,
                 refill_rate: 0,
             },
-            height_for_gas_limit_computation: RollupHeight::GENESIS,
             address_custom_limits: Vec::default(),
             ip_custom_limits: vec![(
                 "10.0.0.5/24".parse().unwrap(),
@@ -962,7 +958,6 @@ mod tests {
                 resources_per_bucket: 5,
                 refill_rate: 0,
             },
-            height_for_gas_limit_computation: RollupHeight::GENESIS,
             address_custom_limits: Vec::default(),
             ip_custom_limits: vec![(
                 "::ffff:10.0.0.42/120".parse().unwrap(),
@@ -1003,7 +998,6 @@ mod tests {
             max_requests_per_second: 1000,
             max_nb_of_concurrent_users_in_rate_limiter: 1000,
             default_limits: loose,
-            height_for_gas_limit_computation: RollupHeight::GENESIS,
             address_custom_limits: vec![(limited_addr, tight)],
             ip_custom_limits: vec![(subnet, tight)],
         };

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -17,7 +17,7 @@ use crate::preferred::sync_sequencer_state::EventReceiverStartNotifier;
 use crate::preferred::AcceptedTx;
 use crate::preferred::BatchSizeTracker;
 use crate::preferred::RollupBlockExecutorConfig;
-use crate::preferred::{comfortable_gas_limit_for_height, PreferredBlobToReplay};
+use crate::preferred::{comfortable_gas_limit, PreferredBlobToReplay};
 use crate::preferred::{
     current_visible_slot_number_according_to_node, get_next_sequence_number_according_to_node,
     is_lagging_less_than_ideal_amount, next_visible_slot_number_increase, BatchCreationError,
@@ -331,19 +331,18 @@ where
         &mut self,
         remaining_slot_gas: <S as GasSpec>::Gas,
     ) {
-        let rollup_height = self.executor.checkpoint.rollup_height_to_access();
         // Check if we're close to the gas limit and close the batch if we are.
-        // We want to close when gas used is at least 95% of the initial gas limit.
-        let initial_gas_limit = <S as GasSpec>::gas_limit_for_height(rollup_height);
-        let comfortable_gas_limit = comfortable_gas_limit_for_height::<S>(rollup_height);
+        // We want to close when gas used is at least 95% of the block gas limit.
+        let block_gas_limit = <S as GasSpec>::block_gas_limit();
+        let comfortable_limit = comfortable_gas_limit::<S>();
 
-        let gas_used = initial_gas_limit
+        let gas_used = block_gas_limit
             .checked_sub(remaining_slot_gas)
-            .expect("remaining_lot_gas is always smaller than initial_gas_limit");
+            .expect("remaining_slot_gas is always smaller than block_gas_limit");
 
-        let close_to_gas_limit = comfortable_gas_limit.dim_is_less_or_eq(gas_used);
+        let close_to_gas_limit = comfortable_limit.dim_is_less_or_eq(gas_used);
         if close_to_gas_limit {
-            tracing::debug!(%comfortable_gas_limit, %gas_used, "Closing and publishing current batch because we're close to the gas limit");
+            tracing::debug!(%comfortable_limit, %gas_used, "Closing and publishing current batch because we're close to the gas limit");
             self.close_current_batch().await;
         }
 

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
@@ -307,16 +307,13 @@ impl InitialStatus {
 }
 
 /// These two constants are used to calculate the comfortable gas limit.
-/// Currently, this is 95% of the initial gas limit. After the comfortable limit is reached,
+/// Currently, this is 95% of the block gas limit. After the comfortable limit is reached,
 /// the sequencer will close and publish the current batch.
 const COMFORTABLE_GAS_LIMIT_MULTIPLIER: u64 = 19;
 const COMFORTABLE_GAS_LIMIT_DIVISOR: u64 = 20;
 
-pub(crate) fn comfortable_gas_limit_for_height<S: Spec>(
-    height: RollupHeight,
-) -> <S as GasSpec>::Gas {
-    let gas_limit = <S as GasSpec>::gas_limit_for_height(height);
-    gas_limit
+pub(crate) fn comfortable_gas_limit<S: Spec>() -> <S as GasSpec>::Gas {
+    <S as GasSpec>::block_gas_limit()
             .scalar_division(COMFORTABLE_GAS_LIMIT_DIVISOR)
             .checked_scalar_product(COMFORTABLE_GAS_LIMIT_MULTIPLIER).unwrap_or_else(|| {
                 panic!(

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_end_to_end.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the preferred sequencer that use [`RollupBuilder`] and
 //! thus test sequencer + node interactions.
 
-use crate::utils::{encode_call, tx_set_value_nonce, EventEmitterModule};
+use crate::utils::{encode_call, EventEmitterModule};
 use crate::utils::{
     generate_paymaster_tx, generate_txs, new_test_rollup, pause_update_state,
     tempdir_inside_codebase_dir, tx_set_value_with_gas, ModuleWithVersionedStateAccessInSlotHook,
@@ -900,7 +900,7 @@ async fn sequencer_filled_up_block() {
         .map(|x| (x * 10) / 9)
         .collect::<Vec<_>>();
     std::env::set_var(
-        "SOV_TEST_CONST_OVERRIDE_INITIAL_GAS_LIMIT",
+        "SOV_TEST_CONST_OVERRIDE_BLOCK_GAS_LIMIT",
         format!("{gas_limit_array:?}"),
     );
     // Set very high initial balance for the admin.
@@ -1316,7 +1316,7 @@ async fn seq_out_of_gas_for_pre_checks() {
     let gas_limit = gas_limit.scalar_division(2);
     let gas_limit_array = gas_limit.as_ref();
     std::env::set_var(
-        "SOV_TEST_CONST_OVERRIDE_INITIAL_GAS_LIMIT",
+        "SOV_TEST_CONST_OVERRIDE_BLOCK_GAS_LIMIT",
         format!("{gas_limit_array:?}"),
     );
     let price_array = config_value!("INITIAL_BASE_FEE_PER_GAS");
@@ -2378,146 +2378,6 @@ async fn seq_many_invalid_txs() {
     let _ = tokio::time::timeout(TEST_NORMAL_SHUTDOWN_TIMEOUT, test_rollup.shutdown())
         .await
         .expect("Rollup shutdown properly");
-}
-
-/// Run a test gas limit update.
-///
-/// This test runs the rollup for ~20 blocks with the gas limit update scheduled for block 12.
-/// We update the limit to a tiny value (50_000) and send expensive txs so that we can observe the gas dynamics
-/// after the update.
-///
-/// A big part of this test is simply running the upgrade with state root assertions enabled (they're enabled by default in test_rollup).
-/// That assertion would catch the most likely issues with node-sequencer disagreement, and the successful execution of the test guarantees
-/// that we haven't hit any panics. The assertions we run here are just extra sanity checks.
-#[tokio::test(flavor = "multi_thread")]
-async fn test_gas_limit_update() {
-    // 1. Configure gas price update timing and params
-    const UPDATED_GAS_LIMIT: [u64; 2] = [50_000, 50_000];
-    const CHANGE_GAS_LIMIT_AFTER_HEIGHT: u32 = 12;
-    std::env::set_var(
-        "SOV_TEST_CONST_OVERRIDE_UPDATED_GAS_LIMIT",
-        format!("{:?}", UPDATED_GAS_LIMIT),
-    );
-    std::env::set_var(
-        "SOV_TEST_CONST_OVERRIDE_CHANGE_GAS_LIMIT_AFTER_HEIGHT",
-        CHANGE_GAS_LIMIT_AFTER_HEIGHT.to_string(),
-    );
-
-    // 2. Boilerplate test setup
-    let (test_rollup, admin) = create_test_rollup(
-        0,
-        TEST_MAX_BATCH_SIZE,
-        TEST_BLOB_PROCESSING_TIMEOUT,
-        MAX_BATCH_EXECUTION_TIME_MILLIS,
-        TEST_FINALIZATION_BLOCKS,
-        BlockProducingConfig::Manual,
-    )
-    .await;
-    test_rollup.produce_enough_finalized_slots().await;
-    test_rollup.wait_for_sequencer_ready().await.unwrap();
-
-    // 3. Setup - initialize empty arrays/values for tracking data. Subscribe to slot notifications
-    let mut sequencer_receipts = vec![];
-    let mut ledger_receipts = vec![];
-    let mut rollup_height;
-    let mut nonce = 0;
-    let mut max_base_fee_per_gas_observed_after_update = 0;
-    let mut slot_subscription = test_rollup
-        .client
-        .client
-        .subscribe_slots_with_children(IncludeChildren::new(true))
-        .await
-        .unwrap();
-
-    // 4. Main loop Submit a tx and save the receipt. Then, force close the batch and produce a block.
-    for i in 0..20_u64 {
-        // 4.1 Submit a tx and save the receipt.
-        let receipt = test_rollup
-            .api_client()
-            .send_raw_tx_to_sequencer(&tx_set_value_nonce::<TestRuntime<TestSpec>>(
-                &admin.private_key,
-                nonce,
-                i,
-                Some(GasUnit::from_dimensions([33_000, 33_000])),
-            ))
-            .await;
-
-        if let Err(e) = &receipt {
-            panic!("Tx {i} failed with error: {e}");
-        } else {
-            nonce += 1;
-            sequencer_receipts.push(receipt.unwrap());
-        }
-
-        // 4.2 Force close the batch and produce a block.
-        let _ = test_rollup.force_close_batch().await;
-        test_rollup.tenderly_produce_blocks(1).await.unwrap();
-        let slot = slot_subscription.next().await.unwrap().unwrap();
-        for batch in slot.batches {
-            for tx in batch.txs {
-                ledger_receipts.push(tx);
-            }
-        }
-
-        // 4.3 Query the rollup hight. After the transition, save the largest base fee value that we observe.
-        rollup_height = test_rollup.height().await.get();
-        if rollup_height > CHANGE_GAS_LIMIT_AFTER_HEIGHT as u64 {
-            let base_fee_per_gas = test_rollup
-                .client
-                .http_get("/rollup/base-fee-per-gas/latest")
-                .await
-                .unwrap();
-            // Parse the integer price from a string like "[10, 10]"
-            let current_base_fee = base_fee_per_gas
-                .trim()
-                .trim_start_matches(r#"{"base_fee_per_gas":[""#)
-                .split('"')
-                .next()
-                .unwrap()
-                .parse::<u64>()
-                .unwrap_or_else(|_| panic!("Failed to parse base fee per gas: {base_fee_per_gas}"));
-            if current_base_fee > max_base_fee_per_gas_observed_after_update {
-                max_base_fee_per_gas_observed_after_update = current_base_fee;
-            }
-        }
-
-        // 4.4 Once we've observed several blocks after the transition, break the loop.
-        if rollup_height.saturating_sub(5) > CHANGE_GAS_LIMIT_AFTER_HEIGHT as u64 {
-            break;
-        }
-    }
-
-    // 5. Produce more blocks to ensure the ledger DB finishes populating. Save the ledger DB contents.
-    for _ in 0..10 {
-        test_rollup.da_service.produce_block_now().await.unwrap();
-        let slot = slot_subscription.next().await.unwrap().unwrap();
-        for batch in slot.batches {
-            for tx in batch.txs {
-                ledger_receipts.push(tx);
-            }
-        }
-    }
-
-    // 6. Assertions
-    // 6.1 Check that the gas price rose after the update. This verifies that our attempted change really did take effect.
-
-    // Before we update the gas limit, the gas price falls to the minimum possible value (7). After the update, assuming all went well,
-    // the price should start rising rapidly since our blocks are always full. Sanity check that.
-    assert!(
-        max_base_fee_per_gas_observed_after_update > 7,
-        "Max observed base fee per gas after update must be greater than 7"
-    );
-
-    // 6.2 Sanity check that the ledger DB agrees with the sequencer on the tx results.
-    assert_eq!(sequencer_receipts.len(), ledger_receipts.len());
-    for (sequencer_receipt, ledger_receipt) in sequencer_receipts
-        .into_iter()
-        .zip(ledger_receipts.into_iter())
-    {
-        let sequencer_receipt = sequencer_receipt.as_ref().receipt.as_ref().unwrap();
-        assert_eq!(sequencer_receipt.result, ledger_receipt.receipt.result);
-        assert_eq!(sequencer_receipt.data, ledger_receipt.receipt.data);
-    }
 }
 
 /// Ensure that we use the correct visible slot number when replaying transactions after a call to `update_state` in the sequencer.

--- a/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
@@ -340,7 +340,6 @@ async fn assert_subnet_bucket_is_shared(subnet: &str, ip_a: &str, ip_b: &str) {
             resources_per_bucket: 5,
             refill_rate: 0,
         },
-        height_for_gas_limit_computation: RollupHeight::GENESIS,
         address_custom_limits: Vec::default(),
         ip_custom_limits: vec![(
             subnet.parse().unwrap(),

--- a/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/rate_limits.rs
@@ -13,7 +13,6 @@ use sov_modules_api::PrivateKey;
 use sov_modules_api::RawTx;
 use sov_modules_api::Spec;
 use sov_modules_stf_blueprint::Runtime;
-use sov_rollup_interface::common::RollupHeight;
 use sov_sequencer::rest_api::AcceptTx;
 use sov_sequencer::SequencerKindConfig;
 use sov_test_utils::generate_operator_runtime_with_kernel;
@@ -119,7 +118,6 @@ async fn test_rate_limiting() {
         max_requests_per_second: 1_000_000,
         address_custom_limits: Vec::default(),
         ip_custom_limits: Vec::default(),
-        height_for_gas_limit_computation: RollupHeight::GENESIS,
     };
 
     let (test_rollup, admin) = create_test_rollup(genesis, sov_config).await;
@@ -172,7 +170,6 @@ async fn test_zero_limit_address() {
     let sov_config = SovRateLimiterConfig {
         max_nb_of_concurrent_users_in_rate_limiter: 1000,
         max_requests_per_second: 1_000_000,
-        height_for_gas_limit_computation: RollupHeight::GENESIS,
         default_limits: Limits {
             resources_per_bucket: 5,
             refill_rate: 100,
@@ -215,7 +212,6 @@ async fn test_correct_ip() {
             resources_per_bucket: 5,
             refill_rate: 0,
         },
-        height_for_gas_limit_computation: RollupHeight::GENESIS,
         address_custom_limits: Vec::default(),
         ip_custom_limits: Vec::default(),
     };
@@ -281,7 +277,6 @@ async fn test_zero_limit_ip() {
 
     let genesis = Genesis::new();
     let sov_config = SovRateLimiterConfig {
-        height_for_gas_limit_computation: RollupHeight::GENESIS,
         max_requests_per_second: 1000,
         max_nb_of_concurrent_users_in_rate_limiter: 1000,
         default_limits: Limits {

--- a/crates/module-system/module-implementations/integration-tests/tests/kernel_interactions/gas_price_soft_confirmations.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/kernel_interactions/gas_price_soft_confirmations.rs
@@ -2,7 +2,7 @@ use sov_chain_state::ChainState;
 use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::GasSpec;
-use sov_rollup_interface::common::{IntoSlotNumber, RollupHeight};
+use sov_rollup_interface::common::IntoSlotNumber;
 use sov_test_utils::generate_optimistic_runtime_with_kernel;
 
 use crate::kernel_interactions::{HighLevelOptimisticGenesisConfig, TestRunner, S};
@@ -95,7 +95,6 @@ fn test_gas_price_soft_confirmations() {
                     .unwrap()
                     .gas_info()
                     .clone(),
-                RollupHeight::GENESIS,
                 1,
             ),
             "The gas price should be the one for the slot after the last visible slot"

--- a/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/registered.rs
+++ b/crates/module-system/module-implementations/integration-tests/tests/stf_blueprint/optimistic/registered.rs
@@ -216,7 +216,7 @@ fn sequencer_run_out_of_gas() {
 #[test]
 fn slot_out_of_gas_tests() {
     env::set_var(
-        "SOV_TEST_CONST_OVERRIDE_INITIAL_GAS_LIMIT",
+        "SOV_TEST_CONST_OVERRIDE_BLOCK_GAS_LIMIT",
         "[10000000000, 10000000000]",
     );
     let priority_fee_bips = PriorityFeeBips::from_percentage(5);

--- a/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/bond_value.rs
+++ b/crates/module-system/module-implementations/sov-attester-incentives/tests/integration/bond_value.rs
@@ -52,7 +52,7 @@ impl TestRole {
 /// Currently, the easiest way to do this is to artificially change the gas cost of some operation in the bank module. We do that
 /// by modifying the runtime manually.
 fn test_cannot_prove_when_gas_price_is_too_high(role: TestRole) {
-    let gas_limit = <<S as Spec>::Gas>::from(config_value!("INITIAL_GAS_LIMIT"));
+    let gas_limit = <<S as Spec>::Gas>::from(config_value!("BLOCK_GAS_LIMIT"));
     let gas_target = gas_limit.scalar_division(2);
 
     let runtime = Default::default();

--- a/crates/module-system/module-implementations/sov-blob-storage/src/validation.rs
+++ b/crates/module-system/module-implementations/sov-blob-storage/src/validation.rs
@@ -4,7 +4,7 @@ use sov_modules_api::digest::Digest;
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::{
     as_u32_or_panic, Amount, BatchWithId, BlobDataWithId, CryptoSpec, DaSpec, Gas, GasArray,
-    GasSpec, KernelStateAccessor, ModuleInfo, PrivilegedKernelAccessor, Spec, VersionReader,
+    GasSpec, KernelStateAccessor, ModuleInfo, PrivilegedKernelAccessor, Spec,
 };
 
 use crate::{BlobStorage, Escrow, ValidatedBlob};
@@ -119,14 +119,7 @@ impl<S: Spec> BlobStorage<S> {
         let best_gas_price_estimate = self.get_new_gas_price(visible_height_increase, state);
 
         let gas_needed_for_pre_exec_checks = <S as GasSpec>::max_tx_check_costs();
-        // Disable preferred sequencer escrow after the gas limit change height.
-        let funds_needed = if state.checkpoint.rollup_height_to_access()
-            > <S as GasSpec>::change_gas_limit_after_height()
-        {
-            Amount::ZERO
-        } else {
-            gas_needed_for_pre_exec_checks.checked_value(best_gas_price_estimate)?
-        };
+        let funds_needed = gas_needed_for_pre_exec_checks.checked_value(best_gas_price_estimate)?;
 
         if funds_needed > available_balance {
             return None;

--- a/crates/module-system/module-implementations/sov-chain-state/src/capabilities.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/capabilities.rs
@@ -289,16 +289,14 @@ impl<S: Spec> ChainState<S> {
 
         // We compute the base fee per gas from the previous slot if it exists
         let base_fee_per_gas = maybe_previous_slot
-            .map(|previous_slot| {
-                Self::compute_base_fee_per_gas(previous_slot.gas_info, leftover_rollup_height, 1)
-            })
+            .map(|previous_slot| Self::compute_base_fee_per_gas(previous_slot.gas_info, 1))
             .unwrap_or_else(|| S::initial_base_fee_per_gas());
 
         let gas_info = BlockGasInfo::new(
             // TODO(@theochap): the gas limit should be updated dynamically `<https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/271`
             // This TODO is for performance enhancement, not a security concern. Updating the gas limit dynamically would allow
             // the work of the prover to follow high level industry trends of the costs to compute zk-proofs.
-            S::gas_limit_for_height(leftover_rollup_height.saturating_add(1)),
+            S::block_gas_limit(),
             base_fee_per_gas,
         );
 
@@ -359,7 +357,7 @@ impl<S: Spec> ChainState<S> {
     ) -> Result<Option<BlockGasInfo<S::Gas>>, Reader::Error> {
         if height == RollupHeight::GENESIS {
             return Ok(Some(BlockGasInfo::new(
-                S::gas_limit_for_height(height),
+                S::block_gas_limit(),
                 S::initial_base_fee_per_gas(),
             )));
         }
@@ -431,12 +429,6 @@ impl<S: Spec> ChainState<S> {
             .map(|gas_info| *gas_info.base_fee_per_gas()))
     }
 
-    /// Returns the slot gas limit at the specified slot height for this state accessor.
-    /// Note that any empty slots in between height n-1 and height n are defined to have the same gas limit as height n.
-    pub fn block_gas_limit_at(&self, height: RollupHeight) -> S::Gas {
-        S::gas_limit_for_height(height)
-    }
-
     /// Returns the base fee per gas accessible at the current slot accessible from the version reader.
     /// This value is safe to be used in the transaction execution context.
     ///
@@ -454,20 +446,6 @@ impl<S: Spec> ChainState<S> {
         <Reader as StateReader<Kernel>>::Error,
     > {
         self.base_fee_per_gas_at(state.rollup_height_to_access(), state)
-    }
-
-    /// Returns the slot gas limit at the current slot accessible from the version reader.
-    pub fn block_gas_limit(
-        &self,
-        current_rollup_height: RollupHeight,
-        is_stale_height: bool,
-    ) -> S::Gas {
-        let height = if is_stale_height {
-            current_rollup_height.saturating_add(1)
-        } else {
-            current_rollup_height
-        };
-        self.block_gas_limit_at(height)
     }
 
     /// This method is used for testing only. It sets the rollup height to zero.

--- a/crates/module-system/module-implementations/sov-chain-state/src/gas.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/gas.rs
@@ -3,7 +3,6 @@ use std::cmp::max;
 use serde::{Deserialize, Serialize};
 use sov_modules_api::macros::config_value;
 use sov_modules_api::{Amount, Gas, GasArray, GasSpec, Spec};
-use sov_rollup_interface::common::RollupHeight;
 use thiserror::Error;
 
 use crate::{BlockGasInfo, ChainState};
@@ -98,9 +97,9 @@ impl<S: Spec> ChainState<S> {
         gas_limit.scalar_division(Self::config_elasticity_multiplier().into())
     }
 
-    /// Computes the initial gas target (genesis block) by calling [`ChainState::gas_target`] on the initial gas limit.
+    /// Computes the initial gas target (genesis block) by calling [`ChainState::gas_target`] on the block gas limit.
     pub fn initial_gas_target() -> S::Gas {
-        Self::gas_target(<S as GasSpec>::initial_gas_limit())
+        Self::gas_target(<S as GasSpec>::block_gas_limit())
     }
 }
 
@@ -207,7 +206,6 @@ impl<S: Spec> ChainState<S> {
     /// of the multi-dimensional gas price is independently updated following EIP-1559.
     pub fn compute_base_fee_per_gas(
         mut parent_gas_info: BlockGasInfo<S::Gas>,
-        parent_rollup_height: RollupHeight,
         slots_since_last_update: u64,
     ) -> <S::Gas as Gas>::Price {
         // We need to compute the base fee per gas for the slots that are not yet visible to us in state, starting from the previous rollup height.
@@ -217,10 +215,7 @@ impl<S: Spec> ChainState<S> {
             // TODO(@theochap): the gas limit should be updated dynamically `<https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/271`
             // This TODO is for performance enhancement, not a security concern. Updating the gas limit dynamically would allow
             // the work of the prover to follow high level industry trends of the costs to compute zk-proofs.
-            parent_gas_info = BlockGasInfo::new(
-                S::gas_limit_for_height(parent_rollup_height.saturating_add(1)),
-                next_base_price,
-            );
+            parent_gas_info = BlockGasInfo::new(S::block_gas_limit(), next_base_price);
         }
         *parent_gas_info.base_fee_per_gas()
     }

--- a/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/lib.rs
@@ -634,13 +634,12 @@ impl<S: Spec> ChainState<S> {
             self.gas_info
                 .get(&stale_rollup_height, state)?
                 .unwrap_or(BlockGasInfo::new(
-                    S::gas_limit_for_height(stale_rollup_height),
+                    S::block_gas_limit(),
                     S::initial_base_fee_per_gas(),
                 ));
 
         Ok(Self::compute_base_fee_per_gas(
             prev_gas_info,
-            stale_rollup_height,
             provisional_visible_height_increase,
         ))
     }

--- a/crates/module-system/module-implementations/sov-chain-state/src/tests/gas_elasticity_multidimensional.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/src/tests/gas_elasticity_multidimensional.rs
@@ -1,5 +1,4 @@
 use sov_modules_api::{Amount, Gas, GasArray, GasPrice, GasSpec, Spec};
-use sov_rollup_interface::common::RollupHeight;
 use sov_test_utils::TestSpec;
 
 use crate::{BlockGasInfo, ChainState};
@@ -14,14 +13,12 @@ const GAS_DELTA_FRACTION: u64 = 2;
 /// Helper function that initializes the gas elasticity tests for the multidimensional case. It computes the new base fee per gas
 /// given the amount of gas used, the initial gas limit and the initial base fee per gas.
 fn test_helper(gas_used: &<TestSpec as Spec>::Gas) -> <<TestSpec as Spec>::Gas as Gas>::Price {
-    let mut parent_gas_info = BlockGasInfo::new(
-        TestSpec::initial_gas_limit(),
-        INITIAL_BASE_FEE_PER_GAS.into(),
-    );
+    let mut parent_gas_info =
+        BlockGasInfo::new(TestSpec::block_gas_limit(), INITIAL_BASE_FEE_PER_GAS.into());
 
     parent_gas_info.update_gas_used(*gas_used);
 
-    ChainState::<TestSpec>::compute_base_fee_per_gas(parent_gas_info, RollupHeight::GENESIS, 1)
+    ChainState::<TestSpec>::compute_base_fee_per_gas(parent_gas_info, 1)
 }
 
 /// Checks that the `base_fee_per_gas` does not change when the gas used is the same as the gas target.

--- a/crates/module-system/module-implementations/sov-chain-state/tests/integration-tests/dynamic_gas_update.rs
+++ b/crates/module-system/module-implementations/sov-chain-state/tests/integration-tests/dynamic_gas_update.rs
@@ -50,7 +50,7 @@ fn setup_dynamic_gas_update_tests() -> (TestData<S>, TestRunner<TestChainStateRu
         },
     );
 
-    let gas_limit = <S as Spec>::Gas::from(config_value!("INITIAL_GAS_LIMIT"));
+    let gas_limit = <S as Spec>::Gas::from(config_value!("BLOCK_GAS_LIMIT"));
     let gas_target = gas_limit.scalar_division(2);
 
     let runtime = TestChainStateRuntime::<S>::default();

--- a/crates/module-system/module-implementations/sov-evm/src/rpc/fee_history.rs
+++ b/crates/module-system/module-implementations/sov-evm/src/rpc/fee_history.rs
@@ -125,9 +125,6 @@ where
         let mut gas_limits = Vec::with_capacity(block_count);
         let mut used_pending_block = false;
         for n in start_block..=end_block {
-            // The gas limits for each block can be computed statically since they don't depend on the gas used.
-            gas_limits.push(S::gas_limit_for_height(RollupHeight::new(n)).as_ref()[0]);
-
             // For all the blocks in the requested range that are already sealed, we can just take the base fee and gas used from the block.
             if sealed_block_numbers.contains(&n) {
                 let block = self
@@ -136,6 +133,10 @@ where
                     .expect("Block was checked to be in range and doesn't exist. This is a bug.");
                 base_fees.push(block.base_fee());
                 gas_used.push(block.gas_used());
+                // Use the block's own stored gas limit (the value `eth_getBlockByNumber` reports) so
+                // that `gasUsedRatio` stays correct for historical blocks even if the gas limit ever
+                // differs from the current one.
+                gas_limits.push(block.header.gas_limit);
                 continue;
             }
 
@@ -167,10 +168,12 @@ where
                 0
             };
             gas_used.push(pending_gas_used);
+            gas_limits.push(pending_block.partial_header().gas_limit);
         }
 
         // Finally, eth_feeHistory always returns info for one block after the last one requested, so we need to compute the base fee for the next block.
-        let gas_limit: u64 = S::gas_limit_for_height(RollupHeight::new(end_block)).as_ref()[0];
+        // This is the *next* (not-yet-produced) block, so the current gas limit is the right value to estimate with.
+        let gas_limit: u64 = S::block_gas_limit().as_ref()[0];
         let actual_parent_gas_usage = gas_used
             .last()
             .expect("At least one gas used must have been collected");

--- a/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/bond.rs
+++ b/crates/module-system/module-implementations/sov-prover-incentives/tests/integration/bond.rs
@@ -171,7 +171,7 @@ fn test_unbonding() {
 /// by modifying the runtime manually.
 #[test]
 fn test_cannot_prove_when_gas_price_is_too_high() {
-    let gas_limit = <S as Spec>::Gas::from(config_value!("INITIAL_GAS_LIMIT"));
+    let gas_limit = <S as Spec>::Gas::from(config_value!("BLOCK_GAS_LIMIT"));
     let gas_target = gas_limit.scalar_division(2);
 
     let runtime = RT::default();

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -1001,12 +1001,6 @@
         "path"
       ]
     },
-    "RollupHeight": {
-      "description": "A rollup \"block number\". Rollup heights increase in order (1, 2, 3, ...),\nregardless of what happens on the underlying DA layer.",
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0
-    },
     "RunnerConfig": {
       "description": "Configuration for StateTransitionRunner.",
       "type": "object",
@@ -1189,10 +1183,6 @@
         "default_limits": {
           "description": "Default limits.",
           "$ref": "#/$defs/Limits"
-        },
-        "height_for_gas_limit_computation": {
-          "description": "Rate limiting on gas is currently disabled, so this param has no impact on runtime behavior.\n\nThis height is used to statically compute the gas limit for the rate limiter. (If this value is less than or equal to CHANGE_GAS_LIMIT_AFTER_HEIGHT in constants.toml,\nthe gas limit will *always* be computed using the initial gas limit for rate limiting. If it is greater, the gas limit will be computed using the updated gas limit.)\nEven after rate limiting based on gas is enabled, you can safely change this param at any time since it only impacts off-chain code.",
-          "$ref": "#/$defs/RollupHeight"
         },
         "ip_custom_limits": {
           "description": "Per-network rate limits. Accepts CIDR notation (`10.0.0.0/8`) or a bare\nIP address (`192.168.1.5`); a bare address is treated as a host network\n(`/32` for IPv4, `/128` for IPv6).",

--- a/crates/module-system/sov-capabilities/src/lib.rs
+++ b/crates/module-system/sov-capabilities/src/lib.rs
@@ -21,7 +21,7 @@ use sov_modules_api::{
     InvalidProofError, ModuleInfo, OperatingMode, Rewards, SovAttestation,
     SovStateTransitionPublicData, Spec, StateAccessor, StateReader, StateWriter, Storage, TxState,
 };
-use sov_modules_api::{ExecutionContext, GasSpec, VersionReader};
+use sov_modules_api::{ExecutionContext, VersionReader};
 use sov_rollup_interface::common::SlotNumber;
 use sov_rollup_interface::zk::aggregated_proof::SerializedAggregatedProof;
 use sov_rollup_interface::Bytes;
@@ -207,14 +207,7 @@ where
         sequencer: &<S::Da as DaSpec>::Address,
         state: &mut Accessor,
     ) {
-        // Only the preferred sequencer is allowed to bond zero tokens. After the gas limit change height, we no longer penalize the preferred sequencer.
-        let mut net_amount = if bond_amount == Amount::ZERO
-            && state.rollup_height_to_access() > <S as GasSpec>::change_gas_limit_after_height()
-        {
-            Amount::ZERO
-        } else {
-            bond_amount.checked_sub(reward.accumulated_penalty).expect("A sequencer can never be penalized more than the amount they have escrowed, regardless of reward accumulation!")
-        };
+        let mut net_amount = bond_amount.checked_sub(reward.accumulated_penalty).expect("A sequencer can never be penalized more than the amount they have escrowed, regardless of reward accumulation!");
         net_amount = net_amount.checked_add(reward.accumulated_reward).expect("Total sequencer reward + escrow amount is greater than the max possible token supply. This is a bug in gas accounting.");
 
         self.sequencer_registry.add_to_stake(

--- a/crates/module-system/sov-kernels/src/basic.rs
+++ b/crates/module-system/sov-kernels/src/basic.rs
@@ -150,15 +150,6 @@ impl<S: Spec> sov_modules_api::capabilities::ChainState for BasicKernel<'_, S> {
             .unwrap_infallible()
     }
 
-    fn block_gas_limit(
-        &self,
-        current_rollup_height: RollupHeight,
-        is_stale_height: bool,
-    ) -> <Self::Spec as Spec>::Gas {
-        self.chain_state
-            .block_gas_limit(current_rollup_height, is_stale_height)
-    }
-
     fn visible_hash_for(
         &self,
         rollup_height: RollupHeight,

--- a/crates/module-system/sov-kernels/src/soft_confirmations.rs
+++ b/crates/module-system/sov-kernels/src/soft_confirmations.rs
@@ -140,15 +140,6 @@ impl<S: Spec> sov_modules_api::capabilities::ChainState for SoftConfirmationsKer
         self.chain_state.base_fee_per_gas(state).unwrap_infallible()
     }
 
-    fn block_gas_limit(
-        &self,
-        current_rollup_height: RollupHeight,
-        is_stale_height: bool,
-    ) -> S::Gas {
-        self.chain_state
-            .block_gas_limit(current_rollup_height, is_stale_height)
-    }
-
     fn visible_hash_for(
         &self,
         rollup_height: RollupHeight,

--- a/crates/module-system/sov-modules-api/src/module/gas_spec.rs
+++ b/crates/module-system/sov-modules-api/src/module/gas_spec.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use sov_modules_macros::config_value_private;
-use sov_rollup_interface::common::RollupHeight;
 
 use super::Spec;
 use crate::gas::GAS_DIMENSIONS;
@@ -89,25 +88,8 @@ pub trait GasSpec:
     fn tx_bias_json_deserialization() -> Self::Gas;
 
     // --- Gas fee adjustment parameters: See https://eips.ethereum.org/EIPS/eip-1559 for a detailed description ---
-    /// The initial gas limit of the rollup.
-    fn initial_gas_limit() -> Self::Gas;
-    /// The updated gas limit of the rollup.
-    fn updated_gas_limit() -> Self::Gas;
-    /// The height at which the gas limit is updated. The change should take effect immediately *after* this rollup block.
-    /// I.e. any rollup block (and any empty slot) after this rollup height will have the updated gas limit.
-    ///
-    /// Note: We define things in this way because the gas limit is needed inside `synchronize_chain`, but at that point we don't yet know whether a rollup block will be created.
-    /// however, we do know if the previous slot created a rollup block or not.
-    fn change_gas_limit_after_height() -> RollupHeight;
-
-    /// Returns the gas limit for a given rollup height.
-    fn gas_limit_for_height(height: RollupHeight) -> Self::Gas {
-        if height > Self::change_gas_limit_after_height() {
-            Self::updated_gas_limit()
-        } else {
-            Self::initial_gas_limit()
-        }
-    }
+    /// The gas limit applied to every rollup block.
+    fn block_gas_limit() -> Self::Gas;
     /// The initial "base fee" that every transaction emits when executed.
     fn initial_base_fee_per_gas() -> <Self::Gas as Gas>::Price;
 
@@ -230,16 +212,8 @@ impl<S: Spec> GasSpec for S {
         <Self::Gas as Gas>::Price::from(actual)
     }
 
-    fn initial_gas_limit() -> Self::Gas {
-        Self::Gas::from(config_value_private!("INITIAL_GAS_LIMIT"))
-    }
-
-    fn change_gas_limit_after_height() -> RollupHeight {
-        RollupHeight::new(config_value_private!("CHANGE_GAS_LIMIT_AFTER_HEIGHT"))
-    }
-
-    fn updated_gas_limit() -> Self::Gas {
-        Self::Gas::from(config_value_private!("UPDATED_GAS_LIMIT"))
+    fn block_gas_limit() -> Self::Gas {
+        Self::Gas::from(config_value_private!("BLOCK_GAS_LIMIT"))
     }
 
     fn max_tx_check_costs() -> Self::Gas {
@@ -263,39 +237,4 @@ impl<S: Spec> GasSpec for S {
     fn process_tx_pre_exec_checks_gas_per_tx_byte() -> Self::Gas {
         new_constant!("PROCESS_TX_PRE_EXEC_GAS_PER_TX_BYTE", Self::Gas)
     }
-}
-
-#[test]
-fn test_gas_limit_for_height() {
-    use crate::default_spec::DefaultSpec;
-    use sov_mock_da::MockDaSpec;
-    use sov_mock_zkvm::MockZkvm;
-    use sov_rollup_interface::execution_mode::Native;
-    type S = DefaultSpec<MockDaSpec, MockZkvm, MockZkvm, Native>;
-    const UPDATED_GAS_LIMIT: [u64; 2] = [1, 1];
-    const CHANGE_GAS_LIMIT_AFTER_HEIGHT: u64 = 1;
-    std::env::set_var(
-        "SOV_TEST_CONST_OVERRIDE_UPDATED_GAS_LIMIT",
-        format!("{:?}", UPDATED_GAS_LIMIT),
-    );
-    std::env::set_var(
-        "SOV_TEST_CONST_OVERRIDE_CHANGE_GAS_LIMIT_AFTER_HEIGHT",
-        CHANGE_GAS_LIMIT_AFTER_HEIGHT.to_string(),
-    );
-
-    assert_ne!(<S as GasSpec>::initial_gas_limit(), <S as GasSpec>::updated_gas_limit(), "Updated gas limit must be different from initial gas limit - this test needs an update. This is not a bug in the SDK");
-    assert_eq!(
-        <S as GasSpec>::gas_limit_for_height(RollupHeight::new(0)),
-        <S as GasSpec>::initial_gas_limit()
-    );
-    assert_eq!(
-        <S as GasSpec>::gas_limit_for_height(RollupHeight::new(1)),
-        <S as GasSpec>::initial_gas_limit()
-    );
-
-    // First height *AFTER* the change gas limit height should be the updated gas limit
-    assert_eq!(
-        <S as GasSpec>::gas_limit_for_height(RollupHeight::new(2)),
-        <S as GasSpec>::updated_gas_limit()
-    );
 }

--- a/crates/module-system/sov-modules-api/src/runtime/capabilities/chain_state.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/capabilities/chain_state.rs
@@ -80,16 +80,6 @@ pub trait ChainState {
         state: &mut Reader,
     ) -> bool;
 
-    /// Returns the slot gas limit accessible at the current *virtual* slot.
-    ///
-    /// Note that the gas limit is defined to change as of the slot immediately after the CHANGE_GAS_LIMIT_AFTER_HEIGHT rollup height.
-    /// so we need to know whether this is a stale height (i.e. another slot being executed at the same height so that we can determine whether to show the updated gas limit at the boundary height).
-    fn block_gas_limit(
-        &self,
-        current_rollup_height: RollupHeight,
-        is_stale_height: bool,
-    ) -> <Self::Spec as Spec>::Gas;
-
     /// Returns the visible root hash accessible at the requested rollup height
     ///
     /// ## Note

--- a/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/lib.rs
@@ -649,9 +649,7 @@ where
         // Note: The gas price should be computed after all the capabilities involving the [`KernelStateAccessor`] to have the
         // most recent version of the visible rollup height.
         let gas_price = runtime.chain_state().base_fee_per_gas(&mut state).expect("The base fee per gas for the current slot should be known at this point! This is a bug. Please report it");
-        let block_gas_limit = runtime
-            .chain_state()
-            .block_gas_limit(state.rollup_height_to_access(), !creates_rollup_block);
+        let block_gas_limit = <S as GasSpec>::block_gas_limit();
 
         let preferred_sequencer = runtime
             .sequencer_remuneration()

--- a/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
+++ b/crates/module-system/sov-modules-stf-blueprint/src/sequencer_mode/registered.rs
@@ -663,24 +663,12 @@ struct AuthAndProcessOutput<S: Spec, I: StateProvider<S>> {
 }
 
 fn penalize_sequencer<S: Spec, RT: Runtime<S>, I: StateProvider<S>>(
-    sequencer_bond: &SequencerBondForTx,
     runtime: &mut RT,
     auth_cost: Amount,
     sequencer_address: &S::Address,
     operating_mode: OperatingMode,
     tx_scratchpad: &mut TxScratchpad<S, I>,
 ) {
-    // After the gas limit change height, the preferred sequencer doesn't bond for pre execution checks.
-    // In this case, we no longer attempt to penalize the sequencer. This feature should only be active for rollups.
-    // that don't use zk proving, since this would be a griefing vector against the prover.
-    if let SequencerBondForTx::Preferred(bond_amount) = sequencer_bond {
-        if bond_amount == &Amount::ZERO
-            && tx_scratchpad.rollup_height_to_access()
-                > <S as GasSpec>::change_gas_limit_after_height()
-        {
-            return;
-        }
-    }
     runtime
         .gas_enforcer()
         .reward_prover_from_sequencer_balance(
@@ -735,14 +723,8 @@ where
         }
     };
 
-    // If the sequencer isn't bonded enough, reject the input unless unless we've passed the gas limit update height (meaning we've done an update) *AND*
-    // the tx is from the preferred sequencer with zero escrow.
-    // (note: The preferred sequencer sending txs with no escrow is a new pattern that becomes legal
-    // after we update the gas limit.)
-    if sequencer_bond.amount() < max_tx_check_value
-        && !(scratchpad.rollup_height_to_access() > <S as GasSpec>::change_gas_limit_after_height()
-            && matches!(sequencer_bond, SequencerBondForTx::Preferred(Amount::ZERO)))
-    {
+    // If the sequencer isn't bonded enough, reject the input.
+    if sequencer_bond.amount() < max_tx_check_value {
         return AuthAndProcessOutput {
             outcome: AuthAndProcessOutcome::IllegalSequencer {
                 reason: OutOfFundsReason::SequencerBondTooLow {
@@ -756,10 +738,7 @@ where
     }
 
     // 3. The slot gas is higher than the gas needed to validate the transaction.
-    // If we've updated the gas limit, disable this check.
-    if slot_gas.dim_is_less_or_eq(max_tx_check_costs)
-        && scratchpad.rollup_height_to_access() <= <S as GasSpec>::change_gas_limit_after_height()
-    {
+    if slot_gas.dim_is_less_or_eq(max_tx_check_costs) {
         return AuthAndProcessOutput {
             outcome: AuthAndProcessOutcome::IllegalSequencer {
                 reason: OutOfFundsReason::SlotGasLimitExhausted {
@@ -817,7 +796,6 @@ where
             return match pre_exec_error {
                 AuthenticationError::FatalError(err, tx_hash) => {
                     penalize_sequencer(
-                        &sequencer_bond,
                         runtime,
                         funds_used_for_authentication,
                         &sequencer_rollup_address,
@@ -837,7 +815,6 @@ where
                 }
                 AuthenticationError::OutOfGas(e) => {
                     penalize_sequencer(
-                        &sequencer_bond,
                         runtime,
                         funds_used_for_authentication,
                         &sequencer_rollup_address,
@@ -894,7 +871,6 @@ where
     match tx_result {
         Err((error, raw_tx)) => {
             penalize_sequencer(
-                &sequencer_bond,
                 runtime,
                 pre_exec_gas_meter.gas_info().gas_value,
                 &sequencer_rollup_address,


### PR DESCRIPTION
Collapse `INITIAL_GAS_LIMIT` and `UPDATED_GAS_LIMIT` into 1

(fee_history.rs): per-block gas limit now comes from each block's own stored header (block.header.gas_limit for sealed, pending_block.partial_header().gas_limit for pending) instead of the runtime constant — matching what `eth_getBlockByNumber` reports. Compiles clean (cargo check -p sov-evm).

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)



## Testing
New test added for preserving EVM fee history

## Docs
Docstrings have been updated
