### PR TITLE
CI: Use less profiles and clean ups

### DIFF
--- a/.github/dependency_review_backup.yml
+++ b/.github/dependency_review_backup.yml
@@ -8,11 +8,13 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: nscloud-ubuntu-22.04-amd64-2x4
+    runs-on: nscloud-ubuntu-24.04-amd64-2x4
+    timeout-minutes: 10
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: "Dependency Review"
-        uses: actions/dependency-review-action@v3
+        # This action publishes no floating major tag; pin a full version.
+        uses: actions/dependency-review-action@v4.9.0
         with:
           fail-on-severity: critical

--- a/.github/workflows/acceptance_test_promote.yml
+++ b/.github/workflows/acceptance_test_promote.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   promote:
-    runs-on: nscloud-ubuntu-22.04-amd64-2x4
+    runs-on: nscloud-ubuntu-24.04-amd64-2x4
     timeout-minutes: 10
     steps:
       - name: Log event details
@@ -32,7 +32,7 @@ jobs:
 
       - name: Checkout commit
         id: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.client_payload.commit_sha }}
           fetch-depth: 0

--- a/.github/workflows/acceptance_test_trigger.yml
+++ b/.github/workflows/acceptance_test_trigger.yml
@@ -24,10 +24,10 @@ env:
 
 jobs:
   trigger:
-    runs-on: nscloud-ubuntu-22.04-amd64-2x4
+    runs-on: nscloud-ubuntu-24.04-amd64-2x4
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ env.DEV_BRANCH }}
           fetch-depth: 0

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -11,15 +11,16 @@ on:
 jobs:
   check-changelog:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Check for demo-rollup changes requiring changelog
         run: |
-          PR_NUMBER=$(echo $GITHUB_REF | sed 's/.*\/pull\/\([0-9]*\).*/\1/')
-
-          if !  grep -q "#${PR_NUMBER}" CHANGELOG.md; then
+          if ! grep -q "#${PR_NUMBER}" CHANGELOG.md; then
             echo "Error: Demo rollup was changed but no changelog entry found for PR #${PR_NUMBER}."
-            echo "If you've already checked in a changelog entry, make sure it contains the literal string `#${PR_NUMBER}`."
+            echo "If you've already added a changelog entry, ensure it contains the literal string #${PR_NUMBER}."
             exit 1
           fi

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'

--- a/.github/workflows/nightly_default_features_tests.yml
+++ b/.github/workflows/nightly_default_features_tests.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   default_features_tests:
     name: default_features_tests
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-300gb-1-93;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=default-features-daily-1-93
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=default-features-daily-1-93
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"

--- a/.github/workflows/nightly_default_features_tests.yml
+++ b/.github/workflows/nightly_default_features_tests.yml
@@ -21,7 +21,7 @@ jobs:
       RUST_BACKTRACE: 1
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust

--- a/.github/workflows/prerelease_checks.yml
+++ b/.github/workflows/prerelease_checks.yml
@@ -15,9 +15,10 @@ on:
 
 jobs:
   check-missing-dependency-versions:
-    runs-on: nscloud-ubuntu-22.04-amd64-2x4
+    runs-on: nscloud-ubuntu-24.04-amd64-2x4
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - run: ./scripts/check_missing_dependency_versions.sh
         shell: bash
         working-directory: .

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ concurrency:
 jobs:
   check-aggregate:
     # Follows the guide at <https://github.com/re-actors/alls-green>.
-    runs-on: nscloud-ubuntu-22.04-amd64-2x4
+    runs-on: nscloud-ubuntu-24.04-amd64-2x4
     timeout-minutes: 5
     if: always()
     needs:
@@ -107,7 +107,7 @@ jobs:
       SKIP_GUEST_BUILD: "1"
       SP1_SKIP_PROGRAM_BUILD: "true"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -142,7 +142,7 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -162,7 +162,7 @@ jobs:
     runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=bench-1-93
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -192,7 +192,7 @@ jobs:
       CARGO_HACK_PARTITION_N: ${{ matrix.partition }}
       CARGO_HACK_PARTITION_M: 3
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -223,7 +223,7 @@ jobs:
       CARGO_HACK_PARTITION_N: ${{ matrix.partition }}
       CARGO_HACK_PARTITION_M: 3
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -243,7 +243,7 @@ jobs:
       SP1_PROVER: "mock"
       RUST_BACKTRACE: 1
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -263,7 +263,7 @@ jobs:
       SKIP_GUEST_BUILD: "1"
       SP1_SKIP_PROGRAM_BUILD: "true"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -285,7 +285,7 @@ jobs:
       RUST_BACKTRACE: 1
       CARGO_BUILD_JOBS: 4
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -304,10 +304,10 @@ jobs:
           fail_ci_if_error: false
 
   cargo-deny-check-licenses:
-    runs-on: nscloud-ubuntu-22.04-amd64-2x4
+    runs-on: nscloud-ubuntu-24.04-amd64-2x4
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: taiki-e/install-action@cargo-deny
         with:
           tool: cargo-deny@0.18.4
@@ -319,7 +319,7 @@ jobs:
   # Temporarily disabled until AWS credentials can be re-issued
   # cargo-doc-artifact:
   #   runs-on:
-  #     - nscloud-ubuntu-22.04-amd64-8x32-with-cache
+  #     - nscloud-ubuntu-24.04-amd64-8x32-with-cache
   #     - nscloud-cache-tag-cache-dev
   #     - nscloud-cache-size-100gb
   #   timeout-minutes: 90
@@ -330,7 +330,7 @@ jobs:
   #     S3_BUCKET_NAME: "sovlabs-ci-rustdoc-artifacts"
   #     AWS_REGION: "us-east-1"
   #   steps:
-  #     - uses: actions/checkout@v5
+  #     - uses: actions/checkout@v6
   #     - uses: namespacelabs/nscloud-cache-action@v1
   #       with:
   #         cache: rust
@@ -377,7 +377,7 @@ jobs:
   #         echo "Docs are available at https://${S3_BUCKET_NAME}.${AWS_REGION}.amazonaws.com/${TARGET_DIR}/index.html";
 
   # deploy-github-pages:
-  #   runs-on: nscloud-ubuntu-22.04-amd64-2x4
+  #   runs-on: nscloud-ubuntu-24.04-amd64-2x4
   #   needs: cargo-doc-artifact
   #   timeout-minutes: 5
   #   if: github.ref == 'refs/heads/stable'
@@ -395,10 +395,10 @@ jobs:
   #       uses: actions/deploy-pages@v4
 
   check-demo-rollup-table-of-contents:
-    runs-on: nscloud-ubuntu-22.04-amd64-2x4
+    runs-on: nscloud-ubuntu-24.04-amd64-2x4
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
       - run: npm install -g doctoc
       - name: Update table of contents for mock-da
         run: doctoc README.md --github --notitle
@@ -421,7 +421,7 @@ jobs:
       SKIP_GUEST_BUILD: "risc0"
       RUST_LOG: "debug,sov_sequencer=trace,sov-celestia-adapter=trace,hyper=info,risc0_zkvm=warn,jsonrpsee-server=info,jsonrpsee-client=info,reqwest=info,sqlx=warn,tiny_http=warn,tower_http=info,tungstenite=info,risc0_circuit_rv32im=info,risc0_zkp::verify=info,h2=info,tower=info"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -448,7 +448,7 @@ jobs:
       SKIP_GUEST_BUILD: "risc0"
       RUST_LOG: "debug,sov_stf_runner=trace,sov_sequencer=trace,hyper=info,risc0_zkvm=warn,jsonrpsee-server=info,jsonrpsee-client=info,reqwest=info,sqlx=warn,tiny_http=warn,tower_http=info,tungstenite=info,risc0_circuit_rv32im=info,risc0_zkp::verify=info,h2=info,tower=info"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -464,16 +464,16 @@ jobs:
     runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=test-1-93
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
       - run: make check-constant-overriding-is-disabled-in-release-mode
 
   validate-packages-to-publish-yml:
