### PR TITLE
Add optional config to enable smooth load shedding

### DIFF
--- a/crates/full-node/full-node-configs/src/sequencer.rs
+++ b/crates/full-node/full-node-configs/src/sequencer.rs
@@ -270,6 +270,11 @@ pub struct PreferredSequencerConfig<Address: Copy> {
     /// lock contention.
     #[serde(default = "default_future_nonce_transaction_timeout_millis")]
     pub future_nonce_transaction_timeout_millis: u64,
+
+    /// Whether to enable the experimental PI controller for rate limiting.
+    /// This smooths out the tx acceptance rate over time, rather than suddenly rejecting all txs when the batch is full.
+    #[serde(default)]
+    pub use_pi_rate_limiter: bool,
 }
 
 impl<Address: Copy> Default for PreferredSequencerConfig<Address> {
@@ -288,6 +293,7 @@ impl<Address: Copy> Default for PreferredSequencerConfig<Address> {
             future_nonce_transaction_timeout_millis:
                 default_future_nonce_transaction_timeout_millis(),
             rate_limiter: None,
+            use_pi_rate_limiter: false,
         }
     }
 }

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_postgres.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/full-node/full-node-configs/src/runner.rs
-assertion_line: 313
 expression: config
 ---
 {
@@ -85,7 +84,8 @@ expression: config
       "num_cache_warmup_workers": 0,
       "rate_limiter": null,
       "maximum_future_nonce_delta": 100,
-      "future_nonce_transaction_timeout_millis": 2000
+      "future_nonce_transaction_timeout_millis": 2000,
+      "use_pi_rate_limiter": false
     },
     "max_batch_size_bytes": 1048576,
     "max_concurrent_batch_blobs": 16,

--- a/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
+++ b/crates/full-node/full-node-configs/src/snapshots/sov_full_node_configs__runner__tests__correct_config_with_rate_limiter.snap
@@ -116,7 +116,8 @@ expression: config
         ]
       },
       "maximum_future_nonce_delta": 100,
-      "future_nonce_transaction_timeout_millis": 2000
+      "future_nonce_transaction_timeout_millis": 2000,
+      "use_pi_rate_limiter": false
     },
     "max_batch_size_bytes": 1048576,
     "max_concurrent_batch_blobs": 16,

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -98,6 +98,7 @@ where
         let (next_sequence_number, db_cache) = db.initial_data().await?;
         let mut handles = vec![];
 
+        let approximate_block_time = self.da.get_approximate_block_time().await; // Load the block time before moving the DA service to the blob sender
         let (blob_sender, blob_sender_handle) = PreferredBlobSender::new(
             self.da,
             ledger_db.clone(),
@@ -180,6 +181,7 @@ where
             cached_txs.write_handle(),
             cache_warm_up_executor,
             start_replica_task_notifier,
+            approximate_block_time,
         );
 
         let test_only_state_update_notification_receiver = synchronized_state

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -130,17 +130,17 @@ where
 ///  - How much longer we expect the current batch to be open (based on estimated block times)
 ///
 /// Based on that data, we set probabilities for accepting or rejecting new transactions. For example,
