### PR TITLE
Sanity check: preferred sequencer refuses startup if blobsender DB has a higher sequencer number than sequencer DB

### DIFF
--- a/crates/full-node/sov-blob-sender/src/lib.rs
+++ b/crates/full-node/sov-blob-sender/src/lib.rs
@@ -218,6 +218,15 @@ where
         &self.hooks
     }
 
+    /// Returns the blobs that were loaded from storage and will be submitted on
+    /// the first publish call after restart.
+    pub fn blobs_to_send_after_restart(&self) -> impl Iterator<Item = &BlobToSend> {
+        self.blobs_to_send_after_restart
+            .as_deref()
+            .into_iter()
+            .flat_map(|blobs| blobs.iter().map(|blob| &blob.blob))
+    }
+
     /// Can be called again with the same [`BlobInternalId`] to resume publishing.
     pub async fn publish_batch_blob(
         &mut self,

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -112,6 +112,20 @@ where
         )
         .await?;
 
+        if let Some(blob_sender_sequence_number) =
+            blob_sender.highest_sequence_number_to_send_after_restart()?
+        {
+            if blob_sender_sequence_number >= next_sequence_number {
+                let _ = shutdown_sender.send(());
+                let preferred_db_highest_sequence_number = next_sequence_number
+                    .checked_sub(1)
+                    .map_or_else(|| "none".to_owned(), |seq| seq.to_string());
+                anyhow::bail!(
+                    "Node state is inconsistent, aborting startup. The BlobSender DB contains a preferred blob with sequence number {blob_sender_sequence_number}, but the preferred sequencer DB's highest known sequence number is {preferred_db_highest_sequence_number}. This could mean the preferred sequencer DB was wiped; this is not supported, but to proceed, the BlobSender DB must also be deleted in the rollup state directory. Otherwise, this as a bug, please report it."
+                );
+            }
+        }
+
         if let Some(blob_sender_handle) = blob_sender_handle {
             handles.push(blob_sender_handle);
         }

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -121,7 +121,7 @@ where
                     .checked_sub(1)
                     .map_or_else(|| "none".to_owned(), |seq| seq.to_string());
                 anyhow::bail!(
-                    "Node state is inconsistent, aborting startup. The BlobSender DB contains a preferred blob with sequence number {blob_sender_sequence_number}, but the preferred sequencer DB's highest known sequence number is {preferred_db_highest_sequence_number}. This could mean the preferred sequencer DB was wiped; this is not supported, but to proceed, the BlobSender DB must also be deleted in the rollup state directory. Otherwise, this as a bug, please report it."
+                    "Node state is inconsistent, aborting startup: BlobSender DB contains a higher blob sequence number than the Preferred Sequencer DB. BlobSender has blobs up to {blob_sender_sequence_number}, but the preferred sequencer only has blobs up to {preferred_db_highest_sequence_number}. This could mean the preferred sequencer DB was wiped; this is not supported, but to proceed, the BlobSender DB must also be deleted in the rollup state directory. Otherwise, this as a bug, please report it."
                 );
             }
         }

--- a/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/preferred_blob_sender.rs
@@ -14,6 +14,9 @@ use tokio::task::JoinHandle;
 use tokio::time::Duration;
 use tracing::debug;
 
+use anyhow::Context;
+use borsh::BorshDeserialize;
+
 use super::db::{ReadBatch, ReadBlob};
 use crate::preferred::db::SequencerRole;
 use crate::PreferredProofDataBytes;
@@ -145,6 +148,25 @@ impl<Da: DaService> PreferredBlobSender<Da> {
         self.nb_of_concurrent_proof_blob_submissions.clone()
     }
 
+    pub(crate) fn highest_sequence_number_to_send_after_restart(
+        &self,
+    ) -> anyhow::Result<Option<u64>> {
+        let Some(ref inner) = self.inner else {
+            return Ok(None);
+        };
+
+        inner
+            .blobs_to_send_after_restart()
+            .map(preferred_blob_sequence_number)
+            .try_fold(None, |highest, sequence_number| {
+                sequence_number.map(|sequence_number| {
+                    Some(highest.map_or(sequence_number, |highest| {
+                        std::cmp::max(highest, sequence_number)
+                    }))
+                })
+            })
+    }
+
     pub(crate) async fn add_txs(&self, blob_id: BlobInternalId, tx_hashes: Arc<Vec<TxHash>>) {
         let Some(ref inner) = self.inner else {
             return;
@@ -203,4 +225,15 @@ fn batch_bytes(batch: ReadBatch) -> anyhow::Result<Arc<[u8]>> {
         data: batch.txs,
     })?
     .into())
+}
+
+fn preferred_blob_sequence_number(blob: &BlobToSend) -> anyhow::Result<u64> {
+    match blob {
+        BlobToSend::Batch { data } => Ok(PreferredBatchData::try_from_slice(data.as_ref())
+            .context("Failed to deserialize preferred batch from BlobSender DB")?
+            .sequence_number),
+        BlobToSend::Proof { data } => Ok(PreferredProofData::try_from_slice(data.as_ref())
+            .context("Failed to deserialize preferred proof from BlobSender DB")?
+            .sequence_number),
+    }
 }

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
@@ -111,11 +111,11 @@ async fn test_startup_fails_if_blob_sender_db_is_ahead_of_preferred_db() {
 
     let err = err.to_string();
     assert!(
-        err.contains("BlobSender DB contains a preferred blob"),
+        err.contains("Node state is inconsistent, aborting startup: BlobSender DB contains a higher blob sequence number than the Preferred Sequencer DB."),
         "Unexpected startup error: {err}"
     );
     assert!(
-        err.contains("preferred sequencer DB's highest known sequence number is none"),
+        err.contains("preferred sequencer only has blobs up to none"),
         "Unexpected startup error: {err}"
     );
 }

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
@@ -1,7 +1,7 @@
-use std::{env, fs};
+use std::{env, fs, time::Duration};
 
 use futures::StreamExt;