-    runs-on: nscloud-ubuntu-22.04-amd64-2x4
+    runs-on: nscloud-ubuntu-24.04-amd64-2x4
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - run: ./scripts/validate_packages_to_publish_yml.sh
         shell: bash
         working-directory: .
@@ -481,7 +481,7 @@ jobs:
   cargo-switcheroo-default:
     runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=switcheroo-1-93
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -499,7 +499,7 @@ jobs:
       SKIP_GUEST_BUILD: "1"
       CARGO_NET_GIT_FETCH_WITH_CLI: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: |
@@ -507,12 +507,7 @@ jobs:
             pnpm
           path: |
             ./typescript/.turbo
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-      - uses: pnpm/action-setup@v4
-        with:
-          package_json_file: ./typescript/package.json
+      # Node.js 20 + pnpm 9 are baked into the base image; no setup needed.
       - name: Run web3-js SDK tests against demo-rollup
         # See the script for more details about what to do if job
         run: |
@@ -529,7 +524,7 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -554,18 +549,14 @@ jobs:
       SKIP_GUEST_BUILD: "1"
       CARGO_NET_GIT_FETCH_WITH_CLI: true
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+      # Node.js 20 + pnpm 9 are baked into the base image; the pnpm store is
+      # cached via the Namespace volume below (no setup-node/pnpm steps needed).
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
-          cache: rust
-      - uses: pnpm/action-setup@v4
-        with:
-          package_json_file: ./typescript/package.json
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 20.x
-          cache: "pnpm"
-          cache-dependency-path: typescript/pnpm-lock.yaml
+          cache: |
+            rust
+            pnpm
       # CI always operates on the entire workspace
       - run: cargo switcheroo disable
         shell: bash
@@ -590,12 +581,14 @@ jobs:
 
   timing_check:
     name: timing_check
+    # Informational only — run on pushes to dev/nightly/stable, not on every PR.
+    if: github.event_name == 'push'
     runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=check-1-93
     timeout-minutes: 60
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust
@@ -611,6 +604,8 @@ jobs:
 
   timing_nextest_all_features:
     name: timing_nextest_all_features
+    # Informational only — run on pushes to dev/nightly/stable, not on every PR.
+    if: github.event_name == 'push'
     runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=nextest_all_features-1-93
     timeout-minutes: 60
     env:
@@ -618,7 +613,7 @@ jobs:
       SP1_PROVER: "mock"
       RUST_BACKTRACE: 1
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
           cache: rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,7 +100,7 @@ jobs:
 
   check:
     name: check
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-dev-300gb-1-93;overrides.cache-tag=check-1-93
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=check-1-93
     timeout-minutes: 60
     env:
       RUSTFLAGS: "-D warnings"
@@ -137,7 +137,7 @@ jobs:
     name: bench_check
     needs: check
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-bench-300gb-1-93;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=bench-1-93
     timeout-minutes: 120
     env:
       RUSTFLAGS: "-D warnings"
@@ -159,7 +159,7 @@ jobs:
     name: rollup_tps_validation
     needs: check
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-bench-300gb-1-93;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=bench-1-93
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v5
@@ -180,7 +180,7 @@ jobs:
     # building dependencies, only checking them, so we can share caches
     # effectively.
     needs: check
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-dev-300gb-1-93;overrides.cache-tag=hack-all-targets-1-93-p${{ matrix.partition }}
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=hack-all-targets-1-93-p${{ matrix.partition }}
     strategy:
       matrix:
         partition: [1, 2, 3]
@@ -211,7 +211,7 @@ jobs:
     # building dependencies, only checking them, so we can share caches
     # effectively.
     needs: check
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-dev-300gb-1-93;overrides.cache-tag=hack-default-targets-1-93-p${{ matrix.partition }}
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=hack-default-targets-1-93-p${{ matrix.partition }}
     strategy:
       matrix:
         partition: [1, 2, 3]
