### PR TITLE
Enrich hyperlane metrics

### DIFF
--- a/crates/full-node/sov-metrics/README.md
+++ b/crates/full-node/sov-metrics/README.md
@@ -265,7 +265,7 @@ Known cases today:
   IDs (`/blocks/12345`, `/tx/0xabc…`) create one series per ID. Normalization is tracked
   in PR #2753.
 - `sov_hyperlane_rate_limiter_capacity` — series count is `monitored_routes × enrolled_domains × 2`.
-  Cardinality is operator-controlled via `WarpExecutionConfig.monitored_route_ids`; a large
+  Cardinality is operator-controlled via `WarpExecutionConfig.monitored_routes`; a large
   monitored list × many enrolled destinations can still pressure InfluxDB. Prefer enumerating
   only the routes you actively care about.
 

--- a/crates/module-system/hyperlane/src/warp/execution_config.rs
+++ b/crates/module-system/hyperlane/src/warp/execution_config.rs
@@ -13,18 +13,28 @@ pub static WARP_EXECUTION_CONFIG: OnceLock<WarpExecutionConfig> = OnceLock::new(
 /// metrics emitted during block processing.
 #[derive(Clone, Default, Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
 pub struct WarpExecutionConfig {
-    /// List of warp route IDs to monitor for metrics.
+    /// Warp routes to monitor for rate limiter metrics.
     ///
     /// Metrics will be emitted for the rate limiters of these routes at the end
-    /// of each block.
+    /// of each block, labelled with the operator-supplied name.
     #[serde(default)]
-    pub monitored_route_ids: Vec<WarpRouteId>,
+    pub monitored_routes: Vec<MonitoredRoute>,
+}
+
+/// A warp route to emit rate limiter metrics for, paired with a human-readable name.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+pub struct MonitoredRoute {
+    /// The id of the route to monitor.
+    pub id: WarpRouteId,
+    /// Human-readable name used to label the route's metrics.
+    pub name: String,
 }
 
 impl<S: Spec> ExecutionInit for Warp<S> {
     type Config = WarpExecutionConfig;
 
     fn init(config: &Self::Config) -> Result<(), Box<dyn std::error::Error>> {
+        tracing::debug!(?config, "Initializing Warp execution config");
         WARP_EXECUTION_CONFIG
             .set(config.clone())
             .map_err(|_| "Warp execution config already initialized")?;
@@ -33,14 +43,14 @@ impl<S: Spec> ExecutionInit for Warp<S> {
 }
 
 impl<S: Spec> Warp<S> {
-    /// Returns the list of warp route IDs that should be monitored for metrics.
+    /// Returns the warp routes that should be monitored for metrics.
     ///
     /// This reads from the global execution configuration set at startup.
-    /// If no configuration is set, returns an empty vector.
-    pub(super) fn get_monitored_route_ids(&self) -> &[WarpRouteId] {
+    /// If no configuration is set, returns an empty slice.
+    pub(super) fn get_monitored_routes(&self) -> &[MonitoredRoute] {
         WARP_EXECUTION_CONFIG
             .get()
-            .map(|config| config.monitored_route_ids.as_slice())
+            .map(|config| config.monitored_routes.as_slice())
             .unwrap_or_default()
     }
 }

--- a/crates/module-system/hyperlane/src/warp/execution_config.rs
+++ b/crates/module-system/hyperlane/src/warp/execution_config.rs
@@ -12,6 +12,7 @@ pub static WARP_EXECUTION_CONFIG: OnceLock<WarpExecutionConfig> = OnceLock::new(
 /// This configuration specifies which warp routes should have their rate limiter
 /// metrics emitted during block processing.
 #[derive(Clone, Default, Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct WarpExecutionConfig {
     /// Warp routes to monitor for rate limiter metrics.
     ///

--- a/crates/module-system/hyperlane/src/warp/hooks.rs
+++ b/crates/module-system/hyperlane/src/warp/hooks.rs
@@ -12,12 +12,14 @@ impl<S: Spec> BlockHooks for Warp<S> {
 
 impl<S: Spec> Warp<S> {
     fn emit_rate_limiter_metrics(&self, state: &mut StateCheckpoint<S>) {
-        let route_ids = self.get_monitored_route_ids();
+        let monitored_routes = self.get_monitored_routes();
         let visible_slot = state.current_visible_slot_number();
 
-        for route_id in route_ids {
-            if let Ok(Some(route)) = self.warp_routes.get(route_id, state) {
-                let route_id = *route_id;
+        for monitored_route in monitored_routes {
+            if let Ok(Some(route)) = self.warp_routes.get(&monitored_route.id, state) {
+                let route_id = monitored_route.id;
+                let route_name = &monitored_route.name;
+                let decimals = route.token_source.local_decimals();
 
                 for &remote_domain in &route.enrolled_destinations {
                     let inbound_metrics = RateLimiterCapacityMetrics {
@@ -31,6 +33,8 @@ impl<S: Spec> Warp<S> {
                         direction: RateLimiterDirection::Inbound,
                         route_id,
                         remote_domain,
+                        route_name: route_name.clone(),
+                        decimals,
                     };
 
                     let outbound_metrics = RateLimiterCapacityMetrics {
@@ -44,6 +48,8 @@ impl<S: Spec> Warp<S> {
                         direction: RateLimiterDirection::Outbound,
                         route_id,
                         remote_domain,
+                        route_name: route_name.clone(),
+                        decimals,
                     };
 
                     sov_metrics::track_metrics(|tracker| {

--- a/crates/module-system/hyperlane/src/warp/hooks.rs
+++ b/crates/module-system/hyperlane/src/warp/hooks.rs
@@ -1,5 +1,6 @@
 use super::metrics::{RateLimiterCapacityMetrics, RateLimiterDirection};
 use super::Warp;
+use sov_modules_api::prelude::UnwrapInfallible as _;
 use sov_modules_api::{BlockHooks, Spec, StateCheckpoint, VersionReader as _};
 
 impl<S: Spec> BlockHooks for Warp<S> {
@@ -16,47 +17,58 @@ impl<S: Spec> Warp<S> {
         let visible_slot = state.current_visible_slot_number();
 
         for monitored_route in monitored_routes {
-            if let Ok(Some(route)) = self.warp_routes.get(&monitored_route.id, state) {
-                let route_id = monitored_route.id;
-                let route_name = &monitored_route.name;
-                let decimals = route.token_source.local_decimals();
+            let Some(route) = self
+                .warp_routes
+                .get(&monitored_route.id, state)
+                .unwrap_infallible()
+            else {
+                tracing::debug!(
+                    route_id = %monitored_route.id,
+                    route_name = %monitored_route.name,
+                    "Monitored warp route not found; skipping rate limiter metrics",
+                );
+                continue;
+            };
 
-                for &remote_domain in &route.enrolled_destinations {
-                    let inbound_metrics = RateLimiterCapacityMetrics {
-                        max_capacity: route.inbound_rate_limiter.max_limit(),
-                        current_capacity: route
-                            .inbound_rate_limiter
-                            .current_limit_with_replenishment(visible_slot),
-                        replenishment_per_slot: route
-                            .inbound_rate_limiter
-                            .limit_replenishment_per_slot(),
-                        direction: RateLimiterDirection::Inbound,
-                        route_id,
-                        remote_domain,
-                        route_name: route_name.clone(),
-                        decimals,
-                    };
+            let route_id = monitored_route.id;
+            let route_name = &monitored_route.name;
+            let decimals = route.token_source.local_decimals();
 
-                    let outbound_metrics = RateLimiterCapacityMetrics {
-                        max_capacity: route.outbound_rate_limiter.max_limit(),
-                        current_capacity: route
-                            .outbound_rate_limiter
-                            .current_limit_with_replenishment(visible_slot),
-                        replenishment_per_slot: route
-                            .outbound_rate_limiter
-                            .limit_replenishment_per_slot(),
-                        direction: RateLimiterDirection::Outbound,
-                        route_id,
-                        remote_domain,
-                        route_name: route_name.clone(),
-                        decimals,
-                    };
+            for &remote_domain in &route.enrolled_destinations {
+                let inbound_metrics = RateLimiterCapacityMetrics {
+                    max_capacity: route.inbound_rate_limiter.max_limit(),
+                    current_capacity: route
+                        .inbound_rate_limiter
+                        .current_limit_with_replenishment(visible_slot),
+                    replenishment_per_slot: route
+                        .inbound_rate_limiter
+                        .limit_replenishment_per_slot(),
+                    direction: RateLimiterDirection::Inbound,
+                    route_id,
+                    remote_domain,
+                    route_name: route_name.clone(),
+                    decimals,
+                };
 
-                    sov_metrics::track_metrics(|tracker| {
-                        tracker.submit(inbound_metrics);
-                        tracker.submit(outbound_metrics);
-                    });
-                }
+                let outbound_metrics = RateLimiterCapacityMetrics {
+                    max_capacity: route.outbound_rate_limiter.max_limit(),
+                    current_capacity: route
+                        .outbound_rate_limiter
+                        .current_limit_with_replenishment(visible_slot),
+                    replenishment_per_slot: route
+                        .outbound_rate_limiter
+                        .limit_replenishment_per_slot(),
+                    direction: RateLimiterDirection::Outbound,
+                    route_id,
+                    remote_domain,
+                    route_name: route_name.clone(),
+                    decimals,
+                };
+
+                sov_metrics::track_metrics(|tracker| {
+                    tracker.submit(inbound_metrics);
+                    tracker.submit(outbound_metrics);
+                });
             }
         }
     }

--- a/crates/module-system/hyperlane/src/warp/metrics.rs
+++ b/crates/module-system/hyperlane/src/warp/metrics.rs
@@ -74,7 +74,10 @@ impl sov_metrics::Metric for RateLimiterCapacityMetrics {
 /// Scales a raw token amount to whole-token units using the token's decimals
 /// (e.g. `742500000` with 6 decimals -> `742.5`). Lossy for amounts beyond
 /// f64's precision, which is acceptable for a metric gauge.
-#[allow(clippy::float_arithmetic, reason = "lossy scaling is fine for a metric gauge")]
+#[allow(
+    clippy::float_arithmetic,
+    reason = "lossy scaling is fine for a metric gauge"
+)]
 fn scale(amount: Amount, decimals: u8) -> f64 {
     amount.0 as f64 / 10f64.powi(i32::from(decimals))
 }

--- a/crates/module-system/hyperlane/src/warp/metrics.rs
+++ b/crates/module-system/hyperlane/src/warp/metrics.rs
@@ -71,24 +71,11 @@ impl sov_metrics::Metric for RateLimiterCapacityMetrics {
     }
 }
 
-/// Scales a raw token amount to whole-token units using the token's decimals,
-/// rendered as a decimal string (e.g. `742500000` with 6 decimals -> `742.5`).
-fn scale(amount: Amount, decimals: u8) -> String {
-    let decimals = usize::from(decimals);
-    if decimals == 0 {
-        return amount.0.to_string();
-    }
-
-    let digits = format!("{:0>width$}", amount.0, width = decimals + 1);
-    let point = digits.len() - decimals;
-    let whole = &digits[..point];
-    let frac = digits[point..].trim_end_matches('0');
-
-    if frac.is_empty() {
-        whole.to_string()
-    } else {
-        format!("{whole}.{frac}")
-    }
+/// Scales a raw token amount to whole-token units using the token's decimals
+/// (e.g. `742500000` with 6 decimals -> `742.5`). Lossy for amounts beyond
+/// f64's precision, which is acceptable for a metric gauge.
+fn scale(amount: Amount, decimals: u8) -> f64 {
+    amount.0 as f64 / 10f64.powi(i32::from(decimals))
 }
 
 /// escapes a string for use as an InfluxDB line-protocol tag value.
@@ -132,21 +119,6 @@ mod tests {
         assert!(
             line.contains("max_capacity=1000,current_capacity=742.5,replenishment_per_slot=0.0115"),
             "amounts should be scaled to whole tokens: {line}"
-        );
-    }
-
-    #[test]
-    fn serializes_fractional_scaled_amount() {
-        let metrics = RateLimiterCapacityMetrics {
-            max_capacity: Amount(1_234_567_891),
-            ..sample("USDC", 8)
-        };
-
-        let line = serialize(&metrics);
-
-        assert!(
-            line.contains("max_capacity=12.34567891"),
-            "non-whole amounts should keep their fractional digits: {line}"
         );
     }
 

--- a/crates/module-system/hyperlane/src/warp/metrics.rs
+++ b/crates/module-system/hyperlane/src/warp/metrics.rs
@@ -74,6 +74,7 @@ impl sov_metrics::Metric for RateLimiterCapacityMetrics {
 /// Scales a raw token amount to whole-token units using the token's decimals
 /// (e.g. `742500000` with 6 decimals -> `742.5`). Lossy for amounts beyond
 /// f64's precision, which is acceptable for a metric gauge.
+#[allow(clippy::float_arithmetic, reason = "lossy scaling is fine for a metric gauge")]
 fn scale(amount: Amount, decimals: u8) -> f64 {
     amount.0 as f64 / 10f64.powi(i32::from(decimals))
 }

--- a/crates/module-system/hyperlane/src/warp/metrics.rs
+++ b/crates/module-system/hyperlane/src/warp/metrics.rs
@@ -36,6 +36,10 @@ pub struct RateLimiterCapacityMetrics {
     pub route_id: WarpRouteId,
     /// The remote domain for tagging specific destinations.
     pub remote_domain: u32,
+    /// Operator-supplied human-readable name of the route.
+    pub route_name: String,
+    /// Decimals of the route's local token, used to scale the raw capacities.
+    pub decimals: u8,
 }
 
 impl sov_metrics::Metric for RateLimiterCapacityMetrics {
@@ -47,20 +51,112 @@ impl sov_metrics::Metric for RateLimiterCapacityMetrics {
         // measurement name & tags
         write!(
             buffer,
-            "{},direction={},route_id={},remote_domain={}",
+            "{},direction={},route_id={},remote_domain={},route_name={}",
             self.measurement_name(),
             self.direction,
             self.route_id,
-            self.remote_domain
+            self.remote_domain,
+            escape_tag(&self.route_name),
         )?;
 
-        // fields
         write!(
             buffer,
             " max_capacity={},current_capacity={},replenishment_per_slot={}",
-            self.max_capacity.0, self.current_capacity.0, self.replenishment_per_slot.0
+            scale(self.max_capacity, self.decimals),
+            scale(self.current_capacity, self.decimals),
+            scale(self.replenishment_per_slot, self.decimals),
         )?;
 
         Ok(())
+    }
+}
+
+/// Scales a raw token amount to whole-token units using the token's decimals,
+/// rendered as a decimal string (e.g. `742500000` with 6 decimals -> `742.5`).
+fn scale(amount: Amount, decimals: u8) -> String {
+    let decimals = usize::from(decimals);
+    if decimals == 0 {
+        return amount.0.to_string();
+    }
+
+    let digits = format!("{:0>width$}", amount.0, width = decimals + 1);
+    let point = digits.len() - decimals;
+    let whole = &digits[..point];
+    let frac = digits[point..].trim_end_matches('0');
+
+    if frac.is_empty() {
+        whole.to_string()
+    } else {
+        format!("{whole}.{frac}")
+    }
+}
+
+/// escapes a string for use as an InfluxDB line-protocol tag value.
+fn escape_tag(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace(',', "\\,")
+        .replace('=', "\\=")
+        .replace(' ', "\\ ")
+}
+
+#[cfg(test)]
+mod tests {
+    use sov_metrics::Metric as _;
+
+    use super::*;
+
+    fn sample(route_name: &str, decimals: u8) -> RateLimiterCapacityMetrics {
+        RateLimiterCapacityMetrics {
+            max_capacity: Amount(1_000_000_000),
+            current_capacity: Amount(742_500_000),
+            replenishment_per_slot: Amount(11_500),
+            direction: RateLimiterDirection::Inbound,
+            route_id: WarpRouteId::from([0xab; 32]),
+            remote_domain: 0x1234,
+            route_name: route_name.to_string(),
+            decimals,
+        }
+    }
+
+    fn serialize(metrics: &RateLimiterCapacityMetrics) -> String {
+        let mut buffer = Vec::new();
+        metrics.serialize_for_telegraf(&mut buffer).unwrap();
+        String::from_utf8(buffer).unwrap()
+    }
+
+    #[test]
+    fn scales_raw_amounts_by_token_decimals() {
+        let line = serialize(&sample("USDC", 6));
+
+        assert!(
+            line.contains("max_capacity=1000,current_capacity=742.5,replenishment_per_slot=0.0115"),
+            "amounts should be scaled to whole tokens: {line}"
+        );
+    }
+
+    #[test]
+    fn serializes_fractional_scaled_amount() {
+        let metrics = RateLimiterCapacityMetrics {
+            max_capacity: Amount(1_234_567_891),
+            ..sample("USDC", 8)
+        };
+
+        let line = serialize(&metrics);
+
+        assert!(
+            line.contains("max_capacity=12.34567891"),
+            "non-whole amounts should keep their fractional digits: {line}"
+        );
+    }
+
+    #[test]
+    fn escapes_route_name_tag() {
+        let line = serialize(&sample("USDC eth,v2", 0));
+
+        assert!(
+            line.contains(r"route_name=USDC\ eth\,v2"),
+            "spaces and commas in tag values must be escaped: {line}"
+        );
     }
 }

--- a/crates/module-system/hyperlane/src/warp/metrics.rs
+++ b/crates/module-system/hyperlane/src/warp/metrics.rs
@@ -56,9 +56,10 @@ impl sov_metrics::Metric for RateLimiterCapacityMetrics {
             self.direction,
             self.route_id,
             self.remote_domain,
-            escape_tag(&self.route_name),
+            sov_metrics::safe_telegraf_string(&self.route_name),
         )?;
 
+        // fields
         write!(
             buffer,
             " max_capacity={},current_capacity={},replenishment_per_slot={}",
@@ -80,15 +81,6 @@ impl sov_metrics::Metric for RateLimiterCapacityMetrics {
 )]
 fn scale(amount: Amount, decimals: u8) -> f64 {
     amount.0 as f64 / 10f64.powi(i32::from(decimals))
-}
-
-/// escapes a string for use as an InfluxDB line-protocol tag value.
-fn escape_tag(value: &str) -> String {
-    value
-        .replace('\\', "\\\\")
-        .replace(',', "\\,")
-        .replace('=', "\\=")
-        .replace(' ', "\\ ")
 }
 
 #[cfg(test)]

--- a/crates/module-system/hyperlane/src/warp/mod.rs
+++ b/crates/module-system/hyperlane/src/warp/mod.rs
@@ -31,7 +31,7 @@ mod metrics;
 mod types;
 
 #[cfg(feature = "native")]
-pub use execution_config::{WarpExecutionConfig, WARP_EXECUTION_CONFIG};
+pub use execution_config::{MonitoredRoute, WarpExecutionConfig, WARP_EXECUTION_CONFIG};
 pub use types::*;
 
 /// Implements support for Hyperlane Warp Routes

--- a/crates/module-system/hyperlane/src/warp/types.rs
+++ b/crates/module-system/hyperlane/src/warp/types.rs
@@ -180,6 +180,16 @@ impl StoredTokenKind {
             anyhow::anyhow!("Amount may not exceed 2^128 - 1 after scaling")
         })?))
     }
+
+    /// The number of decimals of this route's local token.
+    pub fn local_decimals(&self) -> u8 {
+        match self {
+            StoredTokenKind::Synthetic { local_decimals, .. } => *local_decimals,
+            // Bank derives every token id with its decimals encoded in the final byte.
+            StoredTokenKind::Collateral { token } => token.as_bytes()[31],
+            StoredTokenKind::Native => sov_bank::config_gas_token_id().as_bytes()[31],
+        }
+    }
 }
 
 impl TokenKind {


### PR DESCRIPTION
# Description

Makes the following fields available for hyperlane rate limit metrics:

- Human readable route name
- Token values in decimal scaled form rather than raw

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