-/// suppose that we 3 seconds in to a 6 second block time, and we've accepted 4 MB of our 6MB limit. THen the probabilty of accepting a new
+/// suppose that we 3 seconds in to a 6 second block time, and we've accepted 4 MB of our 6MB limit. Then the probability of accepting a new
 /// tx will drop to keep the batch size under control. Note that we compute probabilities for both execution time and batch size,
 /// and then we take the max rejection probability across those two dimensions.
 pub struct PIController {
     pub(crate) batch_start_time: std::time::Instant, // The time when the current batch was opened
     pub(crate) approximate_block_time: std::time::Duration,
-    // The bias term for the the batch size limiter (this lets us correct if we're repeatedly over or undershooting the target batch size)
+    // The bias term for the batch size limiter (this lets us correct if we're repeatedly over or undershooting the target batch size)
     // Expressed in bytes per second. (I.e. if the `P` term of our controller says to accept 1000 bytes per second, and this bias is 40, then we will try to accept 1040 bytes per second.)
     // Can be negative
     pub(crate) size_limit_bias: f64,
-    // The bias term for the the execution time limiter (this lets us correct if we're repeatedly over or undershooting the target execution time)
+    // The bias term for the execution time limiter (this lets us correct if we're repeatedly over or undershooting the target execution time)
     pub(crate) execution_time_limit_bias: f64,
     // The average time to execute a tx in microseconds. Computed as a EWMA over all txs since startup.
     pub(crate) estimated_tx_execution_time_micros: f64,
@@ -148,7 +148,7 @@ pub struct PIController {
     // The last time we ticked the PI controller.
     pub(crate) last_tick_time: std::time::Instant,
     pub(crate) bytes_offered_since_last_tick: u64, // How many bytes worth of tx data we would have accepted given 100% acceptance rate
-    pub(crate) bytes_offered_per_second_ewma: f64, // The weighted average of bytes offered per second
+    pub(crate) bytes_offered_per_second_ewma: f64, // The weighted average of bytes offered per second. EWMA = Exponentially Weighted Moving Average
     pub(crate) current_tx_accept_rate_bytes_per_second: f64,
     pub(crate) execution_time_offered_since_last_tick: f64,
     pub(crate) execution_time_offered_per_second_ewma: f64,
@@ -161,6 +161,7 @@ pub struct PIController {
     pub(crate) load_shed_rejection_debt: f64,
 }
 
+#[allow(clippy::float_arithmetic)]
 impl PIController {
     pub(crate) fn new(
         approximate_block_time: std::time::Duration,
@@ -837,6 +838,7 @@ where
 
     // Implements the I part of a PID controller for the batch size limit; we track our error rate over each batch and tune the bias
     // (does our controller over or under shoot the ideal rate?)
+    #[allow(clippy::float_arithmetic)]
     fn update_size_limit_bias_on_batch_close(&mut self) {
         let (target_size, target_rate_bytes_per_sec) = self.get_target_batch_size_and_growth_rate();
         let target_size = target_size as f64;
@@ -856,6 +858,8 @@ where
 
     // Implements the I part of a PID controller for the batch execution time limit. The I term is used to correct for systematic errors in our execution time limit.
     // It grows when we accept too few transactions over the batch lifetime, and shrinks when we accept too many.
+    // Float arithmetic is allowed because of the offchain nature of rate limiting.
+    #[allow(clippy::float_arithmetic)]
     fn update_execution_time_limit_bias_on_batch_close(&mut self) {
         // How many microseconds of execution time we'd like to spend on this batch.
         let (target_execution_time_micros, target_rate_micros_per_second) =
@@ -905,6 +909,7 @@ where
 
     // Returns the target batch size in bytes and the growth rate for the batch size (in bytes per second).
     // Returns a tuple (target, rate)
+    #[allow(clippy::float_arithmetic)]
     pub(crate) fn get_target_batch_size_and_growth_rate(&self) -> (u64, f64) {
         let target_size = (self.batch_size_tracker.max_batch_size as u64)
             .checked_div(20)
@@ -917,6 +922,7 @@ where
 
     // Returns the target execution time in microseconds and the growth rate for the execution time (in micros per second).
     // Returns a tuple (target, rate)
+    #[allow(clippy::float_arithmetic)]
     pub(crate) fn get_target_execution_time_and_growth_rate(&self) -> (u64, f64) {
         let target_execution_time_micros = self
             .batch_execution_time_limit_micros
@@ -928,6 +934,7 @@ where
         (target_execution_time_micros, target_rate)
     }
 
+    #[allow(clippy::float_arithmetic)]
     fn reset_current_accept_rates_on_batch_close(&mut self) {
         // Update the bytes per second target rate with the latest bias from the PI controller.
         let (_, target_rate) = self.get_target_batch_size_and_growth_rate();
@@ -941,6 +948,7 @@ where
             (target_rate_micros_per_second + self.pi_controller.execution_time_limit_bias).max(0.0);
     }
 
+    #[allow(clippy::float_arithmetic)]
     pub(crate) fn update_estimated_tx_execution_time_micros(&mut self, execution_time_micros: u64) {
         if execution_time_micros == 0 {
             return;
@@ -958,6 +966,7 @@ where
                 + execution_time_micros * 0.25;
     }
 
+    #[allow(clippy::float_arithmetic)]
     pub(crate) fn should_accept_load_shed_tx(&mut self, accept_probability: f64) -> bool {
         let accept_probability = accept_probability.clamp(0.0, 1.0);
         // If the accept probability is 1.0, we accept the tx and clear our rejection debt.

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -57,6 +57,8 @@ const METRICS_BATCH_SIZE: usize = 32;
 /// The constant for the I part of the PID controller for the batch size limit.
 /// The larger this constant, the faster the bias will evolve, but the more likely we are to oscillate.
 const BATCH_SIZE_LIMIT_BIAS_K_I: f64 = 0.1;
+const EXECUTION_TIME_LIMIT_BIAS_POSITIVE_ERROR_K_I: f64 = 0.02; // Positive errors are slow to accumulate, because over-accepting txs early is not easily fixable
+const EXECUTION_TIME_LIMIT_BIAS_NEGATIVE_ERROR_K_I: f64 = 0.2; // Negative errors accumulate faster, because rejecting txs too aggressively is easy to fix by accepting more later.
 
 #[derive(Debug)]
 pub(crate) enum DoNewTxError<S: Spec> {
@@ -144,7 +146,6 @@ pub struct PIController {
     pub(crate) execution_time_limit_bias: f64,
     // The average time to execute a tx in microseconds. Computed as a EWMA over all txs since startup.
     pub(crate) estimated_tx_execution_time_micros: f64,
-    // pub(crate) has_estimated_tx_execution_time: bool, // TODO: Remove
     // The last time we ticked the PI controller.
     pub(crate) last_tick_time: std::time::Instant,
     pub(crate) bytes_offered_since_last_tick: u64, // How many bytes worth of tx data we would have accepted given 100% acceptance rate
@@ -168,6 +169,11 @@ impl PIController {
         max_batch_size: usize,
         batch_execution_time_limit_micros: u64,
     ) -> Self {
+        assert_ne!(
+            approximate_block_time,
+            std::time::Duration::ZERO,
+            "Approximate block time must be non-zero"
+        );
         Self {
             approximate_block_time,
             batch_start_time: std::time::Instant::now(),
@@ -893,9 +899,9 @@ where
         // Negative errors (we've been accepting too many transactions) can react faster to an
         // over-full batch, because rejecting a bit too aggressively only causes the loss of low value txs.
         let k_i = if error_fraction.is_sign_negative() {
-            0.2
+            EXECUTION_TIME_LIMIT_BIAS_NEGATIVE_ERROR_K_I
         } else {
-            0.02
+            EXECUTION_TIME_LIMIT_BIAS_POSITIVE_ERROR_K_I
         };
         // The next bias is old bias + (error fraction * target rate) * the "learning rate" constant "K"
         let next_bias = self.pi_controller.execution_time_limit_bias
@@ -968,10 +974,11 @@ where
 
     #[allow(clippy::float_arithmetic)]
     pub(crate) fn should_accept_load_shed_tx(&mut self, accept_probability: f64) -> bool {
-        let accept_probability = accept_probability.clamp(0.0, 1.0);
-        // If the accept probability is 1.0, we accept the tx and clear our rejection debt.
+        // If the accept probability is 1.0, we accept the tx but it has no impact on our rejection debt.
+        // This means that we will reject txs slightly more aggressively when the probability drops again,
+        // but it prevents bad behavior in case there are mixed probabilities of acceptance
+        // (i.e. high prio txs get a guaranteed 1 while lower prio txs only have a 0.5 chance).
         if accept_probability >= 1.0 {
-            self.pi_controller.load_shed_rejection_debt = 0.0;
             return true;
         }
         // If the accept probability is 0.0 or less, we reject the tx

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/inner.rs
@@ -54,6 +54,9 @@ const COMFORTABLE_SIZE_LIMIT_DIVISOR: u64 = 100;
 const COMFORTABLE_IN_FLIGHT_BLOBS: usize = 5;
 
 const METRICS_BATCH_SIZE: usize = 32;
+/// The constant for the I part of the PID controller for the batch size limit.
+/// The larger this constant, the faster the bias will evolve, but the more likely we are to oscillate.
+const BATCH_SIZE_LIMIT_BIAS_K_I: f64 = 0.1;
 
 #[derive(Debug)]
 pub(crate) enum DoNewTxError<S: Spec> {
@@ -113,6 +116,75 @@ where
     pub(crate) cache_warm_up_executor: CacheWarmUpExecutor<S>,
     pub(crate) start_replica_task_notifier: EventReceiverStartNotifier,
     pub(crate) rate_limiter: SovRateLimiter<S>,
+    pub(crate) pi_controller: PIController,
+}
+
+/// A PI controller for adjusting the batch size and execution time limit based on the current load.
+/// The PI controller allows us to smoothly vary our tx rejection rate as the batch fills up, rather than
+/// switching suddenly from "accept all" to "accept none".
+///
+/// At most every 10 millis we "tick" the PI controller, updating the state with the latest data about...
+///  - The rate at which new transactions are being offered
+///  - The average time/bytes to accept a tx
+///  - The remaining available size/time limits.
+///  - How much longer we expect the current batch to be open (based on estimated block times)
+///
+/// Based on that data, we set probabilities for accepting or rejecting new transactions. For example,
+/// suppose that we 3 seconds in to a 6 second block time, and we've accepted 4 MB of our 6MB limit. THen the probabilty of accepting a new
+/// tx will drop to keep the batch size under control. Note that we compute probabilities for both execution time and batch size,
+/// and then we take the max rejection probability across those two dimensions.
+pub struct PIController {
+    pub(crate) batch_start_time: std::time::Instant, // The time when the current batch was opened
+    pub(crate) approximate_block_time: std::time::Duration,
+    // The bias term for the the batch size limiter (this lets us correct if we're repeatedly over or undershooting the target batch size)
+    // Expressed in bytes per second. (I.e. if the `P` term of our controller says to accept 1000 bytes per second, and this bias is 40, then we will try to accept 1040 bytes per second.)
+    // Can be negative
+    pub(crate) size_limit_bias: f64,
+    // The bias term for the the execution time limiter (this lets us correct if we're repeatedly over or undershooting the target execution time)
+    pub(crate) execution_time_limit_bias: f64,
+    // The average time to execute a tx in microseconds. Computed as a EWMA over all txs since startup.
+    pub(crate) estimated_tx_execution_time_micros: f64,
+    // pub(crate) has_estimated_tx_execution_time: bool, // TODO: Remove
+    // The last time we ticked the PI controller.
+    pub(crate) last_tick_time: std::time::Instant,
+    pub(crate) bytes_offered_since_last_tick: u64, // How many bytes worth of tx data we would have accepted given 100% acceptance rate
+    pub(crate) bytes_offered_per_second_ewma: f64, // The weighted average of bytes offered per second
+    pub(crate) current_tx_accept_rate_bytes_per_second: f64,
+    pub(crate) execution_time_offered_since_last_tick: f64,
+    pub(crate) execution_time_offered_per_second_ewma: f64,
+    // The current rate at which to accept txs based on execution time, given in micros per second.
+    // For example, if we're consuming our execution time budget just a little too fast, this will drop to something like 950000 micros per second.
+    pub(crate) current_tx_accept_rate_execution_time_micros_per_second: f64,
+    // An error correction term which rises when we accept a tx that had some non-zero chance of rejection.
+    // For example, as we accept txs with a 20% chance of rejection, this will rise to .2, .4, .6, etc. Once it hits 1.0,
+    // we deterministically reject the next tx and reset the debt to 0.
+    pub(crate) load_shed_rejection_debt: f64,
+}
+
+impl PIController {
+    pub(crate) fn new(
+        approximate_block_time: std::time::Duration,
+        max_batch_size: usize,
+        batch_execution_time_limit_micros: u64,
+    ) -> Self {
+        Self {
+            approximate_block_time,
+            batch_start_time: std::time::Instant::now(),
+            size_limit_bias: 0.0,
+            execution_time_limit_bias: 0.0,
+            estimated_tx_execution_time_micros: 0.0,
+            last_tick_time: std::time::Instant::now(),
+            bytes_offered_since_last_tick: 0,
+            bytes_offered_per_second_ewma: 0.0,
+            current_tx_accept_rate_bytes_per_second: max_batch_size as f64
+                / approximate_block_time.as_secs_f64(),
+            execution_time_offered_since_last_tick: 0.0,
+            execution_time_offered_per_second_ewma: 0.0,
+            current_tx_accept_rate_execution_time_micros_per_second:
+                batch_execution_time_limit_micros as f64 / approximate_block_time.as_secs_f64(),
+            load_shed_rejection_debt: 0.0,
+        }
+    }
 }
 
 // We submit metrics when this guard is dropped.
@@ -651,6 +723,8 @@ where
             sequence_number,
         };
 
+        self.pi_controller.batch_start_time = std::time::Instant::now();
+
         self.cache_warm_up_executor
             .send_batch_start_notification(notification);
 
@@ -761,6 +835,162 @@ where
         (Ok((rx, remaining_slot_gas)), resource_used)
     }
 
+    // Implements the I part of a PID controller for the batch size limit; we track our error rate over each batch and tune the bias
+    // (does our controller over or under shoot the ideal rate?)
+    fn update_size_limit_bias_on_batch_close(&mut self) {
+        let (target_size, target_rate_bytes_per_sec) = self.get_target_batch_size_and_growth_rate();
+        let target_size = target_size as f64;
+
+        // How far we undershot our target batch size, expressed as a fraction of the target size.
+        let error_fraction =
+            (target_size - self.batch_size_tracker.current_batch_size as f64) / target_size;
+        // The next bias is old bias + (error fraction * target rate) * the "learning rate" constant "K"
+        let next_bias = self.pi_controller.size_limit_bias
+            + BATCH_SIZE_LIMIT_BIAS_K_I * error_fraction * target_rate_bytes_per_sec;
+
+        // Finally, we clamp the bias to be between -0.5 * target rate and 0.5 * target rate to prevent it from growing too large.
+        let bias_min = -0.5 * target_rate_bytes_per_sec;
+        let bias_max = 0.5 * target_rate_bytes_per_sec;
+        self.pi_controller.size_limit_bias = next_bias.clamp(bias_min, bias_max);
+    }
+
+    // Implements the I part of a PID controller for the batch execution time limit. The I term is used to correct for systematic errors in our execution time limit.
+    // It grows when we accept too few transactions over the batch lifetime, and shrinks when we accept too many.
+    fn update_execution_time_limit_bias_on_batch_close(&mut self) {
+        // How many microseconds of execution time we'd like to spend on this batch.
+        let (target_execution_time_micros, target_rate_micros_per_second) =
+            self.get_target_execution_time_and_growth_rate();
+        if target_execution_time_micros == 0 {
+            return;
+        }
+        let target_execution_time_micros = target_execution_time_micros as f64;
+
+        // How much time has elapsed since the batch was opened.
+        let elapsed_secs = self
+            .pi_controller
+            .batch_start_time
+            .elapsed()
+            .min(self.pi_controller.approximate_block_time)
+            .as_secs_f64();
+
+        // How many microseconds of execution time we expect to have spent on this batch by now, if we were accepting txs at the target rate.
+        let expected_execution_time_micros =
+            (target_rate_micros_per_second * elapsed_secs).min(target_execution_time_micros);
+        // How many microseconds of execution time we've actually spent on this batch.
+        let actual_execution_time_micros =
+            self.batch_size_tracker.batch_execution_time_micros as f64;
+        // How far we are from our target execution time, expressed as a fraction of the target execution time.
+        let error_fraction = (expected_execution_time_micros - actual_execution_time_micros)
+            / target_execution_time_micros;
+
+        // We use different learning rates for positive and negative errors.
+        // Positive errors (we've been accepting too few transactions) should accumulate slowly because we don't want to
+        // over-update and run out of space in the *next* batch. Running out of space is very bad - it causes complete downtime until the batch closes.
+        // Negative errors (we've been accepting too many transactions) can react faster to an
+        // over-full batch, because rejecting a bit too aggressively only causes the loss of low value txs.
+        let k_i = if error_fraction.is_sign_negative() {
+            0.2
+        } else {
+            0.02
+        };
+        // The next bias is old bias + (error fraction * target rate) * the "learning rate" constant "K"
+        let next_bias = self.pi_controller.execution_time_limit_bias
+            + k_i * error_fraction * target_rate_micros_per_second;
+        // We clamp the bias to be between -0.5 * target rate and 0.1 * target rate.
+        // As before, we're fine with large negative biases (rejecting too aggressively), but we want to be careful about positive biases (accepting too many transactions).
+        let bias_min = -0.5 * target_rate_micros_per_second;
+        let bias_max = 0.1 * target_rate_micros_per_second;
+        self.pi_controller.execution_time_limit_bias = next_bias.clamp(bias_min, bias_max);
+    }
+
+    // Returns the target batch size in bytes and the growth rate for the batch size (in bytes per second).
+    // Returns a tuple (target, rate)
+    pub(crate) fn get_target_batch_size_and_growth_rate(&self) -> (u64, f64) {
+        let target_size = (self.batch_size_tracker.max_batch_size as u64)
+            .checked_div(20)
+            .and_then(|x| x.checked_mul(19))
+            .unwrap_or(0);
+        let target_rate =
+            target_size as f64 / self.pi_controller.approximate_block_time.as_secs_f64();
+        (target_size, target_rate)
+    }
+
+    // Returns the target execution time in microseconds and the growth rate for the execution time (in micros per second).
+    // Returns a tuple (target, rate)
+    pub(crate) fn get_target_execution_time_and_growth_rate(&self) -> (u64, f64) {
+        let target_execution_time_micros = self
+            .batch_execution_time_limit_micros
+            .checked_div(20)
+            .and_then(|x| x.checked_mul(19))
+            .unwrap_or(0);
+        let target_rate = target_execution_time_micros as f64
+            / self.pi_controller.approximate_block_time.as_secs_f64();
+        (target_execution_time_micros, target_rate)
+    }
+
+    fn reset_current_accept_rates_on_batch_close(&mut self) {
+        // Update the bytes per second target rate with the latest bias from the PI controller.
+        let (_, target_rate) = self.get_target_batch_size_and_growth_rate();
+        self.pi_controller.current_tx_accept_rate_bytes_per_second =
+            (target_rate + self.pi_controller.size_limit_bias).max(0.0);
+
+        // Update the micros per second target rate with the latest bias from the PI controller.
+        let (_, target_rate_micros_per_second) = self.get_target_execution_time_and_growth_rate();
+        self.pi_controller
+            .current_tx_accept_rate_execution_time_micros_per_second =
+            (target_rate_micros_per_second + self.pi_controller.execution_time_limit_bias).max(0.0);
+    }
+
+    pub(crate) fn update_estimated_tx_execution_time_micros(&mut self, execution_time_micros: u64) {
+        if execution_time_micros == 0 {
+            return;
+        }
+
+        let execution_time_micros = execution_time_micros as f64;
+        // If we haven't estimated the tx execution time yet, set it to the first measurement.
+        if self.pi_controller.estimated_tx_execution_time_micros == 0.0 {
+            self.pi_controller.estimated_tx_execution_time_micros = execution_time_micros;
+            return;
+        }
+        // Otherwise, use an EWMA to estimate the tx execution time.
+        self.pi_controller.estimated_tx_execution_time_micros =
+            self.pi_controller.estimated_tx_execution_time_micros * 0.75
+                + execution_time_micros * 0.25;
+    }
+
+    pub(crate) fn should_accept_load_shed_tx(&mut self, accept_probability: f64) -> bool {
+        let accept_probability = accept_probability.clamp(0.0, 1.0);
+        // If the accept probability is 1.0, we accept the tx and clear our rejection debt.
+        if accept_probability >= 1.0 {
+            self.pi_controller.load_shed_rejection_debt = 0.0;
+            return true;
+        }
+        // If the accept probability is 0.0 or less, we reject the tx
+        if accept_probability <= 0.0 {
+            return false;
+        }
+
+        // Otherwise, we add to our rejection debt based on the rejection probability. I.e. if we had a 20% chance of acceptance, we'd add 0.8 to our debt -
+        // this tx on its own makes us almost due to reject another tx.
+        self.pi_controller.load_shed_rejection_debt += 1.0 - accept_probability;
+
+        // If the debt became greater than 1 (meaning we're due to reject a transaction) reject and decrease our debt
+        // otherwise accept.
+        if self.pi_controller.load_shed_rejection_debt >= 1.0 {
+            self.pi_controller.load_shed_rejection_debt -= 1.0;
+            false
+        } else {
+            true
+        }
+    }
+
+    // Updates the PI controller based on the current batch size and execution time.
+    fn update_pi_controller_on_batch_close(&mut self) {
+        self.update_size_limit_bias_on_batch_close();
+        self.update_execution_time_limit_bias_on_batch_close();
+        self.reset_current_accept_rates_on_batch_close();
+    }
+
     /// Closes the current batch.
     ///
     /// This should be called only when...
@@ -772,6 +1002,7 @@ where
     pub(crate) async fn close_current_batch(&mut self) {
         // Terminate the batch.
         let forced_txs = self.executor.end_rollup_block().await;
+        self.update_pi_controller_on_batch_close();
         self.batch_size_tracker = BatchSizeTracker::new(self.seq_config.max_batch_size_bytes);
         let checkpoint = self
             .executor

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/mod.rs
@@ -183,6 +183,7 @@ pub(crate) fn create<S, Rt>(
     tx_cache_writer: TxResultWriter<S, Rt>,
     cache_warm_up_executor: CacheWarmUpExecutor<S>,
     start_replica_task_notifier: EventReceiverStartNotifier,
+    approximate_block_time: Duration,
 ) -> (
     SynchronizedSequencerState<S, Rt>,
     SequencerStateUpdator<S, Rt>,
@@ -238,6 +239,12 @@ where
         cache_warm_up_executor,
         start_replica_task_notifier,
         rate_limiter,
+
+        pi_controller: PIController::new(
+            approximate_block_time,
+            seq_config.max_batch_size_bytes,
+            batch_execution_time_limit_micros,
+        ),
     };
 
     let channel_size = Arc::new(AtomicU32::new(0));
@@ -248,6 +255,7 @@ where
         heap: BTreeMap::new(),
         runtime: Default::default(),
         test_only_state_update_notification_sender: broadcast::channel(100).0,
+        use_pi_rate_limiter: seq_config.sequencer_kind_config.use_pi_rate_limiter,
     };
     let updator = SequencerStateUpdator {
         message_sender,

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -47,6 +47,8 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tracing::debug;
 
+/// The minimum interval between updates for the PI controller.
+const MINIMUM_TICK_SIZE: Duration = Duration::from_millis(10);
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Priority {
     priority: u64,
@@ -884,15 +886,14 @@ where
     // it with the I term to get the current rate. (The I term is updated on each batch close.)
     #[allow(clippy::float_arithmetic)]
     fn tick_rate_limiter(&mut self) -> RateLimitTick {
-        let minimum_tick_size = Duration::from_millis(10);
-        let minimum_offered_rate_per_second = 1.0 / minimum_tick_size.as_secs_f64();
+        let minimum_offered_rate_per_second = 1.0 / MINIMUM_TICK_SIZE.as_secs_f64();
         let now = std::time::Instant::now();
         let time_since_last_tick = now.duration_since(self.inner.pi_controller.last_tick_time);
         let (_, target_execution_time_rate) =
             self.inner.get_target_execution_time_and_growth_rate();
 
         // Early return if it's been less than 10 millis since our last tick
-        if time_since_last_tick < minimum_tick_size {
+        if time_since_last_tick < MINIMUM_TICK_SIZE {
             let pi_controller = &self.inner.pi_controller;
             return RateLimitTick {
                 current_accept_bytes_per_second: pi_controller
@@ -926,7 +927,7 @@ where
             self.inner.pi_controller.bytes_offered_per_second_ewma,
             self.inner.pi_controller.bytes_offered_since_last_tick as f64,
             time_since_last_tick,
-            minimum_tick_size,
+            MINIMUM_TICK_SIZE,
         );
         self.inner.pi_controller.bytes_offered_since_last_tick = 0;
         self.inner.pi_controller.bytes_offered_per_second_ewma = bytes_offered_per_second_ewma;
@@ -939,7 +940,7 @@ where
                 .pi_controller
                 .execution_time_offered_since_last_tick,
             time_since_last_tick,
-            minimum_tick_size,
+            MINIMUM_TICK_SIZE,
         );
         self.inner
             .pi_controller
@@ -963,10 +964,10 @@ where
             if time_since_batch_open < self.inner.pi_controller.approximate_block_time {
                 std::cmp::max(
                     self.inner.pi_controller.approximate_block_time - time_since_batch_open,
-                    minimum_tick_size,
+                    MINIMUM_TICK_SIZE,
                 )
             } else {
-                minimum_tick_size
+                MINIMUM_TICK_SIZE
             };
 
         // Compute the rate limit for the batch size controller

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -84,6 +84,7 @@ where
     pub(super) runtime: Rt,
     pub(crate) test_only_state_update_notification_sender:
         broadcast::Sender<StateUpdateNotification>,
+    pub(crate) use_pi_rate_limiter: bool,
 }
 
 impl<S, Rt> SynchronizedSequencerState<S, Rt>
@@ -878,6 +879,213 @@ where
         inner.trigger_batch_production().await;
     }
 
+    // Takes the current rate limits and returns the next byte and execution-time rates, along with the offered rates.
+    // This implements the P and I parts of a PID controller; this function is responsible for both updating the P term (every tick interval) and combining
+    // it with the I term to get the current rate. (The I term is updated on each batch close.)
+    fn tick_rate_limiter(&mut self) -> RateLimitTick {
+        let minimum_tick_size = Duration::from_millis(10);
+        let minimum_offered_rate_per_second = 1.0 / minimum_tick_size.as_secs_f64();
+        let now = std::time::Instant::now();
+        let time_since_last_tick = now.duration_since(self.inner.pi_controller.last_tick_time);
+        let (_, target_execution_time_rate) =
+            self.inner.get_target_execution_time_and_growth_rate();
+
+        // Early return if it's been less than 10 millis since our last tick
+        if time_since_last_tick < minimum_tick_size {
+            let pi_controller = &self.inner.pi_controller;
+            return RateLimitTick {
+                current_accept_bytes_per_second: pi_controller
+                    .current_tx_accept_rate_bytes_per_second,
+                bytes_offered_per_second_ewma: pi_controller
+                    .bytes_offered_per_second_ewma
+                    .max(minimum_offered_rate_per_second),
+                current_accept_execution_micros_per_second: pi_controller
+                    .current_tx_accept_rate_execution_time_micros_per_second,
+                execution_time_offered_per_second_ewma: pi_controller
+                    .execution_time_offered_per_second_ewma
+                    .max(minimum_offered_rate_per_second),
+                configured_target_execution_micros_per_second: target_execution_time_rate,
+            };
+        }
+        // Set the last tick time to the current time
+        self.inner.pi_controller.last_tick_time = now;
+
+        // Set up variables we'll need
+        let accept_bytes_per_sec = self
+            .inner
+            .pi_controller
+            .current_tx_accept_rate_bytes_per_second;
+        let accept_execution_micros_per_sec = self
+            .inner
+            .pi_controller
+            .current_tx_accept_rate_execution_time_micros_per_second;
+        let (target_size, target_size_rate) = self.inner.get_target_batch_size_and_growth_rate();
+
+        let bytes_offered_per_second_ewma = update_offered_rate_ewma(
+            self.inner.pi_controller.bytes_offered_per_second_ewma,
+            self.inner.pi_controller.bytes_offered_since_last_tick as f64,
+            time_since_last_tick,
+            minimum_tick_size,
+        );
+        self.inner.pi_controller.bytes_offered_since_last_tick = 0;
+        self.inner.pi_controller.bytes_offered_per_second_ewma = bytes_offered_per_second_ewma;
+
+        let execution_time_offered_per_second_ewma = update_offered_rate_ewma(
+            self.inner
+                .pi_controller
+                .execution_time_offered_per_second_ewma,
+            self.inner
+                .pi_controller
+                .execution_time_offered_since_last_tick,
+            time_since_last_tick,
+            minimum_tick_size,
+        );
+        self.inner
+            .pi_controller
+            .execution_time_offered_since_last_tick = 0.0;
+        self.inner
+            .pi_controller
+            .execution_time_offered_per_second_ewma = execution_time_offered_per_second_ewma;
+
+        // Compute the offered rates of execution time and batch size.
+        if execution_time_offered_per_second_ewma <= target_execution_time_rate {
+            self.inner.pi_controller.execution_time_limit_bias =
+                self.inner.pi_controller.execution_time_limit_bias.max(0.0);
+        }
+
+        let time_since_batch_open = if self.inner.executor.has_in_progress_batch() {
+            self.inner.pi_controller.batch_start_time.elapsed()
+        } else {
+            Duration::ZERO
+        };
+        let approx_time_to_batch_close =
+            if time_since_batch_open < self.inner.pi_controller.approximate_block_time {
+                std::cmp::max(
+                    self.inner.pi_controller.approximate_block_time - time_since_batch_open,
+                    minimum_tick_size,
+                )
+            } else {
+                minimum_tick_size
+            };
+
+        // Compute the rate limit for the batch size controller
+        let next_size_growth_rate = {
+            // The ideal rate, of batch growth (in bytes/sec) if we weren't worried about over/under shedding.
+            // This is just the rate in bytes-per-second if we split the remaining batch size budget evenly over the estimated remaining time.
+            let goal_size_growth_rate = (target_size as f64
+                - self.inner.batch_size_tracker.current_batch_size as f64)
+                .max(0.0)
+                / approx_time_to_batch_close.as_secs_f64();
+
+            // Compute our next rate as the goal rate adjusted by the bias term (recall that the bias evolves over time based on our error), clamped to the slew limits.
+            let raw_next_size_growth_rate =
+                (goal_size_growth_rate + self.inner.pi_controller.size_limit_bias).max(0.0);
+            let clamped_next_size_growth_rate = slew_limited_rate(
+                raw_next_size_growth_rate,
+                accept_bytes_per_sec,
+                target_size_rate,
+                time_since_last_tick,
+            ); // Clamp the next rate within our slew limits.
+
+            // Save and return the result
+            self.inner
+                .pi_controller
+                .current_tx_accept_rate_bytes_per_second = clamped_next_size_growth_rate;
+            clamped_next_size_growth_rate
+        };
+
+        // Compute the rate limit for the execution time controller
+        let next_execution_time_rate = {
+            // Execution time is noisy and can hit the hard cap abruptly, so we just set our goal rate to the average target rate (batch execution time cap / block time) plus the bias term.
+            // Note that this is different from the size growth rate, which tries to speed up as we get closer to the close of the batch if the number of accepted bytes is too low.
+            let goal_execution_time_rate = (target_execution_time_rate
+                + self.inner.pi_controller.execution_time_limit_bias)
+                .max(0.0);
+
+            // Clamp to within our slew limits
+            let actual_next_execution_time_rate = slew_limited_rate(
+                goal_execution_time_rate,
+                accept_execution_micros_per_sec,
+                target_execution_time_rate,
+                time_since_last_tick,
+            );
+            // Save and return the result
+            self.inner
+                .pi_controller
+                .current_tx_accept_rate_execution_time_micros_per_second =
+                actual_next_execution_time_rate;
+            actual_next_execution_time_rate
+        };
+
+        RateLimitTick {
+            current_accept_bytes_per_second: next_size_growth_rate,
+            bytes_offered_per_second_ewma,
+            current_accept_execution_micros_per_second: next_execution_time_rate,
+            execution_time_offered_per_second_ewma,
+            configured_target_execution_micros_per_second: target_execution_time_rate,
+        }
+    }
+
+    /// Get the acceptance probability for a given transaction based on...
+    /// 1. the sync distance and the max allowed node distance behind.
+    /// 2. the current batch size, target batch size and frequency, and the rate of offered transactions.
+    fn get_acceptance_probability(&mut self, baked_tx: &FullyBakedTx) -> f64 {
+        // 1. Probability based on batch size and offered rate.
+        self.inner.pi_controller.bytes_offered_since_last_tick += baked_tx.len() as u64;
+        self.inner
+            .pi_controller
+            .execution_time_offered_since_last_tick += self
+            .inner
+            .pi_controller
+            .estimated_tx_execution_time_micros
+            .max(1.0);
+        let RateLimitTick {
+            current_accept_bytes_per_second,
+            bytes_offered_per_second_ewma,
+            current_accept_execution_micros_per_second,
+            execution_time_offered_per_second_ewma,
+            configured_target_execution_micros_per_second,
+        } = self.tick_rate_limiter();
+
+        let accept_probability_batch_size =
+            (current_accept_bytes_per_second / bytes_offered_per_second_ewma).clamp(0.0, 1.0);
+        let accept_probability_execution_time = if execution_time_offered_per_second_ewma
+            <= configured_target_execution_micros_per_second
+        {
+            1.0
+        } else {
+            (current_accept_execution_micros_per_second / execution_time_offered_per_second_ewma)
+                .clamp(0.0, 1.0)
+        };
+
+        // 2. Probability based on sync distance.
+        //
+        // We subtract 1 from both the sync distance and the max_allowed_node distance so that a distance of 0 or 1 results in a 0% chance of shedding load
+        let sync_distance = self
+            .inner
+            .latest_info
+            .sync_status
+            .distance()
+            .saturating_sub(1) as f64;
+        let max_allowed_node_distance_behind = self
+            .inner
+            .seq_config
+            .max_allowed_node_distance_behind
+            .saturating_sub(1)
+            .max(1) as f64;
+        let drop_with_probability = sync_distance / max_allowed_node_distance_behind;
+        let accept_probability_sync_distance = (1.0 - drop_with_probability).clamp(0.0, 1.0);
+
+        // Take the min of the probabilities from the different factors: batch size, execution time and sync distance.
+        let accept_probability = accept_probability_batch_size
+            .min(accept_probability_execution_time)
+            .min(accept_probability_sync_distance);
+        self.runtime.accept_tx_probability(
+            self.runtime.get_transaction_priority(baked_tx),
+            accept_probability,
+        )
+    }
+
     async fn process_accept_tx(
         &mut self,
         baked_tx: FullyBakedTx,
@@ -890,6 +1098,11 @@ where
             .runtime
             .sequencing_data_handler()
             .create_sequencing_data();
+        let load_based_accept_probability = if self.use_pi_rate_limiter {
+            self.get_acceptance_probability(&baked_tx)
+        } else {
+            1.0
+        };
         let mut inner = self.get_inner_with_timing(reason).await;
 
         if inner.is_replica_role() {
@@ -935,6 +1148,15 @@ where
             .allow(ip_and_credential.ip_addr, ip_and_credential.address)
             .map_err(|err| AcceptTxError::RateLimiter(err))?;
 
+        // Shape probabilistic load shedding into a smooth accept stream. Independent random draws
+        // create accepted-transaction clusters, which is especially noisy when accepted txs are
+        // slow and rejected txs are cheap.
+        if !inner.should_accept_load_shed_tx(load_based_accept_probability) {
+            return Err(AcceptTxError::SequencerOverloaded503(
+                "Transaction rejected due to load shedding",
+            ));
+        }
+
         let mut baked_tx = baked_tx;
         // Important: we read the sequencing data from the baked tx inside apply_tx_to_in_progress_batch (which is called from do_new_tx)
         // so this must not be moved without updating do_new_tx. See the comment in apply_tx_to_in_progress_batch for more details.
@@ -944,6 +1166,11 @@ where
         // Do not use `?` or return early here. We must always call `rate_limiter.update`
         // to ensure the limits are updated even for unsuccessful transactions.
         let res = res.map_err(AcceptTxError::NewTxError);
+        if res.is_ok() {
+            inner.update_estimated_tx_execution_time_micros(
+                resource_used.inner.execution_time_micros,
+            );
+        }
         inner.rate_limiter.update(token, resource_used);
         let (rx, remaining_slot_gas) = res?;
 
@@ -1266,4 +1493,52 @@ fn completed_blobs_contain_batch(blobs: &[PreferredBlobToReplay]) -> bool {
     blobs
         .iter()
         .any(|blob| matches!(blob, PreferredBlobToReplay::Batch(_)))
+}
+
+fn update_offered_rate_ewma(
+    previous_rate_per_second: f64,
+    offered_since_last_tick: f64,
+    time_since_last_tick: Duration,
+    ewma_half_life: Duration,
+) -> f64 {
+    let elapsed_secs = time_since_last_tick.as_secs_f64();
+    let half_life_secs = ewma_half_life.as_secs_f64();
+    let previous_sample_weight = 0.5_f64.powf(elapsed_secs / half_life_secs);
+    let current_sample_weight = 1.0 - previous_sample_weight;
+    let current_rate_per_second = offered_since_last_tick / elapsed_secs;
+    let minimum_rate_per_second = 1.0 / half_life_secs;
+
+    (previous_rate_per_second * previous_sample_weight
+        + current_rate_per_second * current_sample_weight)
+        .max(minimum_rate_per_second)
+}
+
+fn slew_limited_rate(
+    goal_rate: f64,
+    current_rate: f64,
+    target_rate: f64,
+    elapsed: Duration,
+) -> f64 {
+    let elapsed_secs = elapsed.as_secs_f64();
+    let rate_up_per_sec = target_rate * 0.25;
+    let rate_down_per_sec = target_rate;
+    let max_up = (rate_up_per_sec * elapsed_secs).min(rate_up_per_sec);
+    let max_down = (rate_down_per_sec * elapsed_secs).min(rate_down_per_sec);
+
+    goal_rate.clamp(current_rate - max_down, current_rate + max_up)
+}
+
+#[derive(Debug)]
+struct RateLimitTick {
+    /// The rate at which to accept new txs in bytes/sec at the current moment (accounting for current batch size and time until close)
+    current_accept_bytes_per_second: f64,
+    /// The EWMA of the rate at which new txs are being offered in bytes/sec
+    bytes_offered_per_second_ewma: f64,
+    /// The rate at which to accept new txs in execution micros/sec given at the current moment (accounting for execution consumed and time until close)
+    current_accept_execution_micros_per_second: f64,
+    /// The EWMA of the rate at which new txs are being offered in execution micros/sec
+    execution_time_offered_per_second_ewma: f64,
+    /// The target execution time in micros/sec. This does not vary with current batch size or time until close.
+    /// We pass it around with the limiters for convenience
+    configured_target_execution_micros_per_second: f64,
 }

--- a/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/sync_sequencer_state/sync_state.rs
@@ -882,6 +882,7 @@ where
     // Takes the current rate limits and returns the next byte and execution-time rates, along with the offered rates.
     // This implements the P and I parts of a PID controller; this function is responsible for both updating the P term (every tick interval) and combining
     // it with the I term to get the current rate. (The I term is updated on each batch close.)
+    #[allow(clippy::float_arithmetic)]
     fn tick_rate_limiter(&mut self) -> RateLimitTick {
         let minimum_tick_size = Duration::from_millis(10);
         let minimum_offered_rate_per_second = 1.0 / minimum_tick_size.as_secs_f64();
@@ -1029,6 +1030,7 @@ where
     /// Get the acceptance probability for a given transaction based on...
     /// 1. the sync distance and the max allowed node distance behind.
     /// 2. the current batch size, target batch size and frequency, and the rate of offered transactions.
+    #[allow(clippy::float_arithmetic)]
     fn get_acceptance_probability(&mut self, baked_tx: &FullyBakedTx) -> f64 {
         // 1. Probability based on batch size and offered rate.
         self.inner.pi_controller.bytes_offered_since_last_tick += baked_tx.len() as u64;
@@ -1495,6 +1497,7 @@ fn completed_blobs_contain_batch(blobs: &[PreferredBlobToReplay]) -> bool {
         .any(|blob| matches!(blob, PreferredBlobToReplay::Batch(_)))
 }
 
+#[allow(clippy::float_arithmetic)]
 fn update_offered_rate_ewma(
     previous_rate_per_second: f64,
     offered_since_last_tick: f64,
@@ -1513,6 +1516,7 @@ fn update_offered_rate_ewma(
         .max(minimum_rate_per_second)
 }
 
+#[allow(clippy::float_arithmetic)]
 fn slew_limited_rate(
     goal_rate: f64,
     current_rate: f64,

--- a/crates/module-system/module-schemas/rollup-config.json
+++ b/crates/module-system/module-schemas/rollup-config.json
@@ -608,6 +608,11 @@
         "recovery_strategy": {
           "description": "Strategy for handling recovery scenarios in the preferred sequencer.",
           "$ref": "#/$defs/RecoveryStrategy"
+        },
+        "use_pi_rate_limiter": {
+          "description": "Whether to enable the experimental PI controller for rate limiting.\nThis smooths out the tx acceptance rate over time, rather than suddenly rejecting all txs when the batch is full.",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false,

--- a/crates/module-system/sov-modules-api/src/runtime/mod.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/mod.rs
@@ -142,6 +142,7 @@ pub trait Runtime<S: Spec>:
         priority: u32,
         current_baseline_acceptance_probability: f64,
     ) -> f64 {
+        #[allow(clippy::match_single_binding)]
         match priority {
             _ => current_baseline_acceptance_probability,
         }

--- a/crates/module-system/sov-modules-api/src/runtime/mod.rs
+++ b/crates/module-system/sov-modules-api/src/runtime/mod.rs
@@ -134,6 +134,19 @@ pub trait Runtime<S: Spec>:
         0
     }
 
+    /// The sequencer assigns a baseline probability of accepting each transaction given the current load.
+    /// When load is low, the probability is `1`. As load increases, the probability decreases to 0 in increments of about .1.
+    /// This function allows a modifier be applied to the probability given the priority of the transaction and the current acceptance probability.
+    fn accept_tx_probability(
+        &self,
+        priority: u32,
+        current_baseline_acceptance_probability: f64,
+    ) -> f64 {
+        match priority {
+            _ => current_baseline_acceptance_probability,
+        }
+    }
+
     /// Checks if a system transaction should be rejected based on the totality of its context.
     fn is_unauthorized_system_tx(
         &self,


### PR DESCRIPTION
# Description

This PR adds a PI controller (a PID controller minus the Derivative term) to control the rate of batch growth across two dimensions - execution time and batch size. This changes the behavior of the sequencer from spiky ("accept all txs until the batch is full, then reject all txs") to smooth (reject X% of txs, updating X every 10ms based on current load and batch size). 

I also add a load shedding switch based on the node's sync distance.

All new functionality is gated behind a new config option: 
```
[sequencer.preferred]
use_pi_rate_limiter = true # defaults to false if omitted
```

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to #2286

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