@@ -236,7 +236,7 @@ jobs:
   nextest_all_features:
     name: nextest_all_features
     # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-all-features-300gb-1-93;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=nextest_all_features-1-93
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=nextest_all_features-1-93
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"
@@ -256,7 +256,7 @@ jobs:
 
   doctests:
     name: doctests
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-test-300gb-1-93
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=test-1-93
     timeout-minutes: 60
     env:
       RUSTFLAGS: "-D warnings"
@@ -277,7 +277,7 @@ jobs:
   coverage:
     name: coverage
     # TODO:try coverage 32x64
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-coverage-300gb-1-93;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=coverage-1-93
     timeout-minutes: 90
     env:
       SKIP_GUEST_BUILD: "1"
@@ -413,7 +413,7 @@ jobs:
         run: git diff --exit-code
 
   check-demo-rollup-bash-commands:
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-demo-rollup-300gb-1-93;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=demo-rollup-1-93
     needs:
       - check
     timeout-minutes: 60
@@ -440,7 +440,7 @@ jobs:
       - run: chmod +x demo-rollup-readme.sh && ./demo-rollup-readme.sh
 
   check-demo-rollup-bash-commands-mock-da:
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-demo-rollup-300gb-1-93;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=demo-rollup-1-93
     needs:
       - check
     timeout-minutes: 60
@@ -461,7 +461,7 @@ jobs:
       - run: chmod +x demo-rollup-readme.sh && ./demo-rollup-readme.sh
 
   check-constant-overriding-is-disabled-in-release-mode:
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-test-300gb-1-93
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=test-1-93
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
@@ -479,7 +479,7 @@ jobs:
         working-directory: .
 
   cargo-switcheroo-default:
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-dev-300gb-1-93
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=switcheroo-1-93
     steps:
       - uses: actions/checkout@v5
       - uses: namespacelabs/nscloud-cache-action@v1
@@ -490,7 +490,7 @@ jobs:
       - run: git diff --exit-code
 
   check-web3-js-sdk-integration:
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-demo-rollup-300gb-1-93;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=demo-rollup-1-93
     needs:
       - check
     timeout-minutes: 60
@@ -524,7 +524,7 @@ jobs:
   rollup_starter_lint:
     name: rollup_starter_lint
     if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-dev-300gb-1-93;overrides.cache-tag=rollup-starter-1-93
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=rollup-starter-1-93
     timeout-minutes: 90
     env:
       RUSTFLAGS: "-D warnings"
@@ -545,7 +545,7 @@ jobs:
         run: make lint
 
   check-demo-rollup-phantom-dapp-e2e:
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-demo-rollup-300gb-1-93;container.privileged=true;container.host-pid-namespace=true
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-32x64-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=demo-rollup-1-93
     needs:
       - check
     timeout-minutes: 60
@@ -590,7 +590,7 @@ jobs:
 
   timing_check:
     name: timing_check
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-dev-300gb-1-93;overrides.cache-tag=check-1-93
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=check-1-93
     timeout-minutes: 60
     env:
       RUSTFLAGS: "-D warnings"
@@ -611,7 +611,7 @@ jobs:
 
   timing_nextest_all_features:
     name: timing_nextest_all_features
-    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-all-features-300gb-1-93;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=nextest_all_features-1-93
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=nextest_all_features-1-93
     timeout-minutes: 60
     env:
       RISC0_DEV_MODE: "true"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -581,8 +581,6 @@ jobs:
 
   timing_check:
     name: timing_check
-    # Informational only — run on pushes to dev/nightly/stable, not on every PR.
-    if: github.event_name == 'push'
     runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;overrides.cache-tag=check-1-93
     timeout-minutes: 60
     env:
@@ -604,8 +602,6 @@ jobs:
 
   timing_nextest_all_features:
     name: timing_nextest_all_features
-    # Informational only — run on pushes to dev/nightly/stable, not on every PR.
-    if: github.event_name == 'push'
     runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=nextest_all_features-1-93
     timeout-minutes: 60
     env:

--- a/.github/workflows/stainless.yml
+++ b/.github/workflows/stainless.yml
@@ -15,8 +15,9 @@ jobs:
   stainless:
     concurrency: upload-openapi-spec-action
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: stainless-api/upload-openapi-spec-action@main
         with:
           stainless_api_key: ${{ secrets.STAINLESS_API_KEY }}