-use sov_blob_sender::BlobSelectorStatus;
+use sov_blob_sender::{BlobSelectorStatus, BlobSubmissionStatus};
 use sov_mock_da::BlockProducingConfig;
 use sov_mock_zkvm::crypto::private_key::Ed25519PrivateKey;
 use sov_modules_api::prelude::*;
@@ -87,9 +87,31 @@ async fn test_startup_fails_if_blob_sender_db_is_ahead_of_preferred_db() {
     let tx = tx_set_many_values(&admin.private_key, 0, vec![7; 100]);
     client.send_raw_tx_to_sequencer(&tx).await.unwrap();
 
+    let mut blob_sender_statuses = test_rollup
+        .subscribe_to_blobs_from_blob_sender()
+        .await
+        .unwrap();
+
     // Pause DA submission after BlobSender persists the blob locally, before it can land on DA.
     test_rollup.da_service.set_blob_submission_pause().await;
     test_rollup.force_close_batch().await.unwrap();
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let blob_status = blob_sender_statuses
+                .next()
+                .await
+                .expect("BlobSender status stream closed before the blob was persisted")
+                .expect("BlobSender status stream returned an error");
+            if matches!(
+                blob_status.blob_submission_status,
+                BlobSubmissionStatus::MustSubmit
+            ) {
+                break;
+            }
+        }
+    })
+    .await
+    .expect("Timeout occurred while waiting for the blob to be persisted in BlobSender DB.");
 
     let builder = test_rollup.shutdown().await.unwrap();
     let storage_path = builder.storage_path();

--- a/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
+++ b/crates/full-node/sov-sequencer/tests/integration/preferred_blob_sender.rs
@@ -1,4 +1,4 @@
-use std::env;
+use std::{env, fs};
 
 use futures::StreamExt;
 use sov_blob_sender::BlobSelectorStatus;
@@ -24,6 +24,8 @@ use crate::preferred_end_to_end::{
     TestingAction,
 };
 use crate::utils::{new_test_rollup, tempdir_inside_codebase_dir, MAX_BATCH_EXECUTION_TIME_MILLIS};
+
+const PREFERRED_SEQUENCER_DB_NAME: &str = "preferred_sequencer";
 
 async fn create_test_rollup() -> (TestRollup<TestBlueprint>, TestUser<TestSpec>) {
     let genesis_config =
@@ -71,6 +73,51 @@ async fn create_test_rollup() -> (TestRollup<TestBlueprint>, TestUser<TestSpec>)
         .await,
         admin,
     )
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_startup_fails_if_blob_sender_db_is_ahead_of_preferred_db() {
+    sov_test_utils::initialize_logging();
+    let (test_rollup, admin) = create_test_rollup().await;
+
+    test_rollup.produce_enough_finalized_slots().await;
+    test_rollup.wait_for_sequencer_ready().await.unwrap();
+
+    let client = test_rollup.api_client().clone();
+    let tx = tx_set_many_values(&admin.private_key, 0, vec![7; 100]);
+    client.send_raw_tx_to_sequencer(&tx).await.unwrap();
+
+    // Pause DA submission after BlobSender persists the blob locally, before it can land on DA.
+    test_rollup.da_service.set_blob_submission_pause().await;
+    test_rollup.force_close_batch().await.unwrap();
+
+    let builder = test_rollup.shutdown().await.unwrap();
+    let storage_path = builder.storage_path();
+    let preferred_db_path = storage_path.path().join(PREFERRED_SEQUENCER_DB_NAME);
+    assert!(
+        preferred_db_path.exists(),
+        "Preferred sequencer DB should exist before simulating a wipe"
+    );
+    // Simulate wiping the preferred sequencer DB while leaving BlobSender DB intact.
+    fs::remove_dir_all(preferred_db_path).unwrap();
+
+    let err = match builder.start().await {
+        Ok(test_rollup) => {
+            test_rollup.shutdown().await.unwrap();
+            panic!("Rollup started despite BlobSender DB being ahead of preferred sequencer DB");
+        }
+        Err(err) => err,
+    };
+
+    let err = err.to_string();
+    assert!(
+        err.contains("BlobSender DB contains a preferred blob"),
+        "Unexpected startup error: {err}"
+    );
+    assert!(
+        err.contains("preferred sequencer DB's highest known sequence number is none"),
+        "Unexpected startup error: {err}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
# Description

Iterates over PrefferedBlobSender blobs on startup, gets the max sequence number and ensures that it's not higher than the highest sequence number from the preferred sequencer DB. If it is, that means the sequencer doesn't know about some blobs that will be sent to DA, which is an inconsistent state and the sequencer cannot operate.

This prevents a footgun in case the preferred sequencer DB is wiped. Now, the node will immediately shut down on startup, with an informative error message to users ("if you wiped the sequencer DB, then delete the blobsender DB as well").

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
