### PR TITLE
fix: use milli-request-counts in the rate-limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2026-06-02
+- #2936 Request rate limiting uses milli-requests instead of always rounding down.
+  * Per-request budget (`milli_req_counter`) is now more fine-grained and will work even with single digit requests per second.
 # 2026-05-26
 - #2918 Adds support for CIDR based rate limiting in preferred sequencer. Existing configs are backwards compatible.
   * **Breaking (behavior)**: corrects a unit bug in the preferred sequencer rate limiter where the per-request budget (`req_counter`) was computed 1000× too large (per-second rate × milliseconds). It now enforces the true requests-per-batch, consistent with the size/execution-time/gas limits. Configs are unchanged; in typical setups the request-count dimension still doesn't bind, but the request-count limit is now 1000× tighter. At low configured request budgets, request-counter refill still uses integer per-millisecond refill and can round down to zero.

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
@@ -118,7 +118,7 @@ impl<G: Gas> Throttler<G> {
         max_allowed_resources: &TotalResources<G>,
         refill_rate: &RefillRatePerMillis<G>,
     ) -> Result<Self, LimitExceeded<G>> {
-	 let how_much_to_fill = {
+        let how_much_to_fill = {
             let since_last_refill = now
                 .duration_since(self.last_refill)
                 .as_millis()

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/limiter.rs
@@ -33,7 +33,7 @@ impl<G: Gas> ResourceUsed<G> {
     ) -> Self {
         Self {
             inner: Resource {
-                req_counter,
+                milli_req_counter: req_counter * 1000,
                 // This cast is safe because a single transaction can never use more than u64::MAX bytes.
                 space_in_bytes: tx_size_in_bytes
                     .try_into()
@@ -118,7 +118,7 @@ impl<G: Gas> Throttler<G> {
         max_allowed_resources: &TotalResources<G>,
         refill_rate: &RefillRatePerMillis<G>,
     ) -> Result<Self, LimitExceeded<G>> {
-        let how_much_to_fill = {
+	 let how_much_to_fill = {
             let since_last_refill = now
                 .duration_since(self.last_refill)
                 .as_millis()
@@ -130,7 +130,6 @@ impl<G: Gas> Throttler<G> {
 
         let total_resource_used_after_refill =
             self.total_resource_used.refill_tokens(&how_much_to_fill);
-
         total_resource_used_after_refill.allow(max_allowed_resources)?;
 
         Ok(Throttler {
@@ -416,7 +415,7 @@ mod tests {
         let default_config = RateLimiterConfig::<TestSpec> {
             max_allowed_resources: TotalResources {
                 inner: Resource {
-                    req_counter: resource_used_per_run.inner.req_counter + 1,
+                    milli_req_counter: resource_used_per_run.inner.milli_req_counter + 1,
                     space_in_bytes: resource_used_per_run.inner.space_in_bytes + 1,
                     execution_time_micros: resource_used_per_run.inner.execution_time_micros + 1,
                     gas_used: Gas::from([0, 0]),
@@ -722,7 +721,7 @@ mod tests {
     fn max_allowed_resources() -> TotalResources<Gas> {
         TotalResources {
             inner: Resource {
-                req_counter: MAX_REQ_COUNT,
+                milli_req_counter: MAX_REQ_COUNT,
                 space_in_bytes: MAX_SPACE_IN_BYTES,
                 execution_time_micros: MAX_EXECUTION_TIME_MICROS,
                 gas_used: Gas::from([0, 0]),
@@ -733,7 +732,7 @@ mod tests {
     fn small_resource_used_per_run() -> ResourceUsed<Gas> {
         ResourceUsed {
             inner: Resource {
-                req_counter: MAX_REQ_COUNT / 100,
+                milli_req_counter: MAX_REQ_COUNT / 100,
                 space_in_bytes: MAX_SPACE_IN_BYTES / 200,
                 execution_time_micros: MAX_EXECUTION_TIME_MICROS / 300,
                 gas_used: Gas::from([0, 0]),
@@ -744,7 +743,7 @@ mod tests {
     fn big_resource_used_per_run() -> ResourceUsed<Gas> {
         ResourceUsed {
             inner: Resource {
-                req_counter: MAX_REQ_COUNT / 2 + 10,
+                milli_req_counter: MAX_REQ_COUNT / 2 + 10,
                 space_in_bytes: MAX_SPACE_IN_BYTES / 3,
                 execution_time_micros: MAX_EXECUTION_TIME_MICROS / 4,
                 gas_used: Gas::from([0, 0]),
@@ -755,7 +754,7 @@ mod tests {
     fn refill_rate() -> RefillRatePerMillis<Gas> {
         RefillRatePerMillis {
             token_resource_per_ms: Resource {
-                req_counter: 2,
+                milli_req_counter: 2,
                 space_in_bytes: 30,
                 execution_time_micros: 400,
                 gas_used: Gas::from([0, 0]),

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
@@ -154,12 +154,10 @@ fn calculate_limits<S: Spec>(
         .expect("Batch execution time limit overflows u64 microseconds");
 
     let max_resources_per_batch = Resource {
-        // requests-per-batch = rate (per second) × batch duration (seconds).
-        // Multiply by milliseconds first, then divide by 1000, to keep sub-second precision.
-        req_counter: max_requests_per_second
+        // milli-requests-per-batch = rate (per second) × batch duration (seconds).
+        milli_req_counter: max_requests_per_second
             .checked_mul(batch_execution_time_limit_millis)
-            .expect("Overflow converting max_requests_per_second to max requests per batch")
-            / 1000,
+            .expect("Overflow converting max_requests_per_second to max requests per batch"),
         // The `expect` is justified because we will never have batches larger than u64::MAX bytes.
         space_in_bytes: max_batch_size_bytes
             .try_into()
@@ -177,21 +175,12 @@ fn calculate_limits<S: Spec>(
     // `max_requests_per_second == 0` are intentional "block everything" sentinels,
     // so leave those untouched.
     if limits.resources_per_bucket > 0 && max_requests_per_second > 0 {
-        max_per_key.req_counter = max_per_key.req_counter.max(1);
+        max_per_key.milli_req_counter = max_per_key.milli_req_counter.max(1);
     }
 
     // Refill per millisecond: over one batch the bucket refills `refill_rate`
     // times its capacity (`max_per_key * limits.refill_rate`), spread across
     // `batch_execution_time_limit_millis`.
-    //
-    // This per-ms rate is an integer. When
-    // `max_per_key.req_counter * limits.refill_rate < batch_execution_time_limit_millis`
-    // the request refill truncates to 0, so the request dimension acts as a hard
-    // cap of `max_per_key.req_counter` that resets only when the throttler is
-    // evicted (~`ttl_in_millis` after the key's last successful request) rather
-    // than refilling smoothly. This surfaces only under floods of unusually cheap
-    // requests; otherwise the size/execution-time limits bind first. Smooth
-    // sub-token request refill is a possible follow-up.
     let refill_rate = max_per_key
         .saturating_mul_by_scalar(limits.refill_rate)
         .div_by_scalar(batch_execution_time_limit_millis);
@@ -487,7 +476,7 @@ mod tests {
 
     fn req_count_config(max_req_count: u64) -> RateLimiterConfig<TestSpec> {
         let mut max_allowed_resources = Resource::max();
-        max_allowed_resources.req_counter = max_req_count;
+        max_allowed_resources.milli_req_counter = max_req_count * 1000;
 
         RateLimiterConfig::<TestSpec> {
             max_allowed_resources: TotalResources {
@@ -502,7 +491,7 @@ mod tests {
     fn one_request() -> ResourceUsed<Gas> {
         ResourceUsed {
             inner: Resource {
-                req_counter: 1,
+                milli_req_counter: 1000,
                 ..Resource::zero()
             },
         }
@@ -569,24 +558,24 @@ mod tests {
             6_000_000,
             RollupHeight::GENESIS,
         );
-        assert_eq!(config.max_allowed_resources.inner.req_counter, 60);
+        assert_eq!(config.max_allowed_resources.inner.milli_req_counter, 60_000);
     }
 
     #[test]
     fn calculate_limits_floors_req_counter_for_subsecond_batch() {
-        // 1000 req/s over a 100 ms batch = 100 requests/batch; resources_per_bucket = 5
-        // would round the per-key budget to 0 (100 * 5 / 1000). The guard floors it at 1.
+        // 10 req/s over a 10 ms batch = 0.1 requests/batch; resources_per_bucket = 5
+        // would round the per-key budget to 0 (0.1 * 5). The guard floors it at 1.
         let config = calculate_limits::<TestSpec>(
             Limits {
                 resources_per_bucket: 5,
                 refill_rate: 0,
             },
-            1000,
-            Duration::from_millis(100),
+            10,
+            Duration::from_millis(10),
             6_000_000,
             RollupHeight::GENESIS,
         );
-        assert_eq!(config.max_allowed_resources.inner.req_counter, 1);
+        assert_eq!(config.max_allowed_resources.inner.milli_req_counter, 1);
     }
 
     #[test]
@@ -603,7 +592,7 @@ mod tests {
             6_000_000,
             RollupHeight::GENESIS,
         );
-        assert_eq!(config.max_allowed_resources.inner.req_counter, 0);
+        assert_eq!(config.max_allowed_resources.inner.milli_req_counter, 0);
     }
 
     #[test]
@@ -620,14 +609,14 @@ mod tests {
             6_000_000,
             RollupHeight::GENESIS,
         );
-        assert_eq!(config.max_allowed_resources.inner.req_counter, 0);
+        assert_eq!(config.max_allowed_resources.inner.milli_req_counter, 0);
     }
 
     #[test]
     fn test_sov_test_limiter() {
         let resource_used_per_run = ResourceUsed {
             inner: Resource {
-                req_counter: 10,
+                milli_req_counter: 10,
                 space_in_bytes: 3000,
                 execution_time_micros: 30,
                 gas_used: Gas::from([0, 0]),
@@ -637,7 +626,7 @@ mod tests {
         // This is enough to make 2 requests.
         let max_allowed_resources = TotalResources {
             inner: Resource {
-                req_counter: 100000,
+                milli_req_counter: 100000,
                 space_in_bytes: 5000,
                 execution_time_micros: 100000,
 
@@ -647,7 +636,7 @@ mod tests {
 
         let refill_rate = RefillRatePerMillis {
             token_resource_per_ms: Resource {
-                req_counter: 1,
+                milli_req_counter: 1,
                 space_in_bytes: 1,
                 execution_time_micros: 1,
                 gas_used: Gas::from([0, 0]),
@@ -907,7 +896,7 @@ mod tests {
         let config = RateLimiterConfig::<TestSpec> {
             max_allowed_resources: TotalResources {
                 inner: Resource {
-                    req_counter: 100000,
+                    milli_req_counter: 100000,
                     space_in_bytes: 5000,
                     execution_time_micros: 100000,
                     gas_used: Gas::from([0, 0]),
@@ -915,7 +904,7 @@ mod tests {
             },
             refill_rate: RefillRatePerMillis {
                 token_resource_per_ms: Resource {
-                    req_counter: 0,
+                    milli_req_counter: 0,
                     space_in_bytes: 0,
                     execution_time_micros: 0,
                     gas_used: Gas::from([0, 0]),

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/mod.rs
@@ -154,7 +154,7 @@ fn calculate_limits<S: Spec>(
         .expect("Batch execution time limit overflows u64 microseconds");
 
     let max_resources_per_batch = Resource {
-        // milli-requests-per-batch = rate (per second) × batch duration (seconds).
+        // milli-requests-per-batch = rate (per second) × batch duration (milli-seconds).
         milli_req_counter: max_requests_per_second
             .checked_mul(batch_execution_time_limit_millis)
             .expect("Overflow converting max_requests_per_second to max requests per batch"),

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
@@ -4,6 +4,7 @@ use sov_modules_api::Gas;
 #[derive(Debug, PartialEq)]
 pub(crate) enum LimitExceeded<G: Gas> {
     RequestCount {
+        // the numbers are in milli-requests to avoid rounding errors
         total_accumulated: u64,
         max_allowed: u64,
     },
@@ -118,8 +119,8 @@ impl<G: Gas> Resource<G> {
         // Using >= instead of > to ensure that a rate limit of zero prevents all requests.
         if self.milli_req_counter >= other.milli_req_counter {
             return Err(LimitExceeded::RequestCount {
-                total_accumulated: self.milli_req_counter / 1000,
-                max_allowed: other.milli_req_counter / 1000,
+                total_accumulated: self.milli_req_counter,
+                max_allowed: other.milli_req_counter,
             });
         }
 
@@ -246,8 +247,8 @@ mod tests {
             assert_eq!(
                 r1.err_if_exceeding(&r2),
                 Err(LimitExceeded::RequestCount {
-                    total_accumulated: { r1.milli_req_counter / 1000 },
-                    max_allowed: { r2.milli_req_counter / 1000 },
+                    total_accumulated: { r1.milli_req_counter },
+                    max_allowed: { r2.milli_req_counter },
                 })
             );
         }

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
@@ -30,7 +30,7 @@ pub(crate) enum LimitExceeded<G: Gas> {
 // Represents a resource that requires rate limiting.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct Resource<G: Gas> {
-    pub(crate) req_counter: u64,
+    pub(crate) milli_req_counter: u64,
     pub(crate) space_in_bytes: u64,
     pub(crate) execution_time_micros: u64,
     pub(crate) gas_used: G,
@@ -39,7 +39,7 @@ pub(crate) struct Resource<G: Gas> {
 impl<G: Gas> Resource<G> {
     pub(crate) fn zero() -> Self {
         Self {
-            req_counter: 0,
+            milli_req_counter: 0,
             space_in_bytes: 0,
             execution_time_micros: 0,
             gas_used: Gas::zero(),
@@ -48,7 +48,7 @@ impl<G: Gas> Resource<G> {
 
     pub(crate) fn max() -> Self {
         Self {
-            req_counter: u64::MAX,
+            milli_req_counter: u64::MAX,
             space_in_bytes: u64::MAX,
             execution_time_micros: u64::MAX,
             gas_used: Gas::max(),
@@ -58,7 +58,7 @@ impl<G: Gas> Resource<G> {
     #[must_use]
     pub(crate) fn saturating_sub(&self, tokens: &Self) -> Self {
         Self {
-            req_counter: self.req_counter.saturating_sub(tokens.req_counter),
+            milli_req_counter: self.milli_req_counter.saturating_sub(tokens.milli_req_counter),
             space_in_bytes: self.space_in_bytes.saturating_sub(tokens.space_in_bytes),
             execution_time_micros: self
                 .execution_time_micros
@@ -73,7 +73,7 @@ impl<G: Gas> Resource<G> {
     #[must_use]
     pub(crate) fn checked_add(&self, other: &Self) -> Option<Self> {
         Some(Self {
-            req_counter: self.req_counter.checked_add(other.req_counter)?,
+            milli_req_counter: self.milli_req_counter.checked_add(other.milli_req_counter)?,
             space_in_bytes: self.space_in_bytes.checked_add(other.space_in_bytes)?,
             execution_time_micros: self
                 .execution_time_micros
@@ -90,7 +90,7 @@ impl<G: Gas> Resource<G> {
             .unwrap_or(G::max());
 
         Self {
-            req_counter: self.req_counter.saturating_mul(scalar),
+            milli_req_counter: self.milli_req_counter.saturating_mul(scalar),
             space_in_bytes: self.space_in_bytes.saturating_mul(scalar),
             execution_time_micros: self.execution_time_micros.saturating_mul(scalar),
             gas_used,
@@ -102,7 +102,7 @@ impl<G: Gas> Resource<G> {
         let gas_used = self.gas_used.scalar_division(scalar);
 
         Self {
-            req_counter: self.req_counter / scalar,
+            milli_req_counter: self.milli_req_counter / scalar,
             space_in_bytes: self.space_in_bytes / scalar,
             execution_time_micros: self.execution_time_micros / scalar,
             gas_used,
@@ -112,10 +112,10 @@ impl<G: Gas> Resource<G> {
     pub(crate) fn err_if_exceeding(&self, other: &Self) -> Result<(), LimitExceeded<G>> {
         // Error if the total accumulated is greater than or equal to the max allowed.
         // Using >= instead of > to ensure that a rate limit of zero prevents all requests.
-        if self.req_counter >= other.req_counter {
+        if self.milli_req_counter >= other.milli_req_counter {
             return Err(LimitExceeded::RequestCount {
-                total_accumulated: self.req_counter,
-                max_allowed: other.req_counter,
+                total_accumulated: self.milli_req_counter / 1000,
+                max_allowed: other.milli_req_counter / 1000,
             });
         }
 
@@ -158,7 +158,7 @@ mod tests {
             gas_used: Gas,
         ) -> Self {
             Self {
-                req_counter,
+                milli_req_counter: req_counter * 1000,
                 space_in_bytes,
                 execution_time_micros,
                 gas_used,
@@ -167,7 +167,7 @@ mod tests {
 
         fn from(n: u64) -> Self {
             Self {
-                req_counter: n,
+                milli_req_counter: n.saturating_mul(1000),
                 space_in_bytes: n,
                 execution_time_micros: n,
                 gas_used: Gas::from([n, n]),
@@ -236,14 +236,14 @@ mod tests {
         {
             let r1 = Resource::new(100, 101, 102, Gas::from([103, 104]));
             let r2 = Resource {
-                req_counter: 1,
+                milli_req_counter: 1000,
                 ..r1
             };
             assert_eq!(
                 r1.err_if_exceeding(&r2),
                 Err(LimitExceeded::RequestCount {
-                    total_accumulated: { r1.req_counter },
-                    max_allowed: { r2.req_counter },
+                    total_accumulated: { r1.milli_req_counter / 1000 },
+                    max_allowed: { r2.milli_req_counter / 1000 },
                 })
             );
         }

--- a/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/rate_limiter/resource.rs
@@ -58,7 +58,9 @@ impl<G: Gas> Resource<G> {
     #[must_use]
     pub(crate) fn saturating_sub(&self, tokens: &Self) -> Self {
         Self {
-            milli_req_counter: self.milli_req_counter.saturating_sub(tokens.milli_req_counter),
+            milli_req_counter: self
+                .milli_req_counter
+                .saturating_sub(tokens.milli_req_counter),
             space_in_bytes: self.space_in_bytes.saturating_sub(tokens.space_in_bytes),
             execution_time_micros: self
                 .execution_time_micros
@@ -73,7 +75,9 @@ impl<G: Gas> Resource<G> {
     #[must_use]
     pub(crate) fn checked_add(&self, other: &Self) -> Option<Self> {
         Some(Self {
-            milli_req_counter: self.milli_req_counter.checked_add(other.milli_req_counter)?,
+            milli_req_counter: self
+                .milli_req_counter
+                .checked_add(other.milli_req_counter)?,
             space_in_bytes: self.space_in_bytes.checked_add(other.space_in_bytes)?,
             execution_time_micros: self
                 .execution_time_micros


### PR DESCRIPTION
So that they are not rounded down to zero.

# Description

*Summary of the changes...*

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