--- a/.github/workflows/typescript.ci.yml
+++ b/.github/workflows/typescript.ci.yml
@@ -14,31 +14,20 @@ on:
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=typescript-ci-1-93
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: ./typescript
     steps:
-      - uses: actions/checkout@v4
-      - name: Cache turbo build setup
-        uses: actions/cache@v4
+      - uses: actions/checkout@v6
+      # Cache the pnpm store and turbo build outputs in a Namespace volume.
+      - uses: namespacelabs/nscloud-cache-action@v1
         with:
-          path: "./typescript/.turbo"
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-      - uses: pnpm/action-setup@v4
-        with:
-          package_json_file: ./typescript/package.json
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-          cache: "pnpm"
-          cache-dependency-path: "./typescript/pnpm-lock.yaml"
-      # bun is used to compile indexer
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.2.5
+          cache: pnpm
+          path: |
+            ./typescript/.turbo
+      # Node 24, pnpm, and Bun are all baked into the base image.
       - name: Install dependencies
         run: pnpm install
       - name: Lint and Format

--- a/.github/workflows/typescript.release.yml
+++ b/.github/workflows/typescript.release.yml
@@ -22,23 +22,21 @@ jobs:
       id-token: write # OpenID Connect token needed for provenance
       pull-requests: write # to create pull request (changesets/action)
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=typescript-release-1-93
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || '' }}
-      - uses: pnpm/action-setup@v4
+      # Cache the pnpm store in a Namespace volume.
+      - uses: namespacelabs/nscloud-cache-action@v1
         with:
-          package_json_file: ./typescript/package.json
+          cache: pnpm
+      # Node 24, pnpm, and Bun are baked into the base image; setup-node is kept
+      # only to configure the npm registry (.npmrc) for publishing.
       - uses: actions/setup-node@v6
         with:
-          node-version: 24.x
-          cache: "pnpm"
-          cache-dependency-path: "./typescript/pnpm-lock.yaml"
           registry-url: 'https://registry.npmjs.org'
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.2.5
       - name: Install dependencies
         run: pnpm install
         working-directory: ./typescript

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ install-risc0-toolchain:  ## install risc0 toolchain
 
 install-sp1-toolchain:  ## install SP1 toolchain
 	curl -L https://sp1up.succinct.xyz | bash
-	~/.sp1/bin/sp1up --version 6.0.2 $${GITHUB_TOKEN:+--token "$$GITHUB_TOKEN"}
+	~/.sp1/bin/sp1up $${GITHUB_TOKEN:+--token "$$GITHUB_TOKEN"} --version 6.2.2
 	~/.sp1/bin/cargo-prove prove --version
 	~/.sp1/bin/cargo-prove prove install-toolchain
 	@echo "SP1 toolchain version:"

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -14,7 +14,6 @@ RUN sudo apt-get update && sudo apt-get install -y \
     curl \
     wget \
     jq \
-    protobuf-compiler \
     clang \
     cmake \
     libclang-dev \
@@ -26,7 +25,7 @@ RUN sudo apt-get update && sudo apt-get install -y \
 # Build and install mold linker from source
 RUN git clone https://github.com/rui314/mold.git /tmp/mold \
     && cd /tmp/mold \
-    && git checkout $(git describe --tags --abbrev=0) \
+    && git checkout v2.41.0 \
     && cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=clang++ \
     && cmake --build build -j$(nproc) \
     && sudo cmake --build build --target install \
@@ -42,7 +41,7 @@ ENV RUSTUP_HOME=/home/runner/.rustup \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.93.0 --profile minimal \
     && . /home/runner/.cargo/env \
     && rustup component add clippy rustfmt rust-src llvm-tools-preview --toolchain 1.93.0 \
-    && rustup toolchain install nightly --component rustfmt --component rust-src --profile minimal \
+    && rustup toolchain install nightly-2026-05-15 --component rustfmt --component rust-src --profile minimal \
     && rustup target add wasm32-unknown-unknown
 
 # Configure cargo to use mold linker
