### PR TITLE
Replica deregister on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2026-06-03
+- #PR_NUMBER Preferred sequencer: replica nodes now deregister from the `nodes` table on graceful shutdown, so node discovery reroutes reads off a departing replica within milliseconds instead of waiting for staleness. Best-effort and bounded; leader removal is unchanged (still timeout-based).
 # 2026-06-02
 - #2936 Request rate limiting uses milli-requests instead of always rounding down.
   * Per-request budget (`milli_req_counter`) is now more fine-grained and will work even with single digit requests per second.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2026-06-03
-- #PR_NUMBER Preferred sequencer: replica nodes now deregister from the `nodes` table on graceful shutdown, so node discovery reroutes reads off a departing replica within milliseconds instead of waiting for staleness. Best-effort and bounded; leader removal is unchanged (still timeout-based).
+- #2940 Preferred sequencer: replica nodes now deregister from the `nodes` table on graceful shutdown, so node discovery reroutes reads off a departing replica within milliseconds instead of waiting for staleness. Best-effort and bounded; leader removal is unchanged (still timeout-based).
 # 2026-06-02
 - #2936 Request rate limiting uses milli-requests instead of always rounding down.
   * Per-request budget (`milli_req_counter`) is now more fine-grained and will work even with single digit requests per second.

--- a/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/heartbeat_task.rs
@@ -92,6 +92,31 @@ impl HeartBeatTask {
         Ok(())
     }
 
+    // Best-effort deregistration of this node from the `nodes` table on shutdown.
+    //
+    // An SLO optimization, not a correctness requirement: on error or timeout we log and
+    // continue, relying on staleness-based filtering as the fallback. Bounded so a slow or
+    // unreachable database cannot delay shutdown.
+    async fn deregister_on_shutdown_best_effort(&self) {
+        const DEREGISTER_TIMEOUT: Duration = Duration::from_millis(500);
+        match tokio::time::timeout(
+            DEREGISTER_TIMEOUT,
+            self.backend.deregister_node_on_shutdown(),
+        )
+        .await
+        {
+            Ok(Ok(())) => {
+                info!(node_id = %self.node_id, "Deregistered node from cluster on shutdown");
+            }
+            Ok(Err(e)) => {
+                warn!(node_id = %self.node_id, error = ?e, "Failed to deregister on shutdown; relying on staleness");
+            }
+            Err(_) => {
+                warn!(node_id = %self.node_id, "Timed out deregistering on shutdown; relying on staleness");
+            }
+        }
+    }
+
     // Spawns a task for the current leader to maintain leadership.
     //
     // Periodically refreshes leadership. If leadership is lost or the database
@@ -150,6 +175,7 @@ impl HeartBeatTask {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
                         info!("Shutdown signal received, stopping election task.");
+                        self.deregister_on_shutdown_best_effort().await;
                         return;
                     }
                     FutureOrShutdownOutput::Output(_) => {
@@ -195,6 +221,7 @@ impl HeartBeatTask {
                 match future_or_shutdown(interval.tick(), &self.shutdown_receiver).await {
                     FutureOrShutdownOutput::Shutdown => {
                         info!("Shutdown signal received, stopping registration task.");
+                        self.deregister_on_shutdown_best_effort().await;
                         return;
                     }
                     FutureOrShutdownOutput::Output(_) => match self.register_node().await {

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -348,6 +348,19 @@ impl PostgresBackend {
         Ok(())
     }
 
+    /// Removes this node's registration from the `nodes` table.
+    ///
+    /// Deleting the row fires the `nodes_changes` NOTIFY trigger so `NodeDiscovery` stops
+    /// routing to this node within milliseconds instead of waiting for staleness. Idempotent
+    /// (deleting an already-missing row is a no-op) and only ever deletes *this* node's row.
+    pub(crate) async fn deregister_node_on_shutdown(&self) -> anyhow::Result<()> {
+        sqlx::query("DELETE FROM nodes WHERE node_id = $1")
+            .bind(&self.node_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     async fn prune_inner(
         &self,
         prune_up_to_including: SequenceNumber,

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/deregister.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/deregister.rs
@@ -1,0 +1,64 @@
+use super::*;
+
+// Counts the rows in the `nodes` table matching `node_id` (0 or 1, since node_id is the
+// primary key). Reads `backend.pool` directly, which is accessible from this submodule.
+async fn count_nodes_row(backend: &PostgresBackend, node_id: &str) -> i64 {
+    sqlx::query_scalar("SELECT COUNT(*) FROM nodes WHERE node_id = $1")
+        .bind(node_id)
+        .fetch_one(&backend.pool)
+        .await
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_deregister_removes_only_own_nodes_row() {
+    let Some(postgres) = setup_test_postgres().await else {
+        return;
+    };
+
+    let node_a = DB::new(&postgres, String::from("node_a"), ConfiguredNodeRole::Replica).await;
+    let node_b = DB::new(&postgres, String::from("node_b"), ConfiguredNodeRole::Replica).await;
+
+    // Register both nodes via a replica heartbeat (no leadership competition).
+    node_a.backend.heartbeat(None).await.unwrap();
+    node_b.backend.heartbeat(None).await.unwrap();
+    assert_eq!(
+        count_nodes_row(&node_a.backend, "node_a").await,
+        1,
+        "node_a should be registered before deregistration"
+    );
+
+    // Deregister only node_a.
+    node_a.backend.deregister_node_on_shutdown().await.unwrap();
+
+    assert_eq!(
+        count_nodes_row(&node_a.backend, "node_a").await,
+        0,
+        "node_a's row should be removed after deregistration"
+    );
+    assert_eq!(
+        count_nodes_row(&node_a.backend, "node_b").await,
+        1,
+        "node_b's row must remain untouched when node_a deregisters"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_deregister_is_idempotent_for_unregistered_node() {
+    let Some(postgres) = setup_test_postgres().await else {
+        return;
+    };
+
+    let node = DB::new(
+        &postgres,
+        String::from("never_registered"),
+        ConfiguredNodeRole::Replica,
+    )
+    .await;
+
+    // Deleting a row that was never inserted must be a no-op, not an error.
+    node.backend
+        .deregister_node_on_shutdown()
+        .await
+        .expect("deregistering an unregistered node should be a no-op");
+}

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/deregister.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/deregister.rs
@@ -16,8 +16,18 @@ async fn test_deregister_removes_only_own_nodes_row() {
         return;
     };
 
-    let node_a = DB::new(&postgres, String::from("node_a"), ConfiguredNodeRole::Replica).await;
-    let node_b = DB::new(&postgres, String::from("node_b"), ConfiguredNodeRole::Replica).await;
+    let node_a = DB::new(
+        &postgres,
+        String::from("node_a"),
+        ConfiguredNodeRole::Replica,
+    )
+    .await;
+    let node_b = DB::new(
+        &postgres,
+        String::from("node_b"),
+        ConfiguredNodeRole::Replica,
+    )
+    .await;
 
     // Register both nodes via a replica heartbeat (no leadership competition).
     node_a.backend.heartbeat(None).await.unwrap();

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/mod.rs
@@ -1,4 +1,5 @@
 mod db_operations;
+mod deregister;
 mod leader_election;
 mod migrations;
 


### PR DESCRIPTION
# Description

Simpler version of https://github.com/Sovereign-Labs/sovereign-sdk/pull/2924 

Where only replica removes itself from nodes list. Avoids all race conditions drama for in-flight batches. 

---

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)


## Testing
All existing tests pass

## Docs
No updates