@@ -60,8 +59,17 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | sudo bash - \
 RUN sudo npm install -g pnpm@9 doctoc
 
 # Install yq for YAML processing
-RUN sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq \
+RUN sudo wget https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64 -O /usr/bin/yq \
     && sudo chmod +x /usr/bin/yq
+
+# Pre-install Playwright system deps + Chromium so the demo-rollup phantom
+# e2e job doesn't apt-install/download on every run. The Chromium build is
+# tied to @playwright/test in typescript/examples/phantom/package.json —
+# bump BOTH in lockstep.
+ENV PLAYWRIGHT_BROWSERS_PATH=/home/runner/.cache/ms-playwright
+RUN sudo npx --yes playwright@1.58.2 install-deps chromium \
+    && npx --yes playwright@1.58.2 install chromium \
+    && sudo rm -rf /root/.npm /home/runner/.npm
 
 RUN PROTOC_VERSION="23.2" \
     && PROTOC_ZIP="protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
@@ -86,7 +94,7 @@ SHELL ["/bin/sh", "-c"]
 # Install SP1 toolchain (AMD64 only - SP1 doesn't support ARM64)
 RUN . /home/runner/.cargo/env \
         && curl -L https://sp1up.succinct.xyz | bash \
-        && /home/runner/.sp1/bin/sp1up --version 6.0.2 \
+        && /home/runner/.sp1/bin/sp1up --version 6.2.2 \
         && /home/runner/.sp1/bin/cargo-prove prove install-toolchain \
         && rm -rf /home/runner/.cargo/registry \
         && rm -rf /home/runner/.cargo/git
@@ -98,7 +106,7 @@ RUN . /home/runner/.cargo/env \
     && cargo install cargo-hack@0.6.37 --locked \
     && cargo install cargo-nextest@0.9.100 --locked \
     && cargo install cargo-llvm-cov@0.6.18 --locked \
-    && cargo install cargo-deny@0.18.3 --locked \
+    && cargo install cargo-deny@0.18.4 --locked \
     && cargo install cargo-insta@1.43.1 --locked \
     && cargo install cargo-machete@0.9.2 --locked \
     && cargo install zepter@1.78.2 --locked \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -49,13 +49,13 @@ RUN mkdir -p /home/runner/.cargo \
     && echo 'linker = "clang"' >> /home/runner/.cargo/config.toml \
     && echo 'rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]' >> /home/runner/.cargo/config.toml
 
-# Install Node.js 20.x
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | sudo bash - \
+# Install Node.js 24.x
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | sudo bash - \
     && sudo apt-get install -y --no-install-recommends nodejs \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Install pnpm and Node.js tools
-RUN sudo npm install -g pnpm@9 doctoc
+# Install pnpm, bun (used to compile the TS indexer), and doctoc
+RUN sudo npm install -g pnpm@9 doctoc bun@1.2.5
 
 # Install yq for YAML processing
 RUN sudo wget https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64 -O /usr/bin/yq \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -6,7 +6,7 @@ FROM ${NAMESPACE_BASE_IMAGE_REF} AS base
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install system dependencies
-RUN sudo apt-get update && sudo apt-get install -y \
+RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
     build-essential \
     pkg-config \
     libssl-dev \
@@ -41,7 +41,6 @@ ENV RUSTUP_HOME=/home/runner/.rustup \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.93.0 --profile minimal \
     && . /home/runner/.cargo/env \
     && rustup component add clippy rustfmt rust-src llvm-tools-preview --toolchain 1.93.0 \
-    && rustup toolchain install nightly-2026-05-15 --component rustfmt --component rust-src --profile minimal \
     && rustup target add wasm32-unknown-unknown
 
 # Configure cargo to use mold linker
@@ -52,7 +51,7 @@ RUN mkdir -p /home/runner/.cargo \
 
 # Install Node.js 20.x
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | sudo bash - \
-    && sudo apt-get install -y nodejs \
+    && sudo apt-get install -y --no-install-recommends nodejs \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # Install pnpm and Node.js tools
@@ -106,18 +105,15 @@ RUN . /home/runner/.cargo/env \
     && cargo install cargo-hack@0.6.37 --locked \
     && cargo install cargo-nextest@0.9.100 --locked \
     && cargo install cargo-llvm-cov@0.6.18 --locked \
-    && cargo install cargo-deny@0.18.4 --locked \
-    && cargo install cargo-insta@1.43.1 --locked \
     && cargo install cargo-machete@0.9.2 --locked \
     && cargo install zepter@1.78.2 --locked \
     && cargo install bashtestmd@0.5.0 --locked \
-    # Clear cargo cache to reduce image size
+    # Clear cargo caches in the same layer that created them (also removes
+    # .global-cache, which must be absent for the cache mount to work).
     && rm -rf /home/runner/.cargo/registry \
     && rm -rf /home/runner/.cargo/git \
+    && rm -rf /home/runner/.cargo/.global-cache \
     && rm -rf /tmp/cargo-*
-
-# Important step to make cache mountable
-RUN rm -rf /home/runner/.cargo/.global-cache
 
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true \
     PATH="/home/runner/.risc0/bin:/home/runner/.sp1/bin:/home/runner/.cargo/bin:${PATH}" \

--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -9,6 +9,8 @@ This folder contains the [Dockerfile](./Dockerfile) used for [Custom Base Image 
 
 The base image needs to be updated any time the environment changes: Rust toolchain upgrade, ZKVM version upgrade, new tool added to the job
 
+The image bakes a pinned Playwright Chromium build. Its version is tied to `@playwright/test` in `typescript/examples/phantom/package.json` — bump both in lockstep, otherwise the demo-rollup e2e job will re-download the browser at runtime.
+
 ## High-level steps
 
 1. Update and verify [`Dockerfile`](./Dockerfile)

--- a/scripts/ci_demo_rollup_phantom_dapp_e2e.sh
+++ b/scripts/ci_demo_rollup_phantom_dapp_e2e.sh
@@ -51,7 +51,10 @@ fi
 cd "$DAPP_DIR"
 pnpm --dir "$TS_DIR" install --frozen-lockfile
 pnpm --dir "$TS_DIR" --filter "${DAPP_PACKAGE}..." build
-pnpm exec playwright install --with-deps chromium
+# System deps + the pinned Chromium build are baked into the CI base image
+# (see docker/ci/Dockerfile). This resolves to a fast no-op there; the
+# --with-deps apt step is intentionally dropped.
+pnpm exec playwright install chromium
 
 CI=true \
 VITE_ROLLUP_URL=http://127.0.0.1:12346 \

--- a/typescript/examples/phantom/package.json
+++ b/typescript/examples/phantom/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
-    "@playwright/test": "^1.40.0",
+    "@playwright/test": "1.58.2",
     "@types/node": "^22.13.4",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         specifier: ^9.30.1
         version: 9.39.4
       '@playwright/test':
-        specifier: ^1.40.0
+        specifier: 1.58.2
         version: 1.58.2
       '@types/node':
         specifier: ^22.13.4


### PR DESCRIPTION
## Main changes

Replace "task specific" profile with generic profile + cache tag.

This way we only have to support 3 base profiles, only CPU and RAM configs we need

- sov-ubuntu-24-04-amd64-16x32-rust-1-93-v20260602
- sov-ubuntu-24-04-amd64-16x64-rust-1-93-v20260602
- sov-ubuntu-24-04-amd64-32x64-rust-1-93-v20260602

Cache is split via tags.

## Other changes

* Updating SP1 toolchain
* Adding chrome driver for playwright
* updated actions/checkout to v6
* updated ubuntu images to 24.04
* added timeouts to some jobs
* Fixed and simplified changelog PR message


## Follow up

After this PR is merged and all PR that have been opened prior that are also merged or closed, we will need to remove old images from namespace.

---

- [x] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [x] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Testing
Existing CI passes

## Docs
No updates
